### PR TITLE
TINY-8525: Fixed a regression with webkit style handling while pasting content

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/util/Tools.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Tools.ts
@@ -14,7 +14,7 @@ interface Tools {
     <T>(arr: ArrayLike<T> | null | undefined, pred?: ArrayCallback<T, boolean>): T[];
     <T>(arr: Record<string, T> | null | undefined, pred?: ObjCallback<T, boolean>): T[];
   };
-  trim: (str: string) => string;
+  trim: (str: string | null | undefined) => string;
   toArray: <T>(obj: ArrayLike<T>) => T[];
   hasOwn: (obj: any, name: string) => boolean;
   makeMap: <T>(items: ArrayLike<T> | string, delim?: string | RegExp, map?: Record<string, T | string>) => Record<string, T | string>;

--- a/modules/tinymce/src/core/main/ts/paste/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/paste/Quirks.ts
@@ -3,6 +3,7 @@ import { Transformations } from '@ephox/acid';
 import Editor from '../api/Editor';
 import Env from '../api/Env';
 import * as Options from '../api/Options';
+import Tools from '../api/util/Tools';
 
 type PreProcessFilter = (editor: Editor, content: string, internal: boolean) => string;
 
@@ -20,7 +21,8 @@ const addPreProcessFilter = (editor: Editor, filterFunc: PreProcessFilter) => {
 
 const rgbRegExp = /rgb\s*\(\s*([0-9]+)\s*,\s*([0-9]+)\s*,\s*([0-9]+)\s*\)/gi;
 
-const rgbToHex = (value: string) => value.replace(rgbRegExp, Transformations.rgbaToHexString).toLowerCase();
+const rgbToHex = (value: string | undefined): string =>
+  Tools.trim(value).replace(rgbRegExp, Transformations.rgbaToHexString).toLowerCase();
 
 /*
  * WebKit has a nasty quirk where the all computed styles gets added to style attributes when copy/pasting contents.

--- a/modules/tinymce/src/core/test/ts/browser/paste/PasteStylesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/PasteStylesTest.ts
@@ -67,4 +67,13 @@ describe('browser.tinymce.core.paste.PasteStylesTest', () => {
     Clipboard.pasteItems(TinyDom.body(editor), { 'text/html': '<span style="color: rgb(224, 62, 45);">b</span>' });
     TinyAssertions.assertContent(editor, `<p><span style="color: rgb(224, 62, 45);">b</span></p>`);
   });
+
+  it('TINY-8525: paste span without any color styles, paste_webkit_styles: color,font-family', () => {
+    const editor = hook.editor();
+    editor.options.set('paste_webkit_styles', 'color,font-family');
+    editor.setContent('<p>test</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 4);
+    Clipboard.pasteItems(TinyDom.body(editor), { 'text/html': '<span style="font-family: Arial,sans-serif;">b</span>' });
+    TinyAssertions.assertContent(editor, `<p><span style="font-family: Arial,sans-serif;">b</span></p>`);
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/paste/PasteStylesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/PasteStylesTest.ts
@@ -20,7 +20,7 @@ describe('browser.tinymce.core.paste.PasteStylesTest', () => {
   beforeEach(() => {
     const editor = hook.editor();
     editor.options.unset('paste_remove_styles_if_webkit');
-    editor.options.unset('paste_remove_styles');
+    editor.options.unset('paste_webkit_styles');
   });
 
   it('TBA: Paste span with encoded style attribute, paste_webkit_styles: font-family', () => {


### PR DESCRIPTION
Related Ticket: TINY-8525

Description of Changes:

Fixes a regression introduced in https://github.com/tinymce/tinymce/pull/7451/ as the string value passed to `rgbToHex` can be undefined if the styles attribute doesn't have the configured webkit styles to retain. I've largely just made it do what it did previously to solve this, so that it both cleans the value and handles the undefined value since `Tools.trim` will convert a nullable value to an empty string. I also fixed the incorrect types for `Tools.trim` to reflect it takes nullable values.

Pre-checks:
* [x] ~Changelog entry added~ 6.0 only issue, so no changelog
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
