### PR TITLE
TINY-8582: Fixed the buttonType property not working for dialog footer buttons

### DIFF
--- a/modules/bridge/CHANGELOG.md
+++ b/modules/bridge/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- The `buttonType` property did not work for dialog footer buttons #TINY-8582
+
 ## 4.0.0 - 2022-03-03
 
 ### Added

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/DialogFooterButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/DialogFooterButton.ts
@@ -11,6 +11,7 @@ export type DialogFooterToggleMenuItem = DialogToggleMenuItem;
 interface BaseDialogFooterButtonSpec {
   name?: string;
   align?: 'start' | 'end';
+  /** @deprecated use `buttonType: "primary"` instead */
   primary?: boolean;
   enabled?: boolean;
   icon?: string;

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/DialogFooterButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/DialogFooterButton.ts
@@ -14,6 +14,7 @@ interface BaseDialogFooterButtonSpec {
   primary?: boolean;
   enabled?: boolean;
   icon?: string;
+  buttonType?: 'primary' | 'secondary';
 }
 
 export interface DialogFooterNormalButtonSpec extends BaseDialogFooterButtonSpec {
@@ -34,9 +35,11 @@ export type DialogFooterButtonSpec = DialogFooterNormalButtonSpec | DialogFooter
 interface BaseDialogFooterButton {
   name: string;
   align: 'start' | 'end';
+  /** @deprecated use `buttonType: "primary"` instead */
   primary: boolean;
   enabled: boolean;
   icon: Optional<string>;
+  buttonType: Optional<'primary' | 'secondary'>;
 }
 
 export interface DialogFooterNormalButton extends BaseDialogFooterButton {
@@ -58,8 +61,11 @@ const baseFooterButtonFields = [
   ComponentSchema.generatedName('button'),
   ComponentSchema.optionalIcon,
   FieldSchema.defaultedStringEnum('align', 'end', [ 'start', 'end' ]),
+  // this should be removed, but must live here because FieldSchema doesn't have a way to manage deprecated fields
   ComponentSchema.primary,
-  ComponentSchema.enabled
+  ComponentSchema.enabled,
+  // this should be defaulted to `secondary` but the implementation needs to manage the deprecation
+  FieldSchema.optionStringEnum('buttonType', [ 'primary', 'secondary' ])
 ];
 
 export const dialogFooterButtonFields = [

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Dialogs will not exceed the window height on smaller screens #TINY-8146
-- The `buttonType` property did not work for dialog footer buttons #TINY-8582
 
 ## 6.0.1 - TBD
 
@@ -21,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - It wasn't possible to select text right after an inline noneditable element #TINY-8567
 - Fixed a double border showing for the `tinymce-5` skin when using `toolbar_location: 'bottom'` #TINY-8564
 - Clipboard content was not generated correctly when cutting and copying `contenteditable="false"` elements #TINY-8563
+- The `buttonType` property did not work for dialog footer buttons #TINY-8582
 
 ## 6.0.0 - 2022-03-03
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Dialogs will not exceed the window height on smaller screens #TINY-8146
+- The `buttonType` property did not work for dialog footer buttons #TINY-8582
 
 ## 6.0.1 - TBD
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/AlertDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/AlertDialog.ts
@@ -20,6 +20,7 @@ export const setup = (extras) => {
         name: 'close-alert',
         text: 'OK',
         primary: true,
+        buttonType: Optional.some('primary'),
         align: 'end',
         enabled: true,
         icon: Optional.none()

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ConfirmDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ConfirmDialog.ts
@@ -24,6 +24,7 @@ export const setup = (extras: ConfirmDialogSetup) => {
         name: 'yes',
         text: 'Yes',
         primary: true,
+        buttonType: Optional.some('primary'),
         align: 'end',
         enabled: true,
         icon: Optional.none()
@@ -34,6 +35,7 @@ export const setup = (extras: ConfirmDialogSetup) => {
       name: 'no',
       text: 'No',
       primary: false,
+      buttonType: Optional.some('secondary'),
       align: 'end',
       enabled: true,
       icon: Optional.none()

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -161,7 +161,6 @@ export const renderFooterButton = (spec: FooterButtonSpec, buttonType: string, b
     const action = getAction(spec.name, buttonType);
     const buttonSpec = {
       ...spec,
-      buttonType: Optional.none(),
       borderless: false
     };
     return renderButton(buttonSpec, action, backstage.shared.providers, [ ]);

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/dialogbutton/DialogFooterButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/dialogbutton/DialogFooterButtonTest.ts
@@ -1,0 +1,61 @@
+import { ApproxStructure, Assertions } from '@ephox/agar';
+import { GuiFactory, TestHelpers } from '@ephox/alloy';
+import { describe, it } from '@ephox/bedrock-client';
+import { Optional } from '@ephox/katamari';
+
+import { renderFooterButton } from 'tinymce/themes/silver/ui/general/Button';
+
+import TestBackstage from '../../../module/TestBackstage';
+
+describe('headless.tinymce.themes.silver.components.dialogbutton.DialogFooterButtonTest', () => {
+  const backstage = TestBackstage();
+  describe('primary style', () => {
+    const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(
+      renderFooterButton({
+        text: 'Submit>Text',
+        name: 'Submit',
+        enabled: true,
+        primary: false,
+        align: 'end',
+        icon: Optional.none(),
+        tooltip: Optional.some('Submit'),
+        buttonType: Optional.some('primary'),
+      }, 'submit', backstage)
+    ));
+
+    it('TINY-8582: buttonType property should take precendence over primary property', () => {
+      Assertions.assertStructure(
+        'Checking CSS of button',
+        ApproxStructure.build((s, str, arr) => s.element('button', {
+          classes: [ arr.has('tox-button'), arr.not('tox-button--secondary'), arr.not('tox-tbtn') ],
+        })),
+        hook.component().element
+      );
+    });
+  });
+
+  describe('secondary style', () => {
+    const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(
+      renderFooterButton({
+        name: 'test-button',
+        text: 'Cancel Button',
+        enabled: true,
+        primary: true,
+        tooltip: Optional.some('Secondary button'),
+        buttonType: Optional.some('secondary'),
+        icon: Optional.none(),
+        align: 'end',
+      }, 'cancel', backstage)
+    ));
+
+    it('TINY-8582: buttonType property should take precendence over primary property', () => {
+      Assertions.assertStructure(
+        'Checking CSS of button',
+        ApproxStructure.build((s, str, arr) => s.element('button', {
+          classes: [ arr.has('tox-button'), arr.has('tox-button--secondary'), arr.not('tox-tbtn') ],
+        })),
+        hook.component().element
+      );
+    });
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogEventTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogEventTest.ts
@@ -39,6 +39,7 @@ describe('headless.tinymce.themes.silver.window.SilverDialogEventTest', () => {
           text: 'Cancel',
           align: 'end',
           primary: false,
+          buttonType: Optional.some('secondary'),
           enabled: true,
           icon: Optional.none()
         },
@@ -48,6 +49,7 @@ describe('headless.tinymce.themes.silver.window.SilverDialogEventTest', () => {
           text: 'Save',
           align: 'end',
           primary: true,
+          buttonType: Optional.some('primary'),
           enabled: true,
           icon: Optional.none()
         }


### PR DESCRIPTION
Related Ticket: TINY-8582

Description of Changes:
* Deprecated primary property of dialog footer buttons
* Fixed the buttonType property not working for dialog footer buttons
* Removed `buttonType = Optional.none()` in Button.ts

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
