### PR TITLE
TINY-8399: Removed support for plugins allowing a mixture of a string array and of space separated strings

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -96,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Removed the jQuery integration #TINY-4518
+- Removed support for the `plugins` option allowing a mixture of a string array and of space separated strings #TINY-8399
 - Removed the deprecated `$`, `Class`, `DomQuery` and `Sizzle` APIs #TINY-4520 #TINY-8326
 - Removed the deprecated `Color`, `JSON`, `JSONP` and `JSONRequest` #TINY-8162
 - Removed the deprecated `XHR` API #TINY-8164

--- a/modules/tinymce/src/core/demo/ts/demo/CommandsDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/CommandsDemo.ts
@@ -100,9 +100,9 @@ export default () => {
     skin_url: '../../../../js/tinymce/skins/ui/oxide',
     selector: 'textarea.tinymce',
     plugins: [
-      'advlist autolink link image lists charmap preview anchor pagebreak',
-      'searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking',
-      'save table directionality emoticons template importcss codesample'
+      'advlist', 'autolink', 'link', 'image', 'lists', 'charmap', 'preview', 'anchor', 'pagebreak',
+      'searchreplace', 'wordcount', 'visualblocks', 'visualchars', 'code', 'fullscreen', 'insertdatetime', 'media', 'nonbreaking',
+      'save', 'table', 'directionality', 'emoticons', 'template', 'importcss', 'codesample'
     ],
     toolbar1: 'bold italic',
     menubar: false

--- a/modules/tinymce/src/core/demo/ts/demo/ContentSecurityPolicyDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContentSecurityPolicyDemo.ts
@@ -83,9 +83,9 @@ const settings = {
     makeSidebar(ed, 'sidebar1', 'green', 200);
   },
   plugins: [
-    'autosave advlist autolink link image lists charmap preview anchor pagebreak',
-    'searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking',
-    'save table directionality emoticons template importcss codesample help'
+    'autosave', 'advlist', 'autolink', 'link', 'image', 'lists', 'charmap', 'preview', 'anchor', 'pagebreak',
+    'searchreplace', 'wordcount', 'visualblocks', 'visualchars', 'code', 'fullscreen', 'insertdatetime', 'media', 'nonbreaking',
+    'save', 'table', 'directionality', 'emoticons', 'template', 'importcss', 'codesample', 'help'
   ],
   // rtl_ui: true,
   add_unload_trigger: false,

--- a/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
@@ -88,9 +88,9 @@ export default () => {
       makeSidebar(ed, 'sidebar1', 'green', 200);
     },
     plugins: [
-      'autosave advlist autolink link image lists charmap preview anchor pagebreak',
-      'searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking',
-      'save table directionality emoticons template importcss codesample help'
+      'autosave', 'advlist', 'autolink', 'link', 'image', 'lists', 'charmap', 'preview', 'anchor', 'pagebreak',
+      'searchreplace', 'wordcount', 'visualblocks', 'visualchars', 'code', 'fullscreen', 'insertdatetime', 'media', 'nonbreaking',
+      'save', 'table', 'directionality', 'emoticons', 'template', 'importcss', 'codesample', 'help'
     ],
     // rtl_ui: true,
     add_unload_trigger: false,

--- a/modules/tinymce/src/core/demo/ts/demo/IframeDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/IframeDemo.ts
@@ -35,7 +35,7 @@ export default () => {
       makeSidebar(ed, 'sidebar1', 'green', 200);
     },
     plugins: [
-      'preview media link image'
+      'preview', 'media', 'link', 'image'
     ],
     add_unload_trigger: false,
     autosave_ask_before_unload: false,

--- a/modules/tinymce/src/core/demo/ts/demo/InlineDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/InlineDemo.ts
@@ -24,9 +24,9 @@ export default () => {
       { title: 'Some title 2', description: 'Some desc 2', content: '<div class="mceTmpl"><span class="cdate">cdate</span><span class="mdate">mdate</span>My content2</div>' }
     ],
     plugins: [
-      'autosave advlist autolink link image lists charmap preview anchor pagebreak',
-      'searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking',
-      'save table directionality emoticons template codesample help'
+      'autosave', 'advlist', 'autolink', 'link', 'image', 'lists', 'charmap', 'preview', 'anchor', 'pagebreak',
+      'searchreplace', 'wordcount', 'visualblocks', 'visualchars', 'code', 'fullscreen', 'insertdatetime', 'media', 'nonbreaking',
+      'save', 'table', 'directionality', 'emoticons', 'template', 'codesample', 'help'
     ]
   };
 

