### PR TITLE
TINY-8606: Fixed the selection not deleted on `InsertParagraph` execution

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Dialogs will not exceed the window height on smaller screens #TINY-8146
 - Text alignment could not be applied to `pre` elements #TINY-7715
-- delete selection on `InsertParagraph` and `mceInsertNewLine` execution #TINY-8606
+- The `InsertParagraph` or `mceInsertNewLine` commands did not delete the current selection like the native command used to #TINY-8606
 
 ## 6.0.1 - 2022-03-23
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Dialogs will not exceed the window height on smaller screens #TINY-8146
 - Text alignment could not be applied to `pre` elements #TINY-7715
+- delete selection on `InsertParagraph` and `mceInsertNewLine` execution #TINY-8606
 
 ## 6.0.1 - 2022-03-23
 

--- a/modules/tinymce/src/core/demo/ts/demo/CommandsDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/CommandsDemo.ts
@@ -38,6 +38,7 @@ export default () => {
     cmd('Indent'),
     cmd('Outdent'),
     cmd('InsertHorizontalRule'),
+    cmd('InsertParagraph'),
     cmd('mceToggleVisualAid'),
     cmd('mceInsertLink', 'url'),
     cmd('selectAll'),

--- a/modules/tinymce/src/core/main/ts/api/commands/NewlineCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/commands/NewlineCommands.ts
@@ -5,6 +5,12 @@ import Editor from '../Editor';
 export const registerCommands = (editor: Editor): void => {
   editor.editorCommands.addCommands({
     insertParagraph: () => {
+      // eslint-disable-next-line no-console
+      console.log('editor.selection: ', editor.selection);
+      // eslint-disable-next-line no-console
+      console.log('editor.selection.destroy: ', editor.selection.destroy);
+      // editor.selection.destroy();
+      editor.selection.setContent('');
       InsertNewLine.insert(editor);
     },
 

--- a/modules/tinymce/src/core/main/ts/api/commands/NewlineCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/commands/NewlineCommands.ts
@@ -1,5 +1,3 @@
-import { execDeleteCommand } from 'tinymce/core/delete/DeleteUtils';
-
 import * as InsertBr from '../../newline/InsertBr';
 import * as InsertNewLine from '../../newline/InsertNewLine';
 import Editor from '../Editor';
@@ -7,9 +5,6 @@ import Editor from '../Editor';
 export const registerCommands = (editor: Editor): void => {
   editor.editorCommands.addCommands({
     insertParagraph: () => {
-      if (editor.selection.isCollapsed() === false) {
-        execDeleteCommand(editor);
-      }
       InsertNewLine.insert(editor);
     },
 

--- a/modules/tinymce/src/core/main/ts/api/commands/NewlineCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/commands/NewlineCommands.ts
@@ -1,3 +1,5 @@
+import { execDeleteCommand } from 'tinymce/core/delete/DeleteUtils';
+
 import * as InsertBr from '../../newline/InsertBr';
 import * as InsertNewLine from '../../newline/InsertNewLine';
 import Editor from '../Editor';
@@ -5,12 +7,9 @@ import Editor from '../Editor';
 export const registerCommands = (editor: Editor): void => {
   editor.editorCommands.addCommands({
     insertParagraph: () => {
-      // eslint-disable-next-line no-console
-      console.log('editor.selection: ', editor.selection);
-      // eslint-disable-next-line no-console
-      console.log('editor.selection.destroy: ', editor.selection.destroy);
-      // editor.selection.destroy();
-      editor.selection.setContent('');
+      if (editor.selection.isCollapsed() === false) {
+        execDeleteCommand(editor);
+      }
       InsertNewLine.insert(editor);
     },
 

--- a/modules/tinymce/src/core/main/ts/keyboard/EnterKey.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/EnterKey.ts
@@ -1,7 +1,6 @@
 import Editor from '../api/Editor';
 import { EditorEvent } from '../api/util/EventDispatcher';
 import VK from '../api/util/VK';
-import { execDeleteCommand } from '../delete/DeleteUtils';
 import * as InsertNewLine from '../newline/InsertNewLine';
 import { endTypingLevelIgnoreLocks } from '../undo/TypingState';
 
@@ -14,10 +13,6 @@ const handleEnterKeyEvent = (editor: Editor, event: EditorEvent<KeyboardEvent>) 
 
   endTypingLevelIgnoreLocks(editor.undoManager);
   editor.undoManager.transact(() => {
-    if (editor.selection.isCollapsed() === false) {
-      execDeleteCommand(editor);
-    }
-
     InsertNewLine.insert(editor, event);
   });
 };

--- a/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
@@ -11,7 +11,7 @@ import * as NewLineAction from './NewLineAction';
 const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>) => {
   NewLineAction.getAction(editor, evt).fold(
     () => {
-      if (editor.selection.isCollapsed() === false) {
+      if (!editor.selection.isCollapsed()) {
         execDeleteCommand(editor);
       }
       if (Type.isNonNullable(evt)) {
@@ -28,7 +28,7 @@ const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>) => {
       }
     },
     () => {
-      if (editor.selection.isCollapsed() === false) {
+      if (!editor.selection.isCollapsed()) {
         execDeleteCommand(editor);
       }
       if (Type.isNonNullable(evt)) {

--- a/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
@@ -2,6 +2,7 @@ import { Fun, Type } from '@ephox/katamari';
 
 import Editor from '../api/Editor';
 import { EditorEvent } from '../api/util/EventDispatcher';
+import { execDeleteCommand } from '../delete/DeleteUtils';
 import { fireFakeBeforeInputEvent, fireFakeInputEvent } from '../keyboard/FakeInputEvents';
 import * as InsertBlock from './InsertBlock';
 import * as InsertBr from './InsertBr';
@@ -10,6 +11,9 @@ import * as NewLineAction from './NewLineAction';
 const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>) => {
   NewLineAction.getAction(editor, evt).fold(
     () => {
+      if (editor.selection.isCollapsed() === false) {
+        execDeleteCommand(editor);
+      }
       if (Type.isNonNullable(evt)) {
         const event = fireFakeBeforeInputEvent(editor, 'insertLineBreak');
         if (event.isDefaultPrevented()) {
@@ -24,6 +28,9 @@ const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>) => {
       }
     },
     () => {
+      if (editor.selection.isCollapsed() === false) {
+        execDeleteCommand(editor);
+      }
       if (Type.isNonNullable(evt)) {
         const event = fireFakeBeforeInputEvent(editor, 'insertParagraph');
         if (event.isDefaultPrevented()) {

--- a/modules/tinymce/src/core/main/ts/newline/NewLineAction.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineAction.ts
@@ -61,7 +61,7 @@ const match = (predicates, action) => {
   };
 };
 
-const getAction = (editor: Editor, evt?) => {
+const getAction = (editor: Editor, evt?): Adt => {
   return LazyEvaluator.evaluateUntil([
     match([ shouldBlockNewLine ], newLineAction.none()),
     match([ inSummaryBlock() ], newLineAction.br()),

--- a/modules/tinymce/src/core/main/ts/newline/NewLineAction.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineAction.ts
@@ -6,7 +6,25 @@ import * as LazyEvaluator from '../util/LazyEvaluator';
 import * as ContextSelectors from './ContextSelectors';
 import * as NewLineUtils from './NewLineUtils';
 
-const newLineAction = Adt.generate([
+export interface NewLineActionAdt {
+  fold: <T> (
+    br: VoidFunction,
+    block: VoidFunction,
+    none: VoidFunction,
+  ) => T;
+  match: <T> (branches: {
+    br: VoidFunction;
+    block: VoidFunction;
+    none: VoidFunction;
+  }) => T;
+  log: (label: string) => void;
+}
+
+const newLineAction: {
+  br: () => NewLineActionAdt;
+  block: () => NewLineActionAdt;
+  none: () => NewLineActionAdt;
+} = Adt.generate([
   { br: [ ] },
   { block: [ ] },
   { none: [ ] }
@@ -61,7 +79,7 @@ const match = (predicates, action) => {
   };
 };
 
-const getAction = (editor: Editor, evt?): Adt => {
+const getAction = (editor: Editor, evt?): NewLineActionAdt => {
   return LazyEvaluator.evaluateUntil([
     match([ shouldBlockNewLine ], newLineAction.none()),
     match([ inSummaryBlock() ], newLineAction.br()),

--- a/modules/tinymce/src/core/test/ts/browser/api/commands/NewlineCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/api/commands/NewlineCommandsTest.ts
@@ -18,7 +18,7 @@ describe('browser.tinymce.core.api.commands.NewlineCommandTest', () => {
     TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
   });
 
-  it('TINY-8606: InsertParagraph command should delect the selectio', () => {
+  it('TINY-8606: InsertParagraph command should delete the selection', () => {
     const editor = hook.editor();
     editor.setContent('<p>This is a test</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], 'This'.length, [ 0, 0 ], 'This is a '.length);
@@ -27,7 +27,7 @@ describe('browser.tinymce.core.api.commands.NewlineCommandTest', () => {
     TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
   });
 
-  it('TINY-8606: mceInsertNewLine command should delect the selectio', () => {
+  it('TINY-8606: mceInsertNewLine command should delete the selection', () => {
     const editor = hook.editor();
     editor.setContent('<p>This is a test</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], 'This'.length, [ 0, 0 ], 'This is a '.length);

--- a/modules/tinymce/src/core/test/ts/browser/api/commands/NewlineCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/api/commands/NewlineCommandsTest.ts
@@ -20,11 +20,18 @@ describe('browser.tinymce.core.api.commands.NewlineCommandTest', () => {
 
   it('TINY-8606: InsertParagraph command ', () => {
     const editor = hook.editor();
+    editor.undoManager.clear();
     editor.setContent('<p>This is a test</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], 'This'.length, [ 0, 0 ], 'This is a '.length);
     editor.execCommand('InsertParagraph');
     TinyAssertions.assertContent(editor, '<p>This</p><p>test</p>');
     TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
+    editor.undoManager.undo();
+
+    setTimeout(() => {
+      TinyAssertions.assertContent(editor, '<p>This is a test</p>');
+      TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
+    }, 0);
   });
 
   it('TINY-7829: mceInsertNewLine command', () => {

--- a/modules/tinymce/src/core/test/ts/browser/api/commands/NewlineCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/api/commands/NewlineCommandsTest.ts
@@ -18,20 +18,22 @@ describe('browser.tinymce.core.api.commands.NewlineCommandTest', () => {
     TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
   });
 
-  it('TINY-8606: InsertParagraph command ', () => {
+  it('TINY-8606: InsertParagraph command should delect the selectio', () => {
     const editor = hook.editor();
-    editor.undoManager.clear();
     editor.setContent('<p>This is a test</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], 'This'.length, [ 0, 0 ], 'This is a '.length);
     editor.execCommand('InsertParagraph');
     TinyAssertions.assertContent(editor, '<p>This</p><p>test</p>');
     TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
-    editor.undoManager.undo();
+  });
 
-    setTimeout(() => {
-      TinyAssertions.assertContent(editor, '<p>This is a test</p>');
-      TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
-    }, 0);
+  it('TINY-8606: mceInsertNewLine command should delect the selectio', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>This is a test</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 'This'.length, [ 0, 0 ], 'This is a '.length);
+    editor.execCommand('mceInsertNewLine');
+    TinyAssertions.assertContent(editor, '<p>This</p><p>test</p>');
+    TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
   });
 
   it('TINY-7829: mceInsertNewLine command', () => {

--- a/modules/tinymce/src/core/test/ts/browser/api/commands/NewlineCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/api/commands/NewlineCommandsTest.ts
@@ -18,6 +18,15 @@ describe('browser.tinymce.core.api.commands.NewlineCommandTest', () => {
     TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
   });
 
+  it('TINY-8606: InsertParagraph command ', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>This is a test</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 'This'.length, [ 0, 0 ], 'This is a '.length);
+    editor.execCommand('InsertParagraph');
+    TinyAssertions.assertContent(editor, '<p>This</p><p>test</p>');
+    TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
+  });
+
   it('TINY-7829: mceInsertNewLine command', () => {
     const editor = hook.editor();
     editor.setContent('<p>123</p>');


### PR DESCRIPTION
Related Ticket: TINY-8606

Description of Changes:

- [X] add line deletion on `InsertParagraph` command with [this logic](https://github.com/tinymce/tinymce/blob/236891ffcdf2fd1b698d020e67c31838fb110019/modules/tinymce/src/core/main/ts/keyboard/EnterKey.ts#L16-L23)
- [X] add `InsertParagraph` command to commands_demo
- [X] add line deletion on `mceInsertNewLine` command
- [X] add a tests for `InsertParagraph` and `mceInsertNewLine`


Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
