### PR TITLE
TINY-8444: Fixed node filters not running when inserting certain content

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -10,6 +10,7 @@ import { Attribute, NodeTypes, Remove, Replication, SugarElement } from '@ephox/
 import createDompurify, { Config, DOMPurifyI } from 'dompurify';
 
 import * as NodeType from '../../dom/NodeType';
+import * as FilterNode from '../../html/FilterNode';
 import { cleanInvalidNodes } from '../../html/InvalidNodes';
 import * as LegacyFilter from '../../html/LegacyFilter';
 import * as ParserFilters from '../../html/ParserFilters';
@@ -83,12 +84,6 @@ interface DomParser {
   addNodeFilter: (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void) => void;
   getNodeFilters: () => ParserFilter[];
   parse: (html: string, args?: ParserArgs) => AstNode;
-}
-
-// For internal parser use only - a summary of which nodes have been matched by which node/attribute filters
-interface FilterMatches {
-  readonly nodes: Record<string, AstNode[]>;
-  readonly attributes: Record<string, AstNode[]>;
 }
 
 type WalkerCallback = (node: AstNode) => void;
@@ -484,86 +479,6 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
 
   const getAttributeFilters = (): ParserFilter[] => [].concat(attributeFilters);
 
-  // Test a single node against the current filters, and add it to any match lists if necessary
-  const filterNode = (node: AstNode, matches: FilterMatches): void => {
-    const name = node.name;
-    // Run element filters
-    if (name in nodeFilters) {
-      const list = matches.nodes[name];
-
-      if (list) {
-        list.push(node);
-      } else {
-        matches.nodes[name] = [ node ];
-      }
-    }
-
-    // Run attribute filters
-    if (node.attributes) {
-      let i = attributeFilters.length;
-      while (i--) {
-        const attrName = attributeFilters[i].name;
-
-        if (attrName in node.attributes.map) {
-          const list = matches.attributes[attrName];
-
-          if (list) {
-            list.push(node);
-          } else {
-            matches.attributes[attrName] = [ node ];
-          }
-        }
-      }
-    }
-  };
-
-  // Run all necessary node filters and attribute filters, based on a match set
-  const runFilters = (matches: FilterMatches, args: ParserArgs): void => {
-    // Run node filters
-    for (const name in matches.nodes) {
-      if (Obj.has(matches.nodes, name)) {
-        const list = nodeFilters[name];
-        const nodes = matches.nodes[name];
-
-        // Remove already removed children
-        let fi = nodes.length;
-        while (fi--) {
-          if (!nodes[fi].parent) {
-            nodes.splice(fi, 1);
-          }
-        }
-
-        const l = list.length;
-        for (let i = 0; i < l; i++) {
-          list[i](nodes, name, args);
-        }
-      }
-    }
-
-    // Run attribute filters
-    const l = attributeFilters.length;
-    for (let i = 0; i < l; i++) {
-      const list = attributeFilters[i];
-
-      if (list.name in matches.attributes) {
-        const nodes = matches.attributes[list.name];
-
-        // Remove already removed children
-        let fi = nodes.length;
-        while (fi--) {
-          if (!nodes[fi].parent) {
-            nodes.splice(fi, 1);
-          }
-        }
-
-        const callbacks = list.callbacks;
-        for (let fi = 0, fl = callbacks.length; fi < fl; fi++) {
-          callbacks[fi](nodes, list.name, args);
-        }
-      }
-    }
-  };
-
   const findInvalidChildren = (node: AstNode, invalidChildren: AstNode[]): void => {
     // Check if the node is a valid child of the parent node. If the child is
     // unknown we don't collect it since it's probably a custom element
@@ -655,8 +570,9 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
     const invalidFinder = validate ? (node: AstNode) => findInvalidChildren(node, invalidChildren) : Fun.noop;
 
     // Set up attribute and node matching
-    const matches: FilterMatches = { nodes: {}, attributes: {}};
-    const matchFinder = (node: AstNode) => filterNode(node, matches);
+    const nodeFilters = getNodeFilters();
+    const matches: FilterNode.FilterMatches = { nodes: {}, attributes: {}};
+    const matchFinder = (node: AstNode) => FilterNode.matchNode(nodeFilters, attributeFilters, node, matches);
 
     // Walk the dom, apply all of the above things
     walkTree(rootNode, [ whitespacePre, matchFinder ], [ whitespacePost, invalidFinder ]);
@@ -683,7 +599,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
 
     // Run filters only when the contents is valid
     if (!args.invalid) {
-      runFilters(matches, args);
+      FilterNode.runFilters(matches, args);
     }
 
     return rootNode;

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -22,6 +22,7 @@ import * as TableDelete from '../delete/TableDelete';
 import * as CefUtils from '../dom/CefUtils';
 import * as NodeType from '../dom/NodeType';
 import * as PaddingBr from '../dom/PaddingBr';
+import * as FilterNode from '../html/FilterNode';
 import { cleanInvalidNodes } from '../html/InvalidNodes';
 import * as RangeNormalizer from '../selection/RangeNormalizer';
 import * as SelectionUtils from '../selection/SelectionUtils';
@@ -312,6 +313,7 @@ export const insertHtmlAtCaret = (editor: Editor, value: string, details: Insert
     fragment.unwrap();
     const invalidChildren = Arr.filter(toExtract, (node) => !editor.schema.isValidChild(parent, node.name));
     cleanInvalidNodes(invalidChildren, editor.schema);
+    FilterNode.filter(parser.getNodeFilters(), parser.getAttributeFilters(), root);
     value = serializer.serialize(root);
 
     // Set the inner/outer HTML depending on if we are in the root or not

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -624,4 +624,19 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     );
     TinyAssertions.assertCursor(editor, [ 1, 1, 0, 0 ], 16);
   });
