### PR TITLE
TINY-8594: Fixed inline toolbar flickering when switching between editors

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Dialogs will not exceed the window height on smaller screens #TINY-8146
 - Text alignment could not be applied to `pre` elements #TINY-7715
+- Inline toolbars flicker when switching between editors #TINY-8594
 
 ## 6.0.1 - 2022-03-23
 

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -106,9 +106,6 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
     editor.nodeChanged();
   };
 
-  // In certain circumstances we need to delay the render function until the next
-  // event loop to ensure things like the current selection are correct.
-
   editor.on('show', render);
   editor.on('hide', ui.hide);
 

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -84,7 +84,7 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
       ui.show();
       return;
     }
-    // console.time("init load");
+
     floatContainer.set(OuterContainer.getHeader(outerContainer).getOrDie());
 
     const uiContainer = getUiContainer(editor);

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -4,7 +4,6 @@ import { DomEvent, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { EditorUiApi } from 'tinymce/core/api/ui/Ui';
-import Delay from 'tinymce/core/api/util/Delay';
 
 import * as Events from '../api/Events';
 import { getUiContainer, isToolbarPersist } from '../api/Options';
@@ -85,7 +84,7 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
       ui.show();
       return;
     }
-
+    // console.time("init load");
     floatContainer.set(OuterContainer.getHeader(outerContainer).getOrDie());
 
     const uiContainer = getUiContainer(editor);
@@ -109,19 +108,18 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
 
   // In certain circumstances we need to delay the render function until the next
   // event loop to ensure things like the current selection are correct.
-  const delayedRender = () => Delay.setEditorTimeout(editor, render, 0);
 
   editor.on('show', render);
   editor.on('hide', ui.hide);
 
   if (!toolbarPersist) {
-    editor.on('focus', delayedRender);
+    editor.on('focus', render);
     editor.on('blur', ui.hide);
   }
 
   editor.on('init', () => {
     if (editor.hasFocus() || toolbarPersist) {
-      delayedRender();
+      render();
     }
   });
 


### PR DESCRIPTION
Related Ticket: TINY-8594, also fixed TINY-8503

Description of Changes:
* Reverted changes that were made in #6916 

The issue occurring in a single frame makes it difficult to write a reliable test

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
