### PR TITLE
TINY-8458: Fix newline commands 

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 - New `sidebar_show` option to show the specified sidebar on initialization #TINY-8710
-- New `newline_behavior` option to control what happens when the enter key is pressed or using commands such as `mceInsertNewLine` #TINY-8458
+- New `newline_behavior` option to control what happens when the enter key is pressed or the `mceInsertNewLine` command is used #TINY-8458
 - New `transparent` property for `iframe` dialog component #TINY-8534
 - New `removeAttributeFilter` and `removeNodeFilter` functions to the `DomParser` and DOM `Serializer` APIs #TINY-7847
 - New `iframe_template_callback` option in the `media` plugin. Patch provided by Namstel #TINY-8684

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Using Ctrl+Shift+Home/End (Cmd+Shift+Up/Down on Mac) would not expand the selection when a `contenteditable="false"` element was at the edge of content #TINY-7795
 - `<pre>` tags were not preserved when copying and pasting content #TINY-7719
 - Preview and Insert Template dialogs display the correct content background color when using dark skins #TINY-8534
+- `InsertLineBreak` command did not replace selected content #TINY-8458
 
 ## 6.0.3 - 2022-05-25
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Using Ctrl+Shift+Home/End (Cmd+Shift+Up/Down on Mac) would not expand the selection when a `contenteditable="false"` element was at the edge of content #TINY-7795
 - `<pre>` tags were not preserved when copying and pasting content #TINY-7719
 - Preview and Insert Template dialogs display the correct content background color when using dark skins #TINY-8534
-- `InsertLineBreak` command did not replace selected content #TINY-8458
+- The `InsertLineBreak` command did not replace selected content #TINY-8458
 
 ## 6.0.3 - 2022-05-25
 

--- a/modules/tinymce/src/core/main/ts/api/commands/NewlineCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/commands/NewlineCommands.ts
@@ -1,3 +1,4 @@
+import * as InsertBlock from '../../newline/InsertBlock';
 import * as InsertBr from '../../newline/InsertBr';
 import * as InsertNewLine from '../../newline/InsertNewLine';
 import Editor from '../Editor';
