### PR TITLE
TINY-8729: Delete is broken when the selection contains CEF at the edge of the content

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -43,8 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Some option values for the `template` plugin weren't escaped properly when doing replacement lookups via a `RegExp` #TINY-7433
 - Copy events were not dispatched in readonly mode #TINY-6800
 - Using Ctrl+Shift+Home/End (Cmd+Shift+Up/Down on Mac) would not expand the selection when a `contenteditable="false"` element was at the edge of content #TINY-7795
-- Delete operations could behave incorrectly if the selection contained
-a `contenteditable="false"` element located at the edge of content #TINY-8729
+- Delete operations could behave incorrectly if the selection contains a `contenteditable="false"` element located at the edge of content #TINY-8729
 
 ## 6.0.3 - 2022-05-25
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Some option values for the `template` plugin weren't escaped properly when doing replacement lookups via a `RegExp` #TINY-7433
 - Copy events were not dispatched in readonly mode #TINY-6800
 - Using Ctrl+Shift+Home/End (Cmd+Shift+Up/Down on Mac) would not expand the selection when a `contenteditable="false"` element was at the edge of content #TINY-7795
+- Delete operations could behave incorrectly if the selection contained
+a `contenteditable="false"` element located at the edge of content #TINY-8729
 
 ## 6.0.3 - 2022-05-25
 

--- a/modules/tinymce/src/core/main/ts/delete/CefDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/CefDelete.ts
@@ -6,7 +6,6 @@ import CaretPosition from '../caret/CaretPosition';
 import * as CefUtils from '../dom/CefUtils';
 import * as NodeType from '../dom/NodeType';
 import { isCefAtEdgeSelected } from '../keyboard/CefUtils';
-import { deleteRng } from '../textpatterns/utils/Utils';
 import * as CefDeleteAction from './CefDeleteAction';
 import * as DeleteElement from './DeleteElement';
 import * as DeleteUtils from './DeleteUtils';
@@ -82,7 +81,7 @@ const backspaceDeleteRange = (editor: Editor, forward: boolean): Optional<() => 
 
   if (isCefAtEdgeSelected(editor)) {
     return Optional.some(() => {
-      deleteRng(editor.dom, editor.selection.getRng(), (elm) => elm === editor.getBody());
+      DeleteUtils.deleteRangeContents(editor, editor.selection.getRng(), SugarElement.fromDom(editor.getBody()));
     });
   }
   return Optional.none();

--- a/modules/tinymce/src/core/main/ts/delete/CefDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/CefDelete.ts
@@ -5,6 +5,8 @@ import Editor from '../api/Editor';
 import CaretPosition from '../caret/CaretPosition';
 import * as CefUtils from '../dom/CefUtils';
 import * as NodeType from '../dom/NodeType';
+import { isCefAtEdgeSelected } from '../keyboard/CefUtils';
+import { deleteRng } from '../textpatterns/utils/Utils';
 import * as CefDeleteAction from './CefDeleteAction';
 import * as DeleteElement from './DeleteElement';
 import * as DeleteUtils from './DeleteUtils';
@@ -78,6 +80,11 @@ const backspaceDeleteRange = (editor: Editor, forward: boolean): Optional<() => 
     );
   }
 
+  if (isCefAtEdgeSelected(editor)) {
+    return Optional.some(() => {
+      deleteRng(editor.dom, editor.selection.getRng(), (elm) => elm === editor.getBody());
+    });
+  }
   return Optional.none();
 };
 

--- a/modules/tinymce/src/core/main/ts/delete/DeleteUtils.ts
+++ b/modules/tinymce/src/core/main/ts/delete/DeleteUtils.ts
@@ -1,11 +1,13 @@
-import { Optional, Optionals } from '@ephox/katamari';
-import { Compare, PredicateFind, SugarElement } from '@ephox/sugar';
+import { Arr, Optional, Optionals } from '@ephox/katamari';
+import { Compare, PredicateFind, Remove, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import { EditorEvent } from '../api/util/EventDispatcher';
 import * as CaretFinder from '../caret/CaretFinder';
 import CaretPosition from '../caret/CaretPosition';
 import { isListItem, isTextBlock } from '../dom/ElementType';
+import * as Empty from '../dom/Empty';
+import * as PaddingBr from '../dom/PaddingBr';
 import * as InlineUtils from '../keyboard/InlineUtils';
 
 const execCommandIgnoreInputEvents = (editor: Editor, command: string) => {
@@ -67,7 +69,35 @@ const willDeleteLastPositionInElement = (forward: boolean, fromPos: CaretPositio
       }
     }).getOr(true);
 
