### PR TITLE
TINY-8641: Add the `dispatchChange` function to the `undoManager`

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed incorrect word breaks in menu dropdowns with scrollbar #TINY-8572
 - The `InsertLineBreak` command did not replace selected content #TINY-8458
 - Delete operations could behave incorrectly if the selection contains a `contenteditable="false"` element located at the edge of content #TINY-8729
-- `uploadImages` no longer triggers two `change` events if there is an error on upload #TINY-8641
+- `uploadImages` no longer triggers two `change` events if there is a removal of images on upload #TINY-8641
 
 ## 6.0.3 - 2022-05-25
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default value for `end_container_on_empty_block` option has been changed to `'blockquote'` #TINY-6559
 - Custom elements are now treated as non-empty elements via the schema #TINY-4784
 - The autocompleter menu element is now positioned instead of the wrapper #TINY-6476
+- Now on `uploadImages` does not trigger `change` event 2 times if there is an error on upload #TINY-8641
 
 ### Fixed
 - Selecting all content with a single image in the content was inconsistent for the keyboard shortcut and menu item #TINY-4550

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `removeAttributeFilter` and `removeNodeFilter` functions to the `DomParser` and DOM `Serializer` APIs #TINY-7847
 - New `iframe_template_callback` option in the `media` plugin. Patch provided by Namstel #TINY-8684
 - New `editor.undoManager.fireIfChanged` API to fire change event only if the last undoManager content layer is diffrent from the current editor
-- New `dispatchIfChanged` UndoManager API to fire the `change` event if the last UndoManager content layer is different from the current editor content #TINY-8641
+- New `dispatchChange` UndoManager API to fire the `change` with current editor status as level and current undoManager layer as lastLevel #TINY-8641
 
 ### Improved
 - Clearer focus states for buttons while navigating with keyboard #TINY-8557

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `transparent` property for `iframe` dialog component #TINY-8534
 - New `removeAttributeFilter` and `removeNodeFilter` functions to the `DomParser` and DOM `Serializer` APIs #TINY-7847
 - New `iframe_template_callback` option in the `media` plugin. Patch provided by Namstel #TINY-8684
+- New `editor.undoManager.fireIfChanged` API to fire change event only if the last undoManager content layer is diffrent from the current editor
 
 ### Improved
 - Clearer focus states for buttons while navigating with keyboard #TINY-8557

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default value for `end_container_on_empty_block` option has been changed to `'blockquote'` #TINY-6559
 - Custom elements are now treated as non-empty elements via the schema #TINY-4784
 - The autocompleter menu element is now positioned instead of the wrapper #TINY-6476
-- Now on `uploadImages` does not trigger `change` event 2 times if there is an error on upload #TINY-8641
+- `uploadImages` no longer triggers two `change` events if there is an error on upload #TINY-8641
 
 ### Fixed
 - Selecting all content with a single image in the content was inconsistent for the keyboard shortcut and menu item #TINY-4550

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default value for `end_container_on_empty_block` option has been changed to `'blockquote'` #TINY-6559
 - Custom elements are now treated as non-empty elements via the schema #TINY-4784
 - The autocompleter menu element is now positioned instead of the wrapper #TINY-6476
-- `uploadImages` no longer triggers two `change` events if there is an error on upload #TINY-8641
 
 ### Fixed
 - Selecting all content with a single image in the content was inconsistent for the keyboard shortcut and menu item #TINY-4550
@@ -59,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed incorrect word breaks in menu dropdowns with scrollbar #TINY-8572
 - The `InsertLineBreak` command did not replace selected content #TINY-8458
 - Delete operations could behave incorrectly if the selection contains a `contenteditable="false"` element located at the edge of content #TINY-8729
+- `uploadImages` no longer triggers two `change` events if there is an error on upload #TINY-8641
 
 ## 6.0.3 - 2022-05-25
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `transparent` property for `iframe` dialog component #TINY-8534
 - New `removeAttributeFilter` and `removeNodeFilter` functions to the `DomParser` and DOM `Serializer` APIs #TINY-7847
 - New `iframe_template_callback` option in the `media` plugin. Patch provided by Namstel #TINY-8684
-- New `editor.undoManager.fireIfChanged` API to fire change event only if the last undoManager content layer is diffrent from the current editor
 - New `dispatchChange` UndoManager API to fire the `change` with current editor status as level and current undoManager layer as lastLevel #TINY-8641
 
 ### Improved

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `removeAttributeFilter` and `removeNodeFilter` functions to the `DomParser` and DOM `Serializer` APIs #TINY-7847
 - New `iframe_template_callback` option in the `media` plugin. Patch provided by Namstel #TINY-8684
 - New `editor.undoManager.fireIfChanged` API to fire change event only if the last undoManager content layer is diffrent from the current editor
+- New `dispatchIfChanged` UndoManager API to fire the `change` event if the last UndoManager content layer is different from the current editor content #TINY-8641
 
 ### Improved
 - Clearer focus states for buttons while navigating with keyboard #TINY-8557

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -1,4 +1,4 @@
-import { Arr } from '@ephox/katamari';
+import { Arr, Strings } from '@ephox/katamari';
 import { Attribute, SugarElement } from '@ephox/sugar';
 
 import * as ErrorReporter from '../ErrorReporter';
@@ -121,7 +121,7 @@ const EditorUpload = (editor: Editor): EditorUpload => {
           let removed = false;
 
           if (uploadInfo.status && Options.shouldReplaceBlobUris(editor)) {
-            if (uploadInfo.url && !image.src.includes(uploadInfo.url)) {
+            if (uploadInfo.url && !Strings.contains(image.src, uploadInfo.url)) {
               shouldDispatchChange = true;
             }
             blobCache.removeByUri(image.src);

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -149,8 +149,7 @@ const EditorUpload = (editor: Editor): EditorUpload => {
           };
         });
 
-        const isRemovingAnImage = Arr.exists(imagesToRemove, (element) => !!blobCache.getByUri(element.src));
-        if (shouldDispatchChange || isRemovingAnImage) {
+        if (shouldDispatchChange) {
           editor.undoManager.dispatchChange();
         }
 

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -149,7 +149,8 @@ const EditorUpload = (editor: Editor): EditorUpload => {
           };
         });
 