@@ -5,15 +6,15 @@ import Editor from '../Editor';
 export const registerCommands = (editor: Editor): void => {
   editor.editorCommands.addCommands({
     insertParagraph: () => {
-      InsertNewLine.insert(editor);
+      InsertNewLine.insertBreak(InsertBlock, editor);
     },
 
     mceInsertNewLine: (_command, _ui, value) => {
       InsertNewLine.insert(editor, value);
     },
 
-    InsertLineBreak: (_command, _ui, value) => {
-      InsertBr.insert(editor, value);
+    InsertLineBreak: (_command, _ui, _value) => {
+      InsertNewLine.insertBreak(InsertBr, editor);
     }
   });
 };

--- a/modules/tinymce/src/core/main/ts/api/commands/NewlineCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/commands/NewlineCommands.ts
@@ -1,12 +1,12 @@
-import * as InsertBlock from '../../newline/InsertBlock';
-import * as InsertBr from '../../newline/InsertBr';
+import { blockbreak } from '../../newline/InsertBlock';
+import { linebreak } from '../../newline/InsertBr';
 import * as InsertNewLine from '../../newline/InsertNewLine';
 import Editor from '../Editor';
 
 export const registerCommands = (editor: Editor): void => {
   editor.editorCommands.addCommands({
     insertParagraph: () => {
-      InsertNewLine.insertBreak(InsertBlock, editor);
+      InsertNewLine.insertBreak(blockbreak, editor);
     },
 
     mceInsertNewLine: (_command, _ui, value) => {
@@ -14,7 +14,7 @@ export const registerCommands = (editor: Editor): void => {
     },
 
     InsertLineBreak: (_command, _ui, _value) => {
-      InsertNewLine.insertBreak(InsertBr, editor);
+      InsertNewLine.insertBreak(linebreak, editor);
     }
   });
 };

--- a/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
@@ -498,6 +498,9 @@ const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>) => {
   editor.dispatch('NewBlock', { newBlock });
 };
 
+const fakeEventName = 'insertParagraph';
+
 export {
-  insert
+  insert,
+  fakeEventName
 };

--- a/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
@@ -500,7 +500,7 @@ const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>) => {
 
 const fakeEventName = 'insertParagraph';
 
-export {
+export const blockbreak = {
   insert,
   fakeEventName
 };

--- a/modules/tinymce/src/core/main/ts/newline/InsertBr.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBr.ts
@@ -165,6 +165,9 @@ const insert = (editor: Editor, evt?) => {
   }
 };
 
+const fakeEventName = 'insertLineBreak';
+
 export {
-  insert
+  insert,
+  fakeEventName
 };

--- a/modules/tinymce/src/core/main/ts/newline/InsertBr.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBr.ts
@@ -167,7 +167,7 @@ const insert = (editor: Editor, evt?) => {
 
 const fakeEventName = 'insertLineBreak';
 
-export {
+export const linebreak = {
   insert,
   fakeEventName
 };

--- a/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
@@ -9,28 +9,30 @@ import * as InsertBlock from './InsertBlock';
 import * as InsertBr from './InsertBr';
 import * as NewLineAction from './NewLineAction';
 
+const insertBreak = (breakType: {
+  insert: (editor: Editor, evt?: EditorEvent<KeyboardEvent>) => void;
+  fakeEventName: string;
+}, editor: Editor, evt?: EditorEvent<KeyboardEvent>) => {
+  if (!editor.selection.isCollapsed()) {
+    execDeleteCommand(editor);
+  }
+  if (Type.isNonNullable(evt)) {
+    const event = fireFakeBeforeInputEvent(editor, breakType.fakeEventName);
+    if (event.isDefaultPrevented()) {
+      return;
+    }
+  }
+
+  breakType.insert(editor, evt);
+
+  if (Type.isNonNullable(evt)) {
+    fireFakeInputEvent(editor, breakType.fakeEventName);
+  }
+};
+
 const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>) => {
-  const insertBreak = (breakType: (editor: Editor, evt?: EditorEvent<KeyboardEvent>) => void, fakeEvent: string) => () => {
-    if (!editor.selection.isCollapsed()) {
-      execDeleteCommand(editor);
-    }
-    if (Type.isNonNullable(evt)) {
-      const event = fireFakeBeforeInputEvent(editor, fakeEvent);
-      if (event.isDefaultPrevented()) {
-        return;
-      }
-    }
-
-    breakType(editor, evt);
-
-    if (Type.isNonNullable(evt)) {
-      fireFakeInputEvent(editor, fakeEvent);
-    }
-  };
-
-  const lineBreak = insertBreak(InsertBr.insert, 'insertLineBreak');
-
-  const blockBreak = insertBreak(InsertBlock.insert, 'insertParagraph');
+  const lineBreak = () => insertBreak(InsertBr, editor, evt);
+  const blockBreak = () => insertBreak(InsertBlock, editor, evt);
 
   const logicalAction = NewLineAction.getAction(editor, evt);
 
@@ -53,5 +55,6 @@ const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>) => {
 };
 
 export {
-  insert
+  insert,
+  insertBreak
 };

--- a/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
@@ -5,8 +5,8 @@ import { getNewlineBehavior } from '../api/Options';
 import { EditorEvent } from '../api/util/EventDispatcher';
 import { execDeleteCommand } from '../delete/DeleteUtils';
 import { fireFakeBeforeInputEvent, fireFakeInputEvent } from '../keyboard/FakeInputEvents';
-import * as InsertBlock from './InsertBlock';
-import * as InsertBr from './InsertBr';
+import { blockbreak } from './InsertBlock';
+import { linebreak } from './InsertBr';
 import * as NewLineAction from './NewLineAction';
 
 const insertBreak = (breakType: {
@@ -31,25 +31,25 @@ const insertBreak = (breakType: {
 };
 
 const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>) => {
-  const lineBreak = () => insertBreak(InsertBr, editor, evt);
-  const blockBreak = () => insertBreak(InsertBlock, editor, evt);
+  const br = () => insertBreak(linebreak, editor, evt);
+  const block = () => insertBreak(blockbreak, editor, evt);
 
   const logicalAction = NewLineAction.getAction(editor, evt);
 
   switch (getNewlineBehavior(editor)) {
     case 'linebreak':
-      logicalAction.fold(lineBreak, lineBreak, Fun.noop);
+      logicalAction.fold(br, br, Fun.noop);
       break;
     case 'block':
-      logicalAction.fold(blockBreak, blockBreak, Fun.noop);
+      logicalAction.fold(block, block, Fun.noop);
       break;
     case 'invert':
-      logicalAction.fold(blockBreak, lineBreak, Fun.noop);
+      logicalAction.fold(block, br, Fun.noop);
       break;
     // implied by the options processor, unnecessary
     // case 'default':
     default:
-      logicalAction.fold(lineBreak, blockBreak, Fun.noop);
+      logicalAction.fold(br, block, Fun.noop);
       break;
   }
 };

--- a/modules/tinymce/src/core/test/ts/browser/api/commands/NewlineCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/api/commands/NewlineCommandsTest.ts
@@ -1,4 +1,4 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { after, before, context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -16,6 +16,25 @@ describe('browser.tinymce.core.api.commands.NewlineCommandTest', () => {
     editor.execCommand('InsertParagraph');
     TinyAssertions.assertContent(editor, '<p>12</p><p>3</p>');
     TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
+  });
+
+  context('TINY-8458: InsertParagraph and newline_behavior', () => {
+    before(() => {
+      hook.editor().options.set('newline_behavior', 'linebreak');
+    });
+
+    after(() => {
+      hook.editor().options.unset('newline_behavior');
+    });
+
+    it('ignores flag set to "linebreak"', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>123</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 2);
+      editor.execCommand('InsertParagraph');
+      TinyAssertions.assertContent(editor, '<p>12</p><p>3</p>');
+      TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
+    });
   });
 
   it('TINY-8606: InsertParagraph command should delete the selection', () => {
@@ -45,6 +64,25 @@ describe('browser.tinymce.core.api.commands.NewlineCommandTest', () => {
     TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
   });
 
+  context('TINY-8458: mceInsertNewline and newline_behavior', () => {
+    before(() => {
+      hook.editor().options.set('newline_behavior', 'linebreak');
+    });
+
+    after(() => {
+      hook.editor().options.unset('newline_behavior');
+    });
+
+    it('honours flag set to "linebreak"', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>123</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 2);
+      editor.execCommand('mceInsertNewLine');
+      TinyAssertions.assertContent(editor, '<p>12<br>3</p>');
+      TinyAssertions.assertCursor(editor, [ 0 ], 2);
+    });
+  });
+
   it('InsertLineBreak command', () => {
     const editor = hook.editor();
     editor.setContent('<p>123</p>');
@@ -61,5 +99,33 @@ describe('browser.tinymce.core.api.commands.NewlineCommandTest', () => {
     TinySelections.setCursor(editor, [ 0, 0 ], 3);
     editor.execCommand('InsertLineBreak');
     TinyAssertions.assertContent(editor, '<p>123<br><br></p>');
+  });
+
+  it('TINY-8458: InsertLineBreak command should delete the selection', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>This is a test</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 'This'.length, [ 0, 0 ], 'This is a '.length);
+    editor.execCommand('InsertLineBreak');
+    TinyAssertions.assertContent(editor, '<p>This<br>test</p>');
+    TinyAssertions.assertCursor(editor, [ 0 ], 2);
+  });
+
+  context('TINY-8458: InsertLineBreak and newline_behavior', () => {
+    before(() => {
+      hook.editor().options.set('newline_behavior', 'block');
+    });
+
+    after(() => {
+      hook.editor().options.unset('newline_behavior');
+    });
+
+    it('ignores flag set to "block"', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>123</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 2);
+      editor.execCommand('InsertLineBreak');
+      TinyAssertions.assertContent(editor, '<p>12<br>3</p>');
+      TinyAssertions.assertCursor(editor, [ 0 ], 2);
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertBrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertBrTest.ts
@@ -6,7 +6,7 @@ import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import * as InsertBr from 'tinymce/core/newline/InsertBr';
+import { linebreak } from 'tinymce/core/newline/InsertBr';
 
 describe('browser.tinymce.core.newline.InsertBrTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -24,7 +24,7 @@ describe('browser.tinymce.core.newline.InsertBrTest', () => {
       editor.setContent('<p>a<a href="#">b</a>c</p>');
       TinySelections.setCursor(editor, [ 0, 1, 0 ], 0);
       editor.nodeChanged();
-      InsertBr.insert(editor);
+      linebreak.insert(editor);
       TinyAssertions.assertSelection(editor, [ 0, 2, 0 ], 1, [ 0, 2, 0 ], 1);
       TinyAssertions.assertContent(editor, '<p>a<br><a href="#">b</a>c</p>');
     });
@@ -34,7 +34,7 @@ describe('browser.tinymce.core.newline.InsertBrTest', () => {
       editor.setContent('<p>a<a href="#">bc</a>d</p>');
       TinySelections.setCursor(editor, [ 0, 1, 0 ], 1);
       editor.nodeChanged();
-      InsertBr.insert(editor);
+      linebreak.insert(editor);
       TinyAssertions.assertSelection(editor, [ 0, 1 ], 2, [ 0, 1 ], 2);
       TinyAssertions.assertContent(editor, '<p>a<a href="#">b<br>c</a>d</p>');
     });
@@ -44,7 +44,7 @@ describe('browser.tinymce.core.newline.InsertBrTest', () => {
       editor.setContent('<p>a<a href="#">b</a>c</p>');
       TinySelections.setCursor(editor, [ 0, 1, 0 ], 1);
       editor.nodeChanged();
-      InsertBr.insert(editor);
+      linebreak.insert(editor);
       TinyAssertions.assertSelection(editor, [ 0 ], 3, [ 0 ], 3);
       TinyAssertions.assertContent(editor, '<p>a<a href="#">b</a><br><br>c</p>');
     });
@@ -54,7 +54,7 @@ describe('browser.tinymce.core.newline.InsertBrTest', () => {
       editor.setContent('<p>a<a href="#">b</a><br /></p>', { format: 'raw' });
       TinySelections.setCursor(editor, [ 0, 1, 0 ], 1);
       editor.nodeChanged();
-      InsertBr.insert(editor);
+      linebreak.insert(editor);
       TinyAssertions.assertSelection(editor, [ 0 ], 3, [ 0 ], 3);
       TinyAssertions.assertContent(editor, '<p>a<a href="#">b</a><br><br></p>');
     });
@@ -66,7 +66,7 @@ describe('browser.tinymce.core.newline.InsertBrTest', () => {
       editor.setContent('<p>a<code>b</code>c</p>');
       TinySelections.setCursor(editor, [ 0, 1, 0 ], 0);
       editor.nodeChanged();
-      InsertBr.insert(editor);
+      linebreak.insert(editor);
       TinyAssertions.assertSelection(editor, [ 0, 1 ], 2, [ 0, 1 ], 2);
       TinyAssertions.assertContent(editor, '<p>a<code><br>b</code>c</p>');
     });
@@ -76,7 +76,7 @@ describe('browser.tinymce.core.newline.InsertBrTest', () => {
       editor.setContent('<p>a<code>bc</code>d</p>');
       TinySelections.setCursor(editor, [ 0, 1, 0 ], 1);
       editor.nodeChanged();
-      InsertBr.insert(editor);
+      linebreak.insert(editor);
       TinyAssertions.assertSelection(editor, [ 0, 1 ], 2, [ 0, 1 ], 2);
       TinyAssertions.assertContent(editor, '<p>a<code>b<br>c</code>d</p>');
     });
@@ -86,7 +86,7 @@ describe('browser.tinymce.core.newline.InsertBrTest', () => {
       editor.setContent('<p>a<code>b</code>c</p>');
       TinySelections.setCursor(editor, [ 0, 1, 0 ], 1);
       editor.nodeChanged();
-      InsertBr.insert(editor);
+      linebreak.insert(editor);
       TinyAssertions.assertSelection(editor, [ 0, 1, 2 ], 0, [ 0, 1, 2 ], 0);
       TinyAssertions.assertContent(editor, '<p>a<code>b<br></code>c</p>');
     });
@@ -97,7 +97,7 @@ describe('browser.tinymce.core.newline.InsertBrTest', () => {
     editor.setContent('<p>a</p>', { format: 'raw' });
     TinySelections.setCursor(editor, [ 0, 0 ], 1);
     editor.nodeChanged();
-    InsertBr.insert(editor);
+    linebreak.insert(editor);
     TinyAssertions.assertContentStructure(editor,
       ApproxStructure.build((s, str, _arr) => s.element('body', {
         children: [
@@ -117,7 +117,7 @@ describe('browser.tinymce.core.newline.InsertBrTest', () => {
   it('Scrolls correctly to inserted br', () => {
     const editor = hook.editor();
     editor.setContent('');
-    Arr.range(100, () => InsertBr.insert(editor));
+    Arr.range(100, () => linebreak.insert(editor));
     const { top } = Scroll.get(TinyDom.document(editor));
     const offsetHeight = Height.get(TinyDom.body(editor));
     const { height } = WindowVisualViewport.getBounds(editor.getWin());


### PR DESCRIPTION
Related Ticket: TINY-8458

Description of Changes:
- Corrected behaviour of InsertParagraph with `newline_behavior` set.
- Fix `InsertLineBreak` bug where it did not delete selection.
- This adds a little bit to our bundle size (the `InsertBreak` and `InsertBr` modules now generate an export object in the bundle where previously the functions were used directly) but it seems worth it.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
