### PR TITLE
fix:Cannot focus at the end of a line with only a few spaces

### DIFF
--- a/modules/tinymce/src/core/main/ts/selection/SelectionUtils.ts
+++ b/modules/tinymce/src/core/main/ts/selection/SelectionUtils.ts
@@ -68,7 +68,7 @@ const moveEndPoint = (dom: DOMUtils, rng: Range, node: Node, start: boolean): vo
   );
 
   do {
-    if (NodeType.isText(node) && Tools.trim(node.nodeValue).length !== 0) {
+    if (NodeType.isText(node) && node.nodeValue.length !== 0) {
       if (start) {
         rng.setStart(node, 0);
       } else {


### PR DESCRIPTION
Related Ticket:

I think that symbols such as white space and tab are also a kind of content and cannot be filtered.
This will prevent me from focusing at the end of a line with only a few spaces,so I don't think TRIM should be used for judging conditions.



Description of Changes:
* Placeholder text

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