--- a/modules/tinymce/src/core/demo/ts/demo/ResponsiveDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ResponsiveDemo.ts
@@ -67,9 +67,8 @@ export default () => {
     mobile: {
       theme: 'silver',
       plugins: [
-        'advlist autolink lists link image charmap preview anchor',
-        'searchreplace visualblocks code fullscreen',
-        'insertdatetime media table'
+        'advlist', 'autolink', 'lists', 'link', 'image', 'charmap', 'preview', 'anchor',
+        'searchreplace', 'visualblocks', 'code', 'fullscreen', 'insertdatetime', 'media', 'table'
       ],
       toolbar: 'fullscreen bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image insertfile undo redo | styles'
     },
@@ -77,10 +76,9 @@ export default () => {
       makeSidebar(ed, 'sidebar1', 'green', 200);
     },
     plugins: [
-      'fullscreen help',
-      'autosave advlist autolink link image lists charmap preview anchor pagebreak',
-      'searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking',
-      'save table directionality emoticons template importcss codesample help'
+      'fullscreen', 'help', 'autosave', 'advlist', 'autolink', 'link', 'image', 'lists', 'charmap', 'preview', 'anchor', 'pagebreak',
+      'searchreplace', 'wordcount', 'visualblocks', 'visualchars', 'code', 'fullscreen', 'insertdatetime', 'media', 'nonbreaking',
+      'save', 'table', 'directionality', 'emoticons', 'template', 'importcss', 'codesample', 'help'
     ],
     // rtl_ui: true,
     add_unload_trigger: false,

--- a/modules/tinymce/src/core/demo/ts/demo/SourceDumpDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/SourceDumpDemo.ts
@@ -11,9 +11,9 @@ export default () => {
     ],
     image_caption: true,
     plugins: [
-      'autosave advlist autolink link image lists charmap preview anchor pagebreak',
-      'searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking',
-      'save table directionality emoticons template importcss codesample help'
+      'autosave', 'advlist', 'autolink', 'link', 'image', 'lists', 'charmap', 'preview', 'anchor', 'pagebreak',
+      'searchreplace', 'wordcount', 'visualblocks', 'visualchars', 'code', 'fullscreen', 'insertdatetime', 'media', 'nonbreaking',
+      'save', 'table', 'directionality', 'emoticons', 'template', 'importcss', 'codesample', 'help'
     ],
     add_unload_trigger: false,
     autosave_ask_before_unload: false,

--- a/modules/tinymce/src/core/demo/ts/demo/StickyToolbarDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/StickyToolbarDemo.ts
@@ -72,9 +72,9 @@ export default () => {
       makeSidebar(ed, 'sidebar1', 'green', 200);
     },
     plugins: [
-      'autosave advlist autolink link image lists charmap preview anchor pagebreak',
-      'searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking',
-      'save table directionality emoticons template importcss codesample help'
+      'autosave', 'advlist', 'autolink', 'link', 'image', 'lists', 'charmap', 'preview', 'anchor', 'pagebreak',
+      'searchreplace', 'wordcount', 'visualblocks', 'visualchars', 'code', 'fullscreen', 'insertdatetime', 'media', 'nonbreaking',
+      'save', 'table', 'directionality', 'emoticons', 'template', 'importcss', 'codesample', 'help'
     ],
     // rtl_ui: true,
     add_unload_trigger: false,

--- a/modules/tinymce/src/core/main/ts/options/NormalizeOptions.ts
+++ b/modules/tinymce/src/core/main/ts/options/NormalizeOptions.ts
@@ -25,12 +25,14 @@ const deviceDetection = PlatformDetection.detect().deviceType;
 const isPhone = deviceDetection.isPhone();
 const isTablet = deviceDetection.isTablet();
 
-const normalizePlugins = (plugins: string | string[]) => {
-  const pluginNames = Type.isArray(plugins) ? plugins.join(' ') : plugins;
-  const trimmedPlugins = Arr.map(Type.isString(pluginNames) ? pluginNames.split(' ') : [ ], Strings.trim);
-  return Arr.filter(trimmedPlugins, (item) => {
-    return item.length > 0;
-  });
+const normalizePlugins = (plugins: string | string[] | undefined) => {
+  if (Type.isNullable(plugins)) {
+    return [];
+  } else {
+    const pluginNames = Type.isArray(plugins) ? plugins : plugins.split(/[ ,]/);
+    const trimmedPlugins = Arr.map(pluginNames, Strings.trim);
+    return Arr.filter(trimmedPlugins, Strings.isNotEmpty);
+  }
 };
 
 const extractSections = (keys: string[], options: RawEditorOptions) => {

--- a/modules/tinymce/src/core/test/ts/browser/options/NormalizeOptionsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/options/NormalizeOptionsTest.ts
@@ -84,11 +84,11 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
 
     it('Override defaults with forced_plugins using strings with spaces', () => {
       const defaultSettings = {
-        forced_plugins: 'a b'
+        forced_plugins: '  a   b'
       };
 
       const userSettings = {
-        plugins: 'c d'
+        plugins: ' c d '
       };
 
       const settings = NormalizeOptions.normalizeOptions(defaultSettings, userSettings);
@@ -98,7 +98,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
 
     it('Override defaults with forced_plugins using strings with commas', () => {
       const defaultSettings = {
-        forced_plugins: 'a, b'
+        forced_plugins: 'a,b'
       };
 
       const userSettings = {

--- a/modules/tinymce/src/core/test/ts/browser/options/NormalizeOptionsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/options/NormalizeOptionsTest.ts
@@ -82,7 +82,7 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
       assert.equal(settings.plugins, 'a b c d', 'Should be both forced and user plugins');
     });
 
-    it('Override defaults with forced_plugins using strings', () => {
+    it('Override defaults with forced_plugins using strings with spaces', () => {
       const defaultSettings = {
         forced_plugins: 'a b'
       };
@@ -96,13 +96,13 @@ describe('browser.tinymce.core.options.NormalizeOptionsTest', () => {
       assert.equal(settings.plugins, 'a b c d', 'Should be both forced and user plugins');
     });
 
-    it('Override defaults with forced_plugins using mixed types and spaces', () => {
+    it('Override defaults with forced_plugins using strings with commas', () => {
       const defaultSettings = {
-        forced_plugins: '  a   b'
+        forced_plugins: 'a, b'
       };
 
       const userSettings = {
-        plugins: [ ' c ', '  d   e ' ]
+        plugins: ' c, d, e '
       };
 
       const settings = NormalizeOptions.normalizeOptions(defaultSettings, userSettings);


### PR DESCRIPTION
Related Ticket: TINY-8399

Description of Changes:

This changes the `plugins` option so it now only accepts a string array or a space separated string, instead of a mixture of the two. For example these are valid:

```js
plugins: 'advlist list image help wordcount'
```
```js
plugins: 'advlist,list,image,help,wordcount'
```
```js
plugins: [ 'advlist', 'list', 'image', 'help', 'wordcount' ]
```
however, this is no longer valid:
```js
plugins: [
  'advlist list image',
  'help wordcount'
]
```

Note: The [documentation](https://www.tiny.cloud/docs/configure/integration-and-setup/#plugins) actually only states we allow the first option, however removing the rest could be too risky and would end up being inconsistent with the built-in `string[]` option processor.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
