### PR TITLE
TINY-7996: Ensure only strings are passed to get/set content events

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Notifications no longer require a timeout to disable the close button #TINY-6679
 - The editor theme is now fetched in parallel with the icons, language pack and plugins #TINY-8453
 - Calls to `editor.selection.setRng` now update the cursor position bookmark used when focus is returned to the editor #TINY-8450
+- The `BeforeSetContent` event will now include the actual serialized content when passing in an `AstNode` to the `editor.setContent` API #TINY-7996
 - The default height of editor has been increased from `200px` to `400px` to improve the usability of the editor #TINY-6860
 
 ### Changed
@@ -86,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `plugins` option now returns a `string` array instead of a space separated string #TINY-8455
 - Replaced 'Powered by Tiny' link text with logo #TINY-8371
 - Renamed the `getWhiteSpaceElements()` function to `getWhitespaceElements()` in the `Schema` API #TINY-8102
+- The `GetContent` event will now always pass a `string` for the `content` property #TINY-7996
 - The `mceInsertTable` command can no longer open the insert table dialog. Use the `mceInsertTableDialog` command instead #TINY-8273
 - Moved non-UI table functionality to core #TINY-8273
 - The `table_style_by_css` option has been set to `true` by default #TINY-8259

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Arr, Cell, Type } from '@ephox/katamari';
+import { Arr, Cell } from '@ephox/katamari';
 import { Attribute, SugarElement } from '@ephox/sugar';
 
 import * as ErrorReporter from '../ErrorReporter';
