### PR TITLE
TINY-6946: Added regression tests for base64 image parsing

### DIFF
--- a/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
@@ -134,7 +134,12 @@ describe('atomic.tinymce.core.html.Base64UrisTest', () => {
     KAssert.eqOptional('Data uri without base64', Optional.none(), parseDataUri('data:image/svg+xml,R4/yw=='));
     KAssert.eqOptional('Data with spaces, tabs and line breaks', Optional.some({ type: 'image/png', data: 'SGVsbG8sI\r\n  Hdv		cmxkIQ==' }), parseDataUri('data:image/png;base64,SGVsbG8sI\r\n  Hdv		cmxkIQ=='));
     KAssert.eqOptional('Corrupted data', Optional.some({ type: 'image/gif', data: 'R0' }), parseDataUri('data:image/gif;base64,R0ÖlGODdhIAAgAIABAP8AAP///ywAAAAAIAAgAAACHoSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gubBQA7AA==%A0'));
-    // eslint-disable-next-line max-len
-    KAssert.eqOptional('Corrupted data due to added letters', Optional.some({ type: 'image/gif', data: 'R0lGODdhIAAgAIABAP8AAP///ywAAAAAIAAgAAACHoSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gubBQA7AA==' }), parseDataUri('data:image/gif;base64,R0lGODdhIAAgAIABAP8AAP///ywAAAAAIAAgAAACHoSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gubBQA7AA==%A0'));
+    KAssert.eqOptional(
+      'Corrupted data due to added letters',
+      Optional.some({
+        type: 'image/gif',
+        data: 'R0lGODdhIAAgAIABAP8AAP///ywAAAAAIAAgAAACHoSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gubBQA7AA=='
+      }),
+      parseDataUri('data:image/gif;base64,R0lGODdhIAAgAIABAP8AAP///ywAAAAAIAAgAAACHoSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gubBQA7AA==%A0'));
   });
 });

--- a/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
@@ -133,5 +133,8 @@ describe('atomic.tinymce.core.html.Base64UrisTest', () => {
     KAssert.eqOptional('Data uri without mime', Optional.none(), parseDataUri('data:base64,R3/yw=='));
     KAssert.eqOptional('Data uri without base64', Optional.none(), parseDataUri('data:image/svg+xml,R4/yw=='));
     KAssert.eqOptional('Data with spaces, tabs and line breaks', Optional.some({ type: 'image/png', data: 'SGVsbG8sI\r\n  Hdv		cmxkIQ==' }), parseDataUri('data:image/png;base64,SGVsbG8sI\r\n  Hdv		cmxkIQ=='));
+    KAssert.eqOptional('Corrupted data', Optional.some({ type: 'image/gif', data: 'R0' }), parseDataUri('data:image/gif;base64,R0ÖlGODdhIAAgAIABAP8AAP///ywAAAAAIAAgAAACHoSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gubBQA7AA==%A0'));
+    // eslint-disable-next-line max-len
+    KAssert.eqOptional('Corrupted data due to added letters', Optional.some({ type: 'image/gif', data: 'R0lGODdhIAAgAIABAP8AAP///ywAAAAAIAAgAAACHoSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gubBQA7AA==' }), parseDataUri('data:image/gif;base64,R0lGODdhIAAgAIABAP8AAP///ywAAAAAIAAgAAACHoSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gubBQA7AA==%A0'));
   });
 });

--- a/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
@@ -135,7 +135,7 @@ describe('atomic.tinymce.core.html.Base64UrisTest', () => {
     KAssert.eqOptional('Data with spaces, tabs and line breaks', Optional.some({ type: 'image/png', data: 'SGVsbG8sI\r\n  Hdv		cmxkIQ==' }), parseDataUri('data:image/png;base64,SGVsbG8sI\r\n  Hdv		cmxkIQ=='));
     KAssert.eqOptional('Corrupted data', Optional.some({ type: 'image/gif', data: 'R0' }), parseDataUri('data:image/gif;base64,R0ÖlGODdhIAAgAIABAP8AAP///ywAAAAAIAAgAAACHoSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gubBQA7AA==%A0'));
     KAssert.eqOptional(
-      'Corrupted data due to added letters',
+      'Corrupted data due to added URL encoded nbsp',
       Optional.some({
         type: 'image/gif',
         data: 'R0lGODdhIAAgAIABAP8AAP///ywAAAAAIAAgAAACHoSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gubBQA7AA=='

--- a/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
@@ -469,7 +469,7 @@ describe('browser.tinymce.core.EditorTest', () => {
     input.parentNode.removeChild(input);
   });
 
-  it('TINY-6946: Images should be properly cleaned up and not cause a crash', () => {
+  it('TINY-6946: Images should be properly cleaned up if they contain invalid trailing data', () => {
     const editor = hook.editor();
     editor.setContent('<img src="data:image/gif;base64,R0lGODdhIAAgAIABAP8AAP///ywAAAAAIAAgAAACHoSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gubBQA7AA==%A0">');
     TinyAssertions.assertContent(editor, '<p><img src="data:image/gif;base64,R0lGODdhIAAgAIABAP8AAP///ywAAAAAIAAgAAACHoSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gubBQA7AA=="></p>');

--- a/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
@@ -3,7 +3,7 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Attribute, Class, SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -467,6 +467,18 @@ describe('browser.tinymce.core.EditorTest', () => {
     assert.isTrue(editor.hasFocus(), 'hasFocus');
 
     input.parentNode.removeChild(input);
+  });
+
+  it('TINY-6946: Images should be properly cleaned up and not cause a crash', () => {
+    const editor = hook.editor();
+    editor.setContent('<img src="data:image/gif;base64,R0lGODdhIAAgAIABAP8AAP///ywAAAAAIAAgAAACHoSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gubBQA7AA==%A0">');
+    TinyAssertions.assertContent(editor, '<p><img src="data:image/gif;base64,R0lGODdhIAAgAIABAP8AAP///ywAAAAAIAAgAAACHoSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gubBQA7AA=="></p>');
+  });
+
+  it('TINY-6946: Images should cut off invalid data, even if the image remains invalid', () => {
+    const editor = hook.editor();
+    editor.setContent('<img src="data:image/gif;base64,R0ÖlGODdhIAAgAIABAP8AAP///ywAAAAAIAAgAAACHoSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gubBQA7AA==%A0">');
+    TinyAssertions.assertContent(editor, '<p><img src="data:image/gif;base64,R0"></p>');
   });
 
   context('hasPlugin', () => {


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Adding tests to ensure that corrupted base64 file data does not cause the editor to crash.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
