### PR TITLE
TINY-8778: New `text_patterns_lookup` option

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- New `text_patterns_lookup` option to provide additional text patterns dynamically #TINY-8778
+
 ### Fixed
 - The Autolink plugin did not work when the text nodes in the content were fragmented #TINY-3723
 - Fixed various incorrect types on public APIs found while enabling TypeScript strict mode #TINY-8806

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -1,5 +1,5 @@
 import { UploadHandler } from '../file/Uploader';
-import { DynamicPatternsLookup, Pattern, RawPattern } from '../textpatterns/core/PatternTypes';
+import { Pattern, RawDynamicPatternsLookup, RawPattern } from '../textpatterns/core/PatternTypes';
 import Editor from './Editor';
 import { PastePostProcessEvent, PastePreProcessEvent } from './EventTypes';
 import { Formats } from './fmt/Format';
@@ -192,7 +192,7 @@ interface BaseEditorOptions {
   table_tab_navigation?: boolean;
   target?: HTMLElement;
   text_patterns?: RawPattern[] | false;
-  text_patterns_lookup?: DynamicPatternsLookup;
+  text_patterns_lookup?: RawDynamicPatternsLookup;
   theme?: string | ThemeInitFunc | false;
   theme_url?: string;
   toolbar?: boolean | string | string[] | Array<ToolbarGroup>;
@@ -278,7 +278,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   preview_styles: string;
   readonly: boolean;
   text_patterns: Pattern[];
-  text_patterns_lookup: DynamicPatternsLookup;
+  text_patterns_lookup: RawDynamicPatternsLookup;
   visual: boolean;
   visual_anchor_class: string;
   visual_table_class: string;

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -1,5 +1,5 @@
 import { UploadHandler } from '../file/Uploader';
-import { Pattern, RawPattern } from '../textpatterns/core/PatternTypes';
+import { DynamicPatternsLookup, Pattern, RawPattern } from '../textpatterns/core/PatternTypes';
 import Editor from './Editor';
 import { PastePostProcessEvent, PastePreProcessEvent } from './EventTypes';
 import { Formats } from './fmt/Format';
@@ -277,6 +277,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   preview_styles: string;
   readonly: boolean;
   text_patterns: Pattern[];
+  text_patterns_lookup?: DynamicPatternsLookup;
   visual: boolean;
   visual_anchor_class: string;
   visual_table_class: string;

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -1,5 +1,5 @@
 import { UploadHandler } from '../file/Uploader';
-import { Pattern, RawDynamicPatternsLookup, RawPattern } from '../textpatterns/core/PatternTypes';
+import { DynamicPatternsLookup, Pattern, RawDynamicPatternsLookup, RawPattern } from '../textpatterns/core/PatternTypes';
 import Editor from './Editor';
 import { PastePostProcessEvent, PastePreProcessEvent } from './EventTypes';
 import { Formats } from './fmt/Format';
@@ -278,7 +278,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   preview_styles: string;
   readonly: boolean;
   text_patterns: Pattern[];
-  text_patterns_lookup: RawDynamicPatternsLookup;
+  text_patterns_lookup: DynamicPatternsLookup;
   visual: boolean;
   visual_anchor_class: string;
   visual_table_class: string;

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -192,6 +192,7 @@ interface BaseEditorOptions {
   table_tab_navigation?: boolean;
   target?: HTMLElement;
   text_patterns?: RawPattern[] | false;
+  text_patterns_lookup?: DynamicPatternsLookup;
   theme?: string | ThemeInitFunc | false;
   theme_url?: string;
   toolbar?: boolean | string | string[] | Array<ToolbarGroup>;
@@ -277,7 +278,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   preview_styles: string;
   readonly: boolean;
   text_patterns: Pattern[];
-  text_patterns_lookup?: DynamicPatternsLookup;
+  text_patterns_lookup: DynamicPatternsLookup;
   visual: boolean;
   visual_anchor_class: string;
   visual_table_class: string;

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -737,8 +737,7 @@ const register = (editor: Editor): void => {
     processor: (value) => {
       if (Type.isFunction(value)) {
         return {
-          // This (ctx => value(ctx)) isn't ETA reduced so that it compiles
-          value: Pattern.fromRawPatternsLookup((ctx) => value(ctx)),
+          value: Pattern.fromRawPatternsLookup(value as PatternTypes.RawDynamicPatternsLookup),
           valid: true,
         };
       } else {

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -2,6 +2,7 @@ import { Arr, Obj, Strings, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 
 import * as Pattern from '../textpatterns/core/Pattern';
+import * as PatternTypes from '../textpatterns/core/PatternTypes';
 import DOMUtils from './dom/DOMUtils';
 import Editor from './Editor';
 import { EditorOptions } from './OptionTypes';
@@ -732,6 +733,21 @@ const register = (editor: Editor): void => {
     ]
   });
 
+  registerOption('text_patterns_lookup', {
+    processor: (value) => {
+      if (Type.isFunction(value)) {
+        return {
+          // This (ctx => value(ctx)) isn't ETA reduced so that it compiles
+          value: Pattern.fromRawPatternsLookup((ctx) => value(ctx)),
+          valid: true,
+        };
+      } else {
+        return { valid: false, message: 'Must be a single function' };
+      }
+    },
+    default: (_ctx: PatternTypes.DynamicPatternContext): PatternTypes.Pattern[] => [ ]
+  });
+
   registerOption('noneditable_class', {
     processor: 'string',
     default: 'mceNonEditable'
@@ -857,9 +873,12 @@ const isPasteAsTextEnabled = option('paste_as_text');
 const getPasteTabSpaces = option('paste_tab_spaces');
 const shouldAllowHtmlDataUrls = option('allow_html_data_urls');
 const getTextPatterns = option('text_patterns');
+const getTextPatternsLookup = option('text_patterns_lookup');
 const getNonEditableClass = option('noneditable_class');
 const getEditableClass = option('editable_class');
 const getNonEditableRegExps = option('noneditable_regexp');
+
+const hasTextPatternsLookup = (editor: Editor) => editor.options.isSet('text_patterns_lookup');
 
 const getFontStyleValues = (editor: Editor): string[] =>
   Tools.explode(editor.options.get('font_size_style_values'));
@@ -964,6 +983,8 @@ export {
   shouldAllowHtmlDataUrls,
   getAllowedImageFileTypes,
   getTextPatterns,
+  getTextPatternsLookup,
+  hasTextPatternsLookup,
   getNonEditableClass,
   getNonEditableRegExps,
   getEditableClass,

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -878,7 +878,7 @@ const getNonEditableClass = option('noneditable_class');
 const getEditableClass = option('editable_class');
 const getNonEditableRegExps = option('noneditable_regexp');
 
-const hasTextPatternsLookup = (editor: Editor) => editor.options.isSet('text_patterns_lookup');
+const hasTextPatternsLookup = (editor: Editor): boolean => editor.options.isSet('text_patterns_lookup');
 
 const getFontStyleValues = (editor: Editor): string[] =>
   Tools.explode(editor.options.get('font_size_style_values'));

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/BlockPattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/BlockPattern.ts
@@ -83,14 +83,14 @@ const findPatterns = (editor: Editor, patternSet: PatternSet): BlockPatternMatch
       // Block patterns do not allow trailing spaces currently. This is related to TINY-8779
       allowTrailingSpaces: false
     });
-    const combinedPatterns = [
-      ...patternSet.blockPatterns,
-      ...extraPatterns
-    ];
-    const patterns = getBlockPatterns(combinedPatterns);
+    // search in the dynamic patterns first
+    const patterns = getBlockPatterns(extraPatterns);
+    const matchedPattern = findPattern(patterns, blockText).orThunk(() => {
+      // Search in the static patterns
+      const patterns = getBlockPatterns(patternSet.blockPatterns);
+      return findPattern(patterns, blockText);
+    });
 
-    // Find the pattern
-    const matchedPattern = findPattern(patterns, blockText);
     return matchedPattern.map((pattern) => {
       if (Tools.trim(blockText).length === pattern.start.length) {
         return [];

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/BlockPattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/BlockPattern.ts
@@ -83,11 +83,11 @@ const findPatterns = (editor: Editor, patternSet: PatternSet): BlockPatternMatch
       // Block patterns do not allow trailing spaces currently. This is related to TINY-8779
       allowTrailingSpaces: false
     });
-    const dynamicPatterns = getBlockPatterns(extraPatterns);
-    const patterns = [
+    const combinedPatterns = [
       ...patternSet.blockPatterns,
-      ...dynamicPatterns
+      ...extraPatterns
     ];
+    const patterns = getBlockPatterns(combinedPatterns);
 
     // Find the pattern
     const matchedPattern = findPattern(patterns, blockText);

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/Pattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/Pattern.ts
@@ -116,7 +116,7 @@ const fromRawPatterns = (patterns: RawPattern[]): Pattern[] => {
   return normalized.values;
 };
 
-const fromRawPatternsLookup = (lookupFn: (ctx: any) => RawPattern[]): DynamicPatternsLookup => {
+const fromRawPatternsLookup = (lookupFn: (ctx: DynamicPatternContext) => RawPattern[]): DynamicPatternsLookup => {
   return (ctx: DynamicPatternContext) => {
     const rawPatterns = lookupFn({
       text: ctx.text,

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/Pattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/Pattern.ts
@@ -1,6 +1,6 @@
 import { Arr, Result, Results, Type } from '@ephox/katamari';
 
-import { BlockPattern, DynamicPatternContext, DynamicPatternsLookup, InlineCmdPattern, InlinePattern, Pattern, PatternError, PatternSet, RawPattern } from './PatternTypes';
+import { BlockPattern, DynamicPatternContext, DynamicPatternsLookup, InlineCmdPattern, InlinePattern, Pattern, PatternError, PatternSet, RawDynamicPatternsLookup, RawPattern } from './PatternTypes';
 
 const isInlinePattern = (pattern: Pattern): pattern is InlinePattern =>
   pattern.type === 'inline-command' || pattern.type === 'inline-format';
@@ -116,7 +116,7 @@ const fromRawPatterns = (patterns: RawPattern[]): Pattern[] => {
   return normalized.values;
 };
 
-const fromRawPatternsLookup = (lookupFn: (ctx: DynamicPatternContext) => RawPattern[]): DynamicPatternsLookup => {
+const fromRawPatternsLookup = (lookupFn: RawDynamicPatternsLookup): DynamicPatternsLookup => {
   return (ctx: DynamicPatternContext) => {
     const rawPatterns = lookupFn(ctx);
     return fromRawPatterns(rawPatterns);

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/Pattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/Pattern.ts
@@ -118,11 +118,7 @@ const fromRawPatterns = (patterns: RawPattern[]): Pattern[] => {
 
 const fromRawPatternsLookup = (lookupFn: (ctx: DynamicPatternContext) => RawPattern[]): DynamicPatternsLookup => {
   return (ctx: DynamicPatternContext) => {
-    const rawPatterns = lookupFn({
-      text: ctx.text,
-      allowTrailingSpaces: ctx.allowTrailingSpaces,
-      block: ctx.block,
-    });
+    const rawPatterns = lookupFn(ctx);
 
     return fromRawPatterns(rawPatterns);
   };

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/Pattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/Pattern.ts
@@ -1,6 +1,6 @@
 import { Arr, Result, Results, Type } from '@ephox/katamari';
 
-import { BlockPattern, InlineCmdPattern, InlinePattern, Pattern, PatternError, PatternSet, RawPattern } from './PatternTypes';
+import { BlockPattern, DynamicPatternContext, DynamicPatternsLookup, InlineCmdPattern, InlinePattern, Pattern, PatternError, PatternSet, RawPattern } from './PatternTypes';
 
 const isInlinePattern = (pattern: Pattern): pattern is InlinePattern =>
   pattern.type === 'inline-command' || pattern.type === 'inline-format';
@@ -103,9 +103,10 @@ const getBlockPatterns = (patterns: Pattern[]): BlockPattern[] =>
 const getInlinePatterns = (patterns: Pattern[]): InlinePattern[] =>
   Arr.filter(patterns, isInlinePattern);
 
-const createPatternSet = (patterns: Pattern[]): PatternSet => ({
+const createPatternSet = (patterns: Pattern[], dynamicPatternsLookup: DynamicPatternsLookup): PatternSet => ({
   inlinePatterns: getInlinePatterns(patterns),
-  blockPatterns: getBlockPatterns(patterns)
+  blockPatterns: getBlockPatterns(patterns),
+  dynamicPatternsLookup
 });
 
 const fromRawPatterns = (patterns: RawPattern[]): Pattern[] => {
@@ -115,10 +116,23 @@ const fromRawPatterns = (patterns: RawPattern[]): Pattern[] => {
   return normalized.values;
 };
 
+const fromRawPatternsLookup = (lookupFn: (ctx: any) => RawPattern[]): DynamicPatternsLookup => {
+  return (ctx: DynamicPatternContext) => {
+    const rawPatterns = lookupFn({
+      text: ctx.text,
+      allowTrailingSpaces: ctx.allowTrailingSpaces,
+      block: ctx.block,
+    });
+
+    return fromRawPatterns(rawPatterns);
+  };
+};
+
 export {
   normalizePattern,
   createPatternSet,
   getBlockPatterns,
   getInlinePatterns,
-  fromRawPatterns
+  fromRawPatterns,
+  fromRawPatternsLookup
 };

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/PatternTypes.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/PatternTypes.ts
@@ -58,6 +58,7 @@ export interface DynamicPatternContext {
 }
 
 export type DynamicPatternsLookup = (ctx: DynamicPatternContext) => Pattern[];
+export type RawDynamicPatternsLookup = (ctx: DynamicPatternContext) => RawPattern[];
 
 // NOTE: A PatternSet should be looked up from the Options *each* time that text_patterns are
 // processed, so that text_patterns respond to changes in options. This is required for some

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/PatternTypes.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/PatternTypes.ts
@@ -51,8 +51,22 @@ export type BlockPattern = BlockFormatPattern | BlockCmdPattern;
 
 export type Pattern = InlinePattern | BlockPattern;
 
-export interface PatternSet {
+export interface DynamicPatternContext {
+  text: string; // the string from the start of the block to the cursor
+  allowTrailingSpaces: boolean; // whether or not to provide text patterns that have trailing spaces
+  block: Node; // the parent block node
+}
+
+export type DynamicPatternsLookup = (ctx: DynamicPatternContext) => Pattern[];
+
+// NOTE: A PatternSet should be looked up from the Options *each* time that text_patterns are
+// processed, so that text_patterns respond to changes in options. This is required for some
+// complex integrations and plugins.
+export interface InlinePatternSet {
   readonly inlinePatterns: InlinePattern[];
+  readonly dynamicPatternsLookup: DynamicPatternsLookup;
+}
+export interface PatternSet extends InlinePatternSet {
   readonly blockPatterns: BlockPattern[];
 }
 

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/PatternTypes.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/PatternTypes.ts
@@ -52,9 +52,9 @@ export type BlockPattern = BlockFormatPattern | BlockCmdPattern;
 export type Pattern = InlinePattern | BlockPattern;
 
 export interface DynamicPatternContext {
-  text: string; // the string from the start of the block to the cursor
-  allowTrailingSpaces: boolean; // whether or not to provide text patterns that have trailing spaces
-  block: Node; // the parent block node
+  readonly text: string; // the string from the start of the block to the cursor
+  readonly allowTrailingSpaces: boolean; // whether or not to provide text patterns that have trailing spaces
+  readonly block: Node; // the parent block node
 }
 
 export type DynamicPatternsLookup = (ctx: DynamicPatternContext) => Pattern[];

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
@@ -9,11 +9,6 @@ import { InlinePatternSet, PatternSet } from '../core/PatternTypes';
 import * as Utils from '../utils/Utils';
 
 const handleEnter = (editor: Editor, patternSet: PatternSet): boolean => {
-  // Skip checking when the selection isn't collapsed
-  if (!editor.selection.isCollapsed()) {
-    return false;
-  }
-
   // Find any matches
   const inlineMatches = InlinePattern.findPatterns(editor, patternSet, false);
   const blockMatches = BlockPattern.findPatterns(editor, patternSet);

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
@@ -5,21 +5,18 @@ import Editor from '../../api/Editor';
 import VK from '../../api/util/VK';
 import * as BlockPattern from '../core/BlockPattern';
 import * as InlinePattern from '../core/InlinePattern';
-import { InlinePattern as InlinePatternType, PatternSet } from '../core/PatternTypes';
+import { InlinePatternSet, PatternSet } from '../core/PatternTypes';
 import * as Utils from '../utils/Utils';
 
-const hasPatterns = (patternSet: PatternSet): boolean =>
-  patternSet.inlinePatterns.length > 0 || patternSet.blockPatterns.length > 0;
-
 const handleEnter = (editor: Editor, patternSet: PatternSet): boolean => {
-  // Skip checking when the selection isn't collapsed or we have no patterns
-  if (!editor.selection.isCollapsed() || !hasPatterns(patternSet)) {
+  // Skip checking when the selection isn't collapsed
+  if (!editor.selection.isCollapsed()) {
     return false;
   }
 
   // Find any matches
-  const inlineMatches = InlinePattern.findPatterns(editor, patternSet.inlinePatterns, false);
-  const blockMatches = BlockPattern.findPatterns(editor, patternSet.blockPatterns);
+  const inlineMatches = InlinePattern.findPatterns(editor, patternSet, false);
+  const blockMatches = BlockPattern.findPatterns(editor, patternSet);
   if (blockMatches.length > 0 || inlineMatches.length > 0) {
     editor.undoManager.add();
     editor.undoManager.extra(
@@ -50,14 +47,15 @@ const handleEnter = (editor: Editor, patternSet: PatternSet): boolean => {
   return false;
 };
 
-const handleInlineKey = (editor: Editor, inlinePatterns: InlinePatternType[]): void => {
-  if (inlinePatterns.length > 0) {
-    const inlineMatches = InlinePattern.findPatterns(editor, inlinePatterns, true);
-    if (inlineMatches.length > 0) {
-      editor.undoManager.transact(() => {
-        InlinePattern.applyMatches(editor, inlineMatches);
-      });
-    }
+const handleInlineKey = (
+  editor: Editor,
+  patternSet: InlinePatternSet
+): void => {
+  const inlineMatches = InlinePattern.findPatterns(editor, patternSet, true);
+  if (inlineMatches.length > 0) {
+    editor.undoManager.transact(() => {
+      InlinePattern.applyMatches(editor, inlineMatches);
+    });
   }
 };
 

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/Keyboard.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/Keyboard.ts
@@ -44,13 +44,7 @@ const setup = (editor: Editor): void => {
     if (!isSelectionCollapsed && hasPatterns) {
       // Passing through just the part of PatternSet that is relevant for inline
       // patterns.
-      KeyHandler.handleInlineKey(
-        editor,
-        {
-          inlinePatterns: patternSet.inlinePatterns,
-          dynamicPatternsLookup: patternSet.dynamicPatternsLookup
-        }
-      );
+      KeyHandler.handleInlineKey(editor, patternSet);
     }
   };
 

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/Keyboard.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/Keyboard.ts
@@ -9,8 +9,6 @@ const setup = (editor: Editor): void => {
   const charCodes = [ ',', '.', ';', ':', '!', '?' ];
   const keyCodes = [ 32 ];
 
-  const isSelectionCollapsed = editor.selection.isCollapsed();
-
   // This is a thunk so that they reflect changes in the underlying options each time they are requested.
   const getPatternSet = () => Pattern.createPatternSet(
     Options.getTextPatterns(editor),
@@ -29,7 +27,7 @@ const setup = (editor: Editor): void => {
         patternSet.blockPatterns.length > 0 ||
         hasDynamicPatterns();
 
-      if (!isSelectionCollapsed && hasPatterns && KeyHandler.handleEnter(editor, patternSet)) {
+      if (editor.selection.isCollapsed() && hasPatterns && KeyHandler.handleEnter(editor, patternSet)) {
         e.preventDefault();
       }
     }
@@ -41,7 +39,7 @@ const setup = (editor: Editor): void => {
     // Do not process anything if we don't have any inline patterns or dynamic lookup defined
     const hasPatterns = patternSet.inlinePatterns.length > 0 || hasDynamicPatterns();
 
-    if (!isSelectionCollapsed && hasPatterns) {
+    if (hasPatterns) {
       KeyHandler.handleInlineKey(editor, patternSet);
     }
   };

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/Keyboard.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/Keyboard.ts
@@ -9,28 +9,58 @@ const setup = (editor: Editor): void => {
   const charCodes = [ ',', '.', ';', ':', '!', '?' ];
   const keyCodes = [ 32 ];
 
-  const getPatternSet = () => Pattern.createPatternSet(Options.getTextPatterns(editor));
-  const getInlinePatterns = () => Pattern.getInlinePatterns(Options.getTextPatterns(editor));
+  // This is a thunk so that they reflect changes in the underlying options each time they are requested.
+  const getPatternSet = () => Pattern.createPatternSet(
+    Options.getTextPatterns(editor),
+    Options.getTextPatternsLookup(editor)
+  );
+
+  // Only used for skipping text pattern matching altogether if nothing has been defined.
+  const hasDynamicPatterns = () => Options.hasTextPatternsLookup(editor);
 
   editor.on('keydown', (e) => {
     if (e.keyCode === 13 && !VK.modifierPressed(e)) {
-      if (KeyHandler.handleEnter(editor, getPatternSet())) {
+      const patternSet = getPatternSet();
+      // Do not process anything if we don't have any inline patterns, block patterns,
+      // or dynamic lookup defined
+      const hasPatterns = patternSet.inlinePatterns.length > 0 ||
+        patternSet.blockPatterns.length > 0 ||
+        hasDynamicPatterns();
+
+      if (hasPatterns && KeyHandler.handleEnter(editor, patternSet)) {
         e.preventDefault();
       }
     }
   }, true);
 
+  const handleInlineTrigger = () => {
+    const patternSet = getPatternSet();
+
+    // Do not process anything if we don't have any inline patterns or dynamic lookup defined
+    const hasPatterns = patternSet.inlinePatterns.length > 0 || hasDynamicPatterns();
+
+    if (hasPatterns) {
+      // Passing through just the part of PatternSet that is relevant for inline
+      // patterns.
+      KeyHandler.handleInlineKey(
+        editor,
+        {
+          inlinePatterns: patternSet.inlinePatterns,
+          dynamicPatternsLookup: patternSet.dynamicPatternsLookup
+        }
+      );
+    }
+  };
+
   editor.on('keyup', (e) => {
     if (KeyHandler.checkKeyCode(keyCodes, e)) {
-      KeyHandler.handleInlineKey(editor, getInlinePatterns());
+      handleInlineTrigger();
     }
   });
 
   editor.on('keypress', (e) => {
     if (KeyHandler.checkCharCode(charCodes, e)) {
-      Delay.setEditorTimeout(editor, () => {
-        KeyHandler.handleInlineKey(editor, getInlinePatterns());
-      });
+      Delay.setEditorTimeout(editor, handleInlineTrigger);
     }
   });
 };

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/Keyboard.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/Keyboard.ts
@@ -19,7 +19,7 @@ const setup = (editor: Editor): void => {
   const hasDynamicPatterns = () => Options.hasTextPatternsLookup(editor);
 
   editor.on('keydown', (e) => {
-    if (e.keyCode === 13 && !VK.modifierPressed(e)) {
+    if (e.keyCode === 13 && !VK.modifierPressed(e) && editor.selection.isCollapsed()) {
       const patternSet = getPatternSet();
       // Do not process anything if we don't have any inline patterns, block patterns,
       // or dynamic lookup defined
@@ -27,7 +27,7 @@ const setup = (editor: Editor): void => {
         patternSet.blockPatterns.length > 0 ||
         hasDynamicPatterns();
 
-      if (editor.selection.isCollapsed() && hasPatterns && KeyHandler.handleEnter(editor, patternSet)) {
+      if (hasPatterns && KeyHandler.handleEnter(editor, patternSet)) {
         e.preventDefault();
       }
     }

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/Keyboard.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/Keyboard.ts
@@ -9,6 +9,8 @@ const setup = (editor: Editor): void => {
   const charCodes = [ ',', '.', ';', ':', '!', '?' ];
   const keyCodes = [ 32 ];
 
+  const isSelectionCollapsed = editor.selection.isCollapsed();
+
   // This is a thunk so that they reflect changes in the underlying options each time they are requested.
   const getPatternSet = () => Pattern.createPatternSet(
     Options.getTextPatterns(editor),
@@ -27,7 +29,7 @@ const setup = (editor: Editor): void => {
         patternSet.blockPatterns.length > 0 ||
         hasDynamicPatterns();
 
-      if (hasPatterns && KeyHandler.handleEnter(editor, patternSet)) {
+      if (!isSelectionCollapsed && hasPatterns && KeyHandler.handleEnter(editor, patternSet)) {
         e.preventDefault();
       }
     }
@@ -39,7 +41,7 @@ const setup = (editor: Editor): void => {
     // Do not process anything if we don't have any inline patterns or dynamic lookup defined
     const hasPatterns = patternSet.inlinePatterns.length > 0 || hasDynamicPatterns();
 
-    if (hasPatterns) {
+    if (!isSelectionCollapsed && hasPatterns) {
       // Passing through just the part of PatternSet that is relevant for inline
       // patterns.
       KeyHandler.handleInlineKey(

--- a/modules/tinymce/src/core/test/ts/atomic/textpatterns/FindBlockPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/textpatterns/FindBlockPatternsTest.ts
@@ -6,19 +6,24 @@ import * as Pattern from 'tinymce/core/textpatterns/core/Pattern';
 
 describe('atomic.tinymce.textpatterns.FindBlockPatternsTest', () => {
   it('should find the start of the default patterns', () => {
-    const patternSet = Pattern.createPatternSet(Pattern.fromRawPatterns([
-      { start: '*', end: '*', format: 'italic' },
-      { start: '**', end: '**', format: 'bold' },
-      { start: '#', format: 'h1' },
-      { start: '##', format: 'h2' },
-      { start: '###', format: 'h3' },
-      { start: '####', format: 'h4' },
-      { start: '#####', format: 'h5' },
-      { start: '######', format: 'h6' },
-      { start: '1. ', cmd: 'InsertOrderedList' },
-      { start: '* ', cmd: 'InsertUnorderedList' },
-      { start: '- ', cmd: 'InsertUnorderedList' }
-    ]));
+    const patternSet = Pattern.createPatternSet(
+      Pattern.fromRawPatterns([
+        { start: '*', end: '*', format: 'italic' },
+        { start: '**', end: '**', format: 'bold' },
+        { start: '#', format: 'h1' },
+        { start: '##', format: 'h2' },
+        { start: '###', format: 'h3' },
+        { start: '####', format: 'h4' },
+        { start: '#####', format: 'h5' },
+        { start: '######', format: 'h6' },
+        { start: '1. ', cmd: 'InsertOrderedList' },
+        { start: '* ', cmd: 'InsertUnorderedList' },
+        { start: '- ', cmd: 'InsertUnorderedList' }
+      ]),
+      // the lookup function isn't important, as this is just focusing on initial
+      // block patterns
+      () => []
+    );
     const defaultPatterns = patternSet.blockPatterns;
 
     const testFindStartPattern = (text: string, expectedPattern: string) => {

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternTest.ts
@@ -35,7 +35,7 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
 
     const getPatternSet = getPatternSetFor(hook);
 
-    it('TBA: # Triggers heading match when block tag matches forced_root_block', () => {
+    it('TBA: # triggers heading match when block tag matches forced_root_block', () => {
       const editor = hook.editor();
       // For block patterns to execute, the block tag must be the same as the
       // forced root block. We aren't sure why this constraint exists.
@@ -56,6 +56,14 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
         ],
         'Checking block pattern matches'
       );
+    });
+
+    it('* does not trigger a match', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>* No match');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      const matches = BlockPattern.findPatterns(editor, getPatternSet());
+      assert.deepEqual(matches, []);
     });
 
     it('TBA: # does not trigger heading match when block tag does not match forced_root_block', () => {
@@ -81,12 +89,13 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
         { start: '#', format: 'h1' },
         { start: '##', format: 'h2' },
         { start: '###', format: 'h3' },
+        { start: '' }
       ],
       text_patterns_lookup: (_ctx) => {
-        // const parentTag = ctx.block.nodeName.toLowerCase();
         return [
           { start: '####', format: 'h4' },
-          { start: 'TBA', cmd: 'mceInsertContent', value: 'To be announced' }
+          { start: 'TBA', cmd: 'mceInsertContent', value: 'To be announced' },
+          { start: '###', cmd: 'mceInsertContent', value: 'h3 heading' }
         ];
       },
       base_url: '/project/tinymce/js/tinymce'
@@ -94,7 +103,7 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
 
     const getPatternSet = getPatternSetFor(hook);
 
-    it('TBA: Match a heading format', () => {
+    it('TBA: Match a heading format which is extending the existing text patterns', () => {
       const editor = hook.editor();
       editor.setContent('<p>#### wow</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], 4);
@@ -143,7 +152,7 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
       );
     });
 
-    it('TBA: Match a heading where its parent block is inside another block tag that does not match forced_root_block', () => {
+    it('TBA: Match a heading where its block tag matches forced_root_block but its parent block does not', () => {
       const editor = hook.editor();
       editor.setContent('<div><p>#### New heading type</p></div>');
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 4);
@@ -172,6 +181,27 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 4);
       const matches = BlockPattern.findPatterns(editor, getPatternSet());
       assert.deepEqual(matches, [], 'Checking block pattern matches do not match for incorrect block tag type');
+    });
+
+    it('TBA: Lookup patterns take precendence over block patterns', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>### is a new heading</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 4);
+      const matches = BlockPattern.findPatterns(editor, getPatternSet());
+      assert.deepEqual(matches, [
+        {
+          pattern: {
+            type: 'block-command',
+            start: '###',
+            cmd: 'mceInsertContent',
+            value: 'h3 heading'
+          },
+          range: {
+            start: [ 0, 0 ],
+            end: [ 0, 0 ]
+          }
+        }
+      ]);
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternTest.ts
@@ -1,27 +1,14 @@
-import { describe, it } from '@ephox/bedrock-client';
-import { Thunk } from '@ephox/katamari';
+import { describe, it, context } from '@ephox/bedrock-client';
 import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import * as Options from 'tinymce/core/api/Options';
 import * as BlockPattern from 'tinymce/core/textpatterns/core/BlockPattern';
-import * as Pattern from 'tinymce/core/textpatterns/core/Pattern';
-import { PatternSet } from 'tinymce/core/textpatterns/core/PatternTypes';
+import { getPatternSetFor } from '../../module/test/TextPatternsUtils';
 
-const getPatternSetFor = (hook: TinyHooks.Hook<Editor>) => Thunk.cached((): PatternSet => {
-  const editor = hook.editor();
-  const rawPatterns = Options.getTextPatterns(editor);
-  const dynamicPatternsLookup = Options.getTextPatternsLookup(editor);
-  return Pattern.createPatternSet(
-    Pattern.fromRawPatterns(rawPatterns),
-    dynamicPatternsLookup
-  );
-});
+describe('atomic.tinymce.textpatterns.FindBlockPatternTest', () => {
 
-describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
-
-  describe('no text_patterns_lookup', () => {
+  context('no text_patterns_lookup', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       text_patterns: [
         { start: '*', end: '*', format: 'italic' },
@@ -34,8 +21,8 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
     }, []);
 
     const getPatternSet = getPatternSetFor(hook);
-
-    it('TINY-8778: # triggers heading match when block tag matches forced_root_block', () => {
+    // TODO: This may not be the expected behaviour, depending on the decisions that being made in https://ephocks.atlassian.net/browse/TINY-4303
+    it('TBA: # triggers heading match when block tag matches forced_root_block', () => {
       const editor = hook.editor();
       // For block patterns to execute, the block tag must be the same as the
       // forced root block. We aren't sure why this constraint exists.
@@ -58,7 +45,7 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
       );
     });
 
-    it('* does not trigger a match', () => {
+    it('TINY-8778: * does not trigger a match', () => {
       const editor = hook.editor();
       editor.setContent('<p>* No match');
       TinySelections.setCursor(editor, [ 0, 0 ], 1);
@@ -66,7 +53,8 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
       assert.deepEqual(matches, []);
     });
 
-    it('TINY-8778: # does not trigger heading match when block tag does not match forced_root_block', () => {
+    // TODO: This may not be the expected behaviour, depending on the decisions that being made in https://ephocks.atlassian.net/browse/TINY-4303
+    it('TBA: # does not trigger heading match when block tag does not match forced_root_block', () => {
       const editor = hook.editor();
       // For block patterns to execute, the block tag must be the same as the
       // forced root block. We aren't sure why this constraint exists.
@@ -81,7 +69,7 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
     });
   });
 
-  describe('with text_patterns_lookup', () => {
+  context('with text_patterns_lookup', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       text_patterns: [
         { start: '*', end: '*', format: 'italic' },
@@ -152,6 +140,7 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
       );
     });
 
+    // TODO: This maybe need to be fixed, depending on the decisions that being made in https://ephocks.atlassian.net/browse/TINY-4303
     it('TINY-8778: Match a heading where its block tag matches forced_root_block but its parent block does not', () => {
       const editor = hook.editor();
       editor.setContent('<div><p>#### New heading type</p></div>');
@@ -175,7 +164,8 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
       );
     });
 
-    it('TINY-8778: Does not trigger a match if the block tag does not match forced_root_block', () => {
+    // TODO: This may not be the expected behaviour, depending on the decisions that being made in https://ephocks.atlassian.net/browse/TINY-4303
+    it('TBA: Does not trigger a match if the block tag does not match forced_root_block', () => {
       const editor = hook.editor();
       editor.setContent('<div>#### New heading type</div>');
       TinySelections.setCursor(editor, [ 0, 0 ], 4);

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternTest.ts
@@ -35,7 +35,7 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
 
     const getPatternSet = getPatternSetFor(hook);
 
-    it('TBA: # triggers heading match when block tag matches forced_root_block', () => {
+    it('TINY-8778: # triggers heading match when block tag matches forced_root_block', () => {
       const editor = hook.editor();
       // For block patterns to execute, the block tag must be the same as the
       // forced root block. We aren't sure why this constraint exists.
@@ -66,7 +66,7 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
       assert.deepEqual(matches, []);
     });
 
-    it('TBA: # does not trigger heading match when block tag does not match forced_root_block', () => {
+    it('TINY-8778: # does not trigger heading match when block tag does not match forced_root_block', () => {
       const editor = hook.editor();
       // For block patterns to execute, the block tag must be the same as the
       // forced root block. We aren't sure why this constraint exists.
@@ -103,7 +103,7 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
 
     const getPatternSet = getPatternSetFor(hook);
 
-    it('TBA: Match a heading format which is extending the existing text patterns', () => {
+    it('TINY-8778: Match a heading format which is extending the existing text patterns', () => {
       const editor = hook.editor();
       editor.setContent('<p>#### wow</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], 4);
@@ -127,7 +127,7 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
       );
     });
 
-    it('TBA: Match a command pattern', () => {
+    it('TINY-8778: Match a command pattern', () => {
       const editor = hook.editor();
       editor.setContent('<p><b>TBA Bold heading</b></p>');
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 3);
@@ -152,7 +152,7 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
       );
     });
 
-    it('TBA: Match a heading where its block tag matches forced_root_block but its parent block does not', () => {
+    it('TINY-8778: Match a heading where its block tag matches forced_root_block but its parent block does not', () => {
       const editor = hook.editor();
       editor.setContent('<div><p>#### New heading type</p></div>');
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 4);
@@ -175,7 +175,7 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
       );
     });
 
-    it('TBA: Does not trigger a match if the block tag does not match forced_root_block', () => {
+    it('TINY-8778: Does not trigger a match if the block tag does not match forced_root_block', () => {
       const editor = hook.editor();
       editor.setContent('<div>#### New heading type</div>');
       TinySelections.setCursor(editor, [ 0, 0 ], 4);
@@ -183,7 +183,7 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
       assert.deepEqual(matches, [], 'Checking block pattern matches do not match for incorrect block tag type');
     });
 
-    it('TBA: Lookup patterns take precendence over block patterns', () => {
+    it('TINY-8778: Lookup patterns take precendence over block patterns', () => {
       const editor = hook.editor();
       editor.setContent('<p>### is a new heading</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], 4);

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternTest.ts
@@ -1,0 +1,95 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { Thunk } from '@ephox/katamari';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import * as Options from 'tinymce/core/api/Options';
+import * as BlockPattern from 'tinymce/core/textpatterns/core/BlockPattern';
+import * as Pattern from 'tinymce/core/textpatterns/core/Pattern';
+import { PatternSet } from 'tinymce/core/textpatterns/core/PatternTypes';
+
+const getPatternSetFor = (hook: TinyHooks.Hook<Editor>) => Thunk.cached((): PatternSet => {
+  const editor = hook.editor();
+  const rawPatterns = Options.getTextPatterns(editor);
+  const dynamicPatternsLookup = Options.getTextPatternsLookup(editor);
+  return Pattern.createPatternSet(
+    Pattern.fromRawPatterns(rawPatterns),
+    dynamicPatternsLookup
+  );
+});
+
+describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
+
+  describe('no text_patterns_lookup', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      text_patterns: [
+        { start: '*', end: '*', format: 'italic' },
+        { start: '**', end: '**', format: 'bold' },
+        { start: '#', format: 'h1' },
+        { start: '##', format: 'h2' },
+        { start: '###', format: 'h3' },
+      ],
+      base_url: '/project/tinymce/js/tinymce'
+    }, [ ]);
+
+    const getPatternSet = getPatternSetFor(hook);
+
+    it('TBA: # Triggers heading match when block tag matches forced_root_block', () => {
+      const editor = hook.editor();
+      // For block patterns to execute, the block tag must be the same as the
+      // forced root block. We aren't sure why this constraint exists.
+      editor.setContent('<p># Heading</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], '# Heading'.length);
+      const matches = BlockPattern.findPatterns(editor, getPatternSet());
+      assert.deepEqual(
+        matches,
+        [
+          {
+            pattern: {
+              type: 'block-format',
+              start: '#',
+              format: 'h1'
+            },
+            range: { start: [ 0, 0 ], end: [ 0, 0 ] }
+          }
+        ],
+        'Checking block pattern matches'
+      );
+    });
+
+    it('TBA: # does not trigger heading match when block tag does not match forced_root_block', () => {
+      const editor = hook.editor();
+      // For block patterns to execute, the block tag must be the same as the
+      // forced root block. We aren't sure why this constraint exists.
+      editor.setContent('<div># Heading</div>');
+      TinySelections.setCursor(editor, [ 0, 0 ], '# Heading'.length);
+      const matches = BlockPattern.findPatterns(editor, getPatternSet());
+      assert.deepEqual(
+        matches,
+        [ ],
+        'Checking block pattern matches do not match for incorrect block tag type'
+      );
+    });
+  });
+
+  describe('with text_patterns_lookup', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      text_patterns: [
+        { start: '*', end: '*', format: 'italic' },
+        { start: '**', end: '**', format: 'bold' },
+        { start: '#', format: 'h1' },
+        { start: '##', format: 'h2' },
+        { start: '###', format: 'h3' },
+      ],
+      base_url: '/project/tinymce/js/tinymce'
+    }, [ ]);
+
+    const getPatternSet = getPatternSetFor(hook);
+
+    it.skip('TBA: # Triggers dynamic match when block tag matches forced_root_block', () => {
+      // eslint-disable-next-line no-console
+      console.log('PatternSet: ', { getPatternSet: getPatternSet() });
+    });
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternTest.ts
@@ -68,7 +68,7 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
       assert.deepEqual(
         matches,
         [],
-        'Checking block pattern matches do not match for incorrect block tag type'
+        'Checking block pattern matches - do not match for incorrect block tag type'
       );
     });
   });
@@ -97,7 +97,7 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
     it('TBA: Match a heading format', () => {
       const editor = hook.editor();
       editor.setContent('<p>#### wow</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+      TinySelections.setCursor(editor, [ 0, 0 ], 4);
       const matches = BlockPattern.findPatterns(editor, getPatternSet());
       assert.deepEqual(
         matches,
@@ -114,14 +114,14 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
             }
           }
         ],
-        'Checking block pattern matches do not match for incorrect block tag type'
+        'Checking block pattern matches'
       );
     });
 
-    it('TBA: Match a text pattern command', () => {
+    it('TBA: Match a command pattern', () => {
       const editor = hook.editor();
       editor.setContent('<p><b>TBA Bold heading</b></p>');
-      TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 3);
       const matches = BlockPattern.findPatterns(editor, getPatternSet());
       assert.deepEqual(
         matches,
@@ -139,14 +139,14 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
             }
           }
         ],
-        'Checking block pattern matches do not match for incorrect block tag type'
+        'Checking block pattern matches'
       );
     });
 
-    it('TBA: Match a heading inside a block tag that is wrapped by another block tag that does not match forced_root_block', () => {
+    it('TBA: Match a heading where its parent block is inside another block tag that does not match forced_root_block', () => {
       const editor = hook.editor();
       editor.setContent('<div><p>#### New heading type</p></div>');
-      TinySelections.setCursor(editor, [ 0, 0, 0 ], 5);
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 4);
       const patterns = getPatternSet();
       const matches = BlockPattern.findPatterns(editor, patterns);
       assert.deepEqual(matches, [
@@ -162,7 +162,7 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
           }
         }
       ],
-      'Checking block pattern matches do not match for incorrect block tag type'
+      'Checking block pattern matches'
       );
     });
 
@@ -171,7 +171,7 @@ describe('browser.tinymce.core.textpatterns.FindBlockPatternTest', () => {
       editor.setContent('<div>#### New heading type</div>');
       TinySelections.setCursor(editor, [ 0, 0 ], 4);
       const matches = BlockPattern.findPatterns(editor, getPatternSet());
-      assert.deepEqual(matches, []);
+      assert.deepEqual(matches, [], 'Checking block pattern matches do not match for incorrect block tag type');
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternsTest.ts
@@ -7,9 +7,9 @@ import * as BlockPattern from 'tinymce/core/textpatterns/core/BlockPattern';
 
 import { getPatternSetFor } from '../../module/test/TextPatternsUtils';
 
-// Same as modules/tinymce/src/core/test/ts/atomic/textpatterns/FindBlockPatternsTest.ts
+// Similar to modules/tinymce/src/core/test/ts/atomic/textpatterns/FindBlockPatternsTest.ts
 // but uses DOM and includes tests for text_patterns_lookup
-describe('atomic.tinymce.textpatterns.FindBlockPatternsTest', () => {
+describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
 
   context('no text_patterns_lookup', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
@@ -24,7 +24,7 @@ describe('atomic.tinymce.textpatterns.FindBlockPatternsTest', () => {
     }, []);
 
     const getPatternSet = getPatternSetFor(hook);
-    // TODO: This may not be the expected behaviour, depending on the decisions that being made in https://ephocks.atlassian.net/browse/TINY-4303
+    // TODO: This may not be the expected behaviour, depending on the decisions that being made in TINY-4303
     it('TBA: # triggers heading match when block tag matches forced_root_block', () => {
       const editor = hook.editor();
       // For block patterns to execute, the block tag must be the same as the
@@ -56,7 +56,7 @@ describe('atomic.tinymce.textpatterns.FindBlockPatternsTest', () => {
       assert.deepEqual(matches, []);
     });
 
-    // TODO: This may not be the expected behaviour, depending on the decisions that being made in https://ephocks.atlassian.net/browse/TINY-4303
+    // TODO: This may not be the expected behaviour, depending on the decisions that being made in TINY-4303
     it('TBA: # does not trigger heading match when block tag does not match forced_root_block', () => {
       const editor = hook.editor();
       // For block patterns to execute, the block tag must be the same as the
@@ -141,7 +141,7 @@ describe('atomic.tinymce.textpatterns.FindBlockPatternsTest', () => {
       );
     });
 
-    // TODO: This maybe need to be fixed, depending on the decisions that being made in https://ephocks.atlassian.net/browse/TINY-4303
+    // TODO: This maybe need to be fixed, depending on the decisions that being made in TINY-4303
     it('TINY-8778: Match a heading where its block tag matches forced_root_block but its parent block does not', () => {
       const editor = hook.editor();
       editor.setContent('<div><p>#### New heading type</p></div>');
@@ -165,7 +165,7 @@ describe('atomic.tinymce.textpatterns.FindBlockPatternsTest', () => {
       );
     });
 
-    // TODO: This may not be the expected behaviour, depending on the decisions that being made in https://ephocks.atlassian.net/browse/TINY-4303
+    // TODO: This may not be the expected behaviour, depending on the decisions that being made in TINY-4303
     it('TBA: Does not trigger a match if the block tag does not match forced_root_block', () => {
       const editor = hook.editor();
       editor.setContent('<div>#### New heading type</div>');

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternsTest.ts
@@ -6,7 +6,9 @@ import Editor from 'tinymce/core/api/Editor';
 import * as BlockPattern from 'tinymce/core/textpatterns/core/BlockPattern';
 import { getPatternSetFor } from '../../module/test/TextPatternsUtils';
 
-describe('atomic.tinymce.textpatterns.FindBlockPatternTest', () => {
+// Same as modules/tinymce/src/core/test/ts/atomic/textpatterns/FindBlockPatternsTest.ts
+// but uses DOM and includes tests for text_patterns_lookup
+describe('atomic.tinymce.textpatterns.FindBlockPatternsTest', () => {
 
   context('no text_patterns_lookup', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternsTest.ts
@@ -1,9 +1,10 @@
-import { describe, it, context } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as BlockPattern from 'tinymce/core/textpatterns/core/BlockPattern';
+
 import { getPatternSetFor } from '../../module/test/TextPatternsUtils';
 
 // Same as modules/tinymce/src/core/test/ts/atomic/textpatterns/FindBlockPatternsTest.ts

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternsTest.ts
@@ -24,6 +24,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
     }, []);
 
     const getPatternSet = getPatternSetFor(hook);
+
     // TODO: This may not be the expected behaviour, depending on the decisions that being made in TINY-4303
     it('TBA: # triggers heading match when block tag matches forced_root_block', () => {
       const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
@@ -1,32 +1,21 @@
-import { describe, it } from '@ephox/bedrock-client';
-import { Obj, Thunk } from '@ephox/katamari';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Obj } from '@ephox/katamari';
 import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import * as Options from 'tinymce/core/api/Options';
 import * as InlinePattern from 'tinymce/core/textpatterns/core/InlinePattern';
-import * as Pattern from 'tinymce/core/textpatterns/core/Pattern';
 import { InlinePattern as InlinePatternType, InlinePatternMatch, InlinePatternSet } from 'tinymce/core/textpatterns/core/PatternTypes';
 import { PathRange } from 'tinymce/core/textpatterns/utils/PathRange';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
+
+import { getPatternSetFor } from '../../module/test/TextPatternsUtils';
 
 interface ExpectedPatternMatch {
   readonly pattern: Partial<InlinePatternType>;
   readonly startRng: PathRange;
   readonly endRng: PathRange;
 }
-
-const getInlinePatternSetFor = (hook: TinyHooks.Hook<Editor>) => Thunk.cached((): InlinePatternSet => {
-  const editor = hook.editor();
-  const rawPatterns = Options.getTextPatterns(editor);
-  const dynamicPatternsLookup = Options.getTextPatternsLookup(editor);
-  const { blockPatterns, ...inlinePatternSet } = Pattern.createPatternSet(
-    Pattern.fromRawPatterns(rawPatterns),
-    dynamicPatternsLookup
-  );
-  return inlinePatternSet;
-});
 
 const getInlinePattern = (editor: Editor, patternSet: InlinePatternSet, space: boolean = false) =>
   InlinePattern.findPatterns(editor, patternSet, space);
@@ -65,9 +54,9 @@ const setContentAndSelection = (editor: Editor, content: string, startPath: numb
 const assertSimpleMatch = (actualMatches: InlinePatternMatch[], matchStart: string, matchEnd: string, formats: string[], startRng: PathRange, endRng: PathRange) =>
   assertPatterns(actualMatches, [{ pattern: { start: matchStart, end: matchEnd, format: formats }, startRng, endRng }]);
 
-describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
+describe('browser.tinymce.textpatterns.FindInlinePatternTest', () => {
 
-  describe('no text_patterns_lookup', () => {
+  context('no text_patterns_lookup', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       plugins: 'lists',
       text_patterns: [
@@ -81,7 +70,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
       base_url: '/project/tinymce/js/tinymce'
     }, [ ListsPlugin ]);
 
-    const getInlinePatternSet = getInlinePatternSetFor(hook);
+    const getInlinePatternSet = getPatternSetFor(hook);
 
     it('TINY-8778: Run on text without pattern returns no matching patterns', () => {
       const editor = hook.editor();
@@ -218,7 +207,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
       ]);
     });
 
-    describe('with just a single ** -> bold inline-format pattern', () => {
+    context('with just a single ** -> bold inline-format pattern', () => {
       const inlinePatternSet: InlinePatternSet = {
         inlinePatterns: [
           { type: 'inline-format', start: '**', end: '**', format: [ 'bold' ] }
@@ -319,7 +308,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
     });
   });
 
-  describe('with text_patterns_lookup', () => {
+  context('with text_patterns_lookup', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       text_patterns: [
         { start: '*', end: '*', format: 'italic' }
@@ -351,7 +340,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
       base_url: '/project/tinymce/js/tinymce'
     }, []);
 
-    const getInlinePatternSet = getInlinePatternSetFor(hook);
+    const getInlinePatternSet = getPatternSetFor(hook);
 
     it('TINY-8778: Code Pattern only runs on with code blocks', () => {
       const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
@@ -337,7 +337,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
             {
               start: '*', end: '*', format: 'bold'
             }
-          ]
+          ];
         } else if (parentTag === 'div' && ctx.text === 'replace-me') {
           return [
             {
@@ -345,7 +345,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
             }
           ];
         } else {
-          return [ ];
+          return [];
         }
       },
       base_url: '/project/tinymce/js/tinymce'
@@ -433,7 +433,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
             }
           }
         ]
-      )
+      );
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
@@ -83,112 +83,112 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
 
     const getInlinePatternSet = getInlinePatternSetFor(hook);
 
-    it('TBA: Run on text without pattern returns no matching patterns', () => {
+    it('TINY-8778: Run on text without pattern returns no matching patterns', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, 'text', [ 0 ], 4);
       const matches = getInlinePattern(editor, getInlinePatternSet());
       assertPatterns(matches, []);
     });
 
-    it('TBA: Run on range that is not on a text node without pattern returns no match', () => {
+    it('TINY-8778: Run on range that is not on a text node without pattern returns no match', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, '<p>text</p>', [ 0 ], 1);
       const matches = getInlinePattern(editor, getInlinePatternSet());
       assertPatterns(matches, []);
     });
 
-    it('TBA: Run on range that is not on a text node with pattern returns a match', () => {
+    it('TINY-8778: Run on range that is not on a text node with pattern returns a match', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, '<p>*a*</p>', [ 0 ], 1);
       const matches = getInlinePattern(editor, getInlinePatternSet());
       assertSimpleMatch(matches, '*', '*', [ 'italic' ], { start: [ 0, 0, 0 ], end: [ 0, 0, 1 ] }, { start: [ 0, 0, 2 ], end: [ 0, 0, 3 ] });
     });
 
-    it('TBA: inline * pattern with no gap to matching token returns no match', () => {
+    it('TINY-8778: inline * pattern with no gap to matching token returns no match', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, '*x***', [ 0 ], 5);
       const matches = getInlinePattern(editor, getInlinePatternSet());
       assertPatterns(matches, []);
     });
 
-    it('TBA: inline * with uncollapsed range returns no match', () => {
+    it('TINY-8778: inline * with uncollapsed range returns no match', () => {
       const editor = hook.editor();
       setContentAndSelection(editor, '*x*&nbsp;', [ 0 ], 3, [ 0 ], 4);
       const matches = getInlinePattern(editor, getInlinePatternSet(), true);
       assertPatterns(matches, []);
     });
 
-    it('TBA: inline * pattern end without content returns no match', () => {
+    it('TINY-8778: inline * pattern end without content returns no match', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, '**', [ 0 ], 2);
       const matches = getInlinePattern(editor, getInlinePatternSet());
       assertPatterns(matches, []);
     });
 
-    it('TBA: inline * and ** end pattern without start pattern no match', () => {
+    it('TINY-8778: inline * and ** end pattern without start pattern no match', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, '***', [ 0 ], 3);
       const matches = getInlinePattern(editor, getInlinePatternSet());
       assertPatterns(matches, []);
     });
 
-    it('TBA: cursor in middle of pattern returns no match', () => {
+    it('TINY-8778: cursor in middle of pattern returns no match', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, '*** x***', [ 0 ], 4);
       const matches = getInlinePattern(editor, getInlinePatternSet(), true);
       assertPatterns(matches, []);
     });
 
-    it('TBA: inline * without content before or after', () => {
+    it('TINY-8778: inline * without content before or after', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, '*x*', [ 0 ], 3);
       const matches = getInlinePattern(editor, getInlinePatternSet());
       assertSimpleMatch(matches, '*', '*', [ 'italic' ], { start: [ 0, 0 ], end: [ 0, 1 ] }, { start: [ 0, 2 ], end: [ 0, 3 ] });
     });
 
-    it('TBA: inline * with content before', () => {
+    it('TINY-8778: inline * with content before', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, 'a *x*', [ 0 ], 5);
       const matches = getInlinePattern(editor, getInlinePatternSet());
       assertSimpleMatch(matches, '*', '*', [ 'italic' ], { start: [ 0, 2 ], end: [ 0, 3 ] }, { start: [ 0, 4 ], end: [ 0, 5 ] });
     });
 
-    it('TBA: inline * with content before and after', () => {
+    it('TINY-8778: inline * with content before and after', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, 'a *x* b', [ 0 ], 5);
       const matches = getInlinePattern(editor, getInlinePatternSet());
       assertSimpleMatch(matches, '*', '*', [ 'italic' ], { start: [ 0, 2 ], end: [ 0, 3 ] }, { start: [ 0, 4 ], end: [ 0, 5 ] });
     });
 
-    it('TBA: inline * with content before and after, with space', () => {
+    it('TINY-8778: inline * with content before and after, with space', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, '***x* **', [ 0 ], 6);
       const matches = getInlinePattern(editor, getInlinePatternSet(), true);
       assertSimpleMatch(matches, '*', '*', [ 'italic' ], { start: [ 0, 2 ], end: [ 0, 3 ] }, { start: [ 0, 4 ], end: [ 0, 5 ] });
     });
 
-    it('TBA: inline ** without content before or after', () => {
+    it('TINY-8778: inline ** without content before or after', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, '**x**', [ 0 ], 5);
       const matches = getInlinePattern(editor, getInlinePatternSet());
       assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 0 ], end: [ 0, 2 ] }, { start: [ 0, 3 ], end: [ 0, 5 ] });
     });
 
-    it('TBA: inline ** with content before', () => {
+    it('TINY-8778: inline ** with content before', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, 'a **x**', [ 0 ], 7);
       const matches = getInlinePattern(editor, getInlinePatternSet());
       assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 2 ], end: [ 0, 4 ] }, { start: [ 0, 5 ], end: [ 0, 7 ] });
     });
 
-    it('TBA: inline ** with content before and after', () => {
+    it('TINY-8778: inline ** with content before and after', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, 'a **x** b', [ 0 ], 7);
       const matches = getInlinePattern(editor, getInlinePatternSet());
       assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 2 ], end: [ 0, 4 ] }, { start: [ 0, 5 ], end: [ 0, 7 ] });
     });
 
-    it('TBA: inline * and ** without content before or after', () => {
+    it('TINY-8778: inline * and ** without content before or after', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, '***x***', [ 0 ], 7);
       const matches = getInlinePattern(editor, getInlinePatternSet());
@@ -198,7 +198,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
       ]);
     });
 
-    it('TBA: inline * and ** with content before', () => {
+    it('TINY-8778: inline * and ** with content before', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, 'a ***x***', [ 0 ], 9);
       const matches = getInlinePattern(editor, getInlinePatternSet());
@@ -208,7 +208,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
       ]);
     });
 
-    it('TBA: inline * and ** with content before and after', () => {
+    it('TINY-8778: inline * and ** with content before and after', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, 'a ***x*** b', [ 0 ], 9);
       const matches = getInlinePattern(editor, getInlinePatternSet());
@@ -226,21 +226,21 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
         dynamicPatternsLookup: () => []
       };
 
-      it('TBA: force only ** pattern and test return on not existing *** pattern', () => {
+      it('TINY-8778: force only ** pattern and test return on not existing *** pattern', () => {
         const editor = hook.editor();
         setContentAndCursor(editor, '***x***', [ 0 ], 7);
         const matches = getInlinePattern(editor, inlinePatternSet);
         assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 1 ], end: [ 0, 3 ] }, { start: [ 0, 5 ], end: [ 0, 7 ] });
       });
 
-      it('TBA: force only ** pattern with leading content and test return on not existing *** pattern', () => {
+      it('TINY-8778: force only ** pattern with leading content and test return on not existing *** pattern', () => {
         const editor = hook.editor();
         setContentAndCursor(editor, 'y ***x***', [ 0 ], 9);
         const matches = getInlinePattern(editor, inlinePatternSet);
         assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 3 ], end: [ 0, 5 ] }, { start: [ 0, 7 ], end: [ 0, 9 ] });
       });
 
-      it('TBA: force only ** pattern with trailing ** text and test return on not existing *** pattern', () => {
+      it('TINY-8778: force only ** pattern with trailing ** text and test return on not existing *** pattern', () => {
         const editor = hook.editor();
         setContentAndCursor(editor, 'y ***x*** **', [ 0 ], 9);
         const matches = getInlinePattern(editor, inlinePatternSet);
@@ -248,7 +248,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
       });
     });
 
-    it('TBA: Check match when input pattern has an empty start value', () => {
+    it('TINY-8778: Check match when input pattern has an empty start value', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, 'brb', [ 0 ], 3);
       const matches = getInlinePattern(editor, getInlinePatternSet());
@@ -257,7 +257,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
       ]);
     });
 
-    it('TBA: Check match when input pattern has an empty end value', () => {
+    it('TINY-8778: Check match when input pattern has an empty end value', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, 'irl', [ 0 ], 3);
       const matches = getInlinePattern(editor, getInlinePatternSet());
@@ -266,7 +266,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
       ]);
     });
 
-    it('TBA: Check match when input pattern uses replacement syntax', () => {
+    it('TINY-8778: Check match when input pattern uses replacement syntax', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, 'asap', [ 0 ], 4);
       const matches = getInlinePattern(editor, getInlinePatternSet());
@@ -275,7 +275,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
       ]);
     });
 
-    it('TBA: Check nested match', () => {
+    it('TINY-8778: Check nested match', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, 'Bring those reports ***asap***!', [ 0 ], 31);
       const matches = getInlinePattern(editor, getInlinePatternSet(), true);
@@ -286,7 +286,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
       ]);
     });
 
-    it('TBA: Check that a pattern will be matched across tag boundaries', () => {
+    it('TINY-8778: Check that a pattern will be matched across tag boundaries', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, '<span>*text</span><span>*</span>', [ 1, 0 ], 1);
       const matches = getInlinePattern(editor, getInlinePatternSet());
@@ -295,7 +295,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
       ]);
     });
 
-    it('TBA: Check that a pattern will be matched across tag boundaries 2', () => {
+    it('TINY-8778: Check that a pattern will be matched across tag boundaries 2', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, '<span>**text*</span><span>*</span>', [ 1, 0 ], 1);
       const matches = getInlinePattern(editor, getInlinePatternSet());
@@ -304,14 +304,14 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
       ]);
     });
 
-    it('TBA: Check that a pattern will not be matched across block boundaries', () => {
+    it('TINY-8778: Check that a pattern will not be matched across block boundaries', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, '<p>*text</p><p>*</p>', [ 1, 0 ], 1);
       const matches = getInlinePattern(editor, getInlinePatternSet());
       assertPatterns(matches, []);
     });
 
-    it('TBA: Check that a pattern will not be matched across block boundaries 2', () => {
+    it('TINY-8778: Check that a pattern will not be matched across block boundaries 2', () => {
       const editor = hook.editor();
       setContentAndCursor(editor, '<p>*text</p><span>*</span>', [ 1, 0 ], 1);
       const matches = getInlinePattern(editor, getInlinePatternSet());
@@ -353,7 +353,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
 
     const getInlinePatternSet = getInlinePatternSetFor(hook);
 
-    it('TBA: Code Pattern only runs on with code blocks', () => {
+    it('TINY-8778: Code Pattern only runs on with code blocks', () => {
       const editor = hook.editor();
       editor.setContent('<pre>`const`</pre>');
       TinySelections.setCursor(editor, [ 0, 0 ], '`const`'.length);
@@ -366,7 +366,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
       );
     });
 
-    it('TBA: Code Pattern does not run with paragraph blocks', () => {
+    it('TINY-8778: Code Pattern does not run with paragraph blocks', () => {
       const editor = hook.editor();
       editor.setContent('<p>`const`</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], '`const`'.length);
@@ -374,7 +374,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
       assertPatterns(matches, []);
     });
 
-    it('TBA: Inline patterns still work when lookup defined', () => {
+    it('TINY-8778: Inline patterns still work when lookup defined', () => {
       const editor = hook.editor();
       editor.setContent('<pre>*const*</pre>');
       TinySelections.setCursor(editor, [ 0, 0 ], '*const*'.length);
@@ -387,7 +387,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
       );
     });
 
-    it('TBA: Inline pattern lookups take precedence over inline patterns', () => {
+    it('TINY-8778: Inline pattern lookups take precedence over inline patterns', () => {
       const editor = hook.editor();
       editor.setContent('<p>*const*</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], '*const*'.length);
@@ -400,7 +400,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
       );
     });
 
-    it('TBA: Inline pattern lookups based on non-matching context text', () => {
+    it('TINY-8778: Inline pattern lookups based on non-matching context text', () => {
       const editor = hook.editor();
       editor.setContent('<div>keep-me</div>');
       TinySelections.setCursor(editor, [ 0, 0 ], 'keep-me'.length);
@@ -408,7 +408,7 @@ describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
       assertPatterns(matches, []);
     });
 
-    it('TBA: Inline pattern lookups based on matching context text', () => {
+    it('TINY-8778: Inline pattern lookups based on matching context text', () => {
       const editor = hook.editor();
       editor.setContent('<div>replace-me</div>');
       TinySelections.setCursor(editor, [ 0, 0 ], 'replace-me'.length);

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
@@ -11,50 +11,49 @@ import ListsPlugin from 'tinymce/plugins/lists/Plugin';
 
 import { getPatternSetFor } from '../../module/test/TextPatternsUtils';
 
-interface ExpectedPatternMatch {
-  readonly pattern: Partial<InlinePatternType>;
-  readonly startRng: PathRange;
-  readonly endRng: PathRange;
-}
-
-const getInlinePattern = (editor: Editor, patternSet: InlinePatternSet, space: boolean = false) =>
-  InlinePattern.findPatterns(editor, patternSet, space);
-
-const assertPatterns = (actualMatches: InlinePatternMatch[], expectedMatches: ExpectedPatternMatch[]) => {
-  assert.lengthOf(actualMatches, expectedMatches.length, 'Pattern count does not match');
-  for (let i = 0; i < expectedMatches.length; i++) {
-    const expected = expectedMatches[i];
-    const actual = actualMatches[i];
-    const pattern = actual.pattern;
-    Obj.each(expected.pattern, (value, key) => {
-      if (Obj.has<any, string>(pattern, key)) {
-        assert.deepEqual(pattern[key], value, 'Pattern ' + (i + 1) + ' property `' + key + '` is not equal');
-      } else {
-        assert.fail('Pattern ' + (i + 1) + ' property `' + key + '` is missing');
-      }
-    });
-    // prepend a 0 because we always add a root node
-    assert.deepEqual(actual.startRng.start, [ 0 ].concat(expected.startRng.start), 'start range - start path does not match');
-    assert.deepEqual(actual.startRng.end, [ 0 ].concat(expected.startRng.end), 'start range - end path does not match');
-    assert.deepEqual(actual.endRng.start, [ 0 ].concat(expected.endRng.start), 'end range - start path does not match');
-    assert.deepEqual(actual.endRng.end, [ 0 ].concat(expected.endRng.end), 'end range - end path does not match');
-  }
-};
-
-const setContentAndCursor = (editor: Editor, content: string, elementPath: number[], offset: number) => {
-  editor.setContent(`<div>${content}</div>`, { format: 'raw' });
-  TinySelections.setCursor(editor, [ 0 ].concat(elementPath), offset);
-};
-
-const setContentAndSelection = (editor: Editor, content: string, startPath: number[], soffset: number, finishPath: number[], foffset: number) => {
-  editor.setContent(`<div>${content}</div>`, { format: 'raw' });
-  TinySelections.setSelection(editor, [ 0 ].concat(startPath), soffset, [ 0 ].concat(finishPath), foffset);
-};
-
-const assertSimpleMatch = (actualMatches: InlinePatternMatch[], matchStart: string, matchEnd: string, formats: string[], startRng: PathRange, endRng: PathRange) =>
-  assertPatterns(actualMatches, [{ pattern: { start: matchStart, end: matchEnd, format: formats }, startRng, endRng }]);
-
 describe('browser.tinymce.textpatterns.FindInlinePatternTest', () => {
+  interface ExpectedPatternMatch {
+    readonly pattern: Partial<InlinePatternType>;
+    readonly startRng: PathRange;
+    readonly endRng: PathRange;
+  }
+
+  const getInlinePattern = (editor: Editor, patternSet: InlinePatternSet, space: boolean = false) =>
+    InlinePattern.findPatterns(editor, patternSet, space);
+
+  const assertPatterns = (actualMatches: InlinePatternMatch[], expectedMatches: ExpectedPatternMatch[]) => {
+    assert.lengthOf(actualMatches, expectedMatches.length, 'Pattern count does not match');
+    for (let i = 0; i < expectedMatches.length; i++) {
+      const expected = expectedMatches[i];
+      const actual = actualMatches[i];
+      const pattern = actual.pattern;
+      Obj.each(expected.pattern, (value, key) => {
+        if (Obj.has<any, string>(pattern, key)) {
+          assert.deepEqual(pattern[key], value, 'Pattern ' + (i + 1) + ' property `' + key + '` is not equal');
+        } else {
+          assert.fail('Pattern ' + (i + 1) + ' property `' + key + '` is missing');
+        }
+      });
+      // prepend a 0 because we always add a root node
+      assert.deepEqual(actual.startRng.start, [ 0 ].concat(expected.startRng.start), 'start range - start path does not match');
+      assert.deepEqual(actual.startRng.end, [ 0 ].concat(expected.startRng.end), 'start range - end path does not match');
+      assert.deepEqual(actual.endRng.start, [ 0 ].concat(expected.endRng.start), 'end range - start path does not match');
+      assert.deepEqual(actual.endRng.end, [ 0 ].concat(expected.endRng.end), 'end range - end path does not match');
+    }
+  };
+
+  const setContentAndCursor = (editor: Editor, content: string, elementPath: number[], offset: number) => {
+    editor.setContent(`<div>${content}</div>`, { format: 'raw' });
+    TinySelections.setCursor(editor, [ 0 ].concat(elementPath), offset);
+  };
+
+  const setContentAndSelection = (editor: Editor, content: string, startPath: number[], soffset: number, finishPath: number[], foffset: number) => {
+    editor.setContent(`<div>${content}</div>`, { format: 'raw' });
+    TinySelections.setSelection(editor, [ 0 ].concat(startPath), soffset, [ 0 ].concat(finishPath), foffset);
+  };
+
+  const assertSimpleMatch = (actualMatches: InlinePatternMatch[], matchStart: string, matchEnd: string, formats: string[], startRng: PathRange, endRng: PathRange) =>
+    assertPatterns(actualMatches, [{ pattern: { start: matchStart, end: matchEnd, format: formats }, startRng, endRng }]);
 
   context('no text_patterns_lookup', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
@@ -7,7 +7,7 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Options from 'tinymce/core/api/Options';
 import * as InlinePattern from 'tinymce/core/textpatterns/core/InlinePattern';
 import * as Pattern from 'tinymce/core/textpatterns/core/Pattern';
-import { InlinePattern as InlinePatternType, InlinePatternMatch } from 'tinymce/core/textpatterns/core/PatternTypes';
+import { InlinePattern as InlinePatternType, InlinePatternMatch, InlinePatternSet } from 'tinymce/core/textpatterns/core/PatternTypes';
 import { PathRange } from 'tinymce/core/textpatterns/utils/PathRange';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
 
@@ -17,285 +17,423 @@ interface ExpectedPatternMatch {
   readonly endRng: PathRange;
 }
 
+const getInlinePatternSetFor = (hook: TinyHooks.Hook<Editor>) => Thunk.cached((): InlinePatternSet => {
+  const editor = hook.editor();
+  const rawPatterns = Options.getTextPatterns(editor);
+  const dynamicPatternsLookup = Options.getTextPatternsLookup(editor);
+  const { blockPatterns, ...inlinePatternSet } = Pattern.createPatternSet(
+    Pattern.fromRawPatterns(rawPatterns),
+    dynamicPatternsLookup
+  );
+  return inlinePatternSet;
+});
+
+const getInlinePattern = (editor: Editor, patternSet: InlinePatternSet, space: boolean = false) =>
+  InlinePattern.findPatterns(editor, patternSet, space);
+
+const assertPatterns = (actualMatches: InlinePatternMatch[], expectedMatches: ExpectedPatternMatch[]) => {
+  assert.lengthOf(actualMatches, expectedMatches.length, 'Pattern count does not match');
+  for (let i = 0; i < expectedMatches.length; i++) {
+    const expected = expectedMatches[i];
+    const actual = actualMatches[i];
+    const pattern = actual.pattern;
+    Obj.each(expected.pattern, (value, key) => {
+      if (Obj.has<any, string>(pattern, key)) {
+        assert.deepEqual(pattern[key], value, 'Pattern ' + (i + 1) + ' property `' + key + '` is not equal');
+      } else {
+        assert.fail('Pattern ' + (i + 1) + ' property `' + key + '` is missing');
+      }
+    });
+    // prepend a 0 because we always add a root node
+    assert.deepEqual(actual.startRng.start, [ 0 ].concat(expected.startRng.start), 'start range - start path does not match');
+    assert.deepEqual(actual.startRng.end, [ 0 ].concat(expected.startRng.end), 'start range - end path does not match');
+    assert.deepEqual(actual.endRng.start, [ 0 ].concat(expected.endRng.start), 'end range - start path does not match');
+    assert.deepEqual(actual.endRng.end, [ 0 ].concat(expected.endRng.end), 'end range - end path does not match');
+  }
+};
+
+const setContentAndCursor = (editor: Editor, content: string, elementPath: number[], offset: number) => {
+  editor.setContent(`<div>${content}</div>`, { format: 'raw' });
+  TinySelections.setCursor(editor, [ 0 ].concat(elementPath), offset);
+};
+
+const setContentAndSelection = (editor: Editor, content: string, startPath: number[], soffset: number, finishPath: number[], foffset: number) => {
+  editor.setContent(`<div>${content}</div>`, { format: 'raw' });
+  TinySelections.setSelection(editor, [ 0 ].concat(startPath), soffset, [ 0 ].concat(finishPath), foffset);
+};
+
+const assertSimpleMatch = (actualMatches: InlinePatternMatch[], matchStart: string, matchEnd: string, formats: string[], startRng: PathRange, endRng: PathRange) =>
+  assertPatterns(actualMatches, [{ pattern: { start: matchStart, end: matchEnd, format: formats }, startRng, endRng }]);
+
 describe('browser.tinymce.core.textpatterns.FindInlinePatternTest', () => {
-  const hook = TinyHooks.bddSetupLight<Editor>({
-    plugins: 'lists',
-    text_patterns: [
-      { start: '*', end: '*', format: 'italic' },
-      { start: '**', end: '**', format: 'bold' },
-      { start: '***', end: '***', format: [ 'bold', 'italic' ] }, // due to priority this will never be used
-      { start: '', end: 'brb', cmd: 'mceInsertContent', value: 'be right back' },
-      { start: 'irl', end: '', cmd: 'mceInsertContent', value: 'in real life' },
-      { start: 'asap', replacement: 'as soon as possible' }
-    ],
-    base_url: '/project/tinymce/js/tinymce'
-  }, [ ListsPlugin ]);
 
-  const inlinePatterns = Thunk.cached(() => {
-    const rawPatterns = Options.getTextPatterns(hook.editor());
-    return Pattern.createPatternSet(Pattern.fromRawPatterns(rawPatterns)).inlinePatterns;
-  });
+  describe('no text_patterns_lookup', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      plugins: 'lists',
+      text_patterns: [
+        { start: '*', end: '*', format: 'italic' },
+        { start: '**', end: '**', format: 'bold' },
+        { start: '***', end: '***', format: [ 'bold', 'italic' ] }, // due to priority this will never be used
+        { start: '', end: 'brb', cmd: 'mceInsertContent', value: 'be right back' },
+        { start: 'irl', end: '', cmd: 'mceInsertContent', value: 'in real life' },
+        { start: 'asap', replacement: 'as soon as possible' }
+      ],
+      base_url: '/project/tinymce/js/tinymce'
+    }, [ ListsPlugin ]);
 
-  const getInlinePattern = (editor: Editor, patterns: InlinePatternType[], space: boolean = false) =>
-    InlinePattern.findPatterns(editor, patterns, space);
+    const getInlinePatternSet = getInlinePatternSetFor(hook);
 
-  const assertPatterns = (actualMatches: InlinePatternMatch[], expectedMatches: ExpectedPatternMatch[]) => {
-    assert.lengthOf(actualMatches, expectedMatches.length, 'Pattern count does not match');
-    for (let i = 0; i < expectedMatches.length; i++) {
-      const expected = expectedMatches[i];
-      const actual = actualMatches[i];
-      const pattern = actual.pattern;
-      Obj.each(expected.pattern, (value, key) => {
-        if (Obj.has<any, string>(pattern, key)) {
-          assert.deepEqual(pattern[key], value, 'Pattern ' + (i + 1) + ' property `' + key + '` is not equal');
-        } else {
-          assert.fail('Pattern ' + (i + 1) + ' property `' + key + '` is missing');
-        }
+    it('TBA: Run on text without pattern returns no matching patterns', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, 'text', [ 0 ], 4);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertPatterns(matches, []);
+    });
+
+    it('TBA: Run on range that is not on a text node without pattern returns no match', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, '<p>text</p>', [ 0 ], 1);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertPatterns(matches, []);
+    });
+
+    it('TBA: Run on range that is not on a text node with pattern returns a match', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, '<p>*a*</p>', [ 0 ], 1);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertSimpleMatch(matches, '*', '*', [ 'italic' ], { start: [ 0, 0, 0 ], end: [ 0, 0, 1 ] }, { start: [ 0, 0, 2 ], end: [ 0, 0, 3 ] });
+    });
+
+    it('TBA: inline * pattern with no gap to matching token returns no match', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, '*x***', [ 0 ], 5);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertPatterns(matches, []);
+    });
+
+    it('TBA: inline * with uncollapsed range returns no match', () => {
+      const editor = hook.editor();
+      setContentAndSelection(editor, '*x*&nbsp;', [ 0 ], 3, [ 0 ], 4);
+      const matches = getInlinePattern(editor, getInlinePatternSet(), true);
+      assertPatterns(matches, []);
+    });
+
+    it('TBA: inline * pattern end without content returns no match', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, '**', [ 0 ], 2);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertPatterns(matches, []);
+    });
+
+    it('TBA: inline * and ** end pattern without start pattern no match', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, '***', [ 0 ], 3);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertPatterns(matches, []);
+    });
+
+    it('TBA: cursor in middle of pattern returns no match', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, '*** x***', [ 0 ], 4);
+      const matches = getInlinePattern(editor, getInlinePatternSet(), true);
+      assertPatterns(matches, []);
+    });
+
+    it('TBA: inline * without content before or after', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, '*x*', [ 0 ], 3);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertSimpleMatch(matches, '*', '*', [ 'italic' ], { start: [ 0, 0 ], end: [ 0, 1 ] }, { start: [ 0, 2 ], end: [ 0, 3 ] });
+    });
+
+    it('TBA: inline * with content before', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, 'a *x*', [ 0 ], 5);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertSimpleMatch(matches, '*', '*', [ 'italic' ], { start: [ 0, 2 ], end: [ 0, 3 ] }, { start: [ 0, 4 ], end: [ 0, 5 ] });
+    });
+
+    it('TBA: inline * with content before and after', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, 'a *x* b', [ 0 ], 5);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertSimpleMatch(matches, '*', '*', [ 'italic' ], { start: [ 0, 2 ], end: [ 0, 3 ] }, { start: [ 0, 4 ], end: [ 0, 5 ] });
+    });
+
+    it('TBA: inline * with content before and after, with space', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, '***x* **', [ 0 ], 6);
+      const matches = getInlinePattern(editor, getInlinePatternSet(), true);
+      assertSimpleMatch(matches, '*', '*', [ 'italic' ], { start: [ 0, 2 ], end: [ 0, 3 ] }, { start: [ 0, 4 ], end: [ 0, 5 ] });
+    });
+
+    it('TBA: inline ** without content before or after', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, '**x**', [ 0 ], 5);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 0 ], end: [ 0, 2 ] }, { start: [ 0, 3 ], end: [ 0, 5 ] });
+    });
+
+    it('TBA: inline ** with content before', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, 'a **x**', [ 0 ], 7);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 2 ], end: [ 0, 4 ] }, { start: [ 0, 5 ], end: [ 0, 7 ] });
+    });
+
+    it('TBA: inline ** with content before and after', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, 'a **x** b', [ 0 ], 7);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 2 ], end: [ 0, 4 ] }, { start: [ 0, 5 ], end: [ 0, 7 ] });
+    });
+
+    it('TBA: inline * and ** without content before or after', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, '***x***', [ 0 ], 7);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertPatterns(matches, [
+        { pattern: { start: '**', end: '**', format: [ 'bold' ] }, startRng: { start: [ 0, 1 ], end: [ 0, 3 ] }, endRng: { start: [ 0, 4 ], end: [ 0, 6 ] }},
+        { pattern: { start: '*', end: '*', format: [ 'italic' ] }, startRng: { start: [ 0, 0 ], end: [ 0, 1 ] }, endRng: { start: [ 0, 6 ], end: [ 0, 7 ] }}
+      ]);
+    });
+
+    it('TBA: inline * and ** with content before', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, 'a ***x***', [ 0 ], 9);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertPatterns(matches, [
+        { pattern: { start: '**', end: '**', format: [ 'bold' ] }, startRng: { start: [ 0, 3 ], end: [ 0, 5 ] }, endRng: { start: [ 0, 6 ], end: [ 0, 8 ] }},
+        { pattern: { start: '*', end: '*', format: [ 'italic' ] }, startRng: { start: [ 0, 2 ], end: [ 0, 3 ] }, endRng: { start: [ 0, 8 ], end: [ 0, 9 ] }}
+      ]);
+    });
+
+    it('TBA: inline * and ** with content before and after', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, 'a ***x*** b', [ 0 ], 9);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertPatterns(matches, [
+        { pattern: { start: '**', end: '**', format: [ 'bold' ] }, startRng: { start: [ 0, 3 ], end: [ 0, 5 ] }, endRng: { start: [ 0, 6 ], end: [ 0, 8 ] }},
+        { pattern: { start: '*', end: '*', format: [ 'italic' ] }, startRng: { start: [ 0, 2 ], end: [ 0, 3 ] }, endRng: { start: [ 0, 8 ], end: [ 0, 9 ] }}
+      ]);
+    });
+
+    describe('with just a single ** -> bold inline-format pattern', () => {
+      const inlinePatternSet: InlinePatternSet = {
+        inlinePatterns: [
+          { type: 'inline-format', start: '**', end: '**', format: [ 'bold' ] }
+        ],
+        dynamicPatternsLookup: () => []
+      };
+
+      it('TBA: force only ** pattern and test return on not existing *** pattern', () => {
+        const editor = hook.editor();
+        setContentAndCursor(editor, '***x***', [ 0 ], 7);
+        const matches = getInlinePattern(editor, inlinePatternSet);
+        assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 1 ], end: [ 0, 3 ] }, { start: [ 0, 5 ], end: [ 0, 7 ] });
       });
-      // prepend a 0 because we always add a root node
-      assert.deepEqual(actual.startRng.start, [ 0 ].concat(expected.startRng.start), 'start range - start path does not match');
-      assert.deepEqual(actual.startRng.end, [ 0 ].concat(expected.startRng.end), 'start range - end path does not match');
-      assert.deepEqual(actual.endRng.start, [ 0 ].concat(expected.endRng.start), 'end range - start path does not match');
-      assert.deepEqual(actual.endRng.end, [ 0 ].concat(expected.endRng.end), 'end range - end path does not match');
-    }
-  };
 
-  const assertSimpleMatch = (actualMatches: InlinePatternMatch[], matchStart: string, matchEnd: string, formats: string[], startRng: PathRange, endRng: PathRange) =>
-    assertPatterns(actualMatches, [{ pattern: { start: matchStart, end: matchEnd, format: formats }, startRng, endRng }]);
+      it('TBA: force only ** pattern with leading content and test return on not existing *** pattern', () => {
+        const editor = hook.editor();
+        setContentAndCursor(editor, 'y ***x***', [ 0 ], 9);
+        const matches = getInlinePattern(editor, inlinePatternSet);
+        assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 3 ], end: [ 0, 5 ] }, { start: [ 0, 7 ], end: [ 0, 9 ] });
+      });
 
-  const setContentAndCursor = (editor: Editor, content: string, elementPath: number[], offset: number) => {
-    editor.setContent(`<div>${content}</div>`, { format: 'raw' });
-    TinySelections.setCursor(editor, [ 0 ].concat(elementPath), offset);
-  };
+      it('TBA: force only ** pattern with trailing ** text and test return on not existing *** pattern', () => {
+        const editor = hook.editor();
+        setContentAndCursor(editor, 'y ***x*** **', [ 0 ], 9);
+        const matches = getInlinePattern(editor, inlinePatternSet);
+        assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 3 ], end: [ 0, 5 ] }, { start: [ 0, 7 ], end: [ 0, 9 ] });
+      });
+    });
 
-  const setContentAndSelection = (editor: Editor, content: string, startPath: number[], soffset: number, finishPath: number[], foffset: number) => {
-    editor.setContent(`<div>${content}</div>`, { format: 'raw' });
-    TinySelections.setSelection(editor, [ 0 ].concat(startPath), soffset, [ 0 ].concat(finishPath), foffset);
-  };
+    it('TBA: Check match when input pattern has an empty start value', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, 'brb', [ 0 ], 3);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertPatterns(matches, [
+        { pattern: { start: '', end: 'brb', value: 'be right back' }, startRng: { start: [ 0, 0 ], end: [ 0, 3 ] }, endRng: { start: [ 0, 0 ], end: [ 0, 3 ] }}
+      ]);
+    });
 
-  it('TBA: Run on text without pattern returns no matching patterns', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, 'text', [ 0 ], 4);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertPatterns(matches, []);
+    it('TBA: Check match when input pattern has an empty end value', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, 'irl', [ 0 ], 3);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertPatterns(matches, [
+        { pattern: { start: '', end: 'irl', value: 'in real life' }, startRng: { start: [ 0, 0 ], end: [ 0, 3 ] }, endRng: { start: [ 0, 0 ], end: [ 0, 3 ] }}
+      ]);
+    });
+
+    it('TBA: Check match when input pattern uses replacement syntax', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, 'asap', [ 0 ], 4);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertPatterns(matches, [
+        { pattern: { start: '', end: 'asap', value: 'as soon as possible' }, startRng: { start: [ 0, 0 ], end: [ 0, 4 ] }, endRng: { start: [ 0, 0 ], end: [ 0, 4 ] }}
+      ]);
+    });
+
+    it('TBA: Check nested match', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, 'Bring those reports ***asap***!', [ 0 ], 31);
+      const matches = getInlinePattern(editor, getInlinePatternSet(), true);
+      assertPatterns(matches, [
+        { pattern: { start: '', end: 'asap', value: 'as soon as possible' }, startRng: { start: [ 0, 23 ], end: [ 0, 27 ] }, endRng: { start: [ 0, 23 ], end: [ 0, 27 ] }},
+        { pattern: { start: '**', end: '**', format: [ 'bold' ] }, startRng: { start: [ 0, 21 ], end: [ 0, 23 ] }, endRng: { start: [ 0, 27 ], end: [ 0, 29 ] }},
+        { pattern: { start: '*', end: '*', format: [ 'italic' ] }, startRng: { start: [ 0, 20 ], end: [ 0, 21 ] }, endRng: { start: [ 0, 29 ], end: [ 0, 30 ] }}
+      ]);
+    });
+
+    it('TBA: Check that a pattern will be matched across tag boundaries', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, '<span>*text</span><span>*</span>', [ 1, 0 ], 1);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertPatterns(matches, [
+        { pattern: { start: '*', end: '*', format: [ 'italic' ] }, startRng: { start: [ 0, 0, 0 ], end: [ 0, 0, 1 ] }, endRng: { start: [ 1, 0, 0 ], end: [ 1, 0, 1 ] }}
+      ]);
+    });
+
+    it('TBA: Check that a pattern will be matched across tag boundaries 2', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, '<span>**text*</span><span>*</span>', [ 1, 0 ], 1);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertPatterns(matches, [
+        { pattern: { start: '**', end: '**', format: [ 'bold' ] }, startRng: { start: [ 0, 0, 0 ], end: [ 0, 0, 2 ] }, endRng: { start: [ 0, 0, 6 ], end: [ 1, 0, 1 ] }}
+      ]);
+    });
+
+    it('TBA: Check that a pattern will not be matched across block boundaries', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, '<p>*text</p><p>*</p>', [ 1, 0 ], 1);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertPatterns(matches, []);
+    });
+
+    it('TBA: Check that a pattern will not be matched across block boundaries 2', () => {
+      const editor = hook.editor();
+      setContentAndCursor(editor, '<p>*text</p><span>*</span>', [ 1, 0 ], 1);
+      const matches = getInlinePattern(editor, getInlinePatternSet());
+      assertPatterns(matches, []);
+    });
   });
 
-  it('TBA: Run on range that is not on a text node without pattern returns no match', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, '<p>text</p>', [ 0 ], 1);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertPatterns(matches, []);
-  });
+  describe('with text_patterns_lookup', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      text_patterns: [
+        { start: '*', end: '*', format: 'italic' }
+      ],
+      text_patterns_lookup: (ctx) => {
+        const parentTag = ctx.block.nodeName.toLowerCase();
+        if (parentTag === 'pre') {
+          return [
+            {
+              start: '`', end: '`', format: 'code'
+            }
+          ];
+        } else if (parentTag === 'p') {
+          return [
+            {
+              start: '*', end: '*', format: 'bold'
+            }
+          ]
+        } else if (parentTag === 'div' && ctx.text === 'replace-me') {
+          return [
+            {
+              start: 'me', replacement: 'you'
+            }
+          ];
+        } else {
+          return [ ];
+        }
+      },
+      base_url: '/project/tinymce/js/tinymce'
+    }, []);
 
-  it('TBA: Run on range that is not on a text node with pattern returns a match', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, '<p>*a*</p>', [ 0 ], 1);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertSimpleMatch(matches, '*', '*', [ 'italic' ], { start: [ 0, 0, 0 ], end: [ 0, 0, 1 ] }, { start: [ 0, 0, 2 ], end: [ 0, 0, 3 ] });
-  });
+    const getInlinePatternSet = getInlinePatternSetFor(hook);
 
-  it('TBA: inline * pattern with no gap to matching token returns no match', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, '*x***', [ 0 ], 5);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertPatterns(matches, []);
-  });
+    it('TBA: Code Pattern only runs on with code blocks', () => {
+      const editor = hook.editor();
+      editor.setContent('<pre>`const`</pre>');
+      TinySelections.setCursor(editor, [ 0, 0 ], '`const`'.length);
+      const matches = getInlinePattern(editor, getInlinePatternSet(), false);
+      assertSimpleMatch(
+        matches, '`', '`', [ 'code' ],
+        // assertCall prepends an 0
+        { start: [ 0, 0 ], end: [ 0, '`'.length ] },
+        { start: [ 0, '`const'.length ], end: [ 0, '`const`'.length ] }
+      );
+    });
 
-  it('TBA: inline * with uncollapsed range returns no match', () => {
-    const editor = hook.editor();
-    setContentAndSelection(editor, '*x*&nbsp;', [ 0 ], 3, [ 0 ], 4);
-    const matches = getInlinePattern(editor, inlinePatterns(), true);
-    assertPatterns(matches, []);
-  });
+    it('TBA: Code Pattern does not run with paragraph blocks', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>`const`</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], '`const`'.length);
+      const matches = getInlinePattern(editor, getInlinePatternSet(), false);
+      assertPatterns(matches, []);
+    });
 
-  it('TBA: inline * pattern end without content returns no match', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, '**', [ 0 ], 2);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertPatterns(matches, []);
-  });
+    it('TBA: Inline patterns still work when lookup defined', () => {
+      const editor = hook.editor();
+      editor.setContent('<pre>*const*</pre>');
+      TinySelections.setCursor(editor, [ 0, 0 ], '*const*'.length);
+      const matches = getInlinePattern(editor, getInlinePatternSet(), false);
+      assertSimpleMatch(
+        matches, '*', '*', [ 'italic' ],
+        // assertCall prepends an 0
+        { start: [ 0, 0 ], end: [ 0, '`'.length ] },
+        { start: [ 0, '*const'.length ], end: [ 0, '*const*'.length ] }
+      );
+    });
 
-  it('TBA: inline * and ** end pattern without start pattern no match', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, '***', [ 0 ], 3);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertPatterns(matches, []);
-  });
+    it('TBA: Inline pattern lookups take precedence over inline patterns', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>*const*</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], '*const*'.length);
+      const matches = getInlinePattern(editor, getInlinePatternSet(), false);
+      assertSimpleMatch(
+        matches, '*', '*', [ 'bold' ],
+        // assertCall prepends an 0
+        { start: [ 0, 0 ], end: [ 0, '`'.length ] },
+        { start: [ 0, '*const'.length ], end: [ 0, '*const*'.length ] }
+      );
+    });
 