-        if (shouldDispatchChange || Arr.exists(imagesToRemove, (element) => !!blobCache.getByUri(element.src))) {
+        const isRemovingAnImage = Arr.exists(imagesToRemove, (element) => !!blobCache.getByUri(element.src));
+        if (shouldDispatchChange || isRemovingAnImage) {
           editor.undoManager.dispatchChange();
         }
 

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -149,7 +149,7 @@ const EditorUpload = (editor: Editor): EditorUpload => {
           };
         });
 
-        if (shouldDispatchChange) {
+        if (shouldDispatchChange || Arr.exists(imagesToRemove, (element) => !!blobCache.getByUri(element.src))) {
           editor.undoManager.dispatchChange();
         }
 

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -112,8 +112,8 @@ const EditorUpload = (editor: Editor): EditorUpload => {
       const blobInfos = Arr.map(imageInfos, (imageInfo) => imageInfo.blobInfo);
 
       return uploader.upload(blobInfos, openNotification(editor)).then(aliveGuard((result) => {
-        let shouldDispatchChange = false;
         const imagesToRemove: HTMLImageElement[] = [];
+        let shouldDispatchChange = false;
 
         const filteredResult: UploadResult[] = Arr.map(result, (uploadInfo, index) => {
           const blobInfo = imageInfos[index].blobInfo;
@@ -153,9 +153,6 @@ const EditorUpload = (editor: Editor): EditorUpload => {
           editor.undoManager.transact(() => {
             Arr.each(imagesToRemove, (element) => {
               editor.dom.remove(element);
-              if (blobCache.getByUri(element.src)) {
-                shouldDispatchChange = true;
-              }
               blobCache.removeByUri(element.src);
             });
           });

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -149,6 +149,10 @@ const EditorUpload = (editor: Editor): EditorUpload => {
           };
         });
 
+        if (shouldDispatchChange) {
+          editor.undoManager.dispatchChange();
+        }
+
         if (imagesToRemove.length > 0 && !Rtc.isRtc(editor)) {
           editor.undoManager.transact(() => {
             Arr.each(imagesToRemove, (element) => {
@@ -156,10 +160,6 @@ const EditorUpload = (editor: Editor): EditorUpload => {
               blobCache.removeByUri(element.src);
             });
           });
-        }
-
-        if (shouldDispatchChange) {
-          editor.undoManager.dispatchChange();
         }
 
         return filteredResult;

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -149,11 +149,12 @@ const EditorUpload = (editor: Editor): EditorUpload => {
           };
         });
 
-        if (shouldDispatchChange && imagesToRemove.length === 0 && !Rtc.isRtc(editor)) {
+        const shouldRemoveImages = imagesToRemove.length > 0 && !Rtc.isRtc(editor);
+        if (shouldDispatchChange && !shouldRemoveImages) {
           editor.undoManager.dispatchChange();
         }
 
-        if (imagesToRemove.length > 0 && !Rtc.isRtc(editor)) {
+        if (shouldRemoveImages) {
           editor.undoManager.transact(() => {
             Arr.each(imagesToRemove, (element) => {
               editor.dom.remove(element);

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -1,4 +1,4 @@
-import { Arr, Cell } from '@ephox/katamari';
+import { Arr } from '@ephox/katamari';
 import { Attribute, SugarElement } from '@ephox/sugar';
 
 import * as ErrorReporter from '../ErrorReporter';
@@ -6,8 +6,6 @@ import { BlobInfoImagePair, ImageScanner } from '../file/ImageScanner';
 import { Uploader } from '../file/Uploader';
 import { UploadStatus } from '../file/UploadStatus';
 import * as Rtc from '../Rtc';
-import * as Levels from '../undo/Levels';
-import { UndoLevel } from '../undo/UndoManagerTypes';
 import Editor from './Editor';
 import Env from './Env';
 import { BlobCache, BlobInfo } from './file/BlobCache';
@@ -38,37 +36,11 @@ interface EditorUpload {
   destroy: () => void;
 }
 
-const UploadChangeHandler = (editor: Editor) => {
-  const lastChangedLevel = Cell<UndoLevel>(null);
-
-  editor.on('change AddUndo', (e) => {
-    lastChangedLevel.set({ ...e.level });
-  });
-
-  const fireIfChanged = () => {
-    const data = editor.undoManager.data;
-    Arr.last(data).filter((level) => {
-      return !Levels.isEq(lastChangedLevel.get(), level);
-    }).each((level) => {
-      editor.setDirty(true);
-      editor.dispatch('change', {
-        level,
-        lastLevel: Arr.get(data, data.length - 2).getOrNull()
-      });
-    });
-  };
-
-  return {
-    fireIfChanged
-  };
-};
-
 const EditorUpload = (editor: Editor): EditorUpload => {
   const blobCache = BlobCache();
   let uploader: Uploader, imageScanner: ImageScanner;
   const uploadStatus = UploadStatus();
   const urlFilters: Array<(img: HTMLImageElement) => boolean> = [];
-  const changeHandler = UploadChangeHandler(editor);
 
   const aliveGuard = <T, R> (callback?: (result: T) => R) => {
     return (result: T) => {
@@ -140,6 +112,7 @@ const EditorUpload = (editor: Editor): EditorUpload => {
       const blobInfos = Arr.map(imageInfos, (imageInfo) => imageInfo.blobInfo);
 
       return uploader.upload(blobInfos, openNotification(editor)).then(aliveGuard((result) => {
+        let shouldDispatchChange = false;
         const imagesToRemove: HTMLImageElement[] = [];
 
         const filteredResult: UploadResult[] = Arr.map(result, (uploadInfo, index) => {
@@ -148,6 +121,9 @@ const EditorUpload = (editor: Editor): EditorUpload => {
           let removed = false;
 
           if (uploadInfo.status && Options.shouldReplaceBlobUris(editor)) {
+            if (uploadInfo.url && !image.src.includes(uploadInfo.url)) {
+              shouldDispatchChange = true;
+            }
             blobCache.removeByUri(image.src);
             if (Rtc.isRtc(editor)) {
               // RTC handles replacing the image URL through callback events
@@ -173,17 +149,20 @@ const EditorUpload = (editor: Editor): EditorUpload => {
           };
         });
 
-        if (filteredResult.length > 0) {
-          changeHandler.fireIfChanged();
-        }
-
         if (imagesToRemove.length > 0 && !Rtc.isRtc(editor)) {
           editor.undoManager.transact(() => {
             Arr.each(imagesToRemove, (element) => {
               editor.dom.remove(element);
+              if (blobCache.getByUri(element.src)) {
+                shouldDispatchChange = true;
+              }
               blobCache.removeByUri(element.src);
             });
           });
+        }
+
+        if (shouldDispatchChange) {
+          editor.undoManager.dispatchChange();
         }
 
         return filteredResult;

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -149,7 +149,7 @@ const EditorUpload = (editor: Editor): EditorUpload => {
           };
         });
 
-        if (shouldDispatchChange) {
+        if (shouldDispatchChange && imagesToRemove.length === 0 && !Rtc.isRtc(editor)) {
           editor.undoManager.dispatchChange();
         }
 

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -1,4 +1,4 @@
-import { Arr, Cell } from '@ephox/katamari';
+import { Arr } from '@ephox/katamari';
 import { Attribute, SugarElement } from '@ephox/sugar';
 
 import * as ErrorReporter from '../ErrorReporter';
@@ -6,8 +6,6 @@ import { BlobInfoImagePair, ImageScanner } from '../file/ImageScanner';
 import { Uploader } from '../file/Uploader';
 import { UploadStatus } from '../file/UploadStatus';
 import * as Rtc from '../Rtc';
-import * as Levels from '../undo/Levels';
-import { UndoLevel } from '../undo/UndoManagerTypes';
 import Editor from './Editor';
 import Env from './Env';
 import { BlobCache, BlobInfo } from './file/BlobCache';
@@ -38,37 +36,11 @@ interface EditorUpload {
   destroy: () => void;
 }
 
-const UploadChangeHandler = (editor: Editor) => {
-  const lastChangedLevel = Cell<UndoLevel>(null);
-
-  editor.on('change AddUndo', (e) => {
-    lastChangedLevel.set({ ...e.level });
-  });
-
-  const fireIfChanged = () => {
-    const data = editor.undoManager.data;
-    Arr.last(data).filter((level) => {
-      return !Levels.isEq(lastChangedLevel.get(), level);
-    }).each((level) => {
-      editor.setDirty(true);
-      editor.dispatch('change', {
-        level,
-        lastLevel: Arr.get(data, data.length - 2).getOrNull()
-      });
-    });
-  };
-
-  return {
-    fireIfChanged
-  };
-};
-
 const EditorUpload = (editor: Editor): EditorUpload => {
   const blobCache = BlobCache();
   let uploader: Uploader, imageScanner: ImageScanner;
   const uploadStatus = UploadStatus();
   const urlFilters: Array<(img: HTMLImageElement) => boolean> = [];
-  const changeHandler = UploadChangeHandler(editor);
 
   const aliveGuard = <T, R> (callback?: (result: T) => R) => {
     return (result: T) => {
@@ -174,7 +146,7 @@ const EditorUpload = (editor: Editor): EditorUpload => {
         });
 
         if (filteredResult.length > 0) {
-          changeHandler.fireIfChanged();
+          editor.undoManager.fireIfChanged();
         }
 
         if (imagesToRemove.length > 0 && !Rtc.isRtc(editor)) {

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -149,18 +149,15 @@ const EditorUpload = (editor: Editor): EditorUpload => {
           };
         });
 
-        const shouldRemoveImages = imagesToRemove.length > 0 && !Rtc.isRtc(editor);
-        if (shouldDispatchChange && !shouldRemoveImages) {
-          editor.undoManager.dispatchChange();
-        }
-
-        if (shouldRemoveImages) {
+        if (imagesToRemove.length > 0 && !Rtc.isRtc(editor)) {
           editor.undoManager.transact(() => {
             Arr.each(imagesToRemove, (element) => {
               editor.dom.remove(element);
               blobCache.removeByUri(element.src);
             });
           });
+        } else if (shouldDispatchChange) {
+          editor.undoManager.dispatchChange();
         }
 
         return filteredResult;

--- a/modules/tinymce/src/core/main/ts/api/UndoManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/UndoManager.ts
@@ -57,21 +57,11 @@ const UndoManager = (editor: Editor): UndoManager => {
      * @method dispatchChange
      */
     dispatchChange: (): void => {
-      const data = undoManager.data;
-      const currentLevel = Levels.createFromEditor(editor);
-
-      const dispatchEvent = (lastLevel: UndoLevel | undefined) => {
-        editor.setDirty(true);
-        editor.dispatch('change', {
-          level: currentLevel,
-          lastLevel
-        });
-      };
-
-      Arr.get(data, index.get()).fold(
-        () => dispatchEvent(undefined),
-        (lastLevel) => dispatchEvent(lastLevel)
-      );
+      editor.setDirty(true);
+      editor.dispatch('change', {
+        level: Levels.createFromEditor(editor),
+        lastLevel: Arr.get(undoManager.data, index.get()).getOrUndefined()
+      });
     },
 
     /**

--- a/modules/tinymce/src/core/main/ts/api/UndoManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/UndoManager.ts
@@ -60,7 +60,7 @@ const UndoManager = (editor: Editor): UndoManager => {
       const data = undoManager.data;
       const currentLevel = Levels.createFromEditor(editor);
 
-      const dispatchEvent = (lastLevel: UndoLevel) => {
+      const dispatchEvent = (lastLevel: UndoLevel | undefined) => {
         editor.setDirty(true);
         editor.dispatch('change', {
           level: currentLevel,

--- a/modules/tinymce/src/core/main/ts/api/UndoManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/UndoManager.ts
@@ -52,7 +52,7 @@ const UndoManager = (editor: Editor): UndoManager => {
     },
 
     /**
-     * Trigger change event if the content in last layer of the undoManager and the current editor content are different
+     * Dispatch a change event if the content in last layer of the undoManager and the current editor content are different
      *
      * @method fireIfChanged
      */

--- a/modules/tinymce/src/core/main/ts/api/UndoManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/UndoManager.ts
@@ -1,4 +1,4 @@
-import { Arr, Cell, Fun, Singleton } from '@ephox/katamari';
+import { Arr, Cell, Singleton } from '@ephox/katamari';
 
 import { Bookmark } from '../bookmark/BookmarkTypes';
 import * as Rtc from '../Rtc';
@@ -62,16 +62,13 @@ const UndoManager = (editor: Editor): UndoManager => {
 
       Arr.last(data).filter((lastLevel) => {
         return !Levels.isEq(lastLevel, currentLevel);
-      }).fold(
-        Fun.noop,
-        (lastLevel) => {
-          editor.setDirty(true);
-          editor.dispatch('change', {
-            level: currentLevel,
-            lastLevel
-          });
-        }
-      );
+      }).each((lastLevel) => {
+        editor.setDirty(true);
+        editor.dispatch('change', {
+          level: currentLevel,
+          lastLevel
+        });
+      });
 
     },
 

--- a/modules/tinymce/src/core/main/ts/api/UndoManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/UndoManager.ts
@@ -69,7 +69,6 @@ const UndoManager = (editor: Editor): UndoManager => {
           lastLevel
         });
       });
-
     },
 
     /**

--- a/modules/tinymce/src/core/main/ts/api/UndoManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/UndoManager.ts
@@ -54,9 +54,9 @@ const UndoManager = (editor: Editor): UndoManager => {
     /**
      * Dispatch a change event if the content in last layer of the undoManager and the current editor content are different
      *
-     * @method fireIfChanged
+     * @method dispatchIfChanged
      */
-    fireIfChanged: (): void => {
+    dispatchIfChanged: (): void => {
       const data = undoManager.data;
       const currentLevel = Levels.createFromEditor(editor);
 

--- a/modules/tinymce/src/core/main/ts/api/UndoManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/UndoManager.ts
@@ -60,15 +60,21 @@ const UndoManager = (editor: Editor): UndoManager => {
       const data = undoManager.data;
       const currentLevel = Levels.createFromEditor(editor);
 
-      Arr.last(data).filter((lastLevel) => {
-        return !Levels.isEq(lastLevel, currentLevel);
-      }).each((lastLevel) => {
+      const dispatchEvent = (lastLevel: UndoLevel) => {
         editor.setDirty(true);
         editor.dispatch('change', {
           level: currentLevel,
           lastLevel
         });
-      });
+      };
+
+      Arr.get(data, index.get()).fold(
+        () => dispatchEvent(currentLevel),
+        (lastLevel) => {
+          if (!Levels.isEq(lastLevel, currentLevel)) {
+            dispatchEvent(lastLevel);
+          }
+        });
     },
 
     /**

--- a/modules/tinymce/src/core/main/ts/api/UndoManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/UndoManager.ts
@@ -69,7 +69,7 @@ const UndoManager = (editor: Editor): UndoManager => {
       };
 
       Arr.get(data, index.get()).fold(
-        () => dispatchEvent(currentLevel),
+        () => dispatchEvent(undefined),
         (lastLevel) => {
           if (!Levels.isEq(lastLevel, currentLevel)) {
             dispatchEvent(lastLevel);

--- a/modules/tinymce/src/core/main/ts/api/UndoManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/UndoManager.ts
@@ -52,11 +52,11 @@ const UndoManager = (editor: Editor): UndoManager => {
     },
 
     /**
-     * Dispatch a change event if the content in last layer of the undoManager and the current editor content are different
+     * Dispatch a change event with current editor status as level and current undoManager layer as lastLevel
      *
-     * @method dispatchIfChanged
+     * @method dispatchChange
      */
-    dispatchIfChanged: (): void => {
+    dispatchChange: (): void => {
       const data = undoManager.data;
       const currentLevel = Levels.createFromEditor(editor);
 
@@ -70,11 +70,8 @@ const UndoManager = (editor: Editor): UndoManager => {
 
       Arr.get(data, index.get()).fold(
         () => dispatchEvent(undefined),
-        (lastLevel) => {
-          if (!Levels.isEq(lastLevel, currentLevel)) {
-            dispatchEvent(lastLevel);
-          }
-        });
+        (lastLevel) => dispatchEvent(lastLevel)
+      );
     },
 
     /**

--- a/modules/tinymce/src/core/main/ts/undo/Setup.ts
+++ b/modules/tinymce/src/core/main/ts/undo/Setup.ts
@@ -32,10 +32,6 @@ export const registerEvents = (editor: Editor, undoManager: UndoManager, locks: 
     undoManager.add();
   });
 
-  editor.on('change AddUndo', (e) => {
-    undoManager.fireIfChanged({ ...e.level });
-  });
-
   // Get position before an execCommand is processed
   editor.on('BeforeExecCommand', (e) => {
     const cmd = e.command;

--- a/modules/tinymce/src/core/main/ts/undo/Setup.ts
+++ b/modules/tinymce/src/core/main/ts/undo/Setup.ts
@@ -32,6 +32,10 @@ export const registerEvents = (editor: Editor, undoManager: UndoManager, locks: 
     undoManager.add();
   });
 
+  editor.on('change AddUndo', (e) => {
+    undoManager.fireIfChanged({ ...e.level });
+  });
+
   // Get position before an execCommand is processed
   editor.on('BeforeExecCommand', (e) => {
     const cmd = e.command;

--- a/modules/tinymce/src/core/main/ts/undo/UndoManagerTypes.ts
+++ b/modules/tinymce/src/core/main/ts/undo/UndoManagerTypes.ts
@@ -20,7 +20,7 @@ export interface UndoManager {
   data: UndoLevel[];
   typing: boolean;
   add: (level?: UndoLevel, event?: EditorEvent<any>) => UndoLevel;
-  dispatchIfChanged: () => void;
+  dispatchChange: () => void;
   beforeChange: () => void;
   undo: () => UndoLevel;
   redo: () => UndoLevel;

--- a/modules/tinymce/src/core/main/ts/undo/UndoManagerTypes.ts
+++ b/modules/tinymce/src/core/main/ts/undo/UndoManagerTypes.ts
@@ -20,7 +20,7 @@ export interface UndoManager {
   data: UndoLevel[];
   typing: boolean;
   add: (level?: UndoLevel, event?: EditorEvent<any>) => UndoLevel;
-  fireIfChanged: (newLastChangedLevel?: UndoLevel) => void;
+  fireIfChanged: () => void;
   beforeChange: () => void;
   undo: () => UndoLevel;
   redo: () => UndoLevel;

--- a/modules/tinymce/src/core/main/ts/undo/UndoManagerTypes.ts
+++ b/modules/tinymce/src/core/main/ts/undo/UndoManagerTypes.ts
@@ -20,7 +20,7 @@ export interface UndoManager {
   data: UndoLevel[];
   typing: boolean;
   add: (level?: UndoLevel, event?: EditorEvent<any>) => UndoLevel;
-  fireIfChanged: () => void;
+  dispatchIfChanged: () => void;
   beforeChange: () => void;
   undo: () => UndoLevel;
   redo: () => UndoLevel;

--- a/modules/tinymce/src/core/main/ts/undo/UndoManagerTypes.ts
+++ b/modules/tinymce/src/core/main/ts/undo/UndoManagerTypes.ts
@@ -20,7 +20,7 @@ export interface UndoManager {
   data: UndoLevel[];
   typing: boolean;
   add: (level?: UndoLevel, event?: EditorEvent<any>) => UndoLevel;
-  fireIfChanged: VoidFunction;
+  fireIfChanged: (newLastChangedLevel?: UndoLevel) => void;
   beforeChange: () => void;
   undo: () => UndoLevel;
   redo: () => UndoLevel;

--- a/modules/tinymce/src/core/main/ts/undo/UndoManagerTypes.ts
+++ b/modules/tinymce/src/core/main/ts/undo/UndoManagerTypes.ts
@@ -20,6 +20,7 @@ export interface UndoManager {
   data: UndoLevel[];
   typing: boolean;
   add: (level?: UndoLevel, event?: EditorEvent<any>) => UndoLevel;
+  fireIfChanged: VoidFunction;
   beforeChange: () => void;
   undo: () => UndoLevel;
   redo: () => UndoLevel;

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -358,8 +358,8 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
       callCount++;
 
       if (callCount === 2) {
-        // Note: This is 1 as only the removal of the image triggers the addition of an undo level and a change event
-        assertEventsLength(1);
+        // Note: This is 2 as the removal of the image also triggers the addition of an undo level and a change event
+        assertEventsLength(2);
 
         // This is in exact since the status of the image can be pending or failed meaning it should try again
         assert.isAtLeast(uploadCount, 1, 'Should at least be one.');

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -358,8 +358,8 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
       callCount++;
 
       if (callCount === 2) {
-        // Note: This is 2 as the removal of the image also triggers the addition of an undo level and a change event
-        assertEventsLength(2);
+        // Note: This is 1 as only the removal of the image triggers the addition of an undo level and a change event
+        assertEventsLength(1);
 
         // This is in exact since the status of the image can be pending or failed meaning it should try again
         assert.isAtLeast(uploadCount, 1, 'Should at least be one.');

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -615,7 +615,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
 
   context('dispatchChange', () => {
     const initialContent = '<p>some inital content</p>';
-    const manualModifiedLevel = 'a modified last level';
+    const manualModifiedLevelContent = 'a modified last level';
 
     const assertChangeEvent = (
       eventContent: { levelContent: string; lastLevelContent: string | undefined },
@@ -654,18 +654,18 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
       assert.equal(changeEventCounter, 0, 'No events should be detected at start');
 
       Arr.last(editor.undoManager.data).each((lastLevel) => {
-        lastLevel.content = manualModifiedLevel;
+        lastLevel.content = manualModifiedLevelContent;
       });
 
       assert.isFalse(editor.isDirty(), 'Editor should not be dirty before dispatchChange');
       editor.undoManager.dispatchChange();
-      assertChangeEvent(currentChangeEvent, initialContent, manualModifiedLevel);
+      assertChangeEvent(currentChangeEvent, initialContent, manualModifiedLevelContent);
       assert.equal(changeEventCounter, 1, '1 event should be detected');
       assert.isTrue(editor.isDirty(), 'Editor should be dirty after dispatchChange');
 
       Arr.range(3, () => {
         editor.undoManager.dispatchChange();
-        assertChangeEvent(currentChangeEvent, initialContent, manualModifiedLevel);
+        assertChangeEvent(currentChangeEvent, initialContent, manualModifiedLevelContent);
       });
 
       assert.equal(changeEventCounter, 4, 'it should continue to call change');

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -618,25 +618,25 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     const manualModifiedLevel = 'a modified last level';
 
     const assertChangeEvent = (
-      eventContent: { level: string; lastLevel: string | undefined },
-      expectedLevel: string | undefined,
-      expectedLastlevel: string | undefined
+      eventContent: { levelContent: string; lastLevelContent: string | undefined },
+      expectedLevelContent: string | undefined,
+      expectedLastlevelContent: string | undefined
     ) => {
       assert.deepEqual(eventContent, {
-        level: expectedLevel,
-        lastLevel: expectedLastlevel
+        levelContent: expectedLevelContent,
+        lastLevelContent: expectedLastlevelContent
       }, 'the level or the last level have not the expected content');
     };
 
     let changeEventCounter: number;
-    let currentChangeEvent: { level: string; lastLevel: string } | undefined;
+    let currentChangeEvent: { levelContent: string; lastLevelContent: string } | undefined;
 
     const onChange = (e: EditorEvent<{
       level: UndoLevel;
       lastLevel: UndoLevel | undefined;
     }>) => {
       changeEventCounter++;
-      currentChangeEvent = { level: e.level?.content, lastLevel: e.lastLevel?.content };
+      currentChangeEvent = { levelContent: e.level?.content, lastLevelContent: e.lastLevel?.content };
     };
 
     beforeEach(() => {

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -618,7 +618,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     const manualModifiedLevel = 'a modified last level';
 
     const assertChangeEvent = (
-      eventContent: { level: string | undefined; lastLevel: string | undefined },
+      eventContent: { level: string; lastLevel: string | undefined },
       expectedLevel: string | undefined,
       expectedLastlevel: string | undefined
     ) => {

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -618,20 +618,22 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     const manualModifiedLevel = 'a modified last level';
 
     const assertChangeEvent = (
-      event: { level: string; lastLevel: string },
+      eventContent: { level: string | undefined; lastLevel: string | undefined },
       expectedLevel: string | undefined,
       expectedLastlevel: string | undefined
     ) => {
-      assert.equal(event.level, expectedLevel, 'Level has not the expected content');
-      assert.equal(event.lastLevel, expectedLastlevel, 'Last level has not the expected content');
+      assert.deepEqual(eventContent, {
+        level: expectedLevel,
+        lastLevel: expectedLastlevel
+      }, 'the level or the last level have not the expected content');
     };
 
     let changeEventCounter: number;
-    let currentChangeEvent: { level: string; lastLevel: string };
+    let currentChangeEvent: { level: string; lastLevel: string } | undefined;
 
     const onChange = (e: EditorEvent<{
       level: UndoLevel;
-      lastLevel: UndoLevel;
+      lastLevel: UndoLevel | undefined;
     }>) => {
       changeEventCounter++;
       currentChangeEvent = { level: e.level?.content, lastLevel: e.lastLevel?.content };

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -616,6 +616,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
   context('dispatchChange', () => {
     const initialContent = '<p>some inital content</p>';
     const manualModifiedLevelContent = 'a modified last level';
+    let editor: Editor;
 
     const assertChangeEvent = (
       eventContent: { levelContent: string; lastLevelContent: string | undefined },
@@ -642,15 +643,13 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     beforeEach(() => {
       changeEventCounter = 0;
       currentChangeEvent = undefined;
+
+      editor = hook.editor();
+      editor.resetContent(initialContent);
+      editor.on('change', onChange);
     });
 
     it('TINY-8641: Dispatch change with current editor status as level and current undoManager layer as lastLevel', () => {
-      const editor = hook.editor();
-
-      editor.resetContent(initialContent);
-
-      editor.on('change', onChange);
-
       assert.equal(changeEventCounter, 0, 'No events should be detected at start');
 
       Arr.last(editor.undoManager.data).each((lastLevel) => {
@@ -674,10 +673,6 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     });
 
     it('TINY-8641: dispatchChange should always fire on empty stack with current content as level and lastLevel', () => {
-      const editor = hook.editor();
-      editor.resetContent(initialContent);
-      editor.on('change', onChange);
-
       editor.undoManager.clear();
       assert.lengthOf(editor.undoManager.data, 0, 'undo manager should be empty after clear');
 

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -639,7 +639,19 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     editor.undoManager.fireIfChanged();
     editor.undoManager.fireIfChanged();
     editor.undoManager.fireIfChanged();
-    assert.equal(changeEventCounter, 1, 'firing again the function should not trigger chage again');
+    assert.equal(changeEventCounter, 4, 'it should countinue to call change till the editor and last level are different');
+
+    editor.undoManager.add();
+    assert.equal(changeEventCounter, 5, 'add should trigger a change as well');
+
+    Arr.last(editor.undoManager.data).each((lastLevel) => {
+      assert.equal(editor.getContent(), lastLevel.content, 'add should add a last layer with the editor content');
+    });
+
+    editor.undoManager.fireIfChanged();
+    editor.undoManager.fireIfChanged();
+    editor.undoManager.fireIfChanged();
+    assert.equal(changeEventCounter, 5, 'it should not continue to trigger change becuase now editor content and last layer are the same');
 
     editor.off('change', onChange);
   });

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -625,6 +625,14 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     let changeEventCounter: number;
     let currentChangeEvent: { level: string; lastLevel: string };
 
+    const onChange = (e: EditorEvent<{
+      level: UndoLevel;
+      lastLevel: UndoLevel;
+    }>) => {
+      changeEventCounter++;
+      currentChangeEvent = { level: e.level.content, lastLevel: e.lastLevel.content };
+    };
+
     beforeEach(() => {
       changeEventCounter = 0;
       currentChangeEvent = undefined;
@@ -634,13 +642,6 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
       const editor = hook.editor();
 
       editor.resetContent(initialContent);
-      const onChange = (e: EditorEvent<{
-        level: UndoLevel;
-        lastLevel: UndoLevel;
-      }>) => {
-        changeEventCounter++;
-        currentChangeEvent = { level: e.level.content, lastLevel: e.lastLevel.content };
-      };
 
       editor.on('change', onChange);
 

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -7,6 +7,7 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { AddUndoEvent } from 'tinymce/core/api/EventTypes';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { UndoLevel } from 'tinymce/core/undo/UndoManagerTypes';
 
 import * as HtmlUtils from '../module/test/HtmlUtils';
@@ -627,7 +628,10 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     };
 
     editor.resetContent(initialContent);
-    const onChange = (e) => {
+    const onChange = (e: EditorEvent<{
+      level: UndoLevel;
+      lastLevel: UndoLevel;
+    }>) => {
       changeEventCounter++;
       currentChangeEvent = { level: e.level.content, lastLevel: e.lastLevel.content };
     };

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
-import { Fun } from '@ephox/katamari';
+import { Arr, Fun } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { LegacyUnit, TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
@@ -610,5 +610,30 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     editor.off('change', onChange);
 
     assert.equal(changeEventCounter, 0, 'No events should be detected');
+  });
+
+  it('TINY-8641: New api add that fire change', () => {
+    const editor = hook.editor();
+    let changeEventCounter = 0;
+
+    editor.resetContent('some inital content');
+    const onChange = () => {
+      changeEventCounter++;
+    };
+
+    editor.on('change', onChange);
+
+    assert.equal(changeEventCounter, 0, '0 event should be detected at start');
+    editor.undoManager.fireIfChanged();
+    assert.equal(changeEventCounter, 0, '0 event should be detected if content is coherent with the undoManager history');
+
+    Arr.last(editor.undoManager.data).each((lastLevel) => {
+      lastLevel.content = 'a modified last level';
+    });
+
+    editor.undoManager.fireIfChanged();
+    assert.equal(changeEventCounter, 1, '1 event should be detected if the content is not coherent with the undoManager history');
+
+    editor.off('change', onChange);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -612,7 +612,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     assert.equal(changeEventCounter, 0, 'No events should be detected');
   });
 
-  it('TINY-8641: fire change if the current content and the undoManager history are incoherent', () => {
+  it('TINY-8641: fire change and set editor dirty if the current content and the undoManager history are incoherent', () => {
     const editor = hook.editor();
     let changeEventCounter = 0;
 
@@ -631,8 +631,10 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
       lastLevel.content = 'a modified last level';
     });
 
+    assert.equal(editor.isDirty(), false, 'Editor should be not dirty before fireIfChanged');
     editor.undoManager.fireIfChanged();
     assert.equal(changeEventCounter, 1, '1 event should be detected if the content is not coherent with the undoManager history');
+    assert.equal(editor.isDirty(), true, 'Editor should be dirty after fireIfChanged');
 
     editor.undoManager.fireIfChanged();
     editor.undoManager.fireIfChanged();

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -613,7 +613,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     assert.equal(changeEventCounter, 0, 'No events should be detected');
   });
 
-  it('TINY-8641: fire change and set editor dirty if the current content and the undoManager history are incoherent', () => {
+  it('TINY-8641: Dispatch change and set editor dirty if the current content and the undoManager history are incoherent', () => {
     const editor = hook.editor();
 
     let changeEventCounter = 0;
@@ -639,26 +639,26 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     editor.on('change', onChange);
 
     assert.equal(changeEventCounter, 0, '0 event should be detected at start');
-    editor.undoManager.fireIfChanged();
+    editor.undoManager.dispatchIfChanged();
     assert.equal(changeEventCounter, 0, '0 event should be detected if content is coherent with the undoManager history');
 
     Arr.last(editor.undoManager.data).each((lastLevel) => {
       lastLevel.content = manualModifiedLevel;
     });
 
-    assert.equal(editor.isDirty(), false, 'Editor should not be dirty before fireIfChanged');
-    editor.undoManager.fireIfChanged();
+    assert.equal(editor.isDirty(), false, 'Editor should not be dirty before dispatchIfChanged');
+    editor.undoManager.dispatchIfChanged();
     assertChangeEvent(currentChangeEvent);
     assert.equal(changeEventCounter, 1, '1 event should be detected if the content is not coherent with the undoManager history');
-    assert.equal(editor.isDirty(), true, 'Editor should be dirty after fireIfChanged');
+    assert.equal(editor.isDirty(), true, 'Editor should be dirty after dispatchIfChanged');
 
-    editor.undoManager.fireIfChanged();
+    editor.undoManager.dispatchIfChanged();
     assertChangeEvent(currentChangeEvent);
 
-    editor.undoManager.fireIfChanged();
+    editor.undoManager.dispatchIfChanged();
     assertChangeEvent(currentChangeEvent);
 
-    editor.undoManager.fireIfChanged();
+    editor.undoManager.dispatchIfChanged();
     assertChangeEvent(currentChangeEvent);
     assert.equal(changeEventCounter, 4, 'it should continue to call change till the editor and last level are different');
 
@@ -669,9 +669,9 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
       assert.equal(editor.getContent(), lastLevel.content, 'add should add a last layer with the editor content');
     });
 
-    editor.undoManager.fireIfChanged();
-    editor.undoManager.fireIfChanged();
-    editor.undoManager.fireIfChanged();
+    editor.undoManager.dispatchIfChanged();
+    editor.undoManager.dispatchIfChanged();
+    editor.undoManager.dispatchIfChanged();
     assert.equal(changeEventCounter, 5, 'it should not continue to trigger change becuase now editor content and last layer are the same');
 
     editor.off('change', onChange);

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -619,25 +619,23 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     let editor: Editor;
 
     const assertChangeEvent = (
-      eventContent: { levelContent: string; lastLevelContent: string | undefined },
+      event: { level: UndoLevel; lastLevel: UndoLevel | undefined } | undefined,
       expectedLevelContent: string | undefined,
       expectedLastlevelContent: string | undefined
     ) => {
-      assert.deepEqual(eventContent, {
-        levelContent: expectedLevelContent,
-        lastLevelContent: expectedLastlevelContent
-      }, 'the level or the last level have not the expected content');
+      assert.equal(event?.level?.content, expectedLevelContent, 'Level has not the expected content');
+      assert.equal(event?.lastLevel?.content, expectedLastlevelContent, 'Last level has not the expected content');
     };
 
     let changeEventCounter: number;
-    let currentChangeEvent: { levelContent: string; lastLevelContent: string } | undefined;
+    let currentChangeEvent: { level: UndoLevel; lastLevel: UndoLevel | undefined } | undefined;
 
     const onChange = (e: EditorEvent<{
       level: UndoLevel;
       lastLevel: UndoLevel | undefined;
     }>) => {
       changeEventCounter++;
-      currentChangeEvent = { levelContent: e.level?.content, lastLevelContent: e.lastLevel?.content };
+      currentChangeEvent = e;
     };
 
     beforeEach(() => {

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -619,8 +619,8 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
 
     const assertChangeEvent = (
       event: { level: string; lastLevel: string },
-      expectedLevel: string = initialContent,
-      expectedLastlevel: string = manualModifiedLevel
+      expectedLevel: string | undefined,
+      expectedLastlevel: string | undefined
     ) => {
       assert.equal(event.level, expectedLevel, 'Level has not the expected content');
       assert.equal(event.lastLevel, expectedLastlevel, 'Last level has not the expected content');
@@ -634,7 +634,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
       lastLevel: UndoLevel;
     }>) => {
       changeEventCounter++;
-      currentChangeEvent = { level: e.level.content, lastLevel: e.lastLevel.content };
+      currentChangeEvent = { level: e.level?.content, lastLevel: e.lastLevel?.content };
     };
 
     beforeEach(() => {
@@ -659,13 +659,13 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
 
       assert.isFalse(editor.isDirty(), 'Editor should not be dirty before dispatchIfChanged');
       editor.undoManager.dispatchIfChanged();
-      assertChangeEvent(currentChangeEvent);
+      assertChangeEvent(currentChangeEvent, initialContent, manualModifiedLevel);
       assert.equal(changeEventCounter, 1, '1 event should be detected if the content is not consistent with the undoManager history');
       assert.isTrue(editor.isDirty(), 'Editor should be dirty after dispatchIfChanged');
 
       Arr.range(3, () => {
         editor.undoManager.dispatchIfChanged();
-        assertChangeEvent(currentChangeEvent);
+        assertChangeEvent(currentChangeEvent, initialContent, manualModifiedLevel);
       });
 
       assert.equal(changeEventCounter, 4, 'it should continue to call change till the editor and last level are different');
@@ -699,7 +699,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
       Arr.range(3, (n) => {
         editor.undoManager.dispatchIfChanged();
         assert.equal(changeEventCounter, n + 1, 'change should be called each time the dispatchIfChanged is called');
-        assertChangeEvent(currentChangeEvent, initialContent, initialContent);
+        assertChangeEvent(currentChangeEvent, initialContent, undefined);
       });
       editor.off('change', onChange);
     });

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -612,7 +612,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     assert.equal(changeEventCounter, 0, 'No events should be detected');
   });
 
-  it('TINY-8641: New api add that fire change', () => {
+  it('TINY-8641: fire change if the current content and the undoManager history are incoherent', () => {
     const editor = hook.editor();
     let changeEventCounter = 0;
 

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -634,6 +634,11 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     editor.undoManager.fireIfChanged();
     assert.equal(changeEventCounter, 1, '1 event should be detected if the content is not coherent with the undoManager history');
 
+    editor.undoManager.fireIfChanged();
+    editor.undoManager.fireIfChanged();
+    editor.undoManager.fireIfChanged();
+    assert.equal(changeEventCounter, 1, 'firing again the function should not trigger chage again');
+
     editor.off('change', onChange);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -613,20 +613,18 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
   });
 
   it('TINY-8641: fire change and set editor dirty if the current content and the undoManager history are incoherent', () => {
-    const itTheExpectedChangeEvent = (e, level, lastLevel): boolean => e && e.level === level && e.lastLevel === lastLevel;
-
     const editor = hook.editor();
 
     let changeEventCounter = 0;
-    let currentChangeEvent;
+    let currentChangeEvent: { level: string; lastLevel: string };
 
     const initialContent = '<p>some inital content</p>';
     const manualModifiedLevel = 'a modified last level';
 
-    const fireAndCheckEvent = (event, level, lastLevel) => assert.isTrue(
-      itTheExpectedChangeEvent(event, level, lastLevel),
-      'change event should have last level as the current content of the editor and lastLevel as the last level in undoManager'
-    );
+    const assertChangeEvent = (event) => {
+      assert.equal(event.level, initialContent, 'Level has not the expected content');
+      assert.equal(event.lastLevel, manualModifiedLevel, 'Last level has not the expected content');
+    };
 
     editor.resetContent(initialContent);
     const onChange = (e) => {
@@ -646,18 +644,18 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
 
     assert.equal(editor.isDirty(), false, 'Editor should not be dirty before fireIfChanged');
     editor.undoManager.fireIfChanged();
-    fireAndCheckEvent(currentChangeEvent, initialContent, manualModifiedLevel);
+    assertChangeEvent(currentChangeEvent);
     assert.equal(changeEventCounter, 1, '1 event should be detected if the content is not coherent with the undoManager history');
     assert.equal(editor.isDirty(), true, 'Editor should be dirty after fireIfChanged');
 
     editor.undoManager.fireIfChanged();
-    fireAndCheckEvent(currentChangeEvent, initialContent, manualModifiedLevel);
+    assertChangeEvent(currentChangeEvent);
 
     editor.undoManager.fireIfChanged();
-    fireAndCheckEvent(currentChangeEvent, initialContent, manualModifiedLevel);
+    assertChangeEvent(currentChangeEvent);
 
     editor.undoManager.fireIfChanged();
-    fireAndCheckEvent(currentChangeEvent, initialContent, manualModifiedLevel);
+    assertChangeEvent(currentChangeEvent);
     assert.equal(changeEventCounter, 4, 'it should continue to call change till the editor and last level are different');
 
     editor.undoManager.add();

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -621,7 +621,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     const initialContent = '<p>some inital content</p>';
     const manualModifiedLevel = 'a modified last level';
 
-    const assertChangeEvent = (event) => {
+    const assertChangeEvent = (event: { level: string; lastLevel: string }) => {
       assert.equal(event.level, initialContent, 'Level has not the expected content');
       assert.equal(event.lastLevel, manualModifiedLevel, 'Last level has not the expected content');
     };

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -653,19 +653,13 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
       Arr.last(editor.undoManager.data).each((lastLevel) => {
         lastLevel.content = manualModifiedLevelContent;
       });
-
       assert.isFalse(editor.isDirty(), 'Editor should not be dirty before dispatchChange');
+
       editor.undoManager.dispatchChange();
+
       assertChangeEvent(currentChangeEvent, initialContent, manualModifiedLevelContent);
       assert.equal(changeEventCounter, 1, '1 event should be detected');
       assert.isTrue(editor.isDirty(), 'Editor should be dirty after dispatchChange');
-
-      Arr.range(3, () => {
-        editor.undoManager.dispatchChange();
-        assertChangeEvent(currentChangeEvent, initialContent, manualModifiedLevelContent);
-      });
-
-      assert.equal(changeEventCounter, 4, 'it should continue to call change');
 
       editor.off('change', onChange);
     });
@@ -674,11 +668,10 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
       editor.undoManager.clear();
       assert.lengthOf(editor.undoManager.data, 0, 'undo manager should be empty after clear');
 
-      Arr.range(3, (n) => {
-        editor.undoManager.dispatchChange();
-        assert.equal(changeEventCounter, n + 1, 'change should be called each time the dispatchChange is called');
-        assertChangeEvent(currentChangeEvent, initialContent, undefined);
-      });
+      editor.undoManager.dispatchChange();
+
+      assertChangeEvent(currentChangeEvent, initialContent, undefined);
+
       editor.off('change', onChange);
     });
   });

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -644,7 +644,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
       lastLevel.content = manualModifiedLevel;
     });
 
-    assert.equal(editor.isDirty(), false, 'Editor should be not dirty before fireIfChanged');
+    assert.equal(editor.isDirty(), false, 'Editor should not be dirty before fireIfChanged');
     editor.undoManager.fireIfChanged();
     fireAndCheckEvent(currentChangeEvent, initialContent, manualModifiedLevel);
     assert.equal(changeEventCounter, 1, '1 event should be detected if the content is not coherent with the undoManager history');
@@ -658,7 +658,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
 
     editor.undoManager.fireIfChanged();
     fireAndCheckEvent(currentChangeEvent, initialContent, manualModifiedLevel);
-    assert.equal(changeEventCounter, 4, 'it should countinue to call change till the editor and last level are different');
+    assert.equal(changeEventCounter, 4, 'it should continue to call change till the editor and last level are different');
 
     editor.undoManager.add();
     assert.equal(changeEventCounter, 5, 'add should trigger a change as well');


### PR DESCRIPTION
Related Ticket: TINY-8641

Description of Changes:
Add the `dispatchChange` function that triggers a change event with current editor status as level and current `undoManager` layer as `lastLevel` in the `undoManager` and the current content of the editor

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