@@ -282,8 +282,7 @@ const EditorUpload = (editor: Editor): EditorUpload => {
   });
 
   editor.on('GetContent', (e) => {
-    // if the content is not a string, we can't process it
-    if (e.source_view || e.format === 'raw' || e.format === 'tree' || !Type.isString(e.content)) {
+    if (e.source_view || e.format === 'raw' || e.format === 'tree') {
       return;
     }
 

--- a/modules/tinymce/src/core/main/ts/api/EventTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/EventTypes.ts
@@ -6,7 +6,7 @@
  */
 
 import { AutocompleterEventArgs } from '../autocomplete/AutocompleteTypes';
-import { Content, GetContentArgs, SetContentArgs } from '../content/ContentTypes';
+import { GetContentArgs, SetContentArgs } from '../content/ContentTypes';
 import { FormatVars } from '../fmt/FormatTypes';
 import { RangeLikeObject } from '../selection/RangeTypes';
 import { UndoLevel } from '../undo/UndoManagerTypes';
@@ -18,14 +18,23 @@ import { InstanceApi } from './WindowManager';
 
 export interface ExecCommandEvent { command: string; ui?: boolean; value?: any }
 
-// TODO Figure out if these properties should be on the ContentArgs types
-export type BeforeGetContentEvent = GetContentArgs & { source_view?: boolean; selection?: boolean; save?: boolean };
-export type GetContentEvent = BeforeGetContentEvent & { content: Content };
-export type BeforeSetContentEvent = SetContentArgs & { source_view?: boolean; paste?: boolean; selection?: boolean };
-export type SetContentEvent = BeforeSetContentEvent & {
+export interface BeforeGetContentEvent extends GetContentArgs {
+  selection?: boolean;
+}
+
+export interface GetContentEvent extends BeforeGetContentEvent {
+  content: string;
+}
+
+export interface BeforeSetContentEvent extends SetContentArgs {
+  content: string;
+  selection?: boolean;
+}
+
+export interface SetContentEvent extends BeforeSetContentEvent {
   /** @deprecated */
   content: string;
-};
+}
 
 export interface NewBlockEvent { newBlock: Element }
 

--- a/modules/tinymce/src/core/main/ts/api/Events.ts
+++ b/modules/tinymce/src/core/main/ts/api/Events.ts
@@ -6,11 +6,12 @@
  */
 
 import { AutocompleterEventArgs } from '../autocomplete/AutocompleteTypes';
-import { Content, GetContentArgs } from '../content/ContentTypes';
 import { FormatVars } from '../fmt/FormatTypes';
 import { RangeLikeObject } from '../selection/RangeTypes';
 import Editor from './Editor';
-import { BeforeSetContentEvent, SetContentEvent, PastePlainTextToggleEvent, PastePostProcessEvent, PastePreProcessEvent } from './EventTypes';
+import {
+  BeforeSetContentEvent, SetContentEvent, PastePlainTextToggleEvent, PastePostProcessEvent, PastePreProcessEvent, GetContentEvent, BeforeGetContentEvent
+} from './EventTypes';
 import { ParserArgs } from './html/DomParser';
 import { EditorEvent } from './util/EventDispatcher';
 
@@ -54,10 +55,10 @@ const fireBeforeSetContent = <T extends BeforeSetContentEvent>(editor: Editor, a
 const fireSetContent = <T extends SetContentEvent>(editor: Editor, args: T) =>
   editor.dispatch('SetContent', args);
 
-const fireBeforeGetContent = <T extends GetContentArgs>(editor: Editor, args: T) =>
+const fireBeforeGetContent = <T extends BeforeGetContentEvent>(editor: Editor, args: T) =>
   editor.dispatch('BeforeGetContent', args);
 
-const fireGetContent = <T extends GetContentArgs & { content: Content }>(editor: Editor, args: T) =>
+const fireGetContent = <T extends GetContentEvent>(editor: Editor, args: T) =>
   editor.dispatch('GetContent', args);
 
 const fireAutocompleterStart = (editor: Editor, args: AutocompleterEventArgs) => editor.dispatch('AutocompleterStart', args);

--- a/modules/tinymce/src/core/main/ts/content/ContentTypes.ts
+++ b/modules/tinymce/src/core/main/ts/content/ContentTypes.ts
@@ -14,17 +14,19 @@ export interface GetContentArgs {
   format: ContentFormat;
   get: boolean;
   getInner: boolean;
-  content?: Content;
   no_events?: boolean;
+  save?: boolean;
+  source_view?: boolean;
   [key: string]: any;
 }
 
 export interface SetContentArgs {
   format: string;
   set: boolean;
-  content: string;
+  content: Content;
   no_events?: boolean;
   no_selection?: boolean;
+  paste?: boolean;
 }
 
 export interface SetContentResult {
@@ -38,6 +40,7 @@ export interface GetSelectionContentArgs extends GetContentArgs {
 }
 
 export interface SetSelectionContentArgs extends SetContentArgs {
+  content: string;
   selection?: boolean;
 }
 
@@ -48,3 +51,6 @@ export interface InsertContentDetails {
     readonly paste: boolean;
   };
 }
+
+export const isTreeNode = (content: unknown): content is AstNode =>
+  content instanceof AstNode;

--- a/modules/tinymce/src/core/main/ts/content/PrePostProcess.ts
+++ b/modules/tinymce/src/core/main/ts/content/PrePostProcess.ts
@@ -9,8 +9,32 @@ import { Result } from '@ephox/katamari';
 
 import Editor from '../api/Editor';
 import * as Events from '../api/Events';
-import AstNode from '../api/html/Node';
-import { Content, GetContentArgs, SetContentArgs } from './ContentTypes';
+import DomParser from '../api/html/DomParser';
+import HtmlSerializer from '../api/html/Serializer';
+import { EditorEvent } from '../api/util/EventDispatcher';
+import { Content, GetContentArgs, isTreeNode, SetContentArgs } from './ContentTypes';
+
+const serializeContent = (content: Content): string =>
+  isTreeNode(content) ? HtmlSerializer({ validate: false }).serialize(content) : content;
+
+const withSerializedContent = <R extends EditorEvent<{ content: string }>>(content: Content, fireEvent: (content: string) => R): R & { content: Content } => {
+  const serializedContent = serializeContent(content);
+  const eventArgs = fireEvent(serializedContent);
+  if (eventArgs.isDefaultPrevented()) {
+    return eventArgs;
+  } else if (isTreeNode(content)) {
+    // Restore the content type back to being an AstNode. If the content has changed we need to
+    // re-parse the new content, otherwise we can return the input.
+    if (eventArgs.content !== serializedContent) {
+      const rootNode = DomParser({ validate: false, forced_root_block: false }).parse(eventArgs.content, { context: content.name });
+      return { ...eventArgs, content: rootNode };
+    } else {
+      return { ...eventArgs, content };
+    }
+  } else {
+    return eventArgs;
+  }
+};
 
 const preProcessGetContent = <T extends GetContentArgs>(editor: Editor, args: T): Result<T, Content> => {
   if (args.no_events) {
@@ -18,8 +42,7 @@ const preProcessGetContent = <T extends GetContentArgs>(editor: Editor, args: T)
   } else {
     const eventArgs = Events.fireBeforeGetContent(editor, args);
     if (eventArgs.isDefaultPrevented()) {
-      const defaultContent = eventArgs.format === 'tree' ? new AstNode('body', 11) : '';
-      return Result.error(Events.fireGetContent(editor, { content: defaultContent, ...eventArgs }).content);
+      return Result.error(Events.fireGetContent(editor, { content: '', ...eventArgs }).content);
     } else {
       return Result.value(eventArgs);
     }
@@ -30,8 +53,8 @@ const postProcessGetContent = <T extends GetContentArgs>(editor: Editor, content
   if (args.no_events) {
     return content;
   } else {
-    const eventArgs = Events.fireGetContent(editor, { ...args, content });
-    return eventArgs.content;
+    const outcome = withSerializedContent(content, (c) => Events.fireGetContent(editor, { ...args, content: c }));
+    return outcome.content;
   }
 };
 
@@ -39,12 +62,12 @@ const preProcessSetContent = <T extends SetContentArgs>(editor: Editor, args: T)
   if (args.no_events) {
     return Result.value(args);
   } else {
-    const eventArgs = Events.fireBeforeSetContent(editor, args);
-    if (eventArgs.isDefaultPrevented()) {
-      Events.fireSetContent(editor, eventArgs);
+    const outcome = withSerializedContent(args.content, (content) => Events.fireBeforeSetContent(editor, { ...args, content }));
+    if (outcome.isDefaultPrevented()) {
+      Events.fireSetContent(editor, outcome);
       return Result.error(undefined);
     } else {
-      return Result.value(eventArgs);
+      return Result.value(outcome);
     }
   }
 };

--- a/modules/tinymce/src/core/main/ts/content/PrePostProcess.ts
+++ b/modules/tinymce/src/core/main/ts/content/PrePostProcess.ts
@@ -53,8 +53,8 @@ const postProcessGetContent = <T extends GetContentArgs>(editor: Editor, content
   if (args.no_events) {
     return content;
   } else {
-    const outcome = withSerializedContent(content, (c) => Events.fireGetContent(editor, { ...args, content: c }));
-    return outcome.content;
+    const processedEventArgs = withSerializedContent(content, (c) => Events.fireGetContent(editor, { ...args, content: c }));
+    return processedEventArgs.content;
   }
 };
 
@@ -62,12 +62,12 @@ const preProcessSetContent = <T extends SetContentArgs>(editor: Editor, args: T)
   if (args.no_events) {
     return Result.value(args);
   } else {
-    const outcome = withSerializedContent(args.content, (content) => Events.fireBeforeSetContent(editor, { ...args, content }));
-    if (outcome.isDefaultPrevented()) {
-      Events.fireSetContent(editor, outcome);
+    const processedEventArgs = withSerializedContent(args.content, (content) => Events.fireBeforeSetContent(editor, { ...args, content }));
+    if (processedEventArgs.isDefaultPrevented()) {
+      Events.fireSetContent(editor, processedEventArgs);
       return Result.error(undefined);
     } else {
-      return Result.value(outcome);
+      return Result.value(processedEventArgs);
     }
   }
 };

--- a/modules/tinymce/src/core/main/ts/content/SetContent.ts
+++ b/modules/tinymce/src/core/main/ts/content/SetContent.ts
@@ -6,30 +6,24 @@
  */
 
 import Editor from '../api/Editor';
-import AstNode from '../api/html/Node';
 import * as Rtc from '../Rtc';
 import { Content, SetContentArgs } from './ContentTypes';
 import { postProcessSetContent, preProcessSetContent } from './PrePostProcess';
 
 const defaultFormat = 'html';
 
-const isTreeNode = (content: unknown): content is AstNode =>
-  content instanceof AstNode;
-
 const setupArgs = (args: Partial<SetContentArgs>, content: Content): SetContentArgs => ({
   format: defaultFormat,
   ...args,
   set: true,
-  content: isTreeNode(content) ? '' : content
+  content
 });
 
 export const setContent = (editor: Editor, content: Content, args: Partial<SetContentArgs> = {}): Content => {
   const defaultedArgs = setupArgs(args, content);
 
   return preProcessSetContent(editor, defaultedArgs).map((updatedArgs) => {
-    // Don't use the content from the args for tree, as it'll be an empty string
-    const updatedContent = isTreeNode(content) ? content : updatedArgs.content;
-    const result = Rtc.setContent(editor, updatedContent, updatedArgs);
+    const result = Rtc.setContent(editor, updatedArgs.content, updatedArgs);
     postProcessSetContent(editor, result.html, updatedArgs);
     return result.content;
   }).getOr(content);

--- a/modules/tinymce/src/core/main/ts/content/SetContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/SetContentImpl.ts
@@ -18,10 +18,7 @@ import { isWsPreserveElement } from '../dom/ElementType';
 import * as NodeType from '../dom/NodeType';
 import * as EditorFocus from '../focus/EditorFocus';
 import * as FilterNode from '../html/FilterNode';
-import { Content, SetContentArgs, SetContentResult } from './ContentTypes';
-
-const isTreeNode = (content: unknown): content is AstNode =>
-  content instanceof AstNode;
+import { Content, isTreeNode, SetContentArgs, SetContentResult } from './ContentTypes';
 
 const moveSelection = (editor: Editor): void => {
   if (EditorFocus.hasFocus(editor)) {
@@ -99,5 +96,5 @@ export const setContentInternal = (editor: Editor, content: Content, args: SetCo
     } else {
       return setContentString(editor, body, content, args);
     }
-  }).getOr({ content, html: args.content });
+  }).getOr({ content, html: isTreeNode(args.content) ? '' : args.content });
 };

--- a/modules/tinymce/src/core/main/ts/init/Render.ts
+++ b/modules/tinymce/src/core/main/ts/init/Render.ts
@@ -237,7 +237,7 @@ const render = (editor: Editor) => {
 
   if (Options.isEncodingXml(editor)) {
     editor.on('GetContent', (e) => {
-      if (e.save && Type.isString(e.content)) {
+      if (e.save) {
         e.content = DOM.encode(e.content);
       }
     });

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -1,12 +1,15 @@
 import { Assertions } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
+import { Arr, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import { BeforeGetContentEvent, BeforeSetContentEvent, GetContentEvent, SetContentEvent } from 'tinymce/core/api/EventTypes';
 import AstNode from 'tinymce/core/api/html/Node';
 import HtmlSerializer from 'tinymce/core/api/html/Serializer';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 const defaultExpectedEvents = [
   'beforesetcontent',
@@ -16,19 +19,19 @@ const defaultExpectedEvents = [
 ];
 
 describe('browser.tinymce.core.content.EditorContentTest', () => {
-  let events: string[] = [];
+  let events: EditorEvent<SetContentEvent | GetContentEvent | BeforeSetContentEvent | BeforeGetContentEvent>[] = [];
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     inline: true,
     setup: (editor) => {
       editor.on('BeforeGetContent GetContent BeforeSetContent SetContent', (e) => {
-        events.push(e.type);
+        events.push(e);
       });
     }
   }, []);
 
   const getFontTree = (): AstNode => {
-    const body = new AstNode('body', 1);
+    const body = new AstNode('body', 11);
     const font = new AstNode('font', 1);
     const text = new AstNode('#text', 3);
 
@@ -46,8 +49,15 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
   };
 
   const assertEventsFiredInOrder = (expectedEvents: string[] = defaultExpectedEvents) => {
-    assert.deepEqual(events, expectedEvents, 'Get content events should have been fired');
+    const names = Arr.map(events, (e) => e.type);
+    assert.deepEqual(names, expectedEvents, 'Get content events should have been fired');
   };
+
+  const assertEventsContentType = () => {
+    const isExpectedTypes = Arr.forall(events, (e) => e.type === 'beforegetcontent' ? Type.isUndefined(e.content) : Type.isString(e.content));
+    assert.isTrue(isExpectedTypes);
+  };
+
   const clearEvents = () => events = [];
 
   beforeEach(() => clearEvents());
@@ -58,6 +68,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
     const html = editor.getContent();
     Assertions.assertHtml('Should be expected html', '<p>html</p>', html);
     assertEventsFiredInOrder();
+    assertEventsContentType();
   });
 
   it('TINY-6281: getContent html with empty editor', () => {
@@ -66,6 +77,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
     const html = editor.getContent();
     Assertions.assertHtml('Should be expected html', '', html);
     assertEventsFiredInOrder();
+    assertEventsContentType();
   });
 
   it('TINY-6281: getContent text', () => {
@@ -79,6 +91,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
     const expected = 'Text to be retrieved' + (isSafari ? '\n\n' : '');
     Assertions.assertHtml('Should be expected text', expected, text);
     assertEventsFiredInOrder();
+    assertEventsContentType();
   });
 
   it('TINY-6281: getContent text with empty editor', () => {
@@ -87,6 +100,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
     const text = editor.getContent({ format: 'text' });
     Assertions.assertHtml('Should be expected text', '', text);
     assertEventsFiredInOrder();
+    assertEventsContentType();
   });
 
   it('TBA: getContent tree', () => {
@@ -95,6 +109,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
     const tree = editor.getContent({ format: 'tree' });
     Assertions.assertHtml('Should be expected tree html', '<p>tree</p>', toHtml(tree));
     assertEventsFiredInOrder();
+    assertEventsContentType();
   });
 
   it('TINY-6281: getContent tree with empty editor', () => {
@@ -104,6 +119,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
     // bogus br that sits in an empty editor is replaced with a &nbsp; by the html parser, hence the space
     Assertions.assertHtml('Should be expected tree html', '<p> </p>', toHtml(tree));
     assertEventsFiredInOrder();
+    assertEventsContentType();
   });
 
   it('TBA: getContent tree filtered', () => {
@@ -112,6 +128,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
     const tree = editor.getContent({ format: 'tree' });
     Assertions.assertHtml('Should be expected tree filtered html', '<p><span style="font-size: 300%;">x</span></p>', toHtml(tree));
     assertEventsFiredInOrder();
+    assertEventsContentType();
   });
 
   it('TBA: setContent html', () => {
@@ -127,6 +144,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
       'beforegetcontent',
       'getcontent'
     ]);
+    assertEventsContentType();
   });
 
   it('TBA: setContent tree', () => {
@@ -154,6 +172,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
       'beforegetcontent',
       'getcontent'
     ]);
+    assertEventsContentType();
   });
 
   it('TBA: setContent tree filtered', () => {
@@ -169,6 +188,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
       'beforegetcontent',
       'getcontent'
     ]);
+    assertEventsContentType();
   });
 
   it('TBA: setContent tree using public api', () => {
@@ -184,6 +204,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
       'beforegetcontent',
       'getcontent'
     ]);
+    assertEventsContentType();
   });
 
   it('TINY-7956: Get content without firing events', () => {
@@ -193,11 +214,35 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
     const html = editor.getContent({ no_events: true });
     Assertions.assertHtml('Should be expected html', '<p>html</p>', html);
     assertEventsFiredInOrder([]);
+    assertEventsContentType();
   });
 
   it('TINY-7956: Set content without firing events', () => {
     const editor = hook.editor();
     editor.setContent('<p>html</p>', { no_events: true });
     assertEventsFiredInOrder([]);
+    assertEventsContentType();
+  });
+
+  it('TINY-7996: Set tree content with content altered in BeforeSetContent', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>tree</p>');
+    editor.once('BeforeSetContent', (e) => {
+      assert.equal(e.content, '<font size="7">x</font>');
+      e.content = '<p>replaced</p>';
+    });
+    editor.setContent(getFontTree());
+    Assertions.assertHtml('Should be replaced html', '<p>replaced</p>', editor.getContent());
+  });
+
+  it('TINY-7996: Get tree content with content altered in GetContent', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>tree</p>');
+    editor.once('GetContent', (e) => {
+      assert.equal(e.content, '<p>tree</p>');
+      e.content = '<p>replaced</p>';
+    });
+    const tree = editor.getContent({ format: 'tree' });
+    Assertions.assertHtml('Should be replaced html', '<p>replaced</p>', toHtml(tree));
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-7996

Description of Changes:
* Update the `GetContent` event to ensure the `content` property is always a string.
* Update the `BeforeSetContent` event to actually serialize the tree passed to `setContent()` instead of always using an empty string. This also means `BeforeSetContent` is actually usable for tree content now.
* Cleaned up a few `isString` checks for the relevant events since they aren't needed anymore and didn't work with `tree` content (which is one reason we're changing this).
* Fixed/improved a few types for the get/set content operations

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
