### PR TITLE
TINY-2316: Corrected company name

### DIFF
--- a/modules/acid/package.json
+++ b/modules/acid/package.json
@@ -14,7 +14,7 @@
     "@ephox/sugar": "^9.0.0-alpha.5",
     "tslib": "^2.0.0"
   },
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "files": [
     "lib/main",

--- a/modules/agar/package.json
+++ b/modules/agar/package.json
@@ -21,7 +21,7 @@
     "browser",
     "test"
   ],
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
     "@ephox/bedrock-client": "11 || 12 || 13",

--- a/modules/alloy/package.json
+++ b/modules/alloy/package.json
@@ -35,7 +35,7 @@
   "keywords": [
     "ui"
   ],
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "main": "./lib/main/ts/ephox/alloy/api/Main.js",
   "module": "./lib/main/ts/ephox/alloy/api/Main.js",

--- a/modules/boss/package.json
+++ b/modules/boss/package.json
@@ -32,7 +32,7 @@
     "test-manual": "bedrock -d src/test/ts",
     "lint": "eslint --config ../../.eslintrc.json src/**/*.ts"
   },
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "main": "./lib/main/ts/ephox/boss/api/Main.js",
   "module": "./lib/main/ts/ephox/boss/api/Main.js",

--- a/modules/boulder/package.json
+++ b/modules/boulder/package.json
@@ -33,7 +33,7 @@
     "CHANGELOG.txt",
     "LICENSE.txt"
   ],
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "main": "./lib/main/ts/ephox/boulder/api/Main.js",
   "module": "./lib/main/ts/ephox/boulder/api/Main.js",

--- a/modules/bridge/package.json
+++ b/modules/bridge/package.json
@@ -17,7 +17,7 @@
     "@ephox/katamari": "^9.0.0-alpha.3",
     "tslib": "^2.0.0"
   },
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "files": [
     "lib/main",

--- a/modules/darwin/package.json
+++ b/modules/darwin/package.json
@@ -27,7 +27,7 @@
     "@ephox/sugar": "^9.0.0-alpha.5",
     "tslib": "^2.0.0"
   },
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "main": "./lib/main/ts/ephox/darwin/api/Main.js",
   "module": "./lib/main/ts/ephox/darwin/api/Main.js",

--- a/modules/dragster/package.json
+++ b/modules/dragster/package.json
@@ -30,7 +30,7 @@
     "lint": "eslint --config ../../.eslintrc.json src/**/*.ts",
     "prepublishOnly": "tsc -b"
   },
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "main": "./lib/main/ts/ephox/dragster/api/Main.js",
   "module": "./lib/main/ts/ephox/dragster/api/Main.js",

--- a/modules/jax/package.json
+++ b/modules/jax/package.json
@@ -19,7 +19,7 @@
   "keywords": [
     "ajax"
   ],
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
     "@ephox/katamari": "^9.0.0-alpha.3",

--- a/modules/katamari-assertions/package.json
+++ b/modules/katamari-assertions/package.json
@@ -13,7 +13,7 @@
     "test-manual": "bedrock -d src/test/ts",
     "lint": "eslint --config ../../.eslintrc.json src/**/*.ts"
   },
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
     "@ephox/bedrock-client": "11 || 12 || 13",

--- a/modules/katamari/package.json
+++ b/modules/katamari/package.json
@@ -13,7 +13,7 @@
     "test-manual": "bedrock -d src/test/ts",
     "lint": "eslint --config ../../.eslintrc.json src/**/*.ts"
   },
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
     "@ephox/dispute": "^1.0.3",

--- a/modules/mcagar/package.json
+++ b/modules/mcagar/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint --config ../../.eslintrc.json src/**/*.ts",
     "prepublishOnly": "tsc -b"
   },
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
     "@ephox/agar": "^7.0.0-alpha.5",

--- a/modules/oxide-icons-default/package.json
+++ b/modules/oxide-icons-default/package.json
@@ -22,6 +22,6 @@
     "README.md",
     "LICENSE.txt"
   ],
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT"
 }

