### PR TITLE
TINY-8589: Cleaned up API documentation

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
@@ -18,29 +18,29 @@ import I18n from './util/I18n';
  * @class tinymce.Theme
  * @example
  * tinymce.ThemeManager.add('MyTheme', (editor) => {
- *     // Setup up custom UI elements in the dom
- *     var div = document.createElement('div');
- *     var iframe = document.createElement('iframe');
- *     document.body.appendChild(div);
- *     document.body.appendChild(iframe);
+ *   // Setup up custom UI elements in the dom
+ *   const div = document.createElement('div');
+ *   const iframe = document.createElement('iframe');
+ *   document.body.appendChild(div);
+ *   document.body.appendChild(iframe);
  *
- *     // Themes should fire the SkinLoaded event once the UI has been created and all StyleSheets have been loaded.
- *     editor.on('init', function() {
- *         editor.fire('SkinLoaded');
- *     });
+ *   // Themes should fire the SkinLoaded event once the UI has been created and all StyleSheets have been loaded.
+ *   editor.on('init', () => {
+ *     editor.fire('SkinLoaded');
+ *   });
  *
- *     // Themes must return a renderUI function that returns the editorContainer. If the editor is not running in inline mode, an iframeContainer should also be returned.
- *     var renderUI = function() {
- *         return {
- *             editorContainer: div,
- *             iframeContainer: iframe
- *         };
- *     };
- *
- *     // Return the renderUI function
+ *   // Themes must return a renderUI function that returns the editorContainer. If the editor is not running in inline mode, an iframeContainer should also be returned.
+ *   const renderUI = () => {
  *     return {
- *         renderUI: renderUI
+ *       editorContainer: div,
+ *       iframeContainer: iframe
  *     };
+ *   };
+ *
+ *   // Return the renderUI function
+ *   return {
+ *     renderUI: renderUI
+ *   };
  * });
  */
 
@@ -57,29 +57,29 @@ import I18n from './util/I18n';
  * @class tinymce.Plugin
  * @example
  * tinymce.PluginManager.add('MyPlugin', (editor, url) => {
- *     // Register a toolbar button that triggers an alert when clicked
- *     // To show this button in the editor, include it in the toolbar setting
- *     editor.ui.registry.addButton('myCustomToolbarButton', {
- *         text: 'My custom button',
- *         onAction: function() {
- *             alert('Button clicked!');
- *         }
- *     });
+ *   // Register a toolbar button that triggers an alert when clicked
+ *   // To show this button in the editor, include it in the toolbar setting
+ *   editor.ui.registry.addButton('myCustomToolbarButton', {
+ *     text: 'My custom button',
+ *     onAction: () => {
+ *       alert('Button clicked!');
+ *     }
+ *   });
  *
- *     // Register a menu item that triggers an alert when clicked
- *     // To show this menu item in the editor, include it in the menu setting
- *     editor.ui.registry.addMenuItem('myCustomMenuItem', {
- *         text: 'My custom menu item',
- *         onAction: function() {
- *             alert('Menu item clicked');
- *         }
- *     });
+ *   // Register a menu item that triggers an alert when clicked
+ *   // To show this menu item in the editor, include it in the menu setting
+ *   editor.ui.registry.addMenuItem('myCustomMenuItem', {
+ *     text: 'My custom menu item',
+ *     onAction: () => {
+ *       alert('Menu item clicked');
+ *     }
+ *   });
  *
- *     // Either return plugin metadata or do not return
- *     return {
- *         name: 'MyPlugin',
- *         url: 'https://mydocs.com/myplugin'
- *     };
+ *   // Either return plugin metadata or do not return
+ *   return {
+ *     name: 'MyPlugin',
+ *     url: 'https://mydocs.com/myplugin'
+ *   };
  * });
  */
 
