### PR TITLE
TINY-8102: Fixed invalid HTML tags used in the deprecated comments

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -378,7 +378,7 @@ class Editor implements EditorObservable {
   /**
    * Returns a configuration parameter by name.
    * <br>
-   * <em>Deprecated in TinyMCE 6.0 and has been marked for removal in TinyMCE 7.0. Use the <code>editor.options.get<code> API instead.</em>
+   * <em>Deprecated in TinyMCE 6.0 and has been marked for removal in TinyMCE 7.0. Use the <code>editor.options.get</code> API instead.</em>
    *
    * @method getParam
    * @param {String} name Configuration parameter to retrieve.

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1808,7 +1808,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     /**
      * Fires the specified event name and optional object on the specified target.
      * <br>
-     * <em>Deprecated in TinyMCE 6.0 and has been marked for removal in TinyMCE 7.0. Use <code>dispatch<code> instead.</em>
+     * <em>Deprecated in TinyMCE 6.0 and has been marked for removal in TinyMCE 7.0. Use <code>dispatch</code> instead.</em>
      *
      * @method fire
      * @param {Node/Document/Window} target Target element or object to fire event on.

--- a/modules/tinymce/src/core/main/ts/api/dom/EventUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/EventUtils.ts
@@ -383,7 +383,7 @@ class EventUtils {
   /**
    * Fires the specified event on the specified target.
    * <br>
-   * <em>Deprecated in TinyMCE 6.0 and has been marked for removal in TinyMCE 7.0. Use <code>dispatch<code> instead.</em>
+   * <em>Deprecated in TinyMCE 6.0 and has been marked for removal in TinyMCE 7.0. Use <code>dispatch</code> instead.</em>
    *
    * @method fire
    * @param {Object} target Target node/window or custom object.

--- a/modules/tinymce/src/core/main/ts/api/util/EventDispatcher.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/EventDispatcher.ts
@@ -128,7 +128,7 @@ class EventDispatcher<T> {
   /**
    * Fires the specified event by name.
    * <br>
-   * <em>Deprecated in TinyMCE 6.0 and has been marked for removal in TinyMCE 7.0. Use <code>dispatch<code> instead.</em>
+   * <em>Deprecated in TinyMCE 6.0 and has been marked for removal in TinyMCE 7.0. Use <code>dispatch</code> instead.</em>
    *
    * @method fire
    * @param {String} name Name of the event to fire.

--- a/modules/tinymce/src/core/main/ts/api/util/Observable.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Observable.ts
@@ -43,7 +43,7 @@ const Observable: Observable<any> = {
    * Fires the specified event by name. Consult the
    * <a href="/docs/advanced/events">event reference</a> for more details on each event.
    * <br>
-   * <em>Deprecated in TinyMCE 6.0 and has been marked for removal in TinyMCE 7.0. Use <code>dispatch<code> instead.</em>
+   * <em>Deprecated in TinyMCE 6.0 and has been marked for removal in TinyMCE 7.0. Use <code>dispatch</code> instead.</em>
    *
    * @method fire
    * @param {String} name Name of the event to fire.


### PR DESCRIPTION
Related Ticket: TINY-8102

Description of Changes:
* Fixed invalid HTML tags used in the deprecated comments

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
