### PR TITLE
TINY-8834: add rel="noopener" to changelog and pricing links

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clearer focus states for buttons while navigating with keyboard #TINY-8557
 - Support annotating certain block elements directly when using the editor annotator API #TINY-8698
 - The `mceLink` command can now take the value `{ dialog: true }` to always open the link dialog #TINY-8057
-- All help dialog links to `https://www.tiny.cloud` now include `rel="noopener"` to avoid potential security issues
+- All help dialog links to `https://www.tiny.cloud` now include `rel="noopener"` to avoid potential security issues #TINY-8834
 
 ### Changed
 - Toggling fullscreen mode with the `fullscreen` plugin now also fires the `ResizeEditor` event #TINY-8701

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clearer focus states for buttons while navigating with keyboard #TINY-8557
 - Support annotating certain block elements directly when using the editor annotator API #TINY-8698
 - The `mceLink` command can now take the value `{ dialog: true }` to always open the link dialog #TINY-8057
+- All help dialog links to `https://www.tiny.cloud` now include `rel="noopener"` to avoid potential security issues
 
 ### Changed
 - Toggling fullscreen mode with the `fullscreen` plugin now also fires the `ResizeEditor` event #TINY-8701

--- a/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
@@ -18,7 +18,7 @@ const tab = (editor: Editor): Dialog.TabSpec => {
       '<p><b>' + I18n.translate('Premium plugins:') + '</b></p>' +
       '<ul>' +
       premiumPluginList +
-      '<li class="tox-help__more-link" "><a href="https://www.tiny.cloud/pricing/?utm_campaign=editor_referral&utm_medium=help_dialog&utm_source=tinymce" target="_blank">' + I18n.translate('Learn more...') + '</a></li>' +
+      '<li class="tox-help__more-link" "><a href="https://www.tiny.cloud/pricing/?utm_campaign=editor_referral&utm_medium=help_dialog&utm_source=tinymce" rel="noopener" target="_blank">' + I18n.translate('Learn more...') + '</a></li>' +
       '</ul>' +
       '</div>';
   };

--- a/modules/tinymce/src/plugins/help/main/ts/ui/VersionTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/VersionTab.ts
@@ -5,7 +5,7 @@ import I18n from 'tinymce/core/api/util/I18n';
 const tab = (): Dialog.TabSpec => {
   const getVersion = (major: string, minor: string) => major.indexOf('@') === 0 ? 'X.X.X' : major + '.' + minor;
   const version = getVersion(EditorManager.majorVersion, EditorManager.minorVersion);
-  const changeLogLink = '<a href="https://www.tiny.cloud/docs/tinymce/6/changelog/?utm_campaign=editor_referral&utm_medium=help_dialog&utm_source=tinymce" target="_blank">TinyMCE ' + version + '</a>';
+  const changeLogLink = '<a href="https://www.tiny.cloud/docs/tinymce/6/changelog/?utm_campaign=editor_referral&utm_medium=help_dialog&utm_source=tinymce" rel="noopener" target="_blank">TinyMCE ' + version + '</a>';
 
   const htmlPanel: Dialog.HtmlPanelSpec = {
     type: 'htmlpanel',

--- a/modules/tinymce/src/plugins/link/main/ts/core/OpenUrl.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/OpenUrl.ts
@@ -5,9 +5,6 @@ const appendClickRemove = (link: HTMLAnchorElement, evt: MouseEvent): void => {
 };
 
 const open = (url: string): void => {
-  // Chrome and Webkit has implemented noopener and works correctly with/without popup blocker
-  // Firefox has it implemented noopener but when the popup blocker is activated it doesn't work
-  // Edge has only implemented noreferrer and it seems to remove opener as well
   const link = document.createElement('a');
   link.target = '_blank';
   link.href = url;


### PR DESCRIPTION
Related Ticket: TINY-8834

Description of Changes:
* Add `rel="noopener"` to a couple of `https://www.tiny.cloud` where it was missing

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable): #7898