### PR TITLE
TINY-4519:  Fixed incorrect Jira number used in the changelog

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -133,7 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed support for Microsoft Word from the opensource paste functionality #TINY-7493
 - Removed support for the `plugins` option allowing a mixture of a string array and of space separated strings #TINY-8399
 - Removed support for the deprecated `false` value for the `forced_root_block` option #TINY-8260
-- Removed the jQuery integration #TINY-4518
+- Removed the jQuery integration #TINY-4519
 - Removed the `imagetools` plugin, which is now classified as a Premium plugin #TINY-8209
 - Removed the `imagetools` dialog component #TINY-8333
 - Removed the `toc` plugin, which is now classified as a Premium plugin #TINY-8250


### PR DESCRIPTION
updated the jquery changelog from TINY-4518 to TINY-4519
Related Ticket:

Description of Changes:
* the original change log entry was incorrect, but now it has been updated

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
