### PR TITLE
TINY-8513: Fixed alloy detached context console warnings when menu items are closed by the onAction

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -112,6 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed sub-menu items not read by screen readers. Patch contributed by westonkd #TINY-8417
 - The Home or End keys would move out of a editable element contained within a noneditable element #TINY-8201
 - Dialogs could not be opened in inline mode before the editor had been rendered #TINY-8397
+- Clicking on menu items could cause an unexpected console warning if the `onAction` function caused the menu to close #TINY-8513
 
 ### Removed
 - Removed support for Microsoft Internet Explorer 11 #TINY-8194 #TINY-8241

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/ItemEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/ItemEvents.ts
@@ -24,7 +24,9 @@ const onMenuItemExecute = <T>(info: OnMenuItemExecuteType<T>, itemResponse: Item
   // If there is an action, run the action
   runWithApi(info, comp)(info.onAction);
   if (!info.triggersSubmenu && itemResponse === ItemResponse.CLOSE_ON_EXECUTE) {
-    AlloyTriggers.emit(comp, SystemEvents.sandboxClose());
+    if (comp.getSystem().isConnected()) {
+      AlloyTriggers.emit(comp, SystemEvents.sandboxClose());
+    }
     simulatedEvent.stop();
   }
 });


### PR DESCRIPTION
Related Ticket: TINY-8513

Description of Changes:

This reverts part of 8ad4a1a2df1b79bc8856d99a0b7be69bcd238001, as this specific line still needs the `isConnected` check since the `onAction` within the execute handler can cause the menu to close/be removed from the DOM (unlike the other cases were the check was removed). That is what's happening with the export menu item, as it triggers the throbber which in turns closes all the open popups.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~ There's no actual function change we can test for, because the trigger that prints the console warning doesn't cause any issue since it's purpose is to close the menu item which has already been done.
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
