### PR TITLE
TINY-8755: Whitelist internal attributes to narrow down what is considered internal

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/dom/ElementUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ElementUtils.ts
@@ -1,6 +1,7 @@
 import { Obj } from '@ephox/katamari';
 
 import * as Bookmarks from '../../bookmark/Bookmarks';
+import { attributeIsInternal } from '../../fmt/FormatUtils';
 import Tools from '../util/Tools';
 import DOMUtils from './DOMUtils';
 
@@ -47,7 +48,7 @@ const ElementUtils = (dom: DOMUtils): ElementUtils => {
         const name = attr.nodeName.toLowerCase();
 
         // Don't compare internal attributes or style
-        if (name.indexOf('_') !== 0 && name !== 'style' && name.indexOf('data-') !== 0) {
+        if (name !== 'style' && !attributeIsInternal(name)) {
           attribs[name] = dom.getAttrib(node, name);
         }
       });

--- a/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
@@ -9,6 +9,49 @@ import * as NodeType from '../dom/NodeType';
 import * as Whitespace from '../text/Whitespace';
 import { BlockFormat, Format, FormatAttrOrStyleValue, FormatVars, InlineFormat, MixedFormat, SelectorFormat } from './FormatTypes';
 
+const internalAttributesPrefixes = [
+  'data-ephox-',
+  'data-mce-',
+  'data-alloy-',
+  'data-snooker-',
+  '_',
+  'aria-'
+];
+
+const internalDataValues = [
+  'data-id',
+  'data-emoticon',
+  'data-collection-item-value',
+  'data-bedrockid',
+  'data-longpress-destination',
+  'data-longpress-state',
+  'data-precloak-visibility',
+  'data-transitioning-destination',
+  'data-transitioning-state',
+  'data-initial-z-index',
+  'data-column',
+  'data-row',
+  'data-initial-top',
+  'data-initial-left',
+  'data-value',
+  'data-drag-left',
+  'data-drag-top',
+  'data-converted-paragraph',
+  'data-tab-interval',
+  'data-list-level',
+  'data-border-margin',
+  'data-text-indent-alt',
+  'data-ms-equation',
+  'data-image-src',
+  'data-pdfprint-id',
+  'data-app-key',
+  'data-zoom-factor',
+  'data-image-id',
+  'data-image-type',
+  'data-name',
+  'data-gramm_editor'
+];
+
 const isNode = (node: any): node is Node => !!(node).nodeType;
 
 const isInlineBlock = (node: Node): boolean => {
@@ -216,6 +259,9 @@ const isMixedFormat = (format: Format): format is MixedFormat =>
 const shouldExpandToSelector = (format: Format) =>
   isSelectorFormat(format) && format.expand !== false && !isInlineFormat(format);
 
+const attributeIsInternal = (attributeName: string): boolean =>
+  Arr.find(internalAttributesPrefixes, (value) => attributeName.indexOf(value) === 0).isSome() || Arr.contains(internalDataValues, attributeName);
+
 export {
   isNode,
   isInlineBlock,
@@ -237,5 +283,6 @@ export {
   isInlineFormat,
   isBlockFormat,
   isMixedFormat,
-  shouldExpandToSelector
+  shouldExpandToSelector,
+  attributeIsInternal
 };

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -291,7 +291,7 @@ const removeFormatInternal = (ed: Editor, format: Format, vars?: FormatVars, nod
     const attrs = dom.getAttribs(elm);
     for (let i = 0; i < attrs.length; i++) {
       const attrName = attrs[i].nodeName;
-      if (attrName.indexOf('_') !== 0 && attrName.indexOf('data-') !== 0) {
+      if (!FormatUtils.attributeIsInternal(attrName)) {
         return removeResult.keep();
       }
     }

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -96,7 +96,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
   it('Toggle OFF - Inline element with data attribute', () => {
     const editor = hook.editor();
     editor.formatter.register('format', { inline: 'b' });
-    editor.getBody().innerHTML = '<p><b data-x="1">1</b></p>';
+    editor.getBody().innerHTML = '<p><b data-mce-x="1">1</b></p>';
     const rng = editor.dom.createRng();
     rng.setStart(editor.dom.select('b')[0].firstChild, 0);
     rng.setEnd(editor.dom.select('b')[0].firstChild, 1);
@@ -623,13 +623,13 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     editor.formatter.register('format', {
       inline: 'b'
     });
-    editor.getBody().innerHTML = '<p><b data-x="1">1234</b>5678</p>';
+    editor.getBody().innerHTML = '<p><b data-mce-x="1">1234</b>5678</p>';
     const rng = editor.dom.createRng();
     rng.setStart(editor.dom.select('p')[0].lastChild, 0);
     rng.setEnd(editor.dom.select('p')[0].lastChild, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
-    assert.equal(getContent(editor), '<p><b data-x="1">12345678</b></p>', 'Inline element merged with left sibling');
+    assert.equal(getContent(editor), '<p><b data-mce-x="1">12345678</b></p>', 'Inline element merged with left sibling');
   });
 
   it(`Don't merge siblings with whitespace between 1`, () => {

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
@@ -3,6 +3,7 @@ import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wr
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import { ZWSP } from 'tinymce/src/core/main/ts/text/Zwsp';
 
 import * as KeyUtils from '../module/test/KeyUtils';
 
@@ -602,5 +603,15 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 5);
     editor.formatter.remove('blockquote');
     TinyAssertions.assertContent(editor, '<p>test test</p>');
+  });
+
+  it('TINY-8755: Non-internal attributes are no longer removed', () => {
+    const editor = hook.editor();
+    // eslint-disable-next-line max-len
+    editor.setContent('<p><strong>bold<span data-field-type="TEXT"><span class="concord-field__value"></span><span class="concord-field__icons"><span style="display: flex; align-items: flex-start;" data-mce-style="display: flex; align-items: flex-start;"><span class="concord-field__required">' + ZWSP + '</span></span></span></span>text</strong></p>', { format: 'raw' });
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 2, [ 0, 0, 2 ], 2);
+    editor.formatter.remove('bold');
+    // eslint-disable-next-line max-len
+    TinyAssertions.assertContent(editor, '<p><strong>bo</strong>ld<span data-field-type="TEXT"><span class="concord-field__value"></span><span class="concord-field__icons"><span style="display: flex; align-items: flex-start;" data-mce-style="display: flex; align-items: flex-start;"><span class="concord-field__required"></span></span></span></span>te<strong>xt</strong></p>', { format: 'raw' });
   });
 });


### PR DESCRIPTION
Description of Changes:
Instead of assuming that all attributes that start with `data-` are internal, try to narrow it down a bit. To allow backwards compatibility also have a list of attributes which do not fit the expected `data-mce-`

Pre-checks:
* [ ] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set

GitHub issues (if applicable):
