### PR TITLE
TINY-8686: Invalid selections would cause errors on newer versions of safari

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Text alignment could not be applied to `pre` elements #TINY-7715
 - UI components, such as dialogs, would in some cases cause the `esc` keyup event to incorrectly trigger inside the editor #TINY-7005
 - Selection direction was not stored/restored when getting/setting selection bookmarks #TINY-8599
+- Selection could cause an error on some versions of Safari #TINY-8686
 - The `InsertParagraph` or `mceInsertNewLine` commands did not delete the current selection like the native command used to #TINY-8606
 - When triple clicking the selection was incorrectly collapsed in the Chrome browser when clicking around nested noneditable content #TINY-8215
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Text alignment could not be applied to `pre` elements #TINY-7715
 - UI components, such as dialogs, would in some cases cause the `esc` keyup event to incorrectly trigger inside the editor #TINY-7005
 - Selection direction was not stored/restored when getting/setting selection bookmarks #TINY-8599
-- Selection could cause an error on some versions of Safari #TINY-8686
+- An exception could be thrown for the `editor.selection.isForward()` API due to an invalid selection on some versions of Safari #TINY-8686
 - The `InsertParagraph` or `mceInsertNewLine` commands did not delete the current selection like the native command used to #TINY-8606
 - When triple clicking the selection was incorrectly collapsed in the Chrome browser when clicking around nested noneditable content #TINY-8215
 

--- a/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
@@ -472,6 +472,7 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
       // See https://bugs.webkit.org/show_bug.cgi?id=230594.
       return true;
     }
+
     return anchorRange.compareBoundaryPoints(anchorRange.START_TO_START, focusRange) <= 0;
   };
 

--- a/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
@@ -459,13 +459,19 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
     }
 
     const anchorRange = dom.createRng();
-    anchorRange.setStart(anchorNode, sel.anchorOffset);
-    anchorRange.collapse(true);
-
     const focusRange = dom.createRng();
-    focusRange.setStart(focusNode, sel.focusOffset);
-    focusRange.collapse(true);
 
+    try {
+      anchorRange.setStart(anchorNode, sel.anchorOffset);
+      anchorRange.collapse(true);
+
+      focusRange.setStart(focusNode, sel.focusOffset);
+      focusRange.collapse(true);
+    } catch (e) {
+      // Safari can generate an invalid selection and error. Silently handle it and default to forward.
+      // See https://bugs.webkit.org/show_bug.cgi?id=230594.
+      return true;
+    }
     return anchorRange.compareBoundaryPoints(anchorRange.START_TO_START, focusRange) <= 0;
   };
 


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Selection caused errors on test node 4

Pre-checks:
* [x] Changelog entry added
* N/A Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
