### PR TITLE
TINY-4784: Treat custom elements as always being non-empty by default

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Getting the text content of the editor now returns newlines instead of an empty string if more than one empty paragraph exists #TINY-8578
 - The `end_container_on_empty_block` option can now take a string of blocks to split when pressing Enter twice #TINY-6559
 - The default value for `end_container_on_empty_block` option has been changed to `'blockquote'` #TINY-6559
+- Custom elements are now treated as non-empty elements via the schema #TINY-4784
 
 ### Fixed
 - Links would open when using alt+enter (option+enter on Mac) even when `preventDefault()` is called on the keydown event #TINY-8661
@@ -30,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When pressing the right arrow key, the caret incorrectly moved before any selected inline boundary element #TINY-8601
 - Indenting or outdenting list items inside a block element that was inside another list item would not work #TINY-7209
 - Switching between unordered and ordered lists would incorrectly alter any parent element that contained that list #TINY-8068
+- Custom elements on blank lines would be be removed during serialization #TINY-4784
 - The URL detection used for `autolink` and smart paste didn't work if a path segment contained valid characters such as `!` and `:` #TINY-8069
 
 ## 6.0.3 - TBD

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When pressing the right arrow key, the caret incorrectly moved before any selected inline boundary element #TINY-8601
 - Indenting or outdenting list items inside a block element that was inside another list item would not work #TINY-7209
 - Switching between unordered and ordered lists would incorrectly alter any parent element that contained that list #TINY-8068
-- Custom elements on blank lines would be be removed during serialization #TINY-4784
+- Custom elements on blank lines would be removed during serialization #TINY-4784
 - The URL detection used for `autolink` and smart paste didn't work if a path segment contained valid characters such as `!` and `:` #TINY-8069
 
 ## 6.0.3 - TBD

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -658,6 +658,10 @@ const Schema = (settings?: SchemaSettings): Schema => {
         children[name] = children[cloneName];
         customElementsMap[name] = cloneName;
 
+        // Treat all custom elements as being non-empty by default
+        nonEmptyElementsMap[name.toUpperCase()] = {};
+        nonEmptyElementsMap[name] = {};
+
         // If it's not marked as inline then add it to valid block elements
         if (!inline) {
           blockElementsMap[name.toUpperCase()] = {};

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -13,7 +13,8 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     disable_nodechange: true,
     entities: 'raw',
     indent: false,
-    base_url: '/project/tinymce/js/tinymce'
+    base_url: '/project/tinymce/js/tinymce',
+    custom_elements: '~foo-bar'
   }, []);
 
   it('TBA: insertAtCaret - i inside text, converts to em', () => {
@@ -638,5 +639,13 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     editor.insertContent('<div>inserted content</div>');
     assert.equal(numNodesFiltered, 1, 'Node filters should have run');
     TinyAssertions.assertContent(editor, '<p>Con</p><div>inserted content</div><p>tent</p>');
+  });
+
+  it('TINY-4784: An empty custom element should not be removed when inserted', () => {
+    const editor = hook.editor();
+    editor.setContent('<p></p>');
+
+    editor.insertContent('<foo-bar contenteditable="false" data-name="foobar"></foo-bar>');
+    TinyAssertions.assertContent(editor, '<p><foo-bar contenteditable="false" data-name="foobar"></foo-bar></p>');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
@@ -667,14 +667,17 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
   it('Custom elements', () => {
     const ser = DomSerializer({
       custom_elements: 'custom1,~custom2',
-      valid_elements: 'custom1,custom2'
+      valid_elements: 'custom1,custom2,#p'
     });
 
     document.createElement('custom1');
     document.createElement('custom2');
 
     DOM.setHTML('test', '<p><custom1>c1</custom1><custom2>c2</custom2></p>');
-    assert.equal(ser.serialize(DOM.get('test')), '<custom1>c1</custom1><custom2>c2</custom2>');
+    assert.equal(ser.serialize(DOM.get('test')), '<custom1>c1</custom1><p><custom2>c2</custom2></p>');
+
+    DOM.setHTML('test', '<custom1></custom1><p><custom2></custom2></p>');
+    assert.equal(ser.serialize(DOM.get('test')), '<custom1></custom1><p><custom2></custom2></p>');
   });
 
   it('Remove internal classes', () => {

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -1,4 +1,4 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
 import { assert } from 'chai';
 
@@ -488,6 +488,34 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
         classC: {},
         classD: {}
       }
+    });
+  });
+
+  context('custom elements', () => {
+    it('TBA: custom elements are added as element rules and copy the span/div rules', () => {
+      const schema = Schema({
+        custom_elements: '~foo-bar,bar-foo'
+      });
+
+      const inlineRule = schema.getElementRule('foo-bar');
+      const spanRule = schema.getElementRule('span');
+      assert.deepEqual(inlineRule.attributes, spanRule.attributes, 'inline custom element rules should be copied from the span rules');
+      assert.deepEqual(inlineRule.attributesOrder, spanRule.attributesOrder, 'inline custom element rules should be copied from the span rules');
+      assert.deepEqual(schema.children['foo-bar'], schema.children.span);
+
+      const blockRule = schema.getElementRule('bar-foo');
+      const divRule = schema.getElementRule('div');
+      assert.deepEqual(blockRule.attributes, divRule.attributes, 'block custom element rules should be copied from the div rules');
+      assert.deepEqual(blockRule.attributesOrder, divRule.attributesOrder, 'block custom element rules should be copied from the div rules');
+      assert.deepEqual(schema.children['bar-foo'], schema.children.div);
+    });
+
+    it('TINY-4784: custom elements should be added to the non-empty elements list by default', () => {
+      const schema = Schema({
+        custom_elements: '~foo-bar,bar-foo'
+      });
+
+      assert.hasAnyKeys(schema.getNonEmptyElements(), [ 'foo-bar', 'FOO-BAR', 'bar-foo', 'BAR-FOO' ]);
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-4784

Description of Changes:
As discussed on slack, we cannot be certain of the intention for custom elements so this updates the schema to treat them as "non-empty" so that the `isEmpty` checks will return false for custom elements. It's also quite common for custom elements/webcomponents to be empty, so this change reflects that.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
