### PR TITLE
TINY-8453: Load the editor theme in parallel with other resources

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The dialog spec `initialData` type is now `Partial<T>` to match the underlying implementation details #TINY-8334
 - Improved support for placing the caret before or after noneditable elements within the editor #TINY-8169
 - Notifications no longer require a timeout to disable the close button #TINY-6679
+- The editor theme is now fetched in parallel with the icons, language pack and plugins #TINY-8453
 
 ### Changed
 - The `DomParser` API no longer uses a custom parser internally and instead uses the native `DOMParser` API #TINY-4627

--- a/modules/tinymce/src/core/main/ts/init/Render.ts
+++ b/modules/tinymce/src/core/main/ts/init/Render.ts
@@ -45,7 +45,7 @@ const loadLanguage = (scriptLoader: ScriptLoader, editor: Editor) => {
   }
 };
 
-const loadTheme = (scriptLoader: ScriptLoader, editor: Editor, suffix: string): void => {
+const loadTheme = (editor: Editor, suffix: string): void => {
   const theme = Options.getTheme(editor);
 
   if (Type.isString(theme) && !hasSkipLoadPrefix(theme) && !Obj.has(ThemeManager.urls, theme)) {
@@ -124,7 +124,7 @@ const loadScripts = (editor: Editor, suffix: string) => {
     }
   };
 
-  loadTheme(scriptLoader, editor, suffix);
+  loadTheme(editor, suffix);
   loadLanguage(scriptLoader, editor);
   loadIcons(scriptLoader, editor, suffix);
   loadPlugins(editor, suffix);

--- a/modules/tinymce/src/core/main/ts/init/Render.ts
+++ b/modules/tinymce/src/core/main/ts/init/Render.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Obj, Optional, Optionals, Type } from '@ephox/katamari';
+import { Arr, Obj, Optional, Optionals, Strings, Type } from '@ephox/katamari';
 import { Attribute, SugarElement } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
@@ -26,6 +26,11 @@ import * as StyleSheetLoaderRegistry from '../dom/StyleSheetLoaderRegistry';
 import * as ErrorReporter from '../ErrorReporter';
 import * as Init from './Init';
 
+interface UrlMeta {
+  readonly url: string;
+  readonly name: Optional<string>;
+}
+
 const DOM = DOMUtils.DOM;
 
 const hasSkipLoadPrefix = (name) => {
@@ -37,7 +42,7 @@ const loadLanguage = (scriptLoader: ScriptLoader, editor: Editor) => {
   const languageUrl = Options.getLanguageUrl(editor);
 
   if (I18n.hasCode(languageCode) === false && languageCode !== 'en') {
-    const url = languageUrl !== '' ? languageUrl : editor.editorManager.baseURL + '/langs/' + languageCode + '.js';
+    const url = Strings.isNotEmpty(languageCode) ? languageUrl : `${editor.editorManager.baseURL}/langs/${languageCode}.js`;
 
     scriptLoader.add(url).catch(() => {
       ErrorReporter.languageLoadError(editor, url, languageCode);
@@ -50,27 +55,22 @@ const loadTheme = (editor: Editor, suffix: string): void => {
 
   if (Type.isString(theme) && !hasSkipLoadPrefix(theme) && !Obj.has(ThemeManager.urls, theme)) {
     const themeUrl = Options.getThemeUrl(editor);
-    const url = themeUrl ? editor.documentBaseURI.toAbsolute(themeUrl) : 'themes/' + theme + '/theme' + suffix + '.js';
+    const url = themeUrl ? editor.documentBaseURI.toAbsolute(themeUrl) : `themes/${theme}/theme${suffix}.js`;
     ThemeManager.load(theme, url).catch(() => {
       ErrorReporter.themeLoadError(editor, url, theme);
     });
   }
 };
 
-interface UrlMeta {
-  url: string;
-  name: Optional<string>;
-}
-
 const getIconsUrlMetaFromUrl = (editor: Editor): Optional<UrlMeta> => Optional.from(Options.getIconsUrl(editor))
-  .filter((url) => url.length > 0)
+  .filter(Strings.isNotEmpty)
   .map((url) => ({
     url,
     name: Optional.none()
   }));
 
 const getIconsUrlMetaFromName = (editor: Editor, name: string | undefined, suffix: string): Optional<UrlMeta> => Optional.from(name)
-  .filter((name) => name.length > 0 && !IconManager.has(name))
+  .filter((name) => Strings.isNotEmpty(name) && !IconManager.has(name))
   .map((name) => ({
     url: `${editor.editorManager.baseURL}/icons/${name}/icons${suffix}.js`,
     name: Optional.some(name)
@@ -103,7 +103,7 @@ const loadPlugins = (editor: Editor, suffix: string) => {
     plugin = Tools.trim(plugin);
 
     if (plugin && !PluginManager.urls[plugin] && !hasSkipLoadPrefix(plugin)) {
-      loadPlugin(plugin, 'plugins/' + plugin + '/plugin' + suffix + '.js');
+      loadPlugin(plugin, `plugins/${plugin}/plugin${suffix}.js`);
     }
   });
 };


### PR DESCRIPTION
Related Ticket: TINY-8453

Description of Changes:

Changes how the scripts are loaded so that the theme is now loaded in parallel with the other resources (e.g. the plugins, icons and language pack). Previously it'd load the theme first and then load the rest of the resources.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~ Existing tests check it loads, but we can't test the order
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
