### PR TITLE
TINY-8594: Backport - Fixed inline toolbars flickering when switching between editors

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Inline toolbars flicker when switching between editors #TINY-8594
+
 ## 5.10.3 - 2022-02-09
 
 ### Fixed

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Inline toolbars flicker when switching between editors #TINY-8594 #TINY-8503
+- Inline toolbars flicker when switching between editors #TINY-8594
+- Multiple inline toolbars are shown after scrolling down and up #TINY-8503
 
 ## 5.10.3 - 2022-02-09
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Inline toolbars flicker when switching between editors #TINY-8594
+- Inline toolbars flicker when switching between editors #TINY-8594 #TINY-8503
 
 ## 5.10.3 - 2022-02-09
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Inline toolbars flicker when switching between editors #TINY-8594
-- Multiple inline toolbars are shown after scrolling down and up #TINY-8503
+- Inline toolbars flickered when switching between editors #TINY-8594
+- Multiple inline toolbars were shown if focused too quickly #TINY-8503
 
 ## 5.10.3 - 2022-02-09
 

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "5.10.3",
+  "version": "5.10.4",
   "private": true,
   "repository": {
     "type": "git",

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -114,21 +114,17 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
     editor.nodeChanged();
   };
 
-  // In certain circumstances we need to delay the render function until the next
-  // event loop to ensure things like the current selection are correct.
-  const delayedRender = () => Delay.setEditorTimeout(editor, render, 0);
-
   editor.on('show', render);
   editor.on('hide', ui.hide);
 
   if (!toolbarPersist) {
-    editor.on('focus', delayedRender);
+    editor.on('focus', render);
     editor.on('blur', ui.hide);
   }
 
   editor.on('init', () => {
     if (editor.hasFocus() || toolbarPersist) {
-      delayedRender();
+      render();
     }
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/MultipleInlineToolbarVisibilityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/MultipleInlineToolbarVisibilityTest.ts
@@ -4,7 +4,7 @@ import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
-describe('browser.tinymce.themes.silver.editor.toolbar.MultipleToolbarVisibilityTest', () => {
+describe('browser.tinymce.themes.silver.editor.toolbar.MultipleInlineToolbarVisibilityTest', () => {
 
   const settings = {
     inline: true,
@@ -14,7 +14,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.MultipleToolbarVisibility
   };
 
   const pWaitForFocus = (editor: Editor) => new Promise((resolve) => {
-    editor.on('focus', resolve);
+    editor.once('focus', resolve);
     editor.focus();
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/MultipleInlineToolbarVisibilityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/MultipleInlineToolbarVisibilityTest.ts
@@ -3,6 +3,7 @@ import { Css } from '@ephox/sugar';
 import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
+import PromisePolyfill from 'tinymce/core/api/util/Promise';
 
 describe('browser.tinymce.themes.silver.editor.toolbar.MultipleInlineToolbarVisibilityTest', () => {
 
@@ -13,7 +14,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.MultipleInlineToolbarVisi
     base_url: '/project/tinymce/js/tinymce'
   };
 
-  const pWaitForFocus = (editor: Editor) => new Promise((resolve) => {
+  const pWaitForFocus = (editor: Editor) => new PromisePolyfill((resolve) => {
     editor.once('focus', resolve);
     editor.focus();
   });
@@ -24,7 +25,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.MultipleInlineToolbarVisi
     editorOne.setContent('<p id="number1"><strong>blarg</strong></p>');
     editorTwo.setContent('<p id="number2">blarg</p>');
 
-    await Promise.all([
+    await PromisePolyfill.all([
       pWaitForFocus(editorOne),
       pWaitForFocus(editorTwo)
     ]);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/MultipleToolbarVisibilityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/MultipleToolbarVisibilityTest.ts
@@ -1,4 +1,3 @@
-import { Waiter } from '@ephox/agar';
 import { Assert, describe, it } from '@ephox/bedrock-client';
 import { Css } from '@ephox/sugar';
 import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
@@ -14,17 +13,25 @@ describe('browser.tinymce.themes.silver.editor.toolbar.MultipleToolbarVisibility
     base_url: '/project/tinymce/js/tinymce'
   };
 
+  const pWaitForFocus = (editor: Editor) => new Promise((resolve) => {
+    editor.on('focus', resolve);
+    editor.focus();
+  });
+
   it('TINY-8503: Does not leave two toolbars showing', async () => {
     const editorOne = await McEditor.pFromSettings<Editor>(settings);
     const editorTwo = await McEditor.pFromSettings<Editor>(settings);
     editorOne.setContent('<p id="number1"><strong>blarg</strong></p>');
     editorTwo.setContent('<p id="number2">blarg</p>');
-    editorOne.focus();
-    editorTwo.focus();
-    await Waiter.pWait(500);
+
+    await Promise.all([
+      pWaitForFocus(editorOne),
+      pWaitForFocus(editorTwo)
+    ]);
 
     Assert.eq('editor 2 toolbar should be showing', 'flex', Css.get(TinyDom.container(editorTwo), 'display'));
     Assert.eq('editor 1 toolbar should be hidden', 'none', Css.get(TinyDom.container(editorOne), 'display'));
+
     McEditor.remove(editorOne);
     McEditor.remove(editorTwo);
   });
@@ -32,12 +39,15 @@ describe('browser.tinymce.themes.silver.editor.toolbar.MultipleToolbarVisibility
   it('TINY-8594: No flickering when switching', async () => {
     const editorOne = await McEditor.pFromHtml<Editor>('<div><p id="number1"><strong>Editor one</strong></p></div>', settings);
     const editorTwo = await McEditor.pFromHtml<Editor>('<div><p id="number2"><strong>Editor two</strong></p></div>', settings);
-    await Waiter.pWait(500);
-    editorOne.focus();
+
+    await pWaitForFocus(editorOne);
     Assert.eq('Editor 1 toolbar should be showing', 'flex', Css.get(TinyDom.container(editorOne), 'display'));
 
-    editorTwo.focus();
+    await pWaitForFocus(editorTwo);
     Assert.eq('Editor 1 toolbar should be hidden', 'none', Css.get(TinyDom.container(editorOne), 'display'));
     Assert.eq('Editor 2 toolbar should be showing', 'flex', Css.get(TinyDom.container(editorTwo), 'display'));
+
+    McEditor.remove(editorTwo);
+    McEditor.remove(editorOne);
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/MultipleToolbarVisibilityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/MultipleToolbarVisibilityTest.ts
@@ -1,0 +1,43 @@
+import { Waiter } from '@ephox/agar';
+import { Assert, describe, it } from '@ephox/bedrock-client';
+import { Css } from '@ephox/sugar';
+import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.toolbar.MultipleToolbarVisibilityTest', () => {
+
+  const settings = {
+    inline: true,
+    menubar: false,
+    toolbar: 'bold italic underline | alignleft aligncenter alignright alignjustify',
+    base_url: '/project/tinymce/js/tinymce'
+  };
+
+  it('TINY-8503: Does not leave two toolbars showing', async () => {
+    const editorOne = await McEditor.pFromSettings<Editor>(settings);
+    const editorTwo = await McEditor.pFromSettings<Editor>(settings);
+    editorOne.setContent('<p id="number1"><strong>blarg</strong></p>');
+    editorTwo.setContent('<p id="number2">blarg</p>');
+    editorOne.focus();
+    editorTwo.focus();
+    await Waiter.pWait(500);
+
+    Assert.eq('editor 2 toolbar should be showing', 'flex', Css.get(TinyDom.container(editorTwo), 'display'));
+    Assert.eq('editor 1 toolbar should be hidden', 'none', Css.get(TinyDom.container(editorOne), 'display'));
+    McEditor.remove(editorOne);
+    McEditor.remove(editorTwo);
+  });
+
+  it('TINY-8594: No flickering when switching', async () => {
+    const editorOne = await McEditor.pFromHtml<Editor>('<div><p id="number1"><strong>Editor one</strong></p></div>', settings);
+    const editorTwo = await McEditor.pFromHtml<Editor>('<div><p id="number2"><strong>Editor two</strong></p></div>', settings);
+    await Waiter.pWait(500);
+    editorOne.focus();
+    Assert.eq('Editor 1 toolbar should be showing', 'flex', Css.get(TinyDom.container(editorOne), 'display'));
+
+    editorTwo.focus();
+    Assert.eq('Editor 1 toolbar should be hidden', 'none', Css.get(TinyDom.container(editorOne), 'display'));
+    Assert.eq('Editor 2 toolbar should be showing', 'flex', Css.get(TinyDom.container(editorTwo), 'display'));
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-8594
Description of Changes:
* Reverted changes that were made in #6916
* Bumped package.json version to 5.10.4

The issue occurring in a single frame makes it difficult to write a reliable test

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
