### PR TITLE
TINY-8861: fix cursor position after pasting a `codesample` snippet

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When a sidebar was opened using the `sidebar_show` option, its associated toggle button was not highlighted #TINY-8873
 - The `autolink` plugin when converting a URL to a link did not fire an `ExecCommand` event, nor did it create an undo level #TINY-8896
 - Worked around a Firefox bug whereby cookies weren't available inside the editor content #TINY-88916
+- The cursor position after pasting a `codesimple` snippet is now in the correct position #TINY-8861
 
 ## 6.1.0 - 2022-06-29
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When a sidebar was opened using the `sidebar_show` option, its associated toggle button was not highlighted #TINY-8873
 - The `autolink` plugin when converting a URL to a link did not fire an `ExecCommand` event, nor did it create an undo level #TINY-8896
 - Worked around a Firefox bug whereby cookies weren't available inside the editor content #TINY-88916
-- The cursor position after pasting a `codesimple` snippet is now in the correct position #TINY-8861
+- The cursor position after pasting or setting content with a `codesample` snippet no longer places the selection inside the non-editable codesample #TINY-8861
 
 ## 6.1.0 - 2022-06-29
 

--- a/modules/tinymce/src/plugins/codesample/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/core/FilterContent.ts
@@ -6,6 +6,9 @@ import Tools from 'tinymce/core/api/util/Tools';
 import * as Prism from '../prism/Prism';
 import * as Utils from '../util/Utils';
 
+const isPre = (node: Node): node is HTMLPreElement =>
+  node.nodeName.toLowerCase() === 'pre';
+
 const setup = (editor: Editor): void => {
   editor.on('PreProcess', (e) => {
     const dom = editor.dom;
@@ -46,6 +49,11 @@ const setup = (editor: Editor): void => {
           Prism.get(editor).highlightElement(elm);
           elm.className = Strings.trim(elm.className);
         });
+
+        const endContainer = editor.selection.getRng().endContainer;
+        if (isPre(endContainer)) {
+          editor.selection.select(endContainer);
+        }
       });
     }
   });

--- a/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSanityTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSanityTest.ts
@@ -41,4 +41,12 @@ describe('browser.tinymce.plugins.codesample.CodeSampleSanityTest', () => {
     await TestUtils.pCancelDialog(editor);
     TinyAssertions.assertContent(editor, '');
   });
+
+  it('TINY-8861: set content places the cursor in a valid position', () => {
+    const editor = hook.editor();
+
+    editor.setContent('<pre class="language-markup"><code>test content</code></pre>');
+    TinyAssertions.assertCursor(editor, [ 0 ], 0);
+    TinyAssertions.assertContent(editor, '<pre class="language-markup"><code>test content</code></pre>');
+  });
 });

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -47,9 +47,9 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
     await TestUtils.pOpenDialogAndAssertInitial(hook.editor(), 'markup', '');
     TestUtils.setTextareaContent('test content');
     await TestUtils.pSubmitDialog(editor);
-    await RealClipboard.pCopy('iframe => body');
+    await pClickEditMenu(editor, 'Copy');
     pressEnter(editor);
