### PR TITLE
TINY-8684: Added iframe_template_callback option

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `sidebar_show` option to show the specified sidebar on initialization #TINY-8710
 - New `newline_behavior` option to control what happens when the enter key is pressed or using commands such as `mceInsertNewLine` #TINY-8458
 - New `removeAttributeFilter` and `removeNodeFilter` functions to the `DomParser` and DOM `Serializer` APIs #TINY-7847
+- New `iframe_template_callback` option in the `media` plugin. Patch provided by Namstel #TINY-8684
 
 ### Changed
 - Toggling fullscreen mode with the `fullscreen` plugin now also fires the `ResizeEditor` event #TINY-8701
@@ -65,9 +66,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multiple inline toolbars were shown if focused too quickly #TINY-8503
 - Added background and additional spacing for the text labeled buttons in the toolbar to improve visual clarity #TINY-8617
 - Toolbar split buttons with text used an incorrect width on touch devices #TINY-8647
-
-### Added
-- Added `iframeTemplateCallback` to the `getIframeHtml` function
 
 ## 6.0.1 - 2022-03-23
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -66,6 +66,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added background and additional spacing for the text labeled buttons in the toolbar to improve visual clarity #TINY-8617
 - Toolbar split buttons with text used an incorrect width on touch devices #TINY-8647
 
+### Added
+- Added `iframeTemplateCallback` to the `getIframeHtml` function
+
 ## 6.0.1 - 2022-03-23
 
 ### Fixed

--- a/modules/tinymce/src/plugins/media/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/api/Options.ts
@@ -21,6 +21,10 @@ const register = (editor: Editor): void => {
     processor: 'function'
   });
 
