### PR TITLE
TINY-8480: Fixed language packs loading incorrectly

### DIFF
--- a/modules/tinymce/src/core/main/ts/init/Render.ts
+++ b/modules/tinymce/src/core/main/ts/init/Render.ts
@@ -42,7 +42,7 @@ const loadLanguage = (scriptLoader: ScriptLoader, editor: Editor) => {
   const languageUrl = Options.getLanguageUrl(editor);
 
   if (I18n.hasCode(languageCode) === false && languageCode !== 'en') {
-    const url = Strings.isNotEmpty(languageCode) ? languageUrl : `${editor.editorManager.baseURL}/langs/${languageCode}.js`;
+    const url = Strings.isNotEmpty(languageUrl) ? languageUrl : `${editor.editorManager.baseURL}/langs/${languageCode}.js`;
 
     scriptLoader.add(url).catch(() => {
       ErrorReporter.languageLoadError(editor, url, languageCode);

--- a/modules/tinymce/src/core/test/assets/js/nested.js
+++ b/modules/tinymce/src/core/test/assets/js/nested.js
@@ -1,0 +1,2 @@
+// load another script to test nested loading, such as in plugins
+tinymce_.ScriptLoader.add('/project/tinymce/src/core/test/assets/js/test.js');

--- a/modules/tinymce/src/core/test/assets/langs/custom.js
+++ b/modules/tinymce/src/core/test/assets/langs/custom.js
@@ -1,0 +1,3 @@
+tinymce.addI18n('custom', {
+  'source': 'translated'
+});

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorLanguageTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorLanguageTest.ts
@@ -1,0 +1,27 @@
+import { UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import I18n from 'tinymce/core/api/util/I18n';
+
+describe('browser.tinymce.core.init.InitEditorLanguageTest', () => {
+  TinyHooks.bddSetupLight<Editor>({
+    language: 'custom',
+    language_url: '/project/tinymce/src/core/test/assets/langs/custom.js',
+    base_url: '/project/tinymce/js/tinymce'
+  }, []);
+
+  // Copy of '/src/core/test/assets/langs/custom.js'. For assertion in test.
+  const customLanguagePack = {
+    source: 'translated'
+  };
+
+  it('TBA: Should have been able to load a custom language pack', () => {
+    UiFinder.notExists(SugarBody.body(), '.tox-notification');
+    assert.equal(I18n.getCode(), 'custom', 'I18n language code should be the custom language code');
+    assert.deepEqual(I18n.getData(), { custom: customLanguagePack }, 'I18n data should have custom language pack');
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-8480

Description of Changes:
* Fixed an incorrect variable being used in the language url generation which caused it to generate an empty url unless `language_url` was configured.
  * **Note:** The test I've added for this doesn't cover this exact case as we can't do that with our current test setup unfortunately, but we had nothing testing a custom language being loaded so this does at least assert languages can be loaded.
* Fixed an issue where the init sequence wasn't waiting for plugin language packs to be loaded before proceeding.
  * **Note:** This was something I'd noticed the old `ScriptLoader` implementation did but found it poor behaviour to be loading scripts not passed in. However, since it's needed for the this case I've added it back, but we may want to look into better solutions long term. It should have been the only thing left out from the old version, so I'm pretty hopefully the ScriptLoader should be identical now (except it now deals with promises instead of callbacks).

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
