### PR TITLE
TINY-8750: Fixed a failing test in CssTest on Chrome 102

### DIFF
--- a/modules/sugar/src/test/ts/browser/CssTest.ts
+++ b/modules/sugar/src/test/ts/browser/CssTest.ts
@@ -39,8 +39,9 @@ UnitTest.test('CssTest', () => {
     Css.copy(c, c2);
     Css.copy(m, c2);
 
-    // NOTE: Safari, Firefox 71+ and Chrome 102+ seem to support styles for math ml tags, so the Css.copy(m, c2) clobbers the previous style
+    // NOTE: Safari, Firefox 71+ and Chromium 102+ seem to support styles for math ml tags, so the Css.copy(m, c2) clobbers the previous style
     const browser = PlatformDetection.detect().browser;
+    // Would cover other Chromium based browsers such as Chrome and Edge
     if (browser.isSafari() || browser.isFirefox() && browser.version.major >= 71 || browser.isChromium() && browser.version.major >= 102) {
       Css.copy(c, c2);
     }

--- a/modules/sugar/src/test/ts/browser/CssTest.ts
+++ b/modules/sugar/src/test/ts/browser/CssTest.ts
@@ -39,7 +39,7 @@ UnitTest.test('CssTest', () => {
     Css.copy(c, c2);
     Css.copy(m, c2);
 
-    // NOTE: Safari, Firefox 71+ and Chrome 102 seem to support styles for math ml tags, so the Css.copy(m, c2) clobbers the previous style
+    // NOTE: Safari, Firefox 71+ and Chrome 102+ seem to support styles for math ml tags, so the Css.copy(m, c2) clobbers the previous style
     const browser = PlatformDetection.detect().browser;
     if (browser.isSafari() || browser.isFirefox() && browser.version.major >= 71 || browser.isChromium() && browser.version.major >= 102) {
       Css.copy(c, c2);

--- a/modules/sugar/src/test/ts/browser/CssTest.ts
+++ b/modules/sugar/src/test/ts/browser/CssTest.ts
@@ -39,7 +39,7 @@ UnitTest.test('CssTest', () => {
     Css.copy(c, c2);
     Css.copy(m, c2);
 
-    // NOTE: Safari and Firefox 71+ seems to support styles for math ml tags, so the Css.copy(m, c2) clobbers the previous style
+    // NOTE: Safari, Firefox 71+ and Chrome 102 seem to support styles for math ml tags, so the Css.copy(m, c2) clobbers the previous style
     const browser = PlatformDetection.detect().browser;
     if (browser.isSafari() || browser.isFirefox() && browser.version.major >= 71 || browser.isChromium() && browser.version.major >= 102) {
       Css.copy(c, c2);

--- a/modules/sugar/src/test/ts/browser/CssTest.ts
+++ b/modules/sugar/src/test/ts/browser/CssTest.ts
@@ -41,7 +41,6 @@ UnitTest.test('CssTest', () => {
 
     // NOTE: Safari, Firefox 71+ and Chromium 102+ seem to support styles for math ml tags, so the Css.copy(m, c2) clobbers the previous style
     const browser = PlatformDetection.detect().browser;
-    // Would cover other Chromium based browsers such as Chrome and Edge
     if (browser.isSafari() || browser.isFirefox() && browser.version.major >= 71 || browser.isChromium() && browser.version.major >= 102) {
       Css.copy(c, c2);
     }

--- a/modules/sugar/src/test/ts/browser/CssTest.ts
+++ b/modules/sugar/src/test/ts/browser/CssTest.ts
@@ -41,7 +41,7 @@ UnitTest.test('CssTest', () => {
 
     // NOTE: Safari and Firefox 71+ seems to support styles for math ml tags, so the Css.copy(m, c2) clobbers the previous style
     const browser = PlatformDetection.detect().browser;
-    if (browser.isSafari() || browser.isFirefox() && browser.version.major >= 71) {
+    if (browser.isSafari() || browser.isFirefox() && browser.version.major >= 71 || browser.isChromium() && browser.version.major >= 102) {
       Css.copy(c, c2);
     }
 


### PR DESCRIPTION
Related Ticket: TINY-8750

Chrome 102 added further MathML support so that those elements can be styled via the browser APIs. And that fails a test in `modules/sugar/src/test/ts/browser/CssTest.ts`. 

Description of Changes:
* Update the check to clobber to the expected CSS for Chrome 102

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
