### PR TITLE
TINY-7433: Fixed values not escaped in generated regular expressions for the template plugin

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom elements on blank lines would be removed during serialization #TINY-4784
 - The URL detection used for `autolink` and smart paste didn't work if a path segment contained valid characters such as `!` and `:` #TINY-8069
 - Cutting content to the clipboard while selecting between the parent list and a nested list would not always set the list style to `none` on the parent list #TINY-8078
+- Some option values for the `template` plugin weren't escaped properly when doing replacement lookups via a `RegExp` #TINY-7433
 - Copy events were not dispatched in readonly mode #TINY-6800
 
 ## 6.0.3 - TBD

--- a/modules/tinymce/src/plugins/template/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/core/FilterContent.ts
@@ -4,6 +4,7 @@ import Tools from 'tinymce/core/api/util/Tools';
 import * as Options from '../api/Options';
 import * as DateTimeHelper from './DateTimeHelper';
 import * as Templates from './Templates';
+import { hasAnyClasses } from './Utils';
 
 const setup = (editor: Editor): void => {
   editor.on('PreProcess', (o) => {
@@ -12,7 +13,7 @@ const setup = (editor: Editor): void => {
     Tools.each(dom.select('div', o.node), (e) => {
       if (dom.hasClass(e, 'mceTmpl')) {
         Tools.each(dom.select('*', e), (e) => {
-          if (dom.hasClass(e, Options.getModificationDateClasses(editor).replace(/\s+/g, '|'))) {
+          if (hasAnyClasses(dom, e, Options.getModificationDateClasses(editor))) {
             e.innerHTML = DateTimeHelper.getDateTime(editor, dateFormat);
           }
         });

--- a/modules/tinymce/src/plugins/template/main/ts/core/Templates.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/core/Templates.ts
@@ -1,4 +1,4 @@
-import { Type } from '@ephox/katamari';
+import { Regex, Type } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
@@ -6,6 +6,7 @@ import Tools from 'tinymce/core/api/util/Tools';
 import * as Options from '../api/Options';
 import * as DateTimeHelper from './DateTimeHelper';
 import { ExternalTemplate, TemplateValues } from './Types';
+import { hasAnyClasses } from './Utils';
 
 const createTemplateList = (editor: Editor, callback: (templates: ExternalTemplate[]) => void) => {
   return (): void => {
@@ -32,7 +33,7 @@ const replaceTemplateValues = (html: string, templateValues: TemplateValues): st
       v = v(k);
     }
 
-    html = html.replace(new RegExp('\\{\\$' + k + '\\}', 'g'), v);
+    html = html.replace(new RegExp('\\{\\$' + Regex.escape(k) + '\\}', 'g'), v);
   });
 
   return html;
@@ -54,9 +55,6 @@ const replaceVals = (editor: Editor, scope: HTMLElement): void => {
   });
 };
 
-const hasClass = (n: Element, c: string): boolean =>
-  new RegExp('\\b' + c + '\\b', 'g').test(n.className);
-
 const insertTemplate = (editor: Editor, _ui: boolean, html: string): void => {
   // Note: ui is unused here but is required since this can be called by execCommand
   const dom = editor.dom;
@@ -74,17 +72,17 @@ const insertTemplate = (editor: Editor, _ui: boolean, html: string): void => {
 
   Tools.each(dom.select('*', el), (n) => {
     // Replace cdate
-    if (hasClass(n, Options.getCreationDateClasses(editor).replace(/\s+/g, '|'))) {
+    if (hasAnyClasses(dom, n, Options.getCreationDateClasses(editor))) {
       n.innerHTML = DateTimeHelper.getDateTime(editor, Options.getCdateFormat(editor));
     }
 
     // Replace mdate
-    if (hasClass(n, Options.getModificationDateClasses(editor).replace(/\s+/g, '|'))) {
+    if (hasAnyClasses(dom, n, Options.getModificationDateClasses(editor))) {
       n.innerHTML = DateTimeHelper.getDateTime(editor, Options.getMdateFormat(editor));
     }
 
     // Replace selection
-    if (hasClass(n, Options.getSelectedContentClasses(editor).replace(/\s+/g, '|'))) {
+    if (hasAnyClasses(dom, n, Options.getSelectedContentClasses(editor))) {
       n.innerHTML = sel;
     }
   });

--- a/modules/tinymce/src/plugins/template/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/core/Utils.ts
@@ -1,4 +1,6 @@
-import { Obj } from '@ephox/katamari';
+import { Arr, Obj } from '@ephox/katamari';
+
+import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 
 const entitiesAttr: Record<string, string> = {
   '"': '&quot;',
@@ -11,6 +13,10 @@ const entitiesAttr: Record<string, string> = {
 const htmlEscape = (html: string): string =>
   html.replace(/["'<>&]/g, (match) => Obj.get(entitiesAttr, match).getOr(match));
 
+const hasAnyClasses = (dom: DOMUtils, n: Element, classes: string): boolean =>
+  Arr.exists(classes.split(/\s+/), (c) => dom.hasClass(n, c));
+
 export {
+  hasAnyClasses,
   htmlEscape
 };

--- a/modules/tinymce/src/plugins/template/test/ts/browser/DatesTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/DatesTest.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/template/Plugin';
@@ -88,6 +88,52 @@ describe('browser.tinymce.plugins.template.DatesTest', () => {
       '<div class="mceTmpl">',
       '<p class="modified">changed modified date</p>',
       '<p class="cdate">fake created date</p>',
+      '</div>'
+    ].join('\n'));
+  });
+
+  it('TBA: Multiple replacement classes provided via options', async () => {
+    const editor = hook.editor();
+    addSettings({
+      templates: [{ title: 'a', description: 'b', content: '<div class="mceTmpl"><p class="cdate1">x</p><p class="mdate2">y</p></div>' }],
+      template_cdate_classes: 'cdate1 cdate2',
+      template_cdate_format: 'fake created date',
+      template_mdate_classes: 'mdate1 mdate2',
+      template_mdate_format: 'fake modified date',
+    });
+    await pInsertTemplate(editor);
+    TinyAssertions.assertContent(editor, [
+      '<div class="mceTmpl">',
+      '<p class="cdate1">fake created date</p>',
+      '<p class="mdate2">fake modified date</p>',
+      '</div>'
+    ].join('\n'));
+    TinySelections.setCursor(editor, [ 0, 1, 0 ], 'fake modified date'.length);
+    editor.insertContent('<p class="mdate1">inserted modified date</p>');
+    addSettings({ template_mdate_format: 'changed modified date' });
+    TinyAssertions.assertContent(editor, [
+      '<div class="mceTmpl">',
+      '<p class="cdate1">fake created date</p>',
+      '<p class="mdate2">changed modified date</p>',
+      '<p class="mdate1">changed modified date</p>',
+      '</div>'
+    ].join('\n'));
+  });
+
+  it('TINY-7433: replacement classes with regex like names', async () => {
+    const editor = hook.editor();
+    addSettings({
+      templates: [{ title: 'a', description: 'b', content: '<div class="mceTmpl"><p class="custom+cdate">x</p><p class="custom+mdate">y</p></div>' }],
+      template_cdate_classes: 'custom+cdate',
+      template_cdate_format: 'fake created date',
+      template_mdate_classes: 'custom+mdate',
+      template_mdate_format: 'fake modified date',
+    });
+    await pInsertTemplate(editor);
+    TinyAssertions.assertContent(editor, [
+      '<div class="mceTmpl">',
+      '<p class="custom+cdate">fake created date</p>',
+      '<p class="custom+mdate">fake modified date</p>',
       '</div>'
     ].join('\n'));
   });

--- a/modules/tinymce/src/plugins/template/test/ts/browser/TemplateSanityTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/TemplateSanityTest.ts
@@ -68,4 +68,13 @@ describe('browser.tinymce.plugins.template.TemplateSanityTest', () => {
     editor.execCommand('mceInsertTemplate', false, '<p>{$name}</p>');
     TinyAssertions.assertContent(editor, '<p>Tester</p>');
   });
+
+  it('TINY-7433: Replace template values with regex like keys', () => {
+    const editor = hook.editor();
+    addSettings({
+      template_replace_values: { 'first+name': 'Tester', 'email': 'test@test.com' },
+    });
+    editor.execCommand('mceInsertTemplate', false, '<p>{$first+name}</p>');
+    TinyAssertions.assertContent(editor, '<p>Tester</p>');
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-7433

Description of Changes:

Fixes some cases where values provided via options were used (that weren't escaped) when constructing a regular expression leading to them being interpreted as regex syntax. In the end I removed using regex entirely for one case as it wasn't a good use case for regex.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
