### PR TITLE
TINY-8540: Fixed text patterns not able to be updated at runtime

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed the dev ZIP missing the required `bin` scripts to build from the source #TINY-8542
+- Fixed a regression whereby text patterns couldn't be updated at runtime #TINY-8540
 
 ## 6.0.0 - 2022-03-03
 

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -1,5 +1,5 @@
 import { UploadHandler } from '../file/Uploader';
-import { RawPattern } from '../textpatterns/core/PatternTypes';
+import { Pattern, RawPattern } from '../textpatterns/core/PatternTypes';
 import Editor from './Editor';
 import { PastePostProcessEvent, PastePreProcessEvent } from './EventTypes';
 import { Formats } from './fmt/Format';
@@ -252,5 +252,5 @@ export interface EditorOptions extends NormalizedEditorOptions {
   noneditable_regexp: RegExp[];
   object_resizing?: string;
   preview_styles?: string;
-  text_patterns?: RawPattern[];
+  text_patterns?: Pattern[];
 }

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -1,6 +1,7 @@
 import { Arr, Obj, Strings, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 
+import * as Pattern from '../textpatterns/core/Pattern';
 import DOMUtils from './dom/DOMUtils';
 import Editor from './Editor';
 import { EditorOptions } from './OptionTypes';
@@ -698,7 +699,8 @@ const register = (editor: Editor) => {
   registerOption('text_patterns', {
     processor: (value) => {
       if (Type.isArrayOf(value, Type.isObject) || value === false) {
-        return { value: value === false ? [] : value, valid: true };
+        const patterns = value === false ? [] : value;
+        return { value: Pattern.fromRawPatterns(patterns), valid: true };
       } else {
         return { valid: false, message: 'Must be an array of objects or false.' };
       }

--- a/modules/tinymce/src/core/main/ts/textpatterns/TextPatterns.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/TextPatterns.ts
@@ -1,28 +1,10 @@
-import { Arr, Cell, Results } from '@ephox/katamari';
-
 import Editor from '../api/Editor';
-import * as Options from '../api/Options';
-import * as Pattern from './core/Pattern';
-import { PatternSet, RawPattern } from './core/PatternTypes';
 import * as Keyboard from './keyboard/Keyboard';
 
-const generatePatternSet = (patterns: RawPattern[]): PatternSet => {
-  const normalized = Results.partition(Arr.map(patterns, Pattern.normalizePattern));
-  // eslint-disable-next-line no-console
-  Arr.each(normalized.errors, (err) => console.error(err.message, err.pattern));
-  return Pattern.createPatternSet(normalized.values);
-};
-
 const setup = (editor: Editor): void => {
-  const patterns = Options.getTextPatterns(editor);
-
-  if (patterns.length > 0) {
-    const patternSet = generatePatternSet(patterns);
-    Keyboard.setup(editor, Cell(patternSet));
-  }
+  Keyboard.setup(editor);
 };
 
 export {
-  setup,
-  generatePatternSet
+  setup
 };

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/Pattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/Pattern.ts
@@ -1,4 +1,4 @@
-import { Arr, Result, Type } from '@ephox/katamari';
+import { Arr, Result, Results, Type } from '@ephox/katamari';
 
 import { BlockPattern, InlineCmdPattern, InlinePattern, Pattern, PatternError, PatternSet, RawPattern } from './PatternTypes';
 
@@ -132,13 +132,29 @@ const denormalizePattern = (pattern: Pattern): RawPattern => {
   }
 };
 
+const getBlockPatterns = (patterns: Pattern[]): BlockPattern[] =>
+  sortPatterns(Arr.filter(patterns, isBlockPattern));
+
+const getInlinePatterns = (patterns: Pattern[]): InlinePattern[] =>
+  Arr.filter(patterns, isInlinePattern);
+
 const createPatternSet = (patterns: Pattern[]): PatternSet => ({
-  inlinePatterns: Arr.filter(patterns, isInlinePattern),
-  blockPatterns: sortPatterns(Arr.filter(patterns, isBlockPattern))
+  inlinePatterns: getInlinePatterns(patterns),
+  blockPatterns: getBlockPatterns(patterns)
 });
+
+const fromRawPatterns = (patterns: RawPattern[]): Pattern[] => {
+  const normalized = Results.partition(Arr.map(patterns, normalizePattern));
+  // eslint-disable-next-line no-console
+  Arr.each(normalized.errors, (err) => console.error(err.message, err.pattern));
+  return normalized.values;
+};
 
 export {
   normalizePattern,
   denormalizePattern,
-  createPatternSet
+  createPatternSet,
+  getBlockPatterns,
+  getInlinePatterns,
+  fromRawPatterns
 };

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
@@ -5,12 +5,15 @@ import Editor from '../../api/Editor';
 import VK from '../../api/util/VK';
 import * as BlockPattern from '../core/BlockPattern';
 import * as InlinePattern from '../core/InlinePattern';
-import { PatternSet } from '../core/PatternTypes';
+import { InlinePattern as InlinePatternType, PatternSet } from '../core/PatternTypes';
 import * as Utils from '../utils/Utils';
 
+const hasPatterns = (patternSet: PatternSet): boolean =>
+  patternSet.inlinePatterns.length > 0 || patternSet.blockPatterns.length > 0;
+
 const handleEnter = (editor: Editor, patternSet: PatternSet): boolean => {
-  // Skip checking when the selection isn't collapsed
-  if (!editor.selection.isCollapsed()) {
+  // Skip checking when the selection isn't collapsed or we have no patterns
+  if (!editor.selection.isCollapsed() || !hasPatterns(patternSet)) {
     return false;
   }
 
@@ -47,12 +50,14 @@ const handleEnter = (editor: Editor, patternSet: PatternSet): boolean => {
   return false;
 };
 
-const handleInlineKey = (editor: Editor, patternSet: PatternSet): void => {
-  const inlineMatches = InlinePattern.findPatterns(editor, patternSet.inlinePatterns, true);
-  if (inlineMatches.length > 0) {
-    editor.undoManager.transact(() => {
-      InlinePattern.applyMatches(editor, inlineMatches);
-    });
+const handleInlineKey = (editor: Editor, inlinePatterns: InlinePatternType[]): void => {
+  if (inlinePatterns.length > 0) {
+    const inlineMatches = InlinePattern.findPatterns(editor, inlinePatterns, true);
+    if (inlineMatches.length > 0) {
+      editor.undoManager.transact(() => {
+        InlinePattern.applyMatches(editor, inlineMatches);
+      });
+    }
   }
 };
 

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/Keyboard.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/Keyboard.ts
@@ -1,18 +1,20 @@
-import { Cell } from '@ephox/katamari';
-
 import Editor from '../../api/Editor';
+import * as Options from '../../api/Options';
 import Delay from '../../api/util/Delay';
 import VK from '../../api/util/VK';
-import { PatternSet } from '../core/PatternTypes';
+import * as Pattern from '../core/Pattern';
 import * as KeyHandler from './KeyHandler';
 
-const setup = (editor: Editor, patternsState: Cell<PatternSet>): void => {
+const setup = (editor: Editor): void => {
   const charCodes = [ ',', '.', ';', ':', '!', '?' ];
   const keyCodes = [ 32 ];
 
+  const getPatternSet = () => Pattern.createPatternSet(Options.getTextPatterns(editor));
+  const getInlinePatterns = () => Pattern.getInlinePatterns(Options.getTextPatterns(editor));
+
   editor.on('keydown', (e) => {
     if (e.keyCode === 13 && !VK.modifierPressed(e)) {
-      if (KeyHandler.handleEnter(editor, patternsState.get())) {
+      if (KeyHandler.handleEnter(editor, getPatternSet())) {
         e.preventDefault();
       }
     }
@@ -20,14 +22,14 @@ const setup = (editor: Editor, patternsState: Cell<PatternSet>): void => {
 
   editor.on('keyup', (e) => {
     if (KeyHandler.checkKeyCode(keyCodes, e)) {
-      KeyHandler.handleInlineKey(editor, patternsState.get());
+      KeyHandler.handleInlineKey(editor, getInlinePatterns());
     }
   });
 
   editor.on('keypress', (e) => {
     if (KeyHandler.checkCharCode(charCodes, e)) {
       Delay.setEditorTimeout(editor, () => {
-        KeyHandler.handleInlineKey(editor, patternsState.get());
+        KeyHandler.handleInlineKey(editor, getInlinePatterns());
       });
     }
   });

--- a/modules/tinymce/src/core/test/ts/atomic/textpatterns/FindBlockPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/textpatterns/FindBlockPatternsTest.ts
@@ -2,11 +2,11 @@ import { describe, it } from '@ephox/bedrock-client';
 import { assert } from 'chai';
 
 import * as BlockPattern from 'tinymce/core/textpatterns/core/BlockPattern';
-import * as TextPatterns from 'tinymce/core/textpatterns/TextPatterns';
+import * as Pattern from 'tinymce/core/textpatterns/core/Pattern';
 
 describe('atomic.tinymce.textpatterns.FindBlockPatternsTest', () => {
   it('should find the start of the default patterns', () => {
-    const patternSet = TextPatterns.generatePatternSet([
+    const patternSet = Pattern.createPatternSet(Pattern.fromRawPatterns([
       { start: '*', end: '*', format: 'italic' },
       { start: '**', end: '**', format: 'bold' },
       { start: '#', format: 'h1' },
@@ -18,7 +18,7 @@ describe('atomic.tinymce.textpatterns.FindBlockPatternsTest', () => {
       { start: '1. ', cmd: 'InsertOrderedList' },
       { start: '* ', cmd: 'InsertUnorderedList' },
       { start: '- ', cmd: 'InsertUnorderedList' }
-    ]);
+    ]));
     const defaultPatterns = patternSet.blockPatterns;
 
     const testFindStartPattern = (text: string, expectedPattern: string) => {

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
@@ -6,8 +6,8 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import * as Options from 'tinymce/core/api/Options';
 import * as InlinePattern from 'tinymce/core/textpatterns/core/InlinePattern';
+import * as Pattern from 'tinymce/core/textpatterns/core/Pattern';
 import { InlinePattern as InlinePatternType, InlinePatternMatch } from 'tinymce/core/textpatterns/core/PatternTypes';
-import * as TextPatterns from 'tinymce/core/textpatterns/TextPatterns';
 import { PathRange } from 'tinymce/core/textpatterns/utils/PathRange';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
 
@@ -33,7 +33,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
 
   const inlinePatterns = Thunk.cached(() => {
     const rawPatterns = Options.getTextPatterns(hook.editor());
-    return TextPatterns.generatePatternSet(rawPatterns).inlinePatterns;
+    return Pattern.createPatternSet(Pattern.fromRawPatterns(rawPatterns)).inlinePatterns;
   });
 
   const getInlinePattern = (editor: Editor, patterns: InlinePatternType[], space: boolean = false) =>

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
@@ -213,4 +213,17 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
     TinyContentActions.keyup(editor, Keys.space());
     TinyAssertions.assertContent(editor, '<p><a href="about:blank"><span class="test">www</span>.google.com</a></p>');
   });
+
+  it('TINY-8540: should be able to add additional patterns (connections requirement)', () => {
+    const editor = hook.editor();
+    Utils.setContentAndPressSpace(editor, 'brb');
+    TinyAssertions.assertContent(editor, '<p>brb&nbsp;</p>');
+
+    editor.options.set('text_patterns', [
+      ...editor.options.get('text_patterns'),
+      { start: 'brb', replacement: 'be right back' }
+    ]);
+    Utils.setContentAndPressSpace(editor, 'brb');
+    TinyAssertions.assertContent(editor, '<p>be right back&nbsp;</p>');
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
@@ -214,7 +214,7 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
     TinyAssertions.assertContent(editor, '<p><a href="about:blank"><span class="test">www</span>.google.com</a></p>');
   });
 
-  it('TINY-8540: should be able to add additional patterns (connections requirement)', () => {
+  it('TINY-8540: should be able to add additional patterns', () => {
     const editor = hook.editor();
     Utils.setContentAndPressSpace(editor, 'brb');
     TinyAssertions.assertContent(editor, '<p>brb&nbsp;</p>');
@@ -225,5 +225,7 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
     ]);
     Utils.setContentAndPressSpace(editor, 'brb');
     TinyAssertions.assertContent(editor, '<p>be right back&nbsp;</p>');
+
+    editor.options.unset('text_patterns');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-8540

Description of Changes:

Fixed a regression in functionality from 5.x whereby text patterns used to be able to be updated at runtime via the `plugins.textpattern.setPatterns()` API. While we don't want to bring that API back, as this is needed for connections our concession here was to make it so the option value can be updated at runtime and the text pattern logic will instead use the updated value. As such this moves the logic around a little so the options processor does the normalization now instead of doing it separately and we then use the normalized option value when matching the patterns.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