-  it('TBA: cursor in middle of pattern returns no match', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, '*** x***', [ 0 ], 4);
-    const matches = getInlinePattern(editor, inlinePatterns(), true);
-    assertPatterns(matches, []);
-  });
+    it('TBA: Inline pattern lookups based on non-matching context text', () => {
+      const editor = hook.editor();
+      editor.setContent('<div>keep-me</div>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 'keep-me'.length);
+      const matches = getInlinePattern(editor, getInlinePatternSet(), false);
+      assertPatterns(matches, []);
+    });
 
-  it('TBA: inline * without content before or after', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, '*x*', [ 0 ], 3);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertSimpleMatch(matches, '*', '*', [ 'italic' ], { start: [ 0, 0 ], end: [ 0, 1 ] }, { start: [ 0, 2 ], end: [ 0, 3 ] });
-  });
-
-  it('TBA: inline * with content before', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, 'a *x*', [ 0 ], 5);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertSimpleMatch(matches, '*', '*', [ 'italic' ], { start: [ 0, 2 ], end: [ 0, 3 ] }, { start: [ 0, 4 ], end: [ 0, 5 ] });
-  });
-
-  it('TBA: inline * with content before and after', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, 'a *x* b', [ 0 ], 5);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertSimpleMatch(matches, '*', '*', [ 'italic' ], { start: [ 0, 2 ], end: [ 0, 3 ] }, { start: [ 0, 4 ], end: [ 0, 5 ] });
-  });
-
-  it('TBA: inline * with content before and after, with space', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, '***x* **', [ 0 ], 6);
-    const matches = getInlinePattern(editor, inlinePatterns(), true);
-    assertSimpleMatch(matches, '*', '*', [ 'italic' ], { start: [ 0, 2 ], end: [ 0, 3 ] }, { start: [ 0, 4 ], end: [ 0, 5 ] });
-  });
-
-  it('TBA: inline ** without content before or after', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, '**x**', [ 0 ], 5);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 0 ], end: [ 0, 2 ] }, { start: [ 0, 3 ], end: [ 0, 5 ] });
-  });
-
-  it('TBA: inline ** with content before', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, 'a **x**', [ 0 ], 7);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 2 ], end: [ 0, 4 ] }, { start: [ 0, 5 ], end: [ 0, 7 ] });
-  });
-
-  it('TBA: inline ** with content before and after', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, 'a **x** b', [ 0 ], 7);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 2 ], end: [ 0, 4 ] }, { start: [ 0, 5 ], end: [ 0, 7 ] });
-  });
-
-  it('TBA: inline * and ** without content before or after', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, '***x***', [ 0 ], 7);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertPatterns(matches, [
-      { pattern: { start: '**', end: '**', format: [ 'bold' ] }, startRng: { start: [ 0, 1 ], end: [ 0, 3 ] }, endRng: { start: [ 0, 4 ], end: [ 0, 6 ] }},
-      { pattern: { start: '*', end: '*', format: [ 'italic' ] }, startRng: { start: [ 0, 0 ], end: [ 0, 1 ] }, endRng: { start: [ 0, 6 ], end: [ 0, 7 ] }}
-    ]);
-  });
-
-  it('TBA: inline * and ** with content before', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, 'a ***x***', [ 0 ], 9);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertPatterns(matches, [
-      { pattern: { start: '**', end: '**', format: [ 'bold' ] }, startRng: { start: [ 0, 3 ], end: [ 0, 5 ] }, endRng: { start: [ 0, 6 ], end: [ 0, 8 ] }},
-      { pattern: { start: '*', end: '*', format: [ 'italic' ] }, startRng: { start: [ 0, 2 ], end: [ 0, 3 ] }, endRng: { start: [ 0, 8 ], end: [ 0, 9 ] }}
-    ]);
-  });
-
-  it('TBA: inline * and ** with content before and after', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, 'a ***x*** b', [ 0 ], 9);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertPatterns(matches, [
-      { pattern: { start: '**', end: '**', format: [ 'bold' ] }, startRng: { start: [ 0, 3 ], end: [ 0, 5 ] }, endRng: { start: [ 0, 6 ], end: [ 0, 8 ] }},
-      { pattern: { start: '*', end: '*', format: [ 'italic' ] }, startRng: { start: [ 0, 2 ], end: [ 0, 3 ] }, endRng: { start: [ 0, 8 ], end: [ 0, 9 ] }}
-    ]);
-  });
-
-  it('TBA: force only ** pattern and test return on not existing *** pattern', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, '***x***', [ 0 ], 7);
-    const matches = getInlinePattern(editor, [{ type: 'inline-format', start: '**', end: '**', format: [ 'bold' ] }]);
-    assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 1 ], end: [ 0, 3 ] }, { start: [ 0, 5 ], end: [ 0, 7 ] });
-  });
-
-  it('TBA: force only ** pattern with leading content and test return on not existing *** pattern', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, 'y ***x***', [ 0 ], 9);
-    const matches = getInlinePattern(editor, [{ type: 'inline-format', start: '**', end: '**', format: [ 'bold' ] }]);
-    assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 3 ], end: [ 0, 5 ] }, { start: [ 0, 7 ], end: [ 0, 9 ] });
-  });
-
-  it('TBA: force only ** pattern with trailing ** text and test return on not existing *** pattern', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, 'y ***x*** **', [ 0 ], 9);
-    const matches = getInlinePattern(editor, [{ type: 'inline-format', start: '**', end: '**', format: [ 'bold' ] }]);
-    assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 3 ], end: [ 0, 5 ] }, { start: [ 0, 7 ], end: [ 0, 9 ] });
-  });
-
-  it('TBA: Check match when input pattern has an empty start value', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, 'brb', [ 0 ], 3);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertPatterns(matches, [
-      { pattern: { start: '', end: 'brb', value: 'be right back' }, startRng: { start: [ 0, 0 ], end: [ 0, 3 ] }, endRng: { start: [ 0, 0 ], end: [ 0, 3 ] }}
-    ]);
-  });
-
-  it('TBA: Check match when input pattern has an empty end value', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, 'irl', [ 0 ], 3);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertPatterns(matches, [
-      { pattern: { start: '', end: 'irl', value: 'in real life' }, startRng: { start: [ 0, 0 ], end: [ 0, 3 ] }, endRng: { start: [ 0, 0 ], end: [ 0, 3 ] }}
-    ]);
-  });
-
-  it('TBA: Check match when input pattern uses replacement syntax', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, 'asap', [ 0 ], 4);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertPatterns(matches, [
-      { pattern: { start: '', end: 'asap', value: 'as soon as possible' }, startRng: { start: [ 0, 0 ], end: [ 0, 4 ] }, endRng: { start: [ 0, 0 ], end: [ 0, 4 ] }}
-    ]);
-  });
-
-  it('TBA: Check nested match', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, 'Bring those reports ***asap***!', [ 0 ], 31);
-    const matches = getInlinePattern(editor, inlinePatterns(), true);
-    assertPatterns(matches, [
-      { pattern: { start: '', end: 'asap', value: 'as soon as possible' }, startRng: { start: [ 0, 23 ], end: [ 0, 27 ] }, endRng: { start: [ 0, 23 ], end: [ 0, 27 ] }},
-      { pattern: { start: '**', end: '**', format: [ 'bold' ] }, startRng: { start: [ 0, 21 ], end: [ 0, 23 ] }, endRng: { start: [ 0, 27 ], end: [ 0, 29 ] }},
-      { pattern: { start: '*', end: '*', format: [ 'italic' ] }, startRng: { start: [ 0, 20 ], end: [ 0, 21 ] }, endRng: { start: [ 0, 29 ], end: [ 0, 30 ] }}
-    ]);
-  });
-
-  it('TBA: Check that a pattern will be matched across tag boundaries', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, '<span>*text</span><span>*</span>', [ 1, 0 ], 1);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertPatterns(matches, [
-      { pattern: { start: '*', end: '*', format: [ 'italic' ] }, startRng: { start: [ 0, 0, 0 ], end: [ 0, 0, 1 ] }, endRng: { start: [ 1, 0, 0 ], end: [ 1, 0, 1 ] }}
-    ]);
-  });
-
-  it('TBA: Check that a pattern will be matched across tag boundaries 2', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, '<span>**text*</span><span>*</span>', [ 1, 0 ], 1);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertPatterns(matches, [
-      { pattern: { start: '**', end: '**', format: [ 'bold' ] }, startRng: { start: [ 0, 0, 0 ], end: [ 0, 0, 2 ] }, endRng: { start: [ 0, 0, 6 ], end: [ 1, 0, 1 ] }}
-    ]);
-  });
-
-  it('TBA: Check that a pattern will not be matched across block boundaries', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, '<p>*text</p><p>*</p>', [ 1, 0 ], 1);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertPatterns(matches, []);
-  });
-
-  it('TBA: Check that a pattern will not be matched across block boundaries 2', () => {
-    const editor = hook.editor();
-    setContentAndCursor(editor, '<p>*text</p><span>*</span>', [ 1, 0 ], 1);
-    const matches = getInlinePattern(editor, inlinePatterns());
-    assertPatterns(matches, []);
+    it('TBA: Inline pattern lookups based on matching context text', () => {
+      const editor = hook.editor();
+      editor.setContent('<div>replace-me</div>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 'replace-me'.length);
+      const matches = getInlinePattern(editor, getInlinePatternSet(), false);
+      assertPatterns(
+        matches,
+        [
+          {
+            // assertCall prepends an 0
+            startRng: {
+              start: [ 0, 'replace-'.length ],
+              end: [ 0, 'replace-me'.length ]
+            },
+            endRng: {
+              start: [ 0, 'replace-'.length ],
+              end: [ 0, 'replace-me'.length ]
+            },
+            pattern: {
+              type: 'inline-command',
+              cmd: 'mceInsertContent',
+              value: 'you'
+            }
+          }
+        ]
+      )
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/module/test/TextPatternsUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/TextPatternsUtils.ts
@@ -1,8 +1,11 @@
 import { ApproxStructure, Keys, StructAssert } from '@ephox/agar';
-import { Unicode } from '@ephox/katamari';
-import { TinyContentActions, TinySelections } from '@ephox/wrap-mcagar';
+import { Thunk, Unicode } from '@ephox/katamari';
+import { TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
+import * as Options from 'tinymce/core/api/Options';
+import * as Pattern from 'tinymce/core/textpatterns/core/Pattern';
+import { PatternSet } from 'tinymce/core/textpatterns/core/PatternTypes';
 
 const setContentAndFireKeystroke = (key: number) => {
   return (editor: Editor, content: string, offset = content.length, elementPath = [ 0, 0 ], wrapInP = true) => {
@@ -108,6 +111,16 @@ const forcedRootBlockStructHelper = (tag: string, content: string) => {
 
 const setContentAndPressEnter = setContentAndFireKeystroke(Keys.enter());
 
+const getPatternSetFor = (hook: TinyHooks.Hook<Editor>) => Thunk.cached((): PatternSet => {
+  const editor = hook.editor();
+  const rawPatterns = Options.getTextPatterns(editor);
+  const dynamicPatternsLookup = Options.getTextPatternsLookup(editor);
+  return Pattern.createPatternSet(
+    Pattern.fromRawPatterns(rawPatterns),
+    dynamicPatternsLookup
+  );
+});
+
 export {
   setContentAndPressSpace,
   setContentAndPressEnter,
@@ -116,5 +129,6 @@ export {
   inlineBlockStructHelper,
   blockStructHelper,
   forcedRootBlockInlineStructHelper,
-  forcedRootBlockStructHelper
+  forcedRootBlockStructHelper,
+  getPatternSetFor
 };


### PR DESCRIPTION
Related Ticket: TINY-8778: 

Description of Changes:
* Added new option `text_patterns_lookup` which allows prepending additional patterns on the fly. The patterns take precedence over `text_patterns` during the matching process

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
