### PR TITLE
TINY-8639: Retain formatted blank lines when `format_empty_lines` is true

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Could not remove values when multiple cells were selected with the cell properties dialog #TINY-8625
 - Could not remove values when multiple rows were selected with the row properties dialog #TINY-8625
 - Empty lines that were formatted in a ranged selection using the `format_empty_lines` option were not kept in the serialized content #TINY-8639
+- The `s` element was missing from the default schema text inline elements #TINY-8639
+- Some text inline elements specified via the schema were not removed when empty by default #TINY-8639
 
 ## 6.0.2 - 2022-04-27
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Could not remove values when multiple cells were selected with the cell properties dialog #TINY-8625
 - Could not remove values when multiple rows were selected with the row properties dialog #TINY-8625
+- Empty lines that were formatted in a ranged selection using the `format_empty_lines` option were not kept in the serialized content #TINY-8639
 
 ## 6.0.2 - 2022-04-27
 

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -12,7 +12,7 @@ import { BlobCache } from '../file/BlobCache';
 import Tools from '../util/Tools';
 import * as URI from '../util/URI';
 import AstNode from './Node';
-import Schema, { SchemaRegExpMap } from './Schema';
+import Schema, { getTextRootBlockElements, SchemaRegExpMap } from './Schema';
 
 /**
  * @summary
@@ -279,8 +279,7 @@ const whitespaceCleaner = (root: AstNode, schema: Schema, settings: DomParserSet
   const nonEmptyElements = schema.getNonEmptyElements();
   const whitespaceElements = schema.getWhitespaceElements();
   const blockElements: Record<string, string> = extend(makeMap('script,style,head,html,body,title,meta,param'), schema.getBlockElements());
-  // NOTE: This is duplicated in ApplyFormat.ts
-  const textRootBlockElements: Record<string, string> = extend(makeMap('td,th,li,dt,dd,figcaption,caption,details,summary'), schema.getTextBlockElements());
+  const textRootBlockElements = getTextRootBlockElements(schema);
   const allWhiteSpaceRegExp = /[ \t\r\n]+/g;
   const startWhiteSpaceRegExp = /^[ \t\r\n]+/;
   const endWhiteSpaceRegExp = /[ \t\r\n]+$/;

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -347,26 +347,16 @@ const whitespaceCleaner = (root: AstNode, schema: Schema, settings: DomParserSet
       if (validate && elementRule) {
         const isNodeEmpty = isEmpty(schema, nonEmptyElements, whitespaceElements, node);
 
-        const removeOrPadd = () => {
-          if (elementRule.removeEmpty && isNodeEmpty) {
-            if (blockElements[node.name]) {
-              node.remove();
-            } else {
-              node.unwrap();
-            }
-          } else if (elementRule.paddEmpty && (isNodeEmpty || isPaddedWithNbsp(node))) {
-            paddEmptyNode(settings, args, blockElements, node);
-          }
-        };
-
-        if (elementRule.paddInEmptyBlock && isNodeEmpty) {
-          if (isTextRootBlockEmpty(node)) {
-            paddEmptyNode(settings, args, blockElements, node);
+        if (elementRule.paddInEmptyBlock && isNodeEmpty && isTextRootBlockEmpty(node)) {
+          paddEmptyNode(settings, args, blockElements, node);
+        } else if (elementRule.removeEmpty && isNodeEmpty) {
+          if (blockElements[node.name]) {
+            node.remove();
           } else {
-            removeOrPadd();
+            node.unwrap();
           }
-        } else {
-          removeOrPadd();
+        } else if (elementRule.paddEmpty && (isNodeEmpty || isPaddedWithNbsp(node))) {
+          paddEmptyNode(settings, args, blockElements, node);
         }
       }
     } else if (node.type === 3) {

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -118,25 +118,15 @@ const split = (items: string, delim?: string): string[] => {
   return items ? items.split(delim || ' ') : [];
 };
 
-const getOrCreateMap = (option: string, defaultValue?: string, extendWith?: SchemaMap): SchemaMap => {
-  // get cached default map or make it if needed
-  let value: Record<string, any> = mapCache[option];
-
-  if (!value) {
-    value = makeMap(defaultValue, ' ', makeMap(defaultValue.toUpperCase(), ' '));
-    value = extend(value, extendWith);
-
-    mapCache[option] = value;
-  }
-
-  return value;
+const createMap = (defaultValue?: string, extendWith?: SchemaMap): SchemaMap => {
+  const value = makeMap(defaultValue, ' ', makeMap(defaultValue.toUpperCase(), ' '));
+  return extend(value, extendWith);
 };
 
 // A curated list using the textBlockElements map and parts of the blockElements map from the schema
 // TODO: TINY-8728 Investigate if the extras can be added directly to the default text block elements
 export const getTextRootBlockElements = (schema: Schema): SchemaMap =>
-  getOrCreateMap(
-    'text_root_block_elements',
+  createMap(
     'td th li dt dd figcaption caption details summary',
     schema.getTextBlockElements()
   );
@@ -439,7 +429,14 @@ const Schema = (settings?: SchemaSettings): Schema => {
     let value = settings[option];
 
     if (!value) {
-      value = getOrCreateMap(option, defaultValue, extendWith);
+      // Get cached default map or make it if needed
+      value = mapCache[option];
+
+      if (!value) {
+        value = createMap(defaultValue, extendWith);
+
+        mapCache[option] = value;
+      }
     } else {
       // Create custom map
       value = makeMap(value, /[, ]/, makeMap(value.toUpperCase(), /[, ]/));

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -15,7 +15,7 @@ export interface SchemaSettings {
   valid_elements?: string;
   valid_styles?: string | Record<string, string>;
   verify_html?: boolean;
-  retain_empty_block_inline_children?: boolean;
+  padd_empty_block_inline_children?: boolean;
 }
 
 export interface Attribute {
@@ -769,7 +769,7 @@ const Schema = (settings?: SchemaSettings): Schema => {
     // - in all other cases, remove the text inline element if it is empty
     each(textInlineElementsMap, (_val, name) => {
       if (elements[name]) {
-        if (settings.retain_empty_block_inline_children) {
+        if (settings.padd_empty_block_inline_children) {
           elements[name].paddInEmptyBlock = true;
         }
         elements[name].removeEmpty = true;

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -118,6 +118,12 @@ const split = (items: string, delim?: string): string[] => {
   return items ? items.split(delim || ' ') : [];
 };
 
+// A curated list using the textBlockElements map and parts of the blockElements map from the schema
+export const getTextRootBlockElements = (schema: Schema): Record<string, {}> => {
+  const extras = 'td,th,li,dt,dd,figcaption,caption,details,summary';
+  return extend(makeMap(`${extras},${extras.toUpperCase()}`), schema.getTextBlockElements());
+};
+
 /**
  * Builds a schema lookup table
  *

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -34,6 +34,7 @@ const canFormatBR = (editor: Editor, format: ApplyFormat, node: HTMLBRElement, p
   // TINY-6483: Can format 'br' if it is contained in a valid empty block and an inline format is being applied
   if (Options.canFormatEmptyLines(editor) && FormatUtils.isInlineFormat(format)) {
     // A curated list using the textBlockElements map and parts of the blockElements map from the schema
+    // NOTE: This is duplicated in DomParser.ts
     const validBRParentElements: Record<string, {}> = {
       ...editor.schema.getTextBlockElements(),
       td: {},

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -4,6 +4,7 @@ import { PredicateExists, SugarElement } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
 import * as Events from '../api/Events';
+import { getTextRootBlockElements } from '../api/html/Schema';
 import * as Options from '../api/Options';
 import Tools from '../api/util/Tools';
 import * as Bookmarks from '../bookmark/Bookmarks';
@@ -33,20 +34,7 @@ const isElementNode = (node: Node): node is Element => {
 const canFormatBR = (editor: Editor, format: ApplyFormat, node: HTMLBRElement, parentName: string) => {
   // TINY-6483: Can format 'br' if it is contained in a valid empty block and an inline format is being applied
   if (Options.canFormatEmptyLines(editor) && FormatUtils.isInlineFormat(format)) {
-    // A curated list using the textBlockElements map and parts of the blockElements map from the schema
-    // NOTE: This is duplicated in DomParser.ts
-    const validBRParentElements: Record<string, {}> = {
-      ...editor.schema.getTextBlockElements(),
-      td: {},
-      th: {},
-      li: {},
-      dt: {},
-      dd: {},
-      figcaption: {},
-      caption: {},
-      details: {},
-      summary: {}
-    };
+    const validBRParentElements = getTextRootBlockElements(editor.schema);
     // If a caret node is present, the format should apply to that, not the br (applicable to collapsed selections)
     const hasCaretNodeSibling = PredicateExists.sibling(SugarElement.fromDom(node), (sibling) => isCaretNode(sibling.dom));
     return Obj.hasNonNullableKey(validBRParentElements, parentName) && Empty.isEmpty(SugarElement.fromDom(node.parentNode), false) && !hasCaretNodeSibling;

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -98,7 +98,7 @@ const mkSchemaSettings = (editor: Editor): SchemaSettings => {
     valid_elements: getOption('valid_elements'),
     valid_styles: getOption('valid_styles'),
     verify_html: getOption('verify_html'),
-    retain_empty_block_inline_children: getOption('format_empty_lines')
+    padd_empty_block_inline_children: getOption('format_empty_lines')
   });
 };
 

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -97,7 +97,8 @@ const mkSchemaSettings = (editor: Editor): SchemaSettings => {
     valid_classes: getOption('valid_classes'),
     valid_elements: getOption('valid_elements'),
     valid_styles: getOption('valid_styles'),
-    verify_html: getOption('verify_html')
+    verify_html: getOption('verify_html'),
+    retain_empty_block_inline_children: getOption('format_empty_lines')
   });
 };
 

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
@@ -9,7 +9,7 @@ interface TestConfig {
   readonly selector: string;
   readonly selectorCount: number;
   readonly html: string;
-  readonly contentFormatRaw?: boolean;
+  readonly rawHtml?: boolean;
   readonly expectedHtml?: string;
   readonly expectedRawHtml?: string;
   readonly select: (editor: Editor) => void;
@@ -56,11 +56,11 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
   const listHTML = `<ul>\n<li>b</li>\n<li>&nbsp;</li>\n</ul>`;
 
   const testFormat = (editor: Editor, config: TestConfig) => {
-    const { selector, selectorCount, html, expectedHtml, expectedRawHtml, contentFormatRaw } = config;
+    const { selector, selectorCount, html, expectedHtml, expectedRawHtml, rawHtml } = config;
     const expectedPresence = { [selector]: selectorCount };
     const expectedPresenceOnRemove = { [selector]: 0 };
 
-    editor.setContent(html, { format: Type.isNonNullable(contentFormatRaw) ? 'raw' : 'html' });
+    editor.setContent(html, { format: rawHtml === true ? 'raw' : 'html' });
     editor.focus();
     config.select(editor);
     config.apply(editor);
@@ -253,7 +253,7 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
         selector: 'strong',
         selectorCount: 3,
         html: '<p>a</p><p><br data-mce-bogus="1"></p><p>b</p>',
-        contentFormatRaw: true,
+        rawHtml: true,
         expectedHtml:
           '<p><strong>a</strong></p>\n' +
           '<p><strong>&nbsp;</strong></p>\n' +
@@ -273,7 +273,7 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
         selector: 's',
         selectorCount: 3,
         html: '<p>a</p><p><br data-mce-bogus="1"></p><p>b</p>',
-        contentFormatRaw: true,
+        rawHtml: true,
         expectedHtml:
           '<p><s>a</s></p>\n' +
           '<p><s>&nbsp;</s></p>\n' +
@@ -293,7 +293,7 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
         selector: 'span[style="text-decoration: underline;"]',
         selectorCount: 3,
         html: '<p>a</p><p><br data-mce-bogus="1"></p><p>b</p>',
-        contentFormatRaw: true,
+        rawHtml: true,
         expectedHtml:
           '<p><span style="text-decoration: underline;">a</span></p>\n' +
           '<p><span style="text-decoration: underline;">&nbsp;</span></p>\n' +
@@ -313,7 +313,7 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
         selector: 'strong',
         selectorCount: 3,
         html: '<p>a</p><p><br data-mce-bogus="1"></p><p>b</p>',
-        contentFormatRaw: true,
+        rawHtml: true,
         expectedHtml:
           '<p><s><strong>a</strong></s></p>\n' +
           '<p><s><strong>&nbsp;</strong></s></p>\n' +
@@ -339,7 +339,7 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
         selector: 'strong',
         selectorCount: 2,
         html: '<p>a</p><ul><li><br data-mce-bogus="1"></li></ul>',
-        contentFormatRaw: true,
+        rawHtml: true,
         expectedHtml:
           '<p><strong>a</strong></p>\n' +
           '<ul>\n<li><strong>&nbsp;</strong></li>\n</ul>',

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
@@ -352,7 +352,7 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
       });
     });
 
-    it('TINY-8369: should be able to insert and type in serialized empty inline format element', async () => {
+    it('TINY-8639: should be able to insert and type in serialized empty inline format element', async () => {
       const editor = hook.editor();
       editor.setContent('<p>a</p><p><br data-mce-bogus="1"></p>', { format: 'raw' });
       selectAll(editor);
@@ -372,7 +372,7 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
       TinyAssertions.assertRawContent(editor, '<p><strong>a</strong></p><p><strong>abc&nbsp;</strong></p>');
     });
 
-    it('TINY-8369: should be able to insert and remove serialized empty inline format element', async () => {
+    it('TINY-8639: should be able to insert and remove serialized empty inline format element', async () => {
       const editor = hook.editor();
       editor.setContent('<p><strong>a</strong></p><p><strong>&nbsp;</strong></p>');
       TinySelections.setCursor(editor, [ 1, 0, 0 ], 0);
@@ -381,7 +381,7 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
       TinyAssertions.assertRawContent(editor, '<p><strong>a</strong></p><p>&nbsp;</p>');
     });
 
-    it('TINY-8369: should serialize caret formatted empty line if the cursor has not moved', () => {
+    it('TINY-8639: should serialize caret formatted empty line if the cursor has not moved', () => {
       const editor = hook.editor();
       editor.setContent('<p>a</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], 1);
@@ -397,28 +397,28 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
   });
 
   context('Parsing empty inline formatting elements', () => {
-    it('TINY-8369: should be padded on an empty line', () => {
+    it('TINY-8639: should be padded on an empty line', () => {
       const editor = hook.editor();
       editor.setContent('<p><strong></strong></p>');
       TinyAssertions.assertRawContent(editor, '<p><strong>&nbsp;</strong></p>');
       TinyAssertions.assertContent(editor, '<p><strong>&nbsp;</strong></p>');
     });
 
-    it('TINY-8369: should be padded when in an empty block', () => {
+    it('TINY-8639: should be padded when in an empty block', () => {
       const editor = hook.editor();
       editor.setContent('<div>test<div><strong></strong></div></div>');
       TinyAssertions.assertRawContent(editor, '<div>test<div><strong>&nbsp;</strong></div></div>');
       TinyAssertions.assertContent(editor, '<div>test\n<div><strong>&nbsp;</strong></div>\n</div>');
     });
 
-    it('TINY-8369: should not be padded when in an non-empty line', () => {
+    it('TINY-8639: should not be padded when in an non-empty line', () => {
       const editor = hook.editor();
       editor.setContent('<p>te<strong></strong>s<s></s>t<span style="text-decoration: underline;"></span>ing</p>');
       TinyAssertions.assertRawContent(editor, '<p>testing</p>');
       TinyAssertions.assertContent(editor, '<p>testing</p>');
     });
 
-    it('TINY-8369: should not be padded when in an non-empty block', () => {
+    it('TINY-8639: should not be padded when in an non-empty block', () => {
       const editor = hook.editor();
       editor.setContent('<div><div>te<strong></strong>st</div></div>');
       TinyAssertions.assertRawContent(editor, '<div><div>test</div></div>');

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
@@ -1,5 +1,7 @@
+import { Keys } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { Type, Unicode } from '@ephox/katamari';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -7,6 +9,9 @@ interface TestConfig {
   readonly selector: string;
   readonly selectorCount: number;
   readonly html: string;
+  readonly contentFormatRaw?: boolean;
+  readonly expectedHtml?: string;
+  readonly expectedRawHtml?: string;
   readonly select: (editor: Editor) => void;
   readonly apply: (editor: Editor) => void;
   readonly remove: (editor: Editor) => void;
@@ -21,7 +26,7 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [], true);
 
-  const tagHTML = (tag: string) => `<${tag}>a</${tag}><${tag}>&nbsp;</${tag}><${tag}>b</${tag}>`;
+  const tagHTML = (tag: string) => `<${tag}>a</${tag}>\n<${tag}>&nbsp;</${tag}>\n<${tag}>b</${tag}>`;
 
   const toggleInlineStyle = (style: string) => (editor: Editor) => {
     TinyUiActions.clickOnToolbar(editor, `[aria-label="${style}"]`);
@@ -30,6 +35,9 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
   const removeCustomFormat = (format: string) => (editor: Editor) => editor.formatter.remove(format);
 
   const selectAll = (editor: Editor) => editor.execCommand('SelectAll');
+
+  const pAssertToolbarButtonState = (editor: Editor, selector: string, active: boolean) =>
+    TinyUiActions.pWaitForUi(editor, `button[aria-label="${selector}"][aria-pressed="${active}"]`);
 
   const tableHTML = `<table style="border-collapse: collapse; width: 100%;" border="1">
   <tbody>
@@ -45,163 +53,377 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
   </tbody>
   </table>`;
 
-  const listHTML = `<ul>
-  <li>b</li>
-  <li>&nbsp;</li>
-  </ul>`;
+  const listHTML = `<ul>\n<li>b</li>\n<li>&nbsp;</li>\n</ul>`;
 
-  const testFormat = (testId: string, label: string, config: TestConfig) => {
-    const { selector, selectorCount, html } = config;
+  const testFormat = (editor: Editor, config: TestConfig) => {
+    const { selector, selectorCount, html, expectedHtml, expectedRawHtml, contentFormatRaw } = config;
     const expectedPresence = { [selector]: selectorCount };
     const expectedPresenceOnRemove = { [selector]: 0 };
 
-    it(`${testId}: Test format: ${label}`, () => {
-      const editor = hook.editor();
-      editor.setContent(html);
-      editor.focus();
-      config.select(editor);
-      config.apply(editor);
-      TinyAssertions.assertContentPresence(editor, expectedPresence);
-      config.remove(editor);
-      TinyAssertions.assertContentPresence(editor, expectedPresenceOnRemove);
+    editor.setContent(html, { format: Type.isNonNullable(contentFormatRaw) ? 'raw' : 'html' });
+    editor.focus();
+    config.select(editor);
+    config.apply(editor);
+    TinyAssertions.assertContentPresence(editor, expectedPresence);
+    if (Type.isNonNullable(expectedHtml)) {
+      TinyAssertions.assertContent(editor, expectedHtml);
+    }
+    if (Type.isNonNullable(expectedRawHtml)) {
+      TinyAssertions.assertRawContent(editor, expectedRawHtml);
+    }
+    config.remove(editor);
+    TinyAssertions.assertContentPresence(editor, expectedPresenceOnRemove);
+    // TinyAssertions.assertContent(editor, html);
+  };
+
+  const testInlineFormats = (editor: Editor, config: PartialTestConfig) => {
+    testFormat(editor, {
+      ...config,
+      selector: 'strong',
+      apply: toggleInlineStyle('Bold'),
+      remove: toggleInlineStyle('Bold')
+    });
+
+    testFormat(editor, {
+      ...config,
+      selector: 'em',
+      apply: toggleInlineStyle('Italic'),
+      remove: toggleInlineStyle('Italic')
+    });
+
+    testFormat(editor, {
+      ...config,
+      selector: 'span[style*="text-decoration: underline;"]',
+      apply: toggleInlineStyle('Underline'),
+      remove: toggleInlineStyle('Underline')
+    });
+
+    testFormat(editor, {
+      ...config,
+      selector: 's',
+      apply: toggleInlineStyle('Strikethrough'),
+      remove: toggleInlineStyle('Strikethrough')
     });
   };
 
-  const sTestInlineFormats = (testId: string, label: string, config: PartialTestConfig) =>
-    context(`${testId}: Test inline formats: ${label}`, () => {
-      testFormat(testId, 'Bold', {
-        ...config,
+  const testBlockFormats = (editor: Editor, config: PartialTestConfig) => {
+    testFormat(editor, {
+      ...config,
+      selector: 'h1',
+      apply: applyCustomFormat('h1'),
+      remove: removeCustomFormat('h1')
+    });
+
+    testFormat(editor, {
+      ...config,
+      selector: 'div',
+      apply: applyCustomFormat('div'),
+      remove: removeCustomFormat('div')
+    });
+  };
+
+  context('Test inline formats on valid blocks', () => {
+    it('TINY-6483: Check inline formats apply to valid empty block (paragraph)', () => {
+      testInlineFormats(hook.editor(), {
+        selectorCount: 3,
+        html: tagHTML('p'),
+        select: selectAll
+      });
+    });
+
+    it('TINY-6483: Check inline formats apply to valid empty block (heading)', () => {
+      testInlineFormats(hook.editor(), {
+        selectorCount: 3,
+        html: tagHTML('p'),
+        select: selectAll
+      });
+    });
+
+    it('TINY-6483: Check inline formats apply to valid empty block (preformat)', () => {
+      testInlineFormats(hook.editor(), {
+        selectorCount: 3,
+        html: tagHTML('pre'),
+        select: selectAll
+      });
+    });
+
+    it('TINY-6483: Check inline formats apply to valid empty block (div)', () => {
+      testInlineFormats(hook.editor(), {
+        selectorCount: 3,
+        html: tagHTML('div'),
+        select: selectAll
+      });
+    });
+
+    it('TINY-6483: Check inline formats apply to valid empty block (blockquote)', () => {
+      testInlineFormats(hook.editor(), {
+        selectorCount: 3,
+        html: tagHTML('blockquote'),
+        select: selectAll
+      });
+    });
+
+    it('TINY-6483: Check inline formats apply to valid empty block (list - li)', () => {
+      testInlineFormats(hook.editor(), {
+        selectorCount: 4,
+        html: `<p>a</p>\n${listHTML}\n<p>c</p>`,
+        select: selectAll
+      });
+    });
+
+    it('TINY-6483: Check inline formats apply to valid empty block (table - td,th)', () => {
+      testInlineFormats(hook.editor(), {
+        selectorCount: 5,
+        html: `<p>a</p>${tableHTML}<p>c</p>`,
+        select: selectAll
+      });
+    });
+  });
+
+  // Test that for a collapsed selection only the caret span is formatted and not the br
+  it('TINY-6483: Check collapsed selection (paragraph)', () => {
+    testInlineFormats(hook.editor(), {
+      selectorCount: 1,
+      html: tagHTML('p'),
+      select: (editor) => TinySelections.setCursor(editor, [ 1, 0 ], 0)
+    });
+  });
+
+  // Test inline format on br surrounded by inline block
+  it('TINY-6483: Check inline format does not apply to empty inline block', () => {
+    testFormat(hook.editor(), {
+      selector: 'strong',
+      selectorCount: 3,
+      html: '<p><em>a</em></p>\n<p><em>&nbsp;</em></p>\n<p><em>b</em></p>',
+      select: selectAll,
+      apply: toggleInlineStyle('Bold'),
+      remove: toggleInlineStyle('Bold')
+    });
+  });
+
+  // Test cells can be formatted with internal table selections
+  it('TINY-6483: Check inline formats apply to table cells with explicit cell selections', () => {
+    testInlineFormats(hook.editor(), {
+      selectorCount: 3,
+      html: `<table style="border-collapse: collapse; width: 100%;" border="1" data-mce-selected="1">
+      <tbody>
+      <tr>
+      <th scope="row" data-mce-selected="1" data-mce-first-selected="1">&nbsp;</th>
+      </tr>
+      <tr>
+      <td data-mce-selected="1">b</td>
+      </tr>
+      <tr>
+      <td data-mce-selected="1" data-mce-last-selected="1">&nbsp;</td>
+      </tr>
+      </tbody>
+      </table>`,
+      select: (editor) => TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0)
+    });
+  });
+
+  context('Test block formats', () => {
+    it('TINY-6483: Check block formats converts valid blocks (paragraphs)', () => {
+      testBlockFormats(hook.editor(), {
+        selectorCount: 3,
+        html: tagHTML('p'),
+        select: selectAll
+      });
+    });
+
+    it('TINY-6483: Check block formats do not apply to invalid empty block (list - li)', () => {
+      testBlockFormats(hook.editor(), {
+        selectorCount: 3,
+        html: `<p>a</p>\n${listHTML}\n<p>c</p>`,
+        select: selectAll
+      });
+    });
+
+    it('TINY-6483: Check block formats do not apply to invalid empty block (table - td,th)', () => {
+      testBlockFormats(hook.editor(), {
+        selectorCount: 3,
+        html: `<p>a</p>\n${tableHTML}<p>c</p>`,
+        select: selectAll
+      });
+    });
+  });
+
+  context('Serializing empty inline format elements', () => {
+    it('TINY-8639: Check inline format is correctly serialized (bold)', () => {
+      testFormat(hook.editor(), {
         selector: 'strong',
+        selectorCount: 3,
+        html: '<p>a</p><p><br data-mce-bogus="1"></p><p>b</p>',
+        contentFormatRaw: true,
+        expectedHtml:
+          '<p><strong>a</strong></p>\n' +
+          '<p><strong>&nbsp;</strong></p>\n' +
+          '<p><strong>b</strong></p>',
+        expectedRawHtml:
+          '<p><strong>a</strong></p>' +
+          '<p><strong><br data-mce-bogus="1"></strong></p>' +
+          '<p><strong>b</strong></p>',
+        select: selectAll,
         apply: toggleInlineStyle('Bold'),
         remove: toggleInlineStyle('Bold')
       });
+    });
 
-      testFormat(testId, 'Italic', {
-        ...config,
-        selector: 'em',
-        apply: toggleInlineStyle('Italic'),
-        remove: toggleInlineStyle('Italic')
-      });
-
-      testFormat(testId, 'Underline', {
-        ...config,
-        selector: 'span[style*="text-decoration: underline;"]',
-        apply: toggleInlineStyle('Underline'),
-        remove: toggleInlineStyle('Underline')
-      });
-
-      testFormat(testId, 'Strikethrough', {
-        ...config,
+    it('TINY-8639: Check inline format is correctly serialized (strikethrough)', () => {
+      testFormat(hook.editor(), {
         selector: 's',
+        selectorCount: 3,
+        html: '<p>a</p><p><br data-mce-bogus="1"></p><p>b</p>',
+        contentFormatRaw: true,
+        expectedHtml:
+          '<p><s>a</s></p>\n' +
+          '<p><s>&nbsp;</s></p>\n' +
+          '<p><s>b</s></p>',
+        expectedRawHtml:
+          '<p><s>a</s></p>' +
+          '<p><s><br data-mce-bogus="1"></s></p>' +
+          '<p><s>b</s></p>',
+        select: selectAll,
         apply: toggleInlineStyle('Strikethrough'),
         remove: toggleInlineStyle('Strikethrough')
       });
     });
 
-  const testBlockFormats = (testId: string, label: string, config: PartialTestConfig) =>
-    context(`${testId}: Test block formats: ${label}`, () => {
-      testFormat(testId, 'h1', {
-        ...config,
-        selector: 'h1',
-        apply: applyCustomFormat('h1'),
-        remove: removeCustomFormat('h1')
-      });
-
-      testFormat(testId, 'div', {
-        ...config,
-        selector: 'div',
-        apply: applyCustomFormat('div'),
-        remove: removeCustomFormat('div')
+    it('TINY-8639: Check inline format is correctly serialized (underline)', () => {
+      testFormat(hook.editor(), {
+        selector: 'span[style="text-decoration: underline;"]',
+        selectorCount: 3,
+        html: '<p>a</p><p><br data-mce-bogus="1"></p><p>b</p>',
+        contentFormatRaw: true,
+        expectedHtml:
+          '<p><span style="text-decoration: underline;">a</span></p>\n' +
+          '<p><span style="text-decoration: underline;">&nbsp;</span></p>\n' +
+          '<p><span style="text-decoration: underline;">b</span></p>',
+        expectedRawHtml:
+          '<p><span style="text-decoration: underline;" data-mce-style="text-decoration: underline;">a</span></p>' +
+          '<p><span style="text-decoration: underline;" data-mce-style="text-decoration: underline;"><br data-mce-bogus="1"></span></p>' +
+          '<p><span style="text-decoration: underline;" data-mce-style="text-decoration: underline;">b</span></p>',
+        select: selectAll,
+        apply: toggleInlineStyle('Underline'),
+        remove: toggleInlineStyle('Underline')
       });
     });
 
-  // Test inline formats on valid blocks
-  sTestInlineFormats('TINY-6483', 'Check inline formats apply to valid empty block (paragraph)', {
-    selectorCount: 3,
-    html: tagHTML('p'),
-    select: selectAll
-  });
-  sTestInlineFormats('TINY-6483', 'Check inline formats apply to valid empty block (heading)', {
-    selectorCount: 3,
-    html: tagHTML('p'),
-    select: selectAll
-  });
-  sTestInlineFormats('TINY-6483', 'Check inline formats apply to valid empty block (preformat)', {
-    selectorCount: 3,
-    html: tagHTML('pre'),
-    select: selectAll
-  });
-  sTestInlineFormats('TINY-6483', 'Check inline formats apply to valid empty block (div)', {
-    selectorCount: 3,
-    html: tagHTML('div'),
-    select: selectAll
-  });
-  sTestInlineFormats('TINY-6483', 'Check inline formats apply to valid empty block (blockquote)', {
-    selectorCount: 3,
-    html: tagHTML('blockquote'),
-    select: selectAll
-  });
-  sTestInlineFormats('TINY-6483', 'Check inline formats apply to valid empty block (list - li)', {
-    selectorCount: 4,
-    html: `<p>a</p>${listHTML}<p>c</p>`,
-    select: selectAll
-  });
-  sTestInlineFormats('TINY-6483', 'Check inline formats apply to valid empty block (table - td,th)', {
-    selectorCount: 5,
-    html: `<p>a</p>${tableHTML}<p>c</p>`,
-    select: selectAll
+    it('TINY-8639: Check inline format is correctly serialized (bold and strikethrough)', () => {
+      testFormat(hook.editor(), {
+        selector: 'strong',
+        selectorCount: 3,
+        html: '<p>a</p><p><br data-mce-bogus="1"></p><p>b</p>',
+        contentFormatRaw: true,
+        expectedHtml:
+          '<p><s><strong>a</strong></s></p>\n' +
+          '<p><s><strong>&nbsp;</strong></s></p>\n' +
+          '<p><s><strong>b</strong></s></p>',
+        expectedRawHtml:
+          '<p><s><strong>a</strong></s></p>' +
+          '<p><s><strong><br data-mce-bogus="1"></strong></s></p>' +
+          '<p><s><strong>b</strong></s></p>',
+        select: selectAll,
+        apply: (editor) => {
+          toggleInlineStyle('Bold')(editor);
+          toggleInlineStyle('Strikethrough')(editor);
+        },
+        remove: (editor) => {
+          toggleInlineStyle('Bold')(editor);
+          toggleInlineStyle('Strikethrough')(editor);
+        },
+      });
+    });
+
+    it('TINY-8639: Check inline format is correctly serialized in list item', () => {
+      testFormat(hook.editor(), {
+        selector: 'strong',
+        selectorCount: 2,
+        html: '<p>a</p><ul><li><br data-mce-bogus="1"></li></ul>',
+        contentFormatRaw: true,
+        expectedHtml:
+          '<p><strong>a</strong></p>\n' +
+          '<ul>\n<li><strong>&nbsp;</strong></li>\n</ul>',
+        expectedRawHtml:
+          '<p><strong>a</strong></p>' +
+          '<ul><li><strong><br data-mce-bogus="1"></strong></li></ul>',
+        select: selectAll,
+        apply: toggleInlineStyle('Bold'),
+        remove: toggleInlineStyle('Bold')
+      });
+    });
+
+    it('TINY-8369: should be able to insert and type in serialized empty inline format element', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p>a</p><p><br data-mce-bogus="1"></p>', { format: 'raw' });
+      selectAll(editor);
+      toggleInlineStyle('Bold')(editor);
+      TinyAssertions.assertRawContent(editor, '<p><strong>a</strong></p><p><strong><br data-mce-bogus="1"></strong></p>');
+      TinyAssertions.assertContent(editor, '<p><strong>a</strong></p>\n<p><strong>&nbsp;</strong></p>');
+
+      TinySelections.setCursor(editor, [ 1, 0, 0 ], 0);
+      await pAssertToolbarButtonState(editor, 'Bold', true);
+
+      const content = editor.getContent();
+      editor.setContent(content);
+      TinyAssertions.assertRawContent(editor, '<p><strong>a</strong></p><p><strong>&nbsp;</strong></p>');
+      TinySelections.setCursor(editor, [ 1, 0, 0 ], 0);
+      await pAssertToolbarButtonState(editor, 'Bold', true);
+      TinyContentActions.type(editor, 'abc');
+      TinyAssertions.assertRawContent(editor, '<p><strong>a</strong></p><p><strong>abc&nbsp;</strong></p>');
+    });
+
+    it('TINY-8369: should be able to insert and remove serialized empty inline format element', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p><strong>a</strong></p><p><strong>&nbsp;</strong></p>');
+      TinySelections.setCursor(editor, [ 1, 0, 0 ], 0);
+      await pAssertToolbarButtonState(editor, 'Bold', true);
+      toggleInlineStyle('Bold')(editor);
+      TinyAssertions.assertRawContent(editor, '<p><strong>a</strong></p><p>&nbsp;</p>');
+    });
+
+    it('TINY-8369: should serialize caret formatted empty line if the cursor has not moved', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>a</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      TinyContentActions.keystroke(editor, Keys.enter());
+      toggleInlineStyle('Bold')(editor);
+      TinyAssertions.assertRawContent(
+        editor,
+        '<p>a</p>' +
+        `<p><span id="_mce_caret" data-mce-bogus="1" data-mce-type="format-caret"><strong>${Unicode.zeroWidth}</strong></span><br data-mce-bogus="1"></p>`
+      );
+      TinyAssertions.assertContent(editor, '<p>a</p>\n<p><strong>&nbsp;</strong></p>');
+    });
   });
 
-  // Test that for a collapsed selection only the caret span is formatted and not the br
-  sTestInlineFormats('TINY-6483', 'Check collapsed selection (paragraph)', {
-    selectorCount: 1,
-    html: tagHTML('p'),
-    select: (editor) => TinySelections.setCursor(editor, [ 1, 0 ], 0)
-  });
+  context('Parsing empty inline formatting elements', () => {
+    it('TINY-8369: should be padded on an empty line', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><strong></strong></p>');
+      TinyAssertions.assertRawContent(editor, '<p><strong>&nbsp;</strong></p>');
+      TinyAssertions.assertContent(editor, '<p><strong>&nbsp;</strong></p>');
+    });
 
-  // Test inline format on br surrounded by inline block
-  testFormat('TINY-6483', 'Check inline format does not apply to empty inline block', {
-    selector: 'strong',
-    selectorCount: 3,
-    html: '<p><em>a</em></p><p><em>&nbsp;<em></p><p><em>b</em></p>',
-    select: selectAll,
-    apply: toggleInlineStyle('Bold'),
-    remove: toggleInlineStyle('Bold')
-  });
+    it('TINY-8369: should be padded when in an empty block', () => {
+      const editor = hook.editor();
+      editor.setContent('<div>test<div><strong></strong></div></div>');
+      TinyAssertions.assertRawContent(editor, '<div>test<div><strong>&nbsp;</strong></div></div>');
+      TinyAssertions.assertContent(editor, '<div>test\n<div><strong>&nbsp;</strong></div>\n</div>');
+    });
 
-  // Test cells can be formatted with internal table selections
-  sTestInlineFormats('TINY-6483', 'Check inline formats apply to table cells with explicit cell selections', {
-    selectorCount: 3,
-    html: `<table style="border-collapse: collapse; width: 100%;" border="1" data-mce-selected="1">
-    <tbody>
-    <tr>
-    <th scope="row" data-mce-selected="1" data-mce-first-selected="1">&nbsp;</th>
-    </tr>
-    <tr>
-    <td data-mce-selected="1">b</td>
-    </tr>
-    <tr>
-    <td data-mce-selected="1" data-mce-last-selected="1">&nbsp;</td>
-    </tr>
-    </tbody>
-    </table>`,
-    select: (editor) => TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0)
-  });
+    it('TINY-8369: should not be padded when in an non-empty line', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>te<strong></strong>s<s></s>t<span style="text-decoration: underline;"></span>ing</p>');
+      TinyAssertions.assertRawContent(editor, '<p>testing</p>');
+      TinyAssertions.assertContent(editor, '<p>testing</p>');
+    });
 
-  // Test block formats
-  testBlockFormats('TINY-6483', 'Check block formats converts valid blocks (paragraphs)', {
-    selectorCount: 3,
-    html: tagHTML('p'),
-    select: selectAll
-  });
-  testBlockFormats('TINY-6483', 'Check block formats do not apply to invalid empty block (list - li)', {
-    selectorCount: 3,
-    html: `<p>a</p>${listHTML}<p>c</p>`,
-    select: selectAll
-  });
-  testBlockFormats('TINY-6483', 'Check block formats do not apply to invalid empty block (table - td,th)', {
-    selectorCount: 3,
-    html: `<p>a</p>${tableHTML}<p>c</p>`,
-    select: selectAll
+    it('TINY-8369: should not be padded when in an non-empty block', () => {
+      const editor = hook.editor();
+      editor.setContent('<div><div>te<strong></strong>st</div></div>');
+      TinyAssertions.assertRawContent(editor, '<div><div>test</div></div>');
+      TinyAssertions.assertContent(editor, '<div>\n<div>test</div>\n</div>');
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
@@ -73,7 +73,6 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
     }
     config.remove(editor);
     TinyAssertions.assertContentPresence(editor, expectedPresenceOnRemove);
-    // TinyAssertions.assertContent(editor, html);
   };
 
   const testInlineFormats = (editor: Editor, config: PartialTestConfig) => {

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1072,8 +1072,20 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     '<p><span style="color: red;"></span></p>' +
     '<p><span></span></p>';
 
-    let parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
+    // Assert default behaviour when padd_empty_block_inline_children is not specified (should be equivalent to false)
+    let parser = DomParser({}, Schema({}));
     let serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml,
+      '<p>\u00a0</p>' +
+      '<p>\u00a0</p>' +
+      '<p>\u00a0</p>' +
+      '<p>\u00a0</p>' +
+      '<p>\u00a0</p>'
+    );
+
+    parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
+    serializedHtml = serializer.serialize(parser.parse(html));
 
     assert.equal(serializedHtml,
       '<p>\u00a0</p>' +
@@ -1102,8 +1114,21 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     '<p><span style="color: red;"> </span></p>' +
     '<p><span> </span></p>';
 
-    let parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
+    // Assert default behaviour when padd_empty_block_inline_children is not specified (should be equivalent to false)
+    let parser = DomParser({}, Schema({}));
     let serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml,
+      '<p><strong> </strong></p>' +
+      '<p><s> </s></p>' +
+      // isEmpty node logic considers a span with no style attribute and a single space to be empty (Node.ts -> isEmpty -> isEmptyTextNode)
+      '<p> </p>' +
+      '<p><span style="color: red;"> </span></p>' +
+      '<p>\u00a0</p>'
+    );
+
+    parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
+    serializedHtml = serializer.serialize(parser.parse(html));
 
     assert.equal(serializedHtml,
       '<p><strong> </strong></p>' +
@@ -1133,8 +1158,20 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     '<p><span style="color: red;">&nbsp;</span></p>' +
     '<p><span>&nbsp;</span></p>';
 
-    let parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
+    // Assert default behaviour when padd_empty_block_inline_children is not specified (should be equivalent to false)
+    let parser = DomParser({}, Schema({}));
     let serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml,
+      '<p><strong>\u00a0</strong></p>' +
+      '<p><s>\u00a0</s></p>' +
+      '<p><span class="test">\u00a0</span></p>' +
+      '<p><span style="color: red;">\u00a0</span></p>' +
+      '<p>\u00a0</p>'
+    );
+
+    parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
+    serializedHtml = serializer.serialize(parser.parse(html));
 
     assert.equal(serializedHtml,
       '<p><strong>\u00a0</strong></p>' +
@@ -1163,8 +1200,20 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     '<p>ab<span style="color: red;"></span>cd</p>' +
     '<p>ab<span></span>cd</p>';
 
-    let parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
+    // Assert default behaviour when padd_empty_block_inline_children is not specified (should be equivalent to false)
+    let parser = DomParser({}, Schema({}));
     let serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml,
+      '<p>abcd</p>' +
+      '<p>abcd</p>' +
+      '<p>abcd</p>' +
+      '<p>abcd</p>' +
+      '<p>abcd</p>'
+    );
+
+    parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
+    serializedHtml = serializer.serialize(parser.parse(html));
 
     assert.equal(serializedHtml,
       '<p>abcd</p>' +

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1072,7 +1072,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     '<p><span style="color: red;"></span></p>' +
     '<p><span></span></p>';
 
-    let parser = DomParser({}, Schema({ retain_empty_block_inline_children: false }));
+    let parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
     let serializedHtml = serializer.serialize(parser.parse(html));
 
     assert.equal(serializedHtml,
@@ -1083,7 +1083,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       '<p>\u00a0</p>'
     );
 
-    parser = DomParser({}, Schema({ retain_empty_block_inline_children: true }));
+    parser = DomParser({}, Schema({ padd_empty_block_inline_children: true }));
     serializedHtml = serializer.serialize(parser.parse(html));
 
     assert.equal(serializedHtml,
@@ -1102,7 +1102,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     '<p><span style="color: red;"> </span></p>' +
     '<p><span> </span></p>';
 
-    let parser = DomParser({}, Schema({ retain_empty_block_inline_children: false }));
+    let parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
     let serializedHtml = serializer.serialize(parser.parse(html));
 
     assert.equal(serializedHtml,
@@ -1114,7 +1114,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       '<p>\u00a0</p>'
     );
 
-    parser = DomParser({}, Schema({ retain_empty_block_inline_children: true }));
+    parser = DomParser({}, Schema({ padd_empty_block_inline_children: true }));
     serializedHtml = serializer.serialize(parser.parse(html));
 
     assert.equal(serializedHtml,
@@ -1133,7 +1133,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     '<p><span style="color: red;">&nbsp;</span></p>' +
     '<p><span>&nbsp;</span></p>';
 
-    let parser = DomParser({}, Schema({ retain_empty_block_inline_children: false }));
+    let parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
     let serializedHtml = serializer.serialize(parser.parse(html));
 
     assert.equal(serializedHtml,
@@ -1144,7 +1144,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       '<p>\u00a0</p>'
     );
 
-    parser = DomParser({}, Schema({ retain_empty_block_inline_children: true }));
+    parser = DomParser({}, Schema({ padd_empty_block_inline_children: true }));
     serializedHtml = serializer.serialize(parser.parse(html));
 
     assert.equal(serializedHtml,
@@ -1163,7 +1163,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     '<p>ab<span style="color: red;"></span>cd</p>' +
     '<p>ab<span></span>cd</p>';
 
-    let parser = DomParser({}, Schema({ retain_empty_block_inline_children: false }));
+    let parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
     let serializedHtml = serializer.serialize(parser.parse(html));
 
     assert.equal(serializedHtml,
@@ -1174,7 +1174,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       '<p>abcd</p>'
     );
 
-    parser = DomParser({}, Schema({ retain_empty_block_inline_children: true }));
+    parser = DomParser({}, Schema({ padd_empty_block_inline_children: true }));
     serializedHtml = serializer.serialize(parser.parse(html));
 
     assert.equal(serializedHtml,

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -498,14 +498,14 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
       assert.isTrue(rules.length > 0 && Arr.forall(rules, (rule) => Type.isUndefined(rule.paddInEmptyBlock)));
     });
 
-    it('TINY-8639: retain_empty_block_inline_children: false', () => {
-      const schema = Schema({ retain_empty_block_inline_children: false });
+    it('TINY-8639: padd_empty_block_inline_children: false', () => {
+      const schema = Schema({ padd_empty_block_inline_children: false });
       const rules = Obj.mapToArray(schema.getTextInlineElements(), (_value, name) => schema.getElementRule(name.toLowerCase()));
       assert.isTrue(rules.length > 0 && Arr.forall(rules, (rule) => Type.isUndefined(rule.paddInEmptyBlock)));
     });
 
-    it('TINY-8639: retain_empty_block_inline_children: true', () => {
-      const schema = Schema({ retain_empty_block_inline_children: true });
+    it('TINY-8639: padd_empty_block_inline_children: true', () => {
+      const schema = Schema({ padd_empty_block_inline_children: true });
       const rules = Obj.mapToArray(schema.getTextInlineElements(), (_value, name) => schema.getElementRule(name.toLowerCase()));
       assert.isTrue(rules.length > 0 && Arr.forall(rules, (rule) => rule.paddInEmptyBlock === true));
     });

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -1,5 +1,5 @@
-import { describe, it } from '@ephox/bedrock-client';
-import { Arr, Obj } from '@ephox/katamari';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr, Obj, Type } from '@ephox/katamari';
 import { assert } from 'chai';
 
 import Schema from 'tinymce/core/api/html/Schema';
@@ -281,10 +281,10 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
   it('getTextInlineElements', () => {
     const schema = Schema();
     assert.deepEqual(schema.getTextInlineElements(), {
-      B: {}, CITE: {}, CODE: {}, DFN: {}, EM: {}, FONT: {}, I: {}, MARK: {}, Q: {},
-      SAMP: {}, SPAN: {}, STRIKE: {}, STRONG: {}, SUB: {}, SUP: {}, U: {}, VAR: {},
-      b: {}, cite: {}, code: {}, dfn: {}, em: {}, font: {}, i: {}, mark: {}, q: {},
-      samp: {}, span: {}, strike: {}, strong: {}, sub: {}, sup: {}, u: {}, var: {}
+      B: {}, CITE: {}, CODE: {}, DFN: {}, EM: {}, FONT: {}, I: {}, MARK: {}, Q: {}, SAMP: {},
+      SPAN: {}, S: {}, STRIKE: {}, STRONG: {}, SUB: {}, SUP: {}, U: {}, VAR: {},
+      b: {}, cite: {}, code: {}, dfn: {}, em: {}, font: {}, i: {}, mark: {}, q: {}, samp: {},
+      span: {}, s: {}, strike: {}, strong: {}, sub: {}, sup: {}, u: {}, var: {}
     });
   });
 
@@ -488,6 +488,26 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
         classC: {},
         classD: {}
       }
+    });
+  });
+
+  context('paddInEmptyBlock', () => {
+    it('TINY-8639: default behaviour', () => {
+      const schema = Schema({});
+      const rules = Obj.mapToArray(schema.getTextInlineElements(), (_value, name) => schema.getElementRule(name.toLowerCase()));
+      assert.isTrue(rules.length > 0 && Arr.forall(rules, (rule) => Type.isUndefined(rule.paddInEmptyBlock)));
+    });
+
+    it('TINY-8639: retain_empty_block_inline_children: false', () => {
+      const schema = Schema({ retain_empty_block_inline_children: false });
+      const rules = Obj.mapToArray(schema.getTextInlineElements(), (_value, name) => schema.getElementRule(name.toLowerCase()));
+      assert.isTrue(rules.length > 0 && Arr.forall(rules, (rule) => Type.isUndefined(rule.paddInEmptyBlock)));
+    });
+
+    it('TINY-8639: retain_empty_block_inline_children: true', () => {
+      const schema = Schema({ retain_empty_block_inline_children: true });
+      const rules = Obj.mapToArray(schema.getTextInlineElements(), (_value, name) => schema.getElementRule(name.toLowerCase()));
+      assert.isTrue(rules.length > 0 && Arr.forall(rules, (rule) => rule.paddInEmptyBlock === true));
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-8639

Description of Changes:
* Update the schema and DomParser so that text inline elements can be padded if they are a child of an empty block. As to whether text inline elements are padded by default is controlled by the `format_empty_lines` option

Coming up with setting and property names for the schema was tricky so am open to suggestions if we are not happy with what I have got currently

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
