### PR TITLE
TINY-8778: Fixed `text_patterns_lookup` being called more than expected when matching patterns

### DIFF
--- a/modules/tinymce/src/core/main/ts/textpatterns/core/BlockPattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/BlockPattern.ts
@@ -72,9 +72,9 @@ const findPatterns = (editor: Editor, block: Element, patternSet: PatternSet, dy
   const blockText = block.textContent ?? '';
   // dynamic patterns take precedence here
   const patterns = getBlockPatterns(dynamicPatterns);
-  const matchedPattern = findPattern(patterns, blockText).orThunk(() => {
+  const matchedPattern = findPattern(patterns, block.textContent).orThunk(() => {
     const patterns = getBlockPatterns(patternSet.blockPatterns);
-    return findPattern(patterns, blockText);
+    return findPattern(patterns, block.textContent);
   });
 
   return matchedPattern.map((pattern) => {

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/BlockPattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/BlockPattern.ts
@@ -62,7 +62,7 @@ const findPattern = <P extends Pattern>(patterns: P[], text: string): Optional<P
   return Arr.find(patterns, (pattern) => text.indexOf(pattern.start) === 0 || nuText.indexOf(pattern.start) === 0);
 };
 
-const findPatterns = (editor: Editor, patternSet: PatternSet, normalizedMatches: boolean): BlockPatternMatch[] => {
+const findPatterns = (editor: Editor, patternSet: PatternSet, dynamicPatterns: Pattern[], normalizedMatches: boolean): BlockPatternMatch[] => {
   const dom = editor.dom;
   const rng = editor.selection.getRng();
 
@@ -73,14 +73,8 @@ const findPatterns = (editor: Editor, patternSet: PatternSet, normalizedMatches:
   }).bind((block) => {
     // Get the block text
     const blockText = block.textContent ?? '';
-
-    // TINY-8781: TODO: text_patterns should announce their changes for accessibility
-    const extraPatterns = patternSet.dynamicPatternsLookup({
-      text: blockText,
-      block
-    });
     // search in the dynamic patterns first
-    const patterns = getBlockPatterns(extraPatterns);
+    const patterns = getBlockPatterns(dynamicPatterns);
     const matchedPattern = findPattern(patterns, blockText).orThunk(() => {
       // Search in the static patterns
       const patterns = getBlockPatterns(patternSet.blockPatterns);

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/BlockPattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/BlockPattern.ts
@@ -8,7 +8,6 @@ import * as Options from '../../api/Options';
 import Tools from '../../api/util/Tools';
 import { generatePathRange, resolvePathRange } from '../utils/PathRange';
 import * as Utils from '../utils/Utils';
-import { getBlockPatterns } from './Pattern';
 import { BlockPattern, BlockPatternMatch, Pattern, PatternSet } from './PatternTypes';
 
 const stripPattern = (dom: DOMUtils, block: Node, pattern: BlockPattern): void => {
@@ -62,22 +61,16 @@ const findPattern = <P extends Pattern>(patterns: P[], text: string): Optional<P
   return Arr.find(patterns, (pattern) => text.indexOf(pattern.start) === 0 || nuText.indexOf(pattern.start) === 0);
 };
 
-const findPatterns = (editor: Editor, block: Element, patternSet: PatternSet, dynamicPatterns: Pattern[], normalizedMatches: boolean): BlockPatternMatch[] => {
+const findPatterns = (editor: Editor, block: Element, patternSet: PatternSet, normalizedMatches: boolean): BlockPatternMatch[] => {
   const dom = editor.dom;
   const forcedRootBlock = Options.getForcedRootBlock(editor);
-  if (block === null || !dom.is(block, forcedRootBlock)) {
+  if (!dom.is(block, forcedRootBlock)) {
     return [];
   }
-  // Get the block text
-  const blockText = block.textContent ?? '';
-  // dynamic patterns take precedence here
-  const patterns = getBlockPatterns(dynamicPatterns);
-  const matchedPattern = findPattern(patterns, block.textContent).orThunk(() => {
-    const patterns = getBlockPatterns(patternSet.blockPatterns);
-    return findPattern(patterns, block.textContent);
-  });
 
-  return matchedPattern.map((pattern) => {
+  // Get the block text and then find a matching pattern
+  const blockText = block.textContent ?? '';
+  return findPattern(patternSet.blockPatterns, blockText).map((pattern) => {
     if (Tools.trim(blockText).length === pattern.start.length) {
       return [];
     }

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
@@ -261,22 +261,19 @@ const addMarkers = (dom: DOMUtils, matches: InlinePatternMatch[]): InlinePattern
   }, [] as InlinePatternMatchWithMarkers[]);
 };
 
-const findPatterns = (editor: Editor, patternSet: InlinePatternSet, dynamicPattern: Pattern[], normalizedMatches: boolean, space: boolean): InlinePatternMatch[] => {
+const findPatterns = (editor: Editor, block: Element, patternSet: InlinePatternSet, dynamicPatterns: Pattern[], normalizedMatches: boolean, space: boolean): InlinePatternMatch[] => {
   const rng = editor.selection.getRng();
   if (!rng.collapsed) {
     return [];
   }
-
-  return Utils.getParentBlock(editor, rng).bind((block) => {
-    const offset = Math.max(0, rng.startOffset - (space ? 1 : 0));
-    const extraPatterns = getInlinePatterns(dynamicPattern);
-    const patterns = {
-      ...patternSet,
-      inlinePatterns: extraPatterns.concat(patternSet.inlinePatterns)
-    };
-    // patternSet.inlinePatterns = dynamicPatterns.concat(patternSet.inlinePatterns);
-    return findPatternsRec(editor, patterns, rng.startContainer, offset, block, space);
-  }).fold(() => [], (result) => result.matches);
+  const offset = Math.max(0, rng.startOffset - (space ? 1 : 0));
+  const extraPatterns = getInlinePatterns(dynamicPatterns);
+  const patterns = {
+    ...patternSet,
+    inlinePatterns: extraPatterns.concat(patternSet.inlinePatterns)
+  };
+  // patternSet.inlinePatterns = dynamicPatterns.concat(patternSet.inlinePatterns);
+  return findPatternsRec(editor, patterns, rng.startContainer, offset, block, normalizedMatches).fold(() => [], (result) => result.matches);
 };
 
 const applyMatches = (editor: Editor, matches: InlinePatternMatch[]): void => {

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
@@ -99,7 +99,7 @@ const findPatternStart = (dom: DOMUtils, pattern: InlinePattern, node: Node, off
   });
 };
 
-const findPattern = (editor: Editor, block: Node, details: PatternDetails, normalizedMatches: boolean): Optional<SearchResults> => {
+const findPattern = (editor: Editor, block: Element, details: PatternDetails, normalizedMatches: boolean): Optional<SearchResults> => {
   const dom = editor.dom;
   const root = dom.getRoot();
   const pattern = details.pattern;
@@ -155,7 +155,7 @@ const findPatternsRec = (
   patterns: InlinePattern[],
   node: Node,
   offset: number,
-  block: Node,
+  block: Element,
   normalizedMatches: boolean
 ): Optional<SearchResults> => {
   const dom = editor.dom;

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
@@ -166,18 +166,7 @@ const findPatternsRec = (
     rng.setStart(block, 0);
     rng.setEnd(node, offset);
     const text = rng.toString();
-
-    // TINY-8781: TODO: text_patterns should announce their changes for accessibility
-    const extraPatterns = patternSet.dynamicPatternsLookup({
-      text,
-      block
-    });
-    const dynamicPatterns = getInlinePatterns(extraPatterns);
-    // Dynamic patterns take precedence over static patterns
-    const patterns = [
-      ...dynamicPatterns,
-      ...patternSet.inlinePatterns,
-    ];
+    const patterns = patternSet.inlinePatterns;
 
     for (let i = 0; i < patterns.length; i++) {
       const pattern = patterns[i];

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
@@ -161,11 +161,7 @@ const findPatternsRec = (
   const dom = editor.dom;
 
   return TextSearch.textBefore(node, offset, dom.getRoot()).bind((endSpot) => {
-    const rng = dom.createRng();
-    rng.setStart(block, 0);
-    rng.setEnd(node, offset);
-    const text = rng.toString();
-
+    const text = Utils.getBeforeText(dom, block, node, offset);
     for (let i = 0; i < patterns.length; i++) {
       const pattern = patterns[i];
       // If the text does not end with the same string as the pattern, then we can exit
@@ -256,13 +252,8 @@ const addMarkers = (dom: DOMUtils, matches: InlinePatternMatch[]): InlinePattern
   }, [] as InlinePatternMatchWithMarkers[]);
 };
 
-const findPatterns = (editor: Editor, block: Element, patternSet: PatternSet, normalizedMatches: boolean, space: boolean): InlinePatternMatch[] => {
-  const rng = editor.selection.getRng();
-  if (!rng.collapsed) {
-    return [];
-  }
-  const offset = Math.max(0, rng.startOffset - (space ? 1 : 0));
-  return findPatternsRec(editor, patternSet.inlinePatterns, rng.startContainer, offset, block, normalizedMatches).fold(() => [], (result) => result.matches);
+const findPatterns = (editor: Editor, block: Element, node: Node, offset: number, patternSet: PatternSet, normalizedMatches: boolean): InlinePatternMatch[] => {
+  return findPatternsRec(editor, patternSet.inlinePatterns, node, offset, block, normalizedMatches).fold(() => [], (result) => result.matches);
 };
 
 const applyMatches = (editor: Editor, matches: InlinePatternMatch[]): void => {

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
@@ -252,9 +252,8 @@ const addMarkers = (dom: DOMUtils, matches: InlinePatternMatch[]): InlinePattern
   }, [] as InlinePatternMatchWithMarkers[]);
 };
 
-const findPatterns = (editor: Editor, block: Element, node: Node, offset: number, patternSet: PatternSet, normalizedMatches: boolean): InlinePatternMatch[] => {
-  return findPatternsRec(editor, patternSet.inlinePatterns, node, offset, block, normalizedMatches).fold(() => [], (result) => result.matches);
-};
+const findPatterns = (editor: Editor, block: Element, node: Node, offset: number, patternSet: PatternSet, normalizedMatches: boolean): InlinePatternMatch[] =>
+  findPatternsRec(editor, patternSet.inlinePatterns, node, offset, block, normalizedMatches).fold(() => [], (result) => result.matches);
 
 const applyMatches = (editor: Editor, matches: InlinePatternMatch[]): void => {
   if (matches.length === 0) {

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/PatternTypes.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/PatternTypes.ts
@@ -62,12 +62,10 @@ export type RawDynamicPatternsLookup = (ctx: DynamicPatternContext) => RawPatter
 // NOTE: A PatternSet should be looked up from the Options *each* time that text_patterns are
 // processed, so that text_patterns respond to changes in options. This is required for some
 // complex integrations and plugins.
-export interface InlinePatternSet {
+export interface PatternSet {
   readonly inlinePatterns: InlinePattern[];
-  readonly dynamicPatternsLookup: DynamicPatternsLookup;
-}
-export interface PatternSet extends InlinePatternSet {
   readonly blockPatterns: BlockPattern[];
+  readonly dynamicPatternsLookup: DynamicPatternsLookup;
 }
 
 interface PatternMatch<T extends Pattern> {

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
@@ -1,19 +1,31 @@
-import { Unicode } from '@ephox/katamari';
+import { Optional, Unicode } from '@ephox/katamari';
 
 import { textBefore } from '../../alien/TextSearch';
 import Editor from '../../api/Editor';
 import VK from '../../api/util/VK';
 import * as BlockPattern from '../core/BlockPattern';
 import * as InlinePattern from '../core/InlinePattern';
-import { InlinePatternSet, PatternSet } from '../core/PatternTypes';
+import { InlinePatternSet, Pattern, PatternSet } from '../core/PatternTypes';
 import * as Utils from '../utils/Utils';
 
+const resolveFromDynamicPatterns = (editor: Editor, patternSet: PatternSet): Pattern[] => {
+  const range = editor.selection.getRng();
+  return Utils.getParentBlock(editor, range).bind((block) => {
+    const blockText = block.textContent ?? '';
+    return Optional.from(patternSet.dynamicPatternsLookup({
+      text: blockText,
+      block
+    }));
+  }).getOr([]);
+};
+
 const handleEnter = (editor: Editor, patternSet: PatternSet): boolean => {
+  const dynamicPatterns = resolveFromDynamicPatterns(editor, patternSet);
   // Find any matches
   // IMPORTANT: We need to get normalized match results since undoing and redoing the editor state
   // via undoManager.extra() will result in the DOM being normalized.
-  const inlineMatches = InlinePattern.findPatterns(editor, patternSet, true, false);
-  const blockMatches = BlockPattern.findPatterns(editor, patternSet, true);
+  const inlineMatches = InlinePattern.findPatterns(editor, patternSet, dynamicPatterns, true, false);
+  const blockMatches = BlockPattern.findPatterns(editor, patternSet, dynamicPatterns, true);
   if (blockMatches.length > 0 || inlineMatches.length > 0) {
     editor.undoManager.add();
     editor.undoManager.extra(
@@ -48,7 +60,8 @@ const handleInlineKey = (
   editor: Editor,
   patternSet: InlinePatternSet
 ): void => {
-  const inlineMatches = InlinePattern.findPatterns(editor, patternSet, false, true);
+  const dynamicPatterns = resolveFromDynamicPatterns(editor, patternSet as PatternSet);
+  const inlineMatches = InlinePattern.findPatterns(editor, patternSet, dynamicPatterns, true, false);
   if (inlineMatches.length > 0) {
     editor.undoManager.transact(() => {
       InlinePattern.applyMatches(editor, inlineMatches);

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
@@ -5,21 +5,12 @@ import Editor from '../../api/Editor';
 import VK from '../../api/util/VK';
 import * as BlockPattern from '../core/BlockPattern';
 import * as InlinePattern from '../core/InlinePattern';
-import { Pattern, PatternSet } from '../core/PatternTypes';
+import { PatternSet } from '../core/PatternTypes';
 import * as Utils from '../utils/Utils';
-
-const resolveFromDynamicPatterns = (patternSet: PatternSet, block: Element): Pattern[] => {
-
-  const blockText = block.textContent ?? '';
-  return patternSet.dynamicPatternsLookup({
-    text: blockText,
-    block
-  });
-};
 
 const handleEnter = (editor: Editor, patternSet: PatternSet): boolean => {
   return Utils.getParentBlock(editor, editor.selection.getRng()).map((block) => {
-    const dynamicPatterns = resolveFromDynamicPatterns(patternSet, block);
+    const dynamicPatterns = Utils.resolveFromDynamicPatterns(patternSet, block);
     // IMPORTANT: We need to get normalized match results since undoing and redoing the editor state
     // via undoManager.extra() will result in the DOM being normalized.
     const inlineMatches = InlinePattern.findPatterns(editor, block, patternSet, dynamicPatterns, true, false);
@@ -60,7 +51,7 @@ const handleInlineKey = (
   patternSet: PatternSet
 ): void => {
   Utils.getParentBlock(editor, editor.selection.getRng()).map((block) => {
-    const dynamicPatterns = resolveFromDynamicPatterns(patternSet, block);
+    const dynamicPatterns = Utils.resolveFromDynamicPatterns(patternSet, block);
     const inlineMatches = InlinePattern.findPatterns(editor, block, patternSet, dynamicPatterns, false, true);
     if (inlineMatches.length > 0) {
       editor.undoManager.transact(() => {

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
@@ -12,7 +12,7 @@ const handleEnter = (editor: Editor, patternSet: PatternSet): boolean => {
   const rng = editor.selection.getRng();
   return Utils.getParentBlock(editor, rng).map((block) => {
     const offset = Math.max(0, rng.startOffset);
-    const dynamicPatternSet = Utils.resolveFromDynamicPatterns(patternSet, block, block.textContent);
+    const dynamicPatternSet = Utils.resolveFromDynamicPatterns(patternSet, block, block.textContent ?? '');
     // IMPORTANT: We need to get normalized match results since undoing and redoing the editor state
     // via undoManager.extra() will result in the DOM being normalized.
     const inlineMatches = InlinePattern.findPatterns(editor, block, rng.startContainer, offset, dynamicPatternSet, true);

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
@@ -1,72 +1,73 @@
-import { Optional, Unicode } from '@ephox/katamari';
+import { Unicode } from '@ephox/katamari';
 
 import { textBefore } from '../../alien/TextSearch';
 import Editor from '../../api/Editor';
 import VK from '../../api/util/VK';
 import * as BlockPattern from '../core/BlockPattern';
 import * as InlinePattern from '../core/InlinePattern';
-import { InlinePatternSet, Pattern, PatternSet } from '../core/PatternTypes';
+import { Pattern, PatternSet } from '../core/PatternTypes';
 import * as Utils from '../utils/Utils';
 
-const resolveFromDynamicPatterns = (editor: Editor, patternSet: PatternSet): Pattern[] => {
-  const range = editor.selection.getRng();
-  return Utils.getParentBlock(editor, range).bind((block) => {
-    const blockText = block.textContent ?? '';
-    return Optional.from(patternSet.dynamicPatternsLookup({
-      text: blockText,
-      block
-    }));
-  }).getOr([]);
+const resolveFromDynamicPatterns = (patternSet: PatternSet, block: Element): Pattern[] => {
+
+  const blockText = block.textContent ?? '';
+  return patternSet.dynamicPatternsLookup({
+    text: blockText,
+    block
+  });
 };
 
 const handleEnter = (editor: Editor, patternSet: PatternSet): boolean => {
-  const dynamicPatterns = resolveFromDynamicPatterns(editor, patternSet);
-  // Find any matches
-  // IMPORTANT: We need to get normalized match results since undoing and redoing the editor state
-  // via undoManager.extra() will result in the DOM being normalized.
-  const inlineMatches = InlinePattern.findPatterns(editor, patternSet, dynamicPatterns, true, false);
-  const blockMatches = BlockPattern.findPatterns(editor, patternSet, dynamicPatterns, true);
-  if (blockMatches.length > 0 || inlineMatches.length > 0) {
-    editor.undoManager.add();
-    editor.undoManager.extra(
-      () => {
-        editor.execCommand('mceInsertNewLine');
-      },
-      () => {
-        // create a cursor position that we can move to avoid the inline formats
-        editor.insertContent(Unicode.zeroWidth);
-        InlinePattern.applyMatches(editor, inlineMatches);
-        BlockPattern.applyMatches(editor, blockMatches);
-        // find the spot before the cursor position
-        const range = editor.selection.getRng();
-        const spot = textBefore(range.startContainer, range.startOffset, editor.dom.getRoot());
-        editor.execCommand('mceInsertNewLine');
-        // clean up the cursor position we used to preserve the format
-        spot.each((s) => {
-          const node = s.container;
-          if (node.data.charAt(s.offset - 1) === Unicode.zeroWidth) {
-            node.deleteData(s.offset - 1, 1);
-            Utils.cleanEmptyNodes(editor.dom, node.parentNode, (e: Node) => e === editor.dom.getRoot());
-          }
-        });
-      }
-    );
-    return true;
-  }
-  return false;
+  return Utils.getParentBlock(editor, editor.selection.getRng()).map((block) => {
+    const dynamicPatterns = resolveFromDynamicPatterns(patternSet, block);
+    // IMPORTANT: We need to get normalized match results since undoing and redoing the editor state
+    // via undoManager.extra() will result in the DOM being normalized.
+    const inlineMatches = InlinePattern.findPatterns(editor, block, patternSet, dynamicPatterns, true, false);
+    const blockMatches = BlockPattern.findPatterns(editor, block, patternSet, dynamicPatterns, true);
+    if (blockMatches.length > 0 || inlineMatches.length > 0) {
+      editor.undoManager.add();
+      editor.undoManager.extra(
+        () => {
+          editor.execCommand('mceInsertNewLine');
+        },
+        () => {
+          // create a cursor position that we can move to avoid the inline formats
+          editor.insertContent(Unicode.zeroWidth);
+          InlinePattern.applyMatches(editor, inlineMatches);
+          BlockPattern.applyMatches(editor, blockMatches);
+          // find the spot before the cursor position
+          const range = editor.selection.getRng();
+          const spot = textBefore(range.startContainer, range.startOffset, editor.dom.getRoot());
+          editor.execCommand('mceInsertNewLine');
+          // clean up the cursor position we used to preserve the format
+          spot.each((s) => {
+            const node = s.container;
+            if (node.data.charAt(s.offset - 1) === Unicode.zeroWidth) {
+              node.deleteData(s.offset - 1, 1);
+              Utils.cleanEmptyNodes(editor.dom, node.parentNode, (e: Node) => e === editor.dom.getRoot());
+            }
+          });
+        }
+      );
+      return true;
+    }
+    return false;
+  }).getOr(false);
 };
 
 const handleInlineKey = (
   editor: Editor,
-  patternSet: InlinePatternSet
+  patternSet: PatternSet
 ): void => {
-  const dynamicPatterns = resolveFromDynamicPatterns(editor, patternSet as PatternSet);
-  const inlineMatches = InlinePattern.findPatterns(editor, patternSet, dynamicPatterns, true, false);
-  if (inlineMatches.length > 0) {
-    editor.undoManager.transact(() => {
-      InlinePattern.applyMatches(editor, inlineMatches);
-    });
-  }
+  Utils.getParentBlock(editor, editor.selection.getRng()).map((block) => {
+    const dynamicPatterns = resolveFromDynamicPatterns(patternSet, block);
+    const inlineMatches = InlinePattern.findPatterns(editor, block, patternSet, dynamicPatterns, false, true);
+    if (inlineMatches.length > 0) {
+      editor.undoManager.transact(() => {
+        InlinePattern.applyMatches(editor, inlineMatches);
+      });
+    }
+  });
 };
 
 const checkKeyEvent = <T>(codes: T[], event: KeyboardEvent, predicate: (code: T, event: KeyboardEvent) => boolean): boolean => {

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/KeyHandler.ts
@@ -10,11 +10,11 @@ import * as Utils from '../utils/Utils';
 
 const handleEnter = (editor: Editor, patternSet: PatternSet): boolean => {
   return Utils.getParentBlock(editor, editor.selection.getRng()).map((block) => {
-    const dynamicPatterns = Utils.resolveFromDynamicPatterns(patternSet, block);
+    const dynamicPatternSet = Utils.resolveFromDynamicPatterns(patternSet, block);
     // IMPORTANT: We need to get normalized match results since undoing and redoing the editor state
     // via undoManager.extra() will result in the DOM being normalized.
-    const inlineMatches = InlinePattern.findPatterns(editor, block, patternSet, dynamicPatterns, true, false);
-    const blockMatches = BlockPattern.findPatterns(editor, block, patternSet, dynamicPatterns, true);
+    const inlineMatches = InlinePattern.findPatterns(editor, block, dynamicPatternSet, true, false);
+    const blockMatches = BlockPattern.findPatterns(editor, block, dynamicPatternSet, true);
     if (blockMatches.length > 0 || inlineMatches.length > 0) {
       editor.undoManager.add();
       editor.undoManager.extra(
@@ -51,8 +51,8 @@ const handleInlineKey = (
   patternSet: PatternSet
 ): void => {
   Utils.getParentBlock(editor, editor.selection.getRng()).map((block) => {
-    const dynamicPatterns = Utils.resolveFromDynamicPatterns(patternSet, block);
-    const inlineMatches = InlinePattern.findPatterns(editor, block, patternSet, dynamicPatterns, false, true);
+    const dynamicPatternSet = Utils.resolveFromDynamicPatterns(patternSet, block);
+    const inlineMatches = InlinePattern.findPatterns(editor, block, dynamicPatternSet, false, true);
     if (inlineMatches.length > 0) {
       editor.undoManager.transact(() => {
         InlinePattern.applyMatches(editor, inlineMatches);

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/Keyboard.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/Keyboard.ts
@@ -34,13 +34,15 @@ const setup = (editor: Editor): void => {
   }, true);
 
   const handleInlineTrigger = () => {
-    const patternSet = getPatternSet();
+    if (editor.selection.isCollapsed()) {
+      const patternSet = getPatternSet();
 
-    // Do not process anything if we don't have any inline patterns or dynamic lookup defined
-    const hasPatterns = patternSet.inlinePatterns.length > 0 || hasDynamicPatterns();
+      // Do not process anything if we don't have any inline patterns or dynamic lookup defined
+      const hasPatterns = patternSet.inlinePatterns.length > 0 || hasDynamicPatterns();
 
-    if (hasPatterns) {
-      KeyHandler.handleInlineKey(editor, patternSet);
+      if (hasPatterns) {
+        KeyHandler.handleInlineKey(editor, patternSet);
+      }
     }
   };
 

--- a/modules/tinymce/src/core/main/ts/textpatterns/utils/Utils.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/utils/Utils.ts
@@ -3,6 +3,7 @@ import { Optional } from '@ephox/katamari';
 import DOMUtils from '../../api/dom/DOMUtils';
 import Editor from '../../api/Editor';
 import * as NodeType from '../../dom/NodeType';
+import { Pattern, PatternSet } from '../core/PatternTypes';
 
 const cleanEmptyNodes = (dom: DOMUtils, node: Node | null, isRoot: (e: Node) => boolean): void => {
   // Recursively walk up the tree while we have a parent and the node is empty. If the node is empty, then remove it.
@@ -36,8 +37,16 @@ const deleteRng = (dom: DOMUtils, rng: Range, isRoot: (e: Node) => boolean, clea
 const getParentBlock = (editor: Editor, rng: Range): Optional<Element> =>
   Optional.from(editor.dom.getParent(rng.startContainer, editor.dom.isBlock));
 
+const resolveFromDynamicPatterns = (patternSet: PatternSet, block: Element): Pattern[] => {
+  const blockText = block.textContent ?? '';
+  return patternSet.dynamicPatternsLookup({
+    text: blockText,
+    block
+  });
+};
 export {
   cleanEmptyNodes,
   deleteRng,
-  getParentBlock
+  getParentBlock,
+  resolveFromDynamicPatterns
 };

--- a/modules/tinymce/src/core/main/ts/textpatterns/utils/Utils.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/utils/Utils.ts
@@ -38,10 +38,9 @@ const deleteRng = (dom: DOMUtils, rng: Range, isRoot: (e: Node) => boolean, clea
 const getParentBlock = (editor: Editor, rng: Range): Optional<Element> =>
   Optional.from(editor.dom.getParent(rng.startContainer, editor.dom.isBlock));
 
-const resolveFromDynamicPatterns = (patternSet: PatternSet, block: Element): PatternSet => {
-  const blockText = block.textContent ?? '';
+const resolveFromDynamicPatterns = (patternSet: PatternSet, block: Element, beforeText: string): PatternSet => {
   const dynamicPatterns = patternSet.dynamicPatternsLookup({
-    text: blockText,
+    text: beforeText,
     block
   });
 
@@ -53,9 +52,17 @@ const resolveFromDynamicPatterns = (patternSet: PatternSet, block: Element): Pat
   };
 };
 
+const getBeforeText = (dom: DOMUtils, block: Node, node: Node, offset: number): string => {
+  const rng = dom.createRng();
+  rng.setStart(block, 0);
+  rng.setEnd(node, offset);
+  return rng.toString();
+};
+
 export {
   cleanEmptyNodes,
   deleteRng,
   getParentBlock,
-  resolveFromDynamicPatterns
+  resolveFromDynamicPatterns,
+  getBeforeText
 };

--- a/modules/tinymce/src/core/main/ts/textpatterns/utils/Utils.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/utils/Utils.ts
@@ -52,7 +52,7 @@ const resolveFromDynamicPatterns = (patternSet: PatternSet, block: Element, befo
   };
 };
 
-const getBeforeText = (dom: DOMUtils, block: Node, node: Node, offset: number): string => {
+const getBeforeText = (dom: DOMUtils, block: Element, node: Node, offset: number): string => {
   const rng = dom.createRng();
   rng.setStart(block, 0);
   rng.setEnd(node, offset);

--- a/modules/tinymce/src/core/main/ts/textpatterns/utils/Utils.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/utils/Utils.ts
@@ -3,7 +3,8 @@ import { Optional } from '@ephox/katamari';
 import DOMUtils from '../../api/dom/DOMUtils';
 import Editor from '../../api/Editor';
 import * as NodeType from '../../dom/NodeType';
-import { Pattern, PatternSet } from '../core/PatternTypes';
+import { getBlockPatterns, getInlinePatterns } from '../core/Pattern';
+import { PatternSet } from '../core/PatternTypes';
 
 const cleanEmptyNodes = (dom: DOMUtils, node: Node | null, isRoot: (e: Node) => boolean): void => {
   // Recursively walk up the tree while we have a parent and the node is empty. If the node is empty, then remove it.
@@ -37,13 +38,21 @@ const deleteRng = (dom: DOMUtils, rng: Range, isRoot: (e: Node) => boolean, clea
 const getParentBlock = (editor: Editor, rng: Range): Optional<Element> =>
   Optional.from(editor.dom.getParent(rng.startContainer, editor.dom.isBlock));
 
-const resolveFromDynamicPatterns = (patternSet: PatternSet, block: Element): Pattern[] => {
+const resolveFromDynamicPatterns = (patternSet: PatternSet, block: Element): PatternSet => {
   const blockText = block.textContent ?? '';
-  return patternSet.dynamicPatternsLookup({
+  const dynamicPatterns = patternSet.dynamicPatternsLookup({
     text: blockText,
     block
   });
+
+  // dynamic patterns take precedence here
+  return {
+    ...patternSet,
+    blockPatterns: getBlockPatterns(dynamicPatterns).concat(patternSet.blockPatterns),
+    inlinePatterns: getInlinePatterns(dynamicPatterns).concat(patternSet.inlinePatterns)
+  };
 };
+
 export {
   cleanEmptyNodes,
   deleteRng,

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternsTest.ts
@@ -4,12 +4,20 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as BlockPattern from 'tinymce/core/textpatterns/core/BlockPattern';
+import { PatternSet } from 'tinymce/core/textpatterns/core/PatternTypes';
+import { getParentBlock, resolveFromDynamicPatterns } from 'tinymce/core/textpatterns/utils/Utils';
 
-import { getPatternSetFor, findPatternsWithDynamicPatterns } from '../../module/test/TextPatternsUtils';
+import { getPatternSetFor } from '../../module/test/TextPatternsUtils';
 
 // Similar to modules/tinymce/src/core/test/ts/atomic/textpatterns/FindBlockPatternsTest.ts
 // but uses DOM and includes tests for text_patterns_lookup
 describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
+
+  const findPatternsWithDynamicPatterns = (editor: Editor, patternSet: PatternSet, normalizedMatches: boolean) => getParentBlock(editor, editor.selection.getRng()).map((block) => {
+    const dynamicPatternSet = resolveFromDynamicPatterns(patternSet, block, block.textContent ?? '');
+    return BlockPattern.findPatterns(editor, block, dynamicPatternSet, normalizedMatches);
+  }).getOr([]);
+
   context('no text_patterns_lookup', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       text_patterns: [
@@ -31,7 +39,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
       // forced root block. We aren't sure why this constraint exists.
       editor.setContent('<p># Heading</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], '# Heading'.length);
-      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), BlockPattern.findPatterns, true);
+      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), true);
       assert.deepEqual(
         matches,
         [
@@ -52,7 +60,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
       const editor = hook.editor();
       editor.setContent('<p>* No match');
       TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), BlockPattern.findPatterns, true);
+      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), true);
       assert.deepEqual(matches, []);
     });
 
@@ -63,7 +71,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
       // forced root block. We aren't sure why this constraint exists.
       editor.setContent('<div># Heading</div>');
       TinySelections.setCursor(editor, [ 0, 0 ], '# Heading'.length);
-      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), BlockPattern.findPatterns, true);
+      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), true);
       assert.deepEqual(
         matches,
         [],
@@ -96,7 +104,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
       const editor = hook.editor();
       editor.setContent('<p>#### wow</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], 4);
-      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), BlockPattern.findPatterns, true);
+      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), true);
       assert.deepEqual(
         matches,
         [
@@ -120,7 +128,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
       const editor = hook.editor();
       editor.setContent('<p><b>TBA Bold heading</b></p>');
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 3);
-      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), BlockPattern.findPatterns, true);
+      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), true);
       assert.deepEqual(
         matches,
         [
@@ -146,7 +154,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
       const editor = hook.editor();
       editor.setContent('<div><p>#### New heading type</p></div>');
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 4);
-      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), BlockPattern.findPatterns, true);
+      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), true);
       assert.deepEqual(matches, [
         {
           pattern: {
@@ -169,7 +177,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
       const editor = hook.editor();
       editor.setContent('<div>#### New heading type</div>');
       TinySelections.setCursor(editor, [ 0, 0 ], 4);
-      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), BlockPattern.findPatterns, true);
+      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), true);
       assert.deepEqual(matches, [], 'Checking block pattern matches do not match for incorrect block tag type');
     });
 
@@ -177,7 +185,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
       const editor = hook.editor();
       editor.setContent('<p>### is a new heading</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], 4);
-      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), BlockPattern.findPatterns, true);
+      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), true);
       assert.deepEqual(matches, [
         {
           pattern: {

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternsTest.ts
@@ -5,12 +5,11 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 import * as BlockPattern from 'tinymce/core/textpatterns/core/BlockPattern';
 
-import { getPatternSetFor } from '../../module/test/TextPatternsUtils';
+import { getPatternSetFor, findPatternsWithDynamicPatterns } from '../../module/test/TextPatternsUtils';
 
 // Similar to modules/tinymce/src/core/test/ts/atomic/textpatterns/FindBlockPatternsTest.ts
 // but uses DOM and includes tests for text_patterns_lookup
 describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
-
   context('no text_patterns_lookup', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       text_patterns: [
@@ -32,7 +31,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
       // forced root block. We aren't sure why this constraint exists.
       editor.setContent('<p># Heading</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], '# Heading'.length);
-      const matches = BlockPattern.findPatterns(editor, getPatternSet(), true);
+      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), BlockPattern.findPatterns, true);
       assert.deepEqual(
         matches,
         [
@@ -53,7 +52,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
       const editor = hook.editor();
       editor.setContent('<p>* No match');
       TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      const matches = BlockPattern.findPatterns(editor, getPatternSet(), true);
+      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), BlockPattern.findPatterns, true);
       assert.deepEqual(matches, []);
     });
 
@@ -64,7 +63,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
       // forced root block. We aren't sure why this constraint exists.
       editor.setContent('<div># Heading</div>');
       TinySelections.setCursor(editor, [ 0, 0 ], '# Heading'.length);
-      const matches = BlockPattern.findPatterns(editor, getPatternSet(), true);
+      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), BlockPattern.findPatterns, true);
       assert.deepEqual(
         matches,
         [],
@@ -97,7 +96,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
       const editor = hook.editor();
       editor.setContent('<p>#### wow</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], 4);
-      const matches = BlockPattern.findPatterns(editor, getPatternSet(), true);
+      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), BlockPattern.findPatterns, true);
       assert.deepEqual(
         matches,
         [
@@ -121,7 +120,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
       const editor = hook.editor();
       editor.setContent('<p><b>TBA Bold heading</b></p>');
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 3);
-      const matches = BlockPattern.findPatterns(editor, getPatternSet(), true);
+      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), BlockPattern.findPatterns, true);
       assert.deepEqual(
         matches,
         [
@@ -147,8 +146,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
       const editor = hook.editor();
       editor.setContent('<div><p>#### New heading type</p></div>');
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 4);
-      const patterns = getPatternSet();
-      const matches = BlockPattern.findPatterns(editor, patterns, true);
+      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), BlockPattern.findPatterns, true);
       assert.deepEqual(matches, [
         {
           pattern: {
@@ -171,7 +169,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
       const editor = hook.editor();
       editor.setContent('<div>#### New heading type</div>');
       TinySelections.setCursor(editor, [ 0, 0 ], 4);
-      const matches = BlockPattern.findPatterns(editor, getPatternSet(), true);
+      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), BlockPattern.findPatterns, true);
       assert.deepEqual(matches, [], 'Checking block pattern matches do not match for incorrect block tag type');
     });
 
@@ -179,7 +177,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
       const editor = hook.editor();
       editor.setContent('<p>### is a new heading</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], 4);
-      const matches = BlockPattern.findPatterns(editor, getPatternSet(), true);
+      const matches = findPatternsWithDynamicPatterns(editor, getPatternSet(), BlockPattern.findPatterns, true);
       assert.deepEqual(matches, [
         {
           pattern: {

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
@@ -333,7 +333,8 @@ describe('browser.tinymce.textpatterns.FindInlinePatternTest', () => {
               start: '*', end: '*', format: 'bold'
             }
           ];
-        } else if (parentTag === 'div' && ctx.text.includes('replace-me')) {
+        } else if (parentTag === 'div' && ctx.text.endsWith('replace-me')) {
+
           return [
             {
               start: 'me', replacement: 'you'
@@ -431,7 +432,7 @@ describe('browser.tinymce.textpatterns.FindInlinePatternTest', () => {
       );
     });
 
-    it('TINY-8778: Inline pattern matches text in the middle', () => {
+    it('TINY-8778: Inline pattern matches text in the middle of a pagraph', () => {
       const editor = hook.editor();
       editor.setContent('<div>Should replace-me in the middle of paragraph</div>');
       TinySelections.setCursor(editor, [ 0, 0 ], 'Should replace-me'.length);
@@ -456,6 +457,18 @@ describe('browser.tinymce.textpatterns.FindInlinePatternTest', () => {
             }
           }
         ]
+      );
+    });
+
+    it('TINY-8778: Does not return a match if the text pattern is not at the cursor', () => {
+      const editor = hook.editor();
+      const content = 'Should not match becauce replace-me is not at the cursor';
+      editor.setContent(`<div>${content}</div>`);
+      TinySelections.setCursor(editor, [ 0, 0 ], content.length);
+      const matches = getInlinePattern(editor, getInlinePatternSet(), false);
+      assertPatterns(
+        matches,
+        []
       );
     });
   });

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as InlinePattern from 'tinymce/core/textpatterns/core/InlinePattern';
-import { InlinePattern as InlinePatternType, InlinePatternMatch, InlinePatternSet, PatternSet } from 'tinymce/core/textpatterns/core/PatternTypes';
+import { InlinePattern as InlinePatternType, InlinePatternMatch, PatternSet } from 'tinymce/core/textpatterns/core/PatternTypes';
 import { PathRange } from 'tinymce/core/textpatterns/utils/PathRange';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
 
@@ -18,7 +18,8 @@ describe('browser.tinymce.textpatterns.FindInlinePatternTest', () => {
     readonly endRng: PathRange;
   }
 
-  const getInlinePattern = (editor: Editor, patternSet: PatternSet, space: boolean = false, normalized: boolean = false) => findPatternsWithDynamicPatterns(editor, patternSet, InlinePattern.findPatterns, space, normalized);
+  const getInlinePattern = (editor: Editor, patternSet: PatternSet, space: boolean = false, normalized: boolean = false) =>
+    findPatternsWithDynamicPatterns(editor, patternSet, InlinePattern.findPatterns, normalized, space);
 
   const assertPatterns = (actualMatches: InlinePatternMatch[], expectedMatches: ExpectedPatternMatch[]) => {
     assert.lengthOf(actualMatches, expectedMatches.length, 'Pattern count does not match');
@@ -206,7 +207,8 @@ describe('browser.tinymce.textpatterns.FindInlinePatternTest', () => {
     });
 
     context('with just a single ** -> bold inline-format pattern', () => {
-      const inlinePatternSet: InlinePatternSet = {
+      const inlinePatternSet: PatternSet = {
+        blockPatterns: [],
         inlinePatterns: [
           { type: 'inline-format', start: '**', end: '**', format: [ 'bold' ] }
         ],
@@ -223,14 +225,14 @@ describe('browser.tinymce.textpatterns.FindInlinePatternTest', () => {
       it('TINY-8778: force only ** pattern with leading content and test return on not existing *** pattern', () => {
         const editor = hook.editor();
         setContentAndCursor(editor, 'y ***x***', [ 0 ], 9);
-        const matches = getInlinePattern(editor, inlinePatternSet as PatternSet);
+        const matches = getInlinePattern(editor, inlinePatternSet);
         assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 3 ], end: [ 0, 5 ] }, { start: [ 0, 7 ], end: [ 0, 9 ] });
       });
 
       it('TINY-8778: force only ** pattern with trailing ** text and test return on not existing *** pattern', () => {
         const editor = hook.editor();
         setContentAndCursor(editor, 'y ***x*** **', [ 0 ], 9);
-        const matches = getInlinePattern(editor, inlinePatternSet as PatternSet);
+        const matches = getInlinePattern(editor, inlinePatternSet);
         assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 3 ], end: [ 0, 5 ] }, { start: [ 0, 7 ], end: [ 0, 9 ] });
       });
     });

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
@@ -224,7 +224,7 @@ describe('browser.tinymce.textpatterns.FindInlinePatternTest', () => {
       it('TINY-8778: force only ** pattern and test return on not existing *** pattern', () => {
         const editor = hook.editor();
         setContentAndCursor(editor, '***x***', [ 0 ], 7);
-        const matches = getInlinePattern(editor, inlinePatternSet as PatternSet);
+        const matches = getInlinePattern(editor, inlinePatternSet);
         assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 1 ], end: [ 0, 3 ] }, { start: [ 0, 5 ], end: [ 0, 7 ] });
       });
 

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
@@ -5,11 +5,11 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as InlinePattern from 'tinymce/core/textpatterns/core/InlinePattern';
-import { InlinePattern as InlinePatternType, InlinePatternMatch, InlinePatternSet } from 'tinymce/core/textpatterns/core/PatternTypes';
+import { InlinePattern as InlinePatternType, InlinePatternMatch, InlinePatternSet, PatternSet } from 'tinymce/core/textpatterns/core/PatternTypes';
 import { PathRange } from 'tinymce/core/textpatterns/utils/PathRange';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
 
-import { getPatternSetFor } from '../../module/test/TextPatternsUtils';
+import { findPatternsWithDynamicPatterns, getPatternSetFor } from '../../module/test/TextPatternsUtils';
 
 describe('browser.tinymce.textpatterns.FindInlinePatternTest', () => {
   interface ExpectedPatternMatch {
@@ -18,8 +18,7 @@ describe('browser.tinymce.textpatterns.FindInlinePatternTest', () => {
     readonly endRng: PathRange;
   }
 
-  const getInlinePattern = (editor: Editor, patternSet: InlinePatternSet, space: boolean = false, normalized: boolean = false) =>
-    InlinePattern.findPatterns(editor, patternSet, normalized, space);
+  const getInlinePattern = (editor: Editor, patternSet: PatternSet, space: boolean = false, normalized: boolean = false) => findPatternsWithDynamicPatterns(editor, patternSet, InlinePattern.findPatterns, space, normalized);
 
   const assertPatterns = (actualMatches: InlinePatternMatch[], expectedMatches: ExpectedPatternMatch[]) => {
     assert.lengthOf(actualMatches, expectedMatches.length, 'Pattern count does not match');
@@ -217,21 +216,21 @@ describe('browser.tinymce.textpatterns.FindInlinePatternTest', () => {
       it('TINY-8778: force only ** pattern and test return on not existing *** pattern', () => {
         const editor = hook.editor();
         setContentAndCursor(editor, '***x***', [ 0 ], 7);
-        const matches = getInlinePattern(editor, inlinePatternSet);
+        const matches = getInlinePattern(editor, inlinePatternSet as PatternSet);
         assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 1 ], end: [ 0, 3 ] }, { start: [ 0, 5 ], end: [ 0, 7 ] });
       });
 
       it('TINY-8778: force only ** pattern with leading content and test return on not existing *** pattern', () => {
         const editor = hook.editor();
         setContentAndCursor(editor, 'y ***x***', [ 0 ], 9);
-        const matches = getInlinePattern(editor, inlinePatternSet);
+        const matches = getInlinePattern(editor, inlinePatternSet as PatternSet);
         assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 3 ], end: [ 0, 5 ] }, { start: [ 0, 7 ], end: [ 0, 9 ] });
       });
 
       it('TINY-8778: force only ** pattern with trailing ** text and test return on not existing *** pattern', () => {
         const editor = hook.editor();
         setContentAndCursor(editor, 'y ***x*** **', [ 0 ], 9);
-        const matches = getInlinePattern(editor, inlinePatternSet);
+        const matches = getInlinePattern(editor, inlinePatternSet as PatternSet);
         assertSimpleMatch(matches, '**', '**', [ 'bold' ], { start: [ 0, 3 ], end: [ 0, 5 ] }, { start: [ 0, 7 ], end: [ 0, 9 ] });
       });
     });

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/ReplacementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/ReplacementTest.ts
@@ -187,6 +187,4 @@ describe('browser.tinymce.core.textpatterns.ReplacementTest', () => {
       testSpaceOnFragmentedText(hook.editor(), getNodes, [ 0, 3 ], 13, '<p>first <strong>element</strong> wow&nbsp; is big</p>');
     });
   });
-
-
 });

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/ReplacementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/ReplacementTest.ts
@@ -187,4 +187,6 @@ describe('browser.tinymce.core.textpatterns.ReplacementTest', () => {
       testSpaceOnFragmentedText(hook.editor(), getNodes, [ 0, 3 ], 13, '<p>first <strong>element</strong> wow&nbsp; is big</p>');
     });
   });
+
+
 });

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsLookupTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsLookupTest.ts
@@ -1,49 +1,47 @@
 import { Keys } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
-import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
+import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { DynamicPatternContext } from 'tinymce/core/textpatterns/core/PatternTypes';
 
 describe('browser.tinymce.textpatterns.TextPatternsLookupTest', () => {
-  context('Number of times text_patterns_lookup is called', () => {
-    const store = TestHelpers.TestStore();
-    const hook = TinyHooks.bddSetupLight<Editor>({
-      text_patterns: [
-        { start: '**', end: '**', format: 'bold' }
-      ],
-      base_url: '/project/tinymce/js/tinymce',
-      text_patterns_lookup: (ctx: DynamicPatternContext) => {
-        store.add(ctx.text);
-        return [
-          { start: '**', end: '**', format: 'italic' }
-        ];
-      }
-    }, [ ]);
+  const store = TestHelpers.TestStore();
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    text_patterns: [
+      { start: '**', end: '**', format: 'bold' }
+    ],
+    base_url: '/project/tinymce/js/tinymce',
+    text_patterns_lookup: (ctx: DynamicPatternContext) => {
+      store.add(ctx.text);
+      return [
+        { start: '**', end: '**', format: 'italic' }
+      ];
+    }
+  }, [ ]);
 
-    const setUp = (editor: Editor, content: string, path: number[], offset: number) => {
-      editor.setContent(`<p>${content}</p>`);
-      editor.focus();
-      TinySelections.setCursor(editor, path, offset);
-    };
+  const setUpContentAndMoveCursor = (editor: Editor, content: string, path: number[], offset: number) => {
+    editor.setContent(`<p>${content}</p>`);
+    editor.focus();
+    TinySelections.setCursor(editor, path, offset);
+  };
 
-    beforeEach(() => {
-      store.clear();
-    });
+  beforeEach(() => {
+    store.clear();
+  });
 
-    it('Twice on pressing enter key', () => {
-      const editor = hook.editor();
-      setUp(hook.editor(), 'brb', [ 0, 0 ], 3 );
-      TinyContentActions.keystroke(editor, Keys.enter());
-      store.assertEq('should be called twiced', [ 'brb', 'brb' ]);
-    });
+  it('TINY-8778: should only be called once when pressing enter key', () => {
+    const editor = hook.editor();
+    setUpContentAndMoveCursor(hook.editor(), 'brb', [ 0, 0 ], 3 );
+    TinyContentActions.keystroke(editor, Keys.enter());
+    store.assertEq('should only be called once', [ 'brb' ]);
+  });
 
-    it('Once on pressing space key', () => {
-      const editor = hook.editor();
-      setUp(hook.editor(), '**brb**', [ 0, 0 ], 7);
-      TinyContentActions.keyup(editor, Keys.space());
-      store.assertEq('should be called only once', [ '**brb**' ]);
-    });
+  it('TINY-8778: should only be called once when pressing space key', () => {
+    const editor = hook.editor();
+    setUpContentAndMoveCursor(hook.editor(), '**brb**', [ 0, 0 ], 7);
+    TinyContentActions.keyup(editor, Keys.space());
+    store.assertEq('should only be called once', [ '**brb**' ]);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsLookupTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsLookupTest.ts
@@ -1,10 +1,11 @@
-import { Keys } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { DynamicPatternContext } from 'tinymce/core/textpatterns/core/PatternTypes';
+
+import * as Utils from '../../module/test/TextPatternsUtils';
 
 describe('browser.tinymce.textpatterns.TextPatternsLookupTest', () => {
   const store = TestHelpers.TestStore();
@@ -21,27 +22,17 @@ describe('browser.tinymce.textpatterns.TextPatternsLookupTest', () => {
     }
   }, [ ]);
 
-  const setUpContentAndMoveCursor = (editor: Editor, content: string, path: number[], offset: number) => {
-    editor.setContent(`<p>${content}</p>`);
-    editor.focus();
-    TinySelections.setCursor(editor, path, offset);
-  };
-
   beforeEach(() => {
     store.clear();
   });
 
   it('TINY-8778: should only be called once when pressing enter key', () => {
-    const editor = hook.editor();
-    setUpContentAndMoveCursor(hook.editor(), 'brb', [ 0, 0 ], 3 );
-    TinyContentActions.keystroke(editor, Keys.enter());
+    Utils.setContentAndPressSpace(hook.editor(), 'brb');
     store.assertEq('should only be called once', [ 'brb' ]);
   });
 
   it('TINY-8778: should only be called once when pressing space key', () => {
-    const editor = hook.editor();
-    setUpContentAndMoveCursor(hook.editor(), '**brb**', [ 0, 0 ], 7);
-    TinyContentActions.keyup(editor, Keys.space());
+    Utils.setContentAndPressSpace(hook.editor(), '**brb**');
     store.assertEq('should only be called once', [ '**brb**' ]);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsLookupTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsLookupTest.ts
@@ -1,0 +1,49 @@
+import { Keys } from '@ephox/agar';
+import { TestHelpers } from '@ephox/alloy';
+import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
+import { TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import { DynamicPatternContext } from 'tinymce/core/textpatterns/core/PatternTypes';
+
+describe('browser.tinymce.textpatterns.TextPatternsLookupTest', () => {
+  context('Number of times text_patterns_lookup is called', () => {
+    const store = TestHelpers.TestStore();
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      text_patterns: [
+        { start: '**', end: '**', format: 'bold' }
+      ],
+      base_url: '/project/tinymce/js/tinymce',
+      text_patterns_lookup: (ctx: DynamicPatternContext) => {
+        store.add(ctx.text);
+        return [
+          { start: '**', end: '**', format: 'italic' }
+        ];
+      }
+    }, [ ]);
+
+    const setUp = (editor: Editor, content: string, path: number[], offset: number) => {
+      editor.setContent(`<p>${content}</p>`);
+      editor.focus();
+      TinySelections.setCursor(editor, path, offset);
+    };
+
+    beforeEach(() => {
+      store.clear();
+    });
+
+    it('Twice on pressing enter key', () => {
+      const editor = hook.editor();
+      setUp(hook.editor(), 'brb', [ 0, 0 ], 3 );
+      TinyContentActions.keystroke(editor, Keys.enter());
+      store.assertEq('should be called twiced', [ 'brb', 'brb' ]);
+    });
+
+    it('Once on pressing space key', () => {
+      const editor = hook.editor();
+      setUp(hook.editor(), '**brb**', [ 0, 0 ], 7);
+      TinyContentActions.keyup(editor, Keys.space());
+      store.assertEq('should be called only once', [ '**brb**' ]);
+    });
+  });
+});

--- a/modules/tinymce/src/core/test/ts/module/test/TextPatternsUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/TextPatternsUtils.ts
@@ -6,7 +6,6 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Options from 'tinymce/core/api/Options';
 import * as Pattern from 'tinymce/core/textpatterns/core/Pattern';
 import { PatternSet } from 'tinymce/core/textpatterns/core/PatternTypes';
-import { getParentBlock, resolveFromDynamicPatterns } from 'tinymce/core/textpatterns/utils/Utils';
 
 const setContentAndFireKeystroke = (key: number) => {
   return (editor: Editor, content: string, offset = content.length, elementPath = [ 0, 0 ], wrapInP = true) => {
@@ -17,12 +16,12 @@ const setContentAndFireKeystroke = (key: number) => {
   };
 };
 
-const setContentAndPressSpace = (editor: Editor, content: string, offset = content.length, elementPath = [ 0, 0 ]) => {
-  editor.setContent('<p>' + content + '</p>');
+const setContentAndPressSpace = (editor: Editor, content: string, offset = content.length, elementPath = [ 0, 0 ], blockElement = 'p') => {
+  editor.setContent(`<${blockElement}>${content}</${blockElement}>`);
   editor.focus();
   TinySelections.setCursor(editor, elementPath, offset);
   editor.execCommand('mceInsertContent', false, ' ');
-  TinyContentActions.keystroke(editor, Keys.space());
+  TinyContentActions.keyup(editor, Keys.space());
 };
 
 const bodyStruct = (children: StructAssert[]) => {
@@ -122,20 +121,6 @@ const getPatternSetFor = (hook: TinyHooks.Hook<Editor>) => Thunk.cached((): Patt
   );
 });
 
-const findPatternsWithDynamicPatterns = <
-  F extends (editor: Editor, block: Element, patternSet: PatternSet, normalized: boolean, allowTrailingSpace?: boolean) => any
->(
-  editor: Editor,
-  patternSet: PatternSet,
-  callback: F,
-  normalized: boolean,
-  allowTrailingSpace: boolean = false
-): ReturnType<F> =>
-  getParentBlock(editor, editor.selection.getRng()).map((block) => {
-    const dynamicPatternSet = resolveFromDynamicPatterns(patternSet, block);
-    return callback(editor, block, dynamicPatternSet, normalized, allowTrailingSpace);
-  }).getOr([]);
-
 export {
   setContentAndPressSpace,
   setContentAndPressEnter,
@@ -145,6 +130,5 @@ export {
   blockStructHelper,
   forcedRootBlockInlineStructHelper,
   forcedRootBlockStructHelper,
-  getPatternSetFor,
-  findPatternsWithDynamicPatterns
+  getPatternSetFor
 };

--- a/modules/tinymce/src/core/test/ts/module/test/TextPatternsUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/TextPatternsUtils.ts
@@ -122,10 +122,19 @@ const getPatternSetFor = (hook: TinyHooks.Hook<Editor>) => Thunk.cached((): Patt
   );
 });
 
-const findPatternsWithDynamicPatterns = (editor: Editor, patternSet: PatternSet, callback: any, normalized: boolean = false, allowTrailingSpace: boolean = false) => getParentBlock(editor, editor.selection.getRng()).map((block) => {
-  const dynamicPatterns = resolveFromDynamicPatterns(patternSet, block);
-  return callback(editor, block, patternSet, dynamicPatterns, normalized, allowTrailingSpace);
-}).getOr([]);
+const findPatternsWithDynamicPatterns = <
+  F extends (editor: Editor, block: Element, patternSet: PatternSet, normalized: boolean, allowTrailingSpace?: boolean) => any
+>(
+  editor: Editor,
+  patternSet: PatternSet,
+  callback: F,
+  normalized: boolean,
+  allowTrailingSpace: boolean = false
+): ReturnType<F> =>
+  getParentBlock(editor, editor.selection.getRng()).map((block) => {
+    const dynamicPatternSet = resolveFromDynamicPatterns(patternSet, block);
+    return callback(editor, block, dynamicPatternSet, normalized, allowTrailingSpace);
+  }).getOr([]);
 
 export {
   setContentAndPressSpace,

--- a/modules/tinymce/src/core/test/ts/module/test/TextPatternsUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/TextPatternsUtils.ts
@@ -6,6 +6,7 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Options from 'tinymce/core/api/Options';
 import * as Pattern from 'tinymce/core/textpatterns/core/Pattern';
 import { PatternSet } from 'tinymce/core/textpatterns/core/PatternTypes';
+import { getParentBlock, resolveFromDynamicPatterns } from 'tinymce/core/textpatterns/utils/Utils';
 
 const setContentAndFireKeystroke = (key: number) => {
   return (editor: Editor, content: string, offset = content.length, elementPath = [ 0, 0 ], wrapInP = true) => {
@@ -121,6 +122,11 @@ const getPatternSetFor = (hook: TinyHooks.Hook<Editor>) => Thunk.cached((): Patt
   );
 });
 
+const findPatternsWithDynamicPatterns = (editor: Editor, patternSet: PatternSet, callback: any, normalized: boolean = false, allowTrailingSpace: boolean = false) => getParentBlock(editor, editor.selection.getRng()).map((block) => {
+  const dynamicPatterns = resolveFromDynamicPatterns(patternSet, block);
+  return callback(editor, block, patternSet, dynamicPatterns, normalized, allowTrailingSpace);
+}).getOr([]);
+
 export {
   setContentAndPressSpace,
   setContentAndPressEnter,
@@ -130,5 +136,6 @@ export {
   blockStructHelper,
   forcedRootBlockInlineStructHelper,
   forcedRootBlockStructHelper,
-  getPatternSetFor
+  getPatternSetFor,
+  findPatternsWithDynamicPatterns
 };


### PR DESCRIPTION
Related Ticket: TINY-8778

Description of Changes:
* This PR address the issue,  which was found in the QA of TINY-8778,  that `text_patterns_lookup` was called more than expected (> 1 time) when matching a pattern on pressing enter or space key.
* Also reduced the number of sorting patterns

@TheSpyder, this might also address TINY-8904

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
