### PR TITLE
TINY-8592: List backspace function no longer steps into tables

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,12 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The `end_container_on_empty_block` option can now take a string of blocks to split when pressing Enter twice #TINY-6559
-- Added optional function parameter to `TreeWalker.prev2`, allowing aborting tree walking efforts #TINY-8592
 - The default value for `end_container_on_empty_block` option has been changed to `'blockquote'` #TINY-6559
 
 ### Fixed
 - Dialogs will not exceed the window height on smaller screens #TINY-8146
-- Some types on functions in `editor.dom.TreeWalker` class missed that it could return undefined #TINY-8592
+- Some types on functions in `tinymce.dom.TreeWalker` class missed that it could return undefined #TINY-8592
 - In some cases backspace would step into tables rather than remain outside #TINY-8592
 - Text alignment could not be applied to `pre` elements #TINY-7715
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Dialogs will not exceed the window height on smaller screens #TINY-8146
-- Some types on functions in `tinymce.dom.TreeWalker` class missed that it could return undefined #TINY-8592
-- In some cases backspace would step into tables rather than remain outside #TINY-8592
+- Some types on functions in the `tinymce.dom.TreeWalker` class missed that it could return undefined #TINY-8592
+- In some cases pressing the backspace key would incorrectly step into tables rather than remain outside #TINY-8592
 - Text alignment could not be applied to `pre` elements #TINY-7715
 
 ## 6.0.1 - 2022-03-23

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,10 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The `end_container_on_empty_block` option can now take a string of blocks to split when pressing Enter twice #TINY-6559
+- Added optional function parameter to `TreeWalker.prev2`, allowing aborting tree walking efforts #TINY-8592
 - The default value for `end_container_on_empty_block` option has been changed to `'blockquote'` #TINY-6559
 
 ### Fixed
 - Dialogs will not exceed the window height on smaller screens #TINY-8146
+- Some types on functions in `editor.dom.TreeWalker` class missed that it could return undefined #TINY-8592
+- In some cases backspace would step into tables rather than remain outside #TINY-8592
 - Text alignment could not be applied to `pre` elements #TINY-7715
 
 ## 6.0.1 - 2022-03-23

