### PR TITLE
TINY-8763: The value of togglable elements was not reset if not defined in the definition

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - The `fakeFocus` property for `InlineView` menus was not respected.
-- The value of togglable elements was not reset if its config was not specified in the definition
+- The value of togglable elements was not reset if its config was not specified in the definition #TINY-8763
 
 ## 10.0.0 - 2022-03-03
 

--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - The `fakeFocus` property for `InlineView` menus was not respected.
+- The value of togglable elements was not reset if its config was not specified in the definition
 
 ## 10.0.0 - 2022-03-03
 

--- a/modules/alloy/src/main/ts/ephox/alloy/dom/Reconcile.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dom/Reconcile.ts
@@ -56,9 +56,11 @@ const reconcileToDom = (definition: DomDefinitionDetail, obsoleted: SugarElement
 
   const updateValue = () => {
     const valueElement = obsoleted as SugarElement<HTMLInputElement | HTMLTextAreaElement>;
-    definition.value
-      .filter((value) => value !== Value.get(valueElement))
-      .each((value) => Value.set(valueElement, value));
+    const value = definition.value.getOrUndefined();
+    if (value !== Value.get(valueElement)) {
+      // TINY-8736: Value.set throws an error in case the value is undefined
+      Value.set(valueElement, value ?? '');
+    }
   };
 
   updateAttrs();

--- a/modules/alloy/src/test/ts/atomic/dom/ReconcileTest.ts
+++ b/modules/alloy/src/test/ts/atomic/dom/ReconcileTest.ts
@@ -18,25 +18,24 @@ describe('ReconcileTest', () => {
   };
 
   // TBA: test for updating styles and attributes
-  it('TINY-8736: Override value of element according to the definition', () => {
-    const component = SugarElement.fromHtml<HTMLInputElement>('<textarea>1234</textarea>');
+  it('TINY-8736: Override the value of element according to the definition', () => {
+    const component = SugarElement.fromHtml<HTMLTextAreaElement>('<textarea></textarea>');
     const definition = {
       ...elementDefinition,
       value: Optional.from('abc')
     };
     const newDom = reconcileToDom(definition, component);
-    assert.equal((newDom.dom as HTMLInputElement).value, 'abc');
+    assert.equal((newDom.dom as HTMLTextAreaElement).value, 'abc');
   });
 
-  it('TINY-8736: Default value of element to empty string if value is not specified in the definition', () => {
-    const component = SugarElement.fromHtml<HTMLInputElement>('<textarea>hi</textarea/>');
+  it('TINY-8736: Default the value of element to empty string if not defined in the definition', () => {
+    const component = SugarElement.fromHtml<HTMLTextAreaElement>('<textarea>hi</textarea/>');
     const newDom = reconcileToDom(elementDefinition, component);
-    assert.equal((newDom.dom as HTMLInputElement).value, '');
+    assert.equal((newDom.dom as HTMLTextAreaElement).value, '');
   });
 
-  it('TINY-8736: Default the modified value of element to empty string if value is not specified in the definition', () => {
+  it('TINY-8736: Default the modified value of element to empty string if not defined in the definition', () => {
     const component = SugarElement.fromHtml<HTMLTextAreaElement>('<textarea>How</textarea>');
-    component.dom.value = 'hello';
     const newDom = reconcileToDom(elementDefinition, component);
     assert.equal((newDom.dom as HTMLTextAreaElement).value, '');
   });

--- a/modules/alloy/src/test/ts/atomic/dom/ReconcileTest.ts
+++ b/modules/alloy/src/test/ts/atomic/dom/ReconcileTest.ts
@@ -1,0 +1,43 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { Optional } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
+
+import { reconcileToDom } from 'ephox/alloy/dom/Reconcile';
+
+describe('ReconcileTest', () => {
+  const elementDefinition = {
+    uid: 'uid-1',
+    tag: '',
+    attributes: {},
+    classes: [],
+    styles: {},
+    value: Optional.from(undefined),
+    innerHtml: Optional.from(undefined),
+    domChildren: []
+  };
+
+  // TBA: test for updating styles and attributes
+  it('TINY-8736: Override value of element according to the definition', () => {
+    const component = SugarElement.fromHtml<HTMLInputElement>('<textarea>1234</textarea>');
+    const definition = {
+      ...elementDefinition,
+      value: Optional.from('abc')
+    };
+    const newDom = reconcileToDom(definition, component);
+    assert.equal((newDom.dom as HTMLInputElement).value, 'abc');
+  });
+
+  it('TINY-8736: Default value of element to empty string if value is not specified in the definition', () => {
+    const component = SugarElement.fromHtml<HTMLInputElement>('<textarea>hi</textarea/>');
+    const newDom = reconcileToDom(elementDefinition, component);
+    assert.equal((newDom.dom as HTMLInputElement).value, '');
+  });
+
+  it('TINY-8736: Default the modified value of element to empty string if value is not specified in the definition', () => {
+    const component = SugarElement.fromHtml<HTMLTextAreaElement>('<textarea>How</textarea>');
+    component.dom.value = 'hello';
+    const newDom = reconcileToDom(elementDefinition, component);
+    assert.equal((newDom.dom as HTMLTextAreaElement).value, '');
+  });
+});

--- a/modules/alloy/src/test/ts/atomic/dom/ReconcileTest.ts
+++ b/modules/alloy/src/test/ts/atomic/dom/ReconcileTest.ts
@@ -33,4 +33,11 @@ describe('ReconcileTest', () => {
     const newDom = reconcileToDom(elementDefinition, component);
     assert.equal((newDom.dom as HTMLTextAreaElement).value, '');
   });
+
+  it('TINY-8736: Should not update value of a non togglable element', () => {
+    const component = SugarElement.fromHtml<HTMLDivElement>('<div>wow</div>');
+    assert.equal((component.dom as any).value, undefined);
+    const newDom = reconcileToDom(elementDefinition, component);
+    assert.equal((newDom.dom as any).value, undefined);
+  });
 });

--- a/modules/alloy/src/test/ts/atomic/dom/ReconcileTest.ts
+++ b/modules/alloy/src/test/ts/atomic/dom/ReconcileTest.ts
@@ -36,8 +36,8 @@ describe('ReconcileTest', () => {
 
   it('TINY-8736: Should not update value of a non togglable element', () => {
     const component = SugarElement.fromHtml<HTMLDivElement>('<div>wow</div>');
-    assert.equal((component.dom as any).value, undefined);
+    assert.isUndefined((component.dom as any).value);
     const newDom = reconcileToDom(elementDefinition, component);
-    assert.equal((newDom.dom as any).value, undefined);
+    assert.isUndefined((newDom.dom as any).value);
   });
 });

--- a/modules/alloy/src/test/ts/atomic/dom/ReconcileTest.ts
+++ b/modules/alloy/src/test/ts/atomic/dom/ReconcileTest.ts
@@ -33,10 +33,4 @@ describe('ReconcileTest', () => {
     const newDom = reconcileToDom(elementDefinition, component);
     assert.equal((newDom.dom as HTMLTextAreaElement).value, '');
   });
-
-  it('TINY-8736: Default the modified value of element to empty string if not defined in the definition', () => {
-    const component = SugarElement.fromHtml<HTMLTextAreaElement>('<textarea>How</textarea>');
-    const newDom = reconcileToDom(elementDefinition, component);
-    assert.equal((newDom.dom as HTMLTextAreaElement).value, '');
-  });
 });


### PR DESCRIPTION
Related Ticket: TINY-8763

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [x] Milestone set
* [x] Review comments resolved

GitHub issues (if applicable):
