### PR TITLE
TINY-8780: Fixed a regression in how special elements were sanitized while parsing

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- Invalid special elements were not cleaned up correctly during sanitization #TINY-8780
 - An exception was thrown when deleting all content if the start or end of the document had a `contenteditable="false"` element #TINY-8877
 - When a sidebar was opened using the `sidebar_show` option, its associated toggle button was not highlighted #TINY-8873
 - The `autolink` plugin when converting a URL to a link did not fire an `ExecCommand` event, nor did it create an undo level #TINY-8896

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1285,6 +1285,19 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     );
   });
 
+  it('TINY-8780: Invalid special elements are removed entirely instead of being unwrapped', () => {
+    const parser = DomParser({ forced_root_block: 'p' }, Schema({ invalid_elements: 'script,style,iframe,textarea,div' }));
+    const html = '<script>var x = 1;</script>' +
+      '<style>.red-text { color: red; }</style>' +
+      '<iframe src="about:blank">content</iframe>' +
+      '<textarea>content</textarea>' +
+      '<p>paragraph</p>' +
+      '<div>div</div>';
+
+    const serializedHtml = serializer.serialize(parser.parse(html));
+    assert.equal(serializedHtml, '<p>paragraph</p><p>div</p>');
+  });
+
   context('validate: false', () => {
     it('invalid elements and attributes should not be removed', () => {
       const parser = DomParser({ validate: false }, Schema({ valid_elements: 'span[id]' }));


### PR DESCRIPTION
Related Ticket: TINY-8780

Description of Changes:

Fixes a regression introduced in TinyMCE 6.0 where part of the old SaxParser logic wasn't converted over meaning special elements weren't quite sanitized/cleaned up correctly. The part that was missed was here: https://github.com/tinymce/tinymce/blob/release/5.10/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts#L568-L574. In this you can see it used to drop/not emit the child content for special elements when it wasn't valid, however the new DomParser implementation only ever unwrapped them.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
