### PR TITLE
TINY-6476: Fixed the autocompleter positioning the menu incorrectly

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Changed tabbing behavior escape key handling to run from `keydown` to `keyup` to prevent unwanted key event propagation #TINY-7005
 
+### Fixed
+- The `fakeFocus` property for `InlineView` menus was not respected.
+
 ## 10.0.0 - 2022-03-03
 
 ### Added

--- a/modules/alloy/src/main/ts/ephox/alloy/api/Main.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/Main.ts
@@ -25,6 +25,7 @@ import {
 } from '../positioning/mode/Anchoring';
 import * as VerticalDir from '../positioning/mode/VerticalDir';
 import * as FormTypes from '../ui/types/FormTypes';
+import * as InlineViewTypes from '../ui/types/InlineViewTypes';
 import * as ItemTypes from '../ui/types/ItemTypes'; // not sure if this is the right thing to expose, but we use it a lot?
 import * as MenuTypes from '../ui/types/MenuTypes';
 import * as SliderTypes from '../ui/types/SliderTypes';
@@ -257,6 +258,7 @@ export {
   // types
   TieredMenuTypes,
   MenuTypes,
+  InlineViewTypes,
   SlotContainerTypes,
   SliderTypes,
   FormTypes,

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/InlineView.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/InlineView.ts
@@ -55,6 +55,7 @@ const makeMenu = (detail: InlineViewDetail, menuSandbox: AlloyComponent, placeme
     data: menuSpec.data,
     markers: menuSpec.menu.markers,
     highlightImmediately: menuSpec.menu.highlightImmediately,
+    fakeFocus: menuSpec.menu.fakeFocus,
 
     onEscape: () => {
       // Note for the future: this should possibly also call detail.onHide

--- a/modules/oxide/src/less/theme/components/form/autocomplete.less
+++ b/modules/oxide/src/less/theme/components/form/autocomplete.less
@@ -9,11 +9,7 @@
   }
 
   .tox-autocompleter .tox-menu {
-    @menu-border-color: @border-color;
-    @menu-box-shadow: none;
-
-    border-color: @menu-border-color;
-    box-shadow: @menu-box-shadow;
+    box-sizing: border-box;
     max-width: 25em;
   }
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `end_container_on_empty_block` option can now take a string of blocks to split when pressing Enter twice #TINY-6559
 - The default value for `end_container_on_empty_block` option has been changed to `'blockquote'` #TINY-6559
 - Custom elements are now treated as non-empty elements via the schema #TINY-4784
+- The autocompleter menu element is now positioned instead of the wrapper #TINY-6476
 
 ### Fixed
 - Selecting all content with a single image in the content was inconsistent for the keyboard shortcut and menu item #TINY-4550

--- a/modules/tinymce/src/themes/silver/main/ts/autocomplete/AutocompleteEditorEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/autocomplete/AutocompleteEditorEvents.ts
@@ -8,7 +8,7 @@ import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import * as AutocompleteTagReader from './AutocompleteTagReader';
 
 export interface AutocompleterUiApi {
-  readonly getView: () => Optional<AlloyComponent>;
+  readonly getMenu: () => Optional<AlloyComponent>;
   readonly isMenuOpen: () => boolean;
   readonly isActive: () => boolean;
   readonly isProcessingAction: () => boolean;
@@ -20,7 +20,7 @@ const setup = (api: AutocompleterUiApi, editor: Editor) => {
     AlloyTriggers.emitWith(item, NativeEvents.keydown(), { raw: e });
   };
 
-  const getItem = (): Optional<AlloyComponent> => api.getView().bind(Highlighting.getHighlighted);
+  const getItem = (): Optional<AlloyComponent> => api.getMenu().bind(Highlighting.getHighlighted);
 
   editor.on('keydown', (e) => {
     const keyCode = e.which;
@@ -40,7 +40,7 @@ const setup = (api: AutocompleterUiApi, editor: Editor) => {
         getItem().fold(
           // No current item, so highlight the first one
           () => {
-            api.getView().each(Highlighting.highlightFirst);
+            api.getMenu().each(Highlighting.highlightFirst);
           },
 
           // There is a current item, so move down in the menu

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/SingleMenu.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/SingleMenu.ts
@@ -1,4 +1,4 @@
-import { AlloyEvents, FocusManagers, ItemTypes, Keying, MenuTypes, TieredMenu, TieredMenuTypes } from '@ephox/alloy';
+import { AlloyEvents, InlineViewTypes, ItemTypes, Keying, TieredMenu, TieredMenuTypes } from '@ephox/alloy';
 import { InlineContent, Menu as BridgeMenu, Toolbar } from '@ephox/bridge';
 import { Arr, Obj, Optional, Optionals } from '@ephox/katamari';
 
@@ -190,36 +190,30 @@ export const createPartialMenu = (
 export const createTieredDataFrom = (partialMenu: TieredMenuTypes.PartialMenuSpec) =>
   TieredMenu.singleData(partialMenu.value, partialMenu);
 
-export const createMenuFrom = (
+export const createInlineMenuFrom = (
   partialMenu: PartialMenuSpec,
   columns: number | 'auto',
   focusMode: FocusMode,
   presets: Toolbar.PresetTypes
-): MenuTypes.MenuSpec => {
-  const focusManager = focusMode === FocusMode.ContentFocus ? FocusManagers.highlights() : FocusManagers.dom();
-
+): InlineViewTypes.InlineMenuSpec => {
   const movement = deriveMenuMovement(columns, presets);
   const menuMarkers = getMenuMarkers(presets);
 
   return {
-    dom: partialMenu.dom,
-    components: partialMenu.components,
-    items: partialMenu.items,
-    value: partialMenu.value,
-    markers: {
-      selectedItem: menuMarkers.selectedItem,
-      item: menuMarkers.item
-    },
-    movement,
-    fakeFocus: focusMode === FocusMode.ContentFocus,
-    focusManager,
-
-    menuBehaviours: SimpleBehaviours.unnamedEvents(columns !== 'auto' ? [ ] : [
-      AlloyEvents.runOnAttached((comp, _se) => {
-        detectSize(comp, 4, menuMarkers.item).each(({ numColumns, numRows }) => {
-          Keying.setGridSize(comp, numRows, numColumns);
-        });
-      })
-    ])
+    data: createTieredDataFrom({
+      ...partialMenu,
+      movement,
+      menuBehaviours: SimpleBehaviours.unnamedEvents(columns !== 'auto' ? [ ] : [
+        AlloyEvents.runOnAttached((comp, _se) => {
+          detectSize(comp, 4, menuMarkers.item).each(({ numColumns, numRows }) => {
+            Keying.setGridSize(comp, numRows, numColumns);
+          });
+        })
+      ])
+    }),
+    menu: {
+      markers: getMenuMarkers(presets),
+      fakeFocus: focusMode === FocusMode.ContentFocus
+    }
   };
 };

--- a/modules/tinymce/src/themes/silver/test/ts/module/AutocompleterUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/AutocompleterUtils.ts
@@ -84,23 +84,31 @@ const pAssertAutocompleterStructure = async (structure: AutocompleterStructure) 
         classes: [ arr.has('tox-autocompleter') ],
         children: [
           s.element('div', {
-            classes: [ arr.has('tox-menu'), arr.has(`tox-collection--${structure.type}`), arr.has('tox-collection') ],
-            children: Arr.map(structure.groups, (group) => s.element('div', {
-              classes: [ arr.has('tox-collection__group') ],
-              children: Arr.map(group, (d) => {
-                if (structure.type === 'list') {
-                  if (Type.isFunction(d)) {
-                    return d(s, str, arr);
-                  } else if (structure.hasIcons) {
-                    return structWithTitleAndIconAndText(d)(s, str, arr);
-                  } else {
-                    return structWithTitleAndText(d)(s, str, arr);
-                  }
-                } else {
-                  return structWithTitleAndIcon(d)(s, str, arr);
-                }
+            children: [
+              s.element('div', {
+                classes: [ arr.has('tox-menu'), arr.has(`tox-collection--${structure.type}`), arr.has('tox-collection') ],
+                styles: {
+                  // TINY-6476: Ensure the menu is positioned not the wrapper
+                  position: str.is('absolute')
+                },
+                children: Arr.map(structure.groups, (group) => s.element('div', {
+                  classes: [ arr.has('tox-collection__group') ],
+                  children: Arr.map(group, (d) => {
+                    if (structure.type === 'list') {
+                      if (Type.isFunction(d)) {
+                        return d(s, str, arr);
+                      } else if (structure.hasIcons) {
+                        return structWithTitleAndIconAndText(d)(s, str, arr);
+                      } else {
+                        return structWithTitleAndText(d)(s, str, arr);
+                      }
+                    } else {
+                      return structWithTitleAndIcon(d)(s, str, arr);
+                    }
+                  })
+                }))
               })
-            }))
+            ]
           })
         ]
       })),


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* Fixes the `tox-autocompleter` sandbox being positioned instead of the menu (which in turn caused some issues with styling). The core issue is that we were using the wrong `InlineView` API as the one being used is meant to position the sandbox so that content can be swapped in and out (such as in context forms). 
* Reverted the CSS workaround done in https://github.com/tinymce/tinymce/pull/7704 due to this bug.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
