### PR TITLE
TINY-8458: Add new `newline_behavior` option

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 - New `sidebar_show` option to show the specified sidebar on initialization #TINY-8710
-- New `newline_behavior` option to control whether blocks or linebreaks are inserted #TINY-8458
+- New `newline_behavior` option to control what happens when the enter key is pressed or using commands such as `mceInsertNewLine` #TINY-8458
 
 ### Changed
 - Toggling fullscreen mode with the `fullscreen` plugin now also fires the `ResizeEditor` event #TINY-8701

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 - New `sidebar_show` option to show the specified sidebar on initialization #TINY-8710
+- New `keyboard_enter_behavior` option to control whether blocks or linebreaks are inserted #TINY-8458
 
 ### Changed
 - Toggling fullscreen mode with the `fullscreen` plugin now also fires the `ResizeEditor` event #TINY-8701

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 - New `sidebar_show` option to show the specified sidebar on initialization #TINY-8710
-- New `keyboard_enter_behavior` option to control whether blocks or linebreaks are inserted #TINY-8458
+- New `newline_behavior` option to control whether blocks or linebreaks are inserted #TINY-8458
 
 ### Changed
 - Toggling fullscreen mode with the `fullscreen` plugin now also fires the `ResizeEditor` event #TINY-8701

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -136,7 +136,7 @@ interface BaseEditorOptions {
   invalid_elements?: string;
   invalid_styles?: string | Record<string, string>;
   keep_styles?: boolean;
-  keyboard_enter_behavior?: string;
+  newline_behavior?: string;
   language?: string;
   language_load?: boolean;
   language_url?: string;

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -136,6 +136,7 @@ interface BaseEditorOptions {
   invalid_elements?: string;
   invalid_styles?: string | Record<string, string>;
   keep_styles?: boolean;
+  keyboard_enter_behavior?: string;
   language?: string;
   language_load?: boolean;
   language_url?: string;

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -136,7 +136,6 @@ interface BaseEditorOptions {
   invalid_elements?: string;
   invalid_styles?: string | Record<string, string>;
   keep_styles?: boolean;
-  newline_behavior?: string;
   language?: string;
   language_load?: boolean;
   language_url?: string;
@@ -149,6 +148,7 @@ interface BaseEditorOptions {
   min_width?: number;
   model?: string;
   model_url?: string;
+  newline_behavior?: 'block' | 'linebreak' | 'invert' | 'default';
   no_newline_selector?: string;
   noneditable_class?: string;
   noneditable_regexp?: RegExp | RegExp[];

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -139,7 +139,7 @@ const register = (editor: Editor) => {
     default: {}
   });
 
-  registerOption('keyboard_enter_behavior', {
+  registerOption('newline_behavior', {
     processor: (value) => {
       const valid = Arr.contains([ 'block', 'linebreak', 'invert', 'default' ], value);
       return valid ? { value, valid } : { valid: false, message: 'Must be one of: block, linebreak, invert or default.' };
@@ -788,7 +788,7 @@ const getContentSecurityPolicy = option('content_security_policy');
 const shouldPutBrInPre = option('br_in_pre');
 const getForcedRootBlock = option('forced_root_block');
 const getForcedRootBlockAttrs = option('forced_root_block_attrs');
-const getKeyboardEnterBehavior = option('keyboard_enter_behavior');
+const getNewlineBehavior = option('newline_behavior');
 const getBrNewLineSelector = option('br_newline_selector');
 const getNoNewLineSelector = option('no_newline_selector');
 const shouldKeepStyles = option('keep_styles');
@@ -891,7 +891,7 @@ export {
   shouldPutBrInPre,
   getForcedRootBlock,
   getForcedRootBlockAttrs,
-  getKeyboardEnterBehavior,
+  getNewlineBehavior,
   getBrNewLineSelector,
   getNoNewLineSelector,
   shouldKeepStyles,

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -139,6 +139,14 @@ const register = (editor: Editor) => {
     default: {}
   });
 
+  registerOption('keyboard_enter_behavior', {
+    processor: (value) => {
+      const valid = Arr.contains([ 'block', 'linebreak', 'invert', 'default' ], value);
+      return valid ? { value, valid } : { valid: false, message: 'Must be one of: block, linebreak, invert or default.' };
+    },
+    default: 'default'
+  });
+
   registerOption('br_newline_selector', {
     processor: 'string',
     default: '.mce-toc h2,figcaption,caption'
@@ -780,6 +788,7 @@ const getContentSecurityPolicy = option('content_security_policy');
 const shouldPutBrInPre = option('br_in_pre');
 const getForcedRootBlock = option('forced_root_block');
 const getForcedRootBlockAttrs = option('forced_root_block_attrs');
+const getKeyboardEnterBehavior = option('keyboard_enter_behavior');
 const getBrNewLineSelector = option('br_newline_selector');
 const getNoNewLineSelector = option('no_newline_selector');
 const shouldKeepStyles = option('keep_styles');
@@ -882,6 +891,7 @@ export {
   shouldPutBrInPre,
   getForcedRootBlock,
   getForcedRootBlockAttrs,
+  getKeyboardEnterBehavior,
   getBrNewLineSelector,
   getNoNewLineSelector,
   shouldKeepStyles,

--- a/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
@@ -45,28 +45,23 @@ const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>) => {
     }
   };
 
+  const logicalAction = NewLineAction.getAction(editor, evt);
+
   switch (getKeyboardEnterBehavior(editor)) {
     case 'linebreak':
-      lineBreak();
+      logicalAction.fold(lineBreak, lineBreak, Fun.noop);
       break;
     case 'block':
-      blockBreak();
+      logicalAction.fold(blockBreak, blockBreak, Fun.noop);
       break;
     case 'invert':
-      NewLineAction.getAction(editor, evt).fold(
-        blockBreak,
-        lineBreak,
-        Fun.noop
-      );
+      logicalAction.fold(blockBreak, lineBreak, Fun.noop);
       break;
     // implied by the options processor, unnecessary
     // case 'default':
     default:
-      NewLineAction.getAction(editor, evt).fold(
-        lineBreak,
-        blockBreak,
-        Fun.noop
-      );
+      logicalAction.fold(lineBreak, blockBreak, Fun.noop);
+      break;
   }
 };
 

--- a/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
@@ -1,7 +1,7 @@
 import { Fun, Type } from '@ephox/katamari';
 
 import Editor from '../api/Editor';
-import { getKeyboardEnterBehavior } from '../api/Options';
+import { getNewlineBehavior } from '../api/Options';
 import { EditorEvent } from '../api/util/EventDispatcher';
 import { execDeleteCommand } from '../delete/DeleteUtils';
 import { fireFakeBeforeInputEvent, fireFakeInputEvent } from '../keyboard/FakeInputEvents';
@@ -47,7 +47,7 @@ const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>) => {
 
   const logicalAction = NewLineAction.getAction(editor, evt);
 
-  switch (getKeyboardEnterBehavior(editor)) {
+  switch (getNewlineBehavior(editor)) {
     case 'linebreak':
       logicalAction.fold(lineBreak, lineBreak, Fun.noop);
       break;

--- a/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
@@ -10,40 +10,27 @@ import * as InsertBr from './InsertBr';
 import * as NewLineAction from './NewLineAction';
 
 const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>) => {
-  const lineBreak = () => {
+  const insertBreak = (breakType: (editor: Editor, evt?: EditorEvent<KeyboardEvent>) => void, fakeEvent: string) => () => {
     if (!editor.selection.isCollapsed()) {
       execDeleteCommand(editor);
     }
     if (Type.isNonNullable(evt)) {
-      const event = fireFakeBeforeInputEvent(editor, 'insertLineBreak');
+      const event = fireFakeBeforeInputEvent(editor, fakeEvent);
       if (event.isDefaultPrevented()) {
         return;
       }
     }
 
-    InsertBr.insert(editor, evt);
+    breakType(editor, evt);
 
     if (Type.isNonNullable(evt)) {
-      fireFakeInputEvent(editor, 'insertLineBreak');
+      fireFakeInputEvent(editor, fakeEvent);
     }
   };
-  const blockBreak = () => {
-    if (!editor.selection.isCollapsed()) {
-      execDeleteCommand(editor);
-    }
-    if (Type.isNonNullable(evt)) {
-      const event = fireFakeBeforeInputEvent(editor, 'insertParagraph');
-      if (event.isDefaultPrevented()) {
-        return;
-      }
-    }
 
-    InsertBlock.insert(editor, evt);
+  const lineBreak = insertBreak(InsertBr.insert, 'insertLineBreak');
 
-    if (Type.isNonNullable(evt)) {
-      fireFakeInputEvent(editor, 'insertParagraph');
-    }
-  };
+  const blockBreak = insertBreak(InsertBlock.insert, 'insertParagraph');
 
   const logicalAction = NewLineAction.getAction(editor, evt);
 

--- a/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
@@ -1,6 +1,7 @@
 import { Fun, Type } from '@ephox/katamari';
 
 import Editor from '../api/Editor';
+import { getKeyboardEnterBehavior } from '../api/Options';
 import { EditorEvent } from '../api/util/EventDispatcher';
 import { execDeleteCommand } from '../delete/DeleteUtils';
 import { fireFakeBeforeInputEvent, fireFakeInputEvent } from '../keyboard/FakeInputEvents';
@@ -9,43 +10,64 @@ import * as InsertBr from './InsertBr';
 import * as NewLineAction from './NewLineAction';
 
 const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>) => {
-  NewLineAction.getAction(editor, evt).fold(
-    () => {
-      if (!editor.selection.isCollapsed()) {
-        execDeleteCommand(editor);
+  const lineBreak = () => {
+    if (!editor.selection.isCollapsed()) {
+      execDeleteCommand(editor);
+    }
+    if (Type.isNonNullable(evt)) {
+      const event = fireFakeBeforeInputEvent(editor, 'insertLineBreak');
+      if (event.isDefaultPrevented()) {
+        return;
       }
-      if (Type.isNonNullable(evt)) {
-        const event = fireFakeBeforeInputEvent(editor, 'insertLineBreak');
-        if (event.isDefaultPrevented()) {
-          return;
-        }
-      }
+    }
 
-      InsertBr.insert(editor, evt);
+    InsertBr.insert(editor, evt);
 
-      if (Type.isNonNullable(evt)) {
-        fireFakeInputEvent(editor, 'insertLineBreak');
+    if (Type.isNonNullable(evt)) {
+      fireFakeInputEvent(editor, 'insertLineBreak');
+    }
+  };
+  const blockBreak = () => {
+    if (!editor.selection.isCollapsed()) {
+      execDeleteCommand(editor);
+    }
+    if (Type.isNonNullable(evt)) {
+      const event = fireFakeBeforeInputEvent(editor, 'insertParagraph');
+      if (event.isDefaultPrevented()) {
+        return;
       }
-    },
-    () => {
-      if (!editor.selection.isCollapsed()) {
-        execDeleteCommand(editor);
-      }
-      if (Type.isNonNullable(evt)) {
-        const event = fireFakeBeforeInputEvent(editor, 'insertParagraph');
-        if (event.isDefaultPrevented()) {
-          return;
-        }
-      }
+    }
 
-      InsertBlock.insert(editor, evt);
+    InsertBlock.insert(editor, evt);
 
-      if (Type.isNonNullable(evt)) {
-        fireFakeInputEvent(editor, 'insertParagraph');
-      }
-    },
-    Fun.noop
-  );
+    if (Type.isNonNullable(evt)) {
+      fireFakeInputEvent(editor, 'insertParagraph');
+    }
+  };
+
+  switch (getKeyboardEnterBehavior(editor)) {
+    case 'linebreak':
+      lineBreak();
+      break;
+    case 'block':
+      blockBreak();
+      break;
+    case 'invert':
+      NewLineAction.getAction(editor, evt).fold(
+        blockBreak,
+        lineBreak,
+        Fun.noop
+      );
+      break;
+    // implied by the options processor, unnecessary
+    // case 'default':
+    default:
+      NewLineAction.getAction(editor, evt).fold(
+        lineBreak,
+        blockBreak,
+        Fun.noop
+      );
+  }
 };
 
 export {

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -484,4 +484,214 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
       });
     });
   });
+
+  context('keyboard_enter_behavior "block"', () => {
+    before(() => {
+      hook.editor().options.set('keyboard_enter_behavior', 'block');
+    });
+
+    after(() => {
+      hook.editor().options.unset('keyboard_enter_behavior');
+    });
+
+    it('Split block in the middle', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>ab</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      insertNewline(editor, { });
+      TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
+      TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
+    });
+
+    it('Split block in the middle with shift+enter', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>ab</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      insertNewline(editor, { shiftKey: true });
+      TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
+      TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
+    });
+
+    context('ignores br_newline_selector', () => {
+      before(() => {
+        hook.editor().options.set('br_newline_selector', 'p');
+      });
+
+      after(() => {
+        hook.editor().options.unset('br_newline_selector');
+      });
+
+      it('Insert newline where br is forced', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, { });
+        editor.nodeChanged();
+        TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
+      });
+
+    });
+
+    context('does not ignore no_newline_selector', () => {
+      before(() => {
+        hook.editor().options.set('no_newline_selector', 'p');
+      });
+
+      after(() => {
+        hook.editor().options.unset('no_newline_selector');
+      });
+
+      it('Insert newline where newline is blocked', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, { });
+        editor.nodeChanged();
+        TinyAssertions.assertContent(editor, '<p>ab</p>');
+      });
+    });
+  });
+
+  context('keyboard_enter_behavior "linebreak"', () => {
+    before(() => {
+      hook.editor().options.set('keyboard_enter_behavior', 'linebreak');
+    });
+
+    after(() => {
+      hook.editor().options.unset('keyboard_enter_behavior');
+    });
+
+    it('Split block in the middle', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>ab</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      insertNewline(editor, { });
+      TinyAssertions.assertContent(editor, '<p>a<br>b</p>');
+      TinyAssertions.assertSelection(editor, [ 0 ], 2, [ 0 ], 2);
+    });
+
+    it('Split block in the middle with shift+enter', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>ab</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      insertNewline(editor, { shiftKey: true });
+      TinyAssertions.assertContent(editor, '<p>a<br>b</p>');
+      TinyAssertions.assertSelection(editor, [ 0 ], 2, [ 0 ], 2);
+    });
+
+    context('ignores br_newline_selector', () => {
+      before(() => {
+        hook.editor().options.set('br_newline_selector', 'p');
+      });
+
+      after(() => {
+        hook.editor().options.unset('br_newline_selector');
+      });
+
+      it('Insert newline where br is not forced', () => {
+        const editor = hook.editor();
+        editor.setContent('<div>ab</div>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, { });
+        editor.nodeChanged();
+        TinyAssertions.assertContent(editor, '<div>a<br>b</div>');
+      });
+
+    });
+
+    context('does not ignore no_newline_selector', () => {
+      before(() => {
+        hook.editor().options.set('no_newline_selector', 'p');
+      });
+
+      after(() => {
+        hook.editor().options.unset('no_newline_selector');
+      });
+
+      it('Insert newline where newline is blocked', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, { });
+        editor.nodeChanged();
+        TinyAssertions.assertContent(editor, '<p>ab</p>');
+      });
+    });
+  });
+
+  context('keyboard_enter_behavior "invert"', () => {
+    before(() => {
+      hook.editor().options.set('keyboard_enter_behavior', 'invert');
+    });
+
+    after(() => {
+      hook.editor().options.unset('keyboard_enter_behavior');
+    });
+
+    it('Split block in the middle', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>ab</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      insertNewline(editor, { });
+      TinyAssertions.assertContent(editor, '<p>a<br>b</p>');
+      TinyAssertions.assertSelection(editor, [ 0 ], 2, [ 0 ], 2);
+    });
+
+    it('Split block in the middle with shift+enter', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>ab</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      insertNewline(editor, { shiftKey: true });
+      TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
+      TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
+    });
+
+    context('inverts br_newline_selector', () => {
+      before(() => {
+        hook.editor().options.set('br_newline_selector', 'p');
+      });
+
+      after(() => {
+        hook.editor().options.unset('br_newline_selector');
+      });
+
+      it('Insert newline where br is forced', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, { });
+        editor.nodeChanged();
+        TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
+      });
+
+      it('Insert newline where br is not forced', () => {
+        const editor = hook.editor();
+        editor.setContent('<div>ab</div>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, { });
+        editor.nodeChanged();
+        TinyAssertions.assertContent(editor, '<div>a<br>b</div>');
+      });
+
+    });
+
+    context('does not ignore no_newline_selector', () => {
+      before(() => {
+        hook.editor().options.set('no_newline_selector', 'p');
+      });
+
+      after(() => {
+        hook.editor().options.unset('no_newline_selector');
+      });
+
+      it('Insert newline where newline is blocked', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, { });
+        editor.nodeChanged();
+        TinyAssertions.assertContent(editor, '<p>ab</p>');
+      });
+    });
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -485,7 +485,7 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
     });
   });
 
