### PR TITLE
TINY-8455: Make the plugins option return type be a string array

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced the `disable(name)` and `enable(name)` functions with a `setEnabled(name, state)` function in the Dialog APIs #TINY-8101
 - The Editor commands APIs will no longer fallback to executing the browsers native command functionality #TINY-7829
 - The Editor query command APIs will now return `false` or an empty string on removed editors #TINY-7829
+- The `plugins` option now returns a `string` array instead of a space separated string #TINY-8455
 - Replaced 'Powered by Tiny' link text with logo #TINY-8371
 
 ### Fixed

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -425,7 +425,7 @@ class Editor implements EditorObservable {
    * tinymce.activeEditor.hasPlugin('table');
    */
   public hasPlugin(name: string, loaded?: boolean): boolean {
-    const hasPlugin = Arr.contains(Options.getPlugins(this).split(/[ ,]/), name);
+    const hasPlugin = Arr.contains(Options.getPlugins(this), name);
     if (hasPlugin) {
       return loaded ? PluginManager.get(name) !== undefined : true;
     } else {

--- a/modules/tinymce/src/core/main/ts/api/EditorOptions.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorOptions.ts
@@ -107,10 +107,7 @@ export interface Options {
    * @param {String} name Name of a registered option.
    * @return {Boolean} True if the option value was successfully set, otherwise false.
    */
-  set: {
-    <K extends keyof EditorOptions>(name: K, value: EditorOptions[K]): boolean;
-    <T>(name: string, value: T): boolean;
-  };
+  set: <K extends string, T>(name: K, value: K extends keyof NormalizedEditorOptions ? NormalizedEditorOptions[K] : T) => boolean;
 
   /**
    * Clear the set value for the specified option and revert back to the default value.

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -245,7 +245,7 @@ export interface RawEditorOptions extends BaseEditorOptions {
 export interface NormalizedEditorOptions extends BaseEditorOptions {
   external_plugins: Record<string, string>;
   forced_plugins: string[];
-  plugins: string;
+  plugins: string[];
 }
 
 export interface EditorOptions extends NormalizedEditorOptions {

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -431,8 +431,8 @@ const register = (editor: Editor) => {
   });
 
   registerOption('plugins', {
-    processor: 'string',
-    default: ''
+    processor: 'string[]',
+    default: []
   });
 
   registerOption('external_plugins', {

--- a/modules/tinymce/src/core/main/ts/init/Init.ts
+++ b/modules/tinymce/src/core/main/ts/init/Init.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Fun, Obj, Optional, Type } from '@ephox/katamari';
+import { Arr, Fun, Obj, Optional, Type } from '@ephox/katamari';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
@@ -56,7 +56,7 @@ const trimLegacyPrefix = (name: string) => {
 const initPlugins = (editor: Editor) => {
   const initializedPlugins = [];
 
-  Tools.each(Options.getPlugins(editor).split(/[ ,]/), (name) => {
+  Arr.each(Options.getPlugins(editor), (name) => {
     initPlugin(editor, initializedPlugins, trimLegacyPrefix(name));
   });
 };

--- a/modules/tinymce/src/core/main/ts/init/Render.ts
+++ b/modules/tinymce/src/core/main/ts/init/Render.ts
@@ -103,10 +103,10 @@ const loadPlugins = (editor: Editor, suffix: string) => {
 
   Obj.each(Options.getExternalPlugins(editor), (url, name) => {
     loadPlugin(name, url);
-    editor.options.set('plugins', Options.getPlugins(editor) + ' ' + name);
+    editor.options.set('plugins', Options.getPlugins(editor).concat(name));
   });
 
-  Arr.each(Options.getPlugins(editor).split(/[ ,]/), (plugin) => {
+  Arr.each(Options.getPlugins(editor), (plugin) => {
     plugin = Tools.trim(plugin);
 
     if (plugin && !PluginManager.urls[plugin]) {

--- a/modules/tinymce/src/core/main/ts/options/NormalizeOptions.ts
+++ b/modules/tinymce/src/core/main/ts/options/NormalizeOptions.ts
@@ -111,7 +111,7 @@ const processPlugins = (isMobileDevice: boolean, sectionResult: SectionResult, d
 
   return Tools.extend(options, {
     forced_plugins: forcedPlugins,
-    plugins: combinedPlugins.join(' ')
+    plugins: combinedPlugins
   });
 };
 

--- a/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
@@ -472,7 +472,7 @@ describe('browser.tinymce.core.EditorTest', () => {
   context('hasPlugin', () => {
     const checkWithoutManager = (title: string, plugins: string, plugin: string, expected: boolean) => {
       const editor = hook.editor();
-      editor.options.set('plugins', plugins);
+      editor.options.set('plugins', plugins.split(/[ ,]/));
       assert.equal(editor.hasPlugin(plugin), expected, title);
     };
 
@@ -482,7 +482,7 @@ describe('browser.tinymce.core.EditorTest', () => {
         PluginManager.add('ParticularPlugin', Fun.noop);
       }
 
-      editor.options.set('plugins', plugins);
+      editor.options.set('plugins', plugins.split(/[ ,]/));
       assert.equal(editor.hasPlugin(plugin, true), expected, title);
 
       if (addToManager) {

--- a/modules/tinymce/src/core/test/ts/browser/options/NormalizeOptionsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/options/NormalizeOptionsTest.ts
@@ -64,7 +64,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
       );
 
       assert.equal(settings.userSetting, 'b', 'Should have the specified userSetting');
-      assert.equal(settings.plugins, 'a', 'Should have the specified default plugin');
+      assert.deepEqual(settings.plugins, [ 'a' ], 'Should have the specified default plugin');
       assert.equal(settings.defaultSetting, 'a', 'Should have the default setting');
     });
 
@@ -79,7 +79,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
 
       const settings = NormalizeOptions.normalizeOptions(defaultSettings, userSettings);
 
-      assert.equal(settings.plugins, 'a b c d', 'Should be both forced and user plugins');
+      assert.deepEqual(settings.plugins, [ 'a', 'b', 'c', 'd' ], 'Should be both forced and user plugins');
     });
 
     it('Override defaults with forced_plugins using strings', () => {
@@ -93,7 +93,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
 
       const settings = NormalizeOptions.normalizeOptions(defaultSettings, userSettings);
 
-      assert.equal(settings.plugins, 'a b c d', 'Should be both forced and user plugins');
+      assert.deepEqual(settings.plugins, [ 'a', 'b', 'c', 'd' ], 'Should be both forced and user plugins');
     });
 
     it('Override defaults with forced_plugins using mixed types and spaces', () => {
@@ -107,7 +107,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
 
       const settings = NormalizeOptions.normalizeOptions(defaultSettings, userSettings);
 
-      assert.equal(settings.plugins, 'a b c d e', 'Should be both forced and user plugins');
+      assert.deepEqual(settings.plugins, [ 'a', 'b', 'c', 'd', 'e' ], 'Should be both forced and user plugins');
     });
 
     it('Override defaults with just default forced_plugins', () => {
@@ -120,7 +120,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
 
       const settings = NormalizeOptions.normalizeOptions(defaultSettings, userSettings);
 
-      assert.equal(settings.plugins, 'a b', 'Should be just default plugins');
+      assert.deepEqual(settings.plugins, [ 'a', 'b' ], 'Should be just default plugins');
     });
 
     it('Override defaults with just user plugins', () => {
@@ -133,7 +133,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
 
       const settings = NormalizeOptions.normalizeOptions(defaultSettings, userSettings);
 
-      assert.equal(settings.plugins, 'a b', 'Should be just user plugins');
+      assert.deepEqual(settings.plugins, [ 'a', 'b' ], 'Should be just user plugins');
     });
 
     it('Override defaults with forced_plugins should not be possible to override', () => {
@@ -148,7 +148,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
 
       const settings = NormalizeOptions.normalizeOptions(defaultSettings, userSettings);
 
-      assert.equal(settings.plugins, 'a b c d', 'Should be just forced and user plugins');
+      assert.deepEqual(settings.plugins, [ 'a', 'b', 'c', 'd' ], 'Should be just forced and user plugins');
     });
   });
 
@@ -156,7 +156,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
     it('Merged settings (desktop)', () => {
       assert.deepEqual(
         NormalizeOptions.combineOptions(false, false, { a: 1, b: 1, c: 1 }, { b: 2 }, { c: 3 }),
-        { a: 1, b: 2, c: 3, external_plugins: {}, forced_plugins: [], plugins: '' },
+        { a: 1, b: 2, c: 3, external_plugins: {}, forced_plugins: [], plugins: [] },
         'Should have validate, forced and empty plugins in the merged settings'
       );
     });
@@ -164,7 +164,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
     it('Merged settings forced_plugins in default override settings (desktop)', () => {
       assert.deepEqual(
         NormalizeOptions.combineOptions(false, false, {}, { forced_plugins: [ 'a' ] }, { plugins: [ 'b' ] }),
-        { external_plugins: {}, forced_plugins: [ 'a' ], plugins: 'a b' },
+        { external_plugins: {}, forced_plugins: [ 'a' ], plugins: [ 'a', 'b' ] },
         'Should have plugins merged with forced plugins'
       );
     });
@@ -172,7 +172,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
     it('Merged settings forced_plugins in default override settings (mobile)', () => {
       assert.deepEqual(
         NormalizeOptions.combineOptions(true, true, {}, { forced_plugins: [ 'a' ] }, { plugins: [ 'b' ] }),
-        { ...expectedPhoneDefaultSettings, external_plugins: {}, forced_plugins: [ 'a' ], plugins: 'a b' },
+        { ...expectedPhoneDefaultSettings, external_plugins: {}, forced_plugins: [ 'a' ], plugins: [ 'a', 'b' ] },
         'Should be have plugins merged with forced plugins'
       );
     });
@@ -183,7 +183,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
           plugins: [ 'b' ],
           mobile: { plugins: [ 'c' ], toolbar_sticky: true }
         }),
-        { external_plugins: {}, forced_plugins: [ 'a' ], plugins: 'a b' },
+        { external_plugins: {}, forced_plugins: [ 'a' ], plugins: [ 'a', 'b' ] },
         'Should not have plugins merged with mobile plugins'
       );
     });
@@ -191,7 +191,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
     it('Merged settings when theme is silver, forced_plugins in default override settings with user mobile settings (mobile)', () => {
       assert.deepEqual(
         NormalizeOptions.combineOptions(true, true, {}, { forced_plugins: [ 'a' ] }, { plugins: [ 'b' ], mobile: { plugins: [ 'lists custom' ] }}),
-        { ...expectedPhoneDefaultSettings, external_plugins: {}, forced_plugins: [ 'a' ], plugins: 'a lists custom' },
+        { ...expectedPhoneDefaultSettings, external_plugins: {}, forced_plugins: [ 'a' ], plugins: [ 'a', 'lists', 'custom' ] },
         'Should not merge forced_plugins with mobile plugins when theme is not mobile'
       );
     });
@@ -199,7 +199,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
     it('Merged settings forced_plugins in default override forced_plugins in user settings', () => {
       assert.deepEqual(
         NormalizeOptions.combineOptions(false, false, {}, { forced_plugins: [ 'a' ] }, { forced_plugins: [ 'b' ] }),
-        { external_plugins: {}, forced_plugins: [ 'a' ], plugins: 'a' },
+        { external_plugins: {}, forced_plugins: [ 'a' ], plugins: [ 'a' ] },
         'Should not have user forced plugins'
       );
     });
@@ -207,7 +207,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
     it('Merged settings when mobile.plugins is undefined, on a mobile device', () => {
       assert.deepEqual(
         NormalizeOptions.combineOptions(true, true, {}, {}, { theme: 'silver', plugins: [ 'lists', 'b', 'autolink' ], mobile: {}}),
-        { ...expectedPhoneDefaultSettings, external_plugins: {}, forced_plugins: [], plugins: 'lists b autolink', theme: 'silver' },
+        { ...expectedPhoneDefaultSettings, external_plugins: {}, forced_plugins: [], plugins: [ 'lists', 'b', 'autolink' ], theme: 'silver' },
         'Should use settings.plugins when mobile theme is not set'
       );
     });
@@ -215,7 +215,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
     it('Merged settings with empty mobile.plugins="" on mobile', () => {
       assert.deepEqual(
         NormalizeOptions.combineOptions(true, true, {}, {}, { mobile: { plugins: '' }}),
-        { ...expectedPhoneDefaultSettings, external_plugins: {}, forced_plugins: [], plugins: '' },
+        { ...expectedPhoneDefaultSettings, external_plugins: {}, forced_plugins: [], plugins: [] },
         'Should not have any plugins when mobile.plugins is explicitly empty'
       );
     });
@@ -223,7 +223,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
     it('Merged settings with defined mobile.plugins', () => {
       assert.deepEqual(
         NormalizeOptions.combineOptions(true, true, {}, {}, { mobile: { plugins: [ 'lists', 'autolink', 'foo', 'bar' ] }}),
-        { ...expectedPhoneDefaultSettings, external_plugins: {}, forced_plugins: [], plugins: 'lists autolink foo bar' },
+        { ...expectedPhoneDefaultSettings, external_plugins: {}, forced_plugins: [], plugins: [ 'lists', 'autolink', 'foo', 'bar' ] },
         'Should allow all plugins'
       );
     });
@@ -234,7 +234,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
           theme: 'test',
           mobile: { plugins: [ 'lists', 'autolink', 'foo', 'bar' ], theme: 'silver' }
         }),
-        { ...expectedPhoneDefaultSettings, theme: 'silver', external_plugins: {}, forced_plugins: [], plugins: 'lists autolink foo bar' },
+        { ...expectedPhoneDefaultSettings, theme: 'silver', external_plugins: {}, forced_plugins: [], plugins: [ 'lists', 'autolink', 'foo', 'bar' ] },
         'Should allow all mobile plugin'
       );
     });
@@ -246,7 +246,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
           plugins: [ 'aa', 'bb', 'cc' ],
           mobile: { plugins: [ 'lists', 'autolink', 'foo', 'bar' ], theme: 'silver' }
         }),
-        { theme: 'silver', external_plugins: {}, forced_plugins: [], plugins: 'aa bb cc' },
+        { theme: 'silver', external_plugins: {}, forced_plugins: [], plugins: [ 'aa', 'bb', 'cc' ] },
         'Should respect the desktop settings'
       );
     });


### PR DESCRIPTION
Related Ticket: TINY-8455

Description of Changes:
* Changes the return type for the `plugins` option to be a `string[]` since that's how it's always used
* Fixed an issue with the `Options.set` types, that meant type checking wasn't really working in some cases since it'd fall-through to the more generic override.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
