### PR TITLE
TINY-8660: Fixed media elements not updating when changing the source URL

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- Some media elements wouldn't update when changing the source URL #TINY-8660
 - Inline toolbars flickered when switching between editors #TINY-8594
 - Multiple inline toolbars were shown if focused too quickly #TINY-8503
 

--- a/modules/tinymce/src/plugins/media/main/ts/core/UpdateHtml.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/UpdateHtml.ts
@@ -69,7 +69,7 @@ const updateHtml = (html: string, data: Partial<MediaData>, updateAll?: boolean,
               break;
 
             case 'iframe':
-              node.attr('src', data.src);
+              node.attr('src', data.source);
               break;
 
             case 'object':


### PR DESCRIPTION
Related Ticket: TINY-8660

Description of Changes:

When reworking the media plugin in 6.0 to use the DomParser the wrong media data property was used which caused the source URL to be unable to be updated for iframe based media.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #7772