+  registerOption('iframe_template_callback', {
+    processor: 'function'
+  });
+
   registerOption('media_live_embeds', {
     processor: 'boolean',
     default: true

--- a/modules/tinymce/src/plugins/media/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/api/Options.ts
@@ -53,6 +53,7 @@ const register = (editor: Editor): void => {
 
 const getAudioTemplateCallback = option<DataToHtmlCallback>('audio_template_callback');
 const getVideoTemplateCallback = option<DataToHtmlCallback>('video_template_callback');
+const getIframeTemplateCallback = option<DataToHtmlCallback>('iframe_template_callback');
 const hasLiveEmbeds = option<boolean>('media_live_embeds');
 const shouldFilterHtml = option<boolean>('media_filter_html');
 const getUrlResolver = option<MediaResolver>('media_url_resolver');
@@ -64,6 +65,7 @@ export {
   register,
   getAudioTemplateCallback,
   getVideoTemplateCallback,
+  getIframeTemplateCallback,
   hasLiveEmbeds,
   shouldFilterHtml,
   getUrlResolver,

--- a/modules/tinymce/src/plugins/media/main/ts/core/DataToHtml.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/DataToHtml.ts
@@ -10,9 +10,14 @@ import * as UrlPatterns from './UrlPatterns';
 
 export type DataToHtmlCallback = (data: MediaData) => string;
 
-const getIframeHtml = (data: MediaData): string => {
-  const allowFullscreen = data.allowfullscreen ? ' allowFullscreen="1"' : '';
-  return '<iframe src="' + data.source + '" width="' + data.width + '" height="' + data.height + '"' + allowFullscreen + '></iframe>';
+const getIframeHtml = (data: MediaData, iframeTemplateCallback: DataToHtmlCallback): string => {
+  if (iframeTemplateCallback) {
+    return iframeTemplateCallback(data);
+  } else {
+    const allowFullscreen = data.allowfullscreen ? ' allowFullscreen="1"' : '';
+
+    return '<iframe src="' + data.source + '" width="' + data.width + '" height="' + data.height + '"' + allowFullscreen + '></iframe>';
+  }
 };
 
 const getFlashHtml = (data: MediaData): string => {
@@ -103,6 +108,7 @@ const dataToHtml = (editor: Editor, dataIn: MediaData): string => {
   } else {
     const audioTemplateCallback = Options.getAudioTemplateCallback(editor);
     const videoTemplateCallback = Options.getVideoTemplateCallback(editor);
+    const iframeTemplateCallback = Options.getIframeTemplateCallback(editor);
 
     data.width = data.width || '300';
     data.height = data.height || '150';
@@ -112,7 +118,7 @@ const dataToHtml = (editor: Editor, dataIn: MediaData): string => {
     });
 
     if (data.type === 'iframe') {
-      return getIframeHtml(data);
+      return getIframeHtml(data, iframeTemplateCallback);
     } else if (data.sourcemime === 'application/x-shockwave-flash') {
       return getFlashHtml(data);
     } else if (data.sourcemime.indexOf('audio') !== -1) {

--- a/modules/tinymce/src/plugins/media/main/ts/core/DataToHtml.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/DataToHtml.ts
@@ -10,12 +10,11 @@ import * as UrlPatterns from './UrlPatterns';
 
 export type DataToHtmlCallback = (data: MediaData) => string;
 
-const getIframeHtml = (data: MediaData, iframeTemplateCallback: DataToHtmlCallback): string => {
+const getIframeHtml = (data: MediaData, iframeTemplateCallback: DataToHtmlCallback | undefined): string => {
   if (iframeTemplateCallback) {
     return iframeTemplateCallback(data);
   } else {
     const allowFullscreen = data.allowfullscreen ? ' allowFullscreen="1"' : '';
-
     return '<iframe src="' + data.source + '" width="' + data.width + '" height="' + data.height + '"' + allowFullscreen + '></iframe>';
   }
 };
@@ -32,7 +31,7 @@ const getFlashHtml = (data: MediaData): string => {
   return html;
 };
 
-const getAudioHtml = (data: MediaData, audioTemplateCallback: DataToHtmlCallback): string => {
+const getAudioHtml = (data: MediaData, audioTemplateCallback: DataToHtmlCallback | undefined): string => {
   if (audioTemplateCallback) {
     return audioTemplateCallback(data);
   } else {
@@ -48,7 +47,7 @@ const getAudioHtml = (data: MediaData, audioTemplateCallback: DataToHtmlCallback
   }
 };
 
-const getVideoHtml = (data: MediaData, videoTemplateCallback: DataToHtmlCallback): string => {
+const getVideoHtml = (data: MediaData, videoTemplateCallback: DataToHtmlCallback | undefined): string => {
   if (videoTemplateCallback) {
     return videoTemplateCallback(data);
   } else {

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DataToHtmlTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DataToHtmlTest.ts
@@ -1,5 +1,6 @@
 import { ApproxStructure, Assertions, StructAssert, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 
@@ -71,4 +72,86 @@ describe('browser.tinymce.plugins.media.core.DataToHtmlTest', () => {
     },
     iframeStruct
   ));
+
+  it('TBA: Assert html structure of audio from template callback', async () => {
+    const editor = hook.editor();
+    const audioTemplateCallback = Fun.constant('<audio id="template" controls="controls"><source src="https://assets.mixkit.co/music/preview/mixkit-tech-house-vibes-130.mp3"></audio>');
+    editor.options.set('audio_template_callback', audioTemplateCallback);
+    const input = {
+      source: 'https://assets.mixkit.co/music/preview/mixkit-tech-house-vibes-130.mp3',
+      altsource: '',
+      poster: ''
+    };
+    const expected = ApproxStructure.build((s, str/* , arr*/) => {
+      return s.element('audio', {
+        children: [
+          s.element('source', {
+            attrs: {
+              src: str.is('https://assets.mixkit.co/music/preview/mixkit-tech-house-vibes-130.mp3')
+            }
+          })
+        ],
+        attrs: {
+          id: str.is('template'),
+          controls: str.is('controls'),
+        }
+      });
+    });
+    await pTestDataToHtml(editor, input, expected);
+    editor.options.unset('audio_template_callback');
+  });
+
+  it('TBA: Assert html structure of video from template callback', async () => {
+    const editor = hook.editor();
+    const videoTemplateCallback = Fun.constant('<video id="template" controls="controls" width="500" height="300" ><source src="https://i.imgur.com/Tu4e5WX.mp4"></video>');
+    editor.options.set('video_template_callback', videoTemplateCallback);
+    const input = {
+      source: 'https://i.imgur.com/Tu4e5WX.mp4',
+      altsource: '',
+      poster: ''
+    };
+    const expected = ApproxStructure.build((s, str/* , arr*/) => {
+      return s.element('video', {
+        children: [
+          s.element('source', {
+            attrs: {
+              src: str.is('https://i.imgur.com/Tu4e5WX.mp4')
+            }
+          })
+        ],
+        attrs: {
+          id: str.is('template'),
+          controls: str.is('controls'),
+          height: str.is('300'),
+          width: str.is('500')
+        }
+      });
+    });
+    await pTestDataToHtml(editor, input, expected);
+    editor.options.unset('video_template_callback');
+  });
+
+  it('TINY-8684: Assert html structure of iframe from template callback', async () => {
+    const editor = hook.editor();
+    const iframeTemplateCallback = Fun.constant('<iframe id="template" title="testcallback" src="https://www.youtube.com/embed/IcgmSRJHu_8" width="500" height="300"></iframe>');
+    editor.options.set('iframe_template_callback', iframeTemplateCallback);
+    const input = {
+      source: 'https://www.youtube.com/embed/IcgmSRJHu_8',
+      altsource: '',
+      poster: ''
+    };
+    const expected = ApproxStructure.build((s, str/* , arr*/) => {
+      return s.element('iframe', {
+        attrs: {
+          src: str.is('https://www.youtube.com/embed/IcgmSRJHu_8'),
+          title: str.is('testcallback'),
+          id: str.is('template'),
+          height: str.is('300'),
+          width: str.is('500')
+        }
+      });
+    });
+    await pTestDataToHtml(editor, input, expected);
+    editor.options.unset('iframe_template_callback');
+  });
 });

--- a/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
+import { DataToHtmlCallback } from 'tinymce/plugins/media/core/DataToHtml';
 import Plugin from 'tinymce/plugins/media/Plugin';
 
 import * as Utils from '../module/test/Utils';
@@ -47,6 +49,15 @@ describe('browser.tinymce.plugins.media.core.SubmitTest', () => {
     await Utils.pAssertEditorContent(editor, expected);
   };
 
+  const pTestTemplateCallbackContentSubmit = async (editor: Editor, templateOption: string, templateCallback: DataToHtmlCallback, url: string, expected: string) => {
+    editor.options.set(templateOption, templateCallback);
+    await Utils.pOpenDialog(editor);
+    await Utils.pPasteSourceValue(editor, url);
+    TinyUiActions.submitDialog(editor);
+    await Utils.pAssertEditorContent(editor, expected);
+    editor.options.unset(templateOption);
+  };
+
   beforeEach(() => {
     hook.editor().setContent('');
   });
@@ -75,5 +86,32 @@ describe('browser.tinymce.plugins.media.core.SubmitTest', () => {
     await pTestManualEmbedContentSubmit(editor, customEmbed, customEmbed);
     editor.options.unset('media_url_resolver');
     await pTestEmbedUnchangedAfterOpenCloseDialog(editor, customEmbed);
+  });
+
+  it('TBA: Set audio_template_callback and embed content, submit dialog and assert content', async () => {
+    // Audio should be any mp3 link to trigger callback
+    const editor = hook.editor();
+    const audioTemplateCallback = Fun.constant('<audio id="template" controls="controls"><source src="https://assets.mixkit.co/music/preview/mixkit-tech-house-vibes-130.mp3"></audio>');
+    const expected = '<p><audio id="template" controls="controls"><source src="https://assets.mixkit.co/music/preview/mixkit-tech-house-vibes-130.mp3"></audio></p>';
+    await pTestTemplateCallbackContentSubmit(editor, 'audio_template_callback', audioTemplateCallback, 'https://assets.mixkit.co/music/preview/mixkit-tech-house-vibes-130.mp3', expected);
+    await pTestEmbedUnchangedAfterOpenCloseDialog(editor, expected);
+  });
+
+  it('TBA: Set video_template_callback and embed content, submit dialog and assert content', async () => {
+    // Video should be any mp4 link to trigger callback
+    const editor = hook.editor();
+    const videoTemplateCallback = Fun.constant('<video id="template" controls="controls" width="500" height="300" ><source src="https://i.imgur.com/Tu4e5WX.mp4"></video>');
+    const expected = '<p><video id="template" controls="controls" width="500" height="300"><source src="https://i.imgur.com/Tu4e5WX.mp4"></video></p>';
+    await pTestTemplateCallbackContentSubmit(editor, 'video_template_callback', videoTemplateCallback, 'https://i.imgur.com/Tu4e5WX.mp4', expected);
+    await pTestEmbedUnchangedAfterOpenCloseDialog(editor, expected);
+  });
+
+  it('TINY-8684: Set iframe_template_callback and embed content, submit dialog and assert content', async () => {
+    // Any youtube link triggers iframe callback
+    const editor = hook.editor();
+    const iframeTemplateCallback = Fun.constant('<iframe id="template" title="testcallback" src="https://www.youtube.com/embed/IcgmSRJHu_8" width="500" height="300"></iframe>');
+    const expected = '<p><iframe id="template" title="testcallback" src="https://www.youtube.com/embed/IcgmSRJHu_8" width="500" height="300"></iframe></p>';
+    await pTestTemplateCallbackContentSubmit(editor, 'iframe_template_callback', iframeTemplateCallback, 'https://www.youtube.com/embed/IcgmSRJHu_8', expected);
+    await pTestEmbedUnchangedAfterOpenCloseDialog(editor, expected);
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-8684

Description of Changes:
* Added iframeTemplateCallback and iframe_template_callback option
* Added tests for all template callback options in media plugin

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

Before merging:

- [x] Squash all the commits except the original authors into a single commit (or whatever makes the most sense)
- [x]  Don't squash merge and either use a rebase merge or a merge commit

GitHub issues (if applicable):