+
+  it('TINY-8444: Inserting block content runs the node filters', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>Content</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 3);
+
+    let numNodesFiltered = 0;
+    editor.parser.addNodeFilter('div', (nodes) => {
+      numNodesFiltered += nodes.length;
+    });
+
+    editor.insertContent('<div>inserted content</div>');
+    assert.equal(numNodesFiltered, 1, 'Node filters should have run');
+    TinyAssertions.assertContent(editor, '<p>Con</p><div>inserted content</div><p>tent</p>');
+  });
 });

--- a/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Obj, Type } from '@ephox/katamari';
+import { Arr, Obj, Strings, Type } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
@@ -124,7 +124,7 @@ const createPreviewNode = (editor: Editor, node: AstNode): AstNode => {
 };
 
 const retainAttributesAndInnerHtml = (editor: Editor, sourceNode: AstNode, targetNode: AstNode): void => {
-  // Prefix all attributes except width, height and style since we
+  // Prefix all attributes except internal (data-mce-*), width, height and style since we
   // will add these to the placeholder
   const attribs = sourceNode.attributes;
   let ai = attribs.length;
@@ -132,7 +132,7 @@ const retainAttributesAndInnerHtml = (editor: Editor, sourceNode: AstNode, targe
     const attrName = attribs[ai].name;
     let attrValue = attribs[ai].value;
 
-    if (attrName !== 'width' && attrName !== 'height' && attrName !== 'style') {
+    if (attrName !== 'width' && attrName !== 'height' && attrName !== 'style' && !Strings.startsWith(attrName, 'data-mce-')) {
       if (attrName === 'data' || attrName === 'src') {
         attrValue = editor.convertURL(attrValue, attrName);
       }

--- a/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
@@ -24,7 +24,7 @@ describe('browser.tinymce.plugins.media.core.SubmitTest', () => {
   const customEmbed =
   '<div style="left: 0px; width: 100%; height: 0px; position: relative; padding-bottom: 56.338%; max-width: 650px;">' +
   '<iframe src="https://www.youtube.com/embed/IcgmSRJHu_8"' +
-  ' width="560" height="314" allowfullscreen="allowfullscreen">' +
+  ' width="560" height="314" allowfullscreen="allowfullscreen" data-mce-fragment="1">' +
   '</iframe></div>';
 
   const pTestResolvedEmbedContentSubmit = async (editor: Editor, url: string, expected: string) => {

--- a/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
@@ -24,7 +24,7 @@ describe('browser.tinymce.plugins.media.core.SubmitTest', () => {
   const customEmbed =
   '<div style="left: 0px; width: 100%; height: 0px; position: relative; padding-bottom: 56.338%; max-width: 650px;">' +
   '<iframe src="https://www.youtube.com/embed/IcgmSRJHu_8"' +
-  ' width="560" height="314" allowfullscreen="allowfullscreen" data-mce-fragment="1">' +
+  ' width="560" height="314" allowfullscreen="allowfullscreen">' +
   '</iframe></div>';
 
   const pTestResolvedEmbedContentSubmit = async (editor: Editor, url: string, expected: string) => {


### PR DESCRIPTION
Related Ticket: TINY-8444

Description of Changes:

This is something that regressed in https://github.com/tinymce/tinymce/pull/7448, as since `parser.parse()` no longer runs and instead we manually patch in the AST nodes then that in turn meant the node filters didn't run in this specific case. As such, I found we actually had 2 sets of filtering code paths, so I've merged them into 1 and updated the insert content logic to ensure the filters are run after we've adjusted the tree.

Note: I've also manually built this and linked it to the premium plugins that were failing and have verified the tests now pass there.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
