### PR TITLE
TINY-8759: Autocompleter checks for block elements and not just for root

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Copying columns in tables could sometimes result in an invalid copy #TINY-8040
 - The URL detection used for `autolink` and smart paste didn't work if a path segment contained valid characters such as `!` and `:` #TINY-8069
 - Cutting content to the clipboard while selecting between the parent list and a nested list would not always set the list style to `none` on the parent list #TINY-8078
-- Autocompleter would sometimes not trigger #TINY-8759
+- The autocompleter would not trigger at the start of nested list items #TINY-8759
 - Some option values for the `template` plugin weren't escaped properly when doing replacement lookups via a `RegExp` #TINY-7433
 - Copy events were not dispatched in readonly mode #TINY-6800
 - Using Ctrl+Shift+Home/End (Cmd+Shift+Up/Down on Mac) would not expand the selection when a `contenteditable="false"` element was at the edge of content #TINY-7795

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Copying columns in tables could sometimes result in an invalid copy #TINY-8040
 - The URL detection used for `autolink` and smart paste didn't work if a path segment contained valid characters such as `!` and `:` #TINY-8069
 - Cutting content to the clipboard while selecting between the parent list and a nested list would not always set the list style to `none` on the parent list #TINY-8078
+- Autocompleter would sometimes not trigger #TINY-8759
 - Some option values for the `template` plugin weren't escaped properly when doing replacement lookups via a `RegExp` #TINY-7433
 - Copy events were not dispatched in readonly mode #TINY-6800
 - Using Ctrl+Shift+Home/End (Cmd+Shift+Up/Down on Mac) would not expand the selection when a `contenteditable="false"` element was at the edge of content #TINY-7795

--- a/modules/tinymce/src/core/main/ts/autocomplete/AutocompleteLookup.ts
+++ b/modules/tinymce/src/core/main/ts/autocomplete/AutocompleteLookup.ts
@@ -15,12 +15,13 @@ export interface AutocompleteLookupInfo {
   lookupData: Promise<AutocompleteLookupData[]>;
 }
 
-const isPreviousCharContent = (dom: DOMUtils, leaf: Spot.SpotPoint<Node>) =>
+const isPreviousCharContent = (dom: DOMUtils, leaf: Spot.SpotPoint<Node>) => {
   // If at the start of the range, then we need to look backwards one more place. Otherwise we just need to look at the current text
-  TextSearch.repeatLeft(dom, leaf.container, leaf.offset, (element, offset) => offset === 0 ? -1 : offset, dom.getRoot()).filter((spot) => {
+  return TextSearch.repeatLeft(dom, leaf.container, leaf.offset, (_element, offset) => offset === 0 ? -1 : offset, dom.getParent(leaf.container, dom.isBlock)).filter((spot) => {
     const char = spot.container.data.charAt(spot.offset - 1);
     return !isWhitespace(char);
   }).isSome();
+};
 
 const isStartOfWord = (dom: DOMUtils) => (rng: Range) => {
   const leaf = TextDescent.toLeaf(rng.startContainer, rng.startOffset);

--- a/modules/tinymce/src/core/main/ts/autocomplete/AutocompleteLookup.ts
+++ b/modules/tinymce/src/core/main/ts/autocomplete/AutocompleteLookup.ts
@@ -17,7 +17,8 @@ export interface AutocompleteLookupInfo {
 
 const isPreviousCharContent = (dom: DOMUtils, leaf: Spot.SpotPoint<Node>) => {
   // If at the start of the range, then we need to look backwards one more place. Otherwise we just need to look at the current text
-  return TextSearch.repeatLeft(dom, leaf.container, leaf.offset, (_element, offset) => offset === 0 ? -1 : offset, dom.getParent(leaf.container, dom.isBlock)).filter((spot) => {
+  const root = dom.getParent(leaf.container, dom.isBlock);
+  return TextSearch.repeatLeft(dom, leaf.container, leaf.offset, (_element, offset) => offset === 0 ? -1 : offset, root).filter((spot) => {
     const char = spot.container.data.charAt(spot.offset - 1);
     return !isWhitespace(char);
   }).isSome();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
@@ -555,6 +555,33 @@ describe('browser.tinymce.themes.silver.editor.autocomplete.AutocompleteTest', (
       TinyContentActions.keydown(editor, Keys.enter());
       await pWaitForAutocompleteToClose();
     });
+
+    it('TINY-8759: In a nested list', async () => {
+      const editor = hook.editor();
+      await pSetContentAndTrigger(editor, {
+        initialContent: '<ul><li>Text<ul><li>*</li></ul></li></ul>',
+        triggerChar: '*',
+        additionalContent: 'bc',
+        cursorPos: {
+          elementPath: [ 1, 0, 1, 0 ],
+          offset: 1
+        }
+      });
+      await TinyUiActions.pWaitForPopup(editor, '.tox-autocompleter div[role="menu"]');
+      await pAssertAutocompleterStructure({
+        type: 'grid',
+        groups: [
+          [
+            { title: 'asterisk-a', icon: '*' },
+            { title: 'asterisk-b', icon: '*' },
+            { title: 'asterisk-c', icon: '*' },
+            { title: 'asterisk-d', icon: '*' }
+          ]
+        ]
+      });
+      TinyContentActions.keydown(editor, Keys.enter());
+      await pWaitForAutocompleteToClose();
+    });
   });
 
   it('Checking autocomplete activation based on content', async () => {


### PR DESCRIPTION
Related Ticket:

Description of Changes:
Autocompleter would step out of block elements to check for previous text, causing it to not trigger in situations where a block element was nested in another, such as a nested list.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
