### PR TITLE
TINY-8552: Fixed the autocompleter failing to start and close properly in some cases

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed the dev ZIP missing the required `bin` scripts to build from the source #TINY-8542
 - Fixed a regression whereby text patterns couldn't be updated at runtime #TINY-8540
+- The autocompleter would not fire the `AutocompleterStart` event nor close the menu in some cases #TINY-8552
 
 ## 6.0.0 - 2022-03-03
 

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/AutocompleterTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/AutocompleterTest.ts
@@ -1,6 +1,7 @@
 import { Keys, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { Arr } from '@ephox/katamari';
+import { InlineContent } from '@ephox/bridge';
+import { Arr, Throttler } from '@ephox/katamari';
 import { TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -9,64 +10,92 @@ import { EditorEvent } from 'tinymce/core/api/PublicApi';
 import { AutocompleterEventArgs, AutocompleteLookupData } from 'tinymce/core/autocomplete/AutocompleteTypes';
 
 describe('browser.tinymce.core.keyboard.AutocompleterTest', () => {
-  const triggerChar = '+';
+  const plusTriggerChar = '+';
+  const dollarsTriggerChar = '$';
+  // This matches the throttle time used in Autocompleter.ts
+  const keyboardThrottleTimer = 50;
+
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     setup: (ed: Editor) => {
+      const onAction = (autocompleteApi: InlineContent.AutocompleterInstanceApi, rng: Range, value: string) => {
+        ed.selection.setRng(rng);
+        ed.insertContent(value);
+        autocompleteApi.hide();
+      };
+
+      const fetch = (ch: string, type: string) => (resolve: (data: InlineContent.AutocompleterContents[]) => void) => {
+        resolve(Arr.map([ 'aa', 'ab' ], (letter) => ({
+          value: `${type}-${letter}`,
+          text: `p-${letter}`,
+          icon: ch
+        })));
+      };
+
       ed.ui.registry.addAutocompleter('Plus1', {
-        ch: triggerChar,
+        ch: plusTriggerChar,
         minChars: 0,
         columns: 1,
-        fetch: (_pattern, _maxResults) => new Promise((resolve) => {
-          resolve(
-            Arr.map([ 'aa', 'ab' ], (letter) => ({
-              value: `plus-${letter}`,
-              text: `p-${letter}`,
-              icon: '+'
-            }))
-          );
-        }),
-        onAction: (autocompleteApi, rng, value) => {
-          ed.selection.setRng(rng);
-          ed.insertContent(value);
-          autocompleteApi.hide();
-        }
+        fetch: (_pattern, _maxResults) => new Promise(fetch(plusTriggerChar, 'plus')),
+        onAction
+      });
+
+      const dollarsFetch = Throttler.last(fetch(dollarsTriggerChar, 'dollars'), keyboardThrottleTimer * 3);
+      ed.ui.registry.addAutocompleter('Dollars1', {
+        ch: dollarsTriggerChar,
+        minChars: 0,
+        columns: 1,
+        fetch: (_pattern, _maxResults) => new Promise(dollarsFetch.throttle),
+        onAction
       });
     }
   }, []);
 
-  const pOpenAutocompleter = async (editor: Editor) => {
+  const pOpenAutocompleter = async (editor: Editor, triggerChar: string) => {
     editor.focus();
     editor.setContent(`<p>${triggerChar}</p>`);
-    TinySelections.setCursor(editor, [ 0, 0 ], triggerChar.length);
-    TinyContentActions.keypress(editor, triggerChar.charCodeAt(0));
+    TinySelections.setCursor(editor, [ 0, 0 ], plusTriggerChar.length);
+    TinyContentActions.keypress(editor, plusTriggerChar.charCodeAt(0));
     // Wait 50ms for the keypress to process
-    await Waiter.pWait(50);
+    await Waiter.pWait(keyboardThrottleTimer);
   };
 
   const pUpdateWithChar = async (editor: Editor, chr: string) => {
     editor.insertContent(chr);
     TinyContentActions.keypress(editor, chr.charCodeAt(0));
     // Wait 50ms for the keypress to process
-    await Waiter.pWait(50);
+    await Waiter.pWait(keyboardThrottleTimer);
   };
 
   const pCloseAutocompleterByKey = async (editor: Editor) => {
     TinyContentActions.keydown(editor, Keys.escape());
     // Wait 50ms for the keypress to process
-    await Waiter.pWait(50);
+    await Waiter.pWait(keyboardThrottleTimer);
   };
 
   const pWaitForEvents = (events: string[], expectedEvents: string[]) =>
     Waiter.pTryUntil('Waited for events to include expected events', () => assert.deepEqual(events, expectedEvents));
 
-  const assertLookupData = (lookupData: AutocompleteLookupData, expectedMatchText: string) => {
+  const pTestWithEvents = async (test: (eventArgs: EditorEvent<AutocompleterEventArgs>[]) => Promise<void>) => {
+    const editor = hook.editor();
+    const eventArgs: EditorEvent<AutocompleterEventArgs>[] = [];
+    const collect = (args: EditorEvent<AutocompleterEventArgs>) => eventArgs.push(args);
+
+    editor.on('AutocompleterStart AutocompleterUpdate', collect);
+
+    await test(eventArgs);
+
+    editor.execCommand('mceAutocompleterClose');
+    editor.off('AutocompleterStart AutocompleterUpdate', collect);
+  };
+
+  const assertLookupData = (lookupData: AutocompleteLookupData, expectedMatchText: string, ch: string, type: string) => {
     assert.equal(lookupData.columns, 1);
     assert.deepEqual(lookupData.highlightOn, []);
     assert.equal(lookupData.matchText, expectedMatchText);
     assert.deepEqual(lookupData.items, [
-      { value: 'plus-aa', text: 'p-aa', icon: '+' },
-      { value: 'plus-ab', text: 'p-ab', icon: '+' },
+      { value: `${type}-aa`, text: 'p-aa', icon: ch },
+      { value: `${type}-ab`, text: 'p-ab', icon: ch },
     ]);
     assert.isFunction(lookupData.onAction);
   };
@@ -77,7 +106,7 @@ describe('browser.tinymce.core.keyboard.AutocompleterTest', () => {
     const collect = (args: EditorEvent<AutocompleterEventArgs>) => events.push(args.type);
 
     editor.on('AutocompleterStart AutocompleterUpdate AutocompleterEnd', collect);
-    await pOpenAutocompleter(editor);
+    await pOpenAutocompleter(editor, plusTriggerChar);
     await pUpdateWithChar(editor, 'a');
     await pCloseAutocompleterByKey(editor);
     await pWaitForEvents(events, [ 'autocompleterstart', 'autocompleterupdate', 'autocompleterend' ]);
@@ -90,7 +119,7 @@ describe('browser.tinymce.core.keyboard.AutocompleterTest', () => {
     const collect = (args: EditorEvent<AutocompleterEventArgs>) => events.push(args.type);
 
     editor.on('AutocompleterUpdate', collect);
-    await pOpenAutocompleter(editor);
+    await pOpenAutocompleter(editor, plusTriggerChar);
     editor.execCommand('mceAutocompleterReload');
     await pWaitForEvents(events, [ 'autocompleterupdate' ]);
     await pCloseAutocompleterByKey(editor);
@@ -103,7 +132,7 @@ describe('browser.tinymce.core.keyboard.AutocompleterTest', () => {
     const collect = (args: EditorEvent<AutocompleterEventArgs>) => events.push(args.type);
 
     editor.on('AutocompleterEnd', collect);
-    await pOpenAutocompleter(editor);
+    await pOpenAutocompleter(editor, plusTriggerChar);
     editor.execCommand('mceAutocompleterClose');
     await pWaitForEvents(events, [ 'autocompleterend' ]);
     editor.off('AutocompleterEnd', collect);
@@ -115,39 +144,51 @@ describe('browser.tinymce.core.keyboard.AutocompleterTest', () => {
     const collect = (args: EditorEvent<AutocompleterEventArgs>) => events.push(args.type);
 
     editor.on('AutocompleterStart AutocompleterUpdate AutocompleterEnd', collect);
-    await pOpenAutocompleter(editor);
+    await pOpenAutocompleter(editor, plusTriggerChar);
     await pUpdateWithChar(editor, 'a');
     TinyContentActions.keydown(editor, Keys.enter());
     await pWaitForEvents(events, [ 'autocompleterstart', 'autocompleterupdate', 'autocompleterend' ]);
     editor.off('AutocompleterStart AutocompleterUpdate AutocompleterEnd', collect);
   });
 
-  it('TINY-8279: autocompleter events start, update should have lookupData', async () => {
+  it('TINY-8279: autocompleter events start, update should have lookupData', () => pTestWithEvents(async (eventArgs) => {
     const editor = hook.editor();
-    const eventArgs: AutocompleterEventArgs[] = [];
-    const collect = (args: EditorEvent<AutocompleterEventArgs>) => eventArgs.push(args);
-
-    editor.on('AutocompleterStart AutocompleterUpdate', collect);
-    await pOpenAutocompleter(editor);
+    await pOpenAutocompleter(editor, plusTriggerChar);
 
     await Waiter.pTryUntil('Waited for AutocompleterStart to include lookupData', () => {
       assert.equal(eventArgs.length, 1);
+      assert.equal(eventArgs[0].type, 'autocompleterstart');
       assert.equal(eventArgs[0].lookupData.length, 1);
 
-      assertLookupData(eventArgs[0].lookupData[0], '');
+      assertLookupData(eventArgs[0].lookupData[0], '', '+', 'plus');
     });
 
     await pUpdateWithChar(editor, 'a');
 
     await Waiter.pTryUntil('Waited for AutocompleterUpdate to include lookupData', () => {
       assert.equal(eventArgs.length, 2);
+      assert.equal(eventArgs[1].type, 'autocompleterupdate');
       assert.equal(eventArgs[1].lookupData.length, 1);
 
-      assertLookupData(eventArgs[1].lookupData[0], 'a');
+      assertLookupData(eventArgs[1].lookupData[0], 'a', '+', 'plus');
     });
+  }));
 
-    editor.execCommand('mceAutocompleterClose');
+  it('TINY-8552: autocompleter starts correctly with throttled fetch', () => pTestWithEvents(async (eventArgs) => {
+    const editor = hook.editor();
 
-    editor.off('AutocompleterStart AutocompleterUpdate', collect);
-  });
+    // Trigger and then immediately type another character
+    await pOpenAutocompleter(editor, dollarsTriggerChar);
+    await pUpdateWithChar(editor, 'a');
+
+    // Note: There won't be an update event here because it didn't start until both chars had been typed
+    // due to the throttle delay and the fact it only runs on the last fetch call.
+    await Waiter.pTryUntil('Waited for AutocompleterStart to include lookupData', () => {
+      assert.equal(eventArgs.length, 1);
+      assert.equal(eventArgs[0].type, 'autocompleterstart');
+      assert.equal(eventArgs[0].lookupData.length, 1);
+
+      assertLookupData(eventArgs[0].lookupData[0], 'a', '$', 'dollars');
+    });
+  }));
 });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/AutocompleterTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/AutocompleterTest.ts
@@ -54,8 +54,8 @@ describe('browser.tinymce.core.keyboard.AutocompleterTest', () => {
   const pOpenAutocompleter = async (editor: Editor, triggerChar: string) => {
     editor.focus();
     editor.setContent(`<p>${triggerChar}</p>`);
-    TinySelections.setCursor(editor, [ 0, 0 ], plusTriggerChar.length);
-    TinyContentActions.keypress(editor, plusTriggerChar.charCodeAt(0));
+    TinySelections.setCursor(editor, [ 0, 0 ], triggerChar.length);
+    TinyContentActions.keypress(editor, triggerChar.charCodeAt(0));
     // Wait 50ms for the keypress to process
     await Waiter.pWait(keyboardThrottleTimer);
   };

--- a/modules/tinymce/src/themes/silver/main/ts/Autocompleter.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Autocompleter.ts
@@ -47,7 +47,7 @@ const register = (editor: Editor, sharedBackstage: UiFactoryBackstageShared) => 
   const isActive = activeState.get;
 
   const hideIfNecessary = () => {
-    if (isActive()) {
+    if (isMenuOpen()) {
       InlineView.hide(autocompleter);
     }
   };


### PR DESCRIPTION
Related Ticket: TINY-8552

Description of Changes:

This fixes an issue whereby the autocompleter wouldn't start correctly which in turn meant the UI state believed the autocompleter wasn't active and therefore wouldn't close the menu. This was largely only an issue when using a throttled fetch function such that the first `fetch` call never ends up resolving.

I've also fixed a very minor regression I noticed in the `esc` key handling as in 5.x it would cancel even when a fetch was running but that's no longer the case and with the 6.x changes it'd only cancel if the UI had been triggered (e.g. the fetch had completed). I'm happy to revert this if we don't think this should happen, but it made sense to me that if you press escape you don't want the menu to pop up after.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
