### PR TITLE
TINY-8575: Fixed the notification manager tests failing in isolation

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
@@ -28,13 +28,16 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
         }
       }, []);
 
-      afterEach(() => {
+      const resetNotifications = () => {
         const editor = hook.editor();
         const notifications = [].concat(editor.notificationManager.getNotifications());
         Arr.each(notifications, (notification) => notification.close());
-
         beforeOpenEvents = [];
         openEvents = [];
+      };
+
+      afterEach(() => {
+        resetNotifications();
       });
 
       // IMPORTANT: This test must be first, as it asserts the service message on load
@@ -57,6 +60,8 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
 
       it('TBA: Should not add duplicate text message', () => {
         const editor = hook.editor();
+        resetNotifications();
+
         const testMsg1: NotificationSpec = { type: 'success', text: 'test success message' };
         const testMsg2: NotificationSpec = { type: 'warning', text: 'test warning message' };
         const testMsg3: NotificationSpec = { type: 'error', text: 'test error message' };
@@ -89,6 +94,8 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
 
       it('TBA: Should add duplicate progressBar messages', () => {
         const editor = hook.editor();
+        resetNotifications();
+
         const testMsg1: NotificationSpec = { text: 'test progressBar message', progressBar: true };
         const notifications = editor.notificationManager.getNotifications();
 
@@ -105,6 +112,8 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
 
       it('TBA: Should add duplicate timeout messages', (done) => {
         const editor = hook.editor();
+        resetNotifications();
+
         const checkClosed = () => {
           if (notifications.length === 0) {
             done();
@@ -128,6 +137,8 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
 
       it('TINY-6058: Should move focus back to the editor when all notifications closed', () => {
         const editor = hook.editor();
+        resetNotifications();
+
         const testMsg1: NotificationSpec = { type: 'warning', text: 'test message 1' };
         const testMsg2: NotificationSpec = { type: 'error', text: 'test message 2' };
         const notifications = editor.notificationManager.getNotifications();
@@ -150,6 +161,8 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
 
       it('TINY-6528: Notification manager should throw events for notification modification', () => {
         const editor = hook.editor();
+        resetNotifications();
+
         const testMsg: NotificationSpec = {
           type: 'warning',
           text: 'unmodified notification text',
@@ -190,6 +203,8 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
 
       it('TBA: Should not open notification if editor is removed', () => {
         const editor = hook.editor();
+        resetNotifications();
+
         const testMsg1: NotificationSpec = { type: 'warning', text: 'test progressBar message' };
 
         editor.remove();


### PR DESCRIPTION
Related Ticket: TINY-8575

Description of Changes:

This test includes a service message that means it opens the notification during init. That in turn causes issues if the first test in the suite doesn't run first, so this adjusts the tests to make sure it always works when the tests are run in isolation.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] ~Milestone set~
* [x] Review comments resolved

GitHub issues (if applicable):
