### PR TITLE
TINY-8602: Ensure choice menu items use the "menuitemradio" aria role

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
-- Added new `immediateGrow` API to the sliding behaviour #TINY-8710
+- Added new `immediateGrow` API to the `Sliding` behaviour #TINY-8710
+- Added new `onToggled` callback property to the `Toggling` behaviour configuration #TINY-8602
+
+### Improved
+- Toggleable menu items can now be configured as `exclusive` and alloy will ensure only 1 exclusive item is toggled in the menu #TINY-8602
 
 ### Changed
 - Changed tabbing behavior escape key handling to run from `keydown` to `keyup` to prevent unwanted key event propagation #TINY-7005

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/ToggleApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/ToggleApis.ts
@@ -18,25 +18,28 @@ const updateClass = (component: AlloyComponent, toggleConfig: TogglingConfig, to
   });
 };
 
+const set = (component: AlloyComponent, toggleConfig: TogglingConfig, toggleState: TogglingState, state: boolean): void => {
+  const initialState = toggleState.get();
+
+  toggleState.set(state);
+  updateClass(component, toggleConfig, toggleState);
+  updateAriaState(component, toggleConfig, toggleState);
+
+  if (initialState !== state) {
+    toggleConfig.onToggled(component, state);
+  }
+};
+
 const toggle = (component: AlloyComponent, toggleConfig: TogglingConfig, toggleState: TogglingState): void => {
   set(component, toggleConfig, toggleState, !toggleState.get());
 };
 
 const on = (component: AlloyComponent, toggleConfig: TogglingConfig, toggleState: TogglingState): void => {
-  toggleState.set(true);
-  updateClass(component, toggleConfig, toggleState);
-  updateAriaState(component, toggleConfig, toggleState);
+  set(component, toggleConfig, toggleState, true);
 };
 
 const off = (component: AlloyComponent, toggleConfig: TogglingConfig, toggleState: TogglingState): void => {
-  toggleState.set(false);
-  updateClass(component, toggleConfig, toggleState);
-  updateAriaState(component, toggleConfig, toggleState);
-};
-
-const set = (component: AlloyComponent, toggleConfig: TogglingConfig, toggleState: TogglingState, state: boolean): void => {
-  const action = state ? on : off;
-  action(component, toggleConfig, toggleState);
+  set(component, toggleConfig, toggleState, false);
 };
 
 const isOn = (component: AlloyComponent, toggleConfig: TogglingConfig, toggleState: TogglingState): boolean =>

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/ToggleModes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/ToggleModes.ts
@@ -32,7 +32,8 @@ const tagAttributes: Record<string, string[]> = {
 const roleAttributes: Record<string, string[]> = {
   button: [ 'aria-pressed' ],
   listbox: [ 'aria-pressed', 'aria-expanded' ],
-  menuitemcheckbox: [ 'aria-checked' ]
+  menuitemcheckbox: [ 'aria-checked' ],
+  menuitemradio: [ 'aria-checked' ]
 };
 
 const detectFromTag = (component: AlloyComponent): Optional<string[]> => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/ToggleSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/ToggleSchema.ts
@@ -8,6 +8,7 @@ export default [
   FieldSchema.defaulted('selected', false),
   FieldSchema.option('toggleClass'),
   FieldSchema.defaulted('toggleOnExecute', true),
+  Fields.onHandler('onToggled'),
 
   FieldSchema.defaultedOf('aria', {
     mode: 'none'

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/TogglingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/TogglingTypes.ts
@@ -26,6 +26,7 @@ export interface TogglingConfig extends Behaviour.BehaviourConfigDetail {
   aria: AriaTogglingConfig;
   toggleOnExecute: boolean;
   selected: boolean;
+  onToggled: (component: AlloyComponent, state: boolean) => void;
 }
 
 export interface TogglingConfigSpec extends Behaviour.BehaviourConfigSpec {
@@ -36,6 +37,7 @@ export interface TogglingConfigSpec extends Behaviour.BehaviourConfigSpec {
   };
   toggleOnExecute?: boolean;
   selected?: boolean;
+  onToggled?: (component: AlloyComponent, state: boolean) => void;
 }
 
 export type TogglingMode = 'expanded' | 'pressed' | 'checked' | 'toggled' | 'selected' | 'none';

--- a/modules/alloy/src/main/ts/ephox/alloy/menu/build/ItemType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/menu/build/ItemType.ts
@@ -28,7 +28,7 @@ const getTogglingSpec = (tConfig: Partial<TogglingConfigSpec> & { exclusive?: bo
   aria: {
     mode: 'checked'
   },
-  // Filter out the additional properties
+  // Filter out the additional properties that are not in Toggling Behaviour's configuration (e.g. exclusive)
   ...Obj.filter(tConfig as { [K in keyof TogglingConfigSpec]: TogglingConfigSpec[K] }, (_value, name) => name !== 'exclusive'),
   onToggled: (component, state) => {
     if (Type.isFunction(tConfig.onToggled)) {

--- a/modules/alloy/src/main/ts/ephox/alloy/menu/util/ItemEvents.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/menu/util/ItemEvents.ts
@@ -7,6 +7,7 @@ import * as AlloyTriggers from '../../api/events/AlloyTriggers';
 
 const hoverEvent = 'alloy.item-hover';
 const focusEvent = 'alloy.item-focus';
+const toggledEvent = 'alloy.item-toggled';
 
 const onHover = (item: AlloyComponent): void => {
   // Firstly, check that the focus isn't already inside the item. This
@@ -26,12 +27,19 @@ const onFocus = (item: AlloyComponent): void => {
   AlloyTriggers.emitWith(item, focusEvent, { item });
 };
 
+const onToggled = (item: AlloyComponent, state: boolean): void => {
+  AlloyTriggers.emitWith(item, toggledEvent, { item, state });
+};
+
 const hover = Fun.constant(hoverEvent);
 const focus = Fun.constant(focusEvent);
+const toggled = Fun.constant(toggledEvent);
 
 export {
   hover,
   focus,
+  toggled,
   onHover,
-  onFocus
+  onFocus,
+  onToggled
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/single/MenuSpec.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/single/MenuSpec.ts
@@ -1,11 +1,12 @@
 import { Arr, Optional } from '@ephox/katamari';
-import { Compare, SelectorFilter } from '@ephox/sugar';
+import { Attribute, Compare, SelectorFilter } from '@ephox/sugar';
 
 import { Composing } from '../../api/behaviour/Composing';
 import { Highlighting } from '../../api/behaviour/Highlighting';
 import { Keying } from '../../api/behaviour/Keying';
 import { Representing } from '../../api/behaviour/Representing';
 import { Toggling } from '../../api/behaviour/Toggling';
+import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as SketchBehaviours from '../../api/component/SketchBehaviours';
 import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as AlloyTriggers from '../../api/events/AlloyTriggers';
@@ -13,6 +14,18 @@ import { CompositeSketchFactory } from '../../api/ui/UiSketcher';
 import * as ItemEvents from '../../menu/util/ItemEvents';
 import * as MenuEvents from '../../menu/util/MenuEvents';
 import { MenuDetail, MenuItemHoverEvent, MenuItemToggledEvent, MenuSpec } from '../types/MenuTypes';
+
+const deselectOtherRadioItems = (menu: AlloyComponent, item: AlloyComponent): void => {
+  // TODO: TINY-8812 - This ideally should be done in a way such that a menu can have multiple radio groups.
+  const checkedRadioItems = SelectorFilter.descendants(menu.element, '[role="menuitemradio"][aria-checked="true"]');
+  Arr.each(checkedRadioItems, (ele) => {
+    if (!Compare.eq(ele, item.element)) {
+      menu.getSystem().getByDom(ele).each((c) => {
+        Toggling.off(c);
+      });
+    }
+  });
+};
 
 const make: CompositeSketchFactory<MenuDetail, MenuSpec> = (detail, components, _spec, _externals) => ({
   uid: detail.uid,
@@ -66,16 +79,8 @@ const make: CompositeSketchFactory<MenuDetail, MenuSpec> = (detail, components, 
     // radio menu items and untoggling them when a certain item is toggled
     AlloyEvents.run<MenuItemToggledEvent>(ItemEvents.toggled(), (menu, simulatedEvent) => {
       const { item, state } = simulatedEvent.event;
-      if (state) {
-        // TODO: TINY-8812 - This ideally should be done in a way such that a menu can have multiple radio groups.
-        const checkedRadioItems = SelectorFilter.descendants(menu.element, '[role="menuitemradio"][aria-checked="true"]');
-        Arr.each(checkedRadioItems, (ele) => {
-          if (!Compare.eq(ele, item.element)) {
-            menu.getSystem().getByDom(ele).each((c) => {
-              Toggling.off(c);
-            });
-          }
-        });
+      if (state && Attribute.get(item.element, 'role') === 'menuitemradio') {
+        deselectOtherRadioItems(menu, item);
       }
     })
   ]),

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/single/MenuSpec.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/single/MenuSpec.ts
@@ -1,16 +1,18 @@
-import { Optional } from '@ephox/katamari';
+import { Arr, Optional } from '@ephox/katamari';
+import { Compare, SelectorFilter } from '@ephox/sugar';
 
 import { Composing } from '../../api/behaviour/Composing';
 import { Highlighting } from '../../api/behaviour/Highlighting';
 import { Keying } from '../../api/behaviour/Keying';
 import { Representing } from '../../api/behaviour/Representing';
+import { Toggling } from '../../api/behaviour/Toggling';
 import * as SketchBehaviours from '../../api/component/SketchBehaviours';
 import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as AlloyTriggers from '../../api/events/AlloyTriggers';
 import { CompositeSketchFactory } from '../../api/ui/UiSketcher';
 import * as ItemEvents from '../../menu/util/ItemEvents';
 import * as MenuEvents from '../../menu/util/MenuEvents';
-import { MenuDetail, MenuItemHoverEvent, MenuSpec } from '../types/MenuTypes';
+import { MenuDetail, MenuItemHoverEvent, MenuItemToggledEvent, MenuSpec } from '../types/MenuTypes';
 
 const make: CompositeSketchFactory<MenuDetail, MenuSpec> = (detail, components, _spec, _externals) => ({
   uid: detail.uid,
@@ -58,6 +60,23 @@ const make: CompositeSketchFactory<MenuDetail, MenuSpec> = (detail, components, 
     AlloyEvents.run<MenuItemHoverEvent>(ItemEvents.hover(), (menu, simulatedEvent) => {
       const item = simulatedEvent.event.item;
       Highlighting.highlight(menu, item);
+    }),
+
+    // Enforce only a single radio menu item is toggled by finding any other toggled
+    // radio menu items and untoggling them when a certain item is toggled
+    AlloyEvents.run<MenuItemToggledEvent>(ItemEvents.toggled(), (menu, simulatedEvent) => {
+      const { item, state } = simulatedEvent.event;
+      if (state) {
+        // TODO: TINY-8812 - This ideally should be done in a way such that a menu can have multiple radio groups.
+        const checkedRadioItems = SelectorFilter.descendants(menu.element, '[role="menuitemradio"][aria-checked="true"]');
+        Arr.each(checkedRadioItems, (ele) => {
+          if (!Compare.eq(ele, item.element)) {
+            menu.getSystem().getByDom(ele).each((c) => {
+              Toggling.off(c);
+            });
+          }
+        });
+      }
     })
   ]),
   components,

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/ItemTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/ItemTypes.ts
@@ -56,7 +56,6 @@ export interface NormalItemSpec {
   data: ItemDataTuple;
   components?: AlloySpec[];
   dom: RawDomSchema;
-  // INVESTIGATE: this might not be right
   toggling?: Partial<TogglingConfigSpec> & { exclusive?: boolean };
   itemBehaviours?: AlloyBehaviourRecord;
   ignoreFocus?: boolean;
@@ -69,7 +68,6 @@ export interface NormalItemDetail extends ItemDetail {
   data: ItemDataTuple;
   components: AlloySpec[];
   dom: RawDomSchema;
-  // INVESTIGATE: this might not be right
   toggling: Optional<Partial<TogglingConfigSpec> & { exclusive?: boolean }>;
   itemBehaviours: SketchBehaviours;
   ignoreFocus?: boolean;

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/ItemTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/ItemTypes.ts
@@ -57,7 +57,7 @@ export interface NormalItemSpec {
   components?: AlloySpec[];
   dom: RawDomSchema;
   // INVESTIGATE: this might not be right
-  toggling?: Partial<TogglingConfigSpec>;
+  toggling?: Partial<TogglingConfigSpec> & { exclusive?: boolean };
   itemBehaviours?: AlloyBehaviourRecord;
   ignoreFocus?: boolean;
   domModification?: DomModificationSpec;
@@ -70,7 +70,7 @@ export interface NormalItemDetail extends ItemDetail {
   components: AlloySpec[];
   dom: RawDomSchema;
   // INVESTIGATE: this might not be right
-  toggling: Optional<Partial<TogglingConfigSpec>>;
+  toggling: Optional<Partial<TogglingConfigSpec> & { exclusive?: boolean }>;
   itemBehaviours: SketchBehaviours;
   ignoreFocus?: boolean;
   domModification: DomModification;

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/MenuTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/MenuTypes.ts
@@ -96,6 +96,11 @@ export interface MenuSpec extends CompositeSketchSpec {
 
 export interface MenuSketcher extends CompositeSketch<MenuSpec> { }
 
+export interface MenuItemToggledEvent extends CustomEvent {
+  readonly item: AlloyComponent;
+  readonly state: boolean;
+}
+
 export interface MenuItemHoverEvent extends CustomEvent {
   readonly item: AlloyComponent;
 }

--- a/modules/alloy/src/test/ts/browser/behaviour/ToggleModesTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/ToggleModesTest.ts
@@ -50,7 +50,7 @@ UnitTest.test('Browser Test: behaviour.ToggleModesTest', () => {
     );
   });
 
-  Logger.sync('Checking role=menuitemcheck and tag=li', () => {
+  Logger.sync('Checking role=menuitemcheckbox and tag=li', () => {
     const menuitem = GuiFactory.build({
       dom: {
         tag: 'li',
@@ -61,6 +61,26 @@ UnitTest.test('Browser Test: behaviour.ToggleModesTest', () => {
     Assertions.assertStructure(
       'Menu Item Checkbox should have aria-checked role',
       ApproxStructure.build((s, str, _arr) => s.element('li', {
+        attrs: {
+          'aria-checked': str.is('true'),
+          'aria-pressed': str.none()
+        }
+      })),
+      menuitem.element
+    );
+  });
+
+  Logger.sync('Checking role=menuitemradio and tag=div', () => {
+    const menuitem = GuiFactory.build({
+      dom: {
+        tag: 'div',
+        attributes: { role: 'menuitemradio' }
+      }
+    });
+    ToggleModes.updateAuto(menuitem, notUsed, true);
+    Assertions.assertStructure(
+      'Menu Item Radio should have aria-checked role',
+      ApproxStructure.build((s, str, _arr) => s.element('div', {
         attrs: {
           'aria-checked': str.is('true'),
           'aria-pressed': str.none()

--- a/modules/alloy/src/test/ts/browser/behaviour/TogglingAriaTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/TogglingAriaTest.ts
@@ -10,7 +10,7 @@ import { Container } from 'ephox/alloy/api/ui/Container';
 
 UnitTest.asynctest('TogglingAriaTest', (success, failure) => {
 
-  GuiSetup.setup((_store, _doc, _body) => GuiFactory.build(
+  GuiSetup.setup((store, _doc, _body) => GuiFactory.build(
     Container.sketch({
       dom: {
         tag: 'div',
@@ -26,11 +26,12 @@ UnitTest.asynctest('TogglingAriaTest', (success, failure) => {
           selected: true,
           aria: {
             mode: 'pressed'
-          }
+          },
+          onToggled: store.adder('toggled')
         })
       ])
     })
-  ), (_doc, _body, _gui, component, _store) => {
+  ), (_doc, _body, _gui, component, store) => {
 
     const testIsSelected = (label: string) => Step.sync(() => {
       Assertions.assertStructure(
@@ -84,10 +85,12 @@ UnitTest.asynctest('TogglingAriaTest', (success, failure) => {
 
     return [
       testIsSelected('Initial'),
+      store.sAssertEq('Should have a toggled event as the item starts as selected', [ 'toggled' ]),
 
       sToggle,
       testNotSelected('selected > toggle'),
       assertIsSelected('selected > toggle', false),
+      store.sAssertEq('Should have another toggled event after toggling off', [ 'toggled', 'toggled' ]),
 
       sToggle,
       testIsSelected('selected > toggle, toggle'),

--- a/modules/alloy/src/test/ts/browser/behaviour/TogglingClassTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/TogglingClassTest.ts
@@ -10,7 +10,7 @@ import { Container } from 'ephox/alloy/api/ui/Container';
 
 UnitTest.asynctest('TogglingClassTest', (success, failure) => {
 
-  GuiSetup.setup((_store, _doc, _body) => GuiFactory.build(
+  GuiSetup.setup((store, _doc, _body) => GuiFactory.build(
     Container.sketch({
       dom: {
         tag: 'div',
@@ -23,15 +23,16 @@ UnitTest.asynctest('TogglingClassTest', (success, failure) => {
       },
       containerBehaviours: Behaviour.derive([
         Toggling.config({
-          selected: true,
+          selected: false,
           toggleClass: 'test-selected',
           aria: {
             mode: 'pressed'
-          }
+          },
+          onToggled: store.adder('toggled')
         })
       ])
     })
-  ), (_doc, _body, _gui, component, _store) => {
+  ), (_doc, _body, _gui, component, store) => {
 
     const testIsSelected = (label: string) => Step.sync(() => {
       Assertions.assertStructure(
@@ -92,22 +93,23 @@ UnitTest.asynctest('TogglingClassTest', (success, failure) => {
     });
 
     return [
-      testIsSelected('Initial'),
+      testNotSelected('Initial'),
+      store.sAssertEq('Should not have a toggled event since the item is not selected', []),
 
       sToggle,
-      testNotSelected('selected > toggle'),
-      assertIsSelected('selected > toggle', false),
-
-      sToggle,
-      testIsSelected('selected > toggle, toggle'),
-      assertIsSelected('selected > toggle, toggle', true),
+      testIsSelected('selected > toggle'),
+      assertIsSelected('selected > toggle', true),
+      store.sAssertEq('Should have a toggled event after toggling on', [ 'toggled' ]),
 
       sDeselect,
       testNotSelected('selected > toggle, toggle, deselect'),
       assertIsSelected('selected > toggle, toggle, deselect', false),
+      store.sAssertEq('Should have a toggled event after toggling off', [ 'toggled', 'toggled' ]),
+
       sDeselect,
       testNotSelected('selected > toggle, toggle, deselect, deselect'),
       assertIsSelected('selected > toggle, toggle, deselect, deselect', false),
+      store.sAssertEq('No additional toggle events should have fired', [ 'toggled', 'toggled' ]),
 
       sSelect,
       testIsSelected('selected > toggle, toggle, deselect, deselect, select'),

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/DropdownListTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/DropdownListTest.ts
@@ -16,6 +16,7 @@ import { Container } from 'ephox/alloy/api/ui/Container';
 import { Dropdown } from 'ephox/alloy/api/ui/Dropdown';
 import { tieredMenu as TieredMenu } from 'ephox/alloy/api/ui/TieredMenu';
 import * as DropdownAssertions from 'ephox/alloy/test/dropdown/DropdownAssertions';
+import { TestItem } from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 import * as TestDropdownMenu from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 import * as NavigationUtils from 'ephox/alloy/test/NavigationUtils';
 import * as TestBroadcasts from 'ephox/alloy/test/TestBroadcasts';
@@ -79,7 +80,7 @@ UnitTest.asynctest('Dropdown List', (success, failure) => {
         },
 
         fetch: () => {
-          const future = Future.pure([
+          const future = Future.pure<TestItem[]>([
             { type: 'item', data: { value: 'alpha', meta: { text: 'Alpha' }}},
             { type: 'item', data: { value: 'beta', meta: { text: 'Beta' }}},
             { type: 'item', data: { value: 'gamma', meta: { text: 'Gamma' }}},

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/MenuRadioTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/MenuRadioTest.ts
@@ -61,14 +61,14 @@ describe('MenuRadioTest', () => {
     AlloyTriggers.dispatch(hook.component(), target, SystemEvents.focusItem());
   };
 
-  const itemStructure = (focused: boolean, checked: boolean): ApproxStructure.Builder<StructAssert> => (s, str, arr) =>
+  const itemStructure = (expected: { focused: boolean; checked: boolean }): ApproxStructure.Builder<StructAssert> => (s, str, arr) =>
     s.element('li', {
       classes: [
-        focused ? arr.has('selected-item') : arr.not('selected-item'),
-        checked ? arr.has('checked') : arr.not('checked'),
+        expected.focused ? arr.has('selected-item') : arr.not('selected-item'),
+        expected.checked ? arr.has('checked') : arr.not('checked'),
       ],
       attrs: {
-        'aria-checked': str.is(String(checked)),
+        'aria-checked': str.is(String(expected.checked)),
         'role': str.is('menuitemradio')
       }
     });
@@ -88,8 +88,8 @@ describe('MenuRadioTest', () => {
           arr.has('test-menu')
         ],
         children: [
-          itemStructure(true, false)(s, str, arr),
-          itemStructure(false, false)(s, str, arr)
+          itemStructure({ focused: true, checked: false })(s, str, arr),
+          itemStructure({ focused: false, checked: false })(s, str, arr)
         ]
       })),
       component.element
@@ -111,8 +111,8 @@ describe('MenuRadioTest', () => {
           arr.has('test-menu')
         ],
         children: [
-          itemStructure(false, false)(s, str, arr),
-          itemStructure(true, false)(s, str, arr)
+          itemStructure({ focused: false, checked: false })(s, str, arr),
+          itemStructure({ focused: true, checked: false })(s, str, arr)
         ]
       })),
       component.element
@@ -137,8 +137,8 @@ describe('MenuRadioTest', () => {
           arr.has('test-menu')
         ],
         children: [
-          itemStructure(true, true)(s, str, arr),
-          itemStructure(false, false)(s, str, arr)
+          itemStructure({ focused: true, checked: true })(s, str, arr),
+          itemStructure({ focused: false, checked: false })(s, str, arr)
         ]
       })),
       component.element
@@ -154,8 +154,8 @@ describe('MenuRadioTest', () => {
           arr.has('test-menu')
         ],
         children: [
-          itemStructure(true, false)(s, str, arr),
-          itemStructure(false, true)(s, str, arr)
+          itemStructure({ focused: true, checked: false })(s, str, arr),
+          itemStructure({ focused: false, checked: true })(s, str, arr)
         ]
       })),
       component.element

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/MenuRadioTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/MenuRadioTest.ts
@@ -1,0 +1,167 @@
+import { ApproxStructure, Assertions, StructAssert, UiFinder } from '@ephox/agar';
+import { beforeEach, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
+
+import * as AddEventsBehaviour from 'ephox/alloy/api/behaviour/AddEventsBehaviour';
+import * as Behaviour from 'ephox/alloy/api/behaviour/Behaviour';
+import { Toggling } from 'ephox/alloy/api/behaviour/Toggling';
+import * as GuiFactory from 'ephox/alloy/api/component/GuiFactory';
+import * as AlloyEvents from 'ephox/alloy/api/events/AlloyEvents';
+import * as AlloyTriggers from 'ephox/alloy/api/events/AlloyTriggers';
+import * as SystemEvents from 'ephox/alloy/api/events/SystemEvents';
+import * as GuiSetup from 'ephox/alloy/api/testhelpers/GuiSetup';
+import { TestStore } from 'ephox/alloy/api/testhelpers/TestStore';
+import { Menu } from 'ephox/alloy/api/ui/Menu';
+import * as MenuEvents from 'ephox/alloy/menu/util/MenuEvents';
+import * as TestDropdownMenu from 'ephox/alloy/test/dropdown/TestDropdownMenu';
+
+describe('MenuRadioTest', () => {
+  const togglingConfig = (store: TestStore, name: string) => ({
+    toggleClass: 'checked',
+    toggleOnExecute: false,
+    selected: false,
+    exclusive: true,
+    onToggled: store.adder(name)
+  });
+
+  const hook = GuiSetup.bddSetup((store, _doc, _body) => GuiFactory.build(
+    Menu.sketch({
+      value: 'test-menu-1',
+      items: Arr.map([
+        { type: 'item', data: { value: 'alpha', meta: { text: 'Alpha' }}, hasSubmenu: false, toggling: togglingConfig(store, 'alpha') },
+        { type: 'item', data: { value: 'beta', meta: { text: 'Beta' }}, hasSubmenu: false, toggling: togglingConfig(store, 'beta') }
+      ], TestDropdownMenu.renderItem),
+      dom: {
+        tag: 'ol',
+        classes: [ 'test-menu' ]
+      },
+      components: [
+        Menu.parts.items({ })
+      ],
+
+      markers: {
+        item: TestDropdownMenu.markers().item,
+        selectedItem: TestDropdownMenu.markers().selectedItem
+      },
+
+      menuBehaviours: Behaviour.derive([
+        AddEventsBehaviour.config('menu-test-behaviour', [
+          AlloyEvents.run(MenuEvents.focus(), store.adder('menu.events.focus'))
+        ])
+      ])
+    })
+  ));
+
+  beforeEach(() => {
+    hook.store().clear();
+  });
+
+  const triggerFocusItem = (target: SugarElement<HTMLLIElement>) => {
+    AlloyTriggers.dispatch(hook.component(), target, SystemEvents.focusItem());
+  };
+
+  const itemStructure = (focused: boolean, checked: boolean): ApproxStructure.Builder<StructAssert> => (s, str, arr) =>
+    s.element('li', {
+      classes: [
+        focused ? arr.has('selected-item') : arr.not('selected-item'),
+        checked ? arr.has('checked') : arr.not('checked'),
+      ],
+      attrs: {
+        'aria-checked': str.is(String(checked)),
+        'role': str.is('menuitemradio')
+      }
+    });
+
+  it('TINY-8602: Focus first menu item and check structure', () => {
+    const component = hook.component();
+    const store = hook.store();
+    const alpha = UiFinder.findIn<HTMLLIElement>(component.element, 'li[data-value="alpha"]').getOrDie();
+
+    store.assertEq('Before focusItem event', []);
+
+    triggerFocusItem(alpha);
+    Assertions.assertStructure(
+      'After focusing item on alpha',
+      ApproxStructure.build((s, str, arr) => s.element('ol', {
+        classes: [
+          arr.has('test-menu')
+        ],
+        children: [
+          itemStructure(true, false)(s, str, arr),
+          itemStructure(false, false)(s, str, arr)
+        ]
+      })),
+      component.element
+    );
+
+    store.assertEq('After focusItem event (alpha)', [ 'menu.events.focus' ]);
+  });
+
+  it('TINY-8602: Focus second menu item and check structure', () => {
+    const component = hook.component();
+    const store = hook.store();
+    const beta = UiFinder.findIn<HTMLLIElement>(component.element, 'li[data-value="beta"]').getOrDie();
+
+    triggerFocusItem(beta);
+    Assertions.assertStructure(
+      'After focusing item on beta',
+      ApproxStructure.build((s, str, arr) => s.element('ol', {
+        classes: [
+          arr.has('test-menu')
+        ],
+        children: [
+          itemStructure(false, false)(s, str, arr),
+          itemStructure(true, false)(s, str, arr)
+        ]
+      })),
+      component.element
+    );
+
+    store.assertEq('After focusItem event (beta)', [ 'menu.events.focus' ]);
+  });
+
+  it('TINY-8602: Toggling between the 2 items ensures only one item is toggled', () => {
+    const component = hook.component();
+    const store = hook.store();
+    const [ alphaComp, betaComp ] = component.components();
+    triggerFocusItem(alphaComp.element);
+
+    store.assertEq('Before toggled event', [ 'menu.events.focus' ]);
+
+    Toggling.on(alphaComp);
+    Assertions.assertStructure(
+      'After toggling alpha item',
+      ApproxStructure.build((s, str, arr) => s.element('ol', {
+        classes: [
+          arr.has('test-menu')
+        ],
+        children: [
+          itemStructure(true, true)(s, str, arr),
+          itemStructure(false, false)(s, str, arr)
+        ]
+      })),
+      component.element
+    );
+
+    store.assertEq('After first toggled event', [ 'menu.events.focus', 'alpha' ]);
+
+    Toggling.on(betaComp);
+    Assertions.assertStructure(
+      'After toggling beta item',
+      ApproxStructure.build((s, str, arr) => s.element('ol', {
+        classes: [
+          arr.has('test-menu')
+        ],
+        children: [
+          itemStructure(true, false)(s, str, arr),
+          itemStructure(false, true)(s, str, arr)
+        ]
+      })),
+      component.element
+    );
+
+    // Note: Alpha is listed twice as it should have been toggled off when beta was toggled
+    store.assertEq('After second toggled event', [ 'menu.events.focus', 'alpha', 'beta', 'alpha' ]);
+  });
+});

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/SplitDropdownTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/SplitDropdownTest.ts
@@ -14,6 +14,7 @@ import * as GuiSetup from 'ephox/alloy/api/testhelpers/GuiSetup';
 import { Container } from 'ephox/alloy/api/ui/Container';
 import { SplitDropdown } from 'ephox/alloy/api/ui/SplitDropdown';
 import { tieredMenu as TieredMenu } from 'ephox/alloy/api/ui/TieredMenu';
+import { TestItem } from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 import * as TestDropdownMenu from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 
 UnitTest.asynctest('SplitDropdown List', (success, failure) => {
@@ -102,7 +103,7 @@ UnitTest.asynctest('SplitDropdown List', (success, failure) => {
         },
 
         fetch: () => {
-          const future = Future.pure([
+          const future = Future.pure<TestItem[]>([
             { type: 'item', data: { value: 'alpha', meta: { text: 'Alpha' }}},
             { type: 'item', data: { value: 'beta', meta: { text: 'Beta' }}}
           ]);

--- a/modules/alloy/src/test/ts/browser/ui/inline/InlineViewTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/inline/InlineViewTest.ts
@@ -10,6 +10,7 @@ import { Container } from 'ephox/alloy/api/ui/Container';
 import { Dropdown } from 'ephox/alloy/api/ui/Dropdown';
 import { InlineView } from 'ephox/alloy/api/ui/InlineView';
 import { tieredMenu as TieredMenu } from 'ephox/alloy/api/ui/TieredMenu';
+import { TestItem } from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 import * as TestDropdownMenu from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 import * as Sinks from 'ephox/alloy/test/Sinks';
 import * as TestBroadcasts from 'ephox/alloy/test/TestBroadcasts';
@@ -210,7 +211,7 @@ UnitTest.asynctest('InlineViewTest', (success, failure) => {
               menu: TestDropdownMenu.part(store)
             },
             fetch: () => {
-              const future = Future.pure([
+              const future = Future.pure<TestItem[]>([
                 { type: 'item', data: { value: optionPrefix.toLowerCase() + '-1', meta: { text: optionPrefix + '-1' }}},
                 { type: 'item', data: { value: optionPrefix.toLowerCase() + '-2' + buttonText, meta: { text: optionPrefix + '-2' }}}
               ]);

--- a/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadEscEnterBubbleTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadEscEnterBubbleTest.ts
@@ -10,6 +10,7 @@ import * as GuiSetup from 'ephox/alloy/api/testhelpers/GuiSetup';
 import { Container } from 'ephox/alloy/api/ui/Container';
 import { tieredMenu as TieredMenu } from 'ephox/alloy/api/ui/TieredMenu';
 import { Typeahead } from 'ephox/alloy/api/ui/Typeahead';
+import { TestItem } from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 import * as TestDropdownMenu from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 import * as Sinks from 'ephox/alloy/test/Sinks';
 import TestTypeaheadSteps from 'ephox/alloy/test/typeahead/TestTypeaheadSteps';
@@ -40,7 +41,7 @@ UnitTest.asynctest('Browser Test: .ui.typeahead.TypeaheadEscEnterBubbleTest', (s
             },
 
             fetch: () => {
-              const items = [
+              const items: TestItem[] = [
                 { type: 'item', data: { value: '1', meta: { text: '1' }}},
                 { type: 'item', data: { value: '2', meta: { text: '2' }}}
               ];

--- a/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadNoBlurTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadNoBlurTest.ts
@@ -10,6 +10,7 @@ import * as GuiSetup from 'ephox/alloy/api/testhelpers/GuiSetup';
 import { Container } from 'ephox/alloy/api/ui/Container';
 import { tieredMenu as TieredMenu } from 'ephox/alloy/api/ui/TieredMenu';
 import { Typeahead } from 'ephox/alloy/api/ui/Typeahead';
+import { TestItem } from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 import * as TestDropdownMenu from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 import * as Sinks from 'ephox/alloy/test/Sinks';
 import * as TestBroadcasts from 'ephox/alloy/test/TestBroadcasts';
@@ -44,7 +45,7 @@ UnitTest.asynctest('Browser Test: .ui.typeahead.TypeaheadNoBlurTest', (success, 
             },
 
             fetch: (_input) => {
-              const future = Future.pure([
+              const future = Future.pure<TestItem[]>([
                 { type: 'item', data: { value: 'choice1', meta: { text: 'choice1' }}},
                 { type: 'item', data: { value: 'choice2', meta: { text: 'choice2' }}}
               ]);

--- a/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadNoReopeningTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadNoReopeningTest.ts
@@ -12,6 +12,7 @@ import * as GuiSetup from 'ephox/alloy/api/testhelpers/GuiSetup';
 import { Container } from 'ephox/alloy/api/ui/Container';
 import { tieredMenu as TieredMenu } from 'ephox/alloy/api/ui/TieredMenu';
 import { Typeahead } from 'ephox/alloy/api/ui/Typeahead';
+import { TestItem } from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 import * as TestDropdownMenu from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 import * as Sinks from 'ephox/alloy/test/Sinks';
 
@@ -44,15 +45,15 @@ UnitTest.asynctest('Browser Test: .ui.typeahead.TypeaheadNoReopeningTest', (succ
 
             fetch: (input) => {
               const text = Value.get(input.element).toLowerCase();
-              const future = Future.pure([
+              const future = Future.pure<TestItem[]>([
                 { type: 'item', data: { value: text + '1', meta: { text: Strings.capitalize(text) + '1' }}},
                 { type: 'item', data: { value: text + '2', meta: { text: Strings.capitalize(text) + '2' }}}
               ]);
 
               return future.map((f) => {
                 // TODO: Test this.
-                const items = text === 'no-data' ? [
-                  { type: 'separator', data: { value: '', meta: { text: 'No data' }}}
+                const items: TestItem[] = text === 'no-data' ? [
+                  { type: 'separator', text: 'No data' }
                 ] : f;
 
                 const menu = TestDropdownMenu.renderMenu({

--- a/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadSelectsOverTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadSelectsOverTest.ts
@@ -10,6 +10,7 @@ import * as GuiSetup from 'ephox/alloy/api/testhelpers/GuiSetup';
 import { Container } from 'ephox/alloy/api/ui/Container';
 import { TieredData, tieredMenu as TieredMenu } from 'ephox/alloy/api/ui/TieredMenu';
 import { Typeahead } from 'ephox/alloy/api/ui/Typeahead';
+import { TestItem } from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 import * as TestDropdownMenu from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 import * as Sinks from 'ephox/alloy/test/Sinks';
 import TestTypeaheadSteps from 'ephox/alloy/test/typeahead/TestTypeaheadSteps';
@@ -23,7 +24,7 @@ UnitTest.asynctest('Browser Test: .ui.typeahead.TypeaheadNoSelectsOverTest', (su
     const sink = Sinks.relativeSink();
 
     const fetch = (_input: AlloyComponent): Future<Optional<TieredData>> => {
-      const future = Future.pure([
+      const future = Future.pure<TestItem[]>([
         { type: 'item', data: { value: 'alpha', meta: { text: 'Alpha' }}},
         { type: 'item', data: { value: 'beta', meta: { text: 'Beta' }}},
         { type: 'item', data: { value: 'gamma', meta: { text: 'Gamma' }}}

--- a/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadTest.ts
@@ -15,6 +15,7 @@ import { tieredMenu as TieredMenu } from 'ephox/alloy/api/ui/TieredMenu';
 import { Typeahead } from 'ephox/alloy/api/ui/Typeahead';
 import { DatasetRepresentingState } from 'ephox/alloy/behaviour/representing/RepresentingTypes';
 import * as DropdownAssertions from 'ephox/alloy/test/dropdown/DropdownAssertions';
+import { TestItem } from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 import * as TestDropdownMenu from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 import * as NavigationUtils from 'ephox/alloy/test/NavigationUtils';
 import * as Sinks from 'ephox/alloy/test/Sinks';
@@ -50,15 +51,15 @@ UnitTest.asynctest('Browser Test: .ui.typeahead.TypeaheadTest', (success, failur
 
             fetch: (input) => {
               const text = Value.get(input.element).toLowerCase();
-              const future = Future.pure([
+              const future = Future.pure<TestItem[]>([
                 { type: 'item', data: { value: text + '1', meta: { text: Strings.capitalize(text) + '1' }}},
                 { type: 'item', data: { value: text + '2', meta: { text: Strings.capitalize(text) + '2' }}}
               ]);
 
               return future.map((f) => {
                 // TODO: Test this.
-                const items = text === 'no-data' ? [
-                  { type: 'separator', text: 'No data', data: { value: '', meta: { text: 'No data' }}}
+                const items: TestItem[] = text === 'no-data' ? [
+                  { type: 'separator', text: 'No data' }
                 ] : f;
 
                 const menu = TestDropdownMenu.renderMenu({

--- a/modules/alloy/src/test/ts/webdriver/spec/TypeaheadTriggerTest.ts
+++ b/modules/alloy/src/test/ts/webdriver/spec/TypeaheadTriggerTest.ts
@@ -9,6 +9,7 @@ import * as GuiSetup from 'ephox/alloy/api/testhelpers/GuiSetup';
 import { Container } from 'ephox/alloy/api/ui/Container';
 import { tieredMenu as TieredMenu } from 'ephox/alloy/api/ui/TieredMenu';
 import { Typeahead } from 'ephox/alloy/api/ui/Typeahead';
+import { TestItem } from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 import * as TestDropdownMenu from 'ephox/alloy/test/dropdown/TestDropdownMenu';
 import * as Sinks from 'ephox/alloy/test/Sinks';
 import TestTypeaheadSteps from 'ephox/alloy/test/typeahead/TestTypeaheadSteps';
@@ -39,15 +40,15 @@ UnitTest.asynctest('TypeaheadTriggerTest (webdriver)', (success, failure) => {
 
             fetch: (input: AlloyComponent) => {
               const text = Value.get(input.element);
-              const future = Future.pure([
+              const future = Future.pure<TestItem[]>([
                 { type: 'item', data: { value: text + '1', meta: { text: text + '1' }}},
                 { type: 'item', data: { value: text + '2', meta: { text: text + '2' }}}
               ]);
 
               return future.map((f) => {
                 // TODO: Test this.
-                const items = text === 'no-data' ? [
-                  { type: 'separator', data: { value: '', meta: { text: 'No data' }}}
+                const items: TestItem[] = text === 'no-data' ? [
+                  { type: 'separator', text: 'No data' }
                 ] : f;
                 const menu = TestDropdownMenu.renderMenu({
                   value: 'blah',

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default value for `end_container_on_empty_block` option has been changed to `'blockquote'` #TINY-6559
 - Custom elements are now treated as non-empty elements via the schema #TINY-4784
 - The autocompleter menu element is now positioned instead of the wrapper #TINY-6476
+- Choice menu items will now use the `menuitemradio` aria role to better reflect that only a single item can be active #TINY-8602
 
 ### Fixed
 - Selecting all content with a single image in the content was inconsistent for the keyboard shortcut and menu item #TINY-4550

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/SplitButtonTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/SplitButtonTest.ts
@@ -45,6 +45,7 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item--active')
                     ],
                     attrs: {
+                      role: str.is('menuitemradio'),
                       title: str.is('Default')
                     },
                     children: [
@@ -59,6 +60,7 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item')
                     ],
                     attrs: {
+                      role: str.is('menuitemradio'),
                       title: str.is('Circle')
                     },
                     children: [
@@ -73,6 +75,7 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item')
                     ],
                     attrs: {
+                      role: str.is('menuitemradio'),
                       title: str.is('Square')
                     },
                     children: [
@@ -115,6 +118,7 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item--active')
                     ],
                     attrs: {
+                      role: str.is('menuitemradio'),
                       title: str.is('Default')
                     },
                     children: [
@@ -129,6 +133,7 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item')
                     ],
                     attrs: {
+                      role: str.is('menuitemradio'),
                       title: str.is('Lower Alpha')
                     },
                     children: [
@@ -143,6 +148,7 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item')
                     ],
                     attrs: {
+                      role: str.is('menuitemradio'),
                       title: str.is('Lower Greek')
                     },
                     children: [
@@ -163,6 +169,7 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item')
                     ],
                     attrs: {
+                      role: str.is('menuitemradio'),
                       title: str.is('Lower Roman')
                     },
                     children: [
@@ -177,6 +184,7 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item')
                     ],
                     attrs: {
+                      role: str.is('menuitemradio'),
                       title: str.is('Upper Alpha')
                     },
                     children: [
@@ -191,6 +199,7 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item')
                     ],
                     attrs: {
+                      role: str.is('menuitemradio'),
                       title: str.is('Upper Roman')
                     },
                     children: [

--- a/modules/tinymce/src/plugins/insertdatetime/test/ts/browser/InsertDatetimeSanityTest.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/test/ts/browser/InsertDatetimeSanityTest.ts
@@ -18,7 +18,7 @@ describe('browser.tinymce.plugins.insertdatetime.InsertDatetimeSanityTest', () =
     const editor = hook.editor();
     TinyUiActions.clickOnToolbar(editor, '[aria-haspopup="true"]');
     await TinyUiActions.pWaitForUi(editor, '[role="menu"]');
-    TinyUiActions.clickOnUi(editor, '[role="menu"] [role="menuitemcheckbox"]:first');
+    TinyUiActions.clickOnUi(editor, '[role="menu"] [role="menuitemradio"]:first');
 
     TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s) => {
       return s.element('body', {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ChoiceItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ChoiceItem.ts
@@ -15,7 +15,8 @@ const renderChoiceItem = (
   useText: boolean,
   presets: Toolbar.PresetItemTypes,
   onItemValueHandler: (itemValue: string) => void,
-  isSelected: boolean, itemResponse: ItemResponse,
+  isSelected: boolean,
+  itemResponse: ItemResponse,
   providersBackstage: UiFactoryBackstageProviders,
   renderIcons: boolean = true
 ) => {
@@ -61,7 +62,8 @@ const renderChoiceItem = (
       toggling: {
         toggleClass: ItemClasses.tickedClass,
         toggleOnExecute: false,
-        selected: spec.active
+        selected: spec.active,
+        exclusive: true
       }
     }
   );

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuChoice.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuChoice.ts
@@ -1,3 +1,4 @@
+import { ItemTypes } from '@ephox/alloy';
 import { Menu as BridgeMenu, Toolbar } from '@ephox/bridge';
 import { Arr, Optional, Optionals } from '@ephox/katamari';
 
@@ -34,13 +35,14 @@ export const createChoiceItems = (
   itemResponse: ItemResponse,
   select: (value: string) => boolean,
   providersBackstage: UiFactoryBackstageProviders
-) => Optionals.cat(
+): ItemTypes.ItemSpec[] => Optionals.cat(
   Arr.map(items, (item) => {
     if (item.type === 'choiceitem') {
       return BridgeMenu.createChoiceMenuItem(item).fold(
         MenuUtils.handleError,
         (d: BridgeMenu.ChoiceMenuItem) => Optional.some(renderChoiceItem(
-          d, columns === 1,
+          d,
+          columns === 1,
           itemPresets,
           onItemValueHandler,
           select(item.value),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuUtils.ts
@@ -24,7 +24,7 @@ export const handleError = (error: StructureSchema.SchemaError<any>): Optional<I
   return Optional.none();
 };
 
-export const createHorizontalPartialMenuWithAlloyItems = (value: string, _hasIcons: boolean, items, _columns: Toolbar.ColumnTypes, _presets: Toolbar.PresetTypes): PartialMenuSpec => {
+export const createHorizontalPartialMenuWithAlloyItems = (value: string, _hasIcons: boolean, items: ItemTypes.ItemSpec[], _columns: Toolbar.ColumnTypes, _presets: Toolbar.PresetTypes): PartialMenuSpec => {
   const structure = forHorizontalCollection(items);
   return {
     value,
@@ -35,7 +35,7 @@ export const createHorizontalPartialMenuWithAlloyItems = (value: string, _hasIco
 };
 
 // TODO: Potentially make this private again.
-export const createPartialMenuWithAlloyItems = (value: string, hasIcons: boolean, items, columns: Toolbar.ColumnTypes, presets: Toolbar.PresetTypes): PartialMenuSpec => {
+export const createPartialMenuWithAlloyItems = (value: string, hasIcons: boolean, items: ItemTypes.ItemSpec[], columns: Toolbar.ColumnTypes, presets: Toolbar.PresetTypes): PartialMenuSpec => {
   if (presets === 'color') {
     const structure = forSwatch(columns);
     return {


### PR DESCRIPTION
Related Ticket: TINY-8602

Description of Changes:

This fixes an accessibility issue whereby our choice menu items were using the `menuitemcheckbox` role when the options were exclusive. As part of this, to be able to tell when different menu items are toggled I've also added a `onToggled` callback to the Toggling configuration spec.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
