### PR TITLE
Fix ctrl+. shortcut key usage

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
+++ b/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
@@ -37,7 +37,8 @@ const keyCodeLookup = {
   f9: 120,
   f10: 121,
   f11: 122,
-  f12: 123
+  f12: 123,
+  '.': 190,
 };
 
 const modifierNames = Tools.makeMap('alt,ctrl,shift,meta,access');

--- a/modules/tinymce/src/core/test/ts/browser/ShortcutsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ShortcutsTest.ts
@@ -72,6 +72,7 @@ describe('browser.tinymce.core.ShortcutsTest', () => {
     assertShortcut('f10', { keyCode: 121 }, true);
     assertShortcut('f11', { keyCode: 122 }, true);
     assertShortcut('f12', { keyCode: 123 }, true);
+    assertShortcut('.', { keyCode: 190 }, true);
   });
 
   it('Remove', () => {


### PR DESCRIPTION
Related Ticket:

Description of Changes:
In both v5 and v6 use of a `ctrl+.` shortcut key currently fires when `ctrl+DELETE` is pressed. This is due to a difference in `keyCode` and `charCode` numbering:
```js
// "." (period)
".".charCodeAt(0); // 46
e.keyCode; // 190

// DEL
// charCodeAt not possible
e.keyCode; // 46
```

As you can see the `keyCode` for `DEL` matches the `charCode` for `.`

https://keycode.info/for/delete
https://keycode.info/for/190

Pre-checks:
* [ ] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
