### PR TITLE
fix: Multiple font-family  display

### DIFF
--- a/modules/tinymce/src/core/main/ts/commands/Font.ts
+++ b/modules/tinymce/src/core/main/ts/commands/Font.ts
@@ -46,8 +46,10 @@ export const fontNameAction = (editor: Editor, value: string): void => {
   editor.nodeChanged();
 };
 
-export const fontNameQuery = (editor: Editor): string => mapRange(editor, (elm: SugarElement<Element>) =>
-  FontInfo.getFontFamily(editor.getBody(), elm.dom)
+export const fontNameQuery = (editor: Editor): string => mapRange(editor, (elm: SugarElement<Element>) => {
+    const fontFamily = FontInfo.getFontFamily(editor.getBody(), elm.dom);
+    return fontFamily ? (fontFamily.split(',').length ? fontFamily.split(',')[0] : fontFamily) : fontFamily
+  }
 ).getOr('');
 
 export const fontSizeAction = (editor: Editor, value: string): void => {


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
When copying HTML to Tinymce, if the HTML has multiple font styles, Tinymce will display them all.However in fact, only the first font style is applied to the current HTML, which can result in inaccurate font styles or multiple font styles being displayed. Now, the problem of multiple font styles is solved by getting the current number of fonts and only reading the first font style as a display

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
