### PR TITLE
TINY-8905: Allow formatter to be able to wrap noneditable elements

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New `text_patterns_lookup` option to provide additional text patterns dynamically #TINY-8778
+- New `format_noneditable_selector` option to specify the `contenteditable="false"` elements that can be wrapped in a format. #TINY-8905
+
+### Improved
+- The formatter can now apply a format to a `contenteditable="false"` element by wrapping it. Configurable using the `format_noneditable_selector` option. #TINY-8905
 
 ### Fixed
 - The Autolink plugin did not work when the text nodes in the content were fragmented #TINY-3723
@@ -15,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The editor focused via the `auto_focus` option was not scrolled into the viewport #TINY-8785
 - Elements with only custom attributes starting with `data-` would sometimes be removed when they shouldn't #TINY-8755
 - Selecting a figure with `class="image"` would incorrectly highlight the link toolbar button #TINY-8832
+- Fixed various issues that occurred when formatting `contenteditable` elements #TINY-8905
 
 ## 6.1.1 - TBA
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The editor focused via the `auto_focus` option was not scrolled into the viewport #TINY-8785
 - Elements with only custom attributes starting with `data-` would sometimes be removed when they shouldn't #TINY-8755
 - Selecting a figure with `class="image"` would incorrectly highlight the link toolbar button #TINY-8832
