### PR TITLE
TINY-8701: Ensure fullscreen fires a ResizeEditor event

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
+- Toggling fullscreen mode with `fullscreen` plugin now also fires the `ResizeEditor` event #TINY-8701
 - Getting the text content of the editor now returns newlines instead of an empty string if more than one empty paragraph exists #TINY-8578
 - The `end_container_on_empty_block` option can now take a string of blocks to split when pressing Enter twice #TINY-6559
 - The default value for `end_container_on_empty_block` option has been changed to `'blockquote'` #TINY-6559

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Spaces would not be added correctly on some browsers when before or after a contenteditable block element #TINY-8588
 - Images were not showing as selected when selecting images alongside other content #TINY-5947
-- Notifications would not properly reposition when toggling to or from fullscreen #TINY-8701
+- Notifications would not properly reposition when toggling fullscreen mode #TINY-8701
 - Dialogs will not exceed the window height on smaller screens #TINY-8146
 - Some types on functions in the `tinymce.dom.TreeWalker` class missed that it could return undefined #TINY-8592
 - In some cases pressing the backspace key would incorrectly step into tables rather than remain outside #TINY-8592

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
-- Toggling fullscreen mode with `fullscreen` plugin now also fires the `ResizeEditor` event #TINY-8701
+- Toggling fullscreen mode with the `fullscreen` plugin now also fires the `ResizeEditor` event #TINY-8701
 - Getting the text content of the editor now returns newlines instead of an empty string if more than one empty paragraph exists #TINY-8578
 - The `end_container_on_empty_block` option can now take a string of blocks to split when pressing Enter twice #TINY-6559
 - The default value for `end_container_on_empty_block` option has been changed to `'blockquote'` #TINY-6559

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Spaces would not be added correctly on some browsers when before or after a contenteditable block element #TINY-8588
 - Images were not showing as selected when selecting images alongside other content #TINY-5947
+- Notifications would not properly reposition when toggling to or from fullscreen #TINY-8701
 - Dialogs will not exceed the window height on smaller screens #TINY-8146
 - Some types on functions in the `tinymce.dom.TreeWalker` class missed that it could return undefined #TINY-8592
 - In some cases pressing the backspace key would incorrectly step into tables rather than remain outside #TINY-8592