--- a/modules/oxide/package.json
+++ b/modules/oxide/package.json
@@ -17,7 +17,7 @@
   "keywords": [
     "TinyMCE"
   ],
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "files": [
     "build/skins/content/**/*.css",

--- a/modules/phoenix/package.json
+++ b/modules/phoenix/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint --config ../../.eslintrc.json src/**/*.ts",
     "prepublishOnly": "tsc -b"
   },
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "main": "./lib/main/ts/ephox/phoenix/api/Main.js",
   "module": "./lib/main/ts/ephox/phoenix/api/Main.js",

--- a/modules/polaris/package.json
+++ b/modules/polaris/package.json
@@ -31,7 +31,7 @@
     "test-manual": "bedrock -d src/test/ts",
     "lint": "eslint --config ../../.eslintrc.json src/**/*.ts"
   },
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "main": "./lib/main/ts/ephox/polaris/api/Main.js",
   "module": "./lib/main/ts/ephox/polaris/api/Main.js",

--- a/modules/porkbun/package.json
+++ b/modules/porkbun/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint --config ../../.eslintrc.json src/**/*.ts",
     "prepublishOnly": "tsc -b"
   },
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "main": "./lib/main/ts/ephox/porkbun/api/Main.js",
   "module": "./lib/main/ts/ephox/porkbun/api/Main.js",

--- a/modules/robin/package.json
+++ b/modules/robin/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@ephox/katamari-assertions": "^4.0.0-alpha.3"
   },
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "main": "./lib/main/ts/ephox/robin/api/Main.js",
   "module": "./lib/main/ts/ephox/robin/api/Main.js",

--- a/modules/sand/package.json
+++ b/modules/sand/package.json
@@ -27,7 +27,7 @@
   "keywords": [
     "platform"
   ],
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
     "@ephox/katamari": "^9.0.0-alpha.3",

--- a/modules/snooker/package.json
+++ b/modules/snooker/package.json
@@ -26,7 +26,7 @@
     "@ephox/sugar": "^9.0.0-alpha.5",
     "tslib": "^2.0.0"
   },
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "main": "./lib/main/ts/ephox/snooker/api/Main.js",
   "module": "./lib/main/ts/ephox/snooker/api/Main.js",

--- a/modules/sugar/package.json
+++ b/modules/sugar/package.json
@@ -19,7 +19,7 @@
     "append",
     "predicate"
   ],
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
     "@ephox/katamari": "^9.0.0-alpha.3",

--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -638,7 +638,7 @@ module.exports = function (grunt) {
                 'directory': 'modules/tinymce'
               },
               'description': 'Web based JavaScript HTML WYSIWYG editor control.',
-              'author': 'Tiny Technologies, Inc',
+              'author': 'Ephox Corporation DBA Tiny Technologies, Inc',
               'main': 'tinymce.js',
               'types': 'tinymce.d.ts',
               'license': 'MIT',
@@ -730,8 +730,8 @@ module.exports = function (grunt) {
         options: {
           id: 'TinyMCE',
           version: packageData.version,
-          authors: 'Tiny Technologies, Inc',
-          owners: 'Tiny Technologies, Inc',
+          authors: 'Ephox Corporation DBA Tiny Technologies, Inc',
+          owners: 'Ephox Corporation DBA Tiny Technologies, Inc',
           description: 'The best WYSIWYG editor! TinyMCE is a platform independent web based Javascript HTML WYSIWYG editor ' +
           'control released as Open Source under MIT by Tiny Technologies, Inc. TinyMCE has the ability to convert HTML ' +
           'TEXTAREA fields or other HTML elements to editor instances. TinyMCE is very easy to integrate ' +

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/tinymce/tinymce"
   },
   "description": "TinyMCE rich text editor",
-  "author": "Tiny Technologies, Inc",
+  "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "bugs": {
     "url": "https://github.com/tinymce/tinymce/issues"
   },


### PR DESCRIPTION
Related Ticket: TINY-2316

Description of Changes:
* This was missed in #7647. The company name in our license txt is different to what we've been using in the package.json files:
https://github.com/tinymce/tinymce/blob/236891ffcdf2fd1b698d020e67c31838fb110019/LICENSE.TXT#L3

This PR updates everywhere we use the company name to the proper full string.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
