### PR TITLE
TINY-8625: Can now reset multiple cells' height, or other values.

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Some types on functions in the `tinymce.dom.TreeWalker` class missed that it could return undefined #TINY-8592
 - In some cases pressing the backspace key would incorrectly step into tables rather than remain outside #TINY-8592
 - Text alignment could not be applied to `pre` elements #TINY-7715
+- Could not remove values when multiple cells were selected with the cell properties dialog #TINY-8625
+- Could not remove values when multiple rows were selected with the row properties dialog #TINY-8625
 - UI components, such as dialogs, would in some cases cause the `esc` keyup event to incorrectly trigger inside the editor #TINY-7005
 - Selection direction was not stored/restored when getting/setting selection bookmarks #TINY-8599
 - The `InsertParagraph` or `mceInsertNewLine` commands did not delete the current selection like the native command used to #TINY-8606

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
@@ -38,18 +38,34 @@ const getSelectedCells = (table: SugarElement<HTMLTableElement>, cells: SugarEle
   }));
 };
 
-const updateSimpleProps = (modifier: DomModifier, colModifier: DomModifier, data: CellData): void => {
-  modifier.setAttrib('scope', data.scope);
-  modifier.setAttrib('class', data.class);
-  modifier.setStyle('height', Utils.addPxSuffix(data.height));
-  colModifier.setStyle('width', Utils.addPxSuffix(data.width));
+const updateSimpleProps = (modifier: DomModifier, colModifier: DomModifier, data: CellData, shouldUse: (key: string) => boolean): void => {
+  if (shouldUse('scope')) {
+    modifier.setAttrib('scope', data.scope);
+  }
+  if (shouldUse('class')) {
+    modifier.setAttrib('class', data.class);
+  }
+  if (shouldUse('height')) {
+    modifier.setStyle('height', Utils.addPxSuffix(data.height));
+  }
+  if (shouldUse('width')) {
+    colModifier.setStyle('width', Utils.addPxSuffix(data.width));
+  }
 };
 
-const updateAdvancedProps = (modifier: DomModifier, data: CellData): void => {
-  modifier.setFormat('tablecellbackgroundcolor', data.backgroundcolor);
-  modifier.setFormat('tablecellbordercolor', data.bordercolor);
-  modifier.setFormat('tablecellborderstyle', data.borderstyle);
-  modifier.setFormat('tablecellborderwidth', Utils.addPxSuffix(data.borderwidth));
+const updateAdvancedProps = (modifier: DomModifier, data: CellData, shouldUse: (key: string) => boolean): void => {
+  if (shouldUse('backgroundcolor')) {
+    modifier.setFormat('tablecellbackgroundcolor', data.backgroundcolor);
+  }
+  if (shouldUse('bordercolor')) {
+    modifier.setFormat('tablecellbordercolor', data.bordercolor);
+  }
+  if (shouldUse('borderstyle')) {
+    modifier.setFormat('tablecellborderstyle', data.borderstyle);
+  }
+  if (shouldUse('borderwidth')) {
+    modifier.setFormat('tablecellborderwidth', Utils.addPxSuffix(data.borderwidth));
+  }
 };
 
 /*
@@ -65,19 +81,18 @@ const updateAdvancedProps = (modifier: DomModifier, data: CellData): void => {
   how as part of this, it doesn't remove any original alignment before
   applying any specified alignment.
  */
-const applyStyleData = (editor: Editor, cells: SelectedCell[], data: CellData): void => {
+const applyStyleData = (editor: Editor, cells: SelectedCell[], data: CellData, wasChanged: (key: string) => boolean): void => {
   const isSingleCell = cells.length === 1;
   Arr.each(cells, (item) => {
     const cellElm = item.element;
-    const modifier = isSingleCell ? DomModifier.normal(editor, cellElm) : DomModifier.ifTruthy(editor, cellElm);
-    const colModifier = item.column.map((col) =>
-      isSingleCell ? DomModifier.normal(editor, col) : DomModifier.ifTruthy(editor, col)
-    ).getOr(modifier);
+    const shouldOverrideCurrentValue = isSingleCell ? Fun.always : wasChanged;
+    const modifier = DomModifier.normal(editor, cellElm);
+    const colModifier = item.column.map((col) => DomModifier.normal(editor, col)).getOr(modifier);
 
-    updateSimpleProps(modifier, colModifier, data);
+    updateSimpleProps(modifier, colModifier, data, shouldOverrideCurrentValue);
 
     if (Options.hasAdvancedCellTab(editor)) {
-      updateAdvancedProps(modifier, data);
+      updateAdvancedProps(modifier, data, shouldOverrideCurrentValue);
     }
 
     // Remove alignment
@@ -119,7 +134,7 @@ const applyCellData = (editor: Editor, cells: SugarElement<HTMLTableCellElement>
 
       // Update the cells styling using the dialog data
       if (styleModified || Obj.has(modifiedData, 'scope')) {
-        applyStyleData(editor, selectedCells, data);
+        applyStyleData(editor, selectedCells, data, Fun.curry(Arr.contains, Obj.keys(modifiedData)));
       }
 
       // Update the cells structure using the dialog data

--- a/modules/tinymce/src/plugins/table/main/ts/ui/DomModifier.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/DomModifier.ts
@@ -8,29 +8,23 @@ export interface DomModifier {
 
 // The get node is required here because it can be transformed
 // when switching between tags (e.g. th and td)
-const modifiers = (testTruthy: boolean) => (editor: Editor, element: Element): DomModifier => {
+const modifiers = (editor: Editor, element: Element): DomModifier => {
   const dom = editor.dom;
 
   const setAttrib = (attr: string, value: string) => {
-    if (!testTruthy || value) {
-      dom.setAttrib(element, attr, value);
-    }
+    dom.setAttrib(element, attr, value);
   };
 
   const setStyle = (prop: string, value: string) => {
-    if (!testTruthy || value) {
-      dom.setStyle(element, prop, value);
-    }
+    dom.setStyle(element, prop, value);
   };
 
   const setFormat = (formatName: string, value: string) => {
-    if (!testTruthy || value) {
-      // Remove format if given an empty string
-      if (value === '') {
-        editor.formatter.remove(formatName, { value: null }, element, true);
-      } else {
-        editor.formatter.apply(formatName, { value }, element);
-      }
+    // Remove format if given an empty string
+    if (value === '') {
+      editor.formatter.remove(formatName, { value: null }, element, true);
+    } else {
+      editor.formatter.apply(formatName, { value }, element);
     }
   };
 
@@ -42,6 +36,5 @@ const modifiers = (testTruthy: boolean) => (editor: Editor, element: Element): D
 };
 
 export const DomModifier = {
-  normal: modifiers(false),
-  ifTruthy: modifiers(true)
+  normal: modifiers
 };

--- a/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
@@ -18,26 +18,37 @@ import * as RowDialogGeneralTab from './RowDialogGeneralTab';
 
 type RowData = Helpers.RowData;
 
-const updateSimpleProps = (modifier: DomModifier, data: RowData): void => {
-  modifier.setAttrib('class', data.class);
-  modifier.setStyle('height', Utils.addPxSuffix(data.height));
+const updateSimpleProps = (modifier: DomModifier, data: RowData, shouldUse: (key: string) => boolean): void => {
+  if (shouldUse('class')) {
+    modifier.setAttrib('class', data.class);
+  }
+  if (shouldUse('height')) {
+    modifier.setStyle('height', Utils.addPxSuffix(data.height));
+  }
 };
 
-const updateAdvancedProps = (modifier: DomModifier, data: RowData): void => {
-  modifier.setStyle('background-color', data.backgroundcolor);
-  modifier.setStyle('border-color', data.bordercolor);
-  modifier.setStyle('border-style', data.borderstyle);
+const updateAdvancedProps = (modifier: DomModifier, data: RowData, shouldUse: (key: string) => boolean): void => {
+  if (shouldUse('backgroundcolor')) {
+    modifier.setStyle('background-color', data.backgroundcolor);
+  }
+  if (shouldUse('bordercolor')) {
+    modifier.setStyle('border-color', data.bordercolor);
+  }
+  if (shouldUse('borderstyle')) {
+    modifier.setStyle('border-style', data.borderstyle);
+  }
 };
 
-const applyStyleData = (editor: Editor, rows: HTMLTableRowElement[], data: RowData, oldData: RowData): void => {
+const applyStyleData = (editor: Editor, rows: HTMLTableRowElement[], data: RowData, oldData: RowData, wasChanged: (key: string) => boolean): void => {
   const isSingleRow = rows.length === 1;
+  const shouldOverrideCurrentValue = isSingleRow ? Fun.always : wasChanged;
   Arr.each(rows, (rowElm) => {
-    const modifier = isSingleRow ? DomModifier.normal(editor, rowElm) : DomModifier.ifTruthy(editor, rowElm);
+    const modifier = DomModifier.normal(editor, rowElm);
 
-    updateSimpleProps(modifier, data);
+    updateSimpleProps(modifier, data, shouldOverrideCurrentValue);
 
     if (Options.hasAdvancedRowTab(editor)) {
-      updateAdvancedProps(modifier, data);
+      updateAdvancedProps(modifier, data, shouldOverrideCurrentValue);
     }
 
     if (data.align !== oldData.align) {
@@ -63,7 +74,7 @@ const applyRowData = (editor: Editor, rows: HTMLTableRowElement[], oldData: RowD
 
     // Update the rows styling using the dialog data
     if (styleModified) {
-      applyStyleData(editor, rows, data, oldData);
+      applyStyleData(editor, rows, data, oldData, Fun.curry(Arr.contains, Obj.keys(modifiedData)));
     }
 
     // Update the rows structure using the dialog data

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
@@ -239,6 +239,118 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
     assertEventsOrder();
   });
 
+  it('TINY-8625: Table cell properties dialog update multiple cells, but does not override unchanged values', async () => {
+    const initialHtml = '<table>' +
+        '<colgroup>' +
+          '<col style="width: 25.3548%;">' +
+          '<col style="width: 74.5433%;">' +
+        '</colgroup>' +
+        '<tbody>' +
+          '<tr>' +
+            '<td data-mce-selected="1" style="height: 200px;">&nbsp;</td>' +
+            '<td data-mce-selected="1" style="height: 200px;">&nbsp;</td>' +
+          '</tr>' +
+        '</tbody>' +
+      '</table>';
+
+    const newHtml = '<table>' +
+      '<colgroup>' +
+        '<col style="width: 25.3548%;">' +
+        '<col style="width: 74.5433%;">' +
+      '</colgroup>' +
+      '<tbody>' +
+        '<tr>' +
+          '<td style="height: 20px;">&nbsp;</td>' +
+          '<td style="height: 20px;">&nbsp;</td>' +
+        '</tr>' +
+      '</tbody>' +
+    '</table>';
+
+    const newData = {
+      height: '20',
+    };
+
+    const initialDialogValues = {
+      width: '',
+      height: '200px',
+      celltype: 'td',
+      halign: '',
+      valign: '',
+      scope: '',
+      backgroundcolor: '',
+      bordercolor: '',
+      borderstyle: '',
+      border: ''
+    };
+
+    const editor = hook.editor();
+    assertEventsOrder([]);
+    editor.setContent(initialHtml);
+    TinySelections.select(editor, 'td:nth-child(2)', [ 0 ]);
+    await TableTestUtils.pOpenTableDialog(editor);
+    TableTestUtils.assertDialogValues(initialDialogValues, true, generalSelectors);
+    TableTestUtils.setDialogValues(newData, true, generalSelectors);
+    await TableTestUtils.pClickDialogButton(editor, true);
+    TinyAssertions.assertContent(editor, newHtml);
+    assertEventsOrder();
+  });
+
+  it('TINY-8625: Table cell properties dialog update multiple cells allows resetting values', async () => {
+    const initialHtml = '<table>' +
+        '<colgroup>' +
+          '<col style="width: 25.3548%;">' +
+          '<col style="width: 74.5433%;">' +
+        '</colgroup>' +
+        '<tbody>' +
+          '<tr>' +
+            '<td data-mce-selected="1" style="height: 200px;">&nbsp;</td>' +
+            '<td data-mce-selected="1" style="height: 200px;">&nbsp;</td>' +
+          '</tr>' +
+        '</tbody>' +
+      '</table>';
+
+    const newHtml = '<table>' +
+      '<colgroup>' +
+        '<col style="width: 25.3548%;">' +
+        '<col style="width: 74.5433%;">' +
+      '</colgroup>' +
+      '<tbody>' +
+        '<tr>' +
+          '<td>&nbsp;</td>' +
+          '<td>&nbsp;</td>' +
+        '</tr>' +
+      '</tbody>' +
+    '</table>';
+
+    const newData = {
+      height: '',
+    };
+
+    const initialDialogValues = {
+      width: '',
+      height: '200px',
+      celltype: 'td',
+      halign: '',
+      valign: '',
+      scope: '',
+      backgroundcolor: '',
+      bordercolor: '',
+      borderstyle: '',
+      border: ''
+    };
+
+    const editor = hook.editor();
+    assertEventsOrder([]);
+    editor.setContent(initialHtml);
+    TinySelections.select(editor, 'td:nth-child(2)', [ 0 ]);
+    await TableTestUtils.pOpenTableDialog(editor);
+    TableTestUtils.assertDialogValues(initialDialogValues, true, generalSelectors);
+    TableTestUtils.setDialogValues(newData, true, generalSelectors);
+    await TableTestUtils.pClickDialogButton(editor, true);
+    TinyAssertions.assertContent(editor, newHtml);
+    assertEventsOrder();
+  });
+
   it('TBA: Remove all styles', async () => {
     const advHtml = '<table><tbody><tr><th style="width: 10px; height: 11px; vertical-align: top; text-align: right; ' +
     'border-color: red; border-style: dashed; background-color: blue;" scope="row">X</th></tr></tbody></table>';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
@@ -220,11 +220,8 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
 
     const newData = {
       align: 'center',
-      height: '',
       type: 'body',
-      backgroundcolor: '',
       bordercolor: 'red',
-      borderstyle: ''
     };
 
     const newHtml =
@@ -239,6 +236,116 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
       '<td>d</td>' +
       '</tr>' +
       '</tbody>' +
+      '</table>';
+
+    const editor = hook.editor();
+    editor.setContent(initialHtml);
+    TinySelections.select(editor, 'tr:nth-child(2) td:nth-child(2)', [ 0 ]);
+    await TableTestUtils.pOpenTableDialog(editor);
+    TableTestUtils.assertDialogValues(initialData, true, generalSelectors);
+    TableTestUtils.setDialogValues(newData, true, generalSelectors);
+    await TableTestUtils.pClickDialogButton(editor, true);
+    TinyAssertions.assertContent(editor, newHtml);
+    assertEvents();
+  });
+
+  it('TINY-8625: Table row properties dialog update multiple rows, but does not override unchanged values', async () => {
+    const initialHtml =
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+        '<tbody>' +
+          '<tr style="height: 20px; border-color: blue;">' +
+            '<td data-mce-selected="1">a</td>' +
+            '<td data-mce-selected="1">b</td>' +
+          '</tr>' +
+          '<tr style="height: 20px; border-color: red;">' +
+            '<td data-mce-selected="1">c</td>' +
+            '<td data-mce-selected="1">d</td>' +
+          '</tr>' +
+        '</tbody>' +
+      '</table>';
+
+    const initialData = {
+      align: '',
+      height: '20px',
+      type: 'body',
+      backgroundcolor: '',
+      bordercolor: '',
+      borderstyle: ''
+    };
+
+    const newData = {
+      align: 'center',
+      height: '30px',
+      type: 'body',
+    };
+
+    const newHtml =
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+        '<tbody>' +
+          '<tr style="height: 30px; text-align: center; border-color: blue;">' +
+            '<td>a</td>' +
+            '<td>b</td>' +
+          '</tr>' +
+          '<tr style="height: 30px; text-align: center; border-color: red;">' +
+            '<td>c</td>' +
+            '<td>d</td>' +
+          '</tr>' +
+        '</tbody>' +
+      '</table>';
+
+    const editor = hook.editor();
+    editor.setContent(initialHtml);
+    TinySelections.select(editor, 'tr:nth-child(2) td:nth-child(2)', [ 0 ]);
+    await TableTestUtils.pOpenTableDialog(editor);
+    TableTestUtils.assertDialogValues(initialData, true, generalSelectors);
+    TableTestUtils.setDialogValues(newData, true, generalSelectors);
+    await TableTestUtils.pClickDialogButton(editor, true);
+    TinyAssertions.assertContent(editor, newHtml);
+    assertEvents();
+  });
+
+  it('TINY-8625: Table row properties dialog update multiple rows allows resetting values', async () => {
+    const initialHtml =
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+        '<tbody>' +
+          '<tr style="height: 20px; border-color: blue;">' +
+            '<td data-mce-selected="1">a</td>' +
+            '<td data-mce-selected="1">b</td>' +
+          '</tr>' +
+          '<tr style="height: 20px; border-color: red;">' +
+            '<td data-mce-selected="1">c</td>' +
+            '<td data-mce-selected="1">d</td>' +
+          '</tr>' +
+        '</tbody>' +
+      '</table>';
+
+    const initialData = {
+      align: '',
+      height: '20px',
+      type: 'body',
+      backgroundcolor: '',
+      bordercolor: '',
+      borderstyle: ''
+    };
+
+    const newData = {
+      align: 'center',
+      height: '',
+      type: 'body',
+    };
+
+    const newHtml =
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+        '<tbody>' +
+          '<tr style="text-align: center; border-color: blue;">' +
+            '<td>a</td>' +
+            '<td>b</td>' +
+          '</tr>' +
+          '<tr style="text-align: center; border-color: red;">' +
+            '<td>c</td>' +
+            '<td>d</td>' +
+          '</tr>' +
+        '</tbody>' +
       '</table>';
 
     const editor = hook.editor();


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Removing values from the dialogs would not remove them when multiple cells/rows were selected.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
