### PR TITLE
TINY-8580: Added missing removed options and cleaned up test

### DIFF
--- a/modules/tinymce/src/core/main/ts/Deprecations.ts
+++ b/modules/tinymce/src/core/main/ts/Deprecations.ts
@@ -8,8 +8,8 @@ const removedOptions = (
   'boolean_attributes,editor_deselector,editor_selector,elements,file_browser_callback_types,filepicker_validator_handler,' +
   'force_hex_style_colors,force_p_newlines,gecko_spellcheck,images_dataimg_filter,media_scripts,mode,move_caret_before_on_enter_elements,' +
   'non_empty_elements,self_closing_elements,short_ended_elements,special,spellchecker_select_languages,spellchecker_whitelist,' +
-  'tab_focus,table_responsive_width,text_block_elements,text_inline_elements,toolbar_drawer,types,validate,whitespace_elements,' +
-  'paste_word_valid_elements,paste_retain_style_properties,paste_convert_word_fake_lists'
+  'tab_focus,tabfocus_elements,table_responsive_width,text_block_elements,text_inline_elements,toolbar_drawer,types,validate,whitespace_elements,' +
+  'paste_enable_default_filters,paste_filter_drop,paste_word_valid_elements,paste_retain_style_properties,paste_convert_word_fake_lists'
 ).split(',');
 
 const removedPlugins = 'bbcode,colorpicker,contextmenu,fullpage,legacyoutput,spellchecker,textcolor'.split(',');

--- a/modules/tinymce/src/core/test/ts/browser/paste/PasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/PasteTest.ts
@@ -22,8 +22,6 @@ describe('browser.tinymce.core.paste.PasteTest', () => {
   afterEach(() => {
     const editor = hook.editor();
     editor.options.unset('paste_remove_styles_if_webkit');
-    editor.options.unset('paste_retain_style_properties');
-    editor.options.unset('paste_enable_default_filters');
     editor.options.unset('paste_data_images');
     editor.options.unset('paste_webkit_styles');
   });


### PR DESCRIPTION
Related Ticket: TINY-8580

Description of Changes:
* Added the 3 options that were missing in the deprecations warnings that were removed in 6.0
* Cleaned up the `PasteTest.ts` file as it still had a couple references to options that were removed

Pre-checks:
* [x] ~Changelog entry added~ This isn't really customer facing so I didn't think it should have a changelog
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
