### PR TITLE
TINY-8877: Fixed a regression that caused an exception to be thrown when deleting all content

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- An exception was thrown when deleting all content if the start or end of the document had a `contenteditable="false"` element #TINY-8877
 - When a sidebar was opened using the `sidebar_show` option, its associated toggle button was not highlighted #TINY-8873
 
 ## 6.1.0 - 2022-06-29

--- a/modules/tinymce/src/core/main/ts/ForceBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/ForceBlocks.ts
@@ -1,11 +1,12 @@
 import { Arr, Fun, Obj } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import { Insert, SugarElement } from '@ephox/sugar';
 
 import Editor from './api/Editor';
 import { SchemaMap } from './api/html/Schema';
 import * as Options from './api/Options';
 import * as Bookmarks from './bookmark/Bookmarks';
 import * as NodeType from './dom/NodeType';
+import * as PaddingBr from './dom/PaddingBr';
 import * as Parents from './dom/Parents';
 import * as EditorFocus from './focus/EditorFocus';
 
@@ -49,6 +50,9 @@ const shouldRemoveTextNode = (blockElements, node) => {
   return false;
 };
 
+const createRootBlock = (editor: Editor): HTMLElement =>
+  editor.dom.create(Options.getForcedRootBlock(editor), Options.getForcedRootBlockAttrs(editor));
+
 const addRootBlocks = (editor: Editor) => {
   const dom = editor.dom, selection = editor.selection;
   const schema = editor.schema, blockElements = schema.getBlockElements();
@@ -87,7 +91,7 @@ const addRootBlocks = (editor: Editor) => {
       }
 
       if (!rootBlockNode) {
-        rootBlockNode = dom.create(forcedRootBlock, Options.getForcedRootBlockAttrs(editor));
+        rootBlockNode = createRootBlock(editor);
         node.parentNode.insertBefore(rootBlockNode, node);
         wrapped = true;
       }
@@ -109,10 +113,24 @@ const addRootBlocks = (editor: Editor) => {
   }
 };
 
