### PR TITLE
TINY-8459: Fixed the statusbar element path not rendering correctly

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/WordCount.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/WordCount.ts
@@ -6,7 +6,7 @@
  */
 
 import {
-  AddEventsBehaviour, AlloyEvents, Behaviour, Button, GuiFactory, Replacing, Representing, SimpleSpec, SystemEvents, Tabstopping
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Button, GuiFactory, Replacing, Representing, SimpleSpec, SystemEvents, Tabstopping
 } from '@ephox/alloy';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -15,13 +15,19 @@ import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as ReadOnly from '../../ReadOnly';
 import { DisablingConfigs } from '../alien/DisablingConfigs';
 
+interface WordCount {
+  readonly words: number;
+  readonly characters: number;
+}
+
 const enum WordCountMode {
   Words = 'words',
   Characters = 'characters'
 }
 
 export const renderWordCount = (editor: Editor, providersBackstage: UiFactoryBackstageProviders): SimpleSpec => {
-  const replaceCountText = (comp, count, mode) => Replacing.set(comp, [ GuiFactory.text(providersBackstage.translate([ '{0} ' + mode, count[mode] ])) ]);
+  const replaceCountText = (comp: AlloyComponent, count: WordCount, mode: WordCountMode) =>
+    Replacing.set(comp, [ GuiFactory.text(providersBackstage.translate([ '{0} ' + mode, count[mode] ])) ]);
 
   return Button.sketch({
     dom: {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
@@ -11,35 +11,43 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
     WordcountPlugin(5);
   });
 
+  const elementPathSpec: ApproxStructure.Builder<StructAssert> = (s, str, arr) =>
+    s.element('div', {
+      classes: [ arr.has('tox-statusbar__path') ],
+      children: [
+        s.element('div', { children: [ s.text(str.is('p')) ] }),
+        s.element('div', { children: [ s.text(str.is(' › ')) ] }),
+        s.element('div', { children: [ s.text(str.is('strong')) ] }),
+        s.element('div', { children: [ s.text(str.is(' › ')) ] }),
+        s.element('div', { children: [ s.text(str.is('em')) ] })
+      ]
+    });
+
+  const brandingSpec: ApproxStructure.Builder<StructAssert> = (s, str, arr) =>
+    s.element('span', {
+      classes: [ arr.has('tox-statusbar__branding') ],
+      children: [
+        s.element('a', {
+          attrs: {
+            'aria-label': str.is('Powered by Tiny')
+          },
+          children: [
+            s.element('svg', {})
+          ]
+        })
+      ]
+    });
+
   const fullStatusbarSpec: ApproxStructure.Builder<StructAssert[]> = (s, str, arr) => [
     s.element('div', {
       classes: [ arr.has('tox-statusbar__text-container') ],
       children: [
-        s.element('div', {
-          classes: [ arr.has('tox-statusbar__path') ],
-          children: [
-            s.element('div', { children: [ s.text(str.is('p')) ] }),
-            s.element('div', { children: [ s.text(str.is(' › ')) ] }),
-            s.element('div', { children: [ s.text(str.is('strong')) ] })
-          ]
-        }),
+        elementPathSpec(s, str, arr),
         s.element('button', {
           classes: [ arr.has('tox-statusbar__wordcount') ],
           children: [ s.text(str.is('2 words')) ]
         }),
-        s.element('span', {
-          classes: [ arr.has('tox-statusbar__branding') ],
-          children: [
-            s.element('a', {
-              attrs: {
-                'aria-label': str.is('Powered by Tiny')
-              },
-              children: [
-                s.element('svg', {})
-              ]
-            })
-          ]
-        })
+        brandingSpec(s, str, arr)
       ]
     }),
     s.element('div', {
@@ -51,27 +59,8 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
     s.element('div', {
       classes: [ arr.has('tox-statusbar__text-container') ],
       children: [
-        s.element('div', {
-          classes: [ arr.has('tox-statusbar__path') ],
-          children: [
-            s.element('div', { children: [ s.text(str.is('p')) ] }),
-            s.element('div', { children: [ s.text(str.is(' › ')) ] }),
-            s.element('div', { children: [ s.text(str.is('strong')) ] })
-          ]
-        }),
-        s.element('span', {
-          classes: [ arr.has('tox-statusbar__branding') ],
-          children: [
-            s.element('a', {
-              attrs: {
-                'aria-label': str.is('Powered by Tiny')
-              },
-              children: [
-                s.element('svg', {})
-              ]
-            })
-          ]
-        })
+        elementPathSpec(s, str, arr),
+        brandingSpec(s, str, arr)
       ]
     }),
     s.element('div', {
@@ -83,27 +72,8 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
     s.element('div', {
       classes: [ arr.has('tox-statusbar__text-container') ],
       children: [
-        s.element('div', {
-          classes: [ arr.has('tox-statusbar__path') ],
-          children: [
-            s.element('div', { children: [ s.text(str.is('p')) ] }),
-            s.element('div', { children: [ s.text(str.is(' › ')) ] }),
-            s.element('div', { children: [ s.text(str.is('strong')) ] })
-          ]
-        }),
-        s.element('span', {
-          classes: [ arr.has('tox-statusbar__branding') ],
-          children: [
-            s.element('a', {
-              attrs: {
-                'aria-label': str.is('Powered by Tiny')
-              },
-              children: [
-                s.element('svg', {})
-              ]
-            })
-          ]
-        })
+        elementPathSpec(s, str, arr),
+        brandingSpec(s, str, arr)
       ]
     })
   ];
@@ -114,7 +84,7 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
       ...config
     });
     editor.focus();
-    editor.setContent('<p><strong>hello world</strong></p>');
+    editor.setContent('<p><strong><em>hello world</em></strong></p>');
     await Waiter.pTryUntil('Wait for editor structure', () => Assertions.assertStructure(structureLabel, editorStructure, TinyDom.container(editor)));
     McEditor.remove(editor);
   };


### PR DESCRIPTION
Related Ticket: TINY-8459

Description of Changes:

This fixes the element path only correctly rendering the last delimiter. The cause of this was that we were using a constant delimiter spec and sharing it for each delimiter. However since `GuiFactory.text()` is a premade text node, it could only be used once in the DOM which is why it broke. I've also cleaned up the element path code a reasonable bit and added various types. I also threw some types in on `WordCount.ts` while I was looking for other cases where we may have misused `GuiFactory.text()` (I didn't find any others though).

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
