### PR TITLE
TINY-8446: Fixed the AstNode serializer breaking pre/textarea elements that start with new lines

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -105,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dialog labels and other text-based UI properties did not escape HTML markup #TINY-7524
 - Deleting content would sometimes not fire `beforeinput` and `input` events as expected #TINY-8168 #TINY-8329
 - Anchor elements would render incorrectly when using the `allow_html_in_named_anchor` option #TINY-3799
+- The `AstNode` HTML serializer did not serialize `pre` or `textarea` elements correctly when they contained newlines #TINY-8446
 - Fixed sub-menu items not read by screen readers. Patch contributed by westonkd #TINY-8417
 
 ### Removed

--- a/modules/tinymce/src/core/main/ts/api/html/Serializer.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Serializer.ts
@@ -123,13 +123,21 @@ const HtmlSerializer = (settings?: HtmlSerializerSettings, schema = Schema()): H
           }
         }
 
-        writer.start(node.name, attrs, isEmpty);
+        writer.start(name, attrs, isEmpty);
 
         if (!isEmpty) {
-          if ((node = node.firstChild)) {
+          let child = node.firstChild;
+          if (child) {
+            // Pre and textarea elements treat the first newline character as optional and will omit it. As such, if the content starts
+            // with a newline we need to add in an additional newline to prevent the current newline in the value being treated as optional
+            // See https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
+            if ((name === 'pre' || name === 'textarea') && child.type === 3 && child.value[0] === '\n') {
+              writer.text('\n', true);
+            }
+
             do {
-              walk(node);
-            } while ((node = node.next));
+              walk(child);
+            } while ((child = child.next));
           }
 
           writer.end(name);

--- a/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
@@ -37,4 +37,24 @@ describe('browser.tinymce.core.html.SerializerTest', () => {
       '<b a="1" b="2">a</b><i a="1" b="2">b</i>'
     );
   });
+
+  it('TINY-8446: Serialize pre elements with content that starts with newlines', () => {
+    const schema = Schema({ valid_elements: 'pre' });
+    const serializer = HtmlSerializer({}, schema);
+
+    assert.equal(
+      serializer.serialize(DomParser({ validate: false }, schema).parse('<pre>\n\ncontent</pre>')),
+      '<pre>\n\ncontent</pre>'
+    );
+  });
+
+  it('TINY-8446: Serialize textarea elements with content that starts with newlines', () => {
+    const schema = Schema({ valid_elements: 'textarea' });
+    const serializer = HtmlSerializer({}, schema);
+
+    assert.equal(
+      serializer.serialize(DomParser({ validate: false }, schema).parse('<textarea>\n\ncontent</textarea>')),
+      '<textarea>\n\ncontent</textarea>'
+    );
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-8446

Description of Changes:

This fixes an issue in the AstNode/HTML serializer whereby newlines are "lost" for pre/textarea elements since the first newline is treated as optional and omitted when parsed by the browser as the newline is treated as an "authoring connivence". As noted in our calls, this however doesn't fix the DOM serializer implementation which does mean the newline is still lost on `getContent`, but it's likely to be a browser serializer bug and we want to follow that up with browser vendors first.

Note: This wasn't an issue in v5, as the custom parser didn't parse per the spec (see the Jira for more details) as it didn't treat the first newline as optional and instead treated it as part of the text inside.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
