### PR TITLE
TINY-8509: Cleaned up various items and upgraded deps

### DIFF
--- a/modules/alloy/src/test/ts/atomic/toolbar/OverflowTest.ts
+++ b/modules/alloy/src/test/ts/atomic/toolbar/OverflowTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Overflows from 'ephox/alloy/toolbar/Overflows';
 
@@ -7,8 +7,8 @@ UnitTest.test('OverflowTest', () => {
 
   const check = (expectedWithin: string[], expectedExtra: string[], total: number, input: string[], overflower: string) => {
     const actual = Overflows.partition(total, input, len, overflower);
-    assert.eq(expectedWithin, actual.within);
-    assert.eq(expectedExtra, actual.extra);
+    Assert.eq('', expectedWithin, actual.within);
+    Assert.eq('', expectedExtra, actual.extra);
   };
 
   check([ 'cat' ], [], 100, [ 'cat' ], 'overflow');

--- a/modules/boss/src/test/ts/atomic/AttributionTest.ts
+++ b/modules/boss/src/test/ts/atomic/AttributionTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import { Gene } from 'ephox/boss/api/Gene';
 import * as Attribution from 'ephox/boss/mutant/Attribution';
@@ -7,15 +7,15 @@ UnitTest.test('AttributionTest', () => {
   const item = Gene('id1', 'name1', [], {}, { border: '10' });
   const b = Gene('id2', 'name2', [], {}, { cat: 'dog' });
 
-  assert.eq({ border: '10' }, item.attrs);
+  Assert.eq('', { border: '10' }, item.attrs);
   Attribution.set(item, 'cat', 'mogel');
-  assert.eq({ border: '10', cat: 'mogel' }, item.attrs);
+  Assert.eq('', { border: '10', cat: 'mogel' }, item.attrs);
   Attribution.remove(item, 'cat');
-  assert.eq({ border: '10' }, item.attrs);
-  assert.eq('10', Attribution.get(item, 'border'));
+  Assert.eq('', { border: '10' }, item.attrs);
+  Assert.eq('', '10', Attribution.get(item, 'border'));
 
   Attribution.copyTo(item, b);
-  assert.eq({
+  Assert.eq('', {
     cat: 'dog',
     border: '10'
   }, b.attrs);

--- a/modules/boss/src/test/ts/atomic/ComparatorTest.ts
+++ b/modules/boss/src/test/ts/atomic/ComparatorTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import { Gene } from 'ephox/boss/api/Gene';
 import * as Comparator from 'ephox/boss/mutant/Comparator';
@@ -11,21 +11,21 @@ UnitTest.test('ComparatorTest', () => {
   const c = Gene('id3', 'c', [], {}, {});
 
   // name
-  assert.eq(true, Comparator.is(a, 'fred,bob,sam'));
-  assert.eq(false, Comparator.is(a, 'fred,sam'));
-  assert.eq(false, Comparator.is(a, 'border'));
+  Assert.eq('', true, Comparator.is(a, 'fred,bob,sam'));
+  Assert.eq('', false, Comparator.is(a, 'fred,sam'));
+  Assert.eq('', false, Comparator.is(a, 'border'));
 
-  assert.eq(true, Comparator.is(b, 'b name'));
-  assert.eq(false, Comparator.is(b, 'dog'));
+  Assert.eq('', true, Comparator.is(b, 'b name'));
+  Assert.eq('', false, Comparator.is(b, 'dog'));
 
   // attr
-  assert.eq(true, Comparator.is(a, '[border]'));
-  assert.eq(false, Comparator.is(a, '[foobar]'));
+  Assert.eq('', true, Comparator.is(a, '[border]'));
+  Assert.eq('', false, Comparator.is(a, '[foobar]'));
 
-  assert.eq(true, Comparator.is(b, '[cat]'));
-  assert.eq(false, Comparator.is(b, '[dog]'));
-  assert.eq(false, Comparator.is(b, '[]'));
+  Assert.eq('', true, Comparator.is(b, '[cat]'));
+  Assert.eq('', false, Comparator.is(b, '[dog]'));
+  Assert.eq('', false, Comparator.is(b, '[]'));
 
-  assert.eq(false, Comparator.is(c, '[]'));
-  assert.eq(false, Comparator.is(c, '[bob]'));
+  Assert.eq('', false, Comparator.is(c, '[]'));
+  Assert.eq('', false, Comparator.is(c, '[bob]'));
 });

--- a/modules/boss/src/test/ts/atomic/CreatorTest.ts
+++ b/modules/boss/src/test/ts/atomic/CreatorTest.ts
@@ -1,8 +1,8 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import { Gene } from 'ephox/boss/api/Gene';
 import * as Creator from 'ephox/boss/mutant/Creator';
 
 UnitTest.test('CreatorTest', () => {
-  assert.eq(Gene('clone**<c>', 'cat', []), Creator.clone(Gene('c', 'cat', [ Gene('kitten', 'kitten') ])));
+  Assert.eq('', Gene('clone**<c>', 'cat', []), Creator.clone(Gene('c', 'cat', [ Gene('kitten', 'kitten') ])));
 });

--- a/modules/boss/src/test/ts/atomic/DownTest.ts
+++ b/modules/boss/src/test/ts/atomic/DownTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
 
 import { Gene } from 'ephox/boss/api/Gene';
@@ -25,7 +25,7 @@ UnitTest.test('DownTest', () => {
     ]), Optional.none());
 
   const check = (expected: string[], actual: Gene[]) => {
-    assert.eq(expected, Arr.map(actual, (item) => {
+    Assert.eq('', expected, Arr.map(actual, (item) => {
       return item.id;
     }));
   };

--- a/modules/boss/src/test/ts/atomic/InsertionTest.ts
+++ b/modules/boss/src/test/ts/atomic/InsertionTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
 
 import { Gene } from 'ephox/boss/api/Gene';
@@ -25,7 +25,7 @@ UnitTest.test('InsertionTest', () => {
     const anchor = Locator.byId(family, anchorId).getOrDie();
     const item = Locator.byId(family, itemId).getOrDie();
     method(anchor, item);
-    assert.eq(expected, Logger.basic(family));
+    Assert.eq('', expected, Logger.basic(family));
   };
 
   const checkBefore = (expected: string, input: Gene, anchorId: string, itemId: string) => {
@@ -40,7 +40,7 @@ UnitTest.test('InsertionTest', () => {
     const family = Tracks.track(input, Optional.none());
     const anchor = Locator.byId(family, anchorId).getOrDie();
     Insertion.wrap(anchor, wrapper);
-    assert.eq(expected, Logger.basic(family));
+    Assert.eq('', expected, Logger.basic(family));
   };
 
   // initially A(B,C(D(E),F))
@@ -61,7 +61,7 @@ UnitTest.test('InsertionTest', () => {
       return Locator.byId(family, itemId).getOrDie('Did not find item: ' + itemId);
     });
     Insertion.afterAll(anchor, items);
-    assert.eq(expected, Logger.basic(family));
+    Assert.eq('', expected, Logger.basic(family));
   };
 
   checkAfterAll('A(B,C(D,E,F))', data(), 'D', [ 'E', 'F' ]);

--- a/modules/boss/src/test/ts/atomic/PropertiesTest.ts
+++ b/modules/boss/src/test/ts/atomic/PropertiesTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import { CommentGene } from 'ephox/boss/api/CommentGene';
 import { Gene } from 'ephox/boss/api/Gene';
@@ -11,7 +11,7 @@ UnitTest.test('PropertiesTest', () => {
   const c = CommentGene('-comment-', 'comment');
 
   const check = (expected: boolean, element: Gene, pred: (e: Gene) => boolean) => {
-    assert.eq(expected, pred(element));
+    Assert.eq('', expected, pred(element));
   };
 
   check(true, g, Properties.isElement);

--- a/modules/boss/src/test/ts/atomic/QueryTest.ts
+++ b/modules/boss/src/test/ts/atomic/QueryTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import { Gene } from 'ephox/boss/api/Gene';
 import { TestUniverse } from 'ephox/boss/api/TestUniverse';
@@ -24,13 +24,13 @@ UnitTest.test('QueryTest', () => {
   const checkPrev = (expected: string, id: string) => {
     const first = universe.find(universe.get(), id).getOrDie();
     const actual = Query.prevSibling(first).map((e) => e.id).getOr('_nope_');
-    assert.eq(expected, actual);
+    Assert.eq('', expected, actual);
   };
 
   const checkNext = (expected: string, id: string) => {
     const first = universe.find(universe.get(), id).getOrDie();
     const actual = Query.nextSibling(first).map((e) => e.id).getOr('_nope_');
-    assert.eq(expected, actual);
+    Assert.eq('', expected, actual);
   };
 
   const checkPosition = (expected: number, one: string, other: string) => {
@@ -38,7 +38,7 @@ UnitTest.test('QueryTest', () => {
     const last = universe.find(universe.get(), other).getOrDie();
 
     const actual = Query.comparePosition(first, last);
-    assert.eq(expected, actual);
+    Assert.eq('', expected, actual);
   };
 
   checkPosition(4, '1.1.1', '1.1.2');

--- a/modules/boss/src/test/ts/atomic/RemovalTest.ts
+++ b/modules/boss/src/test/ts/atomic/RemovalTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
 
 import { Gene } from 'ephox/boss/api/Gene';
@@ -24,7 +24,7 @@ UnitTest.test('RemovalTest', () => {
     const family = Tracks.track(input, Optional.none());
     const item = Locator.byId(family, itemId).getOrDie();
     Removal.unwrap(item);
-    assert.eq(expected, Logger.basic(family));
+    Assert.eq('', expected, Logger.basic(family));
   };
 
   check('A(B,D(E),F)', data(), 'C');

--- a/modules/boss/src/test/ts/atomic/TracksTest.ts
+++ b/modules/boss/src/test/ts/atomic/TracksTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
 
 import { Gene } from 'ephox/boss/api/Gene';
@@ -28,17 +28,17 @@ UnitTest.test('TracksTest', () => {
     return item.parent.getOrDie('Expected to have parent').id;
   };
 
-  assert.eq('A', a.id);
-  assert.eq('B', b.id);
-  assert.eq('C', c.id);
-  assert.eq('D', d.id);
-  assert.eq('E', e.id);
-  assert.eq('F', f.id);
+  Assert.eq('', 'A', a.id);
+  Assert.eq('', 'B', b.id);
+  Assert.eq('', 'C', c.id);
+  Assert.eq('', 'D', d.id);
+  Assert.eq('', 'E', e.id);
+  Assert.eq('', 'F', f.id);
 
-  assert.eq('parent', p(a));
-  assert.eq('A', p(b));
-  assert.eq('A', p(c));
-  assert.eq('C', p(d));
-  assert.eq('D', p(e));
-  assert.eq('C', p(f));
+  Assert.eq('', 'parent', p(a));
+  Assert.eq('', 'A', p(b));
+  Assert.eq('', 'A', p(c));
+  Assert.eq('', 'C', p(d));
+  Assert.eq('', 'D', p(e));
+  Assert.eq('', 'C', p(f));
 });

--- a/modules/boulder/src/test/ts/atomic/api/StructureSchemaFuncTest.ts
+++ b/modules/boulder/src/test/ts/atomic/api/StructureSchemaFuncTest.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@ephox/agar';
-import { Assert, assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Result } from '@ephox/katamari';
 
 import * as FieldSchema from 'ephox/boulder/api/FieldSchema';
@@ -14,7 +14,7 @@ UnitTest.test('Atomic Test: api.StructureSchemaFuncTest', () => {
       const message = StructureSchema.formatError(err);
       Assert.eq(label + '. Was looking to see if contained: ' + expectedPart + '.\nWas: ' + message, true, message.indexOf(expectedPart) > -1);
     }, (val) => {
-      assert.fail(label + '\nExpected error: ' + expectedPart + '\nWas success(' + JSON.stringify(val, null, 2) + ')');
+      Assert.fail(label + '\nExpected error: ' + expectedPart + '\nWas success(' + JSON.stringify(val, null, 2) + ')');
     });
   };
 
@@ -32,7 +32,7 @@ UnitTest.test('Atomic Test: api.StructureSchemaFuncTest', () => {
       }
 
       if (passed !== null) {
-        assert.fail(label + '\nExpected error: ' + expectedPart + '\nWas success(' + JSON.stringify(passed, null, 2) + ')');
+        Assert.fail(label + '\nExpected error: ' + expectedPart + '\nWas success(' + JSON.stringify(passed, null, 2) + ')');
       }
     });
   };

--- a/modules/boulder/src/test/ts/atomic/api/StructureSchemaRawTest.ts
+++ b/modules/boulder/src/test/ts/atomic/api/StructureSchemaRawTest.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@ephox/agar';
-import { Assert, assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Fun, Result } from '@ephox/katamari';
 import { KAssert } from '@ephox/katamari-assertions';
 
@@ -16,7 +16,7 @@ UnitTest.test('StructureSchemaRawTest', () => {
       const message = StructureSchema.formatError(err);
       Assert.eq(label + '. Was looking to see if contained: ' + expectedPart + '.\nWas: ' + message, true, message.indexOf(expectedPart) > -1);
     }, (val) => {
-      assert.fail(label + '\nExpected error: ' + expectedPart + '\nWas success(' + JSON.stringify(val, null, 2) + ')');
+      Assert.fail(label + '\nExpected error: ' + expectedPart + '\nWas success(' + JSON.stringify(val, null, 2) + ')');
     });
   };
 
@@ -423,7 +423,7 @@ UnitTest.test('StructureSchemaRawTest', () => {
       num: 42,
       str: 'a'
     }).fold(
-      () => assert.fail('Should not fail'),
+      () => Assert.fail('Should not fail'),
       (actual) => Assert.eq('Should be expected object', {
         num: 42,
         str: 'a'
@@ -432,7 +432,7 @@ UnitTest.test('StructureSchemaRawTest', () => {
 
     StructureSchema.asRaw<SomeType>('SomeType', schema, {}).fold(
       (err) => Assert.eq('Should be two errors', 2, err.errors.length),
-      () => assert.fail('Should not pass')
+      () => Assert.fail('Should not pass')
     );
   });
 

--- a/modules/dragster/src/test/ts/atomic/DraggerTest.ts
+++ b/modules/dragster/src/test/ts/atomic/DraggerTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Fun, Optional } from '@ephox/katamari';
 import { SugarElement, SugarPosition } from '@ephox/sugar';
 
@@ -17,7 +17,7 @@ UnitTest.test('DraggerTest', () => {
     compare: (old: any, nu: any) => (nu - old) as unknown as SugarPosition,
     extract: (raw: any) => Optional.from(parseInt(raw, 10) as unknown as SugarPosition),
     mutate: (mutation, data) => {
-      assert.eq(argumentToMutate, mutation);
+      Assert.eq('', argumentToMutate, mutation);
       mutations.push(data as any as number);
     },
     sink: (dragApi, _settings) => {
@@ -25,7 +25,7 @@ UnitTest.test('DraggerTest', () => {
       return DragSink({
         element: () => 'element' as unknown as SugarElement<HTMLElement>, // fake element
         start: (v) => {
-          assert.eq(argumentToStart, v);
+          Assert.eq('', argumentToStart, v);
         },
         stop: Fun.noop,
         destroy: Fun.noop
@@ -38,35 +38,35 @@ UnitTest.test('DraggerTest', () => {
   const api = optApi.getOrDie('API not loaded');
   // While dragging is not on, nothing should be collected
   dragging.go(argumentToStart);
-  assert.eq([ ], mutations);
+  Assert.eq('', [ ], mutations);
   api.move('10' as any);
-  assert.eq([ ], mutations);
+  Assert.eq('', [ ], mutations);
   api.move('20' as any);
-  assert.eq([ ], mutations);
+  Assert.eq('', [ ], mutations);
 
   dragging.on();
   // The first value is only used for calibration
   api.move('15' as any);
-  assert.eq([ ], mutations);
+  Assert.eq('', [ ], mutations);
   api.move('20' as any);
-  assert.eq([ 20 - 15 ], mutations);
+  Assert.eq('', [ 20 - 15 ], mutations);
   api.move('21' as any);
-  assert.eq([ 20 - 15, 21 - 20 ], mutations);
+  Assert.eq('', [ 20 - 15, 21 - 20 ], mutations);
   api.drop();
-  assert.eq([ 20 - 15, 21 - 20 ], mutations);
+  Assert.eq('', [ 20 - 15, 21 - 20 ], mutations);
 
   // Now that we have dropped, start moving again and check that it isn't logged.
   api.move('22' as any);
-  assert.eq([ 20 - 15, 21 - 20 ], mutations);
+  Assert.eq('', [ 20 - 15, 21 - 20 ], mutations);
   api.move('23' as any);
-  assert.eq([ 20 - 15, 21 - 20 ], mutations);
+  Assert.eq('', [ 20 - 15, 21 - 20 ], mutations);
 
   // Now, start it again.
   dragging.go(argumentToStart);
-  assert.eq([ 20 - 15, 21 - 20 ], mutations);
+  Assert.eq('', [ 20 - 15, 21 - 20 ], mutations);
   // First one calibrates.
   api.move('24' as any);
-  assert.eq([ 20 - 15, 21 - 20 ], mutations);
+  Assert.eq('', [ 20 - 15, 21 - 20 ], mutations);
   api.move('40' as any);
-  assert.eq([ 20 - 15, 21 - 20, 40 - 24 ], mutations);
+  Assert.eq('', [ 20 - 15, 21 - 20, 40 - 24 ], mutations);
 });

--- a/modules/jax/src/test/ts/atomic/core/UrlBuilderTest.ts
+++ b/modules/jax/src/test/ts/atomic/core/UrlBuilderTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
 
 import { buildUrl } from 'ephox/jax/core/UrlBuilder';
@@ -8,7 +8,7 @@ UnitTest.test('UrlBuilderTest', () => {
 
   // copied from agar, perhaps we should move it to bedrock
   const assertEq = (label: string, expected: string, actual: string) => {
-    assert.eq(expected, actual, `${label}.\n  Expected: ${expected} \n  Actual: ${actual}`);
+    Assert.eq(`${label}.\n  Expected: ${expected} \n  Actual: ${actual}`, expected, actual);
   };
 
   assertEq('Should remain unchanged', 'http://localhost', buildUrl('http://localhost', Optional.none()));

--- a/modules/jax/src/test/ts/browser/AjaxTest.ts
+++ b/modules/jax/src/test/ts/browser/AjaxTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, FutureResult, Result } from '@ephox/katamari';
 
 import { readBlobAsText } from 'ephox/jax/core/BlobReader';
@@ -25,7 +25,7 @@ const expectValue = (label: string, value: any, response: FutureResult<any, Http
       callback(Result.error(new Error(err.message)));
     }, (val) => {
       try {
-        assert.eq(value, val);
+        Assert.eq('', value, val);
         console.log(label, 'passed with ', val);
         callback(Result.value({}));
       } catch (err: any) {
@@ -42,7 +42,7 @@ const expectBlobJson = (label: string, value: any, response: FutureResult<Blob, 
     }, (blob) => {
       readBlobAsText(blob).get((text) => {
         try {
-          assert.eq(JSON.stringify(value, null, '  '), text);
+          Assert.eq('', JSON.stringify(value, null, '  '), text);
           console.log(label, 'passed with ', text);
           callback(Result.value({}));
         } catch (err: any) {

--- a/modules/jax/src/test/ts/browser/HttpDownloadTest.ts
+++ b/modules/jax/src/test/ts/browser/HttpDownloadTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { FutureResult } from '@ephox/katamari';
 
 import { readBlobAsText } from 'ephox/jax/core/BlobReader';
@@ -25,9 +25,9 @@ UnitTest.asynctest('HttpDownloadTest', (success, failure) => {
       (actualText) => {
         const expectedText = JSON.stringify({ results: { data: '123' }}, null, '  ');
 
-        assert.eq(expectedText, actualText, 'Should be the expected text');
-        assert.eq(true, progressCalls > 1, 'Should be more than 1 progress calls');
-        assert.eq(40, total, 'Should be 40 bytes of data in total');
+        Assert.eq('Should be the expected text', expectedText, actualText);
+        Assert.eq('Should be more than 1 progress calls', true, progressCalls > 1);
+        Assert.eq('Should be 40 bytes of data in total', 40, total);
 
         success();
       }

--- a/modules/jax/src/test/ts/browser/HttpJwtTest.ts
+++ b/modules/jax/src/test/ts/browser/HttpJwtTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, FutureResult, Result } from '@ephox/katamari';
 
 import { DataType } from 'ephox/jax/core/DataType';
@@ -12,7 +12,7 @@ const expectError = (label: string, response: FutureResult<any, HttpError<DataTy
   response.get((res) => {
     res.fold((_err) => {
       console.log(label, 'successfully failed');
-      assert.eq(expectedCalls, actualCalls);
+      Assert.eq('', expectedCalls, actualCalls);
       actualCalls = [];
       callback(Result.value({ }));
     }, (_val) => {
@@ -27,9 +27,9 @@ const expectValue = (label: string, value: any, response: FutureResult<any, Http
       callback(Result.error(new Error(err.message)));
     }, (val) => {
       try {
-        assert.eq(value, val);
+        Assert.eq('', value, val);
         console.log(label, 'passed with ', val);
-        assert.eq(expectedCalls, actualCalls);
+        Assert.eq('', expectedCalls, actualCalls);
         actualCalls = [];
         callback(Result.value({}));
       } catch (err) {

--- a/modules/katamari-assertions/package.json
+++ b/modules/katamari-assertions/package.json
@@ -16,7 +16,7 @@
   "author": "Tiny Technologies, Inc",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ephox/bedrock-client": "^11.0.0",
+    "@ephox/bedrock-client": "11 || 12 || 13",
     "@ephox/dispute": "^1.0.3",
     "@ephox/katamari": "^9.0.0-alpha.2",
     "tslib": "^2.0.0"

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Strings.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Strings.ts
@@ -1,8 +1,6 @@
 import * as StrAppend from '../str/StrAppend';
 import { Optional } from './Optional';
 
-const nativeFromCodePoint = String.fromCodePoint;
-
 const checkRange = (str: string, substr: string, start: number): boolean =>
   substr === '' || str.length >= substr.length && str.substr(start, start + substr.length) === substr;
 
@@ -85,43 +83,7 @@ export const isEmpty = (s: string): boolean => !isNotEmpty(s);
 
 export const repeat = (s: string, count: number): string => count <= 0 ? '' : new Array(count + 1).join(s);
 
-// Extract codepoint a la ES2015 String.fromCodePoint
-// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint
-export const fromCodePoint = (...codePoints: number[]): string => {
-  if (nativeFromCodePoint) {
-    return nativeFromCodePoint(...codePoints);
-  } else {
-    const codeUnits: number[] = [];
-    let codeLen = 0;
-    let result = '';
-    for (let index = 0, len = codePoints.length; index !== len; ++index) {
-      let codePoint = +codePoints[index];
-      // correctly handles all cases including `NaN`, `-Infinity`, `+Infinity`
-      // The surrounding `!(...)` is required to correctly handle `NaN` cases
-      // The (codePoint>>>0) === codePoint clause handles decimals and negatives
-      // eslint-disable-next-line no-bitwise
-      if (!(codePoint < 0x10FFFF && (codePoint >>> 0) === codePoint)) {
-        throw RangeError('Invalid code point: ' + codePoint);
-      }
-      if (codePoint <= 0xFFFF) { // BMP code point
-        codeLen = codeUnits.push(codePoint);
-      } else { // Astral code point; split in surrogate halves
-        // https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
-        codePoint -= 0x10000;
-        codeLen = codeUnits.push(
-          // eslint-disable-next-line no-bitwise
-          (codePoint >> 10) + 0xD800,  // highSurrogate
-          (codePoint % 0x400) + 0xDC00 // lowSurrogate
-        );
-      }
-      if (codeLen >= 0x3fff) {
-        result += String.fromCharCode.apply(null, codeUnits);
-        codeUnits.length = 0;
-      }
-    }
-    return result + String.fromCharCode.apply(null, codeUnits);
-  }
-};
+export const fromCodePoint = String.fromCodePoint;
 
 export const toInt = (value: string, radix: number = 10): Optional<number> => {
   const num = parseInt(value, radix);

--- a/modules/oxide/package.json
+++ b/modules/oxide/package.json
@@ -34,6 +34,6 @@
   ],
   "dependencies": {
     "prism-themes": "^1.9.0",
-    "prismjs": "^1.26.0"
+    "prismjs": "^1.27.0"
   }
 }

--- a/modules/phoenix/src/test/ts/atomic/api/extract/ExtractTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/api/extract/ExtractTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 
@@ -32,7 +32,7 @@ UnitTest.test('api.Extract.(from,all,extract,extractTo)', () => {
   const check = (expected: string[], extract: typeof Extract.from, initial: string) => {
     const start = Finder.get(doc, initial);
     const actual = extract(doc, start);
-    assert.eq(expected, Arr.map(actual, TestRenders.typeditem));
+    Assert.eq('', expected, Arr.map(actual, TestRenders.typeditem));
   };
 
   const checkFrom = (expected: string[], initial: string) => {
@@ -42,7 +42,7 @@ UnitTest.test('api.Extract.(from,all,extract,extractTo)', () => {
   const checkAll = (expected: string[], initial: string) => {
     const start = Finder.get(doc, initial);
     const actual = Extract.all(doc, start);
-    assert.eq(expected, Arr.map(actual, (a) => {
+    Assert.eq('', expected, Arr.map(actual, (a) => {
       return a.id;
     }));
   };
@@ -52,15 +52,15 @@ UnitTest.test('api.Extract.(from,all,extract,extractTo)', () => {
   const checkExtract = (expected: {id: string; offset: number}, childId: string, offset: number) => {
     const child = Finder.get(doc, childId);
     const actual = Extract.extract(doc, child, offset);
-    assert.eq(expected.id, actual.element.id);
-    assert.eq(expected.offset, actual.offset);
+    Assert.eq('', expected.id, actual.element.id);
+    Assert.eq('', expected.offset, actual.offset);
   };
 
   const checkExtractTo = (expected: {id: string; offset: number}, childId: string, offset: number, pred: (e: any) => boolean) => {
     const child = Finder.get(doc, childId);
     const actual = Extract.extractTo(doc, child, offset, pred);
-    assert.eq(expected.id, actual.element.id);
-    assert.eq(expected.offset, actual.offset);
+    Assert.eq('', expected.id, actual.element.id);
+    Assert.eq('', expected.offset, actual.offset);
   };
 
   checkFrom([

--- a/modules/phoenix/src/test/ts/atomic/api/extract/ExtractTextTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/api/extract/ExtractTextTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene, Universe } from '@ephox/boss';
 
 import * as Extract from 'ephox/phoenix/api/general/Extract';
@@ -31,7 +31,7 @@ UnitTest.test('ExtractTextTest', () => {
   const check = (expected: string, extract: <E, D>(universe: Universe<E, D>, item: E) => string, initial: string) => {
     const start = Finder.get(doc, initial);
     const actual = extract(doc, start);
-    assert.eq(expected, actual.trim());
+    Assert.eq('', expected, actual.trim());
   };
 
   check('Inside em', Extract.toText, '1.2.4');

--- a/modules/phoenix/src/test/ts/atomic/api/extract/FindTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/api/extract/FindTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Optional } from '@ephox/katamari';
 
@@ -32,13 +32,13 @@ UnitTest.test('api.Extract.find', () => {
     const top = Finder.get(doc, topId);
     const actual = Extract.find(doc, top, offset);
     expected.fold(() => {
-      assert.eq(actual.isNone(), true, 'Expected none, actual: some');
+      Assert.eq('Expected none, actual: some', actual.isNone(), true);
     }, (exp) => {
       actual.fold(() => {
-        assert.fail('Expected some, actual: none');
+        Assert.fail('Expected some, actual: none');
       }, (act) => {
-        assert.eq(exp.id, act.element.id);
-        assert.eq(exp.offset, act.offset);
+        Assert.eq('', exp.id, act.element.id);
+        Assert.eq('', exp.offset, act.offset);
       });
     });
   };

--- a/modules/phoenix/src/test/ts/atomic/api/family/RangeTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/api/family/RangeTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 
@@ -42,7 +42,7 @@ UnitTest.test('RangeTest', () => {
     const start = Finder.get(doc, startId);
     const finish = Finder.get(doc, finishId);
     const actual = Family.range(doc, start, delta1, finish, delta2);
-    assert.eq(expected, Arr.map(actual, (x) => {
+    Assert.eq('', expected, Arr.map(actual, (x) => {
       return x.id;
     }));
   };

--- a/modules/phoenix/src/test/ts/atomic/api/split/RangeTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/api/split/RangeTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 
 import * as Split from 'ephox/phoenix/api/general/Split';
@@ -11,8 +11,8 @@ UnitTest.test('IdentifyTest', () => {
     const base = Finder.get(universe, baseid);
     const end = Finder.get(universe, endid);
     const actual = Split.range(universe, base, baseoffset, end, endoffset);
-    assert.eq(expected, TestRenders.texts(actual));
-    assert.eq(all, TestRenders.texts(universe.get().children));
+    Assert.eq('', expected, TestRenders.texts(actual));
+    Assert.eq('', all, TestRenders.texts(universe.get().children));
   };
 
   check([ 'C', 'aterpillar', 'Go', 'rilla' ], [ 'aterpillar', 'Go' ], 'a', 1, 'b', 2, Gene('root', 'root', [

--- a/modules/phoenix/src/test/ts/atomic/api/split/SplitTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/api/split/SplitTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Optional } from '@ephox/katamari';
 
@@ -30,15 +30,15 @@ UnitTest.test('api.Split.(split,splitByPair)', () => {
   const checkSplit = (before: Optional<string>, after: Optional<string>, text: string, position: number) => {
     const input = generate(text);
     const actual = Split.split(input.universe, input.item, position);
-    assert.eq(true, isEq(before, actual.before));
-    assert.eq(true, isEq(after, actual.after));
+    Assert.eq('', true, isEq(before, actual.before));
+    Assert.eq('', true, isEq(after, actual.after));
   };
 
   const checkPair = (expected: string, middle: string, text: string, start: number, finish: number) => {
     const input = generate(text);
     const actual = Split.splitByPair(input.universe, input.item, start, finish);
-    assert.eq(middle, actual.text);
-    assert.eq(expected, input.universe.shortlog((item) => {
+    Assert.eq('', middle, actual.text);
+    Assert.eq('', expected, input.universe.shortlog((item) => {
       const props = input.universe.property();
       return props.isText(item) ? `text("${props.getText(item)}")` : item.id;
     }));

--- a/modules/phoenix/src/test/ts/atomic/api/wrap/WrapperTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/api/wrap/WrapperTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, Logger, TestUniverse, TextGene } from '@ephox/boss';
 
 import * as Wrapping from 'ephox/phoenix/api/general/Wrapping';
@@ -60,11 +60,11 @@ UnitTest.test('WrapperTest', () => {
   const check = (overall: string, expResult: ExpResult, startId: string, startOffset: number, endId: string, endOffset: number) => {
     counter = 0;
     const actual = Wrapping.leaves(doc, Finder.get(doc, startId), startOffset, Finder.get(doc, endId), endOffset, factory).getOrDie();
-    assert.eq(overall, dump());
-    assert.eq(expResult.beginId, actual.begin.element.id);
-    assert.eq(expResult.beginOffset, actual.begin.offset);
-    assert.eq(expResult.endId, actual.end.element.id);
-    assert.eq(expResult.endOffset, actual.end.offset);
+    Assert.eq('', overall, dump());
+    Assert.eq('', expResult.beginId, actual.begin.element.id);
+    Assert.eq('', expResult.beginOffset, actual.begin.offset);
+    Assert.eq('', expResult.endId, actual.end.element.id);
+    Assert.eq('', expResult.endOffset, actual.end.offset);
   };
 
   // Let's just do stuff.

--- a/modules/phoenix/src/test/ts/atomic/family/GroupTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/family/GroupTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 
@@ -34,7 +34,7 @@ UnitTest.test('GroupTest', () => {
       return Finder.get(doc, id);
     });
     const actual = Group.group(doc, items);
-    assert.eq(expected, Arr.map(actual, (xs) => {
+    Assert.eq('', expected, Arr.map(actual, (xs) => {
       return Arr.map(xs, TestRenders.typeditem);
     }));
   };

--- a/modules/phoenix/src/test/ts/atomic/family/ParentsTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/family/ParentsTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse } from '@ephox/boss';
 
 import * as Parents from 'ephox/phoenix/family/Parents';
@@ -40,7 +40,7 @@ UnitTest.test('ParentsTest', () => {
     const start = Finder.get(doc, first);
     const finish = Finder.get(doc, last);
     const actual = Parents.common(doc, start, finish);
-    assert.eq(expected, actual.getOrDie('No common parent').id);
+    Assert.eq('', expected, actual.getOrDie('No common parent').id);
   };
 
   check('abc', 'abc', 'abcc');

--- a/modules/phoenix/src/test/ts/atomic/gather/WalkerPathTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/gather/WalkerPathTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse } from '@ephox/boss';
 import { Optional } from '@ephox/katamari';
 
@@ -53,7 +53,7 @@ UnitTest.test('WalkerPathTest', () => {
       current = Walker.go(universe, c.item, c.mode, direction);
     }
 
-    assert.eq(expected, path);
+    Assert.eq('', expected, path);
   };
 
   checkPath([

--- a/modules/phoenix/src/test/ts/atomic/injection/InjectionTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/injection/InjectionTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 
 import * as Injection from 'ephox/phoenix/injection/Injection';
@@ -27,7 +27,7 @@ UnitTest.test('InsertAtTest', () => {
     const universe = makeUniverse();
     const start = Finder.get(universe, element);
     Injection.atStartOf(universe, start, offset, injection);
-    assert.eq(expected, universe.shortlog((item) => {
+    Assert.eq('', expected, universe.shortlog((item) => {
       const props = universe.property();
       return props.isText(item) ? `text("${props.getText(item)}")` : item.id;
     }));

--- a/modules/phoenix/src/test/ts/atomic/search/MatchSplitterTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/search/MatchSplitterTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Arr, Optional } from '@ephox/katamari';
 import { PositionArray, PRange } from '@ephox/polaris';
@@ -34,8 +34,8 @@ UnitTest.test('MatchSplitterTest', () => {
     });
 
     const actual = MatchSplitter.separate(universe, list, matches);
-    assert.eq(expected.length, actual.length, 'Wrong sizes for MatchSplitter');
-    assert.eq(expected, Arr.map(actual, (a) => {
+    Assert.eq('Wrong sizes for MatchSplitter', expected.length, actual.length);
+    Assert.eq('', expected, Arr.map(actual, (a) => {
       return {
         text: TestRenders.texts(a.elements),
         exact: a.exact,
@@ -43,7 +43,7 @@ UnitTest.test('MatchSplitterTest', () => {
       };
     }));
 
-    assert.eq(all, TestRenders.texts(universe.get().children));
+    Assert.eq('', all, TestRenders.texts(universe.get().children));
 
   };
 

--- a/modules/phoenix/src/test/ts/atomic/search/SearcherTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/search/SearcherTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Arr, Fun } from '@ephox/katamari';
 
@@ -64,7 +64,7 @@ UnitTest.test('SearcherTest', () => {
         exact: match.exact
       };
     });
-    assert.eq(expected, processed);
+    Assert.eq('', expected, processed);
   };
 
   // An example of some <test> data. The <word> being looked <for> will be <w_or_d> and <for>.|There will be some <tes_t>

--- a/modules/phoenix/src/test/ts/atomic/search/SplitterTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/search/SplitterTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 
@@ -19,17 +19,17 @@ UnitTest.test('SplitterTest', () => {
     const universe = TestUniverse(data);
     const item = Finder.get(universe, id);
     const actual = Splitter.subdivide(universe, item, positions);
-    assert.eq(expected.length, actual.length, 'Incorrect size for subdivide test');
+    Assert.eq('Incorrect size for subdivide test', expected.length, actual.length);
     Arr.each(expected, (exp, i) => {
       const act = actual[i];
       // TODO: Consider removing an expected id from the test case as it isn't really representing anything meaningful
-      assert.eq(exp.id, act.element.id);
-      assert.eq(exp.start, act.start, 'comparing start for ' + exp.id + ': ' + exp.start + ' vs ' + act.start);
-      assert.eq(exp.finish, act.finish, 'comparing finish for ' + exp.id + ': ' + exp.finish + ' vs ' + act.finish);
-      assert.eq(exp.text, act.element.text);
+      Assert.eq('', exp.id, act.element.id);
+      Assert.eq('comparing start for ' + exp.id + ': ' + exp.start + ' vs ' + act.start, exp.start, act.start);
+      Assert.eq('comparing finish for ' + exp.id + ': ' + exp.finish + ' vs ' + act.finish, exp.finish, act.finish);
+      Assert.eq('', exp.text, act.element.text);
     });
 
-    assert.eq(toplevel, Arr.map(universe.get().children, TestRenders.text));
+    Assert.eq('', toplevel, Arr.map(universe.get().children, TestRenders.text));
   };
 
   checkSubdivide([ '_', 'abcdefghijklm', 'n', 'opq', 'rstuvwxyz' ], [

--- a/modules/phoenix/src/test/ts/atomic/util/ContiguousTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/util/ContiguousTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 
@@ -32,11 +32,11 @@ UnitTest.test('Contiguous Text Nodes Test', () => {
 
   const check = (expected: CheckItem[], ids: string[]) => {
     const actual = Contiguous.textnodes(doc, Finder.getAll(doc, ids));
-    assert.eq(expected.length, actual.length);
+    Assert.eq('', expected.length, actual.length);
     Arr.each(expected, (exp, i) => {
       const act = actual[i];
-      assert.eq(exp.parent, act.parent.id);
-      assert.eq(exp.children, TestRenders.ids(act.children));
+      Assert.eq('', exp.parent, act.parent.id);
+      Assert.eq('', exp.children, TestRenders.ids(act.children));
     });
   };
 

--- a/modules/phoenix/src/test/ts/atomic/wrap/NavigationTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/wrap/NavigationTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { CommentGene, Gene, TestUniverse, TextGene } from '@ephox/boss';
 
 import * as Finder from 'ephox/phoenix/test/Finder';
@@ -34,20 +34,20 @@ UnitTest.test('NavigationTest', () => {
 
   const checkLast = (expected: CheckItem, id: string) => {
     const actual = Navigation.toLast(doc, Finder.get(doc, id));
-    assert.eq(expected.element, actual.element.id);
-    assert.eq(expected.offset, actual.offset);
+    Assert.eq('', expected.element, actual.element.id);
+    Assert.eq('', expected.offset, actual.offset);
   };
 
   const checkLower = (expected: CheckItem, id: string) => {
     const actual = Navigation.toLower(doc, Finder.get(doc, id));
-    assert.eq(expected.element, actual.element.id);
-    assert.eq(expected.offset, actual.offset);
+    Assert.eq('', expected.element, actual.element.id);
+    Assert.eq('', expected.offset, actual.offset);
   };
 
   const checkLeaf = (expected: CheckItem, id: string, offset: number) => {
     const actual = Navigation.toLeaf(doc, Finder.get(doc, id), offset);
-    assert.eq(expected.element, actual.element.id);
-    assert.eq(expected.offset, actual.offset);
+    Assert.eq('', expected.element, actual.element.id);
+    Assert.eq('', expected.offset, actual.offset);
   };
 
   checkLower({ element: '1', offset: 2 }, '1');
@@ -64,17 +64,17 @@ UnitTest.test('NavigationTest', () => {
   const checkFreeFallLtr = (expected: CheckItem, universe: TestUniverse, elementId: string) => {
     const element = Finder.get(doc, elementId);
     const actual = Navigation.freefallLtr(universe, element);
-    assert.eq(element.id, elementId);
-    assert.eq(expected.element, actual.element.id);
-    assert.eq(expected.offset, actual.offset);
+    Assert.eq('', element.id, elementId);
+    Assert.eq('', expected.element, actual.element.id);
+    Assert.eq('', expected.offset, actual.offset);
   };
 
   const checkFreeFallRtl = (expected: CheckItem, universe: TestUniverse, elementId: string) => {
     const element = Finder.get(doc, elementId);
     const actual = Navigation.freefallRtl(universe, element);
-    assert.eq(element.id, elementId);
-    assert.eq(expected.element, actual.element.id);
-    assert.eq(expected.offset, actual.offset);
+    Assert.eq('', element.id, elementId);
+    Assert.eq('', expected.element, actual.element.id);
+    Assert.eq('', expected.offset, actual.offset);
   };
 
   // Freefall without comment nodes

--- a/modules/phoenix/src/test/ts/atomic/wrap/WrapperTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/wrap/WrapperTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 
 import * as Finder from 'ephox/phoenix/test/Finder';
@@ -43,8 +43,8 @@ UnitTest.test('WrapperTest', () => {
     };
 
     const actual = Wrapper.reuse(doc, start, startOffset, finish, finishOffset, predicate, nu);
-    assert.eq(expected, TestRenders.ids(actual));
-    assert.eq(postTest, doc.shortlog((item) => {
+    Assert.eq('', expected, TestRenders.ids(actual));
+    Assert.eq('', postTest, doc.shortlog((item) => {
       const props = doc.property();
       return props.isText(item) ? `text("${props.getText(item)}")` : item.id;
     }));

--- a/modules/phoenix/src/test/ts/browser/DomDescentTest.ts
+++ b/modules/phoenix/src/test/ts/browser/DomDescentTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Obj } from '@ephox/katamari';
 import { Hierarchy, SugarElement } from '@ephox/sugar';
 
@@ -38,8 +38,8 @@ UnitTest.test('DomDescentTest', () => {
 
   const check = (expected: CheckItem, actual: SpotPoint<SugarElement>) => {
     const aPath = Hierarchy.path(root, actual.element).getOrDie('Could not extract path');
-    assert.eq(expected.path, aPath);
-    assert.eq(expected.offset, actual.offset);
+    Assert.eq('', expected.path, aPath);
+    Assert.eq('', expected.offset, actual.offset);
   };
 
   // Descending into div should take you to first whitspace node.

--- a/modules/phoenix/src/test/ts/browser/DomGatherTest.ts
+++ b/modules/phoenix/src/test/ts/browser/DomGatherTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
@@ -24,7 +24,7 @@ UnitTest.test('DomGatherTest', () => {
 
   const check = (spec: CheckItem) => {
     const actual = spec.seek(spec.element, spec.predicate, is(page.container)).getOrDie('No actual element found.');
-    assert.eq(spec.expected.dom, actual.dom);
+    Assert.eq('', spec.expected.dom, actual.dom);
   };
 
   const cases: CheckItem[] = [

--- a/modules/phoenix/src/test/ts/browser/DomSearchTest.ts
+++ b/modules/phoenix/src/test/ts/browser/DomSearchTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { Attribute, Html, Insert, InsertAll, Remove, SugarElement } from '@ephox/sugar';
 
@@ -28,7 +28,7 @@ UnitTest.test('DomSearchTest', () => {
       });
     });
 
-    assert.eq(expected, Html.get(container));
+    Assert.eq('', expected, Html.get(container));
   };
 
   check('<span data-word="Sed">Sed</span>', [ 'Sed' ], [ 'Sed' ]);

--- a/modules/phoenix/src/test/ts/browser/DomSearchingTest.ts
+++ b/modules/phoenix/src/test/ts/browser/DomSearchingTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { Pattern } from '@ephox/polaris';
 import { SugarElement } from '@ephox/sugar';
@@ -14,5 +14,5 @@ UnitTest.test('DomSearchingTest', () => {
     pattern: Pattern.unsafetoken('sometext')
   }], Fun.never);
 
-  assert.eq(0, result.length, 'There should be no matches, because some and text are separated by a list boundary');
+  Assert.eq('There should be no matches, because some and text are separated by a list boundary', 0, result.length);
 });

--- a/modules/phoenix/src/test/ts/browser/DomSplitTest.ts
+++ b/modules/phoenix/src/test/ts/browser/DomSplitTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarElement, SugarText, Traverse } from '@ephox/sugar';
 
@@ -20,7 +20,7 @@ UnitTest.test('DomSplitTest', () => {
     }, (v) => {
       const children = Traverse.children(v) as SugarElement<Text>[];
       const text = Arr.map(children, SugarText.get);
-      assert.eq(expected, text);
+      Assert.eq('', expected, text);
     });
   };
 

--- a/modules/phoenix/src/test/ts/browser/DomWrappingTest.ts
+++ b/modules/phoenix/src/test/ts/browser/DomWrappingTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Class, Html, Insert, InsertAll, Remove, SelectorFind, SugarElement, Traverse } from '@ephox/sugar';
 
 import * as DomWrapping from 'ephox/phoenix/api/dom/DomWrapping';
@@ -26,7 +26,7 @@ UnitTest.test('DomWrappingTest', () => {
 
   const checker = (expected: string, p1: number[], offset1: number, p2: number[], offset2: number, input: SugarElement[], initial: string) => {
     check(input, (container: SugarElement) => {
-      assert.eq(initial, Html.get(container));
+      Assert.eq('', initial, Html.get(container));
       const first = c(container, p1);
       const second = c(container, p2);
       DomWrapping.wrapWith(first, offset1, second, offset2, () => {
@@ -35,7 +35,7 @@ UnitTest.test('DomWrappingTest', () => {
         return DomWrapping.nu(basic);
       });
 
-      assert.eq(expected, Html.get(container));
+      Assert.eq('', expected, Html.get(container));
     });
   };
 

--- a/modules/phoenix/src/test/ts/browser/FamilyGroupTest.ts
+++ b/modules/phoenix/src/test/ts/browser/FamilyGroupTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { DomUniverse } from '@ephox/boss';
 import { Arr, Fun } from '@ephox/katamari';
 import { SugarElement, SugarText } from '@ephox/sugar';
@@ -25,7 +25,7 @@ UnitTest.test('FamilyGroupTest', () => {
     const actual = Arr.map(rawActual, (a) => {
       return Arr.map(a, toStr);
     });
-    assert.eq(expected, actual);
+    Assert.eq('', expected, actual);
   };
 
   check([

--- a/modules/polaris/src/test/ts/atomic/api/ArrayBoundariesTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/ArrayBoundariesTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Boundaries from 'ephox/polaris/array/Boundaries';
 
@@ -8,7 +8,7 @@ UnitTest.test('BoundariesTest', () => {
   };
 
   const check = (items: string[], l: string, r: string, pred: (a: string, b: string) => boolean, expected: string[]) => {
-    assert.eq(Boundaries.boundAt(items, l, r, pred), expected);
+    Assert.eq('', Boundaries.boundAt(items, l, r, pred), expected);
   };
 
   check([ 'a', 'b', 'c', 'd', 'e' ], 'b', 'd', comparator, [ 'b', 'c', 'd' ]);

--- a/modules/polaris/src/test/ts/atomic/api/ArraySplitTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/ArraySplitTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 
 import * as Arrays from 'ephox/polaris/api/Arrays';
@@ -7,7 +7,7 @@ import { Splitting } from 'ephox/polaris/api/Splitting';
 UnitTest.test('api.Arrays.splitby', () => {
   const check = <T>(expected: T[][], input: T[], pred: (x: T) => boolean) => {
     const actual = Arrays.splitby(input, pred);
-    assert.eq(expected, actual);
+    Assert.eq('', expected, actual);
   };
 
   check([], [], Fun.always);
@@ -29,7 +29,7 @@ UnitTest.test('api.Arrays.splitby', () => {
 
   const checkAdv = (expected: string[][], input: string[]) => {
     const actual = Arrays.splitbyAdv(input, predicate);
-    assert.eq(expected, actual);
+    Assert.eq('', expected, actual);
   };
 
   checkAdv([ ], [ ]);

--- a/modules/polaris/src/test/ts/atomic/api/ParrayGenerateTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/ParrayGenerateTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
 
 import * as PositionArray from 'ephox/polaris/api/PositionArray';
@@ -20,7 +20,7 @@ UnitTest.test('api.PositionArray.generate', () => {
 
   const check = (expected: string[], input: string[], start?: number) => {
     const result = PositionArray.generate(input, generator, start);
-    assert.eq(expected, Arr.map(result, (item) => {
+    Assert.eq('', expected, Arr.map(result, (item) => {
       return item.start + '->' + item.finish + '@ ' + item.item;
     }));
   };

--- a/modules/polaris/src/test/ts/atomic/api/ParraySplitTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/ParraySplitTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as PositionArray from 'ephox/polaris/api/PositionArray';
 import * as Strings from 'ephox/polaris/api/Strings';
@@ -13,7 +13,7 @@ UnitTest.test('api.PositionArray.splits', () => {
   const check = (expected: string[], input: string[], positions: number[]) => {
     const parray = Parrays.make(input);
     const actual = PositionArray.splits(parray, positions, subdivide);
-    assert.eq(expected, Parrays.dump(actual));
+    Assert.eq('', expected, Parrays.dump(actual));
   };
 
   check([], [], []);

--- a/modules/polaris/src/test/ts/atomic/api/ParraySublistTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/ParraySublistTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as PositionArray from 'ephox/polaris/api/PositionArray';
 import * as Parrays from 'ephox/polaris/test/Parrays';
@@ -7,7 +7,7 @@ UnitTest.test('api.PositionArray.sublist', () => {
   const check = (expected: string[], input: string[], start: number, finish: number) => {
     const parray = Parrays.make(input);
     const actual = PositionArray.sublist(parray, start, finish);
-    assert.eq(expected, Parrays.dump(actual));
+    Assert.eq('', expected, Parrays.dump(actual));
   };
 
   check([], [], 0, 0);

--- a/modules/polaris/src/test/ts/atomic/api/ParrayTranslateTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/ParrayTranslateTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as PositionArray from 'ephox/polaris/api/PositionArray';
 import * as Parrays from 'ephox/polaris/test/Parrays';
@@ -7,7 +7,7 @@ UnitTest.test('api.PositionArray.translate', () => {
   const check = (expected: string[], input: string[], offset: number) => {
     const initial = Parrays.make(input);
     const actual = PositionArray.translate(initial, offset);
-    assert.eq(expected, Parrays.dump(actual));
+    Assert.eq('', expected, Parrays.dump(actual));
   };
 
   check([], [], 0);

--- a/modules/polaris/src/test/ts/atomic/api/RegexesTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/RegexesTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
 
 import * as Regexes from 'ephox/polaris/api/Regexes';
@@ -153,7 +153,7 @@ UnitTest.test('RegexesTest', () => {
 
   Arr.each(trueCases, (cs) => {
     const matched = Regexes.link().exec(cs);
-    assert.eq(cs, matched !== null && matched[0], 'expected true but was false: ' + cs);
+    Assert.eq('expected true but was false: ' + cs, cs, matched !== null && matched[0]);
     if (matched !== null && matched.length > 1) {
       // eslint-disable-next-line no-console
       console.log('matched groups:');
@@ -161,13 +161,13 @@ UnitTest.test('RegexesTest', () => {
         // eslint-disable-next-line no-console
         console.log(i, s);
       });
-      assert.fail('link regex must not capture any groups');
+      Assert.fail('link regex must not capture any groups');
     }
   });
 
   Arr.each(falseCases, (cs) => {
     const match = Regexes.link().exec(cs);
-    assert.eq(false, match !== null && cs === match[0], 'expected false but was true: ' + cs);
+    Assert.eq('expected false but was true: ' + cs, false, match !== null && cs === match[0]);
   });
 
   const autolinks = { // Ignore trailing: \-_.~*+=!&;:\'%@?#^${}(),
@@ -247,9 +247,9 @@ UnitTest.test('RegexesTest', () => {
     const match = Regexes.autolink().exec(k);
     if (match !== null) {
       const url = match[1];
-      assert.eq(true, v === url, 'expected ' + v + ' but was "' + url + '"');
+      Assert.eq('expected ' + v + ' but was "' + url + '"', true, v === url);
     } else {
-      assert.fail('expected ' + v + ' but did not match "' + k + '"');
+      Assert.fail('expected ' + v + ' but did not match "' + k + '"');
     }
   });
 
@@ -281,9 +281,9 @@ UnitTest.test('RegexesTest', () => {
     const match = Regexes.link().exec(k);
     if (match !== null) {
       const url = match[0];
-      assert.eq(true, v === url, 'expected ' + v + ' but was "' + url + '"');
+      Assert.eq('expected ' + v + ' but was "' + url + '"', true, v === url);
     } else {
-      assert.fail('expected ' + v + ' but did not match "' + k + '"');
+      Assert.fail('expected ' + v + ' but did not match "' + k + '"');
     }
   });
 });

--- a/modules/polaris/src/test/ts/atomic/api/SanitiseCssTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/SanitiseCssTest.ts
@@ -1,11 +1,11 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Sanitise from 'ephox/polaris/string/Sanitise';
 
 UnitTest.test('api.Sanitise.css', () => {
   const check = (expected: string, input: string) => {
     const actual = Sanitise.css(input);
-    assert.eq(expected, actual);
+    Assert.eq('', expected, actual);
   };
 
   check('e', '');

--- a/modules/polaris/src/test/ts/atomic/api/SearchFindTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/SearchFindTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Unicode } from '@ephox/katamari';
 
 import * as Pattern from 'ephox/polaris/api/Pattern';
@@ -9,10 +9,10 @@ import { PRegExp } from 'ephox/polaris/pattern/Types';
 UnitTest.test('api.Search.findall (using api.Pattern)', () => {
   const checkAll = (expected: [number, number][], input: string, pattern: PRegExp) => {
     const actual = Search.findall(input, pattern);
-    assert.eq(expected.length, actual.length);
+    Assert.eq('', expected.length, actual.length);
     Arr.each(expected, (exp, i) => {
-      assert.eq(exp[0], actual[i].start);
-      assert.eq(exp[1], actual[i].finish);
+      Assert.eq('', exp[0], actual[i].start);
+      Assert.eq('', exp[1], actual[i].finish);
     });
   };
   const testData = (pattern: PRegExp, name: string) => ({
@@ -22,11 +22,11 @@ UnitTest.test('api.Search.findall (using api.Pattern)', () => {
 
   const checkMany = (expected: [number, number, string][], text: string, targets: ReturnType<typeof testData>[]) => {
     const actual = Search.findmany(text, targets);
-    assert.eq(expected.length, actual.length);
+    Assert.eq('', expected.length, actual.length);
     Arr.each(expected, (exp, i) => {
-      assert.eq(exp[0], actual[i].start);
-      assert.eq(exp[1], actual[i].finish);
-      assert.eq(exp[2], actual[i].name);
+      Assert.eq('', exp[0], actual[i].start);
+      Assert.eq('', exp[1], actual[i].finish);
+      Assert.eq('', exp[2], actual[i].name);
     });
   };
 

--- a/modules/polaris/src/test/ts/atomic/api/StringSplitTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/StringSplitTest.ts
@@ -1,11 +1,11 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Strings from 'ephox/polaris/api/Strings';
 
 UnitTest.test('api.Strings.splits', () => {
   const check = (expected: string[], input: string, points: number[]) => {
     const actual = Strings.splits(input, points);
-    assert.eq(expected, actual);
+    Assert.eq('', expected, actual);
   };
 
   check([ '' ], '', [ ]);

--- a/modules/polaris/src/test/ts/atomic/api/WordsTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/WordsTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 
 import { getWords, WordOptions } from 'ephox/polaris/words/Words';
@@ -18,7 +18,7 @@ UnitTest.test('api.Words.words', () => {
     const wordSets: Char[][] = getWords(chars, (char) => char.char, options);
     const actual = simplifySets(wordSets);
 
-    assert.eq(expected, actual);
+    Assert.eq('', expected, actual);
   };
 
   // splits words on whitespace

--- a/modules/polaris/src/test/ts/atomic/pattern/CharsTest.ts
+++ b/modules/polaris/src/test/ts/atomic/pattern/CharsTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 
 import * as Chars from 'ephox/polaris/pattern/Chars';
@@ -112,10 +112,10 @@ UnitTest.test('CharsTest', () => {
     });
 
     const leftovers = breaks.join('').trim();
-    assert.eq(
+    Assert.eq(
+      'Test: ' + label + '\nExpected all characters in: \n\n"' + str + '" to be known. \nUnknown: ' + leftovers,
       0,
-      leftovers.length,
-      'Test: ' + label + '\nExpected all characters in: \n\n"' + str + '" to be known. \nUnknown: ' + leftovers
+      leftovers.length
     );
   };
 

--- a/modules/polaris/src/test/ts/atomic/words/StringMapperTest.ts
+++ b/modules/polaris/src/test/ts/atomic/words/StringMapperTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as StringMapper from 'ephox/polaris/words/StringMapper';
 import * as UnicodeData from 'ephox/polaris/words/UnicodeData';
@@ -24,22 +24,22 @@ UnitTest.test('Words.StringMapperTest', () => {
   const classify = StringMapper.classify;
 
   const testClassify = () => {
-    assert.eq([ ALETTER, ALETTER, ALETTER ], classify('abc'.split('')));
-    assert.eq([ ALETTER, ALETTER, ALETTER ], classify('åäö'.split('')));
-    assert.eq([ ALETTER, NUMERIC, ALETTER ], classify('a2c'.split('')));
-    assert.eq([ ALETTER, MIDNUMLET, ALETTER, ALETTER, OTHER, ALETTER, ALETTER, ALETTER, ALETTER, ALETTER ], classify(`a'la carte`.split('')));
-    assert.eq([ ALETTER, ALETTER, ALETTER, OTHER, LF, OTHER, ALETTER, ALETTER, ALETTER ], classify('one \n two'.split('')));
-    assert.eq([ NUMERIC, MIDNUM, NUMERIC, NUMERIC, NUMERIC, MIDNUMLET, NUMERIC, NUMERIC ], classify('3,500.10'.split('')));
-    assert.eq([ OTHER, KATAKANA, KATAKANA ], classify('愛ラブ'.split('')));
-    assert.eq([ OTHER, OTHER ], classify('ねこ'.split('')));
-    assert.eq([ MIDLETTER ], classify('·'.split('')));
-    assert.eq([ EXTENDNUMLET, MIDNUMLET, MIDNUM, MIDNUM, MIDNUM, MIDNUM, EXTENDNUMLET, EXTENDNUMLET ], classify('=-+±*/⋉≥'.split('')));
-    assert.eq([ CR ], classify('\r'.split('')));
-    assert.eq([ EXTEND ], classify('̀'.split('')));
-    assert.eq([ NEWLINE ], classify('\x0B'.split('')));
-    assert.eq([ FORMAT ], classify('؃'.split('')));
-    assert.eq([ EXTENDNUMLET ], classify('︴'.split('')));
-    assert.eq([ AT ], classify('@'.split('')));
+    Assert.eq('', [ ALETTER, ALETTER, ALETTER ], classify('abc'.split('')));
+    Assert.eq('', [ ALETTER, ALETTER, ALETTER ], classify('åäö'.split('')));
+    Assert.eq('', [ ALETTER, NUMERIC, ALETTER ], classify('a2c'.split('')));
+    Assert.eq('', [ ALETTER, MIDNUMLET, ALETTER, ALETTER, OTHER, ALETTER, ALETTER, ALETTER, ALETTER, ALETTER ], classify(`a'la carte`.split('')));
+    Assert.eq('', [ ALETTER, ALETTER, ALETTER, OTHER, LF, OTHER, ALETTER, ALETTER, ALETTER ], classify('one \n two'.split('')));
+    Assert.eq('', [ NUMERIC, MIDNUM, NUMERIC, NUMERIC, NUMERIC, MIDNUMLET, NUMERIC, NUMERIC ], classify('3,500.10'.split('')));
+    Assert.eq('', [ OTHER, KATAKANA, KATAKANA ], classify('愛ラブ'.split('')));
+    Assert.eq('', [ OTHER, OTHER ], classify('ねこ'.split('')));
+    Assert.eq('', [ MIDLETTER ], classify('·'.split('')));
+    Assert.eq('', [ EXTENDNUMLET, MIDNUMLET, MIDNUM, MIDNUM, MIDNUM, MIDNUM, EXTENDNUMLET, EXTENDNUMLET ], classify('=-+±*/⋉≥'.split('')));
+    Assert.eq('', [ CR ], classify('\r'.split('')));
+    Assert.eq('', [ EXTEND ], classify('̀'.split('')));
+    Assert.eq('', [ NEWLINE ], classify('\x0B'.split('')));
+    Assert.eq('', [ FORMAT ], classify('؃'.split('')));
+    Assert.eq('', [ EXTENDNUMLET ], classify('︴'.split('')));
+    Assert.eq('', [ AT ], classify('@'.split('')));
   };
 
   testClassify();

--- a/modules/polaris/src/test/ts/atomic/words/WordBoundaryTest.ts
+++ b/modules/polaris/src/test/ts/atomic/words/WordBoundaryTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as StringMapper from 'ephox/polaris/words/StringMapper';
 import * as WordBoundary from 'ephox/polaris/words/WordBoundary';
@@ -10,66 +10,66 @@ UnitTest.test('Words.WordBoundaryTest', () => {
 
   const testWordBoundary = () => {
     // should not break between most characters
-    assert.eq(false, iwb('abc', 1));
-    assert.eq(false, iwb('åäö', 1));
-    assert.eq(false, iwb('üßœ', 1));
+    Assert.eq('', false, iwb('abc', 1));
+    Assert.eq('', false, iwb('åäö', 1));
+    Assert.eq('', false, iwb('üßœ', 1));
 
     // should not break some punctuation
-    assert.eq(false, iwb(`can't`, 2));
-    assert.eq(false, iwb('can’t', 2));
-    assert.eq(false, iwb('foo.bar', 2));
-    assert.eq(false, iwb('foo:bar', 2));
+    Assert.eq('', false, iwb(`can't`, 2));
+    Assert.eq('', false, iwb('can’t', 2));
+    Assert.eq('', false, iwb('foo.bar', 2));
+    Assert.eq('', false, iwb('foo:bar', 2));
 
     // shouldn't break on characters attached to numbers
-    assert.eq(false, iwb('123', 1));
-    assert.eq(false, iwb('a123', 1));
-    assert.eq(false, iwb('1a23', 1));
+    Assert.eq('', false, iwb('123', 1));
+    Assert.eq('', false, iwb('a123', 1));
+    Assert.eq('', false, iwb('1a23', 1));
 
     // shouldn't break on punctuation in number sequences
-    assert.eq(false, iwb('3.14', 1));
-    assert.eq(false, iwb('1,024', 1));
-    assert.eq(false, iwb('5-1', 1));
+    Assert.eq('', false, iwb('3.14', 1));
+    Assert.eq('', false, iwb('1,024', 1));
+    Assert.eq('', false, iwb('5-1', 1));
 
     // should extend characters
-    assert.eq(false, iwb('foo\u00ADbar', 2));
-    assert.eq(false, iwb('foo\u0300bar', 2));
+    Assert.eq('', false, iwb('foo\u00ADbar', 2));
+    Assert.eq('', false, iwb('foo\u0300bar', 2));
 
     // Should NOT break in Katakana
-    assert.eq(false, iwb('カラテ', 1));
+    Assert.eq('', false, iwb('カラテ', 1));
     // Should break between every kanji
-    assert.eq(true, iwb('空手道', 1));
+    Assert.eq('', true, iwb('空手道', 1));
 
     // Shouldn't break inside CRLF
-    assert.eq(false, iwb('foo\r\nbar', 3));
+    Assert.eq('', false, iwb('foo\r\nbar', 3));
 
     // Should break before newlines
-    assert.eq(true, iwb('foo\rbar', 2));
-    assert.eq(true, iwb('foo\nbar', 2));
-    assert.eq(true, iwb('foo\r\nbar', 2));
+    Assert.eq('', true, iwb('foo\rbar', 2));
+    Assert.eq('', true, iwb('foo\nbar', 2));
+    Assert.eq('', true, iwb('foo\r\nbar', 2));
 
     // should break after newlines
-    assert.eq(true, iwb('foo\rbar', 3));
-    assert.eq(true, iwb('foo\nbar', 3));
-    assert.eq(true, iwb('foo\r\nbar', 4));
+    Assert.eq('', true, iwb('foo\rbar', 3));
+    Assert.eq('', true, iwb('foo\nbar', 3));
+    Assert.eq('', true, iwb('foo\r\nbar', 4));
 
     // shouldn't break from extenders
-    assert.eq(false, iwb('foo_bar', 2));
-    assert.eq(false, iwb('__', 0));
+    Assert.eq('', false, iwb('foo_bar', 2));
+    Assert.eq('', false, iwb('__', 0));
 
     // Should break anywhere else
-    assert.eq(true, iwb('foo bar', 2));
-    assert.eq(true, iwb('foo\tbar', 2));
-    assert.eq(true, iwb('foo&bar', 2));
-    assert.eq(true, iwb('foo"bar"', 2));
-    assert.eq(true, iwb('foo(bar)', 2));
-    assert.eq(true, iwb('foo/bar', 2));
+    Assert.eq('', true, iwb('foo bar', 2));
+    Assert.eq('', true, iwb('foo\tbar', 2));
+    Assert.eq('', true, iwb('foo&bar', 2));
+    Assert.eq('', true, iwb('foo"bar"', 2));
+    Assert.eq('', true, iwb('foo(bar)', 2));
+    Assert.eq('', true, iwb('foo/bar', 2));
 
     // should return false when given out of bounds index
-    assert.eq(false, iwb('', 5));
-    assert.eq(false, iwb('', -1));
+    Assert.eq('', false, iwb('', 5));
+    Assert.eq('', false, iwb('', -1));
 
     // should return true for empty string
-    assert.eq(true, iwb('', 0));
+    Assert.eq('', true, iwb('', 0));
   };
 
   testWordBoundary();

--- a/modules/porkbun/src/test/ts/atomic/BinderTest.ts
+++ b/modules/porkbun/src/test/ts/atomic/BinderTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Binder from 'ephox/porkbun/Binder';
 import { Event } from 'ephox/porkbun/Event';
@@ -18,23 +18,23 @@ UnitTest.test('Binder', () => {
     called = true;
   });
 
-  assert.throws(() => {
+  Assert.throws('', () => {
     binder.bind(events.registry.myEvent, (_event) => {
       called = true;
     });
   });
 
   events.trigger.myEvent();
-  assert.eq(true, called);
+  Assert.eq('', true, called);
 
   called = false;
 
   binder.unbind(events.registry.myEvent);
 
   events.trigger.myEvent();
-  assert.eq(false, called);
+  Assert.eq('', false, called);
 
-  assert.throws(() => {
+  Assert.throws('', () => {
     binder.unbind(events.registry.myEvent);
   });
 
@@ -53,5 +53,5 @@ UnitTest.test('Binder', () => {
   events.trigger.myEvent();
   events.trigger.secondEvent();
 
-  assert.eq(0, count);
+  Assert.eq('', 0, count);
 });

--- a/modules/porkbun/src/test/ts/atomic/EventsTest.ts
+++ b/modules/porkbun/src/test/ts/atomic/EventsTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Obj } from '@ephox/katamari';
 
 import { Bindable, Event } from 'ephox/porkbun/Event';
@@ -25,7 +25,7 @@ UnitTest.test('Events', () => {
     });
 
     let called = false;
-    let calledEvent: MyEvent | Record<string, () => any> = {};
+    let calledEvent: MyEvent | Record<string, string> = {};
 
     const handler = (event: MyEvent) => {
       calledEvent = event;
@@ -35,9 +35,9 @@ UnitTest.test('Events', () => {
     events.registry.myEvent.bind(handler);
     events.trigger.myEvent('something');
 
-    assert.eq(true, called);
-    assert.eq(true, Obj.has(calledEvent, 'name'));
-    assert.eq('something', calledEvent.name);
+    Assert.eq('', true, called);
+    Assert.eq('', true, Obj.has(calledEvent, 'name'));
+    Assert.eq('', 'something', calledEvent.name);
 
     called = false;
     calledEvent = {};
@@ -45,8 +45,8 @@ UnitTest.test('Events', () => {
     events.registry.myEvent.unbind(handler);
     events.trigger.myEvent('something');
 
-    assert.eq(false, called);
-    assert.eq(false, Obj.has(calledEvent, 'name'));
+    Assert.eq('', false, called);
+    Assert.eq('', false, Obj.has(calledEvent, 'name'));
 
     // This should not throw an error
     events.registry.myEvent.unbind(handler);
@@ -57,11 +57,11 @@ UnitTest.test('Events', () => {
       emptyEvent: Event([])
     });
 
-    assert.throwsError(
+    Assert.throwsError(
+      'Event bind error: undefined handler',
       () => {
         events.registry.emptyEvent.bind(undefined as any);
-      },
-      'Event bind error: undefined handler'
+      }
     );
   })();
 
@@ -74,15 +74,15 @@ UnitTest.test('Events', () => {
       quack: SourceEvent([ 'a', 'b', 'c' ], ea.registry.chook)
     });
 
-    assert.throwsError(
-      () => eb.trigger.quack('hay', 'bee', 'quee'),
-      'Cannot trigger a source event.'
+    Assert.throwsError(
+      'Cannot trigger a source event.',
+      () => eb.trigger.quack('hay', 'bee', 'quee')
     );
 
     eb.registry.quack.bind((evt) => {
-      assert.eq('ay', evt.a);
-      assert.eq('bee', evt.b);
-      assert.eq('sea', evt.c);
+      Assert.eq('', 'ay', evt.a);
+      Assert.eq('', 'bee', evt.b);
+      Assert.eq('', 'sea', evt.c);
     });
     ea.trigger.chook('ay', 'bee', 'sea');
 
@@ -98,9 +98,9 @@ UnitTest.test('Events', () => {
     });
 
     eb.registry.quack.bind((evt) => {
-      assert.eq('ay', evt.a);
-      assert.eq('bee', evt.b);
-      assert.eq('sea', evt.c);
+      Assert.eq('', 'ay', evt.a);
+      Assert.eq('', 'bee', evt.b);
+      Assert.eq('', 'sea', evt.c);
     });
     ea.trigger.chook('ay', 'bee', 'sea', 'dee', 'eee');
 

--- a/modules/robin/src/test/ts/atomic/api/TextZoneTest.ts
+++ b/modules/robin/src/test/ts/atomic/api/TextZoneTest.ts
@@ -1,4 +1,4 @@
-import { Assert, assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Fun, Optional } from '@ephox/katamari';
 
@@ -55,14 +55,14 @@ UnitTest.test('TextZoneTest', () => {
         // Good
         Fun.noop,
         (act) => {
-          assert.fail(label + '\nShould not have created zone: ' + JSON.stringify(
+          Assert.fail(label + '\nShould not have created zone: ' + JSON.stringify(
             JSON.stringify(rawOne(doc1, act))
           ));
         }
       );
     }, (exp) => {
       actual.fold(() => {
-        assert.fail(label + '\nDid not find a zone. Expected to find: ' + JSON.stringify(exp, null, 2));
+        Assert.fail(label + '\nDid not find a zone. Expected to find: ' + JSON.stringify(exp, null, 2));
       }, (act) => {
         Assert.eq(label + '\nTesting zone: ', exp, rawOne(doc1, act));
       });

--- a/modules/robin/src/test/ts/atomic/clumps/CollectTest.ts
+++ b/modules/robin/src/test/ts/atomic/clumps/CollectTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 
@@ -36,7 +36,7 @@ UnitTest.test('ClumpsTest', () => {
       return { start: a.start.id, soffset: a.soffset, finish: a.finish.id, foffset: a.foffset };
     });
 
-    assert.eq(expected, actual);
+    Assert.eq('', expected, actual);
   };
 
   check([

--- a/modules/robin/src/test/ts/atomic/clumps/FracturesTest.ts
+++ b/modules/robin/src/test/ts/atomic/clumps/FracturesTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 
 import * as Fractures from 'ephox/robin/clumps/Fractures';
@@ -52,7 +52,7 @@ UnitTest.test('FracturesTest', () => {
         doc.insert().appendAll(wrapper, act);
       }
     });
-    assert.eq(expected, doc.shortlog((item) => {
+    Assert.eq('', expected, doc.shortlog((item) => {
       return doc.property().isText(item) ? '"' + item.text + '"' : item.name;
     }));
   };

--- a/modules/robin/src/test/ts/atomic/general/StructureTest.ts
+++ b/modules/robin/src/test/ts/atomic/general/StructureTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse } from '@ephox/boss';
 
 import * as Structure from 'ephox/robin/api/general/Structure';
@@ -19,7 +19,7 @@ UnitTest.test('StructureTest', () => {
   const check = (expected: boolean, id: string) => {
     const item = doc.find(doc.get(), id).getOrDie();
     const actual = Structure.isInline(doc, item);
-    assert.eq(expected, actual);
+    Assert.eq('', expected, actual);
   };
 
   check(false, 'd1');

--- a/modules/robin/src/test/ts/atomic/leftblock/LeftBlockTest.ts
+++ b/modules/robin/src/test/ts/atomic/leftblock/LeftBlockTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 
@@ -20,7 +20,7 @@ UnitTest.test('LeftBlockTest', () => {
 
   const check = (expected: string[], id: string, method: (u: TestUniverse, i: Gene) => Gene[]) => {
     const actual = method(universe, universe.find(universe.get(), id).getOrDie());
-    assert.eq(expected, Arr.map(actual, (x) => {
+    Assert.eq('', expected, Arr.map(actual, (x) => {
       return x.id;
     }));
   };

--- a/modules/robin/src/test/ts/atomic/parent/BreakerTest.ts
+++ b/modules/robin/src/test/ts/atomic/parent/BreakerTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, Logger, TestUniverse, TextGene } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 
@@ -29,7 +29,7 @@ UnitTest.test('BreakerTest', () => {
 
   const doc1 = generator();
   breakToRight(doc1, doc1.find(doc1.get(), 'ol1').getOrDie(), doc1.find(doc1.get(), 'li3').getOrDie());
-  assert.eq(
+  Assert.eq('',
     'root(' +
     'd1(' +
     'd1_t1,' +
@@ -47,9 +47,9 @@ UnitTest.test('BreakerTest', () => {
     return item.name === 'ol';
   }, breakToRight);
 
-  assert.eq('ol1', result.first.id);
-  assert.eq('clone**<ol1>', result.second.getOrDie().id);
-  assert.eq([ 'li2->clone**<li2>', 'ol1->clone**<ol1>' ], Arr.map(result.splits, (spl) => {
+  Assert.eq('', 'ol1', result.first.id);
+  Assert.eq('', 'clone**<ol1>', result.second.getOrDie().id);
+  Assert.eq('', [ 'li2->clone**<li2>', 'ol1->clone**<ol1>' ], Arr.map(result.splits, (spl) => {
     return spl.first.id + '->' + spl.second.id;
   }));
 });

--- a/modules/robin/src/test/ts/atomic/pathway/SimplifyTest.ts
+++ b/modules/robin/src/test/ts/atomic/pathway/SimplifyTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 
@@ -42,7 +42,7 @@ UnitTest.test('SimplifyTest', () => {
     });
 
     const actual = Simplify.simplify(doc, path);
-    assert.eq(expected, Arr.map(actual, (s) => {
+    Assert.eq('', expected, Arr.map(actual, (s) => {
       return s.id;
     }));
   };

--- a/modules/robin/src/test/ts/atomic/util/WordSanitiserTest.ts
+++ b/modules/robin/src/test/ts/atomic/util/WordSanitiserTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Optional, Optionals } from '@ephox/katamari';
 
 import { WordScope } from 'ephox/robin/data/WordScope';
@@ -13,9 +13,9 @@ UnitTest.test('Word Sanitiser', () => {
 
   const check = (expected: WordScope, input: WordScope) => {
     const actual = WordSanitiser.scope(input);
-    assert.eq(expected.word, actual.word);
-    assert.eq(true, Optionals.equals(expected.left, actual.left));
-    assert.eq(true, Optionals.equals(expected.right, actual.right));
+    Assert.eq('', expected.word, actual.word);
+    Assert.eq('', true, Optionals.equals(expected.left, actual.left));
+    Assert.eq('', true, Optionals.equals(expected.right, actual.right));
   };
 
   check(ss('one', '<', '>'), ss('one', '<', '>'));

--- a/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
+++ b/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Optional, Optionals } from '@ephox/katamari';
 
 import { WordScope } from 'ephox/robin/data/WordScope';
@@ -10,17 +10,17 @@ UnitTest.test('words :: Identify', () => {
 
   const check = (expected: WordScope[], input: string) => {
     const actual = Identify.words(input);
-    assert.eq(expected.length, actual.length);
+    Assert.eq('', expected.length, actual.length);
     Arr.map(expected, (x, i) => {
-      assert.eq(expected[i].word, actual[i].word);
-      assert.eq(true, Optionals.equals(expected[i].left, actual[i].left));
-      assert.eq(true, Optionals.equals(expected[i].right, actual[i].right));
+      Assert.eq('', expected[i].word, actual[i].word);
+      Assert.eq('', true, Optionals.equals(expected[i].left, actual[i].left));
+      Assert.eq('', true, Optionals.equals(expected[i].right, actual[i].right));
     });
   };
 
   const checkWords = (expected: string[], input: string) => {
     const actual = Identify.words(input);
-    assert.eq(expected, Arr.map(actual, (a) => {
+    Assert.eq('', expected, Arr.map(actual, (a) => {
       return a.word;
     }));
   };

--- a/modules/robin/src/test/ts/atomic/words/WordDecisionTest.ts
+++ b/modules/robin/src/test/ts/atomic/words/WordDecisionTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Arr, Fun, Optional } from '@ephox/katamari';
 
@@ -27,10 +27,10 @@ UnitTest.test('WordDecisionTest', () => {
   const check = (items: string[], abort: boolean, id: string, slicer: (text: string) => Optional<[number, number]>, _currLanguage: Optional<string>) => {
     const isCustomBoundary = Fun.never;
     const actual = WordDecision.decide(universe, universe.find(universe.get(), id).getOrDie(), slicer, isCustomBoundary);
-    assert.eq(items, Arr.map(actual.items, (item) => {
+    Assert.eq('', items, Arr.map(actual.items, (item) => {
       return item.item.id;
     }));
-    assert.eq(abort, actual.abort);
+    Assert.eq('', abort, actual.abort);
   };
 
   check([], true, 'p1', WordWalking.left.slicer, Optional.none());

--- a/modules/robin/src/test/ts/browser/LeftBlockTest.ts
+++ b/modules/robin/src/test/ts/browser/LeftBlockTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { DomUniverse, Universe } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 import { Hierarchy, Insert, InsertAll, Remove, Replication, SugarBody, SugarElement } from '@ephox/sugar';
@@ -25,13 +25,13 @@ UnitTest.test('LeftBlockTest', () => {
   const check = (expected: string, path: number[], method: <E, D>(universe: Universe<E, D>, item: E) => E[]) => {
     reset();
     const ele = Hierarchy.follow(editor, path);
-    assert.eq(true, ele.isSome(), 'Could not find element at path: ' + path);
+    Assert.eq('Could not find element at path: ' + path, true, ele.isSome());
     ele.each((start) => {
       const group = method(universe, start);
       const clones = Arr.map(group, Replication.deep);
       const div = SugarElement.fromTag('div');
       InsertAll.append(div, clones);
-      assert.eq(expected, div.dom.innerHTML);
+      Assert.eq('', expected, div.dom.innerHTML);
     });
   };
 

--- a/modules/robin/src/test/ts/browser/SmartSelectTest.ts
+++ b/modules/robin/src/test/ts/browser/SmartSelectTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Compare, Hierarchy, Insert, InsertAll, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 
 import * as DomSmartSelect from 'ephox/robin/api/dom/DomSmartSelect';
@@ -69,15 +69,15 @@ UnitTest.test('SmartSelectTest', () => {
     }, (act) => {
       const expStart = Hierarchy.follow(editor, expected.start.element).getOrDie('Could not find expected start');
       const expFinish = Hierarchy.follow(editor, expected.finish.element).getOrDie('Could not find expected finish');
-      assert.eq(true, Compare.eq(expStart, act.startContainer));
-      assert.eq(expected.start.offset, act.startOffset);
-      assert.eq(true, Compare.eq(expFinish, act.endContainer));
-      assert.eq(expected.finish.offset, act.endOffset);
+      Assert.eq('', true, Compare.eq(expStart, act.startContainer));
+      Assert.eq('', expected.start.offset, act.startOffset);
+      Assert.eq('', true, Compare.eq(expFinish, act.endContainer));
+      Assert.eq('', expected.finish.offset, act.endOffset);
 
       const range = document.createRange();
       range.setStart(act.startContainer.dom, act.startOffset);
       range.setEnd(act.endContainer.dom, act.endOffset);
-      assert.eq(expected.word, range.toString());
+      Assert.eq('', expected.word, range.toString());
     });
   };
 

--- a/modules/robin/src/test/ts/browser/api/DomClumpsTest.ts
+++ b/modules/robin/src/test/ts/browser/api/DomClumpsTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { Compare, Hierarchy, Html, Insert, InsertAll, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 
@@ -29,13 +29,13 @@ UnitTest.test('DomClumpsTest', () => {
 
   const checkFracture = (expected: string, start: number[], soffset: number, finish: number[], foffset: number) => {
     DomClumps.fracture(isRoot, find(start), soffset, find(finish), foffset).each(mark);
-    assert.eq(expected, Html.get(container));
+    Assert.eq('', expected, Html.get(container));
   };
 
   const checkFractures = (expected: string, start: number[], soffset: number, finish: number[], foffset: number) => {
     const sections = DomClumps.fractures(isRoot, find(start), soffset, find(finish), foffset);
     Arr.each(sections, mark);
-    assert.eq(expected, Html.get(container));
+    Assert.eq('', expected, Html.get(container));
   };
 
   container.dom.innerHTML =

--- a/modules/robin/src/test/ts/browser/api/DomStructureTest.ts
+++ b/modules/robin/src/test/ts/browser/api/DomStructureTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
@@ -12,11 +12,11 @@ UnitTest.test('DomStructureTest', () => {
     return DomStructure.isInline(element);
   };
   Arr.each(expectInlineElements, (e) => {
-    assert.eq(true, getInline(e), `Expected ${e} to be inline, but it wasn't`);
+    Assert.eq(`Expected ${e} to be inline, but it wasn't`, true, getInline(e));
   });
 
   const expectNonInlineElements = [ 'p', 'div', 'blockquote', 'h1', 'h2', 'h3', 'ul', 'li' ];
   Arr.each(expectNonInlineElements, (e) => {
-    assert.eq(false, getInline(e), `Expected ${e} to not be inline, but it was`);
+    Assert.eq(`Expected ${e} to not be inline, but it was`, false, getInline(e));
   });
 });

--- a/modules/robin/src/test/ts/browser/clumps/ClumpsTest.ts
+++ b/modules/robin/src/test/ts/browser/clumps/ClumpsTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { DomUniverse } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 import { Compare, Hierarchy, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
@@ -35,11 +35,11 @@ UnitTest.test('ClumpsTest', () => {
 
   const check = (expected: Expected[], start: number[], soffset: number, finish: number[], foffset: number) => {
     const actual = Clumps.collect(DomUniverse(), isRoot, find(start), soffset, find(finish), foffset);
-    assert.eq(expected.length, actual.length, 'The length of Clumps was different. Expected: ' + expected.length + ', actual: ' + actual.length);
+    Assert.eq('The length of Clumps was different. Expected: ' + expected.length + ', actual: ' + actual.length, expected.length, actual.length);
     Arr.each(expected, (exp, i) => {
       const act = actual[i];
-      assert.eq(true, Compare.eq(find(exp.start), act.start));
-      assert.eq(true, Compare.eq(find(exp.end), act.finish));
+      Assert.eq('', true, Compare.eq(find(exp.start), act.start));
+      Assert.eq('', true, Compare.eq(find(exp.end), act.finish));
     });
   };
 

--- a/modules/robin/src/test/ts/browser/examples/BlockTest.ts
+++ b/modules/robin/src/test/ts/browser/examples/BlockTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
 import { SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
@@ -12,9 +12,9 @@ UnitTest.test('BlockTest', () => {
     BrowserCheck.run(input, (node) => {
       const actual = DomParent.sharedOne(look, [ node ]);
       actual.fold(() => {
-        assert.fail('Expected a common ' + expected + ' tag');
+        Assert.fail('Expected a common ' + expected + ' tag');
       }, (act) => {
-        assert.eq(expected, SugarNode.name(act));
+        Assert.eq('', expected, SugarNode.name(act));
       });
     });
   };
@@ -23,7 +23,7 @@ UnitTest.test('BlockTest', () => {
     BrowserCheck.run(input, (node) => {
       const actual = DomParent.sharedOne(look, [ node ]);
       actual.each((a) => {
-        assert.fail('Expected no common tag matching the look. Received: ' + SugarNode.name(a));
+        Assert.fail('Expected no common tag matching the look. Received: ' + SugarNode.name(a));
       });
     });
   };
@@ -40,9 +40,9 @@ UnitTest.test('BlockTest', () => {
   BrowserCheck.run('<p>this<span class="child"> is it </span></p>', (node) => {
     const actual = DomParent.sharedOne(DomLook.exact(Traverse.parent(node).getOrDie()), [ node ]);
     actual.fold(() => {
-      assert.fail('Expected a common tag');
+      Assert.fail('Expected a common tag');
     }, (act) => {
-      assert.eq('span', SugarNode.name(act));
+      Assert.eq('', 'span', SugarNode.name(act));
     });
   });
 });

--- a/modules/snooker/src/test/ts/atomic/calc/DeltasTest.ts
+++ b/modules/snooker/src/test/ts/atomic/calc/DeltasTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 
 import * as ResizeBehaviour from 'ephox/snooker/api/ResizeBehaviour';
@@ -21,7 +21,7 @@ UnitTest.test('DeltasTest', () => {
       isRelative: false
     };
     const actual = Deltas.determine(input, column, step, tableSize as TableSize, resizeBehaviour);
-    assert.eq(expected, Arr.map(actual, (num) => Math.round(num)), `${msg}: expected: ${expected}, actual: ${actual}`);
+    Assert.eq(`${msg}: expected: ${expected}, actual: ${actual}`, expected, Arr.map(actual, (num) => Math.round(num)));
   };
 
   Arr.each([ resizeTable, preserveTable ], (mode) => {

--- a/modules/snooker/src/test/ts/atomic/model/FitmentIVTest.ts
+++ b/modules/snooker/src/test/ts/atomic/model/FitmentIVTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Fun, Result } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
@@ -201,10 +201,10 @@ UnitTest.test('FitmentIVTest', () => {
           })();
 
           if (expected === '?') {
-            assert.eq(true, '?_' === (cell.element as unknown as string).substring(0, 2));
+            Assert.eq('', true, '?_' === (cell.element as unknown as string).substring(0, 2));
           } else {
-            assert.eq(expected.isNew, cell.isNew);
-            assert.eq(expected.element, cell.element);
+            Assert.eq('', expected.isNew, cell.isNew);
+            Assert.eq('', expected.element, cell.element);
           }
         });
       });

--- a/modules/snooker/src/test/ts/atomic/operate/MergeOperationsTest.ts
+++ b/modules/snooker/src/test/ts/atomic/operate/MergeOperationsTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
@@ -15,13 +15,13 @@ UnitTest.test('MergeOperationsTest', () => {
   (() => {
     const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], bounds: Structs.Bounds, lead: string) => {
       const actual = MergingOperations.merge(grid, bounds, Fun.tripleEquals, Fun.constant(lead as unknown as SugarElement<any>));
-      assert.eq(expected.length, actual.length);
+      Assert.eq('', expected.length, actual.length);
       Arr.each(expected, (row, i) => {
         Arr.each(row.cells, (cell, j) => {
-          assert.eq(cell.element, actual[i].cells[j].element);
-          assert.eq(cell.isNew, actual[i].cells[j].isNew);
+          Assert.eq('', cell.element, actual[i].cells[j].element);
+          Assert.eq('', cell.isNew, actual[i].cells[j].isNew);
         });
-        assert.eq(row.section, actual[i].section);
+        Assert.eq('', row.section, actual[i].section);
       });
     };
 
@@ -109,14 +109,14 @@ UnitTest.test('MergeOperationsTest', () => {
   (() => {
     const check = (expected: Structs.RowCells[], grid: Structs.RowCells[], target: string) => {
       const actual = MergingOperations.unmerge(grid, target as unknown as SugarElement<any>, Fun.tripleEquals, Fun.constant('?') as any);
-      assert.eq(expected.length, actual.length);
+      Assert.eq('', expected.length, actual.length);
       Arr.each(expected, (row, i) => {
         Arr.each(row.cells, (cell, j) => {
-          assert.eq(cell.element, actual[i].cells[j].element);
-          assert.eq(cell.isNew, actual[i].cells[j].isNew);
+          Assert.eq('', cell.element, actual[i].cells[j].element);
+          Assert.eq('', cell.isNew, actual[i].cells[j].isNew);
         });
-        assert.eq(row.section, actual[i].section, 'section type');
-        assert.eq(row.isNew, actual[i].isNew, 'is new row');
+        Assert.eq('section type', row.section, actual[i].section);
+        Assert.eq('is new row', row.isNew, actual[i].isNew);
       });
     };
 

--- a/modules/snooker/src/test/ts/atomic/resize/RedistributeTest.ts
+++ b/modules/snooker/src/test/ts/atomic/resize/RedistributeTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Redistribution from 'ephox/snooker/resize/Redistribution';
 import { Size } from 'ephox/snooker/resize/Size';
@@ -15,12 +15,12 @@ UnitTest.test('RedistributeTest', () => {
   };
 
   const check = (expected: string[], input: string[], originalWidth: number, newWidth: string) => {
-    assert.eq(expected, Redistribution.redistribute(input, originalWidth, newWidth));
+    Assert.eq('', expected, Redistribution.redistribute(input, originalWidth, newWidth));
   };
 
   const checkValidate = (expected: string, input: string) => {
     const actual = toStr(Redistribution.validate(input));
-    assert.eq(expected, actual);
+    Assert.eq('', expected, actual);
   };
 
   checkValidate('pixels[10]', '10px');
@@ -44,11 +44,11 @@ UnitTest.test('RedistributeTest', () => {
   check([ '', '', '20px' ], [ '', '', '20px' ], 60, '60px');
   check([ '', '', '' ], [ '', '', '' ], 60, '60px');
 
-  assert.eq([ '10px', '10px', '11px' ], Redistribution.normalize([ '10.3px', '10.3px', '10.3px' ]));
-  assert.eq([ '10px', '11px', '10px' ], Redistribution.normalize([ '10px', '11px', '10px' ]));
-  assert.eq([ '33.33%', '33.33%', '33.33%' ], Redistribution.normalize([ '33.33%', '33.33%', '33.33%' ]));
+  Assert.eq('', [ '10px', '10px', '11px' ], Redistribution.normalize([ '10.3px', '10.3px', '10.3px' ]));
+  Assert.eq('', [ '10px', '11px', '10px' ], Redistribution.normalize([ '10px', '11px', '10px' ]));
+  Assert.eq('', [ '33.33%', '33.33%', '33.33%' ], Redistribution.normalize([ '33.33%', '33.33%', '33.33%' ]));
 
-  assert.eq(100, Redistribution.sum([ '100px' ], 10));
-  assert.eq(50, Redistribution.sum([ '50%' ], 10));
-  assert.eq(75, Redistribution.sum([ '50px', '25px' ], 10));
+  Assert.eq('', 100, Redistribution.sum([ '100px' ], 10));
+  Assert.eq('', 50, Redistribution.sum([ '50%' ], 10));
+  Assert.eq('', 75, Redistribution.sum([ '50px', '25px' ], 10));
 });

--- a/modules/snooker/src/test/ts/atomic/util/UtilTest.ts
+++ b/modules/snooker/src/test/ts/atomic/util/UtilTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
 
 import * as Util from 'ephox/snooker/util/Util';
@@ -6,19 +6,19 @@ import * as Util from 'ephox/snooker/util/Util';
 UnitTest.test('UtilTest', () => {
   const eq = (a: number, b: number) => a === b;
 
-  assert.eq([], Util.unique([], eq));
-  assert.eq([ 1 ], Util.unique([ 1 ], eq));
-  assert.eq([ 1, 2, 3, 4 ], Util.unique([ 1, 1, 2, 2, 2, 3, 4, 4 ], eq));
+  Assert.eq('', [], Util.unique([], eq));
+  Assert.eq('', [ 1 ], Util.unique([ 1 ], eq));
+  Assert.eq('', [ 1, 2, 3, 4 ], Util.unique([ 1, 1, 2, 2, 2, 3, 4, 4 ], eq));
 
   const input1: Optional<number>[] = [ Optional.some(50), Optional.some(60), Optional.some(75), Optional.some(95) ];
 
-  assert.eq(10, Util.deduce(input1, 0).getOrDie('m'));
-  assert.eq(15, Util.deduce(input1, 1).getOrDie('o'));
-  assert.eq(20, Util.deduce(input1, 2).getOrDie('p'));
+  Assert.eq('', 10, Util.deduce(input1, 0).getOrDie('m'));
+  Assert.eq('', 15, Util.deduce(input1, 1).getOrDie('o'));
+  Assert.eq('', 20, Util.deduce(input1, 2).getOrDie('p'));
 
   const input2: Optional<number>[] = [ Optional.some(50), Optional.none(), Optional.some(80), Optional.some(120) ];
 
-  assert.eq(15, Util.deduce(input2, 0).getOrDie('input2.test0'));
-  assert.eq(15, Util.deduce(input2, 1).getOrDie('input2.test1'));
-  assert.eq(40, Util.deduce(input2, 2).getOrDie('input2.test2'));
+  Assert.eq('', 15, Util.deduce(input2, 0).getOrDie('input2.test0'));
+  Assert.eq('', 15, Util.deduce(input2, 1).getOrDie('input2.test1'));
+  Assert.eq('', 40, Util.deduce(input2, 2).getOrDie('input2.test2'));
 });

--- a/modules/snooker/src/test/ts/browser/CloneFormatsTest.ts
+++ b/modules/snooker/src/test/ts/browser/CloneFormatsTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Fun, Optional } from '@ephox/katamari';
 import { Html, Insert, SugarElement } from '@ephox/sugar';
 
@@ -22,8 +22,8 @@ UnitTest.test('CloneFormatsTest', () => {
 
   const clonedCell = cloneTableFill.cell(cell);
 
-  assert.eq('<td><strong><em><br></em></strong></td>', Html.getOuter(clonedCell));
+  Assert.eq('', '<td><strong><em><br></em></strong></td>', Html.getOuter(clonedCell));
 
   const noClonedCell = noCloneTableFill.cell(cell);
-  assert.eq('<td><br></td>', Html.getOuter(noClonedCell));
+  Assert.eq('', '<td><br></td>', Html.getOuter(noClonedCell));
 });

--- a/modules/snooker/src/test/ts/browser/CopySelectedTest.ts
+++ b/modules/snooker/src/test/ts/browser/CopySelectedTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Obj, Type } from '@ephox/katamari';
 import { Attribute, Class, Html, InsertAll, SugarElement } from '@ephox/sugar';
 
@@ -97,13 +97,13 @@ UnitTest.test('CopySelectedTest', () => {
     // Verify specified table attributes are not present in replica table
     if (Type.isNonNullable(tableAttributes)) {
       Arr.each(tableAttributes.afterCopy, (attrName) => {
-        assert.eq(false, Attribute.has(replica, attrName));
+        Assert.eq('', false, Attribute.has(replica, attrName));
       });
     }
 
     // Now verify that the table matches the nested array structure of expected
     const assertWithInfo = <T> (exp: T, actual: T, info: string) => {
-      assert.eq(exp, actual, () => 'expected ' + info + ' "' + exp + '", was "' + actual + '"' + ', test "' + label + '". Output HTML:\n' + Html.getOuter(replica));
+      Assert.eq(() => 'expected ' + info + ' "' + exp + '", was "' + actual + '"' + ', test "' + label + '". Output HTML:\n' + Html.getOuter(replica), exp, actual);
     };
 
     const domRows = traverseChildElements(replica);

--- a/modules/snooker/src/test/ts/browser/TableGridSizeTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableGridSizeTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Remove, SugarElement } from '@ephox/sugar';
 
 import * as TableGridSize from 'ephox/snooker/api/TableGridSize';
@@ -8,8 +8,8 @@ UnitTest.test('Table grid size test', () => {
     const tbl = SugarElement.fromHtml<HTMLTableElement>(html);
     const size = TableGridSize.getGridSize(tbl);
 
-    assert.eq(expectedColumnCount, size.columns, 'Should be expected column count');
-    assert.eq(expectedRowCount, size.rows, 'Should be expected row count');
+    Assert.eq('Should be expected column count', expectedColumnCount, size.columns);
+    Assert.eq('Should be expected row count', expectedRowCount, size.rows);
 
     Remove.remove(tbl);
   };

--- a/modules/snooker/src/test/ts/browser/TableLookupTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableLookupTest.ts
@@ -1,4 +1,4 @@
-import { Assert, assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { Compare, Insert, Remove, SelectorFilter, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
 
@@ -20,17 +20,17 @@ UnitTest.test('TableLookupTest - cells', () => {
   const testerFound = (html: string, triggerSelector: string, resultSelector: string, label: string) => {
     testWithSelector(html, triggerSelector, (triggerElement) => {
       const result = TableLookup.cell(triggerElement);
-      assert.eq(true, result.isSome(), label + ': Expected the result to find something');
+      Assert.eq(label + ': Expected the result to find something', true, result.isSome());
       const expectedElement = SelectorFilter.descendants(SugarBody.body(), resultSelector);
-      assert.eq(true, expectedElement.length === 1, label + ': Expected to find only one element in the DOM with the selector ' + resultSelector + ' found: ' + expectedElement.length);
-      assert.eq(true, Compare.eq(expectedElement[0], result.getOrDie()), label + ': The result and the expectation should be the same element');
+      Assert.eq(label + ': Expected to find only one element in the DOM with the selector ' + resultSelector + ' found: ' + expectedElement.length, true, expectedElement.length === 1);
+      Assert.eq(label + ': The result and the expectation should be the same element', true, Compare.eq(expectedElement[0], result.getOrDie()));
     });
   };
 
   const testerShouldNotFind = (html: string, selector: string, label: string) => {
     testWithSelector(html, selector, (triggerElement) => {
       const result = TableLookup.cell(triggerElement);
-      assert.eq(false, result.isSome(), label + ': Expected the result to find nothing');
+      Assert.eq(label + ': Expected the result to find nothing', false, result.isSome());
     });
   };
 
@@ -122,12 +122,12 @@ UnitTest.test('TableLookupTest - cells', () => {
 
     const cells = SelectorFilter.descendants(SugarBody.body(), 'td');
     if (cells.length === 0) {
-      assert.fail('Could not find any table cell element');
+      Assert.fail('Could not find any table cell element');
     } else {
       Arr.each(cells, (cell) => {
         const result = TableLookup.cell(cell);
-        assert.eq(true, result.isSome(), label + ': Expected the result to find something');
-        assert.eq(true, Compare.eq(cell, result.getOrDie()), label + ': The result and the expectation should be the same element');
+        Assert.eq(label + ': Expected the result to find something', true, result.isSome());
+        Assert.eq(label + ': The result and the expectation should be the same element', true, Compare.eq(cell, result.getOrDie()));
       });
 
       Remove.remove(element);
@@ -141,11 +141,11 @@ UnitTest.test('TableLookupTest - cells', () => {
 
     const rows = SelectorFilter.descendants(SugarBody.body(), 'tr');
     if (rows.length === 0) {
-      assert.fail('Could not find any table row elements');
+      Assert.fail('Could not find any table row elements');
     } else {
       Arr.each(rows, (row) => {
         const result = TableLookup.cell(row);
-        assert.eq(false, result.isSome(), label + ': Expected the result to find nothing');
+        Assert.eq(label + ': Expected the result to find nothing', false, result.isSome());
       });
       Remove.remove(element);
     }

--- a/modules/snooker/src/test/ts/browser/TableMergeContentTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableMergeContentTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { Html, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 
@@ -21,7 +21,7 @@ UnitTest.test('TableMergeContentTest', () => {
 
     TableContent.merge(cells);
     Arr.each(specs, (spec, i) => {
-      assert.eq(spec.expected, Html.get(cells[i]), () => spec.label + ' expected:\n' + spec.expected + '\n got: \n' + Html.get(cells[i]));
+      Assert.eq(() => spec.label + ' expected:\n' + spec.expected + '\n got: \n' + Html.get(cells[i]), spec.expected, Html.get(cells[i]));
     });
 
     Remove.remove(table);

--- a/modules/snooker/src/test/ts/browser/TablePositionsTest.ts
+++ b/modules/snooker/src/test/ts/browser/TablePositionsTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
 import { Insert, InsertAll, Remove, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
 
@@ -82,7 +82,7 @@ UnitTest.test('RectangularTest', () => {
     const start = SelectorFilter.descendants<HTMLTableCellElement>(tableTarget, from)[0];
     const finish = SelectorFilter.descendants<HTMLTableCellElement>(tableTarget, to)[0];
     const c = TablePositions.getBox(tableTarget, start, finish);
-    assert.eq(expected, c.isSome());
+    Assert.eq('', expected, c.isSome());
   };
 
   check(table, '#tableA td#B1', '#tableA td#C3', false);

--- a/modules/snooker/src/test/ts/browser/TableSizesTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableSizesTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
 import { Css, Html, Insert, InsertAll, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 
@@ -92,7 +92,7 @@ UnitTest.test('Table Sizes Test (fusebox)', () => {
     return table;
   };
 
-  assert.eq(
+  Assert.eq('',
     '<table style="width: 25px;"><tbody>' +
       '<tr><td style="width: 20px;">A0</td><td style="width: 30%;">B0</td></tr>' +
       '<tr><td style="width: 10px;">A1</td><td style="width: 15px;">B1</td></tr>' +
@@ -103,12 +103,12 @@ UnitTest.test('Table Sizes Test (fusebox)', () => {
     ], '25px'))
   );
 
-  assert.eq([[ '1px', '2px' ], [ '1px', '2px' ]], readWidth(generateW([[ '1px', '2px' ], [ '1px', '2px' ]], '3px')));
+  Assert.eq('', [[ '1px', '2px' ], [ '1px', '2px' ]], readWidth(generateW([[ '1px', '2px' ], [ '1px', '2px' ]], '3px')));
 
   const checkWidth = (expected: string[][], table: SugarElement<HTMLTableElement>, newWidth: string) => {
     Insert.append(SugarBody.body(), table);
     Sizes.redistribute(table, Optional.some(newWidth), Optional.none());
-    assert.eq(expected, readWidth(table));
+    Assert.eq('', expected, readWidth(table));
     Remove.remove(table);
   };
 
@@ -120,7 +120,7 @@ UnitTest.test('Table Sizes Test (fusebox)', () => {
   const checkHeight = (expected: string[][], table: SugarElement<HTMLTableElement>, newHeight: string) => {
     Insert.append(SugarBody.body(), table);
     Sizes.redistribute(table, Optional.none(), Optional.some(newHeight));
-    assert.eq(expected, readHeight(table));
+    Assert.eq('', expected, readHeight(table));
     Remove.remove(table);
   };
 

--- a/modules/snooker/src/test/ts/browser/lookup/BlocksTest.ts
+++ b/modules/snooker/src/test/ts/browser/lookup/BlocksTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { SugarElement, TextContent } from '@ephox/sugar';
 
 import * as Structs from 'ephox/snooker/api/Structs';
@@ -21,7 +21,7 @@ UnitTest.test('BlocksTest', () => {
     f([ s('h', 1, 1), s('i', 1, 2) ], 'tfoot')
   ]);
 
-  assert.eq([ 'a', 'd', 'e' ], Blocks.columns(warehouse).map((c) => {
+  Assert.eq('', [ 'a', 'd', 'e' ], Blocks.columns(warehouse).map((c) => {
     return c.map(TextContent.get).getOrDie();
   }));
 });

--- a/modules/snooker/src/test/ts/browser/operate/ModificationOperationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/operate/ModificationOperationsTest.ts
@@ -1,5 +1,5 @@
 import { Assertions } from '@ephox/agar';
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { Html, SugarElement, SugarNode } from '@ephox/sugar';
 
@@ -25,15 +25,15 @@ UnitTest.test('ModificationOperationsTest', () => {
   };
 
   const assertGrids = (expected: Structs.RowCells[], actual: Structs.RowCells[], checkIsNew: boolean) => {
-    assert.eq(expected.length, actual.length);
+    Assert.eq('', expected.length, actual.length);
     Arr.each(expected, (row, i) => {
       Arr.each(row.cells, (cell, j) => {
         Assertions.assertHtml('Expected elements to have the same HTML', Html.getOuter(cell.element), Html.getOuter(actual[i].cells[j].element));
-        assert.eq(cell.isNew, actual[i].cells[j].isNew);
+        Assert.eq('', cell.isNew, actual[i].cells[j].isNew);
       });
-      assert.eq(row.section, actual[i].section, 'section type');
+      Assert.eq('section type', row.section, actual[i].section);
       if (checkIsNew) {
-        assert.eq(row.isNew, actual[i].isNew, 'is new row');
+        Assert.eq('is new row', row.isNew, actual[i].isNew);
       }
     });
   };

--- a/modules/snooker/src/test/ts/browser/resize/RecalculationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/resize/RecalculationsTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarElement, TextContent } from '@ephox/sugar';
 
@@ -37,17 +37,17 @@ UnitTest.test('RecalculationsTest', () => {
     const actualCellHeight = Recalculations.recalculateHeightForCells(warehouse, sizes.height);
 
     Arr.each(expected, (expt) => {
-      assert.eq(expt.columns, Arr.map(actualColumnWidth, (cell) => ({
+      Assert.eq('', expt.columns, Arr.map(actualColumnWidth, (cell) => ({
         element: TextContent.get(cell.element),
         width: cell.width
       })));
 
-      assert.eq(expt.widths, Arr.map(actualCellWidth, (cell) => ({
+      Assert.eq('', expt.widths, Arr.map(actualCellWidth, (cell) => ({
         element: TextContent.get(cell.element),
         width: cell.width
       })));
 
-      assert.eq(expt.heights, Arr.map(actualCellHeight, (cell) => ({
+      Assert.eq('', expt.heights, Arr.map(actualCellHeight, (cell) => ({
         element: TextContent.get(cell.element),
         height: cell.height
       })));

--- a/modules/snooker/src/test/ts/browser/selection/CellBoundsTest.ts
+++ b/modules/snooker/src/test/ts/browser/selection/CellBoundsTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarElement, TextContent } from '@ephox/sugar';
 
@@ -29,13 +29,13 @@ UnitTest.test('CellBounds.isWithin Test', () => {
   const checkWithin = (expected: boolean, warehouse: Warehouse, bounds: Structs.Bounds, row: number, column: number) => {
     const cell = Warehouse.getAt(warehouse, row, column).getOrDie();
     const actual = CellBounds.isWithin(bounds, cell);
-    assert.eq(expected, actual);
+    Assert.eq('', expected, actual);
   };
 
   const checkInSelection = (expected: boolean, warehouse: Warehouse, bounds: Structs.Bounds, row: number, column: number) => {
     const cell = Warehouse.getAt(warehouse, row, column).getOrDie();
     const actual = CellBounds.inSelection(bounds, cell);
-    assert.eq(expected, actual);
+    Assert.eq('', expected, actual);
   };
 
   checkWithin(false, inputA, bounds1To3, 2, 2);

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/Assertions.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/Assertions.ts
@@ -1,5 +1,5 @@
 import { Assertions } from '@ephox/agar';
-import { assert } from '@ephox/bedrock-client';
+import { Assert } from '@ephox/bedrock-client';
 import { Arr, Optional, Optionals } from '@ephox/katamari';
 import { Attribute, Css, Hierarchy, Html, Insert, Remove, SelectorFilter, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
 
@@ -47,7 +47,7 @@ const checkOld = (
       table,
       result.getOrDie(label + ': could not get result').cursor.getOrDie(label + ': could not find cursor')
     ).getOrDie(label + ': could not find path');
-    assert.eq([ expCell.section, expCell.row, expCell.column ], actualPath);
+    Assert.eq('', [ expCell.section, expCell.row, expCell.column ], actualPath);
   });
 
   // Let's get rid of size information.
@@ -87,7 +87,7 @@ const checkOldMultiple = (
       table,
       result.getOrDie(label + ': could not get result').cursor.getOrDie(label + ': could not find cursor')
     ).getOrDie(label + ': could not find path');
-    assert.eq([ expCell.section, expCell.row, expCell.column ], actualPath);
+    Assert.eq('', [ expCell.section, expCell.row, expCell.column ], actualPath);
   });
 
   // Let's get rid of size information.
@@ -178,7 +178,7 @@ const checkStructure = (
   }, Bridge.generators);
 
   const actualPath = Hierarchy.path(table, result.getOrDie().cursor.getOrDie()).getOrDie('could not find path');
-  assert.eq([ expCell.section, expCell.row, expCell.column ], actualPath);
+  Assert.eq('', [ expCell.section, expCell.row, expCell.column ], actualPath);
 
   // Presence.assertHas(expected, table, 'checking the operation on table: ' + Html.getOuter(table));
   const rows = SelectorFilter.descendants(table, 'tr');
@@ -186,7 +186,7 @@ const checkStructure = (
     const cells = SelectorFilter.descendants<HTMLTableCellElement>(r, 'td,th');
     return Arr.map(cells, Html.get);
   });
-  assert.eq(expected, actual);
+  Assert.eq('', expected, actual);
   Remove.remove(container);
 };
 
@@ -216,7 +216,7 @@ const checkDelete = (
       table,
       result.getOrDie(label + ': could not get result').cursor.getOrDie(label + ': could not find cursor')
     ).getOrDie(label + ': could not find path');
-    assert.eq([ expCell.section, expCell.row, expCell.column ], actualPath);
+    Assert.eq('', [ expCell.section, expCell.row, expCell.column ], actualPath);
   });
 
   // Let's get rid of size information.
@@ -261,7 +261,7 @@ const checkMerge = (
   const all = [ table ].concat(SelectorFilter.descendants(table, 'td,th'));
   Arr.each(all, (elem) => Css.remove(elem, 'width') );
 
-  assert.eq('1', Attribute.get(table, 'border'));
+  Assert.eq('', '1', Attribute.get(table, 'border'));
   // Get around ordering of attribute differences.
   Attribute.remove(table, 'border');
   Assertions.assertHtmlStructure(label, expected, Html.getOuter(table));

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/Fitment.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/Fitment.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ephox/bedrock-client';
+import { Assert } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 
 import { SimpleGenerators } from 'ephox/snooker/api/Generators';
@@ -12,13 +12,13 @@ const mapToStructGrid = (grid: Structs.ElementNew[][]): Structs.RowCells[] => {
 };
 
 const assertGrids = (expected: Structs.RowCells[], actual: Structs.RowCells[]): void => {
-  assert.eq(expected.length, actual.length);
+  Assert.eq('', expected.length, actual.length);
   Arr.each(expected, (row, i) => {
     Arr.each(row.cells, (cell, j) => {
-      assert.eq(cell.element, actual[i].cells[j].element);
-      assert.eq(cell.isNew, actual[i].cells[j].isNew);
+      Assert.eq('', cell.element, actual[i].cells[j].element);
+      Assert.eq('', cell.isNew, actual[i].cells[j].isNew);
     });
-    assert.eq(row.section, actual[i].section);
+    Assert.eq('', row.section, actual[i].section);
   });
 };
 
@@ -31,16 +31,16 @@ const measureTest = (expected: { error: string } | { rowDelta: number; colDelta:
 
   Fitment.measure(startAddress, mapToStructGrid(gridA), mapToStructGrid(gridB)).fold((err) => {
     if ('error' in expected) {
-      assert.eq(expected.error, err);
+      Assert.eq('', expected.error, err);
     } else {
-      assert.fail('An error was not expected. Message was "' + err + '"');
+      Assert.fail('An error was not expected. Message was "' + err + '"');
     }
   }, (delta) => {
     if ('rowDelta' in expected) {
-      assert.eq(expected.rowDelta, delta.rowDelta, 'rowDelta expected: ' + expected.rowDelta + ' actual: ' + delta.rowDelta);
-      assert.eq(expected.colDelta, delta.colDelta, 'colDelta expected: ' + expected.colDelta + ' actual: ' + delta.colDelta);
+      Assert.eq('rowDelta expected: ' + expected.rowDelta + ' actual: ' + delta.rowDelta, expected.rowDelta, delta.rowDelta);
+      Assert.eq('colDelta expected: ' + expected.colDelta + ' actual: ' + delta.colDelta, expected.colDelta, delta.colDelta);
     } else {
-      assert.fail('Expected error "' + expected.error + '" but instead got rowDelta=' + delta.rowDelta + ' colDelta=' + delta.colDelta);
+      Assert.fail('Expected error "' + expected.error + '" but instead got rowDelta=' + delta.rowDelta + ' colDelta=' + delta.colDelta);
     }
   });
 };
@@ -59,8 +59,8 @@ const tailorIVTest = (expected: { rows: number; cols: number }, startAddress: St
   const tailoredGrid = Fitment.tailor(mapToStructGrid(gridA), delta, generator());
   const rows = tailoredGrid.length;
   const cols = tailoredGrid[0].cells.length;
-  assert.eq(expected.rows, rows);
-  assert.eq(expected.cols, cols);
+  Assert.eq('', expected.rows, rows);
+  Assert.eq('', expected.cols, cols);
 };
 
 export {

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/TableMerge.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/TableMerge.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ephox/bedrock-client';
+import { Assert } from '@ephox/bedrock-client';
 import { Arr, Result } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
@@ -14,13 +14,13 @@ const mapToStructGrid = (grid: Structs.ElementNew[][]): Structs.RowCells[] => {
 };
 
 const assertGrids = (expected: Structs.RowCells[], actual: Structs.RowCells[]): void => {
-  assert.eq(expected.length, actual.length);
+  Assert.eq('', expected.length, actual.length);
   Arr.each(expected, (row, i) => {
     Arr.each(row.cells, (cell, j) => {
-      assert.eq(cell.element, actual[i].cells[j].element);
-      assert.eq(cell.isNew, actual[i].cells[j].isNew);
+      Assert.eq('', cell.element, actual[i].cells[j].element);
+      Assert.eq('', cell.isNew, actual[i].cells[j].isNew);
     });
-    assert.eq(row.section, actual[i].section);
+    Assert.eq('', row.section, actual[i].section);
   });
 };
 
@@ -42,15 +42,15 @@ const mergeTest = (
   );
   nuGrid.fold((err) => {
     if ('error' in expected) {
-      assert.eq(expected.error, err);
+      Assert.eq('', expected.error, err);
     } else {
-      assert.fail('Failure was unexpected, got error "' + err + '"');
+      Assert.fail('Failure was unexpected, got error "' + err + '"');
     }
   }, (grid) => {
     if (!('error' in expected)) {
       assertGrids(mapToStructGrid(expected), grid);
     } else {
-      assert.fail('Expected failure "' + expected.error + '" but instead got grid');
+      Assert.fail('Expected failure "' + expected.error + '" but instead got grid');
     }
   });
 };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/Viewable.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/Viewable.ts
@@ -4,9 +4,6 @@ import { SugarElement } from '../node/SugarElement';
 import * as Traverse from '../search/Traverse';
 import * as Visibility from '../view/Visibility';
 
-// TypeScript does not include MutationObserver on the window object, and it's accessed that way for... reasons?
-declare const window: any;
-
 /*
  * Long term it's probably worth looking at using a single event per page the way Resize does.
  * This could get a bit slow with a lot of editors in a heavy page.

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/WindowVisualViewport.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/WindowVisualViewport.ts
@@ -15,29 +15,13 @@ export interface Bounds {
   readonly bottom: number;
 }
 
-// Experimental support for visual viewport
-// TODO: Remove this once using the TS dom library
-interface WindowVisualViewport {
-  readonly offsetLeft: number;
-  readonly offsetTop: number;
-  readonly pageLeft: number;
-  readonly pageTop: number;
-  readonly width: number;
-  readonly height: number;
-  readonly scale: number;
-  readonly addEventListener: (event: string, handler: EventListenerOrEventListenerObject) => void;
-  readonly removeEventListener: (event: string, handler: EventListenerOrEventListenerObject) => void;
-  readonly dispatchEvent: (evt: Event) => boolean;
-}
-
-const get = (_win?: Window): Optional<WindowVisualViewport> => {
+const get = (_win?: Window): Optional<VisualViewport> => {
   const win = _win === undefined ? window : _win;
   if (PlatformDetection.detect().browser.isFirefox()) {
     // TINY-7984: Firefox 91 is returning incorrect values for visualViewport.pageTop, so disable it for now
     return Optional.none();
   } else {
-    // eslint-disable-next-line dot-notation
-    return Optional.from((win as any)['visualViewport']);
+    return Optional.from(win.visualViewport);
   }
 };
 
@@ -86,6 +70,5 @@ const bind = (name: string, callback: EventHandler, _win?: Window): EventUnbinde
 export {
   bind,
   get,
-  getBounds,
-  WindowVisualViewport
+  getBounds
 };

--- a/modules/sugar/src/test/ts/browser/AlignmentTest.ts
+++ b/modules/sugar/src/test/ts/browser/AlignmentTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
@@ -22,7 +22,7 @@ UnitTest.test('AlignmentTest', () => {
 
   const check = (element: SugarElement<Element> | SugarElement<Text>, property: string, value: string, expected: boolean) => {
     const res = Alignment.hasAlignment(element, property, value);
-    assert.eq(expected, res);
+    Assert.eq('', expected, res);
     Traverse.parent(element).each(Remove.remove);
   };
 

--- a/modules/sugar/src/test/ts/browser/AttributePropertyTest.ts
+++ b/modules/sugar/src/test/ts/browser/AttributePropertyTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Attribute from 'ephox/sugar/api/properties/Attribute';
 import { AttributeProperty } from 'ephox/sugar/api/properties/AttributeProperty';
@@ -18,17 +18,17 @@ UnitTest.test('AttributePropertyTest', () => {
   const link = EphoxElement('a');
   Attribute.set(link, 'href', '#');
 
-  assert.eq(false, init.is(link));
-  assert.eq(false, init.is(rtlEl));
-  assert.eq(true, init.is(ltrEl));
+  Assert.eq('', false, init.is(link));
+  Assert.eq('', false, init.is(rtlEl));
+  Assert.eq('', true, init.is(ltrEl));
 
   init.remove(rtlEl);
-  assert.eq(Attribute.get(rtlEl, 'custom'), undefined);
+  Assert.eq('', Attribute.get(rtlEl, 'custom'), undefined);
   init.set(rtlEl);
-  assert.eq(Attribute.get(rtlEl, 'custom'), 'value');
+  Assert.eq('', Attribute.get(rtlEl, 'custom'), 'value');
 
   init.set(link);
-  assert.eq(Attribute.get(link, 'custom'), 'value');
+  Assert.eq('', Attribute.get(link, 'custom'), 'value');
   init.remove(link);
-  assert.eq(Attribute.get(link, 'custom'), undefined);
+  Assert.eq('', Attribute.get(link, 'custom'), undefined);
 });

--- a/modules/sugar/src/test/ts/browser/AttributeTransferTest.ts
+++ b/modules/sugar/src/test/ts/browser/AttributeTransferTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
 
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
@@ -36,15 +36,15 @@ UnitTest.test('AttributeTransfer', () => {
     Attribute.transfer(source, destination, attributes);
     Arr.each(expectedAbsent, (k) => {
       if (Attribute.has(destination, k)) {
-        assert.fail('Result should not have attribute: ' + k);
+        Assert.fail('Result should not have attribute: ' + k);
       }
     });
 
     Obj.each(expectedPresent, (v, k) => {
       if (!Attribute.has(destination, k)) {
-        assert.fail('Result should have attribute: ' + k);
+        Assert.fail('Result should have attribute: ' + k);
       } else {
-        assert.eq(v, Attribute.get(destination, k));
+        Assert.eq('', v, Attribute.get(destination, k));
       }
     });
   };

--- a/modules/sugar/src/test/ts/browser/ClassTest.ts
+++ b/modules/sugar/src/test/ts/browser/ClassTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import * as Attribute from 'ephox/sugar/api/properties/Attribute';
@@ -12,10 +12,10 @@ UnitTest.test('ClassTest', () => {
   const m = MathElement();
 
   const check = (blob: boolean, spot: boolean, mogel: boolean, t: boolean) => {
-    assert.eq(blob, Class.has(c, 'blob'));
-    assert.eq(spot, Class.has(c, 'spot'));
-    assert.eq(mogel, Class.has(c, 'mogel'));
-    assert.eq(t, Class.has(c, 't'));
+    Assert.eq('', blob, Class.has(c, 'blob'));
+    Assert.eq('', spot, Class.has(c, 'spot'));
+    Assert.eq('', mogel, Class.has(c, 'mogel'));
+    Assert.eq('', t, Class.has(c, 't'));
   };
 
   check(false, false, false, false);
@@ -24,7 +24,7 @@ UnitTest.test('ClassTest', () => {
 
   Class.remove(c, 'blob');
   check(false, false, false, false);
-  assert.eq(false, Attribute.has(c, 'class'), 'empty class attribute was not removed');
+  Assert.eq('empty class attribute was not removed', false, Attribute.has(c, 'class'));
 
   Class.add(c, 'blob');
   check(true, false, false, false);
@@ -35,53 +35,53 @@ UnitTest.test('ClassTest', () => {
   Classes.add(c, [ 'mogel', 't' ]);
   check(true, true, true, true);
 
-  assert.eq([ 'blob', 'spot', 'mogel', 't' ], Classes.get(c));
+  Assert.eq('', [ 'blob', 'spot', 'mogel', 't' ], Classes.get(c));
 
   Classes.remove(c, [ 'mogel', 't' ]);
   check(true, true, false, false);
-  assert.eq([ 'blob', 'spot' ], Classes.get(c));
+  Assert.eq('', [ 'blob', 'spot' ], Classes.get(c));
 
   Class.remove(c, 'blob');
   check(false, true, false, false);
 
-  assert.eq(true, Class.toggle(c, 'mogel'));
+  Assert.eq('', true, Class.toggle(c, 'mogel'));
   check(false, true, true, false);
 
-  assert.eq(false, Class.toggle(c, 'mogel'));
+  Assert.eq('', false, Class.toggle(c, 'mogel'));
   check(false, true, false, false);
 
   Class.remove(c, 'spot');
   check(false, false, false, false);
-  assert.eq(false, Attribute.has(c, 'class'), 'empty class attribute was not removed');
+  Assert.eq('empty class attribute was not removed', false, Attribute.has(c, 'class'));
 
   Class.toggle(c, 'spot');
   check(false, true, false, false);
   Class.toggle(c, 'spot');
   check(false, false, false, false);
-  assert.eq(false, Attribute.has(c, 'class'), 'empty class attribute was not removed');
+  Assert.eq('empty class attribute was not removed', false, Attribute.has(c, 'class'));
 
   const incorrect = SugarElement.fromText('a');
-  assert.eq(false, Class.has(incorrect, 'anything'));
+  Assert.eq('', false, Class.has(incorrect, 'anything'));
 
-  assert.eq([], Classes.get(m));
+  Assert.eq('', [], Classes.get(m));
 
   Classes.add(m, [ 'a', 'b' ]);
-  assert.eq([ 'a', 'b' ], Classes.get(m));
+  Assert.eq('', [ 'a', 'b' ], Classes.get(m));
   Classes.remove(m, [ 'a', 'b' ]);
-  assert.eq([], Classes.get(m));
-  assert.eq(false, Class.has(m, 'a'));
+  Assert.eq('', [], Classes.get(m));
+  Assert.eq('', false, Class.has(m, 'a'));
 
   Class.toggle(m, 'a');
-  assert.eq([ 'a' ], Classes.get(m));
+  Assert.eq('', [ 'a' ], Classes.get(m));
   Class.toggle(m, 'a');
-  assert.eq([], Classes.get(m));
+  Assert.eq('', [], Classes.get(m));
 
   const tgl = Class.toggler(m, 'tglClass');
-  assert.eq(false, tgl.isOn());
+  Assert.eq('', false, tgl.isOn());
   tgl.on();
-  assert.eq(true, tgl.isOn());
-  assert.eq([ 'tglClass' ], Classes.get(m));
+  Assert.eq('', true, tgl.isOn());
+  Assert.eq('', [ 'tglClass' ], Classes.get(m));
   tgl.off();
-  assert.eq(false, tgl.isOn());
-  assert.eq([], Classes.get(m));
+  Assert.eq('', false, tgl.isOn());
+  Assert.eq('', [], Classes.get(m));
 });

--- a/modules/sugar/src/test/ts/browser/CommentTest.ts
+++ b/modules/sugar/src/test/ts/browser/CommentTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as SugarComment from 'ephox/sugar/api/node/SugarComment';
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
@@ -11,7 +11,7 @@ UnitTest.test('CommentTest', () => {
     Traverse.child(span, 0).filter(SugarNode.isComment).each((text0) => {
       span.dom.innerHTML = 'smashed';
       const v = SugarComment.get(text0); // Throws in IE10.
-      assert.eq('string', typeof v);
+      Assert.eq('', 'string', typeof v);
     });
   };
 
@@ -19,20 +19,20 @@ UnitTest.test('CommentTest', () => {
 
   const notComment = SugarElement.fromTag('span');
   const c = SugarElement.fromHtml<Comment>('<!--a-->');
-  assert.eq('a', SugarComment.get(c));
+  Assert.eq('', 'a', SugarComment.get(c));
   SugarComment.set(c, 'blue');
-  assert.eq('blue', c.dom.nodeValue);
+  Assert.eq('', 'blue', c.dom.nodeValue);
 
   try {
     SugarComment.get(notComment as any);
-    assert.fail('get on non-comment did not throw');
+    Assert.fail('get on non-comment did not throw');
   } catch (e) {
     // pass
   }
 
   try {
     SugarComment.set(notComment as any, 'bogus');
-    assert.fail('set on non-comment did not throw');
+    Assert.fail('set on non-comment did not throw');
   } catch (e) {
     // pass
   }

--- a/modules/sugar/src/test/ts/browser/CommentsTest.ts
+++ b/modules/sugar/src/test/ts/browser/CommentsTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
 
 import * as SugarComment from 'ephox/sugar/api/node/SugarComment';
@@ -9,12 +9,12 @@ UnitTest.test('CommentsTest', () => {
   const testPage = SugarElement.fromHtml('<div><!--one--></head><body><!--two--><p><!--three--></p></div>');
 
   const all = SugarComments.find(testPage, Optional.none());
-  assert.eq(3, all.length);
-  assert.eq('one', SugarComment.get(all[0]));
-  assert.eq('two', SugarComment.get(all[1]));
-  assert.eq('three', SugarComment.get(all[2]));
+  Assert.eq('', 3, all.length);
+  Assert.eq('', 'one', SugarComment.get(all[0]));
+  Assert.eq('', 'two', SugarComment.get(all[1]));
+  Assert.eq('', 'three', SugarComment.get(all[2]));
 
   const one = SugarComments.find(testPage, Optional.some((value) => value === 'one'));
-  assert.eq(1, one.length);
-  assert.eq('one', SugarComment.get(one[0]));
+  Assert.eq('', 1, one.length);
+  Assert.eq('', 'one', SugarComment.get(one[0]));
 });

--- a/modules/sugar/src/test/ts/browser/CompareTest.ts
+++ b/modules/sugar/src/test/ts/browser/CompareTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Compare from 'ephox/sugar/api/dom/Compare';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
@@ -9,7 +9,7 @@ UnitTest.test('CompareTest', () => {
   TestPage.connect(); // description of structure is in TestPage
 
   const check = (expected: boolean, e1: SugarElement<unknown>, e2: SugarElement<unknown>) => {
-    assert.eq(expected, Compare.eq(e1, e2));
+    Assert.eq('', expected, Compare.eq(e1, e2));
   };
 
   check(true, TestPage.p1, TestPage.p1);
@@ -17,13 +17,13 @@ UnitTest.test('CompareTest', () => {
   check(true, TestPage.s1, TestPage.s1);
   check(false, TestPage.s1, TestPage.s2);
 
-  assert.eq(false, Compare.member(TestPage.p1, []));
-  assert.eq(true, Compare.member(TestPage.p1, [ TestPage.p1 ]));
-  assert.eq(true, Compare.member(TestPage.p1, [ TestPage.t2, TestPage.p1 ]));
-  assert.eq(false, Compare.member(TestPage.p1, [ TestPage.t2 ]));
+  Assert.eq('', false, Compare.member(TestPage.p1, []));
+  Assert.eq('', true, Compare.member(TestPage.p1, [ TestPage.p1 ]));
+  Assert.eq('', true, Compare.member(TestPage.p1, [ TestPage.t2, TestPage.p1 ]));
+  Assert.eq('', false, Compare.member(TestPage.p1, [ TestPage.t2 ]));
 
   const checkIsEqualNode = (expected: boolean, e1: SugarElement<Node>, e2: SugarElement<Node>) => {
-    assert.eq(expected, Compare.isEqualNode(e1, e2));
+    Assert.eq('', expected, Compare.isEqualNode(e1, e2));
   };
 
   checkIsEqualNode(true, SugarElement.fromTag('p'), SugarElement.fromTag('p'));
@@ -74,22 +74,22 @@ UnitTest.test('CompareTest', () => {
   //   TestPage.s2, TestPage.p1);
 
   // Text Node vs Element
-  assert.eq(true, Compare.contains(TestPage.container, TestPage.t6));
-  assert.eq(false, Compare.contains(TestPage.t6, TestPage.container));
-  assert.eq(true, Compare.contains(TestPage.p3, TestPage.t6));
-  assert.eq(false, Compare.contains(TestPage.t6, TestPage.p3));
-  assert.eq(false, Compare.contains(TestPage.t1, TestPage.s2));
-  assert.eq(false, Compare.contains(TestPage.s2, TestPage.t1));
+  Assert.eq('', true, Compare.contains(TestPage.container, TestPage.t6));
+  Assert.eq('', false, Compare.contains(TestPage.t6, TestPage.container));
+  Assert.eq('', true, Compare.contains(TestPage.p3, TestPage.t6));
+  Assert.eq('', false, Compare.contains(TestPage.t6, TestPage.p3));
+  Assert.eq('', false, Compare.contains(TestPage.t1, TestPage.s2));
+  Assert.eq('', false, Compare.contains(TestPage.s2, TestPage.t1));
   // Text Node vs Text Node
-  assert.eq(false, Compare.contains(TestPage.t7, TestPage.t6));
-  assert.eq(false, Compare.contains(TestPage.t6, TestPage.t7));
-  assert.eq(false, Compare.contains(TestPage.t6, TestPage.t6)); // does not contain itself
+  Assert.eq('', false, Compare.contains(TestPage.t7, TestPage.t6));
+  Assert.eq('', false, Compare.contains(TestPage.t6, TestPage.t7));
+  Assert.eq('', false, Compare.contains(TestPage.t6, TestPage.t6)); // does not contain itself
   // Element vs Element
-  assert.eq(true, Compare.contains(TestPage.container, TestPage.d1));
-  assert.eq(false, Compare.contains(TestPage.d1, TestPage.container));
-  assert.eq(false, Compare.contains(TestPage.p1, TestPage.s2));
-  assert.eq(false, Compare.contains(TestPage.s2, TestPage.p1));
-  assert.eq(false, Compare.contains(TestPage.s2, TestPage.s2)); // does not contain itself
+  Assert.eq('', true, Compare.contains(TestPage.container, TestPage.d1));
+  Assert.eq('', false, Compare.contains(TestPage.d1, TestPage.container));
+  Assert.eq('', false, Compare.contains(TestPage.p1, TestPage.s2));
+  Assert.eq('', false, Compare.contains(TestPage.s2, TestPage.p1));
+  Assert.eq('', false, Compare.contains(TestPage.s2, TestPage.s2)); // does not contain itself
 
   // Clean up test page
   Remove.remove(TestPage.container);

--- a/modules/sugar/src/test/ts/browser/CssPropertyTest.ts
+++ b/modules/sugar/src/test/ts/browser/CssPropertyTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import * as Css from 'ephox/sugar/api/properties/Css';
@@ -12,13 +12,13 @@ UnitTest.test('CssProperty', () => {
   const el = EphoxElement('div');
 
   const propertyIsNot = (elm: SugarElement<Element>, propName: string, propValue: string) => {
-    assert.eq(false, init.is(elm));
-    assert.eq(false, Css.get(elm, propName) === propValue, 'Expected ' + elm.dom + ' to not have property ' + propName + ' set to ' + propValue);
+    Assert.eq('', false, init.is(elm));
+    Assert.eq('Expected ' + elm.dom + ' to not have property ' + propName + ' set to ' + propValue, false, Css.get(elm, propName) === propValue);
   };
 
   const propertyIs = (elm: SugarElement<Element>, propName: string, propValue: string) => {
-    assert.eq(true, init.is(elm), 'This is failing because ' + elm.dom + ' should have ' + propName + ':' + propValue + '. But found: ' + Css.get(elm, propName) );
-    assert.eq(true, Css.get(elm, propName) === propValue, 'Expected ' + elm.dom + ' to have property ' + propName + ' set to ' + propValue);
+    Assert.eq('This is failing because ' + elm.dom + ' should have ' + propName + ':' + propValue + '. But found: ' + Css.get(elm, propName), true, init.is(elm));
+    Assert.eq('Expected ' + elm.dom + ' to have property ' + propName + ' set to ' + propValue, true, Css.get(elm, propName) === propValue);
   };
 
   propertyIsNot(el, propertyName, propertyValue);

--- a/modules/sugar/src/test/ts/browser/CssReflowTest.ts
+++ b/modules/sugar/src/test/ts/browser/CssReflowTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
@@ -40,7 +40,7 @@ UnitTest.asynctest('CssReflowTest', (success, failure) => {
     const newspan = Traverse.firstChild(reflowTest).getOrDie('test broke') as SugarElement<HTMLSpanElement>;
     Css.reflow(newspan);
     // TODO: I can't actually make this fail without a reflow, we need a more stressful test. But you get the idea.
-    assert.eq('solid', Css.get(newspan, 'border-left-style'));
+    Assert.eq('', 'solid', Css.get(newspan, 'border-left-style'));
     Remove.remove(newspan);
 
   };

--- a/modules/sugar/src/test/ts/browser/CssTransferTest.ts
+++ b/modules/sugar/src/test/ts/browser/CssTransferTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
 
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
@@ -36,13 +36,13 @@ UnitTest.test('CssTransfer', () => {
     Css.transfer(source, destination, styles);
     Arr.each(expectedAbsent, (k) => {
       if (Css.getRaw(destination, k).isSome()) {
-        assert.fail('Result should not have style: ' + k);
+        Assert.fail('Result should not have style: ' + k);
       }
     });
 
     Obj.each(expectedPresent, (v, k) => {
       const value = Css.getRaw(destination, k).getOrDie('Result should have style: ' + k);
-      assert.eq(v, value);
+      Assert.eq('', v, value);
     });
   };
 

--- a/modules/sugar/src/test/ts/browser/CursorPositionTest.ts
+++ b/modules/sugar/src/test/ts/browser/CursorPositionTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Compare from 'ephox/sugar/api/dom/Compare';
 import * as InsertAll from 'ephox/sugar/api/dom/InsertAll';
@@ -28,12 +28,12 @@ UnitTest.test('Browser Test: CursorPositionTest', () => {
 
   const checkFirst = (label: string, expected: SugarElement<Node>, root: SugarElement<Node>) => {
     const actual = CursorPosition.first(root).getOrDie('No cursor position found for: ' + label);
-    assert.eq(true, Compare.eq(expected, actual), () => 'Incorrect element. \nExpected: ' + Html.getOuter(expected) + '\nWas: ' + Html.getOuter(actual));
+    Assert.eq(() => 'Incorrect element. \nExpected: ' + Html.getOuter(expected) + '\nWas: ' + Html.getOuter(actual), true, Compare.eq(expected, actual));
   };
 
   const checkLast = (label: string, expected: SugarElement<Node>, root: SugarElement<Node>) => {
     const actual = CursorPosition.last(root).getOrDie('No cursor position found for: ' + label);
-    assert.eq(true, Compare.eq(expected, actual), () => 'Incorrect element. \nExpected: ' + Html.getOuter(expected) + '\nWas: ' + Html.getOuter(actual));
+    Assert.eq(() => 'Incorrect element. \nExpected: ' + Html.getOuter(expected) + '\nWas: ' + Html.getOuter(actual), true, Compare.eq(expected, actual));
   };
 
   checkFirst('First of container (should skip empty container)', child3a, container);
@@ -41,19 +41,19 @@ UnitTest.test('Browser Test: CursorPositionTest', () => {
   checkLast('Last of container (should be <br>)', child4, container);
   checkLast('Last of span (should be <br>)', child3d, child3);
 
-  assert.eq(5, Awareness.getEnd(container));
-  assert.eq(2, Awareness.getEnd(child3a));
-  assert.eq(1, Awareness.getEnd(SugarElement.fromTag('img')));
+  Assert.eq('', 5, Awareness.getEnd(container));
+  Assert.eq('', 2, Awareness.getEnd(child3a));
+  Assert.eq('', 1, Awareness.getEnd(SugarElement.fromTag('img')));
 
-  assert.eq(true, Awareness.isEnd(container, 5));
-  assert.eq(false, Awareness.isEnd(container, 4));
+  Assert.eq('', true, Awareness.isEnd(container, 5));
+  Assert.eq('', false, Awareness.isEnd(container, 4));
 
-  assert.eq(true, Awareness.isStart(container, 0));
-  assert.eq(false, Awareness.isStart(container, 1));
+  Assert.eq('', true, Awareness.isStart(container, 0));
+  Assert.eq('', false, Awareness.isStart(container, 1));
 
-  assert.eq(true, Edge.isAtLeftEdge(container, child3a, 0));
-  assert.eq(false, Edge.isAtLeftEdge(container, child2, 1));
+  Assert.eq('', true, Edge.isAtLeftEdge(container, child3a, 0));
+  Assert.eq('', false, Edge.isAtLeftEdge(container, child2, 1));
 
   // INVESTIGATE: Not sure if offset here should be 0 or 1.
-  assert.eq(true, Edge.isAtRightEdge(container, child4, 0));
+  Assert.eq('', true, Edge.isAtRightEdge(container, child4, 0));
 });

--- a/modules/sugar/src/test/ts/browser/DimensionTest.ts
+++ b/modules/sugar/src/test/ts/browser/DimensionTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 
 import * as Insert from 'ephox/sugar/api/dom/Insert';
@@ -34,9 +34,9 @@ UnitTest.test('DimensionTest', () => {
     Insert.append(c, SugarElement.fromHtml('&nbsp;')); // div has no height without content
 
     // disconnected tests
-    assert.eq(0, dimension.get(c));
-    assert.eq(0, dimension.getOuter(c));
-    assert.eq(0, dimension.getInner(c));
+    Assert.eq('', 0, dimension.get(c));
+    Assert.eq('', 0, dimension.getOuter(c));
+    Assert.eq('', 0, dimension.getInner(c));
 
     Insert.append(SugarBody.body(), c);
     Insert.append(SugarBody.body(), m);
@@ -45,9 +45,9 @@ UnitTest.test('DimensionTest', () => {
     dimension.getOuter(m);
     dimension.set(m, 0);
 
-    assert.eq(true, dimension.get(c) > 0);
-    assert.eq(true, dimension.getOuter(c) > 0);
-    assert.eq(true, dimension.getInner(c) > 0);
+    Assert.eq('', true, dimension.get(c) > 0);
+    Assert.eq('', true, dimension.getOuter(c) > 0);
+    Assert.eq('', true, dimension.getInner(c) > 0);
 
     dimension.set(c, 0);
 
@@ -55,21 +55,21 @@ UnitTest.test('DimensionTest', () => {
     // Also in TBIO we don't generally care about JQuery's difference between get() and getOuter()
     Css.set(c, 'padding', '20px');
     // padding only
-    assert.eq(40, dimension.get(c));        // jQuery === 0
-    assert.eq(40, dimension.getOuter(c));
-    assert.eq(0, dimension.getInner(c));
+    Assert.eq('', 40, dimension.get(c));        // jQuery === 0
+    Assert.eq('', 40, dimension.getOuter(c));
+    Assert.eq('', 0, dimension.getInner(c));
 
     Css.set(c, 'border', '2px solid #fff');
     // border + padding
-    assert.eq(44, dimension.get(c));        // jQuery === 0
-    assert.eq(44, dimension.getOuter(c));
-    assert.eq(0, dimension.getInner(c));
+    Assert.eq('', 44, dimension.get(c));        // jQuery === 0
+    Assert.eq('', 44, dimension.getOuter(c));
+    Assert.eq('', 0, dimension.getInner(c));
 
     Css.set(c, 'margin', '3px');
     // border + padding + margin
-    assert.eq(44, dimension.get(c));        // jQuery === 0
-    assert.eq(44, dimension.getOuter(c));
-    assert.eq(0, dimension.getInner(c));
+    Assert.eq('', 44, dimension.get(c));        // jQuery === 0
+    Assert.eq('', 44, dimension.getOuter(c));
+    Assert.eq('', 0, dimension.getInner(c));
 
     // COMPLETE MADNESS: With border-sizing: border-box JQuery does WEIRD SHIT when you set width.
     // This is all so that when you request a width, it gives the same value.
@@ -78,41 +78,41 @@ UnitTest.test('DimensionTest', () => {
     // border + padding + width + margin
     const bpwm = borderBox ? 44 : 64;
     const innerBpwm = borderBox ? 0 : 20;
-    assert.eq(bpwm, dimension.get(c));      // jQuery === 20 in both cases
-    assert.eq(bpwm, dimension.getOuter(c)); // jQuery === 64 in both cases
-    assert.eq(innerBpwm, dimension.getInner(c));
+    Assert.eq('', bpwm, dimension.get(c));      // jQuery === 20 in both cases
+    Assert.eq('', bpwm, dimension.getOuter(c)); // jQuery === 64 in both cases
+    Assert.eq('', innerBpwm, dimension.getInner(c));
 
     Css.remove(c, 'padding');
     // border + mad JQuery width + margin
     const bwmSize = borderBox ? 16 : 20;
-    assert.eq(bwmSize + 4, dimension.get(c)); // jQuery === +0
-    assert.eq(bwmSize + 4, dimension.getOuter(c));
-    assert.eq(bwmSize, dimension.getInner(c));
+    Assert.eq('', bwmSize + 4, dimension.get(c)); // jQuery === +0
+    Assert.eq('', bwmSize + 4, dimension.getOuter(c));
+    Assert.eq('', bwmSize, dimension.getInner(c));
 
     dimension.set(c, 20);
     // border + width + margin
-    assert.eq(bwmSize + 4, dimension.get(c));          // jQuery === 20
-    assert.eq(bwmSize + 4, dimension.getOuter(c));
-    assert.eq(bwmSize, dimension.getInner(c));
+    Assert.eq('', bwmSize + 4, dimension.get(c));          // jQuery === 20
+    Assert.eq('', bwmSize + 4, dimension.getOuter(c));
+    Assert.eq('', bwmSize, dimension.getInner(c));
 
     Css.remove(c, 'border');
     // width + margin
-    assert.eq(20, dimension.get(c));            // jQuery === 24 in border-box mode
-    assert.eq(20, dimension.getOuter(c));       // jQuery === 24 in border-box mode
-    assert.eq(20, dimension.getInner(c));
+    Assert.eq('', 20, dimension.get(c));            // jQuery === 24 in border-box mode
+    Assert.eq('', 20, dimension.getOuter(c));       // jQuery === 24 in border-box mode
+    Assert.eq('', 20, dimension.getInner(c));
 
     dimension.set(c, 20);
     // width + margin
-    assert.eq(20, dimension.get(c));
-    assert.eq(20, dimension.getOuter(c));
-    assert.eq(20, dimension.getInner(c));
+    Assert.eq('', 20, dimension.get(c));
+    Assert.eq('', 20, dimension.getOuter(c));
+    Assert.eq('', 20, dimension.getInner(c));
 
     Css.remove(c, 'margin');
 
     // just width
-    assert.eq(20, dimension.get(c));
-    assert.eq(20, dimension.getOuter(c));
-    assert.eq(20, dimension.getInner(c));
+    Assert.eq('', 20, dimension.get(c));
+    Assert.eq('', 20, dimension.getOuter(c));
+    Assert.eq('', 20, dimension.getInner(c));
 
     // generally dupe with above, but replicates a JQuery test
     Css.setAll(c, {
@@ -124,31 +124,31 @@ UnitTest.test('DimensionTest', () => {
 
     const allSize = borderBox ? 30 : 34;        // jQuery === 26 : 30
     const innerAllSize = borderBox ? 26 : 30;
-    assert.eq(allSize, dimension.get(c));
-    assert.eq(allSize, dimension.getOuter(c));
-    assert.eq(innerAllSize, dimension.getInner(c));
+    Assert.eq('', allSize, dimension.get(c));
+    Assert.eq('', allSize, dimension.getOuter(c));
+    Assert.eq('', innerAllSize, dimension.getInner(c));
     Css.set(c, 'padding', '20px');
     const allSizePlusPadding = borderBox ? 44 : 74; // jQuery === 40 : 70
     const innerAllSizePlusPadding = borderBox ? 0 : 30;
-    assert.eq(allSizePlusPadding, dimension.get(c));
-    assert.eq(allSizePlusPadding, dimension.getOuter(c));
-    assert.eq(innerAllSizePlusPadding, dimension.getInner(c));
+    Assert.eq('', allSizePlusPadding, dimension.get(c));
+    Assert.eq('', allSizePlusPadding, dimension.getOuter(c));
+    Assert.eq('', innerAllSizePlusPadding, dimension.getInner(c));
 
     // TODO: Far more extensive tests involving combinations of border, margin and padding.
 
     Attribute.remove(c, 'style');
     dimension.set(c, 50);
-    assert.eq(50, dimension.get(c));
-    assert.eq(50, dimension.getOuter(c));
+    Assert.eq('', 50, dimension.get(c));
+    Assert.eq('', 50, dimension.getOuter(c));
     Css.set(c, 'visibility', 'hidden');
-    assert.eq(50, dimension.get(c));
-    assert.eq(50, dimension.getOuter(c));
-    assert.eq(50, dimension.getInner(c));
+    Assert.eq('', 50, dimension.get(c));
+    Assert.eq('', 50, dimension.getOuter(c));
+    Assert.eq('', 50, dimension.getInner(c));
 
     Css.set(c, 'border', '5px solid black');
-    assert.eq(60, dimension.get(c));
-    assert.eq(60, dimension.getOuter(c)); // 5 + 50 + 5
-    assert.eq(50, dimension.getInner(c));
+    Assert.eq('', 60, dimension.get(c));
+    Assert.eq('', 60, dimension.getOuter(c)); // 5 + 50 + 5
+    Assert.eq('', 50, dimension.getInner(c));
     Remove.remove(c);
     Remove.remove(m);
   };
@@ -204,11 +204,11 @@ UnitTest.test('DimensionTest', () => {
   // it will accumulative add all the properties and return a cumulative total.
   const dim = Dimension('internal', Fun.constant(1));
   const ctotal = dim.aggregate(container, [ 'padding-top', 'margin-bottom', 'border-top-width', 'border-bottom-width' ]);
-  assert.eq( ( paddingTop + marginBottom + borderWidth + borderWidth ), ctotal);
+  Assert.eq('', (paddingTop + marginBottom + borderWidth + borderWidth), ctotal);
 
   // mixit up, add unknowns
   const mixup = dim.aggregate(container, [ 'padding-top', 'margin-bottom', 'border-top-width', 'border-bottom-width', 'padding-bottom', 'display', 'elmos-house' ]);
-  assert.eq( ( paddingTop + marginBottom + borderWidth + borderWidth + 0 + 0 + 0), mixup);
+  Assert.eq('', (paddingTop + marginBottom + borderWidth + borderWidth + 0 + 0 + 0), mixup);
 
   // Height.setMax test
   // when we set max-height: 100px we mean it!, natively borders and padding are not included in these calculations
@@ -216,69 +216,69 @@ UnitTest.test('DimensionTest', () => {
   Css.set(container, 'max-height', maxHeight + 'px');
 
   const innerHeight = Height.get(inner);
-  assert.eq(1 + 40 + 1, innerHeight);
+  Assert.eq('', 1 + 40 + 1, innerHeight);
 
   // native max-height proof of failure
   const containerHeight = Height.get(container);
-  assert.eq(true, containerHeight > maxHeight, 'failing case the parent boundary should be greater than the allowed maximum');
+  Assert.eq('failing case the parent boundary should be greater than the allowed maximum', true, containerHeight > maxHeight);
   // we use the innerHeight value here because it has yet to hit the maxHeight
-  assert.eq( (borderWidth + paddingTop + innerHeight + borderWidth ), containerHeight, ' failing case true calculation does not match' );
+  Assert.eq('failing case true calculation does not match', (borderWidth + paddingTop + innerHeight + borderWidth ), containerHeight);
 
   const boundsHeight = Height.get(bounds);
-  assert.eq(true, boundsHeight > maxHeight, 'failing case the parent boundary should be greater than the allowed maximum');
+  Assert.eq('failing case the parent boundary should be greater than the allowed maximum', true, boundsHeight > maxHeight);
 
-  // if the child pushes the parent oversize, the parent may be forced to scroll which may not be desireable
-  assert.eq(true, boundsHeight > containerHeight, ' the parent bounds should be the same height as the child container');
+  // if the child pushes the parent oversize, the parent may be forced to scroll which may not be desirable
+  Assert.eq('the parent bounds should be the same height as the child container', true, boundsHeight > containerHeight);
 
   // Passing test, the container should equal to maxHeight set!
   Height.setMax(container, maxHeight);
   // The bounds should not exceed 50 (maxHeight), it should not be forced to scroll
   const boundsAbsHeight = Height.get(bounds);
-  assert.eq(boundsAbsHeight, maxHeight);
+  Assert.eq('', boundsAbsHeight, maxHeight);
 
   // the max-height property should be a compensated value.
   const cssMaxHeight = Css.get(container, 'max-height');
-  assert.eq(( maxHeight - paddingTop - borderWidth - borderWidth - marginBottom ) + 'px', cssMaxHeight);
+  Assert.eq('', ( maxHeight - paddingTop - borderWidth - borderWidth - marginBottom ) + 'px', cssMaxHeight);
 
   // native max-width: proof of failure
   Css.set(container, 'max-width', maxWidth + 'px');
 
   const innerWidth = Width.get(inner);
-  assert.eq(1 + 350 + 1, innerWidth);
+  Assert.eq('', 1 + 350 + 1, innerWidth);
 
   const containerWidth = Width.get(container);
-  assert.eq(true, containerWidth > maxWidth);
+  Assert.eq('', true, containerWidth > maxWidth);
 
   const boundsWidth = Width.get(bounds);
-  assert.eq(true, boundsWidth > maxWidth);
+  Assert.eq('', true, boundsWidth > maxWidth);
 
   // Table height test Firefox will exclude caption from offsetHeight
   const tbl = SugarElement.fromHtml<HTMLTableElement>('<table><caption style="height: 300px"></caption><tbody><tr><td style="height: 10px"></td></tr></tbody></table>');
   Insert.append(bounds, tbl);
-  assert.eq(true, Height.getOuter(tbl) > 300, 'Height should be more than 300');
+  Assert.eq('Height should be more than 300', true, Height.getOuter(tbl) > 300);
 
   // Height on detached node
   const detachedElm = SugarElement.fromHtml<HTMLDivElement>('<div>a</div>');
-  assert.eq(0, Height.getOuter(detachedElm), 'Should be zero for a detached element');
+  Assert.eq('Should be zero for a detached element', 0, Height.getOuter(detachedElm));
 
   // This test is broken in ie10, we don't understand exactly how it calculates max-width, every other platform passes.
   // Since we are not using the Width.setMax method in out codebase, commenting it out till then.
 
   // // We use the maxWidth value, because the container is contained within maxWidth, however ever overall width is calculated as per assertion below, which in total is larger than max-width
-  // assert.eq( (borderWidth + paddingLeft + maxWidth + paddingRight + borderWidth ), containerWidth, ' failing case true calculation does not match' );
+  // Assert.eq('failing case true calculation does not match', (borderWidth + paddingLeft + maxWidth + paddingRight + borderWidth ), containerWidth);
 
   // // Passing test, the container should equal to maxWidth set!
   // Width.setMax(container, maxWidth);
 
   // var boundsAbsWidth = Width.get(bounds);
-  // assert.eq(boundsAbsWidth, maxWidth);
+  // Assert.eq('', boundsAbsWidth, maxWidth);
 
   // var containerAbsWidth = Width.get(container);
-  // assert.eq(containerAbsWidth, maxWidth);
+  // Assert.eq('', containerAbsWidth, maxWidth);
 
   // // the max-width property should be a compensated value.
   // var cssMaxWidth = Css.get(container, 'max-width');
-  // assert.eq(( maxWidth - borderWidth - paddingLeft - paddingRight - borderWidth ) + 'px', cssMaxWidth);
+  // Assert.eq('', ( maxWidth - borderWidth - paddingLeft - paddingRight - borderWidth ) + 'px', cssMaxWidth);
 
   // cleanup
   Remove.remove(bounds);

--- a/modules/sugar/src/test/ts/browser/DirectionTest.ts
+++ b/modules/sugar/src/test/ts/browser/DirectionTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
@@ -19,14 +19,14 @@ UnitTest.test('DirectionTest', () => {
   const assertDirection = (element: SugarElement<Element>, expectedDirection: 'ltr' | 'rtl') => {
     appendToDom(element);
     const dir = Direction.getDirection(element);
-    assert.eq(expectedDirection, dir);
+    Assert.eq('', expectedDirection, dir);
     Remove.remove(element);
   };
 
   const assertOnDirection = (element: SugarElement<Element>, isLeftReturnThis: string, isRightReturnThis: string, expectedOn: string) => {
     appendToDom(element);
     const onDirection = Direction.onDirection(isLeftReturnThis, isRightReturnThis);
-    assert.eq(expectedOn, onDirection(element));
+    Assert.eq('', expectedOn, onDirection(element));
     Remove.remove(element);
   };
 

--- a/modules/sugar/src/test/ts/browser/DocumentPositionTest.ts
+++ b/modules/sugar/src/test/ts/browser/DocumentPositionTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Compare from 'ephox/sugar/api/dom/Compare';
 import * as DocumentPosition from 'ephox/sugar/api/dom/DocumentPosition';
@@ -36,7 +36,7 @@ UnitTest.test('DocumentPositionTest', () => {
   Insert.append(SugarBody.body(), container);
 
   const check = (expected: boolean, start: SugarElement<Node>, soffset: number, finish: SugarElement<Node>, foffset: number, msg: string) => {
-    assert.eq(expected, DocumentPosition.after(start, soffset, finish, foffset), msg);
+    Assert.eq(msg, expected, DocumentPosition.after(start, soffset, finish, foffset));
   };
 
   check(true, container, 1, p1t1, ''.length, 'Selection from (div,end) -> (p1t1,0) should be RTL');
@@ -78,17 +78,17 @@ UnitTest.test('DocumentPositionTest', () => {
           +-p2
              +-p2br
     */
-    assert.eq(true, Compare.eq(div, DocumentPosition.commonAncestorContainer(div, 0, div, 0)),
-      'lca(div,0,div,0)===' + Html.getOuter(DocumentPosition.commonAncestorContainer(div, 0, div, 0)) + `, expected: '<div>...'`);
-    assert.eq(true, Compare.eq(div, DocumentPosition.commonAncestorContainer(p11, 0, p2, 0)),
-      'lca(p1,0,p2,0)===' + Html.getOuter(DocumentPosition.commonAncestorContainer(p11, 0, p2, 0)) + `, expected: '<div>...'`);
-    assert.eq(true, Compare.eq(div, DocumentPosition.commonAncestorContainer(div, 1, div, 2)),
-      'lca(div,1,div,2)===' + Html.getOuter(DocumentPosition.commonAncestorContainer(div, 1, div, 2)) + `, expected: '<div>...'`);
-    assert.eq(true, Compare.eq(div, DocumentPosition.commonAncestorContainer(p1span1, 0, p2br, 0)),
-      'lca(p1span1,0,p2br,0)===' + Html.getOuter(DocumentPosition.commonAncestorContainer(p1span1, 0, p2br, 0)) + `, expected: '<div>...'`);
-    assert.eq(true, Compare.eq(p11, DocumentPosition.commonAncestorContainer(p1text, 0, p1span2, 0)),
-      'lca(p1text,0,p1span2,0)===' + Html.getOuter(DocumentPosition.commonAncestorContainer(p1text, 0, p1span2, 0)) + `, expected: 'p1': <p>One, two...`);
-    assert.eq(true, Compare.eq(p1span, DocumentPosition.commonAncestorContainer(p1span1, 0, p1span2, 0)),
-      'lca(p1span1,0,p1span2,0)===' + Html.getOuter(DocumentPosition.commonAncestorContainer(p1span1, 0, p1span2, 0)) + `, expected: 'p1span': <span>cat dog </span>`);
+    Assert.eq('lca(div,0,div,0)===' + Html.getOuter(DocumentPosition.commonAncestorContainer(div, 0, div, 0)) + `, expected: '<div>...'`,
+      true, Compare.eq(div, DocumentPosition.commonAncestorContainer(div, 0, div, 0)));
+    Assert.eq('lca(p1,0,p2,0)===' + Html.getOuter(DocumentPosition.commonAncestorContainer(p11, 0, p2, 0)) + `, expected: '<div>...'`,
+      true, Compare.eq(div, DocumentPosition.commonAncestorContainer(p11, 0, p2, 0)));
+    Assert.eq('lca(div,1,div,2)===' + Html.getOuter(DocumentPosition.commonAncestorContainer(div, 1, div, 2)) + `, expected: '<div>...'`,
+      true, Compare.eq(div, DocumentPosition.commonAncestorContainer(div, 1, div, 2)));
+    Assert.eq('lca(p1span1,0,p2br,0)===' + Html.getOuter(DocumentPosition.commonAncestorContainer(p1span1, 0, p2br, 0)) + `, expected: '<div>...'`,
+      true, Compare.eq(div, DocumentPosition.commonAncestorContainer(p1span1, 0, p2br, 0)));
+    Assert.eq('lca(p1text,0,p1span2,0)===' + Html.getOuter(DocumentPosition.commonAncestorContainer(p1text, 0, p1span2, 0)) + `, expected: 'p1': <p>One, two...`,
+      true, Compare.eq(p11, DocumentPosition.commonAncestorContainer(p1text, 0, p1span2, 0)));
+    Assert.eq('lca(p1span1,0,p1span2,0)===' + Html.getOuter(DocumentPosition.commonAncestorContainer(p1span1, 0, p1span2, 0)) + `, expected: 'p1span': <span>cat dog </span>`,
+      true, Compare.eq(p1span, DocumentPosition.commonAncestorContainer(p1span1, 0, p1span2, 0)));
   })();
 });

--- a/modules/sugar/src/test/ts/browser/DomFutureTest.ts
+++ b/modules/sugar/src/test/ts/browser/DomFutureTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Compare from 'ephox/sugar/api/dom/Compare';
 import * as DomFuture from 'ephox/sugar/api/dom/DomFuture';
@@ -9,15 +9,15 @@ UnitTest.asynctest('Browser Test: .DomFutureTest', (success) => {
   const testElement = SugarElement.fromTag('button');
 
   DomFuture.waitFor(testElement, 'click', 1000).get((res) => {
-    assert.eq(true, res.isError(), 'Result should be error as click has not yet occurred.');
+    Assert.eq('Result should be error as click has not yet occurred.', true, res.isError());
 
     DomFuture.waitFor(testElement, 'click', 1000).get((r) => {
       r.fold(
         (err) => {
-          assert.fail('Future should have returned value(event). Instead returned error(' + err + ')');
+          Assert.fail('Future should have returned value(event). Instead returned error(' + err + ')');
         },
         (val) => {
-          assert.eq(true, Compare.eq(testElement, val.target), 'Checking that the target of the event is correct');
+          Assert.eq('Checking that the target of the event is correct', true, Compare.eq(testElement, val.target));
           success();
         }
       );

--- a/modules/sugar/src/test/ts/browser/ElementTest.ts
+++ b/modules/sugar/src/test/ts/browser/ElementTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 
@@ -12,12 +12,12 @@ UnitTest.test('ElementTest', () => {
       // expected
       return;
     }
-    assert.fail('function did not throw an error');
+    Assert.fail('function did not throw an error');
   };
 
   const checkEl = <T extends Node | Window>(f: ElementConstructor, el: T, expt: T) => {
     const element = f(el);
-    assert.eq(true, expt === element.dom);
+    Assert.eq('', true, expt === element.dom);
   };
 
   checkErr(SugarElement.fromDom, undefined);

--- a/modules/sugar/src/test/ts/browser/FloatTest.ts
+++ b/modules/sugar/src/test/ts/browser/FloatTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
@@ -11,7 +11,7 @@ import MathElement from 'ephox/sugar/test/MathElement';
 UnitTest.test('FloatTest', () => {
   const image = SugarElement.fromTag('table');
   const m = MathElement();
-  assert.eq(null, Float.getRaw(image));
+  Assert.eq('', null, Float.getRaw(image));
   Float.getRaw(m);
 
   Insert.append(SugarBody.body(), image);
@@ -21,31 +21,31 @@ UnitTest.test('FloatTest', () => {
     'margin-right': 'auto'
   });
 
-  assert.eq('center', Float.divine(image).getOrDie());
+  Assert.eq('', 'center', Float.divine(image).getOrDie());
 
   Float.divine(m);
   Float.getRaw(m);
   Css.remove(m, 'margin-right');
-  assert.eq(false, Float.isCentered(m));
+  Assert.eq('', false, Float.isCentered(m));
   Css.set(m, 'float', 'none');
 
-  assert.eq(true, Float.isCentered(image));
+  Assert.eq('', true, Float.isCentered(image));
 
   Css.remove(image, 'margin-left');
   Css.remove(image, 'margin-right');
 
-  assert.eq('none', Float.divine(image).getOrDie());
+  Assert.eq('', 'none', Float.divine(image).getOrDie());
 
   Css.set(image, 'float', 'none');
-  assert.eq('none', Float.divine(image).getOrDie());
-  assert.eq('none', Float.getRaw(image));
+  Assert.eq('', 'none', Float.divine(image).getOrDie());
+  Assert.eq('', 'none', Float.getRaw(image));
 
   Css.set(image, 'float', 'right');
-  assert.eq('right', Float.divine(image).getOrDie());
+  Assert.eq('', 'right', Float.divine(image).getOrDie());
 
-  assert.eq(false, Float.isCentered(image));
+  Assert.eq('', false, Float.isCentered(image));
   Float.setCentered(image);
-  assert.eq(true, Float.isCentered(image));
+  Assert.eq('', true, Float.isCentered(image));
 
   Remove.remove(image);
 });

--- a/modules/sugar/src/test/ts/browser/FocusTest.ts
+++ b/modules/sugar/src/test/ts/browser/FocusTest.ts
@@ -1,4 +1,4 @@
-import { Assert, assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Optional, OptionalInstances } from '@ephox/katamari';
 
 import * as Compare from 'ephox/sugar/api/dom/Compare';
@@ -23,17 +23,17 @@ UnitTest.test('FocusTest', () => {
   Insert.append(SugarBody.body(), div);
 
   Focus.focus(input);
-  assert.eq(true, Compare.eq(Focus.active().getOrDie(), input));
+  Assert.eq('', true, Compare.eq(Focus.active().getOrDie(), input));
   Focus.focus(div);
-  assert.eq(true, Compare.eq(Focus.active().getOrDie(), div));
+  Assert.eq('', true, Compare.eq(Focus.active().getOrDie(), div));
   Focus.focus(input);
-  assert.eq(true, Compare.eq(Focus.active().getOrDie(), input));
+  Assert.eq('', true, Compare.eq(Focus.active().getOrDie(), input));
   Focus.focusInside(div);
-  assert.eq(true, Compare.eq(Focus.active().getOrDie(), input));
+  Assert.eq('', true, Compare.eq(Focus.active().getOrDie(), input));
   Focus.focusInside(input);
-  assert.eq(true, Compare.eq(Focus.active().getOrDie(), input));
+  Assert.eq('', true, Compare.eq(Focus.active().getOrDie(), input));
   Focus.focus(div);
-  assert.eq(true, Compare.eq(Focus.active().getOrDie(), div));
+  Assert.eq('', true, Compare.eq(Focus.active().getOrDie(), div));
 
   Remove.remove(div);
 });

--- a/modules/sugar/src/test/ts/browser/FragmentTest.ts
+++ b/modules/sugar/src/test/ts/browser/FragmentTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
@@ -15,5 +15,5 @@ UnitTest.test('FragmentTest', () => {
   const container = SugarElement.fromTag('div');
   Insert.append(container, fragment);
 
-  assert.eq('<span>Hi</span><br><p>One</p>', Html.get(container));
+  Assert.eq('', '<span>Hi</span><br><p>One</p>', Html.get(container));
 });

--- a/modules/sugar/src/test/ts/browser/HierarchyTest.ts
+++ b/modules/sugar/src/test/ts/browser/HierarchyTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Compare from 'ephox/sugar/api/dom/Compare';
 import * as Hierarchy from 'ephox/sugar/api/dom/Hierarchy';
@@ -22,23 +22,23 @@ UnitTest.test('HierarchyTest', () => {
   InsertAll.append(p1span, [ p1span1, p1span2 ]);
   Insert.append(p2, p2br);
 
-  assert.eq([ ], Hierarchy.path(div, div).getOrDie());
-  assert.eq([ 0 ], Hierarchy.path(div, p1).getOrDie());
-  assert.eq([ 1 ], Hierarchy.path(div, p2).getOrDie());
-  assert.eq([ 0, 0 ], Hierarchy.path(div, p1text).getOrDie());
-  assert.eq([ 0, 1 ], Hierarchy.path(div, p1textb).getOrDie());
-  assert.eq([ 0, 2 ], Hierarchy.path(div, p1span).getOrDie());
-  assert.eq([ 0, 2, 0 ], Hierarchy.path(div, p1span1).getOrDie());
-  assert.eq([ 0, 2, 1 ], Hierarchy.path(div, p1span2).getOrDie());
-  assert.eq([ 1, 0 ], Hierarchy.path(div, p2br).getOrDie());
+  Assert.eq('', [ ], Hierarchy.path(div, div).getOrDie());
+  Assert.eq('', [ 0 ], Hierarchy.path(div, p1).getOrDie());
+  Assert.eq('', [ 1 ], Hierarchy.path(div, p2).getOrDie());
+  Assert.eq('', [ 0, 0 ], Hierarchy.path(div, p1text).getOrDie());
+  Assert.eq('', [ 0, 1 ], Hierarchy.path(div, p1textb).getOrDie());
+  Assert.eq('', [ 0, 2 ], Hierarchy.path(div, p1span).getOrDie());
+  Assert.eq('', [ 0, 2, 0 ], Hierarchy.path(div, p1span1).getOrDie());
+  Assert.eq('', [ 0, 2, 1 ], Hierarchy.path(div, p1span2).getOrDie());
+  Assert.eq('', [ 1, 0 ], Hierarchy.path(div, p2br).getOrDie());
 
-  assert.eq(true, Compare.eq(div, Hierarchy.follow(div, []).getOrDie()));
-  assert.eq(true, Compare.eq(p1, Hierarchy.follow(div, [ 0 ]).getOrDie()));
-  assert.eq(true, Compare.eq(p2, Hierarchy.follow(div, [ 1 ]).getOrDie()));
-  assert.eq(true, Compare.eq(p1text, Hierarchy.follow(div, [ 0, 0 ]).getOrDie()));
-  assert.eq(true, Compare.eq(p1textb, Hierarchy.follow(div, [ 0, 1 ]).getOrDie()));
-  assert.eq(true, Compare.eq(p1span, Hierarchy.follow(div, [ 0, 2 ]).getOrDie()));
-  assert.eq(true, Compare.eq(p1span1, Hierarchy.follow(div, [ 0, 2, 0 ]).getOrDie()));
-  assert.eq(true, Compare.eq(p1span2, Hierarchy.follow(div, [ 0, 2, 1 ]).getOrDie()));
-  assert.eq(true, Compare.eq(p2br, Hierarchy.follow(div, [ 1, 0 ]).getOrDie()));
+  Assert.eq('', true, Compare.eq(div, Hierarchy.follow(div, []).getOrDie()));
+  Assert.eq('', true, Compare.eq(p1, Hierarchy.follow(div, [ 0 ]).getOrDie()));
+  Assert.eq('', true, Compare.eq(p2, Hierarchy.follow(div, [ 1 ]).getOrDie()));
+  Assert.eq('', true, Compare.eq(p1text, Hierarchy.follow(div, [ 0, 0 ]).getOrDie()));
+  Assert.eq('', true, Compare.eq(p1textb, Hierarchy.follow(div, [ 0, 1 ]).getOrDie()));
+  Assert.eq('', true, Compare.eq(p1span, Hierarchy.follow(div, [ 0, 2 ]).getOrDie()));
+  Assert.eq('', true, Compare.eq(p1span1, Hierarchy.follow(div, [ 0, 2, 0 ]).getOrDie()));
+  Assert.eq('', true, Compare.eq(p1span2, Hierarchy.follow(div, [ 0, 2, 1 ]).getOrDie()));
+  Assert.eq('', true, Compare.eq(p2br, Hierarchy.follow(div, [ 1, 0 ]).getOrDie()));
 });

--- a/modules/sugar/src/test/ts/browser/HtmlTest.ts
+++ b/modules/sugar/src/test/ts/browser/HtmlTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Html from 'ephox/sugar/api/properties/Html';
@@ -9,12 +9,12 @@ UnitTest.test('HtmlTest', () => {
   const c = Div();
   const container = Div();
   Insert.append(container, c);
-  assert.eq('<div></div>', Html.getOuter(c));
+  Assert.eq('', '<div></div>', Html.getOuter(c));
 
-  assert.eq(true, c.dom.parentNode === container.dom, 'getOuter must not change the DOM');
+  Assert.eq('getOuter must not change the DOM', true, c.dom.parentNode === container.dom);
 
   const content = '<p>stuff</p>';
   Html.set(c, content);
-  assert.eq(content, c.dom.innerHTML);
-  assert.eq(content, Html.get(c));
+  Assert.eq('', content, c.dom.innerHTML);
+  Assert.eq('', content, Html.get(c));
 });

--- a/modules/sugar/src/test/ts/browser/InsertTest.ts
+++ b/modules/sugar/src/test/ts/browser/InsertTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Class from 'ephox/sugar/api/properties/Class';
@@ -26,22 +26,22 @@ UnitTest.test('InsertTest', () => {
   Insert.append(container, p);
   Insert.append(container, p2);
   Insert.append(p, span);
-  assert.eq('<p><span></span></p><p></p>', Html.get(container));
+  Assert.eq('', '<p><span></span></p><p></p>', Html.get(container));
 
   Insert.before(p, ol);
-  assert.eq('<ol></ol><p><span></span></p><p></p>', Html.get(container));
+  Assert.eq('', '<ol></ol><p><span></span></p><p></p>', Html.get(container));
 
   Insert.append(ol, li1);
   Insert.after(li1, li2);
   Insert.after(li2, li4);
 
-  assert.eq('<ol><li></li><li class="second third"></li><li class="l4"></li></ol><p><span></span></p><p></p>', Html.get(container));
+  Assert.eq('', '<ol><li></li><li class="second third"></li><li class="l4"></li></ol><p><span></span></p><p></p>', Html.get(container));
 
   Insert.before(li4, li3);
 
-  assert.eq('<ol><li></li><li class="second third"></li><li class="l3"></li><li class="l4"></li></ol><p><span></span></p><p></p>', Html.get(container));
+  Assert.eq('', '<ol><li></li><li class="second third"></li><li class="l3"></li><li class="l4"></li></ol><p><span></span></p><p></p>', Html.get(container));
 
   Insert.prepend(ol, li0);
 
-  assert.eq('<ol><li class="l0"></li><li></li><li class="second third"></li><li class="l3"></li><li class="l4"></li></ol><p><span></span></p><p></p>', Html.get(container));
+  Assert.eq('', '<ol><li class="l0"></li><li></li><li class="second third"></li><li class="l3"></li><li class="l4"></li></ol><p><span></span></p><p></p>', Html.get(container));
 });

--- a/modules/sugar/src/test/ts/browser/IsRootTest.ts
+++ b/modules/sugar/src/test/ts/browser/IsRootTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Fun, Optional } from '@ephox/katamari';
 
 import * as Compare from 'ephox/sugar/api/dom/Compare';
@@ -42,21 +42,21 @@ UnitTest.test('IsRootTest', () => {
   Checkers.checkList([ TestPage.d1 ], SelectorFilter.ancestors(TestPage.p3, '*', isRoot));
   Checkers.checkList([ TestPage.d1 ], PredicateFilter.ancestors(TestPage.p3, Fun.always, isRoot));
 
-  assert.eq(false, SelectorExists.closest(TestPage.p3, 'li', isRoot));
-  assert.eq(false, SelectorExists.closest(TestPage.p3, 'ol,ul', isRoot));
-  assert.eq(false, PredicateExists.closest(TestPage.p3, Checkers.isName('li'), isRoot));
+  Assert.eq('', false, SelectorExists.closest(TestPage.p3, 'li', isRoot));
+  Assert.eq('', false, SelectorExists.closest(TestPage.p3, 'ol,ul', isRoot));
+  Assert.eq('', false, PredicateExists.closest(TestPage.p3, Checkers.isName('li'), isRoot));
 
-  assert.eq(true, SelectorExists.closest(TestPage.p3, 'div', isRoot));
-  assert.eq(true, SelectorExists.closest(TestPage.d1, 'div', isRoot));
-  assert.eq(true, PredicateExists.closest(TestPage.p3, Checkers.isName('div'), isRoot));
-  assert.eq(true, PredicateExists.closest(TestPage.d1, Checkers.isName('div'), isRoot));
+  Assert.eq('', true, SelectorExists.closest(TestPage.p3, 'div', isRoot));
+  Assert.eq('', true, SelectorExists.closest(TestPage.d1, 'div', isRoot));
+  Assert.eq('', true, PredicateExists.closest(TestPage.p3, Checkers.isName('div'), isRoot));
+  Assert.eq('', true, PredicateExists.closest(TestPage.d1, Checkers.isName('div'), isRoot));
 
-  assert.eq(false, SelectorExists.ancestor(TestPage.p3, 'li', isRoot));
-  assert.eq(false, SelectorExists.ancestor(TestPage.p3, 'ol,ul', isRoot));
-  assert.eq(false, PredicateExists.ancestor(TestPage.p3, Checkers.isName('li'), isRoot));
+  Assert.eq('', false, SelectorExists.ancestor(TestPage.p3, 'li', isRoot));
+  Assert.eq('', false, SelectorExists.ancestor(TestPage.p3, 'ol,ul', isRoot));
+  Assert.eq('', false, PredicateExists.ancestor(TestPage.p3, Checkers.isName('li'), isRoot));
 
-  assert.eq(true, SelectorExists.ancestor(TestPage.p3, 'div', isRoot));
-  assert.eq(true, PredicateExists.ancestor(TestPage.p3, Checkers.isName('div'), isRoot));
+  Assert.eq('', true, SelectorExists.ancestor(TestPage.p3, 'div', isRoot));
+  Assert.eq('', true, PredicateExists.ancestor(TestPage.p3, Checkers.isName('div'), isRoot));
 
   Checkers.checkList([ TestPage.d1 ], Traverse.parents(TestPage.p3, isRoot));
   Checkers.checkList([ TestPage.p3, TestPage.d1 ], Traverse.parents(TestPage.t6, isRoot));

--- a/modules/sugar/src/test/ts/browser/LinkTest.ts
+++ b/modules/sugar/src/test/ts/browser/LinkTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Compare from 'ephox/sugar/api/dom/Compare';
 import * as Link from 'ephox/sugar/api/dom/Link';
@@ -12,18 +12,18 @@ UnitTest.test('LinkTest', () => {
   const secondLink = Link.addStylesheet('fake://url2/', realDoc);
 
   const assertStylesheetLink = (raw: HTMLLinkElement, url: string) => {
-    assert.eq(url, raw.href);
-    assert.eq('stylesheet', raw.rel);
-    assert.eq('text/css', raw.type);
+    Assert.eq('', url, raw.href);
+    Assert.eq('', 'stylesheet', raw.rel);
+    Assert.eq('', 'text/css', raw.type);
   };
 
-  assert.eq(2, document.head.children.length - headNodes);
+  Assert.eq('', 2, document.head.children.length - headNodes);
 
   // counting headNodes as "zero"
   const url1 = document.head.children[headNodes] as HTMLLinkElement;
   const url2 = document.head.children[headNodes + 1] as HTMLLinkElement;
-  assert.eq(true, Compare.eq(firstLink, SugarElement.fromDom(url1)), 'first link element was not equal');
-  assert.eq(true, Compare.eq(secondLink, SugarElement.fromDom(url2)), 'second link element was not equal');
+  Assert.eq('first link element was not equal', true, Compare.eq(firstLink, SugarElement.fromDom(url1)));
+  Assert.eq('second link element was not equal', true, Compare.eq(secondLink, SugarElement.fromDom(url2)));
   assertStylesheetLink(url1, 'fake://url1/');
   assertStylesheetLink(url2, 'fake://url2/');
 

--- a/modules/sugar/src/test/ts/browser/LocationTest.ts
+++ b/modules/sugar/src/test/ts/browser/LocationTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Fun, Optional } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 
@@ -46,10 +46,10 @@ UnitTest.asynctest('LocationTest', (success, failure) => {
     // Chrome adds the scrollbar to the left in rtl mode as of Chrome 70+
     SugarLocation.relative(Traverse.documentElement(doc.body)).left;
 
-  const asserteq = <T>(expected: T, actual: T, message: string) => {
+  const asserteq = <T>(expected: T, actual: T, message?: string) => {
     // I wish assert.eq printed expected and actual on failure
-    const m = message === undefined ? undefined : 'expected ' + expected + ', was ' + actual + ': ' + message;
-    assert.eq(expected, actual, m);
+    const m = message === undefined ? '' : 'expected ' + expected + ', was ' + actual + ': ' + message;
+    Assert.eq(m, expected, actual);
   };
 
   const testOne = (i: string, attrMap: TestAttrMap, next: () => void) => {
@@ -128,28 +128,28 @@ UnitTest.asynctest('LocationTest', (success, failure) => {
     // these checks actually depend on the tunic stylesheet. They might not actually be useful.
     const body = SugarBody.body();
     let pos = SugarLocation.absolute(body);
-    assert.eq(0, pos.top);
-    assert.eq(0, pos.left);
+    Assert.eq('', 0, pos.top);
+    Assert.eq('', 0, pos.left);
     pos = SugarLocation.relative(body);
-    assert.eq(0, pos.top); // JQuery doesn't return 0, but this makes more sense
-    assert.eq(0, pos.left);
+    Assert.eq('', 0, pos.top); // JQuery doesn't return 0, but this makes more sense
+    Assert.eq('', 0, pos.left);
     pos = SugarLocation.viewport(body);
-    assert.eq(0, pos.top);
-    assert.eq(0, pos.left);
-    assert.eq(true, scrollBarWidth > 5 && scrollBarWidth < 50 || (platform.os.isMacOS() && scrollBarWidth === 0), 'scroll bar width, got=' + scrollBarWidth);
+    Assert.eq('', 0, pos.top);
+    Assert.eq('', 0, pos.left);
+    Assert.eq('scroll bar width, got=' + scrollBarWidth, true, scrollBarWidth > 5 && scrollBarWidth < 50 || (platform.os.isMacOS() && scrollBarWidth === 0));
   };
 
   const disconnectedChecks = () => {
     const div = SugarElement.fromTag('div');
     let pos = SugarLocation.absolute(div);
-    assert.eq(0, pos.top);
-    assert.eq(0, pos.left);
+    Assert.eq('', 0, pos.top);
+    Assert.eq('', 0, pos.left);
     pos = SugarLocation.relative(div);
-    assert.eq(0, pos.top);
-    assert.eq(0, pos.left);
+    Assert.eq('', 0, pos.top);
+    Assert.eq('', 0, pos.left);
     pos = SugarLocation.viewport(div);
-    assert.eq(0, pos.top);
-    assert.eq(0, pos.left);
+    Assert.eq('', 0, pos.top);
+    Assert.eq('', 0, pos.left);
   };
 
   const absoluteChecks = (doc: TestDocSpec) => {
@@ -403,8 +403,8 @@ UnitTest.asynctest('LocationTest', (success, failure) => {
     runChecks(doc, noScroll);
 
     const scr = Scroll.get(doc.rawDoc);
-    assert.eq(0, scr.left, 'expected 0, left is=' + scr.left);
-    assert.eq(0, scr.top, 'expected 0, top is ' + scr.top);
+    Assert.eq('expected 0, left is=' + scr.left, 0, scr.left);
+    Assert.eq('expected 0, top is ' + scr.top, 0, scr.top);
 
     Scroll.by(leftScroll, topScroll, doc.rawDoc);
     runChecks(doc, withScroll);
@@ -416,14 +416,14 @@ UnitTest.asynctest('LocationTest', (success, failure) => {
   const bodyChecks = (doc: TestDocSpec) => {
     Scroll.to(1000, 1000, doc.rawDoc);
     let pos = SugarLocation.absolute(doc.body);
-    assert.eq(0, pos.top);
-    assert.eq(0, pos.left);
+    Assert.eq('', 0, pos.top);
+    Assert.eq('', 0, pos.left);
     pos = SugarLocation.relative(doc.body);
-    assert.eq(0, pos.top);
-    assert.eq(0, pos.left);
+    Assert.eq('', 0, pos.top);
+    Assert.eq('', 0, pos.left);
     pos = SugarLocation.viewport(doc.body);
-    assert.eq(0, pos.top);
-    assert.eq(0, pos.left);
+    Assert.eq('', 0, pos.top);
+    Assert.eq('', 0, pos.left);
   };
 
   /* Simple verification logic */

--- a/modules/sugar/src/test/ts/browser/NodeTest.ts
+++ b/modules/sugar/src/test/ts/browser/NodeTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 
 import * as NodeTypes from 'ephox/sugar/api/node/NodeTypes';
@@ -9,12 +9,12 @@ import EphoxElement from 'ephox/sugar/test/EphoxElement';
 
 UnitTest.test('NodeTest', () => {
   const check = (node: SugarElement<Node>, nodeType: number, nodeName: string, nodeValue: string | null, isElement: boolean, isText: boolean, isDocument: boolean) => {
-    assert.eq(nodeType, SugarNode.type(node));
-    assert.eq(nodeName, SugarNode.name(node));
-    assert.eq(nodeValue, SugarNode.value(node));
-    assert.eq(isElement, SugarNode.isElement(node));
-    assert.eq(isText, SugarNode.isText(node));
-    assert.eq(isDocument, SugarNode.isDocument(node));
+    Assert.eq('', nodeType, SugarNode.type(node));
+    Assert.eq('', nodeName, SugarNode.name(node));
+    Assert.eq('', nodeValue, SugarNode.value(node));
+    Assert.eq('', isElement, SugarNode.isElement(node));
+    Assert.eq('', isText, SugarNode.isText(node));
+    Assert.eq('', isDocument, SugarNode.isDocument(node));
   };
 
   check(
@@ -54,7 +54,7 @@ UnitTest.test('NodeTest', () => {
       return predicate(input);
     });
 
-    assert.eq(expected, actual);
+    Assert.eq('', expected, actual);
   };
 
   const data = [ '<div>Hello</div>', '<div><span>Hello</span></div>', '<div><!-- I am a comment --></div>' ];

--- a/modules/sugar/src/test/ts/browser/OnNodeTest.ts
+++ b/modules/sugar/src/test/ts/browser/OnNodeTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import * as OnNode from 'ephox/sugar/api/properties/OnNode';
@@ -13,17 +13,17 @@ UnitTest.test('OnNodeTest', () => {
   const hasAlpha = OnNode.hasClass('alpha');
   const hasBeta = OnNode.hasClass('beta');
 
-  assert.eq(false, hasAlpha(element));
+  Assert.eq('', false, hasAlpha(element));
   addAlpha(element);
-  assert.eq(true, hasAlpha(element));
-  assert.eq(false, hasBeta(element));
+  Assert.eq('', true, hasAlpha(element));
+  Assert.eq('', false, hasBeta(element));
   removeAlpha(element);
-  assert.eq(false, hasAlpha(element));
+  Assert.eq('', false, hasAlpha(element));
   addAlpha(element);
-  assert.eq(true, hasAlpha(element));
+  Assert.eq('', true, hasAlpha(element));
   addBeta(element);
-  assert.eq(true, hasBeta(element));
+  Assert.eq('', true, hasBeta(element));
   removeAll(element);
-  assert.eq(false, hasAlpha(element));
-  assert.eq(false, hasBeta(element));
+  Assert.eq('', false, hasAlpha(element));
+  Assert.eq('', false, hasBeta(element));
 });

--- a/modules/sugar/src/test/ts/browser/PredicateTest.ts
+++ b/modules/sugar/src/test/ts/browser/PredicateTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Fun, Optional } from '@ephox/katamari';
 
 import * as Remove from 'ephox/sugar/api/dom/Remove';
@@ -42,20 +42,20 @@ UnitTest.test('PredicateTest', () => {
   Checkers.checkList([ TestPage.s1, TestPage.s2, TestPage.s3, TestPage.s4 ], PredicateFilter.descendants(TestPage.container, Checkers.isName('span')));
   Checkers.checkList([], PredicateFilter.descendants(TestPage.container, Checkers.isName('blockquote')));
 
-  assert.eq(true, PredicateExists.any(Checkers.isName('p')));
-  assert.eq(false, PredicateExists.any(Checkers.isName('table')));
-  assert.eq(true, PredicateExists.ancestor(TestPage.t1, Checkers.isName('p')));
-  assert.eq(false, PredicateExists.ancestor(TestPage.p1, Checkers.isName('p')));
-  assert.eq(false, PredicateExists.ancestor(TestPage.t1, Checkers.isName('span')));
-  assert.eq(true, PredicateExists.closest(TestPage.t1, Checkers.isName('p')));
-  assert.eq(true, PredicateExists.closest(TestPage.p1, Checkers.isName('p')));
-  assert.eq(false, PredicateExists.closest(TestPage.t1, Checkers.isName('span')));
-  assert.eq(true, PredicateExists.sibling(TestPage.p2, Checkers.isName('p')));
-  assert.eq(false, PredicateExists.sibling(TestPage.t1, Checkers.isName('p')));
-  assert.eq(true, PredicateExists.child(TestPage.p1, SugarNode.isText));
-  assert.eq(false, PredicateExists.child(TestPage.p2, SugarNode.isText));
-  assert.eq(true, PredicateExists.descendant(TestPage.p2, SugarNode.isText));
-  assert.eq(false, PredicateExists.descendant(TestPage.s1, Checkers.isName('p')));
+  Assert.eq('', true, PredicateExists.any(Checkers.isName('p')));
+  Assert.eq('', false, PredicateExists.any(Checkers.isName('table')));
+  Assert.eq('', true, PredicateExists.ancestor(TestPage.t1, Checkers.isName('p')));
+  Assert.eq('', false, PredicateExists.ancestor(TestPage.p1, Checkers.isName('p')));
+  Assert.eq('', false, PredicateExists.ancestor(TestPage.t1, Checkers.isName('span')));
+  Assert.eq('', true, PredicateExists.closest(TestPage.t1, Checkers.isName('p')));
+  Assert.eq('', true, PredicateExists.closest(TestPage.p1, Checkers.isName('p')));
+  Assert.eq('', false, PredicateExists.closest(TestPage.t1, Checkers.isName('span')));
+  Assert.eq('', true, PredicateExists.sibling(TestPage.p2, Checkers.isName('p')));
+  Assert.eq('', false, PredicateExists.sibling(TestPage.t1, Checkers.isName('p')));
+  Assert.eq('', true, PredicateExists.child(TestPage.p1, SugarNode.isText));
+  Assert.eq('', false, PredicateExists.child(TestPage.p2, SugarNode.isText));
+  Assert.eq('', true, PredicateExists.descendant(TestPage.p2, SugarNode.isText));
+  Assert.eq('', false, PredicateExists.descendant(TestPage.s1, Checkers.isName('p')));
 
   Remove.remove(TestPage.container);
 });

--- a/modules/sugar/src/test/ts/browser/PrefilterTest.ts
+++ b/modules/sugar/src/test/ts/browser/PrefilterTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Hierarchy from 'ephox/sugar/api/dom/Hierarchy';
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
@@ -27,7 +27,7 @@ UnitTest.test('Browser Test: PrefilterTest', () => {
     const actual = Prefilter.beforeSpecial(element, offset);
 
     const actualS = toString(actual);
-    assert.eq(expected, actualS, 'Test: ' + label + '. Was: ' + actualS + ', but expected: ' + expected);
+    Assert.eq('Test: ' + label + '. Was: ' + actualS + ', but expected: ' + expected, expected, actualS);
   };
 
   check('div 0', 'on(<div><span>dog</span><br><img><span>cat</span></div>, 0)', [ ], 0);

--- a/modules/sugar/src/test/ts/browser/ReadyTest.ts
+++ b/modules/sugar/src/test/ts/browser/ReadyTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Ready from 'ephox/sugar/api/events/Ready';
 
@@ -9,5 +9,5 @@ UnitTest.test('ReadyTest', () => {
   Ready.document(() => {
     called++;
   });
-  assert.eq(1, called);
+  Assert.eq('', 1, called);
 });

--- a/modules/sugar/src/test/ts/browser/RemoveTest.ts
+++ b/modules/sugar/src/test/ts/browser/RemoveTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
@@ -34,24 +34,24 @@ UnitTest.test('RemoveTest', () => {
       Insert.append(SugarBody.body(), container);
     }
 
-    assert.eq('<p><span></span></p><p></p>', Html.get(container));
+    Assert.eq('', '<p><span></span></p><p></p>', Html.get(container));
     Remove.remove(p2);
-    assert.eq('<p><span></span></p>', Html.get(container));
+    Assert.eq('', '<p><span></span></p>', Html.get(container));
     Insert.append(container, p2);
-    assert.eq('<p><span></span></p><p></p>', Html.get(container));
+    Assert.eq('', '<p><span></span></p><p></p>', Html.get(container));
     Remove.remove(span);
-    assert.eq('<p></p><p></p>', Html.get(container));
+    Assert.eq('', '<p></p><p></p>', Html.get(container));
     Remove.empty(container);
 
     // regular empty check
-    assert.eq('', Html.get(container));
-    assert.eq(0, Traverse.children(container).length);
+    Assert.eq('', '', Html.get(container));
+    Assert.eq('', 0, Traverse.children(container).length);
 
     // after inserting an empty text node, empty doesn't always mean empty!
     Insert.append(container, SugarElement.fromText(''));
     Remove.empty(container);
-    assert.eq('', Html.get(container));
-    assert.eq(0, Traverse.children(container).length);
+    Assert.eq('', '', Html.get(container));
+    Assert.eq('', 0, Traverse.children(container).length);
 
     Remove.remove(container);
   };

--- a/modules/sugar/src/test/ts/browser/ReplicationTest.ts
+++ b/modules/sugar/src/test/ts/browser/ReplicationTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Replication from 'ephox/sugar/api/dom/Replication';
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
@@ -13,12 +13,12 @@ interface TestSpec {
 
 UnitTest.test('ReplicationTest', () => {
   const checkValues = (expected: TestSpec, actual: SugarElement<HTMLElement>) => {
-    assert.eq(expected.name, 'span');
-    assert.eq(expected.attrs.href, actual.dom.getAttribute('href'));
-    assert.eq(expected.attrs['data-color'], actual.dom.getAttribute('data-color'));
+    Assert.eq('', expected.name, 'span');
+    Assert.eq('', expected.attrs.href, actual.dom.getAttribute('href'));
+    Assert.eq('', expected.attrs['data-color'], actual.dom.getAttribute('data-color'));
 
-    assert.eq(expected.styles.margin, actual.dom.style.getPropertyValue('margin'));
-    assert.eq(expected.styles.padding, actual.dom.style.getPropertyValue('padding'));
+    Assert.eq('', expected.styles.margin, actual.dom.style.getPropertyValue('margin'));
+    Assert.eq('', expected.styles.padding, actual.dom.style.getPropertyValue('padding'));
   };
 
   const checkCopy = (expected: TestSpec, input: string) => {
@@ -33,7 +33,7 @@ UnitTest.test('ReplicationTest', () => {
     const actual = Replication.mutate(initial, 'span');
 
     // mutate destroys the original element
-    assert.eq(0, Traverse.children(initial).length);
+    Assert.eq('', 0, Traverse.children(initial).length);
 
     checkValues(expected, actual);
   };

--- a/modules/sugar/src/test/ts/browser/ScrollTest.ts
+++ b/modules/sugar/src/test/ts/browser/ScrollTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Fun, Optional } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 
@@ -93,8 +93,8 @@ UnitTest.asynctest('ScrollTest', (success, failure) => {
   const scrollCheck = (x: number, y: number, epsX: number, epsY: number, doc: TestDocSpec, msg: string) => {
     Css.reflow(doc.body);
     const scr = Scroll.get(doc.rawDoc);
-    assert.eq(true, within(x, scr.left, epsX), msg + ' (' + doc.dir + ') Expected scrollCheck x=' + x + ', got=' + scr.left + ', eps=' + epsX);
-    assert.eq(true, within(y, scr.top, epsY), msg + ' (' + doc.dir + ') Expected scrollCheck y=' + y + ', got=' + scr.top + ', eps=' + epsY);
+    Assert.eq(msg + ' (' + doc.dir + ') Expected scrollCheck x=' + x + ', got=' + scr.left + ', eps=' + epsX, true, within(x, scr.left, epsX));
+    Assert.eq(msg + ' (' + doc.dir + ') Expected scrollCheck y=' + y + ', got=' + scr.top + ', eps=' + epsY, true, within(y, scr.top, epsY));
   };
 
   // scroll to (x,y) and check position
@@ -127,7 +127,7 @@ UnitTest.asynctest('ScrollTest', (success, failure) => {
     const cX = Math.round(center.left);
     const cY = Math.round(center.top);
 
-    assert.eq(true, scrollBarWidth > 5 && scrollBarWidth < 50 || (platform.os.isMacOS() && scrollBarWidth === 0), 'scroll bar width, got=' + scrollBarWidth);
+    Assert.eq('scroll bar width, got=' + scrollBarWidth, true, scrollBarWidth > 5 && scrollBarWidth < 50 || (platform.os.isMacOS() && scrollBarWidth === 0));
 
     scrollCheck(0, 0, 0, 0, doc, 'start pos');
 

--- a/modules/sugar/src/test/ts/browser/SelectionRangeTest.ts
+++ b/modules/sugar/src/test/ts/browser/SelectionRangeTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { PlatformDetection } from '@ephox/sand';
 
 import * as Compare from 'ephox/sugar/api/dom/Compare';
@@ -58,10 +58,10 @@ UnitTest.test('WindowSelectionTest', () => {
     const expStart = find(expected.start);
     const expFinish = find(expected.finish);
 
-    assert.eq(true, Compare.eq(expStart, actual.start), 'Start element different');
-    assert.eq(true, Compare.eq(expFinish, actual.finish), 'Finish element different');
-    assert.eq(expected.soffset, actual.soffset);
-    assert.eq(expected.foffset, actual.foffset);
+    Assert.eq('Start element different', true, Compare.eq(expStart, actual.start));
+    Assert.eq('Finish element different', true, Compare.eq(expFinish, actual.finish));
+    Assert.eq('', expected.soffset, actual.soffset);
+    Assert.eq('', expected.foffset, actual.foffset);
   };
 
   const checkUniCodeSelection = (content: string) => {
@@ -73,7 +73,7 @@ UnitTest.test('WindowSelectionTest', () => {
   const checkStringAt = (label: string, expectedStr: string, start: Situ, finish: Situ) => {
     // dont need to set a selection range, just extract the Situ.on() element/offset pair
     const actual = WindowSelection.getAsString(window, SimSelection.relative(start, finish));
-    assert.eq(expectedStr, actual, 'Actual was not expected [' + expectedStr + '|' + actual + ']');
+    Assert.eq('Actual was not expected [' + expectedStr + '|' + actual + ']', expectedStr, actual);
   };
 
   checkSelection(

--- a/modules/sugar/src/test/ts/browser/SelectionRectanglesTest.ts
+++ b/modules/sugar/src/test/ts/browser/SelectionRectanglesTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as InsertAll from 'ephox/sugar/api/dom/InsertAll';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
@@ -24,10 +24,7 @@ UnitTest.test('Browser Test: SelectionRectanglesTest', () => {
     'There should be a rectangle for paragraph 2'
   );
 
-  assert.eq(
-    true, rect1.top < rect2.top, 'Rect 1 should be above Rect 2. (1) was ' +
-    rect1.top + ', and (2) was ' + rect2.top
-  );
+  Assert.eq('Rect 1 should be above Rect 2. (1) was ' + rect1.top + ', and (2) was ' + rect2.top, true, rect1.top < rect2.top);
 
   const bounds1 = WindowSelection.getBounds(window, selP1).getOrDie(
     'There should be bounds for paragraph 1'
@@ -35,12 +32,7 @@ UnitTest.test('Browser Test: SelectionRectanglesTest', () => {
   const bounds2 = WindowSelection.getBounds(window, selP2).getOrDie(
     'There should be bounds for paragraph 2'
   );
-  assert.eq(
-    true,
-    bounds1.top < bounds2.top,
-    'Bounds 1 should be above bound 2. (1) was ' + bounds1.top + ', and (2)' +
-    ' was ' + bounds2.top
-  );
+  Assert.eq('Bounds 1 should be above bound 2. (1) was ' + bounds1.top + ', and (2)' + ' was ' + bounds2.top, true, bounds1.top < bounds2.top);
 
   Remove.remove(p1);
   Remove.remove(p2);

--- a/modules/sugar/src/test/ts/browser/SelectionTest.ts
+++ b/modules/sugar/src/test/ts/browser/SelectionTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Compare from 'ephox/sugar/api/dom/Compare';
 import * as Hierarchy from 'ephox/sugar/api/dom/Hierarchy';
@@ -28,18 +28,18 @@ UnitTest.test('Browser Test: SelectionTest', () => {
 
   const assertNoSelection = (label: string) => {
     WindowSelection.getExact(window).each((_sel) => {
-      assert.fail('There should not be a selection yet: ' + label);
+      Assert.fail('There should not be a selection yet: ' + label);
     });
   };
 
   const assertSelection = (label: string, expStart: SugarElement<Node>, expSoffset: number, expFinish: SugarElement<Node>, expFoffset: number) => {
     WindowSelection.getExact(window).fold(() => {
-      assert.fail('After setting selection ' + label + ', could not find a selection');
+      Assert.fail('After setting selection ' + label + ', could not find a selection');
     }, (sel) => {
-      assert.eq(true, Compare.eq(sel.start, expStart), () => 'Start container should be: ' + Html.getOuter(expStart) + '\n' + label);
-      assert.eq(expSoffset, sel.soffset);
-      assert.eq(true, Compare.eq(sel.finish, expFinish), () => 'Finish container should be ' + Html.getOuter(expFinish) + '\n' + label);
-      assert.eq(expFoffset, sel.foffset);
+      Assert.eq(() => 'Start container should be: ' + Html.getOuter(expStart) + '\n' + label, true, Compare.eq(sel.start, expStart));
+      Assert.eq('', expSoffset, sel.soffset);
+      Assert.eq(() => 'Finish container should be ' + Html.getOuter(expFinish) + '\n' + label, true, Compare.eq(sel.finish, expFinish));
+      Assert.eq('', expFoffset, sel.foffset);
     });
   };
 
@@ -55,7 +55,7 @@ UnitTest.test('Browser Test: SelectionTest', () => {
   const assertFragmentHtml = (expected: string, fragment: SugarElement<Node>) => {
     const div = SugarElement.fromTag('div');
     InsertAll.append(div, Traverse.children(fragment));
-    assert.eq(expected, Html.get(div));
+    Assert.eq('', expected, Html.get(div));
   };
 
   const p1Selected = WindowSelection.forElement(window, p1);
@@ -63,7 +63,7 @@ UnitTest.test('Browser Test: SelectionTest', () => {
   assertFragmentHtml('This is the <strong>first</strong> paragraph', clone);
 
   WindowSelection.replace(window, SimSelection.exactFromRange(p1Selected), SugarElements.fromHtml('<a>link</a><span>word</span>'));
-  assert.eq('<a>link</a><span>word</span>', Html.get(p1));
+  Assert.eq('', '<a>link</a><span>word</span>', Html.get(p1));
 
   WindowSelection.deleteAt(window,
     SimSelection.exact(
@@ -74,7 +74,7 @@ UnitTest.test('Browser Test: SelectionTest', () => {
     )
   );
 
-  assert.eq('<a>li</a><span>d</span>', Html.get(p1));
+  Assert.eq('', '<a>li</a><span>d</span>', Html.get(p1));
 
   Remove.remove(p1);
   Remove.remove(p2);
@@ -82,10 +82,10 @@ UnitTest.test('Browser Test: SelectionTest', () => {
   const assertRng = (selection: SimSelection, expStart: SugarElement<Node>, expSoffset: number, expFinish: SugarElement<Node>, expFoffset: number) => {
     const r = WindowSelection.toNative(selection);
 
-    assert.eq(expStart.dom, r.startContainer, () => 'Start Container should be: ' + Html.getOuter(expStart));
-    assert.eq(expSoffset, r.startOffset, 'Start offset should be: ' + expSoffset);
-    assert.eq(expFinish.dom, r.endContainer, () => 'End Container should be: ' + Html.getOuter(expFinish));
-    assert.eq(expFoffset, r.endOffset, 'End offset should be: ' + expFoffset);
+    Assert.eq(() => 'Start Container should be: ' + Html.getOuter(expStart), expStart.dom, r.startContainer);
+    Assert.eq('Start offset should be: ' + expSoffset, expSoffset, r.startOffset);
+    Assert.eq(() => 'End Container should be: ' + Html.getOuter(expFinish), expFinish.dom, r.endContainer);
+    Assert.eq('End offset should be: ' + expFoffset, expFoffset, r.endOffset);
 
     return r;
   };

--- a/modules/sugar/src/test/ts/browser/SelectionWithinTest.ts
+++ b/modules/sugar/src/test/ts/browser/SelectionWithinTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
 
 import * as InsertAll from 'ephox/sugar/api/dom/InsertAll';
@@ -19,7 +19,7 @@ UnitTest.test('Browser Test: SelectionTest', () => {
   const assertWithin = (expected: Record<string, number>, outer: SugarElement<Node>) => {
     WindowSelection.setToElement(window, outer);
     WindowSelection.getExact(window).fold(() => {
-      assert.fail('Selection should be wrapping: ' + Html.getOuter(outer));
+      Assert.fail('Selection should be wrapping: ' + Html.getOuter(outer));
     }, (sel) => {
       Obj.each(expected, (num, tag) => {
         const actual = WindowSelection.findWithin(
@@ -27,11 +27,8 @@ UnitTest.test('Browser Test: SelectionTest', () => {
           SimSelection.exact(sel.start, sel.soffset, sel.finish, sel.foffset),
           tag
         );
-        assert.eq(
-          num, actual.length, 'Incorrect number of ' + tag + ' tags.\n' +
-          'Expected: ' + num + ', but was: ' + actual.length
-        );
-        assert.eq(true, Arr.forall(actual, (a) => SugarNode.name(a) === tag), 'All tags must be: ' + tag);
+        Assert.eq('Incorrect number of ' + tag + ' tags.\n' + 'Expected: ' + num + ', but was: ' + actual.length, num, actual.length);
+        Assert.eq('All tags must be: ' + tag, true, Arr.forall(actual, (a) => SugarNode.name(a) === tag));
       });
     });
   };

--- a/modules/sugar/src/test/ts/browser/SelectorTest.ts
+++ b/modules/sugar/src/test/ts/browser/SelectorTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
 
 import * as Remove from 'ephox/sugar/api/dom/Remove';
@@ -17,15 +17,15 @@ UnitTest.test('SelectorTest', () => {
 
   const textnode = SugarElement.fromText('');
   const commentnode = SugarElement.fromHtml('<!--a-->');
-  assert.eq(false, Selectors.is(textnode, 'anything'));
-  assert.eq(false, Selectors.is(commentnode, 'anything'));
-  assert.eq([], Selectors.all('anything', textnode));
-  assert.eq([], Selectors.all('anything', commentnode));
+  Assert.eq('', false, Selectors.is(textnode, 'anything'));
+  Assert.eq('', false, Selectors.is(commentnode, 'anything'));
+  Assert.eq('', [], Selectors.all('anything', textnode));
+  Assert.eq('', [], Selectors.all('anything', commentnode));
   Checkers.checkOpt(Optional.none<SugarElement<Element>>(), Selectors.one('anything', textnode));
   Checkers.checkOpt(Optional.none<SugarElement<Element>>(), Selectors.one('anything', commentnode));
-  assert.eq([], SelectorFilter.ancestors(textnode, 'anything'));
-  assert.eq([], SelectorFilter.siblings(textnode, 'anything'));
-  assert.eq([], SelectorFilter.children(textnode, 'anything'));
+  Assert.eq('', [], SelectorFilter.ancestors(textnode, 'anything'));
+  Assert.eq('', [], SelectorFilter.siblings(textnode, 'anything'));
+  Assert.eq('', [], SelectorFilter.children(textnode, 'anything'));
 
   try {
     // IE throws an error running complex queries on an empty div
@@ -33,7 +33,7 @@ UnitTest.test('SelectorTest', () => {
     const empty = Div();
     Selectors.all('img:not([data-ephox-polish-blob])', empty);
   } catch (e: any) {
-    assert.fail(e);
+    Assert.fail(e);
   }
 
   TestPage.connect(); // description of structure is in TestPage
@@ -67,36 +67,36 @@ UnitTest.test('SelectorTest', () => {
   Checkers.checkList([ TestPage.s1, TestPage.s2, TestPage.s3, TestPage.s4 ], SelectorFilter.descendants(TestPage.container, 'span'));
   Checkers.checkList([], SelectorFilter.descendants(TestPage.container, 'blockquote'));
 
-  assert.eq(true, SelectorExists.any('p'));
-  assert.eq(false, SelectorExists.any('table'));
-  assert.eq(true, SelectorExists.ancestor(TestPage.t1, 'p'));
-  assert.eq(false, SelectorExists.ancestor(TestPage.t1, 'span'));
-  assert.eq(true, SelectorExists.sibling(TestPage.p2, 'p'));
-  assert.eq(false, SelectorExists.sibling(TestPage.t1, 'p'));
-  assert.eq(true, SelectorExists.child(TestPage.p1, 'span'));
-  assert.eq(false, SelectorExists.child(TestPage.p2, 'label'));
-  assert.eq(true, SelectorExists.descendant(TestPage.p2, 'span'));
-  assert.eq(false, SelectorExists.closest(TestPage.p1, 'span'));
-  assert.eq(true, SelectorExists.closest(TestPage.p1, 'p'));
-  assert.eq(true, SelectorExists.closest(TestPage.s1, 'p'));
-  assert.eq(true, SelectorExists.closest(TestPage.t1, 'p'));
+  Assert.eq('', true, SelectorExists.any('p'));
+  Assert.eq('', false, SelectorExists.any('table'));
+  Assert.eq('', true, SelectorExists.ancestor(TestPage.t1, 'p'));
+  Assert.eq('', false, SelectorExists.ancestor(TestPage.t1, 'span'));
+  Assert.eq('', true, SelectorExists.sibling(TestPage.p2, 'p'));
+  Assert.eq('', false, SelectorExists.sibling(TestPage.t1, 'p'));
+  Assert.eq('', true, SelectorExists.child(TestPage.p1, 'span'));
+  Assert.eq('', false, SelectorExists.child(TestPage.p2, 'label'));
+  Assert.eq('', true, SelectorExists.descendant(TestPage.p2, 'span'));
+  Assert.eq('', false, SelectorExists.closest(TestPage.p1, 'span'));
+  Assert.eq('', true, SelectorExists.closest(TestPage.p1, 'p'));
+  Assert.eq('', true, SelectorExists.closest(TestPage.s1, 'p'));
+  Assert.eq('', true, SelectorExists.closest(TestPage.t1, 'p'));
 
   // simple selectors
-  assert.eq(false, Selectors.is(TestPage.t1, 'p'), 'Text node should not match "p"');
-  assert.eq(true, Selectors.is(TestPage.p1, 'p'), 'Paragraph should match "p"');
-  assert.eq(false, Selectors.is(TestPage.p1, 'span'), 'Paragraph should not match "span"');
-  assert.eq(false, Selectors.is(TestPage.p1, 'p.blue'), 'Paragraph should not match "p.blue"');
-  assert.eq(true, Selectors.is(TestPage.s3, 'span'), 'Span should match "span"');
+  Assert.eq('Text node should not match "p"', false, Selectors.is(TestPage.t1, 'p'));
+  Assert.eq('Paragraph should match "p"', true, Selectors.is(TestPage.p1, 'p'));
+  Assert.eq('Paragraph should not match "span"', false, Selectors.is(TestPage.p1, 'span'));
+  Assert.eq('Paragraph should not match "p.blue"', false, Selectors.is(TestPage.p1, 'p.blue'));
+  Assert.eq('Span should match "span"', true, Selectors.is(TestPage.s3, 'span'));
 
   // slightly more advanced selectors
-  assert.eq(true, Selectors.is(TestPage.p1, 'div > p'), 'Paragraph should match "p"');
-  assert.eq(true, Selectors.is(TestPage.p1, 'div > p:first-child'), 'Paragraph should match "p"');
-  assert.eq(true, Selectors.is(TestPage.p2, 'div > p:last-child'), 'Paragraph should match "p"');
-  assert.eq(true, Selectors.is(TestPage.s4, 'div > p:last-child span span:last-child'), 'Span should match "span"');
+  Assert.eq('Paragraph should match "p"', true, Selectors.is(TestPage.p1, 'div > p'));
+  Assert.eq('Paragraph should match "p"', true, Selectors.is(TestPage.p1, 'div > p:first-child'));
+  Assert.eq('Paragraph should match "p"', true, Selectors.is(TestPage.p2, 'div > p:last-child'));
+  Assert.eq('Span should match "span"', true, Selectors.is(TestPage.s4, 'div > p:last-child span span:last-child'));
 
   // Mutating content.
   Class.add(TestPage.p1, 'blue');
-  assert.eq(true, Selectors.is(TestPage.p1, 'p.blue'), 'Paragraph should (now) match "p.blue"');
+  Assert.eq('Paragraph should (now) match "p.blue"', true, Selectors.is(TestPage.p1, 'p.blue'));
 
   Remove.remove(TestPage.container);
 });

--- a/modules/sugar/src/test/ts/browser/SizeTest.ts
+++ b/modules/sugar/src/test/ts/browser/SizeTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
@@ -19,36 +19,36 @@ UnitTest.test('SizeTest', () => {
 
   const checker = (cssProp: string, api: SizeApi) => {
     const checkExc = (expected: string, f: () => void) => {
-      assert.throwsError(f, expected);
+      Assert.throwsError('', f, expected);
     };
 
     const exact = () => Css.getRaw(c, cssProp).getOrDie('value was not set');
 
     api.set(c, 100);
-    assert.eq(100, api.get(c));
+    Assert.eq('', 100, api.get(c));
     checkExc(cssProp + '.set accepts only positive integer values. Value was 100%', () => {
       api.set(c, '100%');
     });
     checkExc(cssProp + '.set accepts only positive integer values. Value was 100px', () => {
       api.set(c, '100px');
     });
-    assert.eq('100px', exact());
+    Assert.eq('', '100px', exact());
 
     Css.set(c, cssProp, '85%');
-    assert.eq('85%', exact());
+    Assert.eq('', '85%', exact());
 
     if (SugarBody.inBody(c)) {
       // percentage height is calculated as zero, but percentage width works just fine
       if (cssProp === 'height') {
-        assert.eq(0, api.get(c));
+        Assert.eq('', 0, api.get(c));
       } else {
-        assert.eq(true, api.get(c) > 0);
+        Assert.eq('', true, api.get(c) > 0);
       }
     }
 
     Css.set(c, cssProp, '30px');
-    assert.eq(30, api.get(c));
-    assert.eq('30px', exact());
+    Assert.eq('', 30, api.get(c));
+    Assert.eq('', '30px', exact());
   };
 
   checker('height', Height);

--- a/modules/sugar/src/test/ts/browser/StyleTest.ts
+++ b/modules/sugar/src/test/ts/browser/StyleTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Style from 'ephox/sugar/impl/Style';
 
@@ -6,5 +6,5 @@ UnitTest.test('SizeTest', () => {
   const fakeElement = {
     style: {}
   };
-  assert.eq(false, Style.isSupported(fakeElement as any));
+  Assert.eq('', false, Style.isSupported(fakeElement as any));
 });

--- a/modules/sugar/src/test/ts/browser/TextContentTest.ts
+++ b/modules/sugar/src/test/ts/browser/TextContentTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import * as SugarText from 'ephox/sugar/api/node/SugarText';
@@ -6,18 +6,18 @@ import * as TextContent from 'ephox/sugar/api/properties/TextContent';
 
 UnitTest.test('TextContentTest', () => {
   const element = SugarElement.fromHtml('<p>Hello <strong>World!</strong></p>');
-  assert.eq('Hello World!', TextContent.get(element));
+  Assert.eq('', 'Hello World!', TextContent.get(element));
   TextContent.set(element, 'My text value');
-  assert.eq('My text value', TextContent.get(element));
+  Assert.eq('', 'My text value', TextContent.get(element));
 
   const textnode = SugarElement.fromText('This is just text');
-  assert.eq('This is just text', TextContent.get(textnode));
+  Assert.eq('', 'This is just text', TextContent.get(textnode));
   TextContent.set(textnode, 'new text value');
-  assert.eq('new text value', TextContent.get(textnode));
-  assert.eq('new text value', SugarText.get(textnode));
+  Assert.eq('', 'new text value', TextContent.get(textnode));
+  Assert.eq('', 'new text value', SugarText.get(textnode));
 
   const comment = SugarElement.fromDom(document.createComment('commenting checking'));
-  assert.eq('commenting checking', TextContent.get(comment));
+  Assert.eq('', 'commenting checking', TextContent.get(comment));
   TextContent.set(comment, 'new comment value');
-  assert.eq('new comment value', TextContent.get(comment));
+  Assert.eq('', 'new comment value', TextContent.get(comment));
 });

--- a/modules/sugar/src/test/ts/browser/TextTest.ts
+++ b/modules/sugar/src/test/ts/browser/TextTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import * as SugarNode from 'ephox/sugar/api/node/SugarNode';
@@ -11,7 +11,7 @@ UnitTest.test('TextTest', () => {
     Traverse.child(span, 0).filter(SugarNode.isText).each((text0) => {
       span.dom.innerHTML = 'smashed';
       const v = SugarText.get(text0); // Throws in IE10.
-      assert.eq('string', typeof v);
+      Assert.eq('', 'string', typeof v);
     });
   };
 
@@ -19,20 +19,20 @@ UnitTest.test('TextTest', () => {
 
   const notText = SugarElement.fromTag('span');
   const t = SugarElement.fromText('a');
-  assert.eq('a', SugarText.get(t));
+  Assert.eq('', 'a', SugarText.get(t));
   SugarText.set(t, 'blue');
-  assert.eq('blue', t.dom.nodeValue);
+  Assert.eq('', 'blue', t.dom.nodeValue);
 
   try {
     SugarText.get(notText as any);
-    assert.fail('get on non-text did not throw');
+    Assert.fail('get on non-text did not throw');
   } catch (e) {
     // pass
   }
 
   try {
     SugarText.set(notText as any, 'bogus');
-    assert.fail('set on non-text did not throw');
+    Assert.fail('set on non-text did not throw');
   } catch (e) {
     // pass
   }

--- a/modules/sugar/src/test/ts/browser/TogglerTest.ts
+++ b/modules/sugar/src/test/ts/browser/TogglerTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
@@ -24,29 +24,29 @@ UnitTest.test('TogglerTest', () => {
     check(false);
 
     toggler.on();
-    assert.eq(true, toggler.isOn());
+    Assert.eq('', true, toggler.isOn());
     check(true);
     toggler.on();
-    assert.eq(true, toggler.isOn());
+    Assert.eq('', true, toggler.isOn());
     check(true);
 
     toggler.off();
-    assert.eq(false, toggler.isOn());
+    Assert.eq('', false, toggler.isOn());
     check(false);
     toggler.off();
-    assert.eq(false, toggler.isOn());
+    Assert.eq('', false, toggler.isOn());
     check(false);
 
     toggler.on();
     toggler.off();
-    assert.eq(false, toggler.isOn());
+    Assert.eq('', false, toggler.isOn());
     check(false);
   };
 
   // this is all due for a good refactoring
 
   const checkClass = (has: boolean) => {
-    assert.eq(has, Class.has(c, 'blob'));
+    Assert.eq('', has, Class.has(c, 'blob'));
   };
 
   let c = Div();
@@ -60,7 +60,7 @@ UnitTest.test('TogglerTest', () => {
 
   const checkDisplayBlockRemoved = (has: boolean) => {
     const v = has ? 'none' : 'block';
-    assert.eq(v, Css.get(c, 'display'));
+    Assert.eq('', v, Css.get(c, 'display'));
   };
 
   // behaviour when not connected and not specified - which the link dialog relies on
@@ -72,7 +72,7 @@ UnitTest.test('TogglerTest', () => {
 
   const checkDisplayBlockNone = (has: boolean) => {
     const v = has ? 'block' : 'none';
-    assert.eq(v, Css.get(c, 'display'));
+    Assert.eq('', v, Css.get(c, 'display'));
   };
 
   // normal behaviour
@@ -85,7 +85,7 @@ UnitTest.test('TogglerTest', () => {
 
   const checkVisibilityVisibleRemoved = (has: boolean) => {
     const v = has ? 'hidden' : 'visible';
-    assert.eq(v, Css.get(c, 'visibility'));
+    Assert.eq('', v, Css.get(c, 'visibility'));
   };
 
   // behaviour when not connected and not specified
@@ -97,7 +97,7 @@ UnitTest.test('TogglerTest', () => {
 
   const checkVisibilityVisibleHidden = (has: boolean) => {
     const v = has ? 'visible' : 'hidden';
-    assert.eq(v, Css.get(c, 'visibility'));
+    Assert.eq('', v, Css.get(c, 'visibility'));
   };
 
   // normal behaviour

--- a/modules/sugar/src/test/ts/browser/ValueTest.ts
+++ b/modules/sugar/src/test/ts/browser/ValueTest.ts
@@ -1,14 +1,14 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import * as Value from 'ephox/sugar/api/properties/Value';
 
 UnitTest.test('ValueTest', () => {
   const ta = SugarElement.fromHtml<HTMLTextAreaElement>('<textarea>sometexthere</textarea>');
-  assert.eq('sometexthere', Value.get(ta));
+  Assert.eq('', 'sometexthere', Value.get(ta));
   Value.set(ta, 'one');
-  assert.eq('one', ta.dom.value);
-  assert.eq('one', Value.get(ta));
+  Assert.eq('', 'one', ta.dom.value);
+  Assert.eq('', 'one', Value.get(ta));
 
   let success = false;
   try {
@@ -19,6 +19,6 @@ UnitTest.test('ValueTest', () => {
   }
 
   if (success) {
-    assert.fail('setting undefined did not fail');
+    Assert.fail('setting undefined did not fail');
   }
 });

--- a/modules/sugar/src/test/ts/browser/VisibilityTest.ts
+++ b/modules/sugar/src/test/ts/browser/VisibilityTest.ts
@@ -1,4 +1,4 @@
-import { assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 
@@ -12,27 +12,27 @@ import Div from 'ephox/sugar/test/Div';
 
 UnitTest.test('VisibilityTest', () => {
   const c = Div();
-  assert.eq(false, Visibility.isVisible(c));
+  Assert.eq('', false, Visibility.isVisible(c));
   Insert.append(SugarBody.body(), c);
-  assert.eq(true, Visibility.isVisible(c));
+  Assert.eq('', true, Visibility.isVisible(c));
 
   Css.set(c, 'display', 'none');
-  assert.eq(false, Visibility.isVisible(c));
+  Assert.eq('', false, Visibility.isVisible(c));
 
   const s = SugarElement.fromTag('span');
-  assert.eq(false, Visibility.isVisible(s));
+  Assert.eq('', false, Visibility.isVisible(s));
 
   Insert.append(SugarBody.body(), s);
   const expected = PlatformDetection.detect().browser.isFirefox();
-  assert.eq(expected, Visibility.isVisible(s)); // tricked you! height and width are zero == hidden
+  Assert.eq('', expected, Visibility.isVisible(s)); // tricked you! height and width are zero == hidden
 
   const d = Div();
   Insert.append(c, d);
-  assert.eq(false, Visibility.isVisible(d));
+  Assert.eq('', false, Visibility.isVisible(d));
 
   Css.remove(c, 'display');
-  assert.eq(true, Visibility.isVisible(d));
-  assert.eq(true, Visibility.isVisible(c));
+  Assert.eq('', true, Visibility.isVisible(d));
+  Assert.eq('', true, Visibility.isVisible(c));
 
   Arr.each([ c, d, s ], Remove.remove);
 });

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -23,8 +23,8 @@
     "silver-test-manual": "grunt bedrock-manual:silver"
   },
   "dependencies": {
-    "dompurify": "^2.3.4",
-    "prismjs": "^1.26.0",
+    "dompurify": "^2.3.6",
+    "prismjs": "^1.27.0",
     "tslib": "^2.0.0"
   }
 }

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentEventsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentEventsTest.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions } from '@ephox/mcagar';
-import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatChangeVarsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatChangeVarsTest.ts
@@ -1,7 +1,7 @@
 import { Waiter } from '@ephox/agar';
 import { after, before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Singleton } from '@ephox/katamari';
-import { TinyHooks, TinySelections } from '@ephox/mcagar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/plugins/link/test/ts/browser/LinkDialogOverrideTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/LinkDialogOverrideTest.ts
@@ -1,8 +1,8 @@
 import { UiFinder, UiControls } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Dialog } from '@ephox/bridge';
-import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
@@ -1,9 +1,8 @@
 import { ApproxStructure, Assertions, Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyDom } from '@ephox/mcagar';
 import { Focus, Scroll, SugarBody, SugarElement, SugarLocation, Traverse } from '@ephox/sugar';
-import { TinyHooks } from '@ephox/wrap-mcagar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverRenderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverRenderTest.ts
@@ -1,9 +1,8 @@
 import { UiFinder } from '@ephox/agar';
 import { after, describe, it } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
-import { TinyDom } from '@ephox/mcagar';
 import { SugarElement, SugarShadowDom } from '@ephox/sugar';
-import { TinyHooks } from '@ephox/wrap-mcagar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/patches/dompurify+2.3.6.patch
+++ b/patches/dompurify+2.3.6.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/dompurify/dist/purify.es.js b/node_modules/dompurify/dist/purify.es.js
-index 899e471..414c5d8 100644
+index 12d391a..a9b5c84 100644
 --- a/node_modules/dompurify/dist/purify.es.js
 +++ b/node_modules/dompurify/dist/purify.es.js
-@@ -617,6 +617,12 @@ function createDOMPurify() {
+@@ -618,6 +618,12 @@ function createDOMPurify() {
  
    var HTML_INTEGRATION_POINTS = addToSet({}, ['foreignobject', 'desc', 'title', 'annotation-xml']);
  
@@ -15,7 +15,7 @@ index 899e471..414c5d8 100644
    /* Keep track of all possible SVG and MathML tags
     * so that we can perform the namespace checks
     * correctly. */
-@@ -701,15 +707,9 @@ function createDOMPurify() {
+@@ -702,15 +708,9 @@ function createDOMPurify() {
          return false;
        }
  
@@ -32,7 +32,7 @@ index 899e471..414c5d8 100644
      }
  
      // The code should never reach this place (this means
-@@ -902,7 +902,7 @@ function createDOMPurify() {
+@@ -905,7 +905,7 @@ function createDOMPurify() {
      }
  
      /* Check if tagname contains Unicode */
@@ -41,7 +41,7 @@ index 899e471..414c5d8 100644
        _forceRemove(currentNode);
        return true;
      }
-@@ -917,7 +917,7 @@ function createDOMPurify() {
+@@ -920,7 +920,7 @@ function createDOMPurify() {
      });
  
      /* Detect mXSS attempts abusing namespace confusion */
@@ -50,7 +50,7 @@ index 899e471..414c5d8 100644
        _forceRemove(currentNode);
        return true;
      }
-@@ -1073,6 +1073,7 @@ function createDOMPurify() {
+@@ -1077,6 +1077,7 @@ function createDOMPurify() {
  
        value = stringTrim(attr.value);
        lcName = transformCaseFunc(name);
@@ -58,7 +58,7 @@ index 899e471..414c5d8 100644
  
        /* Execute a hook if present */
        hookEvent.attrName = lcName;
-@@ -1086,11 +1087,9 @@ function createDOMPurify() {
+@@ -1090,11 +1091,9 @@ function createDOMPurify() {
          continue;
        }
  
@@ -71,7 +71,7 @@ index 899e471..414c5d8 100644
          continue;
        }
  
-@@ -1109,20 +1108,23 @@ function createDOMPurify() {
+@@ -1113,20 +1112,23 @@ function createDOMPurify() {
        /* Is `value` valid for this attribute? */
        var lcTag = transformCaseFunc(currentNode.nodeName);
        if (!_isValidAttribute(lcTag, lcName, value)) {
@@ -105,10 +105,10 @@ index 899e471..414c5d8 100644
  
      /* Execute a hook if present */
 diff --git a/node_modules/dompurify/dist/purify.js b/node_modules/dompurify/dist/purify.js
-index 68bc40f..f759fa8 100644
+index aec46c4..1719ab8 100644
 --- a/node_modules/dompurify/dist/purify.js
 +++ b/node_modules/dompurify/dist/purify.js
-@@ -623,6 +623,12 @@
+@@ -624,6 +624,12 @@
  
      var HTML_INTEGRATION_POINTS = addToSet({}, ['foreignobject', 'desc', 'title', 'annotation-xml']);
  
@@ -121,7 +121,7 @@ index 68bc40f..f759fa8 100644
      /* Keep track of all possible SVG and MathML tags
       * so that we can perform the namespace checks
       * correctly. */
-@@ -707,15 +713,9 @@
+@@ -708,15 +714,9 @@
            return false;
          }
  
@@ -138,7 +138,7 @@ index 68bc40f..f759fa8 100644
        }
  
        // The code should never reach this place (this means
-@@ -908,7 +908,7 @@
+@@ -911,7 +911,7 @@
        }
  
        /* Check if tagname contains Unicode */
@@ -147,7 +147,7 @@ index 68bc40f..f759fa8 100644
          _forceRemove(currentNode);
          return true;
        }
-@@ -923,7 +923,7 @@
+@@ -926,7 +926,7 @@
        });
  
        /* Detect mXSS attempts abusing namespace confusion */
@@ -156,7 +156,7 @@ index 68bc40f..f759fa8 100644
          _forceRemove(currentNode);
          return true;
        }
-@@ -1079,6 +1079,7 @@
+@@ -1083,6 +1083,7 @@
  
          value = stringTrim(attr.value);
          lcName = transformCaseFunc(name);
@@ -164,7 +164,7 @@ index 68bc40f..f759fa8 100644
  
          /* Execute a hook if present */
          hookEvent.attrName = lcName;
-@@ -1092,11 +1093,9 @@
+@@ -1096,11 +1097,9 @@
            continue;
          }
  
@@ -177,7 +177,7 @@ index 68bc40f..f759fa8 100644
            continue;
          }
  
-@@ -1115,20 +1114,23 @@
+@@ -1119,20 +1118,23 @@
          /* Is `value` valid for this attribute? */
          var lcTag = transformCaseFunc(currentNode.nodeName);
          if (!_isValidAttribute(lcTag, lcName, value)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,9 +260,9 @@
     xml-writer "^1.6.0"
 
 "@ephox/dispute@^1.0.3":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@ephox/dispute/-/dispute-1.0.10.tgz#99a31c195af0d9a058a7ea6b71fa8bff557abfff"
-  integrity sha512-Zh5om8Sfkg+lpq/jDfYvdU/dOrgjHCXnWYXojZPJJZJxtzZjfEkEQ5U2XF99RZIQofD7Lc+wwon3oUZ0fNL/ig==
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@ephox/dispute/-/dispute-1.0.11.tgz#5d305c020448861c97a9219469bb5062fb18723c"
+  integrity sha512-rzO1gysEMYhaOwIustCoISGlsFQdYj6y/6vroAxX63ahApeeb4UpCjrQY3vh4FK/ZgLbY3cbwzpv0lwPzCRddw==
   dependencies:
     tslib "^2.0.0"
 
@@ -298,14 +298,14 @@
   resolved "https://registry.yarnpkg.com/@ephox/wrap-promise-polyfill/-/wrap-promise-polyfill-2.2.1.tgz#afaabe10bc4c44d167e2f8fa6e722cbd7817d386"
   integrity sha512-hg2IKjR3E8awv6ZPUZtHVLa+ZQkaN1ksVacw40Jq2gg6uMU9GkBTcSOl+9PswBzva2Jg0lxX0r0ipMAWemDwsA==
 
-"@eslint/eslintrc@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.5.tgz#33f1b838dbf1f923bfa517e008362b78ddbbf318"
-  integrity sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==
+"@eslint/eslintrc@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.1.0.tgz#583d12dbec5d4f22f333f9669f7d0b7c7815b4d3"
+  integrity sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
-    espree "^9.2.0"
+    espree "^9.3.1"
     globals "^13.9.0"
     ignore "^4.0.6"
     import-fresh "^3.2.1"
@@ -407,9 +407,9 @@
     through2 "^2.0.3"
 
 "@humanwhocodes/config-array@^0.9.2":
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.2.tgz#68be55c737023009dfc5fe245d51181bb6476914"
-  integrity sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.3.tgz#f2564c744b387775b436418491f15fce6601f63e"
+  integrity sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==
   dependencies:
     "@humanwhocodes/object-schema" "^1.2.1"
     debug "^4.1.1"
@@ -1391,9 +1391,9 @@
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/prismjs@^1.16.6":
-  version "1.16.8"
-  resolved "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.16.8.tgz#ce1b3a673d282937c3d4183d2ff88b9ccedd6d3b"
-  integrity sha512-I8v3yZIvhIwB55MhV+9+FhK5OMokviuQQP4vGmffW18iQGw5cyB6CaBGWFhcIJk+0cyi/PNhNPedlUYTAHoc2Q==
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.26.0.tgz#a1c3809b0ad61c62cac6d4e0c56d610c910b7654"
+  integrity sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==
 
 "@types/puppeteer-core@^5.4.0":
   version "5.4.0"
@@ -2946,14 +2946,15 @@ caseless@~0.12.0:
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
 chai@^4.3.3:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.4.tgz#b55e655b31e1eac7099be4c08c21964fce2e6c49"
-  integrity sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.6.tgz#ffe4ba2d9fa9d6680cc0b370adae709ec9011e9c"
+  integrity sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==
   dependencies:
     assertion-error "^1.1.0"
     check-error "^1.0.2"
     deep-eql "^3.0.1"
     get-func-name "^2.0.0"
+    loupe "^2.3.1"
     pathval "^1.1.1"
     type-detect "^4.0.5"
 
@@ -3951,9 +3952,9 @@ deep-for-each@^3.0.0:
     lodash.isplainobject "^4.0.6"
 
 deep-is@^0.1.3, deep-is@~0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
-  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 deepmerge@^4.0.0:
   version "4.2.2"
@@ -4214,10 +4215,10 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-dompurify@^2.3.4:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.4.tgz#1cf5cf0105ccb4debdf6db162525bd41e6ddacc6"
-  integrity sha512-6BVcgOAVFXjI0JTjEvZy901Rghm+7fDQOrNIcxB4+gdhj6Kwp6T9VBhBY/AbagKHJocRkDYGd6wvI+p4/10xtQ==
+dompurify@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.6.tgz#2e019d7d7617aacac07cbbe3d88ae3ad354cf875"
+  integrity sha512-OFP2u/3T1R5CEgWCEONuJ1a5+MFKnOYpkywpUSxv/dj1LeBT1erK+JwM7zK0ROy2BRhqVCf0LRw/kHqKuMkVGg==
 
 domutils@^1.5.1, domutils@^1.7.0:
   version "1.7.0"
@@ -4598,10 +4599,10 @@ eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-scope@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.0.tgz#c1f6ea30ac583031f203d65c73e723b01298f153"
-  integrity sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==
+eslint-scope@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
+  integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
@@ -4618,17 +4619,17 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.1.0, eslint-visitor-keys@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz#6fbb166a6798ee5991358bc2daa1ba76cc1254a1"
-  integrity sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==
+eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
+  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@^8.0.0, eslint@^8.0.1, eslint@^8.7.0:
-  version "8.7.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.7.0.tgz#22e036842ee5b7cf87b03fe237731675b4d3633c"
-  integrity sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==
+  version "8.9.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.9.0.tgz#a2a8227a99599adc4342fd9b854cb8d8d6412fdb"
+  integrity sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==
   dependencies:
-    "@eslint/eslintrc" "^1.0.5"
+    "@eslint/eslintrc" "^1.1.0"
     "@humanwhocodes/config-array" "^0.9.2"
     ajv "^6.10.0"
     chalk "^4.0.0"
@@ -4636,10 +4637,10 @@ eslint@^8.0.0, eslint@^8.0.1, eslint@^8.7.0:
     debug "^4.3.2"
     doctrine "^3.0.0"
     escape-string-regexp "^4.0.0"
-    eslint-scope "^7.1.0"
+    eslint-scope "^7.1.1"
     eslint-utils "^3.0.0"
-    eslint-visitor-keys "^3.2.0"
-    espree "^9.3.0"
+    eslint-visitor-keys "^3.3.0"
+    espree "^9.3.1"
     esquery "^1.4.0"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
@@ -4669,14 +4670,14 @@ esm@^3.2.0:
   resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
   integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
 
-espree@^9.2.0, espree@^9.3.0:
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.0.tgz#c1240d79183b72aaee6ccfa5a90bc9111df085a8"
-  integrity sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==
+espree@^9.3.1:
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.1.tgz#8793b4bc27ea4c778c19908e0719e7b8f4115bcd"
+  integrity sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==
   dependencies:
     acorn "^8.7.0"
     acorn-jsx "^5.3.1"
-    eslint-visitor-keys "^3.1.0"
+    eslint-visitor-keys "^3.3.0"
 
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
@@ -4940,9 +4941,9 @@ fancy-log@^1.3.2, fancy-log@^1.3.3:
     time-stamp "^1.0.0"
 
 fast-check@^2.0.0, fast-check@^2.20.0:
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-2.21.0.tgz#0d2e20bc65343ee67ec0f58373358140c08a1217"
-  integrity sha512-hkTRytqMceXfnSwPnryIqKkxKJjfcvtVqJrWRb8tgmfyUsGajIgQqDFxCJ+As+l9VLUCcmx6XIYoXeQe2Ih0UA==
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-2.22.0.tgz#b807ef18e10a37e8eb57b28e43974e7986563585"
+  integrity sha512-Yrx1E8fZk6tfSqYaNkwnxj/lOk+vj2KTbbpHDtYoK9MrrL/D204N/rCtcaVSz5bE29g6gW4xj0byresjlFyybg==
   dependencies:
     pure-rand "^5.0.0"
 
@@ -5215,9 +5216,9 @@ flat-cache@^3.0.4:
     rimraf "^3.0.2"
 
 flatted@^3.1.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
-  integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
+  integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
 flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   version "1.1.1"
@@ -5694,9 +5695,9 @@ globals@^11.1.0:
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^13.6.0, globals@^13.9.0:
-  version "13.10.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.10.0.tgz#60ba56c3ac2ca845cfbf4faeca727ad9dd204676"
-  integrity sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==
+  version "13.12.1"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.12.1.tgz#ec206be932e6c77236677127577aa8e50bf1c5cb"
+  integrity sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==
   dependencies:
     type-fest "^0.20.2"
 
@@ -7709,6 +7710,13 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
+loupe@^2.3.1:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.4.tgz#7e0b9bffc76f148f9be769cb1321d3dcf3cb25f3"
+  integrity sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==
+  dependencies:
+    get-func-name "^2.0.0"
+
 lowercase-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
@@ -8130,7 +8138,14 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-"minimatch@2 || 3", minimatch@^3.0.4, minimatch@~3.0.2, minimatch@~3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.4:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@~3.0.2, minimatch@~3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -9476,10 +9491,10 @@ prism-themes@^1.9.0:
   resolved "https://registry.yarnpkg.com/prism-themes/-/prism-themes-1.9.0.tgz#19c034f3205f1e28d75d89728e54ccd745f7e3dd"
   integrity sha512-tX2AYsehKDw1EORwBps+WhBFKc2kxfoFpQAjxBndbZKr4fRmMkv47XN0BghC/K1qwodB1otbe4oF23vUTFDokw==
 
-prismjs@^1.26.0:
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.26.0.tgz#16881b594828bb6b45296083a8cbab46b0accd47"
-  integrity sha512-HUoH9C5Z3jKkl3UunCyiD5jwk0+Hz0fIgQ2nbwU2Oo/ceuTAQAg+pPVnfdt2TJWRVLcxKh9iuoYDUSc8clb5UQ==
+prismjs@^1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
+  integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
 
 process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -10275,17 +10290,10 @@ rollup@^1.23.1:
     "@types/node" "*"
     acorn "^7.1.0"
 
-rollup@^2.48.0:
-  version "2.52.4"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.52.4.tgz#0150247d54fb2f21be4915b898f8764389fea292"
-  integrity sha512-AXgUxxWXyGfsj8GKleR1k8KsG8G+7ZZDRU9RZb9PnLGSyTqI/1qf/+QSp1hRaR40j4yfBCKXs5khtGKiFwihfg==
-  optionalDependencies:
-    fsevents "~2.3.2"
-
-rollup@^2.66.1:
-  version "2.66.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.66.1.tgz#366b0404de353c4331d538c3ad2963934fcb4937"
-  integrity sha512-crSgLhSkLMnKr4s9iZ/1qJCplgAgrRY+igWv8KhG/AjKOJ0YX/WpmANyn8oxrw+zenF3BXWDLa7Xl/QZISH+7w==
+rollup@^2.48.0, rollup@^2.66.1:
+  version "2.67.3"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.67.3.tgz#3f04391fc296f807d067c9081d173e0a33dbd37e"
+  integrity sha512-G/x1vUwbGtP6O5ZM8/sWr8+p7YfZhI18pPqMRtMYMWSbHjKZ/ajHGiM+GWNTlWyOR0EHIdT8LHU+Z4ciIZ1oBw==
   optionalDependencies:
     fsevents "~2.3.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,7 +193,7 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@ephox/bedrock-client@11 || 12 || 13", "@ephox/bedrock-client@^11.0.0", "@ephox/bedrock-client@^11.3.2":
+"@ephox/bedrock-client@11 || 12 || 13", "@ephox/bedrock-client@^11.3.2":
   version "11.3.2"
   resolved "https://registry.yarnpkg.com/@ephox/bedrock-client/-/bedrock-client-11.3.2.tgz#b358d6f9857e751e115c19eb0f9d89bb4135eaf2"
   integrity sha512-tpsOMSfKPhzHBksyz5ZtM4gUjZsUw51i2cCaMuwSysOtiEbB4IKPceYyg4NxsbysSvHY8xAVrzobgj71MJDJvQ==


### PR DESCRIPTION
Related Ticket: TINY-8509

Description of Changes:
* Remove the old IE 11 ponyfill from the sugar `Strings` module
* Cleaned up some old types that were duplicating the TS dom lib or casting as any
* Replace all uses of the old deprecated `assert` bedrock API (this will help to upgrade to Bedrock 13 at a later stage)
* Fixed the bedrock-client version in the katamari-assertions package
* Upgraded dev deps 
* Upgrade `prismjs` and `dompurify` to pull in minor upstream bug fixes
  * Note: I've looked over the changes and done some manual testing with these changes to make sure they are safe. The prismjs one could have been skipped as it's only in things we don't use, but we might as well keep it up to date. The dompurify change does include somewhat of a feature, but it only impacts `WHOLE_DOCUMENT` mode which we don't use.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
