### PR TITLE
Making default color of text marker tool yellow

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -16,6 +16,7 @@ export interface ColorSwatchDialogData {
 type ColorFormat = 'forecolor' | 'hilitecolor';
 
 const fallbackColor = '#000000';
+const fallbackColorBg = '#fbeeb8';
 
 const getCurrentColor = (editor: Editor, format: ColorFormat): Optional<string> => {
   let color: string | undefined;
@@ -232,7 +233,7 @@ const colorPickerDialog = (editor: Editor) => (callback: ColorInputCallback, val
 const register = (editor: Editor) => {
   registerCommands(editor);
   const lastForeColor = Cell(fallbackColor);
-  const lastBackColor = Cell(fallbackColor);
+  const lastBackColor = Cell(fallbackColorBg);
   registerTextColorButton(editor, 'forecolor', 'forecolor', 'Text color', lastForeColor);
   registerTextColorButton(editor, 'backcolor', 'hilitecolor', 'Background color', lastBackColor);
 


### PR DESCRIPTION
Related Ticket:

Description of Changes:
adds a default text highlighter color, old code uses same default color as text color (black),  which doesn't make sense. Solves the problem that users always need to first select a highlighting color before they can use the tool. Especially annoying for users who use keyboard shortcuts often

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
#5411 