### PR TITLE
TINY-8068: changed scope of list operations to closest list host element

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -26,8 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `InsertParagraph` or `mceInsertNewLine` commands did not delete the current selection like the native command used to #TINY-8606
 - When triple clicking the selection was incorrectly collapsed in the Chrome browser when clicking around nested noneditable content #TINY-8215
 - When pressing the right arrow key, the caret incorrectly moved before any selected inline boundary element #TINY-8601
-- Indenting or outdenting list items inside a block element inside a list item would not work #TINY-8068
-- Switching between unordered/ordered lists would incorrectly alter any parent element that contained that list #TINY-8068
+- Indenting or outdenting list items inside a block element that was inside another list item would not work #TINY-7209
+- Switching between unordered and ordered lists would incorrectly alter any parent element that contained that list #TINY-8068
 
 ## 6.0.3 - TBD
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `InsertParagraph` or `mceInsertNewLine` commands did not delete the current selection like the native command used to #TINY-8606
 - When triple clicking the selection was incorrectly collapsed in the Chrome browser when clicking around nested noneditable content #TINY-8215
 - When pressing the right arrow key, the caret incorrectly moved before any selected inline boundary element #TINY-8601
+- Indenting or outdenting list items inside a block element inside a list item would not work #TINY-8068
+- Switching between unordered/ordered lists would incorrectly alter any parent element that contained that list #TINY-8068
 
 ## 6.0.3 - TBD
 

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -139,7 +139,7 @@ const hasCompatibleStyle = (dom: DOMUtils, sib: Element, detail: ListDetail): bo
 const applyList = (editor: Editor, listName: string, detail: ListDetail): void => {
   const rng = editor.selection.getRng();
   let listItemName = 'LI';
-  const root = Selection.getClosestListRootElm(editor, editor.selection.getStart(true));
+  const root = Selection.getClosestListHost(editor, editor.selection.getStart(true));
   const dom = editor.dom;
 
   if (dom.getContentEditable(editor.selection.getNode()) === 'false') {

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -151,7 +151,7 @@ const mergeBackward = (editor: Editor, rng: Range, fromLi: HTMLLIElement, toLi: 
 const backspaceDeleteFromListToListCaret = (editor: Editor, isForward: boolean): boolean => {
   const dom = editor.dom, selection = editor.selection;
   const selectionStartElm = selection.getStart();
-  const root = Selection.getClosestListRootElm(editor, selectionStartElm);
+  const root = Selection.getClosestEditingHost(editor, selectionStartElm);
   const li = dom.getParent(selection.getStart(), 'LI', root) as HTMLLIElement;
 
   if (li) {
@@ -203,7 +203,7 @@ const removeBlock = (dom: DOMUtils, block: Element, root: Node): void => {
 const backspaceDeleteIntoListCaret = (editor: Editor, isForward: boolean): boolean => {
   const dom = editor.dom;
   const selectionStartElm = editor.selection.getStart();
-  const root = Selection.getClosestListRootElm(editor, selectionStartElm);
+  const root = Selection.getClosestEditingHost(editor, selectionStartElm);
   const block = dom.getParent(selectionStartElm, dom.isBlock, root);
 
   if (block && dom.isEmpty(block)) {
@@ -240,7 +240,7 @@ const backspaceDeleteCaret = (editor: Editor, isForward: boolean): boolean => {
 
 const backspaceDeleteRange = (editor: Editor): boolean => {
   const selectionStartElm = editor.selection.getStart();
-  const root = Selection.getClosestListRootElm(editor, selectionStartElm);
+  const root = Selection.getClosestEditingHost(editor, selectionStartElm);
   const startListParent = editor.dom.getParent(selectionStartElm, 'LI,DT,DD', root);
 
   if (startListParent || Selection.getSelectedListItems(editor).length > 0) {

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
@@ -6,17 +6,20 @@ import Tools from 'tinymce/core/api/util/Tools';
 
 import * as NodeType from './NodeType';
 
+const listNames = [ 'OL', 'UL', 'DL' ];
+const listSelector = listNames.join(',');
+
 const getParentList = (editor: Editor, node?: Node): HTMLElement => {
   const selectionStart = node || editor.selection.getStart(true);
 
-  return editor.dom.getParent(selectionStart, 'OL,UL,DL', getClosestListHost(editor, selectionStart));
+  return editor.dom.getParent(selectionStart, listSelector, getClosestListHost(editor, selectionStart));
 };
 
 const isParentListSelected = (parentList: HTMLElement, selectedBlocks: Element[]): boolean =>
   parentList && selectedBlocks.length === 1 && selectedBlocks[0] === parentList;
 
 const findSubLists = (parentList: HTMLElement): HTMLElement[] =>
-  Arr.filter(parentList.querySelectorAll('ol,ul,dl'), NodeType.isListNode);
+  Arr.filter(parentList.querySelectorAll(listSelector), NodeType.isListNode);
 
 const getSelectedSubLists = (editor: Editor): HTMLElement[] => {
   const parentList = getParentList(editor);
@@ -54,15 +57,11 @@ const getClosestEditingHost = (editor: Editor, elm: Node): HTMLElement => {
   return parentTableCell.length > 0 ? parentTableCell[0] : editor.getBody();
 };
 
-const isListHost = (schema: Schema, node: Node) => {
-  const nodeName = node.nodeName;
-  const listNames = [ 'UL', 'OL', 'DL' ];
-
-  return !NodeType.isListNode(node) && !NodeType.isListItemNode(node) && Arr.exists(listNames, (listName) => schema.isValidChild(nodeName, listName));
-};
+const isListHost = (schema: Schema, node: Node) =>
+  !NodeType.isListNode(node) && !NodeType.isListItemNode(node) && Arr.exists(listNames, (listName) => schema.isValidChild(node.nodeName, listName));
 
 const getClosestListHost = (editor: Editor, elm: Node): HTMLElement => {
-  const parentBlocks = editor.dom.getParents<HTMLElement>(elm, (elm) => editor.dom.isBlock(elm));
+  const parentBlocks = editor.dom.getParents<HTMLElement>(elm, editor.dom.isBlock);
   const parentBlock = Arr.find(parentBlocks, (elm) => isListHost(editor.schema, elm));
 
   return parentBlock.getOr(editor.getBody());

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
+import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -447,5 +447,44 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
     );
 
     assert.equal(editor.selection.getNode().nodeName, 'LI');
+  });
+
+  context('Parent context', () => {
+    const testCommandAtTextPath = (command: string) => (inputHtml: string, path: number[], expectedHtml: string) => () => {
+      const editor = hook.editor();
+      editor.setContent(inputHtml);
+
+      TinySelections.setCursor(editor, path, 0);
+      editor.execCommand(command);
+
+      TinyAssertions.assertContent(editor, expectedHtml);
+    };
+
+    const testIndentAtTextPath = testCommandAtTextPath('Indent');
+    const testOutdentAtTextPath = testCommandAtTextPath('Outdent');
+
+    it('TINY-8068: indent list item inside div inside list item', testIndentAtTextPath(
+      '<ul><li>A<div><ul><li>B</li><li>C</li></ul></div></li><li>D</li></ul>',
+      [ 0, 0, 1, 0, 0, 0 ],
+      '<ul><li>A<div><ul><li style="list-style-type: none;"><ul><li>B</li></ul></li><li>C</li></ul></div></li><li>D</li></ul>'
+    ));
+
+    it('TINY-8068: indent list item with a paragraph inside div inside a list item', testIndentAtTextPath(
+      '<ul><li>A<div><ul><li><p>B</p></li><li>C</li></ul></div></li><li>D</li></ul>',
+      [ 0, 0, 1, 0, 0, 0, 0 ],
+      '<ul><li>A<div><ul><li style="list-style-type: none;"><ul><li><p>B</p></li></ul></li><li>C</li></ul></div></li><li>D</li></ul>'
+    ));
+
+    it('TINY-8068: outdent list item inside a div inside a list item', testOutdentAtTextPath(
+      '<ul><li>A<div><ul><li>B</li><li>C</li></ul></div></li><li>D</li></ul>',
+      [ 0, 0, 1, 0, 0, 0 ],
+      '<ul><li>A<div><p>B</p><ul><li>C</li></ul></div></li><li>D</li></ul>'
+    ));
+
+    it('TINY-8068: outdent list item with a paragraph inside div inside a list item', testOutdentAtTextPath(
+      '<ul><li>A<div><ul><li><p>B</p></li><li>C</li></ul></div></li><li>D</li></ul>',
+      [ 0, 0, 1, 0, 0, 0 ],
+      '<ul><li>A<div><p>B</p><ul><li>C</li></ul></div></li><li>D</li></ul>'
+    ));
   });
 });

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -463,25 +463,25 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
     const testIndentAtTextPath = testCommandAtTextPath('Indent');
     const testOutdentAtTextPath = testCommandAtTextPath('Outdent');
 
-    it('TINY-8068: indent list item inside div inside list item', testIndentAtTextPath(
+    it('TINY-7209: indent list item inside div inside list item', testIndentAtTextPath(
       '<ul><li>A<div><ul><li>B</li><li>C</li></ul></div></li><li>D</li></ul>',
       [ 0, 0, 1, 0, 0, 0 ],
       '<ul><li>A<div><ul><li style="list-style-type: none;"><ul><li>B</li></ul></li><li>C</li></ul></div></li><li>D</li></ul>'
     ));
 
-    it('TINY-8068: indent list item with a paragraph inside div inside a list item', testIndentAtTextPath(
+    it('TINY-7209: indent list item with a paragraph inside div inside a list item', testIndentAtTextPath(
       '<ul><li>A<div><ul><li><p>B</p></li><li>C</li></ul></div></li><li>D</li></ul>',
       [ 0, 0, 1, 0, 0, 0, 0 ],
       '<ul><li>A<div><ul><li style="list-style-type: none;"><ul><li><p>B</p></li></ul></li><li>C</li></ul></div></li><li>D</li></ul>'
     ));
 
-    it('TINY-8068: outdent list item inside a div inside a list item', testOutdentAtTextPath(
+    it('TINY-7209: outdent list item inside a div inside a list item', testOutdentAtTextPath(
       '<ul><li>A<div><ul><li>B</li><li>C</li></ul></div></li><li>D</li></ul>',
       [ 0, 0, 1, 0, 0, 0 ],
       '<ul><li>A<div><p>B</p><ul><li>C</li></ul></div></li><li>D</li></ul>'
     ));
 
-    it('TINY-8068: outdent list item with a paragraph inside div inside a list item', testOutdentAtTextPath(
+    it('TINY-7209: outdent list item with a paragraph inside div inside a list item', testOutdentAtTextPath(
       '<ul><li>A<div><ul><li><p>B</p></li><li>C</li></ul></div></li><li>D</li></ul>',
       [ 0, 0, 1, 0, 0, 0 ],
       '<ul><li>A<div><p>B</p><ul><li>C</li></ul></div></li><li>D</li></ul>'

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/OutdentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/OutdentTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinySelections, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -472,5 +472,15 @@ describe('browser.tinymce.plugins.lists.OutdentTest', () => {
     );
 
     assert.equal(editor.selection.getNode().nodeName, 'LI');
+  });
+
+  it('TINY-8068: Outdent list inside a div inside a list item should only remove the nested list', () => {
+    const editor = hook.editor();
+    editor.setContent('<ul><li><div><ul><li>a</li></ul></div></li></ul>');
+
+    TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0, 0 ], 0);
+    editor.execCommand('Outdent');
+
+    TinyAssertions.assertContent(editor, '<ul><li><div><p>a</p></div></li></ul>');
   });
 });

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/RemoveTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinySelections, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -417,5 +417,15 @@ describe('browser.tinymce.plugins.lists.RemoveTest', () => {
         '<li>c</li>' +
       '</ul>'
     );
+  });
+
+  it('TINY-8068: Remove list inside a div inside a list item should only remove the nested list', () => {
+    const editor = hook.editor();
+    editor.setContent('<ul><li><div><ul><li>a</li></ul></div></li></ul>');
+
+    TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0, 0 ], 0);
+    editor.execCommand('InsertUnorderedList');
+
+    TinyAssertions.assertContent(editor, '<ul><li><div><p>a</p></div></li></ul>');
   });
 });


### PR DESCRIPTION
Related Ticket:

Description of Changes:
This makes any element that can hold UL/LI/DL elements except for list elements the scope for list operations. Added more details in the ticket.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
