### PR TITLE
TINY-8639: Retain formatted blank lines when `format_empty_lines` is true (backport)

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Base64 data URIs were not extracted correctly during parsing when proceeded by `data:` text #TINY-8646
+- Empty lines that were formatted in a ranged selection using the `format_empty_lines` option were not kept in the serialized content #TINY-8639
+- The `s` element was missing from the default schema text inline elements #TINY-8639
+- Some text inline elements specified via the schema were not removed when empty by default #TINY-8639
 
 ## 5.10.4 - 2022-04-27
 

--- a/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/SettingsTypes.ts
@@ -110,6 +110,7 @@ interface BaseEditorSettings {
   forced_root_block?: boolean | string;
   forced_root_block_attrs?: Record<string, string>;
   formats?: Formats;
+  format_empty_lines?: boolean;
   gecko_spellcheck?: boolean;
   height?: number | string;
   hidden_input?: boolean;

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -11,6 +11,7 @@ import { PredicateExists, SugarElement } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
 import * as Events from '../api/Events';
+import { getTextRootBlockElements } from '../api/html/Schema';
 import * as Settings from '../api/Settings';
 import Tools from '../api/util/Tools';
 import * as Bookmarks from '../bookmark/Bookmarks';
@@ -40,19 +41,7 @@ const isElementNode = (node: Node): node is Element => {
 const canFormatBR = (editor: Editor, format: ApplyFormat, node: HTMLBRElement, parentName: string) => {
   // TINY-6483: Can format 'br' if it is contained in a valid empty block and an inline format is being applied
   if (Settings.canFormatEmptyLines(editor) && FormatUtils.isInlineFormat(format)) {
-    // A curated list using the textBlockElements map and parts of the blockElements map from the schema
-    const validBRParentElements: Record<string, {}> = {
-      ...editor.schema.getTextBlockElements(),
-      td: {},
-      th: {},
-      li: {},
-      dt: {},
-      dd: {},
-      figcaption: {},
-      caption: {},
-      details: {},
-      summary: {}
-    };
+    const validBRParentElements = getTextRootBlockElements(editor.schema);
     // If a caret node is present, the format should apply to that, not the br (applicable to collapsed selections)
     const hasCaretNodeSibling = PredicateExists.sibling(SugarElement.fromDom(node), (sibling) => isCaretNode(sibling.dom));
     return Obj.hasNonNullableKey(validBRParentElements, parentName) && Empty.isEmpty(SugarElement.fromDom(node.parentNode), false) && !hasCaretNodeSibling;

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -20,7 +20,7 @@ import * as Events from '../api/Events';
 import Formatter from '../api/Formatter';
 import DomParser, { DomParserSettings } from '../api/html/DomParser';
 import AstNode from '../api/html/Node';
-import Schema from '../api/html/Schema';
+import Schema, { SchemaSettings } from '../api/html/Schema';
 import * as Settings from '../api/Settings';
 import UndoManager from '../api/UndoManager';
 import Delay from '../api/util/Delay';
@@ -65,6 +65,34 @@ const getRootName = (editor: Editor): string => editor.inline ? editor.getElemen
 
 const removeUndefined = <T>(obj: T): T => Obj.filter(obj as Record<string, unknown>, (v) => Type.isUndefined(v) === false) as T;
 
+const mkSchemaSettings = (editor: Editor): SchemaSettings => {
+  const settings = editor.settings;
+
+  return removeUndefined<SchemaSettings>({
+    block_elements: settings.block_elements,
+    boolean_attributes: settings.boolean_attributes,
+    custom_elements: settings.custom_elements,
+    extended_valid_elements: settings.extended_valid_elements,
+    invalid_elements: settings.invalid_elements,
+    invalid_styles: settings.invalid_styles,
+    move_caret_before_on_enter_elements: settings.move_caret_before_on_enter_elements,
+    non_empty_elements: settings.non_empty_elements,
+    schema: settings.schema,
+    self_closing_elements: settings.self_closing_elements,
+    short_ended_elements: settings.short_ended_elements,
+    special: settings.special,
+    text_block_elements: settings.text_block_elements,
+    text_inline_elements: settings.text_inline_elements,
+    valid_children: settings.valid_children,
+    valid_classes: settings.valid_classes,
+    valid_elements: settings.valid_elements,
+    valid_styles: settings.valid_styles,
+    verify_html: settings.verify_html,
+    whitespace_elements: settings.whitespace_elements,
+    padd_empty_block_inline_children: settings.format_empty_lines,
+  });
+};
+
 const mkParserSettings = (editor: Editor): DomParserSettings => {
   const settings = editor.settings;
   const blobCache = editor.editorUpload.blobCache;
@@ -100,6 +128,7 @@ const mkSerializerSettings = (editor: Editor): DomSerializerSettings => {
 
   return {
     ...mkParserSettings(editor),
+    ...mkSchemaSettings(editor),
     ...removeUndefined<DomSerializerSettings>({
       // SerializerSettings
       url_converter: settings.url_converter,
@@ -112,28 +141,6 @@ const mkSerializerSettings = (editor: Editor): DomSerializerSettings => {
       indent: settings.indent,
       indent_after: settings.indent_after,
       indent_before: settings.indent_before,
-
-      // Schema settings
-      block_elements: settings.block_elements,
-      boolean_attributes: settings.boolean_attributes,
-      custom_elements: settings.custom_elements,
-      extended_valid_elements: settings.extended_valid_elements,
-      invalid_elements: settings.invalid_elements,
-      invalid_styles: settings.invalid_styles,
-      move_caret_before_on_enter_elements: settings.move_caret_before_on_enter_elements,
-      non_empty_elements: settings.non_empty_elements,
-      schema: settings.schema,
-      self_closing_elements: settings.self_closing_elements,
-      short_ended_elements: settings.short_ended_elements,
-      special: settings.special,
-      text_block_elements: settings.text_block_elements,
-      text_inline_elements: settings.text_inline_elements,
-      valid_children: settings.valid_children,
-      valid_classes: settings.valid_classes,
-      valid_elements: settings.valid_elements,
-      valid_styles: settings.valid_styles,
-      verify_html: settings.verify_html,
-      whitespace_elements: settings.whitespace_elements
     })
   };
 };
@@ -425,7 +432,7 @@ const initContentBody = (editor: Editor, skipWrite?: boolean) => {
   (body as any).disabled = false;
 
   editor.editorUpload = EditorUpload(editor);
-  editor.schema = Schema(settings);
+  editor.schema = Schema(mkSchemaSettings(editor));
   editor.dom = DOMUtils(doc, {
     keep_values: true,
     // Note: Don't bind here, as the binding is handled via the `url_converter_scope`

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
@@ -57,11 +57,11 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
   const listHTML = `<ul>\n<li>b</li>\n<li>&nbsp;</li>\n</ul>`;
 
   const testFormat = (editor: Editor, config: TestConfig) => {
-    const { selector, selectorCount, html, expectedHtml, expectedRawHtml, rawHtml: contentFormatRaw } = config;
+    const { selector, selectorCount, html, rawHtml, expectedHtml, expectedRawHtml } = config;
     const expectedPresence = { [selector]: selectorCount };
     const expectedPresenceOnRemove = { [selector]: 0 };
 
-    editor.setContent(html, { format: Type.isNonNullable(contentFormatRaw) ? 'raw' : 'html' });
+    editor.setContent(html, { format: rawHtml === true ? 'raw' : 'html' });
     editor.focus();
     config.select(editor);
     config.apply(editor);

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
@@ -1,5 +1,7 @@
+import { Keys } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { Type, Unicode } from '@ephox/katamari';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
@@ -8,6 +10,9 @@ interface TestConfig {
   readonly selector: string;
   readonly selectorCount: number;
   readonly html: string;
+  readonly rawHtml?: boolean;
+  readonly expectedHtml?: string;
+  readonly expectedRawHtml?: string;
   readonly select: (editor: Editor) => void;
   readonly apply: (editor: Editor) => void;
   readonly remove: (editor: Editor) => void;
@@ -22,7 +27,7 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Theme ], true);
 
-  const tagHTML = (tag: string) => `<${tag}>a</${tag}><${tag}>&nbsp;</${tag}><${tag}>b</${tag}>`;
+  const tagHTML = (tag: string) => `<${tag}>a</${tag}>\n<${tag}>&nbsp;</${tag}>\n<${tag}>b</${tag}>`;
 
   const toggleInlineStyle = (style: string) => (editor: Editor) => {
     TinyUiActions.clickOnToolbar(editor, `[aria-label="${style}"]`);
@@ -31,6 +36,9 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
   const removeCustomFormat = (format: string) => (editor: Editor) => editor.formatter.remove(format);
 
   const selectAll = (editor: Editor) => editor.execCommand('SelectAll');
+
+  const pAssertToolbarButtonState = (editor: Editor, selector: string, active: boolean) =>
+    TinyUiActions.pWaitForUi(editor, `button[aria-label="${selector}"][aria-pressed="${active}"]`);
 
   const tableHTML = `<table style="border-collapse: collapse; width: 100%;" border="1">
   <tbody>
@@ -46,163 +54,376 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
   </tbody>
   </table>`;
 
-  const listHTML = `<ul>
-  <li>b</li>
-  <li>&nbsp;</li>
-  </ul>`;
+  const listHTML = `<ul>\n<li>b</li>\n<li>&nbsp;</li>\n</ul>`;
 
-  const testFormat = (testId: string, label: string, config: TestConfig) => {
-    const { selector, selectorCount, html } = config;
+  const testFormat = (editor: Editor, config: TestConfig) => {
+    const { selector, selectorCount, html, expectedHtml, expectedRawHtml, rawHtml: contentFormatRaw } = config;
     const expectedPresence = { [selector]: selectorCount };
     const expectedPresenceOnRemove = { [selector]: 0 };
 
-    it(`${testId}: Test format: ${label}`, () => {
-      const editor = hook.editor();
-      editor.setContent(html);
-      editor.focus();
-      config.select(editor);
-      config.apply(editor);
-      TinyAssertions.assertContentPresence(editor, expectedPresence);
-      config.remove(editor);
-      TinyAssertions.assertContentPresence(editor, expectedPresenceOnRemove);
+    editor.setContent(html, { format: Type.isNonNullable(contentFormatRaw) ? 'raw' : 'html' });
+    editor.focus();
+    config.select(editor);
+    config.apply(editor);
+    TinyAssertions.assertContentPresence(editor, expectedPresence);
+    if (Type.isNonNullable(expectedHtml)) {
+      TinyAssertions.assertContent(editor, expectedHtml);
+    }
+    if (Type.isNonNullable(expectedRawHtml)) {
+      TinyAssertions.assertRawContent(editor, expectedRawHtml);
+    }
+    config.remove(editor);
+    TinyAssertions.assertContentPresence(editor, expectedPresenceOnRemove);
+  };
+
+  const testInlineFormats = (editor: Editor, config: PartialTestConfig) => {
+    testFormat(editor, {
+      ...config,
+      selector: 'strong',
+      apply: toggleInlineStyle('Bold'),
+      remove: toggleInlineStyle('Bold')
+    });
+
+    testFormat(editor, {
+      ...config,
+      selector: 'em',
+      apply: toggleInlineStyle('Italic'),
+      remove: toggleInlineStyle('Italic')
+    });
+
+    testFormat(editor, {
+      ...config,
+      selector: 'span[style*="text-decoration: underline;"]',
+      apply: toggleInlineStyle('Underline'),
+      remove: toggleInlineStyle('Underline')
+    });
+
+    testFormat(editor, {
+      ...config,
+      selector: 'span[style*="text-decoration: line-through;"]',
+      apply: toggleInlineStyle('Strikethrough'),
+      remove: toggleInlineStyle('Strikethrough')
     });
   };
 
-  const sTestInlineFormats = (testId: string, label: string, config: PartialTestConfig) =>
-    context(`${testId}: Test inline formats: ${label}`, () => {
-      testFormat(testId, 'Bold', {
-        ...config,
+  const testBlockFormats = (editor: Editor, config: PartialTestConfig) => {
+    testFormat(editor, {
+      ...config,
+      selector: 'h1',
+      apply: applyCustomFormat('h1'),
+      remove: removeCustomFormat('h1')
+    });
+
+    testFormat(editor, {
+      ...config,
+      selector: 'div',
+      apply: applyCustomFormat('div'),
+      remove: removeCustomFormat('div')
+    });
+  };
+
+  context('Test inline formats on valid blocks', () => {
+    it('TINY-6483: Check inline formats apply to valid empty block (paragraph)', () => {
+      testInlineFormats(hook.editor(), {
+        selectorCount: 3,
+        html: tagHTML('p'),
+        select: selectAll
+      });
+    });
+
+    it('TINY-6483: Check inline formats apply to valid empty block (heading)', () => {
+      testInlineFormats(hook.editor(), {
+        selectorCount: 3,
+        html: tagHTML('p'),
+        select: selectAll
+      });
+    });
+
+    it('TINY-6483: Check inline formats apply to valid empty block (preformat)', () => {
+      testInlineFormats(hook.editor(), {
+        selectorCount: 3,
+        html: tagHTML('pre'),
+        select: selectAll
+      });
+    });
+
+    it('TINY-6483: Check inline formats apply to valid empty block (div)', () => {
+      testInlineFormats(hook.editor(), {
+        selectorCount: 3,
+        html: tagHTML('div'),
+        select: selectAll
+      });
+    });
+
+    it('TINY-6483: Check inline formats apply to valid empty block (blockquote)', () => {
+      testInlineFormats(hook.editor(), {
+        selectorCount: 3,
+        html: tagHTML('blockquote'),
+        select: selectAll
+      });
+    });
+
+    it('TINY-6483: Check inline formats apply to valid empty block (list - li)', () => {
+      testInlineFormats(hook.editor(), {
+        selectorCount: 4,
+        html: `<p>a</p>\n${listHTML}\n<p>c</p>`,
+        select: selectAll
+      });
+    });
+
+    it('TINY-6483: Check inline formats apply to valid empty block (table - td,th)', () => {
+      testInlineFormats(hook.editor(), {
+        selectorCount: 5,
+        html: `<p>a</p>${tableHTML}<p>c</p>`,
+        select: selectAll
+      });
+    });
+  });
+
+  // Test that for a collapsed selection only the caret span is formatted and not the br
+  it('TINY-6483: Check collapsed selection (paragraph)', () => {
+    testInlineFormats(hook.editor(), {
+      selectorCount: 1,
+      html: tagHTML('p'),
+      select: (editor) => TinySelections.setCursor(editor, [ 1, 0 ], 0)
+    });
+  });
+
+  // Test inline format on br surrounded by inline block
+  it('TINY-6483: Check inline format does not apply to empty inline block', () => {
+    testFormat(hook.editor(), {
+      selector: 'strong',
+      selectorCount: 3,
+      html: '<p><em>a</em></p>\n<p><em>&nbsp;</em></p>\n<p><em>b</em></p>',
+      select: selectAll,
+      apply: toggleInlineStyle('Bold'),
+      remove: toggleInlineStyle('Bold')
+    });
+  });
+
+  // Test cells can be formatted with internal table selections
+  it('TINY-6483: Check inline formats apply to table cells with explicit cell selections', () => {
+    testInlineFormats(hook.editor(), {
+      selectorCount: 3,
+      html: `<table style="border-collapse: collapse; width: 100%;" border="1" data-mce-selected="1">
+      <tbody>
+      <tr>
+      <th scope="row" data-mce-selected="1" data-mce-first-selected="1">&nbsp;</th>
+      </tr>
+      <tr>
+      <td data-mce-selected="1">b</td>
+      </tr>
+      <tr>
+      <td data-mce-selected="1" data-mce-last-selected="1">&nbsp;</td>
+      </tr>
+      </tbody>
+      </table>`,
+      select: (editor) => TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0)
+    });
+  });
+
+  context('Test block formats', () => {
+    it('TINY-6483: Check block formats converts valid blocks (paragraphs)', () => {
+      testBlockFormats(hook.editor(), {
+        selectorCount: 3,
+        html: tagHTML('p'),
+        select: selectAll
+      });
+    });
+
+    it('TINY-6483: Check block formats do not apply to invalid empty block (list - li)', () => {
+      testBlockFormats(hook.editor(), {
+        selectorCount: 3,
+        html: `<p>a</p>\n${listHTML}\n<p>c</p>`,
+        select: selectAll
+      });
+    });
+
+    it('TINY-6483: Check block formats do not apply to invalid empty block (table - td,th)', () => {
+      testBlockFormats(hook.editor(), {
+        selectorCount: 3,
+        html: `<p>a</p>\n${tableHTML}<p>c</p>`,
+        select: selectAll
+      });
+    });
+  });
+
+  context('Serializing empty inline format elements', () => {
+    it('TINY-8639: Check inline format is correctly serialized (bold)', () => {
+      testFormat(hook.editor(), {
         selector: 'strong',
+        selectorCount: 3,
+        html: '<p>a</p><p><br data-mce-bogus="1"></p><p>b</p>',
+        rawHtml: true,
+        expectedHtml:
+          '<p><strong>a</strong></p>\n' +
+          '<p><strong>&nbsp;</strong></p>\n' +
+          '<p><strong>b</strong></p>',
+        expectedRawHtml:
+          '<p><strong>a</strong></p>' +
+          '<p><strong><br data-mce-bogus="1"></strong></p>' +
+          '<p><strong>b</strong></p>',
+        select: selectAll,
         apply: toggleInlineStyle('Bold'),
         remove: toggleInlineStyle('Bold')
       });
+    });
 
-      testFormat(testId, 'Italic', {
-        ...config,
-        selector: 'em',
-        apply: toggleInlineStyle('Italic'),
-        remove: toggleInlineStyle('Italic')
-      });
-
-      testFormat(testId, 'Underline', {
-        ...config,
-        selector: 'span[style*="text-decoration: underline;"]',
-        apply: toggleInlineStyle('Underline'),
-        remove: toggleInlineStyle('Underline')
-      });
-
-      testFormat(testId, 'Strikethrough', {
-        ...config,
+    it('TINY-8639: Check inline format is correctly serialized (strikethrough)', () => {
+      testFormat(hook.editor(), {
         selector: 'span[style*="text-decoration: line-through;"]',
+        selectorCount: 3,
+        html: '<p>a</p><p><br data-mce-bogus="1"></p><p>b</p>',
+        rawHtml: true,
+        expectedHtml:
+          '<p><span style="text-decoration: line-through;">a</span></p>\n' +
+          '<p><span style="text-decoration: line-through;">&nbsp;</span></p>\n' +
+          '<p><span style="text-decoration: line-through;">b</span></p>',
+        expectedRawHtml:
+          '<p><span style="text-decoration: line-through;" data-mce-style="text-decoration: line-through;">a</span></p>' +
+          '<p><span style="text-decoration: line-through;" data-mce-style="text-decoration: line-through;"><br data-mce-bogus="1"></span></p>' +
+          '<p><span style="text-decoration: line-through;" data-mce-style="text-decoration: line-through;">b</span></p>',
+        select: selectAll,
         apply: toggleInlineStyle('Strikethrough'),
         remove: toggleInlineStyle('Strikethrough')
       });
     });
 
-  const testBlockFormats = (testId: string, label: string, config: PartialTestConfig) =>
-    context(`${testId}: Test block formats: ${label}`, () => {
-      testFormat(testId, 'h1', {
-        ...config,
-        selector: 'h1',
-        apply: applyCustomFormat('h1'),
-        remove: removeCustomFormat('h1')
-      });
-
-      testFormat(testId, 'div', {
-        ...config,
-        selector: 'div',
-        apply: applyCustomFormat('div'),
-        remove: removeCustomFormat('div')
+    it('TINY-8639: Check inline format is correctly serialized (underline)', () => {
+      testFormat(hook.editor(), {
+        selector: 'span[style*="text-decoration: underline;"]',
+        selectorCount: 3,
+        html: '<p>a</p><p><br data-mce-bogus="1"></p><p>b</p>',
+        rawHtml: true,
+        expectedHtml:
+          '<p><span style="text-decoration: underline;">a</span></p>\n' +
+          '<p><span style="text-decoration: underline;">&nbsp;</span></p>\n' +
+          '<p><span style="text-decoration: underline;">b</span></p>',
+        expectedRawHtml:
+          '<p><span style="text-decoration: underline;" data-mce-style="text-decoration: underline;">a</span></p>' +
+          '<p><span style="text-decoration: underline;" data-mce-style="text-decoration: underline;"><br data-mce-bogus="1"></span></p>' +
+          '<p><span style="text-decoration: underline;" data-mce-style="text-decoration: underline;">b</span></p>',
+        select: selectAll,
+        apply: toggleInlineStyle('Underline'),
+        remove: toggleInlineStyle('Underline')
       });
     });
 
-  // Test inline formats on valid blocks
-  sTestInlineFormats('TINY-6483', 'Check inline formats apply to valid empty block (paragraph)', {
-    selectorCount: 3,
-    html: tagHTML('p'),
-    select: selectAll
-  });
-  sTestInlineFormats('TINY-6483', 'Check inline formats apply to valid empty block (heading)', {
-    selectorCount: 3,
-    html: tagHTML('p'),
-    select: selectAll
-  });
-  sTestInlineFormats('TINY-6483', 'Check inline formats apply to valid empty block (preformat)', {
-    selectorCount: 3,
-    html: tagHTML('pre'),
-    select: selectAll
-  });
-  sTestInlineFormats('TINY-6483', 'Check inline formats apply to valid empty block (div)', {
-    selectorCount: 3,
-    html: tagHTML('div'),
-    select: selectAll
-  });
-  sTestInlineFormats('TINY-6483', 'Check inline formats apply to valid empty block (blockquote)', {
-    selectorCount: 3,
-    html: tagHTML('blockquote'),
-    select: selectAll
-  });
-  sTestInlineFormats('TINY-6483', 'Check inline formats apply to valid empty block (list - li)', {
-    selectorCount: 4,
-    html: `<p>a</p>${listHTML}<p>c</p>`,
-    select: selectAll
-  });
-  sTestInlineFormats('TINY-6483', 'Check inline formats apply to valid empty block (table - td,th)', {
-    selectorCount: 5,
-    html: `<p>a</p>${tableHTML}<p>c</p>`,
-    select: selectAll
+    it('TINY-8639: Check inline format is correctly serialized (bold and strikethrough)', () => {
+      testFormat(hook.editor(), {
+        selector: 'strong',
+        selectorCount: 3,
+        html: '<p>a</p><p><br data-mce-bogus="1"></p><p>b</p>',
+        rawHtml: true,
+        expectedHtml:
+          '<p><span style="text-decoration: line-through;"><strong>a</strong></span></p>\n' +
+          '<p><span style="text-decoration: line-through;"><strong>&nbsp;</strong></span></p>\n' +
+          '<p><span style="text-decoration: line-through;"><strong>b</strong></span></p>',
+        expectedRawHtml:
+          '<p><span style="text-decoration: line-through;" data-mce-style="text-decoration: line-through;"><strong>a</strong></span></p>' +
+          '<p><span style="text-decoration: line-through;" data-mce-style="text-decoration: line-through;"><strong><br data-mce-bogus="1"></strong></span></p>' +
+          '<p><span style="text-decoration: line-through;" data-mce-style="text-decoration: line-through;"><strong>b</strong></span></p>',
+        select: selectAll,
+        apply: (editor) => {
+          toggleInlineStyle('Bold')(editor);
+          toggleInlineStyle('Strikethrough')(editor);
+        },
+        remove: (editor) => {
+          toggleInlineStyle('Bold')(editor);
+          toggleInlineStyle('Strikethrough')(editor);
+        },
+      });
+    });
+
+    it('TINY-8639: Check inline format is correctly serialized in list item', () => {
+      testFormat(hook.editor(), {
+        selector: 'strong',
+        selectorCount: 2,
+        html: '<p>a</p><ul><li><br data-mce-bogus="1"></li></ul>',
+        rawHtml: true,
+        expectedHtml:
+          '<p><strong>a</strong></p>\n' +
+          '<ul>\n<li><strong>&nbsp;</strong></li>\n</ul>',
+        expectedRawHtml:
+          '<p><strong>a</strong></p>' +
+          '<ul><li><strong><br data-mce-bogus="1"></strong></li></ul>',
+        select: selectAll,
+        apply: toggleInlineStyle('Bold'),
+        remove: toggleInlineStyle('Bold')
+      });
+    });
+
+    it('TINY-8639: should be able to insert and type in serialized empty inline format element', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p>a</p><p><br data-mce-bogus="1"></p>', { format: 'raw' });
+      selectAll(editor);
+      toggleInlineStyle('Bold')(editor);
+      TinyAssertions.assertRawContent(editor, '<p><strong>a</strong></p><p><strong><br data-mce-bogus="1"></strong></p>');
+      TinyAssertions.assertContent(editor, '<p><strong>a</strong></p>\n<p><strong>&nbsp;</strong></p>');
+
+      TinySelections.setCursor(editor, [ 1, 0, 0 ], 0);
+      await pAssertToolbarButtonState(editor, 'Bold', true);
+
+      const content = editor.getContent();
+      editor.setContent(content);
+      TinyAssertions.assertRawContent(editor, '<p><strong>a</strong></p><p><strong>&nbsp;</strong></p>');
+      TinySelections.setCursor(editor, [ 1, 0, 0 ], 0);
+      await pAssertToolbarButtonState(editor, 'Bold', true);
+      TinyContentActions.type(editor, 'abc');
+      TinyAssertions.assertRawContent(editor, '<p><strong>a</strong></p><p><strong>abc&nbsp;</strong></p>');
+    });
+
+    it('TINY-8639: should be able to insert and remove serialized empty inline format element', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p><strong>a</strong></p><p><strong>&nbsp;</strong></p>');
+      TinySelections.setCursor(editor, [ 1, 0, 0 ], 0);
+      await pAssertToolbarButtonState(editor, 'Bold', true);
+      toggleInlineStyle('Bold')(editor);
+      TinyAssertions.assertRawContent(editor, '<p><strong>a</strong></p><p>&nbsp;</p>');
+    });
+
+    it('TINY-8639: should serialize caret formatted empty line if the cursor has not moved', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>a</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      TinyContentActions.keystroke(editor, Keys.enter());
+      toggleInlineStyle('Bold')(editor);
+      TinyAssertions.assertRawContent(
+        editor,
+        '<p>a</p>' +
+        `<p><span id="_mce_caret" data-mce-bogus="1" data-mce-type="format-caret"><strong>${Unicode.zeroWidth}</strong></span><br data-mce-bogus="1"></p>`
+      );
+      TinyAssertions.assertContent(editor, '<p>a</p>\n<p><strong>&nbsp;</strong></p>');
+    });
   });
 
-  // Test that for a collapsed selection only the caret span is formatted and not the br
-  sTestInlineFormats('TINY-6483', 'Check collapsed selection (paragraph)', {
-    selectorCount: 1,
-    html: tagHTML('p'),
-    select: (editor) => TinySelections.setCursor(editor, [ 1, 0 ], 0)
-  });
+  context('Parsing empty inline formatting elements', () => {
+    it('TINY-8639: should be padded on an empty line', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><strong></strong></p>');
+      TinyAssertions.assertRawContent(editor, '<p><strong>&nbsp;</strong></p>');
+      TinyAssertions.assertContent(editor, '<p><strong>&nbsp;</strong></p>');
+    });
 
-  // Test inline format on br surrounded by inline block
-  testFormat('TINY-6483', 'Check inline format does not apply to empty inline block', {
-    selector: 'strong',
-    selectorCount: 3,
-    html: '<p><em>a</em></p><p><em>&nbsp;<em></p><p><em>b</em></p>',
-    select: selectAll,
-    apply: toggleInlineStyle('Bold'),
-    remove: toggleInlineStyle('Bold')
-  });
+    it('TINY-8639: should be padded when in an empty block', () => {
+      const editor = hook.editor();
+      editor.setContent('<div>test<div><strong></strong></div></div>');
+      TinyAssertions.assertRawContent(editor, '<div>test<div><strong>&nbsp;</strong></div></div>');
+      TinyAssertions.assertContent(editor, '<div>test\n<div><strong>&nbsp;</strong></div>\n</div>');
+    });
 
-  // Test cells can be formatted with internal table selections
-  sTestInlineFormats('TINY-6483', 'Check inline formats apply to table cells with explicit cell selections', {
-    selectorCount: 3,
-    html: `<table style="border-collapse: collapse; width: 100%;" border="1" data-mce-selected="1">
-    <tbody>
-    <tr>
-    <th scope="row" data-mce-selected="1" data-mce-first-selected="1">&nbsp;</th>
-    </tr>
-    <tr>
-    <td data-mce-selected="1">b</td>
-    </tr>
-    <tr>
-    <td data-mce-selected="1" data-mce-last-selected="1">&nbsp;</td>
-    </tr>
-    </tbody>
-    </table>`,
-    select: (editor) => TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0)
-  });
+    it('TINY-8639: should not be padded when in an non-empty line', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>te<strong></strong>s<span style="text-decoration: line-through;"></span>t<span style="text-decoration: underline;"></span>ing</p>');
+      TinyAssertions.assertRawContent(editor, '<p>testing</p>');
+      TinyAssertions.assertContent(editor, '<p>testing</p>');
+    });
 
-  // Test block formats
-  testBlockFormats('TINY-6483', 'Check block formats converts valid blocks (paragraphs)', {
-    selectorCount: 3,
-    html: tagHTML('p'),
-    select: selectAll
-  });
-  testBlockFormats('TINY-6483', 'Check block formats do not apply to invalid empty block (list - li)', {
-    selectorCount: 3,
-    html: `<p>a</p>${listHTML}<p>c</p>`,
-    select: selectAll
-  });
-  testBlockFormats('TINY-6483', 'Check block formats do not apply to invalid empty block (table - td,th)', {
-    selectorCount: 3,
-    html: `<p>a</p>${tableHTML}<p>c</p>`,
-    select: selectAll
+    it('TINY-8639: should not be padded when in an non-empty block', () => {
+      const editor = hook.editor();
+      editor.setContent('<div><div>te<strong></strong>st</div></div>');
+      TinyAssertions.assertRawContent(editor, '<div><div>test</div></div>');
+      TinyAssertions.assertContent(editor, '<div>\n<div>test</div>\n</div>');
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -816,4 +816,174 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       '</table>'
     );
   });
+
+  it('TINY-8639: handling empty text inline elements when root block is empty', () => {
+    const html = '<p><strong></strong></p>' +
+    '<p><s></s></p>' +
+    '<p><span class="test"></span></p>' +
+    '<p><span style="color: red;"></span></p>' +
+    '<p><span></span></p>';
+
+    // Assert default behaviour when padd_empty_block_inline_children is not specified (should be equivalent to false)
+    let parser = DomParser({}, Schema({}));
+    let serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml,
+      '<p>\u00a0</p>' +
+      '<p>\u00a0</p>' +
+      '<p>\u00a0</p>' +
+      '<p>\u00a0</p>' +
+      '<p>\u00a0</p>'
+    );
+
+    parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
+    serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml,
+      '<p>\u00a0</p>' +
+      '<p>\u00a0</p>' +
+      '<p>\u00a0</p>' +
+      '<p>\u00a0</p>' +
+      '<p>\u00a0</p>'
+    );
+
+    parser = DomParser({}, Schema({ padd_empty_block_inline_children: true }));
+    serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml,
+      '<p><strong>\u00a0</strong></p>' +
+      '<p><s>\u00a0</s></p>' +
+      '<p><span class="test">\u00a0</span></p>' +
+      '<p><span style="color: red;">\u00a0</span></p>' +
+      '<p>\u00a0</p>'
+    );
+  });
+
+  it('TINY-8639: handling single space text inline elements when root block is otherwise empty', () => {
+    const html = '<p><strong> </strong></p>' +
+    '<p><s> </s></p>' +
+    '<p><span class="test"> </span></p>' +
+    '<p><span style="color: red;"> </span></p>' +
+    '<p><span> </span></p>';
+
+    // Assert default behaviour when padd_empty_block_inline_children is not specified (should be equivalent to false)
+    let parser = DomParser({}, Schema({}));
+    let serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml,
+      '<p><strong> </strong></p>' +
+      '<p><s> </s></p>' +
+      // isEmpty node logic considers a span with no style attribute and a single space to be empty (Node.ts -> isEmpty -> isEmptyTextNode)
+      '<p>\u00a0</p>' +
+      '<p><span style="color: red;"> </span></p>' +
+      '<p>\u00a0</p>'
+    );
+
+    parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
+    serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml,
+      '<p><strong> </strong></p>' +
+      '<p><s> </s></p>' +
+      // isEmpty node logic considers a span with no style attribute and a single space to be empty (Node.ts -> isEmpty -> isEmptyTextNode)
+      '<p>\u00a0</p>' +
+      '<p><span style="color: red;"> </span></p>' +
+      '<p>\u00a0</p>'
+    );
+
+    parser = DomParser({}, Schema({ padd_empty_block_inline_children: true }));
+    serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml,
+      '<p><strong> </strong></p>' +
+      '<p><s> </s></p>' +
+      '<p><span class="test">\u00a0</span></p>' +
+      '<p><span style="color: red;"> </span></p>' +
+      '<p>\u00a0</p>'
+    );
+  });
+
+  it('TINY-8639: handling single nbsp text inline elements when root block is otherwise empty', () => {
+    const html = '<p><strong>&nbsp;</strong></p>' +
+    '<p><s>&nbsp;</s></p>' +
+    '<p><span class="test">&nbsp;</span></p>' +
+    '<p><span style="color: red;">&nbsp;</span></p>' +
+    '<p><span>&nbsp;</span></p>';
+
+    // Assert default behaviour when padd_empty_block_inline_children is not specified (should be equivalent to false)
+    let parser = DomParser({}, Schema({}));
+    let serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml,
+      '<p><strong>\u00a0</strong></p>' +
+      '<p><s>\u00a0</s></p>' +
+      '<p><span class="test">\u00a0</span></p>' +
+      '<p><span style="color: red;">\u00a0</span></p>' +
+      '<p>\u00a0</p>'
+    );
+
+    parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
+    serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml,
+      '<p><strong>\u00a0</strong></p>' +
+      '<p><s>\u00a0</s></p>' +
+      '<p><span class="test">\u00a0</span></p>' +
+      '<p><span style="color: red;">\u00a0</span></p>' +
+      '<p>\u00a0</p>'
+    );
+
+    parser = DomParser({}, Schema({ padd_empty_block_inline_children: true }));
+    serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml,
+      '<p><strong>\u00a0</strong></p>' +
+      '<p><s>\u00a0</s></p>' +
+      '<p><span class="test">\u00a0</span></p>' +
+      '<p><span style="color: red;">\u00a0</span></p>' +
+      '<p>\u00a0</p>'
+    );
+  });
+
+  it('TINY-8639: should always remove empty inline element if it is not in an empty block', () => {
+    const html = '<p>ab<strong></strong>cd</p>' +
+    '<p>ab<s></s>cd</p>' +
+    '<p>ab<span class="test"></span>cd</p>' +
+    '<p>ab<span style="color: red;"></span>cd</p>' +
+    '<p>ab<span></span>cd</p>';
+
+    // Assert default behaviour when padd_empty_block_inline_children is not specified (should be equivalent to false)
+    let parser = DomParser({}, Schema({}));
+    let serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml,
+      '<p>abcd</p>' +
+      '<p>abcd</p>' +
+      '<p>abcd</p>' +
+      '<p>abcd</p>' +
+      '<p>abcd</p>'
+    );
+
+    parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
+    serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml,
+      '<p>abcd</p>' +
+      '<p>abcd</p>' +
+      '<p>abcd</p>' +
+      '<p>abcd</p>' +
+      '<p>abcd</p>'
+    );
+
+    parser = DomParser({}, Schema({ padd_empty_block_inline_children: true }));
+    serializedHtml = serializer.serialize(parser.parse(html));
+
+    assert.equal(serializedHtml,
+      '<p>abcd</p>' +
+      '<p>abcd</p>' +
+      '<p>abcd</p>' +
+      '<p>abcd</p>' +
+      '<p>abcd</p>'
+    );
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -1,5 +1,5 @@
-import { describe, it } from '@ephox/bedrock-client';
-import { Arr, Obj } from '@ephox/katamari';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr, Obj, Type } from '@ephox/katamari';
 import { assert } from 'chai';
 
 import Schema from 'tinymce/core/api/html/Schema';
@@ -272,9 +272,9 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
     const schema = Schema();
     assert.deepEqual(schema.getTextInlineElements(), {
       B: {}, CITE: {}, CODE: {}, DFN: {}, EM: {}, FONT: {}, I: {}, MARK: {}, Q: {},
-      SAMP: {}, SPAN: {}, STRIKE: {}, STRONG: {}, SUB: {}, SUP: {}, U: {}, VAR: {},
+      SAMP: {}, SPAN: {}, S: {}, STRIKE: {}, STRONG: {}, SUB: {}, SUP: {}, U: {}, VAR: {},
       b: {}, cite: {}, code: {}, dfn: {}, em: {}, font: {}, i: {}, mark: {}, q: {},
-      samp: {}, span: {}, strike: {}, strong: {}, sub: {}, sup: {}, u: {}, var: {}
+      samp: {}, span: {}, s: {}, strike: {}, strong: {}, sub: {}, sup: {}, u: {}, var: {}
     });
   });
 
@@ -521,6 +521,26 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
         classC: {},
         classD: {}
       }
+    });
+  });
+
+  context('paddInEmptyBlock', () => {
+    it('TINY-8639: default behaviour', () => {
+      const schema = Schema({});
+      const rules = Obj.mapToArray(schema.getTextInlineElements(), (_value, name) => schema.getElementRule(name.toLowerCase()));
+      assert.isTrue(rules.length > 0 && Arr.forall(rules, (rule) => Type.isUndefined(rule.paddInEmptyBlock)));
+    });
+
+    it('TINY-8639: padd_empty_block_inline_children: false', () => {
+      const schema = Schema({ padd_empty_block_inline_children: false });
+      const rules = Obj.mapToArray(schema.getTextInlineElements(), (_value, name) => schema.getElementRule(name.toLowerCase()));
+      assert.isTrue(rules.length > 0 && Arr.forall(rules, (rule) => Type.isUndefined(rule.paddInEmptyBlock)));
+    });
+
+    it('TINY-8639: padd_empty_block_inline_children: true', () => {
+      const schema = Schema({ padd_empty_block_inline_children: true });
+      const rules = Obj.mapToArray(schema.getTextInlineElements(), (_value, name) => schema.getElementRule(name.toLowerCase()));
+      assert.isTrue(rules.length > 0 && Arr.forall(rules, (rule) => rule.paddInEmptyBlock === true));
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-8639

Description of Changes:
* Update the schema and DomParser so that text inline elements can be padded if they are a child of an empty block. As to whether text inline elements are padded by default is controlled by the `format_empty_lines` option

All of the files are largely the same except for InitContentBody.ts and DomParser.ts

Original PR: #7835

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [X] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
