### PR TITLE
TINY-8661: Stop links from opening when preventDefault is called

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default value for `end_container_on_empty_block` option has been changed to `'blockquote'` #TINY-6559
 
 ### Fixed
-- Links would open when using alt+enter (option+enter on Mac) even when preventDefault is called on the keydown event #TINY-8661
+- Links would open when using alt+enter (option+enter on Mac) even when `preventDefault()` is called on the keydown event #TINY-8661
 - Spaces would not be added correctly on some browsers when before or after a contenteditable block element #TINY-8588
 - Images were not showing as selected when selecting images alongside other content #TINY-5947
 - Dialogs will not exceed the window height on smaller screens #TINY-8146

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default value for `end_container_on_empty_block` option has been changed to `'blockquote'` #TINY-6559
 
 ### Fixed
-- Links would open when using alt+enter (option+enter on Mac) even when preventDefault is called on the event #TINY-8661
+- Links would open when using alt+enter (option+enter on Mac) even when preventDefault is called on the keydown event #TINY-8661
 - Spaces would not be added correctly on some browsers when before or after a contenteditable block element #TINY-8588
 - Images were not showing as selected when selecting images alongside other content #TINY-5947
 - Dialogs will not exceed the window height on smaller screens #TINY-8146

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default value for `end_container_on_empty_block` option has been changed to `'blockquote'` #TINY-6559
 
 ### Fixed
+- Links would open when using alt+enter (option+enter on Mac) even when preventDefault is called on the event #TINY-8661
 - Spaces would not be added correctly on some browsers when before or after a contenteditable block element #TINY-8588
 - Images were not showing as selected when selecting images alongside other content #TINY-5947
 - Dialogs will not exceed the window height on smaller screens #TINY-8146

--- a/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
@@ -49,10 +49,12 @@ const setupGotoLinks = (editor: Editor): void => {
   });
 
   editor.on('keydown', (e) => {
-    const link = getSelectedLink(editor);
-    if (!e.isDefaultPrevented() && link && e.keyCode === 13 && hasOnlyAltModifier(e)) {
-      e.preventDefault();
-      gotoLink(editor, link);
+    if (!e.isDefaultPrevented() && e.keyCode === 13 && hasOnlyAltModifier(e)) {
+      const link = getSelectedLink(editor);
+      if (link) {
+        e.preventDefault();
+        gotoLink(editor, link);
+      }
     }
   });
 };

--- a/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
@@ -50,7 +50,7 @@ const setupGotoLinks = (editor: Editor): void => {
 
   editor.on('keydown', (e) => {
     const link = getSelectedLink(editor);
-    if (!e.defaultPrevented && link && e.keyCode === 13 && hasOnlyAltModifier(e)) {
+    if (!e.isDefaultPrevented() && link && e.keyCode === 13 && hasOnlyAltModifier(e)) {
       e.preventDefault();
       gotoLink(editor, link);
     }

--- a/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
@@ -50,7 +50,7 @@ const setupGotoLinks = (editor: Editor): void => {
 
   editor.on('keydown', (e) => {
     const link = getSelectedLink(editor);
-    if (link && e.keyCode === 13 && hasOnlyAltModifier(e)) {
+    if (!e.defaultPrevented && link && e.keyCode === 13 && hasOnlyAltModifier(e)) {
       e.preventDefault();
       gotoLink(editor, link);
     }

--- a/modules/tinymce/src/plugins/link/test/ts/browser/PreventDefaultTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/PreventDefaultTest.ts
@@ -1,0 +1,51 @@
+import { Keys } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinySelections, TinyContentActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/link/Plugin';
+
+import { TestLinkUi } from '../module/TestLinkUi';
+
+describe('browser.tinymce.plugins.link.PreventDefaultTest', () => {
+
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'link',
+    toolbar: 'link openlink unlink',
+    base_url: '/project/tinymce/js/tinymce',
+    setup: (ed) => {
+      const hasOnlyAltModifier = (e) => {
+        return (
+          e.altKey === true &&
+          e.shiftKey === false &&
+          e.ctrlKey === false &&
+          e.metaKey === false
+        );
+      };
+
+      ed.on(
+        'keydown',
+        (event) => {
+          if (event.keyCode === 13 && hasOnlyAltModifier(event)) {
+            event.preventDefault();
+          }
+        },
+        true
+      );
+    },
+  }, [ Plugin ]);
+
+  it('TINY-8661: links should not open when using alt+enter (option+enter on Mac) when preventDefault() is called', () => {
+    TestLinkUi.clearHistory();
+    const editor = hook.editor();
+    editor.setContent(`<h1><a href="#foo">foo anchor</a></h1><p style="height: 5000px;">long p</p><p id="foo">foo</p>`);
+    const pos = editor.getWin().scrollY;
+    assert.equal(pos, 0);
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 3);
+    TinyContentActions.keydown(editor, Keys.enter(), {
+      altKey: true,
+    });
+    assert.equal(editor.getWin().scrollY, pos);
+  });
+});

--- a/modules/tinymce/src/plugins/link/test/ts/browser/PreventDefaultTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/PreventDefaultTest.ts
@@ -15,7 +15,7 @@ describe('browser.tinymce.plugins.link.PreventDefaultTest', () => {
     toolbar: 'link openlink unlink',
     base_url: '/project/tinymce/js/tinymce',
     setup: (ed) => {
-      const hasOnlyAltModifier = (e) => {
+      const hasOnlyAltModifier = (e: KeyboardEvent) => {
         return (
           e.altKey === true &&
           e.shiftKey === false &&


### PR DESCRIPTION
Related Ticket: TINY-8661

Description of Changes:
Stop links from opening using alt+enter (option+enter on Mac) when preventDefault is called

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
