### PR TITLE
TINY-8443: Change default height of editor

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -82,7 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `plugins` option now returns a `string` array instead of a space separated string #TINY-8455
 - Replaced 'Powered by Tiny' link text with logo #TINY-8371
 - Changed the default height of Editor from 200px to 400px #TINY-8443
-- The `min-height` of Editor is set to 100px so the UI can't be hidden while resizing #TINY-8443
+- Set the default value of `min_height` to 100px so the UI can't be hidden while resizing #TINY-8443
 
 ### Fixed
 - The object returned from the `editor.fire()` API was incorrect if the editor had been removed #TINY-8018

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -81,6 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Editor query command APIs will now return `false` or an empty string on removed editors #TINY-7829
 - The `plugins` option now returns a `string` array instead of a space separated string #TINY-8455
 - Replaced 'Powered by Tiny' link text with logo #TINY-8371
+- Changed the default height of Editor from 200px to 400px #TINY-8443
+- The `min-height` of Editor is set to 100px so the UI can't be hidden while resizing #TINY-8443
 
 ### Fixed
 - The object returned from the `editor.fire()` API was incorrect if the editor had been removed #TINY-8018

--- a/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
@@ -53,7 +53,6 @@ export default () => {
       { title: 'Some class', value: 'class-name' }
     ],
     importcss_append: true,
