### PR TITLE
TINY-8617: Improve visual clarity for text based toolbar selects

### DIFF
--- a/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
@@ -35,6 +35,8 @@
 @toolbar-separator-color: @border-color;
 @toolbar-padding-y: 0px;
 @toolbar-padding-x: 0px;
+@toolbar-button-bespoke-background-color: transparent;
+@toolbar-button-bespoke-spacing-x: @toolbar-button-spacing-x;
 @toolbar-separator-distance: 0;
 @color-tint: #207ab7;
 @panel-border-radius: 3px;

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-select-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-select-button.less
@@ -3,7 +3,9 @@
 // When making changes here, please review menubar/menubar.less and menubar/menubar-button.less
 //
 
+@toolbar-button-bespoke-background-color: contrast(@background-color, darken(@background-color, 3%), lighten(@background-color, 7%));
 @toolbar-button-bespoke-label-max-width: 7em;
+@toolbar-button-bespoke-spacing-x: 4px;
 
 .tox {
   .tox-tbtn--select {
@@ -31,10 +33,18 @@
 
   // Make dynamic text labeled buttons fixed width to prevent them from
   // jumping around when the content changes.
-  .tox-tbtn--bespoke .tox-tbtn__select-label {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    width: @toolbar-button-bespoke-label-max-width;
+  .tox-tbtn--bespoke {
+    background: @toolbar-button-bespoke-background-color;
+
+    & + .tox-tbtn--bespoke {
+      margin-inline-start: @toolbar-button-bespoke-spacing-x;
+    }
+
+    .tox-tbtn__select-label {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      width: @toolbar-button-bespoke-label-max-width;
+    }
   }
 }

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Added background and additional spacing for the text labeled buttons in the toolbar to improve visual clarity #TINY-8617
+
 ## 6.0.1 - 2022-03-23
 
 ### Fixed


### PR DESCRIPTION
Related Ticket: TINY-8617

Description of Changes:
* Added background and additional spacing for the text labeled buttons in the toolbar to improve visual clarity

Pre-checks:
* [X] Changelog entry added
* [X] ~Tests have been added (if applicable)~
* [X] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved