### PR TITLE
TINY-5947: Fixed images not showing as selected when selecting all content

### DIFF
--- a/modules/oxide/src/less/theme/content/selection/selection.less
+++ b/modules/oxide/src/less/theme/content/selection/selection.less
@@ -98,7 +98,7 @@
     }
   }
 
-  img::selection {
+  img[data-mce-selected]::selection {
     background: none;
   }
 }

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default value for `end_container_on_empty_block` option has been changed to `'blockquote'` #TINY-6559
 
 ### Fixed
-- Images were not showing as selected when selecting images with alongside other content #TINY-5947
+- Images were not showing as selected when selecting images alongside other content #TINY-5947
 - Dialogs will not exceed the window height on smaller screens #TINY-8146
 - Text alignment could not be applied to `pre` elements #TINY-7715
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default value for `end_container_on_empty_block` option has been changed to `'blockquote'` #TINY-6559
 
 ### Fixed
+- Images were not showing as selected when selecting all content #TINY-5947
 - Dialogs will not exceed the window height on smaller screens #TINY-8146
 - Text alignment could not be applied to `pre` elements #TINY-7715
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default value for `end_container_on_empty_block` option has been changed to `'blockquote'` #TINY-6559
 
 ### Fixed
-- Images were not showing as selected when selecting all content #TINY-5947
+- Images were not showing as selected when selecting images with alongside other content #TINY-5947
 - Dialogs will not exceed the window height on smaller screens #TINY-8146
 - Text alignment could not be applied to `pre` elements #TINY-7715
 

--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -279,7 +279,7 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
     // But data-mce-selected can be values other than 1 so keep existing value if
     // node has one, and remove data-mce-selected from everything else
     const nodeElm = SugarElement.fromDom(elm);
-    Arr.each(SelectorFilter.descendants(SugarElement.fromDom(editor.getBody()), '*[data-mce-selected]'), (elm) => {
+    Arr.each(SelectorFilter.descendants(SugarElement.fromDom(editor.getBody()), `*[${elementSelectionAttr}]`), (elm) => {
       if (!Compare.eq(nodeElm, elm)) {
         Attribute.remove(elm, elementSelectionAttr);
       }

--- a/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
@@ -9,6 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 
 describe('browser.tinymce.core.dom.ControlSelectionTest', () => {
+  const imgSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAGUlEQVR4nGK5aLGTATdgwiM3gqUBAQAA//8ukgHZvWHlnwAAAABJRU5ErkJggg==';
   const eventCounter = Cell<Record<string, number>>({ });
   const hook = TinyHooks.bddSetupLight<Editor>({
     add_unload_trigger: false,
@@ -86,7 +87,7 @@ describe('browser.tinymce.core.dom.ControlSelectionTest', () => {
 
   it('TBA: Select image by context menu clicking on it', () => {
     const editor = hook.editor();
-    editor.setContent('<p><img src="http://www.google.com/google.jpg" width="100" height="100"></p>');
+    editor.setContent(`<p><img src="${imgSrc}" width="100" height="100"></p>`);
     contextMenuClickInMiddleOf(editor, [ 0, 0 ]);
     TinyAssertions.assertSelection(editor, [ 0 ], 0, [ 0 ], 1);
   });
@@ -186,5 +187,15 @@ describe('browser.tinymce.core.dom.ControlSelectionTest', () => {
     await pResizeAndAssertDimensions(editor, 'iframe', '#mceResizeHandlese', 100, 50, 402, 202);
     const wrapper = UiFinder.findIn(TinyDom.body(editor), 'span.mce-preview-object').getOrDie();
     getAndAssertDimensions(wrapper, 402 + 100, 202 + 50);
+  });
+
+  it('TINY-5947: data-mce-selected should be set synchronously when selecting control elements', async () => {
+    const editor = hook.editor();
+    editor.setContent(`<p><img src="${imgSrc}" width="100" height="100"></p>`);
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    TinyAssertions.assertContentPresence(editor, {
+      'img[data-mce-selected="1"]': 1
+    });
+    await UiFinder.pWaitForVisible('Wait for resize handlers to show', TinyDom.body(editor), '#mceResizeHandlese');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-5947

Description of Changes:

This fixes an issue where the browser selection would never show for images when more than just the image was selected. The main cause is the CSS we used, however to make that work without flickering it required a change to how we do the selection as we need to ensure the `data-mce-selected` attribute is set immediately, not in the next event loop. This does mean a little bit of the logic runs more often on node change or similar events, but I've tried to keep it minimised so as to not cause performance problems.

Note: I also did some very minor cleanup while I was messing with the code.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #5450