### PR TITLE
TINY-7817: avoid moving the selection to a comment with the normalization

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `InsertLineBreak` command did not replace selected content #TINY-8458
 - Delete operations could behave incorrectly if the selection contains a `contenteditable="false"` element located at the edge of content #TINY-8729
 - `uploadImages` no longer triggers two `change` events if there is a removal of images on upload #TINY-8641
-- The selection is not moved over a comment on `editor.focus()` if the first element is a comment #TINY-7817
+- The selection is not moved over a comment by `editor.selection.normalize()` if the first element is a comment #TINY-7817
 
 ## 6.0.3 - 2022-05-25
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `InsertLineBreak` command did not replace selected content #TINY-8458
 - Delete operations could behave incorrectly if the selection contains a `contenteditable="false"` element located at the edge of content #TINY-8729
 - `uploadImages` no longer triggers two `change` events if there is a removal of images on upload #TINY-8641
-- The `getBookmark` function work correclty when the selection is on a comment #TINY-7817
+- The the selection is not moved over a comment on `editor.focus()` if the first element is a comment #TINY-7817
 
 ## 6.0.3 - 2022-05-25
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `InsertLineBreak` command did not replace selected content #TINY-8458
 - Delete operations could behave incorrectly if the selection contains a `contenteditable="false"` element located at the edge of content #TINY-8729
 - `uploadImages` no longer triggers two `change` events if there is a removal of images on upload #TINY-8641
+- The `getBookmark` function work correclty when the selection is on a comment #TINY-7817
 
 ## 6.0.3 - 2022-05-25
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `InsertLineBreak` command did not replace selected content #TINY-8458
 - Delete operations could behave incorrectly if the selection contains a `contenteditable="false"` element located at the edge of content #TINY-8729
 - `uploadImages` no longer triggers two `change` events if there is a removal of images on upload #TINY-8641
-- The the selection is not moved over a comment on `editor.focus()` if the first element is a comment #TINY-7817
+- The selection is not moved over a comment on `editor.focus()` if the first element is a comment #TINY-7817
 
 ## 6.0.3 - 2022-05-25
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `InsertLineBreak` command did not replace selected content #TINY-8458
 - Delete operations could behave incorrectly if the selection contains a `contenteditable="false"` element located at the edge of content #TINY-8729
 - `uploadImages` no longer triggers two `change` events if there is a removal of images on upload #TINY-8641
-- The selection is not moved over a comment by `editor.selection.normalize()` if the first element is a comment #TINY-7817
+- The selection is no longer incorrectly moved inside a comment by the `editor.selection.normalize()` API #TINY-7817
 
 ## 6.0.3 - 2022-05-25
 

