### PR TITLE
Lists listen to ExecCommand events, so it's possible to cancel indent/outdent via BeforeExecCommand

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Dialogs will not exceed the window height on smaller screens #TINY-8146
+- Lists are listening to indent/outdent events though ExecCommand, so it's possible to cancel it via BeforeExecCommand
 
 ## 6.0.1 - 2022-03-23
 

--- a/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
@@ -20,7 +20,7 @@ const registerDialog = (editor: Editor): void => {
 };
 
 const register = (editor: Editor): void => {
-  editor.on('BeforeExecCommand', (e) => {
+  editor.on('ExecCommand', (e) => {
     const cmd = e.command.toLowerCase();
 
     if (cmd === 'indent') {


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* Lists listen to ExecCommand events, so it's possible to cancel indent/outdent via BeforeExecCommand

Pre-checks:
* [x] Changelog entry added
* [ ] ~~Tests have been added (if applicable)~~
* [ ] ~~Branch prefixed with `feature/` for new features (if applicable)~~

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable): #7719 
