### PR TITLE
TINY-8441: Updated docs links for 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Used and trusted by millions of developers, TinyMCE is the world’s most custom
 
 With more than 350M+ downloads every year, we’re also one of the most trusted enterprise-grade open source HTML editors on the internet. There’s currently more than 100M+ products worldwide, powered by Tiny. As a high powered WYSIWYG editor, TinyMCE is built to scale, designed to innovate, and thrives on delivering results to difficult edge-cases.
 
-You can access a [full featured demo of TinyMCE](https://www.tiny.cloud/docs/demo/full-featured/) in the docs on the TinyMCE website.
+You can access a [full featured demo of TinyMCE](https://www.tiny.cloud/docs/tinymce/6/os-full-featured.html) in the docs on the TinyMCE website.
 
 <p align="center">
   <img alt="Screenshot of the TinyMCE Editor" src="https://www.tiny.cloud/storage/github-readme-images/tinymce-editor.png"\>
@@ -16,17 +16,17 @@ You can access a [full featured demo of TinyMCE](https://www.tiny.cloud/docs/dem
 
 Getting started with the TinyMCE rich text editor is easy, and for simple configurations can be done in less than 5 minutes.
 
-[TinyMCE Cloud Deployment Quick Start Guide](https://www.tiny.cloud/docs/quick-start/)
+[TinyMCE Cloud Deployment Quick Start Guide](https://www.tiny.cloud/docs/tinymce/6/cloud-quick-start.html)
 
-[TinyMCE Self-hosted Deployment Guide](https://www.tiny.cloud/docs/general-configuration-guide/advanced-install/)
+[TinyMCE Self-hosted Deployment Guide](https://www.tiny.cloud/docs/tinymce/6/javascript-pm.html)
 
-TinyMCE provides a range of configuration options that allow you to integrate it into your application. Start customizing with a [basic setup](https://www.tiny.cloud/docs/general-configuration-guide/basic-setup/).
+TinyMCE provides a range of configuration options that allow you to integrate it into your application. Start customizing with a [basic setup](https://www.tiny.cloud/docs/tinymce/6/basic-setup.html).
 
 Configure it for one of three modes of editing:
 
-- [TinyMCE classic editing mode](https://www.tiny.cloud/docs/general-configuration-guide/use-tinymce-classic/).
-- [TinyMCE inline editing mode](https://www.tiny.cloud/docs/general-configuration-guide/use-tinymce-inline/).
-- [TinyMCE distraction-free editing mode](https://www.tiny.cloud/docs/general-configuration-guide/use-tinymce-distraction-free/).
+- [TinyMCE classic editing mode](https://www.tiny.cloud/docs/tinymce/6/use-tinymce-classic.html).
+- [TinyMCE inline editing mode](https://www.tiny.cloud/docs/tinymce/6/use-tinymce-inline.html).
+- [TinyMCE distraction-free editing mode](https://www.tiny.cloud/docs/tinymce/6/use-tinymce-distraction-free.html).
 
 ## Features
 
@@ -38,13 +38,13 @@ TinyMCE is easily integrated into your projects with the help of components such
 - [tinymce-vue](https://github.com/tinymce/tinymce-vue)
 - [tinymce-angular](https://github.com/tinymce/tinymce-angular)
 
-With over 29 integrations, and 400+ APIs, see the TinyMCE docs for a full list of editor [integrations](https://www.tiny.cloud/docs/integrations/).
+With over 29 integrations, and 400+ APIs, see the TinyMCE docs for a full list of editor [integrations](https://www.tiny.cloud/docs/tinymce/6/integrations.html).
 
 ### Customization
 
-It is easy to [configure the UI](https://www.tiny.cloud/docs/general-configuration-guide/customize-ui/) of your rich text editor to match the design of your site, product or application. Due to its flexibility, you can [configure the editor](https://www.tiny.cloud/docs/general-configuration-guide/basic-setup/) with as much or as little functionality as you like, depending on your requirements.
+It is easy to [configure the UI](https://www.tiny.cloud/docs/tinymce/6/customize-ui.html) of your rich text editor to match the design of your site, product or application. Due to its flexibility, you can [configure the editor](https://www.tiny.cloud/docs/tinymce/6/basic-setup.html) with as much or as little functionality as you like, depending on your requirements.
 
-With [50+ powerful plugins available](https://www.tiny.cloud/apps/), and content editable as the basis of TinyMCE, adding additional functionality is as simple as including a single line of code.
+With [50+ powerful plugins available](https://www.tiny.cloud/tinymce/features/), and content editable as the basis of TinyMCE, adding additional functionality is as simple as including a single line of code.
 
 Realizing the full power of most plugins requires only a few lines more.
 
@@ -52,7 +52,7 @@ Realizing the full power of most plugins requires only a few lines more.
 
 Sometimes your editor requirements can be quite unique, and you need the freedom and flexibility to innovate. Thanks to TinyMCE being open source, you can view the source code and develop your own extensions for custom functionality to meet your own requirements.
 
-The TinyMCE [API](https://www.tiny.cloud/docs/api/) is exposed to make it easier for you to write custom functionality that fits within the existing framework of TinyMCE [UI components](https://www.tiny.cloud/docs/ui-components/).
+The TinyMCE [API](https://www.tiny.cloud/docs/tinymce/6/apis/tinymce.root.html) is exposed to make it easier for you to write custom functionality that fits within the existing framework of TinyMCE [UI components](https://www.tiny.cloud/docs/tinymce/6/custom-ui-components.html).
 
 ### Extended Features and Support
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Used and trusted by millions of developers, TinyMCE is the world’s most custom
 
 With more than 350M+ downloads every year, we’re also one of the most trusted enterprise-grade open source HTML editors on the internet. There’s currently more than 100M+ products worldwide, powered by Tiny. As a high powered WYSIWYG editor, TinyMCE is built to scale, designed to innovate, and thrives on delivering results to difficult edge-cases.
 
-You can access a [full featured demo of TinyMCE](https://www.tiny.cloud/docs/tinymce/6/os-full-featured.html) in the docs on the TinyMCE website.
+You can access a [full featured demo of TinyMCE](https://www.tiny.cloud/docs/tinymce/6/premium-full-featured.html) in the docs on the TinyMCE website.
 
 <p align="center">
   <img alt="Screenshot of the TinyMCE Editor" src="https://www.tiny.cloud/storage/github-readme-images/tinymce-editor.png"\>
@@ -18,7 +18,7 @@ Getting started with the TinyMCE rich text editor is easy, and for simple config
 
 [TinyMCE Cloud Deployment Quick Start Guide](https://www.tiny.cloud/docs/tinymce/6/cloud-quick-start.html)
 
-[TinyMCE Self-hosted Deployment Guide](https://www.tiny.cloud/docs/tinymce/6/javascript-pm.html)
+[TinyMCE Self-hosted Deployment Guide](https://www.tiny.cloud/docs/tinymce/6/npm-projects.html)
 
 TinyMCE provides a range of configuration options that allow you to integrate it into your application. Start customizing with a [basic setup](https://www.tiny.cloud/docs/tinymce/6/basic-setup.html).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,10 +7,11 @@ Tiny Technologies, Inc. supports the following community versions of TinyMCE:
 | Version | Supported                      |
 | ------- | ------------------------------ |
 | 5.10.x  | &#10004;                       |
+| 6.x     | &#10004;                       |
 | Other   | &#10006;                       |
 
-For supported enterprise versions of TinyMCE, refer to the enterprise [Supported TinyMCE versions documentation](https://www.tiny.cloud/docs/enterprise/system-requirements/#supportedtinymceversions).
+For supported enterprise versions of TinyMCE, refer to the enterprise [Supported TinyMCE versions documentation](https://www.tiny.cloud/docs/tinymce/6/support.html#_supported_versions_and_platforms).
 
 ## Reporting a Vulnerability
 
-For details on how to report security issues to Tiny, refer to the [Reporting TinyMCE security issues documentation](https://www.tiny.cloud/docs/advanced/security/#reportingtinymcesecurityissues).
+For details on how to report security issues to Tiny, refer to the [Reporting TinyMCE security issues documentation](https://www.tiny.cloud/docs/tinymce/6/security.html#_reporting_tinymce_security_issues).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ Tiny Technologies, Inc. supports the following community versions of TinyMCE:
 | Version | Supported                      |
 | ------- | ------------------------------ |
 | 5.10.x  | &#10004;                       |
-| 6.0.x     | &#10004;                       |
+| 6.0.x    | &#10004;                       |
 | Other   | &#10006;                       |
 
 For supported enterprise versions of TinyMCE, refer to the enterprise [Supported TinyMCE versions documentation](https://www.tiny.cloud/docs/tinymce/6/support.html#supportedversionsandplatforms).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,11 +7,11 @@ Tiny Technologies, Inc. supports the following community versions of TinyMCE:
 | Version | Supported                      |
 | ------- | ------------------------------ |
 | 5.10.x  | &#10004;                       |
-| 6.x     | &#10004;                       |
+| 6.0.x     | &#10004;                       |
 | Other   | &#10006;                       |
 
-For supported enterprise versions of TinyMCE, refer to the enterprise [Supported TinyMCE versions documentation](https://www.tiny.cloud/docs/tinymce/6/support.html#_supported_versions_and_platforms).
+For supported enterprise versions of TinyMCE, refer to the enterprise [Supported TinyMCE versions documentation](https://www.tiny.cloud/docs/tinymce/6/support.html#supportedversionsandplatforms).
 
 ## Reporting a Vulnerability
 
-For details on how to report security issues to Tiny, refer to the [Reporting TinyMCE security issues documentation](https://www.tiny.cloud/docs/tinymce/6/security.html#_reporting_tinymce_security_issues).
+For details on how to report security issues to Tiny, refer to the [Reporting TinyMCE security issues documentation](https://www.tiny.cloud/docs/tinymce/6/security.html#reportingtinymcesecurityissues).

--- a/modules/oxide-icons-default/README.md
+++ b/modules/oxide-icons-default/README.md
@@ -1,6 +1,6 @@
 # Default icons for TinyMCE
 
-This project contains the default icons for TinyMCE. Icons is loaded into the editor using a icon pack file. You can use this project as a basis for building your own icon packs. For instructions on how to make your own icon pack, see the [TinyMCE documentation](http://tiny.cloud/docs/advanced/creating-a-skin/#modifyingtheicons)
+This project contains the default icons for TinyMCE. Icons is loaded into the editor using a icon pack file. You can use this project as a basis for building your own icon packs. For instructions on how to make your own icon pack, see the [TinyMCE documentation](https://www.tiny.cloud/docs/tinymce/6/creating-an-icon-pack.html)
 
 ## Building the icon pack
 The icon pack build process uses [Node](http://nodejs.org/) and [Gulp](http://gulpjs.com/). Make sure you have both installed before you continue.

--- a/modules/oxide/README.md
+++ b/modules/oxide/README.md
@@ -1,7 +1,7 @@
 # TinyMCE Oxide skin tools
 This project contains the default skins as well as tools and files needed to build your own skin for TinyMCE.
 
-Visit the [TinyMCE documentation](https://www.tiny.cloud/docs/advanced/creating-a-skin/) for instruction on how to create and build skins for TinyMCE.
+Visit the [TinyMCE documentation](https://www.tiny.cloud/docs/tinymce/6/creating-a-skin.html) for instruction on how to create and build skins for TinyMCE.
 
 ## Building the skins
 The build process uses [Node](http://nodejs.org/) and [Gulp](http://gulpjs.com/). Make sure you have both installed before you continue.

--- a/modules/oxide/src/less/skins/ui/dark/content.less
+++ b/modules/oxide/src/less/skins/ui/dark/content.less
@@ -1,5 +1,19 @@
 @import 'src/less/theme/content-ui';
 
+// Enable some UI components like anchor SVGs to invert colors.
+@content-ui-darkmode: true;
+
+// Darken block object's selection outline, in this case by
+// reusing the resize handle color.
+@object-block-selected-color: @resize-handle-color;
+
+// Make table cell selection overlay lighter
+@table-selection-blend-mode: lighten;
+
+// Remove the table cell selection border as the blend mode
+// already give the selected border color enough contrast
+@table-selection-border-color: transparent;
+
 body {
   font-family: sans-serif;
 }

--- a/modules/oxide/src/less/skins/ui/default/content.less
+++ b/modules/oxide/src/less/skins/ui/default/content.less
@@ -1,22 +1,7 @@
 @import 'src/less/theme/content-ui';
 
-// Enable some UI components like anchor SVGs to invert colors.
-@content-ui-darkmode: true;
-
-// Darken block object's selection outline, in this case by
-// reusing the resize handle color.
-@object-block-selected-color: @resize-handle-color;
-
-// Make table cell selection overlay lighter
-@table-selection-blend-mode: lighten;
-
-// Remove the table cell selection border as the blend mode
-// already give the selected border color enough contrast
-@table-selection-border-color: transparent;
-
 body {
   font-family: sans-serif;
-  margin: 2rem 3rem;
 }
 
 table {

--- a/modules/oxide/src/less/skins/ui/tinymce-5-dark/content.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5-dark/content.less
@@ -1,5 +1,4 @@
 @import 'src/less/theme/content-ui';
-@import 'src/less/skins/ui/tinymce-5/content';
 
 // Enable some UI components like anchor SVGs to invert colors.
 @content-ui-darkmode: true;

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -1397,6 +1397,8 @@ Full documentation for the version 5 features and changes is available at https:
 
 Developer preview 1
 
+Initial list of features and changes is available at https://tiny.cloud/docs-preview/release-notes/new-features/
+
 ## 4.9.11 - 2020-07-13
 
 ### Fixed

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -96,7 +96,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default value for the `schema` option has been changed to `html5` #TINY-8261
 - The default value for the `table_style_by_css` option has been changed to `true` #TINY-8259
 - The default value for the `table_use_colgroups` option has been changed to `true` #TINY-8259
-- The URL links to the TinyMCE docs reference site #TINY-8441
 
 ### Fixed
 - The object returned from the `editor.fire()` API was incorrect if the editor had been removed #TINY-8018

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -1224,7 +1224,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 5.0.0 - 2019-02-04
 
-Full documentation for the version 5 features and changes is available at https://www.tiny.cloud/docs/release-notes/
+Full documentation for the version 5 features and changes is available at https://www.tiny.cloud/docs/tinymce/5/5_0_0-release-notes-overview.html
 
 ### Added
 - Added links and registered names with * to denote premium plugins in Plugins tab of Help dialog #TINY-3223
@@ -1396,8 +1396,6 @@ Full documentation for the version 5 features and changes is available at https:
 ## 5.0.0-preview-1 - 2018-10-01
 
 Developer preview 1
-
-Initial list of features and changes is available at https://tiny.cloud/docs-preview/release-notes/new-features/
 
 ## 4.9.11 - 2020-07-13
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -1224,7 +1224,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 5.0.0 - 2019-02-04
 
-Full documentation for the version 5 features and changes is available at https://www.tiny.cloud/docs/tinymce/5/5_0_0-release-notes-overview.html
+Full documentation for the version 5 features and changes is available at https://www.tiny.cloud/docs/tinymce/5/release-notes/release-notes50.html
 
 ### Added
 - Added links and registered names with * to denote premium plugins in Plugins tab of Help dialog #TINY-3223
@@ -1397,7 +1397,7 @@ Full documentation for the version 5 features and changes is available at https:
 
 Developer preview 1
 
-Initial list of features and changes is available at https://tiny.cloud/tinymce/5/release-notes/release-notes50.html
+Initial list of features and changes is available at https://www.tiny.cloud/docs/tinymce/5/release-notes/release-notes50.html
 
 ## 4.9.11 - 2020-07-13
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -96,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default value for the `schema` option has been changed to `html5` #TINY-8261
 - The default value for the `table_style_by_css` option has been changed to `true` #TINY-8259
 - The default value for the `table_use_colgroups` option has been changed to `true` #TINY-8259
+- The URL links to the TinyMCE docs reference site #TINY-8441
 
 ### Fixed
 - The object returned from the `editor.fire()` API was incorrect if the editor had been removed #TINY-8018

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -1397,7 +1397,7 @@ Full documentation for the version 5 features and changes is available at https:
 
 Developer preview 1
 
-Initial list of features and changes is available at https://tiny.cloud/docs-preview/release-notes/new-features/
+Initial list of features and changes is available at https://tiny.cloud/tinymce/5/release-notes/release-notes50.html
 
 ## 4.9.11 - 2020-07-13
 

--- a/modules/tinymce/README.md
+++ b/modules/tinymce/README.md
@@ -80,8 +80,8 @@ __How to Contribute to the Docs__
 
 Docs are hosted on Github in the [tinymce-docs](https://github.com/tinymce/tinymce-docs) repo.
 
-[How to contribute](https://www.tiny.cloud/docs/advanced/contributing-docs/) to the docs, including a style guide, can be found on the TinyMCE website.
+[How to contribute](https://github.com/tinymce/tinymce-docs/blob/main/CONTRIBUTING.md) to the docs, including a style guide, can be found on the GitHub repo.
 
-[Documentation](https://www.tiny.cloud/docs/)
+[Documentation](https://www.tiny.cloud/docs/tinymce/6/)
 
-[Log feedback](https://github.com/tinymce/tinymce/labels/5.x)
+[Log feedback](https://github.com/tinymce/tinymce/labels/6.x)

--- a/modules/tinymce/src/core/main/ts/Deprecations.ts
+++ b/modules/tinymce/src/core/main/ts/Deprecations.ts
@@ -48,7 +48,7 @@ const logRemovedWarnings = (rawOptions: RawEditorOptions, normalizedOptions: Nor
     // eslint-disable-next-line no-console
     console.warn(
       'The following deprecated features are currently enabled and have been removed in TinyMCE 6.0. These features will no longer work and should be removed from the TinyMCE configuration. ' +
-      'See https://www.tiny.cloud/docs/tinymce/6/6_0_0-release-notes-overview.html for more information.' +
+      'See https://www.tiny.cloud/docs/tinymce/6/migration-from-5x.html for more information.' +
       themesMessage +
       pluginsMessage +
       settingsMessage

--- a/modules/tinymce/src/core/main/ts/Deprecations.ts
+++ b/modules/tinymce/src/core/main/ts/Deprecations.ts
@@ -48,7 +48,7 @@ const logRemovedWarnings = (rawOptions: RawEditorOptions, normalizedOptions: Nor
     // eslint-disable-next-line no-console
     console.warn(
       'The following deprecated features are currently enabled and have been removed in TinyMCE 6.0. These features will no longer work and should be removed from the TinyMCE configuration. ' +
-      'See https://www.tiny.cloud/docs/release-notes/6.0-upcoming-changes/ for more information.' +
+      'See https://www.tiny.cloud/docs/tinymce/6/6_0_0-release-notes-overview.html for more information.' +
       themesMessage +
       pluginsMessage +
       settingsMessage

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -360,7 +360,7 @@ const EditorManager: EditorManager = {
       if (Env.browser.isIE() || Env.browser.isEdge()) {
         ErrorReporter.initError(
           'TinyMCE does not support the browser you are using. For a list of supported' +
-          ' browsers please see: https://www.tiny.cloud/docs/tinymce/6/support.html#_supported_web_browsers'
+          ' browsers please see: https://www.tiny.cloud/docs/tinymce/6/support.html#supportedwebbrowsers'
         );
         return [];
       } else if (isQuirksMode) {

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -305,7 +305,7 @@ const EditorManager: EditorManager = {
   /**
    * Initializes a set of editors. This method will create editors based on various settings.
    * <br /><br />
-   * For information on basic usage of <code>init</code>, see: <a href="https://www.tiny.cloud/docs/general-configuration-guide/basic-setup/">Basic setup</a>.
+   * For information on basic usage of <code>init</code>, see: <a href="https://www.tiny.cloud/docs/tinymce/6/basic-setup.html">Basic setup</a>.
    *
    * @method init
    * @param {Object} options Options object to be passed to each editor instance.
@@ -360,7 +360,7 @@ const EditorManager: EditorManager = {
       if (Env.browser.isIE() || Env.browser.isEdge()) {
         ErrorReporter.initError(
           'TinyMCE does not support the browser you are using. For a list of supported' +
-          ' browsers please see: https://www.tinymce.com/docs/get-started/system-requirements/'
+          ' browsers please see: https://www.tiny.cloud/docs/tinymce/6/support.html#_supported_web_browsers'
         );
         return [];
       } else if (isQuirksMode) {

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -172,7 +172,7 @@ const NotificationManager = (editor: Editor): NotificationManager => {
      * @method open
      * @param {Object} args A <code>name: value</code> collection containing settings such as: <code>timeout</code>, <code>type</code>, and message (<code>text</code>).
      * <br /><br />
-     * For information on the available settings, see: <a href="https://www.tiny.cloud/docs/advanced/creating-custom-notifications/">Create custom notifications</a>.
+     * For information on the available settings, see: <a href="https://www.tiny.cloud/docs/tinymce/6/creating-custom-notifications.html">Create custom notifications</a>.
      */
     open,
 

--- a/modules/tinymce/src/core/main/ts/api/WindowManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/WindowManager.ts
@@ -142,7 +142,7 @@ const WindowManager = (editor: Editor): WindowManager => {
      * Opens a new window.
      *
      * @method open
-     * @param {Object} args For a list of options, see: <a href="https://www.tiny.cloud/docs/ui-components/dialog/#configurationoptions">Dialog - Configuration options</a>.
+     * @param {Object} args For a list of options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/dialog-configuration.html#_configuration_options">Dialog - Configuration options</a>.
      */
     open,
 
@@ -150,7 +150,7 @@ const WindowManager = (editor: Editor): WindowManager => {
      * Opens a new window for the specified url.
      *
      * @method openUrl
-     * @param {Object} args For a list of options, see: <a href="https://www.tiny.cloud/docs/ui-components/urldialog/#urldialogconfiguration">URL dialog configuration</a>.
+     * @param {Object} args For a list of options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/urldialog.html#_configuration">URL dialog configuration</a>.
      */
     openUrl,
 

--- a/modules/tinymce/src/core/main/ts/api/WindowManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/WindowManager.ts
@@ -142,7 +142,7 @@ const WindowManager = (editor: Editor): WindowManager => {
      * Opens a new window.
      *
      * @method open
-     * @param {Object} args For a list of options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/dialog-configuration.html#_configuration_options">Dialog - Configuration options</a>.
+     * @param {Object} args For a list of options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/dialog-configuration.html#configurationoptions">Dialog - Configuration options</a>.
      */
     open,
 
@@ -150,7 +150,7 @@ const WindowManager = (editor: Editor): WindowManager => {
      * Opens a new window for the specified url.
      *
      * @method openUrl
-     * @param {Object} args For a list of options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/urldialog.html#_configuration">URL dialog configuration</a>.
+     * @param {Object} args For a list of options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/urldialog.html#configuration">URL dialog configuration</a>.
      */
     openUrl,
 

--- a/modules/tinymce/src/core/main/ts/api/fmt/StyleFormat.ts
+++ b/modules/tinymce/src/core/main/ts/api/fmt/StyleFormat.ts
@@ -1,6 +1,6 @@
 import { BlockFormat, InlineFormat, SelectorFormat } from './Format';
 
-// somewhat documented at https://www.tiny.cloud/docs/tinymce/6/content-formatting.html#_formats
+// somewhat documented at https://www.tiny.cloud/docs/tinymce/6/content-formatting.html#formats
 export type StyleFormat = BlockStyleFormat | InlineStyleFormat | SelectorStyleFormat;
 export type AllowedFormat = Separator | FormatReference | StyleFormat | NestedFormatting;
 

--- a/modules/tinymce/src/core/main/ts/api/fmt/StyleFormat.ts
+++ b/modules/tinymce/src/core/main/ts/api/fmt/StyleFormat.ts
@@ -1,6 +1,6 @@
 import { BlockFormat, InlineFormat, SelectorFormat } from './Format';
 
-// somewhat documented at https://www.tiny.cloud/docs/configure/content-formatting/#style_formats
+// somewhat documented at https://www.tiny.cloud/docs/tinymce/6/content-formatting.html#_formats
 export type StyleFormat = BlockStyleFormat | InlineStyleFormat | SelectorStyleFormat;
 export type AllowedFormat = Separator | FormatReference | StyleFormat | NestedFormatting;
 

--- a/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
+++ b/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
@@ -16,7 +16,7 @@ const registry = () => {
      * Emoticons and Charmap use an autocompleter.
      * <br>
      * For information on creating an autocompleter, see:
-     * <a href="https://www.tiny.cloud/docs/ui-components/autocompleter/">
+     * <a href="https://www.tiny.cloud/docs/tinymce/6/autocompleter.html">
      * UI Components - Autocompleter</a>.
      *
      * @method addAutocompleter
@@ -31,7 +31,7 @@ const registry = () => {
      * via keyboard navigation controls.
      * <br>
      * For information on creating a basic toolbar button, see:
-     * <a href="https://www.tiny.cloud/docs/ui-components/typesoftoolbarbuttons/#basicbutton">
+     * <a href="https://www.tiny.cloud/docs/tinymce/6/custom-basic-toolbar-button.html">
      * UI Components - Types of toolbar buttons: Basic button</a>.
      *
      * @method addButton
@@ -50,7 +50,7 @@ const registry = () => {
      * contextual input form appears allowing for quick changes to the url field.
      * <br>
      * For information on creating context forms, see:
-     * <a href="https://www.tiny.cloud/docs/ui-components/contextform/">
+     * <a href="https://www.tiny.cloud/docs/tinymce/6/contextform.html">
      * UI Components - Context forms</a>.
      *
      * @method addContextForm
@@ -65,7 +65,7 @@ const registry = () => {
      * for example, the cursor is inside a table.
      * <br>
      * For information on creating context menus, see:
-     * <a href="https://www.tiny.cloud/docs/ui-components/contextmenu/">
+     * <a href="https://www.tiny.cloud/docs/tinymce/6/contextmenu.html">
      * UI Components - Context Menu</a>.
      *
      * @method addContextMenu
@@ -80,7 +80,7 @@ const registry = () => {
      * the cursor is on an image element.
      * <br>
      * For information on creating context toolbars, see:
-     * <a href="https://www.tiny.cloud/docs/ui-components/contexttoolbar/">
+     * <a href="https://www.tiny.cloud/docs/tinymce/6/contexttoolbar.html">
      * UI Components - Context Toolbar</a>.
      *
      * @method addContextToolbar
@@ -111,7 +111,7 @@ const registry = () => {
      * addNestedMenuItem or addToggleMenuItem.
      * <br>
      * For information on creating a toolbar menu button, see:
-     * <a href="https://www.tiny.cloud/docs/ui-components/typesoftoolbarbuttons/#menubutton">
+     * <a href="https://www.tiny.cloud/docs/tinymce/6/custom-menu-toolbar-button.html">
      * UI Components - Types of toolbar buttons: Menu button</a>.
      *
      * @method addMenuButton
@@ -126,7 +126,7 @@ const registry = () => {
      * via keyboard navigation controls.
      * <br>
      * For information on creating a basic menu item, see:
-     * <a href="https://www.tiny.cloud/docs/ui-components/menuitems/#basicmenuitems">
+     * <a href="https://www.tiny.cloud/docs/tinymce/6/creating-custom-menu-items.html">
      * UI Components - Custom menu items: Basic menu items</a>.
      *
      * @method addMenuItem
@@ -142,7 +142,7 @@ const registry = () => {
      * created by addMenuItem, addNestedMenuItem or addToggleMenuItem.
      * <br>
      * For information on creating a nested menu item, see:
-     * <a href="https://www.tiny.cloud/docs/ui-components/menuitems/#nestedmenuitems">
+     * <a href="https://www.tiny.cloud/docs/tinymce/6/custom-nested-menu-items.html">
      * UI Components - Custom menu items: Nested menu items</a>.
      *
      * @method addNestedMenuItem
@@ -162,7 +162,7 @@ const registry = () => {
      * sidebar for its Ui components.
      * <br>
      * For information on creating a custom sidebar, see:
-     * <a href="https://www.tiny.cloud/docs/ui-components/customsidebar/">
+     * <a href="https://www.tiny.cloud/docs/tinymce/6/customsidebar.html">
      * UI Components - Custom sidebar</a>.
      *
      * @method addSidebar
@@ -177,7 +177,7 @@ const registry = () => {
      * a split button to simplify its functionality.
      * <br>
      * For information on creating a split toolbar button, see:
-     * <a href="https://www.tiny.cloud/docs/ui-components/typesoftoolbarbuttons/#splitbutton">
+     * <a href="https://www.tiny.cloud/docs/tinymce/6/custom-split-toolbar-button.html">
      * UI Components - Types of toolbar buttons: Split button</a>.
      *
      * @method addSplitButton
@@ -192,7 +192,7 @@ const registry = () => {
      * be set in the configuration.
      * <br>
      * For information on creating a toggle toolbar button, see:
-     * <a href="https://www.tiny.cloud/docs/ui-components/typesoftoolbarbuttons/#togglebutton">
+     * <a href="https://www.tiny.cloud/docs/tinymce/6/custom-toggle-toolbar-button.html">
      * UI Components - Types of toolbar buttons: Toggle button</a>.
      *
      * @method addToggleButton
@@ -211,7 +211,7 @@ const registry = () => {
      * <em>Added in TinyMCE 5.2</em>
      * <br>
      * For information on creating a group toolbar button, see:
-     * <a href="https://www.tiny.cloud/docs/ui-components/typesoftoolbarbuttons/#grouptoolbarbutton">
+     * <a href="https://www.tiny.cloud/docs/tinymce/6/custom-group-toolbar-button.html">
      * UI Components - Types of toolbar buttons: Group toolbar button</a>.
      *
      * @method addGroupToolbarButton
@@ -226,7 +226,7 @@ const registry = () => {
      * showing a tick in the menu item to represent state.
      * <br>
      * For information on creating a toggle menu item, see:
-     * <a href="https://www.tiny.cloud/docs/ui-components/menuitems/#togglemenuitems">
+     * <a href="https://www.tiny.cloud/docs/tinymce/6/custom-toggle-menu-items.html">
      * UI Components - Custom menu items: Toggle menu items</a>.
      *
      * @method addToggleMenuItem

--- a/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
@@ -33,7 +33,7 @@ const tab = (editor: Editor): Dialog.TabSpec => {
     return typeof getMetadata === 'function' ? makeLink(getMetadata()) : key;
   }, (x) => {
     const name = x.type === PluginUrls.PluginType.Premium ? `${x.name}*` : x.name;
-    return makeLink({ name, url: `https://www.tiny.cloud/docs/plugins/${x.type}/${x.slug}` });
+    return makeLink({ name, url: `https://www.tiny.cloud/docs/tinymce/6/${x.slug}.html` });
   });
 
   const getPluginKeys = (editor: Editor) => {

--- a/modules/tinymce/src/plugins/help/main/ts/ui/VersionTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/VersionTab.ts
@@ -5,7 +5,7 @@ import I18n from 'tinymce/core/api/util/I18n';
 const tab = (): Dialog.TabSpec => {
   const getVersion = (major: string, minor: string) => major.indexOf('@') === 0 ? 'X.X.X' : major + '.' + minor;
   const version = getVersion(EditorManager.majorVersion, EditorManager.minorVersion);
-  const changeLogLink = '<a href="https://www.tiny.cloud/docs/changelog/?utm_campaign=editor_referral&utm_medium=help_dialog&utm_source=tinymce" target="_blank">TinyMCE ' + version + '</a>';
+  const changeLogLink = '<a href="https://www.tiny.cloud/docs/tinymce/6/changelog.html?utm_campaign=editor_referral&utm_medium=help_dialog&utm_source=tinymce" target="_blank">TinyMCE ' + version + '</a>';
 
   const htmlPanel: Dialog.HtmlPanelSpec = {
     type: 'htmlpanel',

--- a/modules/tinymce/src/plugins/quickbars/demo/html/demo.html
+++ b/modules/tinymce/src/plugins/quickbars/demo/html/demo.html
@@ -36,8 +36,8 @@
 
 
         <p>
-          One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy.
-          Learn more at <a href='https://www.tiny.cloud/tinydrive/'>tiny.cloud/tinydrive</a>, where you’ll find a working demo and an opportunity to provide feedback to the product team.
+          One of these enhancements is <strong>Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy.
+          Learn more at <a href='https://www.tiny.cloud/drive/'>Drive</a>, where you’ll find a working demo and an opportunity to provide feedback to the product team.
         </p>
 
         <h3>An editor for every project</h3>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11972,9 +11972,9 @@ urix@^0.1.0:
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
 url-parse@^1.4.3, url-parse@^1.5.3:
-  version "1.5.7"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.7.tgz#00780f60dbdae90181f51ed85fb24109422c932a"
-  integrity sha512-HxWkieX+STA38EDk7CE9MEryFeHCKzgagxlGvsdS7WBImq9Mk+PGwiT56w82WI3aicwJA8REp42Cxo98c8FZMA==
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Updated embedded URL links to docs from within the core source code
* Updated help dialog plugin links to the docs
* Updated docs repo to fill missing landing pages

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
