### PR TITLE
TINY-8568: Fix incorrect copying of colgroup table with colspans/rowspans

### DIFF
--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Fixed
-- `CopySelected` was incorrectly extracting a selected cells table for tables with colgroups.
+- The `CopySelected` module was incorrectly extracting the selected cells in a table that contained colgroups.
 
 ## 11.0.0 - 2022-03-03
 

--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 11.0.2 - 2022-03-18
+
 ### Fixed
 - The `CopySelected` module was incorrectly extracting the selected cells in a table that contained colgroups.
 

--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- `CopySelected` was incorrectly extracting a selected cells table for tables with colgroups.
+
 ## 11.0.0 - 2022-03-03
 
 ### Added

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CopySelected.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CopySelected.ts
@@ -153,7 +153,8 @@ const extract = (table: SugarElement<HTMLTableElement>, selectedSelector: string
   const unselectedCells = LayerSelector.filterFirstLayer(replica, 'th,td', (cell) => Selectors.is(cell, selector));
   Arr.each(unselectedCells, Remove.remove);
 
-  fillInGaps(list, replicaHouse, replicaStats, isSelected);
+  const rows = Arr.filter(list, (row) => row.section !== 'colgroup');
+  fillInGaps(rows, replicaHouse, replicaStats, isSelected);
 
   const house = Warehouse.fromTable(table);
   const widthDelta = getTableWidthDelta(table, house, tableSize, replicaStats);

--- a/modules/snooker/src/test/ts/browser/CopySelectedTest.ts
+++ b/modules/snooker/src/test/ts/browser/CopySelectedTest.ts
@@ -5,17 +5,26 @@ import { Attribute, Class, Html, InsertAll, SugarElement } from '@ephox/sugar';
 import * as CopySelected from 'ephox/snooker/api/CopySelected';
 import { LOCKED_COL_ATTR } from 'ephox/snooker/util/LockedColumnUtils';
 
-interface TestData {
-  selected: boolean;
-  html: string;
-  rowspan?: string;
-  colspan?: string;
-  locked?: boolean;
+interface TestDataCell {
+  readonly type: 'cell';
+  readonly selected: boolean;
+  readonly html: string;
+  readonly rowspan?: string;
+  readonly colspan?: string;
+  readonly locked?: boolean;
 }
 
+interface TestDataCol {
+  readonly type: 'col';
+  readonly id: string;
+  readonly span?: string;
+}
+
+type TestData = TestDataCell | TestDataCol;
+
 interface TableAttributes {
-  beforeCopy: Record<string, string | boolean | number>; // attributes to set on the table before copy
-  afterCopy: string[]; // attributes that should not be on the table after copy
+  readonly beforeCopy: Record<string, string | boolean | number>; // attributes to set on the table before copy
+  readonly afterCopy: string[]; // attributes that should not be on the table after copy
 }
 
 UnitTest.test('CopySelectedTest', () => {
@@ -28,9 +37,10 @@ UnitTest.test('CopySelectedTest', () => {
   };
 
   // data objects for input/expected
-  const data = (selected: boolean) => {
-    return (text: string, rowspan?: number, colspan?: number, locked: boolean = false): TestData => {
+  const dCell = (selected: boolean) => {
+    return (text: string, rowspan?: number, colspan?: number, locked: boolean = false): TestDataCell => {
       return {
+        type: 'cell',
         selected,
         html: text,
         rowspan: rowspan === undefined ? undefined : String(rowspan),
@@ -39,40 +49,60 @@ UnitTest.test('CopySelectedTest', () => {
       };
     };
   };
-  const s = data(true);
-  const ns = data(false);
-  const gen = (): TestData => {
-    return {
-      selected: false,
-      html: '<br>'
-    };
-  };
+
+  const dCol = (id: string, span?: number): TestDataCol => ({
+    type: 'col',
+    id,
+    span: span === undefined ? undefined : String(span),
+  });
+
+  const s = dCell(true);
+  const ns = dCell(false);
+  const gen = () => ns('<br>');
 
   // generate a table structure from a nested array
-  const generateInput = (input: TestData[][]) => {
+  const generateInput = (input: TestData[][]): SugarElement<HTMLTableElement> => {
     const lockedCols: Record<number, true> = {};
     const table = SugarElement.fromTag('table');
     const rows = Arr.map(input, (row) => {
+      let isCellRow = true;
       const cells = Arr.map(row, (cell, idx) => {
-        const td = SugarElement.fromTag('td');
-        if (cell.rowspan !== undefined) {
-          Attribute.set(td, 'rowspan', cell.rowspan);
+        if (cell.type === 'cell') {
+          const td = SugarElement.fromTag('td');
+          if (cell.rowspan !== undefined) {
+            Attribute.set(td, 'rowspan', cell.rowspan);
+          }
+          if (cell.colspan !== undefined) {
+            Attribute.set(td, 'colspan', cell.colspan);
+          }
+          if (cell.selected) {
+            Class.add(td, SEL_CLASS);
+          }
+          if (cell.locked) {
+            lockedCols[idx] = true;
+          }
+          Html.set(td, cell.html);
+          return td;
+        } else {
+          isCellRow = false;
+          const col = SugarElement.fromTag('col');
+          if (cell.span !== undefined) {
+            Attribute.set(col, 'span', cell.span);
+          }
+          Attribute.set(col, 'data-col-id', cell.id);
+          return col;
         }
-        if (cell.colspan !== undefined) {
-          Attribute.set(td, 'colspan', cell.colspan);
-        }
-        if (cell.selected) {
-          Class.add(td, SEL_CLASS);
-        }
-        if (cell.locked) {
-          lockedCols[idx] = true;
-        }
-        Html.set(td, cell.html);
-        return td;
       });
-      const tr = SugarElement.fromTag('tr');
-      InsertAll.append(tr, cells);
-      return tr;
+
+      if (isCellRow) {
+        const tr = SugarElement.fromTag('tr');
+        InsertAll.append(tr, cells);
+        return tr;
+      } else {
+        const colgroup = SugarElement.fromTag('colgroup');
+        InsertAll.append(colgroup, cells);
+        return colgroup;
+      }
     });
     const withNewlines = Arr.bind(rows, (row) => {
       return [ SugarElement.fromText('\n'), row ];
@@ -112,11 +142,17 @@ UnitTest.test('CopySelectedTest', () => {
       const domCells = traverseChildElements(domRows[i]);
       assertWithInfo(row.length, domCells.length, 'number of cells in output row ' + i + ' to be ');
       Arr.each(row, (cell, j) => {
-        const domCell = domCells[j] as SugarElement<HTMLElement>;
-        assertWithInfo(cell.html, Html.get(domCell), 'cell text');
-        assertWithInfo(cell.rowspan, Attribute.get(domCell, 'rowspan'), 'rowspan');
-        assertWithInfo(cell.colspan, Attribute.get(domCell, 'colspan'), 'colspan');
-        assertWithInfo(cell.selected, Class.has(domCell, SEL_CLASS), 'selected class');
+        if (cell.type === 'cell') {
+          const domCell = domCells[j] as SugarElement<HTMLTableCellElement>;
+          assertWithInfo(cell.html, Html.get(domCell), 'cell text');
+          assertWithInfo(cell.rowspan, Attribute.get(domCell, 'rowspan'), 'rowspan');
+          assertWithInfo(cell.colspan, Attribute.get(domCell, 'colspan'), 'colspan');
+          assertWithInfo(cell.selected, Class.has(domCell, SEL_CLASS), 'selected class');
+        } else {
+          const domCol = domCells[j] as SugarElement<HTMLTableColElement>;
+          assertWithInfo(cell.id, Attribute.get(domCol, 'data-col-id'), 'col id');
+          assertWithInfo(cell.span, Attribute.get(domCol, 'span'), 'span');
+        }
       });
     });
   };
@@ -129,6 +165,16 @@ UnitTest.test('CopySelectedTest', () => {
     [
       [ s('A', 1, 1) ]
     ]);
+
+  check('entire table, single cell, colgroup',
+    [
+      [ dCol('1') ],
+      [ s('A') ]
+    ],
+    [
+      [ dCol('1') ],
+      [ s('A', 1, 1) ]
+    ]);
   // //////////////////////////////////////////////////
   check('entire table, simple',
     [
@@ -139,13 +185,30 @@ UnitTest.test('CopySelectedTest', () => {
       [ s('A', 1, 1), s('B', 1, 1) ],
       [ s('C', 1, 1), s('D', 1, 1) ]
     ]);
+
+  check('entire table, simple, colgroup',
+    [
+      [ dCol('1'), dCol('2') ],
+      [ s('A', 1, 1), s('B', 1, 1) ],
+      [ s('C', 1, 1), s('D', 1, 1) ]
+    ],
+    [
+      [ dCol('1'), dCol('2') ],
+      [ s('A', 1, 1), s('B', 1, 1) ],
+      [ s('C', 1, 1), s('D', 1, 1) ]
+    ]);
   // //////////////////////////////////////////////////
   const entireComplex = [
     [ s('A', 2, 2), s('B', 1, 1) ],
     [ s('C', 1, 1) ],
     [ s('D', 1, 1), s('E', 1, 1), s('F', 1, 1) ]
   ];
+  const entireComplexColgroup = [
+    [ dCol('1'), dCol('2'), dCol('3') ],
+    ...entireComplex
+  ];
   check('entire table, complex', entireComplex, entireComplex);
+  check('entire table, complex, colgroup', entireComplexColgroup, entireComplexColgroup);
   // //////////////////////////////////////////////////
   check('single row, simple',
     [
@@ -155,12 +218,34 @@ UnitTest.test('CopySelectedTest', () => {
       [ s('A', 1, 1), s('B', 1, 1), s('C', 1, 1) ],
       [ ns('D', 1, 2), ns('E', 1, 1) ]
     ]);
+
+  check('single row, simple, colgroup',
+    [
+      [ dCol('1'), dCol('2'), dCol('3') ],
+      [ s('A'), s('B'), s('C') ]
+    ],
+    [
+      [ dCol('1'), dCol('2'), dCol('3') ],
+      [ s('A', 1, 1), s('B', 1, 1), s('C', 1, 1) ],
+      [ ns('D', 1, 2), ns('E', 1, 1) ]
+    ]);
   // //////////////////////////////////////////////////
   check('single row, removing colspans',
     [
       [ s('A'), s('B'), s('C') ]
     ],
     [
+      [ s('A', 1, 1), s('B', 1, 2), s('C', 1, 1) ],
+      [ ns('D', 1, 2), ns('E', 1, 1), ns('F', 1, 1) ]
+    ]);
+
+  check('single row, removing colspans, colgroup',
+    [
+      [ dCol('1'), dCol('2'), dCol('3'), dCol('4') ],
+      [ s('A'), s('B'), s('C') ]
+    ],
+    [
+      [ dCol('1'), dCol('2'), dCol('3'), dCol('4') ],
       [ s('A', 1, 1), s('B', 1, 2), s('C', 1, 1) ],
       [ ns('D', 1, 2), ns('E', 1, 1), ns('F', 1, 1) ]
     ]);
@@ -176,6 +261,20 @@ UnitTest.test('CopySelectedTest', () => {
       [ s('D', 1, 1), ns('E', 1, 1), ns('F', 1, 1) ],
       [ s('G', 1, 1), ns('H', 1, 1), ns('I', 1, 1) ]
     ]);
+
+  check('single column, simple, colgroup',
+    [
+      [ dCol('1') ],
+      [ s('A') ],
+      [ s('D') ],
+      [ s('G') ]
+    ],
+    [
+      [ dCol('1'), dCol('2'), dCol('3') ],
+      [ s('A', 1, 1), ns('B', 1, 1), ns('C', 1, 1) ],
+      [ s('D', 1, 1), ns('E', 1, 1), ns('F', 1, 1) ],
+      [ s('G', 1, 1), ns('H', 1, 1), ns('I', 1, 1) ]
+    ]);
   // //////////////////////////////////////////////////
   check('single column, removing rowspans',
     [
@@ -184,6 +283,21 @@ UnitTest.test('CopySelectedTest', () => {
       [ s('I') ]
     ],
     [
+      [ s('A', 1, 1), ns('B', 1, 1), ns('C', 1, 1) ],
+      [ s('D', 2, 1), ns('E', 1, 1), ns('F', 1, 1) ],
+      [ ns('G', 1, 1), ns('H', 1, 1) ],
+      [ s('I', 1, 1), ns('J', 1, 1), ns('K', 1, 1) ]
+    ]);
+
+  check('single column, removing rowspans, colgroup',
+    [
+      [ dCol('1') ],
+      [ s('A') ],
+      [ s('D') ],
+      [ s('I') ]
+    ],
+    [
+      [ dCol('1'), dCol('2'), dCol('3') ],
       [ s('A', 1, 1), ns('B', 1, 1), ns('C', 1, 1) ],
       [ s('D', 2, 1), ns('E', 1, 1), ns('F', 1, 1) ],
       [ ns('G', 1, 1), ns('H', 1, 1) ],
@@ -217,6 +331,25 @@ UnitTest.test('CopySelectedTest', () => {
       [ ns('L', 1, 2), ns('M', 1, 1) ]
     ]
   );
+
+  check('non rectangular square in top right of complex table from polish demo, colgroup',
+    [
+      [ dCol('2'), dCol('3'), dCol('4') ],
+      [ s('B', 2, 2), s('C', 1, 1) ],
+      [ s('E', 2, 1) ],
+      [ gen(), gen() ]
+    ],
+    [
+      [ dCol('1'), dCol('2'), dCol('3'), dCol('4') ],
+      [ ns('A', 1, 1), s('B', 2, 2), s('C', 1, 1) ],
+      [ ns('D', 1, 1), s('E', 2, 1) ],
+      [ ns('F', 3, 3) ],
+      [ ns('G', 1, 1) ],
+      [ ns('H', 1, 1) ],
+      [ ns('I', 2, 1), ns('J', 1, 1), ns('K', 1, 2) ],
+      [ ns('L', 1, 2), ns('M', 1, 1) ]
+    ]
+  );
   // //////////////////////////////////////////////////
   check('square in top left of complex table from polish demo',
     [
@@ -224,6 +357,24 @@ UnitTest.test('CopySelectedTest', () => {
       [ s('D', 1, 1) ]
     ],
     [
+      [ s('A', 1, 1), s('B', 2, 2), ns('C', 1, 1) ],
+      [ s('D', 1, 1), ns('E', 2, 1) ],
+      [ ns('F', 3, 3) ],
+      [ ns('G', 1, 1) ],
+      [ ns('H', 1, 1) ],
+      [ ns('I', 2, 1), ns('J', 1, 1), ns('K', 1, 2) ],
+      [ ns('L', 1, 2), ns('M', 1, 1) ]
+    ]
+  );
+
+  check('square in top left of complex table from polish demo, colgroup',
+    [
+      [ dCol('1'), dCol('2'), dCol('3') ],
+      [ s('A', 1, 1), s('B', 2, 2) ],
+      [ s('D', 1, 1) ]
+    ],
+    [
+      [ dCol('1'), dCol('2'), dCol('3'), dCol('4') ],
       [ s('A', 1, 1), s('B', 2, 2), ns('C', 1, 1) ],
       [ s('D', 1, 1), ns('E', 2, 1) ],
       [ ns('F', 3, 3) ],
@@ -251,6 +402,26 @@ UnitTest.test('CopySelectedTest', () => {
       [ ns('L', 1, 2), ns('M', 1, 1) ]
     ]
   );
+
+  check('column from right side of complex table from polish demo, colgroup',
+    [
+      [ dCol('4') ],
+      [ s('C') ],
+      [ s('E') ],
+      [ s('G') ],
+      [ s('H') ]
+    ],
+    [
+      [ dCol('1'), dCol('2'), dCol('3'), dCol('4') ],
+      [ ns('A', 1, 1), ns('B', 2, 2), s('C', 1, 1) ],
+      [ ns('D', 1, 1), s('E', 2, 1) ],
+      [ ns('F', 3, 3) ],
+      [ s('G', 1, 1) ],
+      [ s('H', 1, 1) ],
+      [ ns('I', 2, 1), ns('J', 1, 1), ns('K', 1, 2) ],
+      [ ns('L', 1, 2), ns('M', 1, 1) ]
+    ]
+  );
   // //////////////////////////////////////////////////
   check('non rectangular small portion of complex table from polish demo',
     [
@@ -258,6 +429,24 @@ UnitTest.test('CopySelectedTest', () => {
       [ s('L', 1, 2), s('M', 1, 1) ]
     ],
     [ // K L M
+      [ ns('A', 1, 1), ns('B', 2, 2), ns('C', 1, 1) ],
+      [ ns('D', 1, 1), ns('E', 2, 1) ],
+      [ ns('F', 3, 3) ],
+      [ ns('G', 1, 1) ],
+      [ ns('H', 1, 1) ],
+      [ ns('I', 2, 1), ns('J', 1, 1), s('K', 1, 2) ],
+      [ s('L', 1, 2), s('M', 1, 1) ]
+    ]
+  );
+
+  check('non rectangular small portion of complex table from polish demo, colgroup',
+    [
+      [ dCol('2'), dCol('3'), dCol('4') ],
+      [ gen(), s('K', 1, 2) ],
+      [ s('L', 1, 2), s('M', 1, 1) ]
+    ],
+    [ // K L M
+      [ dCol('1'), dCol('2'), dCol('3'), dCol('4') ],
       [ ns('A', 1, 1), ns('B', 2, 2), ns('C', 1, 1) ],
       [ ns('D', 1, 1), ns('E', 2, 1) ],
       [ ns('F', 3, 3) ],
@@ -287,6 +476,28 @@ UnitTest.test('CopySelectedTest', () => {
       [ ns('L', 1, 2), ns('M', 1, 1) ]
     ]
   );
+
+  check('non rectangular complex middle of complex table from polish demo, colgroup',
+    [
+      [ dCol('1'), dCol('2'), dCol('3'), dCol('4') ],
+      [ gen(), s('B', 2, 2), gen() ],
+      [ gen(), gen() ],
+      [ s('F', 3, 3), gen() ],
+      [ gen() ],
+      [ gen() ],
+      [ gen(), s('J', 1, 1), s('K', 1, 2) ]
+    ],
+    [ // B F J K
+      [ dCol('1'), dCol('2'), dCol('3'), dCol('4') ],
+      [ ns('A', 1, 1), s('B', 2, 2), ns('C', 1, 1) ],
+      [ ns('D', 1, 1), ns('E', 2, 1) ],
+      [ s('F', 3, 3) ],
+      [ ns('G', 1, 1) ],
+      [ ns('H', 1, 1) ],
+      [ ns('I', 2, 1), s('J', 1, 1), s('K', 1, 2) ],
+      [ ns('L', 1, 2), ns('M', 1, 1) ]
+    ]
+  );
   // //////////////////////////////////////////////////
   check('single column, simple with locked cells',
     [
@@ -299,6 +510,20 @@ UnitTest.test('CopySelectedTest', () => {
       [ s('D', 1, 1, true), ns('E', 1, 1), ns('F', 1, 1) ],
       [ s('G', 1, 1, true), ns('H', 1, 1), ns('I', 1, 1) ]
     ], { beforeCopy: {}, afterCopy: [ LOCKED_COL_ATTR ] });
+
+  check('single column, simple with locked cells, colgroup',
+    [
+      [ dCol('1') ],
+      [ s('A') ],
+      [ s('D') ],
+      [ s('G') ]
+    ],
+    [
+      [ dCol('1'), dCol('2'), dCol('3') ],
+      [ s('A', 1, 1, true), ns('B', 1, 1), ns('C', 1, 1) ],
+      [ s('D', 1, 1, true), ns('E', 1, 1), ns('F', 1, 1) ],
+      [ s('G', 1, 1, true), ns('H', 1, 1), ns('I', 1, 1) ]
+    ], { beforeCopy: {}, afterCopy: [ LOCKED_COL_ATTR ] });
   // //////////////////////////////////////////////////
   check('single column, simple with removable table attributes',
     [
@@ -307,6 +532,28 @@ UnitTest.test('CopySelectedTest', () => {
       [ s('G') ]
     ],
     [
+      [ s('A', 1, 1), ns('B', 1, 1), ns('C', 1, 1) ],
+      [ s('D', 1, 1), ns('E', 1, 1), ns('F', 1, 1) ],
+      [ s('G', 1, 1), ns('H', 1, 1), ns('I', 1, 1) ]
+    ],
+    {
+      beforeCopy: {
+        [ LOCKED_COL_ATTR ]: '0',
+        'data-snooker-col-series': 'numbers'
+      },
+      afterCopy: [ LOCKED_COL_ATTR, 'data-snooker-col-series' ]
+    }
+  );
+
+  check('single column, simple with removable table attributes, colgroup',
+    [
+      [ dCol('1') ],
+      [ s('A') ],
+      [ s('D') ],
+      [ s('G') ]
+    ],
+    [
+      [ dCol('1'), dCol('2'), dCol('3') ],
       [ s('A', 1, 1), ns('B', 1, 1), ns('C', 1, 1) ],
       [ s('D', 1, 1), ns('E', 1, 1), ns('F', 1, 1) ],
       [ s('G', 1, 1), ns('H', 1, 1), ns('I', 1, 1) ]

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed the dev ZIP missing the required `bin` scripts to build from the source #TINY-8542
 - Fixed a regression whereby text patterns couldn't be updated at runtime #TINY-8540
-- Fixed an issue where colgroup tables could be copied incorrectly in some cases #TINY-8568
+- Fixed an issue where tables with colgroups could be copied incorrectly in some cases #TINY-8568
 - Naked buttons better adapt to various background colors, improved text contrast in notifications #TINY-8533
 - The autocompleter would not fire the `AutocompleterStart` event nor close the menu in some cases #TINY-8552
 - Clipboard content was not generated correctly when cutting and copying `contenteditable="false"` elements #TINY-8563

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed the dev ZIP missing the required `bin` scripts to build from the source #TINY-8542
 - Fixed a regression whereby text patterns couldn't be updated at runtime #TINY-8540
+- Fixed an issue where colgroup tables could be copied incorrectly in some cases #TINY-8568
 - Naked buttons better adapt to various background colors, improved text contrast in notifications #TINY-8533
 - The autocompleter would not fire the `AutocompleterStart` event nor close the menu in some cases #TINY-8552
 - Clipboard content was not generated correctly when cutting and copying `contenteditable="false"` elements #TINY-8563


### PR DESCRIPTION
Related Ticket: TINY-8568

Description of Changes:
* Make sure only `td` cells are passed to the `fillInGaps` function. Handling of cols is done further down in the `clean` function already

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
