### PR TITLE
TINY-8832: Figure class="image" incorrectly highlights link on the toolbar

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Autolink plugin did not work when the text nodes in the content were fragmented #TINY-3723
 - Fixed various incorrect types on public APIs found while enabling TypeScript strict mode #TINY-8806
 - The editor focused via the `auto_focus` option was not scrolled into the viewport #TINY-8785
-- selecting a figure with class="image" would incorrectly highlight the link toggle button
+- Selecting a figure with class="image" would incorrectly highlight the link toggle button #TINY-8832
 
 ## 6.1.0 - 2022-06-29
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Autolink plugin did not work when the text nodes in the content were fragmented #TINY-3723
 - Fixed various incorrect types on public APIs found while enabling TypeScript strict mode #TINY-8806
 - The editor focused via the `auto_focus` option was not scrolled into the viewport #TINY-8785
-- Selecting a figure with class="image" would incorrectly highlight the link toggle button #TINY-8832
+- Selecting a figure with `class="image"` would incorrectly highlight the link toolbar button #TINY-8832
 
 ## 6.1.0 - 2022-06-29
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Autolink plugin did not work when the text nodes in the content were fragmented #TINY-3723
 - Fixed various incorrect types on public APIs found while enabling TypeScript strict mode #TINY-8806
 - The editor focused via the `auto_focus` option was not scrolled into the viewport #TINY-8785
+- selecting a figure with class="image" would incorrectly highlight the link toggle button
 
 ## 6.1.0 - 2022-06-29
 

--- a/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
@@ -1,3 +1,5 @@
+import { Optional, Optionals } from '@ephox/katamari';
+
 import Editor from 'tinymce/core/api/Editor';
 import { NodeChangeEvent } from 'tinymce/core/api/EventTypes';
 import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
@@ -64,7 +66,7 @@ const toggleState = (editor: Editor, toggler: (e: NodeChangeEvent) => void): () 
 };
 
 const toggleActiveState = (editor: Editor) => (api: Toolbar.ToolbarToggleButtonInstanceApi | Menu.ToggleMenuItemInstanceApi): () => void => {
-  const updateState = () => api.setActive(!editor.mode.isReadOnly() && Utils.getAnchorElement(editor, editor.selection.getNode()) !== null);
+  const updateState = () => api.setActive(!editor.mode.isReadOnly() && Utils.getAnchorElement(editor, editor.selection.getNode()).isSome());
   updateState();
   return toggleState(editor, updateState);
 };

--- a/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
@@ -1,5 +1,3 @@
-import { Optional, Optionals } from '@ephox/katamari';
-
 import Editor from 'tinymce/core/api/Editor';
 import { NodeChangeEvent } from 'tinymce/core/api/EventTypes';
 import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
@@ -72,7 +70,7 @@ const toggleActiveState = (editor: Editor) => (api: Toolbar.ToolbarToggleButtonI
 };
 
 const toggleEnabledState = (editor: Editor) => (api: Toolbar.ToolbarButtonInstanceApi | Menu.MenuItemInstanceApi): () => void => {
-  const updateState = () => api.setEnabled(Utils.getAnchorElement(editor, editor.selection.getNode()) !== null);
+  const updateState = () => api.setEnabled(Utils.getAnchorElement(editor, editor.selection.getNode()).isSome());
   updateState();
   return toggleState(editor, updateState);
 };

