### PR TITLE
TINY-8896: Fixed a regression in the autolink conversion logic

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - When a sidebar was opened using the `sidebar_show` option, its associated toggle button was not highlighted #TINY-8873
+- The `autolink` plugin when converting a URL to a link did not fire an `ExecCommand` event, nor did create an undo level #TINY-8896
 
 ## 6.1.0 - 2022-06-29
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - When a sidebar was opened using the `sidebar_show` option, its associated toggle button was not highlighted #TINY-8873
-- The `autolink` plugin when converting a URL to a link did not fire an `ExecCommand` event, nor did create an undo level #TINY-8896
+- The `autolink` plugin when converting a URL to a link did not fire an `ExecCommand` event, nor did it create an undo level #TINY-8896
 
 ## 6.1.0 - 2022-06-29
 

--- a/modules/tinymce/src/plugins/autolink/main/ts/core/Keys.ts
+++ b/modules/tinymce/src/plugins/autolink/main/ts/core/Keys.ts
@@ -209,7 +209,7 @@ const handleEnter = (editor: Editor, e: EditorEvent<KeyboardEvent>): void => {
     // If we have a match then we need to take over the enter behaviour to ensure the undo stack
     // allows undoing just the URL change without undoing the enter
     e.preventDefault();
-    editor.execCommand('mceInsertNewLine');
+    editor.execCommand('mceInsertNewLine', false, e);
     convertToLink(editor, result);
   }
 };

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
@@ -5,6 +5,8 @@ import { assert } from 'chai';
 import fc from 'fast-check';
 
 import Editor from 'tinymce/core/api/Editor';
+import { ExecCommandEvent } from 'tinymce/core/api/EventTypes';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import Plugin from 'tinymce/plugins/autolink/Plugin';
 
 import * as KeyUtils from '../module/test/KeyUtils';
@@ -186,5 +188,25 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     assert.equal(typeUrl(editor, '(https://www.domain.com,'), '<p>(<a href="https://www.domain.com">https://www.domain.com</a>,&nbsp;</p>');
     assert.equal(typeUrl(editor, '[https://www.domain.com,'), '<p>[<a href="https://www.domain.com">https://www.domain.com</a>,&nbsp;</p>');
     assert.equal(typeUrl(editor, '{https://www.domain.com'), '<p>{<a href="https://www.domain.com">https://www.domain.com</a>&nbsp;</p>');
+  });
+
+  it('TINY-8896: should fire a createlink ExecCommand event when converting a URL to a link', () => {
+    const editor = hook.editor();
+    const events = [];
+    const logEvent = (e: EditorEvent<ExecCommandEvent>) => {
+      events.push(`${e.type.toLowerCase()}-${e.command.toLowerCase()}`);
+    };
+    editor.on('BeforeExecCommand ExecCommand', logEvent);
+    typeUrl(editor, 'http://www.domain.com');
+    assert.deepEqual(events, [ 'beforeexeccommand-createlink', 'execcommand-createlink' ], 'The createlink ExecCommand events should have fired');
+    editor.off('BeforeExecCommand ExecCommand', logEvent);
+  });
+
+  it('TINY-8896: should add an undo level for the link conversion', () => {
+    const editor = hook.editor();
+    assertIsLink(editor, 'http://www.domain.com', 'http://www.domain.com');
+    editor.undoManager.undo();
+    TinyAssertions.assertContent(editor, '<p>http://www.domain.com&nbsp;</p>');
+    TinyAssertions.assertCursor(editor, [ 0, 0 ], 'http://www.domain.com\u00a0'.length);
   });
 });

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
@@ -205,8 +205,21 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
   it('TINY-8896: should add an undo level for the link conversion', () => {
     const editor = hook.editor();
     assertIsLink(editor, 'http://www.domain.com', 'http://www.domain.com');
+    TinyAssertions.assertCursor(editor, [ 0 ], 2);
     editor.undoManager.undo();
     TinyAssertions.assertContent(editor, '<p>http://www.domain.com&nbsp;</p>');
     TinyAssertions.assertCursor(editor, [ 0, 0 ], 'http://www.domain.com\u00a0'.length);
+
+    typeAnEclipsedURL(editor, 'http://www.domain.com', 'http://www.domain.com');
+    TinyAssertions.assertCursor(editor, [ 0 ], 3);
+    editor.undoManager.undo();
+    TinyAssertions.assertContent(editor, '<p>(http://www.domain.com)</p>');
+    TinyAssertions.assertCursor(editor, [ 0, 0 ], '(http://www.domain.com)'.length);
+
+    typeNewlineURL(editor, 'http://www.domain.com', 'http://www.domain.com');
+    TinyAssertions.assertCursor(editor, [ 1 ], 0);
+    editor.undoManager.undo();
+    TinyAssertions.assertContent(editor, '<p>http://www.domain.com</p><p>&nbsp;</p>');
+    TinyAssertions.assertCursor(editor, [ 1 ], 0);
   });
 });