-  context('newline_behavior "block"', () => {
+  context('TINY-8458: newline_behavior "block"', () => {
     before(() => {
       hook.editor().options.set('newline_behavior', 'block');
     });
@@ -529,7 +529,6 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
         editor.nodeChanged();
         TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
       });
-
     });
 
     context('does not ignore no_newline_selector', () => {
@@ -552,7 +551,7 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
     });
   });
 
-  context('newline_behavior "linebreak"', () => {
+  context('TINY-8458: newline_behavior "linebreak"', () => {
     before(() => {
       hook.editor().options.set('newline_behavior', 'linebreak');
     });
@@ -596,7 +595,6 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
         editor.nodeChanged();
         TinyAssertions.assertContent(editor, '<div>a<br>b</div>');
       });
-
     });
 
     context('does not ignore no_newline_selector', () => {
@@ -619,7 +617,7 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
     });
   });
 
-  context('newline_behavior "invert"', () => {
+  context('TINY-8458: newline_behavior "invert"', () => {
     before(() => {
       hook.editor().options.set('newline_behavior', 'invert');
     });
@@ -672,7 +670,6 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
         editor.nodeChanged();
         TinyAssertions.assertContent(editor, '<div>a<br>b</div>');
       });
-
     });
 
     context('does not ignore no_newline_selector', () => {

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -485,13 +485,13 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
     });
   });
 