+const freefallRtl = (root: SugarElement<Node>): Optional<SugarElement<Node>> => {
+  const child = SugarNode.isComment(root) ? Traverse.prevSibling(root) : Traverse.lastChild(root);
+  return child.bind(freefallRtl).orThunk(() => Optional.some(root));
+};
+
+const deleteRangeContents = (editor: Editor, rng: Range, root: SugarElement<HTMLElement>, moveSelection: boolean = true): void => {
+  rng.deleteContents();
+  // Pad the last block node
+  const lastNode = freefallRtl(root).getOr(root);
+  const lastBlock = SugarElement.fromDom(editor.dom.getParent(lastNode.dom, editor.dom.isBlock));
+  if (Empty.isEmpty(lastBlock)) {
+    PaddingBr.fillWithPaddingBr(lastBlock);
+    if (moveSelection) {
+      editor.selection.setCursorLocation(lastBlock.dom, 0);
+    }
+  }
+  // Clean up any additional leftover nodes. If the last block wasn't a direct child, then we also need to clean up siblings
+  if (!Compare.eq(root, lastBlock)) {
+    const additionalCleanupNodes = Optionals.is(Traverse.parent(lastBlock), root) ? [] : Traverse.siblings(lastBlock);
+    Arr.each(additionalCleanupNodes.concat(Traverse.children(root)), (node) => {
+      if (!Compare.eq(node, lastBlock) && !Compare.contains(node, lastBlock) && Empty.isEmpty(node)) {
+        Remove.remove(node);
+      }
+    });
+  }
+};
+
 export {
+  deleteRangeContents,
   execDeleteCommand,
   execForwardDeleteCommand,
   getParentBlock,

--- a/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDelete.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
-import { Attribute, Compare, Remove, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
+import { Attribute, Compare, Remove, SugarElement, SugarNode } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import * as CaretFinder from '../caret/CaretFinder';
@@ -12,14 +12,10 @@ import * as PaddingBr from '../dom/PaddingBr';
 import * as Parents from '../dom/Parents';
 import * as TableCellSelection from '../selection/TableCellSelection';
 import * as DeleteElement from './DeleteElement';
+import { deleteRangeContents } from './DeleteUtils';
 import * as TableDeleteAction from './TableDeleteAction';
 
 type OutsideTableDetails = TableDeleteAction.OutsideTableDetails;
-
-const freefallRtl = (root: SugarElement<Node>): Optional<SugarElement<Node>> => {
-  const child = SugarNode.isComment(root) ? Traverse.prevSibling(root) : Traverse.lastChild(root);
-  return child.bind(freefallRtl).orThunk(() => Optional.some(root));
-};
 
 // Reset the contenteditable state and fill the content with a padding br
 const cleanCells = (cells: SugarElement<HTMLTableCellElement>[]): void =>
@@ -150,25 +146,7 @@ const emptyMultiTableCells = (
 // Delete the contents of a range inside a cell. Runs on tables that are a single cell or partial selections that need to be cleaned up.
 const deleteCellContents = (editor: Editor, rng: Range, cell: SugarElement<HTMLTableCellElement>, moveSelection: boolean = true): Optional<() => void> =>
   Optional.some(() => {
-    rng.deleteContents();
-    // Pad the last block node
-    const lastNode = freefallRtl(cell).getOr(cell);
-    const lastBlock = SugarElement.fromDom(editor.dom.getParent(lastNode.dom, editor.dom.isBlock));
-    if (Empty.isEmpty(lastBlock)) {
-      PaddingBr.fillWithPaddingBr(lastBlock);
-      if (moveSelection) {
-        editor.selection.setCursorLocation(lastBlock.dom, 0);
-      }
-    }
-    // Clean up any additional leftover nodes. If the last block wasn't a direct child, then we also need to clean up siblings
-    if (!Compare.eq(cell, lastBlock)) {
-      const additionalCleanupNodes = Optionals.is(Traverse.parent(lastBlock), cell) ? [] : Traverse.siblings(lastBlock);
-      Arr.each(additionalCleanupNodes.concat(Traverse.children(cell)), (node) => {
-        if (!Compare.eq(node, lastBlock) && !Compare.contains(node, lastBlock) && Empty.isEmpty(node)) {
-          Remove.remove(node);
-        }
-      });
-    }
+    deleteRangeContents(editor, rng, cell, moveSelection);
   });
 
 const deleteTableElement = (editor: Editor, table: SugarElement<HTMLTableElement>): Optional<() => void> =>

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
@@ -1,5 +1,5 @@
 import { ApproxStructure, Keys } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -139,5 +139,35 @@ describe('browser.tinymce.core.delete.CefDeleteTest', () => {
         });
       })
     );
