### PR TITLE
TINY-8527: Dark skin fixes

### DIFF
--- a/modules/oxide/src/less/skins/ui/dark/skin.less
+++ b/modules/oxide/src/less/skins/ui/dark/skin.less
@@ -5,3 +5,19 @@
 //
 
 @background-color: #222F3E;
+@tinymce-separator-color: rgba(255,255,255,.15);
+
+@editor-header-border: 1px solid @tinymce-separator-color;
+@editor-header-box-shadow: none;
+@editor-header-sticky-box-shadow: @editor-header-box-shadow;
+@editor-bottom-header-box-shadow: @editor-header-box-shadow;
+@editor-bottom-header-sticky-box-shadow: @editor-header-box-shadow;
+
+@menu-border-color: @tinymce-separator-color;
+@menu-box-shadow: none;
+
+@insert-table-picker-border-color: @tinymce-separator-color;
+
+.tox.tox-tinymce-aux .tox-toolbar__overflow {
+  box-shadow: 0 0 0 1px @tinymce-separator-color;
+}

--- a/modules/oxide/src/less/theme/components/color-swatch/color-swatch.less
+++ b/modules/oxide/src/less/theme/components/color-swatch/color-swatch.less
@@ -3,6 +3,7 @@
 //
 
 @swatch-size: 30px;
+@swatch-picker-button-icon-fill: @text-color;
 @swatch-picker-button-icon-height: 24px;
 @swatch-picker-button-icon-width: 24px;
 @swatch-remove-color-stroke-color: #e74c3c;
@@ -60,6 +61,7 @@
     width: @swatch-size;
 
     svg {
+      fill: @swatch-picker-button-icon-fill;
       height: @swatch-picker-button-icon-height;
       width: @swatch-picker-button-icon-width;
     }

--- a/modules/oxide/src/less/theme/components/editor/editor.less
+++ b/modules/oxide/src/less/theme/components/editor/editor.less
@@ -2,6 +2,7 @@
 // Editor
 //
 
+@editor-header-border: none;
 @editor-header-box-shadow: 0 2px 2px -2px fade(@color-black, 10%), 0 8px 8px -4px fade(@color-black, 7%);
 @editor-header-sticky-box-shadow: 0 2px 2px -2px fade(@color-black, 20%), 0 8px 8px -4px fade(@color-black, 15%);
 @editor-bottom-header-box-shadow: none;
@@ -23,6 +24,7 @@
 
   &:not(.tox-tinymce-inline) .tox-editor-header {
     background-color: @background-color;
+    border-bottom: @editor-header-border;
     box-shadow: @editor-header-box-shadow;
     padding: @pad-xs 0;
     transition: box-shadow .5s;

--- a/modules/oxide/src/less/theme/components/notification/notification.less
+++ b/modules/oxide/src/less/theme/components/notification/notification.less
@@ -8,25 +8,33 @@
 @notification-font-weight: @font-weight-normal;
 @notification-padding: @pad-xs;
 
-@notification-success-background-color: tint(@color-success, 80%);
-@notification-success-border-color: tint(@color-success, 70%);
+@notification-success-background-color: mix(@background-color, @color-success, 80%);
+@notification-success-border-color: mix(@background-color, @color-success, 70%);
 @notification-success-text-color: @text-color;
-@notification-success-link-color: shade(@color-success, 30%);
+@notification-success-link-color: mix(@text-color, @color-success, 30%);
 
-@notification-warn-background-color: #fffaea;
-@notification-warn-border-color: darken(@notification-warn-background-color, 15%);
-@notification-warn-text-color: @text-color;
-@notification-warn-link-color: @text-color;
+// Yellow warning color mixes particularly bad with darker colors, hence additional checks
+@notification-warn-background-color: ._notification-luma-checker(tint(@_color-warn, 80%), @background-color)[@result];
+@notification-warn-border-color: ._notification-luma-checker(tint(@_color-warn, 70%), @tinymce-separator-color)[@result];
+@notification-warn-text-color: ._notification-luma-checker(@text-color, mix(@text-color, @_color-warn, 70%))[@result];
+@notification-warn-link-color: ._notification-luma-checker(mix(@text-color, @_color-warn, 30%), @_color-warn)[@result];
 
-@notification-error-background-color: tint(@color-error, 87%);
-@notification-error-border-color: tint(@color-error, 75%);
+@notification-error-background-color: mix(@background-color, @color-error, 80%);
+@notification-error-border-color: mix(@background-color, @color-error, 70%);
 @notification-error-text-color: @text-color;
-@notification-error-link-color: @color-error;
+@notification-error-link-color: mix(@text-color, @color-error, 30%);
 
-@notification-info-background-color: #d9edf7;
-@notification-info-border-color: #779ecb;
+@notification-info-background-color: mix(@background-color, @_color-info, 80%);
+@notification-info-border-color: mix(@background-color, @_color-info, 70%);
 @notification-info-text-color: @text-color;
-@notification-info-link-color: @text-color;
+@notification-info-link-color: mix(@text-color, @_color-info, 30%);
+
+// Private variables
+._notification-luma-checker(@color-light, @color-dark) {
+  @result: if((luma(@background-color) > 50%), @color-light, @color-dark);
+}
+@_color-warn: #ffcc00;
+@_color-info: #3087eb;
 
 .tox {
   // Wraps around many notifications

--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -24,7 +24,7 @@
 @content-ui-darkmode: false; // Change this to true to get white icons in the content such as bookmarks.
 
 // Colors
-@border-color: #eee;
+@border-color: darken(@background-color, 6.5%);
 @text-color: contrast(@background-color, @color-black, @color-white);
 @text-color-muted: contrast(@background-color, fade(@color-black, 70%), fade(@color-white, 50%));
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -114,7 +114,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Home or End keys would move out of a editable element contained within a noneditable element #TINY-8201
 - Dialogs could not be opened in inline mode before the editor had been rendered #TINY-8397
 - Clicking on menu items could cause an unexpected console warning if the `onAction` function caused the menu to close #TINY-8513
-- Fixed various color bugs for the dark skins #TINY-8527
+- Fixed various color and contrast issues for the dark skins #TINY-8527
 
 ### Removed
 - Removed support for Microsoft Internet Explorer 11 #TINY-8194 #TINY-8241

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -114,6 +114,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Home or End keys would move out of a editable element contained within a noneditable element #TINY-8201
 - Dialogs could not be opened in inline mode before the editor had been rendered #TINY-8397
 - Clicking on menu items could cause an unexpected console warning if the `onAction` function caused the menu to close #TINY-8513
+- Fixed various color bugs for the dark skins #TINY-8527
 
 ### Removed
 - Removed support for Microsoft Internet Explorer 11 #TINY-8194 #TINY-8241


### PR DESCRIPTION
Related Ticket: TINY-8527

Description of Changes:
* Modified Notifications bg, border and text colors to support both dark and light skins
* Header, statusbar and menu dividers made more consistent in dark skin
* Replaced shadows with borders for menu dropdowns in dark skin
* Color picker icon now reacts to menu darker backgrounds in dark skin

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues:
Fixes [notifications issue #7370](https://github.com/tinymce/tinymce/issues/7370)
Fixes [color picker icon #7369](https://github.com/tinymce/tinymce/issues/7369)
