### PR TITLE
TINY-8450: Update selection bookmark when the 'AfterSetSelectionRange' event is fired

### DIFF
--- a/modules/mcagar/CHANGELOG.md
+++ b/modules/mcagar/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
-- `getSel()` to the `EditorTypes.Selection` interface
-- `setRawSelection()` to the `TinySelections` helper methods
+- The `getSel()` function to the `EditorTypes.Selection` interface.
+- The `setRawSelection()` function to the `TinySelections` helper methods to allow setting the selection without using any TinyMCE APIs.
 
 ### Improved
 - Updated the APIs to work with the TinyMCE 6 options API.

--- a/modules/mcagar/CHANGELOG.md
+++ b/modules/mcagar/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- `getSel()` to the `EditorTypes.Selection` interface
+- `setRawSelection()` to the `TinySelections` helper methods
+
 ### Improved
 - Updated the APIs to work with the TinyMCE 6 options API.
 

--- a/modules/mcagar/CHANGELOG.md
+++ b/modules/mcagar/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
-- The `getSel()` function to the `EditorTypes.Selection` interface.
-- The `setRawSelection()` function to the `TinySelections` helper methods to allow setting the selection without using any TinyMCE APIs.
+- Added the `getSel()` function to the `EditorTypes.Selection` interface.
+- Added the `setRawSelection()` function to the `TinySelections` helper methods to allow setting the selection without using any TinyMCE APIs.
 
 ### Improved
 - Updated the APIs to work with the TinyMCE 6 options API.

--- a/modules/mcagar/src/main/ts/ephox/mcagar/alien/EditorTypes.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/alien/EditorTypes.ts
@@ -1,10 +1,11 @@
 type EventCallback = (event: any) => void;
 
-export interface Selection {
+export interface EditorSelection {
   win: Window;
 
   setRng: (rng: Range) => void;
   getRng: () => Range | null;
+  getSel: () => Selection | null;
   select: (node: Node, content?: boolean) => Node;
   setCursorLocation: (node?: Node, offset?: number) => void;
   isCollapsed: () => boolean;
@@ -29,7 +30,7 @@ export interface Editor {
 
   dom: any;
   editorCommands: any;
-  selection: Selection;
+  selection: EditorSelection;
   windowManager: any;
   ui: {
     registry: any;

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinySelections.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinySelections.ts
@@ -6,7 +6,7 @@ import { TinyDom } from '../TinyDom';
 
 const setRawSelection = (editor: Editor, startPath: number[], soffset: number, finishPath: number[], foffset: number): void => {
   const rng = createDomSelection(TinyDom.body(editor), startPath, soffset, finishPath, foffset);
-  const sel = editor.getWin().getSelection();
+  const sel = editor.selection.getSel();
   if (sel) {
     sel.removeAllRanges();
     sel.addRange(rng);

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinySelections.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinySelections.ts
@@ -4,6 +4,15 @@ import { Editor } from '../../alien/EditorTypes';
 import { createDomSelection } from '../../selection/SelectionTools';
 import { TinyDom } from '../TinyDom';
 
+const setRawSelection = (editor: Editor, startPath: number[], soffset: number, finishPath: number[], foffset: number): void => {
+  const rng = createDomSelection(TinyDom.body(editor), startPath, soffset, finishPath, foffset);
+  const sel = editor.getWin().getSelection();
+  if (sel) {
+    sel.removeAllRanges();
+    sel.addRange(rng);
+  }
+};
+
 const setSelection = (editor: Editor, startPath: number[], soffset: number, finishPath: number[], foffset: number, fireNodeChange: boolean = true): void => {
   const rng = createDomSelection(TinyDom.body(editor), startPath, soffset, finishPath, foffset);
   editor.selection.setRng(rng);
@@ -31,5 +40,6 @@ export {
   select,
   setCursor,
   setSelection,
+  setRawSelection,
   setSelectionFrom
 };

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved support for placing the caret before or after noneditable elements within the editor #TINY-8169
 - Notifications no longer require a timeout to disable the close button #TINY-6679
 - The editor theme is now fetched in parallel with the icons, language pack and plugins #TINY-8453
+- Calls to `editor.selection.setRng` now update the cursor position bookmark used when focus is returned to the editor
 
 ### Changed
 - The `DomParser` API no longer uses a custom parser internally and instead uses the native `DOMParser` API #TINY-4627

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved support for placing the caret before or after noneditable elements within the editor #TINY-8169
 - Notifications no longer require a timeout to disable the close button #TINY-6679
 - The editor theme is now fetched in parallel with the icons, language pack and plugins #TINY-8453
-- Calls to `editor.selection.setRng` now update the cursor position bookmark used when focus is returned to the editor
+- Calls to `editor.selection.setRng` now update the cursor position bookmark used when focus is returned to the editor #TINY-8450
 
 ### Changed
 - The `DomParser` API no longer uses a custom parser internally and instead uses the native `DOMParser` API #TINY-4627

--- a/modules/tinymce/src/core/main/ts/selection/SelectionRestore.ts
+++ b/modules/tinymce/src/core/main/ts/selection/SelectionRestore.ts
@@ -38,7 +38,7 @@ const registerMouseUp = (editor: Editor, throttledStore: StoreThrottler) => {
 const registerEditorEvents = (editor: Editor, throttledStore: StoreThrottler) => {
   registerMouseUp(editor, throttledStore);
 
-  editor.on('keyup NodeChange', (e) => {
+  editor.on('keyup NodeChange AfterSetSelectionRange', (e) => {
     if (!isManualNodeChange(e)) {
       SelectionBookmark.store(editor);
     }

--- a/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkInlineEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkInlineEditorTest.ts
@@ -60,6 +60,19 @@ describe('browser.tinymce.core.selection.SelectionBookmarkInlineEditorTest', () 
   before(() => addTestDiv());
   after(() => removeTestDiv());
 
+  it('assert bookmark is updated in response to `setRng`', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>a</p><p>b</p>');
+    // In FireFox blurring the editor adds an undo level that triggers a nodechange that creates a bookmark,
+    // so by adding an undo level first we keep it from adding a bookmark because the undo manager
+    // does not add a new undolevel if it is the same as the previous level.
+    editor.undoManager.add();
+
+    TinySelections.setRawSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 0);
+    TinySelections.setSelection(editor, [ 1, 0 ], 1, [ 1, 0 ], 1, false); // Ensure node change doesn't fire
+    assertBookmark(editor, [ 1, 0 ], 1, [ 1, 0 ], 1);
+  });
+
   it('assert selection after no nodechanged, should not restore', () => {
     const editor = hook.editor();
     editor.setContent('<p>a</p><p>b</p>');
@@ -69,7 +82,7 @@ describe('browser.tinymce.core.selection.SelectionBookmarkInlineEditorTest', () 
     editor.undoManager.add();
 
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 0);
-    TinySelections.setSelection(editor, [ 1, 0 ], 1, [ 1, 0 ], 1, false); // Ensure node change doesn't fire
+    TinySelections.setRawSelection(editor, [ 1, 0 ], 1, [ 1, 0 ], 1);
     assertBookmark(editor, [ 0, 0 ], 0, [ 0, 0 ], 0);
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkInlineEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkInlineEditorTest.ts
@@ -62,11 +62,7 @@ describe('browser.tinymce.core.selection.SelectionBookmarkInlineEditorTest', () 
 
   it('assert bookmark is updated in response to `setRng`', () => {
     const editor = hook.editor();
-    editor.setContent('<p>a</p><p>b</p>');
-    // In FireFox blurring the editor adds an undo level that triggers a nodechange that creates a bookmark,
-    // so by adding an undo level first we keep it from adding a bookmark because the undo manager
-    // does not add a new undolevel if it is the same as the previous level.
-    editor.undoManager.add();
+    editor.resetContent('<p>a</p><p>b</p>');
 
     TinySelections.setRawSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 0);
     TinySelections.setSelection(editor, [ 1, 0 ], 1, [ 1, 0 ], 1, false); // Ensure node change doesn't fire
@@ -75,11 +71,7 @@ describe('browser.tinymce.core.selection.SelectionBookmarkInlineEditorTest', () 
 
   it('assert selection after no nodechanged, should not restore', () => {
     const editor = hook.editor();
-    editor.setContent('<p>a</p><p>b</p>');
-    // In FireFox blurring the editor adds an undo level that triggers a nodechange that creates a bookmark,
-    // so by adding an undo level first we keep it from adding a bookmark because the undo manager
-    // does not add a new undolevel if it is the same as the previous level.
-    editor.undoManager.add();
+    editor.resetContent('<p>a</p><p>b</p>');
 
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 0);
     TinySelections.setRawSelection(editor, [ 1, 0 ], 1, [ 1, 0 ], 1);


### PR DESCRIPTION
Related Ticket: TINY-8450

Description of Changes:
* Add `AfterSetSelectionRange` to the list of events that trigger storing the selection bookmark
* Update the test that verifies a 'bookmark doesn't change' scenario to use native selection

Perhaps other tests should be updated too, since the `setRng` call is now the one updating the bookmark as well as the other conditions in the test. I'm not sure.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