-    await RealClipboard.pPaste('iframe => body');
+    await pPaste(editor);
     pressEnter(editor);
 
     TinyAssertions.assertContent(editor,
@@ -70,7 +70,7 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
 
     TinySelections.setSelection(editor, [], 0, [ ((browser.isFirefox() || browser.isSafari()) ? 1 : 2), 0 ], 9);
 
-    await RealClipboard.pCopy('iframe => body');
+    await pClickEditMenu(editor, 'Copy');
     TinySelections.setCursor(editor, [ 1 ], 1);
 
     await pPaste(editor);

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -1,0 +1,48 @@
+import { Keys, RealClipboard } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/fullscreen/Plugin';
+
+import * as TestUtils from '../module/CodeSampleTestUtils';
+
+describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'codesample',
+    toolbar: 'codesample',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ]);
+
+  const pressEnter = (editor: Editor) => {
+    const overrides = { keyCode: Keys.enter() };
+
+    const getInputEventArgs = (eventType: string) => ({ ...new window.InputEvent(eventType), ...overrides });
+    const getKeyboardEventArgs = (eventType: string) => ({ ...new window.KeyboardEvent(eventType), ...overrides });
+
+    editor.dispatch('keydown', getKeyboardEventArgs('keydown'));
+    editor.dispatch('beforeinput', getInputEventArgs('beforeinput'));
+    editor.dispatch('input', getInputEventArgs('input'));
+    editor.dispatch('keyup', getKeyboardEventArgs('keyup'));
+  };
+
+  it('TINY-8861: press enter after paste a code sample should not add newline inside the code', async () => {
+    const editor = hook.editor();
+
+    await TestUtils.pOpenDialogAndAssertInitial(hook.editor(), 'markup', '');
+    TestUtils.setTextareaContent('test content');
+    await TestUtils.pSubmitDialog(editor);
+    await RealClipboard.pCopy('iframe => body');
+    pressEnter(editor);
+    await RealClipboard.pPaste('iframe => body');
+    pressEnter(editor);
+
+    TinyAssertions.assertContent(editor,
+      '<p><br></p>' +
+      '<p><br></p>' +
+      '<pre class="language-markup" contenteditable="false">test content</pre>' +
+      '<pre class="language-markup" contenteditable="false">test content</pre>',
+      { format: 'raw' }
+    );
+  });
+});

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -1,8 +1,7 @@
-import { Keys, RealClipboard, Keyboard } from '@ephox/agar';
+import { Keys, RealClipboard } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { PlatformDetection } from '@ephox/sand';
-import { Focus } from '@ephox/sugar';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/codesample/Plugin';
@@ -16,10 +15,7 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ]);
 
-  const pressEnter = (editor: Editor) => {
-    const focused = Focus.active(TinyDom.document(editor)).getOrDie();
-    Keyboard.keystroke(Keys.enter(), {}, focused);
-  };
+  const pressEnter = (editor: Editor) => TinyContentActions.keystroke(editor, Keys.enter());
 
   beforeEach(function () {
     const browser = PlatformDetection.detect().browser;

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -1,6 +1,6 @@
 import { Keys, RealClipboard } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/fullscreen/Plugin';
@@ -42,6 +42,31 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
       '<p><br></p>' +
       '<pre class="language-markup" contenteditable="false">test content</pre>' +
       '<pre class="language-markup" contenteditable="false">test content</pre>',
+      { format: 'raw' }
+    );
+  });
+
+  it('TINY-8861: coping and pating a piece of code and a text should leave the cursor on the text after paste', async () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<pre class="language-markup" contenteditable="false">test content</pre>' +
+      '<p>test text</p>'
+    );
+
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 2 ], 1);
+
+    await RealClipboard.pCopy('iframe => body');
+    TinySelections.setCursor(editor, [ 2 ], 1);
+
+    await RealClipboard.pPaste('iframe => body');
+    pressEnter(editor);
+
+    TinyAssertions.assertContent(editor,
+      '<pre class="language-markup" contenteditable="false">test content</pre>' +
+      '<p>test text</p>' +
+      '<pre class="language-markup" contenteditable="false">test content</pre>' +
+      '<p>test text</p>' +
+      '<p><br data-mce-bogus="1"></p>',
       { format: 'raw' }
     );
   });

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -51,11 +51,10 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
       '<pre class="language-markup" contenteditable="false" data-mce-highlighted="true">test content</pre>' +
       '<p>test text</p>'
     );
-
-    TinySelections.setSelection(editor, [ 0 ], 0, [ 2 ], 1);
+    TinySelections.setSelection(editor, [], 1, [ 2, 0 ], 9);
 
     await RealClipboard.pCopy('iframe => body');
-    TinySelections.setCursor(editor, [ 2 ], 1);
+    TinySelections.setCursor(editor, [ 1 ], 1);
 
     await RealClipboard.pPaste('iframe => body');
     pressEnter(editor);

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -43,8 +43,8 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
     TinyAssertions.assertContent(editor,
       '<p><br></p>' +
       '<p><br></p>' +
-      '<pre class="language-markup" contenteditable="false">test content</pre>' +
-      '<pre class="language-markup" contenteditable="false">test content</pre>',
+      '<pre class="language-markup" contenteditable="false" data-mce-highlighted="true">test content</pre>' +
+      '<pre class="language-markup" contenteditable="false" data-mce-highlighted="true">test content</pre>',
       { format: 'raw' }
     );
   });
