### PR TITLE
TINY-8532: Fixed an exception getting thrown when clicking in the editor if it had html comments

### DIFF
--- a/modules/tinymce/src/core/main/ts/dom/Dimensions.ts
+++ b/modules/tinymce/src/core/main/ts/dom/Dimensions.ts
@@ -20,15 +20,15 @@ const getNodeClientRects = (node: Node): NodeClientRect[] => {
 
   if (NodeType.isElement(node)) {
     return toArrayWithNode(node.getClientRects());
-  }
-
-  if (NodeType.isText(node)) {
+  } else if (NodeType.isText(node)) {
     const rng = node.ownerDocument.createRange();
 
     rng.setStart(node, 0);
     rng.setEnd(node, node.data.length);
 
     return toArrayWithNode(rng.getClientRects());
+  } else {
+    return [];
   }
 };
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/DimensionsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/DimensionsTest.ts
@@ -33,4 +33,13 @@ describe('browser.tinymce.core.dom.DimensionsTest', () => {
     LegacyUnit.equalDom(clientRects[0].node, viewElm.childNodes[0]);
     LegacyUnit.equalDom(clientRects[1].node, viewElm.childNodes[1]);
   });
+
+  it('TINY-8532: getClientRects with comment nodes', () => {
+    const viewElm = setupHtml('<b>a</b><!--comment--><b>b</b>');
+    const clientRects = Dimensions.getClientRects(Arr.from(viewElm.childNodes));
+
+    assert.lengthOf(clientRects, 2);
+    LegacyUnit.equalDom(clientRects[0].node, viewElm.childNodes[0]);
+    LegacyUnit.equalDom(clientRects[1].node, viewElm.childNodes[2]);
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-8532

Description of Changes:

This caused `undefined` to be returned since there was no return statement, which meant the array was something like `[ Object, undefined, Object ]` which threw an exception in `Arr.flatten`. Since non-visible nodes like comments should be ignored and we should always have a return case, I've just updated it to return an empty array.

Pre-checks:
* [x] ~Changelog entry added~ (only an issue in 6.0)
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
