### PR TITLE
TINY-8201: Pressing the "End" key within a CEF element causes the selection to incorrectly leave the element

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deleting content would sometimes not fire `beforeinput` and `input` events as expected #TINY-8168 #TINY-8329
 - Anchor elements would render incorrectly when using the `allow_html_in_named_anchor` option #TINY-3799
 - Fixed sub-menu items not read by screen readers. Patch contributed by westonkd #TINY-8417
+- The Home or End keys would move out of a editable element contained within a noneditable element #TINY-8201
 
 ### Removed
 - Removed the jQuery integration #TINY-4518

--- a/modules/tinymce/src/core/main/ts/caret/CaretUtils.ts
+++ b/modules/tinymce/src/core/main/ts/caret/CaretUtils.ts
@@ -6,7 +6,7 @@
  */
 
 import { Fun, Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import { PredicateFind, SugarElement } from '@ephox/sugar';
 
 import DomTreeWalker from '../api/dom/TreeWalker';
 import * as NodeType from '../dom/NodeType';
@@ -76,14 +76,10 @@ const findNode = (node: Node, direction: number, predicateFn: (node: Node) => bo
   return null;
 };
 
-const getEditingHost = (node: Node, rootNode?: Node): Node | undefined => {
-  for (node = node.parentNode; node && node !== rootNode; node = node.parentNode) {
-    if (isContentEditableTrue(node)) {
-      return node;
-    }
-  }
-
-  return rootNode;
+const getEditingHost = (node: Node, rootNode: HTMLElement): HTMLElement => {
+  return PredicateFind.ancestor(SugarElement.fromDom(node), (node) => isContentEditableTrue(node.dom), (node) => node.dom === rootNode)
+    .map((elm) => elm.dom)
+    .getOr(rootNode) as HTMLElement;
 };
 
 const getParentBlock = (node: Node, rootNode?: Node): Node | null => {
@@ -101,7 +97,7 @@ const getParentBlock = (node: Node, rootNode?: Node): Node | null => {
 const isInSameBlock = (caretPosition1: CaretPosition, caretPosition2: CaretPosition, rootNode?: Node): boolean =>
   getParentBlock(caretPosition1.container(), rootNode) === getParentBlock(caretPosition2.container(), rootNode);
 
-const isInSameEditingHost = (caretPosition1: CaretPosition, caretPosition2: CaretPosition, rootNode?: Node): boolean =>
+const isInSameEditingHost = (caretPosition1: CaretPosition, caretPosition2: CaretPosition, rootNode: HTMLElement): boolean =>
   getEditingHost(caretPosition1.container(), rootNode) === getEditingHost(caretPosition2.container(), rootNode);
 
 const getChildNodeAtRelativeOffset = (relativeOffset: number, caretPosition: CaretPosition): Node | null => {

--- a/modules/tinymce/src/core/main/ts/caret/CaretUtils.ts
+++ b/modules/tinymce/src/core/main/ts/caret/CaretUtils.ts
@@ -77,9 +77,11 @@ const findNode = (node: Node, direction: number, predicateFn: (node: Node) => bo
 };
 
 const getEditingHost = (node: Node, rootNode: HTMLElement): HTMLElement => {
-  return PredicateFind.ancestor(SugarElement.fromDom(node), (node) => isContentEditableTrue(node.dom), (node) => node.dom === rootNode)
+  const isCETrue = (node: SugarElement<Node>): node is SugarElement<HTMLElement> => isContentEditableTrue(node.dom);
+  const isRoot = (node: SugarElement<Node>) => node.dom === rootNode;
+  return PredicateFind.ancestor(SugarElement.fromDom(node), isCETrue, isRoot)
     .map((elm) => elm.dom)
-    .getOr(rootNode) as HTMLElement;
+    .getOr(rootNode);
 };
 
 const getParentBlock = (node: Node, rootNode?: Node): Node | null => {

--- a/modules/tinymce/src/core/main/ts/keyboard/NavigationUtils.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/NavigationUtils.ts
@@ -130,16 +130,15 @@ const moveVertically = (editor: Editor, direction: LineWalker.VDirection, range:
 
 const getLineEndPoint = (editor: Editor, forward: boolean): Optional<CaretPosition> => {
   const rng = editor.selection.getRng();
-  const body = editor.getBody();
+  const from = forward ? CaretPosition.fromRangeEnd(rng) : CaretPosition.fromRangeStart(rng);
+  const host = CaretUtils.getEditingHost(from.container(), editor.getBody());
 
   if (forward) {
-    const from = CaretPosition.fromRangeEnd(rng);
-    const result = getPositionsUntilNextLine(body, from);
-    return Arr.last(result.positions);
+    const lineInfo = getPositionsUntilNextLine(host, from);
+    return Arr.last(lineInfo.positions);
   } else {
-    const from = CaretPosition.fromRangeStart(rng);
-    const result = getPositionsUntilPreviousLine(body, from);
-    return Arr.head(result.positions);
+    const lineInfo = getPositionsUntilPreviousLine(host, from);
+    return Arr.head(lineInfo.positions);
   }
 };
 

--- a/modules/tinymce/src/core/test/ts/browser/caret/CaretUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/CaretUtilsTest.ts
@@ -122,27 +122,32 @@ describe('browser.tinymce.core.CaretUtilTest', () => {
 
     assert.isTrue(CaretUtils.isInSameEditingHost(
       CaretPosition(findElm('p:first-of-type').firstChild, 0),
-      CaretPosition(findElm('p:first-of-type').firstChild, 1)
+      CaretPosition(findElm('p:first-of-type').firstChild, 1),
+      getRoot()
     ));
 
     assert.isTrue(CaretUtils.isInSameEditingHost(
       CaretPosition(findElm('p:first-of-type').firstChild, 0),
-      CaretPosition(getRoot().childNodes[1], 1)
+      CaretPosition(getRoot().childNodes[1], 1),
+      getRoot()
     ));
 
     assert.isTrue(CaretUtils.isInSameEditingHost(
       CaretPosition(findElm('span span:first-of-type').firstChild, 0),
-      CaretPosition(findElm('span span:first-of-type').firstChild, 1)
+      CaretPosition(findElm('span span:first-of-type').firstChild, 1),
+      getRoot()
     ));
 
     assert.isFalse(CaretUtils.isInSameEditingHost(
       CaretPosition(findElm('p:first-of-type').firstChild, 0),
-      CaretPosition(findElm('span span:first-of-type').firstChild, 1)
+      CaretPosition(findElm('span span:first-of-type').firstChild, 1),
+      getRoot()
     ));
 
     assert.isFalse(CaretUtils.isInSameEditingHost(
       CaretPosition(findElm('span span:first-of-type').firstChild, 0),
-      CaretPosition(findElm('span span:last-of-type').firstChild, 1)
+      CaretPosition(findElm('span span:last-of-type').firstChild, 1),
+      getRoot()
     ));
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorLanguageTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorLanguageTest.ts
@@ -22,6 +22,6 @@ describe('browser.tinymce.core.init.InitEditorLanguageTest', () => {
   it('TBA: Should have been able to load a custom language pack', () => {
     UiFinder.notExists(SugarBody.body(), '.tox-notification');
     assert.equal(I18n.getCode(), 'custom', 'I18n language code should be the custom language code');
-    assert.deepEqual(I18n.getData(), { custom: customLanguagePack }, 'I18n data should have custom language pack');
+    assert.deepEqual(I18n.getData().custom, customLanguagePack, 'I18n data should have custom language pack');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/HomeEndKeysTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/HomeEndKeysTest.ts
@@ -17,7 +17,7 @@ describe('browser.tinymce.core.keyboard.HomeEndKeysTest', () => {
       editor.setContent('<p>123</p><p><span contenteditable="false">CEF</span>456</p>');
       TinySelections.setCursor(editor, [ 1, 1 ], 3);
       TinyContentActions.keystroke(editor, Keys.home());
-      TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
+      TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
     });
 
     it('Home key should move caret from after cef to before cef', () => {
@@ -25,7 +25,7 @@ describe('browser.tinymce.core.keyboard.HomeEndKeysTest', () => {
       editor.setContent('<p><span contenteditable="false">CEF</span></p>');
       TinySelections.setCursor(editor, [ 0 ], 1);
       TinyContentActions.keystroke(editor, Keys.home());
-      TinyAssertions.assertSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 0);
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
     });
 
     it('Home key should move caret to before cef from the start of range', () => {
@@ -33,7 +33,7 @@ describe('browser.tinymce.core.keyboard.HomeEndKeysTest', () => {
       editor.setContent('<p>123</p><p><span contenteditable="false">CEF</span>456<br>789</p>');
       TinySelections.setSelection(editor, [ 1, 1 ], 3, [ 1, 1 ], 3);
       TinyContentActions.keystroke(editor, Keys.home());
-      TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
+      TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
     });
 
     it('Home key should not move caret before cef within the same block if there is a BR in between', () => {
@@ -41,7 +41,7 @@ describe('browser.tinymce.core.keyboard.HomeEndKeysTest', () => {
       editor.setContent('<p>123</p><p><span contenteditable="false">CEF</span><br>456</p>');
       TinySelections.setCursor(editor, [ 1, 2 ], 3);
       TinyContentActions.keystroke(editor, Keys.home());
-      TinyAssertions.assertSelection(editor, [ 1, 2 ], 3, [ 1, 2 ], 3);
+      TinyAssertions.assertCursor(editor, [ 1, 2 ], 3);
     });
 
     it('Home key should not move caret if there is no cef', () => {
@@ -49,7 +49,7 @@ describe('browser.tinymce.core.keyboard.HomeEndKeysTest', () => {
       editor.setContent('<p>123</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], 1);
       TinyContentActions.keystroke(editor, Keys.home());
-      TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 1);
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
     });
 
     it('TINY-8201: Home key should not move caret outside of closest editing host', () => {
@@ -85,7 +85,7 @@ describe('browser.tinymce.core.keyboard.HomeEndKeysTest', () => {
       editor.setContent('<p>123<span contenteditable="false">CEF</span></p><p>456</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       TinyContentActions.keystroke(editor, Keys.end());
-      TinyAssertions.assertSelection(editor, [ 0, 2 ], 1, [ 0, 2 ], 1);
+      TinyAssertions.assertCursor(editor, [ 0, 2 ], 1);
     });
 
     it('End key should move caret from before cef to after cef', () => {
@@ -93,7 +93,7 @@ describe('browser.tinymce.core.keyboard.HomeEndKeysTest', () => {
       editor.setContent('<p><span contenteditable="false">CEF</span></p>');
       TinySelections.setCursor(editor, [ 0 ], 0);
       TinyContentActions.keystroke(editor, Keys.end());
-      TinyAssertions.assertSelection(editor, [ 0, 1 ], 1, [ 0, 1 ], 1);
+      TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
     });
 
     it('End key should move caret to after cef from the end of range', () => {
@@ -101,7 +101,7 @@ describe('browser.tinymce.core.keyboard.HomeEndKeysTest', () => {
       editor.setContent('<p>123<br>456<span contenteditable="false">CEF</span></p>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 2 ], 0);
       TinyContentActions.keystroke(editor, Keys.end());
-      TinyAssertions.assertSelection(editor, [ 0, 4 ], 1, [ 0, 4 ], 1);
+      TinyAssertions.assertCursor(editor, [ 0, 4 ], 1);
     });
 
     it('End key should not move caret after cef within the same block if there is a BR in between', () => {
@@ -109,7 +109,7 @@ describe('browser.tinymce.core.keyboard.HomeEndKeysTest', () => {
       editor.setContent('<p>123<br><span contenteditable="false">CEF</span></p><p>456</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       TinyContentActions.keystroke(editor, Keys.end());
-      TinyAssertions.assertSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 0);
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
     });
 
     it('End key should not move caret if there is no cef', () => {
@@ -117,7 +117,7 @@ describe('browser.tinymce.core.keyboard.HomeEndKeysTest', () => {
       editor.setContent('<p>123</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], 1);
       TinyContentActions.keystroke(editor, Keys.end());
-      TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 1);
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
     });
 
     it('TINY-8201: End key should not move caret outside of closest editing host', () => {

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/HomeEndKeysTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/HomeEndKeysTest.ts
@@ -52,6 +52,14 @@ describe('browser.tinymce.core.keyboard.HomeEndKeysTest', () => {
       TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 1);
     });
 
+    it('TINY-8201: Home key should not move caret outside of closest editing host', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>x</p><div contenteditable="false"><div contenteditable="true"><p>123</p></div></div>');
+      TinySelections.setCursor(editor, [ 1, 0, 0, 0 ], 1);
+      TinyContentActions.keystroke(editor, Keys.home());
+      TinyAssertions.assertCursor(editor, [ 1, 0, 0, 0 ], 1);
+    });
+
     context('Inline boundaries', () => {
       it('TINY-4612: move caret out and at the beginning of the element', () => {
         const editor = hook.editor();
@@ -110,6 +118,14 @@ describe('browser.tinymce.core.keyboard.HomeEndKeysTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 1);
       TinyContentActions.keystroke(editor, Keys.end());
       TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 1);
+    });
+
+    it('TINY-8201: End key should not move caret outside of closest editing host', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>x</p><div contenteditable="false"><div contenteditable="true"><p>123</p></div></div>');
+      TinySelections.setCursor(editor, [ 1, 0, 0, 0 ], 1);
+      TinyContentActions.keystroke(editor, Keys.end());
+      TinyAssertions.assertCursor(editor, [ 1, 0, 0, 0 ], 1);
     });
 
     context('Inline boundaries', () => {

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/HomeEndKeysTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/HomeEndKeysTest.ts
@@ -60,6 +60,14 @@ describe('browser.tinymce.core.keyboard.HomeEndKeysTest', () => {
       TinyAssertions.assertCursor(editor, [ 1, 0, 0, 0 ], 1);
     });
 
+    it('TINY-8201: Home key should move caret to closest cef inside the closest editing host', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>x</p><div contenteditable="false"><div contenteditable="true"><p><span contenteditable="false">CEF</span>123</p></div></div>');
+      TinySelections.setCursor(editor, [ 1, 0, 0, 1 ], 1);
+      TinyContentActions.keystroke(editor, Keys.home());
+      TinyAssertions.assertCursor(editor, [ 1, 0, 0, 0 ], 0);
+    });
+
     context('Inline boundaries', () => {
       it('TINY-4612: move caret out and at the beginning of the element', () => {
         const editor = hook.editor();
@@ -126,6 +134,14 @@ describe('browser.tinymce.core.keyboard.HomeEndKeysTest', () => {
       TinySelections.setCursor(editor, [ 1, 0, 0, 0 ], 1);
       TinyContentActions.keystroke(editor, Keys.end());
       TinyAssertions.assertCursor(editor, [ 1, 0, 0, 0 ], 1);
+    });
+
+    it('TINY-8201: End key should move caret to closest cef inside the closest editing host', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>x</p><div contenteditable="false"><div contenteditable="true"><p>123<span contenteditable="false">CEF</span></p></div></div>');
+      TinySelections.setCursor(editor, [ 1, 0, 0, 0 ], 1);
+      TinyContentActions.keystroke(editor, Keys.end());
+      TinyAssertions.assertCursor(editor, [ 1, 0, 0, 2 ], 1);
     });
 
     context('Inline boundaries', () => {


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Fixes an issue where home and end keys would move outside the current editable host element
* Sneaked in a fix for a test that was flaking on/off due to the 100 test pivot point moving around
* Cleaned up the tests a bit so that is uses `assertCursor` instead of `assertSelection`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
