### PR TITLE
TINY-8099: Updated changelogs and SECURITY.md for 6.1.0 release

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,9 +5,9 @@
 Tiny Technologies, Inc. supports the following community versions of TinyMCE:
 
 | Version | Supported                      |
-| ------- | ------------------------------ |
+|---------| ------------------------------ |
 | 5.10.x  | &#10004;                       |
-| 6.0.x   | &#10004;                       |
+| 6.1.x   | &#10004;                       |
 | Other   | &#10006;                       |
 
 For supported enterprise versions of TinyMCE, refer to the enterprise [Supported TinyMCE versions documentation](https://www.tiny.cloud/docs/tinymce/6/support/#supportedversionsandplatforms).

--- a/modules/acid/package.json
+++ b/modules/acid/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@ephox/acid",
   "description": "Color library including Alloy UI component for a color picker",
-  "version": "5.0.2-alpha.2",
+  "version": "5.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
     "directory": "modules/acid"
   },
   "dependencies": {
-    "@ephox/alloy": "^10.1.0-alpha.2",
-    "@ephox/boulder": "^7.0.2-alpha.1",
-    "@ephox/katamari": "^9.0.2-alpha.1",
-    "@ephox/sugar": "^9.0.2-alpha.1",
+    "@ephox/alloy": "^10.1.0",
+    "@ephox/boulder": "^7.0.2",
+    "@ephox/katamari": "^9.0.2",
+    "@ephox/sugar": "^9.0.2",
     "tslib": "^2.0.0"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",

--- a/modules/agar/CHANGELOG.md
+++ b/modules/agar/CHANGELOG.md
@@ -6,9 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 7.1.0 - 2022-06-29
+
 ### Added
 - Added `detail` property to emulated mouse events settings.
-- Added `pClick` to the `RealMouse` API. 
+- Added `pClick` to the `RealMouse` API.
 
 ## 7.0.0 - 2022-03-03
 

--- a/modules/agar/package.json
+++ b/modules/agar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/agar",
-  "version": "7.1.0-alpha.1",
+  "version": "7.1.0",
   "description": "Testing infrastructure",
   "repository": {
     "type": "git",
@@ -26,16 +26,16 @@
   "dependencies": {
     "@ephox/bedrock-client": "11 || 12 || 13",
     "@ephox/bedrock-common": "11 || 12 || 13",
-    "@ephox/jax": "^7.0.2-alpha.1",
-    "@ephox/sand": "^6.0.2-alpha.1",
-    "@ephox/sugar": "^9.0.2-alpha.1",
+    "@ephox/jax": "^7.0.2",
+    "@ephox/sand": "^6.0.2",
+    "@ephox/sugar": "^9.0.2",
     "@types/sizzle": "^2.3.3",
     "fast-check": "^2.0.0",
     "sizzle": "^2.3.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^4.0.2-alpha.1"
+    "@ephox/katamari-assertions": "^4.0.2"
   },
   "files": [
     "lib/main",

--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 10.1.0 - 2022-06-29
+
 ### Added
 - Added new `immediateGrow` API to the `Sliding` behaviour #TINY-8710
 - Added new `onToggled` callback property to the `Toggling` behaviour configuration #TINY-8602

--- a/modules/alloy/package.json
+++ b/modules/alloy/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@ephox/alloy",
-  "version": "10.1.0-alpha.2",
+  "version": "10.1.0",
   "description": "Ui Framework",
   "dependencies": {
-    "@ephox/agar": "^7.1.0-alpha.1",
-    "@ephox/boulder": "^7.0.2-alpha.1",
-    "@ephox/katamari": "^9.0.2-alpha.1",
-    "@ephox/sand": "^6.0.2-alpha.1",
-    "@ephox/sugar": "^9.0.2-alpha.1",
+    "@ephox/agar": "^7.1.0",
+    "@ephox/boulder": "^7.0.2",
+    "@ephox/katamari": "^9.0.2",
+    "@ephox/sand": "^6.0.2",
+    "@ephox/sugar": "^9.0.2",
     "tslib": "^2.0.0"
   },
   "files": [

--- a/modules/boss/package.json
+++ b/modules/boss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/boss",
   "description": "Generic wrapper to document models - DomUniverse vs TestUniverse",
-  "version": "6.0.2-alpha.1",
+  "version": "6.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -19,12 +19,12 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^9.0.2-alpha.1",
-    "@ephox/sugar": "^9.0.2-alpha.1",
+    "@ephox/katamari": "^9.0.2",
+    "@ephox/sugar": "^9.0.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^4.0.2-alpha.1"
+    "@ephox/katamari-assertions": "^4.0.2"
   },
   "scripts": {
     "prepublishOnly": "tsc -b",

--- a/modules/boulder/package.json
+++ b/modules/boulder/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@ephox/boulder",
-  "version": "7.0.2-alpha.1",
+  "version": "7.0.2",
   "description": "Basic javascript object validation",
   "dependencies": {
-    "@ephox/katamari": "^9.0.2-alpha.1"
+    "@ephox/katamari": "^9.0.2"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^4.0.2-alpha.1"
+    "@ephox/katamari-assertions": "^4.0.2"
   },
   "scripts": {
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",

--- a/modules/bridge/package.json
+++ b/modules/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/bridge",
-  "version": "4.0.3-alpha.1",
+  "version": "4.0.3",
   "description": "Ui API for TinyMCE 5",
   "repository": {
     "type": "git",
@@ -13,8 +13,8 @@
     "lint": "eslint --config ../../.eslintrc.json src/**/*.ts"
   },
   "dependencies": {
-    "@ephox/boulder": "^7.0.2-alpha.1",
-    "@ephox/katamari": "^9.0.2-alpha.1",
+    "@ephox/boulder": "^7.0.2",
+    "@ephox/katamari": "^9.0.2",
     "tslib": "^2.0.0"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",

--- a/modules/darwin/package.json
+++ b/modules/darwin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/darwin",
   "description": "This project's purpose is to handle selection and cursor navigation.",
-  "version": "8.0.3-alpha.1",
+  "version": "8.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -19,12 +19,12 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^9.0.2-alpha.1",
-    "@ephox/phoenix": "^8.0.2-alpha.1",
-    "@ephox/robin": "^10.0.2-alpha.1",
-    "@ephox/sand": "^6.0.2-alpha.1",
-    "@ephox/snooker": "^11.0.3-alpha.1",
-    "@ephox/sugar": "^9.0.2-alpha.1",
+    "@ephox/katamari": "^9.0.2",
+    "@ephox/phoenix": "^8.0.2",
+    "@ephox/robin": "^10.0.2",
+    "@ephox/sand": "^6.0.2",
+    "@ephox/snooker": "^11.0.3",
+    "@ephox/sugar": "^9.0.2",
     "tslib": "^2.0.0"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",

--- a/modules/dragster/package.json
+++ b/modules/dragster/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/dragster",
   "description": "This project handles dragging.",
-  "version": "7.0.2-alpha.1",
+  "version": "7.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -19,9 +19,9 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^9.0.2-alpha.1",
-    "@ephox/porkbun": "^7.0.2-alpha.1",
-    "@ephox/sugar": "^9.0.2-alpha.1",
+    "@ephox/katamari": "^9.0.2",
+    "@ephox/porkbun": "^7.0.2",
+    "@ephox/sugar": "^9.0.2",
     "tslib": "^2.0.0"
   },
   "scripts": {

--- a/modules/jax/package.json
+++ b/modules/jax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/jax",
-  "version": "7.0.2-alpha.1",
+  "version": "7.0.2",
   "description": "AJAX library",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
-    "@ephox/katamari": "^9.0.2-alpha.1",
+    "@ephox/katamari": "^9.0.2",
     "tslib": "^2.0.0"
   },
   "files": [

--- a/modules/katamari-assertions/package.json
+++ b/modules/katamari-assertions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/katamari-assertions",
-  "version": "4.0.2-alpha.1",
+  "version": "4.0.2",
   "description": "Bedrock test assertions for Katamari",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   "dependencies": {
     "@ephox/bedrock-client": "11 || 12 || 13",
     "@ephox/dispute": "^1.0.3",
-    "@ephox/katamari": "^9.0.2-alpha.1",
+    "@ephox/katamari": "^9.0.2",
     "tslib": "^2.0.0"
   },
   "files": [

--- a/modules/katamari/.gitignore
+++ b/modules/katamari/.gitignore
@@ -17,6 +17,5 @@ ephox-katamari-*.tgz
 
 package-lock.json
 
-jenkins-plumbing
 yarn.lock
 yarn-error.log

--- a/modules/katamari/package.json
+++ b/modules/katamari/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/katamari",
-  "version": "9.0.2-alpha.1",
+  "version": "9.0.2",
   "description": "Basic data type library",
   "repository": {
     "type": "git",

--- a/modules/mcagar/package.json
+++ b/modules/mcagar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/mcagar",
-  "version": "8.0.2-alpha.1",
+  "version": "8.0.2",
   "description": "Tinymce agar wrapper",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
-    "@ephox/agar": "^7.1.0-alpha.1",
-    "@ephox/katamari": "^9.0.2-alpha.1",
-    "@ephox/sand": "^6.0.2-alpha.1",
-    "@ephox/sugar": "^9.0.2-alpha.1",
+    "@ephox/agar": "^7.1.0",
+    "@ephox/katamari": "^9.0.2",
+    "@ephox/sand": "^6.0.2",
+    "@ephox/sugar": "^9.0.2",
     "fast-check": "^2.0.0",
     "tslib": "^2.0.0"
   },

--- a/modules/oxide-icons-default/.gitignore
+++ b/modules/oxide-icons-default/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 scratch
+yarn-error.log

--- a/modules/oxide-icons-default/package.json
+++ b/modules/oxide-icons-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/oxide-icons-default",
-  "version": "2.0.2-alpha.1",
+  "version": "2.0.2",
   "description": "The default icon pack for TinyMCE",
   "repository": {
     "type": "git",

--- a/modules/oxide/.stylelintrc
+++ b/modules/oxide/.stylelintrc
@@ -6,7 +6,7 @@
   "rules": {
     "number-leading-zero": "never",
     "order/properties-alphabetical-order": true,
-    "at-rule-empty-line-before": ["always", { ignoreAtRules: "import"}],
+    "at-rule-empty-line-before": ["always", { "ignoreAtRules": "import" }],
     "function-calc-no-invalid": null
   }
 }

--- a/modules/oxide/package.json
+++ b/modules/oxide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/oxide",
-  "version": "2.1.0-alpha.2",
+  "version": "2.1.0",
   "description": "TinyMCE 5 Oxide skin",
   "repository": {
     "type": "git",

--- a/modules/phoenix/package.json
+++ b/modules/phoenix/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/phoenix",
   "description": "DOM node text gathering library, rose from the ashes of some other projects we can't remember the names of now (edit: seek, sherlock, gift)",
-  "version": "8.0.2-alpha.1",
+  "version": "8.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -19,14 +19,14 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/boss": "^6.0.2-alpha.1",
-    "@ephox/katamari": "^9.0.2-alpha.1",
-    "@ephox/polaris": "^6.0.2-alpha.1",
-    "@ephox/sugar": "^9.0.2-alpha.1",
+    "@ephox/boss": "^6.0.2",
+    "@ephox/katamari": "^9.0.2",
+    "@ephox/polaris": "^6.0.2",
+    "@ephox/sugar": "^9.0.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^4.0.2-alpha.1"
+    "@ephox/katamari-assertions": "^4.0.2"
   },
   "scripts": {
     "test-manual": "bedrock -d src/test",

--- a/modules/polaris/CHANGELOG.md
+++ b/modules/polaris/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 6.0.2 - 2022-06-29
+
 ### Fixed
 - Fixed incorrect `Regexes.link` URL detection for path segments that contain valid characters such as `!` and `:` #TINY-5074
 

--- a/modules/polaris/package.json
+++ b/modules/polaris/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/polaris",
   "description": "This project does data manipulation on arrays and strings.",
-  "version": "6.0.2-alpha.1",
+  "version": "6.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -19,11 +19,11 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^9.0.2-alpha.1",
+    "@ephox/katamari": "^9.0.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^4.0.2-alpha.1"
+    "@ephox/katamari-assertions": "^4.0.2"
   },
   "scripts": {
     "prepublishOnly": "tsc -b",

--- a/modules/porkbun/package.json
+++ b/modules/porkbun/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/porkbun",
   "description": "Event framework for JavaScript",
-  "version": "7.0.2-alpha.1",
+  "version": "7.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -19,7 +19,7 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^9.0.2-alpha.1"
+    "@ephox/katamari": "^9.0.2"
   },
   "scripts": {
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",

--- a/modules/robin/package.json
+++ b/modules/robin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/robin",
   "description": "This project is for grouping sibling DOM nodes together by boundary points, for example the list of elements and nodes representing a word.",
-  "version": "10.0.2-alpha.1",
+  "version": "10.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -19,15 +19,15 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/boss": "^6.0.2-alpha.1",
-    "@ephox/katamari": "^9.0.2-alpha.1",
-    "@ephox/phoenix": "^8.0.2-alpha.1",
-    "@ephox/polaris": "^6.0.2-alpha.1",
-    "@ephox/sugar": "^9.0.2-alpha.1",
+    "@ephox/boss": "^6.0.2",
+    "@ephox/katamari": "^9.0.2",
+    "@ephox/phoenix": "^8.0.2",
+    "@ephox/polaris": "^6.0.2",
+    "@ephox/sugar": "^9.0.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^4.0.2-alpha.1"
+    "@ephox/katamari-assertions": "^4.0.2"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",

--- a/modules/sand/package.json
+++ b/modules/sand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/sand",
-  "version": "6.0.2-alpha.1",
+  "version": "6.0.2",
   "description": "Platform detection library",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
-    "@ephox/katamari": "^9.0.2-alpha.1",
+    "@ephox/katamari": "^9.0.2",
     "tslib": "^2.0.0"
   },
   "main": "./lib/main/ts/ephox/sand/api/Main.js",

--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 11.0.3 - 2022-06-29
+
 ### Fixed
 - Copying one or more columns with a cell with colspan which starts outside of the selected area will no longer result in a copy with one or more cells missing.
 - Pasting a column into a table with a colspan cell will no longer result in missing cells.

--- a/modules/snooker/package.json
+++ b/modules/snooker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/snooker",
   "description": "This project implements the table model.",
-  "version": "11.0.3-alpha.1",
+  "version": "11.0.3",
   "files": [
     "lib/main",
     "lib/demo",
@@ -19,11 +19,11 @@
     "directory": "modules/snooker"
   },
   "dependencies": {
-    "@ephox/dragster": "^7.0.2-alpha.1",
-    "@ephox/katamari": "^9.0.2-alpha.1",
-    "@ephox/porkbun": "^7.0.2-alpha.1",
-    "@ephox/robin": "^10.0.2-alpha.1",
-    "@ephox/sugar": "^9.0.2-alpha.1",
+    "@ephox/dragster": "^7.0.2",
+    "@ephox/katamari": "^9.0.2",
+    "@ephox/porkbun": "^7.0.2",
+    "@ephox/robin": "^10.0.2",
+    "@ephox/sugar": "^9.0.2",
     "tslib": "^2.0.0"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",

--- a/modules/sugar/package.json
+++ b/modules/sugar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/sugar",
-  "version": "9.0.2-alpha.1",
+  "version": "9.0.2",
   "description": "Basic DOM manipulation",
   "repository": {
     "type": "git",
@@ -22,11 +22,11 @@
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
-    "@ephox/katamari": "^9.0.2-alpha.1",
-    "@ephox/sand": "^6.0.2-alpha.1"
+    "@ephox/katamari": "^9.0.2",
+    "@ephox/sand": "^6.0.2"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^4.0.2-alpha.1"
+    "@ephox/katamari-assertions": "^4.0.2"
   },
   "files": [
     "lib/main",

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 6.1.0 - 2022-06-29
+
 ### Added
 - New `sidebar_show` option to show the specified sidebar on initialization. #TINY-8710
 - New `newline_behavior` option controls what happens when the Return or Enter key is pressed or the `mceInsertNewLine` command is used. #TINY-8458

--- a/versions.txt
+++ b/versions.txt
@@ -1,6 +1,2 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
-
-alloy@10.1.0
-agar@7.1.0
-polaris@6.0.2


### PR DESCRIPTION
Related Ticket: TINY-8099

Description of Changes:
* Updated the changelogs for 6.1.0 release
* Updated the SECURITY.md file to point to `6.1.x`
* Emptied the `versions.txt` file

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