-    height: 400,
     image_advtab: true,
     file_picker_callback: (callback, _value, meta) => {
       if (meta.fieldname === 'poster') {

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -359,7 +359,7 @@ const setup = (editor: Editor): RenderInfo => {
       if (Css.isValidValue('div', 'height', parsedHeight)) {
         Css.set(outerContainer.element, 'height', parsedHeight);
       } else {
-        Css.set(outerContainer.element, 'height', '200px');
+        Css.set(outerContainer.element, 'height', '400px');
       }
     }
 

--- a/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
@@ -14,6 +14,8 @@ import EditorManager from 'tinymce/core/api/EditorManager';
 import Env from 'tinymce/core/api/Env';
 import { EditorOptions, ToolbarGroup } from 'tinymce/core/api/OptionTypes';
 
+import * as Utils from '../ui/sizing/Utils';
+
 export type ToolbarGroupOption = ToolbarGroup;
 
 export enum ToolbarMode {
@@ -45,6 +47,10 @@ const register = (editor: Editor): void => {
 
   const stringOrFalseProcessor = (value: unknown) => Type.isString(value) || value === false;
   const stringOrNumberProcessor = (value: unknown) => Type.isString(value) || Type.isNumber(value);
+  const cssHeightOrDefault = () => {
+    const cssHeight = Utils.parseToInt(DOMUtils.DOM.getStyle(editor.getElement(), 'height', true));
+    return Math.max(cssHeight.fold(Fun.constant(0), Fun.identity), 400);
+  };
 
   registerOption('skin', {
     processor: (value) => Type.isString(value) || value === false,
@@ -57,7 +63,7 @@ const register = (editor: Editor): void => {
 
   registerOption('height', {
     processor: stringOrNumberProcessor,
-    default: Math.max(editor.getElement().offsetHeight, 200)
+    default: cssHeightOrDefault()
   });
 
   registerOption('width', {

--- a/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
@@ -72,7 +72,8 @@ const register = (editor: Editor): void => {
   });
 
   registerOption('min_height', {
-    processor: 'number'
+    processor: 'number',
+    default: 100
   });
 
   registerOption('min_width', {
@@ -280,7 +281,7 @@ const isReadOnly = option('readonly');
 const getHeightOption = option('height');
 const getWidthOption = option('width');
 const getMinWidthOption = wrapOptional(option('min_width'));
-const getMinHeightOption = wrapOptional(option('min_height'));
+const getMinHeightOption = option('min_height');
 const getMaxWidthOption = wrapOptional(option('max_width'));
 const getMaxHeightOption = wrapOptional(option('max_height'));
 const getUserStyleFormats = wrapOptional(option('style_formats'));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizing/EditorSize.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizing/EditorSize.ts
@@ -14,7 +14,7 @@ import * as Utils from './Utils';
 
 export const getHeight = (editor: Editor) => {
   const baseHeight = Options.getHeightOption(editor);
-  const minHeight = Options.getMinHeightOption(editor);
+  const minHeight = Optional.from(Options.getMinHeightOption(editor));
   const maxHeight = Options.getMaxHeightOption(editor);
 
   return Utils.parseToInt(baseHeight).map((height) => Utils.calcCappedSize(height, minHeight, maxHeight));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizing/Resize.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizing/Resize.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Obj } from '@ephox/katamari';
+import { Obj, Optional } from '@ephox/katamari';
 import { Css, Height, SugarElement, SugarPosition, Width } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -26,7 +26,7 @@ export enum ResizeTypes {
 export const getDimensions = (editor: Editor, deltas: SugarPosition, resizeType: ResizeTypes, originalHeight: number, originalWidth: number) => {
   const dimensions: EditorDimensions = {};
 
-  dimensions.height = Utils.calcCappedSize(originalHeight + deltas.top, Options.getMinHeightOption(editor), Options.getMaxHeightOption(editor));
+  dimensions.height = Utils.calcCappedSize(originalHeight + deltas.top, Optional.from(Options.getMinHeightOption(editor)), Options.getMaxHeightOption(editor));
 
   if (resizeType === ResizeTypes.Both) {
     dimensions.width = Utils.calcCappedSize(originalWidth + deltas.left, Options.getMinWidthOption(editor), Options.getMaxWidthOption(editor));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/DefaultHeight.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/DefaultHeight.ts
@@ -1,0 +1,47 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { McEditor } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.DefaultHeight', () => {
+  const baseSettings = {
+    base_url: '/project/tinymce/js/tinymce'
+  };
+
+  it('TINY-8443: Default height should be 400px', async () => {
+    const editor = await McEditor.pFromSettings<Editor>(baseSettings);
+    assert.equal(editor.getContainer().offsetHeight, 400);
+    McEditor.remove(editor);
+  });
+
+  it('TINY-8443: Option heigh takes precedence', async () => {
+    const editor = await McEditor.pFromSettings<Editor>({ height: 500, ...baseSettings });
+    assert.equal(editor.getContainer().offsetHeight, 500);
+    McEditor.remove(editor);
+  });
+
+  it('TINY-8443: CSS height takes precendence in the absence of option height', async () => {
+    const editor = await McEditor.pFromHtml<Editor>('<div style="height: 600px"></div>', baseSettings);
+    assert.equal(editor.getContainer().offsetHeight, 600);
+    McEditor.remove(editor);
+  });
+
+  it('TINY-8443: Use default height if CSS height is less and option height is not specified', async () => {
+    const editor = await McEditor.pFromHtml<Editor>('<div style="height: 200px"></div>', baseSettings);
+    assert.equal(editor.getContainer().offsetHeight, 400);
+    McEditor.remove(editor);
+  });
+
+  it('TINY-8443: Option height should take precedence over CSS height', async () => {
+    const editor = await McEditor.pFromHtml<Editor>('<div style="height: 600px"></div>', { height: 721, ...baseSettings });
+    assert.equal(editor.getContainer().offsetHeight, 721);
+    McEditor.remove(editor);
+  });
+
+  it('TINY-8443: Default min-height to 100px', async () => {
+    const editor = await McEditor.pFromSettings<Editor>({ height: 80, ...baseSettings });
+    assert.equal(editor.getContainer().offsetHeight, 100);
+    McEditor.remove(editor);
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
@@ -114,21 +114,21 @@ describe('browser.tinymce.themes.silver.editor.NotificationManagerImplTest', () 
       assertStructure('Check success notification structure', nSuccess, 'success', 'Message 4');
 
       // Check items are positioned so that they are stacked
-      assertPosition('Error notification', nError, 220, -200);
-      assertPosition('Warning notification', nWarn, 220, -152);
-      assertPosition('Info notification', nInfo, 220, -104);
-      assertPosition('Success notification', nSuccess, 220, -56);
+      assertPosition('Error notification', nError, 220, -400);
+      assertPosition('Warning notification', nWarn, 220, -352);
+      assertPosition('Info notification', nInfo, 220, -304);
+      assertPosition('Success notification', nSuccess, 220, -256);
 
       nError.close();
 
-      assertPosition('Warning notification', nWarn, 220, -200);
-      assertPosition('Info notification', nInfo, 220, -150);
-      assertPosition('Success notification', nSuccess, 220, -100);
+      assertPosition('Warning notification', nWarn, 220, -400);
+      assertPosition('Info notification', nInfo, 220, -350);
+      assertPosition('Success notification', nSuccess, 220, -300);
 
       nInfo.close();
 
-      assertPosition('Warning notification', nWarn, 220, -200);
-      assertPosition('Success notification', nSuccess, 220, -150);
+      assertPosition('Warning notification', nWarn, 220, -400);
+      assertPosition('Success notification', nSuccess, 220, -350);
 
       nWarn.close();
       nSuccess.close();
@@ -162,12 +162,12 @@ describe('browser.tinymce.themes.silver.editor.NotificationManagerImplTest', () 
       // Scroll so the editor is below the bottom of the window
       Scroll.to(0, 0);
       const notification1 = openNotification(editor, 'success', 'Message');
-      assertPosition('Below window notification', notification1, 226, -2200);
+      assertPosition('Below window notification', notification1, 226, -2400);
       notification1.close();
 
       // Scroll so the header is above the top of the window, but the bottom of the editor is in view
       const topOfEditor = SugarLocation.absolute(TinyDom.container(editor)).top;
-      Scroll.to(0, topOfEditor + 100);
+      Scroll.to(0, topOfEditor + 300);
       const notification2 = openNotification(editor, 'success', 'Message');
       assertPosition('Partial editor view notification', notification2, 226, -2100);
       notification2.close();
@@ -185,7 +185,7 @@ describe('browser.tinymce.themes.silver.editor.NotificationManagerImplTest', () 
       const editor = hook.editor();
 
       const notifications = Arr.range(9, (i) => openNotification(editor, 'success', `Message ${i + 1}`));
-      assertPosition('Last notification is outside the content area', notifications[notifications.length - 1], 220, 185);
+      assertPosition('Last notification is outside the content area', notifications[notifications.length - 1], 220, -15);
 
       Arr.each(notifications, (notification) => notification.close());
     });


### PR DESCRIPTION
Related Ticket: TINY-8443

Description of Changes:
* Changed the default height of Editor from 200px to 400px
* Defaulted the min height of Editor to 100px so the UI can't be hidden while resizing

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