--- a/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
@@ -68,13 +68,13 @@ const applyRelTargetRules = (rel: string, isUnsafe: boolean): string => {
 const trimCaretContainers = (text: string): string =>
   text.replace(/\uFEFF/g, '');
 
-const getAnchorElement = (editor: Editor, selectedElm?: Element): HTMLAnchorElement | null => {
+const getAnchorElement = (editor: Editor, selectedElm?: Element): Optional<HTMLAnchorElement> => {
   selectedElm = selectedElm || editor.selection.getNode();
   if (isImageFigure(selectedElm)) {
     // for an image contained in a figure we look for a link inside the selected element
-    return editor.dom.select<HTMLAnchorElement>('a[href]', selectedElm)[0];
+    return Optional.from(editor.dom.select<HTMLAnchorElement>('a[href]', selectedElm)[0]);
   } else {
-    return editor.dom.getParent<HTMLAnchorElement>(selectedElm, 'a[href]');
+    return Optional.from(editor.dom.getParent<HTMLAnchorElement>(selectedElm, 'a[href]'));
   }
 };
 
@@ -117,8 +117,8 @@ const getLinkAttrs = (data: LinkDialogOutput): LinkAttrs => {
 
 const handleExternalTargets = (href: string, assumeExternalTargets: AssumeExternalTargets): string => {
   if ((assumeExternalTargets === AssumeExternalTargets.ALWAYS_HTTP
-        || assumeExternalTargets === AssumeExternalTargets.ALWAYS_HTTPS)
-      && !hasProtocol(href)) {
+    || assumeExternalTargets === AssumeExternalTargets.ALWAYS_HTTPS)
+    && !hasProtocol(href)) {
     return assumeExternalTargets + '://' + href;
   }
   return href;

--- a/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
@@ -79,7 +79,10 @@ const getAnchorElement = (editor: Editor, selectedElm?: Element): Optional<HTMLA
 };
 
 const getAnchorText = (selection: EditorSelection, anchorElm: Optional<HTMLAnchorElement>): string => {
-  const text = anchorElm.fold(() => selection.getContent({ format: 'text' }), (anchorElm) => (anchorElm.innerText || anchorElm.textContent));
+  const text = anchorElm.fold(
+    () => selection.getContent({ format: 'text' }),
+    (anchorElm) => anchorElm.innerText || anchorElm.textContent
+  );
   return trimCaretContainers(text);
 };
 

--- a/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
@@ -182,12 +182,14 @@ const linkDomMutation = (editor: Editor, attachState: AttachState, data: LinkDia
       attachState.attach();
     }
 
-    anchorElm.fold(() => {
-      createLink(editor, selectedElm, data.text, linkAttrs);
-    }, (elm) => {
-      editor.focus();
-      updateLink(editor, elm, data.text, linkAttrs);
-    });
+    anchorElm.fold(
+      () => {
+        createLink(editor, selectedElm, data.text, linkAttrs);
+      },
+      (elm) => {
+        editor.focus();
+        updateLink(editor, elm, data.text, linkAttrs);
+      });
   });
 };
 

--- a/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
@@ -78,8 +78,8 @@ const getAnchorElement = (editor: Editor, selectedElm?: Element): Optional<HTMLA
   }
 };
 
