### PR TITLE
TINY-8563: Fixed internal marks not added to clipboard content when cef elements were selected

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a regression whereby text patterns couldn't be updated at runtime #TINY-8540
 - Naked buttons better adapt to various background colors, improved text contrast in notifications #TINY-8533
 - The autocompleter would not fire the `AutocompleterStart` event nor close the menu in some cases #TINY-8552
+- Clipboard content was not generated correctly when cutting and copying `contenteditable="false"` elements #TINY-8563
 
 ## 6.0.0 - 2022-03-03
 

--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -43,11 +43,6 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
   const isFakeSelectionTargetElement = (node: Node): node is HTMLElement =>
     node !== rootNode && (isContentEditableFalse(node) || NodeType.isMedia(node)) && dom.isChildOf(node, rootNode);
 
-  const getRealSelectionElement = () => {
-    const container = dom.get(realSelectionId);
-    return container ? container.getElementsByTagName('*')[0] as HTMLElement : container;
-  };
-
   const setRange = (range: Range | null) => {
     if (range) {
       selection.setRng(range);
@@ -190,22 +185,6 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
 
       if (!isFakeSelectionElement(parentNode)) {
         removeElementSelection();
-      }
-    });
-
-    editor.on('copy', (e) => {
-      const clipboardData = e.clipboardData;
-
-      // Make sure we get proper html/text for the fake cE=false selection
-      if (!e.isDefaultPrevented() && e.clipboardData) {
-        const realSelectionElement = getRealSelectionElement();
-        if (realSelectionElement) {
-          e.preventDefault();
-          clipboardData.clearData();
-          clipboardData.setData('text/html', realSelectionElement.outerHTML);
-          // outerText is a nonstandard property and doesn't exist on Firefox, so fallback to innerText
-          clipboardData.setData('text/plain', (realSelectionElement as any).outerText || realSelectionElement.innerText);
-        }
       }
     });
 

--- a/modules/tinymce/src/core/test/ts/browser/paste/InternalClipboardTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/InternalClipboardTest.ts
@@ -121,6 +121,14 @@ describe('browser.tinymce.core.paste.InternalClipboardTest', () => {
           '</table>', 'ab');
       TinyAssertions.assertSelection(editor, [ 0, 0, 0, 1, 0 ], 0, [ 0, 0, 0, 1, 0 ], 0);
     });
+
+    it('TINY-8563: Copy cef element', () => {
+      const editor = hook.editor();
+      copy(editor, '<p>a<span contenteditable="false">bc</span></p>', [ 0 ], 1, [ 0 ], 2);
+      assertClipboardData('<!-- x-tinymce/html --><span contenteditable="false">bc</span>', 'bc');
+      TinyAssertions.assertContent(editor, '<p>a<span contenteditable="false">bc</span></p>');
+      TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 2);
+    });
   });
 
   context('cut', () => {
@@ -156,6 +164,14 @@ describe('browser.tinymce.core.paste.InternalClipboardTest', () => {
       cut(editor, '<p>abc</p>', [ 0, 0 ], 1, [ 0, 0 ], 1);
       assertClipboardData('', '');
       await pWaitUntilAssertContent(editor, '<p>abc</p>');
+      TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 1);
+    });
+
+    it('TINY-8563: Cut cef element', async () => {
+      const editor = hook.editor();
+      cut(editor, '<p>a<span contenteditable="false">bc</span></p>', [ 0 ], 1, [ 0 ], 2);
+      assertClipboardData('<!-- x-tinymce/html --><span contenteditable="false">bc</span>', 'bc');
+      await pWaitUntilAssertContent(editor, '<p>a</p>');
       TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 1);
     });
   });


### PR DESCRIPTION
Related Ticket: TINY-8563

Description of Changes:

This removes the `copy` logic for CEF elements in the `SelectionOverrides` code because this is no longer needed now that we have the paste plugin in core. Additionally, having this here meant it ran first and didn't add the internal HTML comment mark to the clipboard content, which in turn caused issues when pasting it within the editor. Now the reason this isn't needed, is the paste logic uses `editor.selection.getRng()` to get the range and clone the contents, so `SelectionOverrides` already adjusts the range back to the real element instead of the offscreen clone.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
