### PR TITLE
TINY-8528: Fix mixed up content styles for dark & light modes

### DIFF
--- a/modules/oxide/src/less/skins/ui/dark/content.less
+++ b/modules/oxide/src/less/skins/ui/dark/content.less
@@ -1,5 +1,19 @@
 @import 'src/less/theme/content-ui';
 
+// Enable some UI components like anchor SVGs to invert colors.
+@content-ui-darkmode: true;
+
+// Darken block object's selection outline, in this case by
+// reusing the resize handle color.
+@object-block-selected-color: @resize-handle-color;
+
+// Make table cell selection overlay lighter
+@table-selection-blend-mode: lighten;
+
+// Remove the table cell selection border as the blend mode
+// already give the selected border color enough contrast
+@table-selection-border-color: transparent;
+
 body {
   font-family: sans-serif;
 }

--- a/modules/oxide/src/less/skins/ui/default/content.less
+++ b/modules/oxide/src/less/skins/ui/default/content.less
@@ -1,22 +1,7 @@
 @import 'src/less/theme/content-ui';
 
-// Enable some UI components like anchor SVGs to invert colors.
-@content-ui-darkmode: true;
-
-// Darken block object's selection outline, in this case by
-// reusing the resize handle color.
-@object-block-selected-color: @resize-handle-color;
-
-// Make table cell selection overlay lighter
-@table-selection-blend-mode: lighten;
-
-// Remove the table cell selection border as the blend mode
-// already give the selected border color enough contrast
-@table-selection-border-color: transparent;
-
 body {
   font-family: sans-serif;
-  margin: 2rem 3rem;
 }
 
 table {

--- a/modules/oxide/src/less/skins/ui/tinymce-5-dark/content.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5-dark/content.less
@@ -1,5 +1,4 @@
 @import 'src/less/theme/content-ui';
-@import 'src/less/skins/ui/tinymce-5/content';
 
 // Enable some UI components like anchor SVGs to invert colors.
 @content-ui-darkmode: true;


### PR DESCRIPTION
Related Ticket: TINY-8528

Description of Changes:
* Fix mixed up content styles for dark & light modes

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved
