### PR TITLE
TINY-7847: Added new parser/serializer remove filter APIs

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - New `sidebar_show` option to show the specified sidebar on initialization #TINY-8710
 - New `newline_behavior` option to control what happens when the enter key is pressed or using commands such as `mceInsertNewLine` #TINY-8458
+- New `removeAttributeFilter` and `removeNodeFilter` functions to the `DomParser` and DOM `Serializer` APIs #TINY-7847
 
 ### Changed
 - Toggling fullscreen mode with the `fullscreen` plugin now also fires the `ResizeEditor` event #TINY-8701

--- a/modules/tinymce/src/core/main/ts/api/dom/Serializer.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Serializer.ts
@@ -111,7 +111,7 @@ const DomSerializer = (settings: DomSerializerSettings, editor?: Editor): DomSer
      * Removes a node filter function or removes all filter functions from the parser used by the serializer for the node names provided.
      *
      * @method removeNodeFilter
-     * @param {String} name Comma separated list of nodes names to remove filters for.
+     * @param {String} name Comma separated list of node names to remove filters for.
      * @param {Function} callback Optional callback function to only remove a specific callback.
      * @example
      * // Remove a single filter
@@ -130,7 +130,7 @@ const DomSerializer = (settings: DomSerializerSettings, editor?: Editor): DomSer
      * Removes an attribute filter function or removes all filter functions from the parser used by the serializer for the attribute names provided.
      *
      * @method removeAttributeFilter
-     * @param {String} name Comma separated list of attributes names to remove filters for.
+     * @param {String} name Comma separated list of attribute names to remove filters for.
      * @param {Function} callback Optional callback function to only remove a specific callback.
      * @example
      * // Remove a single filter

--- a/modules/tinymce/src/core/main/ts/api/dom/Serializer.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Serializer.ts
@@ -29,7 +29,7 @@ const DomSerializer = (settings: DomSerializerSettings, editor?: Editor): DomSer
      * and then execute the callback once it has finished parsing the document.
      *
      * @method addNodeFilter
