### PR TITLE
Only show image tab bar when hasUploadTab is true

### DIFF
--- a/modules/tinymce/src/plugins/image/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/Dialog.ts
@@ -275,7 +275,7 @@ const closeHandler = (state: ImageDialogState) => (): void => {
 };
 
 const makeDialogBody = (info: ImageDialogInfo): DialogType.TabPanelSpec | DialogType.PanelSpec => {
-  if (info.hasAdvTab || info.hasUploadUrl || info.hasUploadHandler) {
+  if (info.hasAdvTab || (info.hasUploadUrl && info.hasUploadTab) || info.hasUploadHandler) {
     const tabPanel: DialogType.TabPanelSpec = {
       type: 'tabpanel',
       tabs: Arr.flatten([


### PR DESCRIPTION
Hide the tab bar when setting an upload url to support automatic uploads and disabling the upload tab. This avoid the image upload dialog from having a tab bar with just one tab (general).