### PR TITLE
TINY-8916: Worked around a Firefox bug whereby cookies weren't available inside the editor content

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An exception was thrown when deleting all content if the start or end of the document had a `contenteditable="false"` element #TINY-8877
 - When a sidebar was opened using the `sidebar_show` option, its associated toggle button was not highlighted #TINY-8873
 - The `autolink` plugin when converting a URL to a link did not fire an `ExecCommand` event, nor did it create an undo level #TINY-8896
+- Worked around a Firefox bug whereby cookies weren't available inside the editor content #TINY-88916
 
 ## 6.1.0 - 2022-06-29
 

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -8,6 +8,7 @@ import DomSerializer, { DomSerializerSettings } from '../api/dom/Serializer';
 import StyleSheetLoader from '../api/dom/StyleSheetLoader';
 import Editor from '../api/Editor';
 import EditorUpload from '../api/EditorUpload';
+import Env from '../api/Env';
 import * as Events from '../api/Events';
 import Formatter from '../api/Formatter';
 import DomParser, { DomParserSettings } from '../api/html/DomParser';
@@ -481,7 +482,17 @@ const initContentBody = (editor: Editor, skipWrite?: boolean) => {
       // Continue to init the editor
       contentBodyLoaded(editor);
     });
-    iframe.srcdoc = editor.iframeHTML;
+
+    // TINY-8916: Firefox has a bug in its srcdoc implementation that prevents cookies being sent so unfortunately we need
+    // to fallback to legacy APIs to load the iframe content. See https://bugzilla.mozilla.org/show_bug.cgi?id=1741489
+    if (Env.browser.isFirefox()) {
+      const doc = editor.getDoc();
+      doc.open();
+      doc.write(editor.iframeHTML);
+      doc.close();
+    } else {
+      iframe.srcdoc = editor.iframeHTML;
+    }
   } else {
     contentBodyLoaded(editor);
   }

--- a/modules/tinymce/src/core/test/ts/browser/init/InitIframeEditorCookiesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitIframeEditorCookiesTest.ts
@@ -1,0 +1,22 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.init.InitIframeCookiesTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+  }, []);
+
+  it('TINY-8916: Ensure cookies from the root document are accessible within the iframe', () => {
+    const editor = hook.editor();
+    const name = 'mce-custom-cookie-' + Math.floor(Math.random() * 1000);
+    const date = new Date();
+    date.setTime(date.getTime() + (60 * 1000)); // Add 1min
+    document.cookie = `${name}=test; expires=${date.toUTCString()}; path=/; SameSite=Strict`;
+
+    const doc = editor.getDoc();
+    assert.include(doc.cookie, name);
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-8916

Description of Changes:

This changes how the initial iframe content is loaded only on Firefox to fallback to the older browser APIs we used in TinyMCE 5 due to https://bugzilla.mozilla.org/show_bug.cgi?id=1741489.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
Fixes #7746 