@@ -244,21 +244,19 @@ const AddOnManager = <T>(): AddOnManager<T> => {
      * @return {tinymce.Theme/tinymce.Plugin} The same theme or plugin instance that got passed in.
      * @example
      * // Create a simple plugin
-     * tinymce.create('tinymce.plugins.TestPlugin', {
-     *   TestPlugin: function(ed, url) {
-     *   ed.on('click', function(e) {
-     *      ed.windowManager.alert('Hello World!');
+     * const TestPlugin = (ed, url) => {
+     *   ed.on('click', (e) => {
+     *     ed.windowManager.alert('Hello World!');
      *   });
-     *   }
-     * });
+     * };
      *
      * // Register plugin using the add method
-     * tinymce.PluginManager.add('test', tinymce.plugins.TestPlugin);
+     * tinymce.PluginManager.add('test', TestPlugin);
      *
      * // Initialize TinyMCE
      * tinymce.init({
-     *  ...
-     *  plugins: '-test' // Init the plugin but don't try to load it
+     *   ...
+     *   plugins: '-test' // Init the plugin but don't try to load it
      * });
      */
     add,
@@ -280,8 +278,8 @@ const AddOnManager = <T>(): AddOnManager<T> => {
      *
      * // Initialize TinyMCE
      * tinymce.init({
-     *  ...
-     *  plugins: '-myplugin' // Don't try to load it again
+     *   ...
+     *   plugins: '-myplugin' // Don't try to load it again
      * });
      */
     load,

--- a/modules/tinymce/src/core/main/ts/api/Annotator.ts
+++ b/modules/tinymce/src/core/main/ts/api/Annotator.ts
@@ -66,7 +66,7 @@ const Annotator = (editor: Editor): Annotator => {
      *
      * @method annotationChanged
      * @param {String} name Name of annotation to listen for
-     * @param {function} callback Calback with (state, name, and data) fired when the annotation
+     * @param {Function} callback Callback with (state, name, and data) fired when the annotation
      * at the cursor changes. If state if false, data will not be provided.
      */
     annotationChanged: (name: string, callback: AnnotationListenerApi) => {

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -56,7 +56,7 @@ import WindowManager from './WindowManager';
  * tinymce.activeEditor.dom.addClass(tinymce.activeEditor.dom.select('p'), 'someclass');
  *
  * // Gets the current editors selection as text
- * tinymce.activeEditor.selection.getContent({format: 'text'});
+ * tinymce.activeEditor.selection.getContent({ format: 'text' });
  *
  * // Creates a new editor instance
  * const ed = new tinymce.Editor('textareaid', {
@@ -456,7 +456,7 @@ class Editor implements EditorObservable {
    *   setup: (ed) => {
    *     // Register example command
    *     ed.addCommand('mycommand', (ui, v) => {
-   *       ed.windowManager.alert('Hello world!! Selection: ' + ed.selection.getContent({format: 'text'}));
+   *       ed.windowManager.alert('Hello world!! Selection: ' + ed.selection.getContent({ format: 'text' }));
    *     });
    *   }
    * });
@@ -787,7 +787,7 @@ class Editor implements EditorObservable {
    * tinymce.get('my_editor').setContent(data);
    *
    * // Sets the content of the activeEditor editor using the specified format
-   * tinymce.activeEditor.setContent('<p>Some html</p>', {format: 'html'});
+   * tinymce.activeEditor.setContent('<p>Some html</p>', { format: 'html' });
    */
   public setContent(content: string, args?: Partial<EditorContent.SetContentArgs>): string;
   public setContent(content: AstNode, args?: Partial<EditorContent.SetContentArgs>): AstNode;
@@ -808,7 +808,7 @@ class Editor implements EditorObservable {
    * console.debug(tinymce.activeEditor.getContent());
    *
    * // Get the contents of the currently active editor as plain text
-   * tinymce.activeEditor.getContent({format: 'text'});
+   * tinymce.activeEditor.getContent({ format: 'text' });
    *
    * // Get content of a specific editor:
    * tinymce.get('content id').getContent()

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -59,8 +59,8 @@ import WindowManager from './WindowManager';
  * tinymce.activeEditor.selection.getContent({format: 'text'});
  *
  * // Creates a new editor instance
- * var ed = new tinymce.Editor('textareaid', {
- *     some_setting: 1
+ * const ed = new tinymce.Editor('textareaid', {
+ *   some_setting: 1
  * }, tinymce.EditorManager);
  *
  * ed.render();
@@ -169,7 +169,7 @@ class Editor implements EditorObservable {
    * Editor options API
    *
    * @property options
-   * @type tinymce.options.Options
+   * @type tinymce.EditorOptions
    */
   public options: EditorOptions;
 
@@ -381,10 +381,10 @@ class Editor implements EditorObservable {
    * @deprecated Use editor.options.get instead
    * @example
    * // Returns a specific config value from the currently active editor
-   * var someval = tinymce.activeEditor.getParam('myvalue');
+   * const someval = tinymce.activeEditor.getParam('myvalue');
    *
    * // Returns a specific config value from a specific editor instance by id
-   * var someval2 = tinymce.get('my_editor').getParam('myvalue');
+   * const someval2 = tinymce.get('my_editor').getParam('myvalue');
    */
   public getParam <K extends BuiltInOptionType>(name: string, defaultVal: BuiltInOptionTypeMap[K], type: K): BuiltInOptionTypeMap[K];
   public getParam <K extends keyof NormalizedEditorOptions>(name: K, defaultVal?: NormalizedEditorOptions[K], type?: BuiltInOptionType): NormalizedEditorOptions[K];
@@ -446,19 +446,19 @@ class Editor implements EditorObservable {
    *
    * @method addCommand
    * @param {String} name Command name to add/override.
-   * @param {addCommandCallback} callback Function to execute when the command occurs.
+   * @param {Function} callback Function to execute when the command occurs.
    * @param {Object} scope Optional scope to execute the function in.
    * @example
    * // Adds a custom command that later can be executed using execCommand
    * tinymce.init({
-   *    ...
+   *  ...
    *
-   *    setup: function(ed) {
-   *       // Register example command
-   *       ed.addCommand('mycommand', function(ui, v) {
-   *          ed.windowManager.alert('Hello world!! Selection: ' + ed.selection.getContent({format: 'text'}));
-   *       });
-   *    }
+   *   setup: (ed) => {
+   *     // Register example command
+   *     ed.addCommand('mycommand', (ui, v) => {
+   *       ed.windowManager.alert('Hello world!! Selection: ' + ed.selection.getContent({format: 'text'}));
+   *     });
+   *   }
    * });
    */
   public addCommand(name: string, callback: EditorCommandCallback, scope?: object) {
@@ -479,7 +479,7 @@ class Editor implements EditorObservable {
    *
    * @method addQueryStateHandler
    * @param {String} name Command name to add/override.
-   * @param {addQueryStateHandlerCallback} callback Function to execute when the command state retrieval occurs.
+   * @param {Function} callback Function to execute when the command state retrieval occurs.
    * @param {Object} scope Optional scope to execute the function in.
    */
   public addQueryStateHandler(name: string, callback: () => boolean, scope?: any) {
@@ -498,7 +498,7 @@ class Editor implements EditorObservable {
    *
    * @method addQueryValueHandler
    * @param {String} name Command name to add/override.
-   * @param {addQueryValueHandlerCallback} callback Function to execute when the command value retrieval occurs.
+   * @param {Function} callback Function to execute when the command value retrieval occurs.
    * @param {Object} scope Optional scope to execute the function in.
    */
   public addQueryValueHandler(name: string, callback: () => string, scope?: any) {
@@ -521,21 +521,19 @@ class Editor implements EditorObservable {
    * @param {Object} scope Optional scope to execute the function in.
    * @return {Boolean} true/false state if the shortcut was added or not.
    * @example
-   * editor.addShortcut('ctrl+a', "description of the shortcut", function() {});
-   * editor.addShortcut('ctrl+alt+a', "description of the shortcut", function() {});
+   * editor.addShortcut('ctrl+a', 'description of the shortcut', () => {});
+   * editor.addShortcut('ctrl+alt+a', 'description of the shortcut', () => {});
    * // "meta" maps to Command on Mac and Ctrl on PC
-   * editor.addShortcut('meta+a', "description of the shortcut", function() {});
+   * editor.addShortcut('meta+a', 'description of the shortcut', () => {});
    * // "access" maps to Control+Option on Mac and shift+alt on PC
-   * editor.addShortcut('access+a', "description of the shortcut", function() {});
+   * editor.addShortcut('access+a', 'description of the shortcut', () => {});
    *
-   * editor.addShortcut(
-   *  'meta+access+c', 'Opens the code editor dialog.', function () {
-   *    editor.execCommand('mceCodeEditor');
+   * editor.addShortcut('meta+access+c', 'Opens the code editor dialog.', () => {
+   *   editor.execCommand('mceCodeEditor');
    * });
    *
-   * editor.addShortcut(
-   *  'meta+shift+32', 'Inserts "Hello, World!" for meta+shift+space', function () {
-   *    editor.execCommand('mceInsertContent', false, 'Hello, World!');
+   * editor.addShortcut('meta+shift+32', 'Inserts "Hello, World!" for meta+shift+space', () => {
+   *   editor.execCommand('mceInsertContent', false, 'Hello, World!');
    * });
    */
   public addShortcut(pattern: string, desc: string, cmdFunc: string | [string, boolean, any] | (() => void), scope?: any) {
@@ -549,7 +547,7 @@ class Editor implements EditorObservable {
    * @method execCommand
    * @param {String} cmd Command name to execute, for example mceLink or Bold.
    * @param {Boolean} ui Specifies if a UI (dialog) should be presented or not.
-   * @param {{Object/Array/String/Number/Boolean} value Optional command value, this can be anything.
+   * @param {Object/Array/String/Number/Boolean} value Optional command value, this can be anything.
    * @param {Object} args Optional arguments object.
    * @return {Boolean} true or false if the command was supported or not.
    */
@@ -561,7 +559,7 @@ class Editor implements EditorObservable {
    * Returns a command specific state, for example if bold is enabled or not.
    *
    * @method queryCommandState
-   * @param {string} cmd Command to query state from.
+   * @param {String} cmd Command to query state from.
    * @return {Boolean} Command specific state, for example if bold is enabled or not.
    */
   public queryCommandState(cmd: string): boolean {
@@ -572,8 +570,8 @@ class Editor implements EditorObservable {
    * Returns a command specific value, for example the current font size.
    *
    * @method queryCommandValue
-   * @param {string} cmd Command to query value from.
-   * @return {string} Command value, for example the current font size or an empty string (`""`) if the query command is not found.
+   * @param {String} cmd Command to query value from.
+   * @return {String} Command value, for example the current font size or an empty string (`""`) if the query command is not found.
    */
   public queryCommandValue(cmd: string): string {
     return this.editorCommands.queryCommandValue(cmd);
@@ -869,8 +867,9 @@ class Editor implements EditorObservable {
    * @method isDirty
    * @return {Boolean} True/false if the editor is dirty or not. It will get dirty if the user has made modifications to the contents.
    * @example
-   * if (tinymce.activeEditor.isDirty())
-   *     alert("You must save your contents.");
+   * if (tinymce.activeEditor.isDirty()) {
+   *   alert("You must save your contents.");
+   * }
    */
   public isDirty() {
     return !this.isNotDirty;
@@ -883,13 +882,13 @@ class Editor implements EditorObservable {
    * @method setDirty
    * @param {Boolean} state True/false if the editor is considered dirty.
    * @example
-   * function ajaxSave() {
-   *     var editor = tinymce.get('elm1');
+   * const ajaxSave = () => {
+   *   const editor = tinymce.get('elm1');
    *
-   *     // Save contents using some XHR call
-   *     alert(editor.getContent());
+   *   // Save contents using some XHR call
+   *   alert(editor.getContent());
    *
-   *     editor.setDirty(false); // Force not dirty state
+   *   editor.setDirty(false); // Force not dirty state
    * }
    */
   public setDirty(state: boolean) {
@@ -1004,10 +1003,10 @@ class Editor implements EditorObservable {
    * manipulation functions.
    *
    * @method convertURL
-   * @param {string} url URL to convert.
-   * @param {string} name Attribute name src, href etc.
-   * @param {string/HTMLElement} elm Tag name or HTML DOM element depending on HTML or DOM insert.
-   * @return {string} Converted URL string.
+   * @param {String} url URL to convert.
+   * @param {String} name Attribute name src, href etc.
+   * @param {String/HTMLElement} elm Tag name or HTML DOM element depending on HTML or DOM insert.
+   * @return {String} Converted URL string.
    */
   public convertURL(url: string, name: string, elm?): string {
     const self = this, getOption = self.options.get;

--- a/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
@@ -106,8 +106,8 @@ class EditorCommands {
    * Returns a command specific value, for example the current font size.
    *
    * @method queryCommandValue
-   * @param {string} cmd Command to query value from.
-   * @return {string} Command value, for example the current font size or an empty string (`""`) if the query command is not found.
+   * @param {String} cmd Command to query value from.
+   * @return {String} Command value, for example the current font size or an empty string (`""`) if the query command is not found.
    */
   public queryCommandValue(command: string): string {
     if (this.editor.quirks.isHidden() || this.editor.removed) {

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -318,9 +318,9 @@ const EditorManager: EditorManager = {
    *
    * // Initializes a editor instance using the shorter version and with a promise
    * tinymce.init({
-   *    some_settings : 'some value'
-   * }).then(function(editors) {
-   *    ...
+   *   some_settings : 'some value'
+   * }).then((editors) => {
+   *   ...
    * });
    */
   init(options: RawEditorOptions) {
@@ -448,18 +448,18 @@ const EditorManager: EditorManager = {
    * @return {tinymce.Editor/Array} Editor instance or an array of editor instances.
    * @example
    * // Adds an onclick event to an editor by id
-   * tinymce.get('mytextbox').on('click', function(e) {
-   *    ed.windowManager.alert('Hello world!');
+   * tinymce.get('mytextbox').on('click', (e) => {
+   *   ed.windowManager.alert('Hello world!');
    * });
    *
    * // Adds an onclick event to an editor by index
-   * tinymce.get(0).on('click', function(e) {
-   *    ed.windowManager.alert('Hello world!');
+   * tinymce.get(0).on('click', (e) => {
+   *   ed.windowManager.alert('Hello world!');
    * });
    *
    * // Adds an onclick event to an editor by id (longer version)
-   * tinymce.EditorManager.get('mytextbox').on('click', function(e) {
-   *    ed.windowManager.alert('Hello world!');
+   * tinymce.EditorManager.get('mytextbox').on('click', (e) => {
+   *   ed.windowManager.alert('Hello world!');
    * });
    */
   // eslint-disable-next-line prefer-arrow/prefer-arrow-functions

--- a/modules/tinymce/src/core/main/ts/api/EditorObservable.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorObservable.ts
@@ -20,7 +20,7 @@ const DOM = DOMUtils.DOM;
 let customEventRootDelegates;
 
 /**
- * Returns the event target so for the specified event. Some events fire
+ * Returns the event target for the specified event. Some events fire
  * only on document, some fire on documentElement etc. This also handles the
  * custom event root setting where it returns that element instead of the body.
  *

--- a/modules/tinymce/src/core/main/ts/api/EditorOptions.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorOptions.ts
@@ -52,9 +52,9 @@ export interface OptionSpec<T, U> extends BaseOptionSpec {
 }
 
 /**
- * TinyMCE Options API.
+ * TinyMCE Editor Options API.
  *
- * @class tinymce.editor.Options
+ * @class tinymce.EditorOptions
  */
 
 export interface Options {

--- a/modules/tinymce/src/core/main/ts/api/FakeClipboard.ts
+++ b/modules/tinymce/src/core/main/ts/api/FakeClipboard.ts
@@ -21,7 +21,7 @@ interface FakeClipboard {
   /**
    * Create a FakeClipboardItem instance that is used when reading or writing data via the FakeClipboard API.
    *
-   * @constructor FakeClipboardItem
+   * @method FakeClipboardItem
    * @param {Object} items An object with the type as the key and any data as the value.
    * @returns {FakeClipboard.FakeClipboardItem} A new fake clipboard item to represent the specified items.
    */

--- a/modules/tinymce/src/core/main/ts/api/FakeClipboard.ts
+++ b/modules/tinymce/src/core/main/ts/api/FakeClipboard.ts
@@ -21,9 +21,9 @@ interface FakeClipboard {
   /**
    * Create a FakeClipboardItem instance that is used when reading or writing data via the FakeClipboard API.
    *
-   * @method FakeClipboardItem
+   * @constructor FakeClipboardItem
    * @param {Object} items An object with the type as the key and any data as the value.
-   * @returns {tinymce.FakeClipboard.FakeClipboardItem} A new fake clipboard item to represent the specified items.
+   * @returns {FakeClipboard.FakeClipboardItem} A new fake clipboard item to represent the specified items.
    */
   readonly FakeClipboardItem: (items: Record<string, any>) => FakeClipboardItem;
 

--- a/modules/tinymce/src/core/main/ts/api/Formatter.ts
+++ b/modules/tinymce/src/core/main/ts/api/Formatter.ts
@@ -20,7 +20,7 @@ import Editor from './Editor';
  * @example
  * tinymce.activeEditor.formatter.register('mycustomformat', {
  *   inline: 'span',
- *   styles: {color: '#ff0000'}
+ *   styles: { color: '#ff0000' }
  * });
  *
  * tinymce.activeEditor.formatter.apply('mycustomformat');

--- a/modules/tinymce/src/core/main/ts/api/Formatter.ts
+++ b/modules/tinymce/src/core/main/ts/api/Formatter.ts
@@ -11,18 +11,19 @@ import { RangeLikeObject } from '../selection/RangeTypes';
 import Editor from './Editor';
 
 /**
+ * @summary
  * Text formatter engine class. This class is used to apply formats like bold, italic, font size
  * etc to the current selection or specific nodes. This engine was built to replace the browser's
  * default formatting logic for execCommand due to its inconsistent and buggy behavior.
  *
  * @class tinymce.Formatter
  * @example
- *  tinymce.activeEditor.formatter.register('mycustomformat', {
- *    inline: 'span',
- *    styles: {color: '#ff0000'}
- *  });
+ * tinymce.activeEditor.formatter.register('mycustomformat', {
+ *   inline: 'span',
+ *   styles: {color: '#ff0000'}
+ * });
  *
- *  tinymce.activeEditor.formatter.apply('mycustomformat');
+ * tinymce.activeEditor.formatter.apply('mycustomformat');
  */
 
 interface Formatter extends FormatRegistry {
@@ -60,7 +61,7 @@ const Formatter = (editor: Editor): Formatter => {
      *
      * @method has
      * @param {String} name Format name to check if a format exists.
-     * @return {boolean} True/False if a format for the specified name exists.
+     * @return {Boolean} True/False if a format for the specified name exists.
      */
     has: formats.has,
 
@@ -126,7 +127,7 @@ const Formatter = (editor: Editor): Formatter => {
      * @param {Object} vars Optional list of variables to replace before checking it.
      * @param {Node} node Optional node to check.
      * @param {Boolean} similar Optional argument to specify that similar formats should be checked instead of only exact formats.
-     * @return {boolean} true/false if the specified selection/node matches the format.
+     * @return {Boolean} true/false if the specified selection/node matches the format.
      */
     match: (name, vars?, node?, similar?) => Rtc.matchFormat(editor, name, vars, node, similar),
 
@@ -169,7 +170,7 @@ const Formatter = (editor: Editor): Formatter => {
      *
      * @method canApply
      * @param {String} name Name of format to check.
-     * @return {boolean} true/false if the specified format can be applied to the current selection/node.
+     * @return {Boolean} true/false if the specified format can be applied to the current selection/node.
      */
     canApply: (name) => Rtc.canApplyFormat(editor, name),
 
@@ -178,7 +179,7 @@ const Formatter = (editor: Editor): Formatter => {
      *
      * @method formatChanged
      * @param {String} formats Comma separated list of formats to check for.
-     * @param {function} callback Callback with state and args when the format is changed/toggled on/off.
+     * @param {Function} callback Callback with state and args when the format is changed/toggled on/off.
      * @param {Boolean} similar True/false state if the match should handle similar or exact formats.
      * @param {Object} vars Restrict the format being watched to only match if the variables applied are equal to vars.
      */
@@ -191,8 +192,8 @@ const Formatter = (editor: Editor): Formatter => {
      * @param {String/Object} format Format to generate preview css text for.
      * @return {String} Css text for the specified format.
      * @example
-     * var cssText1 = editor.formatter.getCssText('bold');
-     * var cssText2 = editor.formatter.getCssText({inline: 'b'});
+     * const cssText1 = editor.formatter.getCssText('bold');
+     * const cssText2 = editor.formatter.getCssText({ inline: 'b' });
      */
     getCssText: Fun.curry(Preview.getCssText, editor)
   };

--- a/modules/tinymce/src/core/main/ts/api/Mode.ts
+++ b/modules/tinymce/src/core/main/ts/api/Mode.ts
@@ -5,7 +5,7 @@ import { isReadOnly, registerReadOnlyContentFilters, registerReadOnlySelectionBl
 import Editor from './Editor';
 
 /**
- * TinyMCE 5 Mode API.
+ * TinyMCE Editor Mode API.
  *
  * @class tinymce.EditorMode
  */
@@ -63,7 +63,7 @@ export interface EditorModeApi {
    * Flags whether the editor should be made readonly while this mode is active.
    *
    * @property editorReadOnly
-   * @type boolean
+   * @type Boolean
    */
   editorReadOnly: boolean;
 }

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -45,8 +45,8 @@ interface NotificationManager {
  * @example
  * // Opens a new notification of type "error" with text "An error occurred."
  * tinymce.activeEditor.notificationManager.open({
- *    text: 'An error occurred.',
- *    type: 'error'
+ *   text: 'An error occurred.',
+ *   type: 'error'
  * });
  */
 

--- a/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
+++ b/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
@@ -7,21 +7,19 @@ import Tools from './util/Tools';
  *
  * @class tinymce.Shortcuts
  * @example
- * editor.shortcuts.add('ctrl+a', "description of the shortcut", function() {});
- * editor.shortcuts.add('ctrl+alt+a', "description of the shortcut", function() {});
+ * editor.shortcuts.add('ctrl+a', 'description of the shortcut', () => {});
+ * editor.shortcuts.add('ctrl+alt+a', 'description of the shortcut', () => {});
  * // "meta" maps to Command on Mac and Ctrl on PC
- * editor.shortcuts.add('meta+a', "description of the shortcut", function() {});
+ * editor.shortcuts.add('meta+a', 'description of the shortcut', () => {});
  * // "access" maps to Control+Option on Mac and shift+alt on PC
- * editor.shortcuts.add('access+a', "description of the shortcut", function() {});
+ * editor.shortcuts.add('access+a', 'description of the shortcut', () => {});
  *
- * editor.shortcuts.add(
- *  'meta+access+c', 'Opens the code editor dialog.', function () {
- *    editor.execCommand('mceCodeEditor');
+ * editor.shortcuts.add('meta+access+c', 'Opens the code editor dialog.', () => {
+ *   editor.execCommand('mceCodeEditor');
  * });
  *
- * editor.shortcuts.add(
- *  'meta+shift+32', 'Inserts "Hello, World!" for meta+shift+space', function () {
- *    editor.execCommand('mceInsertContent', false, 'Hello, World!');
+ * editor.shortcuts.add('meta+shift+32', 'Inserts "Hello, World!" for meta+shift+space', () => {
+ *   editor.execCommand('mceInsertContent', false, 'Hello, World!');
  * });
  */
 

--- a/modules/tinymce/src/core/main/ts/api/UndoManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/UndoManager.ts
@@ -115,7 +115,7 @@ const UndoManager = (editor: Editor): UndoManager => {
      * be ignored. So a translation can include calls to execCommand or editor.insertContent.
      *
      * @method transact
-     * @param {function} callback Function that gets executed and has dom manipulation logic in it.
+     * @param {Function} callback Function that gets executed and has dom manipulation logic in it.
      * @return {Object} Undo level that got added or null it a level wasn't needed.
      */
     transact: (callback: () => void): UndoLevel => {
@@ -128,7 +128,7 @@ const UndoManager = (editor: Editor): UndoManager => {
      * include calls to execCommand or editor.insertContent.
      *
      * @method ignore
-     * @param {function} callback Function that gets executed and has dom manipulation logic in it.
+     * @param {Function} callback Function that gets executed and has dom manipulation logic in it.
      */
     ignore: (callback: () => void) => {
       Rtc.ignore(editor, locks, callback);
@@ -140,8 +140,8 @@ const UndoManager = (editor: Editor): UndoManager => {
      * undo level that the user doesn't see until they undo.
      *
      * @method extra
-     * @param {function} callback1 Function that does mutation but gets stored as a "hidden" extra undo level.
-     * @param {function} callback2 Function that does mutation but gets displayed to the user.
+     * @param {Function} callback1 Function that does mutation but gets stored as a "hidden" extra undo level.
+     * @param {Function} callback2 Function that does mutation but gets displayed to the user.
      */
     extra: (callback1: () => void, callback2: () => void) => {
       Rtc.extra(editor, undoManager, index, callback1, callback2);

--- a/modules/tinymce/src/core/main/ts/api/WindowManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/WindowManager.ts
@@ -11,19 +11,20 @@ import { Dialog } from './ui/Ui';
  * @class tinymce.WindowManager
  * @example
  * // Opens a new dialog with the file.htm file and the size 320x240
- * // It also adds a custom parameter this can be retrieved by using tinyMCEPopup.getWindowArg inside the dialog.
- * tinymce.activeEditor.windowManager.open({
- *    url: 'file.htm',
- *    width: 320,
- *    height: 240
- * }, {
- *    custom_param: 1
+ * tinymce.activeEditor.windowManager.openUrl({
+ *   title: 'Custom Dialog',
+ *   url: 'file.htm',
+ *   width: 320,
+ *   height: 240
  * });
  *
  * // Displays an alert box using the active editors window manager instance
  * tinymce.activeEditor.windowManager.alert('Hello world!');
  *
- * // Displays an confirm box and an alert message will be displayed depending on what you choose in the confirm
+ * // Displays a confirm box and an alert message will be displayed depending on what you choose in the confirm
+ * tinymce.activeEditor.windowManager.confirm('Do you want to do something?', (state) => {
+ *   const message = state ? 'Ok' : 'Cancel';
+ *   tinymce.activeEditor.windowManager.alert(message);
  * });
  */
 
@@ -160,7 +161,7 @@ const WindowManager = (editor: Editor): WindowManager => {
      *
      * @method alert
      * @param {String} message Text to display in the new alert dialog.
-     * @param {function} callback (Optional) Callback function to be executed after the user has selected ok.
+     * @param {Function} callback (Optional) Callback function to be executed after the user has selected ok.
      * @param {Object} scope (Optional) Scope to execute the callback in.
      * @example
      * // Displays an alert box using the active editors window manager instance
@@ -174,15 +175,13 @@ const WindowManager = (editor: Editor): WindowManager => {
      *
      * @method confirm
      * @param {String} message Text to display in the new confirm dialog.
-     * @param {function} callback (Optional) Callback function to be executed after the user has selected ok or cancel.
+     * @param {Function} callback (Optional) Callback function to be executed after the user has selected ok or cancel.
      * @param {Object} scope (Optional) Scope to execute the callback in.
      * @example
-     * // Displays an confirm box and an alert message will be displayed depending on what you choose in the confirm
-     * tinymce.activeEditor.windowManager.confirm("Do you want to do something", function(s) {
-     *    if (s)
-     *       tinymce.activeEditor.windowManager.alert("Ok");
-     *    else
-     *       tinymce.activeEditor.windowManager.alert("Cancel");
+     * // Displays a confirm box and an alert message will be displayed depending on what you choose in the confirm
+     * tinymce.activeEditor.windowManager.confirm('Do you want to do something?', (state) => {
+     *   const message = state ? 'Ok' : 'Cancel';
+     *   tinymce.activeEditor.windowManager.alert(message);
      * });
      */
     confirm,

--- a/modules/tinymce/src/core/main/ts/api/dom/BookmarkManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/BookmarkManager.ts
@@ -34,7 +34,7 @@ const BookmarkManager = (selection: EditorSelection): BookmarkManager => {
      * @return {Object} Bookmark object, use moveToBookmark with this object to restore the selection.
      * @example
      * // Stores a bookmark of the current selection
-     * var bm = tinymce.activeEditor.selection.getBookmark();
+     * const bm = tinymce.activeEditor.selection.getBookmark();
      *
      * tinymce.activeEditor.setContent(tinymce.activeEditor.getContent() + 'Some new content');
      *
@@ -50,7 +50,7 @@ const BookmarkManager = (selection: EditorSelection): BookmarkManager => {
      * @param {Object} bookmark Bookmark to restore selection from.
      * @example
      * // Stores a bookmark of the current selection
-     * var bm = tinymce.activeEditor.selection.getBookmark();
+     * const bm = tinymce.activeEditor.selection.getBookmark();
      *
      * tinymce.activeEditor.setContent(tinymce.activeEditor.getContent() + 'Some new content');
      *

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1300,7 +1300,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      * were passed in.
      * @example
      * // Adds a new paragraph to the end of the active editor
-     * tinymce.activeEditor.dom.add(tinymce.activeEditor.getBody(), 'p', {title: 'my title'}, 'Some content');
+     * tinymce.activeEditor.dom.add(tinymce.activeEditor.getBody(), 'p', { title: 'my title' }, 'Some content');
      */
     add,
 
@@ -1314,7 +1314,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      * @return {Element} HTML DOM node element that got created.
      * @example
      * // Adds an element where the caret/selection is in the active editor
-     * var el = tinymce.activeEditor.dom.create('div', {id: 'test', 'class': 'myclass'}, 'some content');
+     * var el = tinymce.activeEditor.dom.create('div', { id: 'test', 'class': 'myclass' }, 'some content');
      * tinymce.activeEditor.selection.setNode(el);
      */
     create,
@@ -1329,7 +1329,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      * @return {String} String with new HTML element, for example: <a href="#">test</a>.
      * @example
      * // Creates a html chunk and inserts it at the current selection/caret location
-     * tinymce.activeEditor.selection.setContent(tinymce.activeEditor.dom.createHTML('a', {href: 'test.html'}, 'some line'));
+     * tinymce.activeEditor.selection.setContent(tinymce.activeEditor.dom.createHTML('a', { href: 'test.html' }, 'some line'));
      */
     createHTML,
 
@@ -1396,10 +1396,10 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      * @param {Object} styles Name/Value collection of style items to add to the element(s).
      * @example
      * // Sets styles on all paragraphs in the currently active editor
-     * tinymce.activeEditor.dom.setStyles(tinymce.activeEditor.dom.select('p'), {'background-color': 'red', 'color': 'green'});
+     * tinymce.activeEditor.dom.setStyles(tinymce.activeEditor.dom.select('p'), { 'background-color': 'red', 'color': 'green' });
      *
      * // Sets styles to an element by id in the current document
-     * tinymce.DOM.setStyles('mydiv', {'background-color': 'red', 'color': 'green'});
+     * tinymce.DOM.setStyles('mydiv', { 'background-color': 'red', 'color': 'green' });
      */
     setStyles,
 
@@ -1436,10 +1436,10 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      * @param {Object} attrs Name/Value collection of attribute items to add to the element(s).
      * @example
      * // Sets class and title attributes on all paragraphs in the active editor
-     * tinymce.activeEditor.dom.setAttribs(tinymce.activeEditor.dom.select('p'), {'class': 'myclass', title: 'some title'});
+     * tinymce.activeEditor.dom.setAttribs(tinymce.activeEditor.dom.select('p'), { 'class': 'myclass', title: 'some title' });
      *
      * // Sets class and title attributes on a specific element in the current page
-     * tinymce.DOM.setAttribs('mydiv', {'class': 'myclass', title: 'some title'});
+     * tinymce.DOM.setAttribs('mydiv', { 'class': 'myclass', title: 'some title' });
      */
     setAttribs,
 
@@ -1734,7 +1734,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      * @param {Object} elements Optional name/value object with elements that are automatically treated as non-empty elements.
      * @return {Boolean} true/false if the node is empty or not.
      * @example
-     * tinymce.DOM.isEmpty(node, {img: true});
+     * tinymce.DOM.isEmpty(node, { img: true });
      */
     isEmpty,
 

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1188,7 +1188,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      *
      * @method getRect
      * @param {Element/String} elm Element object or element ID to get rectangle from.
-     * @return {object} Rectangle for specified element object with x, y, w, h fields.
+     * @return {Object} Rectangle for specified element object with x, y, w, h fields.
      */
     getRect,
 
@@ -1197,7 +1197,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      *
      * @method getSize
      * @param {Element/String} elm Element object or element ID to get rectangle from.
-     * @return {object} Rectangle for specified element object with w, h fields.
+     * @return {Object} Rectangle for specified element object with w, h fields.
      */
     getSize,
 
@@ -1209,7 +1209,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      *
      * @method getParent
      * @param {Node/String} node DOM node to search parents on or ID string.
-     * @param {function} selector Selection function or CSS selector to execute on each node.
+     * @param {Function} selector Selection function or CSS selector to execute on each node.
      * @param {Node} root Optional root element, never go beyond this point.
      * @return {Node} DOM Node or null if it wasn't found.
      */
@@ -1221,7 +1221,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      *
      * @method getParents
      * @param {Node/String} node DOM node to search parents on or ID string.
-     * @param {function} selector Selection function to execute on each node or CSS pattern.
+     * @param {Function} selector Selection function to execute on each node or CSS pattern.
      * @param {Node} root Optional root element, never go beyond this point.
      * @return {Array} Array of nodes or null if it wasn't found.
      */
@@ -1460,7 +1460,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      * @method getPos
      * @param {Element/String} elm HTML element or element id to get x, y position from.
      * @param {Element} rootElm Optional root element to stop calculations at.
-     * @return {object} Absolute position of the specified element object with x, y fields.
+     * @return {Object} Absolute position of the specified element object with x, y fields.
      */
     getPos,
 
@@ -1712,7 +1712,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      *
      * @method run
      * @param {String/Element/Array} elm ID or DOM element object or array with ids or elements.
-     * @param {function} func Function to execute for each item.
+     * @param {Function} func Function to execute for each item.
      * @param {Object} scope Optional scope to execute the function in.
      * @return {Object/Array} Single object, or an array of objects if multiple input elements were passed in.
      */
@@ -1730,11 +1730,11 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     /**
      * Returns true/false if the specified node is to be considered empty or not.
      *
-     * @example
-     * tinymce.DOM.isEmpty(node, {img: true});
      * @method isEmpty
      * @param {Object} elements Optional name/value object with elements that are automatically treated as non-empty elements.
      * @return {Boolean} true/false if the node is empty or not.
+     * @example
+     * tinymce.DOM.isEmpty(node, {img: true});
      */
     isEmpty,
 
@@ -1745,7 +1745,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      * @method createRng
      * @return {DOMRange} DOM Range object.
      * @example
-     * var rng = tinymce.DOM.createRng();
+     * const rng = tinymce.DOM.createRng();
      * alert(rng.startContainer + "," + rng.startOffset);
      */
     createRng,
@@ -1755,7 +1755,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      *
      * @method nodeIndex
      * @param {Node} node Node to look for.
-     * @param {boolean} normalized Optional true/false state if the index is what it would be after a normalization.
+     * @param {Boolean} normalized Optional true/false state if the index is what it would be after a normalization.
      * @return {Number} Index of the specified node.
      */
     nodeIndex: findNodeIndex,
@@ -1780,9 +1780,9 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      * @param {Element/Document/Window/Array} target Target element to bind events to.
      * handler to or an array of elements/ids/documents.
      * @param {String} name Name of event handler to add, for example: click.
-     * @param {function} func Function to execute when the event occurs.
+     * @param {Function} func Function to execute when the event occurs.
      * @param {Object} scope Optional scope to execute the function in.
-     * @return {function} Function callback handler the same as the one passed in.
+     * @return {Function} Function callback handler the same as the one passed in.
      */
     bind: bind as DOMUtils['bind'],
 
@@ -1792,8 +1792,8 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      * @method unbind
      * @param {Element/Document/Window/Array} target Target element to unbind events on.
      * @param {String} name Event handler name, for example: "click"
-     * @param {function} func Function to remove.
-     * @return {bool/Array} Bool state of true if the handler was removed, or an array of states if multiple input elements
+     * @param {Function} func Function to remove.
+     * @return {Boolean/Array} Bool state of true if the handler was removed, or an array of states if multiple input elements
      * were passed in.
      */
     unbind: unbind as DOMUtils['unbind'],

--- a/modules/tinymce/src/core/main/ts/api/dom/ElementUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ElementUtils.ts
@@ -25,7 +25,7 @@ const ElementUtils = (dom: DOMUtils): ElementUtils => {
    * @method compare
    * @param {Node} node1 First node to compare with.
    * @param {Node} node2 Second node to compare with.
-   * @return {boolean} True/false if the nodes are the same or not.
+   * @return {Boolean} True/false if the nodes are the same or not.
    */
   const compare = (node1, node2) => {
     // Not the same name
@@ -61,7 +61,7 @@ const ElementUtils = (dom: DOMUtils): ElementUtils => {
      * @private
      * @param {Object} obj1 First object to compare.
      * @param {Object} obj2 Second object to compare.
-     * @return {boolean} True/false if the objects matches or not.
+     * @return {Boolean} True/false if the objects matches or not.
      */
     const compareObjects = (obj1, obj2) => {
       let value, name;

--- a/modules/tinymce/src/core/main/ts/api/dom/EventUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/EventUtils.ts
@@ -153,9 +153,9 @@ class EventUtils {
    * @method bind
    * @param {Object} target Target node/window or custom object.
    * @param {String} names Name of the event to bind.
-   * @param {function} callback Callback function to execute when the event occurs.
+   * @param {Function} callback Callback function to execute when the event occurs.
    * @param {Object} scope Scope to call the callback function on, defaults to target.
-   * @return {function} Callback function that got bound.
+   * @return {Function} Callback function that got bound.
    */
   public bind <K extends keyof HTMLElementEventMap>(target: any, name: K, callback: EventUtilsCallback<HTMLElementEventMap[K]>, scope?: any): EventUtilsCallback<HTMLElementEventMap[K]>;
   public bind <T = any>(target: any, names: string, callback: EventUtilsCallback<T>, scope?: any): EventUtilsCallback<T>;
@@ -286,7 +286,7 @@ class EventUtils {
    * @method unbind
    * @param {Object} target Target node/window or custom object.
    * @param {String} names Optional event name to unbind.
-   * @param {function} callback Optional callback function to unbind.
+   * @param {Function} callback Optional callback function to unbind.
    * @return {EventUtils} Event utils instance.
    */
   public unbind <K extends keyof HTMLElementEventMap>(target: any, name: K, callback?: EventUtilsCallback<HTMLElementEventMap[K]>): this;

--- a/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
@@ -13,19 +13,17 @@ import DOMUtils from './DOMUtils';
  * tinymce.ScriptLoader.load('somescript.js');
  *
  * // Load a script using a unique instance of the script loader
- * var scriptLoader = new tinymce.dom.ScriptLoader();
+ * const scriptLoader = new tinymce.dom.ScriptLoader();
  *
  * scriptLoader.load('somescript.js');
  *
  * // Load multiple scripts
- * var scriptLoader = new tinymce.dom.ScriptLoader();
- *
  * scriptLoader.add('somescript1.js');
  * scriptLoader.add('somescript2.js');
  * scriptLoader.add('somescript3.js');
  *
- * scriptLoader.loadQueue(function() {
- *    alert('All scripts are now loaded.');
+ * scriptLoader.loadQueue().then(() => {
+ *   alert('All scripts are now loaded.');
  * });
  */
 
@@ -138,7 +136,7 @@ class ScriptLoader {
    * the script loader or to skip it from loading some script.
    *
    * @method markDone
-   * @param {string} url Absolute URL to the script to mark as loaded.
+   * @param {String} url Absolute URL to the script to mark as loaded.
    */
   public markDone(url: string) {
     this.states[url] = LOADED;

--- a/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
@@ -192,7 +192,7 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
    * @return {Object} Bookmark object, use moveToBookmark with this object to restore the selection.
    * @example
    * // Stores a bookmark of the current selection
-   * var bm = tinymce.activeEditor.selection.getBookmark();
+   * const bm = tinymce.activeEditor.selection.getBookmark();
    *
    * tinymce.activeEditor.setContent(tinymce.activeEditor.getContent() + 'Some new content');
    *
@@ -208,7 +208,7 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
    * @param {Object} bookmark Bookmark to restore selection from.
    * @example
    * // Stores a bookmark of the current selection
-   * var bm = tinymce.activeEditor.selection.getBookmark();
+   * const bm = tinymce.activeEditor.selection.getBookmark();
    *
    * tinymce.activeEditor.setContent(tinymce.activeEditor.getContent() + 'Some new content');
    *
@@ -492,7 +492,7 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
    *
    * @method selectorChanged
    * @param {String} selector CSS selector to check for.
-   * @param {function} callback Callback with state and args when the selector is matches or not.
+   * @param {Function} callback Callback with state and args when the selector is matches or not.
    */
   const selectorChanged = (selector: string, callback: (active: boolean, args: { node: Node; selector: String; parents: Element[] }) => void) => {
     selectorChangedWithUnbind(selector, callback);

--- a/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
@@ -144,7 +144,7 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
    * alert(tinymce.activeEditor.selection.getContent());
    *
    * // Alerts the currently selected contents as plain text
-   * alert(tinymce.activeEditor.selection.getContent({format: 'text'}));
+   * alert(tinymce.activeEditor.selection.getContent({ format: 'text' }));
    */
   const getContent = (args?: Partial<GetSelectionContentArgs>): any => GetSelectionContent.getContent(editor, args);
 
@@ -426,7 +426,7 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
    * @return {Element} Returns the element that got passed in.
    * @example
    * // Inserts a DOM node at current selection/caret location
-   * tinymce.activeEditor.selection.setNode(tinymce.activeEditor.dom.create('img', {src: 'some.gif', title: 'some title'}));
+   * tinymce.activeEditor.selection.setNode(tinymce.activeEditor.dom.create('img', { src: 'some.gif', title: 'some title' }));
    */
   const setNode = (elm: Element): Element => {
     setContent(dom.getOuterHTML(elm));

--- a/modules/tinymce/src/core/main/ts/api/dom/Serializer.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Serializer.ts
@@ -28,15 +28,15 @@ const DomSerializer = (settings: DomSerializerSettings, editor?: Editor): DomSer
      * Adds a node filter function to the parser used by the serializer, the parser will collect the specified nodes by name
      * and then execute the callback once it has finished parsing the document.
      *
-     * @example
-     * parser.addNodeFilter('p,h1', function(nodes, name) {
-     *  for (var i = 0; i < nodes.length; i++) {
-     *   console.log(nodes[i].name);
-     *  }
-     * });
      * @method addNodeFilter
      * @method {String} name Comma separated list of nodes to collect.
-     * @param {function} callback Callback function to execute once it has collected nodes.
+     * @param {Function} callback Callback function to execute once it has collected nodes.
+     * @example
+     * parser.addNodeFilter('p,h1', (nodes, name) => {
+     *   for (let i = 0; i < nodes.length; i++) {
+     *     console.log(nodes[i].name);
+     *   }
+     * });
      */
     addNodeFilter: domSerializer.addNodeFilter,
 
@@ -45,15 +45,15 @@ const DomSerializer = (settings: DomSerializerSettings, editor?: Editor): DomSer
      * collect nodes that has the specified attributes
      * and then execute the callback once it has finished parsing the document.
      *
-     * @example
-     * parser.addAttributeFilter('src,href', function(nodes, name) {
-     *  for (var i = 0; i < nodes.length; i++) {
-     *   console.log(nodes[i].name);
-     *  }
-     * });
      * @method addAttributeFilter
      * @method {String} name Comma separated list of nodes to collect.
-     * @param {function} callback Callback function to execute once it has collected nodes.
+     * @param {Function} callback Callback function to execute once it has collected nodes.
+     * @example
+     * parser.addAttributeFilter('src,href', (nodes, name) => {
+     *   for (let i = 0; i < nodes.length; i++) {
+     *     console.log(nodes[i].name);
+     *   }
+     * });
      */
     addAttributeFilter: domSerializer.addAttributeFilter,
 

--- a/modules/tinymce/src/core/main/ts/api/dom/TextSeeker.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/TextSeeker.ts
@@ -20,8 +20,9 @@ interface TextSeeker {
  *
  * @class tinymce.dom.TextSeeker
  * @example
- * var startOfWord = TextSeeker(editor.dom).backwards(startNode, startOffset, function(textNode, offset, text) {
- *   var lastSpaceCharIndex = text.lastIndexOf(' ');
+ * const seeker = tinymce.dom.TextSeeker(editor.dom);
+ * const startOfWord = seeker.backwards(startNode, startOffset, (textNode, offset, text) => {
+ *   const lastSpaceCharIndex = text.lastIndexOf(' ');
  *   if (lastSpaceCharIndex !== -1) {
  *     return lastSpaceCharIndex + 1;
  *   } else {

--- a/modules/tinymce/src/core/main/ts/api/dom/TreeWalker.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/TreeWalker.ts
@@ -9,10 +9,10 @@ export interface DomTreeWalkerConstructor {
  *
  * @class tinymce.dom.TreeWalker
  * @example
- * var walker = new tinymce.dom.TreeWalker(startNode);
+ * const walker = new tinymce.dom.TreeWalker(startNode);
  *
  * do {
- *     console.log(walker.current());
+ *   console.log(walker.current());
  * } while (walker.next());
  */
 

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -21,7 +21,7 @@ import Schema, { SchemaRegExpMap } from './Schema';
  * So for example: <p>a<p>b</p>c</p> will become <p>a</p><p>b</p><p>c</p>
  *
  * @example
- * const parser = tinymce.html.DomParser({validate: true}, schema);
+ * const parser = tinymce.html.DomParser({ validate: true }, schema);
  * const rootNode = parser.parse('<h1>content</h1>');
  *
  * @class tinymce.html.DomParser

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -15,13 +15,14 @@ import AstNode from './Node';
 import Schema, { SchemaRegExpMap } from './Schema';
 
 /**
+ * @summary
  * This class parses HTML code into a DOM like structure of nodes it will remove redundant whitespace and make
  * sure that the node tree is valid according to the specified schema.
  * So for example: <p>a<p>b</p>c</p> will become <p>a</p><p>b</p><p>c</p>
  *
  * @example
- * var parser = new tinymce.html.DomParser({validate: true}, schema);
- * var rootNode = parser.parse('<h1>content</h1>');
+ * const parser = tinymce.html.DomParser({validate: true}, schema);
+ * const rootNode = parser.parse('<h1>content</h1>');
  *
  * @class tinymce.html.DomParser
  * @version 3.4
@@ -407,15 +408,15 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
    * Adds a node filter function to the parser, the parser will collect the specified nodes by name
    * and then execute the callback once it has finished parsing the document.
    *
-   * @example
-   * parser.addNodeFilter('p,h1', function(nodes, name) {
-   *  for (var i = 0; i < nodes.length; i++) {
-   *   console.log(nodes[i].name);
-   *  }
-   * });
    * @method addNodeFilter
    * @param {String} name Comma separated list of nodes to collect.
-   * @param {function} callback Callback function to execute once it has collected nodes.
+   * @param {Function} callback Callback function to execute once it has collected nodes.
+   * @example
+   * parser.addNodeFilter('p,h1', (nodes, name) => {
+   *   for (var i = 0; i < nodes.length; i++) {
+   *     console.log(nodes[i].name);
+   *   }
+   * });
    */
   const addNodeFilter = (name: string, callback: ParserFilterCallback) => {
     each(explode(name), (name) => {
@@ -445,15 +446,15 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
    * Adds a attribute filter function to the parser, the parser will collect nodes that has the specified attributes
    * and then execute the callback once it has finished parsing the document.
    *
-   * @example
-   * parser.addAttributeFilter('src,href', function(nodes, name) {
-   *  for (var i = 0; i < nodes.length; i++) {
-   *   console.log(nodes[i].name);
-   *  }
-   * });
    * @method addAttributeFilter
    * @param {String} name Comma separated list of nodes to collect.
-   * @param {function} callback Callback function to execute once it has collected nodes.
+   * @param {Function} callback Callback function to execute once it has collected nodes.
+   * @example
+   * parser.addAttributeFilter('src,href', (nodes, name) => {
+   *   for (let i = 0; i < nodes.length; i++) {
+   *     console.log(nodes[i].name);
+   *   }
+   * });
    */
   const addAttributeFilter = (name: string, callback: ParserFilterCallback) => {
     each(explode(name), (name) => {
@@ -537,12 +538,12 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
   /**
    * Parses the specified HTML string into a DOM like node tree and returns the result.
    *
-   * @example
-   * var rootNode = new DomParser({...}).parse('<b>text</b>');
    * @method parse
    * @param {String} html Html string to sax parse.
    * @param {Object} args Optional args object that gets passed to all filter functions.
    * @return {tinymce.html.Node} Root node containing the tree.
+   * @example
+   * const rootNode = tinymce.html.DomParser({...}).parse('<b>text</b>');
    */
   const parse = (html: string, args: ParserArgs = {}): AstNode => {
     const validate = defaultedSettings.validate;

--- a/modules/tinymce/src/core/main/ts/api/html/Entities.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Entities.ts
@@ -182,7 +182,7 @@ const encodeNamed = (text: string, attr?: boolean, entities?: EntitiesMap): stri
  * @method getEncodeFunc
  * @param {String} name Comma separated list of encoders for example named,numeric.
  * @param {String} entities Optional parameter with entities to use instead of the built in set.
- * @return {function} Encode function to be used.
+ * @return {Function} Encode function to be used.
  */
 const getEncodeFunc = (name: string, entities?: EntitiesMap | string) => {
   const entitiesMap = buildEntitiesLookup(entities) || namedEntities;

--- a/modules/tinymce/src/core/main/ts/api/html/Node.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Node.ts
@@ -490,7 +490,7 @@ class AstNode {
    * @param {Function} predicate Optional predicate that gets called after the other rules determine that the node is empty. Should return true if the node is a content node.
    * @return {Boolean} true/false if the node is empty or not.
    * @example
-   * node.isEmpty({img: true});
+   * node.isEmpty({ img: true });
    */
   public isEmpty(elements: SchemaMap, whitespace: SchemaMap = {}, predicate?: (node: AstNode) => boolean): boolean {
     const self = this;

--- a/modules/tinymce/src/core/main/ts/api/html/Node.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Node.ts
@@ -75,12 +75,11 @@ export interface AstNodeConstructor {
 /**
  * This class is a minimalistic implementation of a DOM like node used by the DomParser class.
  *
- * @example
- * var node = new tinymce.html.Node('strong', 1);
- * someRoot.append(node);
- *
  * @class tinymce.html.Node
  * @version 3.4
+ * @example
+ * const node = new tinymce.html.Node('strong', 1);
+ * someRoot.append(node);
  */
 
 class AstNode {
@@ -138,12 +137,11 @@ class AstNode {
   /**
    * Replaces the current node with the specified one.
    *
-   * @example
-   * someNode.replace(someNewNode);
-   *
    * @method replace
    * @param {tinymce.html.Node} node Node to replace the current node with.
    * @return {tinymce.html.Node} The old node that got replaced.
+   * @example
+   * someNode.replace(someNewNode);
    */
   public replace(node: AstNode): AstNode {
     const self = this;
@@ -161,15 +159,14 @@ class AstNode {
   /**
    * Gets/sets or removes an attribute by name.
    *
-   * @example
-   * someNode.attr("name", "value"); // Sets an attribute
-   * console.log(someNode.attr("name")); // Gets an attribute
-   * someNode.attr("name", null); // Removes an attribute
-   *
    * @method attr
    * @param {String} name Attribute name to set or get.
    * @param {String} value Optional value to set.
    * @return {String/tinymce.html.Node} String or undefined on a get operation or the current node on a set operation.
+   * @example
+   * someNode.attr('name', 'value'); // Sets an attribute
+   * console.log(someNode.attr('name')); // Gets an attribute
+   * someNode.attr('name', null); // Removes an attribute
    */
   public attr(name: string, value: string | null): AstNode | undefined;
   public attr(name: Record<string, string | null>): AstNode | undefined;
@@ -234,11 +231,10 @@ class AstNode {
    * Does a shallow clones the node into a new node. It will also exclude id attributes since
    * there should only be one id per document.
    *
-   * @example
-   * var clonedNode = node.clone();
-   *
    * @method clone
    * @return {tinymce.html.Node} New copy of the original node.
+   * @example
+   * const clonedNode = node.clone();
    */
   public clone(): AstNode {
     const self = this;
@@ -271,10 +267,9 @@ class AstNode {
   /**
    * Wraps the node in in another node.
    *
+   * @method wrap
    * @example
    * node.wrap(wrapperNode);
-   *
-   * @method wrap
    */
   public wrap(wrapper: AstNode): AstNode {
     const self = this;
@@ -288,10 +283,9 @@ class AstNode {
   /**
    * Unwraps the node in other words it removes the node but keeps the children.
    *
+   * @method unwrap
    * @example
    * node.unwrap();
-   *
-   * @method unwrap
    */
   public unwrap(): void {
     const self = this;
@@ -308,11 +302,10 @@ class AstNode {
   /**
    * Removes the node from it's parent.
    *
-   * @example
-   * node.remove();
-   *
    * @method remove
    * @return {tinymce.html.Node} Current node that got removed.
+   * @example
+   * node.remove();
    */
   public remove(): AstNode {
     const self = this, parent = self.parent, next = self.next, prev = self.prev;
@@ -347,12 +340,11 @@ class AstNode {
   /**
    * Appends a new node as a child of the current node.
    *
-   * @example
-   * node.append(someNode);
-   *
    * @method append
    * @param {tinymce.html.Node} node Node to append as a child of the current one.
    * @return {tinymce.html.Node} The node that got appended.
+   * @example
+   * node.append(someNode);
    */
   public append(node: AstNode): AstNode {
     const self = this;
@@ -378,14 +370,13 @@ class AstNode {
   /**
    * Inserts a node at a specific position as a child of this node.
    *
-   * @example
-   * parentNode.insert(newChildNode, oldChildNode);
-   *
    * @method insert
    * @param {tinymce.html.Node} node Node to insert as a child of this node.
    * @param {tinymce.html.Node} refNode Reference node to set node before/after.
    * @param {Boolean} before Optional state to insert the node before the reference node.
    * @return {tinymce.html.Node} The node that got inserted.
+   * @example
+   * parentNode.insert(newChildNode, oldChildNode);
    */
   public insert(node: AstNode, refNode: AstNode, before?: boolean): AstNode {
 
@@ -493,13 +484,13 @@ class AstNode {
   /**
    * Returns true/false if the node is to be considered empty or not.
    *
-   * @example
-   * node.isEmpty({img: true});
    * @method isEmpty
    * @param {Object} elements Name/value object with elements that are automatically treated as non empty elements.
    * @param {Object} whitespace Name/value object with elements that are automatically treated whitespace preservables.
-   * @param {function} predicate Optional predicate that gets called after the other rules determine that the node is empty. Should return true if the node is a content node.
+   * @param {Function} predicate Optional predicate that gets called after the other rules determine that the node is empty. Should return true if the node is a content node.
    * @return {Boolean} true/false if the node is empty or not.
+   * @example
+   * node.isEmpty({img: true});
    */
   public isEmpty(elements: SchemaMap, whitespace: SchemaMap = {}, predicate?: (node: AstNode) => boolean): boolean {
     const self = this;

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -832,12 +832,12 @@ const Schema = (settings?: SchemaSettings): Schema => {
   /**
    * Name/value map object with valid parents and children to those parents.
    *
-   * @example
-   * children = {
-   *    div:{p:{}, h1:{}}
-   * };
    * @field children
    * @type Object
+   * @example
+   * children = {
+   *    div: { p:{}, h1:{} }
+   * };
    */
 
   /**

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -97,15 +97,15 @@ interface SchemaLookupTable {
  * Schema validator class.
  *
  * @class tinymce.html.Schema
- * @example
- *  if (tinymce.activeEditor.schema.isValidChild('p', 'span'))
- *    alert('span is valid child of p.');
- *
- *  if (tinymce.activeEditor.schema.getElementRule('p'))
- *    alert('P is a valid element.');
- *
- * @class tinymce.html.Schema
  * @version 3.4
+ * @example
+ * if (tinymce.activeEditor.schema.isValidChild('p', 'span')) {
+ *   alert('span is valid child of p.');
+ * }
+ *
+ * if (tinymce.activeEditor.schema.getElementRule('p')) {
+ *   alert('P is a valid element.');
+ * }
  */
 
 const mapCache: Record<string, SchemaLookupTable> = {}, dummyObj = {};

--- a/modules/tinymce/src/core/main/ts/api/html/Serializer.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Serializer.ts
@@ -14,11 +14,10 @@ interface HtmlSerializer {
 /**
  * This class is used to serialize down the DOM tree into a string using a Writer instance.
  *
- *
- * @example
- * new tinymce.html.Serializer().serialize(new tinymce.html.DomParser().parse('<p>text</p>'));
  * @class tinymce.html.Serializer
  * @version 3.4
+ * @example
+ * tinymce.html.Serializer().serialize(new tinymce.html.DomParser().parse('<p>text</p>'));
  */
 
 const HtmlSerializer = (settings?: HtmlSerializerSettings, schema = Schema()): HtmlSerializer => {
@@ -30,11 +29,11 @@ const HtmlSerializer = (settings?: HtmlSerializerSettings, schema = Schema()): H
   /**
    * Serializes the specified node into a string.
    *
-   * @example
-   * new tinymce.html.Serializer().serialize(new tinymce.html.DomParser().parse('<p>text</p>'));
    * @method serialize
    * @param {tinymce.html.Node} node Node instance to serialize.
    * @return {String} String with HTML based on DOM tree.
+   * @example
+   * tinymce.html.Serializer().serialize(new tinymce.html.DomParser().parse('<p>text</p>'));
    */
   const serialize = (node: AstNode): string => {
     const validate = settings.validate;

--- a/modules/tinymce/src/core/main/ts/api/html/Serializer.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Serializer.ts
@@ -17,7 +17,7 @@ interface HtmlSerializer {
  * @class tinymce.html.Serializer
  * @version 3.4
  * @example
- * tinymce.html.Serializer().serialize(new tinymce.html.DomParser().parse('<p>text</p>'));
+ * tinymce.html.Serializer().serialize(tinymce.html.DomParser().parse('<p>text</p>'));
  */
 
 const HtmlSerializer = (settings?: HtmlSerializerSettings, schema = Schema()): HtmlSerializer => {
@@ -33,7 +33,7 @@ const HtmlSerializer = (settings?: HtmlSerializerSettings, schema = Schema()): H
    * @param {tinymce.html.Node} node Node instance to serialize.
    * @return {String} String with HTML based on DOM tree.
    * @example
-   * tinymce.html.Serializer().serialize(new tinymce.html.DomParser().parse('<p>text</p>'));
+   * tinymce.html.Serializer().serialize(tinymce.html.DomParser().parse('<p>text</p>'));
    */
   const serialize = (node: AstNode): string => {
     const validate = settings.validate;

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -1,20 +1,19 @@
 /**
  * This class is used to parse CSS styles it also compresses styles to reduce the output size.
  *
+ * @class tinymce.html.Styles
+ * @version 3.4
  * @example
- * var Styles = tinymce.html.Styles({
- *    url_converter: function(url) {
- *       return url;
- *    }
+ * const Styles = tinymce.html.Styles({
+ *   url_converter: (url) => {
+ *     return url;
+ *   }
  * });
  *
  * styles = Styles.parse('border: 1px solid red');
  * styles.color = 'red';
  *
- * console.log(new tinymce.html.Styles().serialize(styles));
- *
- * @class tinymce.html.Styles
- * @version 3.4
+ * console.log(tinymce.html.Styles().serialize(styles));
  */
 
 import { Obj, Unicode } from '@ephox/katamari';

--- a/modules/tinymce/src/core/main/ts/api/html/Writer.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Writer.ts
@@ -8,7 +8,7 @@ import Entities from './Entities';
  * @class tinymce.html.Writer
  * @version 3.4
  * @example
- * const writer = tinymce.html.Writer({indent: true});
+ * const writer = tinymce.html.Writer({ indent: true });
  * writer.start('node', { attr: 'value });
  * writer.end('node');
  * console.log(writer.getContent());

--- a/modules/tinymce/src/core/main/ts/api/html/Writer.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Writer.ts
@@ -3,16 +3,15 @@ import Tools from '../util/Tools';
 import Entities from './Entities';
 
 /**
- * This class is used to write HTML tags out it can be used with the Serializer or the SaxParser.
- *
- * @class tinymce.html.Writer
- * @example
- * var writer = new tinymce.html.Writer({indent: true});
- * var parser = new tinymce.html.SaxParser(writer).parse('<p><br></p>');
- * console.log(writer.getContent());
+ * This class is used to write HTML tags out it can be used with the Serializer.
  *
  * @class tinymce.html.Writer
  * @version 3.4
+ * @example
+ * const writer = tinymce.html.Writer({indent: true});
+ * writer.start('node', { attr: 'value });
+ * writer.end('node');
+ * console.log(writer.getContent());
  */
 
 const makeMap = Tools.makeMap;

--- a/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
+++ b/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
@@ -1,7 +1,7 @@
 import { Registry } from '@ephox/bridge';
 
 /**
- * TinyMCE 5 Ui registration API.
+ * TinyMCE UI registration API.
  *
  * @class tinymce.editor.ui.Registry
  */
@@ -22,7 +22,6 @@ const registry = () => {
      * @method addAutocompleter
      * @param {String} name Unique name identifying this autocomplete configuration.
      * @param {InlineContent.AutocompleterSpec} obj The autocomplete configuration object.
-     * @return {void} void
      */
     addAutocompleter: bridge.addAutocompleter,
 
@@ -37,7 +36,6 @@ const registry = () => {
      * @method addButton
      * @param {String} name Unique name identifying the button, this button name will be used in the toolbar configuration to reference the button.
      * @param {Toolbar.ToolbarButtonSpec} obj the button configuration object.
-     * @return {void} void
      */
     addButton: bridge.addButton,
 
@@ -56,7 +54,6 @@ const registry = () => {
      * @method addContextForm
      * @param {String} name Unique name identifying the new contextual form item.
      * @param {Toolbar.ContextFormSpec} obj the context form configuration object.
-     * @return {void} void
      */
     addContextForm: bridge.addContextForm,
 
@@ -71,7 +68,6 @@ const registry = () => {
      * @method addContextMenu
      * @param {String} name Unique name identifying the new context menu.
      * @param {Menu.ContextMenuSpec} obj The context menu configuration object.
-     * @return {void} void
      */
     addContextMenu: bridge.addContextMenu,
 
@@ -86,7 +82,6 @@ const registry = () => {
      * @method addContextToolbar
      * @param {String} name Unique name identifying the new context toolbar.
      * @param {Toolbar.ContextToolbarSpec} obj The context menu configuration object.
-     * @return {void} void
      */
     addContextToolbar: bridge.addContextToolbar,
 
@@ -97,8 +92,7 @@ const registry = () => {
      *
      * @method addIcon
      * @param {String} name Unique name identifying the new icon.
-     * @param {svgData} string The SVG data string the browser will use to render the SVG icon.
-     * @return {void} void
+     * @param {String} svgData The SVG data string the browser will use to render the SVG icon.
      * @example
      * //To add a simple triangle icon:
      * editor.ui.registry.addIcon('triangleUp', '<svg height="24" width="24"><path d="M12 0 L24 24 L0 24 Z" /></svg>' );
@@ -117,7 +111,6 @@ const registry = () => {
      * @method addMenuButton
      * @param {String} name Unique name identifying the new menu button.
      * @param {Toolbar.ToolbarMenuButtonSpec} obj The menu button configuration object.
-     * @return {void} void
      */
     addMenuButton: bridge.addMenuButton,
 
@@ -132,7 +125,6 @@ const registry = () => {
      * @method addMenuItem
      * @param {String} name Unique name identifying the new menu item.
      * @param {Menu.MenuItemSpec} obj The menu item configuration object.
-     * @return {void} void
      */
     addMenuItem: bridge.addMenuItem,
 
@@ -148,7 +140,6 @@ const registry = () => {
      * @method addNestedMenuItem
      * @param {String} name Unique name identifying the new nested menu item.
      * @param {Menu.NestedMenuItemSpec} obj The nested menu item configuration object.
-     * @return {void} void
      */
     addNestedMenuItem: bridge.addNestedMenuItem,
 
@@ -168,7 +159,6 @@ const registry = () => {
      * @method addSidebar
      * @param {String} name Unique name identifying the new sidebar.
      * @param {Sidebar.SidebarSpec} obj The sidebar configuration object.
-     * @return {void} void
      */
     addSidebar: bridge.addSidebar,
 
@@ -183,7 +173,6 @@ const registry = () => {
      * @method addSplitButton
      * @param {String} name Unique name identifying the new split button.
      * @param {Toolbar.ToolbarSplitButtonSpec} obj The split button configuration object.
-     * @return {void} void
      */
     addSplitButton: bridge.addSplitButton,
 
@@ -198,7 +187,6 @@ const registry = () => {
      * @method addToggleButton
      * @param {String} name Unique name identifying the new split button.
      * @param {Toolbar.ToolbarToggleButtonSpec} obj The toggle button configuration object.
-     * @return {void} void
      */
     addToggleButton: bridge.addToggleButton,
 
@@ -217,7 +205,6 @@ const registry = () => {
      * @method addGroupToolbarButton
      * @param {String} name Unique name identifying the new group toolbar button.
      * @param {Toolbar.GroupToolbarButtonSpec} obj The group toolbar button configuration object.
-     * @return {void} void
      */
     addGroupToolbarButton: bridge.addGroupToolbarButton,
 
@@ -232,7 +219,6 @@ const registry = () => {
      * @method addToggleMenuItem
      * @param {String} name Unique name identifying the new menu item.
      * @param {Menu.ToggleMenuItemSpec} obj The menu item configuration object.
-     * @return {void} void
      */
     addToggleMenuItem: bridge.addToggleMenuItem,
 

--- a/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
+++ b/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
@@ -95,7 +95,7 @@ const registry = () => {
      * @param {String} svgData The SVG data string the browser will use to render the SVG icon.
      * @example
      * //To add a simple triangle icon:
-     * editor.ui.registry.addIcon('triangleUp', '<svg height="24" width="24"><path d="M12 0 L24 24 L0 24 Z" /></svg>' );
+     * editor.ui.registry.addIcon('triangleUp', '<svg height="24" width="24"><path d="M12 0 L24 24 L0 24 Z" /></svg>');
      */
     addIcon: bridge.addIcon,
 

--- a/modules/tinymce/src/core/main/ts/api/util/Delay.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Delay.ts
@@ -36,7 +36,7 @@ const Delay: Delay = {
    *
    * @method setEditorTimeout
    * @param {tinymce.Editor} editor Editor instance to check the removed state on.
-   * @param {function} callback Callback to execute when timer runs out.
+   * @param {Function} callback Callback to execute when timer runs out.
    * @param {Number} time Optional time to wait before the callback is executed, defaults to 0.
    * @return {Number} Timeout id number.
    */
@@ -53,7 +53,7 @@ const Delay: Delay = {
    * still alive when the callback gets executed.
    *
    * @method setEditorInterval
-   * @param {function} callback Callback to execute when interval time runs out.
+   * @param {Function} callback Callback to execute when interval time runs out.
    * @param {Number} time Optional time to wait before the callback is executed, defaults to 0.
    * @return {Number} Timeout id number.
    */

--- a/modules/tinymce/src/core/main/ts/api/util/EventDispatcher.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/EventDispatcher.ts
@@ -73,7 +73,7 @@ export interface EventDispatcherConstructor<T extends NativeEventMap> {
  * const eventDispatcher = new EventDispatcher();
  *
  * eventDispatcher.on('click', () => console.log('data'));
- * eventDispatcher.dispatch('click', {data: 123});
+ * eventDispatcher.dispatch('click', { data: 123 });
  */
 
 const nativeEvents = Tools.makeMap(

--- a/modules/tinymce/src/core/main/ts/api/util/EventDispatcher.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/EventDispatcher.ts
@@ -70,10 +70,10 @@ export interface EventDispatcherConstructor<T extends NativeEventMap> {
  *
  * @class tinymce.util.EventDispatcher
  * @example
- *  var eventDispatcher = new EventDispatcher();
+ * const eventDispatcher = new EventDispatcher();
  *
- *  eventDispatcher.on('click', function() {console.log('data');});
- *  eventDispatcher.dispatch('click', {data: 123});
+ * eventDispatcher.on('click', () => console.log('data'));
+ * eventDispatcher.dispatch('click', {data: 123});
  */
 
 const nativeEvents = Tools.makeMap(
@@ -193,12 +193,12 @@ class EventDispatcher<T> {
    *
    * @method on
    * @param {String} name Event name or space separated list of events to bind.
-   * @param {callback} callback Callback to be executed when the event occurs.
+   * @param {Function} callback Callback to be executed when the event occurs.
    * @param {Boolean} prepend Optional flag if the event should be prepended. Use this with care.
    * @return {Object} Current class instance.
    * @example
-   * instance.on('event', function(e) {
-   *     // Callback logic
+   * instance.on('event', (e) => {
+   *   // Callback logic
    * });
    */
   public on <K extends string>(name: K, callback: false | ((event: EditorEvent<MappedEvent<T, K>>) => void), prepend?: boolean, extra?: {}): this {
@@ -244,7 +244,7 @@ class EventDispatcher<T> {
    *
    * @method off
    * @param {String?} name Name of the event to unbind.
-   * @param {callback?} callback Callback to unbind.
+   * @param {Function?} callback Callback to unbind.
    * @return {Object} Current class instance.
    * @example
    * // Unbind specific callback
@@ -312,12 +312,12 @@ class EventDispatcher<T> {
    *
    * @method once
    * @param {String} name Event name or space separated list of events to bind.
-   * @param {callback} callback Callback to be executed when the event occurs.
+   * @param {Function} callback Callback to be executed when the event occurs.
    * @param {Boolean} prepend Optional flag if the event should be prepended. Use this with care.
    * @return {Object} Current class instance.
    * @example
-   * instance.once('event', function(e) {
-   *     // Callback logic
+   * instance.once('event', (e) => {
+   *   // Callback logic
    * });
    */
   public once <K extends string>(name: K, callback: (event: EditorEvent<MappedEvent<T, K>>) => void, prepend?: boolean): this {

--- a/modules/tinymce/src/core/main/ts/api/util/ImageUploader.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/ImageUploader.ts
@@ -43,7 +43,7 @@ const ImageUploader = (editor: Editor): ImageUploader => {
      *
      * @method upload
      * @param {Array} blobInfos  A BlobInfo array containing the image data to upload. A BlobInfo can be created by calling `editor.editorUpload.blobCache.create()`.
-     * @param {boolean} showNotification (Optional) When set to true, a notification with a progress bar will be shown during image uploads.
+     * @param {Boolean} showNotification (Optional) When set to true, a notification with a progress bar will be shown during image uploads.
      */
     upload: (blobInfos: BlobInfo[], showNotification: boolean = true) =>
       uploader.upload(blobInfos, showNotification ? openNotification(editor) : undefined)

--- a/modules/tinymce/src/core/main/ts/api/util/LocalStorage.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/LocalStorage.ts
@@ -7,7 +7,7 @@ import * as FakeStorage from './FakeStorage';
  * @private
  * @example
  * tinymce.util.LocalStorage.setItem('key', 'value');
- * var value = tinymce.util.LocalStorage.getItem('key');
+ * const value = tinymce.util.LocalStorage.getItem('key');
  */
 
 let localStorage: Storage;

--- a/modules/tinymce/src/core/main/ts/api/util/Observable.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Observable.ts
@@ -91,12 +91,12 @@ const Observable: Observable<any> = {
    *
    * @method on
    * @param {String} name Event name or space separated list of events to bind.
-   * @param {callback} callback Callback to be executed when the event occurs.
+   * @param {Function} callback Callback to be executed when the event occurs.
    * @param {Boolean} prepend Optional flag if the event should be prepended. Use this with care.
    * @return {Object} Current class instance.
    * @example
-   * instance.on('event', function(e) {
-   *     // Callback logic
+   * instance.on('event', (e) => {
+   *   // Callback logic
    * });
    */
   on(name, callback, prepend?) {
@@ -109,7 +109,7 @@ const Observable: Observable<any> = {
    *
    * @method off
    * @param {String?} name Name of the event to unbind.
-   * @param {callback?} callback Callback to unbind.
+   * @param {Function?} callback Callback to unbind.
    * @return {Object} Current class instance.
    * @example
    * // Unbind specific callback
@@ -131,7 +131,7 @@ const Observable: Observable<any> = {
    *
    * @method once
    * @param {String} name Name of the event to bind.
-   * @param {callback} callback Callback to bind only once.
+   * @param {Function} callback Callback to bind only once.
    * @return {Object} Current class instance.
    */
   once(name, callback) {

--- a/modules/tinymce/src/core/main/ts/api/util/Tools.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Tools.ts
@@ -247,12 +247,12 @@ const Tools: Tools = {
    * @param {Object} s Optional scope to execute the callback in.
    * @example
    * // Iterate an array
-   * tinymce.each([1,2,3], (v, i) => {
+   * tinymce.each([ 1,2,3 ], (v, i) => {
    *   console.debug("Value: " + v + ", Index: " + i);
    * });
    *
    * // Iterate an object
-   * tinymce.each({a: 1, b: 2, c: 3], (v, k) => {
+   * tinymce.each({ a: 1, b: 2, c: 3 }, (v, k) => {
    *   console.debug("Value: " + v + ", Key: " + k);
    * });
    */
@@ -279,7 +279,7 @@ const Tools: Tools = {
    * @return {Array} New array with values imported and filtered based in input.
    * @example
    * // Filter out some items, this will return an array with 4 and 5
-   * const items = tinymce.grep([1,2,3,4,5], (v) => v > 3);
+   * const items = tinymce.grep([ 1,2,3,4,5 ], (v) => v > 3);
    */
   grep: ArrUtils.filter,
 

--- a/modules/tinymce/src/core/main/ts/api/util/Tools.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Tools.ts
@@ -58,7 +58,7 @@ const trim = (str) => {
  *
  * @method is
  * @param {Object} obj Object to check type of.
- * @param {string} type Optional type to check for.
+ * @param {String} type Optional type to check for.
  * @return {Boolean} true/false if the object is of the specified type.
  */
 const is = (obj: any, type: string) => {
@@ -134,7 +134,7 @@ const extend = (obj, ...exts: any[]) => {
  *
  * @method walk
  * @param {Object} o Object tree to walk though.
- * @param {function} f Function to call for each item.
+ * @param {Function} f Function to call for each item.
  * @param {String} n Optional name of collection inside the objects to walk for example childNodes.
  * @param {String} s Optional scope to execute the function in.
  */
@@ -165,7 +165,7 @@ const walk = function (o, f, n?, s?) {
  * @return {Object} Last object in path or null if it couldn't be resolved.
  * @example
  * // Resolve a path into an object reference
- * var obj = tinymce.resolve('a.b.c.d');
+ * const obj = tinymce.resolve('a.b.c.d');
  */
 const resolve = (n, o?) => {
   let i, l;
@@ -188,11 +188,11 @@ const resolve = (n, o?) => {
  * Splits a string but removes the whitespace before and after each value.
  *
  * @method explode
- * @param {string} s String to split.
- * @param {string} d Delimiter to split by.
+ * @param {String} s String to split.
+ * @param {String} d Delimiter to split by.
  * @example
  * // Split a string into an array with a,b,c
- * var arr = tinymce.explode('a, b,   c');
+ * const arr = tinymce.explode('a, b,   c');
  */
 const explode = (s, d?) => {
   if (!s || is(s, 'array')) {
@@ -220,7 +220,7 @@ const Tools: Tools = {
    *
    * @method isArray
    * @param {Object} obj Object to check.
-   * @return {boolean} true/false state if the object is an array or not.
+   * @return {Boolean} true/false state if the object is an array or not.
    */
   isArray: ArrUtils.isArray,
 
@@ -243,17 +243,17 @@ const Tools: Tools = {
    *
    * @method each
    * @param {Object} o Collection to iterate.
-   * @param {function} cb Callback function to execute for each item.
+   * @param {Function} cb Callback function to execute for each item.
    * @param {Object} s Optional scope to execute the callback in.
    * @example
    * // Iterate an array
-   * tinymce.each([1,2,3], function(v, i) {
-   *     console.debug("Value: " + v + ", Index: " + i);
+   * tinymce.each([1,2,3], (v, i) => {
+   *   console.debug("Value: " + v + ", Index: " + i);
    * });
    *
    * // Iterate an object
-   * tinymce.each({a: 1, b: 2, c: 3], function(v, k) {
-   *     console.debug("Value: " + v + ", Key: " + k);
+   * tinymce.each({a: 1, b: 2, c: 3], (v, k) => {
+   *   console.debug("Value: " + v + ", Key: " + k);
    * });
    */
   each: ArrUtils.each,
@@ -264,7 +264,7 @@ const Tools: Tools = {
    *
    * @method map
    * @param {Array} array Array of items to iterate.
-   * @param {function} callback Function to call for each item. It's return value will be the new value.
+   * @param {Function} callback Function to call for each item. It's return value will be the new value.
    * @return {Array} Array with new values based on function return values.
    */
   map: ArrUtils.map,
@@ -275,11 +275,11 @@ const Tools: Tools = {
    *
    * @method grep
    * @param {Array} a Array of items to loop though.
-   * @param {function} f Function to call for each item. Include/exclude depends on it's return value.
+   * @param {Function} f Function to call for each item. Include/exclude depends on it's return value.
    * @return {Array} New array with values imported and filtered based in input.
    * @example
    * // Filter out some items, this will return an array with 4 and 5
-   * var items = tinymce.grep([1,2,3,4,5], function(v) {return v > 3;});
+   * const items = tinymce.grep([1,2,3,4,5], (v) => v > 3);
    */
   grep: ArrUtils.filter,
 

--- a/modules/tinymce/src/core/main/ts/api/util/URI.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/URI.ts
@@ -234,7 +234,7 @@ class URI {
    * Sets the internal path part of the URI.
    *
    * @method setPath
-   * @param {string} path Path string to set.
+   * @param {String} path Path string to set.
    */
   public setPath(path: string) {
     const pathMatch = /^(.*?)\/?(\w+)?$/.exec(path);
@@ -257,7 +257,7 @@ class URI {
    * @return {String} Relative URI from the point specified in the current URI instance.
    * @example
    * // Converts an absolute URL to an relative URL url will be somedir/somefile.htm
-   * var url = new tinymce.util.URI('http://www.site.com/dir/').toRelative('http://www.site.com/dir/somedir/somefile.htm');
+   * const url = new tinymce.util.URI('http://www.site.com/dir/').toRelative('http://www.site.com/dir/somedir/somefile.htm');
    */
   public toRelative(uri: string): string {
     let output;
@@ -305,7 +305,7 @@ class URI {
    * @return {String} Absolute URI from the point specified in the current URI instance.
    * @example
    * // Converts an relative URL to an absolute URL url will be http://www.site.com/dir/somedir/somefile.htm
-   * var url = new tinymce.util.URI('http://www.site.com/dir/').toAbsolute('somedir/somefile.htm');
+   * const url = new tinymce.util.URI('http://www.site.com/dir/').toAbsolute('somedir/somefile.htm');
    */
   public toAbsolute(uri: string, noHost?: boolean): string {
     const absoluteUri = new URI(uri, { base_uri: this });

--- a/modules/tinymce/src/core/main/ts/bookmark/CaretBookmark.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/CaretBookmark.ts
@@ -20,8 +20,8 @@ import * as ArrUtils from '../util/ArrUtils';
  * @static
  * @class tinymce.caret.CaretBookmark
  * @example
- * var bookmark = CaretBookmark.create(rootElm, CaretPosition.before(rootElm.firstChild));
- * var caretPosition = CaretBookmark.resolve(bookmark);
+ * const bookmark = CaretBookmark.create(rootElm, CaretPosition.before(rootElm.firstChild));
+ * const caretPosition = CaretBookmark.resolve(bookmark);
  */
 
 const isText = NodeType.isText;

--- a/modules/tinymce/src/core/main/ts/caret/CaretPosition.ts
+++ b/modules/tinymce/src/core/main/ts/caret/CaretPosition.ts
@@ -18,8 +18,8 @@ type GeomClientRect = ClientRect.ClientRect;
  * @private
  * @class tinymce.caret.CaretPosition
  * @example
- * var caretPos1 = CaretPosition(container, offset);
- * var caretPos2 = CaretPosition.fromRangeStart(someRange);
+ * const caretPos1 = CaretPosition(container, offset);
+ * const caretPos2 = CaretPosition.fromRangeStart(someRange);
  */
 
 const isElement = NodeType.isElement;

--- a/modules/tinymce/src/core/main/ts/caret/CaretWalker.ts
+++ b/modules/tinymce/src/core/main/ts/caret/CaretWalker.ts
@@ -20,10 +20,10 @@ export interface CaretWalker {
  * @private
  * @class tinymce.caret.CaretWalker
  * @example
- * var caretWalker = new CaretWalker(rootElm);
+ * const caretWalker = CaretWalker(rootElm);
  *
- * var prevLogicalCaretPosition = caretWalker.prev(CaretPosition.fromRangeStart(range));
- * var nextLogicalCaretPosition = caretWalker.next(CaretPosition.fromRangeEnd(range));
+ * const prevLogicalCaretPosition = caretWalker.prev(CaretPosition.fromRangeStart(range));
+ * const nextLogicalCaretPosition = caretWalker.next(CaretPosition.fromRangeEnd(range));
  */
 
 export enum HDirection {

--- a/modules/tinymce/src/core/main/ts/file/Uploader.ts
+++ b/modules/tinymce/src/core/main/ts/file/Uploader.ts
@@ -11,17 +11,17 @@ import { UploadStatus } from './UploadStatus';
  * @private
  * @class tinymce.file.Uploader
  * @example
- * var uploader = new Uploader({
- *     url: '/upload.php',
- *     basePath: '/base/path',
- *     credentials: true,
- *     handler: function(data, success, failure) {
- *         ...
- *     }
+ * const uploader = new Uploader({
+ *   url: '/upload.php',
+ *   basePath: '/base/path',
+ *   credentials: true,
+ *   handler: (data, success, failure) => {
+ *     ...
+ *   }
  * });
  *
- * uploader.upload(blobInfos).then(function(result) {
- *     ...
+ * uploader.upload(blobInfos).then((result) => {
+ *   ...
  * });
  */
 

--- a/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
@@ -54,8 +54,8 @@ const moveStart = (dom: DOMUtils, selection: EditorSelection, rng: Range) => {
  *
  * @private
  * @param {Node} node Node to start at.
- * @param {boolean} next (Optional) Include next or previous node defaults to previous.
- * @param {boolean} inc (Optional) Include the current node in checking. Defaults to false.
+ * @param {Boolean} next (Optional) Include next or previous node defaults to previous.
+ * @param {Boolean} inc (Optional) Include the current node in checking. Defaults to false.
  * @return {Node} Next or previous node or undefined if it wasn't found.
  */
 const getNonWhiteSpaceSibling = (node: Node, next?: boolean, inc?: boolean) => {
@@ -122,7 +122,7 @@ const replaceVars = (value: FormatAttrOrStyleValue, vars?: FormatVars): string =
  * @private
  * @param {String/Node} str1 Node or string to compare.
  * @param {String/Node} str2 Node or string to compare.
- * @return {boolean} True/false if they match.
+ * @return {Boolean} True/false if they match.
  */
 const isEq = (str1, str2) => {
   str1 = str1 || '';

--- a/modules/tinymce/src/core/main/ts/text/ExtendingChar.ts
+++ b/modules/tinymce/src/core/main/ts/text/ExtendingChar.ts
@@ -4,7 +4,7 @@
  * @private
  * @class tinymce.text.ExtendingChar
  * @example
- * var isExtending = ExtendingChar.isExtendingChar('a');
+ * const isExtending = ExtendingChar.isExtendingChar('a');
  */
 
 // Generated from: http://www.unicode.org/Public/UNIDATA/DerivedCoreProperties.txt

--- a/modules/tinymce/src/core/main/ts/text/Zwsp.ts
+++ b/modules/tinymce/src/core/main/ts/text/Zwsp.ts
@@ -7,8 +7,8 @@ import { Unicode } from '@ephox/katamari';
  * @private
  * @class tinymce.text.Zwsp
  * @example
- * var isZwsp = Zwsp.isZwsp('\uFEFF');
- * var abc = Zwsp.trim('a\uFEFFc');
+ * const isZwsp = Zwsp.isZwsp('\uFEFF');
+ * const abc = Zwsp.trim('a\uFEFFc');
  */
 
 // This is technically not a ZWSP but a ZWNBSP or a BYTE ORDER MARK it used to be a ZWSP

--- a/modules/tinymce/tools/docs/tinymce.Editor.js
+++ b/modules/tinymce/tools/docs/tinymce.Editor.js
@@ -75,8 +75,8 @@
  * @property initialized
  * @type Boolean
  * @example
- * function isEditorInitialized(editor) {
- *     return editor && editor.initialized;
+ * const isEditorInitialized = (editor) => {
+ *   return editor && editor.initialized;
  * }
  */
 
@@ -90,13 +90,11 @@
  * tinymce.activeEditor.windowManager.alert('Hello world!');
  *
  * // Opens a new dialog with the file.htm file and the size 320x240
- * // It also adds a custom parameter this can be retrieved by using tinyMCEPopup.getWindowArg inside the dialog.
- * tinymce.activeEditor.windowManager.open({
- *    url: 'file.htm',
- *    width: 320,
- *    height: 240
- * }, {
- *    custom_param: 1
+ * tinymce.activeEditor.windowManager.openUrl({
+ *   title: 'Custom Dialog',
+ *   url: 'file.htm',
+ *   width: 320,
+ *   height: 240
  * });
  */
 

--- a/modules/tinymce/tools/docs/tinymce.Editor.js
+++ b/modules/tinymce/tools/docs/tinymce.Editor.js
@@ -105,7 +105,10 @@
  * @type tinymce.NotificationManager
  * @example
  * // Shows a notification info message.
- * tinymce.activeEditor.notificationManager.open({text: 'Hello world!', type: 'info'});
+ * tinymce.activeEditor.notificationManager.open({
+ *   text: 'Hello world!',
+ *   type: 'info'
+ * });
  */
 
 /**


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* When updating `moxiedoc` to use `xref`s instead of links a few links were broken so fixed those
* Fixed the various examples to use ES6 and fixed formatting issues
* Made the types used consistent (e.g. `{String}` vs `{string}`)
* Fixed some incorrect references to `TinyMCE 5` in the API docs

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
