### PR TITLE
TINY-8578: Newlines for more than one empty line.

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
+- Calling `tinymce.getContent({format: 'text'})` now returns newlines instead of empty string if more than one paragraph exists #TINY-8578
 - The `end_container_on_empty_block` option can now take a string of blocks to split when pressing Enter twice #TINY-6559
 - The default value for `end_container_on_empty_block` option has been changed to `'blockquote'` #TINY-6559
 

--- a/modules/tinymce/src/core/main/ts/content/GetContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/GetContentImpl.ts
@@ -23,7 +23,8 @@ const getContentFromBody = (editor: Editor, args: GetContentArgs, body: HTMLElem
     content = Tools.trim(TrimHtml.trimExternal(editor.serializer, body.innerHTML));
   } else if (args.format === 'text') {
     // return empty string for text format when editor is empty to avoid bogus elements being returned in content
-    content = editor.dom.isEmpty(body) ? '' : Zwsp.trim(body.innerText || body.textContent);
+    content = Zwsp.trim(body.innerText || body.textContent);
+    content = '\n' === content ? '' : content;
   } else if (args.format === 'tree') {
     content = editor.serializer.serialize(body, args);
   } else {

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -94,6 +94,46 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
     assertEventsContentType();
   });
 
+  it('TINY-8578: getContent text, empty line in div', () => {
+    const editor = hook.editor();
+    editor.setContent('<div><p></p></div>');
+    const text = editor.getContent({ format: 'text' });
+    const expected = '';
+    Assertions.assertEq('Should be expected text', expected, text);
+    assertEventsFiredInOrder();
+    assertEventsContentType();
+  });
+
+  it('TINY-8578: getContent text, empty line', () => {
+    const editor = hook.editor();
+    editor.setContent('<p></p>');
+    const text = editor.getContent({ format: 'text' });
+    const expected = '';
+    Assertions.assertEq('Should be expected text', expected, text);
+    assertEventsFiredInOrder();
+    assertEventsContentType();
+  });
+
+  it('TINY-8578: getContent text, two empty lines in div', () => {
+    const editor = hook.editor();
+    editor.setContent('<div><p></p><p></p></div>');
+    const text = editor.getContent({ format: 'text' });
+    const isSafari = PlatformDetection.detect().browser.isSafari();
+    Assertions.assertEq('Should be expected text', isSafari ? '\n\n' : '\n\n\n\n', text);
+    assertEventsFiredInOrder();
+    assertEventsContentType();
+  });
+
+  it('TINY-8578: getContent text, two empty lines', () => {
+    const editor = hook.editor();
+    editor.setContent('<p></p><p></p>');
+    const text = editor.getContent({ format: 'text' });
+    const isSafari = PlatformDetection.detect().browser.isSafari();
+    Assertions.assertEq('Should be expected text', isSafari ? '\n\n' : '\n\n\n\n', text);
+    assertEventsFiredInOrder();
+    assertEventsContentType();
+  });
+
   it('TINY-6281: getContent text with empty editor', () => {
     const editor = hook.editor();
     editor.setContent('');


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Only return empty string if there is only one paragraph ( or at least, if the `body.innerText` returns zero or one newlines... ).

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