--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -165,7 +165,7 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
     editor.on('SetSelectionRange', (e) => {
       // If the range is set inside a short ended element, then move it
       // to the side as IE for example will try to add content inside
-      e.range = normalizeVoidElementSelection(e.range);
+      e.range = normalizeVoidAndCommentElementSelection(e.range);
 
       const rng = setElementSelection(e.range, e.forward);
       if (rng) {
@@ -202,15 +202,16 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
   const isRangeInCaretContainer = (rng: Range) =>
     isWithinCaretContainer(rng.startContainer) || isWithinCaretContainer(rng.endContainer);
 
-  const normalizeVoidElementSelection = (rng: Range) => {
+  const normalizeVoidAndCommentElementSelection = (rng: Range) => {
     const voidElements = editor.schema.getVoidElements();
     const newRng = dom.createRng();
     const startContainer = rng.startContainer;
     const startOffset = rng.startOffset;
     const endContainer = rng.endContainer;
     const endOffset = rng.endOffset;
+    const isToNormalize = (node: Node): boolean => NodeType.isComment(node) || Obj.has(voidElements, node.nodeName.toLowerCase());
 
-    if (Obj.has(voidElements, startContainer.nodeName.toLowerCase())) {
+    if (isToNormalize(startContainer)) {
       if (startOffset === 0) {
         newRng.setStartBefore(startContainer);
       } else {
@@ -220,7 +221,7 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
       newRng.setStart(startContainer, startOffset);
     }
 
-    if (Obj.has(voidElements, endContainer.nodeName.toLowerCase())) {
+    if (isToNormalize(endContainer)) {
       if (endOffset === 0) {
         newRng.setEndBefore(endContainer);
       } else {

--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -209,9 +209,8 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
     const startOffset = rng.startOffset;
     const endContainer = rng.endContainer;
     const endOffset = rng.endOffset;
-    const isToNormalize = (node: Node): boolean => NodeType.isComment(node) || Obj.has(voidElements, node.nodeName.toLowerCase());
 
-    if (isToNormalize(startContainer)) {
+    if (Obj.has(voidElements, startContainer.nodeName.toLowerCase())) {
       if (startOffset === 0) {
         newRng.setStartBefore(startContainer);
       } else {
@@ -221,7 +220,7 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
       newRng.setStart(startContainer, startOffset);
     }
 
-    if (isToNormalize(endContainer)) {
+    if (Obj.has(voidElements, endContainer.nodeName.toLowerCase())) {
       if (endOffset === 0) {
         newRng.setEndBefore(endContainer);
       } else {

--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -165,7 +165,7 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
     editor.on('SetSelectionRange', (e) => {
       // If the range is set inside a short ended element, then move it
       // to the side as IE for example will try to add content inside
-      e.range = normalizeVoidAndCommentElementSelection(e.range);
+      e.range = normalizeVoidElementSelection(e.range);
 
       const rng = setElementSelection(e.range, e.forward);
       if (rng) {
@@ -202,7 +202,7 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
   const isRangeInCaretContainer = (rng: Range) =>
     isWithinCaretContainer(rng.startContainer) || isWithinCaretContainer(rng.endContainer);
 
-  const normalizeVoidAndCommentElementSelection = (rng: Range) => {
+  const normalizeVoidElementSelection = (rng: Range) => {
     const voidElements = editor.schema.getVoidElements();
     const newRng = dom.createRng();
     const startContainer = rng.startContainer;

--- a/modules/tinymce/src/core/main/ts/bookmark/GetBookmark.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/GetBookmark.ts
@@ -4,7 +4,6 @@ import DOMUtils from '../api/dom/DOMUtils';
 import EditorSelection from '../api/dom/Selection';
 import Tools from '../api/util/Tools';
 import * as CaretContainer from '../caret/CaretContainer';
-import * as CaretFinder from '../caret/CaretFinder';
 import CaretPosition from '../caret/CaretPosition';
 import * as NodeType from '../dom/NodeType';
 import { rangeInsertNode } from '../selection/RangeInsertNode';
@@ -87,13 +86,6 @@ const findIndex = (dom: DOMUtils, name: string, element: Element) => {
   return count;
 };
 
-const moveEndPointComment = (container: Node, offset: number, rng: Range, start: boolean): void => {
-  CaretFinder.firstPositionIn(container.parentElement).each((pos: CaretPosition) => {
-    const node = pos.getNode();
-    rng['set' + (start ? 'Start' : 'End')](node, offset);
-  });
-};
-
 const moveEndPoint = (rng: Range, start: boolean) => {
   let container, offset;
   const prefix = start ? 'start' : 'end';
@@ -109,12 +101,10 @@ const moveEndPoint = (rng: Range, start: boolean) => {
       offset = start ? 0 : container.childNodes.length;
       rng['set' + (start ? 'Start' : 'End')](container, offset);
     }
-  } else if (container.nodeName === '#comment') {
-    moveEndPointComment(container, offset, rng, start);
   }
 };
 
-const normalizeInvalidSelection = (rng: Range) => {
+const normalizeTableCellSelection = (rng: Range) => {
   moveEndPoint(rng, true);
   moveEndPoint(rng, false);
 
@@ -203,7 +193,7 @@ const getPersistentBookmark = (selection: EditorSelection, filled: boolean): IdB
   }
 
   // W3C method
-  const rng2 = normalizeInvalidSelection(rng.cloneRange());
+  const rng2 = normalizeTableCellSelection(rng.cloneRange());
 
   // Insert end marker
   if (!collapsed) {
@@ -212,7 +202,7 @@ const getPersistentBookmark = (selection: EditorSelection, filled: boolean): IdB
     rangeInsertNode(dom, rng2, endBookmarkNode);
   }
 
-  rng = normalizeInvalidSelection(rng);
+  rng = normalizeTableCellSelection(rng);
   rng.collapse(true);
   const startBookmarkNode = createBookmarkSpan(dom, id + '_start', filled);
   rangeInsertNode(dom, rng, startBookmarkNode);

--- a/modules/tinymce/src/core/main/ts/bookmark/GetBookmark.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/GetBookmark.ts
@@ -101,7 +101,7 @@ const moveEndPoint = (rng: Range, start: boolean) => {
   container = rng[prefix + 'Container'];
   offset = rng[prefix + 'Offset'];
 
-  // normalizeTableCellSelection
+  // normalize Table Cell selection
   if (NodeType.isElement(container) && container.nodeName === 'TR') {
     const childNodes = container.childNodes;
     container = childNodes[Math.min(start ? offset : offset - 1, childNodes.length - 1)];

--- a/modules/tinymce/src/core/main/ts/bookmark/GetBookmark.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/GetBookmark.ts
@@ -87,7 +87,7 @@ const findIndex = (dom: DOMUtils, name: string, element: Element) => {
   return count;
 };
 
-const moveEndPointComment = (container: Node, offset: number, rng: Range, start: boolean) => {
+const moveEndPointComment = (container: Node, offset: number, rng: Range, start: boolean): void => {
   CaretFinder.firstPositionIn(container.parentElement).each((pos: CaretPosition) => {
     const node = pos.getNode();
     rng['set' + (start ? 'Start' : 'End')](node, offset);

--- a/modules/tinymce/src/core/main/ts/selection/NormalizeRange.ts
+++ b/modules/tinymce/src/core/main/ts/selection/NormalizeRange.ts
@@ -97,6 +97,10 @@ const findTextNodeRelative = (dom: DOMUtils, isAfterNode: boolean, collapsed: bo
     lastInlineElement = node;
   }
 
+  if (NodeType.isComment(lastInlineElement)) {
+    return Optional.none();
+  }
+
   // Only fetch the last inline element when in caret mode for now
   if (collapsed && lastInlineElement) {
     return Optional.some(CaretPosition(lastInlineElement, 0));

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
@@ -7,7 +7,7 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import {
-  Bookmark, IdBookmark, isIdBookmark, isIndexBookmark, isPathBookmark, isRangeBookmark, isStringPathBookmark
+  Bookmark, isIdBookmark, isIndexBookmark, isPathBookmark, isRangeBookmark, isStringPathBookmark
 } from 'tinymce/core/bookmark/BookmarkTypes';
 import * as GetBookmark from 'tinymce/core/bookmark/GetBookmark';
 import * as ResolveBookmark from 'tinymce/core/bookmark/ResolveBookmark';
@@ -225,10 +225,7 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
   }));
 
   describe('TINY-7817', () => {
-    const hook = TinyHooks.bddSetup<Editor>({
-      menubar: false,
-      toolbar: false,
-      statusbar: false,
+    const hook = TinyHooks.bddSetupLight<Editor>({
       base_url: '/project/tinymce/js/tinymce'
     }, [], false);
 
@@ -244,12 +241,10 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
 
     it('TINY-7817: bookmark should be insert correclty even if the selection is on a comment', () => {
       const editor = hook.editor();
-      const getMockContent = (bookmark?: string): string => `<div><!-- Whatever -->${bookmark ?? ''} <img></div>`;
-      let bookmarkId: string;
 
-      editor.resetContent(getMockContent());
+      editor.resetContent('<div><!-- Whatever --> <img></div>');
       editor.addCommand('getBookmarkProxyCommand', () => {
-        bookmarkId = (editor.selection.getBookmark() as IdBookmark).id;
+        editor.selection.getBookmark();
       });
 
       const clickHandler = (): void => {
@@ -259,23 +254,17 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
 
       outsideButton.dom.click();
       outsideButton.dom.removeEventListener('click', clickHandler);
-
-      assert.equal(
-        editor.getBody().innerHTML,
-        getMockContent(`<span data-mce-type="bookmark" id="${bookmarkId}_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow: hidden; line-height: 0px;"></span>`),
-        'Editor should now contain the bookmark in the correct position'
-      );
-      editor.resetContent();
+      TinyAssertions.assertContentPresence(editor, {
+        '[data-mce-type="bookmark"]': 1
+      });
     });
 
     it('TINY-7817: bookmark should be insert correclty even if the selection is on a comment and next element is also a comment', () => {
       const editor = hook.editor();
-      const getMockContent = (bookmark?: string): string => `<div><!-- Whatever --><!-- second comment -->${bookmark ?? ''} <img></div>`;
-      let bookmarkId: string;
 
-      editor.resetContent(getMockContent());
+      editor.resetContent('<div><!-- Whatever --><!-- second comment --> <img></div>');
       editor.addCommand('getBookmarkProxyCommand', () => {
-        bookmarkId = (editor.selection.getBookmark() as IdBookmark).id;
+        editor.selection.getBookmark();
       });
 
       const clickHandler = (): void => {
@@ -286,12 +275,9 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
       outsideButton.dom.click();
       outsideButton.dom.removeEventListener('click', clickHandler);
 
-      assert.equal(
-        editor.getBody().innerHTML,
-        getMockContent(`<span data-mce-type="bookmark" id="${bookmarkId}_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow: hidden; line-height: 0px;"></span>`),
-        'Editor should now contain the bookmark in the correct position'
-      );
-      editor.resetContent('');
+      TinyAssertions.assertContentPresence(editor, {
+        '[data-mce-type="bookmark"]': 1
+      });
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
@@ -238,16 +238,20 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
     });
     Insert.append(SugarBody.body(), outsideButton);
 
-    document.getElementById('getBookmarkButton').addEventListener('click', () => {
+    const clickHandler = (): void => {
       editor.execCommand('getBookmarkProxyCommand');
-    });
+    };
+    outsideButton.dom.addEventListener('click', clickHandler);
 
     outsideButton.dom.click();
+    outsideButton.dom.removeEventListener('click', clickHandler);
 
     assert.equal(
       editor.getBody().innerHTML,
       getMockContent('<span data-mce-type="bookmark" id="mce_1_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow: hidden; line-height: 0px;"></span> '),
       'Editor should now contain the bookmark in the correct position'
     );
+
+    Remove.remove(outsideButton);
   }));
 });

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
@@ -226,8 +226,13 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
 
   it('TINY-7817: bookmark should be insert correclty even if the selection is on a comment', bookmarkTest((editor) => {
     const outsideButton: SugarElement<HTMLButtonElement> = SugarElement.fromHtml('<button id="getBookmarkButton">Get Bookmark</button>');
+    const getMockContent = (bookmark: string): string => '<div>' +
+      '<!-- Whatever -->' +
+      bookmark +
+      '<img src="https://en.wikipedia.org/wiki/Bear#/media/File:Ursidae-01.jpg" width="1200" height="300" data-mce-src="https://en.wikipedia.org/wiki/Bear#/media/File:Ursidae-01.jpg">' +
+    '</div>';
 
-    editor.resetContent('<div><!-- Whatever --> <img src="https://en.wikipedia.org/wiki/Bear#/media/File:Ursidae-01.jpg" width="1200" height="300"></div>');
+    editor.resetContent(getMockContent(' '));
     editor.addCommand('getBookmarkProxyCommand', () => {
       editor.selection.getBookmark();
     });
@@ -241,11 +246,8 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
 
     assert.equal(
       editor.getBody().innerHTML,
-      '<div>' +
-        '<!-- Whatever -->' +
-        '<span data-mce-type="bookmark" id="mce_1_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow: hidden; line-height: 0px;"></span> ' +
-        '<img src="https://en.wikipedia.org/wiki/Bear#/media/File:Ursidae-01.jpg" width="1200" height="300" data-mce-src="https://en.wikipedia.org/wiki/Bear#/media/File:Ursidae-01.jpg">' +
-      '</div>',
-      'Editor should now contain the bookmark in the correct position');
+      getMockContent('<span data-mce-type="bookmark" id="mce_1_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow: hidden; line-height: 0px;"></span> '),
+      'Editor should now contain the bookmark in the correct position'
+    );
   }));
 });

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
@@ -225,12 +225,8 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
   }));
 
   it('TINY-7817: bookmark should be insert correclty even if the selection is on a comment', bookmarkTest((editor) => {
+    const getMockContent = (bookmark: string): string => `<div><!-- Whatever -->${bookmark}<img></div>`;
     const outsideButton: SugarElement<HTMLButtonElement> = SugarElement.fromHtml('<button id="getBookmarkButton">Get Bookmark</button>');
-    const getMockContent = (bookmark: string): string => '<div>' +
-      '<!-- Whatever -->' +
-      bookmark +
-      '<img src="https://en.wikipedia.org/wiki/Bear#/media/File:Ursidae-01.jpg" width="1200" height="300" data-mce-src="https://en.wikipedia.org/wiki/Bear#/media/File:Ursidae-01.jpg">' +
-    '</div>';
 
     editor.resetContent(getMockContent(' '));
     editor.addCommand('getBookmarkProxyCommand', () => {

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
@@ -250,4 +250,31 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
 
     Remove.remove(outsideButton);
   }));
+
+  it('TINY-7817: bookmark should be insert correclty even if the selection is on a comment and next element is also a comment', bookmarkTest((editor) => {
+    const getMockContent = (bookmark?: string): string => `<div><!-- Whatever --><!-- second comment -->${bookmark ?? ''} <img></div>`;
+    const outsideButton: SugarElement<HTMLButtonElement> = SugarElement.fromHtml('<button id="getBookmarkButton">Get Bookmark</button>');
+
+    editor.resetContent(getMockContent());
+    editor.addCommand('getBookmarkProxyCommand', () => {
+      editor.selection.getBookmark();
+    });
+    Insert.append(SugarBody.body(), outsideButton);
+
+    const clickHandler = (): void => {
+      editor.execCommand('getBookmarkProxyCommand');
+    };
+    outsideButton.dom.addEventListener('click', clickHandler);
+
+    outsideButton.dom.click();
+    outsideButton.dom.removeEventListener('click', clickHandler);
+
+    assert.equal(
+      editor.getBody().innerHTML,
+      getMockContent('<span data-mce-type="bookmark" id="mce_1_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow: hidden; line-height: 0px;"></span>'),
+      'Editor should now contain the bookmark in the correct position'
+    );
+
+    Remove.remove(outsideButton);
+  }));
 });

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
@@ -226,21 +226,17 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
 
   it('TINY-7817: bookmark should be insert correclty even if the selection is on a comment', bookmarkTest((editor) => {
     const outsideButton: SugarElement<HTMLButtonElement> = SugarElement.fromHtml('<button id="buttonToClick">Button</button>');
-    const resetButton: SugarElement<HTMLButtonElement> = SugarElement.fromHtml('<button id="resetButtonToClick">Reset Button</button>');
 
-    editor.resetContent('');
+    editor.resetContent('<div><!-- Whatever --> <img src="https://en.wikipedia.org/wiki/Bear#/media/File:Ursidae-01.jpg" width="1200" height="300"></div>');
     editor.addCommand('getBookmarkProxyCommand', () => {
       editor.selection.getBookmark();
     });
     Insert.append(SugarBody.body(), outsideButton);
-    Insert.append(SugarBody.body(), resetButton);
+
     document.getElementById('buttonToClick').addEventListener('click', () => {
       editor.execCommand('getBookmarkProxyCommand');
     });
-    document.getElementById('resetButtonToClick').addEventListener('click', () => {
-      editor.resetContent('<div><!-- Whatever --> <img src="https://en.wikipedia.org/wiki/Bear#/media/File:Ursidae-01.jpg" width="1200" height="300"></div>');
-    });
-    resetButton.dom.click();
+
     outsideButton.dom.click();
 
     assert.equal(

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
@@ -1,5 +1,5 @@
 import { Assertions, Cursors } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { after, before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { Hierarchy, Html, Remove, Replication, SelectorFilter, SugarElement, Insert, SugarBody } from '@ephox/sugar';
 import { McEditor, TinyAssertions, TinyDom, TinySelections } from '@ephox/wrap-mcagar';
@@ -224,57 +224,61 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
     TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
   }));
 
-  it('TINY-7817: bookmark should be insert correclty even if the selection is on a comment', bookmarkTest((editor) => {
-    const getMockContent = (bookmark?: string): string => `<div><!-- Whatever -->${bookmark ?? ''} <img></div>`;
+  context('TINY-7817', () => {
     const outsideButton: SugarElement<HTMLButtonElement> = SugarElement.fromHtml('<button id="getBookmarkButton">Get Bookmark</button>');
 
-    editor.resetContent(getMockContent());
-    editor.addCommand('getBookmarkProxyCommand', () => {
-      editor.selection.getBookmark();
+    before(() => {
+      Insert.append(SugarBody.body(), outsideButton);
     });
-    Insert.append(SugarBody.body(), outsideButton);
 
-    const clickHandler = (): void => {
-      editor.execCommand('getBookmarkProxyCommand');
-    };
-    outsideButton.dom.addEventListener('click', clickHandler);
-
-    outsideButton.dom.click();
-    outsideButton.dom.removeEventListener('click', clickHandler);
-
-    assert.equal(
-      editor.getBody().innerHTML,
-      getMockContent('<span data-mce-type="bookmark" id="mce_1_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow: hidden; line-height: 0px;"></span>'),
-      'Editor should now contain the bookmark in the correct position'
-    );
-
-    Remove.remove(outsideButton);
-  }));
-
-  it('TINY-7817: bookmark should be insert correclty even if the selection is on a comment and next element is also a comment', bookmarkTest((editor) => {
-    const getMockContent = (bookmark?: string): string => `<div><!-- Whatever --><!-- second comment -->${bookmark ?? ''} <img></div>`;
-    const outsideButton: SugarElement<HTMLButtonElement> = SugarElement.fromHtml('<button id="getBookmarkButton">Get Bookmark</button>');
-
-    editor.resetContent(getMockContent());
-    editor.addCommand('getBookmarkProxyCommand', () => {
-      editor.selection.getBookmark();
+    after(() => {
+      Remove.remove(outsideButton);
     });
-    Insert.append(SugarBody.body(), outsideButton);
 
-    const clickHandler = (): void => {
-      editor.execCommand('getBookmarkProxyCommand');
-    };
-    outsideButton.dom.addEventListener('click', clickHandler);
+    it('TINY-7817: bookmark should be insert correclty even if the selection is on a comment', bookmarkTest((editor) => {
+      const getMockContent = (bookmark?: string): string => `<div><!-- Whatever -->${bookmark ?? ''} <img></div>`;
 
-    outsideButton.dom.click();
-    outsideButton.dom.removeEventListener('click', clickHandler);
+      editor.resetContent(getMockContent());
+      editor.addCommand('getBookmarkProxyCommand', () => {
+        editor.selection.getBookmark();
+      });
 
-    assert.equal(
-      editor.getBody().innerHTML,
-      getMockContent('<span data-mce-type="bookmark" id="mce_1_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow: hidden; line-height: 0px;"></span>'),
-      'Editor should now contain the bookmark in the correct position'
-    );
+      const clickHandler = (): void => {
+        editor.execCommand('getBookmarkProxyCommand');
+      };
+      outsideButton.dom.addEventListener('click', clickHandler);
 
-    Remove.remove(outsideButton);
-  }));
+      outsideButton.dom.click();
+      outsideButton.dom.removeEventListener('click', clickHandler);
+
+      assert.equal(
+        editor.getBody().innerHTML,
+        getMockContent('<span data-mce-type="bookmark" id="mce_1_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow: hidden; line-height: 0px;"></span>'),
+        'Editor should now contain the bookmark in the correct position'
+      );
+    }));
+
+    it('TINY-7817: bookmark should be insert correclty even if the selection is on a comment and next element is also a comment', bookmarkTest((editor) => {
+      const getMockContent = (bookmark?: string): string => `<div><!-- Whatever --><!-- second comment -->${bookmark ?? ''} <img></div>`;
+
+      editor.resetContent(getMockContent());
+      editor.addCommand('getBookmarkProxyCommand', () => {
+        editor.selection.getBookmark();
+      });
+
+      const clickHandler = (): void => {
+        editor.execCommand('getBookmarkProxyCommand');
+      };
+      outsideButton.dom.addEventListener('click', clickHandler);
+
+      outsideButton.dom.click();
+      outsideButton.dom.removeEventListener('click', clickHandler);
+
+      assert.equal(
+        editor.getBody().innerHTML,
+        getMockContent('<span data-mce-type="bookmark" id="mce_1_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow: hidden; line-height: 0px;"></span>'),
+        'Editor should now contain the bookmark in the correct position'
+      );
+    }));
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
@@ -225,10 +225,10 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
   }));
 
   it('TINY-7817: bookmark should be insert correclty even if the selection is on a comment', bookmarkTest((editor) => {
-    const getMockContent = (bookmark: string): string => `<div><!-- Whatever -->${bookmark}<img></div>`;
+    const getMockContent = (bookmark?: string): string => `<div><!-- Whatever -->${bookmark ?? ''} <img></div>`;
     const outsideButton: SugarElement<HTMLButtonElement> = SugarElement.fromHtml('<button id="getBookmarkButton">Get Bookmark</button>');
 
-    editor.resetContent(getMockContent(' '));
+    editor.resetContent(getMockContent());
     editor.addCommand('getBookmarkProxyCommand', () => {
       editor.selection.getBookmark();
     });
@@ -244,7 +244,7 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
 
     assert.equal(
       editor.getBody().innerHTML,
-      getMockContent('<span data-mce-type="bookmark" id="mce_1_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow: hidden; line-height: 0px;"></span> '),
+      getMockContent('<span data-mce-type="bookmark" id="mce_1_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow: hidden; line-height: 0px;"></span>'),
       'Editor should now contain the bookmark in the correct position'
     );
 

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
@@ -225,7 +225,7 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
   }));
 
   it('TINY-7817: bookmark should be insert correclty even if the selection is on a comment', bookmarkTest((editor) => {
-    const outsideButton: SugarElement<HTMLButtonElement> = SugarElement.fromHtml('<button id="buttonToClick">Button</button>');
+    const outsideButton: SugarElement<HTMLButtonElement> = SugarElement.fromHtml('<button id="getBookmarkButton">Get Bookmark</button>');
 
     editor.resetContent('<div><!-- Whatever --> <img src="https://en.wikipedia.org/wiki/Bear#/media/File:Ursidae-01.jpg" width="1200" height="300"></div>');
     editor.addCommand('getBookmarkProxyCommand', () => {
@@ -233,7 +233,7 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
     });
     Insert.append(SugarBody.body(), outsideButton);
 
-    document.getElementById('buttonToClick').addEventListener('click', () => {
+    document.getElementById('getBookmarkButton').addEventListener('click', () => {
       editor.execCommand('getBookmarkProxyCommand');
     });
 

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
@@ -256,7 +256,7 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
       binding.unbind();
     };
 
-    it('TINY-7817: bookmark should be insert correclty even if the first element of content is a comment', () => {
+    it('TINY-7817: bookmark should be inserted correctly even if the first element of content is a comment', () => {
       const editor = hook.editor();
       setSelectionToCommentAndTriggerGetBookmark(editor, '<div><!-- Whatever --> <img></div>');
       TinyAssertions.assertContentPresence(editor, {
@@ -264,7 +264,7 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
       });
     });
 
-    it('TINY-7817: bookmark should be insert correclty even if the first element of content is a comment and next element is also a comment', () => {
+    it('TINY-7817: bookmark should be inserted correctly even if the first element of content is a comment and next element is also a comment', () => {
       const editor = hook.editor();
       setSelectionToCommentAndTriggerGetBookmark(editor, '<div><!-- Whatever --><!-- second comment --> <img></div>');
       TinyAssertions.assertContentPresence(editor, {

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
@@ -224,7 +224,7 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
     TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
   }));
 
-  context('Get bookmark should work if selection is on a comment', () => {
+  context('Get bookmark should work if the first element of the content is a comment', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       base_url: '/project/tinymce/js/tinymce'
     }, [], false);
@@ -253,7 +253,7 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
       Remove.remove(outsideButton);
     });
 
-    it('TINY-7817: bookmark should be insert correclty even if the selection is on a comment', () => {
+    it('TINY-7817: bookmark should be insert correclty even if the first element of content is a comment', () => {
       const editor = hook.editor();
       setSelectionToCommentAndTriggerGetBookmark(editor, '<div><!-- Whatever --> <img></div>');
       TinyAssertions.assertContentPresence(editor, {
@@ -261,7 +261,7 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
       });
     });
 
-    it('TINY-7817: bookmark should be insert correclty even if the selection is on a comment and next element is also a comment', () => {
+    it('TINY-7817: bookmark should be insert correclty even if the first element of content is a comment and next element is also a comment', () => {
       const editor = hook.editor();
       setSelectionToCommentAndTriggerGetBookmark(editor, '<div><!-- Whatever --><!-- second comment --> <img></div>');
       TinyAssertions.assertContentPresence(editor, {

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
@@ -243,7 +243,7 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
       statusbar: false,
     }, setupElement, []);
 
-    const setSelectionToCommentAndTriggerGetBookmark = (editor: Editor, content: string) => {
+    const setContentAndTriggerGetBookmark = (editor: Editor, content: string) => {
       editor.resetContent(content);
       editor.addCommand('getBookmarkProxyCommand', () => {
         editor.selection.getBookmark();
@@ -258,7 +258,7 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
 
     it('TINY-7817: bookmark should be inserted correctly even if the first element of content is a comment', () => {
       const editor = hook.editor();
-      setSelectionToCommentAndTriggerGetBookmark(editor, '<div><!-- Whatever --> <img></div>');
+      setContentAndTriggerGetBookmark(editor, '<div><!-- Whatever --> <img></div>');
       TinyAssertions.assertContentPresence(editor, {
         '[data-mce-type="bookmark"]': 1
       });
@@ -266,7 +266,7 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
 
     it('TINY-7817: bookmark should be inserted correctly even if the first element of content is a comment and next element is also a comment', () => {
       const editor = hook.editor();
-      setSelectionToCommentAndTriggerGetBookmark(editor, '<div><!-- Whatever --><!-- second comment --> <img></div>');
+      setContentAndTriggerGetBookmark(editor, '<div><!-- Whatever --><!-- second comment --> <img></div>');
       TinyAssertions.assertContentPresence(editor, {
         '[data-mce-type="bookmark"]': 1
       });

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
@@ -228,11 +228,16 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
     const outsideButton: SugarElement<HTMLButtonElement> = SugarElement.fromHtml('<button id="getBookmarkButton">Get Bookmark</button>');
     const setupElement = () => {
       const element = SugarElement.fromTag('textarea');
+
+      Insert.append(SugarBody.body(), element);
       Insert.append(SugarBody.body(), outsideButton);
 
       return {
         element,
-        teardown: () => Remove.remove(outsideButton)
+        teardown: () => {
+          Remove.remove(element);
+          Remove.remove(outsideButton);
+        }
       };
     };
 

--- a/modules/tinymce/src/core/test/ts/browser/selection/NormalizeRangeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/NormalizeRangeTest.ts
@@ -229,6 +229,12 @@ describe('browser.tinymce.core.selection.NormalizeRangeTest', () => {
       const range = normalizeRange([], 3, [], 3);
       assertRangeNone(range);
     });
+
+    it('Should not normalize into comment', () => {
+      setHtml('<p><!-- some comment -->some test<img /></p>');
+      const range = normalizeRange([ 0, 0 ], 0, [ 0, 0 ], 0);
+      assertRangeNone(range);
+    });
   });
 
   context('Normalize caret positions', () => {

--- a/modules/tinymce/src/core/test/ts/browser/selection/NormalizeRangeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/NormalizeRangeTest.ts
@@ -229,6 +229,12 @@ describe('browser.tinymce.core.selection.NormalizeRangeTest', () => {
       const range = normalizeRange([], 3, [], 3);
       assertRangeNone(range);
     });
+
+    it('Should not normalize caret into previous inline element if it is a comment', () => {
+      setHtml('<p><!-- a comment -->b</p>');
+      const range = normalizeRange([ 0, 1 ], 0, [ 0, 1 ], 0);
+      assertRangeNone(range);
+    });
   });
 
   context('Normalize caret positions', () => {
@@ -296,12 +302,6 @@ describe('browser.tinymce.core.selection.NormalizeRangeTest', () => {
       setHtml('<p><i><b></b></i><br /></p>');
       const range = normalizeRange([ 0 ], 1, [ 0 ], 1);
       assertRange(viewBlock.get(), range, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0);
-    });
-
-    it('Should normalize into next element after comment', () => {
-      setHtml('<div><!-- some comment -->some text<img /></div>');
-      const range = normalizeRange([], 0, [], 0);
-      assertRange(viewBlock.get(), range, [ 0, 1 ], 0, [ 0, 1 ], 0);
     });
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/selection/NormalizeRangeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/NormalizeRangeTest.ts
@@ -229,12 +229,6 @@ describe('browser.tinymce.core.selection.NormalizeRangeTest', () => {
       const range = normalizeRange([], 3, [], 3);
       assertRangeNone(range);
     });
-
-    it('Should not normalize into comment', () => {
-      setHtml('<p><!-- some comment -->some test<img /></p>');
-      const range = normalizeRange([ 0, 0 ], 0, [ 0, 0 ], 0);
-      assertRangeNone(range);
-    });
   });
 
   context('Normalize caret positions', () => {
@@ -302,6 +296,12 @@ describe('browser.tinymce.core.selection.NormalizeRangeTest', () => {
       setHtml('<p><i><b></b></i><br /></p>');
       const range = normalizeRange([ 0 ], 1, [ 0 ], 1);
       assertRange(viewBlock.get(), range, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0);
+    });
+
+    it('Should normalize into next element after comment', () => {
+      setHtml('<div><!-- some comment -->some text<img /></div>');
+      const range = normalizeRange([], 0, [], 0);
+      assertRange(viewBlock.get(), range, [ 0, 1 ], 0, [ 0, 1 ], 0);
     });
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/selection/NormalizeRangeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/NormalizeRangeTest.ts
@@ -230,7 +230,7 @@ describe('browser.tinymce.core.selection.NormalizeRangeTest', () => {
       assertRangeNone(range);
     });
 
-    it('Should not normalize caret into previous inline element if it is a comment', () => {
+    it('TINY-7817: Should not normalize caret into previous inline element if it is a comment', () => {
       setHtml('<p><!-- a comment -->b</p>');
       const range = normalizeRange([ 0, 1 ], 0, [ 0, 1 ], 0);
       assertRangeNone(range);


### PR DESCRIPTION
Related Ticket: TINY-7817

Description of Changes:
At the moment there is a [mechanism](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/core/main/ts/selection/NormalizeRange.ts#L216) that normalizes caret and moves it left from the text node into the previous inline element text node if this previous inline node is a comment the caret is positioned over it and this can cause problems like trying to insert a tag into a comment

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
