### PR TITLE
TINY-8801: Allow the comments sidebar area to scroll

### DIFF
--- a/modules/oxide/src/less/theme/components/comments/comment.less
+++ b/modules/oxide/src/less/theme/components/comments/comment.less
@@ -70,6 +70,7 @@
   }
 
   .tox-comment__expander {
+    cursor: pointer;
     padding-top: @pad-sm;
 
     p {

--- a/modules/oxide/src/less/theme/components/comments/comment.less
+++ b/modules/oxide/src/less/theme/components/comments/comment.less
@@ -205,6 +205,7 @@
 
   .tox-conversations {
     margin: @pad-sm;
+    overflow: auto;
   }
 }
 //end tox


### PR DESCRIPTION
Related Ticket: TINY-8801

Description of Changes:
* Make the entire conversation area scroll when it needs to. This is not how the UI is designed, it's supposed to scroll in between the 'comments' header and the reply box, but when the textarea is taller than the editor this overflow is necessary.
* Special note that this fix does not appear to impact the design when the textarea is a normal size, as the comments plugin sets it to `display: flex`. I've only tested this manually, I'm not sure if we have tests for this.
* Bonus fix - the 'show more' text now uses a pointer cursor.

Pre-checks:
* [x] ~Changelog entry added~ (changelog will go in the comments plugin)
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set

GitHub issues (if applicable):
