### PR TITLE
TINY-3422: Removed style field from image dialog

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -137,6 +137,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the undocumented `mceResetDesignMode`, `mceRepaint` and `mceBeginUndoLevel` commands #TINY-7829
 - Removed the `execCommand` handler function from the plugin and theme interfaces #TINY-7829
 - Removed the `SaxParser` API #TINY-8218
+- Removed the style field from the `image` plugin dialog advanced tab #TINY-3422
 
 ### Deprecated
 - The dialog button component `primary` property has been deprecated in favour of the new `buttonType` property #TINY-8304

--- a/modules/tinymce/src/plugins/image/main/ts/ui/AdvTab.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/AdvTab.ts
@@ -14,11 +14,6 @@ const makeTab = (_info: ImageDialogInfo): Dialog.TabSpec => ({
   name: 'advanced',
   items: [
     {
-      type: 'input',
-      label: 'Style',
-      name: 'style'
-    },
-    {
       type: 'grid',
       columns: 2,
       items: [

--- a/modules/tinymce/src/plugins/image/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/Dialog.ts
@@ -225,40 +225,6 @@ const changeImages = (helpers: Helpers, info: ImageDialogInfo, state: ImageDialo
   changeSrc(helpers, info, state, api);
 };
 
-const calcVSpace = (css: StyleMap): string => {
-  const matchingTopBottom = css['margin-top'] && css['margin-bottom'] && css['margin-top'] === css['margin-bottom'];
-  return matchingTopBottom ? Utils.removePixelSuffix(String(css['margin-top'])) : '';
-};
-
-const calcHSpace = (css: StyleMap): string => {
-  const matchingLeftRight = css['margin-right'] && css['margin-left'] && css['margin-right'] === css['margin-left'];
-  return matchingLeftRight ? Utils.removePixelSuffix(String(css['margin-right'])) : '';
-};
-
-const calcBorderWidth = (css: StyleMap): string =>
-  css['border-width'] ? Utils.removePixelSuffix(String(css['border-width'])) : '';
-
-const calcBorderStyle = (css: StyleMap): string =>
-  css['border-style'] ? String(css['border-style']) : '';
-
-const calcStyle = (parseStyle: Helpers['parseStyle'], serializeStyle: Helpers['serializeStyle'], css: StyleMap): string =>
-  serializeStyle(parseStyle(serializeStyle(css)));
-
-const changeStyle2 = (parseStyle: Helpers['parseStyle'], serializeStyle: Helpers['serializeStyle'], data: ImageDialogData): ImageDialogData => {
-  const css = Utils.mergeMargins(parseStyle(data.style));
-  const dataCopy: ImageDialogData = Merger.deepMerge({}, data);
-  // Move opposite equal margins to vspace/hspace field
-  dataCopy.vspace = calcVSpace(css);
-  dataCopy.hspace = calcHSpace(css);
-  // Move border-width
-  dataCopy.border = calcBorderWidth(css);
-  // Move border-style
-  dataCopy.borderstyle = calcBorderStyle(css);
-  // Reserialize style
-  dataCopy.style = calcStyle(parseStyle, serializeStyle, css);
-  return dataCopy;
-};
-
 const changeFileInput = (helpers: Helpers, info: ImageDialogInfo, state: ImageDialogState, api: API): void => {
   const data = api.getData();
   api.block('Uploading image'); // What msg do we pass to the lock?
@@ -340,10 +306,10 @@ const submitHandler = (editor: Editor, info: ImageDialogInfo, helpers: Helpers) 
 
   // The data architecture relies on passing everything through the style field for validation.
   // Since the style field was removed that process must be simulated on submit.
-  const finalData = changeStyle2(helpers.parseStyle, helpers.serializeStyle, {
+  const finalData = {
     ...data,
     style: getStyleValue(helpers.normalizeCss, toImageData(data, false))
-  });
+  };
 
   editor.execCommand('mceUpdateImage', false, toImageData(finalData, info.hasAccessibilityOptions));
   editor.editorUpload.uploadImagesAuto();

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogTest.ts
@@ -104,8 +104,6 @@ describe('browser.tinymce.plugins.image.DialogTest', () => {
     pressDown(editor);
     await pAssertFocused('Advanced tab', '.tox-dialog__body-nav-item:contains("Advanced")');
     pressTab(editor);
-    await pAssertFocused('Style', '.tox-textfield');
-    pressTab(editor);
     await pAssertFocused('Vertical space', '.tox-textfield');
     pressTab(editor);
     await pAssertFocused('Horizontal space', '.tox-textfield');

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
@@ -5,7 +5,7 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
 
-import { advancedTabSelectors, assertInputValue, fillActiveDialog, ImageDialogData, setInputValue } from '../module/Helpers';
+import { advancedTabSelectors, assertInputValue, fillActiveDialog, ImageDialogData } from '../module/Helpers';
 
 describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -40,10 +40,9 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
   const pCreateTestOnEmptyEditor = (editor: Editor, data: Partial<ImageDialogData>, expectedContent: string) =>
     pCreateTestWithContent(editor, '', { element: [ 0 ], offset: 0 }, data, expectedContent);
 
-  const pCreateTestUpdatedStyle = async (editor: Editor, style: string, assertion: () => void) => {
-    await pInitAndOpenDialog(editor, '', { element: [ 0 ], offset: 0 });
+  const pCreateTestValidatingAdvancedTab = async (editor: Editor, style: string, assertion: () => void) => {
+    await pInitAndOpenDialog(editor, `<img style="${style}" src="src" alt="alt">`, { start: { element: [ 0 ], offset: 0 }, finish: { element: [ 0 ], offset: 1 }});
     TinyUiActions.clickOnUi(editor, '.tox-tab:contains("Advanced")');
-    setInputValue(advancedTabSelectors.style, style);
     assertion();
     TinyUiActions.submitDialog(editor);
   };
@@ -71,27 +70,14 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
         src: {
           value: 'src'
         },
-        style: 'border-width: 10px; border-style: solid;'
+        border: '10px',
+        borderstyle: 'solid'
       },
       '<p><img style="border-width: 10px; border-style: solid;" src="src" alt="alt"></p>'
     )
   );
 
-  it('TBA: Advanced image dialog margin style only options on empty editor', () =>
-    pCreateTestOnEmptyEditor(
-      hook.editor(),
-      {
-        alt: 'alt',
-        src: {
-          value: 'src'
-        },
-        style: 'margin: 10px;'
-      },
-      '<p><img style="margin: 10px;" src="src" alt="alt"></p>'
-    )
-  );
-
-  it('TBA: Advanced image dialog overridden border style options on empty editor', () =>
+  it('TBA: Advanced image dialog border style options on empty editor', () =>
     pCreateTestOnEmptyEditor(
       hook.editor(),
       {
@@ -100,13 +86,12 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
         src: {
           value: 'src'
         },
-        style: 'border-width: 15px;'
       },
       '<p><img style="border-width: 10px;" src="src" alt="alt"></p>'
     )
   );
 
-  it('TBA: Advanced image dialog overridden margin style options on empty editor', () =>
+  it('TBA: Advanced image dialog margin style options on empty editor', () =>
     pCreateTestOnEmptyEditor(
       hook.editor(),
       {
@@ -115,7 +100,6 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
         src: {
           value: 'src'
         },
-        style: 'margin-left: 15px; margin-top: 20px;',
         vspace: '10'
       },
       '<p><img style="margin: 10px;" src="src" alt="alt"></p>'
@@ -143,85 +127,78 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
   );
 
   it('TBA: Advanced image dialog non-shorthand horizontal margin style change test', () =>
-    pCreateTestUpdatedStyle(
+    pCreateTestValidatingAdvancedTab(
       hook.editor(),
       'margin-left: 15px; margin-right: 15px;',
       () => {
         assertInputValue(advancedTabSelectors.vspace, '');
         assertInputValue(advancedTabSelectors.hspace, '15');
-        assertInputValue(advancedTabSelectors.style, 'margin-left: 15px; margin-right: 15px;');
       }
     )
   );
 
   it('TBA: Advanced image dialog non-shorthand vertical margin style change test', () =>
-    pCreateTestUpdatedStyle(
+    pCreateTestValidatingAdvancedTab(
       hook.editor(),
       'margin-top: 15px; margin-bottom: 15px;',
       () => {
         assertInputValue(advancedTabSelectors.vspace, '15');
         assertInputValue(advancedTabSelectors.hspace, '');
-        assertInputValue(advancedTabSelectors.style, 'margin-top: 15px; margin-bottom: 15px;');
       }
     )
   );
 
   it('TBA: Advanced image dialog shorthand margin 1 value style change test', () =>
-    pCreateTestUpdatedStyle(
+    pCreateTestValidatingAdvancedTab(
       hook.editor(),
       'margin: 5px;',
       () => {
         assertInputValue(advancedTabSelectors.vspace, '5');
         assertInputValue(advancedTabSelectors.hspace, '5');
-        assertInputValue(advancedTabSelectors.style, 'margin: 5px;');
       }
     )
   );
 
   it('TBA: Advanced image dialog shorthand margin 2 value style change test', () =>
-    pCreateTestUpdatedStyle(
+    pCreateTestValidatingAdvancedTab(
       hook.editor(),
       'margin: 5px 10px;',
       () => {
         assertInputValue(advancedTabSelectors.vspace, '5');
         assertInputValue(advancedTabSelectors.hspace, '10');
-        assertInputValue(advancedTabSelectors.style, 'margin: 5px 10px 5px 10px;');
       }
     )
   );
 
   it('TBA: Advanced image dialog shorthand margin 3 value style change test', () =>
-    pCreateTestUpdatedStyle(
+    pCreateTestValidatingAdvancedTab(
       hook.editor(),
       'margin: 5px 10px 15px;',
       () => {
         assertInputValue(advancedTabSelectors.vspace, '');
         assertInputValue(advancedTabSelectors.hspace, '10');
-        assertInputValue(advancedTabSelectors.style, 'margin: 5px 10px 15px 10px;');
       }
     )
   );
 
   it('TBA: Advanced image dialog shorthand margin 4 value style change test', () =>
-    pCreateTestUpdatedStyle(
+    pCreateTestValidatingAdvancedTab(
       hook.editor(),
       'margin: 5px 10px 15px 20px;',
       () => {
         assertInputValue(advancedTabSelectors.vspace, '');
         assertInputValue(advancedTabSelectors.hspace, '');
-        assertInputValue(advancedTabSelectors.style, 'margin: 5px 10px 15px 20px;');
       }
     )
   );
 
   it('TBA: Advanced image dialog shorthand margin 4 value style with single value override change test', () =>
-    pCreateTestUpdatedStyle(
+    pCreateTestValidatingAdvancedTab(
       hook.editor(),
       'margin: 5px 10px 15px 20px; margin-top: 15px;',
       () => {
         assertInputValue(advancedTabSelectors.vspace, '15');
         assertInputValue(advancedTabSelectors.hspace, '');
-        assertInputValue(advancedTabSelectors.style, 'margin: 15px 10px 15px 20px;');
       }
     )
   );

--- a/modules/tinymce/src/plugins/image/test/ts/module/Helpers.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/module/Helpers.ts
@@ -20,7 +20,6 @@ export interface ImageDialogData {
   class: string;
   border: string;
   hspace: string;
-  style: string;
   vspace: string;
   borderstyle: string;
 }
@@ -39,7 +38,6 @@ export const generalTabSelectors = {
 
 export const advancedTabSelectors = {
   border: 'label.tox-label:contains("Border width") + input.tox-textfield',
-  style: 'label.tox-label:contains("Style") + input.tox-textfield',
   hspace: 'label.tox-label:contains("Horizontal space") + input.tox-textfield',
   vspace: 'label.tox-label:contains("Vertical space") + input.tox-textfield',
   borderstyle: 'label.tox-label:contains("Border style") + div.tox-listboxfield > .tox-listbox'


### PR DESCRIPTION
Related Ticket: TINY-3422

Description of Changes:
* Removed style field from the advanced tab of image dialog
* Adjusted dialog logic to calculate the style value on submit instead of on change

This was much harder than it first appeared, because every other field on the advanced tab did not store information independently. When updated they simply patched the style field, and the style field is what was serialised when the dialog was submitted.

Dialogs cannot store information in the API data other than fields that exist in the dialog, so I had to refactor the style generation logic into the submit handler. That itself required some additional work because it was very specifically structured to not have access to the other helper functions.

Technically this also means invalid values in the other fields are not dealt with until submit, but looking at the existing behaviour this validation was already an implicit behaviour. The only sign that invalid values would be ignored was that the style field did not update when they were entered.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
