### PR TITLE
TINY-8349: Convert xhr to fetch where possible

### DIFF
--- a/modules/tinymce/src/core/main/ts/file/Conversions.ts
+++ b/modules/tinymce/src/core/main/ts/file/Conversions.ts
@@ -12,38 +12,10 @@ interface DataUriResult {
   readonly data: string;
 }
 
-const blobUriToBlob = (url: string): Promise<Blob> => {
-  return new Promise((resolve, reject) => {
-
-    const rejectWithError = () => {
-      reject('Cannot convert ' + url + ' to Blob. Resource might not exist or is inaccessible.');
-    };
-
-    try {
-      const xhr = new XMLHttpRequest();
-
-      xhr.open('GET', url, true);
-      xhr.responseType = 'blob';
-
-      xhr.onload = () => {
-        if (xhr.status === 200) {
-          resolve(xhr.response);
-        } else {
-          // IE11 makes it into onload but responds with status 500
-          rejectWithError();
-        }
-      };
-
-      // Chrome fires an error event instead of the exception
-      // Also there seems to be no way to intercept the message that is logged to the console
-      xhr.onerror = rejectWithError;
-
-      xhr.send();
-    } catch (ex) {
-      rejectWithError();
-    }
-  });
-};
+const blobUriToBlob = (url: string): Promise<Blob> =>
+  fetch(url)
+    .then((res) => res.ok ? res.blob() : Promise.reject())
+    .catch(() => Promise.reject(`Cannot convert ${url} to Blob. Resource might not exist or is inaccessible.`));
 
 const parseDataUri = (uri: string): DataUriResult => {
   let type: string | undefined;


### PR DESCRIPTION
Related Ticket: TINY-8349

Description of Changes:
* Convert native uses of xhr to fetch

There is still one use of xhr in the repo but since it requires progress state and fetch does not provide a simple way to do this, it is better to leave that as is for now

Pre-checks:
* [X] ~~Changelog entry added~~ From an integrator perspective nothing should have changed so I am not sure if a changelog is needed
* [X] Tests have been added (if applicable) Looked like there was sufficient tests already
* [X] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
