### PR TITLE
TINY-8511: Removed the no longer useful paste_filter_drop option

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -138,6 +138,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the `shortEnded` and `fixed` properties on `tinymce.html.Node` class #TINY-8205
 - Removed the `mceInsertRawHTML` command #TINY-8214
 - Removed the style field from the `image` plugin dialog advanced tab #TINY-3422
+- Removed the `paste_filter_drop` option as native drag and drop handling is no longer supported #TINY-8511
 - Removed the legacy `mobile` theme #TINY-7832
 - Removed the deprecated `$`, `Class`, `DomQuery` and `Sizzle` APIs #TINY-4520 #TINY-8326
 - Removed the deprecated `Color`, `JSON`, `JSONP` and `JSONRequest` #TINY-8162

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -156,7 +156,6 @@ interface BaseEditorOptions {
   paste_as_text?: boolean;
   paste_block_drop?: boolean;
   paste_data_images?: boolean;
-  paste_filter_drop?: boolean;
   paste_merge_formats?: boolean;
   paste_postprocess?: PastePostProcessFn;
   paste_preprocess?: PastePreProcessFn;

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -657,11 +657,6 @@ const register = (editor: Editor) => {
     default: true
   });
 
-  registerOption('paste_filter_drop', {
-    processor: 'boolean',
-    default: true
-  });
-
   registerOption('paste_preprocess', {
     processor: 'function'
   });
@@ -837,7 +832,6 @@ const shouldBrowserSpellcheck = option('browser_spellcheck');
 const getProtect = option('protect');
 const shouldPasteBlockDrop = option('paste_block_drop');
 const shouldPasteDataImages = option('paste_data_images');
-const shouldPasteFilterDrop = option('paste_filter_drop');
 const getPastePreProcess = option('paste_preprocess');
 const getPastePostProcess = option('paste_postprocess');
 const getPasteWebkitStyles = option('paste_webkit_styles');
@@ -943,7 +937,6 @@ export {
   getProtect,
   shouldPasteBlockDrop,
   shouldPasteDataImages,
-  shouldPasteFilterDrop,
   getPastePreProcess,
   getPastePostProcess,
   getPasteWebkitStyles,


### PR DESCRIPTION
Related Ticket: TINY-8511

Description of Changes:

This removes the `paste_filter_drop` option as upon further review we found the only thing it does is control whether the TinyMCE drop handling takes over or whether it should fallback to the native logic. So given we don't want native logic running for TinyMCE 6 (since it's not compatible with RTC, etc...), then this option provides no longer is useful given the other filtering logic (e.g. Word) has already been removed as well.

Note: I've already checked with QA and Product since removing this isn't in scope of our allowed freeze changes.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
