### PR TITLE
TINY-8756: Updated GitHub CODEOWNERS and PR template files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-* @tinymce/editor-platform-team @spocke @lnewson @ltrouton @HAFRMO @tiny-ben-tran
+* @tinymce/tinymce-reviewers
 
 # Oxide changes should include the design team as well
-/modules/oxide/ @tinymce/editor-platform-team @lostkeys @noxuhax @spocke @lnewson @ltrouton @HAFRMO @tiny-ben-tran
-/modules/oxide-icons-default/ @tinymce/editor-platform-team @lostkeys @noxuhax @spocke @lnewson @ltrouton @HAFRMO @tiny-ben-tran
+/modules/oxide/ @tinymce/tinymce-reviewers @noxuhax
+/modules/oxide-icons-default/ @tinymce/tinymce-reviewers @noxuhax
 
 # Katamari changes should include the integrations team as well
-/modules/katamari/ @tinymce/editor-platform-team @tinymce/integrations-team @spocke @lnewson @ltrouton @HAFRMO @tiny-ben-tran
+/modules/katamari/ @tinymce/tinymce-reviewers @tinymce/integrations-team

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Related Ticket:
+Related Ticket: 
 
 Description of Changes:
 * Placeholder text
@@ -6,10 +6,9 @@ Description of Changes:
 Pre-checks:
 * [ ] Changelog entry added
 * [ ] Tests have been added (if applicable)
-* [ ] Branch prefixed with `feature/` for new features (if applicable)
+* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`
 
 Review:
 * [ ] Milestone set
-* [ ] Review comments resolved
 
 GitHub issues (if applicable):


### PR DESCRIPTION
Related Ticket: TINY-8756

Description of Changes:
* Update the codeowners to use the new reviewers group
* Remove the comments resolved checkbox from the PR template as we'll use the branch protection instead
* Fix a couple minor things in the PR template

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/` for new features (if applicable)~

Review:
* [x] ~Milestone set~
* [x] Review comments resolved

GitHub issues (if applicable):