--- a/modules/tinymce/src/plugins/autolink/test/ts/module/test/KeyUtils.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/module/test/KeyUtils.ts
@@ -9,10 +9,20 @@ const charCodeToKeyCode = (charCode: number): number => {
     '0': 48, '1': 49, '2': 50, '3': 51, '4': 52, '5': 53, '6': 54, '7': 55, '8': 56, '9': 57, 'a': 65, 'b': 66, 'c': 67,
     'd': 68, 'e': 69, 'f': 70, 'g': 71, 'h': 72, 'i': 73, 'j': 74, 'k': 75, 'l': 76, 'm': 77, 'n': 78, 'o': 79, 'p': 80,
     'q': 81, 'r': 82, 's': 83, 't': 84, 'u': 85, 'v': 86, 'w': 87, 'x': 88, 'y': 89, 'z': 90, ' ': 32, ',': 188, '-': 189,
-    '.': 190, '/': 191, '\\': 220, '[': 219, ']': 221, '\'': 222, ';': 186, '=': 187, '(': 57, ')': 48
+    '.': 190, '/': 191, '\\': 220, '[': 219, ']': 221, '{': 219, '}': 221, '\'': 222, ';': 186, '=': 187, '(': 57, ')': 48
   };
 
   return Obj.get(lookup, String.fromCharCode(charCode)).getOr(charCode);
+};
+
+const needsShiftModifier = (charCode: number): boolean => {
+  const lookup: Record<string, boolean> = {
+    '(': true, ')': true, '{': true, '}': true, '+': true, '_': true, ':': true, '"': true,
+    '<': true, '>': true, '?': true, '!': true, '@': true, '#': true, '$': true, '%': true,
+    '^': true, '&': true, '*': true, '|': true
+  };
+
+  return Obj.has(lookup, String.fromCharCode(charCode));
 };
 
 const needsNbsp = (rng: Range, chr: string): boolean => {
@@ -34,8 +44,8 @@ const type = (editor: Editor, chr: string | number | Record<string, number | str
   let evt: Record<string, any>;
   let offset: number;
 
-  const fakeEvent = (target: Node, type: string, evt: Record<string, any>) => {
-    editor.dom.dispatch(target, type, evt);
+  const fakeEvent = (type: string, evt: Record<string, any>) => {
+    return editor.dispatch(type, evt);
   };
 
   // Numeric keyCode
@@ -68,67 +78,75 @@ const type = (editor: Editor, chr: string | number | Record<string, number | str
 
   evt = evt || { keyCode, charCode };
 
-  const startElm = editor.selection.getStart();
-  fakeEvent(startElm, 'keydown', evt);
-  fakeEvent(startElm, 'keypress', { ...evt, keyCode: evt.charCode });
+  if (needsShiftModifier(charCode)) {
+    evt.shiftKey = true;
+  }
 
-  if (!evt.isDefaultPrevented()) {
-    if (keyCode === 8) {
-      const selection: any = (editor.getDoc() as any).selection;
-      if (selection) {
-        const legacyRng: any = selection.createRange();
+  const keydownEvent = fakeEvent('keydown', evt);
+  if (keydownEvent.isDefaultPrevented()) {
+    return;
+  }
 
-        if (legacyRng.text.length === 0) {
-          legacyRng.moveStart('character', -1);
-          legacyRng.select();
-        }
+  const keypressEvent = fakeEvent('keypress', { ...evt, keyCode: evt.charCode });
+  if (keypressEvent.isDefaultPrevented()) {
+    return;
+  }
 
-        legacyRng.execCommand('Delete', false, null);
-      } else {
-        const rng = editor.selection.getRng();
+  if (keyCode === 8) {
+    const selection: any = (editor.getDoc() as any).selection;
+    if (selection) {
+      const legacyRng: any = selection.createRange();
 
-        if (rng.collapsed) {
-          if (rng.startContainer.nodeType === 1) {
-            const nodes = rng.startContainer.childNodes;
-            const lastNode = nodes[nodes.length - 1];
-
-            // If caret is at <p>abc|</p> and after the abc text node then move it to the end of the text node
-            // Expand the range to include the last char <p>ab[c]</p> since IE 11 doesn't delete otherwise
-            if (rng.startOffset >= nodes.length - 1 && lastNode && isText(lastNode) && lastNode.data.length > 0) {
-              rng.setStart(lastNode, lastNode.data.length - 1);
-              rng.setEnd(lastNode, lastNode.data.length);
-              editor.selection.setRng(rng);
-            }
-          } else if (rng.startContainer.nodeType === 3) {
-            // If caret is at <p>abc|</p> and after the abc text node then move it to the end of the text node
-            // Expand the range to include the last char <p>ab[c]</p> since IE 11 doesn't delete otherwise
-            offset = rng.startOffset;
-            if (offset > 0) {
-              rng.setStart(rng.startContainer, offset - 1);
-              rng.setEnd(rng.startContainer, offset);
-              editor.selection.setRng(rng);
-            }
-          }
-        }
-
-        editor.getDoc().execCommand('Delete', false, null);
+      if (legacyRng.text.length === 0) {
+        legacyRng.moveStart('character', -1);
+        legacyRng.select();
       }
-    } else if (typeof chr === 'string') {
+
+      legacyRng.execCommand('Delete', false, null);
+    } else {
       const rng = editor.selection.getRng();
 
-      if (isText(rng.startContainer) && rng.collapsed) {
-        rng.startContainer.insertData(rng.startOffset, needsNbsp(rng, chr) ? Unicode.nbsp : chr);
-        rng.setStart(rng.startContainer, rng.startOffset + 1);
-        rng.collapse(true);
-        editor.selection.setRng(rng);
-      } else {
-        rng.deleteContents();
-        rng.insertNode(editor.getDoc().createTextNode(chr));
+      if (rng.collapsed) {
+        if (rng.startContainer.nodeType === 1) {
+          const nodes = rng.startContainer.childNodes;
+          const lastNode = nodes[nodes.length - 1];
+
+          // If caret is at <p>abc|</p> and after the abc text node then move it to the end of the text node
+          // Expand the range to include the last char <p>ab[c]</p> since IE 11 doesn't delete otherwise
+          if (rng.startOffset >= nodes.length - 1 && lastNode && isText(lastNode) && lastNode.data.length > 0) {
+            rng.setStart(lastNode, lastNode.data.length - 1);
+            rng.setEnd(lastNode, lastNode.data.length);
+            editor.selection.setRng(rng);
+          }
+        } else if (rng.startContainer.nodeType === 3) {
+          // If caret is at <p>abc|</p> and after the abc text node then move it to the end of the text node
+          // Expand the range to include the last char <p>ab[c]</p> since IE 11 doesn't delete otherwise
+          offset = rng.startOffset;
+          if (offset > 0) {
+            rng.setStart(rng.startContainer, offset - 1);
+            rng.setEnd(rng.startContainer, offset);
+            editor.selection.setRng(rng);
+          }
+        }
       }
+
+      editor.getDoc().execCommand('Delete', false, null);
+    }
+  } else if (typeof chr === 'string') {
+    const rng = editor.selection.getRng();
+
+    if (isText(rng.startContainer) && rng.collapsed) {
+      rng.startContainer.insertData(rng.startOffset, needsNbsp(rng, chr) ? Unicode.nbsp : chr);
+      rng.setStart(rng.startContainer, rng.startOffset + 1);
+      rng.collapse(true);
+      editor.selection.setRng(rng);
+    } else {
+      rng.deleteContents();
+      rng.insertNode(editor.getDoc().createTextNode(chr));
     }
   }
 
-  fakeEvent(startElm, 'keyup', evt);
+  fakeEvent('keyup', evt);
 };
 
 const typeString = (editor: Editor, str: string): void => {


### PR DESCRIPTION
Related Ticket: TINY-8896

Description of Changes:
* Fixes the `createlink` `ExecCommand` event no longer firing that was being relied on elsewhere.
* Fixes that an undo level was no longer created because we weren't calling `editor.execCommand` anymore.
* Fixes issues with the undo level restoring the selection in an unexpected place or the undo stack having an unexpected order (this was an issue in 5.x as well). This involved reworking the bracket logic to use `keyup` and overriding the enter logic (similar to how textpattern works) to make sure the events happened in the correct order.
   * Note: As discussed with @TheSpyder, hopefully after 6.2 we could even look at making this build on top of the text pattern logic instead.
 * Fixed the fake test typing logic to ensure it fired with the correct shift key modifier and that it fired via the editor as it would normally.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
