### PR TITLE
TINY-8625: Can now reset multiple cells' height, or other values

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Could not remove values when multiple cells were selected with the cell properties dialog #TINY-8625
+- Could not remove values when multiple rows were selected with the row properties dialog #TINY-8625
+
 ## 6.0.2 - 2022-04-27
 
 ### Fixed

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "private": true,
   "repository": {
     "type": "git",

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
@@ -38,32 +38,32 @@ const getSelectedCells = (table: SugarElement<HTMLTableElement>, cells: SugarEle
   }));
 };
 
-const updateSimpleProps = (modifier: DomModifier, colModifier: DomModifier, data: CellData, shouldUse: (key: string) => boolean): void => {
-  if (shouldUse('scope')) {
+const updateSimpleProps = (modifier: DomModifier, colModifier: DomModifier, data: CellData, shouldUpdate: (key: string) => boolean): void => {
+  if (shouldUpdate('scope')) {
     modifier.setAttrib('scope', data.scope);
   }
-  if (shouldUse('class')) {
+  if (shouldUpdate('class')) {
     modifier.setAttrib('class', data.class);
   }
-  if (shouldUse('height')) {
+  if (shouldUpdate('height')) {
     modifier.setStyle('height', Utils.addPxSuffix(data.height));
   }
-  if (shouldUse('width')) {
+  if (shouldUpdate('width')) {
     colModifier.setStyle('width', Utils.addPxSuffix(data.width));
   }
 };
 
-const updateAdvancedProps = (modifier: DomModifier, data: CellData, shouldUse: (key: string) => boolean): void => {
-  if (shouldUse('backgroundcolor')) {
+const updateAdvancedProps = (modifier: DomModifier, data: CellData, shouldUpdate: (key: string) => boolean): void => {
+  if (shouldUpdate('backgroundcolor')) {
     modifier.setFormat('tablecellbackgroundcolor', data.backgroundcolor);
   }
-  if (shouldUse('bordercolor')) {
+  if (shouldUpdate('bordercolor')) {
     modifier.setFormat('tablecellbordercolor', data.bordercolor);
   }
-  if (shouldUse('borderstyle')) {
+  if (shouldUpdate('borderstyle')) {
     modifier.setFormat('tablecellborderstyle', data.borderstyle);
   }
-  if (shouldUse('borderwidth')) {
+  if (shouldUpdate('borderwidth')) {
     modifier.setFormat('tablecellborderwidth', Utils.addPxSuffix(data.borderwidth));
   }
 };

--- a/modules/tinymce/src/plugins/table/main/ts/ui/DomModifier.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/DomModifier.ts
@@ -8,7 +8,7 @@ export interface DomModifier {
 
 // The get node is required here because it can be transformed
 // when switching between tags (e.g. th and td)
-const modifiers = (editor: Editor, element: Element): DomModifier => {
+const normal = (editor: Editor, element: Element): DomModifier => {
   const dom = editor.dom;
 
   const setAttrib = (attr: string, value: string) => {
@@ -36,5 +36,5 @@ const modifiers = (editor: Editor, element: Element): DomModifier => {
 };
 
 export const DomModifier = {
-  normal: modifiers
+  normal
 };

--- a/modules/tinymce/src/plugins/table/main/ts/ui/DomModifier.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/DomModifier.ts
@@ -8,29 +8,23 @@ export interface DomModifier {
 
 // The get node is required here because it can be transformed
 // when switching between tags (e.g. th and td)
-const modifiers = (testTruthy: boolean) => (editor: Editor, element: Element): DomModifier => {
+const modifiers = (editor: Editor, element: Element): DomModifier => {
   const dom = editor.dom;
 
   const setAttrib = (attr: string, value: string) => {
-    if (!testTruthy || value) {
-      dom.setAttrib(element, attr, value);
-    }
+    dom.setAttrib(element, attr, value);
   };
 
   const setStyle = (prop: string, value: string) => {
-    if (!testTruthy || value) {
-      dom.setStyle(element, prop, value);
-    }
+    dom.setStyle(element, prop, value);
   };
 
   const setFormat = (formatName: string, value: string) => {
-    if (!testTruthy || value) {
-      // Remove format if given an empty string
-      if (value === '') {
-        editor.formatter.remove(formatName, { value: null }, element, true);
-      } else {
-        editor.formatter.apply(formatName, { value }, element);
-      }
+    // Remove format if given an empty string
+    if (value === '') {
+      editor.formatter.remove(formatName, { value: null }, element, true);
+    } else {
+      editor.formatter.apply(formatName, { value }, element);
     }
   };
 
@@ -42,6 +36,5 @@ const modifiers = (testTruthy: boolean) => (editor: Editor, element: Element): D
 };
 
 export const DomModifier = {
-  normal: modifiers(false),
-  ifTruthy: modifiers(true)
+  normal: modifiers
 };

--- a/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
@@ -18,23 +18,23 @@ import * as RowDialogGeneralTab from './RowDialogGeneralTab';
 
 type RowData = Helpers.RowData;
 
-const updateSimpleProps = (modifier: DomModifier, data: RowData, shouldUse: (key: string) => boolean): void => {
-  if (shouldUse('class')) {
+const updateSimpleProps = (modifier: DomModifier, data: RowData, shouldUpdate: (key: string) => boolean): void => {
+  if (shouldUpdate('class')) {
     modifier.setAttrib('class', data.class);
   }
-  if (shouldUse('height')) {
+  if (shouldUpdate('height')) {
     modifier.setStyle('height', Utils.addPxSuffix(data.height));
   }
 };
 
-const updateAdvancedProps = (modifier: DomModifier, data: RowData, shouldUse: (key: string) => boolean): void => {
-  if (shouldUse('backgroundcolor')) {
+const updateAdvancedProps = (modifier: DomModifier, data: RowData, shouldUpdate: (key: string) => boolean): void => {
+  if (shouldUpdate('backgroundcolor')) {
     modifier.setStyle('background-color', data.backgroundcolor);
   }
-  if (shouldUse('bordercolor')) {
+  if (shouldUpdate('bordercolor')) {
     modifier.setStyle('border-color', data.bordercolor);
   }
-  if (shouldUse('borderstyle')) {
+  if (shouldUpdate('borderstyle')) {
     modifier.setStyle('border-style', data.borderstyle);
   }
 };

--- a/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
@@ -18,26 +18,37 @@ import * as RowDialogGeneralTab from './RowDialogGeneralTab';
 
 type RowData = Helpers.RowData;
 
-const updateSimpleProps = (modifier: DomModifier, data: RowData): void => {
-  modifier.setAttrib('class', data.class);
-  modifier.setStyle('height', Utils.addPxSuffix(data.height));
+const updateSimpleProps = (modifier: DomModifier, data: RowData, shouldUse: (key: string) => boolean): void => {
+  if (shouldUse('class')) {
+    modifier.setAttrib('class', data.class);
+  }
+  if (shouldUse('height')) {
+    modifier.setStyle('height', Utils.addPxSuffix(data.height));
+  }
 };
 
-const updateAdvancedProps = (modifier: DomModifier, data: RowData): void => {
-  modifier.setStyle('background-color', data.backgroundcolor);
-  modifier.setStyle('border-color', data.bordercolor);
-  modifier.setStyle('border-style', data.borderstyle);
+const updateAdvancedProps = (modifier: DomModifier, data: RowData, shouldUse: (key: string) => boolean): void => {
+  if (shouldUse('backgroundcolor')) {
+    modifier.setStyle('background-color', data.backgroundcolor);
+  }
+  if (shouldUse('bordercolor')) {
+    modifier.setStyle('border-color', data.bordercolor);
+  }
+  if (shouldUse('borderstyle')) {
+    modifier.setStyle('border-style', data.borderstyle);
+  }
 };
 
-const applyStyleData = (editor: Editor, rows: HTMLTableRowElement[], data: RowData, oldData: RowData): void => {
+const applyStyleData = (editor: Editor, rows: HTMLTableRowElement[], data: RowData, oldData: RowData, wasChanged: (key: string) => boolean): void => {
   const isSingleRow = rows.length === 1;
+  const shouldOverrideCurrentValue = isSingleRow ? Fun.always : wasChanged;
   Arr.each(rows, (rowElm) => {
-    const modifier = isSingleRow ? DomModifier.normal(editor, rowElm) : DomModifier.ifTruthy(editor, rowElm);
+    const modifier = DomModifier.normal(editor, rowElm);
 
-    updateSimpleProps(modifier, data);
+    updateSimpleProps(modifier, data, shouldOverrideCurrentValue);
 
     if (Options.hasAdvancedRowTab(editor)) {
-      updateAdvancedProps(modifier, data);
+      updateAdvancedProps(modifier, data, shouldOverrideCurrentValue);
     }
 
     if (data.align !== oldData.align) {
@@ -63,7 +74,7 @@ const applyRowData = (editor: Editor, rows: HTMLTableRowElement[], oldData: RowD
 
     // Update the rows styling using the dialog data
     if (styleModified) {
-      applyStyleData(editor, rows, data, oldData);
+      applyStyleData(editor, rows, data, oldData, Fun.curry(Arr.contains, Obj.keys(modifiedData)));
     }
 
     // Update the rows structure using the dialog data

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
@@ -239,6 +239,118 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
     assertEventsOrder();
   });
 
+  it('TINY-8625: Table cell properties dialog update multiple cells, but does not override unchanged values', async () => {
+    const initialHtml = '<table>' +
+        '<colgroup>' +
+          '<col style="width: 25.3548%;">' +
+          '<col style="width: 74.5433%;">' +
+        '</colgroup>' +
+        '<tbody>' +
+          '<tr>' +
+            '<td data-mce-selected="1" style="height: 200px;">&nbsp;</td>' +
+            '<td data-mce-selected="1" style="height: 200px;">&nbsp;</td>' +
+          '</tr>' +
+        '</tbody>' +
+      '</table>';
+
+    const newHtml = '<table>' +
+      '<colgroup>' +
+        '<col style="width: 25.3548%;">' +
+        '<col style="width: 74.5433%;">' +
+      '</colgroup>' +
+      '<tbody>' +
+        '<tr>' +
+          '<td style="height: 20px;">&nbsp;</td>' +
+          '<td style="height: 20px;">&nbsp;</td>' +
+        '</tr>' +
+      '</tbody>' +
+    '</table>';
+
+    const newData = {
+      height: '20',
+    };
+
+    const initialDialogValues = {
+      width: '',
+      height: '200px',
+      celltype: 'td',
+      halign: '',
+      valign: '',
+      scope: '',
+      backgroundcolor: '',
+      bordercolor: '',
+      borderstyle: '',
+      border: ''
+    };
+
+    const editor = hook.editor();
+    assertEventsOrder([]);
+    editor.setContent(initialHtml);
+    TinySelections.select(editor, 'td:nth-child(2)', [ 0 ]);
+    await TableTestUtils.pOpenTableDialog(editor);
+    TableTestUtils.assertDialogValues(initialDialogValues, true, generalSelectors);
+    TableTestUtils.setDialogValues(newData, true, generalSelectors);
+    await TableTestUtils.pClickDialogButton(editor, true);
+    TinyAssertions.assertContent(editor, newHtml);
+    assertEventsOrder();
+  });
+
+  it('TINY-8625: Table cell properties dialog update multiple cells allows resetting values', async () => {
+    const initialHtml = '<table>' +
+        '<colgroup>' +
+          '<col style="width: 25.3548%;">' +
+          '<col style="width: 74.5433%;">' +
+        '</colgroup>' +
+        '<tbody>' +
+          '<tr>' +
+            '<td data-mce-selected="1" style="height: 200px;">&nbsp;</td>' +
+            '<td data-mce-selected="1" style="height: 200px;">&nbsp;</td>' +
+          '</tr>' +
+        '</tbody>' +
+      '</table>';
+
+    const newHtml = '<table>' +
+      '<colgroup>' +
+        '<col style="width: 25.3548%;">' +
+        '<col style="width: 74.5433%;">' +
+      '</colgroup>' +
+      '<tbody>' +
+        '<tr>' +
+          '<td>&nbsp;</td>' +
+          '<td>&nbsp;</td>' +
+        '</tr>' +
+      '</tbody>' +
+    '</table>';
+
+    const newData = {
+      height: '',
+    };
+
+    const initialDialogValues = {
+      width: '',
+      height: '200px',
+      celltype: 'td',
+      halign: '',
+      valign: '',
+      scope: '',
+      backgroundcolor: '',
+      bordercolor: '',
+      borderstyle: '',
+      border: ''
+    };
+
+    const editor = hook.editor();
+    assertEventsOrder([]);
+    editor.setContent(initialHtml);
+    TinySelections.select(editor, 'td:nth-child(2)', [ 0 ]);
+    await TableTestUtils.pOpenTableDialog(editor);
+    TableTestUtils.assertDialogValues(initialDialogValues, true, generalSelectors);
+    TableTestUtils.setDialogValues(newData, true, generalSelectors);
+    await TableTestUtils.pClickDialogButton(editor, true);
+    TinyAssertions.assertContent(editor, newHtml);
+    assertEventsOrder();
+  });
+
   it('TBA: Remove all styles', async () => {
     const advHtml = '<table><tbody><tr><th style="width: 10px; height: 11px; vertical-align: top; text-align: right; ' +
     'border-color: red; border-style: dashed; background-color: blue;" scope="row">X</th></tr></tbody></table>';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
@@ -220,11 +220,8 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
 
     const newData = {
       align: 'center',
-      height: '',
       type: 'body',
-      backgroundcolor: '',
       bordercolor: 'red',
-      borderstyle: ''
     };
 
     const newHtml =
@@ -239,6 +236,116 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
       '<td>d</td>' +
       '</tr>' +
       '</tbody>' +
+      '</table>';
+
+    const editor = hook.editor();
+    editor.setContent(initialHtml);
+    TinySelections.select(editor, 'tr:nth-child(2) td:nth-child(2)', [ 0 ]);
+    await TableTestUtils.pOpenTableDialog(editor);
+    TableTestUtils.assertDialogValues(initialData, true, generalSelectors);
+    TableTestUtils.setDialogValues(newData, true, generalSelectors);
+    await TableTestUtils.pClickDialogButton(editor, true);
+    TinyAssertions.assertContent(editor, newHtml);
+    assertEvents();
+  });
+
+  it('TINY-8625: Table row properties dialog update multiple rows, but does not override unchanged values', async () => {
+    const initialHtml =
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+        '<tbody>' +
+          '<tr style="height: 20px; border-color: blue;">' +
+            '<td data-mce-selected="1">a</td>' +
+            '<td data-mce-selected="1">b</td>' +
+          '</tr>' +
+          '<tr style="height: 20px; border-color: red;">' +
+            '<td data-mce-selected="1">c</td>' +
+            '<td data-mce-selected="1">d</td>' +
+          '</tr>' +
+        '</tbody>' +
+      '</table>';
+
+    const initialData = {
+      align: '',
+      height: '20px',
+      type: 'body',
+      backgroundcolor: '',
+      bordercolor: '',
+      borderstyle: ''
+    };
+
+    const newData = {
+      align: 'center',
+      height: '30px',
+      type: 'body',
+    };
+
+    const newHtml =
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+        '<tbody>' +
+          '<tr style="height: 30px; text-align: center; border-color: blue;">' +
+            '<td>a</td>' +
+            '<td>b</td>' +
+          '</tr>' +
+          '<tr style="height: 30px; text-align: center; border-color: red;">' +
+            '<td>c</td>' +
+            '<td>d</td>' +
+          '</tr>' +
+        '</tbody>' +
+      '</table>';
+
+    const editor = hook.editor();
+    editor.setContent(initialHtml);
+    TinySelections.select(editor, 'tr:nth-child(2) td:nth-child(2)', [ 0 ]);
+    await TableTestUtils.pOpenTableDialog(editor);
+    TableTestUtils.assertDialogValues(initialData, true, generalSelectors);
+    TableTestUtils.setDialogValues(newData, true, generalSelectors);
+    await TableTestUtils.pClickDialogButton(editor, true);
+    TinyAssertions.assertContent(editor, newHtml);
+    assertEvents();
+  });
+
+  it('TINY-8625: Table row properties dialog update multiple rows allows resetting values', async () => {
+    const initialHtml =
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+        '<tbody>' +
+          '<tr style="height: 20px; border-color: blue;">' +
+            '<td data-mce-selected="1">a</td>' +
+            '<td data-mce-selected="1">b</td>' +
+          '</tr>' +
+          '<tr style="height: 20px; border-color: red;">' +
+            '<td data-mce-selected="1">c</td>' +
+            '<td data-mce-selected="1">d</td>' +
+          '</tr>' +
+        '</tbody>' +
+      '</table>';
+
+    const initialData = {
+      align: '',
+      height: '20px',
+      type: 'body',
+      backgroundcolor: '',
+      bordercolor: '',
+      borderstyle: ''
+    };
+
+    const newData = {
+      align: 'center',
+      height: '',
+      type: 'body',
+    };
+
+    const newHtml =
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+        '<tbody>' +
+          '<tr style="text-align: center; border-color: blue;">' +
+            '<td>a</td>' +
+            '<td>b</td>' +
+          '</tr>' +
+          '<tr style="text-align: center; border-color: red;">' +
+            '<td>c</td>' +
+            '<td>d</td>' +
+          '</tr>' +
+        '</tbody>' +
       '</table>';
 
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
@@ -304,7 +304,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
     assertEvents();
   });
 
-  it('TINY-8625: Table row properties dialog updates multiple rows allows resetting values', async () => {
+  it('TINY-8625: Table row properties dialog updates multiple rows and allows resetting values', async () => {
     const initialHtml =
       '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
         '<tbody>' +

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
@@ -249,7 +249,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
     assertEvents();
   });
 
-  it('TINY-8625: Table row properties dialog update multiple rows, but does not override unchanged values', async () => {
+  it('TINY-8625: Table row properties dialog updates multiple rows, but does not override unchanged values', async () => {
     const initialHtml =
       '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
         '<tbody>' +
@@ -304,7 +304,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
     assertEvents();
   });
 
-  it('TINY-8625: Table row properties dialog update multiple rows allows resetting values', async () => {
+  it('TINY-8625: Table row properties dialog updates multiple rows allows resetting values', async () => {
     const initialHtml =
       '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
         '<tbody>' +


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Removing values from the dialogs would not remove them when multiple cells/rows were selected.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #7731