--- a/modules/tinymce/src/core/main/ts/api/dom/TreeWalker.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/TreeWalker.ts
@@ -1,5 +1,3 @@
-import { Fun, Type } from '@ephox/katamari';
-
 export interface DomTreeWalkerConstructor {
   readonly prototype: DomTreeWalker;
 
@@ -66,8 +64,8 @@ class DomTreeWalker {
     return this.node;
   }
 
-  public prev2(shallow?: boolean, abortIf?: (node: Node | undefined) => boolean): Node | undefined {
-    this.node = this.findPreviousNode(this.node, Type.isFunction(abortIf) ? abortIf : Fun.never, shallow);
+  public prev2(shallow?: boolean): Node | undefined {
+    this.node = this.findPreviousNode(this.node, shallow);
     return this.node;
   }
 
@@ -98,12 +96,12 @@ class DomTreeWalker {
     }
   }
 
-  private findPreviousNode(node: Node | undefined, abortIf: (node: Node | undefined) => boolean, shallow?: boolean): undefined | Node {
+  private findPreviousNode(node: Node | undefined, shallow?: boolean): undefined | Node {
     let sibling: Node, parent: Node, child: Node;
 
     if (node) {
       sibling = node.previousSibling;
-      if (this.rootNode && sibling === this.rootNode || abortIf(sibling)) {
+      if (this.rootNode && sibling === this.rootNode) {
         return;
       }
 
@@ -111,10 +109,6 @@ class DomTreeWalker {
         if (!shallow) {
           // Walk down to the most distant child
           for (child = sibling.lastChild; child; child = child.lastChild) {
-            if (abortIf(child)) {
-              return;
-            }
-
             if (!child.lastChild) {
               return child;
             }
@@ -125,7 +119,7 @@ class DomTreeWalker {
       }
 
       parent = node.parentNode;
-      if (parent && parent !== this.rootNode && !abortIf(parent)) {
+      if (parent && parent !== this.rootNode) {
         return parent;
       }
     }

--- a/modules/tinymce/src/core/main/ts/api/dom/TreeWalker.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/TreeWalker.ts
@@ -36,7 +36,7 @@ class DomTreeWalker {
    * Returns the current node.
    *
    * @method current
-   * @return {Node | undefined} Current node where the walker is, or undefined if the walker has reached the end.
+   * @return {Node/undefined} Current node where the walker is, or undefined if the walker has reached the end.
    */
   public current(): Node | undefined {
     return this.node;
@@ -46,7 +46,7 @@ class DomTreeWalker {
    * Walks to the next node in tree.
    *
    * @method next
-   * @return {Node | undefined} Current node where the walker is after moving to the next node, or undefined if the walker has reached the end.
+   * @return {Node/undefined} Current node where the walker is after moving to the next node, or undefined if the walker has reached the end.
    */
   public next(shallow?: boolean): Node | undefined {
     this.node = this.findSibling(this.node, 'firstChild', 'nextSibling', shallow);
@@ -57,7 +57,7 @@ class DomTreeWalker {
    * Walks to the previous node in tree.
    *
    * @method prev
-   * @return {Node | undefined} Current node where the walker is after moving to the previous node, or undefined if the walker has reached the end.
+   * @return {Node/undefined} Current node where the walker is after moving to the previous node, or undefined if the walker has reached the end.
    */
   public prev(shallow?: boolean): Node | undefined {
     this.node = this.findSibling(this.node, 'lastChild', 'previousSibling', shallow);

--- a/modules/tinymce/src/core/main/ts/api/dom/TreeWalker.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/TreeWalker.ts
@@ -96,7 +96,7 @@ class DomTreeWalker {
     }
   }
 
-  private findPreviousNode(node: Node | undefined, shallow?: boolean): undefined | Node {
+  private findPreviousNode(node: Node | undefined, shallow?: boolean): Node | undefined {
     let sibling: Node, parent: Node, child: Node;
 
     if (node) {

--- a/modules/tinymce/src/core/test/ts/browser/dom/TreeWalkerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/TreeWalkerTest.ts
@@ -46,6 +46,8 @@ describe('browser.tinymce.core.dom.TreeWalkerTest', () => {
     nodes = all(viewBlock.get()).slice(1);
   });
 
+  const isTextNode = (node: Node | undefined): node is Text => node && node.nodeType === 3;
+
   const compareNodeLists = (expectedNodes: ArrayLike<Node>, actualNodes: ArrayLike<Node>) => {
     if (expectedNodes.length !== actualNodes.length) {
       return false;
@@ -95,5 +97,31 @@ describe('browser.tinymce.core.dom.TreeWalkerTest', () => {
 
     actualNodes = actualNodes.reverse();
     assert.isTrue(compareNodeLists(viewBlock.get().childNodes, actualNodes), 'Should be the same');
+  });
+
+  it('TINY-8592: prev2 with abortIf function when reaching 4', () => {
+    const walker = new DomTreeWalker(nodes[nodes.length - 1], viewBlock.get());
+    let actualNodes;
+
+    actualNodes = [ walker.current() ];
+    while ((walker.prev2(false, (node: Node | undefined) => node && isTextNode(node) && node.textContent === '4'))) {
+      actualNodes.push(walker.current());
+    }
+
+    actualNodes = actualNodes.reverse();
+    assert.isTrue(compareNodeLists(nodes.slice(9), actualNodes), 'Should be the same');
+  });
+
+  it('TINY-8592: prev2 with abortIf function and shallow mode', () => {
+    const walker = new DomTreeWalker(nodes[nodes.length - 1], viewBlock.get());
+    let actualNodes;
+
+    actualNodes = [ walker.current() ];
+    while ((walker.prev2(false, (node: Node | undefined) => node && !isTextNode(node)))) {
+      actualNodes.push(walker.current());
+    }
+
+    actualNodes = actualNodes.reverse();
+    assert.isTrue(compareNodeLists([ viewBlock.get().childNodes.item(2) ], actualNodes), 'Should be the same');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/TreeWalkerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/TreeWalkerTest.ts
@@ -46,8 +46,6 @@ describe('browser.tinymce.core.dom.TreeWalkerTest', () => {
     nodes = all(viewBlock.get()).slice(1);
   });
 
-  const isTextNode = (node: Node | undefined): node is Text => node && node.nodeType === 3;
-
   const compareNodeLists = (expectedNodes: ArrayLike<Node>, actualNodes: ArrayLike<Node>) => {
     if (expectedNodes.length !== actualNodes.length) {
       return false;
@@ -97,31 +95,5 @@ describe('browser.tinymce.core.dom.TreeWalkerTest', () => {
 
     actualNodes = actualNodes.reverse();
     assert.isTrue(compareNodeLists(viewBlock.get().childNodes, actualNodes), 'Should be the same');
-  });
-
-  it('TINY-8592: prev2 with abortIf function when reaching 4', () => {
-    const walker = new DomTreeWalker(nodes[nodes.length - 1], viewBlock.get());
-    let actualNodes;
-
-    actualNodes = [ walker.current() ];
-    while ((walker.prev2(false, (node: Node | undefined) => node && isTextNode(node) && node.textContent === '4'))) {
-      actualNodes.push(walker.current());
-    }
-
-    actualNodes = actualNodes.reverse();
-    assert.isTrue(compareNodeLists(nodes.slice(9), actualNodes), 'Should be the same');
-  });
-
-  it('TINY-8592: prev2 with abortIf function and shallow mode', () => {
-    const walker = new DomTreeWalker(nodes[nodes.length - 1], viewBlock.get());
-    let actualNodes;
-
-    actualNodes = [ walker.current() ];
-    while ((walker.prev2(false, (node: Node | undefined) => node && !isTextNode(node)))) {
-      actualNodes.push(walker.current());
-    }
-
-    actualNodes = actualNodes.reverse();
-    assert.isTrue(compareNodeLists([ viewBlock.get().childNodes.item(2) ], actualNodes), 'Should be the same');
   });
 });

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -1,4 +1,4 @@
-import { Arr } from '@ephox/katamari';
+import { Arr, Optionals } from '@ephox/katamari';
 import { Compare, PredicateFind, Remove, SugarElement, SugarNode } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
@@ -215,7 +215,7 @@ const backspaceDeleteIntoListCaret = (editor: Editor, isForward: boolean): boole
       const otherLiCell = PredicateFind.closest(SugarElement.fromDom(otherLi), findValidElement, findRoot);
       const caretCell = PredicateFind.closest(SugarElement.fromDom(rng.startContainer), findValidElement, findRoot);
 
-      if (otherLiCell !== caretCell) {
+      if (!Optionals.equals(otherLiCell, caretCell, (a, b) => a.dom === b.dom)) {
         return false;
       }
 

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -215,7 +215,7 @@ const backspaceDeleteIntoListCaret = (editor: Editor, isForward: boolean): boole
       const otherLiCell = PredicateFind.closest(SugarElement.fromDom(otherLi), findValidElement, findRoot);
       const caretCell = PredicateFind.closest(SugarElement.fromDom(rng.startContainer), findValidElement, findRoot);
 
-      if (!Optionals.equals(otherLiCell, caretCell, (a, b) => a.dom === b.dom)) {
+      if (!Optionals.equals(otherLiCell, caretCell, Compare.eq)) {
         return false;
       }
 

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -209,16 +209,16 @@ const backspaceDeleteIntoListCaret = (editor: Editor, isForward: boolean): boole
     const rng = ListRangeUtils.normalizeRange(editor.selection.getRng());
     const otherLi = dom.getParent(findNextCaretContainer(editor, rng, isForward, root), 'LI', root);
 
-    const findValidElement = (element: SugarElement<Node>) => Arr.contains([ 'td', 'th', 'caption' ], SugarNode.name(element));
-    const findRoot = (node: SugarElement<Node>) => node.dom === root;
-    const otherLiCell = PredicateFind.closest(SugarElement.fromDom(otherLi), findValidElement, findRoot);
-    const caretCell = PredicateFind.closest(SugarElement.fromDom(rng.startContainer), findValidElement, findRoot);
-
-    if (otherLiCell !== caretCell) {
-      return false;
-    }
-
     if (otherLi) {
+      const findValidElement = (element: SugarElement<Node>) => Arr.contains([ 'td', 'th', 'caption' ], SugarNode.name(element));
+      const findRoot = (node: SugarElement<Node>) => node.dom === root;
+      const otherLiCell = PredicateFind.closest(SugarElement.fromDom(otherLi), findValidElement, findRoot);
+      const caretCell = PredicateFind.closest(SugarElement.fromDom(rng.startContainer), findValidElement, findRoot);
+
+      if (otherLiCell !== caretCell) {
+        return false;
+      }
+
       editor.undoManager.transact(() => {
         removeBlock(dom, block, root);
         ToggleList.mergeWithAdjacentLists(dom, otherLi.parentNode as Element);

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -37,7 +37,8 @@ const findNextCaretContainer = (editor: Editor, rng: Range, isForward: boolean, 
     }
   }
 
-  while ((node = (isForward ? walker.next() : walker.prev2()))) {
+  const walkFn = isForward ? walker.next.bind(walker) : walker.prev2.bind(walker);
+  while ((node = walkFn())) {
     if (node.nodeName === 'LI' && !node.hasChildNodes()) {
       return node;
     }

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -37,7 +37,7 @@ const findNextCaretContainer = (editor: Editor, rng: Range, isForward: boolean, 
     }
   }
 
-  while ((node = walker[isForward ? 'next' : 'prev2']())) {
+  while ((node = (isForward ? walker.next() : walker.prev2(false, (checkNode: Node | undefined) => checkNode && checkNode.nodeName === 'TABLE')))) {
     if (node.nodeName === 'LI' && !node.hasChildNodes()) {
       return node;
     }

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteFromBlockIntoLiTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteFromBlockIntoLiTest.ts
@@ -34,6 +34,59 @@ describe('Browser Test: .RemoveTrailingBlockquoteTest', () => {
     TinyAssertions.assertContent(editor, content);
   });
 
+  it('TINY-8592: backspace inside cell', () => {
+    const editor = hook.editor();
+    editor.setContent('<table>' +
+        '<tbody>' +
+          '<tr>' +
+            '<td>' +
+              '<ul>' +
+                '<li>a</li>' +
+              '</ul>' +
+              '<p>&nbsp;</p>' +
+            '</td>' +
+          '</tr>' +
+        '</tbody>' +
+      '</table>');
+    TinySelections.setCursor(editor, [ 0, 0, 0, 0, 1 ], 0);
+    TinyContentActions.keystroke(editor, Keys.backspace());
+    TinyAssertions.assertCursor(editor, [0, 0, 0, 0, 0, 0, 0 ], 1);
+    TinyAssertions.assertContent(editor, '<table>' +
+        '<tbody>' +
+          '<tr>' +
+            '<td>' +
+              '<ul>' +
+                '<li>a</li>' +
+              '</ul>' +
+            '</td>' +
+          '</tr>' +
+        '</tbody>' +
+      '</table>');
+  });
+
+  it('TINY-8592: backspace inside different cells', () => {
+    const editor = hook.editor();
+    const content = '<table>' +
+        '<tbody>' +
+          '<tr>' +
+            '<td>' +
+              '<ul>' +
+                '<li>a</li>' +
+              '</ul>' +
+            '</td>' +
+            '<td>' +
+              '&nbsp;' +
+            '</td>' +
+          '</tr>' +
+        '</tbody>' +
+      '</table>';
+    editor.setContent(content);
+    TinySelections.setCursor(editor, [ 0, 0, 0, 1, 0 ], 0);
+    TinyContentActions.keystroke(editor, Keys.backspace());
+    TinyAssertions.assertCursor(editor, [ 0, 0, 0,1 ], 0);
+    TinyAssertions.assertContent(editor, content);
+  });
+
   it('TBA: backspace from p inside div into li', () => {
     const editor = hook.editor();
     editor.setContent('<ul><li>a</li></ul><div><p><br /></p></div>');

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteFromBlockIntoLiTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteFromBlockIntoLiTest.ts
@@ -13,6 +13,27 @@ describe('Browser Test: .RemoveTrailingBlockquoteTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ]);
 
+  it('TINY-8592: backspace from p outside of table with no change', () => {
+    const editor = hook.editor();
+    const content = '<table>' +
+        '<tbody>' +
+          '<tr>' +
+            '<td>' +
+              '<ul>' +
+                '<li>a</li>' +
+              '</ul>' +
+            '</td>' +
+          '</tr>' +
+        '</tbody>' +
+      '</table>' +
+      '<p>&nbsp;</p>';
+    editor.setContent(content);
+    TinySelections.setCursor(editor, [ 1 ], 0);
+    TinyContentActions.keystroke(editor, Keys.backspace());
+    TinyAssertions.assertCursor(editor, [ 1 ], 0);
+    TinyAssertions.assertContent(editor, content);
+  });
+
   it('TBA: backspace from p inside div into li', () => {
     const editor = hook.editor();
     editor.setContent('<ul><li>a</li></ul><div><p><br /></p></div>');

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteFromBlockIntoLiTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteFromBlockIntoLiTest.ts
@@ -50,7 +50,7 @@ describe('Browser Test: .RemoveTrailingBlockquoteTest', () => {
       '</table>');
     TinySelections.setCursor(editor, [ 0, 0, 0, 0, 1 ], 0);
     TinyContentActions.keystroke(editor, Keys.backspace());
-    TinyAssertions.assertCursor(editor, [0, 0, 0, 0, 0, 0, 0 ], 1);
+    TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0, 0, 0, 0 ], 1);
     TinyAssertions.assertContent(editor, '<table>' +
         '<tbody>' +
           '<tr>' +
@@ -83,7 +83,7 @@ describe('Browser Test: .RemoveTrailingBlockquoteTest', () => {
     editor.setContent(content);
     TinySelections.setCursor(editor, [ 0, 0, 0, 1, 0 ], 0);
     TinyContentActions.keystroke(editor, Keys.backspace());
-    TinyAssertions.assertCursor(editor, [ 0, 0, 0,1 ], 0);
+    TinyAssertions.assertCursor(editor, [ 0, 0, 0, 1 ], 0);
     TinyAssertions.assertContent(editor, content);
   });
 


### PR DESCRIPTION
Related Ticket:

Description of Changes:
List plugin should no longer step into tables if the last cell of the table contains a list at the end. Also added typing to reflect TreeWalker's ability return undefined in addition to a Node ( such as when reaching the end of a walk ).

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