@@ -52,7 +52,7 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
   it('TINY-8861: copying and pasting a piece of code and a text should leave the cursor on the text after paste', async () => {
     const editor = hook.editor();
     editor.setContent(
-      '<pre class="language-markup" contenteditable="false">test content</pre>' +
+      '<pre class="language-markup" contenteditable="false" data-mce-highlighted="true">test content</pre>' +
       '<p>test text</p>'
     );
 
@@ -65,9 +65,9 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
     pressEnter(editor);
 
     TinyAssertions.assertContent(editor,
-      '<pre class="language-markup" contenteditable="false">test content</pre>' +
+      '<pre class="language-markup" contenteditable="false" data-mce-highlighted="true">test content</pre>' +
       '<p>test text</p>' +
-      '<pre class="language-markup" contenteditable="false">test content</pre>' +
+      '<pre class="language-markup" contenteditable="false" data-mce-highlighted="true">test content</pre>' +
       '<p>test text</p>' +
       '<p><br data-mce-bogus="1"></p>',
       { format: 'raw' }

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -1,5 +1,5 @@
 import { Keys, RealClipboard } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -25,6 +25,10 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
     editor.dispatch('input', getInputEventArgs('input'));
     editor.dispatch('keyup', getKeyboardEventArgs('keyup'));
   };
+
+  beforeEach(() => {
+    hook.editor().setContent('');
+  });
 
   it('TINY-8861: press enter after paste a code sample should not add newline inside the code', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -33,6 +33,10 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
     }
   };
 
+  const getMockPreString = (content: string) => browser.isFirefox() ?
+    `<pre class="language-markup" data-mce-highlighted="true" contenteditable="false">${content}</pre>` :
+    `<pre class="language-markup" contenteditable="false" data-mce-highlighted="true">${content}</pre>`;
+
   beforeEach(() => {
     hook.editor().setContent('');
   });
@@ -51,8 +55,8 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
     TinyAssertions.assertContent(editor,
       '<p><br></p>' +
       '<p><br></p>' +
-      '<pre class="language-markup" contenteditable="false" data-mce-highlighted="true">test content</pre>' +
-      '<pre class="language-markup" contenteditable="false" data-mce-highlighted="true">test content</pre>',
+      getMockPreString('test content') +
+      getMockPreString('test content'),
       { format: 'raw' }
     );
   });
@@ -73,9 +77,9 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
     pressEnter(editor);
 
     TinyAssertions.assertContent(editor,
-      '<pre class="language-markup" contenteditable="false" data-mce-highlighted="true">test content</pre>' +
+      getMockPreString('test content') +
       '<p>test text</p>' +
-      '<pre class="language-markup" contenteditable="false" data-mce-highlighted="true">test content</pre>' +
+      getMockPreString('test content') +
       '<p>test text</p>' +
       '<p><br data-mce-bogus="1"></p>',
       { format: 'raw' }

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -49,7 +49,7 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
     );
   });
 
