### PR TITLE
TINY-8564: Fix double border with toolbar_location: bottom

### DIFF
--- a/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
@@ -72,6 +72,11 @@
     margin-bottom: -1px;
   }
 
+  &:not(.tox-tinymce-inline).tox-tinymce--toolbar-bottom .tox-editor-header {
+    border-top: none;
+    box-shadow: none;
+  }
+
   // Double .tox selector to increase specificity over `:not(.tox-tinymce-inline)` from new style
   &.tox.tox-tinymce--toolbar-sticky-on {
     .tox-editor-header {
@@ -112,7 +117,13 @@
   }
 
   .tox-menubar + .tox-toolbar,
+  .tox-menubar + .tox-toolbar-overlord {
+    border-top: none;
+  }
+
+  .tox-menubar + .tox-toolbar,
   .tox-menubar + .tox-toolbar-overlord .tox-toolbar__primary {
+    border-top: 1px solid @toolbar-separator-color;
     margin-top: -1px; // Fix to hide menubar bottom border below the toolbar
   }
 
@@ -123,7 +134,7 @@
 
   &:not(.tox-tinymce-inline) .tox-editor-header:not(:first-child) .tox-toolbar-overlord:first-child .tox-toolbar__primary,
   &:not(.tox-tinymce-inline) .tox-editor-header:not(:first-child) .tox-toolbar:first-child {
-    border-top: 1px solid @border-color;
+    border-top: 1px solid @toolbar-separator-color;
   }
 
   .tox-toolbar__group {

--- a/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
@@ -116,7 +116,6 @@
     background: @toolbar-background !important;
   }
 
-  .tox-menubar + .tox-toolbar,
   .tox-menubar + .tox-toolbar-overlord {
     border-top: none;
   }

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a regression whereby text patterns couldn't be updated at runtime #TINY-8540
 - Naked buttons better adapt to various background colors, improved text contrast in notifications #TINY-8533
 - The autocompleter would not fire the `AutocompleterStart` event nor close the menu in some cases #TINY-8552
+- Fixed double border with `toolbar_location: bottom` #TINY-8564
 
 ## 6.0.0 - 2022-03-03
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a regression whereby text patterns couldn't be updated at runtime #TINY-8540
 - Naked buttons better adapt to various background colors, improved text contrast in notifications #TINY-8533
 - The autocompleter would not fire the `AutocompleterStart` event nor close the menu in some cases #TINY-8552
-- Fixed double border with `toolbar_location: bottom` #TINY-8564
+- Fixed a double border showing for the `tinymce-5` skin when using `toolbar_location: 'bottom'` #TINY-8564
 
 ## 6.0.0 - 2022-03-03
 


### PR DESCRIPTION
Related Ticket: TINY-8564

Description of Changes:
* Fix double border with `toolbar_location: bottom`

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved
