### PR TITLE
TINY-8873: Fix sidebar toggle button active state when using `sidebar_show` option

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- When a sidebar was opened using the `sidebar_show` option, its associated toggle button was not highlighted #TINY-8873
+
 ## 6.1.0 - 2022-06-29
 
 ### Added

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -89,6 +89,15 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
   Attachment.attachSystem(uiRoot, uiComponents.uiMothership);
 
   editor.on('PostRender', () => {
+    // Set the sidebar before the toolbar and menubar
+    // - each sidebar has an associated toggle toolbar button that needs to check the
+    //   sidebar that is set to determine its active state on setup
+    OuterContainer.setSidebar(
+      outerContainer,
+      rawUiConfig.sidebar,
+      Options.getSidebarShow(editor)
+    );
+
     setToolbar(editor, uiComponents, rawUiConfig, backstage);
     lastToolbarWidth.set(editor.getWin().innerWidth);
 
@@ -96,17 +105,6 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
       outerContainer,
       identifyMenus(editor, rawUiConfig)
     );
-
-    const sidebarShow = Options.getSidebarShow(editor)?.toLowerCase();
-    OuterContainer.setSidebar(
-      outerContainer,
-      rawUiConfig.sidebar,
-      sidebarShow
-    );
-    // Make sure any listeners of ToggleSidebar are notified if sidebar is open
-    if (OuterContainer.whichSidebar(outerContainer) === sidebarShow) {
-      editor.dispatch('ToggleSidebar');
-    }
 
     setupEvents(editor, uiComponents);
   });

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -97,11 +97,16 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
       identifyMenus(editor, rawUiConfig)
     );
 
+    const sidebarShow = Options.getSidebarShow(editor)?.toLowerCase();
     OuterContainer.setSidebar(
       outerContainer,
       rawUiConfig.sidebar,
-      Options.getSidebarShow(editor)
+      sidebarShow
     );
+    // Make sure any listeners of ToggleSidebar are notified if sidebar is open
+    if (OuterContainer.whichSidebar(outerContainer) === sidebarShow) {
+      editor.dispatch('ToggleSidebar');
+    }
 
     setupEvents(editor, uiComponents);
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
@@ -30,6 +30,7 @@ const setup = (editor: Editor) => {
         buttonApi.setActive(isActive());
       },
       onSetup: (buttonApi) => {
+        buttonApi.setActive(isActive());
         const handleToggle = () => buttonApi.setActive(isActive());
         editor.on('ToggleSidebar', handleToggle);
         return () => {


### PR DESCRIPTION
Related Ticket: TINY-8873

Description of Changes:
* Make sure the associated toolbar toggle button is highlighted if the sidebar is opened using the `sidebar_show` option
	* The associated toolbar toggle button listens to the `ToggleSidebar` event [here ](https://github.com/tinymce/tinymce/blob/c3b6572e2d5a42f6b4a17bfe4d565bea3f5c85a0/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts#L34) so utilising this for the change

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set

GitHub issues (if applicable):
