### PR TITLE
TINY-8567: fixed issue where it was not possible to select text after a inline noneditable

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a regression whereby text patterns couldn't be updated at runtime #TINY-8540
 - Naked buttons better adapt to various background colors, improved text contrast in notifications #TINY-8533
 - The autocompleter would not fire the `AutocompleterStart` event nor close the menu in some cases #TINY-8552
-
+- It wasn't possible to select text right after an inline noneditable element #TINY-8567
 ## 6.0.0 - 2022-03-03
 
 ### Added

--- a/modules/tinymce/src/core/main/ts/caret/ClosestCaretCandidate.ts
+++ b/modules/tinymce/src/core/main/ts/caret/ClosestCaretCandidate.ts
@@ -51,7 +51,10 @@ const clientInfo = (rect: NodeClientRect, clientX: number): FakeCaretInfo => {
   };
 };
 
-const horizontalDistance: DistanceFn = (rect, x, _y) => x > rect.left && x < rect.right ? 0 : Math.min(Math.abs(rect.left - x), Math.abs(rect.right - x));
+// Measure the distance between the x and the closest edge of the rect.
+// If the x is inside the rect then always return 0.
+const horizontalDistance: DistanceFn = (rect, x, _y) =>
+  x > rect.left && x < rect.right ? 0 : Math.min(Math.abs(rect.left - x), Math.abs(rect.right - x));
 
 const closestChildCaretCandidateNodeRect = (children: ChildNode[], clientX: number, clientY: number): Optional<NodeClientRect> => {
   const caretCandidateRect = (rect: NodeClientRect) => {

--- a/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
@@ -248,7 +248,7 @@ describe('browser.tinymce.core.ClosestCaretCandidateTest', () => {
         })
       );
 
-      it('TINY-8567: should find the left noeditable node as the closest candidate since the point is beyond the 2 pixels edge between the text node and element', () =>
+      it('TINY-8567: should find the left noneditable node as the closest candidate since the point is beyond the 2 pixels edge between the text node and element', () =>
         testClosestCaretCandidate({
           html: '<span contenteditable="false" style="display: inline-block; margin-right: 5px; width: 10px; height: 10px; background: green"></span><span>hello</span>',
           targetPath: [ 0 ],

--- a/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
@@ -175,6 +175,87 @@ describe('browser.tinymce.core.ClosestCaretCandidateTest', () => {
           expected: Optional.some([ 0 ])
         })
       );
+
+      it('TINY-8567: should find the text node as the closest caret candidate since the point is within the text node', () =>
+        testClosestCaretCandidate({
+          html: '<span contenteditable="false" style="display: inline-block; width: 10px; height: 10px; background: green"></span>hello',
+          targetPath: [ 0 ],
+          dx: 15, dy: 5,
+          expected: Optional.some([ 1 ])
+        })
+      );
+
+      it('TINY-8567: should find the left text node as the closest candidate since the point is at the edge between the text node and element', () =>
+        testClosestCaretCandidate({
+          html: 'hello<span contenteditable="false" style="display: inline-block; width: 10px; height: 10px; background: green"></span>',
+          targetPath: [ 1 ],
+          dx: 0, dy: 5,
+          expected: Optional.some([ 0 ])
+        })
+      );
+
+      it('TINY-8567: should find the right text node as the closest candidate since the point is at the edge between the text node and element', () =>
+        testClosestCaretCandidate({
+          html: '<span contenteditable="false" style="display: inline-block; width: 10px; height: 10px; background: green"></span>hello',
+          targetPath: [ 0 ],
+          dx: 10, dy: 5,
+          expected: Optional.some([ 1 ])
+        })
+      );
+
+      it('TINY-8567: should find the left wrapped text node as the closest candidate since the point is at the edge between the text node and element', () =>
+        testClosestCaretCandidate({
+          html: '<span>hello</span><span contenteditable="false" style="display: inline-block; width: 10px; height: 10px; background: green"></span>',
+          targetPath: [ 1 ],
+          dx: 0, dy: 5,
+          expected: Optional.some([ 0, 0 ])
+        })
+      );
+
+      it('TINY-8567: should find the right wrapped text node as the closest candidate since the point is at the edge between the text node and element', () =>
+        testClosestCaretCandidate({
+          html: '<span contenteditable="false" style="display: inline-block; width: 10px; height: 10px; background: green"></span><span>hello</span>',
+          targetPath: [ 0 ],
+          dx: 10, dy: 5,
+          expected: Optional.some([ 1, 0 ])
+        })
+      );
+
+      it('TINY-8567: should find the left wrapped text node as the closest candidate since the point is within the 2 pixels edge between the text node and element', () =>
+        testClosestCaretCandidate({
+          html: '<span>hello</span><span contenteditable="false" style="display: inline-block; margin-left: 2px; width: 10px; height: 10px; background: green"></span>',
+          targetPath: [ 1 ],
+          dx: -1, dy: 5,
+          expected: Optional.some([ 0, 0 ])
+        })
+      );
+
+      it('TINY-8567: should find the right wrapped text node as the closest candidate since the point is within the 2 pixels edge between the text node and element', () =>
+        testClosestCaretCandidate({
+          html: '<span contenteditable="false" style="display: inline-block; margin-right: 2px; width: 10px; height: 10px; background: green"></span><span>hello</span>',
+          targetPath: [ 0 ],
+          dx: 11, dy: 5,
+          expected: Optional.some([ 1, 0 ])
+        })
+      );
+
+      it('TINY-8567: should find the right noneditable node as the closest candidate since the point is beyond the 2 pixels edge between the text node and element', () =>
+        testClosestCaretCandidate({
+          html: '<span>hello</span><span contenteditable="false" style="display: inline-block; margin-left: 5px; width: 10px; height: 10px; background: green"></span>',
+          targetPath: [ 1 ],
+          dx: -1, dy: 5,
+          expected: Optional.some([ 1 ])
+        })
+      );
+
+      it('TINY-8567: should find the left noeditable node as the closest candidate since the point is beyond the 2 pixels edge between the text node and element', () =>
+        testClosestCaretCandidate({
+          html: '<span contenteditable="false" style="display: inline-block; margin-right: 5px; width: 10px; height: 10px; background: green"></span><span>hello</span>',
+          targetPath: [ 0 ],
+          dx: 11, dy: 5,
+          expected: Optional.some([ 0 ])
+        })
+      );
     });
   });
 


### PR DESCRIPTION
Related Ticket: TINY-8567

Description of Changes:
* Fixes and issue where it wasn't possible to select text after an inline noneditable element.
* It now treats horizontal elements that intersect the x coordinate the same as vertical elements. That means they now have a 0 distance.
* It also favors the text node if there are two candidates that are very close to each other. This is to make it easier to select text after a noneditable if the space between the noneditable and the text node is very small like 2 pixels or less.
* It also fixes a bug where the root children would not be handled correctly if you didn't find a caret candidate in the target element under the specified x, y position.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
