### PR TITLE
TINY-8457: Deprecate the content property for setContent event

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -135,6 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 - The dialog button component `primary` property has been deprecated in favour of the new `buttonType` property #TINY-8304
+- The `SetContent` event `content` property has been deprecated and will be removed in the next major release #TINY-8457
 
 ## 5.10.2 - 2021-11-17
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -136,7 +136,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - The dialog button component `primary` property has been deprecated in favour of the new `buttonType` property #TINY-8304
 - The `content` property on the `SetContent` event has been deprecated and will be removed in the next major release #TINY-8457
-- The return value of the `editor.setContent` API has been deprecated and will be removed in the next major release #TINY-8457
 
 ## 5.10.2 - 2021-11-17
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -136,6 +136,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - The dialog button component `primary` property has been deprecated in favour of the new `buttonType` property #TINY-8304
 - The `content` property on the `SetContent` event has been deprecated and will be removed in the next major release #TINY-8457
+- The return value of the `editor.setContent` API has been deprecated and will be removed in the next major release #TINY-8457
 
 ## 5.10.2 - 2021-11-17
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -135,7 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 - The dialog button component `primary` property has been deprecated in favour of the new `buttonType` property #TINY-8304
-- The `SetContent` event `content` property has been deprecated and will be removed in the next major release #TINY-8457
+- The `content` property on the `SetContent` event has been deprecated and will be removed in the next major release #TINY-8457
 
 ## 5.10.2 - 2021-11-17
 

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -778,11 +778,13 @@ class Editor implements EditorObservable {
   /**
    * Sets the specified content to the editor instance, this will cleanup the content before it gets set using
    * the different cleanup rules options.
+   * <br>
+   * <em>Note: The content return value was deprecated in TinyMCE 6.0 and has been marked for removal in TinyMCE 7.0.</em>
    *
    * @method setContent
    * @param {String} content Content to set to editor, normally HTML contents but can be other formats as well.
    * @param {Object} args Optional content object, this gets passed around through the whole set process.
-   * @deprecated @return {String} HTML string that got set into the editor.
+   * @return {String} HTML string that got set into the editor.
    * @example
    * // Sets the HTML contents of the activeEditor editor
    * tinymce.activeEditor.setContent('<span>some</span> html');

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -782,7 +782,7 @@ class Editor implements EditorObservable {
    * @method setContent
    * @param {String} content Content to set to editor, normally HTML contents but can be other formats as well.
    * @param {Object} args Optional content object, this gets passed around through the whole set process.
-   * @return {String} HTML string that got set into the editor.
+   * @deprecated @return {String} HTML string that got set into the editor.
    * @example
    * // Sets the HTML contents of the activeEditor editor
    * tinymce.activeEditor.setContent('<span>some</span> html');

--- a/modules/tinymce/src/core/main/ts/api/EventTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/EventTypes.ts
@@ -23,9 +23,7 @@ export type BeforeGetContentEvent = GetContentArgs & { source_view?: boolean; se
 export type GetContentEvent = BeforeGetContentEvent & { content: Content };
 export type BeforeSetContentEvent = SetContentArgs & { source_view?: boolean; paste?: boolean; selection?: boolean };
 export type SetContentEvent = BeforeSetContentEvent & {
-  /**
-   * @deprecated
-   */
+  /** @deprecated */
   content: string;
 };
 

--- a/modules/tinymce/src/core/main/ts/api/EventTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/EventTypes.ts
@@ -22,7 +22,12 @@ export interface ExecCommandEvent { command: string; ui?: boolean; value?: any }
 export type BeforeGetContentEvent = GetContentArgs & { source_view?: boolean; selection?: boolean; save?: boolean };
 export type GetContentEvent = BeforeGetContentEvent & { content: Content };
 export type BeforeSetContentEvent = SetContentArgs & { source_view?: boolean; paste?: boolean; selection?: boolean };
-export type SetContentEvent = BeforeSetContentEvent;
+export type SetContentEvent = BeforeSetContentEvent & {
+  /**
+   * @deprecated
+   */
+  content: string;
+};
 
 export interface NewBlockEvent { newBlock: Element }
 

--- a/modules/tinymce/src/core/main/ts/api/Events.ts
+++ b/modules/tinymce/src/core/main/ts/api/Events.ts
@@ -6,11 +6,11 @@
  */
 
 import { AutocompleterEventArgs } from '../autocomplete/AutocompleteTypes';
-import { Content, GetContentArgs, SetContentArgs } from '../content/ContentTypes';
+import { Content, GetContentArgs } from '../content/ContentTypes';
 import { FormatVars } from '../fmt/FormatTypes';
 import { RangeLikeObject } from '../selection/RangeTypes';
 import Editor from './Editor';
-import { PastePlainTextToggleEvent, PastePostProcessEvent, PastePreProcessEvent } from './EventTypes';
+import { BeforeSetContentEvent, SetContentEvent, PastePlainTextToggleEvent, PastePostProcessEvent, PastePreProcessEvent } from './EventTypes';
 import { ParserArgs } from './html/DomParser';
 import { EditorEvent } from './util/EventDispatcher';
 
@@ -48,10 +48,10 @@ const fireFormatApply = (editor: Editor, format: string, node: Node | RangeLikeO
 const fireFormatRemove = (editor: Editor, format: string, node: Node | RangeLikeObject, vars: FormatVars | undefined) =>
   editor.fire('FormatRemove', { format, node, vars });
 
-const fireBeforeSetContent = <T extends SetContentArgs>(editor: Editor, args: T) =>
+const fireBeforeSetContent = <T extends BeforeSetContentEvent>(editor: Editor, args: T) =>
   editor.fire('BeforeSetContent', args);
 
-const fireSetContent = <T extends SetContentArgs>(editor: Editor, args: T) =>
+const fireSetContent = <T extends SetContentEvent>(editor: Editor, args: T) =>
   editor.fire('SetContent', args);
 
 const fireBeforeGetContent = <T extends GetContentArgs>(editor: Editor, args: T) =>


### PR DESCRIPTION
Related Ticket: TINY-8457

Description of Changes:
* The `content` property is problematic on the SetContent event for rtc and it also doesn't make much sense to have it.
* add @deprecated tag for `SetContentEvent.content` property
* update changelog

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