--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -466,7 +466,7 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
   editor.on('init', () => {
     disableGeckoResize();
 
-    editor.on('NodeChange ResizeEditor ResizeWindow ResizeContent drop FullscreenStateChanged', updateResizeRect);
+    editor.on('NodeChange ResizeEditor ResizeWindow ResizeContent drop', updateResizeRect);
 
     // Update resize rect while typing in a table
     editor.on('keyup compositionend', (e) => {

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/api/Events.ts
@@ -2,6 +2,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 const fireFullscreenStateChanged = (editor: Editor, state: boolean): void => {
   editor.dispatch('FullscreenStateChanged', { state });
+  editor.dispatch('ResizeEditor', { state });
 };
 
 export {

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/api/Events.ts
@@ -2,7 +2,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 const fireFullscreenStateChanged = (editor: Editor, state: boolean): void => {
   editor.dispatch('FullscreenStateChanged', { state });
-  editor.dispatch('ResizeEditor', { state });
+  editor.dispatch('ResizeEditor');
 };
 
 export {

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
@@ -12,7 +12,7 @@ import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 
 describe('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', () => {
-  let firedEvents = [];
+  let firedEvents: string[] = [];
   const platform = PlatformDetection.detect();
 
   afterEach(() => {
@@ -40,9 +40,9 @@ describe('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', () => {
     }
   };
 
-  const assertApiAndLastEvent = (editor: Editor, state: boolean) => {
+  const assertApiAndEvents = (editor: Editor, state: boolean) => {
     assert.equal(editor.plugins.fullscreen.isFullscreen(), state, 'Editor isFullscreen state');
-    assert.deepEqual(firedEvents, [ 'fullscreenstatechanged', state, 'resizeeditor' ], 'Fired event state');
+    assert.deepEqual(firedEvents, [ 'fullscreenstatechanged:' + state, 'resizeeditor' ], 'Should be expected events and state');
   };
 
   const assertHtmlAndBodyState = (editor: Editor, shouldExist: boolean) => {
@@ -115,9 +115,10 @@ describe('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', () => {
         setup: (editor: Editor) => {
           firedEvents = [];
           editor.on('FullscreenStateChanged ResizeEditor', (e: any) => {
-            firedEvents.push(e.type);
             if (Type.isBoolean(e.state)) {
-              firedEvents.push(e.state);
+              firedEvents.push(`${e.type}:${e.state}`);
+            } else {
+              firedEvents.push(e.type);
             }
           });
         }
@@ -127,7 +128,7 @@ describe('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', () => {
         const editor = hook.editor();
         assertPageState(editor, false);
         editor.execCommand('mceFullScreen');
-        assertApiAndLastEvent(editor, true);
+        assertApiAndEvents(editor, true);
         firedEvents = [];
         assertPageState(editor, true);
         editor.execCommand('mceLink');
@@ -135,7 +136,7 @@ describe('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', () => {
         closeOnlyWindow(editor);
         assertPageState(editor, true);
         editor.execCommand('mceFullScreen');
-        assertApiAndLastEvent(editor, false);
+        assertApiAndEvents(editor, false);
         assertPageState(editor, false);
       });
 
@@ -143,7 +144,7 @@ describe('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', () => {
         const editor = hook.editor();
         assertPageState(editor, false);
         fullScreenKeyCombination(editor);
-        assertApiAndLastEvent(editor, true);
+        assertApiAndEvents(editor, true);
         firedEvents = [];
         assertPageState(editor, true);
         editor.execCommand('mceLink');
@@ -151,14 +152,14 @@ describe('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', () => {
         closeOnlyWindow(editor);
         assertPageState(editor, true);
         fullScreenKeyCombination(editor);
-        assertApiAndLastEvent(editor, false);
+        assertApiAndEvents(editor, false);
         assertPageState(editor, false);
       });
 
       it('TINY-2884: Toggle fullscreen with keyboard and cleanup editor should clean up classes', () => {
         const editor = hook.editor();
         fullScreenKeyCombination(editor);
-        assertApiAndLastEvent(editor, true);
+        assertApiAndEvents(editor, true);
         assertPageState(editor, true);
         fullScreenKeyCombination(editor);
       });
@@ -170,7 +171,7 @@ describe('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', () => {
         editor.execCommand('mceFullScreen');
         assertPositionChanged(notification, positions);
         notification.close();
-        assertApiAndLastEvent(editor, true);
+        assertApiAndEvents(editor, true);
         assertPageState(editor, true);
         editor.execCommand('mceFullScreen');
       });
@@ -184,7 +185,7 @@ describe('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', () => {
         editor.execCommand('mceFullScreen');
         assertPositionChanged(notification, positions);
         notification.close();
-        assertApiAndLastEvent(editor, false);
+        assertApiAndEvents(editor, false);
         assertPageState(editor, false);
       });
     });

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
@@ -96,7 +96,7 @@ describe('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', () => {
 
   const assertPositionChanged = (notification: NotificationApi, oldPos: { left: number; top: number }) => {
     const position = getNotificationPosition(notification);
-    assert.isFalse(position.top === oldPos.top && position.left === oldPos.left);
+    assert.isFalse(position.top === oldPos.top && position.left === oldPos.left, 'Notification position not updated as expected');
   };
 
   const fullScreenKeyCombination = (editor: Editor) => {


### PR DESCRIPTION
Related Ticket:

Description of Changes:
This issue was detected as one where notifications are not appropriately moved when toggling fullscreen. I thought it might be better for the fullscreen plugin to fire the `resizeeditor`-event instead of making the notifications listen to the `fullscreenstatechanged` as it seemed more generic, since fullscreen does change the size of the editor.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