-const setup = (editor: Editor) => {
+const insertEmptyLine = (editor: Editor, root: SugarElement<HTMLElement>, insertBlock: (root: SugarElement<HTMLElement>, block: SugarElement<HTMLElement>) => void): Range => {
+  const block = SugarElement.fromDom(createRootBlock(editor));
+  const br = PaddingBr.createPaddingBr();
+
+  Insert.append(block, br);
+  insertBlock(root, block);
+
+  const rng = document.createRange();
+  rng.setStartBefore(br.dom);
+  rng.setEndBefore(br.dom);
+  return rng;
+};
+
+const setup = (editor: Editor): void => {
   editor.on('NodeChange', Fun.curry(addRootBlocks, editor));
 };
 
 export {
+  insertEmptyLine,
   setup
 };

--- a/modules/tinymce/src/core/main/ts/caret/CaretContainer.ts
+++ b/modules/tinymce/src/core/main/ts/caret/CaretContainer.ts
@@ -1,4 +1,5 @@
 import * as NodeType from '../dom/NodeType';
+import * as PaddingBr from '../dom/PaddingBr';
 import * as Zwsp from '../text/Zwsp';
 import { CaretPosition } from './CaretPosition';
 
@@ -115,18 +116,12 @@ const isAfterInline = (pos: CaretPosition): boolean => {
   return container.data.charAt(pos.offset() - 1) === Zwsp.ZWSP || pos.isAtEnd() && isCaretContainerInline(container.nextSibling);
 };
 
-const createBogusBr = (): Element => {
-  const br = document.createElement('br');
-  br.setAttribute('data-mce-bogus', '1');
-  return br;
-};
-
 const insertBlock = (blockName: string, node: Node, before: boolean): HTMLElement => {
   const doc = node.ownerDocument;
   const blockNode = doc.createElement(blockName);
   blockNode.setAttribute('data-mce-caret', before ? 'before' : 'after');
   blockNode.setAttribute('data-mce-bogus', 'all');
-  blockNode.appendChild(createBogusBr());
+  blockNode.appendChild(PaddingBr.createPaddingBr().dom);
   const parentNode = node.parentNode;
 
   if (!before) {

--- a/modules/tinymce/src/core/main/ts/dom/PaddingBr.ts
+++ b/modules/tinymce/src/core/main/ts/dom/PaddingBr.ts
@@ -1,5 +1,5 @@
 import { Arr, Unicode } from '@ephox/katamari';
-import { Insert, Remove, SelectorFilter, SugarElement, SugarNode, SugarText, Traverse } from '@ephox/sugar';
+import { Attribute, Insert, Remove, SelectorFilter, SugarElement, SugarNode, SugarText, Traverse } from '@ephox/sugar';
 
 import * as ElementType from './ElementType';
 
@@ -23,9 +23,15 @@ const removeTrailingBr = (elm: SugarElement<Node>): void => {
   }
 };
 
+const createPaddingBr = (): SugarElement<HTMLBRElement> => {
+  const br = SugarElement.fromTag('br');
+  Attribute.set(br, 'data-mce-bogus', '1');
+  return br;
+};
+
 const fillWithPaddingBr = (elm: SugarElement<Node>): void => {
   Remove.empty(elm);
-  Insert.append(elm, SugarElement.fromHtml('<br data-mce-bogus="1">'));
+  Insert.append(elm, createPaddingBr());
 };
 
 const isPaddingContents = (elm: SugarElement<Node>): boolean => {
@@ -47,6 +53,7 @@ const trimBlockTrailingBr = (elm: SugarElement<Node>): void => {
 };
 
 export {
+  createPaddingBr,
   removeTrailingBr,
   fillWithPaddingBr,
   isPaddedElement,

--- a/modules/tinymce/src/core/main/ts/keyboard/ContentEndpointNavigation.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/ContentEndpointNavigation.ts
@@ -1,39 +1,13 @@
 import { Arr, Fun } from '@ephox/katamari';
-import { Attribute, Compare, Insert, PredicateFind, SugarElement, SugarNode } from '@ephox/sugar';
+import { Compare, Insert, PredicateFind, SugarElement, SugarNode } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
-import * as Options from '../api/Options';
 import CaretPosition from '../caret/CaretPosition';
 import { isAtFirstLine, isAtLastLine } from '../caret/LineReader';
 import * as ElementType from '../dom/ElementType';
+import * as ForceBlocks from '../ForceBlocks';
 
 const isTarget = (node: SugarElement) => Arr.contains([ 'figcaption' ], SugarNode.name(node));
-
-const rangeBefore = (target: SugarElement) => {
-  const rng = document.createRange();
-  rng.setStartBefore(target.dom);
-  rng.setEndBefore(target.dom);
-  return rng;
-};
-
-const insertElement = (root: SugarElement, elm: SugarElement, forward: boolean) => {
-  if (forward) {
-    Insert.append(root, elm);
-  } else {
-    Insert.prepend(root, elm);
-  }
-};
-
-const insertEmptyLine = (root: SugarElement, forward: boolean, blockName: string, attrs: Record<string, string>) => {
-  const block = SugarElement.fromTag(blockName);
-  const br = SugarElement.fromTag('br');
-
-  Attribute.setAll(block, attrs);
-  Insert.append(block, br);
-  insertElement(root, block, forward);
-
-  return rangeBefore(br);
-};
 
 const getClosestTargetBlock = (pos: CaretPosition, root: SugarElement) => {
   const isRoot = Fun.curry(Compare.eq, root);
@@ -45,12 +19,11 @@ const isAtFirstOrLastLine = (root: SugarElement, forward: boolean, pos: CaretPos
 const moveCaretToNewEmptyLine = (editor: Editor, forward: boolean) => {
   const root = SugarElement.fromDom(editor.getBody());
   const pos = CaretPosition.fromRangeStart(editor.selection.getRng());
-  const rootBlock = Options.getForcedRootBlock(editor);
-  const rootBlockAttrs = Options.getForcedRootBlockAttrs(editor);
 
   return getClosestTargetBlock(pos, root).exists(() => {
     if (isAtFirstOrLastLine(root, forward, pos)) {
-      const rng = insertEmptyLine(root, forward, rootBlock, rootBlockAttrs);
+      const insertFn = forward ? Insert.append : Insert.prepend;
+      const rng = ForceBlocks.insertEmptyLine(editor, root, insertFn);
       editor.selection.setRng(rng);
       return true;
     } else {

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
@@ -214,7 +214,7 @@ describe('browser.tinymce.core.delete.CefDeleteTest', () => {
     });
   });
 
-  context('Cleaning up after rng.deleteContens call', () => {
+  context('Cleaning up after rng.deleteContents call', () => {
     applyForDeleteAndBackspace(({ label, key }) => {
       it(`TINY-8729: should clean up empty nodes and padd empty block with bogus br when ${label} is pressed`, () => {
         const editor = hook.editor();
@@ -234,6 +234,15 @@ describe('browser.tinymce.core.delete.CefDeleteTest', () => {
         TinyContentActions.keystroke(editor, key());
         TinyAssertions.assertRawContent(editor, '<ul><li><br data-mce-bogus="1"></li></ul>');
         TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
+      });
+
+      it(`TINY-8877: should delete when all content is selected and add back the forced root block when ${label} is pressed`, () => {
+        const editor = hook.editor();
+        editor.setContent('<p contenteditable="false">CEF</p><p>Second line</p><p contenteditable="false">CEF</p>');
+        editor.execCommand('SelectAll');
+        TinyContentActions.keystroke(editor, key());
+        TinyAssertions.assertRawContent(editor, '<p><br data-mce-bogus="1"></p>');
+        TinyAssertions.assertCursor(editor, [ 0 ], 0);
       });
     });
   });


### PR DESCRIPTION
Related Ticket: TINY-8873

Description of Changes:
* Fixed a regression caused by https://github.com/tinymce/tinymce/pull/7892. The problem is that in `DeleteUtils.ts` the `getParent` call can return `null` and will if the node passed in is the root/body node. So this corrects that logic and also makes the delete logic properly handle padding an empty editor by inserting the root block.
  * Note: This exception actually isn't thrown in `develop` because the strict types made me do a similar fix (though it didn't handle padding the root/body properly). So +1 for strict types I guess?
* I also cleaned up some duplication for other cases where I found we were inserting the root block in the delete/navigation logic, so we now hopefully only have the one bit of code for generating that.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