-     * @method {String} name Comma separated list of nodes to collect.
+     * @param {String} name Comma separated list of nodes to collect.
      * @param {Function} callback Callback function to execute once it has collected nodes.
      * @example
      * serializer.addNodeFilter('p,h1', (nodes, name) => {
@@ -46,7 +46,7 @@ const DomSerializer = (settings: DomSerializerSettings, editor?: Editor): DomSer
      * and then execute the callback once it has finished parsing the document.
      *
      * @method addAttributeFilter
-     * @method {String} name Comma separated list of attributes to collect.
+     * @param {String} name Comma separated list of attributes to collect.
      * @param {Function} callback Callback function to execute once it has collected nodes.
      * @example
      * serializer.addAttributeFilter('src,href', (nodes, name) => {

--- a/modules/tinymce/src/core/main/ts/api/dom/Serializer.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Serializer.ts
@@ -32,7 +32,7 @@ const DomSerializer = (settings: DomSerializerSettings, editor?: Editor): DomSer
      * @method {String} name Comma separated list of nodes to collect.
      * @param {Function} callback Callback function to execute once it has collected nodes.
      * @example
-     * parser.addNodeFilter('p,h1', (nodes, name) => {
+     * serializer.addNodeFilter('p,h1', (nodes, name) => {
      *   for (let i = 0; i < nodes.length; i++) {
      *     console.log(nodes[i].name);
      *   }
@@ -41,15 +41,15 @@ const DomSerializer = (settings: DomSerializerSettings, editor?: Editor): DomSer
     addNodeFilter: domSerializer.addNodeFilter,
 
     /**
-     * Adds a attribute filter function to the parser used by the serializer, the parser will
+     * Adds an attribute filter function to the parser used by the serializer, the parser will
      * collect nodes that has the specified attributes
      * and then execute the callback once it has finished parsing the document.
      *
      * @method addAttributeFilter
-     * @method {String} name Comma separated list of nodes to collect.
+     * @method {String} name Comma separated list of attributes to collect.
      * @param {Function} callback Callback function to execute once it has collected nodes.
      * @example
-     * parser.addAttributeFilter('src,href', (nodes, name) => {
+     * serializer.addAttributeFilter('src,href', (nodes, name) => {
      *   for (let i = 0; i < nodes.length; i++) {
      *     console.log(nodes[i].name);
      *   }
@@ -105,7 +105,45 @@ const DomSerializer = (settings: DomSerializerSettings, editor?: Editor): DomSer
 
     getNodeFilters: domSerializer.getNodeFilters,
 
-    getAttributeFilters: domSerializer.getAttributeFilters
+    getAttributeFilters: domSerializer.getAttributeFilters,
+
+    /**
+     * Removes a node filter function or removes all filter functions from the parser used by the serializer for the node names provided.
+     *
+     * @method removeNodeFilter
+     * @param {String} name Comma separated list of nodes names to remove filters for.
+     * @param {Function} callback Optional callback function to only remove a specific callback.
+     * @example
+     * // Remove a single filter
+     * serializer.removeNodeFilter('p,h1', (nodes, name) => {
+     *   for (var i = 0; i < nodes.length; i++) {
+     *     console.log(nodes[i].name);
+     *   }
+     * });
+     *
+     * // Remove all filters
+     * serializer.removeNodeFilter('p,h1');
+     */
+    removeNodeFilter: domSerializer.removeNodeFilter,
+
+    /**
+     * Removes an attribute filter function or removes all filter functions from the parser used by the serializer for the attribute names provided.
+     *
+     * @method removeAttributeFilter
+     * @param {String} name Comma separated list of attributes names to remove filters for.
+     * @param {Function} callback Optional callback function to only remove a specific callback.
+     * @example
+     * // Remove a single filter
+     * serializer.removeAttributeFilter('src,href', (nodes, name) => {
+     *   for (let i = 0; i < nodes.length; i++) {
+     *     console.log(nodes[i].name);
+     *   }
+     * });
+     *
+     * // Remove all filters
+     * serializer.removeAttributeFilter('src,href');
+     */
+    removeAttributeFilter: domSerializer.removeAttributeFilter
   };
 };
 

--- a/modules/tinymce/src/core/main/ts/api/dom/Serializer.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Serializer.ts
@@ -115,11 +115,7 @@ const DomSerializer = (settings: DomSerializerSettings, editor?: Editor): DomSer
      * @param {Function} callback Optional callback function to only remove a specific callback.
      * @example
      * // Remove a single filter
-     * serializer.removeNodeFilter('p,h1', (nodes, name) => {
-     *   for (var i = 0; i < nodes.length; i++) {
-     *     console.log(nodes[i].name);
-     *   }
-     * });
+     * serializer.removeNodeFilter('p,h1', someCallback);
      *
      * // Remove all filters
      * serializer.removeNodeFilter('p,h1');
@@ -134,11 +130,7 @@ const DomSerializer = (settings: DomSerializerSettings, editor?: Editor): DomSer
      * @param {Function} callback Optional callback function to only remove a specific callback.
      * @example
      * // Remove a single filter
-     * serializer.removeAttributeFilter('src,href', (nodes, name) => {
-     *   for (let i = 0; i < nodes.length; i++) {
-     *     console.log(nodes[i].name);
-     *   }
-     * });
+     * serializer.removeAttributeFilter('src,href', someCallback);
      *
      * // Remove all filters
      * serializer.removeAttributeFilter('src,href');

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -442,7 +442,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
    * Removes a node filter function or removes all filter functions from the parser for the node names provided.
    *
    * @method removeNodeFilter
-   * @param {String} name Comma separated list of nodes names to remove filters for.
+   * @param {String} name Comma separated list of node names to remove filters for.
    * @param {Function} callback Optional callback function to only remove a specific callback.
    * @example
    * // Remove a single filter
@@ -479,7 +479,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
    * Removes an attribute filter function or removes all filter functions from the parser for the attribute names provided.
    *
    * @method removeAttributeFilter
-   * @param {String} name Comma separated list of attributes names to remove filters for.
+   * @param {String} name Comma separated list of attribute names to remove filters for.
    * @param {Function} callback Optional callback function to only remove a specific callback.
    * @example
    * // Remove a single filter

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -4,7 +4,7 @@ import createDompurify, { Config, DOMPurifyI } from 'dompurify';
 
 import * as NodeType from '../../dom/NodeType';
 import * as FilterNode from '../../html/FilterNode';
-import { FilterRegistry, Filter as BaseFilter } from '../../html/FilterRegistry';
+import * as FilterRegistry from '../../html/FilterRegistry';
 import { cleanInvalidNodes } from '../../html/InvalidNodes';
 import * as LegacyFilter from '../../html/LegacyFilter';
 import * as ParserFilters from '../../html/ParserFilters';
@@ -46,7 +46,7 @@ export interface ParserArgs {
 
 export type ParserFilterCallback = (nodes: AstNode[], name: string, args: ParserArgs) => void;
 
-export interface ParserFilter extends BaseFilter<ParserFilterCallback> {}
+export interface ParserFilter extends FilterRegistry.Filter<ParserFilterCallback> {}
 
 export interface DomParserSettings {
   allow_html_data_urls?: boolean;
@@ -390,8 +390,8 @@ const getRootBlockName = (settings: DomParserSettings, args: ParserArgs) => {
 };
 
 const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomParser => {
-  const nodeFilterRegistry = FilterRegistry<ParserFilterCallback>();
-  const attributeFilterRegistry = FilterRegistry<ParserFilterCallback>();
+  const nodeFilterRegistry = FilterRegistry.create<ParserFilterCallback>();
+  const attributeFilterRegistry = FilterRegistry.create<ParserFilterCallback>();
 
   // Apply setting defaults
   const defaultedSettings = {
@@ -446,11 +446,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
    * @param {Function} callback Optional callback function to only remove a specific callback.
    * @example
    * // Remove a single filter
-   * parser.removeNodeFilter('p,h1', (nodes, name) => {
-   *   for (var i = 0; i < nodes.length; i++) {
-   *     console.log(nodes[i].name);
-   *   }
-   * });
+   * parser.removeNodeFilter('p,h1', someCallback);
    *
    * // Remove all filters
    * parser.removeNodeFilter('p,h1');
@@ -483,11 +479,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
    * @param {Function} callback Optional callback function to only remove a specific callback.
    * @example
    * // Remove a single filter
-   * parser.removeAttributeFilter('src,href', (nodes, name) => {
-   *   for (let i = 0; i < nodes.length; i++) {
-   *     console.log(nodes[i].name);
-   *   }
-   * });
+   * parser.removeAttributeFilter('src,href', someCallback);
    *
    * // Remove all filters
    * parser.removeAttributeFilter('src,href');

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -4,6 +4,7 @@ import createDompurify, { Config, DOMPurifyI } from 'dompurify';
 
 import * as NodeType from '../../dom/NodeType';
 import * as FilterNode from '../../html/FilterNode';
+import { FilterRegistry, Filter as BaseFilter } from '../../html/FilterRegistry';
 import { cleanInvalidNodes } from '../../html/InvalidNodes';
 import * as LegacyFilter from '../../html/LegacyFilter';
 import * as ParserFilters from '../../html/ParserFilters';
@@ -28,7 +29,7 @@ import Schema, { getTextRootBlockElements, SchemaRegExpMap } from './Schema';
  * @version 3.4
  */
 
-const makeMap = Tools.makeMap, each = Tools.each, explode = Tools.explode, extend = Tools.extend;
+const makeMap = Tools.makeMap, extend = Tools.extend;
 
 export interface ParserArgs {
   getInner?: boolean | number;
@@ -45,10 +46,7 @@ export interface ParserArgs {
 
 export type ParserFilterCallback = (nodes: AstNode[], name: string, args: ParserArgs) => void;
 
-export interface ParserFilter {
-  name: string;
-  callbacks: ParserFilterCallback[];
-}
+export interface ParserFilter extends BaseFilter<ParserFilterCallback> {}
 
 export interface DomParserSettings {
   allow_html_data_urls?: boolean;
@@ -73,10 +71,12 @@ export interface DomParserSettings {
 
 interface DomParser {
   schema: Schema;
-  addAttributeFilter: (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void) => void;
+  addAttributeFilter: (name: string, callback: ParserFilterCallback) => void;
   getAttributeFilters: () => ParserFilter[];
-  addNodeFilter: (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void) => void;
+  removeAttributeFilter: (name: string, callback?: ParserFilterCallback) => void;
+  addNodeFilter: (name: string, callback: ParserFilterCallback) => void;
   getNodeFilters: () => ParserFilter[];
+  removeNodeFilter: (name: string, callback?: ParserFilterCallback) => void;
   parse: (html: string, args?: ParserArgs) => AstNode;
 }
 
@@ -390,8 +390,8 @@ const getRootBlockName = (settings: DomParserSettings, args: ParserArgs) => {
 };
 
 const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomParser => {
-  const nodeFilters: Record<string, ParserFilterCallback[]> = {};
-  const attributeFilters: ParserFilter[] = [];
+  const nodeFilterRegistry = FilterRegistry<ParserFilterCallback>();
+  const attributeFilterRegistry = FilterRegistry<ParserFilterCallback>();
 
   // Apply setting defaults
   const defaultedSettings = {
@@ -434,36 +434,35 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
    *   }
    * });
    */
-  const addNodeFilter = (name: string, callback: ParserFilterCallback) => {
-    each(explode(name), (name) => {
-      let list = nodeFilters[name];
+  const addNodeFilter = nodeFilterRegistry.addFilter;
 
-      if (!list) {
-        nodeFilters[name] = list = [];
-      }
-
-      list.push(callback);
-    });
-  };
-
-  const getNodeFilters = (): ParserFilter[] => {
-    const out = [];
-
-    for (const name in nodeFilters) {
-      if (Obj.has(nodeFilters, name)) {
-        out.push({ name, callbacks: nodeFilters[name] });
-      }
-    }
-
-    return out;
-  };
+  const getNodeFilters = nodeFilterRegistry.getFilters;
 
   /**
-   * Adds a attribute filter function to the parser, the parser will collect nodes that has the specified attributes
+   * Removes a node filter function or removes all filter functions from the parser for the node names provided.
+   *
+   * @method removeNodeFilter
+   * @param {String} name Comma separated list of nodes names to remove filters for.
+   * @param {Function} callback Optional callback function to only remove a specific callback.
+   * @example
+   * // Remove a single filter
+   * parser.removeNodeFilter('p,h1', (nodes, name) => {
+   *   for (var i = 0; i < nodes.length; i++) {
+   *     console.log(nodes[i].name);
+   *   }
+   * });
+   *
+   * // Remove all filters
+   * parser.removeNodeFilter('p,h1');
+   */
+  const removeNodeFilter = nodeFilterRegistry.removeFilter;
+
+  /**
+   * Adds an attribute filter function to the parser, the parser will collect nodes that has the specified attributes
    * and then execute the callback once it has finished parsing the document.
    *
    * @method addAttributeFilter
-   * @param {String} name Comma separated list of nodes to collect.
+   * @param {String} name Comma separated list of attributes to collect.
    * @param {Function} callback Callback function to execute once it has collected nodes.
    * @example
    * parser.addAttributeFilter('src,href', (nodes, name) => {
@@ -472,22 +471,28 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
    *   }
    * });
    */
-  const addAttributeFilter = (name: string, callback: ParserFilterCallback) => {
-    each(explode(name), (name) => {
-      let i;
+  const addAttributeFilter = attributeFilterRegistry.addFilter;
 
-      for (i = 0; i < attributeFilters.length; i++) {
-        if (attributeFilters[i].name === name) {
-          attributeFilters[i].callbacks.push(callback);
-          return;
-        }
-      }
+  const getAttributeFilters = attributeFilterRegistry.getFilters;
 
-      attributeFilters.push({ name, callbacks: [ callback ] });
-    });
-  };
-
-  const getAttributeFilters = (): ParserFilter[] => [].concat(attributeFilters);
+  /**
+   * Removes an attribute filter function or removes all filter functions from the parser for the attribute names provided.
+   *
+   * @method removeAttributeFilter
+   * @param {String} name Comma separated list of attributes names to remove filters for.
+   * @param {Function} callback Optional callback function to only remove a specific callback.
+   * @example
+   * // Remove a single filter
+   * parser.removeAttributeFilter('src,href', (nodes, name) => {
+   *   for (let i = 0; i < nodes.length; i++) {
+   *     console.log(nodes[i].name);
+   *   }
+   * });
+   *
+   * // Remove all filters
+   * parser.removeAttributeFilter('src,href');
+   */
+  const removeAttributeFilter = attributeFilterRegistry.removeFilter;
 
   const findInvalidChildren = (node: AstNode, invalidChildren: AstNode[]): void => {
     // Check if the node is a valid child of the parent node. If the child is
@@ -580,9 +585,8 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
     const invalidFinder = validate ? (node: AstNode) => findInvalidChildren(node, invalidChildren) : Fun.noop;
 
     // Set up attribute and node matching
-    const nodeFilters = getNodeFilters();
     const matches: FilterNode.FilterMatches = { nodes: {}, attributes: {}};
-    const matchFinder = (node: AstNode) => FilterNode.matchNode(nodeFilters, attributeFilters, node, matches);
+    const matchFinder = (node: AstNode) => FilterNode.matchNode(getNodeFilters(), getAttributeFilters(), node, matches);
 
     // Walk the dom, apply all of the above things
     walkTree(rootNode, [ whitespacePre, matchFinder ], [ whitespacePost, invalidFinder ]);
@@ -619,8 +623,10 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
     schema,
     addAttributeFilter,
     getAttributeFilters,
+    removeAttributeFilter,
     addNodeFilter,
     getNodeFilters,
+    removeNodeFilter,
     parse
   };
 

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerImpl.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerImpl.ts
@@ -4,7 +4,7 @@ import { SugarElement } from '@ephox/sugar';
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
 import * as Events from '../api/Events';
-import DomParser, { DomParserSettings, ParserArgs, ParserFilter } from '../api/html/DomParser';
+import DomParser, { DomParserSettings, ParserArgs, ParserFilter, ParserFilterCallback } from '../api/html/DomParser';
 import AstNode from '../api/html/Node';
 import Schema, { SchemaSettings } from '../api/html/Schema';
 import HtmlSerializer, { HtmlSerializerSettings } from '../api/html/Serializer';
@@ -23,10 +23,12 @@ interface DomSerializerSettings extends DomParserSettings, WriterSettings, Schem
 
 interface DomSerializerImpl {
   schema: Schema;
-  addNodeFilter: (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void) => void;
-  addAttributeFilter: (name: string, callback: (nodes: AstNode[], name: string, args: ParserArgs) => void) => void;
+  addNodeFilter: (name: string, callback: ParserFilterCallback) => void;
+  addAttributeFilter: (name: string, callback: ParserFilterCallback) => void;
   getNodeFilters: () => ParserFilter[];
   getAttributeFilters: () => ParserFilter[];
+  removeNodeFilter: (name: string, callback?: ParserFilterCallback) => void;
+  removeAttributeFilter: (name: string, callback?: ParserFilterCallback) => void;
   serialize: {
     (node: Element, parserArgs: { format: 'tree' } & ParserArgs): AstNode;
     (node: Element, parserArgs?: ParserArgs): string;
@@ -112,7 +114,9 @@ const DomSerializerImpl = (settings: DomSerializerSettings, editor: Editor): Dom
     addTempAttr: Fun.curry(addTempAttr, htmlParser, tempAttrs),
     getTempAttrs: Fun.constant(tempAttrs),
     getNodeFilters: htmlParser.getNodeFilters,
-    getAttributeFilters: htmlParser.getAttributeFilters
+    getAttributeFilters: htmlParser.getAttributeFilters,
+    removeNodeFilter: htmlParser.removeNodeFilter,
+    removeAttributeFilter: htmlParser.removeAttributeFilter
   };
 };
 

--- a/modules/tinymce/src/core/main/ts/html/FilterRegistry.ts
+++ b/modules/tinymce/src/core/main/ts/html/FilterRegistry.ts
@@ -15,7 +15,7 @@ export interface FilterRegistry<C extends Function> {
   readonly removeFilter: (name: string, callback?: C) => void;
 }
 
-export const FilterRegistry = <C extends Function>(): FilterRegistry<C> => {
+export const create = <C extends Function>(): FilterRegistry<C> => {
   const filters: Record<string, Filter<C>> = {};
 
   const addFilter = (name: string, callback: C): void => {

--- a/modules/tinymce/src/core/main/ts/html/FilterRegistry.ts
+++ b/modules/tinymce/src/core/main/ts/html/FilterRegistry.ts
@@ -1,0 +1,58 @@
+import { Arr, Obj, Type } from '@ephox/katamari';
+
+import Tools from '../api/util/Tools';
+
+const explode = Tools.explode;
+
+export interface Filter<C extends Function> {
+  name: string;
+  callbacks: C[];
+}
+
+export interface FilterRegistry<C extends Function> {
+  readonly addFilter: (name: string, callback: C) => void;
+  readonly getFilters: () => Filter<C>[];
+  readonly removeFilter: (name: string, callback?: C) => void;
+}
+
+export const FilterRegistry = <C extends Function>(): FilterRegistry<C> => {
+  const filters: Record<string, Filter<C>> = {};
+
+  const addFilter = (name: string, callback: C): void => {
+    Arr.each(explode(name), (name) => {
+      if (!Obj.has(filters, name)) {
+        filters[name] = { name, callbacks: [] };
+      }
+
+      filters[name].callbacks.push(callback);
+    });
+  };
+
+  const getFilters = (): Filter<C>[] =>
+    Obj.values(filters);
+
+  const removeFilter = (name: string, callback?: C): void => {
+    Arr.each(explode(name), (name) => {
+      if (Obj.has(filters, name)) {
+        if (Type.isNonNullable(callback)) {
+          const filter = filters[name];
+          const newCallbacks = Arr.filter(filter.callbacks, (c) => c !== callback);
+          // If all callbacks have been removed then remove the filter reference
+          if (newCallbacks.length > 0) {
+            filter.callbacks = newCallbacks;
+          } else {
+            delete filters[name];
+          }
+        } else {
+          delete filters[name];
+        }
+      }
+    });
+  };
+
+  return {
+    addFilter,
+    getFilters,
+    removeFilter
+  };
+};

--- a/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
@@ -800,4 +800,24 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     assert.equal(lastAttributeFilter.name, 'data-something', 'Should be the last registered filter attribute name');
     assert.equal(lastAttributeFilter.callbacks[0], attrFilter, 'Should be the last registered attribute filter function');
   });
+
+  it('TINY-7847: removeNodeFilter/removeAttributeFilter', () => {
+    const ser = DomSerializer({ });
+    const nodeFilter = Fun.noop;
+    const attrFilter = Fun.noop;
+    const numNodeFilters = ser.getNodeFilters().length;
+    const numAttrFilters = ser.getAttributeFilters().length;
+
+    ser.addNodeFilter('some-tag', nodeFilter);
+    ser.addAttributeFilter('data-something', attrFilter);
+
+    assert.lengthOf(ser.getNodeFilters(), numNodeFilters + 1, 'Number of node filters');
+    assert.lengthOf(ser.getAttributeFilters(), numAttrFilters + 1, 'Number of attribute filters');
+
+    ser.removeNodeFilter('some-tag', nodeFilter);
+    ser.removeAttributeFilter('data-something', attrFilter);
+
+    assert.lengthOf(ser.getNodeFilters(), numNodeFilters, 'Number of node filters');
+    assert.lengthOf(ser.getAttributeFilters(), numAttrFilters, 'Number of attribute filters');
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-7847

Description of Changes:
* Added the new `removeNodeFilter` and `removeAttributeFilter` functions to the parser/serializer APIs.
* Abstracted the filter registry logic out into a separate module to avoid duplication between nodes/attributes.
* Fixed a couple of minor issues with the existing parser/serializer doc strings/examples.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
