### PR TITLE
TINY-8440: Fixed the replaceBy and replaceAt apis not working correctly with premade components

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/replacing/ReplaceApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/replacing/ReplaceApis.ts
@@ -4,14 +4,15 @@ import { Compare, Insert, SugarElement } from '@ephox/sugar';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { AlloySpec } from '../../api/component/SpecTypes';
 import * as Attachment from '../../api/system/Attachment';
+import * as Patching from '../../dom/Patching';
 import * as InternalAttachment from '../../system/InternalAttachment';
 import { Stateless } from '../common/BehaviourState';
 import { withoutReuse, withReuse } from './ReplacingAll';
 import { ReplacingConfig } from './ReplacingTypes';
 
-const virtualReplace = (component: AlloyComponent, replacee: AlloyComponent, _replaceeIndex: number, childSpec: AlloySpec) => {
+const virtualReplace = (component: AlloyComponent, replacee: AlloyComponent, replaceeIndex: number, childSpec: AlloySpec) => {
   InternalAttachment.virtualDetach(replacee);
-  const child = component.getSystem().buildOrPatch(childSpec, Optional.some(replacee.element));
+  const child = Patching.patchSpecChild(component.element, replaceeIndex, childSpec, component.getSystem().buildOrPatch);
   InternalAttachment.virtualAttach(component, child);
   component.syncComponents();
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/replacing/ReplacingAll.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/replacing/ReplacingAll.ts
@@ -1,5 +1,4 @@
 import { Arr } from '@ephox/katamari';
-import { Traverse } from '@ephox/sugar';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { AlloySpec } from '../../api/component/SpecTypes';
@@ -22,10 +21,7 @@ const withReuse = (parent: AlloyComponent, data: AlloySpec[]): void => {
       return patchSpecChildren(
         parent.element,
         data,
-        (d, i) => {
-          const optObsoleted = Traverse.child(parent.element, i);
-          return parent.getSystem().buildOrPatch(d, optObsoleted);
-        }
+        parent.getSystem().buildOrPatch
       );
     });
   }, parent.element);

--- a/modules/alloy/src/test/ts/browser/behaviour/ReplacingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/ReplacingTest.ts
@@ -56,13 +56,13 @@ UnitTest.asynctest('ReplacingTest', (success, failure) => {
       components: [ ]
     });
 
-    const sCheckReplaceAt = (label: string, comp: AlloyComponent, expectedClasses: string[], inputClasses: string[], replaceeIndex: number, replaceClass: Optional<string>) => Logger.t(
-      `${label}: Check replaceAt(${replaceeIndex}, "${replaceClass}") for data: [${inputClasses.join(', ')}]`,
+    const sCheckReplaceAtWith = (label: string, comp: AlloyComponent, expectedClasses: string[], inputClasses: string[], replaceeIndex: number, replaceSpec: Optional<AlloySpec>) => Logger.t(
+      `${label}: Check replaceAt(${replaceeIndex}, with spec for data: [${inputClasses.join(', ')}]`,
       Step.sync(() => {
         Replacing.set(comp,
           Arr.map(inputClasses, (ic) => makeTag('div', [ ic ]))
         );
-        Replacing.replaceAt(comp, replaceeIndex, replaceClass.map((clazz) => makeTag('div', [ clazz ])));
+        Replacing.replaceAt(comp, replaceeIndex, replaceSpec);
         Assertions.assertStructure(
           'Asserting structure',
           ApproxStructure.build((s, _str, arr) => s.element('div', {
@@ -72,6 +72,9 @@ UnitTest.asynctest('ReplacingTest', (success, failure) => {
         );
       })
     );
+
+    const sCheckReplaceAt = (label: string, comp: AlloyComponent, expectedClasses: string[], inputClasses: string[], replaceeIndex: number, replaceClass: Optional<string>) =>
+      sCheckReplaceAtWith(label, comp, expectedClasses, inputClasses, replaceeIndex, replaceClass.map((clazz) => makeTag('div', [ clazz ])));
 
     return Arr.map([
       { comp: withoutReuseComp, label: 'Without reuse' },
@@ -418,12 +421,21 @@ UnitTest.asynctest('ReplacingTest', (success, failure) => {
         ),
 
         sCheckReplaceAt(
-          '.replaceAt 2 of 3 with nothing',
+          '.replaceAt 1 of 3 with nothing',
           spec.comp,
           [ 'original1', 'original3' ],
           [ 'original1', 'original2', 'original3' ],
           1,
           Optional.none()
+        ),
+
+        sCheckReplaceAtWith(
+          '.replaceAt 2 of 3 with premade spec',
+          spec.comp,
+          [ 'original1', 'original2', 'replaceAt-2' ],
+          [ 'original1', 'original2', 'original3' ],
+          2,
+          Optional.some(GuiFactory.premade(GuiFactory.build(makeTag('div', [ 'replaceAt-2' ]))))
         )
       ]);
     }).concat([


### PR DESCRIPTION
Related Ticket: TINY-8440

Description of Changes:
* Fixed an issue with the `Replacing.replaceBy` and `Replacing.replaceAt` APIs when passing in a premade component when `reuseDom` is enabled
* Did some minor reworking as well to allow the `buildOrPatch` function to be passed directly to the `Patching` functions

Pre-checks:
* [x] ~Changelog entry added~ - Hasn't been released yet
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