+  });
+
+  context('cef is at the start/end of the content and covered with the selection', () => {
+    it('TINY-8729: should delete selected content when cef block is at the start', () => {
+      const editor = hook.editor();
+      editor.setContent('<p contenteditable="false">CEF</p><p>abc</p>');
+      // actual content: <p data-mce-caret="before"></p><p contenteditable="false">CEF</p><p>abc</p>
+      TinySelections.setSelection(editor, [ 0 ], 0, [ 2, 0 ], 2);
+      TinyContentActions.keystroke(editor, Keys.backspace());
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
+      TinyAssertions.assertContent(editor, '<p>c</p>');
+    });
+
+    it('TINY-8729: should delete selected content when cef block is at the end', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>abc</p><p contenteditable="false">CEF</p>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 1, [], 2);
+      TinyContentActions.keystroke(editor, Keys.backspace());
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+      TinyAssertions.assertContent(editor, '<p>a</p>');
+    });
+
+    it('TINY-8729: should delete selected content when cef block is at the start and at the end', () => {
+      const editor = hook.editor();
+      editor.setContent('<p contenteditable="false">CEF</p><p>abc</p><p contenteditable="false">CEF</p>');
+      // actual content: <p data-mce-caret="before"></p><p contenteditable="false">CEF</p><p>abc</p><p contenteditable="false">CEF</p>
+      TinySelections.setSelection(editor, [ 0 ], 0, [], 4);
+      TinyContentActions.keystroke(editor, Keys.backspace());
+      TinyAssertions.assertContent(editor, '');
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
@@ -226,7 +226,7 @@ describe('browser.tinymce.core.delete.CefDeleteTest', () => {
         TinyAssertions.assertCursor(editor, [ 0 ], 0);
       });
 
-      it(`TINY-8729-4: should delete selected content and padd empty list item with bogus br when ${label} is pressed`, () => {
+      it(`TINY-8729: should delete selected content and padd empty list item with bogus br when ${label} is pressed`, () => {
         const editor = hook.editor();
         editor.setContent('<ul><li><span contenteditable="false">CEF</span></li></ul>');
         // actual content: <ul><li>&#xFEFF<span contenteditable="false">CEF</span></li></ul>

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
@@ -142,7 +142,7 @@ describe('browser.tinymce.core.delete.CefDeleteTest', () => {
     );
   });
 
-  context('cef is at the start/end of the content and covered with the selection', () => {
+  context('cef block is at the start/end of the content and covered with the selection', () => {
     Arr.each([ Keys.delete, Keys.backspace ], (ks) => {
       it('TINY-8729: should delete selected content when cef block is at the start', () => {
         const editor = hook.editor();
@@ -172,6 +172,39 @@ describe('browser.tinymce.core.delete.CefDeleteTest', () => {
         TinyAssertions.assertContent(editor, '');
       });
     });
+  });
 
+  context('inline cef is at the start/end of the content and covered with the selection', () => {
+    Arr.each([ Keys.delete, Keys.backspace ], (ks) => {
+      it('TINY-8729: should delete selected content when inline cef is at the start', () => {
+        const editor = hook.editor();
+        editor.setContent('<p><span contenteditable="false">CEF</span>abc</p>');
+        // actual content: <p>&#xFEFF<span contenteditable="false">CEF</span>abc</p>
+        TinySelections.setSelection(editor, [ 0 ], 0, [ 0, 2 ], 2);
+        TinyContentActions.keystroke(editor, ks());
+        TinyAssertions.assertCursor(editor, [ 0 ], 0);
+        TinyAssertions.assertContent(editor, '<p>c</p>');
+      });
+
+      it('TINY-8729: should delete selected content when inline cef is at the end', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>abc<span contenteditable="false">CEF</span></p>');
+        // actual content: <p>&#xFEFF<span contenteditable="false">CEF</span>abc</p>
+        TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0 ], 2);
+        TinyContentActions.keystroke(editor, ks());
+        TinyAssertions.assertCursor(editor, [ 0 ], 1);
+        TinyAssertions.assertContent(editor, '<p>a</p>');
+      });
+
+      it('TINY-8729: should delete selected content when inline cef is at the start and at the end', () => {
+        const editor = hook.editor();
+        editor.setContent('<p><span contenteditable="false">CEF</span>abc<span contenteditable="false">CEF</span></p>');
+        // actual content: <p>&#xFEFF<span contenteditable="false">CEF</span>abc<span contenteditable="false">CEF</span></p>
+        TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 4);
+        TinyContentActions.keystroke(editor, ks());
+        TinyAssertions.assertCursor(editor, [ 0 ], 0);
+        TinyAssertions.assertContent(editor, '');
+      });
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
@@ -1,5 +1,6 @@
 import { ApproxStructure, Keys } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -142,32 +143,35 @@ describe('browser.tinymce.core.delete.CefDeleteTest', () => {
   });
 
   context('cef is at the start/end of the content and covered with the selection', () => {
-    it('TINY-8729: should delete selected content when cef block is at the start', () => {
-      const editor = hook.editor();
-      editor.setContent('<p contenteditable="false">CEF</p><p>abc</p>');
-      // actual content: <p data-mce-caret="before"></p><p contenteditable="false">CEF</p><p>abc</p>
-      TinySelections.setSelection(editor, [ 0 ], 0, [ 2, 0 ], 2);
-      TinyContentActions.keystroke(editor, Keys.backspace());
-      TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
-      TinyAssertions.assertContent(editor, '<p>c</p>');
+    Arr.each([ Keys.delete, Keys.backspace ], (ks) => {
+      it('TINY-8729: should delete selected content when cef block is at the start', () => {
+        const editor = hook.editor();
+        editor.setContent('<p contenteditable="false">CEF</p><p>abc</p>');
+        // actual content: <p data-mce-caret="before"></p><p contenteditable="false">CEF</p><p>abc</p>
+        TinySelections.setSelection(editor, [ 0 ], 0, [ 2, 0 ], 2);
+        TinyContentActions.keystroke(editor, ks());
+        TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
+        TinyAssertions.assertContent(editor, '<p>c</p>');
+      });
+
+      it('TINY-8729: should delete selected content when cef block is at the end', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>abc</p><p contenteditable="false">CEF</p>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 1, [], 2);
+        TinyContentActions.keystroke(editor, ks());
+        TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+        TinyAssertions.assertContent(editor, '<p>a</p>');
+      });
+
+      it('TINY-8729: should delete selected content when cef block is at the start and at the end', () => {
+        const editor = hook.editor();
+        editor.setContent('<p contenteditable="false">CEF</p><p>abc</p><p contenteditable="false">CEF</p>');
+        // actual content: <p data-mce-caret="before"></p><p contenteditable="false">CEF</p><p>abc</p><p contenteditable="false">CEF</p>
+        TinySelections.setSelection(editor, [ 0 ], 0, [], 4);
+        TinyContentActions.keystroke(editor, ks());
+        TinyAssertions.assertContent(editor, '');
+      });
     });
 
-    it('TINY-8729: should delete selected content when cef block is at the end', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>abc</p><p contenteditable="false">CEF</p>');
-      TinySelections.setSelection(editor, [ 0, 0 ], 1, [], 2);
-      TinyContentActions.keystroke(editor, Keys.backspace());
-      TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
-      TinyAssertions.assertContent(editor, '<p>a</p>');
-    });
-
-    it('TINY-8729: should delete selected content when cef block is at the start and at the end', () => {
-      const editor = hook.editor();
-      editor.setContent('<p contenteditable="false">CEF</p><p>abc</p><p contenteditable="false">CEF</p>');
-      // actual content: <p data-mce-caret="before"></p><p contenteditable="false">CEF</p><p>abc</p><p contenteditable="false">CEF</p>
-      TinySelections.setSelection(editor, [ 0 ], 0, [], 4);
-      TinyContentActions.keystroke(editor, Keys.backspace());
-      TinyAssertions.assertContent(editor, '');
-    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
@@ -207,4 +207,18 @@ describe('browser.tinymce.core.delete.CefDeleteTest', () => {
       });
     });
   });
+
+  context('Cleaning up after rng.deleteContens call', () => {
+    Arr.each([ Keys.backspace, Keys.delete ], (ks) => {
+      it('TINY-8729: should clean up empty nodes and padd empty block with bogus br', () => {
+        const editor = hook.editor();
+        editor.setContent('<p><strong>W</strong>elcom<strong>e</strong></p><p contenteditable="false">CEF</p>');
+        TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ ], 2);
+        TinyContentActions.keystroke(editor, ks());
+        // it should remove empty  <p><strong></strong></p> nodes
+        TinyAssertions.assertRawContent(editor, '<p><br data-mce-bogus="1"></p>');
+        TinyAssertions.assertCursor(editor, [ 0 ], 0);
+      });
+    });
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
@@ -5,6 +5,12 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@
 
 import Editor from 'tinymce/core/api/Editor';
 
+const applyForDeleteAndBackspace = (fn: (pair: {label: string; key: () => number}) => void) =>
+  Arr.each([
+    { label: 'Delete', key: Keys.delete },
+    { label: 'Backspace', key: Keys.backspace }
+  ], fn);
+
 describe('browser.tinymce.core.delete.CefDeleteTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
@@ -143,65 +149,65 @@ describe('browser.tinymce.core.delete.CefDeleteTest', () => {
   });
 
   context('cef block is at the start/end of the content and covered with the selection', () => {
-    Arr.each([ Keys.delete, Keys.backspace ], (ks) => {
-      it('TINY-8729: should delete selected content when cef block is at the start', () => {
+    applyForDeleteAndBackspace(({ label, key }) => {
+      it(`TINY-8729: should delete selected content when cef block is at the start and ${label} is pressed`, () => {
         const editor = hook.editor();
         editor.setContent('<p contenteditable="false">CEF</p><p>abc</p>');
         // actual content: <p data-mce-caret="before"></p><p contenteditable="false">CEF</p><p>abc</p>
         TinySelections.setSelection(editor, [ 0 ], 0, [ 2, 0 ], 2);
-        TinyContentActions.keystroke(editor, ks());
+        TinyContentActions.keystroke(editor, key());
         TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
         TinyAssertions.assertContent(editor, '<p>c</p>');
       });
 
-      it('TINY-8729: should delete selected content when cef block is at the end', () => {
+      it(`TINY-8729: should delete selected content when cef block is at the end and ${label} is pressed`, () => {
         const editor = hook.editor();
         editor.setContent('<p>abc</p><p contenteditable="false">CEF</p>');
         TinySelections.setSelection(editor, [ 0, 0 ], 1, [], 2);
-        TinyContentActions.keystroke(editor, ks());
+        TinyContentActions.keystroke(editor, key());
         TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
         TinyAssertions.assertContent(editor, '<p>a</p>');
       });
 
-      it('TINY-8729: should delete selected content when cef block is at the start and at the end', () => {
+      it(`TINY-8729: should delete selected content when cef block is at the start and at the end after ${label} is pressed`, () => {
         const editor = hook.editor();
         editor.setContent('<p contenteditable="false">CEF</p><p>abc</p><p contenteditable="false">CEF</p>');
         // actual content: <p data-mce-caret="before"></p><p contenteditable="false">CEF</p><p>abc</p><p contenteditable="false">CEF</p>
         TinySelections.setSelection(editor, [ 0 ], 0, [], 4);
-        TinyContentActions.keystroke(editor, ks());
+        TinyContentActions.keystroke(editor, key());
         TinyAssertions.assertContent(editor, '');
       });
     });
   });
 
   context('inline cef is at the start/end of the content and covered with the selection', () => {
-    Arr.each([ Keys.delete, Keys.backspace ], (ks) => {
-      it('TINY-8729: should delete selected content when inline cef is at the start', () => {
+    applyForDeleteAndBackspace(({ label, key }) => {
+      it(`TINY-8729: should delete selected content when inline cef is at the start and ${label} is pressed`, () => {
         const editor = hook.editor();
         editor.setContent('<p><span contenteditable="false">CEF</span>abc</p>');
         // actual content: <p>&#xFEFF<span contenteditable="false">CEF</span>abc</p>
         TinySelections.setSelection(editor, [ 0 ], 0, [ 0, 2 ], 2);
-        TinyContentActions.keystroke(editor, ks());
+        TinyContentActions.keystroke(editor, key());
         TinyAssertions.assertCursor(editor, [ 0 ], 0);
         TinyAssertions.assertContent(editor, '<p>c</p>');
       });
 
-      it('TINY-8729: should delete selected content when inline cef is at the end', () => {
+      it(`TINY-8729: should delete selected content when inline cef is at the end and ${label} is pressed`, () => {
         const editor = hook.editor();
         editor.setContent('<p>abc<span contenteditable="false">CEF</span></p>');
         // actual content: <p>&#xFEFF<span contenteditable="false">CEF</span>abc</p>
         TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0 ], 2);
-        TinyContentActions.keystroke(editor, ks());
+        TinyContentActions.keystroke(editor, key());
         TinyAssertions.assertCursor(editor, [ 0 ], 1);
         TinyAssertions.assertContent(editor, '<p>a</p>');
       });
 
-      it('TINY-8729: should delete selected content when inline cef is at the start and at the end', () => {
+      it(`TINY-8729: should delete selected content when inline cef is at the start and at the end after ${label} is pressed`, () => {
         const editor = hook.editor();
         editor.setContent('<p><span contenteditable="false">CEF</span>abc<span contenteditable="false">CEF</span></p>');
         // actual content: <p>&#xFEFF<span contenteditable="false">CEF</span>abc<span contenteditable="false">CEF</span></p>
         TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 4);
-        TinyContentActions.keystroke(editor, ks());
+        TinyContentActions.keystroke(editor, key());
         TinyAssertions.assertCursor(editor, [ 0 ], 0);
         TinyAssertions.assertContent(editor, '');
       });
@@ -209,15 +215,25 @@ describe('browser.tinymce.core.delete.CefDeleteTest', () => {
   });
 
   context('Cleaning up after rng.deleteContens call', () => {
-    Arr.each([ Keys.backspace, Keys.delete ], (ks) => {
-      it('TINY-8729: should clean up empty nodes and padd empty block with bogus br', () => {
+    applyForDeleteAndBackspace(({ label, key }) => {
+      it(`TINY-8729: should clean up empty nodes and padd empty block with bogus br when ${label} is pressed`, () => {
         const editor = hook.editor();
         editor.setContent('<p><strong>W</strong>elcom<strong>e</strong></p><p contenteditable="false">CEF</p>');
         TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ ], 2);
-        TinyContentActions.keystroke(editor, ks());
+        TinyContentActions.keystroke(editor, key());
         // it should remove empty  <p><strong></strong></p> nodes
         TinyAssertions.assertRawContent(editor, '<p><br data-mce-bogus="1"></p>');
         TinyAssertions.assertCursor(editor, [ 0 ], 0);
+      });
+
+      it(`TINY-8729-4: should delete selected content and padd empty list item with bogus br when ${label} is pressed`, () => {
+        const editor = hook.editor();
+        editor.setContent('<ul><li><span contenteditable="false">CEF</span></li></ul>');
+        // actual content: <ul><li>&#xFEFF<span contenteditable="false">CEF</span></li></ul>
+        TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0 ], 2);
+        TinyContentActions.keystroke(editor, key());
+        TinyAssertions.assertRawContent(editor, '<ul><li><br data-mce-bogus="1"></li></ul>');
+        TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
       });
     });
   });


### PR DESCRIPTION
Related Ticket: TINY-8729

Description of Changes:
* Overrides default deletion when the selection contains cef at the start or the end of the document and explicitly removes selected content

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