-  it('TINY-8861: coping and pating a piece of code and a text should leave the cursor on the text after paste', async () => {
+  it('TINY-8861: copying and pasting a piece of code and a text should leave the cursor on the text after paste', async () => {
     const editor = hook.editor();
     editor.setContent(
       '<pre class="language-markup" contenteditable="false">test content</pre>' +

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -68,7 +68,7 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
       '<p>test text</p>'
     );
 
-    TinySelections.setSelection(editor, [], 0, [ ((browser.isFirefox() || browser.isSafari()) ? 1 : 2), 0 ], 9);
+    TinySelections.setSelection(editor, [], 0, [ (browser.isFirefox() ? 1 : 2), 0 ], 9);
 
     await pClickEditMenu(editor, 'Copy');
     TinySelections.setCursor(editor, [ 1 ], 1);

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -1,5 +1,6 @@
 import { Keys, RealClipboard } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
+import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -26,7 +27,11 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
     editor.dispatch('keyup', getKeyboardEventArgs('keyup'));
   };
 
-  beforeEach(() => {
+  beforeEach(function () {
+    const browser = PlatformDetection.detect().browser;
+    if (browser.isSafari()) {
+      this.skip();
+    }
     hook.editor().setContent('');
   });
 

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -68,7 +68,7 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
       '<p>test text</p>'
     );
 
-    TinySelections.setSelection(editor, [], 0, [ (browser.isFirefox() ? 1 : 2), 0 ], 9);
+    TinySelections.setSelection(editor, [], 0, [ ((browser.isFirefox() || browser.isSafari()) ? 1 : 2), 0 ], 9);
 
     await RealClipboard.pCopy('iframe => body');
     TinySelections.setCursor(editor, [ 1 ], 1);

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Plugin from 'tinymce/plugins/fullscreen/Plugin';
+import Plugin from 'tinymce/plugins/codesample/Plugin';
 
 import * as TestUtils from '../module/CodeSampleTestUtils';
 

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -8,20 +8,6 @@ import Plugin from 'tinymce/plugins/codesample/Plugin';
 
 import * as TestUtils from '../module/CodeSampleTestUtils';
 
-const pClickEditMenu = async (editor: Editor, item: string): Promise<void> => {
-  TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
-  await TinyUiActions.pWaitForUi(editor, '*[role="menu"]');
-  await RealMouse.pClickOn(`div[title=${item}]`);
-};
-
-const pPaste = async (editor: Editor): Promise<void> => {
-  if (PlatformDetection.detect().browser.isSafari()) {
-    await pClickEditMenu(editor, 'Paste');
-  } else {
-    await RealClipboard.pPaste('iframe => body');
-  }
-};
-
 describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'codesample',
@@ -32,6 +18,20 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
   const pressEnter = (editor: Editor) => TinyContentActions.keystroke(editor, Keys.enter());
 
   const browser = PlatformDetection.detect().browser;
+
+  const pClickEditMenu = async (editor: Editor, item: string): Promise<void> => {
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
+    await TinyUiActions.pWaitForUi(editor, '*[role="menu"]');
+    await RealMouse.pClickOn(`div[title=${item}]`);
+  };
+
+  const pPaste = async (editor: Editor): Promise<void> => {
+    if (PlatformDetection.detect().browser.isSafari()) {
+      await pClickEditMenu(editor, 'Paste');
+    } else {
+      await RealClipboard.pPaste('iframe => body');
+    }
+  };
 
   beforeEach(() => {
     hook.editor().setContent('');

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -26,7 +26,7 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
   };
 
   const pPaste = async (editor: Editor): Promise<void> => {
-    if (PlatformDetection.detect().browser.isSafari()) {
+    if (browser.isSafari()) {
       await pClickEditMenu(editor, 'Paste');
     } else {
       await RealClipboard.pPaste('iframe => body');

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -1,7 +1,8 @@
-import { Keys, RealClipboard } from '@ephox/agar';
+import { Keys, RealClipboard, Keyboard } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { PlatformDetection } from '@ephox/sand';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { Focus } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/codesample/Plugin';
@@ -16,15 +17,8 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
   }, [ Plugin ]);
 
   const pressEnter = (editor: Editor) => {
-    const overrides = { keyCode: Keys.enter() };
-
-    const getInputEventArgs = (eventType: string) => ({ ...new window.InputEvent(eventType), ...overrides });
-    const getKeyboardEventArgs = (eventType: string) => ({ ...new window.KeyboardEvent(eventType), ...overrides });
-
-    editor.dispatch('keydown', getKeyboardEventArgs('keydown'));
-    editor.dispatch('beforeinput', getInputEventArgs('beforeinput'));
-    editor.dispatch('input', getInputEventArgs('input'));
-    editor.dispatch('keyup', getKeyboardEventArgs('keyup'));
+    const focused = Focus.active(TinyDom.document(editor)).getOrDie();
+    Keyboard.keystroke(Keys.enter(), {}, focused);
   };
 
   beforeEach(function () {


### PR DESCRIPTION
Related Ticket: TINY-8861

Description of Changes:
The problem here is that copying and pasting snippet generated from `codesample` plugin the cursor is placed in the wrong place so pressing enter the row is added into the code and not outside.

the solution that I tried is to replicate logic similar to the one used when it is inserted a new [snippet](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/plugins/codesample/main/ts/core/CodeSample.ts#L25), on `SetContent` event of `codesimple` plugin

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set

GitHub issues (if applicable):