-const getAnchorText = (selection: EditorSelection, anchorElm: HTMLAnchorElement): string => {
-  const text = anchorElm ? (anchorElm.innerText || anchorElm.textContent) : selection.getContent({ format: 'text' });
+const getAnchorText = (selection: EditorSelection, anchorElm: Optional<HTMLAnchorElement>): string => {
+  const text = anchorElm.fold(() => selection.getContent({ format: 'text' }), (anchorElm) => (anchorElm.innerText || anchorElm.textContent));
   return trimCaretContainers(text);
 };
 
@@ -179,12 +179,12 @@ const linkDomMutation = (editor: Editor, attachState: AttachState, data: LinkDia
       attachState.attach();
     }
 
-    if (anchorElm) {
-      editor.focus();
-      updateLink(editor, anchorElm, data.text, linkAttrs);
-    } else {
+    anchorElm.fold(() => {
       createLink(editor, selectedElm, data.text, linkAttrs);
-    }
+    }, (elm) => {
+      editor.focus();
+      updateLink(editor, elm, data.text, linkAttrs);
+    });
   });
 };
 

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -98,7 +98,7 @@ const setupContextToolbars = (editor: Editor): void => {
     predicate: (node) => !!Utils.getAnchorElement(editor, node) && Options.hasContextToolbar(editor),
     initValue: () => {
       const elm = Utils.getAnchorElement(editor);
-      return elm.fold(Fun.constant(''), (elm) => Utils.getHref(elm));
+      return elm.fold(Fun.constant(''), Utils.getHref);
     },
     commands: [
       {

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -68,7 +68,7 @@ const setupContextToolbars = (editor: Editor): void => {
 
   const onSetupLink = (buttonApi: InlineContent.ContextFormButtonInstanceApi) => {
     const node = editor.selection.getNode();
-    buttonApi.setEnabled(Utils.getAnchorElement(editor, node) !== null);
+    buttonApi.setEnabled(Utils.getAnchorElement(editor, node).isSome());
     return Fun.noop;
   };
 
@@ -79,7 +79,7 @@ const setupContextToolbars = (editor: Editor): void => {
   const getLinkText = (value: string) => {
     const anchor = Utils.getAnchorElement(editor);
     const onlyText = Utils.isOnlyTextSelected(editor);
-    if (!anchor && onlyText) {
+    if (anchor.isNone() && onlyText) {
       const text = Utils.getAnchorText(editor.selection, anchor);
       return Optional.some(text.length > 0 ? text : value);
     } else {
@@ -98,7 +98,7 @@ const setupContextToolbars = (editor: Editor): void => {
     predicate: (node) => !!Utils.getAnchorElement(editor, node) && Options.hasContextToolbar(editor),
     initValue: () => {
       const elm = Utils.getAnchorElement(editor);
-      return !!elm ? Utils.getHref(elm) : '';
+      return elm.fold(Fun.constant(''), (elm) => Utils.getHref(elm));
     },
     commands: [
       {

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
@@ -47,8 +47,8 @@ const handleSubmit = (editor: Editor, info: LinkDialogInfo) => (api: Dialog.Dial
 };
 
 const collectData = (editor: Editor): Promise<LinkDialogInfo> => {
-  const anchorNode: HTMLAnchorElement = Utils.getAnchorElement(editor);
-  return DialogInfo.collect(editor, anchorNode);
+  const anchorNode = Utils.getAnchorElement(editor);
+  return DialogInfo.collect(editor, anchorNode.getOrNull());
 };
 
 const getInitialData = (info: LinkDialogInfo, defaultTarget: Optional<string>): LinkDialogData => {

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
@@ -48,7 +48,7 @@ const handleSubmit = (editor: Editor, info: LinkDialogInfo) => (api: Dialog.Dial
 
 const collectData = (editor: Editor): Promise<LinkDialogInfo> => {
   const anchorNode = Utils.getAnchorElement(editor);
-  return DialogInfo.collect(editor, anchorNode.getOrNull());
+  return DialogInfo.collect(editor, anchorNode);
 };
 
 const getInitialData = (info: LinkDialogInfo, defaultTarget: Optional<string>): LinkDialogData => {

--- a/modules/tinymce/src/plugins/link/main/ts/ui/DialogInfo.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/DialogInfo.ts
@@ -21,11 +21,11 @@ const extractFromAnchor = (editor: Editor, anchor: Optional<HTMLAnchorElement>):
   const dom = editor.dom;
   const onlyText = Utils.isOnlyTextSelected(editor);
   const text: Optional<string> = onlyText ? Optional.some(Utils.getAnchorText(editor.selection, anchor)) : Optional.none();
-  const url: Optional<string> = anchor.bind((anchor) => Optional.from(dom.getAttrib(anchor, 'href')));
-  const target: Optional<string> = anchor.bind((anchor) => Optional.from(dom.getAttrib(anchor, 'target')));
-  const rel = anchor.bind((anchor) => nonEmptyAttr(dom, anchor, 'rel'));
-  const linkClass = anchor.bind((anchor) => nonEmptyAttr(dom, anchor, 'class'));
-  const title = anchor.bind((anchor) => nonEmptyAttr(dom, anchor, 'title'));
+  const url: Optional<string> = anchor.bind((anchorElm) => Optional.from(dom.getAttrib(anchorElm, 'href')));
+  const target: Optional<string> = anchor.bind((anchorElm) => Optional.from(dom.getAttrib(anchorElm, 'target')));
+  const rel = anchor.bind((anchorElm) => nonEmptyAttr(dom, anchorElm, 'rel'));
+  const linkClass = anchor.bind((anchorElm) => nonEmptyAttr(dom, anchorElm, 'class'));
+  const title = anchor.bind((anchorElm) => nonEmptyAttr(dom, anchorElm, 'title'));
 
   return {
     url,

--- a/modules/tinymce/src/plugins/link/main/ts/ui/DialogInfo.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/DialogInfo.ts
@@ -17,15 +17,15 @@ const nonEmptyAttr = (dom: DOMUtils, elem: string | Element, name: string): Opti
   return val !== null && val.length > 0 ? Optional.some(val) : Optional.none();
 };
 
-const extractFromAnchor = (editor: Editor, anchor: HTMLAnchorElement): LinkDialogInfo['anchor'] => {
+const extractFromAnchor = (editor: Editor, anchor: Optional<HTMLAnchorElement>): LinkDialogInfo['anchor'] => {
   const dom = editor.dom;
   const onlyText = Utils.isOnlyTextSelected(editor);
-  const text: Optional<string> = onlyText ? Optional.some(Utils.getAnchorText(editor.selection, Optional.from(anchor))) : Optional.none();
-  const url: Optional<string> = anchor ? Optional.some(dom.getAttrib(anchor, 'href')) : Optional.none();
-  const target: Optional<string> = anchor ? Optional.from(dom.getAttrib(anchor, 'target')) : Optional.none();
-  const rel = nonEmptyAttr(dom, anchor, 'rel');
-  const linkClass = nonEmptyAttr(dom, anchor, 'class');
-  const title = nonEmptyAttr(dom, anchor, 'title');
+  const text: Optional<string> = onlyText ? Optional.some(Utils.getAnchorText(editor.selection, anchor)) : Optional.none();
+  const url: Optional<string> = anchor.bind((anchor) => Optional.from(dom.getAttrib(anchor, 'href')));
+  const target: Optional<string> = anchor.bind((anchor) => Optional.from(dom.getAttrib(anchor, 'target')));
+  const rel = anchor.bind((anchor) => nonEmptyAttr(dom, anchor, 'rel'));
+  const linkClass = anchor.bind((anchor) => nonEmptyAttr(dom, anchor, 'class'));
+  const title = anchor.bind((anchor) => nonEmptyAttr(dom, anchor, 'title'));
 
   return {
     url,
@@ -37,7 +37,7 @@ const extractFromAnchor = (editor: Editor, anchor: HTMLAnchorElement): LinkDialo
   };
 };
 
-const collect = (editor: Editor, linkNode: HTMLAnchorElement): Promise<LinkDialogInfo> =>
+const collect = (editor: Editor, linkNode: Optional<HTMLAnchorElement>): Promise<LinkDialogInfo> =>
   LinkListOptions.getLinks(editor).then((links) => {
     const anchor = extractFromAnchor(editor, linkNode);
     return {
@@ -50,7 +50,7 @@ const collect = (editor: Editor, linkNode: HTMLAnchorElement): Promise<LinkDialo
         anchor: AnchorListOptions.getAnchors(editor),
         link: links
       },
-      optNode: Optional.from(linkNode),
+      optNode: linkNode,
       flags: {
         titleEnabled: Options.shouldShowLinkTitle(editor)
       }

--- a/modules/tinymce/src/plugins/link/main/ts/ui/DialogInfo.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/DialogInfo.ts
@@ -20,7 +20,7 @@ const nonEmptyAttr = (dom: DOMUtils, elem: string | Element, name: string): Opti
 const extractFromAnchor = (editor: Editor, anchor: HTMLAnchorElement): LinkDialogInfo['anchor'] => {
   const dom = editor.dom;
   const onlyText = Utils.isOnlyTextSelected(editor);
-  const text: Optional<string> = onlyText ? Optional.some(Utils.getAnchorText(editor.selection, anchor)) : Optional.none();
+  const text: Optional<string> = onlyText ? Optional.some(Utils.getAnchorText(editor.selection, Optional.from(anchor))) : Optional.none();
   const url: Optional<string> = anchor ? Optional.some(dom.getAttrib(anchor, 'href')) : Optional.none();
   const target: Optional<string> = anchor ? Optional.from(dom.getAttrib(anchor, 'target')) : Optional.none();
   const rel = nonEmptyAttr(dom, anchor, 'rel');

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
@@ -44,9 +44,7 @@ describe('browser.tinymce.plugins.link.SelectedImageFigureTest', () => {
       </figure>
 `);
     TinySelections.select(editor, 'figure', []);
-    await UiFinder.pWaitForState('link toolbar button is active', SugarBody.body(), '[title="Insert/edit link"]', (elm) => {
-      return Class.has(elm, 'tox-tbtn--enabled');
-    });
+    await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"].tox-tbtn--enabled');
   });
 
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
@@ -1,6 +1,6 @@
-import { UiFinder, Waiter } from '@ephox/agar';
+import { UiFinder } from '@ephox/agar';
 import { describe, it, before, after } from '@ephox/bedrock-client';
-import { SugarBody } from '@ephox/sugar';
+import { Class, SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -31,9 +31,9 @@ describe('browser.tinymce.plugins.link.SelectedImageFigureTest', () => {
       </figure>
 `);
     TinySelections.select(editor, 'figure', []);
-    await Waiter.pWait(100);
-    UiFinder.exists(SugarBody.body(), '[title="Insert/edit link"]');
-    UiFinder.notExists(SugarBody.body(), `[title="Insert/edit link"].tox-tbtn--enabled`);
+    await UiFinder.pWaitForState('link toolbar button is NOT active', SugarBody.body(), '[title="Insert/edit link"]', (elm) => {
+      return !Class.has(elm, 'tox-tbtn--enabled');
+    });
   });
 
   it('TINY-8832: link button should be highlighted when there is a link in a figure element', async () => {
@@ -44,8 +44,9 @@ describe('browser.tinymce.plugins.link.SelectedImageFigureTest', () => {
       </figure>
 `);
     TinySelections.select(editor, 'figure', []);
-    await Waiter.pWait(100);
-    UiFinder.exists(SugarBody.body(), `[title="Insert/edit link"].tox-tbtn--enabled`);
+    await UiFinder.pWaitForState('link toolbar button is active', SugarBody.body(), '[title="Insert/edit link"]', (elm) => {
+      return Class.has(elm, 'tox-tbtn--enabled');
+    });
   });
 
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
@@ -1,0 +1,51 @@
+import { UiFinder, Waiter } from '@ephox/agar';
+import { describe, it, before, after } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/link/Plugin';
+
+import { TestLinkUi } from '../module/TestLinkUi';
+
+describe('browser.tinymce.plugins.link.SelectedImageFigureTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'link image',
+    toolbar: 'link',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ]);
+
+  before(() => {
+    TestLinkUi.clearHistory();
+  });
+
+  after(() => {
+    TestLinkUi.clearHistory();
+  });
+
+  it('TINY-8832: link button should not be highlighted when there is no link in a figure element', async () => {
+    const editor = hook.editor();
+    editor.setContent(`
+      <figure class="image"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
+        <figcaption>Caption</figcaption>
+      </figure>
+`);
+    TinySelections.select(editor, 'figure', []);
+    await Waiter.pWait(100);
+    UiFinder.exists(SugarBody.body(), '[title="Insert/edit link"]');
+    UiFinder.notExists(SugarBody.body(), `[title="Insert/edit link"].tox-tbtn--enabled`);
+  });
+
+  it('TINY-8832: link button should be highlighted when there is a link in a figure element', async () => {
+    const editor = hook.editor();
+    editor.setContent(`
+      <figure class="image"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
+        <figcaption><a href="http://tiny.cloud">Caption</a></figcaption>
+      </figure>
+`);
+    TinySelections.select(editor, 'figure', []);
+    await Waiter.pWait(100);
+    UiFinder.exists(SugarBody.body(), `[title="Insert/edit link"].tox-tbtn--enabled`);
+  });
+
+});

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
@@ -32,11 +32,13 @@ describe('browser.tinymce.plugins.link.SelectedImageFigureTest', () => {
       </figure>
     `);
 
-    TinySelections.select(editor, 'figure.no-link', []);
     await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
 
     TinySelections.select(editor, 'figure.has-link', []);
     await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"].tox-tbtn--enabled');
+
+    TinySelections.select(editor, 'figure.no-link', []);
+    await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
   });
 
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
@@ -31,9 +31,7 @@ describe('browser.tinymce.plugins.link.SelectedImageFigureTest', () => {
       </figure>
 `);
     TinySelections.select(editor, 'figure', []);
-    await UiFinder.pWaitForState('link toolbar button is NOT active', SugarBody.body(), '[title="Insert/edit link"]', (elm) => {
-      return !Class.has(elm, 'tox-tbtn--enabled');
-    });
+    await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
   });
 
   it('TINY-8832: link button should be highlighted when there is a link in a figure element', async () => {

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
@@ -27,7 +27,7 @@ describe('browser.tinymce.plugins.link.SelectedImageFigureTest', () => {
       <figure class="image"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
         <figcaption>Caption</figcaption>
       </figure>
-`);
+    `);
     TinySelections.select(editor, 'figure', []);
     await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
   });
@@ -38,7 +38,7 @@ describe('browser.tinymce.plugins.link.SelectedImageFigureTest', () => {
       <figure class="image"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
         <figcaption><a href="http://tiny.cloud">Caption</a></figcaption>
       </figure>
-`);
+    `);
     TinySelections.select(editor, 'figure', []);
     await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"].tox-tbtn--enabled');
   });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
@@ -21,24 +21,26 @@ describe('browser.tinymce.plugins.link.SelectedImageFigureTest', () => {
     TestLinkUi.clearHistory();
   });
 
-  it('TINY-8832: link button should NOT be highlighted when there is no link in a figure element', async () => {
+  it('TINY-8832: link button should not be highlighted when there is no link in a figure element', async () => {
     const editor = hook.editor();
     editor.setContent(`
-      <figure class="image no-link"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
+      <figure class="image"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
         <figcaption>Caption</figcaption>
       </figure>
-      <figure class="image has-link"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
+`);
+    TinySelections.select(editor, 'figure', []);
+    await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
+  });
+
+  it('TINY-8832: link button should be highlighted when there is a link in a figure element', async () => {
+    const editor = hook.editor();
+    editor.setContent(`
+      <figure class="image"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
         <figcaption><a href="http://tiny.cloud">Caption</a></figcaption>
       </figure>
-    `);
-
-    await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
-
-    TinySelections.select(editor, 'figure.has-link', []);
+`);
+    TinySelections.select(editor, 'figure', []);
     await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"].tox-tbtn--enabled');
-
-    TinySelections.select(editor, 'figure.no-link', []);
-    await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
   });
 
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
@@ -21,25 +21,21 @@ describe('browser.tinymce.plugins.link.SelectedImageFigureTest', () => {
     TestLinkUi.clearHistory();
   });
 
-  it('TINY-8832: link button should not be highlighted when there is no link in a figure element', async () => {
+  it('TINY-8832: link button should NOT be highlighted when there is no link in a figure element', async () => {
     const editor = hook.editor();
     editor.setContent(`
-      <figure class="image"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
+      <figure class="image no-link"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
         <figcaption>Caption</figcaption>
       </figure>
-    `);
-    TinySelections.select(editor, 'figure', []);
-    await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
-  });
-
-  it('TINY-8832: link button should be highlighted when there is a link in a figure element', async () => {
-    const editor = hook.editor();
-    editor.setContent(`
-      <figure class="image"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
+      <figure class="image has-link"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
         <figcaption><a href="http://tiny.cloud">Caption</a></figcaption>
       </figure>
     `);
-    TinySelections.select(editor, 'figure', []);
+
+    TinySelections.select(editor, 'figure.no-link', []);
+    await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
+
+    TinySelections.select(editor, 'figure.has-link', []);
     await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"].tox-tbtn--enabled');
   });
 

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
@@ -1,7 +1,5 @@
-import { UiFinder } from '@ephox/agar';
 import { describe, it, before, after } from '@ephox/bedrock-client';
-import { Class, SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
@@ -29,7 +27,7 @@ describe('browser.tinymce.plugins.link.SelectedImageFigureTest', () => {
       <figure class="image"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
         <figcaption>Caption</figcaption>
       </figure>
-`);
+    `);
     TinySelections.select(editor, 'figure', []);
     await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
   });
@@ -40,7 +38,7 @@ describe('browser.tinymce.plugins.link.SelectedImageFigureTest', () => {
       <figure class="image"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
         <figcaption><a href="http://tiny.cloud">Caption</a></figcaption>
       </figure>
-`);
+    `);
     TinySelections.select(editor, 'figure', []);
     await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"].tox-tbtn--enabled');
   });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
@@ -21,26 +21,24 @@ describe('browser.tinymce.plugins.link.SelectedImageFigureTest', () => {
     TestLinkUi.clearHistory();
   });
 
-  it('TINY-8832: link button should not be highlighted when there is no link in a figure element', async () => {
+  it('TINY-8832: link button should NOT be highlighted when there is no link in a figure element', async () => {
     const editor = hook.editor();
     editor.setContent(`
-      <figure class="image"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
+      <figure class="image no-link"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
         <figcaption>Caption</figcaption>
       </figure>
-    `);
-    TinySelections.select(editor, 'figure', []);
-    await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
-  });
-
-  it('TINY-8832: link button should be highlighted when there is a link in a figure element', async () => {
-    const editor = hook.editor();
-    editor.setContent(`
-      <figure class="image"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
+      <figure class="image has-link"><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400">
         <figcaption><a href="http://tiny.cloud">Caption</a></figcaption>
       </figure>
     `);
-    TinySelections.select(editor, 'figure', []);
+
+    await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
+
+    TinySelections.select(editor, 'figure.has-link', []);
     await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"].tox-tbtn--enabled');
+
+    TinySelections.select(editor, 'figure.no-link', []);
+    await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
   });
 
 });


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
Fix a bug where the link button would get highlighted when selecting a figure even though it doesn't contain a link

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
