### PR TITLE
TINY-8779: Fixed text pattern throwing a range error when there were fragmented text nodes in a paragraph

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed various incorrect types on public APIs found while enabling TypeScript strict mode #TINY-8806
 - The editor focused via the `auto_focus` option was not scrolled into the viewport #TINY-8785
 - Selecting a figure with `class="image"` would incorrectly highlight the link toolbar button #TINY-8832
-- Fixed a bug where the text pattern logic threw error when there were two or more text nodes in a paragraph #TINY-8779
+- Fixed a bug where the text pattern logic threw an error when there were two or more text nodes in a paragraph #TINY-8779
 
 ## 6.1.1 - TBA
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed various incorrect types on public APIs found while enabling TypeScript strict mode #TINY-8806
 - The editor focused via the `auto_focus` option was not scrolled into the viewport #TINY-8785
 - Selecting a figure with `class="image"` would incorrectly highlight the link toolbar button #TINY-8832
-- Fixed a bug where the text pattern logic threw error when there are two or more text nodes in a paragraph #TINY-8779
+- Fixed a bug where the text pattern logic threw error when there were two or more text nodes in a paragraph #TINY-8779
 
 ## 6.1.1 - TBA
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed various incorrect types on public APIs found while enabling TypeScript strict mode #TINY-8806
 - The editor focused via the `auto_focus` option was not scrolled into the viewport #TINY-8785
 - Selecting a figure with `class="image"` would incorrectly highlight the link toolbar button #TINY-8832
+- Fixed a bug where the text pattern logic threw error when there are two or more text nodes in a paragraph #TINY-8779
 
 ## 6.1.1 - TBA
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed various incorrect types on public APIs found while enabling TypeScript strict mode #TINY-8806
 - The editor focused via the `auto_focus` option was not scrolled into the viewport #TINY-8785
 - Selecting a figure with `class="image"` would incorrectly highlight the link toolbar button #TINY-8832
-- Fixed a bug where the text pattern logic threw an error when there were two or more text nodes in a paragraph #TINY-8779
+- The text pattern logic threw an error when there were two or more text nodes in a paragraph #TINY-8779
 
 ## 6.1.1 - TBA
 

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
@@ -9,6 +9,11 @@ import { InlinePatternSet, PatternSet } from '../core/PatternTypes';
 import * as Utils from '../utils/Utils';
 
 const handleEnter = (editor: Editor, patternSet: PatternSet): boolean => {
+  // TINY-8779: mceInsertNewLine calls normalize() which alters the structure of the body content,
+  // in which text nodes of a paragraph are merged into one. This makes the range of any matching patterns become invalid
+  // as the text nodes are no longer existed after normalization. So do a normalize() prior finding any matches
+  editor.getBody().normalize();
+
   // Find any matches
   const inlineMatches = InlinePattern.findPatterns(editor, patternSet, false);
   const blockMatches = BlockPattern.findPatterns(editor, patternSet);

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
@@ -14,6 +14,7 @@ const handleEnter = (editor: Editor, patternSet: PatternSet): boolean => {
   // So call normalize() to merge fragmented text nodes before finding matching patterns
   // And because of an issue on safari https://bugs.webkit.org/show_bug.cgi?id=230594
   // we use bookmark to restore the selection after normalize()
+  // TODO: Revisit this block of code after TINY-8909 is completed
   const bookmark = editor.selection.getBookmark(2, true);
   editor.getBody().normalize();
   editor.selection.moveToBookmark(bookmark);

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
@@ -9,9 +9,9 @@ import { InlinePatternSet, PatternSet } from '../core/PatternTypes';
 import * as Utils from '../utils/Utils';
 
 const handleEnter = (editor: Editor, patternSet: PatternSet): boolean => {
-  // TINY-8779: mceInsertNewLine calls normalize() which alters the structure of the body content,
-  // in which text nodes of a paragraph are merged into one. This makes the range of any matching patterns become invalid
-  // as the text nodes are no longer existed after normalization. So do a normalize() prior finding any matches
+  // TINY-8779: The applying text pattern logic throws a range error because it attempts to set the range to a non-existing text node.
+  // The undoManager.extra() stores the content as a string and then set it back via setContent() which results in the fragmented text nodes being merged.
+  // So call normalize() to merge fragmented text nodes before finding matching patterns
   editor.getBody().normalize();
 
   // Find any matches

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/ReplacementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/ReplacementTest.ts
@@ -3,7 +3,6 @@ import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { InsertAll, Remove, SugarElement } from '@ephox/sugar';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
-import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -153,9 +152,7 @@ describe('browser.tinymce.core.textpatterns.ReplacementTest', () => {
     TinyContentActions.keystroke(editor, Keys.enter());
   });
 
-  context('TINY-8779: Matches text nodes in a paragraph', () => {
-    let editor: Editor;
-
+  context('Matches text nodes in a paragraph', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       text_patterns: [
         { start: 'one_error', replacement: 'no_error' }
@@ -165,25 +162,21 @@ describe('browser.tinymce.core.textpatterns.ReplacementTest', () => {
     }, [ ]);
 
     const setCursorAndPressEnterAndAssert = (editor: Editor, texts: string[], expected: string) => {
+      editor.setContent('<p></p>');
       const targetParagraph = editor.dom.select('p')[0];
       Arr.each(texts, (t) => targetParagraph.appendChild(document.createTextNode(t)));
       editor.focus();
       TinySelections.setCursor(editor, [ 0, 2 ], 6);
       TinyContentActions.keystroke(editor, Keys.enter());
-      assert.equal(editor.getContent(), expected);
+      TinyAssertions.assertContent(editor, expected);
     };
 
-    beforeEach(() => {
-      editor = hook.editor();
-      editor.setContent('<p></p>');
-    });
-
     it('Pattern matches the second text node', () => {
-      setCursorAndPressEnterAndAssert(editor, [ 'one', '_error', ' for sure' ], '<p><br>no_error</p><p>for sure</p>');
+      setCursorAndPressEnterAndAssert(hook.editor(), [ 'one', '_error', ' for sure' ], '<p><br>no_error</p><p>for sure</p>');
     });
 
     it('Pattern matches the last text node', () => {
-      setCursorAndPressEnterAndAssert(editor, [ 'one', '_error' ], '<p><br>no_error</p><p>&nbsp;</p>');
+      setCursorAndPressEnterAndAssert(hook.editor(), [ 'one', '_error' ], '<p><br>no_error</p><p>&nbsp;</p>');
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/ReplacementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/ReplacementTest.ts
@@ -153,7 +153,7 @@ describe('browser.tinymce.core.textpatterns.ReplacementTest', () => {
     TinyContentActions.keystroke(editor, Keys.enter());
   });
 
-  context('TINY-8779: Matches text nodes nodes in a paragraph', () => {
+  context('TINY-8779: Matches text nodes in a paragraph', () => {
     let editor: Editor;
 
     const hook = TinyHooks.bddSetupLight<Editor>({


### PR DESCRIPTION
Related Ticket: TINY-8779

Description of Changes:
* Fixed a bug where the text pattern logic threw an error when there were two or more text nodes in a paragraph

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
