### PR TITLE
TINY-8646: Fix base64 encoded image not displayed following `data:` text

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,10 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 5.10.5 - 2022-05-05
-
 ### Fixed
-- Base64 data URI was not extracted correctly following `data:` text #TINY-8646
+- Base64 data URIs were not extracted correctly during parsing when proceded by `data:` text #TINY-8646
 
 ## 5.10.4 - 2022-04-27
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Base64 data URIs were not extracted correctly during parsing when proceded by `data:` text #TINY-8646
+- Base64 data URIs were not extracted correctly during parsing when proceeded by `data:` text #TINY-8646
 
 ## 5.10.4 - 2022-04-27
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Base64 encoded image was not displayed following `data:` text #TINY-8646
+
 ## 5.10.4 - 2022-04-27
 
 ### Fixed

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,8 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 5.10.5 - 2022-05-05
+
 ### Fixed
-- Base64 encoded image was not displayed following `data:` text #TINY-8646
+- Base64 data URI was not extracted correctly following `data:` text #TINY-8646
 
 ## 5.10.4 - 2022-04-27
 

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "5.10.4",
+  "version": "5.10.5",
   "private": true,
   "repository": {
     "type": "git",

--- a/modules/tinymce/src/core/main/ts/html/Base64Uris.ts
+++ b/modules/tinymce/src/core/main/ts/html/Base64Uris.ts
@@ -22,7 +22,7 @@ export interface Base64UriParts {
 }
 
 export const extractBase64DataUris = (html: string): Base64Extract => {
-  const dataImageUri = /data:[^;<" ]+;base64,([a-z0-9\+\/=\s]+)/gi;
+  const dataImageUri = /data:[^;<"'\s]+;base64,([a-z0-9\+\/=\s]+)/gi;
   const chunks: string[] = [];
   const uris: UriMap = {};
   const prefix = Id.generate('img');

--- a/modules/tinymce/src/core/main/ts/html/Base64Uris.ts
+++ b/modules/tinymce/src/core/main/ts/html/Base64Uris.ts
@@ -22,7 +22,7 @@ export interface Base64UriParts {
 }
 
 export const extractBase64DataUris = (html: string): Base64Extract => {
-  const dataImageUri = /data:[^;]+;base64,([a-z0-9\+\/=\s]+)/gi;
+  const dataImageUri = /data:[^;<]+;base64,([a-z0-9\+\/=\s]+)/gi;
   const chunks: string[] = [];
   const uris: UriMap = {};
   const prefix = Id.generate('img');

--- a/modules/tinymce/src/core/main/ts/html/Base64Uris.ts
+++ b/modules/tinymce/src/core/main/ts/html/Base64Uris.ts
@@ -22,7 +22,7 @@ export interface Base64UriParts {
 }
 
 export const extractBase64DataUris = (html: string): Base64Extract => {
-  const dataImageUri = /data:[^;<]+;base64,([a-z0-9\+\/=\s]+)/gi;
+  const dataImageUri = /data:[^;<" ]+;base64,([a-z0-9\+\/=\s]+)/gi;
   const chunks: string[] = [];
   const uris: UriMap = {};
   const prefix = Id.generate('img');

--- a/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
@@ -98,6 +98,28 @@ describe('atomic.tinymce.core.html.Base64UrisTest', () => {
         }
       }
     );
+
+    testExtract(
+      'TINY-8646: Should extract base64 encoded image following `data:` text on the same paragaph',
+      '<p>my data:<img src="data:image/gif;base64,R0/yw=="/></p>',
+      {
+        html: '<p>my data:<img src="$prefix_0"/></p>',
+        uris: {
+          $prefix_0: 'data:image/gif;base64,R0/yw=='
+        }
+      }
+    );
+
+    testExtract(
+      'TINY-8646: Should extract base64 encoded image in the next paragraph following `data:` text',
+      '<p>my data:</p><p><img src="data:image/gif;base64,R0/yw=="/></p>',
+      {
+        html: '<p>my data:</p><p><img src="$prefix_0"/></p>',
+        uris: {
+          $prefix_0: 'data:image/gif;base64,R0/yw=='
+        }
+      }
+    );
   });
 
   const testRestoreDataUris = (label: string, inputResult: Base64Extract, inputHtml: string, expectedHtml: string) => {

--- a/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
@@ -145,9 +145,9 @@ describe('atomic.tinymce.core.html.Base64UrisTest', () => {
 
     testExtract(
       'TINY-8646: Should extract based64 encoded image when single quotes are used',
-      '<img name=\'data:\'src=\'data:image/gif;base64,R0/yw==\'/>',
+      `<img name='data:'src='data:image/gif;base64,R0/yw=='/>`,
       {
-        html: '<img name=\'data:\'src=\'$prefix_0\'/>',
+        html: `<img name='data:'src='$prefix_0'/>`,
         uris: {
           $prefix_0: 'data:image/gif;base64,R0/yw=='
         }

--- a/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
@@ -145,9 +145,20 @@ describe('atomic.tinymce.core.html.Base64UrisTest', () => {
 
     testExtract(
       'TINY-8646: Should extract based64 encoded image when single quotes are used',
-      '<img name=\'data:\' src=\'data:image/gif;base64,R0/yw==\'/>',
+      '<img name=\'data:\'src=\'data:image/gif;base64,R0/yw==\'/>',
       {
-        html: '<img name=\'data:\' src=\'$prefix_0\'/>',
+        html: '<img name=\'data:\'src=\'$prefix_0\'/>',
+        uris: {
+          $prefix_0: 'data:image/gif;base64,R0/yw=='
+        }
+      }
+    );
+
+    testExtract(
+      'TINY-8646: Should extract based64 encoded image when whitespaces are used (eg newline, tabs)',
+      '<img name="data:"\n' + 'src="data:image/gif;base64,R0/yw=="/>',
+      {
+        html: '<img name="data:"\n' + 'src="$prefix_0"/>',
         uris: {
           $prefix_0: 'data:image/gif;base64,R0/yw=='
         }

--- a/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/html/Base64UrisTest.ts
@@ -120,6 +120,39 @@ describe('atomic.tinymce.core.html.Base64UrisTest', () => {
         }
       }
     );
+
+    testExtract(
+      'TINY-8646: Should extract based64 encoded image following an attribute with `data:` text as a value',
+      '<img name="data:" src="data:image/gif;base64,R0/yw=="/>',
+      {
+        html: '<img name="data:" src="$prefix_0"/>',
+        uris: {
+          $prefix_0: 'data:image/gif;base64,R0/yw=='
+        }
+      }
+    );
+
+    testExtract(
+      'TINY-8646: Should extract based64 encoded image when there is no space between attributes',
+      '<img name="data:"src="data:image/gif;base64,R0/yw=="/>',
+      {
+        html: '<img name="data:"src="$prefix_0"/>',
+        uris: {
+          $prefix_0: 'data:image/gif;base64,R0/yw=='
+        }
+      }
+    );
+
+    testExtract(
+      'TINY-8646: Should extract based64 encoded image when single quotes are used',
+      '<img name=\'data:\' src=\'data:image/gif;base64,R0/yw==\'/>',
+      {
+        html: '<img name=\'data:\' src=\'$prefix_0\'/>',
+        uris: {
+          $prefix_0: 'data:image/gif;base64,R0/yw=='
+        }
+      }
+    );
   });
 
   const testRestoreDataUris = (label: string, inputResult: Base64Extract, inputHtml: string, expectedHtml: string) => {


### PR DESCRIPTION
Related Ticket: TINY-8646

Description:
- Updated the regex in `Base64Uris()` function as suggested in the ticket

**Note:** The bug seems to be fixed without updating `parseDataUri()` as suggested in the fix. I just leave it as is


Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
Fixes #7737