-- Fixed various issues that occurred when formatting `contenteditable` elements #TINY-8905
+- Fixed various issues that occurred when formatting `contenteditable` elements. #TINY-8905
 
 ## 6.1.1 - TBA
 

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -109,7 +109,7 @@ interface BaseEditorOptions {
   forced_root_block?: string;
   forced_root_block_attrs?: Record<string, string>;
   formats?: Formats;
-  format_wrap_noneditable_selectors?: string[];
+  format_noneditable_selector?: string;
   height?: number | string;
   hidden_input?: boolean;
   icons?: string;
@@ -259,6 +259,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   font_size_style_values: string;
   forced_root_block: string;
   forced_root_block_attrs: Record<string, string>;
+  format_noneditable_selector: string;
   iframe_attrs: Record<string, string>;
   images_file_types: string;
   images_upload_base_path: string;

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -109,6 +109,7 @@ interface BaseEditorOptions {
   forced_root_block?: string;
   forced_root_block_attrs?: Record<string, string>;
   formats?: Formats;
+  format_wrap_noneditable_selectors?: string[];
   height?: number | string;
   hidden_input?: boolean;
   icons?: string;

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -380,6 +380,11 @@ const register = (editor: Editor): void => {
     default: false
   });
 
+  registerOption('format_wrap_noneditable_selectors', {
+    processor: 'string[]',
+    default: []
+  });
+
   registerOption('preview_styles', {
     processor: (value) => {
       const valid = value === false || Type.isString(value);
@@ -822,6 +827,7 @@ const isInlineBoundariesEnabled = option('inline_boundaries');
 const getFormats = option('formats');
 const getPreviewStyles = option('preview_styles');
 const canFormatEmptyLines = option('format_empty_lines');
+const getWrapNoneditableSelectors = option('format_wrap_noneditable_selectors');
 const getCustomUiSelector = option('custom_ui_selector');
 const isInline = option('inline');
 const hasHiddenInput = option('hidden_input');
@@ -924,6 +930,7 @@ export {
   getFormats,
   getPreviewStyles,
   canFormatEmptyLines,
+  getWrapNoneditableSelectors,
   getCustomUiSelector,
   getThemeUrl,
   getModelUrl,

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -381,9 +381,9 @@ const register = (editor: Editor): void => {
     default: false
   });
 
-  registerOption('format_wrap_noneditable_selectors', {
-    processor: 'string[]',
-    default: []
+  registerOption('format_noneditable_selector', {
+    processor: 'string',
+    default: ''
   });
 
   registerOption('preview_styles', {
@@ -842,7 +842,7 @@ const isInlineBoundariesEnabled = option('inline_boundaries');
 const getFormats = option('formats');
 const getPreviewStyles = option('preview_styles');
 const canFormatEmptyLines = option('format_empty_lines');
-const getWrapNoneditableSelectors = option('format_wrap_noneditable_selectors');
+const getFormatNoneditableSelector = option('format_noneditable_selector');
 const getCustomUiSelector = option('custom_ui_selector');
 const isInline = option('inline');
 const hasHiddenInput = option('hidden_input');
@@ -949,7 +949,7 @@ export {
   getFormats,
   getPreviewStyles,
   canFormatEmptyLines,
-  getWrapNoneditableSelectors,
+  getFormatNoneditableSelector,
   getCustomUiSelector,
   getThemeUrl,
   getModelUrl,

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -221,6 +221,7 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
             parentNode.insertBefore(currentWrapElm, node);
             newWrappers.push(currentWrapElm);
           }
+
           // Wrappable noneditable element has been handled so go back to previous state
           if (isWrappableNoneditableElm && hasContentEditableState) {
             contentEditable = lastContentEditable;

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -146,7 +146,7 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
           contentEditable = contentEditableValue === 'true';
           // Unless the noneditable element is wrappable, we don't want to wrap the container, only it's editable children
           hasContentEditableState = true;
-          isWrappableNoneditableElm = FormatUtils.isWrappableNoneditable(dom, node);
+          isWrappableNoneditableElm = FormatUtils.isWrappableNoneditable(ed, node);
         }
 
         const isMatchingWrappingBlock = isWrappingBlockFormat && MatchFormat.matchNode(ed, node, name, vars);
@@ -315,7 +315,7 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
       }
     }
 
-    if (formatApplied || !FormatUtils.isWrappableNoneditable(dom, node)) {
+    if (formatApplied || !FormatUtils.isWrappableNoneditable(ed, node)) {
       Events.fireFormatApply(ed, name, selectedNode, vars);
       return;
     }

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -27,10 +27,6 @@ import * as MergeFormats from './MergeFormats';
 
 const each = Tools.each;
 
-const isElementNode = (node: Node): node is Element => {
-  return NodeType.isElement(node) && !Bookmarks.isBookmarkNode(node) && !isCaretNode(node) && !NodeType.isBogus(node);
-};
-
 const canFormatBR = (editor: Editor, format: ApplyFormat, node: HTMLBRElement, parentName: string) => {
   // TINY-6483: Can format 'br' if it is contained in a valid empty block and an inline format is being applied
   if (Options.canFormatEmptyLines(editor) && FormatUtils.isInlineFormat(format) && node.parentNode) {
@@ -122,6 +118,10 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
     const newWrappers: Element[] = [];
     let contentEditable = true;
 
+    const isWrappingBlockFormat = FormatUtils.isBlockFormat(format) && format.wrapper;
+    const isNonWrappingBlockFormat = FormatUtils.isBlockFormat(format) && !format.wrapper;
+    const isWrapNameFormat = FormatUtils.isInlineFormat(format) || FormatUtils.isBlockFormat(format);
+
     // Setup wrapper element
     const wrapName: string | undefined = (format as InlineFormat).inline || (format as BlockFormat).block;
     const wrapElm = createWrapElement(wrapName);
@@ -134,16 +134,33 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
       const process = (node: Node) => {
         let hasContentEditableState = false;
         let lastContentEditable = contentEditable;
+        let isWrappableNoneditableElm = false;
         const nodeName = node.nodeName.toLowerCase();
         const parentNode = node.parentNode as Node;
         const parentName = parentNode.nodeName.toLowerCase();
 
         // Node has a contentEditable value
-        if (NodeType.isElement(node) && dom.getContentEditable(node)) {
+        const contentEditableValue = dom.getContentEditable(node);
+        if (Type.isNonNullable(contentEditableValue)) {
           lastContentEditable = contentEditable;
-          contentEditable = dom.getContentEditable(node) === 'true';
-          hasContentEditableState = true; // We don't want to wrap the container only it's children
+          contentEditable = contentEditableValue === 'true';
+          // Unless the noneditable element is wrappable, we don't want to wrap the container, only it's editable children
+          hasContentEditableState = true;
+          isWrappableNoneditableElm = FormatUtils.isWrappableNoneditable(dom, node);
         }
+
+        const isMatchingWrappingBlock = isWrappingBlockFormat && MatchFormat.matchNode(ed, node, name, vars);
+
+        const isEditableDescendant = contentEditable && !hasContentEditableState;
+        const isValidBlockFormatForNode = isNonWrappingBlockFormat && FormatUtils.isTextBlock(ed, nodeName) && FormatUtils.isValid(ed, parentName, wrapName);
+        const canRenameBlock = isEditableDescendant && isValidBlockFormatForNode;
+
+        const isValidWrapNode = isWrapNameFormat && FormatUtils.isValid(ed, wrapName, nodeName) && FormatUtils.isValid(ed, parentName, wrapName);
+        // If it is not node specific, it means that it was not passed into 'formatter.apply` and is withiin the editor selection
+        const isZwsp = !nodeSpecific && NodeType.isText(node) && Zwsp.isZwsp(node.data);
+        const isCaret = isCaretNode(node);
+        const isCorrectFormatForNode = !FormatUtils.isInlineFormat(format) || !dom.isBlock(node);
+        const canWrapNode = (isEditableDescendant || isWrappableNoneditableElm) && isValidWrapNode && !isZwsp && !isCaret && isCorrectFormatForNode;
 
         // Stop wrapping on br elements except when valid
         if (NodeType.isBr(node) && !canFormatBR(ed, format, node, parentName)) {
@@ -155,16 +172,12 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
           return;
         }
 
-        // If node is wrapper type
-        if (FormatUtils.isBlockFormat(format) && format.wrapper && MatchFormat.matchNode(ed, node, name, vars)) {
+        if (isMatchingWrappingBlock) {
           currentWrapElm = null;
           return;
         }
 
-        // Can we rename the block
-        // TODO: Break this if up, too complex
-        if (contentEditable && !hasContentEditableState && FormatUtils.isBlockFormat(format) &&
-          !format.wrapper && FormatUtils.isTextBlock(ed, nodeName) && FormatUtils.isValid(ed, parentName, wrapName)) {
+        if (canRenameBlock) {
           const elm = dom.rename(node as Element, wrapName);
           setElementFormat(elm);
           newWrappers.push(elm);
@@ -172,7 +185,6 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
           return;
         }
 
-        // Handle selector patterns
         if (FormatUtils.isSelectorFormat(format)) {
           let found = applyNodeStyle(formatList, node);
 
@@ -188,20 +200,17 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
           }
         }
 
-        // Is it valid to wrap this item
-        // TODO: Break this if up, too complex
-        if (contentEditable && !hasContentEditableState && FormatUtils.isValid(ed, wrapName, nodeName) && FormatUtils.isValid(ed, parentName, wrapName) &&
-          Type.isNonNullable(wrapElm) &&
-          !(!nodeSpecific && NodeType.isText(node) && Zwsp.isZwsp(node.data)) &&
-          !isCaretNode(node) &&
-          (!FormatUtils.isInlineFormat(format) || !dom.isBlock(node))
-        ) {
+        if (canWrapNode) {
           // Start wrapping
           if (!currentWrapElm) {
             // Wrap the node
             currentWrapElm = dom.clone(wrapElm, false) as Element;
             parentNode.insertBefore(currentWrapElm, node);
             newWrappers.push(currentWrapElm);
+          }
+          // Wrappable noneditable element has been handled so go back to previous state
+          if (isWrappableNoneditableElm && hasContentEditableState) {
+            contentEditable = lastContentEditable;
           }
 
           currentWrapElm.appendChild(node);
@@ -254,8 +263,8 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
 
       const mergeStyles = (node: Element): Element => {
         // Check if a child was found and of the same type as the current node
-        const childElement = Arr.find(node.childNodes, isElementNode)
-          .filter((child) => MatchFormat.matchName(dom, child, format));
+        const childElement = Arr.find(node.childNodes, FormatUtils.isElementNode)
+          .filter((child) => dom.getContentEditable(child) !== 'false' && MatchFormat.matchName(dom, child, format));
         return childElement.map((child) => {
           const clone = dom.clone(child, false) as Element;
           setElementFormat(clone);
@@ -282,6 +291,7 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
           node = mergeStyles(node);
         }
 
+        // TODO: Make sure all of the below handle noneditable elements correctly
         MergeFormats.mergeWithChildren(ed, formatList, vars, node);
         MergeFormats.mergeWithParents(ed, format, name, vars, node);
         MergeFormats.mergeBackgroundColorAndFontSize(dom, format, vars, node);
@@ -292,18 +302,23 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
     });
   };
 
-  if (dom.getContentEditable(selection.getNode()) === 'false') {
-    node = selection.getNode();
+  const selectedNode = selection.getNode();
+  if (dom.getContentEditable(selectedNode) === 'false') {
+    node = selectedNode;
+    let formatApplied = false;
     for (let i = 0, l = formatList.length; i < l; i++) {
       const formatItem = formatList[i];
       if (formatItem.ceFalseOverride && FormatUtils.isSelectorFormat(formatItem) && dom.is(node, formatItem.selector)) {
         setElementFormat(node as Element, formatItem);
+        formatApplied = true;
         break;
       }
     }
 
-    Events.fireFormatApply(ed, name, node, vars);
-    return;
+    if (formatApplied || !FormatUtils.isWrappableNoneditable(dom, node)) {
+      Events.fireFormatApply(ed, name, selectedNode, vars);
+      return;
+    }
   }
 
   if (format) {

--- a/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
@@ -22,7 +22,7 @@ const isInlineBlock = (node: Node): boolean => {
   return node && /^(IMG)$/.test(node.nodeName);
 };
 
-const isContentEditable = (elm: HTMLElement): boolean =>
+const isEditable = (elm: HTMLElement): boolean =>
   elm.isContentEditable === true;
 
 const moveStart = (dom: DOMUtils, selection: EditorSelection, rng: Range): void => {
@@ -280,7 +280,7 @@ export {
   isNode,
   isElementNode,
   isInlineBlock,
-  isContentEditable,
+  isEditable,
   moveStart,
   getNonWhiteSpaceSibling,
   isTextBlock,

--- a/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
@@ -1,5 +1,5 @@
 import { Transformations } from '@ephox/acid';
-import { Arr, Obj, Optionals, Type } from '@ephox/katamari';
+import { Arr, Obj, Optionals, Strings, Type } from '@ephox/katamari';
 import { Selectors, SugarElement } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
@@ -107,8 +107,10 @@ const isEmptyTextNode = (node: Node | null): boolean => {
 };
 
 const isWrapNoneditableTarget = (editor: Editor, node: Node): boolean => {
-  const selectors = [ '[data-mce-cef-wrappable]' ].concat(Options.getWrapNoneditableSelectors(editor)).join(',');
-  return Selectors.is(SugarElement.fromDom(node), selectors);
+  const baseDataSelector = '[data-mce-cef-wrappable]';
+  const formatNoneditableSelector = Options.getFormatNoneditableSelector(editor);
+  const selector = Strings.isEmpty(formatNoneditableSelector) ? baseDataSelector : `${baseDataSelector},${formatNoneditableSelector}`;
+  return Selectors.is(SugarElement.fromDom(node), selector);
 };
 
 // A noneditable element is wrappable if it:
@@ -253,6 +255,12 @@ const areSimilarFormats = (editor: Editor, formatName: string, otherFormatName: 
 const isBlockFormat = (format: Format): format is BlockFormat =>
   Obj.hasNonNullableKey(format as any, 'block');
 
+const isWrappingBlockFormat = (format: Format): format is BlockFormat =>
+  isBlockFormat(format) && format.wrapper;
+
+const isNonWrappingBlockFormat = (format: Format): format is BlockFormat =>
+  isBlockFormat(format) && !format.wrapper;
+
 const isSelectorFormat = (format: Format): format is SelectorFormat =>
   Obj.hasNonNullableKey(format as any, 'selector');
 
@@ -287,6 +295,8 @@ export {
   isSelectorFormat,
   isInlineFormat,
   isBlockFormat,
+  isWrappingBlockFormat,
+  isNonWrappingBlockFormat,
   isMixedFormat,
   shouldExpandToSelector
 };

--- a/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
@@ -22,6 +22,9 @@ const isInlineBlock = (node: Node): boolean => {
   return node && /^(IMG)$/.test(node.nodeName);
 };
 
+const isContentEditable = (elm: HTMLElement): boolean =>
+  elm.isContentEditable === true;
+
 const moveStart = (dom: DOMUtils, selection: EditorSelection, rng: Range): void => {
   const offset = rng.startOffset;
   let container = rng.startContainer;
@@ -277,6 +280,7 @@ export {
   isNode,
   isElementNode,
   isInlineBlock,
+  isContentEditable,
   moveStart,
   getNonWhiteSpaceSibling,
   isTextBlock,

--- a/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
@@ -14,7 +14,7 @@ const each = Tools.each;
 
 const mergeTextDecorationsAndColor = (dom: DOMUtils, format: ApplyFormat, vars: FormatVars | undefined, node: Node): void => {
   const processTextDecorationsAndColor = (n: Node) => {
-    if (NodeType.isElement(n) && NodeType.isElement(n.parentNode) && FormatUtils.isContentEditable(n)) {
+    if (NodeType.isElement(n) && NodeType.isElement(n.parentNode) && FormatUtils.isEditable(n)) {
       const parentTextDecoration = FormatUtils.getTextDecoration(dom, n.parentNode);
       if (dom.getStyle(n, 'color') && parentTextDecoration) {
         dom.setStyle(n, 'text-decoration', parentTextDecoration);
@@ -34,8 +34,9 @@ const mergeTextDecorationsAndColor = (dom: DOMUtils, format: ApplyFormat, vars: 
 const mergeBackgroundColorAndFontSize = (dom: DOMUtils, format: ApplyFormat, vars: FormatVars | undefined, node: Node): void => {
   // nodes with font-size should have their own background color as well to fit the line-height (see TINY-882)
   if (format.styles && format.styles.backgroundColor) {
+    const hasFontSize = hasStyle(dom, 'fontSize');
     processChildElements(node,
-      (elm) => hasStyle(dom, 'fontSize')(elm) && FormatUtils.isContentEditable(elm),
+      (elm) => hasFontSize(elm) && FormatUtils.isEditable(elm),
       applyStyle(dom, 'backgroundColor', FormatUtils.replaceVars(format.styles.backgroundColor, vars))
     );
   }
@@ -44,12 +45,13 @@ const mergeBackgroundColorAndFontSize = (dom: DOMUtils, format: ApplyFormat, var
 const mergeSubSup = (dom: DOMUtils, format: ApplyFormat, vars: FormatVars | undefined, node: Node): void => {
   // Remove font size on all descendants of a sub/sup and remove the inverse elements
   if (FormatUtils.isInlineFormat(format) && (format.inline === 'sub' || format.inline === 'sup')) {
+    const hasFontSize = hasStyle(dom, 'fontSize');
     processChildElements(node,
-      (elm) => hasStyle(dom, 'fontSize')(elm) && FormatUtils.isContentEditable(elm),
+      (elm) => hasFontSize(elm) && FormatUtils.isEditable(elm),
       applyStyle(dom, 'fontSize', '')
     );
 
-    const inverseTagDescendants = Arr.filter(dom.select(format.inline === 'sup' ? 'sub' : 'sup', node), FormatUtils.isContentEditable);
+    const inverseTagDescendants = Arr.filter(dom.select(format.inline === 'sup' ? 'sub' : 'sup', node), FormatUtils.isEditable);
     dom.remove(inverseTagDescendants, true);
   }
 };

--- a/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
@@ -1,3 +1,5 @@
+import { Arr } from '@ephox/katamari';
+
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
 import Tools from '../api/util/Tools';
@@ -12,11 +14,11 @@ const each = Tools.each;
 
 const mergeTextDecorationsAndColor = (dom: DOMUtils, format: ApplyFormat, vars: FormatVars | undefined, node: Node): void => {
   const processTextDecorationsAndColor = (n: Node) => {
-    if (NodeType.isElement(n) && NodeType.isElement(n.parentNode) && dom.getContentEditable(n.parentNode) !== 'false' && dom.getContentEditable(n) !== 'false') {
-      const textDecoration = FormatUtils.getTextDecoration(dom, n.parentNode);
-      if (dom.getStyle(n, 'color') && textDecoration) {
-        dom.setStyle(n, 'text-decoration', textDecoration);
-      } else if (dom.getStyle(n, 'text-decoration') === textDecoration) {
+    if (NodeType.isElement(n) && NodeType.isElement(n.parentNode) && FormatUtils.isContentEditable(n)) {
+      const parentTextDecoration = FormatUtils.getTextDecoration(dom, n.parentNode);
+      if (dom.getStyle(n, 'color') && parentTextDecoration) {
+        dom.setStyle(n, 'text-decoration', parentTextDecoration);
+      } else if (dom.getStyle(n, 'text-decoration') === parentTextDecoration) {
         dom.setStyle(n, 'text-decoration', null);
       }
     }
@@ -33,26 +35,28 @@ const mergeBackgroundColorAndFontSize = (dom: DOMUtils, format: ApplyFormat, var
   // nodes with font-size should have their own background color as well to fit the line-height (see TINY-882)
   if (format.styles && format.styles.backgroundColor) {
     processChildElements(node,
-      hasStyle(dom, 'fontSize'),
+      (elm) => hasStyle(dom, 'fontSize')(elm) && FormatUtils.isContentEditable(elm),
       applyStyle(dom, 'backgroundColor', FormatUtils.replaceVars(format.styles.backgroundColor, vars))
     );
   }
 };
 
 const mergeSubSup = (dom: DOMUtils, format: ApplyFormat, vars: FormatVars | undefined, node: Node): void => {
-  // Remove font size on all children of a sub/sup and remove the inverse element
+  // Remove font size on all descendants of a sub/sup and remove the inverse elements
   if (FormatUtils.isInlineFormat(format) && (format.inline === 'sub' || format.inline === 'sup')) {
     processChildElements(node,
-      hasStyle(dom, 'fontSize'),
+      (elm) => hasStyle(dom, 'fontSize')(elm) && FormatUtils.isContentEditable(elm),
       applyStyle(dom, 'fontSize', '')
     );
 
-    dom.remove(dom.select(format.inline === 'sup' ? 'sub' : 'sup', node), true);
+    const inverseTagDescendants = Arr.filter(dom.select(format.inline === 'sup' ? 'sub' : 'sup', node), FormatUtils.isContentEditable);
+    dom.remove(inverseTagDescendants, true);
   }
 };
 
 const mergeWithChildren = (editor: Editor, formatList: ApplyFormat[], vars: FormatVars | undefined, node: Node): void => {
   // Remove/merge children
+  // Note: RemoveFormat.removeFormat will not remove formatting from noneditable nodes
   each(formatList, (format) => {
     // Merge all children of similar type will move styles from child to parent
     // this: <span style="color:red"><b><span style="color:red; font-size:10px">text</span></b></span>
@@ -71,6 +75,7 @@ const mergeWithChildren = (editor: Editor, formatList: ApplyFormat[], vars: Form
 
 const mergeWithParents = (editor: Editor, format: ApplyFormat, name: string, vars: FormatVars | undefined, node: Node): void => {
   // Remove format if direct parent already has the same format
+  // Note: RemoveFormat.removeFormat will not remove formatting from noneditable nodes
   const parentNode = node.parentNode;
   if (MatchFormat.matchNode(editor, parentNode, name, vars)) {
     if (RemoveFormat.removeFormat(editor, format, vars, node)) {

--- a/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
@@ -12,7 +12,7 @@ const each = Tools.each;
 
 const mergeTextDecorationsAndColor = (dom: DOMUtils, format: ApplyFormat, vars: FormatVars | undefined, node: Node): void => {
   const processTextDecorationsAndColor = (n: Node) => {
-    if (NodeType.isElement(n) && NodeType.isElement(n.parentNode)) {
+    if (NodeType.isElement(n) && NodeType.isElement(n.parentNode) && dom.getContentEditable(n.parentNode) !== 'false' && dom.getContentEditable(n) !== 'false') {
       const textDecoration = FormatUtils.getTextDecoration(dom, n.parentNode);
       if (dom.getStyle(n, 'color') && textDecoration) {
         dom.setStyle(n, 'text-decoration', textDecoration);

--- a/modules/tinymce/src/core/main/ts/fmt/MergeUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MergeUtils.ts
@@ -31,8 +31,8 @@ const findElementSibling = (node: Node, siblingName: 'nextSibling' | 'previousSi
 
 const mergeSiblingsNodes = (editor: Editor, prev: Node | undefined, next: Node | undefined) => {
   const elementUtils = ElementUtils(editor);
-  const isPrevEditable = prev && NodeType.isElement(prev) && FormatUtils.isContentEditable(prev);
-  const isNextEditable = next && NodeType.isElement(next) && FormatUtils.isContentEditable(next);
+  const isPrevEditable = NodeType.isElement(prev) && FormatUtils.isEditable(prev);
+  const isNextEditable = NodeType.isElement(next) && FormatUtils.isEditable(next);
 
   // Check if next/prev exists and that they are elements
   if (isPrevEditable && isNextEditable) {
@@ -77,7 +77,7 @@ const clearChildStyles = (dom: DOMUtils, format: ApplyFormat, node: Node): void 
   if (format.clear_child_styles) {
     const selector = format.links ? '*:not(a)' : '*';
     each(dom.select(selector, node), (childNode) => {
-      if (isElementNode(childNode) && FormatUtils.isContentEditable(childNode)) {
+      if (isElementNode(childNode) && FormatUtils.isEditable(childNode)) {
         each(format.styles, (_value, name: string) => {
           dom.setStyle(childNode, name, '');
         });

--- a/modules/tinymce/src/core/main/ts/fmt/MergeUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MergeUtils.ts
@@ -72,10 +72,10 @@ const mergeSiblings = (dom: DOMUtils, format: ApplyFormat, vars: FormatVars | un
 const clearChildStyles = (dom: DOMUtils, format: ApplyFormat, node: Node): void => {
   if (format.clear_child_styles) {
     const selector = format.links ? '*:not(a)' : '*';
-    each(dom.select(selector, node), (node) => {
-      if (isElementNode(node)) {
-        each(format.styles, (value, name: string) => {
-          dom.setStyle(node, name, '');
+    each(dom.select(selector, node), (childNode) => {
+      if (isElementNode(childNode) && dom.getContentEditableParent(childNode) !== 'false') {
+        each(format.styles, (_value, name: string) => {
+          dom.setStyle(childNode, name, '');
         });
       }
     });

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -197,13 +197,13 @@ const removeFormatInternal = (ed: Editor, format: Format, vars?: FormatVars, nod
   const dom = ed.dom;
   const elementUtils = ElementUtils(ed);
 
-  // Check if node matches format
-  if (node && !MatchFormat.matchName(dom, node, format) && !isColorFormatAndAnchor(node, format)) {
+  // Check if node is noneditable and can have the format removed from it
+  if (!format.ceFalseOverride && node && dom.getContentEditableParent(node) === 'false') {
     return removeResult.keep();
   }
 
-  // Check if node is noneditable and can have the format removed from it
-  if (!format.ceFalseOverride && node && dom.getContentEditableParent(node) === 'false') {
+  // Check if node matches format
+  if (node && !MatchFormat.matchName(dom, node, format) && !isColorFormatAndAnchor(node, format)) {
     return removeResult.keep();
   }
 
@@ -439,7 +439,6 @@ const wrapAndSplit = (
 const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range, similar?: boolean): void => {
   const formatList = ed.formatter.get(name) as Format[];
   const format = formatList[0];
-  let contentEditable = true;
   const dom = ed.dom;
   const selection = ed.selection;
 
@@ -458,29 +457,18 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
 
   // Merges the styles for each node
   const process = (node: Node) => {
-    let lastContentEditable = true;
-    let hasContentEditableState = false;
-
-    // Node has a contentEditable value
-    if (NodeType.isElement(node) && dom.getContentEditable(node)) {
-      lastContentEditable = contentEditable;
-      contentEditable = dom.getContentEditable(node) === 'true';
-      hasContentEditableState = true; // We don't want to wrap the container only it's children
-    }
 
     // Grab the children first since the nodelist might be changed
     const children = Arr.from(node.childNodes);
 
     // Process current node
-    if (contentEditable && !hasContentEditableState) {
-      const removed = removeNodeFormat(node);
+    const removed = removeNodeFormat(node);
 
-      // TINY-6567/TINY-7393: Include the parent if using an expanded selector format and no match was found for the current node
-      const currentNodeMatches = removed || Arr.exists(formatList, (f) => MatchFormat.matchName(dom, node, f));
-      const parentNode = node.parentNode;
-      if (!currentNodeMatches && Type.isNonNullable(parentNode) && FormatUtils.shouldExpandToSelector(format)) {
-        removeNodeFormat(parentNode);
-      }
+    // TINY-6567/TINY-7393: Include the parent if using an expanded selector format and no match was found for the current node
+    const currentNodeMatches = removed || Arr.exists(formatList, (f) => MatchFormat.matchName(dom, node, f));
+    const parentNode = node.parentNode;
+    if (!currentNodeMatches && Type.isNonNullable(parentNode) && FormatUtils.shouldExpandToSelector(format)) {
+      removeNodeFormat(parentNode);
     }
 
     // Process the children
@@ -488,10 +476,6 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
       if (children.length) {
         for (let i = 0; i < children.length; i++) {
           process(children[i]);
-        }
-
-        if (hasContentEditableState) {
-          contentEditable = lastContentEditable; // Restore last contentEditable state from stack
         }
       }
     }
@@ -628,25 +612,6 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
 
     Events.fireFormatRemove(ed, name, node, vars);
     return;
-  }
-
-  const selectedNode = selection.getNode();
-  if (dom.getContentEditable(selectedNode) === 'false') {
-    node = selectedNode;
-    let formatRemoved = false;
-    for (let i = 0; i < formatList.length; i++) {
-      if (formatList[i].ceFalseOverride) {
-        formatRemoved = removeFormat(ed, formatList[i], vars, node, node);
-        if (formatRemoved) {
-          break;
-        }
-      }
-    }
-
-    if (formatRemoved) {
-      Events.fireFormatRemove(ed, name, node, vars);
-      return;
-    }
   }
 
   if (!selection.isCollapsed() || !FormatUtils.isInlineFormat(format) || TableCellSelection.getCellsFromEditor(ed).length) {

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
@@ -1,0 +1,660 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr, Type } from '@ephox/katamari';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+interface Action {
+  readonly select: (editor: Editor) => void;
+  readonly expectedHtml: string;
+  readonly pAssertBefore?: (editor: Editor) => Promise<void>;
+  readonly pAssertAfter?: (editor: Editor) => Promise<void>;
+}
+
+interface FormatInfo {
+  readonly label: string;
+  readonly tag: string;
+  readonly html: string;
+  readonly toggle: (editor: Editor) => void;
+  readonly useToolbar: boolean;
+}
+
+describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    toolbar: 'forecolor backcolor | bold italic underline strikethrough | alignleft',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [], true);
+
+  const toggleInlineStyle = (style: string) => (editor: Editor) => {
+    TinyUiActions.clickOnToolbar(editor, `[aria-label="${style}"]`);
+  };
+  const toggleCustomFormat = (format: string, vars?: Record<string, any>) => (editor: Editor) => editor.formatter.toggle(format, vars);
+
+  const selectAll = (editor: Editor) => editor.execCommand('SelectAll');
+
+  const pAssertToolbarButtonState = (selector: string, active: boolean) => async (editor: Editor) => {
+    await TinyUiActions.pWaitForUi(editor, `button[aria-label="${selector}"][aria-pressed="${active}"]`);
+  };
+
+  const pTestFormat = (format: (editor: Editor) => void) => async (editor: Editor, actions: Action[]) => {
+    for (const action of actions) {
+      const { select, expectedHtml, pAssertBefore, pAssertAfter } = action;
+      select(editor);
+      if (Type.isNonNullable(pAssertBefore)) {
+        await pAssertBefore(editor);
+      }
+      format(editor);
+      TinyAssertions.assertContent(editor, expectedHtml);
+      if (Type.isNonNullable(pAssertAfter)) {
+        await pAssertAfter(editor);
+      }
+    }
+  };
+
+  const boldFormat: FormatInfo = {
+    label: 'Bold',
+    tag: 'strong',
+    html: 'strong',
+    toggle: toggleInlineStyle('Bold'),
+    useToolbar: true
+  };
+
+  const underlineFormat: FormatInfo = {
+    label: 'Underline',
+    tag: 'span',
+    html: 'span style="text-decoration: underline;"',
+    toggle: toggleInlineStyle('Underline'),
+    useToolbar: true
+  };
+
+  const forecolorFormat: FormatInfo = {
+    label: 'Text color',
+    tag: 'span',
+    html: 'span style="color: rgb(255, 0, 0);"',
+    toggle: toggleCustomFormat('forecolor', { value: '#ff0000' }),
+    useToolbar: false
+  };
+
+  context('noneditable inline elements', () => {
+    const selectNoneditableSpan = (editor: Editor) =>
+      TinySelections.select(editor, 'span[contenteditable="false"]', []);
+
+    // Make sure different inline formats are tested
+    Arr.each([ boldFormat, underlineFormat, forecolorFormat ], (format) => {
+      const pAssertToolbar = (state: boolean) =>
+        format.useToolbar ? pAssertToolbarButtonState(format.label, state) : () => Promise.resolve();
+      const pTest = pTestFormat(format.toggle);
+
+      context('wrappable noneditable', () => {
+        Arr.each([
+          {
+            label: 'wrappable noneditable span',
+            noneditableHtml: '<span contenteditable="false" data-mce-cef-wrappable="true">second</span>'
+          },
+          {
+            label: 'wrappable noneditable span with inner format',
+            noneditableHtml: `<span contenteditable="false" data-mce-cef-wrappable="true">s<${format.html}>eco</${format.tag}>nd</span>`
+          },
+        ], (scenario) => {
+          const { label, noneditableHtml } = scenario;
+          const initialHtml = `<p>first ${noneditableHtml} third</p>`;
+
+          context(label, () => {
+            it(`TINY-8842: select noneditable, toggle ${format.label}, select noneditable, toggle ${format.label}`, async () => {
+              const editor = hook.editor();
+              editor.setContent(initialHtml);
+              await pTest(editor, [
+                {
+                  select: selectNoneditableSpan,
+                  expectedHtml: `<p>first <${format.html}>${noneditableHtml}</${format.tag}> third</p>`,
+                  pAssertAfter: pAssertToolbar(true)
+                },
+                {
+                  select: selectNoneditableSpan,
+                  expectedHtml: initialHtml,
+                  pAssertAfter: pAssertToolbar(false)
+                },
+              ]);
+            });
+
+            it(`TINY-8842: select noneditable, toggle ${format.label}, select all, toggle ${format.label}`, async () => {
+              const editor = hook.editor();
+              editor.setContent(initialHtml);
+              await pTest(editor, [
+                {
+                  select: selectNoneditableSpan,
+                  expectedHtml: `<p>first <${format.html}>${noneditableHtml}</${format.tag}> third</p>`,
+                  pAssertAfter: pAssertToolbar(true)
+                },
+                {
+                  select: selectAll,
+                  expectedHtml: `<p><${format.html}>first ${noneditableHtml} third</${format.tag}></p>`,
+                  pAssertAfter: pAssertToolbar(true)
+                },
+              ]);
+            });
+
+            it(`TINY-8842: select all, toggle ${format.label}, select noneditable, toggle ${format.label}`, async () => {
+              const editor = hook.editor();
+              editor.setContent(initialHtml);
+              await pTest(editor, [
+                {
+                  select: selectAll,
+                  expectedHtml: `<p><${format.html}>first ${noneditableHtml} third</${format.tag}></p>`,
+                  pAssertAfter: pAssertToolbar(true)
+                },
+                {
+                  select: selectNoneditableSpan,
+                  expectedHtml: `<p><${format.html}>first </${format.tag}>${noneditableHtml}<${format.html}> third</${format.tag}></p>`,
+                  pAssertAfter: pAssertToolbar(false)
+                },
+              ]);
+            });
+
+            it(`TINY-8842: select all, toggle ${format.label}, select all, toggle ${format.label}`, async () => {
+              const editor = hook.editor();
+              editor.setContent(initialHtml);
+              await pTest(editor, [
+                {
+                  select: selectAll,
+                  expectedHtml: `<p><${format.html}>first ${noneditableHtml} third</${format.tag}></p>`,
+                  pAssertAfter: pAssertToolbar(true)
+                },
+                {
+                  // format.toggle for forecolor does not work properly with selectAll so manually setting selection
+                  select: () => TinySelections.setSelection(editor, [ 0 ], 0, [], 1),
+                  expectedHtml: initialHtml,
+                  pAssertAfter: pAssertToolbar(false)
+                },
+              ]);
+            });
+          });
+        });
+      });
+
+      context('non-wrappble noneditable', () => {
+        Arr.each([
+          {
+            label: 'noneditable span',
+            noneditableHtml: '<span contenteditable="false">second</span>'
+          },
+          {
+            label: 'noneditable span with inner format',
+            noneditableHtml: `<span contenteditable="false">s<${format.html}>eco</${format.tag}>nd</span>`
+          },
+        ], (scenario) => {
+          const { label, noneditableHtml } = scenario;
+          const initialHtml = `<p>first ${noneditableHtml} third</p>`;
+
+          context(label, () => {
+            it(`TINY-8842: select noneditable, toggle ${format.label}`, async () => {
+              const editor = hook.editor();
+              editor.setContent(initialHtml);
+              await pTest(editor, [
+                {
+                  select: selectNoneditableSpan,
+                  expectedHtml: initialHtml,
+                  pAssertAfter: pAssertToolbar(false)
+                },
+                {
+                  select: selectAll,
+                  expectedHtml: [
+                    `<p><${format.html}>first </${format.tag}>` +
+                    noneditableHtml,
+                    `<${format.html}> third</${format.tag}></p>`,
+                  ].join(''),
+                  pAssertAfter: pAssertToolbar(true)
+                },
+              ]);
+            });
+
+            it(`TINY-8842: select all, toggle ${format.label}`, async () => {
+              const editor = hook.editor();
+              editor.setContent(initialHtml);
+              await pTest(editor, [
+                {
+                  select: selectAll,
+                  expectedHtml: [
+                    `<p><${format.html}>first </${format.tag}>` +
+                    noneditableHtml,
+                    `<${format.html}> third</${format.tag}></p>`,
+                  ].join(''),
+                  pAssertAfter: pAssertToolbar(true)
+                },
+              ]);
+            });
+          });
+        });
+      });
+
+      // A wrappable noneditable should act the same as non-wrappable noneditable
+      context('noneditable with nested editable text', () => {
+        Arr.each([
+          {
+            label: 'wrappable noneditable span',
+            noneditableBeforeHtml: '<span contenteditable="false" data-mce-cef-wrappable="true">a',
+            noneditableAfterHtml: 'b</span>'
+          },
+          {
+            label: 'non-wrappable noneditable span',
+            noneditableBeforeHtml: '<span contenteditable="false">a',
+            noneditableAfterHtml: 'b</span>'
+          },
+        ], (scenario) => {
+          const { label, noneditableBeforeHtml, noneditableAfterHtml } = scenario;
+          const editableHtml = `<span contenteditable="true">editable</span>`;
+          const noneditableHtml = `${noneditableBeforeHtml}${editableHtml}${noneditableAfterHtml}`;
+          const initialHtml = `<p>first ${noneditableHtml} third</p>`;
+
+          context(label, () => {
+            it(`TINY-8842: select noneditable, toggle ${format.label}`, async () => {
+              const editor = hook.editor();
+              editor.setContent(initialHtml);
+              await pTest(editor, [
+                {
+                  select: selectNoneditableSpan,
+                  expectedHtml: initialHtml,
+                  pAssertAfter: pAssertToolbar(false)
+                },
+              ]);
+            });
+
+            it(`TINY-8842: select all, toggle ${format.label}, collapsed in editable, toggle ${format.label}`, async () => {
+              const editor = hook.editor();
+              editor.setContent(initialHtml);
+              await pTest(editor, [
+                {
+                  select: selectAll,
+                  expectedHtml: `<p><${format.html}>first </${format.tag}>${noneditableBeforeHtml}<span contenteditable="true"><${format.html}>editable</${format.tag}></span>${noneditableAfterHtml}<${format.html}> third</${format.tag}></p>`,
+                  pAssertAfter: pAssertToolbar(true)
+                },
+                {
+                  select: () => TinySelections.setCursor(editor, [ 0, 1, 1, 0, 0 ], 1),
+                  expectedHtml: `<p><${format.html}>first</${format.tag}> ${noneditableBeforeHtml}<span contenteditable="true">editable</span>${noneditableAfterHtml} <${format.html}>third</${format.tag}></p>`,
+                  pAssertAfter: pAssertToolbar(false)
+                },
+              ]);
+            });
+
+            it(`TINY-8842: collapsed in editable, toggle ${format.label}, collapsed in editable, toggle ${format.label}`, async () => {
+              const editor = hook.editor();
+              editor.setContent(initialHtml);
+              await pTest(editor, [
+                {
+                  select: () => TinySelections.setCursor(editor, [ 0, 1, 1, 0 ], 1),
+                  expectedHtml: `<p>first ${noneditableBeforeHtml}<span contenteditable="true"><${format.html}>editable</${format.tag}></span>${noneditableAfterHtml} third</p>`,
+                  pAssertAfter: pAssertToolbar(true)
+                },
+                {
+                  select: () => TinySelections.setCursor(editor, [ 0, 1, 1, 0, 0 ], 1),
+                  expectedHtml: initialHtml,
+                  pAssertAfter: pAssertToolbar(false)
+                },
+              ]);
+            });
+
+            it(`TINY-8842: collapsed selection in editable, toggle ${format.label}, select noneditable, toggle ${format.label}`, async () => {
+              const editor = hook.editor();
+              editor.setContent(initialHtml);
+              await pTest(editor, [
+                {
+                  select: () => TinySelections.setCursor(editor, [ 0, 1, 1, 0 ], 1),
+                  expectedHtml: `<p>first ${noneditableBeforeHtml}<span contenteditable="true"><${format.html}>editable</${format.tag}></span>${noneditableAfterHtml} third</p>`,
+                  pAssertAfter: pAssertToolbar(true)
+                },
+                {
+                  select: selectNoneditableSpan,
+                  // Should remain the same
+                  expectedHtml: `<p>first ${noneditableBeforeHtml}<span contenteditable="true"><${format.html}>editable</${format.tag}></span>${noneditableAfterHtml} third</p>`,
+                  pAssertAfter: pAssertToolbar(false)
+                },
+              ]);
+            });
+
+            it(`TINY-8842: ranged selection in editable, toggle ${format.label}, select all in editable, toggle ${format.label}`, async () => {
+              const editor = hook.editor();
+              editor.setContent(initialHtml);
+              await pTest(editor, [
+                {
+                  select: () => TinySelections.setSelection(editor, [ 0, 1, 1, 0 ], 1, [ 0, 1, 1, 0 ], 3),
+                  expectedHtml: `<p>first ${noneditableBeforeHtml}<span contenteditable="true">e<${format.html}>di</${format.tag}>table</span>${noneditableAfterHtml} third</p>`,
+                  pAssertAfter: pAssertToolbar(true)
+                },
+                {
+                  select: selectAll,
+                  expectedHtml: `<p>first ${noneditableBeforeHtml}<span contenteditable="true"><${format.html}>editable</${format.tag}></span>${noneditableAfterHtml} third</p>`,
+                  pAssertAfter: pAssertToolbar(true)
+                },
+              ]);
+            });
+          });
+        });
+      });
+    });
+
+    context(`matching noneditable element and format tag`, () => {
+      Arr.each([
+        {
+          format: boldFormat,
+          noneditableHtml: `<${boldFormat.html} contenteditable="false" data-mce-cef-wrappable="true">s<${boldFormat.html}>econ</${boldFormat.tag}>d</${boldFormat.tag}>`
+        },
+        {
+          format: underlineFormat,
+          noneditableHtml: `<${underlineFormat.html} contenteditable="false" data-mce-cef-wrappable="true">s<${underlineFormat.html}>econ</${underlineFormat.tag}>d</${underlineFormat.tag}>`
+        },
+        {
+          format: forecolorFormat,
+          noneditableHtml: `<${forecolorFormat.html} contenteditable="false" data-mce-cef-wrappable="true">s<${forecolorFormat.html}>econ</${forecolorFormat.tag}>d</${forecolorFormat.tag}>`
+        }
+      ], (scenario) => {
+        const { noneditableHtml, format } = scenario;
+
+        const initialHtml = `<p>first ${noneditableHtml} third</p>`;
+        const selectCEF = (editor: Editor) => TinySelections.select(editor, `${format.tag}[contenteditable="false"]`, []);
+        const pAssertToolbar = (state: boolean) =>
+          format.useToolbar ? pAssertToolbarButtonState(format.label, state) : () => Promise.resolve();
+        const pTest = pTestFormat(format.toggle);
+
+        it(`TINY-8842: select noneditable, toggle ${format.label}`, async () => {
+          const editor = hook.editor();
+          editor.setContent(initialHtml);
+          await pTest(editor, [
+            {
+              select: selectCEF,
+              expectedHtml: initialHtml,
+              pAssertAfter: pAssertToolbar(true)
+            },
+          ]);
+        });
+
+        it(`TINY-8842: select all, toggle ${format.label}, select noneditable, toggle ${format.label}`, async () => {
+          const editor = hook.editor();
+          editor.setContent(initialHtml);
+          await pTest(editor, [
+            {
+              select: selectAll,
+              expectedHtml: `<p><${format.html}>first ${noneditableHtml} third</${format.tag}></p>`,
+              pAssertAfter: pAssertToolbar(true)
+            },
+            {
+              select: selectCEF,
+              expectedHtml: `<p><${format.html}>first </${format.tag}>${noneditableHtml}<${format.html}> third</${format.tag}></p>`,
+              pAssertAfter: pAssertToolbar(true)
+            },
+          ]);
+        });
+      });
+    });
+
+    context('toggling block formats', () => {
+      it('TINY-8842: wrappable noneditable inline element should not affect toggling block format', async () => {
+        const editor = hook.editor();
+        const initialHtml = `<p>first <span contenteditable="false" data-mce-cef-wrappable="true">second</span> third</p>`;
+        editor.setContent(initialHtml);
+        await pTestFormat(toggleCustomFormat('h1'))(editor, [
+          {
+            select: selectNoneditableSpan,
+            expectedHtml: `<h1>first <span contenteditable="false" data-mce-cef-wrappable="true">second</span> third</h1>`
+          },
+          {
+            select: selectNoneditableSpan,
+            expectedHtml: initialHtml
+          },
+          {
+            select: () => TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 0, 2 ], 4),
+            expectedHtml: `<h1>first <span contenteditable="false" data-mce-cef-wrappable="true">second</span> third</h1>`
+          },
+        ]);
+      });
+
+      it('TINY-8842: wrappable noneditable inline element should not affect toggling wrapper block format', async () => {
+        const editor = hook.editor();
+        const initialHtml = `<p>first <span contenteditable="false" data-mce-cef-wrappable="true">second</span> third</p>`;
+        editor.setContent(initialHtml);
+        await pTestFormat(toggleCustomFormat('blockquote'))(editor, [
+          {
+            select: selectNoneditableSpan,
+            expectedHtml: [
+              '<blockquote>',
+              initialHtml,
+              '</blockquote>'
+            ].join('\n')
+          },
+          {
+            select: selectNoneditableSpan,
+            expectedHtml: initialHtml
+          },
+          {
+            select: () => TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 0, 2 ], 4),
+            expectedHtml: [
+              '<blockquote>',
+              initialHtml,
+              '</blockquote>'
+            ].join('\n')
+          },
+        ]);
+      });
+    });
+  });
+
+  context('noneditable blocks', () => {
+    const toggleBlockquote = toggleCustomFormat('blockquote');
+    const pTest = pTestFormat(toggleBlockquote);
+    const selectCEF = (editor: Editor) => TinySelections.select(editor, 'p[contenteditable="false"]', []);
+
+    it('TINY-8842: select noneditable, toggle wrapper format, select noneditable, toggle wrapper format', async () => {
+      const editor = hook.editor();
+      editor.setContent(`<p>before</p><p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p><p>after</p>`);
+      await pTest(editor, [
+        {
+          select: selectCEF,
+          expectedHtml: [
+            '<p>before</p>',
+            '<blockquote>',
+            '<p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p>',
+            '</blockquote>',
+            '<p>after</p>'
+          ].join('\n')
+        },
+        {
+          select: selectCEF,
+          expectedHtml: [
+            '<p>before</p>',
+            '<p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p>',
+            '<p>after</p>'
+          ].join('\n')
+        },
+      ]);
+    });
+
+    it('TINY-8842: select all, toggle wrapper format, select all, toggle wrapper format', async () => {
+      const editor = hook.editor();
+      editor.setContent(`<p>before</p><p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p><p>after</p>`);
+      await pTest(editor, [
+        {
+          select: selectAll,
+          expectedHtml: [
+            '<blockquote>',
+            '<p>before</p>',
+            '<p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p>',
+            '<p>after</p>',
+            '</blockquote>'
+          ].join('\n')
+        },
+        {
+          select: selectAll,
+          expectedHtml: [
+            '<p>before</p>',
+            '<p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p>',
+            '<p>after</p>'
+          ].join('\n')
+        },
+      ]);
+    });
+
+    it('TINY-8842: select all, toggle wrapper format, select noneditable, toggle wrapper format', async () => {
+      const editor = hook.editor();
+      editor.setContent(`<p>before</p><p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p><p>after</p>`);
+      await pTest(editor, [
+        {
+          select: selectAll,
+          expectedHtml: [
+            '<blockquote>',
+            '<p>before</p>',
+            '<p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p>',
+            '<p>after</p>',
+            '</blockquote>'
+          ].join('\n')
+        },
+        {
+          select: selectCEF,
+          expectedHtml: [
+            '<blockquote>',
+            '<p>before</p>',
+            '</blockquote>',
+            '<p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p>',
+            '<blockquote>',
+            '<p>after</p>',
+            '</blockquote>'
+          ].join('\n')
+        },
+      ]);
+    });
+
+    it('TINY-8842: select noneditable, toggle wrapper format, select all, toggle wrapper format', async () => {
+      const editor = hook.editor();
+      editor.setContent(`<p>before</p><p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p><p>after</p>`);
+      await pTest(editor, [
+        {
+          select: selectCEF,
+          expectedHtml: [
+            '<p>before</p>',
+            '<blockquote>',
+            '<p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p>',
+            '</blockquote>',
+            '<p>after</p>',
+          ].join('\n')
+        },
+        {
+          select: selectAll,
+          expectedHtml: [
+            '<blockquote>',
+            '<p>before</p>',
+            '<p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p>',
+            '<p>after</p>',
+            '</blockquote>'
+          ].join('\n')
+        },
+      ]);
+    });
+
+    it('TINY-8842: toggle wrapper format on editable blocks, select noneditable, toggle wrapper format', async () => {
+      const editor = hook.editor();
+      editor.setContent(`<p>before</p><p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p><p>after</p>`);
+      await pTest(editor, [
+        {
+          select: () => TinySelections.setCursor(editor, [ 0, 0 ], 1),
+          expectedHtml: [
+            '<blockquote>',
+            '<p>before</p>',
+            '</blockquote>',
+            '<p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p>',
+            '<p>after</p>',
+          ].join('\n')
+        },
+        {
+          select: () => TinySelections.setCursor(editor, [ 2, 0 ], 1),
+          expectedHtml: [
+            '<blockquote>',
+            '<p>before</p>',
+            '</blockquote>',
+            '<p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p>',
+            '<blockquote>',
+            '<p>after</p>',
+            '</blockquote>'
+          ].join('\n')
+        },
+        {
+          select: selectCEF,
+          expectedHtml: [
+            '<blockquote>',
+            '<p>before</p>',
+            '<p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p>',
+            '<p>after</p>',
+            '</blockquote>'
+          ].join('\n')
+        },
+      ]);
+    });
+
+    it('TINY-8842: should not be able to change noneditable block tag with block format', async () => {
+      const editor = hook.editor();
+      editor.setContent(`<p>before</p><p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p><p>after</p>`);
+      await pTestFormat(toggleCustomFormat('h1'))(editor, [
+        {
+          select: selectCEF,
+          expectedHtml: [
+            '<p>before</p>',
+            '<p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p>',
+            '<p>after</p>'
+          ].join('\n')
+        },
+        {
+          select: selectAll,
+          expectedHtml: [
+            '<h1>before</h1>',
+            '<p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p>',
+            '<h1>after</h1>'
+          ].join('\n')
+        },
+      ]);
+    });
+
+    it('TINY-8842: should not be able to wrap noneditable block without a wrappable attribute', async () => {
+      const editor = hook.editor();
+      editor.setContent(`<p>before</p><p contenteditable="false">noneditable</p><p>after</p>`);
+      await pTest(editor, [
+        {
+          select: selectCEF,
+          expectedHtml: [
+            '<p>before</p>',
+            '<p contenteditable="false">noneditable</p>',
+            '<p>after</p>'
+          ].join('\n')
+        },
+        {
+          select: selectAll,
+          expectedHtml: [
+            '<blockquote>',
+            '<p>before</p>',
+            '</blockquote>',
+            '<p contenteditable="false">noneditable</p>',
+            '<blockquote>',
+            '<p>after</p>',
+            '</blockquote>'
+          ].join('\n')
+        },
+        {
+          select: selectCEF,
+          expectedHtml: [
+            '<blockquote>',
+            '<p>before</p>',
+            '</blockquote>',
+            '<p contenteditable="false">noneditable</p>',
+            '<blockquote>',
+            '<p>after</p>',
+            '</blockquote>'
+          ].join('\n')
+        },
+        {
+          select: selectAll,
+          expectedHtml: [
+            '<p>before</p>',
+            '<p contenteditable="false">noneditable</p>',
+            '<p>after</p>',
+          ].join('\n')
+        },
+      ]);
+    });
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
@@ -1,4 +1,4 @@
-import { context, describe, it } from '@ephox/bedrock-client';
+import { after, before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Type } from '@ephox/katamari';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
@@ -76,6 +76,16 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
   };
 
   context('noneditable inline elements', () => {
+    before(() => {
+      const editor = hook.editor();
+      editor.options.set('format_wrap_noneditable_selectors', [ 'span[data-wrappable="true"]' ]);
+    });
+
+    after(() => {
+      const editor = hook.editor();
+      editor.options.unset('format_wrap_noneditable_selectors');
+    });
+
     const selectNoneditableSpan = (editor: Editor) =>
       TinySelections.select(editor, 'span[contenteditable="false"]', []);
 
@@ -89,11 +99,11 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
         Arr.each([
           {
             label: 'wrappable noneditable span',
-            noneditableHtml: '<span contenteditable="false" data-mce-cef-wrappable="true">second</span>'
+            noneditableHtml: '<span contenteditable="false" data-wrappable="true">second</span>'
           },
           {
             label: 'wrappable noneditable span with inner format',
-            noneditableHtml: `<span contenteditable="false" data-mce-cef-wrappable="true">s<${format.html}>eco</${format.tag}>nd</span>`
+            noneditableHtml: `<span contenteditable="false" data-wrappable="true">s<${format.html}>eco</${format.tag}>nd</span>`
           },
         ], (scenario) => {
           const { label, noneditableHtml } = scenario;
@@ -438,20 +448,30 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
   });
 
   context('noneditable blocks', () => {
+    before(() => {
+      const editor = hook.editor();
+      editor.options.set('format_wrap_noneditable_selectors', [ 'p[data-wrappable="true"]' ]);
+    });
+
+    after(() => {
+      const editor = hook.editor();
+      editor.options.unset('format_wrap_noneditable_selectors');
+    });
+
     const toggleBlockquote = toggleCustomFormat('blockquote');
     const pTest = pTestFormat(toggleBlockquote);
     const selectCEF = (editor: Editor) => TinySelections.select(editor, 'p[contenteditable="false"]', []);
 
     it('TINY-8842: select noneditable, toggle wrapper format, select noneditable, toggle wrapper format', async () => {
       const editor = hook.editor();
-      editor.setContent(`<p>before</p><p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p><p>after</p>`);
+      editor.setContent(`<p>before</p><p contenteditable="false" data-wrappable="true">noneditable</p><p>after</p>`);
       await pTest(editor, [
         {
           select: selectCEF,
           expectedHtml: [
             '<p>before</p>',
             '<blockquote>',
-            '<p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p>',
+            '<p contenteditable="false" data-wrappable="true">noneditable</p>',
             '</blockquote>',
             '<p>after</p>'
           ].join('\n')
@@ -460,7 +480,7 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
           select: selectCEF,
           expectedHtml: [
             '<p>before</p>',
-            '<p contenteditable="false" data-mce-cef-wrappable="true">noneditable</p>',
+            '<p contenteditable="false" data-wrappable="true">noneditable</p>',
             '<p>after</p>'
           ].join('\n')
         },

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
@@ -78,12 +78,12 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
   context('noneditable inline elements', () => {
     before(() => {
       const editor = hook.editor();
-      editor.options.set('format_wrap_noneditable_selectors', [ 'span[data-wrappable="true"]' ]);
+      editor.options.set('format_noneditable_selector', 'span[data-wrappable="true"]');
     });
 
     after(() => {
       const editor = hook.editor();
-      editor.options.unset('format_wrap_noneditable_selectors');
+      editor.options.unset('format_noneditable_selector');
     });
 
     const selectNoneditableSpan = (editor: Editor) =>
@@ -450,12 +450,12 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
   context('noneditable blocks', () => {
     before(() => {
       const editor = hook.editor();
-      editor.options.set('format_wrap_noneditable_selectors', [ 'p[data-wrappable="true"]' ]);
+      editor.options.set('format_noneditable_selector', 'p[data-wrappable="true"]');
     });
 
     after(() => {
       const editor = hook.editor();
-      editor.options.unset('format_wrap_noneditable_selectors');
+      editor.options.unset('format_noneditable_selector');
     });
 
     const toggleBlockquote = toggleCustomFormat('blockquote');

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
@@ -263,7 +263,7 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
               await pTest(editor, [
                 {
                   select: selectNoneditableSpan,
-                  expectedHtml: initialHtml,
+                  expectedHtml: `<p>first ${noneditableBeforeHtml}<span contenteditable="true"><${format.html}>editable</${format.tag}></span>${noneditableAfterHtml} third</p>`,
                   pAssertAfter: pAssertToolbar(false)
                 },
               ]);


### PR DESCRIPTION
Related Ticket: TINY-8905

Description of Changes:
* Allow a non-editable element to be wrapped if it is specifically marked as wrappable and also does not have any editable descendants
	* Currently the marker is a `data-mce-cef-wrappable` data attribute. I am open to suggestions if there is a better way to indicate wrappable elements whether that be an option or something else
* Refactor some of the `if` blocks in ApplyFormat.ts to hopefully make them easier to reason about
* Make sure styling on a non-editable element or on a child of a non-editable element is not eagerly removed so that the non-editable behaviour is respected	 

Pre-checks:
* [x] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set

GitHub issues (if applicable):
