### PR TITLE
TINY-8040: Copying and pasting columns will no longer generate illegal tables when interacting with colspan

### DIFF
--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Copying one or more columns with a cell with colspan which starts outside of the selected area will no longer result in a copy with one or more cells missing.
+- Pasting a column into a table with a colspan cell will no longer result in missing cells.
+
 ## 11.0.2 - 2022-03-18
 
 ### Fixed

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CopyCols.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CopyCols.ts
@@ -4,6 +4,7 @@ import { Attribute, InsertAll, Replication, SugarElement } from '@ephox/sugar';
 import { onUnlockedCells, TargetSelection } from '../model/RunOperation';
 import * as CellUtils from '../util/CellUtils';
 import { CellElement } from '../util/TableTypes';
+import { ColumnExt, DetailExt } from './Structs';
 import { Warehouse } from './Warehouse';
 
 const constrainSpan = (element: SugarElement<CellElement>, property: 'colspan' | 'rowspan' | 'span', value: number) => {
@@ -15,9 +16,16 @@ const constrainSpan = (element: SugarElement<CellElement>, property: 'colspan' |
   }
 };
 
+const isColInRange = (minColRange: number, maxColRange: number) =>
+  (cell: ColumnExt | DetailExt) => {
+    const endCol = cell.column + cell.colspan - 1;
+    const startCol = cell.column;
+    return endCol >= minColRange && startCol < maxColRange;
+  };
+
 const generateColGroup = (house: Warehouse, minColRange: number, maxColRange: number): SugarElement<HTMLTableColElement>[] => {
   if (Warehouse.hasColumns(house)) {
-    const colsToCopy = Arr.filter(Warehouse.justColumns(house), (col) => col.column >= minColRange && col.column < maxColRange);
+    const colsToCopy = Arr.filter(Warehouse.justColumns(house), isColInRange(minColRange, maxColRange));
     const copiedCols = Arr.map(colsToCopy, (c) => {
       const clonedCol = Replication.deep(c.element);
       constrainSpan(clonedCol, 'span', maxColRange - minColRange);
@@ -33,7 +41,7 @@ const generateColGroup = (house: Warehouse, minColRange: number, maxColRange: nu
 
 const generateRows = (house: Warehouse, minColRange: number, maxColRange: number): SugarElement<HTMLTableRowElement>[] =>
   Arr.map(house.all, (row) => {
-    const cellsToCopy = Arr.filter(row.cells, (cell) => (cell.column + cell.colspan > minColRange) && cell.column < maxColRange);
+    const cellsToCopy = Arr.filter(row.cells, isColInRange(minColRange, maxColRange));
     const copiedCells = Arr.map(cellsToCopy, (cell) => {
       const clonedCell = Replication.deep(cell.element);
       constrainSpan(clonedCell, 'colspan', maxColRange - minColRange);

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CopyCols.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CopyCols.ts
@@ -33,7 +33,7 @@ const generateColGroup = (house: Warehouse, minColRange: number, maxColRange: nu
 
 const generateRows = (house: Warehouse, minColRange: number, maxColRange: number): SugarElement<HTMLTableRowElement>[] =>
   Arr.map(house.all, (row) => {
-    const cellsToCopy = Arr.filter(row.cells, (cell) => cell.column >= minColRange && cell.column < maxColRange);
+    const cellsToCopy = Arr.filter(row.cells, (cell) => (cell.column + cell.colspan > minColRange) && cell.column < maxColRange);
     const copiedCells = Arr.map(cellsToCopy, (cell) => {
       const clonedCell = Replication.deep(cell.element);
       constrainSpan(clonedCell, 'colspan', maxColRange - minColRange);

--- a/modules/snooker/src/main/ts/ephox/snooker/operate/MergingOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/operate/MergingOperations.ts
@@ -61,11 +61,12 @@ const splitCols = (grid: Structs.RowCells[], index: number, comparator: CompElm,
   if (index > 0 && index < grid[0].cells.length) {
     Arr.each(grid, (row) => {
       const prevCell = row.cells[index - 1];
-      const current = row.cells[index];
-      const isToReplace = comparator(current.element, prevCell.element);
+      let offset = 0;
+      const substitute = substitution();
 
-      if (isToReplace) {
-        GridRow.mutateCell(row, index, Structs.elementnew(substitution(), true, current.isLocked));
+      while (comparator(prevCell.element, row.cells[index + offset].element)) {
+        GridRow.mutateCell(row, index + offset, Structs.elementnew(substitute, true, row.cells[index + offset].isLocked));
+        offset++;
       }
     });
   }

--- a/modules/snooker/src/test/ts/browser/CopyColumnsTest.ts
+++ b/modules/snooker/src/test/ts/browser/CopyColumnsTest.ts
@@ -1,10 +1,10 @@
-import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { Hierarchy, Html, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 
 import { copyCols } from 'ephox/snooker/api/CopyCols';
 
-UnitTest.test('CopyColumnsTest', () => {
+describe('CopyColumnsTest', () => {
   const check = (
     label: string,
     inputHtml: string,
@@ -17,7 +17,7 @@ UnitTest.test('CopyColumnsTest', () => {
     Insert.append(SugarBody.body(), table);
 
     const rowsOpt = copyCols(table, {
-      selection: [ Hierarchy.follow(table, [ section, row, column, 0 ]).getOrDie(label + ': could not follow path') ]
+      selection: [Hierarchy.follow(table, [section, row, column, 0]).getOrDie(label + ': could not follow path')]
     });
     const copiedHtml = rowsOpt.map((rows) => Arr.map(rows, Html.getOuter).join('')).getOr('');
 
@@ -42,129 +42,152 @@ UnitTest.test('CopyColumnsTest', () => {
 
   const colspanTable = (hasColgroup: boolean = false, lockedColumns: number[] = []) =>
     `<table ${lockedColumns.length > 0 ? `data-snooker-locked-cols="${lockedColumns.join(',')}"` : ''}>` +
-  `${hasColgroup ? '<colgroup><col /><col /></colgroup>' : ''}` +
-  '<thead>' +
-  '<tr><td>H1</td><td>H2</td><td>H3</td></tr>' +
-  '</thead>' +
-  '<tbody>' +
-  '<tr><td>A2</td><td>B2</td><td>C2</td></tr>' +
-  '<tr><td colspan="2">A3</td><td>C3</td></tr>' +
-  '<tr><td colspan="3">A4</td></tr>' +
-  '</tbody>' +
-  '<tfoot>' +
-  '<tr><td>F1</td><td>F2</td><td>F3</td></tr>' +
-  '</tfoot>' +
-  '</table>';
+    `${hasColgroup ? '<colgroup><col /><col /></colgroup>' : ''}` +
+    '<thead>' +
+    '<tr><td>H1</td><td>H2</td><td>H3</td></tr>' +
+    '</thead>' +
+    '<tbody>' +
+    '<tr><td>A2</td><td>B2</td><td>C2</td></tr>' +
+    '<tr><td colspan="2">A3</td><td>C3</td></tr>' +
+    '<tr><td colspan="3">A4</td></tr>' +
+    '</tbody>' +
+    '<tfoot>' +
+    '<tr><td>F1</td><td>F2</td><td>F3</td></tr>' +
+    '</tfoot>' +
+    '</table>';
 
   const rowspanTable = (hasColgroup: boolean = false, lockedColumns: number[] = []) =>
     `<table ${lockedColumns.length > 0 ? `data-snooker-locked-cols="${lockedColumns.join(',')}"` : ''}>` +
-  `${hasColgroup ? '<colgroup><col /><col /></colgroup>' : ''}` +
-  '<thead>' +
-  '<tr><td>H1</td><td>H2</td></tr>' +
-  '</thead>' +
-  '<tbody>' +
-  '<tr><td rowspan="2">A2</td><td>B2</td></tr>' +
-  '<tr><td>B3</td></tr>' +
-  '</tbody>' +
-  '<tfoot>' +
-  '<tr><td>F1</td><td>F2</td></tr>' +
-  '</tfoot>' +
-  '</table>';
+    `${hasColgroup ? '<colgroup><col /><col /></colgroup>' : ''}` +
+    '<thead>' +
+    '<tr><td>H1</td><td>H2</td></tr>' +
+    '</thead>' +
+    '<tbody>' +
+    '<tr><td rowspan="2">A2</td><td>B2</td></tr>' +
+    '<tr><td>B3</td></tr>' +
+    '</tbody>' +
+    '<tfoot>' +
+    '<tr><td>F1</td><td>F2</td></tr>' +
+    '</tfoot>' +
+    '</table>';
 
-  check(
-    'Test copying column from basic table',
-    defaultTable(),
-    (
-      '<tr><td scope="col">H2</td></tr>' +
-      '<tr><td>B2</td></tr>' +
-      '<tr><td>B3</td></tr>' +
-      '<tr><td>F2</td></tr>'
-    ),
-    0, 0, 1
-  );
+  it('TBA: Test copying column from basic table', () =>
+    check(
+      'Test copying column from basic table',
+      defaultTable(),
+      (
+        '<tr><td scope="col">H2</td></tr>' +
+        '<tr><td>B2</td></tr>' +
+        '<tr><td>B3</td></tr>' +
+        '<tr><td>F2</td></tr>'
+      ),
+      0, 0, 1
+    ));
 
-  check(
-    'Test copying column from rowspan table',
-    rowspanTable(),
-    (
-      '<tr><td>H1</td></tr>' +
-      '<tr><td rowspan="2">A2</td></tr>' +
-      '<tr></tr>' +
-      '<tr><td>F1</td></tr>'
-    ),
-    1, 0, 0
-  );
+  it('TBA: Test copying column from rowspan table', () =>
+    check(
+      'Test copying column from rowspan table',
+      rowspanTable(),
+      (
+        '<tr><td>H1</td></tr>' +
+        '<tr><td rowspan="2">A2</td></tr>' +
+        '<tr></tr>' +
+        '<tr><td>F1</td></tr>'
+      ),
+      1, 0, 0
+    ));
 
-  check(
-    'Test copying column from colspan table with selection in colspan cell',
-    colspanTable(),
-    (
-      '<tr><td>H1</td><td>H2</td></tr>' +
-      '<tr><td>A2</td><td>B2</td></tr>' +
-      '<tr><td colspan="2">A3</td></tr>' +
-      '<tr><td colspan="2">A4</td></tr>' +
-      '<tr><td>F1</td><td>F2</td></tr>'
-    ),
-    1, 1, 0
-  );
+  it('TBA: Test copying column from colspan table with selection in colspan cell', () =>
+    check(
+      'Test copying column from colspan table with selection in colspan cell',
+      colspanTable(),
+      (
+        '<tr><td>H1</td><td>H2</td></tr>' +
+        '<tr><td>A2</td><td>B2</td></tr>' +
+        '<tr><td colspan="2">A3</td></tr>' +
+        '<tr><td colspan="2">A4</td></tr>' +
+        '<tr><td>F1</td><td>F2</td></tr>'
+      ),
+      1, 1, 0
+    ));
 
-  check(
-    'Test copying column from colspan table with selection not in colspan cell',
-    colspanTable(),
-    (
-      '<tr><td>H1</td></tr>' +
-      '<tr><td>A2</td></tr>' +
-      '<tr><td>A3</td></tr>' +
-      '<tr><td>A4</td></tr>' +
-      '<tr><td>F1</td></tr>'
-    ),
-    1, 0, 0
-  );
+  it('TBA: Test copying column from colspan table with selection not in colspan cell', () =>
+    check(
+      'Test copying column from colspan table with selection not in colspan cell',
+      colspanTable(),
+      (
+        '<tr><td>H1</td></tr>' +
+        '<tr><td>A2</td></tr>' +
+        '<tr><td>A3</td></tr>' +
+        '<tr><td>A4</td></tr>' +
+        '<tr><td>F1</td></tr>'
+      ),
+      1, 0, 0
+    ));
 
-  check(
-    'Test copying column from colgroup table',
-    defaultTable(true),
-    (
-      '<colgroup><col></colgroup>' +
-      '<tr><td scope="col">H2</td></tr>' +
-      '<tr><td>B2</td></tr>' +
-      '<tr><td>B3</td></tr>' +
-      '<tr><td>F2</td></tr>'
-    ),
-    2, 0, 1
-  );
+  it('TINY-8040: Test copying column from colspan table with selection in colspan cell', () =>
+    check(
+      'Test copying column from colspan table with selection in colspan cell',
+      colspanTable(),
+      (
+        '<tr><td>H2</td></tr>' +
+        '<tr><td>B2</td></tr>' +
+        '<tr><td>A3</td></tr>' +
+        '<tr><td>A4</td></tr>' +
+        '<tr><td>F2</td></tr>'
+      ),
+      1, 0, 1
+    ));
 
-  check(
-    'Test copying column from colgroup table with locked column - selection not in locked column',
-    defaultTable(true, [ 1 ]),
-    (
-      '<colgroup><col></colgroup>' +
-      '<tr><td scope="col">H1</td></tr>' +
-      '<tr><td>A2</td></tr>' +
-      '<tr><td>A3</td></tr>' +
-      '<tr><td>F1</td></tr>'
-    ),
-    2, 0, 0
-  );
+  it('TBA: Test copying column from colgroup table', () =>
+    check(
+      'Test copying column from colgroup table',
+      defaultTable(true),
+      (
+        '<colgroup><col></colgroup>' +
+        '<tr><td scope="col">H2</td></tr>' +
+        '<tr><td>B2</td></tr>' +
+        '<tr><td>B3</td></tr>' +
+        '<tr><td>F2</td></tr>'
+      ),
+      2, 0, 1
+    ));
 
-  check(
-    'Test copying column from colgroup table with locked column - selection in locked column (0)',
-    defaultTable(true, [ 0 ]),
-    '',
-    2, 0, 0
-  );
+  it('TBA: Test copying column from colgroup table with locked column - selection not in locked column', () =>
+    check(
+      'Test copying column from colgroup table with locked column - selection not in locked column',
+      defaultTable(true, [1]),
+      (
+        '<colgroup><col></colgroup>' +
+        '<tr><td scope="col">H1</td></tr>' +
+        '<tr><td>A2</td></tr>' +
+        '<tr><td>A3</td></tr>' +
+        '<tr><td>F1</td></tr>'
+      ),
+      2, 0, 0
+    ));
 
-  check(
-    'Test copying column from colgroup table with locked column - selection in locked column (1)',
-    defaultTable(true, [ 1 ]),
-    '',
-    2, 0, 1
-  );
+  it('TBA: Test copying column from colgroup table with locked column - selection in locked column (0)', () =>
+    check(
+      'Test copying column from colgroup table with locked column - selection in locked column (0)',
+      defaultTable(true, [0]),
+      '',
+      2, 0, 0
+    ));
 
-  check(
-    'Test copying column from colgroup table with multiple locked columns',
-    defaultTable(true, [ 0, 1 ]),
-    '',
-    2, 1, 1
-  );
+  it('TBA: Test copying column from colgroup table with locked column - selection in locked column (1)', () =>
+    check(
+      'Test copying column from colgroup table with locked column - selection in locked column (1)',
+      defaultTable(true, [1]),
+      '',
+      2, 0, 1
+    ));
+
+  it('TBA: Test copying column from colgroup table with multiple locked columns', () =>
+    check(
+      'Test copying column from colgroup table with multiple locked columns',
+      defaultTable(true, [0, 1]),
+      '',
+      2, 1, 1
+    ));
 });

--- a/modules/snooker/src/test/ts/browser/CopyColumnsTest.ts
+++ b/modules/snooker/src/test/ts/browser/CopyColumnsTest.ts
@@ -17,7 +17,7 @@ describe('CopyColumnsTest', () => {
     Insert.append(SugarBody.body(), table);
 
     const rowsOpt = copyCols(table, {
-      selection: [Hierarchy.follow(table, [section, row, column, 0]).getOrDie(label + ': could not follow path')]
+      selection: [ Hierarchy.follow(table, [ section, row, column, 0 ]).getOrDie(label + ': could not follow path') ]
     });
     const copiedHtml = rowsOpt.map((rows) => Arr.map(rows, Html.getOuter).join('')).getOr('');
 
@@ -156,7 +156,7 @@ describe('CopyColumnsTest', () => {
   it('TBA: Test copying column from colgroup table with locked column - selection not in locked column', () =>
     check(
       'Test copying column from colgroup table with locked column - selection not in locked column',
-      defaultTable(true, [1]),
+      defaultTable(true, [ 1 ]),
       (
         '<colgroup><col></colgroup>' +
         '<tr><td scope="col">H1</td></tr>' +
@@ -170,7 +170,7 @@ describe('CopyColumnsTest', () => {
   it('TBA: Test copying column from colgroup table with locked column - selection in locked column (0)', () =>
     check(
       'Test copying column from colgroup table with locked column - selection in locked column (0)',
-      defaultTable(true, [0]),
+      defaultTable(true, [ 0 ]),
       '',
       2, 0, 0
     ));
@@ -178,7 +178,7 @@ describe('CopyColumnsTest', () => {
   it('TBA: Test copying column from colgroup table with locked column - selection in locked column (1)', () =>
     check(
       'Test copying column from colgroup table with locked column - selection in locked column (1)',
-      defaultTable(true, [1]),
+      defaultTable(true, [ 1 ]),
       '',
       2, 0, 1
     ));
@@ -186,7 +186,7 @@ describe('CopyColumnsTest', () => {
   it('TBA: Test copying column from colgroup table with multiple locked columns', () =>
     check(
       'Test copying column from colgroup table with multiple locked columns',
-      defaultTable(true, [0, 1]),
+      defaultTable(true, [ 0, 1 ]),
       '',
       2, 1, 1
     ));

--- a/modules/snooker/src/test/ts/browser/PasteColumnOperationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/PasteColumnOperationsTest.ts
@@ -1,502 +1,608 @@
-import { UnitTest } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 
 import * as TableOperations from 'ephox/snooker/api/TableOperations';
 import * as Assertions from 'ephox/snooker/test/Assertions';
 import { generateTestTable } from 'ephox/snooker/test/CreateTableUtils';
 
-UnitTest.test('PasteColumnOperationsTest', () => {
-  Assertions.checkPaste(
-    'TBA',
+describe('PasteColumnOperationsTest', () => {
+  it('TBA: Test1', () =>
+    Assertions.checkPaste(
+      'TBA',
 
-    (
-      '<table>' +
-      '<thead>' +
-      '<tr><td>H1</td><td>X1</td><td>H2</td></tr>' +
-      '</thead>' +
-      '<tbody>' +
-      '<tr><td>A2</td><td>X2</td><td>B2</td></tr>' +
-      '<tr><td>A3</td><td>X3</td><td>B3</td></tr>' +
-      '</tbody>' +
-      '<tfoot>' +
-      '<tr><td>F1</td><td>X4</td><td>F2</td></tr>' +
-      '</tfoot>' +
-      '</table>'
-    ),
+      (
+        '<table>' +
+        '<thead>' +
+        '<tr><td>H1</td><td>X1</td><td>H2</td></tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr><td>A2</td><td>X2</td><td>B2</td></tr>' +
+        '<tr><td>A3</td><td>X3</td><td>B3</td></tr>' +
+        '</tbody>' +
+        '<tfoot>' +
+        '<tr><td>F1</td><td>X4</td><td>F2</td></tr>' +
+        '</tfoot>' +
+        '</table>'
+      ),
 
-    (
-      '<table>' +
-      '<thead>' +
-      '<tr><td>H1</td><td>H2</td></tr>' +
-      '</thead>' +
-      '<tbody>' +
-      '<tr><td>A2</td><td>B2</td></tr>' +
-      '<tr><td>A3</td><td>B3</td></tr>' +
-      '</tbody>' +
-      '<tfoot>' +
-      '<tr><td>F1</td><td>F2</td></tr>' +
-      '</tfoot>' +
-      '</table>'
-    ),
+      (
+        '<table>' +
+        '<thead>' +
+        '<tr><td>H1</td><td>H2</td></tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr><td>A2</td><td>B2</td></tr>' +
+        '<tr><td>A3</td><td>B3</td></tr>' +
+        '</tbody>' +
+        '<tfoot>' +
+        '<tr><td>F1</td><td>F2</td></tr>' +
+        '</tfoot>' +
+        '</table>'
+      ),
 
-    '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
+      '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
 
-    TableOperations.pasteColsAfter, 0, 0, 0
+      TableOperations.pasteColsAfter, 0, 0, 0
+    )
   );
 
-  Assertions.checkPaste(
-    'TBA',
+  it('TBA: Test2', () =>
+    Assertions.checkPaste(
+      'TBA',
 
-    (
-      '<table>' +
-      '<thead>' +
-      '<tr><td>H1</td><td>H2</td><td>X1</td></tr>' +
-      '</thead>' +
-      '<tbody>' +
-      '<tr><td>A2</td><td>B2</td><td>X2</td></tr>' +
-      '<tr><td>A3</td><td>B3</td><td>X3</td></tr>' +
-      '</tbody>' +
-      '<tfoot>' +
-      '<tr><td>F1</td><td>F2</td><td>X4</td></tr>' +
-      '</tfoot>' +
-      '</table>'
-    ),
+      (
+        '<table>' +
+        '<thead>' +
+        '<tr><td>H1</td><td>H2</td><td>X1</td></tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr><td>A2</td><td>B2</td><td>X2</td></tr>' +
+        '<tr><td>A3</td><td>B3</td><td>X3</td></tr>' +
+        '</tbody>' +
+        '<tfoot>' +
+        '<tr><td>F1</td><td>F2</td><td>X4</td></tr>' +
+        '</tfoot>' +
+        '</table>'
+      ),
 
-    (
-      '<table>' +
-      '<thead>' +
-      '<tr><td>H1</td><td>H2</td></tr>' +
-      '</thead>' +
-      '<tbody>' +
-      '<tr><td>A2</td><td>B2</td></tr>' +
-      '<tr><td>A3</td><td>B3</td></tr>' +
-      '</tbody>' +
-      '<tfoot>' +
-      '<tr><td>F1</td><td>F2</td></tr>' +
-      '</tfoot>' +
-      '</table>'
-    ),
+      (
+        '<table>' +
+        '<thead>' +
+        '<tr><td>H1</td><td>H2</td></tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr><td>A2</td><td>B2</td></tr>' +
+        '<tr><td>A3</td><td>B3</td></tr>' +
+        '</tbody>' +
+        '<tfoot>' +
+        '<tr><td>F1</td><td>F2</td></tr>' +
+        '</tfoot>' +
+        '</table>'
+      ),
 
-    '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
+      '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
 
-    TableOperations.pasteColsAfter, 1, 1, 1
+      TableOperations.pasteColsAfter, 1, 1, 1
+    )
   );
 
-  Assertions.checkPaste(
-    'TBA',
+  it('TBA: Test3', () =>
+    Assertions.checkPaste(
+      'TBA',
 
-    (
-      '<table>' +
-      '<thead>' +
-      '<tr><td>X1</td><td>H1</td><td>H2</td></tr>' +
-      '</thead>' +
-      '<tbody>' +
-      '<tr><td>X2</td><td>A2</td><td>B2</td></tr>' +
-      '<tr><td>X3</td><td>A3</td><td>B3</td></tr>' +
-      '</tbody>' +
-      '<tfoot>' +
-      '<tr><td>X4</td><td>F1</td><td>F2</td></tr>' +
-      '</tfoot>' +
-      '</table>'
-    ),
+      (
+        '<table>' +
+        '<thead>' +
+        '<tr><td>X1</td><td>H1</td><td>H2</td></tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr><td>X2</td><td>A2</td><td>B2</td></tr>' +
+        '<tr><td>X3</td><td>A3</td><td>B3</td></tr>' +
+        '</tbody>' +
+        '<tfoot>' +
+        '<tr><td>X4</td><td>F1</td><td>F2</td></tr>' +
+        '</tfoot>' +
+        '</table>'
+      ),
 
-    (
-      '<table>' +
-      '<thead>' +
-      '<tr><td>H1</td><td>H2</td></tr>' +
-      '</thead>' +
-      '<tbody>' +
-      '<tr><td>A2</td><td>B2</td></tr>' +
-      '<tr><td>A3</td><td>B3</td></tr>' +
-      '</tbody>' +
-      '<tfoot>' +
-      '<tr><td>F1</td><td>F2</td></tr>' +
-      '</tfoot>' +
-      '</table>'
-    ),
+      (
+        '<table>' +
+        '<thead>' +
+        '<tr><td>H1</td><td>H2</td></tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr><td>A2</td><td>B2</td></tr>' +
+        '<tr><td>A3</td><td>B3</td></tr>' +
+        '</tbody>' +
+        '<tfoot>' +
+        '<tr><td>F1</td><td>F2</td></tr>' +
+        '</tfoot>' +
+        '</table>'
+      ),
 
-    '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
+      '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
 
-    TableOperations.pasteColsBefore, 0, 0, 0
+      TableOperations.pasteColsBefore, 0, 0, 0
+    )
   );
 
-  Assertions.checkPaste(
-    'TBA',
+  it('TBA: Test4', () =>
+    Assertions.checkPaste(
+      'TBA',
 
-    (
-      '<table>' +
-      '<thead>' +
-      '<tr><td>H1</td><td>X1</td><td>H2</td></tr>' +
-      '</thead>' +
-      '<tbody>' +
-      '<tr><td>A2</td><td>X2</td><td>B2</td></tr>' +
-      '<tr><td>A3</td><td>X3</td><td>B3</td></tr>' +
-      '</tbody>' +
-      '<tfoot>' +
-      '<tr><td>F1</td><td>X4</td><td>F2</td></tr>' +
-      '</tfoot>' +
-      '</table>'
-    ),
+      (
+        '<table>' +
+        '<thead>' +
+        '<tr><td>H1</td><td>X1</td><td>H2</td></tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr><td>A2</td><td>X2</td><td>B2</td></tr>' +
+        '<tr><td>A3</td><td>X3</td><td>B3</td></tr>' +
+        '</tbody>' +
+        '<tfoot>' +
+        '<tr><td>F1</td><td>X4</td><td>F2</td></tr>' +
+        '</tfoot>' +
+        '</table>'
+      ),
 
-    (
-      '<table>' +
-      '<thead>' +
-      '<tr><td>H1</td><td>H2</td></tr>' +
-      '</thead>' +
-      '<tbody>' +
-      '<tr><td>A2</td><td>B2</td></tr>' +
-      '<tr><td>A3</td><td>B3</td></tr>' +
-      '</tbody>' +
-      '<tfoot>' +
-      '<tr><td>F1</td><td>F2</td></tr>' +
-      '</tfoot>' +
-      '</table>'
-    ),
+      (
+        '<table>' +
+        '<thead>' +
+        '<tr><td>H1</td><td>H2</td></tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr><td>A2</td><td>B2</td></tr>' +
+        '<tr><td>A3</td><td>B3</td></tr>' +
+        '</tbody>' +
+        '<tfoot>' +
+        '<tr><td>F1</td><td>F2</td></tr>' +
+        '</tfoot>' +
+        '</table>'
+      ),
 
-    '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
+      '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
 
-    TableOperations.pasteColsBefore, 1, 1, 1
+      TableOperations.pasteColsBefore, 1, 1, 1
+    )
   );
 
-  // Colspan
-  Assertions.checkPaste(
-    'TBA',
+  it('TBA: Test5', () =>
+    // Colspan
+    Assertions.checkPaste(
+      'TBA',
 
-    (
-      '<table>' +
-      '<thead>' +
-      '<tr><td>H1</td><td colspan="2">X1</td><td>H2</td></tr>' +
-      '</thead>' +
-      '<tbody>' +
-      '<tr><td>A2</td><td>X2</td><td>Y2</td><td>B2</td></tr>' +
-      '<tr><td>A3</td><td>X3</td><td>Y3</td><td>B3</td></tr>' +
-      '</tbody>' +
-      '<tfoot>' +
-      '<tr><td>F1</td><td>X4</td><td>Y4</td><td>F2</td></tr>' +
-      '</tfoot>' +
-      '</table>'
-    ),
+      (
+        '<table>' +
+        '<thead>' +
+        '<tr><td>H1</td><td colspan="2">X1</td><td>H2</td></tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr><td>A2</td><td>X2</td><td>Y2</td><td>B2</td></tr>' +
+        '<tr><td>A3</td><td>X3</td><td>Y3</td><td>B3</td></tr>' +
+        '</tbody>' +
+        '<tfoot>' +
+        '<tr><td>F1</td><td>X4</td><td>Y4</td><td>F2</td></tr>' +
+        '</tfoot>' +
+        '</table>'
+      ),
 
-    (
-      '<table>' +
-      '<thead>' +
-      '<tr><td>H1</td><td>H2</td></tr>' +
-      '</thead>' +
-      '<tbody>' +
-      '<tr><td>A2</td><td>B2</td></tr>' +
-      '<tr><td>A3</td><td>B3</td></tr>' +
-      '</tbody>' +
-      '<tfoot>' +
-      '<tr><td>F1</td><td>F2</td></tr>' +
-      '</tfoot>' +
-      '</table>'
-    ),
+      (
+        '<table>' +
+        '<thead>' +
+        '<tr><td>H1</td><td>H2</td></tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr><td>A2</td><td>B2</td></tr>' +
+        '<tr><td>A3</td><td>B3</td></tr>' +
+        '</tbody>' +
+        '<tfoot>' +
+        '<tr><td>F1</td><td>F2</td></tr>' +
+        '</tfoot>' +
+        '</table>'
+      ),
 
-    '<tr><td colspan="2">X1</td></tr><tr><td>X2</td><td>Y2</td></tr><tr><td>X3</td><td>Y3</td></tr><tr><td>X4</td><td>Y4</td></tr>',
+      '<tr><td colspan="2">X1</td></tr><tr><td>X2</td><td>Y2</td></tr><tr><td>X3</td><td>Y3</td></tr><tr><td>X4</td><td>Y4</td></tr>',
 
-    TableOperations.pasteColsAfter, 0, 0, 0
+      TableOperations.pasteColsAfter, 0, 0, 0
+    )
   );
 
-  // Rowspan
-  Assertions.checkPaste(
-    'TBA',
+  it('TBA: Test6', () =>
+    // Rowspan
+    Assertions.checkPaste(
+      'TBA',
 
-    (
-      '<table>' +
-      '<thead>' +
-      '<tr><td>H1</td><td>X1</td><td>H2</td></tr>' +
-      '</thead>' +
-      '<tbody>' +
-      '<tr><td>A2</td><td rowspan="2">X2</td><td>B2</td></tr>' +
-      '<tr><td>A3</td><td>B3</td></tr>' +
-      '</tbody>' +
-      '<tfoot>' +
-      '<tr><td>F1</td><td>X4</td><td>F2</td></tr>' +
-      '</tfoot>' +
-      '</table>'
-    ),
+      (
+        '<table>' +
+        '<thead>' +
+        '<tr><td>H1</td><td>X1</td><td>H2</td></tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr><td>A2</td><td rowspan="2">X2</td><td>B2</td></tr>' +
+        '<tr><td>A3</td><td>B3</td></tr>' +
+        '</tbody>' +
+        '<tfoot>' +
+        '<tr><td>F1</td><td>X4</td><td>F2</td></tr>' +
+        '</tfoot>' +
+        '</table>'
+      ),
 
-    (
-      '<table>' +
-      '<thead>' +
-      '<tr><td>H1</td><td>H2</td></tr>' +
-      '</thead>' +
-      '<tbody>' +
-      '<tr><td>A2</td><td>B2</td></tr>' +
-      '<tr><td>A3</td><td>B3</td></tr>' +
-      '</tbody>' +
-      '<tfoot>' +
-      '<tr><td>F1</td><td>F2</td></tr>' +
-      '</tfoot>' +
-      '</table>'
-    ),
+      (
+        '<table>' +
+        '<thead>' +
+        '<tr><td>H1</td><td>H2</td></tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr><td>A2</td><td>B2</td></tr>' +
+        '<tr><td>A3</td><td>B3</td></tr>' +
+        '</tbody>' +
+        '<tfoot>' +
+        '<tr><td>F1</td><td>F2</td></tr>' +
+        '</tfoot>' +
+        '</table>'
+      ),
 
-    '<tr><td>X1</td></tr><tr><td rowspan="2">X2</td></tr><tr></tr><tr><td>X4</td></tr>',
+      '<tr><td>X1</td></tr><tr><td rowspan="2">X2</td></tr><tr></tr><tr><td>X4</td></tr>',
 
-    TableOperations.pasteColsBefore, 1, 0, 1
+      TableOperations.pasteColsBefore, 1, 0, 1
+    )
   );
 
-  Assertions.checkPaste(
-    'Test pasting cols (before) into table where num of rows in copied cols is less than number of rows in the table being pasted into',
+  it('TBA: Test pasting cols (before) into table where num of rows in copied cols is less than number of rows in the table being pasted into', () =>
+    Assertions.checkPaste(
+      'Test pasting cols (before) into table where num of rows in copied cols is less than number of rows in the table being pasted into',
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>X1</td><td>B2</td></tr>',
-        '<tr><td>A3</td><td>?</td><td>B3</td></tr>'
-      ],
-      [], [],
-      { numCols: 3, colgroup: false, lockedColumns: [ 0 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>X1</td><td>B2</td></tr>',
+          '<tr><td>A3</td><td>?</td><td>B3</td></tr>'
+        ],
+        [], [],
+        { numCols: 3, colgroup: false, lockedColumns: [ 0 ] }
+      ),
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>B2</td></tr>',
-        '<tr><td>A3</td><td>B3</td></tr>'
-      ],
-      [], [],
-      { numCols: 2, colgroup: false, lockedColumns: [ 0 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>B2</td></tr>',
+          '<tr><td>A3</td><td>B3</td></tr>'
+        ],
+        [], [],
+        { numCols: 2, colgroup: false, lockedColumns: [ 0 ] }
+      ),
 
-    '<tr><td>X1</td></tr>',
+      '<tr><td>X1</td></tr>',
 
-    TableOperations.pasteColsBefore, 0, 0, 1
+      TableOperations.pasteColsBefore, 0, 0, 1
+    )
   );
 
-  Assertions.checkPaste(
-    'Test pasting cols (after) into table where num of rows in copied cols is less than number of rows in the table being pasted into',
+  it('TBA: Test pasting cols (after) into table where num of rows in copied cols is less than number of rows in the table being pasted into', () =>
+    Assertions.checkPaste(
+      'Test pasting cols (after) into table where num of rows in copied cols is less than number of rows in the table being pasted into',
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>X1</td><td>B2</td></tr>',
-        '<tr><td>A3</td><td>?</td><td>B3</td></tr>'
-      ],
-      [], [],
-      { numCols: 3, colgroup: false, lockedColumns: [ 2 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>X1</td><td>B2</td></tr>',
+          '<tr><td>A3</td><td>?</td><td>B3</td></tr>'
+        ],
+        [], [],
+        { numCols: 3, colgroup: false, lockedColumns: [ 2 ] }
+      ),
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>B2</td></tr>',
-        '<tr><td>A3</td><td>B3</td></tr>'
-      ],
-      [], [],
-      { numCols: 2, colgroup: false, lockedColumns: [ 1 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>B2</td></tr>',
+          '<tr><td>A3</td><td>B3</td></tr>'
+        ],
+        [], [],
+        { numCols: 2, colgroup: false, lockedColumns: [ 1 ] }
+      ),
 
-    '<tr><td>X1</td></tr>',
+      '<tr><td>X1</td></tr>',
 
-    TableOperations.pasteColsAfter, 0, 0, 0
+      TableOperations.pasteColsAfter, 0, 0, 0
+    )
   );
 
-  Assertions.checkPaste(
-    'Test pasting cols (before) into table where num of rows in copied cols is greater than number of rows in the table being pasted into',
+  it('TBA: Test pasting cols (before) into table where num of rows in copied cols is greater than number of rows in the table being pasted into', () =>
+    Assertions.checkPaste(
+      'Test pasting cols (before) into table where num of rows in copied cols is greater than number of rows in the table being pasted into',
 
-    generateTestTable(
-      [
-        '<tr><td>X1</td><td>A2</td><td>B2</td></tr>',
-        '<tr><td>X2</td><td>A3</td><td>B3</td></tr>',
-        '<tr><td>X3</td><td>?</td><td>?</td></tr>',
-        '<tr><td>X4</td><td>?</td><td>?</td></tr>'
-      ],
-      [], [],
-      { numCols: 3, colgroup: false, lockedColumns: [ 2 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>X1</td><td>A2</td><td>B2</td></tr>',
+          '<tr><td>X2</td><td>A3</td><td>B3</td></tr>',
+          '<tr><td>X3</td><td>?</td><td>?</td></tr>',
+          '<tr><td>X4</td><td>?</td><td>?</td></tr>'
+        ],
+        [], [],
+        { numCols: 3, colgroup: false, lockedColumns: [ 2 ] }
+      ),
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>B2</td></tr>',
-        '<tr><td>A3</td><td>B3</td></tr>'
-      ],
-      [], [],
-      { numCols: 2, colgroup: false, lockedColumns: [ 1 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>B2</td></tr>',
+          '<tr><td>A3</td><td>B3</td></tr>'
+        ],
+        [], [],
+        { numCols: 2, colgroup: false, lockedColumns: [ 1 ] }
+      ),
 
-    '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
+      '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
 
-    TableOperations.pasteColsBefore, 0, 0, 0
+      TableOperations.pasteColsBefore, 0, 0, 0
+    )
   );
 
-  Assertions.checkPaste(
-    'Test pasting cols (after) into table where num of rows in copied cols is greater than number of rows in the table being pasted into',
+  it('TBA: Test pasting cols (after) into table where num of rows in copied cols is greater than number of rows in the table being pasted into', () =>
+    Assertions.checkPaste(
+      'Test pasting cols (after) into table where num of rows in copied cols is greater than number of rows in the table being pasted into',
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>B2</td><td>X1</td></tr>',
-        '<tr><td>A3</td><td>B3</td><td>X2</td></tr>',
-        '<tr><td>?</td><td>?</td><td>X3</td></tr>',
-        '<tr><td>?</td><td>?</td><td>X4</td></tr>'
-      ],
-      [], [],
-      { numCols: 3, colgroup: false, lockedColumns: [ 0 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>B2</td><td>X1</td></tr>',
+          '<tr><td>A3</td><td>B3</td><td>X2</td></tr>',
+          '<tr><td>?</td><td>?</td><td>X3</td></tr>',
+          '<tr><td>?</td><td>?</td><td>X4</td></tr>'
+        ],
+        [], [],
+        { numCols: 3, colgroup: false, lockedColumns: [ 0 ] }
+      ),
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>B2</td></tr>',
-        '<tr><td>A3</td><td>B3</td></tr>'
-      ],
-      [], [],
-      { numCols: 2, colgroup: false, lockedColumns: [ 0 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>B2</td></tr>',
+          '<tr><td>A3</td><td>B3</td></tr>'
+        ],
+        [], [],
+        { numCols: 2, colgroup: false, lockedColumns: [ 0 ] }
+      ),
 
-    '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
+      '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
 
-    TableOperations.pasteColsAfter, 0, 0, 1
+      TableOperations.pasteColsAfter, 0, 0, 1
+    )
   );
 
-  Assertions.checkPaste(
-    'TINY-6765: Test that pasting cols (before) is a noop when the first column in the table is locked and selected',
+  it('TINY-6765: Test that pasting cols (before) is a noop when the first column in the table is locked and selected', () =>
+    Assertions.checkPaste(
+      'TINY-6765: Test that pasting cols (before) is a noop when the first column in the table is locked and selected',
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>B2</td></tr>',
-        '<tr><td>A3</td><td>B3</td></tr>'
-      ],
-      [], [],
-      { numCols: 2, colgroup: false, lockedColumns: [ 0 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>B2</td></tr>',
+          '<tr><td>A3</td><td>B3</td></tr>'
+        ],
+        [], [],
+        { numCols: 2, colgroup: false, lockedColumns: [ 0 ] }
+      ),
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>B2</td></tr>',
-        '<tr><td>A3</td><td>B3</td></tr>'
-      ],
-      [], [],
-      { numCols: 2, colgroup: false, lockedColumns: [ 0 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>B2</td></tr>',
+          '<tr><td>A3</td><td>B3</td></tr>'
+        ],
+        [], [],
+        { numCols: 2, colgroup: false, lockedColumns: [ 0 ] }
+      ),
 
-    '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
+      '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
 
-    TableOperations.pasteColsBefore, 0, 0, 0
+      TableOperations.pasteColsBefore, 0, 0, 0
+    )
   );
 
-  Assertions.checkPaste(
-    'TINY-6765: Test that pasting cols (after) is not a noop when the first column in the table is locked and selected',
+  it('TINY-6765: Test that pasting cols (after) is not a noop when the first column in the table is locked and selected', () =>
+    Assertions.checkPaste(
+      'TINY-6765: Test that pasting cols (after) is not a noop when the first column in the table is locked and selected',
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>X1</td><td>B2</td></tr>',
-        '<tr><td>A3</td><td>X2</td><td>B3</td></tr>'
-      ],
-      [], [],
-      { numCols: 3, colgroup: false, lockedColumns: [ 0 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>X1</td><td>B2</td></tr>',
+          '<tr><td>A3</td><td>X2</td><td>B3</td></tr>'
+        ],
+        [], [],
+        { numCols: 3, colgroup: false, lockedColumns: [ 0 ] }
+      ),
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>B2</td></tr>',
-        '<tr><td>A3</td><td>B3</td></tr>'
-      ],
-      [], [],
-      { numCols: 2, colgroup: false, lockedColumns: [ 0 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>B2</td></tr>',
+          '<tr><td>A3</td><td>B3</td></tr>'
+        ],
+        [], [],
+        { numCols: 2, colgroup: false, lockedColumns: [ 0 ] }
+      ),
 
-    '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
+      '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
 
-    TableOperations.pasteColsAfter, 0, 0, 0
+      TableOperations.pasteColsAfter, 0, 0, 0
+    )
   );
 
-  Assertions.checkPaste(
-    'TINY-6765: Test that pasting cols (before) is not a noop when the last column in the table is locked and selected',
+  it('TINY-6765: Test that pasting cols (before) is not a noop when the last column in the table is locked and selected', () =>
+    Assertions.checkPaste(
+      'TINY-6765: Test that pasting cols (before) is not a noop when the last column in the table is locked and selected',
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>X1</td><td>B2</td></tr>',
-        '<tr><td>A3</td><td>X2</td><td>B3</td></tr>'
-      ],
-      [], [],
-      { numCols: 3, colgroup: false, lockedColumns: [ 2 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>X1</td><td>B2</td></tr>',
+          '<tr><td>A3</td><td>X2</td><td>B3</td></tr>'
+        ],
+        [], [],
+        { numCols: 3, colgroup: false, lockedColumns: [ 2 ] }
+      ),
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>B2</td></tr>',
-        '<tr><td>A3</td><td>B3</td></tr>'
-      ],
-      [], [],
-      { numCols: 2, colgroup: false, lockedColumns: [ 1 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>B2</td></tr>',
+          '<tr><td>A3</td><td>B3</td></tr>'
+        ],
+        [], [],
+        { numCols: 2, colgroup: false, lockedColumns: [ 1 ] }
+      ),
 
-    '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
+      '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
 
-    TableOperations.pasteColsBefore, 0, 0, 1
+      TableOperations.pasteColsBefore, 0, 0, 1
+    )
   );
 
-  Assertions.checkPaste(
-    'TINY-6765: Test that pasting cols (after) is a noop when the last column in the table is locked and selected',
+  it('TINY-6765: Test that pasting cols (after) is a noop when the last column in the table is locked and selected', () =>
+    Assertions.checkPaste(
+      'TINY-6765: Test that pasting cols (after) is a noop when the last column in the table is locked and selected',
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>B2</td></tr>',
-        '<tr><td>A3</td><td>B3</td></tr>'
-      ],
-      [], [],
-      { numCols: 2, colgroup: false, lockedColumns: [ 1 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>B2</td></tr>',
+          '<tr><td>A3</td><td>B3</td></tr>'
+        ],
+        [], [],
+        { numCols: 2, colgroup: false, lockedColumns: [ 1 ] }
+      ),
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>B2</td></tr>',
-        '<tr><td>A3</td><td>B3</td></tr>'
-      ],
-      [], [],
-      { numCols: 2, colgroup: false, lockedColumns: [ 1 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>B2</td></tr>',
+          '<tr><td>A3</td><td>B3</td></tr>'
+        ],
+        [], [],
+        { numCols: 2, colgroup: false, lockedColumns: [ 1 ] }
+      ),
 
-    '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
+      '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
 
-    TableOperations.pasteColsAfter, 0, 0, 1
+      TableOperations.pasteColsAfter, 0, 0, 1
+    )
   );
 
-  Assertions.checkPaste(
-    'TINY-6765: Test that pasting cols (before) is not a noop when the selected locked column is not the first or last column',
+  it('TINY-6765: Test that pasting cols (before) is not a noop when the selected locked column is not the first or last column', () =>
+    Assertions.checkPaste(
+      'TINY-6765: Test that pasting cols (before) is not a noop when the selected locked column is not the first or last column',
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>X1</td><td>B2</td><td>C2</td></tr>',
-        '<tr><td>A3</td><td>X2</td><td>B3</td><td>C3</td></tr>'
-      ],
-      [], [],
-      { numCols: 4, colgroup: false, lockedColumns: [ 2 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>X1</td><td>B2</td><td>C2</td></tr>',
+          '<tr><td>A3</td><td>X2</td><td>B3</td><td>C3</td></tr>'
+        ],
+        [], [],
+        { numCols: 4, colgroup: false, lockedColumns: [ 2 ] }
+      ),
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>B2</td><td>C2</td></tr>',
-        '<tr><td>A3</td><td>B3</td><td>C3</td></tr>'
-      ],
-      [], [],
-      { numCols: 3, colgroup: false, lockedColumns: [ 1 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>B2</td><td>C2</td></tr>',
+          '<tr><td>A3</td><td>B3</td><td>C3</td></tr>'
+        ],
+        [], [],
+        { numCols: 3, colgroup: false, lockedColumns: [ 1 ] }
+      ),
 
-    '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
+      '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
 
-    TableOperations.pasteColsBefore, 0, 0, 1
+      TableOperations.pasteColsBefore, 0, 0, 1
+    )
   );
 
-  Assertions.checkPaste(
-    'TINY-6765: Test that pasting cols (after) is not a noop when the selected locked column is not the first or last column',
+  it('TINY-6765: Test that pasting cols (after) is not a noop when the selected locked column is not the first or last column', () =>
+    Assertions.checkPaste(
+      'TINY-6765: Test that pasting cols (after) is not a noop when the selected locked column is not the first or last column',
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>B2</td><td>X1</td><td>C2</td></tr>',
-        '<tr><td>A3</td><td>B3</td><td>X2</td><td>C3</td></tr>'
-      ],
-      [], [],
-      { numCols: 4, colgroup: false, lockedColumns: [ 1 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>B2</td><td>X1</td><td>C2</td></tr>',
+          '<tr><td>A3</td><td>B3</td><td>X2</td><td>C3</td></tr>'
+        ],
+        [], [],
+        { numCols: 4, colgroup: false, lockedColumns: [ 1 ] }
+      ),
 
-    generateTestTable(
-      [
-        '<tr><td>A2</td><td>B2</td><td>C2</td></tr>',
-        '<tr><td>A3</td><td>B3</td><td>C3</td></tr>'
-      ],
-      [], [],
-      { numCols: 3, colgroup: false, lockedColumns: [ 1 ] }
-    ),
+      generateTestTable(
+        [
+          '<tr><td>A2</td><td>B2</td><td>C2</td></tr>',
+          '<tr><td>A3</td><td>B3</td><td>C3</td></tr>'
+        ],
+        [], [],
+        { numCols: 3, colgroup: false, lockedColumns: [ 1 ] }
+      ),
 
-    '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
+      '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
 
-    TableOperations.pasteColsAfter, 0, 0, 1
+      TableOperations.pasteColsAfter, 0, 0, 1
+    )
+  );
+
+  it('TINY-8040: Paste a column into the middle of a large colspan, after version', () =>
+    Assertions.checkPaste(
+      'Paste a column into the middle of a large colspan',
+
+      (
+        '<table>' +
+          '<thead>' +
+            '<tr><td>H1</td><td>H2</td><td>H3</td><td>H4</td><td>H5</td><td>H6</td><td>X</td><td>H7</td><td>H8</td><td>H9</td><td>H0</td></tr>' +
+          '</thead>' +
+          '<tbody>' +
+            '<tr><td>A1</td><td colspan="5">A2</td><td>?</td><td colspan="3">?</td><td>A3</td></tr>' +
+          '</tbody>' +
+        '</table>'
+      ),
+
+      (
+        '<table>' +
+          '<thead>' +
+            '<tr><td>H1</td><td>H2</td><td>H3</td><td>H4</td><td>H5</td><td>H6</td><td>H7</td><td>H8</td><td>H9</td><td>H0</td></tr>' +
+          '</thead>' +
+          '<tbody>' +
+            '<tr><td>A1</td><td colspan="8">A2</td><td>A3</td></tr>' +
+          '</tbody>' +
+        '</table>'
+      ),
+
+      (
+        '<tr>' +
+          '<td>X</td>' +
+        '</tr>' +
+        '<tr></tr>'
+      ),
+
+      TableOperations.pasteColsAfter, 0, 0, 5
+    )
+  );
+
+  it('TINY-8040: Paste a column into the middle of a large colspan, before version', () =>
+    Assertions.checkPaste(
+      'Paste a column into the middle of a large colspan',
+
+      (
+        '<table>' +
+          '<thead>' +
+            '<tr><td>H1</td><td>H2</td><td>H3</td><td>H4</td><td>H5</td><td>X</td><td>H6</td><td>H7</td><td>H8</td><td>H9</td><td>H0</td></tr>' +
+          '</thead>' +
+          '<tbody>' +
+            '<tr><td>A1</td><td colspan="4">A2</td><td>?</td><td colspan="4">?</td><td>A3</td></tr>' +
+          '</tbody>' +
+        '</table>'
+      ),
+
+      (
+        '<table>' +
+          '<thead>' +
+            '<tr><td>H1</td><td>H2</td><td>H3</td><td>H4</td><td>H5</td><td>H6</td><td>H7</td><td>H8</td><td>H9</td><td>H0</td></tr>' +
+          '</thead>' +
+          '<tbody>' +
+            '<tr><td>A1</td><td colspan="8">A2</td><td>A3</td></tr>' +
+          '</tbody>' +
+        '</table>'
+      ),
+
+      (
+        '<tr>' +
+          '<td>X</td>' +
+        '</tr>' +
+        '<tr></tr>'
+      ),
+
+      TableOperations.pasteColsBefore, 0, 0, 5
+    )
   );
 
   /*

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switching between unordered and ordered lists would incorrectly alter any parent element that contained that list #TINY-8068
 - Custom elements on blank lines would be removed during serialization #TINY-4784
 - Pasting columns in tables could sometimes result in an invalid table #TINY-8040
+- Copying columns in tables could sometimes result in an invalid copy #TINY-8040
 - The URL detection used for `autolink` and smart paste didn't work if a path segment contained valid characters such as `!` and `:` #TINY-8069
 - Cutting content to the clipboard while selecting between the parent list and a nested list would not always set the list style to `none` on the parent list #TINY-8078
 - Copy events were not dispatched in readonly mode #TINY-6800

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Indenting or outdenting list items inside a block element that was inside another list item would not work #TINY-7209
 - Switching between unordered and ordered lists would incorrectly alter any parent element that contained that list #TINY-8068
 - Custom elements on blank lines would be removed during serialization #TINY-4784
+- Pasting columns in tables could sometimes result in an invalid table #TINY-8040
 - The URL detection used for `autolink` and smart paste didn't work if a path segment contained valid characters such as `!` and `:` #TINY-8069
 - Cutting content to the clipboard while selecting between the parent list and a nested list would not always set the list style to `none` on the parent list #TINY-8078
 - Copy events were not dispatched in readonly mode #TINY-6800


### PR DESCRIPTION
Related Ticket:

Description of Changes:
This issue is only concerned with preventing the editor from creating illegal tables.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