-  context('keyboard_enter_behavior "block"', () => {
+  context('newline_behavior "block"', () => {
     before(() => {
-      hook.editor().options.set('keyboard_enter_behavior', 'block');
+      hook.editor().options.set('newline_behavior', 'block');
     });
 
     after(() => {
-      hook.editor().options.unset('keyboard_enter_behavior');
+      hook.editor().options.unset('newline_behavior');
     });
 
     it('Split block in the middle', () => {
@@ -552,13 +552,13 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
     });
   });
 
-  context('keyboard_enter_behavior "linebreak"', () => {
+  context('newline_behavior "linebreak"', () => {
     before(() => {
-      hook.editor().options.set('keyboard_enter_behavior', 'linebreak');
+      hook.editor().options.set('newline_behavior', 'linebreak');
     });
 
     after(() => {
-      hook.editor().options.unset('keyboard_enter_behavior');
+      hook.editor().options.unset('newline_behavior');
     });
 
     it('Split block in the middle', () => {
@@ -619,13 +619,13 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
     });
   });
 
-  context('keyboard_enter_behavior "invert"', () => {
+  context('newline_behavior "invert"', () => {
     before(() => {
-      hook.editor().options.set('keyboard_enter_behavior', 'invert');
+      hook.editor().options.set('newline_behavior', 'invert');
     });
 
     after(() => {
-      hook.editor().options.unset('keyboard_enter_behavior');
+      hook.editor().options.unset('newline_behavior');
     });
 
     it('Split block in the middle', () => {


### PR DESCRIPTION
Related Ticket: TINY-8458

Description of Changes:
* New option that can be used to adjust when to use block breaks vs line breaks.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
discussion #7342