### PR TITLE
TINY-8586: Fix contrast ratio for error messages

### DIFF
--- a/modules/oxide/src/less/theme/components/notification/notification.less
+++ b/modules/oxide/src/less/theme/components/notification/notification.less
@@ -98,7 +98,7 @@
     }
 
     a {
-      color: @color-error;
+      color: @notification-error-link-color;
     }
 
     svg {

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - It wasn't possible to select text right after an inline noneditable element #TINY-8567
 - Fixed a double border showing for the `tinymce-5` skin when using `toolbar_location: 'bottom'` #TINY-8564
 - Clipboard content was not generated correctly when cutting and copying `contenteditable="false"` elements #TINY-8563
+- Fix contrast ratio for error messages #TINY-8586
 
 ## 6.0.0 - 2022-03-03
 


### PR DESCRIPTION
Related Ticket: TINY-8586

Description of Changes:
* Fix incorrectly assigned link color in error messages

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved