### PR TITLE
TINY-8921: Fixed more strict type errors in the core demos and tests

### DIFF
--- a/modules/agar/CHANGELOG.md
+++ b/modules/agar/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Improved
+- Exposed the `ArrayAssert` and `StringAssert` types.
+
 ## 7.1.0 - 2022-06-29
 
 ### Added

--- a/modules/agar/src/main/ts/ephox/agar/api/Main.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Main.ts
@@ -1,4 +1,4 @@
-import { StructAssert, StructAssertAdv, StructAssertBasic } from '../assertions/ApproxStructures';
+import { ArrayAssert, StringAssert, StructAssert, StructAssertAdv, StructAssertBasic } from '../assertions/ApproxStructures';
 import * as ApproxStructure from './ApproxStructure';
 import * as Arbitraries from './Arbitraries';
 import * as Assertions from './Assertions';
@@ -68,6 +68,8 @@ export {
   UiFinder,
   Waiter,
   Touch,
+  ArrayAssert,
+  StringAssert,
   StructAssert,
   StructAssertBasic,
   StructAssertAdv,

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/McEditor.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/McEditor.ts
@@ -67,7 +67,7 @@ const pFromElement = <T extends EditorType = EditorType>(element: SugarElement<E
   });
 };
 
-const pFromHtml = <T extends EditorType = EditorType>(html: string | null, settings: Record<string, any>): Promise<T> => {
+const pFromHtml = <T extends EditorType = EditorType>(html: string | null | undefined, settings: Record<string, any>): Promise<T> => {
   const element = html ? SugarElement.fromHtml<Element>(html) : SugarElement.fromTag(settings.inline ? 'div' : 'textarea');
   return pFromElement(element, settings);
 };

--- a/modules/tinymce/.eslintrc.json
+++ b/modules/tinymce/.eslintrc.json
@@ -17,7 +17,7 @@
     },
     // Re-enable things that are passing for explicit module boundary types
     {
-      "files": [ "src/core/main/**/*.ts" ],
+      "files": [ "src/core/main/**/*.ts", "src/core/test/**/*.ts" ],
       "rules": {
         "@typescript-eslint/explicit-module-boundary-types": [ "error", { "allowArgumentsExplicitlyTypedAsAny": true }]
       }

--- a/modules/tinymce/.eslintrc.json
+++ b/modules/tinymce/.eslintrc.json
@@ -17,7 +17,7 @@
     },
     // Re-enable things that are passing for explicit module boundary types
     {
-      "files": [ "src/core/main/**/*.ts", "src/core/test/**/*.ts" ],
+      "files": [ "src/core/**/*.ts" ],
       "rules": {
         "@typescript-eslint/explicit-module-boundary-types": [ "error", { "allowArgumentsExplicitlyTypedAsAny": true }]
       }

--- a/modules/tinymce/src/core/demo/ts/demo/AnnotationsDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/AnnotationsDemo.ts
@@ -1,8 +1,8 @@
 import { Fun } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
 
-declare let tinymce: any;
+declare let tinymce: TinyMCE;
 
 const contentStyles = `
 .mce-annotation { background-color: lightgreen; }
@@ -10,7 +10,7 @@ const contentStyles = `
 [data-mce-annotation="beta"][data-mce-annotation-active] { background-color: yellow; }
 `;
 
-export default () => {
+export default (): void => {
   tinymce.init({
     skin_url: '../../../../js/tinymce/skins/ui/oxide',
     selector: 'div.tinymce',
@@ -21,7 +21,7 @@ export default () => {
     height: 400,
     content_style: contentStyles,
 
-    setup: (editor: Editor) => {
+    setup: (editor) => {
       editor.ui.registry.addButton('annotate-alpha', {
         text: 'Annotate',
         onAction: () => {

--- a/modules/tinymce/src/core/demo/ts/demo/CommandsDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/CommandsDemo.ts
@@ -1,9 +1,12 @@
 import { Arr } from '@ephox/katamari';
+import { DomEvent, Html, Insert, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
 
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
 
-export default () => {
-  const cmd = (command, value?) => {
+declare let tinymce: TinyMCE;
+
+export default (): void => {
+  const cmd = (command: string, value?: string | number) => {
     return { command, value };
   };
 
@@ -88,13 +91,14 @@ export default () => {
     cmd('mceEditImage')
   ];
 
+  const container = SelectorFind.descendant(SugarBody.body(), '#ephox-ui').getOrDie();
   Arr.each(commands, (cmd) => {
-    const btn = document.createElement('button');
-    btn.innerHTML = cmd.command;
-    btn.onclick = () => {
-      tinymce.activeEditor.execCommand(cmd.command, false, cmd.value);
-    };
-    document.querySelector('#ephox-ui').appendChild(btn);
+    const btn = SugarElement.fromTag('button');
+    Html.set(btn, cmd.command);
+    DomEvent.bind(btn, 'click', () => {
+      tinymce.activeEditor?.execCommand(cmd.command, false, cmd.value);
+    });
+    Insert.append(container, btn);
   });
 
   tinymce.init({

--- a/modules/tinymce/src/core/demo/ts/demo/ContentEditableFalseDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContentEditableFalseDemo.ts
@@ -1,15 +1,19 @@
 /* eslint-disable no-console */
-import Editor from 'tinymce/core/api/Editor';
+import { Global } from '@ephox/katamari';
 
-declare const window: any;
-declare let tinymce: any;
+import { Editor, TinyMCE } from 'tinymce/core/api/PublicApi';
+import CaretPosition from 'tinymce/core/caret/CaretPosition';
 
-export default () => {
+declare const tinymce: TinyMCE;
 
-  const paintClientRect = (rect, color, id) => {
-    const editor: Editor = tinymce.activeEditor;
+export default (): void => {
+
+  const isTextNode = (node: Node): node is Text =>
+    node.nodeType === 3;
+
+  const paintClientRect = (rect: DOMRect, color: string, id: string) => {
+    const editor = tinymce.activeEditor as Editor;
     const dom = editor.dom;
-    let rectDiv: HTMLElement;
     const viewPort = editor.dom.getViewPort();
 
     if (!rect) {
@@ -17,8 +21,7 @@ export default () => {
     }
 
     color = color || 'red';
-    id = id || color;
-    rectDiv = dom.get(id);
+    let rectDiv = dom.get(id || color);
 
     if (!rectDiv) {
       rectDiv = dom.add(editor.getBody(), 'div');
@@ -36,17 +39,17 @@ export default () => {
     });
   };
 
-  const paintClientRects = (rects, color) => {
-    tinymce.util.Tools.each(rects, (rect, index) => {
+  const paintClientRects = (rects: DOMRect[], color: string) => {
+    tinymce.each(rects, (rect, index) => {
       paintClientRect(rect, color, color + index);
     });
   };
 
-  const logPos = (caretPosition) => {
+  const logPos = (caretPosition: CaretPosition) => {
     const container = caretPosition.container(),
       offset = caretPosition.offset();
 
-    if (container.nodeType === 3) {
+    if (isTextNode(container)) {
       if (container.data[offset]) {
         console.log(container.data[offset]);
       } else {
@@ -57,9 +60,9 @@ export default () => {
     }
   };
 
-  window.paintClientRect = paintClientRect;
-  window.paintClientRects = paintClientRects;
-  window.logPos = logPos;
+  Global.paintClientRect = paintClientRect;
+  Global.paintClientRects = paintClientRects;
+  Global.logPos = logPos;
 
   tinymce.init({
     selector: 'textarea.tinymce',
@@ -82,6 +85,4 @@ export default () => {
     plugins: [ 'code' ],
     content_css: '../css/content_editable.css'
   });
-
-  window.tinymce = tinymce;
 };

--- a/modules/tinymce/src/core/demo/ts/demo/ContentSecurityPolicyDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContentSecurityPolicyDemo.ts
@@ -2,9 +2,11 @@
 import { Merger } from '@ephox/katamari';
 import { Css, SugarElement } from '@ephox/sugar';
 
-declare let tinymce: any;
+import { Editor, RawEditorOptions, TinyMCE } from 'tinymce/core/api/PublicApi';
 
-const makeSidebar = (ed, name: string, background: string, width: number) => {
+declare let tinymce: TinyMCE;
+
+const makeSidebar = (ed: Editor, name: string, background: string, width: number) => {
   ed.ui.registry.addSidebar(name, {
     icon: 'comment',
     tooltip: 'Tooltip for ' + name,
@@ -29,7 +31,7 @@ const makeSidebar = (ed, name: string, background: string, width: number) => {
   });
 };
 
-const settings = {
+const settings: RawEditorOptions = {
   skin_url: '../../../../js/tinymce/skins/ui/oxide',
   content_css: '../../../../js/tinymce/skins/content/default/content.css',
   images_upload_url: 'd',

--- a/modules/tinymce/src/core/demo/ts/demo/CustomThemeDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/CustomThemeDemo.ts
@@ -1,12 +1,17 @@
-declare const tinymce: any;
+import { Class, Insert, SelectorFind, SugarBody, SugarElement, Value } from '@ephox/sugar';
 
-export default () => {
-  const textarea = document.createElement('textarea');
-  textarea.rows = 20;
-  textarea.cols = 80;
-  textarea.innerHTML = '<p>Bolt</p>';
-  textarea.classList.add('tinymce');
-  document.querySelector('#ephox-ui').appendChild(textarea);
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare const tinymce: TinyMCE;
+
+export default (): void => {
+  const textarea = SugarElement.fromTag('textarea');
+  textarea.dom.rows = 20;
+  textarea.dom.cols = 80;
+  Value.set(textarea, '<p>Bolt</p>');
+  Class.add(textarea, 'tinymce');
+  const container = SelectorFind.descendant(SugarBody.body(), '#ephox-ui').getOrDie();
+  Insert.append(container, textarea);
 
   tinymce.init({
     selector: 'textarea',
@@ -36,7 +41,7 @@ export default () => {
         });
       });
 
-      editor.on(() => {
+      editor.on('PreInit', () => {
         tinymce.each(dom.select('button', editorContainer), (button) => {
           editor.formatter.formatChanged(dom.getAttrib(button, 'data-mce-command'), (state) => {
             button.style.color = state ? 'red' : '';
@@ -46,8 +51,7 @@ export default () => {
 
       return {
         editorContainer,
-        iframeContainer: editorContainer.lastChild,
-        iframeHeight: target.offsetHeight - editorContainer.firstChild.offsetHeight
+        iframeContainer: editorContainer.lastChild as HTMLElement
       };
     },
     height: 600

--- a/modules/tinymce/src/core/demo/ts/demo/FixedToolbarContainerDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FixedToolbarContainerDemo.ts
@@ -1,6 +1,8 @@
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
 
-export default () => {
+declare let tinymce: TinyMCE;
+
+export default (): void => {
   tinymce.init({
     selector: '#editor',
     inline: true,

--- a/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
@@ -2,13 +2,13 @@
 import { Merger } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
-import { RawEditorOptions, TinyMCE } from 'tinymce/core/api/PublicApi';
+import { Editor, RawEditorOptions, TinyMCE } from 'tinymce/core/api/PublicApi';
 
 declare let tinymce: TinyMCE;
 
-export default () => {
+export default (): void => {
 
-  const makeSidebar = (ed, name: string, background: string, width: number) => {
+  const makeSidebar = (ed: Editor, name: string, background: string, width: number) => {
     ed.ui.registry.addSidebar(name, {
       icon: 'comment',
       tooltip: 'Tooltip for ' + name,

--- a/modules/tinymce/src/core/demo/ts/demo/IframeDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/IframeDemo.ts
@@ -2,11 +2,13 @@
 import { Merger } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
-declare let tinymce: any;
+import { Editor, RawEditorOptions, TinyMCE } from 'tinymce/core/api/PublicApi';
 
-export default () => {
+declare let tinymce: TinyMCE;
 
-  const makeSidebar = (ed, name: string, background: string, width: number) => {
+export default (): void => {
+
+  const makeSidebar = (ed: Editor, name: string, background: string, width: number) => {
     ed.ui.registry.addSidebar(name, {
       icon: 'comment',
       tooltip: 'Tooltip for ' + name,
@@ -27,7 +29,7 @@ export default () => {
     });
   };
 
-  const settings = {
+  const settings: RawEditorOptions = {
     skin_url: '../../../../js/tinymce/skins/ui/oxide',
     content_css: '../../../../js/tinymce/skins/content/default/content.css',
     selector: 'textarea',

--- a/modules/tinymce/src/core/demo/ts/demo/InlineDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/InlineDemo.ts
@@ -1,8 +1,10 @@
-declare let tinymce: any;
+import { RawEditorOptions, TinyMCE } from 'tinymce/core/api/PublicApi';
 
-export default () => {
+declare let tinymce: TinyMCE;
 
-  const settings = {
+export default (): void => {
+
+  const settings: RawEditorOptions = {
     selector: '.tinymce',
     inline: true,
     content_css: '../../../../js/tinymce/skins/content/default/content.css',

--- a/modules/tinymce/src/core/demo/ts/demo/ResponsiveDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ResponsiveDemo.ts
@@ -1,10 +1,12 @@
 import { SugarElement } from '@ephox/sugar';
 
-declare let tinymce: any;
+import { Editor, RawEditorOptions, TinyMCE } from 'tinymce/core/api/PublicApi';
 
-export default () => {
+declare let tinymce: TinyMCE;
 
-  const makeSidebar = (ed, name: string, background: string, width: number) => {
+export default (): void => {
+
+  const makeSidebar = (ed: Editor, name: string, background: string, width: number) => {
     ed.ui.registry.addSidebar(name, {
       icon: 'comment',
       tooltip: 'Tooltip for ' + name,
@@ -20,7 +22,7 @@ export default () => {
     });
   };
 
-  const settings = {
+  const settings: RawEditorOptions = {
     skin_url: '../../../../js/tinymce/skins/ui/oxide',
     content_css: '../../../../js/tinymce/skins/content/default/content.css',
     images_upload_url: 'd',

--- a/modules/tinymce/src/core/demo/ts/demo/ShadowDomDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ShadowDomDemo.ts
@@ -1,18 +1,22 @@
-declare let tinymce: any;
+import { Insert, SelectorFind, SugarBody, SugarElement, Value } from '@ephox/sugar';
 
-export default (init: ShadowRootInit) => {
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
 
-  const shadowHost = document.getElementById('shadow-host');
-  shadowHost.tabIndex = 1;
+declare let tinymce: TinyMCE;
 
-  const shadow = shadowHost.attachShadow(init);
+export default (init: ShadowRootInit): void => {
 
-  const node = document.createElement('textarea');
-  node.value = 'here is some content';
-  shadow.appendChild(node);
+  const shadowHost = SelectorFind.descendant<HTMLElement>(SugarBody.body(), '#shadow-host').getOrDie();
+  shadowHost.dom.tabIndex = 1;
+
+  const shadow = SugarElement.fromDom(shadowHost.dom.attachShadow(init));
+
+  const node = SugarElement.fromTag('textarea');
+  Value.set(node, 'here is some content');
+  Insert.append(shadow, node);
 
   tinymce.init({
-    target: node,
+    target: node.dom,
     plugins: 'advlist charmap code codesample emoticons fullscreen image link lists media preview searchreplace table wordcount'
   });
 };

--- a/modules/tinymce/src/core/demo/ts/demo/ShadowDomInlineDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ShadowDomInlineDemo.ts
@@ -1,18 +1,22 @@
-declare let tinymce: any;
+import { Insert, SelectorFind, SugarBody, SugarElement, TextContent } from '@ephox/sugar';
 
-export default (init: ShadowRootInit) => {
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
 
-  const shadowHost = document.getElementById('shadow-host');
+declare let tinymce: TinyMCE;
 
-  const shadow = shadowHost.attachShadow(init);
+export default (init: ShadowRootInit): void => {
+
+  const shadowHost = SelectorFind.descendant<HTMLElement>(SugarBody.body(), '#shadow-host').getOrDie();
+
+  const shadow = SugarElement.fromDom(shadowHost.dom.attachShadow(init));
 
   let i = 0;
   const addSection = (): void => {
-    const node = document.createElement('div');
-    node.textContent = 'content section ' + i++;
-    shadow.appendChild(node);
+    const node = SugarElement.fromTag('div');
+    TextContent.set(node, 'content section ' + i++);
+    Insert.append(shadow, node);
     tinymce.init({
-      target: node,
+      target: node.dom,
       inline: true
     });
   };

--- a/modules/tinymce/src/core/demo/ts/demo/SourceDumpDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/SourceDumpDemo.ts
@@ -1,9 +1,13 @@
-declare let tinymce: any;
+import { Checked, SelectorFind, SugarBody, Value } from '@ephox/sugar';
 
-export default () => {
+import { Editor, TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
+
+export default (): void => {
   tinymce.init({
     selector: 'textarea#editor',
-    skin_url: '../../../../js/tinymce/skins/lightgray',
+    skin_url: '../../../../js/tinymce/skins/ui/oxide',
     content_css: '../../../../js/tinymce/skins/content/default/content.css',
     templates: [
       { title: 'Some title 1', description: 'Some desc 1', content: 'My content' },
@@ -24,9 +28,10 @@ export default () => {
     }
   });
 
-  const dumpSource = (editor) => {
-    const textArea = document.getElementById('source') as HTMLTextAreaElement;
-    const raw = document.getElementById('raw') as HTMLInputElement;
-    textArea.value = raw.checked ? editor.getBody().innerHTML : editor.getContent();
+  const dumpSource = (editor: Editor) => {
+    const textarea = SelectorFind.descendant<HTMLTextAreaElement>(SugarBody.body(), '#source').getOrDie();
+    const raw = SelectorFind.descendant<HTMLInputElement>(SugarBody.body(), '#raw').getOrDie();
+    const content = Checked.get(raw) ? editor.getBody().innerHTML : editor.getContent();
+    Value.set(textarea, content);
   };
 };

--- a/modules/tinymce/src/core/demo/ts/demo/StickyToolbarDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/StickyToolbarDemo.ts
@@ -1,10 +1,12 @@
 import { SugarElement } from '@ephox/sugar';
 
-declare let tinymce: any;
+import { Editor, RawEditorOptions, TinyMCE } from 'tinymce/core/api/PublicApi';
 
-export default () => {
+declare let tinymce: TinyMCE;
 
-  const makeSidebar = (ed, name: string, background: string, width: number) => {
+export default (): void => {
+
+  const makeSidebar = (ed: Editor, name: string, background: string, width: number) => {
     ed.ui.registry.addSidebar(name, {
       icon: 'comment',
       tooltip: 'Tooltip for ' + name,
@@ -24,7 +26,7 @@ export default () => {
     });
   };
 
-  const stickySettings = {
+  const stickySettings: RawEditorOptions = {
     skin_url: '../../../../js/tinymce/skins/ui/oxide',
     content_css: '../../../../js/tinymce/skins/content/default/content.css',
     images_upload_url: 'd',

--- a/modules/tinymce/src/core/demo/ts/demo/TinyMceDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/TinyMceDemo.ts
@@ -1,11 +1,15 @@
-declare let tinymce: any;
+import { Class, Insert, SelectorFind, SugarBody, SugarElement, Value } from '@ephox/sugar';
 
-export default () => {
-  const textarea = document.createElement('textarea');
-  textarea.innerHTML = '<p>Bolt</p>';
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
 
-  textarea.classList.add('tinymce');
-  document.querySelector('#ephox-ui').appendChild(textarea);
+declare let tinymce: TinyMCE;
+
+export default (): void => {
+  const textarea = SugarElement.fromTag('textarea');
+  Value.set(textarea, '<p>Bolt</p>');
+  Class.add(textarea, 'tinymce');
+  const container = SelectorFind.descendant(SugarBody.body(), '#ephox-ui').getOrDie();
+  Insert.append(container, textarea);
 
   tinymce.init({
     // imagetools_cors_hosts: ["moxiecode.cachefly.net"],

--- a/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
@@ -101,7 +101,7 @@ interface AddOnManager<T> {
   urls: Record<string, string>;
   lookup: Record<string, { instance: AddOnConstructor<T> }>;
   get: (name: string) => AddOnConstructor<T> | undefined;
-  requireLangPack: (name: string, languages: string) => void;
+  requireLangPack: (name: string, languages?: string) => void;
   add: (id: string, addOn: AddOnConstructor<T>) => AddOnConstructor<T>;
   remove: (name: string) => void;
   createUrl: (baseUrl: UrlObject, dep: string | UrlObject) => UrlObject;
@@ -131,7 +131,7 @@ const AddOnManager = <T>(): AddOnManager<T> => {
     return undefined;
   };
 
-  const loadLanguagePack = (name: string, languages: string): void => {
+  const loadLanguagePack = (name: string, languages?: string): void => {
     const language = I18n.getCode();
     const wrappedLanguages = ',' + (languages || '') + ',';
 
@@ -142,7 +142,7 @@ const AddOnManager = <T>(): AddOnManager<T> => {
     ScriptLoader.ScriptLoader.add(urls[ name ] + '/langs/' + language + '.js');
   };
 
-  const requireLangPack = (name: string, languages: string) => {
+  const requireLangPack = (name: string, languages?: string) => {
     if (AddOnManager.languageLoad !== false) {
       if (isLoaded(name)) {
         loadLanguagePack(name, languages);

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -464,7 +464,9 @@ class Editor implements EditorObservable {
    *   }
    * });
    */
-  public addCommand(name: string, callback: EditorCommandCallback, scope?: object): void {
+  public addCommand<S>(name: string, callback: EditorCommandCallback<S>, scope: S): void;
+  public addCommand(name: string, callback: EditorCommandCallback<Editor>): void;
+  public addCommand(name: string, callback: EditorCommandCallback<any>, scope?: object): void {
     /**
      * Callback function that gets called when a command is executed.
      *
@@ -485,7 +487,9 @@ class Editor implements EditorObservable {
    * @param {Function} callback Function to execute when the command state retrieval occurs.
    * @param {Object} scope Optional scope to execute the function in.
    */
-  public addQueryStateHandler(name: string, callback: () => boolean, scope?: any): void {
+  public addQueryStateHandler<S>(name: string, callback: (this: S) => boolean, scope?: S): void;
+  public addQueryStateHandler(name: string, callback: (this: Editor) => boolean): void;
+  public addQueryStateHandler(name: string, callback: (this: any) => boolean, scope?: any): void {
     /**
      * Callback function that gets called when a queryCommandState is executed.
      *
@@ -504,7 +508,9 @@ class Editor implements EditorObservable {
    * @param {Function} callback Function to execute when the command value retrieval occurs.
    * @param {Object} scope Optional scope to execute the function in.
    */
-  public addQueryValueHandler(name: string, callback: () => string, scope?: any): void {
+  public addQueryValueHandler<S>(name: string, callback: (this: S) => string, scope: S): void;
+  public addQueryValueHandler(name: string, callback: (this: Editor) => string): void;
+  public addQueryValueHandler(name: string, callback: (this: any) => string, scope?: any): void {
     /**
      * Callback function that gets called when a queryCommandValue is executed.
      *

--- a/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
@@ -11,7 +11,7 @@ import Editor from './Editor';
  * @class tinymce.EditorCommands
  */
 
-export type EditorCommandCallback = (ui: boolean, value: any) => void;
+export type EditorCommandCallback<S> = (this: S, ui: boolean, value: any) => void;
 export type EditorCommandsCallback = (command: string, ui: boolean, value?: any) => void;
 
 interface Commands {
@@ -142,7 +142,9 @@ class EditorCommands {
     });
   }
 
-  public addCommand(command: string, callback: EditorCommandCallback, scope?: any): void {
+  public addCommand<S>(command: string, callback: EditorCommandCallback<S>, scope: S): void;
+  public addCommand(command: string, callback: EditorCommandCallback<Editor>): void;
+  public addCommand(command: string, callback: EditorCommandCallback<any>, scope?: any): void {
     const lowerCaseCommand = command.toLowerCase();
     this.commands.exec[lowerCaseCommand] = (_command, ui, value) => callback.call(scope ?? this.editor, ui, value);
   }
@@ -171,7 +173,9 @@ class EditorCommands {
    * @param {Function} callback Function to execute when the command state retrieval occurs.
    * @param {Object} scope Optional scope to execute the function in.
    */
-  public addQueryStateHandler(command: string, callback: () => boolean, scope?: any): void {
+  public addQueryStateHandler<S>(command: string, callback: (this: S) => boolean, scope: S): void;
+  public addQueryStateHandler(command: string, callback: (this: Editor) => boolean): void;
+  public addQueryStateHandler(command: string, callback: (this: any) => boolean, scope?: any): void {
     this.commands.state[command.toLowerCase()] = () => callback.call(scope ?? this.editor);
   }
 
@@ -184,7 +188,9 @@ class EditorCommands {
    * @param {Function} callback Function to execute when the command value retrieval occurs.
    * @param {Object} scope Optional scope to execute the function in.
    */
-  public addQueryValueHandler(command: string, callback: () => string, scope?: any): void {
+  public addQueryValueHandler<S>(command: string, callback: (this: S) => string, scope: S): void;
+  public addQueryValueHandler(command: string, callback: (this: Editor) => string): void;
+  public addQueryValueHandler(command: string, callback: (this: any) => string, scope?: any): void {
     this.commands.value[command.toLowerCase()] = () => callback.call(scope ?? this.editor);
   }
 }

--- a/modules/tinymce/src/core/main/ts/api/EventTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/EventTypes.ts
@@ -6,6 +6,7 @@ import { UndoLevel } from '../undo/UndoManagerTypes';
 import { SetAttribEvent } from './dom/DOMUtils';
 import Editor from './Editor';
 import { ParserArgs } from './html/DomParser';
+import { NotificationApi, NotificationSpec } from './NotificationManager';
 import { Dialog } from './ui/Ui';
 import { NativeEventMap } from './util/EventDispatcher';
 import { InstanceApi } from './WindowManager';
@@ -52,7 +53,8 @@ export interface ShowCaretEvent { target: Node; direction: number; before: boole
 
 export interface SwitchModeEvent { mode: string }
 
-export interface AddUndoEvent { level: UndoLevel; lastLevel: UndoLevel | undefined; originalEvent: Event | undefined }
+export interface ChangeEvent { level: UndoLevel; lastLevel: UndoLevel | undefined }
+export interface AddUndoEvent extends ChangeEvent { originalEvent: Event | undefined }
 export interface UndoRedoEvent { level: UndoLevel }
 
 export interface WindowEvent<T extends Dialog.DialogData> { dialog: InstanceApi<T> }
@@ -88,6 +90,14 @@ export interface TableEventData {
 }
 export interface TableModifiedEvent extends TableEventData {
   readonly table: HTMLTableElement;
+}
+
+export interface BeforeOpenNotificationEvent {
+  notification: NotificationSpec;
+}
+
+export interface OpenNotificationEvent {
+  notification: NotificationApi;
 }
 
 export interface EditorEventMap extends Omit<NativeEventMap, 'blur' | 'focus'> {
@@ -145,6 +155,7 @@ export interface EditorEventMap extends Omit<NativeEventMap, 'blur' | 'focus'> {
   'Undo': UndoRedoEvent;
   'BeforeAddUndo': AddUndoEvent;
   'AddUndo': AddUndoEvent;
+  'change': ChangeEvent;
   'CloseWindow': WindowEvent<any>;
   'OpenWindow': WindowEvent<any>;
   'ProgressState': ProgressStateEvent;
@@ -165,6 +176,11 @@ export interface EditorEventMap extends Omit<NativeEventMap, 'blur' | 'focus'> {
   'NewRow': NewTableRowEvent;
   'NewCell': NewTableCellEvent;
   'SetAttrib': SetAttribEvent;
+  'hide': { };
+  'show': { };
+  'dirty': { };
+  'BeforeOpenNotification': BeforeOpenNotificationEvent;
+  'OpenNotification': OpenNotificationEvent;
 }
 
 export interface EditorManagerEventMap {

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -7,7 +7,7 @@ import Editor from './Editor';
 import * as Options from './Options';
 
 export interface NotificationManagerImpl {
-  open: (spec: NotificationSpec, closeCallback?: () => void) => NotificationApi;
+  open: (spec: NotificationSpec, closeCallback: () => void) => NotificationApi;
   close: <T extends NotificationApi>(notification: T) => void;
   getArgs: <T extends NotificationApi>(notification: T) => NotificationSpec;
 }

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -25,7 +25,7 @@ export type ThemeInitFunc = (editor: Editor, elm: HTMLElement) => {
 
 export type SetupCallback = (editor: Editor) => void;
 
-export type FilePickerCallback = (callback: Function, value: any, meta: Record<string, any>) => void;
+export type FilePickerCallback = (callback: (value: string, meta?: Record<string, any>) => void, value: string, meta: Record<string, any>) => void;
 export type FilePickerValidationStatus = 'valid' | 'unknown' | 'invalid' | 'none';
 export type FilePickerValidationCallback = (info: { type: string; url: string }, callback: (validation: { status: FilePickerValidationStatus; message: string }) => void) => void;
 

--- a/modules/tinymce/src/core/main/ts/api/UndoManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/UndoManager.ts
@@ -1,6 +1,7 @@
 import { Arr, Cell, Singleton } from '@ephox/katamari';
 
 import { Bookmark } from '../bookmark/BookmarkTypes';
+import * as GetBookmark from '../bookmark/GetBookmark';
 import * as Rtc from '../Rtc';
 import * as Levels from '../undo/Levels';
 import { addKeyboardShortcuts, registerEvents } from '../undo/Setup';
@@ -45,7 +46,7 @@ const UndoManager = (editor: Editor): UndoManager => {
      * @method add
      * @param {Object} level Optional undo level object to add.
      * @param {DOMEvent} event Optional event responsible for the creation of the undo level.
-     * @return {Object} Undo level that got added or null it a level wasn't needed.
+     * @return {Object} Undo level that got added or null if a level wasn't needed.
      */
     add: (level?: Partial<UndoLevel>, event?: Event): UndoLevel | null => {
       return Rtc.addUndoLevel(editor, undoManager, index, locks, beforeBookmark, level, event);
@@ -58,8 +59,10 @@ const UndoManager = (editor: Editor): UndoManager => {
      */
     dispatchChange: (): void => {
       editor.setDirty(true);
+      const level = Levels.createFromEditor(editor) as UndoLevel;
+      level.bookmark = GetBookmark.getUndoBookmark(editor.selection);
       editor.dispatch('change', {
-        level: Levels.createFromEditor(editor),
+        level,
         lastLevel: Arr.get(undoManager.data, index.get()).getOrUndefined()
       });
     },

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -112,8 +112,8 @@ interface DOMUtils {
     <T extends Node>(elm: T): T;
     (elm: string): HTMLElement | null;
   };
-  getNext: (node: Node, selector: string | ((node: Node) => boolean)) => Node | null;
-  getPrev: (node: Node, selector: string | ((node: Node) => boolean)) => Node | null;
+  getNext: (node: Node | null, selector: string | ((node: Node) => boolean)) => Node | null;
+  getPrev: (node: Node | null, selector: string | ((node: Node) => boolean)) => Node | null;
   select: {
     <K extends keyof HTMLElementTagNameMap>(selector: K, scope?: string | Node): Array<HTMLElementTagNameMap[K]>;
     <T extends HTMLElement = HTMLElement>(selector: string, scope?: string | Node): T[];
@@ -122,12 +122,12 @@ interface DOMUtils {
     <T extends Element>(elm: Node | Node[] | null, selector: string): elm is T;
     (elm: Node | Node[] | null, selector: string): boolean;
   };
-  add: (parentElm: RunArguments, name: string | Element, attrs?: Record<string, string | boolean | number>, html?: string | Node, create?: boolean) => HTMLElement;
+  add: (parentElm: RunArguments, name: string | Element, attrs?: Record<string, string | boolean | number | null>, html?: string | Node | null, create?: boolean) => HTMLElement;
   create: {
-    <K extends keyof HTMLElementTagNameMap>(name: K, attrs?: Record<string, string | boolean | number>, html?: string | Node): HTMLElementTagNameMap[K];
-    (name: string, attrs?: Record<string, string | boolean | number>, html?: string | Node): HTMLElement;
+    <K extends keyof HTMLElementTagNameMap>(name: K, attrs?: Record<string, string | boolean | number | null>, html?: string | Node | null): HTMLElementTagNameMap[K];
+    (name: string, attrs?: Record<string, string | boolean | number | null>, html?: string | Node | null): HTMLElement;
   };
-  createHTML: (name: string, attrs?: Record<string, string>, html?: string) => string;
+  createHTML: (name: string, attrs?: Record<string, string | null>, html?: string) => string;
   createFragment: (html?: string) => DocumentFragment;
   remove: {
     <T extends Node>(node: T | T[], keepChildren?: boolean): typeof node extends Array<any> ? T[] : T;
@@ -573,7 +573,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     return parents && parents.length > 0 ? parents[0] : null;
   };
 
-  const _findSib = (node: Node, selector: string | ((node: Node) => boolean), name: 'previousSibling' | 'nextSibling') => {
+  const _findSib = (node: Node | null, selector: string | ((node: Node) => boolean), name: 'previousSibling' | 'nextSibling') => {
     let func = selector;
 
     if (node) {
@@ -595,9 +595,9 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     return null;
   };
 
-  const getNext = (node: Node, selector: string | ((node: Node) => boolean)) => _findSib(node, selector, 'nextSibling');
+  const getNext = (node: Node | null, selector: string | ((node: Node) => boolean)) => _findSib(node, selector, 'nextSibling');
 
-  const getPrev = (node: Node, selector: string | ((node: Node) => boolean)) => _findSib(node, selector, 'previousSibling');
+  const getPrev = (node: Node | null, selector: string | ((node: Node) => boolean)) => _findSib(node, selector, 'previousSibling');
 
   const isParentNode = (node: Node): node is ParentNode =>
     Type.isFunction((node as any).querySelectorAll);
@@ -642,7 +642,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     });
   };
 
-  const add = (parentElm: RunArguments, name: string | Element, attrs?: Record<string, string | boolean | number>, html?: string | Node, create?: boolean): HTMLElement =>
+  const add = (parentElm: RunArguments, name: string | Element, attrs?: Record<string, string | boolean | number | null>, html?: string | Node | null, create?: boolean): HTMLElement =>
     run(parentElm, (parentElm) => {
       const newElm = Type.isString(name) ? doc.createElement(name) : name;
 
@@ -661,13 +661,13 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
       return !create ? parentElm.appendChild(newElm) : newElm;
     }) as HTMLElement;
 
-  const create = (name: string, attrs?: Record<string, string | boolean | number>, html?: string | Node): HTMLElement =>
+  const create = (name: string, attrs?: Record<string, string | boolean | number | null>, html?: string | Node | null): HTMLElement =>
     add(doc.createElement(name), name, attrs, html, true);
 
   const decode = Entities.decode;
   const encode = Entities.encodeAllRaw;
 
-  const createHTML = (name: string, attrs?: Record<string, string>, html: string = ''): string => {
+  const createHTML = (name: string, attrs?: Record<string, string | null>, html: string = ''): string => {
     let outHtml = '<' + name;
 
     for (const key in attrs) {

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -302,14 +302,12 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
     serialize: (styles: StyleMap, elementName?: string): string => {
       let css = '';
 
-      const serializeStyles = (name: string, validStyleList: Record<string, string[]>) => {
-        let value;
-
-        const styleList = validStyleList[name];
+      const serializeStyles = (elemName: string, validStyleList: Record<string, string[]>) => {
+        const styleList = validStyleList[elemName];
         if (styleList) {
           for (let i = 0, l = styleList.length; i < l; i++) {
-            name = styleList[i];
-            value = styles[name];
+            const name = styleList[i];
+            const value = styles[name];
 
             if (value) {
               css += (css.length > 0 ? ' ' : '') + name + ': ' + value + ';';

--- a/modules/tinymce/src/core/main/ts/api/html/Writer.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Writer.ts
@@ -35,7 +35,7 @@ interface Writer {
   getContent: () => string;
   pi: (name: string, text?: string) => void;
   reset: () => void;
-  start: (name: string, attrs?: Attributes, empty?: boolean) => void;
+  start: (name: string, attrs?: Attributes | null, empty?: boolean) => void;
   text: (text: string, raw?: boolean) => void;
 }
 
@@ -58,7 +58,7 @@ const Writer = (settings?: WriterSettings): Writer => {
      * @param {Array} attrs Optional array of objects containing an attribute name and value, or undefined if the element has no attributes.
      * @param {Boolean} empty Optional empty state if the tag should serialize as a void element. For example: `<img />`
      */
-    start: (name: string, attrs?: Attributes, empty?: boolean) => {
+    start: (name: string, attrs?: Attributes | null, empty?: boolean) => {
       if (indent && indentBefore[name] && html.length > 0) {
         const value = html[html.length - 1];
 

--- a/modules/tinymce/src/core/main/ts/api/util/EventDispatcher.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/EventDispatcher.ts
@@ -107,12 +107,12 @@ class EventDispatcher<T> {
     return !!nativeEvents[name.toLowerCase()];
   }
 
-  private readonly settings: Record<string, any>;
-  private readonly scope: {};
+  private readonly settings: EventDispatcherSettings;
+  private readonly scope: any;
   private readonly toggleEvent: (name: string, toggle: boolean) => void;
   private bindings: Bindings<T> = {};
 
-  public constructor(settings?: Record<string, any>) {
+  public constructor(settings?: EventDispatcherSettings) {
     this.settings = settings || {};
     this.scope = this.settings.scope || this;
     this.toggleEvent = this.settings.toggleEvent || Fun.never;

--- a/modules/tinymce/src/core/main/ts/autocomplete/AutocompleteTag.ts
+++ b/modules/tinymce/src/core/main/ts/autocomplete/AutocompleteTag.ts
@@ -24,9 +24,11 @@ const create = (editor: Editor, range: Range): void => {
   }
 };
 
-const detect = (elm: SugarElement<Node>): Optional<SugarElement<Element>> => SelectorFind.closest(elm, autocompleteSelector);
+const detect = (elm: SugarElement<Node>): Optional<SugarElement<Element>> =>
+  SelectorFind.closest(elm, autocompleteSelector);
 
-const findIn = (elm: SugarElement<Element>): Optional<SugarElement> => SelectorFind.descendant(elm, autocompleteSelector);
+const findIn = (elm: SugarElement<Element>): Optional<SugarElement<Element>> =>
+  SelectorFind.descendant(elm, autocompleteSelector);
 
 const remove = (editor: Editor, elm: SugarElement<Element>): void =>
   findIn(elm).each((wrapper) => {

--- a/modules/tinymce/src/core/main/ts/caret/CaretContainer.ts
+++ b/modules/tinymce/src/core/main/ts/caret/CaretContainer.ts
@@ -31,7 +31,7 @@ const isCaretContainer = (node: Node | null | undefined): boolean =>
 const hasContent = (node: Node): boolean =>
   node.firstChild !== node.lastChild || !NodeType.isBr(node.firstChild);
 
-const insertInline = (node: Node, before: boolean): Node => {
+const insertInline = (node: Node, before: boolean): Text => {
   const doc = node.ownerDocument ?? document;
   const textNode = doc.createTextNode(Zwsp.ZWSP);
   const parentNode = node.parentNode;
@@ -84,7 +84,7 @@ const prependInline = (node: Node | null): Node | null => {
   }
 };
 
-const appendInline = (node: Node | null): Node | null => {
+const appendInline = (node: Node | null): Text | null => {
   if (NodeType.isText(node)) {
     const data = node.data;
     if (data.length > 0 && data.charAt(data.length - 1) !== Zwsp.ZWSP) {

--- a/modules/tinymce/src/core/main/ts/fmt/FormatChanged.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatChanged.ts
@@ -8,7 +8,7 @@ import { FormatVars } from './FormatTypes';
 import * as FormatUtils from './FormatUtils';
 import * as MatchFormat from './MatchFormat';
 
-export type FormatChangeCallback = (state: boolean, data: { node: Node; format: string; parents: any }) => void;
+export type FormatChangeCallback = (state: boolean, data: { node: Node; format: string; parents: Element[] }) => void;
 
 export type RegisteredFormats = Record<string, CallbackGroup>;
 

--- a/modules/tinymce/src/core/main/ts/fmt/FormatTypes.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatTypes.ts
@@ -18,7 +18,7 @@ export interface BaseFormat<T> {
   links?: boolean;
   mixed?: boolean;
   block_expand?: boolean;
-  onmatch?: (node: Node, fmt: T, itemName: string) => boolean;
+  onmatch?: (node: Element, fmt: T, itemName: string) => boolean;
 
   // These are only used when removing formats
   remove?: 'none' | 'empty' | 'all';
@@ -51,7 +51,7 @@ export interface CommonFormat<T> extends BaseFormat<T> {
   preview?: string | false;
 
   // These are only used when applying formats
-  onformat?: (elm: Node, fmt: T, vars?: FormatVars, node?: Node | RangeLikeObject | null) => void;
+  onformat?: (elm: Element, fmt: T, vars?: FormatVars, node?: Node | RangeLikeObject | null) => void;
   clear_child_styles?: boolean;
   merge_siblings?: boolean;
   merge_with_parents?: boolean;

--- a/modules/tinymce/src/core/main/ts/undo/Levels.ts
+++ b/modules/tinymce/src/core/main/ts/undo/Levels.ts
@@ -85,7 +85,7 @@ const hasEqualCleanedContent = (level1: NewUndoLevel, level2: NewUndoLevel): boo
   getCleanLevelContent(level1) === getCleanLevelContent(level2);
 
 // Most of the time the contents is equal so it's faster to first check that using strings then fallback to a cleaned dom comparison
-const isEq = (level1: NewUndoLevel, level2: NewUndoLevel): boolean => {
+const isEq = (level1: NewUndoLevel | undefined, level2: NewUndoLevel | undefined): boolean => {
   if (!level1 || !level2) {
     return false;
   } else if (hasEqualContent(level1, level2)) {

--- a/modules/tinymce/src/core/test/ts/atomic/keyboard/MatchKeysTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/keyboard/MatchKeysTest.ts
@@ -7,7 +7,7 @@ import * as MatchKeys from 'tinymce/core/keyboard/MatchKeys';
 type KeyPattern = MatchKeys.KeyPattern;
 
 describe('atomic.tinymce.core.keyboard.MatchKeysTest', () => {
-  const state = Cell([]);
+  const state = Cell<string[]>([]);
 
   const event = (evt: Partial<KeyboardEvent>): KeyboardEvent => {
     return {
@@ -48,7 +48,7 @@ describe('atomic.tinymce.core.keyboard.MatchKeysTest', () => {
     });
   };
 
-  const testExecute = (label: string, patterns: KeyPattern[], event: KeyboardEvent, expectedData: string[], expectedMatch) => {
+  const testExecute = (label: string, patterns: KeyPattern[], event: KeyboardEvent, expectedData: string[], expectedMatch: Required<KeyPattern>) => {
     return it(label, () => {
       state.set([]);
 

--- a/modules/tinymce/src/core/test/ts/atomic/textpatterns/FindBlockPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/textpatterns/FindBlockPatternsTest.ts
@@ -27,7 +27,7 @@ describe('atomic.tinymce.textpatterns.FindBlockPatternsTest', () => {
     const defaultPatterns = patternSet.blockPatterns;
 
     const testFindStartPattern = (text: string, expectedPattern: string) => {
-      const actual = BlockPattern.findPattern(defaultPatterns, text).getOrNull();
+      const actual = BlockPattern.findPattern(defaultPatterns, text).getOrDie();
       assert.equal(actual.start, expectedPattern, 'Assert correct pattern');
     };
 

--- a/modules/tinymce/src/core/test/ts/browser/AddOnManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/AddOnManagerTest.ts
@@ -47,7 +47,7 @@ const unpatch = (proto: any, name?: string): void => {
 };
 
 describe('browser.tinymce.core.AddOnManagerTest', () => {
-  let languagePackUrl: string;
+  let languagePackUrl: string | null;
 
   const getLanguagePackUrl = (code: string, languages?: string) => {
     languagePackUrl = null;

--- a/modules/tinymce/src/core/test/ts/browser/EditorAutoFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorAutoFocusTest.ts
@@ -6,6 +6,7 @@ import { assert } from 'chai';
 import 'tinymce';
 import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
+import { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
 
 describe('browser.tinymce.core.EditorAutoFocusTest', () => {
   before(() => {
@@ -32,7 +33,7 @@ describe('browser.tinymce.core.EditorAutoFocusTest', () => {
     return top > 0 && top + 50 < window.innerHeight;
   };
 
-  const pSetupEditorAutoFocus = (id: string, settings) => {
+  const pSetupEditorAutoFocus = (id: string, options: RawEditorOptions) => {
     const height = restOfWindowHeight();
     return new Promise((resolve) => {
       EditorManager.init({
@@ -45,14 +46,14 @@ describe('browser.tinymce.core.EditorAutoFocusTest', () => {
         init_instance_callback: (editor: Editor) => {
           editor.on('focus', resolve);
         },
-        ...settings
+        ...options
       });
     });
   };
 
-  const pTestEditorAutoFocus = async (id: string, settings) => {
-    await pSetupEditorAutoFocus(id, settings);
-    const editor = EditorManager.get(id);
+  const pTestEditorAutoFocus = async (id: string, options: RawEditorOptions) => {
+    await pSetupEditorAutoFocus(id, options);
+    const editor = EditorManager.get(id) as Editor;
     assert.isTrue(editor.hasFocus());
     assert.isTrue(isInViewport(editor));
   };

--- a/modules/tinymce/src/core/test/ts/browser/EditorCleanupTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorCleanupTest.ts
@@ -8,32 +8,32 @@ import Editor from 'tinymce/core/api/Editor';
 import { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
 import VisualBlocksPlugin from 'tinymce/plugins/visualblocks/Plugin';
 
-const assertPageLinkPresence = (url: string, exists: boolean): void => {
-  const links = document.head.querySelectorAll(`link[href="${url}"]`);
-  assert.equal(links.length > 0, exists, `Should have link with url="${url}"`);
-};
-
-const testCleanup = (comment: string, settings: RawEditorOptions, html: string = '<div></div>', fn: (editor) => void = Fun.noop) => {
-  it(comment, async () => {
-    // spin the editor up and down, getting a reference to its target element in between
-    const editor = await McEditor.pFromHtml<Editor>(html, { base_url: '/project/tinymce/js/tinymce', ...settings });
-    const element = TinyDom.targetElement(editor);
-    // Run any additional chains
-    fn(editor);
-    editor.remove();
-    // first, remove the id of the element, as that's inserted from McEditor.cFromHtml and is out of our control
-    Attribute.remove(element, 'id');
-    // assert that the html of the element is correct
-    assert.equal(Truncate.getHtml(element), html, comment + ' all properties on the element should be cleaned up');
-    // remove the element
-    Remove.remove(element);
-  });
-};
-
 describe('browser.tinymce.core.EditorCleanupTest', () => {
   before(() => {
     VisualBlocksPlugin();
   });
+
+  const assertPageLinkPresence = (url: string, exists: boolean): void => {
+    const links = document.head.querySelectorAll(`link[href="${url}"]`);
+    assert.equal(links.length > 0, exists, `Should have link with url="${url}"`);
+  };
+
+  const testCleanup = (comment: string, settings: RawEditorOptions, html: string = '<div></div>', fn: (editor: Editor) => void = Fun.noop) => {
+    it(comment, async () => {
+      // spin the editor up and down, getting a reference to its target element in between
+      const editor = await McEditor.pFromHtml<Editor>(html, { base_url: '/project/tinymce/js/tinymce', ...settings });
+      const element = TinyDom.targetElement(editor);
+      // Run any additional chains
+      fn(editor);
+      editor.remove();
+      // first, remove the id of the element, as that's inserted from McEditor.cFromHtml and is out of our control
+      Attribute.remove(element, 'id');
+      // assert that the html of the element is correct
+      assert.equal(Truncate.getHtml(element), html, comment + ' all properties on the element should be cleaned up');
+      // remove the element
+      Remove.remove(element);
+    });
+  };
 
   testCleanup('TINY-4001: Inline editor should clean up attributes', { inline: true });
 

--- a/modules/tinymce/src/core/test/ts/browser/EditorManagerCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorManagerCommandsTest.ts
@@ -3,6 +3,7 @@ import { Arr } from '@ephox/katamari';
 import { assert } from 'chai';
 
 import 'tinymce';
+import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import Theme from 'tinymce/themes/silver/Theme';
 
@@ -68,12 +69,12 @@ describe('browser.tinymce.core.EditorManagerCommandsTest', () => {
       selector: 'textarea#ed_1',
       init_instance_callback: (_editor1) => {
         assert.lengthOf(EditorManager.get(), 1);
-        assert.isFalse(EditorManager.get('ed_1').mode.isReadOnly());
+        assert.isFalse(EditorManager.get('ed_1')?.mode.isReadOnly());
         EditorManager.execCommand('mceAddEditor', false, {
           id: 'ed_2',
           options: {
             readonly: true,
-            init_instance_callback: (editor2) => {
+            init_instance_callback: (editor2: Editor) => {
               assert.lengthOf(EditorManager.get(), 2);
               assert.isTrue(editor2.mode.isReadOnly());
               done();

--- a/modules/tinymce/src/core/test/ts/browser/EditorManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorManagerTest.ts
@@ -38,9 +38,9 @@ describe('browser.tinymce.core.EditorManagerTest', () => {
         assert.equal(EditorManager.get(0), EditorManager.activeEditor);
         assert.isNull(EditorManager.get(1));
         assert.isNull(EditorManager.get('noid'));
-        assert.isNull(EditorManager.get(undefined));
+        assert.isNull(EditorManager.get(undefined as any));
         assert.equal(EditorManager.get()[0], EditorManager.activeEditor);
-        assert.equal(EditorManager.get(EditorManager.activeEditor.id), EditorManager.activeEditor);
+        assert.equal(EditorManager.get((EditorManager.activeEditor as Editor).id), EditorManager.activeEditor);
         assert.notEqual(EditorManager.get(), EditorManager.get());
 
         // Trigger save
@@ -55,7 +55,7 @@ describe('browser.tinymce.core.EditorManagerTest', () => {
 
         // Re-init on same id
         EditorManager.init({
-          selector: '#' + EditorManager.activeEditor.id,
+          selector: '#' + (EditorManager.activeEditor as Editor).id,
         });
 
         assert.lengthOf(EditorManager.get(), 1);

--- a/modules/tinymce/src/core/test/ts/browser/EditorOptionsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorOptionsTest.ts
@@ -7,7 +7,7 @@ import Editor from 'tinymce/core/api/Editor';
 import * as EditorOptions from 'tinymce/core/api/EditorOptions';
 
 describe('browser.tinymce.core.EditorOptionsTest', () => {
-  let processed = [];
+  let processed: unknown[] = [];
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
   }, []);

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemoveTest.ts
@@ -66,7 +66,7 @@ describe('browser.tinymce.core.EditorRemoveTest', () => {
   it('remove editor where the body has been removed', async () => {
     const editor = await McEditor.pFromHtml<Editor>('<textarea></textarea>', settings);
     const body = editor.getBody();
-    body.parentNode.removeChild(body);
+    body.parentNode?.removeChild(body);
     McEditor.remove(editor);
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/EditorRemovedApiTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorRemovedApiTest.ts
@@ -11,7 +11,7 @@ describe('browser.tinymce.core.EditorRemovedApiTest', () => {
     test_callback: Fun.noop
   }, []);
 
-  const tryAccess = (name: string, expectedValue: any) => {
+  const tryAccess = (name: keyof Editor, expectedValue: any) => {
     const editor = hook.editor();
     const result = editor[name]();
     assert.equal(result, expectedValue, 'Should be expected value on a removed editor');

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -37,7 +37,7 @@ const randBlobDataUri = (width: number, height: number) => {
   const canvas = document.createElement('canvas');
   canvas.width = width;
   canvas.height = height;
-  const ctx = canvas.getContext('2d');
+  const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
   const imageData = ctx.createImageData(width, height);
   imageData.data.set(Arr.range(imageData.data.length, () => random(0, 255)));
   ctx.putImageData(imageData, 0, 0);
@@ -65,7 +65,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     canvas.width = 320;
     canvas.height = 200;
 
-    const context = canvas.getContext('2d');
+    const context = canvas.getContext('2d') as CanvasRenderingContext2D;
     context.fillStyle = '#ff0000';
     context.fillRect(0, 0, 160, 100);
     context.fillStyle = '#00ff00';
@@ -163,7 +163,8 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
 
   it('TBA: uploadImages (callback)', () => {
     const editor = hook.editor();
-    let uploadedBlobInfo, uploadUri;
+    let uploadedBlobInfo: BlobInfo;
+    let uploadUri: string;
 
     setInitialContent(editor, imageHtml(testBlobDataUri));
 
@@ -185,7 +186,8 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
 
   it('TBA: uploadImages (promise)', () => {
     const editor = hook.editor();
-    let uploadedBlobInfo, uploadUri;
+    let uploadedBlobInfo: BlobInfo | null;
+    let uploadUri: string;
 
     setInitialContent(editor, imageHtml(testBlobDataUri));
 
@@ -197,7 +199,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
 
     assertEventsLength(0);
     return editor.uploadImages().then((result) => {
-      assertResult(editor, 'Upload the images', uploadUri, uploadedBlobInfo, result);
+      assertResult(editor, 'Upload the images', uploadUri, uploadedBlobInfo as BlobInfo, result);
       assertEventsLength(1);
     }).then(() => {
       uploadedBlobInfo = null;
@@ -211,12 +213,12 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
 
   it('TBA: uploadImages retain blob urls after upload', () => {
     const editor = hook.editor();
-    let uploadedBlobInfo;
+    let uploadedBlobInfo: BlobInfo | null;
 
     const assertResultRetainsUrl = (results: UploadResult[]) => {
       assert.isTrue(results[0].status, 'uploadImages retain blob urls after upload');
       assert.isTrue(hasBlobAsSource(results[0].element), 'Not a blob url');
-      assert.equal(editor.getContent(), '<p><img src="' + uploadedBlobInfo.filename() + '"></p>', 'uploadImages retain blob urls after upload');
+      assert.equal(editor.getContent(), '<p><img src="' + uploadedBlobInfo?.filename() + '"></p>', 'uploadImages retain blob urls after upload');
 
       return results;
     };
@@ -244,7 +246,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
 
   it('TBA: uploadImages reuse filename', () => {
     const editor = hook.editor();
-    let uploadedBlobInfo;
+    let uploadedBlobInfo: BlobInfo;
 
     editor.options.set('images_reuse_filename', true);
     setInitialContent(editor, imageHtml(testBlobDataUri));
@@ -281,7 +283,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     const editor = hook.editor();
     let uploadCount = 0, callCount = 0;
 
-    const uploadDone = (result) => {
+    const uploadDone = (result: UploadResult[]) => {
       callCount++;
       assertEventsLength(1);
 

--- a/modules/tinymce/src/core/test/ts/browser/FakeClipboardTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FakeClipboardTest.ts
@@ -3,7 +3,7 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import FakeClipboard from 'tinymce/core/api/FakeClipboard';
+import FakeClipboard, { FakeClipboardItem } from 'tinymce/core/api/FakeClipboard';
 
 describe('browser.tinymce.core.FakeClipboardTest', () => {
   TinyHooks.bddSetupLight<Editor>({
@@ -38,7 +38,7 @@ describe('browser.tinymce.core.FakeClipboardTest', () => {
     });
     FakeClipboard.write([ item ]);
 
-    const clipboardItems = FakeClipboard.read();
+    const clipboardItems = FakeClipboard.read() as FakeClipboardItem[];
     assert.lengthOf(clipboardItems, 1);
     assert.equal(clipboardItems[0].getType('text'), 'hello');
   });
@@ -49,7 +49,7 @@ describe('browser.tinymce.core.FakeClipboardTest', () => {
       FakeClipboard.FakeClipboardItem({ text: 'item2' }),
     ]);
 
-    const clipboardItems = FakeClipboard.read();
+    const clipboardItems = FakeClipboard.read() as FakeClipboardItem[];
     assert.lengthOf(clipboardItems, 2);
     assert.equal(clipboardItems[0].getType('text'), 'item1');
     assert.equal(clipboardItems[1].getType('text'), 'item2');
@@ -61,7 +61,7 @@ describe('browser.tinymce.core.FakeClipboardTest', () => {
     });
     FakeClipboard.write([ item ]);
 
-    const clipboardItems = FakeClipboard.read();
+    const clipboardItems = FakeClipboard.read() as FakeClipboardItem[];
     assert.lengthOf(clipboardItems, 1);
 
     FakeClipboard.clear();
@@ -77,6 +77,7 @@ describe('browser.tinymce.core.FakeClipboardTest', () => {
       FakeClipboard.FakeClipboardItem({ obj: testObj })
     ]);
 
-    assert.deepEqual(FakeClipboard.read()[0].getType('obj'), testObj);
+    const clipboardItems = FakeClipboard.read() as FakeClipboardItem[];
+    assert.deepEqual(clipboardItems[0].getType('obj'), testObj);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
@@ -1,6 +1,6 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { Fun, Strings } from '@ephox/katamari';
+import { Strings } from '@ephox/katamari';
 import { SugarBody, TextContent } from '@ephox/sugar';
 import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
@@ -20,9 +20,9 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
     font_size_formats: '8pt=1 12pt 12.75pt 13pt 24pt 32pt'
   }, []);
 
-  const assertSelectBoxDisplayValue = (editor, title, expectedValue) => {
+  const assertSelectBoxDisplayValue = (editor: Editor, title: string, expectedValue: string) => {
     const selectBox = UiFinder.findIn(SugarBody.body(), '*[title="' + title + '"]').getOrDie();
-    const value = Fun.compose(Strings.trim, TextContent.get)(selectBox);
+    const value = Strings.trim(TextContent.get(selectBox) ?? '');
     assert.equal(value, expectedValue, 'Should be the expected display value');
   };
 

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
@@ -1,6 +1,6 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { Arr, Fun, Strings } from '@ephox/katamari';
+import { Arr, Strings } from '@ephox/katamari';
 import { SugarBody, TextContent } from '@ephox/sugar';
 import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
@@ -25,9 +25,9 @@ describe('browser.tinymce.core.FontSelectTest', () => {
     '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;' // Wordpress
   ];
 
-  const assertSelectBoxDisplayValue = (editor: Editor, title, expectedValue) => {
+  const assertSelectBoxDisplayValue = (editor: Editor, title: string, expectedValue: string) => {
     const selectBox = UiFinder.findIn(SugarBody.body(), '*[title="' + title + '"]').getOrDie();
-    const value = Fun.compose(Strings.trim, TextContent.get)(selectBox);
+    const value = Strings.trim(TextContent.get(selectBox) ?? '');
     assert.equal(value, expectedValue, 'Should be the expected display value');
   };
 

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -34,8 +34,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>1234</p><ul><li>first element</li><li>second element</li></ul><p>5678</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[1].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[1].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(
@@ -54,8 +54,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p><b>1234</b></p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('b')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('b')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('b')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('b')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.toggle('format');
     assert.equal(getContent(editor), '<p><b>1234</b></p>');
@@ -70,8 +70,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>1<b>23</b>4</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('b')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('b')[0].firstChild, 2);
+    rng.setStart(editor.dom.select('b')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('b')[0].firstChild as Text, 2);
     editor.selection.setRng(rng);
     editor.formatter.toggle('format');
     assert.equal(getContent(editor), '<p>1<b>23</b>4</p>');
@@ -86,8 +86,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>1<b>234</b></p><p><b>123</b>4</p>'; // '<p>1234</p><p>1234</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('b')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('b')[1].firstChild, 3);
+    rng.setStart(editor.dom.select('b')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('b')[1].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.formatter.toggle('format');
     assert.equal(getContent(editor), '<p>1<b>234</b></p><p><b>123</b>4</p>');
@@ -98,8 +98,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     editor.formatter.register('format', { inline: 'b' });
     editor.getBody().innerHTML = '<p><b data-mce-x="1">1</b></p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('b')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('b')[0].firstChild, 1);
+    rng.setStart(editor.dom.select('b')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('b')[0].firstChild as Text, 1);
     editor.selection.setRng(rng);
     editor.formatter.toggle('format');
     assert.equal(getContent(editor), '<p>1</p>');
@@ -114,8 +114,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>1234</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<p><b>1234</b></p>', 'Inline element on selected text');
@@ -131,8 +131,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p><b>12</b>34</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('b')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].lastChild, 2);
+    rng.setStart(editor.dom.select('b')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].lastChild as Text, 2);
     editor.selection.setRng(rng);
     editor.formatter.toggle('format');
     assert.equal(getContent(editor), '<p><b>1234</b></p>', 'Extend formating if start of selection is already formatted');
@@ -145,8 +145,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>1234</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 1);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 3);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 1);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<p>1<b>23</b>4</p>', 'Inline element on partially selected text');
@@ -162,8 +162,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>1234</p><p>1234</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 1);
-    rng.setEnd(editor.dom.select('p')[1].firstChild, 3);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 1);
+    rng.setEnd(editor.dom.select('p')[1].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<p>1<b>234</b></p><p><b>123</b>4</p>');
@@ -226,8 +226,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>1234</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<p><b id="value2" title="value1">1234</b></p>', 'Inline element with attributes');
@@ -244,8 +244,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>1234</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<p><b style="color: rgb(255, 0, 0); font-size: 10px;">1234</b></p>', 'Inline element with styles');
@@ -266,8 +266,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>1234</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(
@@ -284,8 +284,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>x<em><span>1234</span></em>y</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('span')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('span')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('span')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('span')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<p>x<b><em><span>1234</span></em></b>y</p>', 'Inline element with wrapable parents');
@@ -312,8 +312,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p><b>a<em>1234</em>b</b></p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('em')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('em')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('em')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('em')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<p><b>a<em>1234</em>b</b></p>', 'Inline element with redundant parent');
@@ -384,8 +384,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     }]);
     editor.getBody().innerHTML = '<p><strong>a<em>1234</em>b</strong></p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('em')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('em')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('em')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('em')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<p><strong>a<em>1234</em>b</strong></p>', 'Inline element with redundant parent 1');
@@ -403,8 +403,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     }]);
     editor.getBody().innerHTML = '<p><span style="font-weight:bold">a<em>1234</em>b</span></p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('em')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('em')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('em')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('em')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<p><span style="font-weight: bold;">a<em>1234</em>b</span></p>', 'Inline element with redundant parent 2');
@@ -424,8 +424,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     }]);
     editor.getBody().innerHTML = '<p><span style="font-weight:bold"><strong><b>a<em>1234</em>b</b></strong></span></p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('em')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('em')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('em')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('em')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(
@@ -442,8 +442,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>a<b>12<b>34</b>56</b>b</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('b')[0].firstChild, 1);
-    rng.setEnd(editor.dom.select('b')[0].lastChild, 1);
+    rng.setStart(editor.dom.select('b')[0].firstChild as Text, 1);
+    rng.setEnd(editor.dom.select('b')[0].lastChild as Text, 1);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<p>a<b>123456</b>b</p>', 'Inline element merged with parent and child');
@@ -583,8 +583,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p><b>1234</b>5678</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].lastChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].lastChild, 4);
+    rng.setStart(editor.dom.select('p')[0].lastChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].lastChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<p><b>12345678</b></p>', 'Inline element merged with left sibling');
@@ -597,8 +597,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>1234<b>5678</b></p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<p><b>12345678</b></p>', 'Inline element merged with right sibling');
@@ -625,8 +625,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p><b data-mce-x="1">1234</b>5678</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].lastChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].lastChild, 4);
+    rng.setStart(editor.dom.select('p')[0].lastChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].lastChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<p><b data-mce-x="1">12345678</b></p>', 'Inline element merged with left sibling');
@@ -639,8 +639,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p><b>a</b> b</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].lastChild, 1);
-    rng.setEnd(editor.dom.select('p')[0].lastChild, 2);
+    rng.setStart(editor.dom.select('p')[0].lastChild as Text, 1);
+    rng.setEnd(editor.dom.select('p')[0].lastChild as Text, 2);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<p><b>a</b> <b>b</b></p>', `Don't merge siblings with whitespace between 1`);
@@ -653,8 +653,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>a <b>b</b></p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 1);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 1);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<p><b>a</b> <b>b</b></p>', `Don't merge siblings with whitespace between 2`);
@@ -707,8 +707,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p><em><i><ins>1234</ins></i></em><em>text1</em><em>text2</em></p><p><em>5678</em></p><p>9012</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('ins')[0].firstChild, 1);
-    rng.setEnd(editor.dom.select('p')[2].firstChild, 4);
+    rng.setStart(editor.dom.select('ins')[0].firstChild as Text, 1);
+    rng.setEnd(editor.dom.select('p')[2].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(
@@ -725,8 +725,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>9012</p><p><em>5678</em></p><p><em><i><ins>1234</ins></i></em><em>text1</em><em>text2</em></p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('em')[3].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('em')[3].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(
@@ -743,8 +743,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>1234</p><table><tbody><tr><td>123</td></tr></tbody></table><p>5678</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[1].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[1].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(
@@ -767,8 +767,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>1234</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format', {
       color: '#ff0000',
@@ -802,19 +802,19 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
       inline: 'b',
       styles: {
         color: (vars) => {
-          return vars.color + '00ff';
+          return vars?.color + '00ff';
         }
       },
       attributes: {
         title: (vars) => {
-          return vars.title + '2';
+          return vars?.title + '2';
         }
       }
     });
     editor.getBody().innerHTML = '<p>1234</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format', {
       color: '#ff',
@@ -830,8 +830,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>1234</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<div>1234</div>', 'Block element on selected text');
@@ -844,8 +844,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>1234</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 1);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 3);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 1);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<div>1234</div>', 'Block element on partially selected text');
@@ -903,8 +903,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<div><h1>1234</h1></div>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('h1')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('h1')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('h1')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('h1')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<div><p>1234</p></div>', 'Block element on nested element');
@@ -917,8 +917,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '1234';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.getBody().firstChild, 0);
-    rng.setEnd(editor.getBody().firstChild, 4);
+    rng.setStart(editor.getBody().firstChild as Text, 0);
+    rng.setEnd(editor.getBody().firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<div>1234</div>', 'Block element on selected non wrapped text 1');
@@ -931,8 +931,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '1234<br />4567<br />8910';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.getBody().firstChild, 0);
-    rng.setEnd(editor.getBody().lastChild, 4);
+    rng.setStart(editor.getBody().firstChild as Text, 0);
+    rng.setEnd(editor.getBody().lastChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<div>1234</div><div>4567</div><div>8910</div>', 'Block element on selected non wrapped text 2');
@@ -960,8 +960,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<h1>1234</h1><p>5678</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('h1')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('h1')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<blockquote><h1>1234</h1><p>5678</p></blockquote>', 'Block element wrapper 1');
@@ -975,8 +975,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<h1>1234</h1>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('h1')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('h1')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('h1')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('h1')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<blockquote><h1>1234</h1></blockquote>', 'Block element wrapper 2');
@@ -1011,8 +1011,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>1234</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(
@@ -1061,8 +1061,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p>1234</p><div>test</div><p>1234</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[1].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[1].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(
@@ -1086,8 +1086,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.getBody().innerHTML = '<p class=\"c d\" title=\"test\">1234</p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(
@@ -1153,8 +1153,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     const editor = hook.editor();
     const rng = editor.dom.createRng();
     editor.setContent('<p><span style="font-family: Arial;"><strong>test1 test2</strong> test3 test4 test5 test6</span></p>');
-    rng.setStart(editor.dom.select('strong')[0].firstChild, 6);
-    rng.setEnd(editor.dom.select('strong')[0].firstChild, 11);
+    rng.setStart(editor.dom.select('strong')[0].firstChild as Text, 6);
+    rng.setEnd(editor.dom.select('strong')[0].firstChild as Text, 11);
     editor.focus();
     editor.selection.setRng(rng);
     editor.execCommand('Italic');
@@ -1169,8 +1169,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     const editor = hook.editor();
     editor.setContent('<p>123<a href="#">abc</a>456</p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].lastChild, 3);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].lastChild as Text, 3);
     editor.selection.setRng(rng);
 
     editor.formatter.register('format', {
@@ -1193,8 +1193,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     const editor = hook.editor();
     editor.setContent('<p><span style="font-size: 10px;">123<a href="#">abc</a>456</span></p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('span')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('span')[0].lastChild, 3);
+    rng.setStart(editor.dom.select('span')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('span')[0].lastChild as Text, 3);
     editor.selection.setRng(rng);
 
     editor.formatter.register('format', {
@@ -1217,8 +1217,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     const editor = hook.editor();
     editor.setContent('<ul><li>text<ul><li>nested</li></ul></li></ul>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('li')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('li')[0].firstChild, 1);
+    rng.setStart(editor.dom.select('li')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('li')[0].firstChild as Text, 1);
     editor.selection.setRng(rng);
     editor.formatter.apply('h1');
     assert.equal(
@@ -1257,8 +1257,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     editor.formatter.register('format', { inline: 'strong' });
     editor.setContent('<ol><li>a</li><li>b<ul><li>c</li><li>d<br /><ol><li>e</li><li>f</li></ol></li></ul></li><li>g</li></ol>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('li')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('li')[6].firstChild, 1);
+    rng.setStart(editor.dom.select('li')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('li')[6].firstChild as Text, 1);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(
@@ -1274,8 +1274,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     const editor = hook.editor();
     editor.setContent('<ul><li>text<ul><li>nested</li></ul></li></ul>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('li')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('li')[1].firstChild, 1);
+    rng.setStart(editor.dom.select('li')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('li')[1].firstChild as Text, 1);
     editor.selection.setRng(rng);
     editor.formatter.apply('h1');
     assert.equal(
@@ -1289,8 +1289,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     const editor = hook.editor();
     editor.setContent('<ul><li>before<ul><li>nested</li></ul>after</li></ul>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('li')[0].lastChild, 1);
-    rng.setEnd(editor.dom.select('li')[0].lastChild, 2);
+    rng.setStart(editor.dom.select('li')[0].lastChild as Text, 1);
+    rng.setEnd(editor.dom.select('li')[0].lastChild as Text, 2);
     editor.selection.setRng(rng);
     editor.formatter.apply('h1');
     assert.equal(
@@ -1304,8 +1304,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     const editor = hook.editor();
     editor.setContent('<ul><li>before<ul><li>nested</li></ul>after</li></ul>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('li')[1].firstChild, 0);
-    rng.setEnd(editor.dom.select('li')[0].lastChild, 1);
+    rng.setStart(editor.dom.select('li')[1].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('li')[0].lastChild as Text, 1);
     editor.selection.setRng(rng);
     editor.formatter.apply('h1');
     assert.equal(
@@ -1319,8 +1319,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     const editor = hook.editor();
     editor.setContent('<ul><li>before<ul><li>nested</li></ul>after</li></ul>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('li')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('li')[0].lastChild, 1);
+    rng.setStart(editor.dom.select('li')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('li')[0].lastChild as Text, 1);
     editor.selection.setRng(rng);
     editor.formatter.apply('h1');
     assert.equal(
@@ -1404,8 +1404,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
       'text-decoration: underline;\">yellowredyellow</span></span></p>'
     );
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('span')[1].firstChild, 6);
-    rng.setEnd(editor.dom.select('span')[1].firstChild, 9);
+    rng.setStart(editor.dom.select('span')[1].firstChild as Text, 6);
+    rng.setEnd(editor.dom.select('span')[1].firstChild as Text, 9);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(getContent(editor), '<p style="font-size: 22pt;"><span style="text-decoration: underline;"><span style="color: yellow;' +
@@ -1431,8 +1431,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
       ` some <span style="color: rgb(255, 0, 0);">example</span></strong></em> text</span></p>`
     );
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('strong')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('span')[4].lastChild, 5);
+    rng.setStart(editor.dom.select('strong')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('span')[4].lastChild as Text, 5);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(
@@ -1459,8 +1459,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.setContent('<p><span style="text-decoration: underline;">This is some text.</span></p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('span')[0].firstChild, 8);
-    rng.setEnd(editor.dom.select('span')[0].firstChild, 12);
+    rng.setStart(editor.dom.select('span')[0].firstChild as Text, 8);
+    rng.setEnd(editor.dom.select('span')[0].firstChild as Text, 12);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     editor.formatter.remove('format');
@@ -1485,8 +1485,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
       'background-color: #ff0000">some</span> text.</span></p>'
     );
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('span')[1].firstChild, 0);
-    rng.setEnd(editor.dom.select('span')[1].firstChild, 4);
+    rng.setStart(editor.dom.select('span')[1].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('span')[1].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.remove('format');
     assert.equal(
@@ -1667,8 +1667,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
 
     editor.setContent('<p>abc</p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 3);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 3);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 3);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 3);
     editor.selection.setRng(rng);
 
     editor.formatter.apply('format');
@@ -1692,7 +1692,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     editor.getBody().innerHTML = '<p><br></p>';
     editor.formatter.register('format1', { inline: 'b' });
     editor.formatter.register('format2', { inline: 'i' });
-    editor.selection.setCursorLocation(editor.getBody().firstChild, 0);
+    editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 0);
     editor.formatter.apply('format1');
     editor.formatter.apply('format2');
     assert.equal(1, editor.dom.select('b').length, 'Should be one b element');
@@ -1741,8 +1741,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     editor.setContent('<p>abc</p><p contenteditable="false">def</p><p>ghi</p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[2].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[2].firstChild, 3);
+    rng.setStart(editor.dom.select('p')[2].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[2].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.formatter.apply('format');
     assert.equal(editor.getContent(), '<p>abc</p><p contenteditable="false">def</p><p><b>ghi</b></p>', 'Text in last paragraph is bold');
@@ -1864,8 +1864,8 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     editor.getBody().innerHTML = '<p>a<span id="b" data-mce-type="bookmark"></span>b</p>';
 
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].lastChild, 1);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].lastChild as Text, 1);
     editor.selection.setRng(rng);
 
     editor.formatter.register('format', {
@@ -2243,7 +2243,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     editor.setContent('<p>a</p>');
     editor.formatter.register('format', {
       inline: 'span',
-      onformat: (elm) => {
+      onformat: (elm: Element) => {
         elm.className = 'x';
       }
     });
@@ -2258,7 +2258,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     editor.formatter.register('format', { inline: 'b' });
 
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
     rng.setEnd(editor.dom.select('li')[0], 0);
     editor.selection.setRng(rng);
 

--- a/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
@@ -23,8 +23,8 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     editor.formatter.register('bold', { inline: 'b' });
     editor.setContent('<p><b>1234</b></p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('b')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('b')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('b')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('b')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     assert.isTrue(editor.formatter.match('bold'), 'Selected style element text');
   });
@@ -34,8 +34,8 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     editor.formatter.register('color', { inline: 'span', styles: { color: '#ff0000' }});
     editor.setContent('<p><span style="color:#ff0000">1234</span></p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('span')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('span')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('span')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('span')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     assert.isTrue(editor.formatter.match('color'), 'Selected style element with css styles');
   });
@@ -45,8 +45,8 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     editor.formatter.register('color', { inline: 'span', styles: [ 'color' ] });
     editor.setContent('<p><span style="color:#ff0000">1234</span></p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('span')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('span')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('span')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('span')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     assert.isTrue(editor.formatter.match('color'), 'Selected style element with css styles');
   });
@@ -56,8 +56,8 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     editor.formatter.register('fontsize', { inline: 'font', attributes: { size: '7' }});
     editor.setContent('<p><font size="7">1234</font></p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('font')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('font')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('font')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('font')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     assert.isTrue(editor.formatter.match('fontsize'), 'Selected style element with attributes');
   });
@@ -70,8 +70,8 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     ]);
     editor.setContent('<p><strong>1234</strong></p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('strong')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('strong')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('strong')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('strong')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     assert.isTrue(editor.formatter.match('multiple'), 'Selected style element text multiple formats');
   });
@@ -81,8 +81,8 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     editor.formatter.register('complex', { inline: 'span', styles: { fontWeight: 'bold' }});
     editor.setContent('<p><span style="color:#ff0000; font-weight:bold">1234</span></p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('span')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('span')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('span')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('span')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     assert.isTrue(editor.formatter.match('complex'), 'Selected complex style element');
   });
@@ -92,8 +92,8 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     editor.formatter.register('bold', { inline: 'b' });
     editor.setContent('<p>1234</p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     assert.isFalse(editor.formatter.match('bold'), 'Selected non style element text');
   });
@@ -103,8 +103,8 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     editor.formatter.register('bold', { inline: 'b' });
     editor.setContent('<p><b>1234</b>5678</p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('b')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].lastChild, 4);
+    rng.setStart(editor.dom.select('b')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].lastChild as Text, 4);
     editor.selection.setRng(rng);
     assert.isTrue(editor.formatter.match('bold'), 'Selected partial style element (start)');
   });
@@ -114,8 +114,8 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     editor.formatter.register('bold', { inline: 'b' });
     editor.setContent('<p>1234<b>5678</b></p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('b')[0].lastChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('b')[0].lastChild as Text, 4);
     editor.selection.setRng(rng);
     assert.isFalse(editor.formatter.match('bold'), 'Selected partial style element (end)');
   });
@@ -125,8 +125,8 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     editor.formatter.register('bold', { inline: 'b' });
     editor.setContent('<p><b><em><span>1234</span></em></b></p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('span')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('span')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('span')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('span')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     assert.isTrue(editor.formatter.match('bold'), 'Selected element text with parent inline element');
   });
@@ -136,8 +136,8 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     editor.formatter.register('complex', { inline: 'span', styles: { color: '%color' }});
     editor.setContent('<p><span style="color:#ff0000">1234</span></p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('span')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('span')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('span')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('span')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     assert.isTrue(editor.formatter.match('complex', { color: '#ff0000' }), 'Selected element match with variable');
   });
@@ -148,15 +148,15 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
       inline: 'span',
       styles: {
         color: (vars) => {
-          return vars.color + '00';
+          return vars?.color + '00';
         }
       }
     });
 
     editor.setContent('<p><span style="color:#ff0000">1234</span></p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('span')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('span')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('span')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('span')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     assert.isTrue(editor.formatter.match('complex', { color: '#ff00' }), 'Selected element match with variable and function');
   });
@@ -234,7 +234,7 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     const editor = hook.editor();
     editor.formatter.register('format', {
       inline: 'span',
-      onmatch: (elm) => {
+      onmatch: (elm: Element) => {
         return elm.className === 'x';
       }
     });
@@ -248,7 +248,8 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
 
   it('formatChanged complex format', () => {
     const editor = hook.editor();
-    let newState, newArgs;
+    let newState: boolean | undefined;
+    let newArgs: { node: Node; format: string; parents: Element[] } | undefined;
 
     editor.formatter.register('complex', { inline: 'span', styles: { color: '%color' }});
 
@@ -264,17 +265,17 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     editor.formatter.apply('complex', { color: '#FF0000' });
     editor.nodeChanged();
     assert.isTrue(newState);
-    assert.equal(newArgs.format, 'complex');
-    LegacyUnit.equalDom(newArgs.node, editor.getBody().firstChild.firstChild);
-    assert.lengthOf(newArgs.parents, 2);
+    assert.equal(newArgs?.format, 'complex');
+    LegacyUnit.equalDom(newArgs?.node as Node, editor.getBody().firstChild?.firstChild as Node);
+    assert.lengthOf(newArgs?.parents ?? [], 2);
 
     // Check remove
     editor.formatter.remove('complex', { color: '#FF0000' });
     editor.nodeChanged();
     assert.isFalse(newState);
-    assert.equal(newArgs.format, 'complex');
-    LegacyUnit.equalDom(newArgs.node, editor.getBody().firstChild);
-    assert.lengthOf(newArgs.parents, 1);
+    assert.equal(newArgs?.format, 'complex');
+    LegacyUnit.equalDom(newArgs?.node as Node, editor.getBody().firstChild as Node);
+    assert.lengthOf(newArgs?.parents ?? [], 1);
 
     // Unbind the format change handler
     handler.unbind();
@@ -290,20 +291,20 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     const rng = editor.dom.createRng();
 
     // Check link format matches on link
-    rng.setStart(editor.dom.select('a')[0].firstChild, 1);
-    rng.setEnd(editor.dom.select('a')[0].firstChild, 1);
+    rng.setStart(editor.dom.select('a')[0].firstChild as Text, 1);
+    rng.setEnd(editor.dom.select('a')[0].firstChild as Text, 1);
     editor.selection.setRng(rng);
     assert.isTrue(editor.formatter.match('link'), 'Match on link format');
 
     // Check link format does not match on normal text
-    rng.setStart(editor.dom.select('p')[1].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[1].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[1].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[1].firstChild as Text, 4);
     editor.selection.setRng(rng);
     assert.isFalse(editor.formatter.match('link'), 'No match on normal text');
 
     // Check link format does not match on bare anchor
-    rng.setStart(editor.dom.select('a')[1].firstChild, 2);
-    rng.setStart(editor.dom.select('a')[1].firstChild, 2);
+    rng.setStart(editor.dom.select('a')[1].firstChild as Text, 2);
+    rng.setStart(editor.dom.select('a')[1].firstChild as Text, 2);
     editor.selection.setRng(rng);
     assert.isFalse(editor.formatter.match('link'), 'No match on bare anchor');
 

--- a/modules/tinymce/src/core/test/ts/browser/FormatterClosestTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterClosestTest.ts
@@ -9,7 +9,7 @@ describe('browser.tinymce.core.FormatterClosestTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [], true);
 
-  const assertClosest = (names: string[], expectedName: string) => {
+  const assertClosest = (names: string[], expectedName: string | null) => {
     const actualName = hook.editor().formatter.closest(names);
     assert.equal(actualName, expectedName, 'Should match expected format name');
   };

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
@@ -29,8 +29,8 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { inline: 'b' });
     editor.getBody().innerHTML = '<p><b>1234</b></p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('b')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('b')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('b')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('b')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.remove('format');
     assert.equal(getContent(editor), '<p>1234</p>', 'Inline element on selected text');
@@ -41,8 +41,8 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { selector: 'b', remove: 'all' });
     editor.getBody().innerHTML = '<p><b title="text">1234</b></p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('b')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('b')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('b')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('b')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.remove('format');
     assert.equal(getContent(editor), '<p>1234</p>', 'Inline element on selected text with remove=all');
@@ -65,8 +65,8 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { inline: 'span', styles: { fontWeight: 'bold' }});
     editor.getBody().innerHTML = '<p><span style="font-weight:bold; color:#FF0000"><em>1234</em></span></p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('em')[0].firstChild, 1);
-    rng.setEnd(editor.dom.select('em')[0].firstChild, 3);
+    rng.setStart(editor.dom.select('em')[0].firstChild as Text, 1);
+    rng.setEnd(editor.dom.select('em')[0].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.formatter.remove('format');
     assert.equal(getContent(editor), '<p><span style="color: #ff0000; font-weight: bold;">' +
@@ -80,8 +80,8 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { inline: 'b' });
     editor.getBody().innerHTML = '<p><b>1234</b></p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('b')[0].firstChild, 2);
-    rng.setEnd(editor.dom.select('b')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('b')[0].firstChild as Text, 2);
+    rng.setEnd(editor.dom.select('b')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.remove('format');
     assert.equal(getContent(editor), '<p><b>12</b>34</p>', 'Partially selected inline element text');
@@ -92,8 +92,8 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { inline: 'b' });
     editor.getBody().innerHTML = '<p><b><em><span>1234</span></em></b></p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('span')[0].firstChild, 2);
-    rng.setEnd(editor.dom.select('span')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('span')[0].firstChild as Text, 2);
+    rng.setEnd(editor.dom.select('span')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.remove('format');
     assert.equal(getContent(editor), '<p><b><em><span>12</span></em></b><em><span>34</span></em></p>', 'Partially selected inline element text with children');
@@ -104,8 +104,8 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { inline: 'span', styles: { fontWeight: 'bold' }});
     editor.getBody().innerHTML = '<p><span style="font-weight:bold"><em><span style="color:#ff0000;font-weight:bold">1234</span></em></span></p>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('span')[1].firstChild, 2);
-    rng.setEnd(editor.dom.select('span')[1].firstChild, 4);
+    rng.setStart(editor.dom.select('span')[1].firstChild as Text, 2);
+    rng.setEnd(editor.dom.select('span')[1].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.remove('format');
     assert.equal(getContent(editor), '<p><span style="font-weight: bold;"><em><span style="color: #ff0000; font-weight: bold;">12</span>' +
@@ -142,7 +142,7 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
       inline: 'span',
       styles: {
         color: (vars) => {
-          return vars.color + '00';
+          return vars?.color + '00';
         }
       },
       exact: true
@@ -213,7 +213,7 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.getBody().innerHTML = '<p><b><em>x<b>abc</b>y</em></b></p>';
     const rng = editor.dom.createRng();
     rng.setStart(editor.dom.select('p')[0], 0);
-    rng.setEnd(editor.dom.select('b')[1].firstChild, 3);
+    rng.setEnd(editor.dom.select('b')[1].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.formatter.remove('format');
     assert.equal(getContent(editor), '<p><em>x</em><em>abc</em><b><em>y</em></b></p>', 'End within start');
@@ -224,8 +224,8 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { block: 'h1' });
     editor.getBody().innerHTML = '<h1>text</h1>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('h1')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('h1')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('h1')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('h1')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.remove('format');
     assert.equal(getContent(editor), '<p>text</p>', 'Remove block format');
@@ -236,8 +236,8 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { block: 'blockquote', wrapper: true });
     editor.getBody().innerHTML = '<blockquote><p>text</p></blockquote>';
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.remove('format');
     assert.equal(getContent(editor), '<p>text</p>', 'Remove wrapper block format');
@@ -248,8 +248,8 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { selector: 'span', attributes: [ 'style', 'class' ], remove: 'empty', split: true, expand: false, deep: true });
     const rng = editor.dom.createRng();
     editor.getBody().innerHTML = '<p style="color:#ff0000"><span style="color:#00ff00">text</span></p>';
-    rng.setStart(editor.dom.select('span')[0].firstChild, 1);
-    rng.setEnd(editor.dom.select('span')[0].firstChild, 3);
+    rng.setStart(editor.dom.select('span')[0].firstChild as Text, 1);
+    rng.setEnd(editor.dom.select('span')[0].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.formatter.remove('format');
     assert.equal(getContent(editor), '<p style="color: #ff0000;"><span style="color: #00ff00;">t</span>ex<span style="color: #00ff00;">t</span></p>', 'Remove span format within block with style');
@@ -260,8 +260,8 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { inline: 'b' });
     const rng = editor.dom.createRng();
     editor.getBody().innerHTML = '<p><b>text</b></p>';
-    rng.setStart(editor.dom.select('b')[0].firstChild, 1);
-    rng.setEnd(editor.dom.select('b')[0].firstChild, 3);
+    rng.setStart(editor.dom.select('b')[0].firstChild as Text, 1);
+    rng.setEnd(editor.dom.select('b')[0].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.formatter.remove('format');
     assert.equal(getContent(editor), '<p><b>t</b>ex<b>t</b></p>');
@@ -275,8 +275,8 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { block: 'p' });
     const rng = editor.dom.createRng();
     editor.getBody().innerHTML = content;
-    rng.setStart(editor.dom.select('p')[0].firstChild, 4);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 4);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.formatter.remove('format');
     assert.equal(getContent(editor), content);
@@ -357,8 +357,8 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { inline: 'b' });
     editor.setContent('<p>abc</p><p contenteditable="false"><b>def</b></p><p><b>ghj</b></p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('b')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('b')[1].firstChild, 3);
+    rng.setStart(editor.dom.select('b')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('b')[1].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.formatter.remove('format');
     assert.equal(editor.getContent(), '<p>abc</p><p contenteditable="false"><b>def</b></p><p>ghj</p>', 'Text in last paragraph is not bold');

--- a/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
@@ -343,8 +343,8 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('<p><a href="#">a</a>b</p>');
 
     const rng = editor.dom.createRng();
-    rng.setStart(editor.getBody().firstChild.lastChild, 0);
-    rng.setEnd(editor.getBody().firstChild.lastChild, 1);
+    rng.setStart(editor.getBody().firstChild?.lastChild as Text, 0);
+    rng.setEnd(editor.getBody().firstChild?.lastChild as Text, 1);
     editor.selection.setRng(rng);
 
     editor.execCommand('mceInsertLink', false, 'link');
@@ -408,7 +408,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     const editor = hook.editor();
     editor.setContent('<table><tbody><tr><td>A</td></tr><tr><td>B</td></tr></tbody></table>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('td')[1].firstChild, 0);
+    rng.setStart(editor.dom.select('td')[1].firstChild as Text, 0);
     rng.setEnd(editor.getBody(), 1);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertLink', false, { href: 'x' });
@@ -521,7 +521,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     assert.equal(editor.getContent(), '<p>test 123 <a href="123">123</a> 123</p>');
 
     editor.setContent('<p><em>test<span id="x">test <strong>123</strong></span><a href="123">123</a> 123</em></p>');
-    editor.selection.select(editor.dom.get('x'));
+    editor.selection.select(editor.dom.get('x') as HTMLSpanElement);
     editor.execCommand('RemoveFormat');
     assert.equal(editor.getContent(), '<p><em>test</em><span id="x">test 123</span><em><a href="123">123</a> 123</em></p>');
 

--- a/modules/tinymce/src/core/test/ts/browser/MiscCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/MiscCommandsTest.ts
@@ -20,19 +20,22 @@ describe('browser.tinymce.core.MiscCommandsTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, []);
 
+  const isTextNode = (node: Node): node is Text =>
+    node.nodeType === 3;
+
   const normalizeRng = (rng: Range) => {
-    if (rng.startContainer.nodeType === 3) {
+    if (isTextNode(rng.startContainer)) {
       if (rng.startOffset === 0) {
         rng.setStartBefore(rng.startContainer);
-      } else if (rng.startOffset >= rng.startContainer.nodeValue.length - 1) {
+      } else if (rng.startOffset >= rng.startContainer.data.length - 1) {
         rng.setStartAfter(rng.startContainer);
       }
     }
 
-    if (rng.endContainer.nodeType === 3) {
+    if (isTextNode(rng.endContainer)) {
       if (rng.endOffset === 0) {
         rng.setEndBefore(rng.endContainer);
-      } else if (rng.endOffset >= rng.endContainer.nodeValue.length - 1) {
+      } else if (rng.endOffset >= rng.endContainer.data.length - 1) {
         rng.setEndAfter(rng.endContainer);
       }
     }
@@ -46,14 +49,14 @@ describe('browser.tinymce.core.MiscCommandsTest', () => {
 
     editor.setContent('<p>123</p>');
     rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 1);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 2);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 1);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 2);
     editor.selection.setRng(rng);
     editor.execCommand('InsertHorizontalRule');
     assert.equal(editor.getContent(), '<p>1</p><hr><p>3</p>');
     rng = normalizeRng(editor.selection.getRng());
     assert.isTrue(rng.collapsed);
-    Assertions.assertDomEq('Nodes are not equal', SugarElement.fromDom(editor.getBody().lastChild), SugarElement.fromDom(rng.startContainer));
+    Assertions.assertDomEq('Nodes are not equal', SugarElement.fromDom(editor.getBody().lastChild as HTMLParagraphElement), SugarElement.fromDom(rng.startContainer));
     assert.equal(rng.startContainer.nodeName, 'P');
     assert.equal(rng.startOffset, 0);
     assert.equal(rng.endContainer.nodeName, 'P');

--- a/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
@@ -5,6 +5,7 @@ import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import { BeforeOpenNotificationEvent, OpenNotificationEvent } from 'tinymce/core/api/EventTypes';
 import { NotificationSpec } from 'tinymce/core/api/NotificationManager';
 
 describe('browser.tinymce.core.NotificationManagerTest', () => {
@@ -13,8 +14,8 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
     { label: 'Shadow Dom Editor', setup: TinyHooks.bddSetupInShadowRoot }
   ], (tester) => {
     context(tester.label, () => {
-      let beforeOpenEvents = [];
-      let openEvents = [];
+      let beforeOpenEvents: BeforeOpenNotificationEvent[] = [];
+      let openEvents: OpenNotificationEvent[] = [];
       const hook = tester.setup<Editor>({
         service_message: 'service notification text',
         add_unload_trigger: false,
@@ -22,7 +23,7 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
         indent: false,
         entities: 'raw',
         base_url: '/project/tinymce/js/tinymce',
-        setup: (editor) => {
+        setup: (editor: Editor) => {
           editor.on('BeforeOpenNotification', (event) => beforeOpenEvents.push(event));
           editor.on('OpenNotification', (event) => openEvents.push(event));
         }
@@ -30,7 +31,7 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
 
       const resetNotifications = () => {
         const editor = hook.editor();
-        const notifications = [].concat(editor.notificationManager.getNotifications());
+        const notifications = [ ...editor.notificationManager.getNotifications() ];
         Arr.each(notifications, (notification) => notification.close());
         beforeOpenEvents = [];
         openEvents = [];

--- a/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
@@ -167,13 +167,13 @@ describe('browser.tinymce.core.SelectionOverridesTest', () => {
     const rng = document.createRange();
     const firstSpan = editor.dom.select('span[contenteditable=false]')[0];
     const secondSpan = editor.dom.select('span[contenteditable=false]')[1];
-    const p = secondSpan.parentNode;
+    const p = secondSpan.parentNode as HTMLParagraphElement;
     if (firstSpan.previousSibling) {
       p.removeChild(firstSpan.previousSibling);
     }
     p.appendChild(document.createTextNode(Zwsp.ZWSP));
 
-    rng.setEnd(secondSpan.nextSibling, 1);
+    rng.setEnd(secondSpan.nextSibling as Text, 1);
     rng.setStartBefore(firstSpan);
 
     editor.selection.setRng(rng, false);

--- a/modules/tinymce/src/core/test/ts/browser/ShortcutsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ShortcutsTest.ts
@@ -18,7 +18,7 @@ describe('browser.tinymce.core.ShortcutsTest', () => {
 
   it('Shortcuts formats', () => {
     const editor = hook.editor();
-    const assertShortcut = (shortcut: string, args, assertState: boolean) => {
+    const assertShortcut = (shortcut: string, args: Partial<KeyboardEvent>, assertState: boolean) => {
       let called = false;
 
       editor.shortcuts.add(shortcut, '', () => {
@@ -32,7 +32,7 @@ describe('browser.tinymce.core.ShortcutsTest', () => {
         metaKey: false
       }, args);
 
-      editor.dispatch('keydown', args);
+      editor.dispatch('keydown', args as KeyboardEvent);
 
       if (assertState) {
         assert.isTrue(called, `Shortcut wasn't called: ` + shortcut);

--- a/modules/tinymce/src/core/test/ts/browser/WindowManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/WindowManagerTest.ts
@@ -3,6 +3,8 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import { WindowEvent } from 'tinymce/core/api/EventTypes';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 describe('browser.tinymce.core.WindowManagerTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -15,7 +17,8 @@ describe('browser.tinymce.core.WindowManagerTest', () => {
 
   it('OpenWindow/CloseWindow events', () => {
     const editor = hook.editor();
-    let openWindowArgs, closeWindowArgs;
+    let openWindowArgs: EditorEvent<WindowEvent<any>> | undefined;
+    let closeWindowArgs: EditorEvent<WindowEvent<any>> | undefined;
 
     editor.on('CloseWindow', (e) => {
       closeWindowArgs = e;
@@ -35,8 +38,8 @@ describe('browser.tinymce.core.WindowManagerTest', () => {
       buttons: []
     });
 
-    assert.equal(openWindowArgs.type, 'openwindow');
-    assert.equal(closeWindowArgs.type, 'closewindow');
+    assert.equal(openWindowArgs?.type, 'openwindow');
+    assert.equal(closeWindowArgs?.type, 'closewindow');
 
     editor.off('CloseWindow OpenWindow');
   });

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationPersistenceTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationPersistenceTest.ts
@@ -25,7 +25,7 @@ describe('browser.tinymce.core.annotate.AnnotationPersistenceTest', () => {
     McEditor.remove(editor);
   };
 
-  const settingsWithPersistence = {
+  const settingsWithPersistence: AnnotatorSettings = {
     persistent: true,
     decorate: (uid, data) => ({
       attributes: {
@@ -35,7 +35,7 @@ describe('browser.tinymce.core.annotate.AnnotationPersistenceTest', () => {
     })
   };
 
-  const settingsWithDefaultPersistence = {
+  const settingsWithDefaultPersistence: AnnotatorSettings = {
     decorate: (uid, data) => ({
       attributes: {
         'data-test-anything': data.anything
@@ -44,7 +44,7 @@ describe('browser.tinymce.core.annotate.AnnotationPersistenceTest', () => {
     })
   };
 
-  const settingsWithoutPersistence = {
+  const settingsWithoutPersistence: AnnotatorSettings = {
     persistent: false,
     decorate: (uid, data) => ({
       attributes: {

--- a/modules/tinymce/src/core/test/ts/browser/api/dom/RangeUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/api/dom/RangeUtilsTest.ts
@@ -27,12 +27,14 @@ describe('browser.tinymce.core.api.dom.RangeUtilsTest', () => {
   it(`don't normalize at anchors`, () => {
     viewBlock.update('a<a href="#">b</a>c');
 
-    const rng1 = createRange(viewBlock.get().firstChild, 1, viewBlock.get().firstChild, 1);
+    const firstChild = viewBlock.get().firstChild as Node;
+    const rng1 = createRange(firstChild, 1, firstChild, 1);
     const rng1Clone = rng1.cloneRange();
     assert.isFalse(RangeUtils(DOM).normalize(rng1));
     assertRange(rng1Clone, rng1);
 
-    const rng2 = createRange(viewBlock.get().lastChild, 0, viewBlock.get().lastChild, 0);
+    const lastChild = viewBlock.get().lastChild as Node;
+    const rng2 = createRange(lastChild, 0, lastChild, 0);
     const rng2Clone = rng2.cloneRange();
     assert.isFalse(RangeUtils(DOM).normalize(rng2));
     assertRange(rng2Clone, rng2);

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/CaretBookmarkTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/CaretBookmarkTest.ts
@@ -17,6 +17,9 @@ describe('browser.tinymce.core.CaretBookmarkTest', () => {
     return CaretPosition(textNode, offset);
   };
 
+  const getElement = (id: string): HTMLElement =>
+    document.getElementById(id) as HTMLElement;
+
   it('create element index', () => {
     setupHtml('<b></b><i></i><b></b>');
     assert.equal(CaretBookmark.create(getRoot(), CaretPosition.before(getRoot().childNodes[0])), 'b[0],before');
@@ -50,37 +53,37 @@ describe('browser.tinymce.core.CaretBookmarkTest', () => {
 
   it('create br element index', () => {
     setupHtml('<p><br data-mce-bogus="1"></p><p><br></p>');
-    assert.equal(CaretBookmark.create(getRoot(), CaretPosition.before(getRoot().firstChild.firstChild)), 'p[0]/br[0],before');
-    assert.equal(CaretBookmark.create(getRoot(), CaretPosition.before(getRoot().lastChild.firstChild)), 'p[1]/br[0],before');
+    assert.equal(CaretBookmark.create(getRoot(), CaretPosition.before(getRoot().firstChild?.firstChild as Node)), 'p[0]/br[0],before');
+    assert.equal(CaretBookmark.create(getRoot(), CaretPosition.before(getRoot().lastChild?.firstChild as Node)), 'p[1]/br[0],before');
   });
 
   it('create deep element index', () => {
     setupHtml('<p><span>a</span><span><b id="a"></b><b id="b"></b><b id="c"></b></span></p>');
-    assert.equal(CaretBookmark.create(getRoot(), CaretPosition.before(document.getElementById('a'))), 'p[0]/span[1]/b[0],before');
-    assert.equal(CaretBookmark.create(getRoot(), CaretPosition.before(document.getElementById('b'))), 'p[0]/span[1]/b[1],before');
-    assert.equal(CaretBookmark.create(getRoot(), CaretPosition.before(document.getElementById('c'))), 'p[0]/span[1]/b[2],before');
-    assert.equal(CaretBookmark.create(getRoot(), CaretPosition.after(document.getElementById('c'))), 'p[0]/span[1]/b[2],after');
+    assert.equal(CaretBookmark.create(getRoot(), CaretPosition.before(getElement('a'))), 'p[0]/span[1]/b[0],before');
+    assert.equal(CaretBookmark.create(getRoot(), CaretPosition.before(getElement('b'))), 'p[0]/span[1]/b[1],before');
+    assert.equal(CaretBookmark.create(getRoot(), CaretPosition.before(getElement('c'))), 'p[0]/span[1]/b[2],before');
+    assert.equal(CaretBookmark.create(getRoot(), CaretPosition.after(getElement('c'))), 'p[0]/span[1]/b[2],after');
   });
 
   it('create deep text index', () => {
     setupHtml('<p><span>a</span><span id="x">a<b></b>b<b></b>ccc</span></p>');
     assert.equal(
-      CaretBookmark.create(getRoot(), createTextPos(document.getElementById('x').childNodes[0], 0)),
+      CaretBookmark.create(getRoot(), createTextPos(getElement('x').childNodes[0], 0)),
       'p[0]/span[1]/text()[0],0'
     );
     assert.equal(
-      CaretBookmark.create(getRoot(), createTextPos(document.getElementById('x').childNodes[2], 1)),
+      CaretBookmark.create(getRoot(), createTextPos(getElement('x').childNodes[2], 1)),
       'p[0]/span[1]/text()[1],1'
     );
     assert.equal(
-      CaretBookmark.create(getRoot(), createTextPos(document.getElementById('x').childNodes[4], 3)),
+      CaretBookmark.create(getRoot(), createTextPos(getElement('x').childNodes[4], 3)),
       'p[0]/span[1]/text()[2],3'
     );
   });
 
   it('create element index from bogus', () => {
     setupHtml('<b></b><span data-mce-bogus="1"><b></b><span data-mce-bogus="1"><b></b><b></b></span></span>');
-    assert.equal(CaretBookmark.create(getRoot(), CaretPosition.before(getRoot().lastChild.lastChild.childNodes[1])), 'b[3],before');
+    assert.equal(CaretBookmark.create(getRoot(), CaretPosition.before(getRoot().lastChild?.lastChild?.childNodes[1] as Node)), 'b[3],before');
   });
 
   it('resolve element index', () => {
@@ -95,7 +98,7 @@ describe('browser.tinymce.core.CaretBookmarkTest', () => {
     setupHtml('<h-2X>abc</h-2X>');
     CaretAsserts.assertCaretPosition(
       CaretBookmark.resolve(getRoot(), 'h-2X[0]/text()[0],2'),
-      createTextPos(getRoot().childNodes[0].firstChild, 2)
+      createTextPos(getRoot().childNodes[0].firstChild as Text, 2)
     );
   });
 
@@ -103,19 +106,19 @@ describe('browser.tinymce.core.CaretBookmarkTest', () => {
     setupHtml('<p><span>a</span><span><b id="a"></b><b id="b"></b><b id="c"></b></span></p>');
     CaretAsserts.assertCaretPosition(
       CaretBookmark.resolve(getRoot(), 'p[0]/span[1]/b[0],before'),
-      CaretPosition.before(document.getElementById('a'))
+      CaretPosition.before(getElement('a'))
     );
     CaretAsserts.assertCaretPosition(
       CaretBookmark.resolve(getRoot(), 'p[0]/span[1]/b[1],before'),
-      CaretPosition.before(document.getElementById('b'))
+      CaretPosition.before(getElement('b'))
     );
     CaretAsserts.assertCaretPosition(
       CaretBookmark.resolve(getRoot(), 'p[0]/span[1]/b[2],before'),
-      CaretPosition.before(document.getElementById('c'))
+      CaretPosition.before(getElement('c'))
     );
     CaretAsserts.assertCaretPosition(
       CaretBookmark.resolve(getRoot(), 'p[0]/span[1]/b[2],after'),
-      CaretPosition.after(document.getElementById('c'))
+      CaretPosition.after(getElement('c'))
     );
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/caret/CaretCandidateTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/CaretCandidateTest.ts
@@ -33,10 +33,10 @@ describe('browser.tinymce.core.CaretCandidateTest', () => {
 
   it('isInEditable', () => {
     setupHtml('abc<span contentEditable="true"><b><span contentEditable="false">X</span></b></span>');
-    assert.isFalse(CaretCandidate.isInEditable(SelectorFind.descendant(getRoot(), 'span span').getOrDie().dom.firstChild, getRoot().dom));
+    assert.isFalse(CaretCandidate.isInEditable(SelectorFind.descendant(getRoot(), 'span span').getOrDie().dom.firstChild as Node, getRoot().dom));
     assert.isTrue(CaretCandidate.isInEditable(SelectorFind.descendant(getRoot(), 'span span').getOrDie().dom, getRoot().dom));
     assert.isTrue(CaretCandidate.isInEditable(SelectorFind.descendant(getRoot(), 'span').getOrDie().dom, getRoot().dom));
-    assert.isTrue(CaretCandidate.isInEditable(getRoot().dom.firstChild, getRoot().dom));
+    assert.isTrue(CaretCandidate.isInEditable(getRoot().dom.firstChild as Node, getRoot().dom));
   });
 
   it('isAtomic', () => {

--- a/modules/tinymce/src/core/test/ts/browser/caret/CaretContainerRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/CaretContainerRemoveTest.ts
@@ -18,7 +18,7 @@ describe('browser.tinymce.core.CaretContainerRemoveTest', () => {
   it('remove', () => {
     setupHtml('<span contentEditable="false">1</span>');
 
-    CaretContainer.insertInline(getRoot().firstChild, true);
+    CaretContainer.insertInline(getRoot().firstChild as Node, true);
     assert.isTrue(CaretContainer.isCaretContainerInline(getRoot().firstChild), 'Should be inline container');
 
     CaretContainerRemove.remove(getRoot().firstChild);
@@ -28,10 +28,10 @@ describe('browser.tinymce.core.CaretContainerRemoveTest', () => {
   it('removeAndReposition block in same parent at offset', () => {
     setupHtml('<span contentEditable="false">1</span>');
 
-    CaretContainer.insertBlock('p', getRoot().firstChild, true);
+    CaretContainer.insertBlock('p', getRoot().firstChild as Node, true);
     assert.isTrue(CaretContainer.isCaretContainerBlock(getRoot().firstChild), 'Should be block container');
 
-    const pos = CaretContainerRemove.removeAndReposition(getRoot().firstChild, CaretPosition(getRoot(), 0));
+    const pos = CaretContainerRemove.removeAndReposition(getRoot().firstChild as Node, CaretPosition(getRoot(), 0));
     assert.equal(pos.offset(), 0, 'Should be unchanged offset');
     Assertions.assertDomEq('Should be unchanged container', SugarElement.fromDom(getRoot()), SugarElement.fromDom(pos.container()));
     assert.isFalse(CaretContainer.isCaretContainerBlock(getRoot().firstChild), 'Should not be block container');

--- a/modules/tinymce/src/core/test/ts/browser/caret/CaretContainerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/CaretContainerTest.ts
@@ -41,51 +41,51 @@ describe('browser.tinymce.core.CaretContainerTest', () => {
 
   it('insertInline before element', () => {
     setupHtml('<span contentEditable="false">1</span>');
-    LegacyUnit.equalDom(CaretContainer.insertInline(getRoot().firstChild, true), getRoot().firstChild);
+    LegacyUnit.equalDom(CaretContainer.insertInline(getRoot().firstChild as HTMLSpanElement, true), getRoot().firstChild as Text);
     assert.isTrue(CaretContainer.isCaretContainerInline(getRoot().firstChild));
   });
 
   it('insertInline after element', () => {
     setupHtml('<span contentEditable="false">1</span>');
-    LegacyUnit.equalDom(CaretContainer.insertInline(getRoot().firstChild, false), getRoot().lastChild);
+    LegacyUnit.equalDom(CaretContainer.insertInline(getRoot().firstChild as HTMLSpanElement, false), getRoot().lastChild as Text);
     assert.isTrue(CaretContainer.isCaretContainerInline(getRoot().lastChild));
   });
 
   it('insertInline between elements', () => {
     setupHtml('<span contentEditable="false">1</span><span contentEditable="false">1</span>');
-    LegacyUnit.equalDom(CaretContainer.insertBlock('p', getRoot().lastChild, true), getRoot().childNodes[1]);
+    LegacyUnit.equalDom(CaretContainer.insertBlock('p', getRoot().lastChild as HTMLSpanElement, true), getRoot().childNodes[1]);
     assert.isTrue(CaretContainer.isCaretContainerBlock(getRoot().childNodes[1]));
   });
 
   it('insertInline before element with ZWSP', () => {
     setupHtml('abc' + Zwsp.ZWSP + '<span contentEditable="false">1</span>');
-    LegacyUnit.equalDom(CaretContainer.insertInline(getRoot().lastChild, true), getRoot().childNodes[1]);
+    LegacyUnit.equalDom(CaretContainer.insertInline(getRoot().lastChild as HTMLSpanElement, true), getRoot().childNodes[1]);
     assert.isFalse(CaretContainer.isCaretContainerInline(getRoot().firstChild));
     assert.isTrue(CaretContainer.isCaretContainerInline(getRoot().childNodes[1]));
   });
 
   it('insertInline after element with ZWSP', () => {
     setupHtml('<span contentEditable="false">1</span>' + Zwsp.ZWSP + 'abc');
-    LegacyUnit.equalDom(CaretContainer.insertInline(getRoot().firstChild, false), getRoot().childNodes[1]);
+    LegacyUnit.equalDom(CaretContainer.insertInline(getRoot().firstChild as HTMLSpanElement, false), getRoot().childNodes[1]);
     assert.isFalse(CaretContainer.isCaretContainerInline(getRoot().lastChild));
     assert.isTrue(CaretContainer.isCaretContainerInline(getRoot().childNodes[1]));
   });
 
   it('insertBlock before element', () => {
     setupHtml('<span contentEditable="false">1</span>');
-    LegacyUnit.equalDom(CaretContainer.insertBlock('p', getRoot().firstChild, true), getRoot().firstChild);
+    LegacyUnit.equalDom(CaretContainer.insertBlock('p', getRoot().firstChild as HTMLSpanElement, true), getRoot().firstChild as Element);
     assert.isTrue(CaretContainer.isCaretContainerBlock(getRoot().firstChild));
   });
 
   it('insertBlock after element', () => {
     setupHtml('<span contentEditable="false">1</span>');
-    LegacyUnit.equalDom(CaretContainer.insertBlock('p', getRoot().firstChild, false), getRoot().lastChild);
+    LegacyUnit.equalDom(CaretContainer.insertBlock('p', getRoot().firstChild as HTMLSpanElement, false), getRoot().lastChild as Element);
     assert.isTrue(CaretContainer.isCaretContainerBlock(getRoot().lastChild));
   });
 
   it('insertBlock between elements', () => {
     setupHtml('<span contentEditable="false">1</span><span contentEditable="false">1</span>');
-    LegacyUnit.equalDom(CaretContainer.insertInline(getRoot().lastChild, true), getRoot().childNodes[1]);
+    LegacyUnit.equalDom(CaretContainer.insertInline(getRoot().lastChild as HTMLSpanElement, true), getRoot().childNodes[1]);
     assert.isTrue(CaretContainer.isCaretContainerInline(getRoot().childNodes[1]));
   });
 
@@ -103,7 +103,7 @@ describe('browser.tinymce.core.CaretContainerTest', () => {
 
   it('hasContent', () => {
     setupHtml('<span contentEditable="false">1</span>');
-    const caretContainerBlock = CaretContainer.insertBlock('p', getRoot().firstChild, true);
+    const caretContainerBlock = CaretContainer.insertBlock('p', getRoot().firstChild as HTMLSpanElement, true);
     assert.isFalse(CaretContainer.hasContent(caretContainerBlock));
     caretContainerBlock.insertBefore(document.createTextNode('a'), caretContainerBlock.firstChild);
     assert.isTrue(CaretContainer.hasContent(caretContainerBlock));
@@ -111,7 +111,7 @@ describe('browser.tinymce.core.CaretContainerTest', () => {
 
   it('showCaretContainerBlock', () => {
     setupHtml('<span contentEditable="false">1</span>');
-    const caretContainerBlock = CaretContainer.insertBlock('p', getRoot().firstChild, true) as HTMLElement;
+    const caretContainerBlock = CaretContainer.insertBlock('p', getRoot().firstChild as HTMLSpanElement, true) as HTMLElement;
     caretContainerBlock.insertBefore(document.createTextNode('a'), caretContainerBlock.firstChild);
     CaretContainer.showCaretContainerBlock(caretContainerBlock);
     assert.equal(caretContainerBlock.outerHTML, '<p>a</p>');
@@ -137,27 +137,27 @@ describe('browser.tinymce.core.CaretContainerTest', () => {
 
   it('isBeforeInline', () => {
     setupHtml(Zwsp.ZWSP + 'a');
-    assert.isTrue(CaretContainer.isBeforeInline(CaretPosition(getRoot().firstChild, 0)));
-    assert.isFalse(CaretContainer.isBeforeInline(CaretPosition(getRoot().firstChild, 1)));
+    assert.isTrue(CaretContainer.isBeforeInline(CaretPosition(getRoot().firstChild as Text, 0)));
+    assert.isFalse(CaretContainer.isBeforeInline(CaretPosition(getRoot().firstChild as Text, 1)));
   });
 
   it('isBeforeInline 2', () => {
     setupHtml('a');
     viewBlock.get().insertBefore(document.createTextNode(Zwsp.ZWSP), viewBlock.get().firstChild);
-    assert.isTrue(CaretContainer.isBeforeInline(CaretPosition(getRoot().firstChild, 0)));
-    assert.isFalse(CaretContainer.isBeforeInline(CaretPosition(getRoot().firstChild, 1)));
+    assert.isTrue(CaretContainer.isBeforeInline(CaretPosition(getRoot().firstChild as Text, 0)));
+    assert.isFalse(CaretContainer.isBeforeInline(CaretPosition(getRoot().firstChild as Text, 1)));
   });
 
   it('isAfterInline', () => {
     setupHtml(Zwsp.ZWSP + 'a');
-    assert.isTrue(CaretContainer.isAfterInline(CaretPosition(getRoot().firstChild, 1)));
-    assert.isFalse(CaretContainer.isAfterInline(CaretPosition(getRoot().firstChild, 0)));
+    assert.isTrue(CaretContainer.isAfterInline(CaretPosition(getRoot().firstChild as Text, 1)));
+    assert.isFalse(CaretContainer.isAfterInline(CaretPosition(getRoot().firstChild as Text, 0)));
   });
 
   it('isAfterInline 2', () => {
     setupHtml('a');
     viewBlock.get().insertBefore(document.createTextNode(Zwsp.ZWSP), viewBlock.get().firstChild);
-    assert.isTrue(CaretContainer.isAfterInline(CaretPosition(getRoot().firstChild, 1)));
-    assert.isFalse(CaretContainer.isAfterInline(CaretPosition(getRoot().firstChild, 0)));
+    assert.isTrue(CaretContainer.isAfterInline(CaretPosition(getRoot().firstChild as Text, 1)));
+    assert.isFalse(CaretContainer.isAfterInline(CaretPosition(getRoot().firstChild as Text, 0)));
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/caret/CaretPositionPredicatesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/CaretPositionPredicatesTest.ts
@@ -46,14 +46,14 @@ describe('browser.tinymce.core.CaretPositionPredicateTest', () => {
   it('TBA: isEmptyText', () => {
     setupHtml('');
     getRoot().appendChild(document.createTextNode(''));
-    assert.isTrue(isEmptyText(CaretPosition(getRoot().firstChild, 0)));
-    assert.isTrue(isEmptyText(CaretPosition(getRoot().firstChild, 1)));
+    assert.isTrue(isEmptyText(CaretPosition(getRoot().firstChild as Text, 0)));
+    assert.isTrue(isEmptyText(CaretPosition(getRoot().firstChild as Text, 1)));
 
     setupHtml('<span data-mce-type="bookmark">' + ZWSP + '</span>');
-    const span = getRoot().firstChild;
+    const span = getRoot().firstChild as HTMLSpanElement;
     assert.isFalse(isEmptyText(CaretPosition(span, 0)));
     assert.isFalse(isEmptyText(CaretPosition(span, 1)));
-    assert.isTrue(isEmptyText(CaretPosition(span.firstChild, 0)));
-    assert.isTrue(isEmptyText(CaretPosition(span.firstChild, 1)));
+    assert.isTrue(isEmptyText(CaretPosition(span.firstChild as Text, 0)));
+    assert.isTrue(isEmptyText(CaretPosition(span.firstChild as Text, 1)));
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/caret/CaretPositionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/CaretPositionTest.ts
@@ -18,8 +18,8 @@ describe('browser.tinymce.core.CaretPositionTest', () => {
     setupHtml('abc');
     LegacyUnit.equalDom(CaretPosition(getRoot(), 0).container(), getRoot());
     assert.strictEqual(CaretPosition(getRoot(), 1).offset(), 1);
-    LegacyUnit.equalDom(CaretPosition(getRoot().firstChild, 0).container(), getRoot().firstChild);
-    assert.strictEqual(CaretPosition(getRoot().firstChild, 1).offset(), 1);
+    LegacyUnit.equalDom(CaretPosition(getRoot().firstChild as Text, 0).container(), getRoot().firstChild as Text);
+    assert.strictEqual(CaretPosition(getRoot().firstChild as Text, 1).offset(), 1);
   });
 
   it('fromRangeStart', () => {
@@ -27,8 +27,8 @@ describe('browser.tinymce.core.CaretPositionTest', () => {
     CaretAsserts.assertCaretPosition(CaretPosition.fromRangeStart(createRange(getRoot(), 0)), CaretPosition(getRoot(), 0));
     CaretAsserts.assertCaretPosition(CaretPosition.fromRangeStart(createRange(getRoot(), 1)), CaretPosition(getRoot(), 1));
     CaretAsserts.assertCaretPosition(
-      CaretPosition.fromRangeStart(createRange(getRoot().firstChild, 1)),
-      CaretPosition(getRoot().firstChild, 1)
+      CaretPosition.fromRangeStart(createRange(getRoot().firstChild as Text, 1)),
+      CaretPosition(getRoot().firstChild as Text, 1)
     );
   });
 
@@ -39,21 +39,21 @@ describe('browser.tinymce.core.CaretPositionTest', () => {
       CaretPosition(getRoot(), 1)
     );
     CaretAsserts.assertCaretPosition(
-      CaretPosition.fromRangeEnd(createRange(getRoot().firstChild, 0, getRoot().firstChild, 1)),
-      CaretPosition(getRoot().firstChild, 1)
+      CaretPosition.fromRangeEnd(createRange(getRoot().firstChild as Text, 0, getRoot().firstChild as Text, 1)),
+      CaretPosition(getRoot().firstChild as Text, 1)
     );
   });
 
   it('after', () => {
     setupHtml('abc<b>123</b>');
-    CaretAsserts.assertCaretPosition(CaretPosition.after(getRoot().firstChild), CaretPosition(getRoot(), 1));
-    CaretAsserts.assertCaretPosition(CaretPosition.after(getRoot().lastChild), CaretPosition(getRoot(), 2));
+    CaretAsserts.assertCaretPosition(CaretPosition.after(getRoot().firstChild as Text), CaretPosition(getRoot(), 1));
+    CaretAsserts.assertCaretPosition(CaretPosition.after(getRoot().lastChild as HTMLElement), CaretPosition(getRoot(), 2));
   });
 
   it('before', () => {
     setupHtml('abc<b>123</b>');
-    CaretAsserts.assertCaretPosition(CaretPosition.before(getRoot().firstChild), CaretPosition(getRoot(), 0));
-    CaretAsserts.assertCaretPosition(CaretPosition.before(getRoot().lastChild), CaretPosition(getRoot(), 1));
+    CaretAsserts.assertCaretPosition(CaretPosition.before(getRoot().firstChild as Text), CaretPosition(getRoot(), 0));
+    CaretAsserts.assertCaretPosition(CaretPosition.before(getRoot().lastChild as HTMLElement), CaretPosition(getRoot(), 1));
   });
 
   it('isAtStart', () => {
@@ -61,9 +61,9 @@ describe('browser.tinymce.core.CaretPositionTest', () => {
     assert.isTrue(CaretPosition(getRoot(), 0).isAtStart());
     assert.isFalse(CaretPosition(getRoot(), 1).isAtStart());
     assert.isFalse(CaretPosition(getRoot(), 3).isAtStart());
-    assert.isTrue(CaretPosition(getRoot().firstChild, 0).isAtStart());
-    assert.isFalse(CaretPosition(getRoot().firstChild, 1).isAtStart());
-    assert.isFalse(CaretPosition(getRoot().firstChild, 3).isAtStart());
+    assert.isTrue(CaretPosition(getRoot().firstChild as Text, 0).isAtStart());
+    assert.isFalse(CaretPosition(getRoot().firstChild as Text, 1).isAtStart());
+    assert.isFalse(CaretPosition(getRoot().firstChild as Text, 3).isAtStart());
   });
 
   it('isAtEnd', () => {
@@ -71,29 +71,29 @@ describe('browser.tinymce.core.CaretPositionTest', () => {
     assert.isTrue(CaretPosition(getRoot(), 3).isAtEnd());
     assert.isFalse(CaretPosition(getRoot(), 2).isAtEnd());
     assert.isFalse(CaretPosition(getRoot(), 0).isAtEnd());
-    assert.isTrue(CaretPosition(getRoot().firstChild, 3).isAtEnd());
-    assert.isFalse(CaretPosition(getRoot().firstChild, 0).isAtEnd());
-    assert.isFalse(CaretPosition(getRoot().firstChild, 1).isAtEnd());
+    assert.isTrue(CaretPosition(getRoot().firstChild as Text, 3).isAtEnd());
+    assert.isFalse(CaretPosition(getRoot().firstChild as Text, 0).isAtEnd());
+    assert.isFalse(CaretPosition(getRoot().firstChild as Text, 1).isAtEnd());
   });
 
   it('toRange', () => {
     setupHtml('abc');
     CaretAsserts.assertRange(CaretPosition(getRoot(), 0).toRange(), createRange(getRoot(), 0));
     CaretAsserts.assertRange(CaretPosition(getRoot(), 1).toRange(), createRange(getRoot(), 1));
-    CaretAsserts.assertRange(CaretPosition(getRoot().firstChild, 1).toRange(), createRange(getRoot().firstChild, 1));
+    CaretAsserts.assertRange(CaretPosition(getRoot().firstChild as Text, 1).toRange(), createRange(getRoot().firstChild as Text, 1));
   });
 
   it('isEqual', () => {
     setupHtml('abc');
     assert.isTrue(CaretPosition(getRoot(), 0).isEqual(CaretPosition(getRoot(), 0)));
     assert.isFalse(CaretPosition(getRoot(), 1).isEqual(CaretPosition(getRoot(), 0)));
-    assert.isFalse(CaretPosition(getRoot(), 0).isEqual(CaretPosition(getRoot().firstChild, 0)));
+    assert.isFalse(CaretPosition(getRoot(), 0).isEqual(CaretPosition(getRoot().firstChild as Text, 0)));
   });
 
   it('isVisible', () => {
     setupHtml('<b>  abc</b>');
-    assert.isFalse(CaretPosition(getRoot().firstChild.firstChild, 0).isVisible());
-    assert.isTrue(CaretPosition(getRoot().firstChild.firstChild, 3).isVisible());
+    assert.isFalse(CaretPosition(getRoot().firstChild?.firstChild as Text, 0).isVisible());
+    assert.isTrue(CaretPosition(getRoot().firstChild?.firstChild as Text, 3).isVisible());
   });
 
   it('getClientRects', () => {
@@ -109,7 +109,7 @@ describe('browser.tinymce.core.CaretPositionTest', () => {
       '<br>'
     );
 
-    assert.lengthOf(CaretPosition(getRoot().firstChild.firstChild, 0).getClientRects(), 1);
+    assert.lengthOf(CaretPosition(getRoot().firstChild?.firstChild as Text, 0).getClientRects(), 1);
     assert.lengthOf(CaretPosition(getRoot(), 1).getClientRects(), 1);
     assert.lengthOf(CaretPosition(getRoot(), 2).getClientRects(), 2);
     assert.lengthOf(CaretPosition(getRoot(), 3).getClientRects(), 2);
@@ -133,7 +133,7 @@ describe('browser.tinymce.core.CaretPositionTest', () => {
   it('getClientRects at last visible character', () => {
     setupHtml('<b>a  </b>');
 
-    assert.lengthOf(CaretPosition(getRoot().firstChild.firstChild, 1).getClientRects(), 1);
+    assert.lengthOf(CaretPosition(getRoot().firstChild?.firstChild as Text, 1).getClientRects(), 1);
   });
 
   it('getClientRects at extending character', () => {
@@ -141,62 +141,62 @@ describe('browser.tinymce.core.CaretPositionTest', () => {
     const textNode = getRoot().firstChild as Text;
     textNode.appendData('\u0301b');
 
-    assert.lengthOf(CaretPosition(getRoot().firstChild, 0).getClientRects(), 1);
-    assert.lengthOf(CaretPosition(getRoot().firstChild, 1).getClientRects(), 0);
-    assert.lengthOf(CaretPosition(getRoot().firstChild, 2).getClientRects(), 1);
+    assert.lengthOf(CaretPosition(textNode, 0).getClientRects(), 1);
+    assert.lengthOf(CaretPosition(textNode, 1).getClientRects(), 0);
+    assert.lengthOf(CaretPosition(textNode, 2).getClientRects(), 1);
   });
 
   it('getClientRects at whitespace character', () => {
     setupHtml('  a  ');
 
-    assert.lengthOf(CaretPosition(getRoot().firstChild, 0).getClientRects(), 0);
-    assert.lengthOf(CaretPosition(getRoot().firstChild, 1).getClientRects(), 0);
-    assert.lengthOf(CaretPosition(getRoot().firstChild, 2).getClientRects(), 1);
-    assert.lengthOf(CaretPosition(getRoot().firstChild, 3).getClientRects(), 1);
-    assert.lengthOf(CaretPosition(getRoot().firstChild, 4).getClientRects(), 0);
-    assert.lengthOf(CaretPosition(getRoot().firstChild, 5).getClientRects(), 0);
+    assert.lengthOf(CaretPosition(getRoot().firstChild as Text, 0).getClientRects(), 0);
+    assert.lengthOf(CaretPosition(getRoot().firstChild as Text, 1).getClientRects(), 0);
+    assert.lengthOf(CaretPosition(getRoot().firstChild as Text, 2).getClientRects(), 1);
+    assert.lengthOf(CaretPosition(getRoot().firstChild as Text, 3).getClientRects(), 1);
+    assert.lengthOf(CaretPosition(getRoot().firstChild as Text, 4).getClientRects(), 0);
+    assert.lengthOf(CaretPosition(getRoot().firstChild as Text, 5).getClientRects(), 0);
   });
 
   it('getClientRects at only one text node should return client rects', () => {
     setupHtml('<p>a<br>b</p>');
-    assert.isAbove(CaretPosition(getRoot().firstChild.firstChild, 0).getClientRects().length, 0);
-    assert.isAbove(CaretPosition(getRoot().firstChild.firstChild, 1).getClientRects().length, 0);
-    assert.isAbove(CaretPosition(getRoot().firstChild.lastChild, 0).getClientRects().length, 0);
-    assert.isAbove(CaretPosition(getRoot().firstChild.lastChild, 1).getClientRects().length, 0);
+    assert.isAbove(CaretPosition(getRoot().firstChild?.firstChild as Text, 0).getClientRects().length, 0);
+    assert.isAbove(CaretPosition(getRoot().firstChild?.firstChild as Text, 1).getClientRects().length, 0);
+    assert.isAbove(CaretPosition(getRoot().firstChild?.lastChild as Text, 0).getClientRects().length, 0);
+    assert.isAbove(CaretPosition(getRoot().firstChild?.lastChild as Text, 1).getClientRects().length, 0);
   });
 
   it('getNode', () => {
     setupHtml('<b>abc</b><input><input>');
 
-    LegacyUnit.equalDom(CaretPosition(getRoot().firstChild.firstChild, 0).getNode(), getRoot().firstChild.firstChild);
-    LegacyUnit.equalDom(CaretPosition(getRoot(), 1).getNode(), getRoot().childNodes[1]);
-    LegacyUnit.equalDom(CaretPosition(getRoot(), 2).getNode(), getRoot().childNodes[2]);
-    LegacyUnit.equalDom(CaretPosition(getRoot(), 3).getNode(), getRoot().childNodes[2]);
+    LegacyUnit.equalDom(CaretPosition(getRoot().firstChild?.firstChild as Text, 0).getNode() as Text, getRoot().firstChild?.firstChild as Text);
+    LegacyUnit.equalDom(CaretPosition(getRoot(), 1).getNode() as HTMLElement, getRoot().childNodes[1]);
+    LegacyUnit.equalDom(CaretPosition(getRoot(), 2).getNode() as HTMLInputElement, getRoot().childNodes[2]);
+    LegacyUnit.equalDom(CaretPosition(getRoot(), 3).getNode() as HTMLInputElement, getRoot().childNodes[2]);
   });
 
   it('getNode (before)', () => {
     setupHtml('<b>abc</b><input><input>');
 
-    LegacyUnit.equalDom(CaretPosition(getRoot().firstChild.firstChild, 0).getNode(true), getRoot().firstChild.firstChild);
-    LegacyUnit.equalDom(CaretPosition(getRoot(), 1).getNode(true), getRoot().childNodes[0]);
-    LegacyUnit.equalDom(CaretPosition(getRoot(), 2).getNode(true), getRoot().childNodes[1]);
-    LegacyUnit.equalDom(CaretPosition(getRoot(), 3).getNode(true), getRoot().childNodes[2]);
+    LegacyUnit.equalDom(CaretPosition(getRoot().firstChild?.firstChild as Text, 0).getNode(true) as Text, getRoot().firstChild?.firstChild as Text);
+    LegacyUnit.equalDom(CaretPosition(getRoot(), 1).getNode(true) as HTMLElement, getRoot().childNodes[0]);
+    LegacyUnit.equalDom(CaretPosition(getRoot(), 2).getNode(true) as HTMLInputElement, getRoot().childNodes[1]);
+    LegacyUnit.equalDom(CaretPosition(getRoot(), 3).getNode(true) as HTMLInputElement, getRoot().childNodes[2]);
   });
 
   it('isAtStart/isAtEnd/isTextPosition', () => {
     setupHtml('<b>abc</b><p><input></p>');
 
-    assert.isTrue(CaretPosition.isAtStart(CaretPosition(getRoot().firstChild.firstChild, 0)));
-    assert.isFalse(CaretPosition.isAtStart(CaretPosition(getRoot().firstChild.firstChild, 1)));
-    assert.isFalse(CaretPosition.isAtStart(CaretPosition(getRoot().firstChild.firstChild, 3)));
-    assert.isTrue(CaretPosition.isAtStart(CaretPosition(getRoot().lastChild, 0)));
-    assert.isFalse(CaretPosition.isAtStart(CaretPosition(getRoot().lastChild, 1)));
-    assert.isTrue(CaretPosition.isAtEnd(CaretPosition(getRoot().firstChild.firstChild, 3)));
-    assert.isFalse(CaretPosition.isAtEnd(CaretPosition(getRoot().firstChild.firstChild, 1)));
-    assert.isFalse(CaretPosition.isAtEnd(CaretPosition(getRoot().firstChild.firstChild, 0)));
-    assert.isTrue(CaretPosition.isAtEnd(CaretPosition(getRoot().lastChild, 1)));
-    assert.isFalse(CaretPosition.isAtEnd(CaretPosition(getRoot().lastChild, 0)));
-    assert.isTrue(CaretPosition.isTextPosition(CaretPosition(getRoot().firstChild.firstChild, 0)));
-    assert.isFalse(CaretPosition.isTextPosition(CaretPosition(getRoot().lastChild, 0)));
+    assert.isTrue(CaretPosition.isAtStart(CaretPosition(getRoot().firstChild?.firstChild as Text, 0)));
+    assert.isFalse(CaretPosition.isAtStart(CaretPosition(getRoot().firstChild?.firstChild as Text, 1)));
+    assert.isFalse(CaretPosition.isAtStart(CaretPosition(getRoot().firstChild?.firstChild as Text, 3)));
+    assert.isTrue(CaretPosition.isAtStart(CaretPosition(getRoot().lastChild as HTMLParagraphElement, 0)));
+    assert.isFalse(CaretPosition.isAtStart(CaretPosition(getRoot().lastChild as HTMLParagraphElement, 1)));
+    assert.isTrue(CaretPosition.isAtEnd(CaretPosition(getRoot().firstChild?.firstChild as Text, 3)));
+    assert.isFalse(CaretPosition.isAtEnd(CaretPosition(getRoot().firstChild?.firstChild as Text, 1)));
+    assert.isFalse(CaretPosition.isAtEnd(CaretPosition(getRoot().firstChild?.firstChild as Text, 0)));
+    assert.isTrue(CaretPosition.isAtEnd(CaretPosition(getRoot().lastChild as HTMLParagraphElement, 1)));
+    assert.isFalse(CaretPosition.isAtEnd(CaretPosition(getRoot().lastChild as HTMLParagraphElement, 0)));
+    assert.isTrue(CaretPosition.isTextPosition(CaretPosition(getRoot().firstChild?.firstChild as Text, 0)));
+    assert.isFalse(CaretPosition.isTextPosition(CaretPosition(getRoot().lastChild as HTMLParagraphElement, 0)));
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/caret/CaretUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/CaretUtilsTest.ts
@@ -30,7 +30,7 @@ describe('browser.tinymce.core.CaretUtilTest', () => {
   const replaceWithZwsp = (node: Node) => {
     Arr.each(node.childNodes, (childNode) => {
       if (childNode.nodeType === 3) {
-        childNode.nodeValue = childNode.nodeValue.replace(/__ZWSP__/, ZWSP);
+        childNode.nodeValue = (childNode as Text).data.replace(/__ZWSP__/, ZWSP);
       } else {
         replaceWithZwsp(childNode);
       }
@@ -58,55 +58,55 @@ describe('browser.tinymce.core.CaretUtilTest', () => {
   it('findNode', () => {
     setupHtml('<b>abc</b><b><i>123</i></b>def');
 
-    const isBold = (node: Node) => {
-      return node.nodeName === 'B';
+    const isBold = (node: Node | null) => {
+      return node?.nodeName === 'B';
     };
 
-    const isText = (node: Node) => {
-      return node.nodeType === 3;
+    const isText = (node: Node | null) => {
+      return node?.nodeType === 3;
     };
 
-    LegacyUnit.equalDom(CaretUtils.findNode(getRoot(), 1, isBold, getRoot()), getRoot().firstChild);
-    LegacyUnit.equalDom(CaretUtils.findNode(getRoot(), 1, isText, getRoot()), getRoot().firstChild.firstChild);
+    LegacyUnit.equalDom(CaretUtils.findNode(getRoot(), 1, isBold, getRoot()) as Node, getRoot().firstChild as HTMLElement);
+    LegacyUnit.equalDom(CaretUtils.findNode(getRoot(), 1, isText, getRoot()) as Node, getRoot().firstChild?.firstChild as Text);
     assert.isNull(CaretUtils.findNode(getRoot().childNodes[1], 1, isBold, getRoot().childNodes[1]));
-    assert.equal(CaretUtils.findNode(getRoot().childNodes[1], 1, isText, getRoot().childNodes[1]).nodeName, '#text');
-    LegacyUnit.equalDom(CaretUtils.findNode(getRoot(), -1, isBold, getRoot()), getRoot().childNodes[1]);
-    LegacyUnit.equalDom(CaretUtils.findNode(getRoot(), -1, isText, getRoot()), getRoot().lastChild);
+    assert.equal(CaretUtils.findNode(getRoot().childNodes[1], 1, isText, getRoot().childNodes[1])?.nodeName, '#text');
+    LegacyUnit.equalDom(CaretUtils.findNode(getRoot(), -1, isBold, getRoot()) as Node, getRoot().childNodes[1]);
+    LegacyUnit.equalDom(CaretUtils.findNode(getRoot(), -1, isText, getRoot()) as Node, getRoot().lastChild as Text);
   });
 
   it('getEditingHost', () => {
     setupHtml('<span contentEditable="true"><span contentEditable="false"></span></span>');
 
     LegacyUnit.equalDom(CaretUtils.getEditingHost(getRoot(), getRoot()), getRoot());
-    LegacyUnit.equalDom(CaretUtils.getEditingHost(getRoot().firstChild, getRoot()), getRoot());
-    LegacyUnit.equalDom(CaretUtils.getEditingHost(getRoot().firstChild.firstChild, getRoot()), getRoot().firstChild);
+    LegacyUnit.equalDom(CaretUtils.getEditingHost(getRoot().firstChild as HTMLSpanElement, getRoot()), getRoot());
+    LegacyUnit.equalDom(CaretUtils.getEditingHost(getRoot().firstChild?.firstChild as Text, getRoot()), getRoot().firstChild as HTMLSpanElement);
   });
 
   it('getParentBlock', () => {
     setupHtml('<p>abc</p><div><p><table><tr><td>X</td></tr></p></div>');
 
-    LegacyUnit.equalDom(CaretUtils.getParentBlock(findElm('p:first-of-type')), findElm('p:first-of-type'));
-    LegacyUnit.equalDom(CaretUtils.getParentBlock(findElm('td:first-of-type').firstChild), findElm('td:first-of-type'));
-    LegacyUnit.equalDom(CaretUtils.getParentBlock(findElm('td:first-of-type')), findElm('td:first-of-type'));
-    LegacyUnit.equalDom(CaretUtils.getParentBlock(findElm('table')), findElm('table'));
+    LegacyUnit.equalDom(CaretUtils.getParentBlock(findElm('p:first-of-type')) as HTMLParagraphElement, findElm('p:first-of-type') as HTMLParagraphElement);
+    LegacyUnit.equalDom(CaretUtils.getParentBlock(findElm('td:first-of-type')?.firstChild as Text) as HTMLTableCellElement, findElm('td:first-of-type') as HTMLTableCellElement);
+    LegacyUnit.equalDom(CaretUtils.getParentBlock(findElm('td:first-of-type')) as HTMLTableCellElement, findElm('td:first-of-type') as HTMLTableCellElement);
+    LegacyUnit.equalDom(CaretUtils.getParentBlock(findElm('table')) as HTMLElement, findElm('table') as HTMLElement);
   });
 
   it('isInSameBlock', () => {
     setupHtml('<p>abc</p><p>def<b>ghj</b></p>');
 
     assert.isFalse(CaretUtils.isInSameBlock(
-      CaretPosition(findElm('p:first-of-type').firstChild, 0),
-      CaretPosition(findElm('p:last-of-type').firstChild, 0)
+      CaretPosition(findElm('p:first-of-type')?.firstChild as Text, 0),
+      CaretPosition(findElm('p:last-of-type')?.firstChild as Text, 0)
     ));
 
     assert.isTrue(CaretUtils.isInSameBlock(
-      CaretPosition(findElm('p:first-of-type').firstChild, 0),
-      CaretPosition(findElm('p:first-of-type').firstChild, 0)
+      CaretPosition(findElm('p:first-of-type')?.firstChild as Text, 0),
+      CaretPosition(findElm('p:first-of-type')?.firstChild as Text, 0)
     ));
 
     assert.isTrue(CaretUtils.isInSameBlock(
-      CaretPosition(findElm('p:last-of-type').firstChild, 0),
-      CaretPosition(findElm('b').firstChild, 0)
+      CaretPosition(findElm('p:last-of-type')?.firstChild as Text, 0),
+      CaretPosition(findElm('b')?.firstChild as Text, 0)
     ));
   });
 
@@ -121,32 +121,32 @@ describe('browser.tinymce.core.CaretUtilTest', () => {
     );
 
     assert.isTrue(CaretUtils.isInSameEditingHost(
-      CaretPosition(findElm('p:first-of-type').firstChild, 0),
-      CaretPosition(findElm('p:first-of-type').firstChild, 1),
+      CaretPosition(findElm('p:first-of-type')?.firstChild as Text, 0),
+      CaretPosition(findElm('p:first-of-type')?.firstChild as Text, 1),
       getRoot()
     ));
 
     assert.isTrue(CaretUtils.isInSameEditingHost(
-      CaretPosition(findElm('p:first-of-type').firstChild, 0),
+      CaretPosition(findElm('p:first-of-type')?.firstChild as Text, 0),
       CaretPosition(getRoot().childNodes[1], 1),
       getRoot()
     ));
 
     assert.isTrue(CaretUtils.isInSameEditingHost(
-      CaretPosition(findElm('span span:first-of-type').firstChild, 0),
-      CaretPosition(findElm('span span:first-of-type').firstChild, 1),
+      CaretPosition(findElm('span span:first-of-type')?.firstChild as Text, 0),
+      CaretPosition(findElm('span span:first-of-type')?.firstChild as Text, 1),
       getRoot()
     ));
 
     assert.isFalse(CaretUtils.isInSameEditingHost(
-      CaretPosition(findElm('p:first-of-type').firstChild, 0),
-      CaretPosition(findElm('span span:first-of-type').firstChild, 1),
+      CaretPosition(findElm('p:first-of-type')?.firstChild as Text, 0),
+      CaretPosition(findElm('span span:first-of-type')?.firstChild as Text, 1),
       getRoot()
     ));
 
     assert.isFalse(CaretUtils.isInSameEditingHost(
-      CaretPosition(findElm('span span:first-of-type').firstChild, 0),
-      CaretPosition(findElm('span span:last-of-type').firstChild, 1),
+      CaretPosition(findElm('span span:first-of-type')?.firstChild as Text, 0),
+      CaretPosition(findElm('span span:last-of-type')?.firstChild as Text, 1),
       getRoot()
     ));
   });
@@ -156,10 +156,10 @@ describe('browser.tinymce.core.CaretUtilTest', () => {
       'abc<span contentEditable="false">1</span>def'
     );
 
-    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().firstChild, 2)), createRange(getRoot().firstChild, 2));
-    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().firstChild, 3)), createRange(getRoot(), 1));
-    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().lastChild, 2)), createRange(getRoot().lastChild, 2));
-    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().lastChild, 0)), createRange(getRoot(), 2));
+    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().firstChild as Text, 2)), createRange(getRoot().firstChild as Text, 2));
+    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().firstChild as Text, 3)), createRange(getRoot(), 1));
+    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().lastChild as Text, 2)), createRange(getRoot().lastChild as Text, 2));
+    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().lastChild as Text, 0)), createRange(getRoot(), 2));
   });
 
   it('normalizeRange deep', () => {
@@ -168,15 +168,15 @@ describe('browser.tinymce.core.CaretUtilTest', () => {
     );
 
     assertRange(
-      CaretUtils.normalizeRange(1, getRoot(), createRange(findElm('b').firstChild, 2)),
-      createRange(findElm('b').firstChild, 2)
+      CaretUtils.normalizeRange(1, getRoot(), createRange(findElm('b')?.firstChild as Text, 2)),
+      createRange(findElm('b')?.firstChild as Text, 2)
     );
-    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(findElm('b').firstChild, 3)), createRange(getRoot(), 1));
+    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(findElm('b')?.firstChild as Text, 3)), createRange(getRoot(), 1));
     assertRange(
-      CaretUtils.normalizeRange(-1, getRoot(), createRange(findElm('i:last-of-type b').firstChild, 1)),
-      createRange(findElm('i:last-of-type b').firstChild, 1)
+      CaretUtils.normalizeRange(-1, getRoot(), createRange(findElm('i:last-of-type b')?.firstChild as Text, 1)),
+      createRange(findElm('i:last-of-type b')?.firstChild as Text, 1)
     );
-    assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(findElm('i:last-of-type b').firstChild, 0)), createRange(getRoot(), 2));
+    assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(findElm('i:last-of-type b')?.firstChild as Text, 0)), createRange(getRoot(), 2));
   });
 
   it('normalizeRange break at candidate', () => {
@@ -185,12 +185,12 @@ describe('browser.tinymce.core.CaretUtilTest', () => {
     );
 
     assertRange(
-      CaretUtils.normalizeRange(1, getRoot(), createRange(findElm('b').firstChild, 3)),
-      createRange(findElm('b').firstChild, 3)
+      CaretUtils.normalizeRange(1, getRoot(), createRange(findElm('b')?.firstChild as Text, 3)),
+      createRange(findElm('b')?.firstChild as Text, 3)
     );
     assertRange(
-      CaretUtils.normalizeRange(1, getRoot(), createRange(findElm('b:last-of-type').lastChild, 0)),
-      createRange(findElm('b:last-of-type').lastChild, 0)
+      CaretUtils.normalizeRange(1, getRoot(), createRange(findElm('b:last-of-type')?.lastChild as Text, 0)),
+      createRange(findElm('b:last-of-type')?.lastChild as Text, 0)
     );
   });
 
@@ -199,10 +199,10 @@ describe('browser.tinymce.core.CaretUtilTest', () => {
       '<p data-mce-caret="before">\u00a0</p><p contentEditable="false">1</p><p data-mce-caret="after">\u00a0</p>'
     );
 
-    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(findElm('p:first-of-type').firstChild, 0)), createRange(getRoot(), 1));
-    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(findElm('p:first-of-type').firstChild, 1)), createRange(getRoot(), 1));
-    assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(findElm('p:last-of-type').firstChild, 0)), createRange(getRoot(), 2));
-    assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(findElm('p:last-of-type').firstChild, 1)), createRange(getRoot(), 2));
+    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(findElm('p:first-of-type')?.firstChild as Text, 0)), createRange(getRoot(), 1));
+    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(findElm('p:first-of-type')?.firstChild as Text, 1)), createRange(getRoot(), 1));
+    assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(findElm('p:last-of-type')?.firstChild as Text, 0)), createRange(getRoot(), 2));
+    assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(findElm('p:last-of-type')?.firstChild as Text, 1)), createRange(getRoot(), 2));
   });
 
   it('normalizeRange at inline caret container', () => {
@@ -213,16 +213,16 @@ describe('browser.tinymce.core.CaretUtilTest', () => {
     getRoot().insertBefore(document.createTextNode(ZWSP), getRoot().childNodes[1]);
     getRoot().insertBefore(document.createTextNode(ZWSP), getRoot().childNodes[3]);
 
-    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().firstChild, 3)), createRange(getRoot(), 2));
+    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().firstChild as Text, 3)), createRange(getRoot(), 2));
     assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().childNodes[1], 0)), createRange(getRoot(), 2));
     assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().childNodes[1], 1)), createRange(getRoot(), 2));
-    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().lastChild, 0)), createRange(getRoot(), 3));
+    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().lastChild as Text, 0)), createRange(getRoot(), 3));
     assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().childNodes[3], 0)), createRange(getRoot(), 3));
     assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().childNodes[3], 1)), createRange(getRoot(), 3));
-    assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(getRoot().firstChild, 3)), createRange(getRoot(), 2));
+    assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(getRoot().firstChild as Text, 3)), createRange(getRoot(), 2));
     assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(getRoot().childNodes[1], 0)), createRange(getRoot(), 2));
     assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(getRoot().childNodes[1], 1)), createRange(getRoot(), 2));
-    assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(getRoot().lastChild, 0)), createRange(getRoot(), 3));
+    assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(getRoot().lastChild as Text, 0)), createRange(getRoot(), 3));
     assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(getRoot().childNodes[3], 0)), createRange(getRoot(), 3));
     assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(getRoot().childNodes[3], 1)), createRange(getRoot(), 3));
   });
@@ -232,10 +232,10 @@ describe('browser.tinymce.core.CaretUtilTest', () => {
       'abc' + ZWSP + '<span contentEditable="false">1</span>' + ZWSP + 'def'
     );
 
-    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().firstChild, 3)), createRange(getRoot(), 1));
-    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().firstChild, 4)), createRange(getRoot(), 1));
-    assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(getRoot().lastChild, 0)), createRange(getRoot(), 2));
-    assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(getRoot().lastChild, 1)), createRange(getRoot(), 2));
+    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().firstChild as Text, 3)), createRange(getRoot(), 1));
+    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().firstChild as Text, 4)), createRange(getRoot(), 1));
+    assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(getRoot().lastChild as Text, 0)), createRange(getRoot(), 2));
+    assertRange(CaretUtils.normalizeRange(-1, getRoot(), createRange(getRoot().lastChild as Text, 1)), createRange(getRoot(), 2));
   });
 
   it('normalizeRange at inline caret container after block', () => {
@@ -243,6 +243,6 @@ describe('browser.tinymce.core.CaretUtilTest', () => {
       '<p><span contentEditable="false">1</span></p>' + ZWSP + 'abc'
     );
 
-    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().lastChild, 0)), createRange(getRoot().lastChild, 0));
+    assertRange(CaretUtils.normalizeRange(1, getRoot(), createRange(getRoot().lastChild as Text, 0)), createRange(getRoot().lastChild as Text, 0));
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/caret/CaretWalkerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/CaretWalkerTest.ts
@@ -19,11 +19,11 @@ describe('browser.tinymce.core.CaretWalkerTest', () => {
   };
 
   const findElmPos = (selector: string, offset: number) => {
-    return CaretPosition(getRoot().querySelector(selector), offset);
+    return CaretPosition(getRoot().querySelector(selector) as Node, offset);
   };
 
   const findTextPos = (selector: string, offset: number) => {
-    return CaretPosition(getRoot().querySelector(selector).firstChild, offset);
+    return CaretPosition(getRoot().querySelector(selector)?.firstChild as Text, offset);
   };
 
   let logicalCaret: CaretWalker;
@@ -43,14 +43,14 @@ describe('browser.tinymce.core.CaretWalkerTest', () => {
 
   it('within text node in root', () => {
     setupHtml('abc');
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot().firstChild, 0)), CaretPosition(getRoot().firstChild, 1));
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot().firstChild, 1)), CaretPosition(getRoot().firstChild, 2));
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot().firstChild, 2)), CaretPosition(getRoot().firstChild, 3));
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot().firstChild, 3)), null);
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot().firstChild, 3)), CaretPosition(getRoot().firstChild, 2));
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot().firstChild, 2)), CaretPosition(getRoot().firstChild, 1));
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot().firstChild, 1)), CaretPosition(getRoot().firstChild, 0));
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot().firstChild, 0)), null);
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot().firstChild as Text, 0)), CaretPosition(getRoot().firstChild as Text, 1));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot().firstChild as Text, 1)), CaretPosition(getRoot().firstChild as Text, 2));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot().firstChild as Text, 2)), CaretPosition(getRoot().firstChild as Text, 3));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot().firstChild as Text, 3)), null);
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot().firstChild as Text, 3)), CaretPosition(getRoot().firstChild as Text, 2));
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot().firstChild as Text, 2)), CaretPosition(getRoot().firstChild as Text, 1));
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot().firstChild as Text, 1)), CaretPosition(getRoot().firstChild as Text, 0));
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot().firstChild as Text, 0)), null);
   });
 
   it('within text node in element', () => {
@@ -67,10 +67,10 @@ describe('browser.tinymce.core.CaretWalkerTest', () => {
 
   it('from index text node over comment', () => {
     setupHtml('abcd<!-- x -->efgh');
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot(), 0)), CaretPosition(getRoot().firstChild, 0));
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot(), 1)), CaretPosition(getRoot().lastChild, 0));
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot(), 2)), CaretPosition(getRoot().firstChild, 4));
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot(), 3)), CaretPosition(getRoot().lastChild, 4));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot(), 0)), CaretPosition(getRoot().firstChild as Text, 0));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot(), 1)), CaretPosition(getRoot().lastChild as Text, 0));
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot(), 2)), CaretPosition(getRoot().firstChild as Text, 4));
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot(), 3)), CaretPosition(getRoot().lastChild as Text, 4));
   });
 
   it('from text to text across elements', () => {
@@ -81,35 +81,35 @@ describe('browser.tinymce.core.CaretWalkerTest', () => {
 
   it('from text to text across elements with siblings', () => {
     setupHtml('<p>abc<b><!-- x --></b></p><p><b><!-- x --></b></p><p><b><!-- x --></b>def</p>');
-    CaretAsserts.assertCaretPosition(logicalCaret.next(findTextPos('p:first-of-type', 3)), CaretPosition(findElm('p:last-of-type').lastChild, 0));
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(findElm('p:last-of-type').lastChild, 0)), findTextPos('p:first-of-type', 3));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(findTextPos('p:first-of-type', 3)), CaretPosition(findElm('p:last-of-type')?.lastChild as Text, 0));
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(findElm('p:last-of-type')?.lastChild as Text, 0)), findTextPos('p:first-of-type', 3));
   });
 
   it('from input to text', () => {
     setupHtml('123<input>456');
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot(), 2)), CaretPosition(getRoot().lastChild, 0));
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot(), 1)), CaretPosition(getRoot().firstChild, 3));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot(), 2)), CaretPosition(getRoot().lastChild as Text, 0));
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot(), 1)), CaretPosition(getRoot().firstChild as Text, 3));
   });
 
   it('from input to input across elements', () => {
     setupHtml('<p><input></p><p><input></p>');
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(findElm('p:first-of-type'), 1)), CaretPosition(findElm('p:last-of-type'), 0));
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(findElm('p:last-of-type'), 0)), CaretPosition(findElm('p:first-of-type'), 1));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(findElm('p:first-of-type') as HTMLParagraphElement, 1)), CaretPosition(findElm('p:last-of-type') as HTMLParagraphElement, 0));
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(findElm('p:last-of-type') as HTMLParagraphElement, 0)), CaretPosition(findElm('p:first-of-type') as HTMLParagraphElement, 1));
   });
 
   it('next br to br across elements', () => {
     setupHtml('<p><br></p><p><br></p>');
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(findElm('p:first-of-type'), 0)), CaretPosition(findElm('p:last-of-type'), 0));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(findElm('p:first-of-type') as HTMLParagraphElement, 0)), CaretPosition(findElm('p:last-of-type') as HTMLParagraphElement, 0));
   });
 
   it('from text node to before cef span over br', () => {
     setupHtml('<p>a<br><span contenteditable="false">X</span></p>');
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(findElm('p'), 1)), CaretPosition(findElm('p'), 2));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(findElm('p') as HTMLParagraphElement, 1)), CaretPosition(findElm('p') as HTMLParagraphElement, 2));
   });
 
   it('prev br to br across elements', () => {
     setupHtml('<p><br></p><p><br></p>');
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(findElm('p:last-of-type'), 0)), CaretPosition(findElm('p:first-of-type'), 0));
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(findElm('p:last-of-type') as HTMLParagraphElement, 0)), CaretPosition(findElm('p:first-of-type') as HTMLParagraphElement, 0));
   });
 
   it('from before/after br to text', () => {
@@ -117,7 +117,7 @@ describe('browser.tinymce.core.CaretWalkerTest', () => {
     CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot(), 0)), CaretPosition(getChildNode(1), 0));
     CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot(), 2)), CaretPosition(getChildNode(3), 0));
     CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot(), 4)), CaretPosition(getChildNode(5), 0));
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot(), 5)), CaretPosition(getRoot().lastChild, 0));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot(), 5)), CaretPosition(getRoot().lastChild as Text, 0));
     CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot(), 5)), CaretPosition(getRoot(), 4));
     CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot(), 4)), CaretPosition(getChildNode(3), 3));
     CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot(), 1)), CaretPosition(getRoot(), 0));
@@ -162,7 +162,7 @@ describe('browser.tinymce.core.CaretWalkerTest', () => {
   it('over script/style/textarea', () => {
     setupHtml('a<script>//x</script>b<style>x{}</style>c<textarea>x</textarea>d');
     CaretAsserts.assertCaretPosition(
-      logicalCaret.next(CaretPosition(getRoot().firstChild, 1)),
+      logicalCaret.next(CaretPosition(getRoot().firstChild as Text, 1)),
       CaretPosition(getRoot().childNodes[2], 0)
     );
     CaretAsserts.assertCaretPosition(
@@ -180,26 +180,26 @@ describe('browser.tinymce.core.CaretWalkerTest', () => {
 
   it('around tables', () => {
     setupHtml('a<table><tr><td>A</td></tr></table><table><tr><td>B</td></tr></table>b');
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot().firstChild, 1)), CaretPosition(getRoot(), 1));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot().firstChild as Text, 1)), CaretPosition(getRoot(), 1));
     CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot(), 1)), findTextPos('td:first-of-type', 0));
     CaretAsserts.assertCaretPosition(logicalCaret.next(findTextPos('td:first-of-type', 1)), CaretPosition(getRoot(), 2));
     CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot(), 2)), findTextPos('table:last-of-type td', 0));
     CaretAsserts.assertCaretPosition(logicalCaret.next(findTextPos('table:last-of-type td', 1)), CaretPosition(getRoot(), 3));
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot(), 3)), CaretPosition(getRoot().lastChild, 0));
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot().lastChild, 0)), CaretPosition(getRoot(), 3));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot(), 3)), CaretPosition(getRoot().lastChild as Text, 0));
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot().lastChild as Text, 0)), CaretPosition(getRoot(), 3));
     CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot(), 3)), findTextPos('table:last-of-type td', 1));
     CaretAsserts.assertCaretPosition(logicalCaret.prev(findTextPos('table:last-of-type td', 0)), CaretPosition(getRoot(), 2));
     CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot(), 2)), findTextPos('td:first-of-type', 1));
     CaretAsserts.assertCaretPosition(logicalCaret.prev(findTextPos('td:first-of-type', 0)), CaretPosition(getRoot(), 1));
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot(), 1)), CaretPosition(getRoot().firstChild, 1));
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot(), 1)), CaretPosition(getRoot().firstChild as Text, 1));
   });
 
   it('over cE=false', () => {
     setupHtml('123<span contentEditable="false">a</span>456');
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot().firstChild, 3)), CaretPosition(getRoot(), 1));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot().firstChild as Text, 3)), CaretPosition(getRoot(), 1));
     CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot(), 1)), CaretPosition(getRoot(), 2));
     CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot(), 2)), CaretPosition(getRoot(), 1));
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot().lastChild, 0)), CaretPosition(getRoot(), 2));
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot().lastChild as Text, 0)), CaretPosition(getRoot(), 2));
   });
   /*
     it('from outside cE=false to nested cE=true', () => {
@@ -241,7 +241,7 @@ describe('browser.tinymce.core.CaretWalkerTest', () => {
       '<p>abc</p>'
     );
 
-    CaretAsserts.assertCaretPosition(logicalCaret.next(findTextPos('span span', 3)), CaretPosition(findElm('p'), 1));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(findTextPos('span span', 3)), CaretPosition(findElm('p') as HTMLParagraphElement, 1));
   });
 
   it('around cE=false inside nested cE=true', () => {
@@ -255,14 +255,14 @@ describe('browser.tinymce.core.CaretWalkerTest', () => {
       '</span>'
     );
 
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(findElm('span span'), 0)), CaretPosition(findElm('span span'), 1));
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(findElm('span span'), 1)), CaretPosition(findElm('span span'), 2));
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(findElm('span span'), 2)), CaretPosition(findElm('span span'), 3));
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(findElm('span span'), 3)), CaretPosition(getRoot(), 1));
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(findElm('span span'), 0)), CaretPosition(getRoot(), 0));
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(findElm('span span'), 1)), CaretPosition(findElm('span span'), 0));
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(findElm('span span'), 2)), CaretPosition(findElm('span span'), 1));
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(findElm('span span'), 3)), CaretPosition(findElm('span span'), 2));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(findElm('span span') as HTMLSpanElement, 0)), CaretPosition(findElm('span span') as HTMLSpanElement, 1));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(findElm('span span') as HTMLSpanElement, 1)), CaretPosition(findElm('span span') as HTMLSpanElement, 2));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(findElm('span span') as HTMLSpanElement, 2)), CaretPosition(findElm('span span') as HTMLSpanElement, 3));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(findElm('span span') as HTMLSpanElement, 3)), CaretPosition(getRoot(), 1));
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(findElm('span span') as HTMLSpanElement, 0)), CaretPosition(getRoot(), 0));
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(findElm('span span') as HTMLSpanElement, 1)), CaretPosition(findElm('span span') as HTMLSpanElement, 0));
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(findElm('span span') as HTMLSpanElement, 2)), CaretPosition(findElm('span span') as HTMLSpanElement, 1));
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(findElm('span span') as HTMLSpanElement, 3)), CaretPosition(findElm('span span') as HTMLSpanElement, 2));
   });
 
   it('next from last node', () => {
@@ -302,7 +302,7 @@ describe('browser.tinymce.core.CaretWalkerTest', () => {
 
   it('never into caret containers', () => {
     setupHtml('abc<b data-mce-caret="1">def</b>ghi');
-    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot().firstChild, 3)), CaretPosition(getRoot().lastChild, 0));
-    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot().lastChild, 0)), CaretPosition(getRoot().firstChild, 3));
+    CaretAsserts.assertCaretPosition(logicalCaret.next(CaretPosition(getRoot().firstChild as Text, 3)), CaretPosition(getRoot().lastChild as Text, 0));
+    CaretAsserts.assertCaretPosition(logicalCaret.prev(CaretPosition(getRoot().lastChild as Text, 0)), CaretPosition(getRoot().firstChild as Text, 3));
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretTest.ts
@@ -38,7 +38,7 @@ describe('browser.tinymce.core.caret.FakeCaretTest', () => {
   it('show/hide (before, block)', () => {
     Html.set(getRoot(), '<div>a</div>');
 
-    const rng = fakeCaret.show(true, SelectorFind.descendant(getRoot(), 'div').getOrDie().dom);
+    const rng = fakeCaret.show(true, SelectorFind.descendant(getRoot(), 'div').getOrDie().dom) as Range;
     const fakeCaretElm = Traverse.children(getRoot())[0] as SugarElement<HTMLElement>;
 
     assert.equal(SugarNode.name(fakeCaretElm), 'p');
@@ -52,7 +52,7 @@ describe('browser.tinymce.core.caret.FakeCaretTest', () => {
   it('show/hide (after, block)', () => {
     Html.set(getRoot(), '<div>a</div>');
 
-    const rng = fakeCaret.show(false, SelectorFind.descendant(getRoot(), 'div').getOrDie().dom);
+    const rng = fakeCaret.show(false, SelectorFind.descendant(getRoot(), 'div').getOrDie().dom) as Range;
     const fakeCaretElm = Traverse.children(getRoot())[1] as SugarElement<HTMLElement>;
 
     assert.equal(SugarNode.name(fakeCaretElm), 'p');
@@ -66,7 +66,7 @@ describe('browser.tinymce.core.caret.FakeCaretTest', () => {
   it('show/hide (before, inline)', () => {
     Html.set(getRoot(), '<span>a</span>');
 
-    const rng = fakeCaret.show(true, SelectorFind.descendant(getRoot(), 'span').getOrDie().dom);
+    const rng = fakeCaret.show(true, SelectorFind.descendant(getRoot(), 'span').getOrDie().dom) as Range;
     const fakeCaretText = Traverse.children(getRoot());
 
     assert.equal(SugarNode.name(fakeCaretText[0]), '#text');
@@ -80,7 +80,7 @@ describe('browser.tinymce.core.caret.FakeCaretTest', () => {
   it('show/hide (after, inline)', () => {
     Html.set(getRoot(), '<span>a</span>');
 
-    const rng = fakeCaret.show(false, SelectorFind.descendant(getRoot(), 'span').getOrDie().dom);
+    const rng = fakeCaret.show(false, SelectorFind.descendant(getRoot(), 'span').getOrDie().dom) as Range;
     const fakeCaretText = Traverse.children(getRoot());
 
     assert.equal(SugarNode.name(fakeCaretText[1]), '#text');

--- a/modules/tinymce/src/core/test/ts/browser/caret/LineWalkerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/LineWalkerTest.ts
@@ -24,20 +24,20 @@ describe('browser.tinymce.core.LineWalkerTest', () => {
     };
 
     Html.set(SugarElement.fromDom(getRoot()), '<span contentEditable="false">a</span><span>b</span>');
-    result = LineWalker.positionsUntil(1, getRoot(), predicate, getRoot().firstChild);
+    result = LineWalker.positionsUntil(1, getRoot(), predicate, getRoot().firstChild as HTMLSpanElement);
     assert.lengthOf(result, 3);
-    LegacyUnit.equalDom(result[0].position.getNode(), getRoot().lastChild);
-    LegacyUnit.equalDom(result[1].position.getNode(), getRoot().lastChild.firstChild);
-    LegacyUnit.equalDom(result[2].position.getNode(), getRoot().lastChild.firstChild);
+    LegacyUnit.equalDom(result[0].position.getNode() as Node, getRoot().lastChild as HTMLSpanElement);
+    LegacyUnit.equalDom(result[1].position.getNode() as Node, getRoot().lastChild?.firstChild as Text);
+    LegacyUnit.equalDom(result[2].position.getNode() as Node, getRoot().lastChild?.firstChild as Text);
     assert.equal(predicateCallCount, 3);
 
     predicateCallCount = 0;
     Html.set(SugarElement.fromDom(getRoot()), '<span>a</span><span contentEditable="false">b</span>');
-    result = LineWalker.positionsUntil(-1, getRoot(), predicate, getRoot().lastChild);
+    result = LineWalker.positionsUntil(-1, getRoot(), predicate, getRoot().lastChild as HTMLSpanElement);
     assert.lengthOf(result, 3);
-    LegacyUnit.equalDom(result[0].position.getNode(), getRoot().lastChild);
-    LegacyUnit.equalDom(result[1].position.getNode(), getRoot().firstChild.firstChild);
-    LegacyUnit.equalDom(result[2].position.getNode(), getRoot().firstChild.firstChild);
+    LegacyUnit.equalDom(result[0].position.getNode() as Node, getRoot().lastChild as HTMLSpanElement);
+    LegacyUnit.equalDom(result[1].position.getNode() as Node, getRoot().firstChild?.firstChild as Text);
+    LegacyUnit.equalDom(result[2].position.getNode() as Node, getRoot().firstChild?.firstChild as Text);
     assert.equal(predicateCallCount, 3);
   });
 
@@ -51,7 +51,7 @@ describe('browser.tinymce.core.LineWalkerTest', () => {
 
     Html.set(SugarElement.fromDom(getRoot()), '<p>a</p><p>b</p><p>c</p>');
 
-    const caretPosition = CaretPosition(getRoot().lastChild.lastChild, 1);
+    const caretPosition = CaretPosition(getRoot().lastChild?.lastChild as Text, 1);
     const result = LineWalker.upUntil(getRoot(), predicate, caretPosition);
 
     assert.lengthOf(result, 3);
@@ -71,7 +71,7 @@ describe('browser.tinymce.core.LineWalkerTest', () => {
 
     Html.set(SugarElement.fromDom(getRoot()), '<p>a</p><p>b</p><p>c</p>');
 
-    const caretPosition = CaretPosition(getRoot().firstChild.firstChild, 0);
+    const caretPosition = CaretPosition(getRoot().firstChild?.firstChild as Text, 0);
     const result = LineWalker.downUntil(getRoot(), predicate, caretPosition);
 
     assert.lengthOf(result, 3);

--- a/modules/tinymce/src/core/test/ts/browser/commands/LineHeightTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/commands/LineHeightTest.ts
@@ -4,6 +4,8 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import { ChangeEvent, ExecCommandEvent } from 'tinymce/core/api/EventTypes';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 describe('browser.tinymce.core.commands.LineHeightTest', () => {
   const platform = PlatformDetection.detect();
@@ -73,11 +75,11 @@ describe('browser.tinymce.core.commands.LineHeightTest', () => {
   });
 
   it('TINY-7048: LineHeight event order is correct', () => {
-    const events = [];
+    const events: string[] = [];
     const editor = hook.editor();
     editor.setContent('<p>Hello</p>');
-    const logEvents = (e) => {
-      if (e.command?.toLowerCase() !== 'mcefocus') {
+    const logEvents = (e: EditorEvent<ExecCommandEvent | ChangeEvent>) => {
+      if ((e as ExecCommandEvent).command?.toLowerCase() !== 'mcefocus') {
         events.push(e.type.toLowerCase());
       }
     };

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentEventsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentEventsTest.ts
@@ -12,7 +12,7 @@ describe('browser.tinymce.core.content.EditorContentEventsTest', () => {
 
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
-    setup: (editor) => {
+    setup: (editor: Editor) => {
       editor.on('BeforeGetContent GetContent BeforeSetContent SetContent', (e) => {
         events.push(e.type);
       });

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentNotInitializedTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentNotInitializedTest.ts
@@ -29,7 +29,7 @@ describe('browser.tinymce.core.content.EditorContentNotInitializedTest', () => {
 
   const removeBodyElement = (editor: Editor) => {
     const body = editor.getBody();
-    body.parentNode.removeChild(body);
+    body.parentNode?.removeChild(body);
   };
 
   it('set content on editor without initializing it', () => {

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -30,7 +30,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         let events: EditorEvent<SetContentEvent | GetContentEvent | BeforeSetContentEvent | BeforeGetContentEvent>[] = [];
         const hook = TinyHooks.bddSetupLight<Editor>({
           base_url: '/project/tinymce/js/tinymce',
-          setup: (editor) => {
+          setup: (editor: Editor) => {
             editor.on('BeforeGetContent GetContent BeforeSetContent SetContent', (e) => {
               events.push(e);
             });

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentCommandTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentCommandTest.ts
@@ -18,19 +18,22 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, []);
 
+  const isTextNode = (node: Node): node is Text =>
+    node.nodeType === 3;
+
   const normalizeRng = (rng: Range) => {
-    if (rng.startContainer.nodeType === 3) {
+    if (isTextNode(rng.startContainer)) {
       if (rng.startOffset === 0) {
         rng.setStartBefore(rng.startContainer);
-      } else if (rng.startOffset >= rng.startContainer.nodeValue.length - 1) {
+      } else if (rng.startOffset >= rng.startContainer.data.length - 1) {
         rng.setStartAfter(rng.startContainer);
       }
     }
 
-    if (rng.endContainer.nodeType === 3) {
+    if (isTextNode(rng.endContainer)) {
       if (rng.endOffset === 0) {
         rng.setEndBefore(rng.endContainer);
-      } else if (rng.endOffset >= rng.endContainer.nodeValue.length - 1) {
+      } else if (rng.endOffset >= rng.endContainer.data.length - 1) {
         rng.setEndAfter(rng.endContainer);
       }
     }
@@ -43,8 +46,8 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.setContent('<p>1234</p>');
     editor.focus();
     let rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 1);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 3);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 1);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<p>abc</p>');
     assert.equal(editor.getContent(), '<p>1</p><p>abc</p><p>4</p>');
@@ -74,7 +77,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.setContent('<h1>abc</h1>');
     LegacyUnit.setSelection(editor, 'h1', 3);
     editor.execCommand('mceInsertContent', false, '<hr>');
-    LegacyUnit.equalDom(editor.selection.getNode(), editor.getBody().lastChild);
+    LegacyUnit.equalDom(editor.selection.getNode(), editor.getBody().lastChild as HTMLHeadingElement);
     assert.equal(editor.selection.getNode().nodeName, 'H1');
     assert.equal(editor.getContent(), '<h1>abc</h1><hr><h1>\u00a0</h1>');
   });
@@ -84,7 +87,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.setContent('<h1>abc</h1><p>def</p>');
     LegacyUnit.setSelection(editor, 'h1', 3);
     editor.execCommand('mceInsertContent', false, '<hr>');
-    LegacyUnit.equalDom(editor.selection.getNode(), editor.getBody().lastChild);
+    LegacyUnit.equalDom(editor.selection.getNode(), editor.getBody().lastChild as HTMLParagraphElement);
     assert.equal(editor.selection.getNode().nodeName, 'P');
     assert.equal(editor.getContent(), '<h1>abc</h1><hr><p>def</p>');
   });
@@ -94,7 +97,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.setContent('<h1><strong>abc</strong></h1><p>def</p>');
     LegacyUnit.setSelection(editor, 'strong', 3);
     editor.execCommand('mceInsertContent', false, '<hr>');
-    LegacyUnit.equalDom(editor.selection.getNode(), editor.getBody().lastChild);
+    LegacyUnit.equalDom(editor.selection.getNode(), editor.getBody().lastChild as HTMLParagraphElement);
     assert.equal(editor.selection.getNode().nodeName, 'P');
     assert.equal(editor.getContent(), '<h1><strong>abc</strong></h1><hr><p>def</p>');
   });
@@ -124,8 +127,8 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
 
     editor.setContent('<p>1234</p>');
     rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 4);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<p>abc</p>');
     assert.equal(editor.getContent(), '<p>abc</p>');
@@ -135,7 +138,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     assert.equal(rng.startOffset, 1);
     assert.equal(rng.endContainer.nodeName, 'P');
     assert.equal(rng.endOffset, 1);
-    assert.equal(rng.startContainer.innerHTML, 'abc');
+    assert.equal((rng.startContainer as HTMLParagraphElement).innerHTML, 'abc');
   });
 
   it('mceInsertContent - pre in text of pre', () => {
@@ -144,8 +147,8 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
 
     editor.setContent('<pre>1234</pre>');
     rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('pre')[0].firstChild, 1);
-    rng.setEnd(editor.dom.select('pre')[0].firstChild, 3);
+    rng.setStart(editor.dom.select('pre')[0].firstChild as Text, 1);
+    rng.setEnd(editor.dom.select('pre')[0].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<pre>abc</pre>');
     assert.equal(editor.getContent(), '<pre>1</pre><pre>abc</pre><pre>4</pre>');
@@ -155,7 +158,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     assert.equal(rng.startOffset, 1);
     assert.equal(rng.endContainer.nodeName, 'PRE');
     assert.equal(rng.endOffset, 1);
-    assert.equal(rng.startContainer.innerHTML, 'abc');
+    assert.equal((rng.startContainer as HTMLPreElement).innerHTML, 'abc');
   });
 
   it('mceInsertContent - h1 in text of h1', () => {
@@ -164,8 +167,8 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
 
     editor.setContent('<h1>1234</h1>');
     rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('h1')[0].firstChild, 1);
-    rng.setEnd(editor.dom.select('h1')[0].firstChild, 3);
+    rng.setStart(editor.dom.select('h1')[0].firstChild as Text, 1);
+    rng.setEnd(editor.dom.select('h1')[0].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<h1>abc</h1>');
     assert.equal(editor.getContent(), '<h1>1</h1><h1>abc</h1><h1>4</h1>');
@@ -175,7 +178,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     assert.equal(rng.startOffset, 1);
     assert.equal(rng.endContainer.nodeName, 'H1');
     assert.equal(rng.endOffset, 1);
-    assert.equal(rng.startContainer.innerHTML, 'abc');
+    assert.equal((rng.startContainer as HTMLHeadingElement).innerHTML, 'abc');
   });
 
   it('mceInsertContent - li inside li', () => {
@@ -184,8 +187,8 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
 
     editor.setContent('<ul><li>1234</li></ul>');
     rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('li')[0].firstChild, 1);
-    rng.setEnd(editor.dom.select('li')[0].firstChild, 3);
+    rng.setStart(editor.dom.select('li')[0].firstChild as Text, 1);
+    rng.setEnd(editor.dom.select('li')[0].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<li>abc</li>');
     assert.equal(editor.getContent(), '<ul><li>1</li><li>abc</li><li>4</li></ul>');
@@ -195,7 +198,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     assert.equal(rng.startOffset, 1);
     assert.equal(rng.endContainer.nodeName, 'LI');
     assert.equal(rng.endOffset, 1);
-    assert.equal(rng.startContainer.innerHTML, 'abc');
+    assert.equal((rng.startContainer as HTMLLIElement).innerHTML, 'abc');
   });
 
   it('mceInsertContent - p inside empty editor', () => {
@@ -236,8 +239,8 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
 
     editor.getBody().innerHTML = '<p><br></p>';
     rng = editor.dom.createRng();
-    rng.setStart(editor.getBody().firstChild, 0);
-    rng.setEnd(editor.getBody().firstChild, 0);
+    rng.setStart(editor.getBody().firstChild as Text, 0);
+    rng.setEnd(editor.getBody().firstChild as Text, 0);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, 'abc');
     assert.equal(editor.getBody().innerHTML.toLowerCase(), '<p>abc</p>');
@@ -247,7 +250,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     assert.equal(rng.startOffset, 1);
     assert.equal(rng.endContainer.nodeName, 'P');
     assert.equal(rng.endOffset, 1);
-    assert.equal(rng.startContainer.innerHTML, 'abc');
+    assert.equal((rng.startContainer as HTMLParagraphElement).innerHTML, 'abc');
   });
 
   it('mceInsertContent - image inside p', () => {
@@ -256,8 +259,8 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
 
     editor.setContent('<p>1</p>');
     rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 1);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 1);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<img src="about:blank" />');
     assert.equal(editor.getContent(), '<p><img src="about:blank"></p>');
@@ -274,8 +277,8 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     // Convert legacy content
     editor.setContent('<p>1</p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 1);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 1);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<strike>strike</strike><font size="7">font</font>');
     assert.equal(
@@ -290,14 +293,14 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
 
     editor.setContent('<p>123</p>');
     rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 1);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 2);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 1);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 2);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<hr />');
     assert.equal(editor.getContent(), '<p>1</p><hr><p>3</p>');
     rng = normalizeRng(editor.selection.getRng());
     assert.isTrue(rng.collapsed);
-    LegacyUnit.equalDom(rng.startContainer, editor.getBody().lastChild);
+    LegacyUnit.equalDom(rng.startContainer, editor.getBody().lastChild as HTMLParagraphElement);
     assert.equal(rng.startContainer.nodeName, 'P');
     assert.equal(rng.startOffset, 0);
     assert.equal(rng.endContainer.nodeName, 'P');
@@ -324,12 +327,12 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
 
   it('mceInsertContent - invalid insertion with spans on page', () => {
     const editor = hook.editor();
-    const startingContent = '<p>123 testing <em>span later in document</em></p>',
-      insertedContent = '<ul><li>u</li><li>l</li></ul>';
+    const startingContent = '<p>123 testing <em>span later in document</em></p>';
+    const insertedContent = '<ul><li>u</li><li>l</li></ul>';
     editor.setContent(startingContent);
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 0);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 0);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, insertedContent);
 

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -136,7 +136,7 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
 
   it('TBA: insertAtCaret prevent default of beforeSetContent', () => {
     const editor = hook.editor();
-    let args: EditorEvent<SetContentEvent>;
+    let args: EditorEvent<SetContentEvent> | undefined;
 
     const handler = (e: EditorEvent<SetContentEvent>) => {
       if (e.selection === true) {
@@ -154,12 +154,12 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     editor.on('SetContent', collector);
 
     editor.setContent('<p>a</p>');
-    editor.selection.setCursorLocation(editor.dom.select('p')[0].firstChild, 0);
+    editor.selection.setCursorLocation(editor.dom.select('p')[0].firstChild as Text, 0);
     InsertContent.insertAtCaret(editor, { content: '<p>b</p>', paste: true });
     assert.equal(editor.getContent(), '<h1>c</h1>');
-    assert.equal(args.content, '<h1>b</h1>');
-    assert.equal(args.type, 'setcontent');
-    assert.isTrue(args.paste);
+    assert.equal(args?.content, '<h1>b</h1>');
+    assert.equal(args?.type, 'setcontent');
+    assert.isTrue(args?.paste);
 
     editor.off('BeforeSetContent', handler);
     editor.on('BeforeSetContent', collector);

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
@@ -17,7 +17,7 @@ describe('browser.tinymce.core.delete.CefDeleteTest', () => {
   }, [], true);
 
   const fakeBackspaceKeyOnRange = (editor: Editor) => {
-    editor.getDoc().execCommand('Delete', false, null);
+    editor.getDoc().execCommand('Delete');
     TinyContentActions.keyup(editor, Keys.backspace());
   };
 

--- a/modules/tinymce/src/core/test/ts/browser/delete/DeleteBeforeInputEventTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/DeleteBeforeInputEventTest.ts
@@ -4,7 +4,7 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
-import { pressKeyAction, testBeforeInputEvent } from '../util/BeforeInputEventUtils';
+import { pressKeyAction, testBeforeInputEvent } from '../../module/test/BeforeInputEventUtils';
 
 describe('browser.tinymce.core.delete.DeleteBeforeInputEventTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/core/test/ts/browser/delete/DeleteCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/DeleteCommandsTest.ts
@@ -6,7 +6,7 @@ import Editor from 'tinymce/core/api/Editor';
 import * as DeleteCommands from 'tinymce/core/delete/DeleteCommands';
 
 describe('browser.tinymce.core.delete.DeleteCommandsTest', () => {
-  const caret = Cell<Text>(null);
+  const caret = Cell<Text | null>(null);
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     indent: false

--- a/modules/tinymce/src/core/test/ts/browser/dom/DimensionsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/DimensionsTest.ts
@@ -18,11 +18,11 @@ describe('browser.tinymce.core.dom.DimensionsTest', () => {
   it('getClientRects', () => {
     const viewElm = setupHtml('abc<span>123</span>');
 
-    assert.lengthOf(Dimensions.getClientRects([ viewElm.firstChild ]), 1);
-    assert.lengthOf(Dimensions.getClientRects([ viewElm.lastChild ]), 1);
-    LegacyUnit.equalDom(Dimensions.getClientRects([ viewElm.firstChild ])[0].node, viewElm.firstChild);
-    assert.isAbove(Dimensions.getClientRects([ viewElm.firstChild ])[0].left, 3);
-    assert.isAbove(Dimensions.getClientRects([ viewElm.lastChild ])[0].left, 3);
+    assert.lengthOf(Dimensions.getClientRects([ viewElm.firstChild as Text ]), 1);
+    assert.lengthOf(Dimensions.getClientRects([ viewElm.lastChild as HTMLSpanElement ]), 1);
+    LegacyUnit.equalDom(Dimensions.getClientRects([ viewElm.firstChild as Text ])[0].node, viewElm.firstChild as Text);
+    assert.isAbove(Dimensions.getClientRects([ viewElm.firstChild as HTMLSpanElement ])[0].left, 3);
+    assert.isAbove(Dimensions.getClientRects([ viewElm.lastChild as Text ])[0].left, 3);
   });
 
   it('getClientRects from array', () => {

--- a/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
@@ -1,4 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
+import { Type } from '@ephox/katamari';
 import { assert } from 'chai';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
@@ -9,6 +10,9 @@ import * as HtmlUtils from '../../module/test/HtmlUtils';
 
 describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
   const DOM = DOMUtils(document, { keep_values: true, schema: Schema() });
+
+  const getTestElement = (id: string = 'test') =>
+    DOM.get(id) as HTMLElement;
 
   it('parseStyle', () => {
     DOM.add(document.body, 'div', { id: 'test' });
@@ -50,7 +54,7 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
     // equal(dom.getAttrib('test2', 'style'), Env.ue && !window.getSelection ?
     // 'border: #00ff00 1px solid;' : 'border: 1px solid #00ff00;'); // IE has a separate output
 
-    dom.get('test').innerHTML = '<span id="test2" style="background-image: url(http://www.site.com/test.gif);"></span>';
+    (dom.get('test') as HTMLElement).innerHTML = '<span id="test2" style="background-image: url(http://www.site.com/test.gif);"></span>';
     assert.equal(dom.getAttrib('test2', 'style'), `background-image: url('Xhttp://www.site.com/test.gifY');`, 'incorrect attribute value');
 
     DOM.remove('test');
@@ -59,19 +63,19 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
   it('addClass', () => {
     DOM.add(document.body, 'div', { id: 'test' });
 
-    DOM.get('test').className = '';
+    getTestElement().className = '';
     DOM.addClass('test', 'abc');
-    assert.equal(DOM.get('test').className, 'abc', 'incorrect classname');
+    assert.equal(getTestElement().className, 'abc', 'incorrect classname');
 
     DOM.addClass('test', '123');
-    assert.equal(DOM.get('test').className, 'abc 123', 'incorrect classname');
+    assert.equal(getTestElement().className, 'abc 123', 'incorrect classname');
 
-    DOM.get('test').innerHTML = '<span id="test2"></span><span id="test3"></span><span id="test4"></span>';
+    getTestElement().innerHTML = '<span id="test2"></span><span id="test3"></span><span id="test4"></span>';
     DOM.addClass(DOM.select('span', 'test'), 'abc');
-    assert.equal(DOM.get('test2').className, 'abc', 'incorrect classname');
-    assert.equal(DOM.get('test3').className, 'abc', 'incorrect classname');
-    assert.equal(DOM.get('test4').className, 'abc', 'incorrect classname');
-    DOM.get('test').innerHTML = '';
+    assert.equal((getTestElement('test2')).className, 'abc', 'incorrect classname');
+    assert.equal((getTestElement('test3')).className, 'abc', 'incorrect classname');
+    assert.equal((getTestElement('test4')).className, 'abc', 'incorrect classname');
+    getTestElement().innerHTML = '';
 
     DOM.remove('test');
   });
@@ -79,21 +83,21 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
   it('removeClass', () => {
     DOM.add(document.body, 'div', { id: 'test' });
 
-    DOM.get('test').className = 'abc 123 xyz';
+    getTestElement().className = 'abc 123 xyz';
     DOM.removeClass('test', '123');
-    assert.equal(DOM.get('test').className, 'abc xyz', 'incorrect classname');
+    assert.equal(getTestElement().className, 'abc xyz', 'incorrect classname');
 
-    DOM.get('test').innerHTML = (
+    getTestElement().innerHTML = (
       '<span id="test2" class="test1"></span><span id="test3" class="test test1 test"></span><span id="test4" class="test1 test"></span>'
     );
     DOM.removeClass(DOM.select('span', 'test'), 'test1');
-    assert.equal(DOM.get('test2').className, '', 'incorrect classname');
-    assert.equal(DOM.get('test3').className, 'test', 'incorrect classname');
-    assert.equal(DOM.get('test4').className, 'test', 'incorrect classname');
+    assert.equal((getTestElement('test2')).className, '', 'incorrect classname');
+    assert.equal((getTestElement('test3')).className, 'test', 'incorrect classname');
+    assert.equal((getTestElement('test4')).className, 'test', 'incorrect classname');
 
-    DOM.get('test').innerHTML = '<span id="test2" class="test"></span>';
+    getTestElement().innerHTML = '<span id="test2" class="test"></span>';
     DOM.removeClass('test2', 'test');
-    assert.equal(DOM.get('test').innerHTML, '<span id="test2"></span>', 'incorrect classname');
+    assert.equal(getTestElement().innerHTML, '<span id="test2"></span>', 'incorrect classname');
 
     DOM.remove('test');
   });
@@ -101,46 +105,44 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
   it('hasClass', () => {
     DOM.add(document.body, 'div', { id: 'test' });
 
-    DOM.get('test').className = 'abc 123 xyz';
+    getTestElement().className = 'abc 123 xyz';
     assert.isTrue(DOM.hasClass('test', 'abc'), 'incorrect hasClass result');
     assert.isTrue(DOM.hasClass('test', '123'), 'incorrect hasClass result');
     assert.isTrue(DOM.hasClass('test', 'xyz'), 'incorrect hasClass result');
     assert.isFalse(DOM.hasClass('test', 'aaa'), 'incorrect hasClass result');
 
-    DOM.get('test').className = 'abc';
+    getTestElement().className = 'abc';
     assert.isTrue(DOM.hasClass('test', 'abc'), 'incorrect hasClass result');
 
-    DOM.get('test').className = 'aaa abc';
+    getTestElement().className = 'aaa abc';
     assert.isTrue(DOM.hasClass('test', 'abc'), 'incorrect hasClass result');
 
-    DOM.get('test').className = 'abc aaa';
+    getTestElement().className = 'abc aaa';
     assert.isTrue(DOM.hasClass('test', 'abc'), 'incorrect hasClass result');
 
     DOM.remove('test');
   });
 
   it('add', () => {
-    let e;
-
     DOM.add(document.body, 'div', { id: 'test' });
 
     DOM.add('test', 'span', { class: 'abc 123' }, 'content <b>abc</b>');
-    e = DOM.get('test').getElementsByTagName('span')[0];
+    let e = getTestElement().getElementsByTagName('span')[0];
     assert.equal(e.className, 'abc 123', 'incorrect className');
     assert.equal(e.innerHTML.toLowerCase(), 'content <b>abc</b>', 'incorrect innerHTML');
     DOM.remove(e);
 
     DOM.add('test', 'span', { class: 'abc 123' });
-    e = DOM.get('test').getElementsByTagName('span')[0];
+    e = getTestElement().getElementsByTagName('span')[0];
     assert.equal(e.className, 'abc 123', 'incorrect classname');
     DOM.remove(e);
 
     DOM.add('test', 'span');
-    e = DOM.get('test').getElementsByTagName('span')[0];
+    e = getTestElement().getElementsByTagName('span')[0];
     assert.equal(e.nodeName, 'SPAN', 'incorrect nodeName');
     DOM.remove(e);
 
-    DOM.get('test').innerHTML = '<span id="test2"></span><span id="test3"></span><span id="test4"></span>';
+    getTestElement().innerHTML = '<span id="test2"></span><span id="test3"></span><span id="test4"></span>';
     DOM.add([ 'test2', 'test3', 'test4' ], 'span', { class: 'abc 123' });
     assert.equal(DOM.select('span', 'test').length, 6, 'incorrect length');
 
@@ -161,7 +163,7 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
       class: 'abc 123'
     }, 'content <b>abc</b>'), '<span id="id1" class="abc 123">content <b>abc</b></span>');
     assert.equal(DOM.createHTML('span', { id: 'id1', class: 'abc 123' }), '<span id="id1" class="abc 123"></span>');
-    assert.equal(DOM.createHTML('span', { id: null, class: undefined }), '<span></span>');
+    assert.equal(DOM.createHTML('span', { id: null, class: undefined } as any), '<span></span>');
     assert.equal(DOM.createHTML('span'), '<span></span>');
     assert.equal(DOM.createHTML('span', {}, 'content <b>abc</b>'), '<span>content <b>abc</b></span>');
     assert.equal(DOM.createHTML('img', {}), '<img />');
@@ -177,11 +179,11 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
     DOM.add(document.body, 'div', { id: 'test' });
 
     DOM.show('test');
-    assert.equal(DOM.get('test').style.display, '');
+    assert.equal(getTestElement().style.display, '');
     assert.isFalse(DOM.isHidden('test'));
 
     DOM.hide('test');
-    assert.equal(DOM.get('test').style.display, 'none');
+    assert.equal(getTestElement().style.display, 'none');
     assert.isTrue(DOM.isHidden('test'));
 
     // Cleanup
@@ -212,7 +214,7 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
     assert.isFalse(DOM.is(DOM.get('textX'), 'div#textX2'));
     assert.isFalse(DOM.is(null, 'div#textX2'));
 
-    DOM.get('test').innerHTML = '<div><span class="test">ab<span><a id="test2" href="">abc</a>c</span></span></div>';
+    getTestElement().innerHTML = '<div><span class="test">ab<span><a id="test2" href="">abc</a>c</span></span></div>';
 
     assert.isTrue(DOM.is(DOM.select('span', 'test'), 'span'));
     assert.isTrue(DOM.is(DOM.select('#test2', 'test'), '#test2'));
@@ -283,10 +285,10 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
 
     DOM.add(document.body, 'div', { id: 'test' });
 
-    DOM.get('test').innerHTML = '<span id="test2" class="test"></span>';
+    getTestElement().innerHTML = '<span id="test2" class="test"></span>';
     assert.isTrue(check(DOM.getAttribs('test2'), 'id,class'));
 
-    DOM.get('test').innerHTML = '<input id="test2" type="checkbox" name="test" value="1" disabled readonly checked></span>';
+    getTestElement().innerHTML = '<input id="test2" type="checkbox" name="test" value="1" disabled readonly checked></span>';
     assert.isTrue(check(DOM.getAttribs('test2'), 'id,type,name,value,disabled,readonly,checked'));
 
     DOM.remove('test');
@@ -334,33 +336,33 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
     DOM.remove('test');
   });
 
-  const eqNodeName = (name) => (n) => n.nodeName === name;
+  const eqNodeName = (name: string) => (n: Node) => n.nodeName === name;
 
   it('getParent', () => {
     DOM.add(document.body, 'div', { id: 'test' });
 
-    DOM.get('test').innerHTML = '<div><span>ab<a id="test2" href="">abc</a>c</span></div>';
+    getTestElement().innerHTML = '<div><span>ab<a id="test2" href="">abc</a>c</span></div>';
 
-    assert.equal(DOM.getParent('test2', eqNodeName('SPAN')).nodeName, 'SPAN');
-    assert.equal(DOM.getParent('test2', eqNodeName('BODY')).nodeName, 'BODY');
+    assert.equal(DOM.getParent('test2', eqNodeName('SPAN'))?.nodeName, 'SPAN');
+    assert.equal(DOM.getParent('test2', eqNodeName('BODY'))?.nodeName, 'BODY');
     assert.isNull(DOM.getParent('test2', eqNodeName('BODY'), document.body));
     assert.isNull(DOM.getParent('test2', eqNodeName('X')));
-    assert.equal(DOM.getParent('test2', 'SPAN').nodeName, 'SPAN');
-    assert.isNull(DOM.getParent('test2', 'body', DOM.get('test')));
+    assert.equal(DOM.getParent('test2', 'SPAN')?.nodeName, 'SPAN');
+    assert.isNull(DOM.getParent('test2', 'body', getTestElement()));
 
-    DOM.get('test').innerHTML = '';
+    getTestElement().innerHTML = '';
 
     DOM.remove('test');
   });
 
   it('getParents', () => {
     DOM.add(document.body, 'div', { id: 'test' });
-    DOM.get('test').innerHTML = '<div><span class="test">ab<span><a id="test2" href="">abc</a>c</span></span></div>';
+    getTestElement().innerHTML = '<div><span class="test">ab<span><a id="test2" href="">abc</a>c</span></span></div>';
 
     assert.lengthOf(DOM.getParents('test2', eqNodeName('SPAN')), 2);
     assert.lengthOf(DOM.getParents('test2', 'span'), 2);
     assert.lengthOf(DOM.getParents('test2', 'span.test'), 1);
-    assert.lengthOf(DOM.getParents('test2', 'body', DOM.get('test')), 0);
+    assert.lengthOf(DOM.getParents('test2', 'body', getTestElement()), 0);
 
     // getParents should stop at DocumentFragment
     const frag = document.createDocumentFragment();
@@ -393,7 +395,7 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
 
     DOM.setAttrib('test', 'style', '');
 
-    DOM.get('test').innerHTML = '<div style="width:320px;height:240px"><div id="test2" style="width:50%;height:240px"></div></div>';
+    getTestElement().innerHTML = '<div style="width:320px;height:240px"><div id="test2" style="width:50%;height:240px"></div></div>';
     r = DOM.getRect('test2');
     assert.equal(r.w, 160);
 
@@ -401,15 +403,15 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
   });
 
   it('getSize', () => {
-    let r;
+    let r: { w: number; h: number };
 
     DOM.add(document.body, 'div', { id: 'test' });
 
-    DOM.get('test').innerHTML = '<div style="width:320px;height:240px"><div id="test2" style="width:50%;height:240px"></div></div>';
+    getTestElement().innerHTML = '<div style="width:320px;height:240px"><div id="test2" style="width:50%;height:240px"></div></div>';
     r = DOM.getSize('test2');
     assert.equal(r.w, 160);
 
-    DOM.get('test').innerHTML = '<div style="width:320px;height:240px"><div id="test2" style="width:100px;height:240px"></div></div>';
+    getTestElement().innerHTML = '<div style="width:320px;height:240px"><div id="test2" style="width:100px;height:240px"></div></div>';
     r = DOM.getSize('test2');
     assert.equal(r.w, 100);
 
@@ -420,12 +422,12 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
   it('getNext', () => {
     DOM.add(document.body, 'div', { id: 'test' });
 
-    DOM.get('test').innerHTML = '<strong>A</strong><span>B</span><em>C</em>';
-    assert.equal(DOM.getNext(DOM.get('test').firstChild, '*').nodeName, 'SPAN');
-    assert.equal(DOM.getNext(DOM.get('test').firstChild, 'em').nodeName, 'EM');
-    assert.isNull(DOM.getNext(DOM.get('test').firstChild, 'div'));
+    getTestElement().innerHTML = '<strong>A</strong><span>B</span><em>C</em>';
+    assert.equal(DOM.getNext(getTestElement().firstChild as HTMLElement, '*')?.nodeName, 'SPAN');
+    assert.equal(DOM.getNext(getTestElement().firstChild as HTMLElement, 'em')?.nodeName, 'EM');
+    assert.isNull(DOM.getNext(getTestElement().firstChild as HTMLElement, 'div'));
     assert.isNull(DOM.getNext(null, 'div'));
-    assert.equal(DOM.getNext(DOM.get('test').firstChild, eqNodeName('EM')).nodeName, 'EM');
+    assert.equal(DOM.getNext(getTestElement().firstChild as HTMLElement, eqNodeName('EM'))?.nodeName, 'EM');
 
     DOM.remove('test');
   });
@@ -433,12 +435,12 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
   it('getPrev', () => {
     DOM.add(document.body, 'div', { id: 'test' });
 
-    DOM.get('test').innerHTML = '<strong>A</strong><span>B</span><em>C</em>';
-    assert.equal(DOM.getPrev(DOM.get('test').lastChild, '*').nodeName, 'SPAN');
-    assert.equal(DOM.getPrev(DOM.get('test').lastChild, 'strong').nodeName, 'STRONG');
-    assert.isNull(DOM.getPrev(DOM.get('test').lastChild, 'div'));
+    getTestElement().innerHTML = '<strong>A</strong><span>B</span><em>C</em>';
+    assert.equal(DOM.getPrev(getTestElement().lastChild as HTMLElement, '*')?.nodeName, 'SPAN');
+    assert.equal(DOM.getPrev(getTestElement().lastChild as HTMLElement, 'strong')?.nodeName, 'STRONG');
+    assert.isNull(DOM.getPrev(getTestElement().lastChild as HTMLElement, 'div'));
     assert.isNull(DOM.getPrev(null, 'div'));
-    assert.equal(DOM.getPrev(DOM.get('test').lastChild, eqNodeName('STRONG')).nodeName, 'STRONG');
+    assert.equal(DOM.getPrev(getTestElement().lastChild as HTMLElement, eqNodeName('STRONG'))?.nodeName, 'STRONG');
 
     DOM.remove('test');
   });
@@ -448,7 +450,7 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
 
     DOM.loadCSS('tinymce/dom/test.css?a=1,tinymce/dom/test.css?a=2,tinymce/dom/test.css?a=3');
 
-    Tools.each(document.getElementsByTagName('link'), (n: HTMLLinkElement) => {
+    Tools.each(document.getElementsByTagName('link'), (n) => {
       if (n.href.indexOf('test.css?a=') !== -1 && !n.crossOrigin) {
         c++;
       }
@@ -461,10 +463,15 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
     let c = 0;
 
     // Create an iframe to load in, so that we are using a different document. Otherwise DOMUtils will fallback to using the default.
-    const iframe = DOM.create('iframe', { src: `javascript=''` }) as HTMLIFrameElement;
+    const iframe = DOM.create('iframe', { src: `javascript=''` });
     DOM.add(document.body, iframe);
 
-    const iframeDoc = iframe.contentWindow.document;
+    const iframeDoc = iframe.contentWindow?.document || iframe.contentDocument;
+    if (Type.isNullable(iframeDoc)) {
+      assert.fail('Iframe document is not available');
+      return;
+    }
+
     iframeDoc.open();
     iframeDoc.write('<html><body></body></html>');
     iframeDoc.close();
@@ -472,7 +479,7 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
     const CustomDOM = DOMUtils(iframeDoc, { keep_values: true, schema: Schema(), contentCssCors: true });
     CustomDOM.loadCSS('tinymce/dom/test_cors.css?a=1,tinymce/dom/test_cors.css?a=2,tinymce/dom/test_cors.css?a=3');
 
-    Tools.each(iframeDoc.getElementsByTagName('link'), (n: HTMLLinkElement) => {
+    Tools.each(iframeDoc.getElementsByTagName('link'), (n) => {
       if (n.href.indexOf('test_cors.css?a=') !== -1 && n.crossOrigin === 'anonymous') {
         c++;
       }
@@ -488,11 +495,11 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
 
     DOM.setHTML('test', '<span id="test2"></span>');
     DOM.insertAfter(DOM.create('br'), 'test2');
-    assert.equal(DOM.get('test2').nextSibling.nodeName, 'BR');
+    assert.equal(DOM.get('test2')?.nextSibling?.nodeName, 'BR');
 
     DOM.setHTML('test', '<span>test</span><span id="test2"></span><span>test</span>');
     DOM.insertAfter(DOM.create('br'), 'test2');
-    assert.equal(DOM.get('test2').nextSibling.nodeName, 'BR');
+    assert.equal(DOM.get('test2')?.nextSibling?.nodeName, 'BR');
 
     DOM.remove('test');
   });
@@ -509,7 +516,7 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
 
     DOM.setHTML('test', '<span id="test2"><span>test</span><span>test2</span></span>');
     DOM.remove('test2', true);
-    assert.equal(DOM.get('test').innerHTML.toLowerCase(), '<span>test</span><span>test2</span>');
+    assert.equal(getTestElement().innerHTML.toLowerCase(), '<span>test</span><span>test2</span>');
 
     DOM.setHTML('test', '<span id="test2"><span>test</span><span>test2</span></span>');
     assert.equal((DOM.remove('test2') as Node).nodeName, 'SPAN');
@@ -522,11 +529,11 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
 
     DOM.setHTML('test', '<span id="test2"><span>test</span><span>test2</span></span>');
     DOM.replace(DOM.create('div', { id: 'test2' }), 'test2', true);
-    assert.equal(DOM.get('test2').innerHTML.toLowerCase(), '<span>test</span><span>test2</span>');
+    assert.equal(DOM.get('test2')?.innerHTML.toLowerCase(), '<span>test</span><span>test2</span>');
 
     DOM.setHTML('test', '<span id="test2"><span>test</span><span>test2</span></span>');
     DOM.replace(DOM.create('div', { id: 'test2' }), 'test2');
-    assert.equal(DOM.get('test2').innerHTML, '');
+    assert.equal(DOM.get('test2')?.innerHTML, '');
 
     DOM.remove('test');
   });
@@ -543,10 +550,10 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
 
     DOM.setHTML('test', '<span id="test2"><span>test</span><span>test2</span></span>');
     DOM.setOuterHTML('test2', '<div id="test2">123</div><div id="test3">abc</div>');
-    assert.equal(Tools.trim(DOM.get('test').innerHTML).toLowerCase().replace(/>\s+</g, '><').replace(/\"/g, ''), '<div id=test2>123</div><div id=test3>abc</div>');
+    assert.equal(Tools.trim(getTestElement().innerHTML).toLowerCase().replace(/>\s+</g, '><').replace(/\"/g, ''), '<div id=test2>123</div><div id=test3>abc</div>');
 
     DOM.setHTML('test', 'test');
-    assert.equal(Tools.trim(DOM.getOuterHTML(DOM.get('test').firstChild as Element)), 'test');
+    assert.equal(Tools.trim(DOM.getOuterHTML(getTestElement().firstChild as Element)), 'test');
 
     DOM.remove('test');
   });
@@ -562,46 +569,46 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
     DOM.add(document.body, 'div', { id: 'test' });
 
     DOM.setHTML('test', '<p><b>text1<span>inner</span>text2</b></p>');
-    parent = DOM.select('p', DOM.get('test'))[0];
-    point = DOM.select('span', DOM.get('test'))[0];
+    parent = DOM.select('p', getTestElement())[0];
+    point = DOM.select('span', getTestElement())[0];
     DOM.split(parent, point);
-    assert.equal(DOM.get('test').innerHTML.toLowerCase().replace(/\s+/g, ''), '<p><b>text1</b></p><span>inner</span><p><b>text2</b></p>');
+    assert.equal(getTestElement().innerHTML.toLowerCase().replace(/\s+/g, ''), '<p><b>text1</b></p><span>inner</span><p><b>text2</b></p>');
 
     DOM.setHTML('test', '<p><strong>  &nbsp;  <span></span>cd</strong></p>');
-    parent = DOM.select('strong', DOM.get('test'))[0];
-    point = DOM.select('span', DOM.get('test'))[0];
+    parent = DOM.select('strong', getTestElement())[0];
+    point = DOM.select('span', getTestElement())[0];
     DOM.split(parent, point);
-    assert.equal(DOM.get('test').innerHTML.toLowerCase(), '<p><strong>  &nbsp;  </strong><span></span><strong>cd</strong></p>', 'TINY-6251: Do not remove spaces containing nbsp');
+    assert.equal(getTestElement().innerHTML.toLowerCase(), '<p><strong>  &nbsp;  </strong><span></span><strong>cd</strong></p>', 'TINY-6251: Do not remove spaces containing nbsp');
 
     DOM.setHTML('test', '<ul><li>first line<br><ul><li><span>second</span> <span>line</span></li><li>third line<br></li></ul></li></ul>');
-    parent = DOM.select('li:nth-child(1)', DOM.get('test'))[0];
-    point = DOM.select('ul li:nth-child(2)', DOM.get('test'))[0];
+    parent = DOM.select('li:nth-child(1)', getTestElement())[0];
+    point = DOM.select('ul li:nth-child(2)', getTestElement())[0];
     DOM.split(parent, point);
-    assert.equal(HtmlUtils.cleanHtml(DOM.get('test').innerHTML), '<ul><li>first line<br><ul><li><span>second</span> <span>line</span></li></ul></li><li>third line<br></li></ul>');
+    assert.equal(HtmlUtils.cleanHtml(getTestElement().innerHTML), '<ul><li>first line<br><ul><li><span>second</span> <span>line</span></li></ul></li><li>third line<br></li></ul>');
 
     DOM.setHTML('test', '<p><b>&nbsp; <span>inner</span>text2</b></p>');
-    parent = DOM.select('p', DOM.get('test'))[0];
-    point = DOM.select('span', DOM.get('test'))[0];
+    parent = DOM.select('p', getTestElement())[0];
+    point = DOM.select('span', getTestElement())[0];
     DOM.split(parent, point);
-    assert.equal(HtmlUtils.cleanHtml(DOM.get('test').innerHTML), '<p><b>&nbsp; </b></p><span>inner</span><p><b>text2</b></p>');
+    assert.equal(HtmlUtils.cleanHtml(getTestElement().innerHTML), '<p><b>&nbsp; </b></p><span>inner</span><p><b>text2</b></p>');
 
     DOM.setHTML('test', '<p><b><a id="anchor"></a><span>inner</span>text2</b></p>');
-    parent = DOM.select('p', DOM.get('test'))[0];
-    point = DOM.select('span', DOM.get('test'))[0];
+    parent = DOM.select('p', getTestElement())[0];
+    point = DOM.select('span', getTestElement())[0];
     DOM.split(parent, point);
-    assert.equal(HtmlUtils.cleanHtml(DOM.get('test').innerHTML), '<p><b><a id="anchor"></a></b></p><span>inner</span><p><b>text2</b></p>');
+    assert.equal(HtmlUtils.cleanHtml(getTestElement().innerHTML), '<p><b><a id="anchor"></a></b></p><span>inner</span><p><b>text2</b></p>');
 
     DOM.setHTML('test', '<p>text<span style="text-decoration: underline;"> <span>t</span></span>ext</p>');
-    parent = DOM.select('span', DOM.get('test'))[0];
-    point = DOM.select('span', DOM.get('test'))[1];
+    parent = DOM.select('span', getTestElement())[0];
+    point = DOM.select('span', getTestElement())[1];
     DOM.split(parent, point);
-    assert.equal(DOM.get('test').innerHTML, '<p>text<span style="text-decoration: underline;"> </span><span>t</span>ext</p>', 'TINY-6268: Do not remove spaces at start of split');
+    assert.equal(getTestElement().innerHTML, '<p>text<span style="text-decoration: underline;"> </span><span>t</span>ext</p>', 'TINY-6268: Do not remove spaces at start of split');
 
     DOM.setHTML('test', '<p>tex<span style="text-decoration: underline;"><span>t</span> </span>text</p>');
-    parent = DOM.select('span', DOM.get('test'))[0];
-    point = DOM.select('span', DOM.get('test'))[1];
+    parent = DOM.select('span', getTestElement())[0];
+    point = DOM.select('span', getTestElement())[1];
     DOM.split(parent, point);
-    assert.equal(DOM.get('test').innerHTML, '<p>tex<span>t</span><span style="text-decoration: underline;"> </span>text</p>', 'TINY-6268: Do not remove spaces at end of split');
+    assert.equal(getTestElement().innerHTML, '<p>tex<span>t</span><span style="text-decoration: underline;"> </span>text</p>', 'TINY-6268: Do not remove spaces at end of split');
 
     DOM.remove('test');
   });
@@ -609,15 +616,15 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
   it('nodeIndex', () => {
     DOM.add(document.body, 'div', { id: 'test' }, 'abc<b>abc</b>abc');
 
-    assert.equal(DOM.nodeIndex(DOM.get('test').childNodes[0]), 0);
-    assert.equal(DOM.nodeIndex(DOM.get('test').childNodes[1]), 1);
-    assert.equal(DOM.nodeIndex(DOM.get('test').childNodes[2]), 2);
+    assert.equal(DOM.nodeIndex(getTestElement().childNodes[0]), 0);
+    assert.equal(DOM.nodeIndex(getTestElement().childNodes[1]), 1);
+    assert.equal(DOM.nodeIndex(getTestElement().childNodes[2]), 2);
 
-    DOM.get('test').insertBefore(DOM.doc.createTextNode('a'), DOM.get('test').firstChild);
-    DOM.get('test').insertBefore(DOM.doc.createTextNode('b'), DOM.get('test').firstChild);
+    getTestElement().insertBefore(DOM.doc.createTextNode('a'), getTestElement().firstChild);
+    getTestElement().insertBefore(DOM.doc.createTextNode('b'), getTestElement().firstChild);
 
-    assert.equal(DOM.nodeIndex(DOM.get('test').lastChild), 4);
-    assert.equal(DOM.nodeIndex(DOM.get('test').lastChild, true), 2);
+    assert.equal(DOM.nodeIndex(getTestElement().lastChild as Text), 4);
+    assert.equal(DOM.nodeIndex(getTestElement().lastChild as Text, true), 2);
 
     DOM.remove('test');
   });
@@ -628,10 +635,10 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
     const domUtils = DOMUtils(document);
 
     DOM.setHTML('test', '<hr>');
-    assert.isFalse(domUtils.isEmpty(DOM.get('test')));
+    assert.isFalse(domUtils.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<p><br></p>');
-    assert.isTrue(domUtils.isEmpty(DOM.get('test')));
+    assert.isTrue(domUtils.isEmpty(getTestElement()));
 
     DOM.remove('test');
   });
@@ -640,70 +647,70 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
     DOM.schema = Schema(); // A schema will be added when used within a editor instance
     DOM.add(document.body, 'div', { id: 'test' }, '');
 
-    assert.isTrue(DOM.isEmpty(DOM.get('test')));
+    assert.isTrue(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<br />');
-    assert.isTrue(DOM.isEmpty(DOM.get('test')));
+    assert.isTrue(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<br /><br />');
-    assert.isFalse(DOM.isEmpty(DOM.get('test')));
+    assert.isFalse(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', 'text');
-    assert.isFalse(DOM.isEmpty(DOM.get('test')));
+    assert.isFalse(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<span>text</span>');
-    assert.isFalse(DOM.isEmpty(DOM.get('test')));
+    assert.isFalse(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<span></span>');
-    assert.isTrue(DOM.isEmpty(DOM.get('test')));
+    assert.isTrue(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<div><span><b></b></span><b></b><em></em></div>');
-    assert.isTrue(DOM.isEmpty(DOM.get('test')));
+    assert.isTrue(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<div><span><b></b></span><b></b><em>X</em></div>');
-    assert.isFalse(DOM.isEmpty(DOM.get('test')));
+    assert.isFalse(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<div><span><b></b></span><b></b><em> </em></div>');
-    assert.isTrue(DOM.isEmpty(DOM.get('test')));
+    assert.isTrue(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<div><span><b></b></span><b></b><em><a name="x"></a></em></div>');
-    assert.isFalse(DOM.isEmpty(DOM.get('test')));
+    assert.isFalse(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<img src="tinymce/ui/img/raster.gif">');
-    assert.isFalse(DOM.isEmpty(DOM.get('test')));
+    assert.isFalse(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<span data-mce-bookmark="1"></span>');
-    assert.isFalse(DOM.isEmpty(DOM.get('test')));
+    assert.isFalse(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<span data-mce-style="color:Red"></span>');
-    assert.isTrue(DOM.isEmpty(DOM.get('test')));
+    assert.isTrue(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<div><!-- comment --></div>');
-    assert.isFalse(DOM.isEmpty(DOM.get('test')));
+    assert.isFalse(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<span data-mce-bogus="1"></span>');
-    assert.isTrue(DOM.isEmpty(DOM.get('test')));
+    assert.isTrue(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<span data-mce-bogus="1">a</span>');
-    assert.isFalse(DOM.isEmpty(DOM.get('test')));
+    assert.isFalse(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<span data-mce-bogus="all">a</span>');
-    assert.isTrue(DOM.isEmpty(DOM.get('test')));
+    assert.isTrue(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<span data-mce-bogus="all">a</span>b');
-    assert.isFalse(DOM.isEmpty(DOM.get('test')));
+    assert.isFalse(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<code> </code>');
-    assert.isFalse(DOM.isEmpty(DOM.get('test')));
+    assert.isFalse(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<pre> </pre>');
-    assert.isFalse(DOM.isEmpty(DOM.get('test')));
+    assert.isFalse(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<code></code>');
-    assert.isFalse(DOM.isEmpty(DOM.get('test')));
+    assert.isFalse(DOM.isEmpty(getTestElement()));
 
     DOM.setHTML('test', '<pre></pre>');
-    assert.isFalse(DOM.isEmpty(DOM.get('test')));
+    assert.isFalse(DOM.isEmpty(getTestElement()));
 
     DOM.remove('test');
   });

--- a/modules/tinymce/src/core/test/ts/browser/dom/EventUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/EventUtilsTest.ts
@@ -2,7 +2,7 @@ import { after, afterEach, before, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { assert } from 'chai';
 
-import EventUtils from 'tinymce/core/api/dom/EventUtils';
+import EventUtils, { EventUtilsEvent } from 'tinymce/core/api/dom/EventUtils';
 
 describe('browser.tinymce.core.dom.EventUtilsTest', () => {
   const eventUtils = EventUtils.Event;
@@ -21,7 +21,9 @@ describe('browser.tinymce.core.dom.EventUtilsTest', () => {
 
   after(() => {
     const testDiv = document.querySelector('#testDiv');
-    testDiv.parentNode.removeChild(testDiv);
+    if (testDiv) {
+      testDiv.parentNode?.removeChild(testDiv);
+    }
   });
 
   afterEach(() => {
@@ -29,7 +31,7 @@ describe('browser.tinymce.core.dom.EventUtilsTest', () => {
   });
 
   it('unbind all', () => {
-    let result;
+    let result: Record<string, boolean>;
 
     eventUtils.bind(window, 'click', () => {
       result.click = true;
@@ -56,7 +58,7 @@ describe('browser.tinymce.core.dom.EventUtilsTest', () => {
   });
 
   it('unbind event', () => {
-    let result;
+    let result: Record<string, boolean>;
 
     eventUtils.bind(window, 'click', () => {
       result.click = true;
@@ -88,7 +90,7 @@ describe('browser.tinymce.core.dom.EventUtilsTest', () => {
   });
 
   it('unbind callback', () => {
-    let result;
+    let result: Record<string, boolean>;
 
     eventUtils.bind(window, 'click', () => {
       result.click = true;
@@ -117,13 +119,13 @@ describe('browser.tinymce.core.dom.EventUtilsTest', () => {
   });
 
   it('unbind multiple', () => {
+    const result: Record<string, boolean> = {};
     eventUtils.bind(window, 'mouseup mousedown click', (e) => {
       result[e.type] = true;
     });
 
     eventUtils.unbind(window, 'mouseup mousedown');
 
-    const result = {};
     eventUtils.dispatch(window, 'mouseup');
     eventUtils.dispatch(window, 'mousedown');
     eventUtils.dispatch(window, 'click');
@@ -131,11 +133,11 @@ describe('browser.tinymce.core.dom.EventUtilsTest', () => {
   });
 
   it('bind multiple', () => {
+    const result: Record<string, boolean> = {};
     eventUtils.bind(window, 'mouseup mousedown', (e) => {
       result[e.type] = true;
     });
 
-    const result = {};
     eventUtils.dispatch(window, 'mouseup');
     eventUtils.dispatch(window, 'mousedown');
     eventUtils.dispatch(window, 'click');
@@ -143,7 +145,7 @@ describe('browser.tinymce.core.dom.EventUtilsTest', () => {
   });
 
   it('bind/fire bubbling', () => {
-    let result;
+    let result: Record<string, boolean>;
 
     eventUtils.bind(window, 'click', () => {
       result.window = true;
@@ -187,7 +189,7 @@ describe('browser.tinymce.core.dom.EventUtilsTest', () => {
   });
 
   it('bubbling with prevented default', () => {
-    let result;
+    let result: Record<string, boolean>;
 
     eventUtils.bind(window, 'click', (e) => {
       result.window = true;
@@ -223,7 +225,7 @@ describe('browser.tinymce.core.dom.EventUtilsTest', () => {
       result.click3 = true;
     });
 
-    const result = {} as Record<string, any>;
+    const result: Record<string, boolean> = {};
     eventUtils.dispatch(window, 'click');
     assert.deepEqual(result, { click1: true, click2: true });
   });
@@ -242,13 +244,13 @@ describe('browser.tinymce.core.dom.EventUtilsTest', () => {
       e.stopPropagation();
     });
 
-    const result = {} as Record<string, any>;
+    const result: Record<string, boolean> = {};
     eventUtils.dispatch(document.getElementById('inner'), 'click');
     assert.deepEqual(result, { click3: true });
   });
 
   it('clean window', () => {
-    let result;
+    let result: Record<string, boolean>;
 
     eventUtils.bind(window, 'click', () => {
       result.click1 = true;
@@ -277,7 +279,7 @@ describe('browser.tinymce.core.dom.EventUtilsTest', () => {
   });
 
   it('clean document', () => {
-    let result;
+    let result: Record<string, boolean>;
 
     eventUtils.bind(window, 'click', () => {
       result.click1 = true;
@@ -310,7 +312,7 @@ describe('browser.tinymce.core.dom.EventUtilsTest', () => {
   });
 
   it('clean element', () => {
-    let result;
+    let result: Record<string, boolean>;
 
     eventUtils.bind(window, 'click', () => {
       result.click1 = true;
@@ -339,7 +341,7 @@ describe('browser.tinymce.core.dom.EventUtilsTest', () => {
   });
 
   it('mouseenter/mouseleave bind/unbind', () => {
-    let result = {};
+    let result: Record<string, boolean> = {};
 
     eventUtils.bind(document.body, 'mouseenter mouseleave', (e) => {
       result[e.type] = true;
@@ -400,7 +402,7 @@ describe('browser.tinymce.core.dom.EventUtilsTest', () => {
   });
 
   it('event states when event object is fired twice', () => {
-    const result = {};
+    const result: Record<string, boolean> = {};
 
     eventUtils.bind(window, 'keydown', (e) => {
       result[e.type] = true; e.preventDefault(); e.stopPropagation();
@@ -421,9 +423,9 @@ describe('browser.tinymce.core.dom.EventUtilsTest', () => {
   });
 
   it('unbind inside callback', () => {
-    let data;
+    let data: string;
 
-    const append = (value) => {
+    const append = (value: string) => {
       return () => {
         data += value;
       };
@@ -448,17 +450,17 @@ describe('browser.tinymce.core.dom.EventUtilsTest', () => {
   });
 
   it('ready/DOMContentLoaded (domLoaded = true)', () => {
-    let evt;
+    let evt: EventUtilsEvent<any> | undefined;
 
     eventUtils.bind(window, 'ready', (e) => {
       evt = e;
     });
-    assert.equal(evt.type, 'ready');
+    assert.equal(evt?.type, 'ready');
   });
 
   it('ready/DOMContentLoaded (document.readyState check)', () => {
     const doc = document as any;
-    let evt;
+    let evt: EventUtilsEvent<any> | undefined;
 
     try {
       doc.readyState = 'loading';

--- a/modules/tinymce/src/core/test/ts/browser/dom/NodePathTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/NodePathTest.ts
@@ -15,22 +15,27 @@ describe('browser.tinymce.core.dom.NodePathTest', () => {
   it('create', () => {
     setupHtml('<p>a<b>12<input></b></p>');
 
-    assert.deepEqual(NodePath.create(getRoot(), getRoot().firstChild), [ 0 ]);
-    assert.deepEqual(NodePath.create(getRoot(), getRoot().firstChild.firstChild), [ 0, 0 ]);
-    assert.deepEqual(NodePath.create(getRoot(), getRoot().firstChild.lastChild.lastChild), [ 1, 1, 0 ]);
+    assert.deepEqual(NodePath.create(getRoot(), getRoot().firstChild as HTMLParagraphElement), [ 0 ]);
+    assert.deepEqual(NodePath.create(getRoot(), getRoot().firstChild?.firstChild as Text), [ 0, 0 ]);
+    assert.deepEqual(NodePath.create(getRoot(), getRoot().firstChild?.lastChild?.lastChild as HTMLInputElement), [ 1, 1, 0 ]);
   });
 
   it('resolve', () => {
     setupHtml('<p>a<b>12<input></b></p>');
 
-    LegacyUnit.equalDom(NodePath.resolve(getRoot(), NodePath.create(getRoot(), getRoot().firstChild)), getRoot().firstChild);
+    const para = getRoot().firstChild as HTMLParagraphElement;
+    LegacyUnit.equalDom(NodePath.resolve(getRoot(), NodePath.create(getRoot(), para)) as Node, para);
+
+    const firstText = para.firstChild as Text;
     LegacyUnit.equalDom(
-      NodePath.resolve(getRoot(), NodePath.create(getRoot(), getRoot().firstChild.firstChild)),
-      getRoot().firstChild.firstChild
+      NodePath.resolve(getRoot(), NodePath.create(getRoot(), firstText)) as Text,
+      firstText
     );
+
+    const input = para.lastChild?.lastChild as HTMLInputElement;
     LegacyUnit.equalDom(
-      NodePath.resolve(getRoot(), NodePath.create(getRoot(), getRoot().firstChild.lastChild.lastChild)),
-      getRoot().firstChild.lastChild.lastChild
+      NodePath.resolve(getRoot(), NodePath.create(getRoot(), input)) as HTMLInputElement,
+      input
     );
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
@@ -92,7 +92,7 @@ describe('browser.tinymce.core.dom.ScrollIntoViewTest', () => {
   const assertScrollIntoViewEventInfo = (editor: Editor, value: StateAndHandler, expectedElementSelector: string, expectedAlignToTop: boolean) => {
     const state = value.state.get();
     const expectedTarget = SugarElement.fromDom(editor.dom.select(expectedElementSelector)[0]);
-    const actualTarget = SugarElement.fromDom(state.elm);
+    const actualTarget = SugarElement.fromDom(state.elm as HTMLElement);
     Assertions.assertDomEq('Target should be expected element', expectedTarget, actualTarget);
     assert.equal(state.alignToTop, expectedAlignToTop, 'Align to top should be expected value');
     editor.off('ScrollIntoView', value.handler);

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionEventsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionEventsTest.ts
@@ -39,19 +39,19 @@ describe('browser.tinymce.core.dom.SelectionEventsTest', () => {
     editor.off(eventName, value.handler);
   };
 
-  const assertSetSelectionEventArgs = (editor: Editor, expectedForward: boolean, value: HandlerAndArgs) => {
+  const assertSetSelectionEventArgs = (editor: Editor, expectedForward: boolean | undefined, value: HandlerAndArgs) => {
     assert.equal(value.eventArgs.get().forward, expectedForward, 'Should be expected forward flag');
     assertSelectAllRange(editor, value.eventArgs.get().range);
   };
 
   const getSelectAllRng = (editor: Editor) => {
     const rng = document.createRange();
-    rng.setStartBefore(editor.getBody().firstChild);
-    rng.setEndAfter(editor.getBody().firstChild);
+    rng.setStartBefore(editor.getBody().firstChild as Node);
+    rng.setEndAfter(editor.getBody().firstChild as Node);
     return rng;
   };
 
-  const setRng = (editor: Editor, forward: boolean) => {
+  const setRng = (editor: Editor, forward: boolean | undefined) => {
     editor.selection.setRng(getSelectAllRng(editor), forward);
   };
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionQuirksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionQuirksTest.ts
@@ -30,8 +30,8 @@ describe('browser.tinymce.core.dom.SelectionQuirksTest', () => {
     editor.setContent('<p>a<img src="about:blank" style="float: right"></p>');
     TinySelections.setSelection(editor, [ 0 ], 1, [ 0 ], 2);
     const selection = editor.selection.getSel();
-    assert.equal(selection.anchorNode.nodeName, 'P', 'Anchor node should be the paragraph not the text node');
-    assert.equal(selection.anchorOffset, 1, 'Anchor offset should be the element index');
+    assert.equal(selection?.anchorNode?.nodeName, 'P', 'Anchor node should be the paragraph not the text node');
+    assert.equal(selection?.anchorOffset, 1, 'Anchor offset should be the element index');
   });
 
   it('Normalize on key events when range is collapsed', () => {

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
@@ -3,6 +3,8 @@ import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import { GetContentEvent, SetContentEvent } from 'tinymce/core/api/EventTypes';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { Bookmark } from 'tinymce/core/bookmark/BookmarkTypes';
 import * as CaretContainer from 'tinymce/core/caret/CaretContainer';
 import * as Zwsp from 'tinymce/core/text/Zwsp';
@@ -23,7 +25,7 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
   it('getContent', () => {
     const editor = hook.editor();
     let rng = editor.dom.createRng();
-    let eventObj;
+    let eventObj: EditorEvent<GetContentEvent> | undefined;
 
     // Get selected contents
     editor.setContent('<p>text</p>');
@@ -41,9 +43,7 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     LegacyUnit.equal(editor.selection.getContent(), '', 'Get selected contents (collapsed)');
 
     // Get selected contents, onGetContent event
-    eventObj = {};
-
-    const handler = (event) => {
+    const handler = (event: EditorEvent<GetContentEvent>) => {
       eventObj = event;
     };
 
@@ -54,7 +54,7 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     rng.setEnd(editor.getBody(), 1);
     editor.selection.setRng(rng);
     editor.selection.getContent();
-    LegacyUnit.equal(eventObj.content, '<p>text</p>', 'Get selected contents, onGetContent event');
+    LegacyUnit.equal(eventObj?.content, '<p>text</p>', 'Get selected contents, onGetContent event');
     editor.off('GetContent', handler);
   });
 
@@ -62,8 +62,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     const editor = hook.editor();
     editor.setContent('<p><em>text</em></p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('em')[0].firstChild, 1);
-    rng.setEnd(editor.dom.select('em')[0].firstChild, 3);
+    rng.setStart(editor.dom.select('em')[0].firstChild as Text, 1);
+    rng.setEnd(editor.dom.select('em')[0].firstChild as Text, 3);
     editor.selection.setRng(rng);
     LegacyUnit.equal(editor.selection.getContent({ contextual: true }), '<em>ex</em>', 'Get selected contents');
   });
@@ -82,7 +82,7 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
   it('setContent', () => {
     const editor = hook.editor();
     let rng = editor.dom.createRng();
-    let eventObj;
+    let eventObj: EditorEvent<SetContentEvent> | undefined;
 
     // Set contents at selection
     editor.setContent('<p>text</p>');
@@ -113,17 +113,17 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     // Insert in middle of paragraph
     editor.setContent('<p>beforeafter</p>');
     rng = editor.dom.createRng();
-    rng.setStart(editor.getBody().firstChild.firstChild, 'before'.length);
-    rng.setEnd(editor.getBody().firstChild.firstChild, 'before'.length);
+    rng.setStart(editor.getBody().firstChild?.firstChild as Text, 'before'.length);
+    rng.setEnd(editor.getBody().firstChild?.firstChild as Text, 'before'.length);
     editor.selection.setRng(rng);
     editor.selection.setContent('<br />');
     LegacyUnit.equal(editor.getContent(), '<p>before<br>after</p>', 'Set contents at selection (inside paragraph)');
 
     // Check the caret is left in the correct position.
     rng = editor.selection.getRng();
-    LegacyUnit.equalDom(rng.startContainer, editor.getBody().firstChild, 'Selection start container');
+    LegacyUnit.equalDom(rng.startContainer, editor.getBody().firstChild as HTMLParagraphElement, 'Selection start container');
     LegacyUnit.equal(rng.startOffset, 2, 'Selection start offset');
-    LegacyUnit.equalDom(rng.endContainer, editor.getBody().firstChild, 'Selection end container');
+    LegacyUnit.equalDom(rng.endContainer, editor.getBody().firstChild as HTMLParagraphElement, 'Selection end container');
     LegacyUnit.equal(rng.endOffset, 2, 'Selection end offset');
 
     editor.setContent('<p>text</p>');
@@ -140,9 +140,7 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     LegacyUnit.equal(rng.endOffset, 0, 'Selection end offset');
 
     // Set selected contents, onSetContent event
-    eventObj = {};
-
-    const handler = (event) => {
+    const handler = (event: EditorEvent<SetContentEvent>) => {
       eventObj = event;
     };
 
@@ -153,7 +151,7 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     rng.setEnd(editor.getBody(), 1);
     editor.selection.setRng(rng);
     editor.selection.setContent('<div>text</div>');
-    LegacyUnit.equal(eventObj.content, '<div>text</div>', 'Set selected contents, onSetContent event');
+    LegacyUnit.equal(eventObj?.content, '<div>text</div>', 'Set selected contents, onSetContent event');
     editor.off('SetContent', handler);
   });
 
@@ -163,8 +161,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
 
     // Selected contents
     editor.setContent('<p id="a">text</p><p id="b">text</p>');
-    rng.setStart(editor.getBody().firstChild.firstChild, 0);
-    rng.setEnd(editor.getBody().lastChild.firstChild, 0);
+    rng.setStart(editor.getBody().firstChild?.firstChild as Text, 0);
+    rng.setEnd(editor.getBody().lastChild?.firstChild as Text, 0);
     editor.selection.setRng(rng);
     LegacyUnit.equal(editor.selection.getStart().id, 'a', 'Selected contents (getStart)');
     LegacyUnit.equal(editor.selection.getEnd().id, 'b', 'Selected contents (getEnd)');
@@ -172,8 +170,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     // Selected contents (collapsed)
     editor.setContent('<p id="a">text</p>\n<p id="b">text</p>');
     rng = editor.dom.createRng();
-    rng.setStart(editor.getBody().firstChild.firstChild, 0);
-    rng.setEnd(editor.getBody().firstChild.firstChild, 0);
+    rng.setStart(editor.getBody().firstChild?.firstChild as Text, 0);
+    rng.setEnd(editor.getBody().firstChild?.firstChild as Text, 0);
     editor.selection.setRng(rng);
     LegacyUnit.equal(editor.selection.getStart().id, 'a', 'Selected contents (getStart, collapsed)');
     LegacyUnit.equal(editor.selection.getEnd().id, 'a', 'Selected contents (getEnd, collapsed)');
@@ -193,8 +191,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     const editor = hook.editor();
     editor.setContent('<p><!-- x --></p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.getBody().firstChild, 0);
-    rng.setEnd(editor.getBody().firstChild, 0);
+    rng.setStart(editor.getBody().firstChild as HTMLParagraphElement, 0);
+    rng.setEnd(editor.getBody().firstChild as HTMLParagraphElement, 0);
     editor.selection.setRng(rng);
 
     LegacyUnit.equal(editor.selection.getStart().nodeName, 'P', 'Node name should be paragraph');
@@ -210,8 +208,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
 
     // Get persistent bookmark simple text selection
     editor.setContent('<p>text</p>');
-    rng.setStart(editor.getBody().firstChild.firstChild, 1);
-    rng.setEnd(editor.getBody().firstChild.firstChild, 3);
+    rng.setStart(editor.getBody().firstChild?.firstChild as Text, 1);
+    rng.setEnd(editor.getBody().firstChild?.firstChild as Text, 3);
     editor.selection.setRng(rng);
     bookmark = editor.selection.getBookmark();
     LegacyUnit.equal(editor.getContent(), '<p>text</p>', 'Editor contents (text)');
@@ -221,8 +219,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     // Get persistent bookmark multiple elements text selection
     editor.setContent('<p>text</p>\n<p>text</p>');
     rng = editor.dom.createRng();
-    rng.setStart(editor.getBody().firstChild.firstChild, 1);
-    rng.setEnd(editor.getBody().lastChild.firstChild, 3);
+    rng.setStart(editor.getBody().firstChild?.firstChild as Text, 1);
+    rng.setEnd(editor.getBody().lastChild?.firstChild as Text, 3);
     editor.selection.setRng(rng);
     bookmark = editor.selection.getBookmark();
     LegacyUnit.equal(editor.getContent(), '<p>text</p>\n<p>text</p>', 'Editor contents (elements)');
@@ -237,8 +235,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
 
     // Get persistent bookmark simple text selection
     editor.setContent('<p>text</p>');
-    rng.setStart(editor.getBody().firstChild.firstChild, 1);
-    rng.setEnd(editor.getBody().firstChild.firstChild, 3);
+    rng.setStart(editor.getBody().firstChild?.firstChild as Text, 1);
+    rng.setEnd(editor.getBody().firstChild?.firstChild as Text, 3);
     editor.selection.setRng(rng);
     bookmark = editor.selection.getBookmark(1);
     LegacyUnit.equal(editor.getContent(), '<p>text</p>', 'Editor contents (text)');
@@ -248,8 +246,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     // Get persistent bookmark multiple elements text selection
     editor.setContent('<p>text</p>\n<p>text</p>');
     rng = editor.dom.createRng();
-    rng.setStart(editor.getBody().firstChild.firstChild, 1);
-    rng.setEnd(editor.getBody().lastChild.firstChild, 3);
+    rng.setStart(editor.getBody().firstChild?.firstChild as Text, 1);
+    rng.setEnd(editor.getBody().lastChild?.firstChild as Text, 3);
     editor.selection.setRng(rng);
     bookmark = editor.selection.getBookmark(1);
     LegacyUnit.equal(editor.getContent(), '<p>text</p>\n<p>text</p>', 'Editor contents (elements)');
@@ -261,8 +259,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     const editor = hook.editor();
     editor.setContent('<p>text</p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.getBody().firstChild.firstChild, 1);
-    rng.setEnd(editor.getBody().firstChild.firstChild, 3);
+    rng.setStart(editor.getBody().firstChild?.firstChild as Text, 1);
+    rng.setEnd(editor.getBody().firstChild?.firstChild as Text, 3);
     editor.selection.setRng(rng);
     const bookmark = editor.selection.getBookmark(2);
     LegacyUnit.equal(editor.getContent(), '<p>text</p>', 'Editor contents (text)');
@@ -288,8 +286,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     // Get non intrusive bookmark multiple elements text selection
     editor.setContent('<p>text</p>\n<p>text</p>');
     const rng = editor.dom.createRng();
-    rng.setStart(editor.getBody().firstChild.firstChild, 1);
-    rng.setEnd(editor.getBody().lastChild.firstChild, 3);
+    rng.setStart(editor.getBody().firstChild?.firstChild as Text, 1);
+    rng.setEnd(editor.getBody().lastChild?.firstChild as Text, 3);
     editor.selection.setRng(rng);
     const bookmark = editor.selection.getBookmark(2);
     LegacyUnit.equal(editor.getContent(), '<p>text</p>\n<p>text</p>', 'Editor contents (elements)');
@@ -306,8 +304,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     editor.dom.select('p')[0].appendChild(editor.dom.doc.createTextNode('a'));
     editor.dom.select('p')[0].appendChild(editor.dom.doc.createTextNode('text'));
     const rng = editor.dom.createRng();
-    rng.setStart(editor.getBody().firstChild.lastChild, 1);
-    rng.setEnd(editor.getBody().lastChild.firstChild, 3);
+    rng.setStart(editor.getBody().firstChild?.lastChild as Text, 1);
+    rng.setEnd(editor.getBody().lastChild?.firstChild as Text, 3);
     editor.selection.setRng(rng);
     const bookmark = editor.selection.getBookmark(2);
     LegacyUnit.equal(editor.getContent(), '<p>textaaatext</p>\n<p>text</p>', 'Editor contents (fragmented, elements)');
@@ -324,8 +322,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     editor.dom.select('p')[0].appendChild(editor.dom.doc.createTextNode('a'));
     editor.dom.select('p')[0].appendChild(editor.dom.doc.createTextNode('text'));
     const rng = editor.dom.createRng();
-    rng.setStart(editor.getBody().firstChild.lastChild, 1);
-    rng.setEnd(editor.getBody().lastChild.firstChild, 3);
+    rng.setStart(editor.getBody().firstChild?.lastChild as Text, 1);
+    rng.setEnd(editor.getBody().lastChild?.firstChild as Text, 3);
     editor.selection.setRng(rng);
     const bookmark = editor.selection.getBookmark(2, true);
     editor.setContent(editor.getContent());
@@ -343,8 +341,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     editor.dom.select('p')[0].appendChild(editor.dom.doc.createTextNode(Zwsp.ZWSP));
     editor.dom.select('p')[0].appendChild(editor.dom.doc.createTextNode('text'));
     const rng = editor.dom.createRng();
-    rng.setStart(editor.getBody().firstChild.lastChild, 1);
-    rng.setEnd(editor.getBody().lastChild.firstChild, 3);
+    rng.setStart(editor.getBody().firstChild?.lastChild as Text, 1);
+    rng.setEnd(editor.getBody().lastChild?.firstChild as Text, 3);
     editor.selection.setRng(rng);
     const bookmark = editor.selection.getBookmark(2, true);
     editor.setContent(editor.getContent());
@@ -358,16 +356,16 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.setContent('<p><img src="about:blank" /></p>');
-    rng.setStart(editor.getBody().firstChild, 0);
-    rng.setEnd(editor.getBody().firstChild, 0);
+    rng.setStart(editor.getBody().firstChild as HTMLParagraphElement, 0);
+    rng.setEnd(editor.getBody().firstChild as HTMLParagraphElement, 0);
     editor.selection.setRng(rng);
     const bookmark = editor.selection.getBookmark(2, true);
     editor.getBody().innerHTML = editor.getBody().innerHTML;
     editor.selection.moveToBookmark(bookmark);
     rng = editor.selection.getRng();
-    LegacyUnit.equalDom(rng.startContainer, editor.getBody().firstChild);
+    LegacyUnit.equalDom(rng.startContainer, editor.getBody().firstChild as HTMLParagraphElement);
     LegacyUnit.equal(rng.startOffset, 0);
-    LegacyUnit.equalDom(rng.endContainer, editor.getBody().firstChild);
+    LegacyUnit.equalDom(rng.endContainer, editor.getBody().firstChild as HTMLParagraphElement);
     LegacyUnit.equal(rng.endOffset, 0);
   });
 
@@ -376,16 +374,16 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.setContent('<p><img src="about:blank" /></p>');
-    rng.setStart(editor.getBody().firstChild, 0);
-    rng.setEnd(editor.getBody().firstChild, 1);
+    rng.setStart(editor.getBody().firstChild as HTMLParagraphElement, 0);
+    rng.setEnd(editor.getBody().firstChild as HTMLParagraphElement, 1);
     editor.selection.setRng(rng);
     const bookmark = editor.selection.getBookmark(2, true);
     editor.getBody().innerHTML = editor.getBody().innerHTML;
     editor.selection.moveToBookmark(bookmark);
     rng = editor.selection.getRng();
-    LegacyUnit.equalDom(rng.startContainer, editor.getBody().firstChild);
+    LegacyUnit.equalDom(rng.startContainer, editor.getBody().firstChild as HTMLParagraphElement);
     LegacyUnit.equal(rng.startOffset, 0);
-    LegacyUnit.equalDom(rng.endContainer, editor.getBody().firstChild);
+    LegacyUnit.equalDom(rng.endContainer, editor.getBody().firstChild as HTMLParagraphElement);
     LegacyUnit.equal(rng.endOffset, 1);
   });
 
@@ -394,16 +392,16 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.setContent('<p><img src="about:blank" /></p>');
-    rng.setStart(editor.getBody().firstChild, 1);
-    rng.setEnd(editor.getBody().firstChild, 1);
+    rng.setStart(editor.getBody().firstChild as HTMLParagraphElement, 1);
+    rng.setEnd(editor.getBody().firstChild as HTMLParagraphElement, 1);
     editor.selection.setRng(rng);
     const bookmark = editor.selection.getBookmark(2, true);
     editor.getBody().innerHTML = editor.getBody().innerHTML;
     editor.selection.moveToBookmark(bookmark);
     rng = editor.selection.getRng();
-    LegacyUnit.equalDom(rng.startContainer, editor.getBody().firstChild);
+    LegacyUnit.equalDom(rng.startContainer, editor.getBody().firstChild as HTMLParagraphElement);
     LegacyUnit.equal(rng.startOffset, 1);
-    LegacyUnit.equalDom(rng.endContainer, editor.getBody().firstChild);
+    LegacyUnit.equalDom(rng.endContainer, editor.getBody().firstChild as HTMLParagraphElement);
     LegacyUnit.equal(rng.endOffset, 1);
   });
 
@@ -412,16 +410,16 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.setContent('<p>abc<b>123</b></p>');
-    rng.setStart(editor.getBody().firstChild, 0);
-    rng.setEnd(editor.getBody().firstChild, 2);
+    rng.setStart(editor.getBody().firstChild as HTMLParagraphElement, 0);
+    rng.setEnd(editor.getBody().firstChild as HTMLParagraphElement, 2);
     editor.selection.setRng(rng);
     const bookmark = editor.selection.getBookmark(2, true);
     editor.getBody().innerHTML = editor.getBody().innerHTML;
     editor.selection.moveToBookmark(bookmark);
     rng = editor.selection.getRng();
-    LegacyUnit.equalDom(rng.startContainer, editor.getBody().firstChild);
+    LegacyUnit.equalDom(rng.startContainer, editor.getBody().firstChild as HTMLParagraphElement);
     LegacyUnit.equal(rng.startOffset, 0);
-    LegacyUnit.equalDom(rng.endContainer, editor.getBody().firstChild);
+    LegacyUnit.equalDom(rng.endContainer, editor.getBody().firstChild as HTMLParagraphElement);
     LegacyUnit.equal(rng.endOffset, 2);
   });
 
@@ -431,16 +429,16 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
 
     // Get bookmark after element
     editor.setContent('<p><b>123</b>abc</p>');
-    rng.setStart(editor.getBody().lastChild, 1);
-    rng.setEnd(editor.getBody().lastChild, 2);
+    rng.setStart(editor.getBody().lastChild as HTMLParagraphElement, 1);
+    rng.setEnd(editor.getBody().lastChild as HTMLParagraphElement, 2);
     editor.selection.setRng(rng);
     const bookmark = editor.selection.getBookmark(2, true);
     editor.getBody().innerHTML = editor.getBody().innerHTML;
     editor.selection.moveToBookmark(bookmark);
     rng = editor.selection.getRng();
-    LegacyUnit.equalDom(rng.startContainer, editor.getBody().lastChild);
+    LegacyUnit.equalDom(rng.startContainer, editor.getBody().lastChild as HTMLParagraphElement);
     LegacyUnit.equal(rng.startOffset, 1);
-    LegacyUnit.equalDom(rng.endContainer, editor.getBody().lastChild);
+    LegacyUnit.equalDom(rng.endContainer, editor.getBody().lastChild as HTMLParagraphElement);
     LegacyUnit.equal(rng.endOffset, 2);
   });
 
@@ -449,16 +447,16 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.setContent('<p>abc<b>123</b>abc</p>');
-    rng.setStart(editor.getBody().firstChild.childNodes[1].firstChild, 1);
-    rng.setEnd(editor.getBody().firstChild.childNodes[1].firstChild, 2);
+    rng.setStart(editor.getBody().firstChild?.childNodes[1].firstChild as Text, 1);
+    rng.setEnd(editor.getBody().firstChild?.childNodes[1].firstChild as Text, 2);
     editor.selection.setRng(rng);
     const bookmark = editor.selection.getBookmark(2, true);
     editor.getBody().innerHTML = editor.getBody().innerHTML;
     editor.selection.moveToBookmark(bookmark);
     rng = editor.selection.getRng();
-    LegacyUnit.equalDom(rng.startContainer, editor.getBody().firstChild.childNodes[1].firstChild);
+    LegacyUnit.equalDom(rng.startContainer, editor.getBody().firstChild?.childNodes[1].firstChild as Text);
     LegacyUnit.equal(rng.startOffset, 1);
-    LegacyUnit.equalDom(rng.endContainer, editor.getBody().firstChild.childNodes[1].firstChild);
+    LegacyUnit.equalDom(rng.endContainer, editor.getBody().firstChild?.childNodes[1].firstChild as Text);
     LegacyUnit.equal(rng.endOffset, 2);
   });
 
@@ -467,16 +465,16 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.setContent('<p>abc</p>');
-    rng.setStart(editor.getBody().firstChild.firstChild, 1);
-    rng.setEnd(editor.getBody().firstChild.firstChild, 2);
+    rng.setStart(editor.getBody().firstChild?.firstChild as Text, 1);
+    rng.setEnd(editor.getBody().firstChild?.firstChild as Text, 2);
     editor.selection.setRng(rng);
     const bookmark = editor.selection.getBookmark(2, true);
     editor.getBody().innerHTML = editor.getBody().innerHTML;
     editor.selection.moveToBookmark(bookmark);
     rng = editor.selection.getRng();
-    LegacyUnit.equalDom(rng.startContainer, editor.getBody().firstChild.firstChild);
+    LegacyUnit.equalDom(rng.startContainer, editor.getBody().firstChild?.firstChild as Text);
     LegacyUnit.equal(rng.startOffset, 1);
-    LegacyUnit.equalDom(rng.endContainer, editor.getBody().firstChild.firstChild);
+    LegacyUnit.equalDom(rng.endContainer, editor.getBody().firstChild?.firstChild as Text);
     LegacyUnit.equal(rng.endOffset, 2);
   });
 
@@ -489,9 +487,9 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     editor.getBody().innerHTML = editor.getBody().innerHTML;
     editor.selection.moveToBookmark(bookmark);
     const rng = editor.selection.getRng();
-    LegacyUnit.equalDom(rng.startContainer, editor.dom.select('td')[0].firstChild);
+    LegacyUnit.equalDom(rng.startContainer, editor.dom.select('td')[0].firstChild as Text);
     LegacyUnit.equal(rng.startOffset, 1);
-    LegacyUnit.equalDom(rng.endContainer, editor.dom.select('td')[0].firstChild);
+    LegacyUnit.equalDom(rng.endContainer, editor.dom.select('td')[0].firstChild as Text);
     LegacyUnit.equal(rng.endOffset, 2);
   });
 
@@ -510,8 +508,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     editor.setContent('<p><input><span contentEditable="false">1</span></p>');
     CaretContainer.insertInline(editor.dom.select('span')[0], true);
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('span')[0].previousSibling, 0);
-    rng.setEnd(editor.dom.select('span')[0].previousSibling, 0);
+    rng.setStart(editor.dom.select('span')[0].previousSibling as HTMLInputElement, 0);
+    rng.setEnd(editor.dom.select('span')[0].previousSibling as HTMLInputElement, 0);
     editor.selection.setRng(rng);
     const bookmark = editor.selection.getBookmark(2);
     editor.setContent('<p><input><span contentEditable="false">1</span></p>');
@@ -572,8 +570,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     const editor = hook.editor();
     editor.setContent('<table><tbody><tr><td id="a"><br /></td><td id="b"><br /></td></tr></tbody></table>');
     editor.selection.select(editor.dom.select('table')[0], true);
-    LegacyUnit.equal(editor.dom.getParent(editor.selection.getStart(), 'td').id, 'a', 'Expand to text content 2 (start)');
-    LegacyUnit.equal(editor.dom.getParent(editor.selection.getEnd(), 'td').id, 'b', 'Expand to text content 2 (end)');
+    LegacyUnit.equal(editor.dom.getParent(editor.selection.getStart(), 'td')?.id, 'a', 'Expand to text content 2 (start)');
+    LegacyUnit.equal(editor.dom.getParent(editor.selection.getEnd(), 'td')?.id, 'b', 'Expand to text content 2 (end)');
   });
 
   it('getNode', () => {
@@ -581,42 +579,47 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.setContent('<p id="p1"><span id="s1">span1</span> word <span id="s2">span2</span> word <span id="s3">span3</span></p>');
-    rng.setStart(editor.dom.get('s1').firstChild, 0);
-    rng.setEnd(editor.dom.get('s1').nextSibling, 0);
+    const p1 = editor.dom.get('p1') as HTMLParagraphElement;
+    const s1 = editor.dom.get('s1') as HTMLSpanElement;
+    const s2 = editor.dom.get('s2') as HTMLSpanElement;
+    const s3 = editor.dom.get('s3') as HTMLSpanElement;
+
+    rng.setStart(s1.firstChild as Text, 0);
+    rng.setEnd(s1.nextSibling as Text, 0);
     editor.selection.setRng(rng);
     LegacyUnit.equalDom(
       editor.selection.getNode(),
-      editor.dom.get('s1'),
+      s1,
       'Detect selection ends immediately after node at start of paragraph.'
     );
 
     rng = editor.dom.createRng();
-    rng.setStart(editor.dom.get('s2').previousSibling, (editor.dom.get('s2').previousSibling as Text).length);
-    rng.setEnd(editor.dom.get('s2').nextSibling, 0);
+    rng.setStart(s2.previousSibling as Text, (s2.previousSibling as Text).length);
+    rng.setEnd(s2.nextSibling as Text, 0);
     editor.selection.setRng(rng);
     LegacyUnit.equalDom(
       editor.selection.getNode(),
-      editor.dom.get('s2'),
+      s2,
       'Detect selection immediately surrounds node in middle of paragraph.'
     );
 
     rng = editor.dom.createRng();
-    rng.setStart(editor.dom.get('s3').previousSibling, (editor.dom.get('s3').previousSibling as Text).length);
-    rng.setEnd(editor.dom.get('s3').lastChild, (editor.dom.get('s3').lastChild as Text).length);
+    rng.setStart(s3.previousSibling as Text, (s3.previousSibling as Text).length);
+    rng.setEnd(s3.lastChild as Text, (s3.lastChild as Text).length);
     editor.selection.setRng(rng);
     LegacyUnit.equalDom(
       editor.selection.getNode(),
-      editor.dom.get('s3'),
+      s3,
       'Detect selection starts immediately before node at end of paragraph.'
     );
 
     rng = editor.dom.createRng();
-    rng.setStart(editor.dom.get('s2').previousSibling, (editor.dom.get('s2').previousSibling as Text).length);
-    rng.setEnd(editor.dom.get('s3').lastChild, (editor.dom.get('s3').lastChild as Text).length);
+    rng.setStart(s2.previousSibling as Text, (s2.previousSibling as Text).length);
+    rng.setEnd(s3.lastChild as Text, (s3.lastChild as Text).length);
     editor.selection.setRng(rng);
     LegacyUnit.equalDom(
       editor.selection.getNode(),
-      editor.dom.get('p1'),
+      p1,
       'Detect selection wrapping multiple nodes does not collapse.'
     );
   });
@@ -661,8 +664,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.setContent('<p>a<b contentEditable="false">b</b>c</p>');
-    rng.setStart(editor.getBody().firstChild.lastChild, 0);
-    rng.setEnd(editor.getBody().firstChild.lastChild, 0);
+    rng.setStart(editor.getBody().firstChild?.lastChild as Text, 0);
+    rng.setEnd(editor.getBody().firstChild?.lastChild as Text, 0);
     editor.selection.setRng(rng);
     editor.selection.normalize();
 
@@ -805,10 +808,10 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
 
     const rng = editor.selection.getRng();
     LegacyUnit.equal(rng.startContainer.nodeName, '#text', 'startContainer node name');
-    LegacyUnit.equal(rng.startContainer.parentNode.nodeName, 'B');
+    LegacyUnit.equal(rng.startContainer.parentNode?.nodeName, 'B');
     LegacyUnit.equal(rng.startOffset, 1, 'startContainer offset');
     LegacyUnit.equal(rng.endContainer.nodeName, '#text');
-    LegacyUnit.equal(rng.endContainer.parentNode.nodeName, 'B');
+    LegacyUnit.equal(rng.endContainer.parentNode?.nodeName, 'B');
     LegacyUnit.equal(rng.endOffset, 1, 'endOffset offset');
   });
 
@@ -820,10 +823,10 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
 
     const rng = editor.selection.getRng();
     LegacyUnit.equal(rng.startContainer.nodeName, '#text', 'startContainer node name');
-    LegacyUnit.equal(rng.startContainer.parentNode.nodeName, 'I');
+    LegacyUnit.equal(rng.startContainer.parentNode?.nodeName, 'I');
     LegacyUnit.equal(rng.startOffset, 0, 'startContainer offset');
     LegacyUnit.equal(rng.endContainer.nodeName, '#text');
-    LegacyUnit.equal(rng.endContainer.parentNode.nodeName, 'I');
+    LegacyUnit.equal(rng.endContainer.parentNode?.nodeName, 'I');
     LegacyUnit.equal(rng.endOffset, 1, 'endOffset offset');
   });
 
@@ -865,8 +868,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.getBody().innerHTML = '<p><i><b></b></i><br /></p>';
-    rng.setStartBefore(editor.getBody().firstChild.lastChild);
-    rng.setEndBefore(editor.getBody().firstChild.lastChild);
+    rng.setStartBefore(editor.getBody().firstChild?.lastChild as HTMLBRElement);
+    rng.setEndBefore(editor.getBody().firstChild?.lastChild as HTMLBRElement);
     editor.selection.setRng(rng);
     editor.selection.normalize();
 
@@ -880,8 +883,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.getBody().innerHTML = '<p><span id="_mce_caret">' + Zwsp.ZWSP + '</span><br /></p>';
-    rng.setStartBefore(editor.getBody().firstChild.lastChild);
-    rng.setEndBefore(editor.getBody().firstChild.lastChild);
+    rng.setStartBefore(editor.getBody().firstChild?.lastChild as HTMLBRElement);
+    rng.setEndBefore(editor.getBody().firstChild?.lastChild as HTMLBRElement);
     editor.selection.setRng(rng);
     editor.selection.normalize();
 
@@ -895,8 +898,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.getBody().innerHTML = '<p><i><b></b></i><br /><br /></p>';
-    rng.setStartBefore(editor.getBody().firstChild.lastChild);
-    rng.setEndBefore(editor.getBody().firstChild.lastChild);
+    rng.setStartBefore(editor.getBody().firstChild?.lastChild as HTMLBRElement);
+    rng.setEndBefore(editor.getBody().firstChild?.lastChild as HTMLBRElement);
     editor.selection.setRng(rng);
     editor.selection.normalize();
 
@@ -910,8 +913,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.getBody().innerHTML = '<p><i><b><br /></b></i><br /></p>';
-    rng.setStartBefore(editor.getBody().firstChild.lastChild);
-    rng.setEndBefore(editor.getBody().firstChild.lastChild);
+    rng.setStartBefore(editor.getBody().firstChild?.lastChild as HTMLBRElement);
+    rng.setEndBefore(editor.getBody().firstChild?.lastChild as HTMLBRElement);
     editor.selection.setRng(rng);
     editor.selection.normalize();
 
@@ -925,8 +928,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.getBody().innerHTML = '<table><tr><td>X</td></tr></table>';
-    rng.setStartBefore(editor.getBody().firstChild);
-    rng.setEndAfter(editor.getBody().lastChild);
+    rng.setStartBefore(editor.getBody().firstChild as HTMLTableElement);
+    rng.setEndAfter(editor.getBody().lastChild as HTMLTableElement);
     editor.selection.setRng(rng);
     editor.selection.normalize();
 
@@ -942,8 +945,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.getBody().innerHTML = '<p>a</p>';
-    rng.setStartAfter(editor.getBody().firstChild);
-    rng.setEndAfter(editor.getBody().lastChild);
+    rng.setStartAfter(editor.getBody().firstChild as HTMLParagraphElement);
+    rng.setEndAfter(editor.getBody().lastChild as HTMLParagraphElement);
     editor.selection.setRng(rng);
     editor.selection.normalize();
 
@@ -959,8 +962,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.getBody().innerHTML = '<p>a<br /></p>';
-    rng.setStart(editor.getBody().firstChild, 2);
-    rng.setEnd(editor.getBody().firstChild, 2);
+    rng.setStart(editor.getBody().firstChild as HTMLParagraphElement, 2);
+    rng.setEnd(editor.getBody().firstChild as HTMLParagraphElement, 2);
     editor.selection.setRng(rng);
     editor.selection.normalize();
 
@@ -976,8 +979,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.setContent('<p><br /></p>');
-    rng.setStart(editor.getBody().firstChild, 1);
-    rng.setEnd(editor.getBody().firstChild, 1);
+    rng.setStart(editor.getBody().firstChild as HTMLParagraphElement, 1);
+    rng.setEnd(editor.getBody().firstChild as HTMLParagraphElement, 1);
     editor.selection.setRng(rng);
     editor.selection.normalize();
 
@@ -1027,8 +1030,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.setContent('<p>a<br /><br /></p>');
-    rng.setStart(editor.getBody().firstChild, 3);
-    rng.setEnd(editor.getBody().firstChild, 3);
+    rng.setStart(editor.getBody().firstChild as HTMLParagraphElement, 3);
+    rng.setEnd(editor.getBody().firstChild as HTMLParagraphElement, 3);
     editor.selection.setRng(rng);
     editor.selection.normalize();
 
@@ -1054,7 +1057,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
 
   it('selectorChanged', () => {
     const editor = hook.editor();
-    let newState: boolean, newArgs;
+    let newState: boolean | undefined;
+    let newArgs: { node: Node; selector: String; parents: Node[] } | undefined;
 
     editor.selection.selectorChanged('a[href]', (state, args) => {
       newState = state;
@@ -1066,21 +1070,23 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     editor.nodeChanged();
 
     assert.isTrue(newState);
-    assert.equal(newArgs.selector, 'a[href]');
-    LegacyUnit.equalDom(newArgs.node, editor.getBody().firstChild.firstChild);
-    assert.lengthOf(newArgs.parents, 2);
+    assert.equal(newArgs?.selector, 'a[href]');
+    LegacyUnit.equalDom(newArgs?.node as Node, editor.getBody().firstChild?.firstChild as HTMLAnchorElement);
+    assert.lengthOf(newArgs?.parents ?? [], 2);
 
     editor.setContent('<p>text</p>');
     LegacyUnit.setSelection(editor, 'p', 0, 'p', 4);
     editor.nodeChanged();
-    assert.equal(newArgs.selector, 'a[href]');
-    LegacyUnit.equalDom(newArgs.node, editor.getBody().firstChild);
-    assert.lengthOf(newArgs.parents, 1);
+    assert.equal(newArgs?.selector, 'a[href]');
+    LegacyUnit.equalDom(newArgs?.node as Node, editor.getBody().firstChild as HTMLParagraphElement);
+    assert.lengthOf(newArgs?.parents ?? [], 1);
   });
 
   it('selectorChangedWithUnbind', () => {
     const editor = hook.editor();
-    let newState: boolean, newArgs, calls = 0;
+    let newState: boolean | undefined;
+    let newArgs: { node: Node; selector: String; parents: Node[] } | undefined;
+    let calls = 0;
 
     const { unbind } = editor.selection.selectorChangedWithUnbind('a[href]', (state, args) => {
       newState = state;
@@ -1093,9 +1099,9 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     editor.nodeChanged();
 
     assert.isTrue(newState);
-    assert.equal(newArgs.selector, 'a[href]');
-    LegacyUnit.equalDom(newArgs.node, editor.getBody().firstChild.firstChild);
-    assert.lengthOf(newArgs.parents, 2);
+    assert.equal(newArgs?.selector, 'a[href]');
+    LegacyUnit.equalDom(newArgs?.node as Node, editor.getBody().firstChild?.firstChild as HTMLAnchorElement);
+    assert.lengthOf(newArgs?.parents ?? [], 2);
     assert.equal(calls, 1, 'selectorChangedWithUnbind callback is only called once');
 
     unbind();
@@ -1109,7 +1115,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
 
   it('TINY-3463: selectorChanged should setup the active state if already selected', () => {
     const editor = hook.editor();
-    let newState: boolean, newArgs;
+    let newState: boolean | undefined;
+    let newArgs: { node: Node; selector: String; parents: Node[] } | undefined;
 
     editor.setContent('<p>some <a href="#">text</a></p>');
     LegacyUnit.setSelection(editor, 'a', 0, 'a', 4);
@@ -1123,8 +1130,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     editor.nodeChanged();
 
     assert.isFalse(newState);
-    assert.equal(newArgs.selector, 'a[href]');
-    assert.lengthOf(newArgs.parents, 1);
+    assert.equal(newArgs?.selector, 'a[href]');
+    assert.lengthOf(newArgs?.parents ?? [], 1);
   });
 
   it('setRng', () => {
@@ -1132,11 +1139,11 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     let rng = editor.dom.createRng();
 
     editor.setContent('<p>x</p>');
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 1);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 1);
 
     editor.selection.setRng(rng);
-    editor.selection.setRng(null);
+    editor.selection.setRng(null as any);
 
     rng = editor.selection.getRng();
     LegacyUnit.equal(rng.startContainer.nodeName, '#text');
@@ -1151,8 +1158,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
 
     editor.setContent('<p>x</p>');
 
-    rng.setStart(editor.dom.select('p')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('p')[0].firstChild, 1);
+    rng.setStart(editor.dom.select('p')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 1);
     editor.selection.setRng(rng);
 
     const tmpNode = document.createTextNode('y');
@@ -1173,7 +1180,7 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     const editor = hook.editor();
 
     editor.setContent('<p><strong><em>x</em></strong></p>');
-    const textNode = editor.dom.select('em')[0].firstChild;
+    const textNode = editor.dom.select('em')[0].firstChild as Text;
 
     editor.setContent('');
 
@@ -1216,7 +1223,7 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
 */
   it('image selection webkit bug', () => {
     const editor = hook.editor();
-    const testImageSelection = (inputHtml, expectedContainerName, expectedOffset) => {
+    const testImageSelection = (inputHtml: string, expectedContainerName: string, expectedOffset: number) => {
       editor.setContent(inputHtml);
       editor.selection.select(editor.dom.select('img')[0]);
 
@@ -1229,7 +1236,8 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
       LegacyUnit.equal(editor.selection.getStart().nodeName, 'IMG');
       LegacyUnit.equal(editor.selection.getEnd().nodeName, 'IMG');
 
-      const nativeRng = editor.selection.getSel().getRangeAt(0);
+      const nativeSel = editor.selection.getSel() as Selection;
+      const nativeRng = nativeSel.getRangeAt(0);
       LegacyUnit.equal(nativeRng.startContainer.nodeName, 'P');
       LegacyUnit.equal(nativeRng.startOffset, expectedOffset);
       LegacyUnit.equal(nativeRng.startContainer.nodeName, 'P');

--- a/modules/tinymce/src/core/test/ts/browser/dom/SerializerEventsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SerializerEventsTest.ts
@@ -4,6 +4,8 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import { PostProcessEvent, PreProcessEvent } from 'tinymce/core/api/EventTypes';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 describe('browser.tinymce.core.dom.SerializerEventsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -14,7 +16,8 @@ describe('browser.tinymce.core.dom.SerializerEventsTest', () => {
 
   it('Pre/post process events', () => {
     const editor = hook.editor();
-    let preProcessArgs, postProcessArgs;
+    let preProcessArgs: EditorEvent<PreProcessEvent> | undefined;
+    let postProcessArgs: EditorEvent<PostProcessEvent> | undefined;
 
     editor.on('PreProcess', (o) => {
       preProcessArgs = o;
@@ -33,13 +36,13 @@ describe('browser.tinymce.core.dom.SerializerEventsTest', () => {
       editor.serializer.serialize(editor.getBody(), { test: 'abc', getInner: true })
     );
 
-    assert.equal(preProcessArgs.test, 'abc', 'Should be expected preprocess custom arg');
-    assert.equal(preProcessArgs.format, 'html', 'Should be expected preprocess format');
-    assert.equal(preProcessArgs.node.firstChild.tagName, 'P', 'Should be expected element child');
-    assert.equal(postProcessArgs.test, 'abc', 'Should be expected postprocess custom arg');
-    assert.equal(postProcessArgs.format, 'html', 'Should be expected postprocess format');
+    assert.equal(preProcessArgs?.test, 'abc', 'Should be expected preprocess custom arg');
+    assert.equal(preProcessArgs?.format, 'html', 'Should be expected preprocess format');
+    assert.equal(preProcessArgs?.node.firstChild?.nodeName, 'P', 'Should be expected element child');
+    assert.equal(postProcessArgs?.test, 'abc', 'Should be expected postprocess custom arg');
+    assert.equal(postProcessArgs?.format, 'html', 'Should be expected postprocess format');
     assert.equal(
-      postProcessArgs.content,
+      postProcessArgs?.content,
       '<p><span id="test2" class="abc"><em class="123">abc</em></span>123<a href="file.html">link</a></p>',
       'Should be expected postprocess format'
     );

--- a/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
@@ -20,40 +20,46 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     viewBlock.update('');
   });
 
+  const setTestHtml = (html: string) =>
+    DOM.setHTML('test', html);
+
+  const getTestElement = () =>
+    DOM.get('test') as HTMLElement;
+
   it('Schema rules', () => {
     let ser = DomSerializer({ fix_list_elements: true });
 
     ser.setRules('@[id|title|class|style],div,img[src|alt|-style|border],span,hr');
-    DOM.setHTML('test', '<img title="test" src="tinymce/ui/img/raster.gif" data-mce-src="tinymce/ui/img/raster.gif" alt="test" ' +
+    setTestHtml('<img title="test" src="tinymce/ui/img/raster.gif" data-mce-src="tinymce/ui/img/raster.gif" alt="test" ' +
       'border="0" style="border: 1px solid red" class="test" /><span id="test2">test</span><hr />');
     assert.equal(
-      ser.serialize(DOM.get('test'), { getInner: true }),
+      ser.serialize(getTestElement(), { getInner: true }),
       '<img title="test" class="test" src="tinymce/ui/img/raster.gif" ' +
       'alt="test" border="0"><span id="test2">test</span><hr>', 'Global rule'
     );
 
     ser.setRules('*a[*],em/i[*],strong/b[*i*]');
-    DOM.setHTML('test', '<a href="test" data-mce-href="test">test</a><strong title="test" class="test">test2</strong><em title="test">test3</em>');
-    assert.equal(ser.serialize(DOM.get('test')), '<a href="test">test</a><strong title="test">test2</strong><em title="test">' +
+    setTestHtml('<a href="test" data-mce-href="test">test</a><strong title="test" class="test">test2</strong><em title="test">test3</em>');
+    assert.equal(ser.serialize(getTestElement()), '<a href="test">test</a><strong title="test">test2</strong><em title="test">' +
       'test3</em>', 'Wildcard rules');
 
     ser.setRules('br,hr,input[type|name|value],div[id],span[id],strong/b,a,em/i,a[!href|!name],img[src|border=0|title={$uid}]');
-    DOM.setHTML('test', '<br /><hr /><input type="text" name="test" value="val" class="no" />' +
+    setTestHtml('<br /><hr /><input type="text" name="test" value="val" class="no" />' +
       '<span id="test2" class="no"><b class="no">abc</b><em class="no">123</em></span>123<a href="file.html" ' +
       'data-mce-href="file.html">link</a><a name="anchor"></a><a>no</a><img src="tinymce/ui/img/raster.gif" ' +
       'data-mce-src="tinymce/ui/img/raster.gif" />');
-    assert.equal(ser.serialize(DOM.get('test')), '<div id="test"><br><hr><input type="text" name="test" value="val">' +
+    assert.equal(ser.serialize(getTestElement()), '<div id="test"><br><hr><input type="text" name="test" value="val">' +
       '<span id="test2"><strong>abc</strong><em>123</em></span>123<a href="file.html">link</a>' +
       '<a name="anchor"></a>no<img src="tinymce/ui/img/raster.gif" border="0" title="mce_0"></div>', 'Output name and attribute rules');
 
     ser.setRules('img[src|border=0|alt=]');
-    DOM.setHTML('test', '<img src="tinymce/ui/img/raster.gif" data-mce-src="tinymce/ui/img/raster.gif" border="0" alt="" />');
-    assert.equal(ser.serialize(DOM.get('test')), '<img src="tinymce/ui/img/raster.gif" border="0" alt="">', 'Default attribute with empty value');
+    setTestHtml('<img src="tinymce/ui/img/raster.gif" data-mce-src="tinymce/ui/img/raster.gif" border="0" alt="" />');
+    assert.equal(ser.serialize(getTestElement()), '<img src="tinymce/ui/img/raster.gif" border="0" alt="">', 'Default attribute with empty value');
 
     ser.setRules('img[src|border=0|alt=],div[style|id],*[*]');
-    DOM.setHTML('test', '<img src="tinymce/ui/img/raster.gif" data-mce-src="tinymce/ui/img/raster.gif" /><hr />');
+    setTestHtml('<img src="tinymce/ui/img/raster.gif" data-mce-src="tinymce/ui/img/raster.gif" /><hr />');
     assert.equal(
-      ser.serialize(DOM.get('test'), { getInner: true }),
+      ser.serialize(getTestElement(), { getInner: true }),
       '<img src="tinymce/ui/img/raster.gif" border="0" alt=""><hr>'
     );
 
@@ -61,16 +67,16 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
       valid_elements: 'img[src|border=0|alt=]',
       extended_valid_elements: 'div[id],img[src|alt=]'
     });
-    DOM.setHTML('test', '<img src="tinymce/ui/img/raster.gif" data-mce-src="tinymce/ui/img/raster.gif" alt="" />');
+    setTestHtml('<img src="tinymce/ui/img/raster.gif" data-mce-src="tinymce/ui/img/raster.gif" alt="" />');
     assert.equal(
-      ser.serialize(DOM.get('test')),
+      ser.serialize(getTestElement()),
       '<div id="test"><img src="tinymce/ui/img/raster.gif" alt=""></div>'
     );
 
     ser = DomSerializer({ invalid_elements: 'hr,br' });
-    DOM.setHTML('test', '<img src="tinymce/ui/img/raster.gif" data-mce-src="tinymce/ui/img/raster.gif" /><hr /><br />');
+    setTestHtml('<img src="tinymce/ui/img/raster.gif" data-mce-src="tinymce/ui/img/raster.gif" /><hr /><br />');
     assert.equal(
-      ser.serialize(DOM.get('test'), { getInner: true }),
+      ser.serialize(getTestElement(), { getInner: true }),
       '<img src="tinymce/ui/img/raster.gif">'
     );
   });
@@ -78,33 +84,33 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
   it('allow_unsafe_link_target (default)', () => {
     const ser = DomSerializer({ });
 
-    DOM.setHTML('test', '<a href="a" target="_blank">a</a><a href="b" target="_blank">b</a>');
+    setTestHtml('<a href="a" target="_blank">a</a><a href="b" target="_blank">b</a>');
     assert.equal(
-      ser.serialize(DOM.get('test'), { getInner: true }),
+      ser.serialize(getTestElement(), { getInner: true }),
       '<a href="a" target="_blank" rel="noopener">a</a><a href="b" target="_blank" rel="noopener">b</a>'
     );
 
-    DOM.setHTML('test', '<a href="a" rel="lightbox" target="_blank">a</a><a href="b" rel="lightbox" target="_blank">b</a>');
+    setTestHtml('<a href="a" rel="lightbox" target="_blank">a</a><a href="b" rel="lightbox" target="_blank">b</a>');
     assert.equal(
-      ser.serialize(DOM.get('test'), { getInner: true }),
+      ser.serialize(getTestElement(), { getInner: true }),
       '<a href="a" target="_blank" rel="lightbox noopener">a</a><a href="b" target="_blank" rel="lightbox noopener">b</a>'
     );
 
-    DOM.setHTML('test', '<a href="a" rel="lightbox x" target="_blank">a</a><a href="b" rel="lightbox x" target="_blank">b</a>');
+    setTestHtml('<a href="a" rel="lightbox x" target="_blank">a</a><a href="b" rel="lightbox x" target="_blank">b</a>');
     assert.equal(
-      ser.serialize(DOM.get('test'), { getInner: true }),
+      ser.serialize(getTestElement(), { getInner: true }),
       '<a href="a" target="_blank" rel="lightbox noopener x">a</a><a href="b" target="_blank" rel="lightbox noopener x">b</a>'
     );
 
-    DOM.setHTML('test', '<a href="a" rel="noopener a" target="_blank">a</a>');
+    setTestHtml('<a href="a" rel="noopener a" target="_blank">a</a>');
     assert.equal(
-      ser.serialize(DOM.get('test'), { getInner: true }),
+      ser.serialize(getTestElement(), { getInner: true }),
       '<a href="a" target="_blank" rel="noopener a">a</a>'
     );
 
-    DOM.setHTML('test', '<a href="a" rel="a noopener b" target="_blank">a</a>');
+    setTestHtml('<a href="a" rel="a noopener b" target="_blank">a</a>');
     assert.equal(
-      ser.serialize(DOM.get('test'), { getInner: true }),
+      ser.serialize(getTestElement(), { getInner: true }),
       '<a href="a" target="_blank" rel="a noopener b">a</a>'
     );
   });
@@ -112,9 +118,9 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
   it('allow_unsafe_link_target (disabled)', () => {
     const ser = DomSerializer({ allow_unsafe_link_target: true });
 
-    DOM.setHTML('test', '<a href="a" target="_blank">a</a><a href="b" target="_blank">b</a>');
+    setTestHtml('<a href="a" target="_blank">a</a><a href="b" target="_blank">b</a>');
     assert.equal(
-      ser.serialize(DOM.get('test'), { getInner: true }),
+      ser.serialize(getTestElement(), { getInner: true }),
       '<a href="a" target="_blank">a</a><a href="b" target="_blank">b</a>'
     );
   });
@@ -122,9 +128,9 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
   it('format tree', () => {
     const ser = DomSerializer({ });
 
-    DOM.setHTML('test', 'a');
+    setTestHtml('a');
     assert.equal(
-      ser.serialize(DOM.get('test'), { format: 'tree' }).name,
+      ser.serialize(getTestElement(), { format: 'tree' }).name,
       'body'
     );
   });
@@ -133,20 +139,20 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     let ser: DomSerializer;
 
     ser = DomSerializer({ entity_encoding: 'numeric' });
-    DOM.setHTML('test', '&lt;&gt;&amp;&quot;&nbsp;&aring;&auml;&ouml;');
-    assert.equal(ser.serialize(DOM.get('test'), { getInner: true }), '&lt;&gt;&amp;"&#160;&#229;&#228;&#246;');
+    setTestHtml('&lt;&gt;&amp;&quot;&nbsp;&aring;&auml;&ouml;');
+    assert.equal(ser.serialize(getTestElement(), { getInner: true }), '&lt;&gt;&amp;"&#160;&#229;&#228;&#246;');
 
     ser = DomSerializer({ entity_encoding: 'named' });
-    DOM.setHTML('test', '&lt;&gt;&amp;&quot;&nbsp;&aring;&auml;&ouml;');
-    assert.equal(ser.serialize(DOM.get('test'), { getInner: true }), '&lt;&gt;&amp;"&nbsp;&aring;&auml;&ouml;');
+    setTestHtml('&lt;&gt;&amp;&quot;&nbsp;&aring;&auml;&ouml;');
+    assert.equal(ser.serialize(getTestElement(), { getInner: true }), '&lt;&gt;&amp;"&nbsp;&aring;&auml;&ouml;');
 
     ser = DomSerializer({ entity_encoding: 'named+numeric', entities: '160,nbsp,34,quot,38,amp,60,lt,62,gt' });
-    DOM.setHTML('test', '&lt;&gt;&amp;&quot;&nbsp;&aring;&auml;&ouml;');
-    assert.equal(ser.serialize(DOM.get('test'), { getInner: true }), '&lt;&gt;&amp;"&nbsp;&#229;&#228;&#246;');
+    setTestHtml('&lt;&gt;&amp;&quot;&nbsp;&aring;&auml;&ouml;');
+    assert.equal(ser.serialize(getTestElement(), { getInner: true }), '&lt;&gt;&amp;"&nbsp;&#229;&#228;&#246;');
 
     ser = DomSerializer({ entity_encoding: 'raw' });
-    DOM.setHTML('test', '&lt;&gt;&amp;&quot;&nbsp;&aring;&auml;&ouml;');
-    assert.equal(ser.serialize(DOM.get('test'), { getInner: true }), '&lt;&gt;&amp;"\u00a0\u00e5\u00e4\u00f6');
+    setTestHtml('&lt;&gt;&amp;&quot;&nbsp;&aring;&auml;&ouml;');
+    assert.equal(ser.serialize(getTestElement(), { getInner: true }), '&lt;&gt;&amp;"\u00a0\u00e5\u00e4\u00f6');
   });
 
   it('Form elements (general)', () => {
@@ -157,23 +163,23 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
       'option[value|selected],textarea[name|disabled|readonly]'
     );
 
-    DOM.setHTML('test', '<input type="text" />');
-    assert.equal(ser.serialize(DOM.get('test')), '<input type="text">');
+    setTestHtml('<input type="text" />');
+    assert.equal(ser.serialize(getTestElement()), '<input type="text">');
 
-    DOM.setHTML('test', '<input type="text" value="text" length="128" maxlength="129" />');
-    assert.equal(ser.serialize(DOM.get('test')), '<input type="text" value="text" length="128" maxlength="129">');
+    setTestHtml('<input type="text" value="text" length="128" maxlength="129" />');
+    assert.equal(ser.serialize(getTestElement()), '<input type="text" value="text" length="128" maxlength="129">');
 
-    DOM.setHTML('test', '<form method="post"><input type="hidden" name="formmethod" value="get" /></form>');
-    assert.equal(ser.serialize(DOM.get('test')), '<form method="post"><input type="hidden" name="formmethod" value="get"></form>');
+    setTestHtml('<form method="post"><input type="hidden" name="formmethod" value="get" /></form>');
+    assert.equal(ser.serialize(getTestElement()), '<form method="post"><input type="hidden" name="formmethod" value="get"></form>');
 
-    DOM.setHTML('test', '<label for="test">label</label>');
-    assert.equal(ser.serialize(DOM.get('test')), '<label for="test">label</label>');
+    setTestHtml('<label for="test">label</label>');
+    assert.equal(ser.serialize(getTestElement()), '<label for="test">label</label>');
 
-    DOM.setHTML('test', '<input type="checkbox" value="test" /><input type="button" /><textarea></textarea>');
+    setTestHtml('<input type="checkbox" value="test" /><input type="button" /><textarea></textarea>');
 
     // Edge will add an empty input value so remove that to normalize test since it doesn't break anything
     assert.equal(
-      ser.serialize(DOM.get('test')).replace(/ value=""/g, ''),
+      ser.serialize(getTestElement()).replace(/ value=""/g, ''),
       '<input type="checkbox" value="test"><input type="button"><textarea></textarea>'
     );
   });
@@ -183,17 +189,17 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
 
     ser.setRules('form[method],label[for],input[type|name|value|checked|disabled|readonly|length|maxlength],select[multiple],option[value|selected]');
 
-    DOM.setHTML('test', '<input type="checkbox" value="1">');
-    assert.equal(ser.serialize(DOM.get('test')), '<input type="checkbox" value="1">');
+    setTestHtml('<input type="checkbox" value="1">');
+    assert.equal(ser.serialize(getTestElement()), '<input type="checkbox" value="1">');
 
-    DOM.setHTML('test', '<input type="checkbox" value="1" checked disabled readonly>');
-    assert.equal(ser.serialize(DOM.get('test')), '<input type="checkbox" value="1" checked="checked" disabled="disabled" readonly="readonly">');
+    setTestHtml('<input type="checkbox" value="1" checked disabled readonly>');
+    assert.equal(ser.serialize(getTestElement()), '<input type="checkbox" value="1" checked="checked" disabled="disabled" readonly="readonly">');
 
-    DOM.setHTML('test', '<input type="checkbox" value="1" checked="1" disabled="1" readonly="1">');
-    assert.equal(ser.serialize(DOM.get('test')), '<input type="checkbox" value="1" checked="checked" disabled="disabled" readonly="readonly">');
+    setTestHtml('<input type="checkbox" value="1" checked="1" disabled="1" readonly="1">');
+    assert.equal(ser.serialize(getTestElement()), '<input type="checkbox" value="1" checked="checked" disabled="disabled" readonly="readonly">');
 
-    DOM.setHTML('test', '<input type="checkbox" value="1" checked="true" disabled="true" readonly="true">');
-    assert.equal(ser.serialize(DOM.get('test')), '<input type="checkbox" value="1" checked="checked" disabled="disabled" readonly="readonly">');
+    setTestHtml('<input type="checkbox" value="1" checked="true" disabled="true" readonly="true">');
+    assert.equal(ser.serialize(getTestElement()), '<input type="checkbox" value="1" checked="checked" disabled="disabled" readonly="readonly">');
   });
 
   it('Form elements (select)', () => {
@@ -201,26 +207,26 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
 
     ser.setRules('form[method],label[for],input[type|name|value|checked|disabled|readonly|length|maxlength],select[multiple],option[value|selected]');
 
-    DOM.setHTML('test', '<select><option value="1">test1</option><option value="2" selected>test2</option></select>');
-    assert.equal(ser.serialize(DOM.get('test')), '<select><option value="1">test1</option><option value="2" selected="selected">test2</option></select>');
+    setTestHtml('<select><option value="1">test1</option><option value="2" selected>test2</option></select>');
+    assert.equal(ser.serialize(getTestElement()), '<select><option value="1">test1</option><option value="2" selected="selected">test2</option></select>');
 
-    DOM.setHTML('test', '<select><option value="1">test1</option><option selected="1" value="2">test2</option></select>');
-    assert.equal(ser.serialize(DOM.get('test')), '<select><option value="1">test1</option><option value="2" selected="selected">test2</option></select>');
+    setTestHtml('<select><option value="1">test1</option><option selected="1" value="2">test2</option></select>');
+    assert.equal(ser.serialize(getTestElement()), '<select><option value="1">test1</option><option value="2" selected="selected">test2</option></select>');
 
-    DOM.setHTML('test', '<select><option value="1">test1</option><option value="2" selected="true">test2</option></select>');
-    assert.equal(ser.serialize(DOM.get('test')), '<select><option value="1">test1</option><option value="2" selected="selected">test2</option></select>');
+    setTestHtml('<select><option value="1">test1</option><option value="2" selected="true">test2</option></select>');
+    assert.equal(ser.serialize(getTestElement()), '<select><option value="1">test1</option><option value="2" selected="selected">test2</option></select>');
 
-    DOM.setHTML('test', '<select multiple></select>');
-    assert.equal(ser.serialize(DOM.get('test')), '<select multiple="multiple"></select>');
+    setTestHtml('<select multiple></select>');
+    assert.equal(ser.serialize(getTestElement()), '<select multiple="multiple"></select>');
 
-    DOM.setHTML('test', '<select multiple="multiple"></select>');
-    assert.equal(ser.serialize(DOM.get('test')), '<select multiple="multiple"></select>');
+    setTestHtml('<select multiple="multiple"></select>');
+    assert.equal(ser.serialize(getTestElement()), '<select multiple="multiple"></select>');
 
-    DOM.setHTML('test', '<select multiple="1"></select>');
-    assert.equal(ser.serialize(DOM.get('test')), '<select multiple="multiple"></select>');
+    setTestHtml('<select multiple="1"></select>');
+    assert.equal(ser.serialize(getTestElement()), '<select multiple="multiple"></select>');
 
-    DOM.setHTML('test', '<select></select>');
-    assert.equal(ser.serialize(DOM.get('test')), '<select></select>');
+    setTestHtml('<select></select>');
+    assert.equal(ser.serialize(getTestElement()), '<select></select>');
   });
 
   it('List elements', () => {
@@ -228,20 +234,20 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
 
     ser.setRules('ul[compact],ol,li');
 
-    DOM.setHTML('test', '<ul compact></ul>');
-    assert.equal(ser.serialize(DOM.get('test')), '<ul compact="compact"></ul>');
+    setTestHtml('<ul compact></ul>');
+    assert.equal(ser.serialize(getTestElement()), '<ul compact="compact"></ul>');
 
-    DOM.setHTML('test', '<ul compact="compact"></ul>');
-    assert.equal(ser.serialize(DOM.get('test')), '<ul compact="compact"></ul>');
+    setTestHtml('<ul compact="compact"></ul>');
+    assert.equal(ser.serialize(getTestElement()), '<ul compact="compact"></ul>');
 
-    DOM.setHTML('test', '<ul compact="1"></ul>');
-    assert.equal(ser.serialize(DOM.get('test')), '<ul compact="compact"></ul>');
+    setTestHtml('<ul compact="1"></ul>');
+    assert.equal(ser.serialize(getTestElement()), '<ul compact="compact"></ul>');
 
-    DOM.setHTML('test', '<ul></ul>');
-    assert.equal(ser.serialize(DOM.get('test')), '<ul></ul>');
+    setTestHtml('<ul></ul>');
+    assert.equal(ser.serialize(getTestElement()), '<ul></ul>');
 
-    DOM.setHTML('test', '<ol><li>a</li><ol><li>b</li><li>c</li></ol><li>e</li></ol>');
-    assert.equal(ser.serialize(DOM.get('test')), '<ol><li>a<ol><li>b</li><li>c</li></ol></li><li>e</li></ol>');
+    setTestHtml('<ol><li>a</li><ol><li>b</li><li>c</li></ol><li>e</li></ol>');
+    assert.equal(ser.serialize(getTestElement()), '<ol><li>a<ol><li>b</li><li>c</li></ol></li><li>e</li></ol>');
   });
 
   it('Tables', () => {
@@ -249,17 +255,17 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
 
     ser.setRules('table,tr,td[nowrap]');
 
-    DOM.setHTML('test', '<table><tr><td></td></tr></table>');
-    assert.equal(ser.serialize(DOM.get('test')), '<table><tr><td></td></tr></table>');
+    setTestHtml('<table><tr><td></td></tr></table>');
+    assert.equal(ser.serialize(getTestElement()), '<table><tr><td></td></tr></table>');
 
-    DOM.setHTML('test', '<table><tr><td nowrap></td></tr></table>');
-    assert.equal(ser.serialize(DOM.get('test')), '<table><tr><td nowrap="nowrap"></td></tr></table>');
+    setTestHtml('<table><tr><td nowrap></td></tr></table>');
+    assert.equal(ser.serialize(getTestElement()), '<table><tr><td nowrap="nowrap"></td></tr></table>');
 
-    DOM.setHTML('test', '<table><tr><td nowrap="nowrap"></td></tr></table>');
-    assert.equal(ser.serialize(DOM.get('test')), '<table><tr><td nowrap="nowrap"></td></tr></table>');
+    setTestHtml('<table><tr><td nowrap="nowrap"></td></tr></table>');
+    assert.equal(ser.serialize(getTestElement()), '<table><tr><td nowrap="nowrap"></td></tr></table>');
 
-    DOM.setHTML('test', '<table><tr><td nowrap="1"></td></tr></table>');
-    assert.equal(ser.serialize(DOM.get('test')), '<table><tr><td nowrap="nowrap"></td></tr></table>');
+    setTestHtml('<table><tr><td nowrap="1"></td></tr></table>');
+    assert.equal(ser.serialize(getTestElement()), '<table><tr><td nowrap="nowrap"></td></tr></table>');
   });
 
   it('Styles', () => {
@@ -267,8 +273,8 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
 
     ser.setRules('*[*]');
 
-    DOM.setHTML('test', '<span style="border: 1px solid red" data-mce-style="border: 1px solid red;">test</span>');
-    assert.equal(ser.serialize(DOM.get('test'), { getInner: true }), '<span style="border: 1px solid red;">test</span>');
+    setTestHtml('<span style="border: 1px solid red" data-mce-style="border: 1px solid red;">test</span>');
+    assert.equal(ser.serialize(getTestElement(), { getInner: true }), '<span style="border: 1px solid red;">test</span>');
   });
 
   it('Comments', () => {
@@ -276,8 +282,8 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
 
     ser.setRules('*[*]');
 
-    DOM.setHTML('test', '<!-- abc -->');
-    assert.equal(ser.serialize(DOM.get('test'), { getInner: true }), '<!-- abc -->');
+    setTestHtml('<!-- abc -->');
+    assert.equal(ser.serialize(getTestElement(), { getInner: true }), '<!-- abc -->');
   });
 
   it('Non HTML elements and attributes', () => {
@@ -286,11 +292,11 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     ser.setRules('*[*]');
     ser.schema.addValidChildren('+div[prefix:test]');
 
-    DOM.setHTML('test', '<div test:attr="test">test</div>');
-    assert.equal(ser.serialize(DOM.get('test'), { getInner: true }), '<div test:attr="test">test</div>');
+    setTestHtml('<div test:attr="test">test</div>');
+    assert.equal(ser.serialize(getTestElement(), { getInner: true }), '<div test:attr="test">test</div>');
 
-    DOM.setHTML('test', 'test1<prefix:test>Test</prefix:test>test2');
-    assert.equal(ser.serialize(DOM.get('test'), { getInner: true }), 'test1<prefix:test>Test</prefix:test>test2');
+    setTestHtml('test1<prefix:test>Test</prefix:test>test2');
+    assert.equal(ser.serialize(getTestElement(), { getInner: true }), 'test1<prefix:test>Test</prefix:test>test2');
   });
 
   it('Padd empty elements', () => {
@@ -298,8 +304,8 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
 
     ser.setRules('#p');
 
-    DOM.setHTML('test', '<p>test</p><p></p>');
-    assert.equal(ser.serialize(DOM.get('test')), '<p>test</p><p>&nbsp;</p>');
+    setTestHtml('<p>test</p><p></p>');
+    assert.equal(ser.serialize(getTestElement()), '<p>test</p><p>&nbsp;</p>');
   });
 
   it('Do not padd empty elements with padded children', () => {
@@ -307,8 +313,8 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
 
     ser.setRules('#p,#span,b');
 
-    DOM.setHTML('test', '<p><span></span></p><p><b><span></span></b></p>');
-    assert.equal(ser.serialize(DOM.get('test')), '<p><span>&nbsp;</span></p><p><b><span>&nbsp;</span></b></p>');
+    setTestHtml('<p><span></span></p><p><b><span></span></b></p>');
+    assert.equal(ser.serialize(getTestElement()), '<p><span>&nbsp;</span></p><p><b><span>&nbsp;</span></b></p>');
   });
 
   it('Remove empty elements', () => {
@@ -316,16 +322,16 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
 
     ser.setRules('-p');
 
-    DOM.setHTML('test', '<p>test</p><p></p>');
-    assert.equal(ser.serialize(DOM.get('test')), '<p>test</p>');
+    setTestHtml('<p>test</p><p></p>');
+    assert.equal(ser.serialize(getTestElement()), '<p>test</p>');
   });
 
   it('Script with non JS type attribute', () => {
     const ser = DomSerializer({ fix_list_elements: true });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<s' + 'cript type="mylanguage"></s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<s' + 'cript type="mylanguage"></s' + 'cript>');
+    setTestHtml('<s' + 'cript type="mylanguage"></s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<s' + 'cript type="mylanguage"></s' + 'cript>');
   });
 
   // TODO: TINY-4627/TINY-8363
@@ -333,9 +339,9 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     const ser = DomSerializer({ fix_list_elements: true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<s' + 'cript>// <img src="test"><a href="#"></a></s' + 'cript>');
+    setTestHtml('<s' + 'cript>// <img src="test"><a href="#"></a></s' + 'cript>');
     assert.equal(
-      ser.serialize(DOM.get('test')).replace(/\r/g, ''),
+      ser.serialize(getTestElement()).replace(/\r/g, ''),
       '<s' + 'cript>// <![CDATA[\n// <img src="test"><a href="#"></a>\n// ]]></s' + 'cript>'
     );
   });
@@ -345,9 +351,9 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     const ser = DomSerializer({ fix_list_elements: true });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<s' + 'cript>// <img src="test"><a href="#"></a></s' + 'cript>');
+    setTestHtml('<s' + 'cript>// <img src="test"><a href="#"></a></s' + 'cript>');
     assert.equal(
-      ser.serialize(DOM.get('test')).replace(/\r/g, ''),
+      ser.serialize(getTestElement()).replace(/\r/g, ''),
       '<s' + 'cript>// <img src="test"><a href="#"></a></s' + 'cript>'
     );
   });
@@ -356,41 +362,41 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     const ser = DomSerializer({ fix_list_elements: true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<s' + 'cript>1 < 2;</s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<s' + 'cript>// <![CDATA[\n1 < 2;\n// ]]></s' + 'cript>');
+    setTestHtml('<s' + 'cript>1 < 2;</s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<s' + 'cript>// <![CDATA[\n1 < 2;\n// ]]></s' + 'cript>');
   });
 
   it('Script with less than', () => {
     const ser = DomSerializer({ fix_list_elements: true });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<s' + 'cript>1 < 2;</s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<s' + 'cript>1 < 2;</s' + 'cript>');
+    setTestHtml('<s' + 'cript>1 < 2;</s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<s' + 'cript>1 < 2;</s' + 'cript>');
   });
 
   it('Script with type attrib and less than with element_format: xhtml', () => {
     const ser = DomSerializer({ fix_list_elements: true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<s' + 'cript type="text/javascript">1 < 2;</s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<script type="text/javascript">// <![CDATA[\n1 < 2;\n// ]]></s' + 'cript>');
+    setTestHtml('<s' + 'cript type="text/javascript">1 < 2;</s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<script type="text/javascript">// <![CDATA[\n1 < 2;\n// ]]></s' + 'cript>');
   });
 
   it('Script with type attrib and less than', () => {
     const ser = DomSerializer({ fix_list_elements: true });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<s' + 'cript type="text/javascript">1 < 2;</s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<script type=\"text/javascript\">1 < 2;</script>');
+    setTestHtml('<s' + 'cript type="text/javascript">1 < 2;</s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<script type=\"text/javascript\">1 < 2;</script>');
   });
 
   it('Script with whitespace in beginning/end with element_format: xhtml', () => {
     const ser = DomSerializer({ fix_list_elements: true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script>\n\t1 < 2;\n\t if (2 < 1)\n\t\talert(1);\n</s' + 'cript>');
+    setTestHtml('<script>\n\t1 < 2;\n\t if (2 < 1)\n\t\talert(1);\n</s' + 'cript>');
     assert.equal(
-      ser.serialize(DOM.get('test')).replace(/\r/g, ''),
+      ser.serialize(getTestElement()).replace(/\r/g, ''),
       '<s' + 'cript>// <![CDATA[\n\t1 < 2;\n\t if (2 < 1)\n\t\talert(1);\n// ]]></s' + 'cript>'
     );
   });
@@ -399,9 +405,9 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     const ser = DomSerializer({ fix_list_elements: true });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script>\n\t1 < 2;\n\t if (2 < 1)\n\t\talert(1);\n</s' + 'cript>');
+    setTestHtml('<script>\n\t1 < 2;\n\t if (2 < 1)\n\t\talert(1);\n</s' + 'cript>');
     assert.equal(
-      ser.serialize(DOM.get('test')).replace(/\r/g, ''),
+      ser.serialize(getTestElement()).replace(/\r/g, ''),
       '<script>\n\t1 < 2;\n\t if (2 < 1)\n\t\talert(1);\n</script>'
     );
   });
@@ -410,176 +416,176 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     const ser = DomSerializer({ fix_list_elements: true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script><!-- 1 < 2; // --></s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<s' + 'cript>// <![CDATA[\n1 < 2;\n// ]]></s' + 'cript>');
+    setTestHtml('<script><!-- 1 < 2; // --></s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<s' + 'cript>// <![CDATA[\n1 < 2;\n// ]]></s' + 'cript>');
   });
 
   it('Script with a HTML comment and less than', () => {
     const ser = DomSerializer({ fix_list_elements: true });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script><!-- 1 < 2; // --></s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<script><!-- 1 < 2; // --></script>');
+    setTestHtml('<script><!-- 1 < 2; // --></s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<script><!-- 1 < 2; // --></script>');
   });
 
   it('Script with white space in beginning, comment and less than with element_format: xhtml', () => {
     const ser = DomSerializer({ fix_list_elements: true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script>\n\n<!-- 1 < 2;\n\n--></s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<s' + 'cript>// <![CDATA[\n1 < 2;\n// ]]></s' + 'cript>');
+    setTestHtml('<script>\n\n<!-- 1 < 2;\n\n--></s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<s' + 'cript>// <![CDATA[\n1 < 2;\n// ]]></s' + 'cript>');
   });
 
   it('Script with white space in beginning, comment and less than', () => {
     const ser = DomSerializer({ fix_list_elements: true });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script>\n\n<!-- 1 < 2;\n\n--></s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<script>\n\n<!-- 1 < 2;\n\n--></script>');
+    setTestHtml('<script>\n\n<!-- 1 < 2;\n\n--></s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<script>\n\n<!-- 1 < 2;\n\n--></script>');
   });
 
   it('Script with comments and cdata with element_format: xhtml', () => {
     const ser = DomSerializer({ fix_list_elements: true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script>// <![CDATA[1 < 2; // ]]></s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<s' + 'cript>// <![CDATA[\n1 < 2;\n// ]]></s' + 'cript>');
+    setTestHtml('<script>// <![CDATA[1 < 2; // ]]></s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<s' + 'cript>// <![CDATA[\n1 < 2;\n// ]]></s' + 'cript>');
   });
 
   it('Script with comments and cdata', () => {
     const ser = DomSerializer({ fix_list_elements: true });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script>// <![CDATA[1 < 2; // ]]></s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<script>// <![CDATA[1 < 2; // ]]></script>');
+    setTestHtml('<script>// <![CDATA[1 < 2; // ]]></s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<script>// <![CDATA[1 < 2; // ]]></script>');
   });
 
   it('Script with cdata with element_format: xhtml', () => {
     const ser = DomSerializer({ fix_list_elements: true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script><![CDATA[1 < 2; ]]></s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<s' + 'cript>// <![CDATA[\n1 < 2;\n// ]]></s' + 'cript>');
+    setTestHtml('<script><![CDATA[1 < 2; ]]></s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<s' + 'cript>// <![CDATA[\n1 < 2;\n// ]]></s' + 'cript>');
   });
 
   it('Script with cdata', () => {
     const ser = DomSerializer({ fix_list_elements: true });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script><![CDATA[1 < 2; ]]></s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<script><![CDATA[1 < 2; ]]></script>');
+    setTestHtml('<script><![CDATA[1 < 2; ]]></s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<script><![CDATA[1 < 2; ]]></script>');
   });
 
   it('Script whitespace in beginning/end and cdata with element_format: xhtml', () => {
     const ser = DomSerializer({ fix_list_elements: true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script>\n\n<![CDATA[\n\n1 < 2;\n\n]]>\n\n</s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<s' + 'cript>// <![CDATA[\n1 < 2;\n// ]]></s' + 'cript>');
+    setTestHtml('<script>\n\n<![CDATA[\n\n1 < 2;\n\n]]>\n\n</s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<s' + 'cript>// <![CDATA[\n1 < 2;\n// ]]></s' + 'cript>');
   });
 
   it('Script whitespace in beginning/end and cdata', () => {
     const ser = DomSerializer({ fix_list_elements: true });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script>\n\n<![CDATA[\n\n1 < 2;\n\n]]>\n\n</s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<script>\n\n<![CDATA[\n\n1 < 2;\n\n]]>\n\n</script>');
+    setTestHtml('<script>\n\n<![CDATA[\n\n1 < 2;\n\n]]>\n\n</s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<script>\n\n<![CDATA[\n\n1 < 2;\n\n]]>\n\n</script>');
   });
 
   it('Whitespace preserve in pre', () => {
     const ser = DomSerializer({ fix_list_elements: true });
     ser.setRules('pre');
 
-    DOM.setHTML('test', '<pre>  </pre>');
-    assert.equal(ser.serialize(DOM.get('test')), '<pre>  </pre>');
+    setTestHtml('<pre>  </pre>');
+    assert.equal(ser.serialize(getTestElement()), '<pre>  </pre>');
   });
 
   it('Script with src attr', () => {
     const ser = DomSerializer({ fix_list_elements: true });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script src="test.js" data-mce-src="test.js"></s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')), '<s' + 'cript src="test.js"></s' + 'cript>');
+    setTestHtml('<script src="test.js" data-mce-src="test.js"></s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()), '<s' + 'cript src="test.js"></s' + 'cript>');
   });
 
   it('Script with HTML comment, comment and CDATA with element_format: xhtml', () => {
     const ser = DomSerializer({ fix_list_elements: true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script><!--// <![CDATA[var hi = "hello";// ]]>--></s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')), '<script>// <![CDATA[\nvar hi = \"hello\";\n// ]]></s' + 'cript>');
+    setTestHtml('<script><!--// <![CDATA[var hi = "hello";// ]]>--></s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()), '<script>// <![CDATA[\nvar hi = \"hello\";\n// ]]></s' + 'cript>');
   });
 
   it('Script with HTML comment, comment and CDATA', () => {
     const ser = DomSerializer({ fix_list_elements: true });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script><!--// <![CDATA[var hi = "hello";// ]]>--></s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')), '<script><!--// <![CDATA[var hi = \"hello\";// ]]>--></script>');
+    setTestHtml('<script><!--// <![CDATA[var hi = "hello";// ]]>--></s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()), '<script><!--// <![CDATA[var hi = \"hello\";// ]]>--></script>');
   });
 
   it('Script with block comment around cdata with element_format: xhtml', () => {
     const ser = DomSerializer({ fix_list_elements: true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script>/* <![CDATA[ */\nvar hi = "hello";\n/* ]]> */</s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')), '<script>// <![CDATA[\nvar hi = \"hello\";\n// ]]></s' + 'cript>');
+    setTestHtml('<script>/* <![CDATA[ */\nvar hi = "hello";\n/* ]]> */</s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()), '<script>// <![CDATA[\nvar hi = \"hello\";\n// ]]></s' + 'cript>');
   });
 
   it('Script with block comment around cdata', () => {
     const ser = DomSerializer({ fix_list_elements: true });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script>/* <![CDATA[ */\nvar hi = "hello";\n/* ]]> */</s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')), '<script>/* <![CDATA[ */\nvar hi = \"hello\";\n/* ]]> */</script>');
+    setTestHtml('<script>/* <![CDATA[ */\nvar hi = "hello";\n/* ]]> */</s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()), '<script>/* <![CDATA[ */\nvar hi = \"hello\";\n/* ]]> */</script>');
   });
 
   it('Script with html comment and block comment around cdata with element_format: xhtml', () => {
     const ser = DomSerializer({ fix_list_elements: true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script><!-- /* <![CDATA[ */\nvar hi = "hello";\n/* ]]>*/--></s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')), '<script>// <![CDATA[\nvar hi = \"hello\";\n// ]]></s' + 'cript>');
+    setTestHtml('<script><!-- /* <![CDATA[ */\nvar hi = "hello";\n/* ]]>*/--></s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()), '<script>// <![CDATA[\nvar hi = \"hello\";\n// ]]></s' + 'cript>');
   });
 
   it('Script with html comment and block comment around cdata', () => {
     const ser = DomSerializer({ fix_list_elements: true });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script><!-- /* <![CDATA[ */\nvar hi = "hello";\n/* ]]>*/--></s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')), '<script><!-- /* <![CDATA[ */\nvar hi = \"hello\";\n/* ]]>*/--></script>');
+    setTestHtml('<script><!-- /* <![CDATA[ */\nvar hi = "hello";\n/* ]]>*/--></s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()), '<script><!-- /* <![CDATA[ */\nvar hi = \"hello\";\n/* ]]>*/--></script>');
   });
 
   it('Script with line comment and html comment with element_format: xhtml', () => {
     const ser = DomSerializer({ fix_list_elements: true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script>// <!--\nvar hi = "hello";\n// --></s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')), '<script>// <![CDATA[\nvar hi = \"hello\";\n// ]]></s' + 'cript>');
+    setTestHtml('<script>// <!--\nvar hi = "hello";\n// --></s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()), '<script>// <![CDATA[\nvar hi = \"hello\";\n// ]]></s' + 'cript>');
   });
 
   it('Script with line comment and html comment', () => {
     const ser = DomSerializer({ fix_list_elements: true });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script>// <!--\nvar hi = "hello";\n// --></s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')), '<script>// <!--\nvar hi = \"hello\";\n// --></script>');
+    setTestHtml('<script>// <!--\nvar hi = "hello";\n// --></s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()), '<script>// <!--\nvar hi = \"hello\";\n// --></script>');
   });
 
   it('Script with block comment around html comment with element_format: xhtml', () => {
     const ser = DomSerializer({ fix_list_elements: true, element_format: 'xhtml' });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script>/* <!-- */\nvar hi = "hello";\n/*-->*/</s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')), '<script>// <![CDATA[\nvar hi = \"hello\";\n// ]]></s' + 'cript>');
+    setTestHtml('<script>/* <!-- */\nvar hi = "hello";\n/*-->*/</s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()), '<script>// <![CDATA[\nvar hi = \"hello\";\n// ]]></s' + 'cript>');
   });
 
   it('Script with block comment around html comment', () => {
     const ser = DomSerializer({ fix_list_elements: true });
     ser.setRules('script[type|language|src]');
 
-    DOM.setHTML('test', '<script>/* <!-- */\nvar hi = "hello";\n/*-->*/</s' + 'cript>');
-    assert.equal(ser.serialize(DOM.get('test')), '<script>/* <!-- */\nvar hi = \"hello\";\n/*-->*/</script>');
+    setTestHtml('<script>/* <!-- */\nvar hi = "hello";\n/*-->*/</s' + 'cript>');
+    assert.equal(ser.serialize(getTestElement()), '<script>/* <!-- */\nvar hi = \"hello\";\n/*-->*/</script>');
   });
 
   it('Protected blocks', () => {
@@ -587,57 +593,57 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
 
     ser.setRules('noscript[test]');
 
-    DOM.setHTML('test', '<!--mce:protected ' + escape('<noscript test="test"><br></noscript>') + '-->');
-    assert.equal(ser.serialize(DOM.get('test')), '<noscript test="test"><br></noscript>');
+    setTestHtml('<!--mce:protected ' + escape('<noscript test="test"><br></noscript>') + '-->');
+    assert.equal(ser.serialize(getTestElement()), '<noscript test="test"><br></noscript>');
 
-    DOM.setHTML('test', '<!--mce:protected ' + escape('<noscript><br></noscript>') + '-->');
-    assert.equal(ser.serialize(DOM.get('test')), '<noscript><br></noscript>');
+    setTestHtml('<!--mce:protected ' + escape('<noscript><br></noscript>') + '-->');
+    assert.equal(ser.serialize(getTestElement()), '<noscript><br></noscript>');
 
-    DOM.setHTML('test', '<!--mce:protected ' + escape('<noscript><!-- text --><br></noscript>') + '-->');
-    assert.equal(ser.serialize(DOM.get('test')), '<noscript><!-- text --><br></noscript>');
+    setTestHtml('<!--mce:protected ' + escape('<noscript><!-- text --><br></noscript>') + '-->');
+    assert.equal(ser.serialize(getTestElement()), '<noscript><!-- text --><br></noscript>');
   });
 
   it('Style with whitespace at beginning with element_format: xhtml', () => {
     const ser = DomSerializer({ fix_list_elements: true, valid_children: '+body[style]', element_format: 'xhtml' });
     ser.setRules('style');
 
-    DOM.setHTML('test', '<style> body { background:#fff }</style>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<style><!--\n body { background:#fff }\n--></style>');
+    setTestHtml('<style> body { background:#fff }</style>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<style><!--\n body { background:#fff }\n--></style>');
   });
 
   it('Style with whitespace at beginning', () => {
     const ser = DomSerializer({ fix_list_elements: true, valid_children: '+body[style]' });
     ser.setRules('style');
 
-    DOM.setHTML('test', '<style> body { background:#fff }</style>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<style> body { background:#fff }</style>');
+    setTestHtml('<style> body { background:#fff }</style>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<style> body { background:#fff }</style>');
   });
 
   it('Style with cdata with element_format: xhtml', () => {
     const ser = DomSerializer({ fix_list_elements: true, valid_children: '+body[style]', element_format: 'xhtml' });
     ser.setRules('style');
 
-    DOM.setHTML('test', '<style>\r\n<![CDATA[\r\n   body { background:#fff }]]></style>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<style><!--\nbody { background:#fff }\n--></style>');
+    setTestHtml('<style>\r\n<![CDATA[\r\n   body { background:#fff }]]></style>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<style><!--\nbody { background:#fff }\n--></style>');
   });
 
   it('Style with cdata', () => {
     const ser = DomSerializer({ fix_list_elements: true, valid_children: '+body[style]' });
     ser.setRules('style');
 
-    DOM.setHTML('test', '<style>\r\n<![CDATA[\r\n   body { background:#fff }]]></style>');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '<style>\n<![CDATA[\n   body { background:#fff }]]></style>');
+    setTestHtml('<style>\r\n<![CDATA[\r\n   body { background:#fff }]]></style>');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '<style>\n<![CDATA[\n   body { background:#fff }]]></style>');
   });
 
   it('CDATA', () => {
     const ser = DomSerializer({ fix_list_elements: true, preserve_cdata: true });
     ser.setRules('span');
 
-    DOM.setHTML('test', '123<!--[CDATA[<test>]]-->abc');
-    assert.equal(ser.serialize(DOM.get('test')), '123<![CDATA[<test>]]>abc');
+    setTestHtml('123<!--[CDATA[<test>]]-->abc');
+    assert.equal(ser.serialize(getTestElement()), '123<![CDATA[<test>]]>abc');
 
-    DOM.setHTML('test', '123<!--[CDATA[<te\n\nst>]]-->abc');
-    assert.equal(ser.serialize(DOM.get('test')).replace(/\r/g, ''), '123<![CDATA[<te\n\nst>]]>abc');
+    setTestHtml('123<!--[CDATA[<te\n\nst>]]-->abc');
+    assert.equal(ser.serialize(getTestElement()).replace(/\r/g, ''), '123<![CDATA[<te\n\nst>]]>abc');
   });
 
   it('BR at end of blocks', () => {
@@ -645,8 +651,8 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
 
     ser.setRules('ul,li,br');
 
-    DOM.setHTML('test', '<ul><li>test<br /></li><li>test<br /></li><li>test<br /></li></ul>');
-    assert.equal(ser.serialize(DOM.get('test')), '<ul><li>test</li><li>test</li><li>test</li></ul>');
+    setTestHtml('<ul><li>test<br /></li><li>test<br /></li><li>test<br /></li></ul>');
+    assert.equal(ser.serialize(getTestElement()), '<ul><li>test</li><li>test</li><li>test</li></ul>');
   });
 
   it('Map elements', () => {
@@ -659,7 +665,7 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
       '<map id="planetmap" name="planetmap"><area shape="rect" coords="0,0,82,126" href="sun.htm" data-mce-href="sun.htm" target="_blank" alt="sun" /></map>'
     );
     assert.equal(
-      ser.serialize(DOM.get('test')).toLowerCase(),
+      ser.serialize(getTestElement()).toLowerCase(),
       '<map id="planetmap" name="planetmap"><area shape="rect" coords="0,0,82,126" href="sun.htm" target="_blank" alt="sun"></map>'
     );
   });
@@ -673,11 +679,11 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     document.createElement('custom1');
     document.createElement('custom2');
 
-    DOM.setHTML('test', '<p><custom1>c1</custom1><custom2>c2</custom2></p>');
-    assert.equal(ser.serialize(DOM.get('test')), '<custom1>c1</custom1><p><custom2>c2</custom2></p>');
+    setTestHtml('<p><custom1>c1</custom1><custom2>c2</custom2></p>');
+    assert.equal(ser.serialize(getTestElement()), '<custom1>c1</custom1><p><custom2>c2</custom2></p>');
 
-    DOM.setHTML('test', '<custom1></custom1><p><custom2></custom2></p>');
-    assert.equal(ser.serialize(DOM.get('test')), '<custom1></custom1><p><custom2></custom2></p>');
+    setTestHtml('<custom1></custom1><p><custom2></custom2></p>');
+    assert.equal(ser.serialize(getTestElement()), '<custom1></custom1><p><custom2></custom2></p>');
   });
 
   it('Remove internal classes', () => {
@@ -685,20 +691,20 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
       valid_elements: 'span[class]'
     });
 
-    DOM.setHTML('test', '<span class="a mce-item-X mce-item-selected b"></span>');
-    assert.equal(ser.serialize(DOM.get('test')), '<span class="a b"></span>');
+    setTestHtml('<span class="a mce-item-X mce-item-selected b"></span>');
+    assert.equal(ser.serialize(getTestElement()), '<span class="a b"></span>');
 
-    DOM.setHTML('test', '<span class="a mce-item-X"></span>');
-    assert.equal(ser.serialize(DOM.get('test')), '<span class="a"></span>');
+    setTestHtml('<span class="a mce-item-X"></span>');
+    assert.equal(ser.serialize(getTestElement()), '<span class="a"></span>');
 
-    DOM.setHTML('test', '<span class="mce-item-X"></span>');
-    assert.equal(ser.serialize(DOM.get('test')), '<span></span>');
+    setTestHtml('<span class="mce-item-X"></span>');
+    assert.equal(ser.serialize(getTestElement()), '<span></span>');
 
-    DOM.setHTML('test', '<span class="mce-item-X b"></span>');
-    assert.equal(ser.serialize(DOM.get('test')), '<span class=" b"></span>');
+    setTestHtml('<span class="mce-item-X b"></span>');
+    assert.equal(ser.serialize(getTestElement()), '<span class=" b"></span>');
 
-    DOM.setHTML('test', '<span class="b mce-item-X"></span>');
-    assert.equal(ser.serialize(DOM.get('test')), '<span class="b"></span>');
+    setTestHtml('<span class="b mce-item-X"></span>');
+    assert.equal(ser.serialize(getTestElement()), '<span class="b"></span>');
   });
 
   it('Restore tabindex', () => {
@@ -706,8 +712,8 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
       valid_elements: 'span[tabindex]'
     });
 
-    DOM.setHTML('test', '<span data-mce-tabindex="42"></span>');
-    assert.equal(ser.serialize(DOM.get('test')), '<span tabindex="42"></span>');
+    setTestHtml('<span data-mce-tabindex="42"></span>');
+    assert.equal(ser.serialize(getTestElement()), '<span tabindex="42"></span>');
   });
 
   it('Trailing BR (IE11)', () => {
@@ -715,11 +721,11 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
       valid_elements: 'p,br'
     });
 
-    DOM.setHTML('test', '<p>a</p><br><br>');
-    assert.equal(ser.serialize(DOM.get('test')), '<p>a</p>');
+    setTestHtml('<p>a</p><br><br>');
+    assert.equal(ser.serialize(getTestElement()), '<p>a</p>');
 
-    DOM.setHTML('test', 'a<br><br>');
-    assert.equal(ser.serialize(DOM.get('test')), 'a');
+    setTestHtml('a<br><br>');
+    assert.equal(ser.serialize(getTestElement()), 'a');
   });
 
   it('addTempAttr', () => {
@@ -728,8 +734,8 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     ser.addTempAttr('data-x');
     ser.addTempAttr('data-y');
 
-    DOM.setHTML('test', '<p data-x="1" data-y="2" data-z="3">a</p>');
-    assert.equal(ser.serialize(DOM.get('test'), { getInner: 1 }), '<p data-z="3">a</p>');
+    setTestHtml('<p data-x="1" data-y="2" data-z="3">a</p>');
+    assert.equal(ser.serialize(getTestElement(), { getInner: 1 }), '<p data-z="3">a</p>');
     assert.equal(TrimHtml.trimExternal(ser, '<p data-x="1" data-y="2" data-z="3">a</p>'), '<p data-z="3">a</p>');
   });
 
@@ -740,27 +746,27 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     ser1.addTempAttr('data-x');
     ser2.addTempAttr('data-x');
 
-    DOM.setHTML('test', '<p data-x="1" data-z="3">a</p>');
-    assert.equal(ser1.serialize(DOM.get('test'), { getInner: 1 }), '<p data-z="3">a</p>');
+    setTestHtml('<p data-x="1" data-z="3">a</p>');
+    assert.equal(ser1.serialize(getTestElement(), { getInner: 1 }), '<p data-z="3">a</p>');
     assert.equal(TrimHtml.trimExternal(ser1, '<p data-x="1" data-z="3">a</p>'), '<p data-z="3">a</p>');
-    assert.equal(ser2.serialize(DOM.get('test'), { getInner: 1 }), '<p data-z="3">a</p>');
+    assert.equal(ser2.serialize(getTestElement(), { getInner: 1 }), '<p data-z="3">a</p>');
     assert.equal(TrimHtml.trimExternal(ser2, '<p data-x="1" data-z="3">a</p>'), '<p data-z="3">a</p>');
   });
 
   it('trim data-mce-bogus="all"', () => {
     const ser = DomSerializer({});
 
-    DOM.setHTML('test', 'a<p data-mce-bogus="all">b</p>c');
-    assert.equal(ser.serialize(DOM.get('test'), { getInner: 1 }), 'ac');
+    setTestHtml('a<p data-mce-bogus="all">b</p>c');
+    assert.equal(ser.serialize(getTestElement(), { getInner: 1 }), 'ac');
     assert.equal(TrimHtml.trimExternal(ser, 'a<p data-mce-bogus="all">b</p>c'), 'ac');
   });
 
   it('zwsp should not be treated as contents', () => {
     const ser = DomSerializer({ });
 
-    DOM.setHTML('test', '<p>' + Zwsp.ZWSP + '</p>');
+    setTestHtml('<p>' + Zwsp.ZWSP + '</p>');
     assert.equal(
-      ser.serialize(DOM.get('test'), { getInner: true }),
+      ser.serialize(getTestElement(), { getInner: true }),
       '<p>&nbsp;</p>'
     );
   });
@@ -768,7 +774,7 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
   it('nested bookmark nodes', () => {
     const ser = DomSerializer({ });
 
-    DOM.setHTML('test', '<p>' +
+    setTestHtml('<p>' +
       '<span data-mce-type="bookmark" id="mce_5_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow:hidden;line-height:0px">' +
         '<span data-mce-type="bookmark" id="mce_6_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow:hidden;line-height:0px"></span>' +
         '<span data-mce-type="bookmark" id="mce_7_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow:hidden;line-height:0px"></span>' +
@@ -779,7 +785,7 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
       '<span data-mce-type="bookmark" id="mce_8_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow:hidden;line-height:0px"></span>' +
     '</p>');
     assert.equal(
-      ser.serialize(DOM.get('test'), { getInner: true }),
+      ser.serialize(getTestElement(), { getInner: true }),
       '<p>a</p>'
     );
   });

--- a/modules/tinymce/src/core/test/ts/browser/dom/TreeWalkerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/TreeWalkerTest.ts
@@ -10,7 +10,7 @@ describe('browser.tinymce.core.dom.TreeWalkerTest', () => {
   let nodes: Node[];
 
   before(() => {
-    const all = (node) => {
+    const all = (node: Node) => {
       let list = [ node ];
 
       if (node.hasChildNodes()) {
@@ -63,9 +63,9 @@ describe('browser.tinymce.core.dom.TreeWalkerTest', () => {
   it('next', () => {
     const walker = new DomTreeWalker(nodes[0], viewBlock.get());
 
-    const actualNodes = [ walker.current() ];
+    const actualNodes: Node[] = [ walker.current() as Node ];
     while ((walker.next())) {
-      actualNodes.push(walker.current());
+      actualNodes.push(walker.current() as Node);
     }
 
     assert.isTrue(compareNodeLists(nodes, actualNodes), 'Should be the same');
@@ -73,11 +73,10 @@ describe('browser.tinymce.core.dom.TreeWalkerTest', () => {
 
   it('prev2', () => {
     const walker = new DomTreeWalker(nodes[nodes.length - 1], viewBlock.get());
-    let actualNodes;
 
-    actualNodes = [ walker.current() ];
+    let actualNodes: Node[] = [ walker.current() as Node ];
     while ((walker.prev2())) {
-      actualNodes.push(walker.current());
+      actualNodes.push(walker.current() as Node);
     }
 
     actualNodes = actualNodes.reverse();
@@ -86,11 +85,10 @@ describe('browser.tinymce.core.dom.TreeWalkerTest', () => {
 
   it('prev2(shallow:true)', () => {
     const walker = new DomTreeWalker(nodes[nodes.length - 1], viewBlock.get());
-    let actualNodes;
 
-    actualNodes = [ walker.current() ];
+    let actualNodes: Node[] = [ walker.current() as Node ];
     while ((walker.prev2(true))) {
-      actualNodes.push(walker.current());
+      actualNodes.push(walker.current() as Node);
     }
 
     actualNodes = actualNodes.reverse();

--- a/modules/tinymce/src/core/test/ts/browser/dom/TrimHtmlTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/TrimHtmlTest.ts
@@ -24,7 +24,7 @@ describe('browser.tinymce.core.dom.TrimHtmlTest', () => {
   });
 
   it('findMatchingEndTagIndex', () => {
-    const testFindMatchingEndTag = (html, startIndex, expectedIndex) => {
+    const testFindMatchingEndTag = (html: string, startIndex: number, expectedIndex: number) => {
       assert.equal(TrimHtml.findMatchingEndTagIndex(Schema({}), html, startIndex), expectedIndex);
     };
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/TrimNodeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/TrimNodeTest.ts
@@ -11,7 +11,7 @@ describe('browser.tinymce.core.dom.TrimNodeTest', () => {
     it(label, () => {
       const elm = document.createElement('div');
       elm.innerHTML = inputHtml;
-      TrimNode.trimNode(dom, elm.firstChild);
+      TrimNode.trimNode(dom, elm.firstChild as Node);
 
       const actual = elm.innerHTML;
       assert.equal(actual, expectedTrimmedHtml, 'is correct trimmed html');

--- a/modules/tinymce/src/core/test/ts/browser/file/ImageScannerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/file/ImageScannerTest.ts
@@ -16,7 +16,7 @@ describe('browser.tinymce.core.file.ImageScannerTest', () => {
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" height="100" width="100"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></svg>`;
   const encodedSrc = 'data:image/svg+xml,' + encodeURIComponent(svg);
   const invalidBlobUriSrc = 'blob:70BE8432-BA4D-4787-9AB9-86563351FBF7';
-  let blobUriSrc;
+  let blobUriSrc: string | undefined;
 
   before(() => {
     return Conversions.uriToBlob(base64Src).then((blob) => {
@@ -43,7 +43,7 @@ describe('browser.tinymce.core.file.ImageScannerTest', () => {
       const encodedImageResult = result[2] as BlobInfoImagePair;
       assert.typeOf(result[result.length - 1], 'string', 'Last item is not the image, but error message.');
       assert.equal('data:image/gif;base64,' + base64ImageResult.blobInfo.base64(), base64Src);
-      LegacyUnit.equalDom(base64ImageResult.image, viewBlock.get().firstChild);
+      LegacyUnit.equalDom(base64ImageResult.image, viewBlock.get().firstChild as HTMLImageElement);
       assert.equal('data:image/svg+xml;base64,' + encodedImageResult.blobInfo.base64(), 'data:image/svg+xml;base64,' + btoa(svg));
       LegacyUnit.equalDom(encodedImageResult.image, viewBlock.get().childNodes.item(2));
     });
@@ -65,7 +65,7 @@ describe('browser.tinymce.core.file.ImageScannerTest', () => {
       assert.lengthOf(result, 1);
       const firstResult = result[0] as BlobInfoImagePair;
       assert.equal('data:image/gif;base64,' + firstResult.blobInfo.base64(), base64Src);
-      LegacyUnit.equalDom(firstResult.image, viewBlock.get().firstChild);
+      LegacyUnit.equalDom(firstResult.image, viewBlock.get().firstChild as HTMLImageElement);
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/CaretFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/CaretFormatTest.ts
@@ -413,10 +413,10 @@ describe('browser.tinymce.core.fmt.CaretFormatTest', () => {
 
   it('getParentCaretContainer', () => {
     const body = SugarElement.fromHtml('<div><span id="_mce_caret">a</span></div>');
-    const caret = SugarElement.fromDom(body.dom.firstChild);
+    const caret = SugarElement.fromDom(body.dom.firstChild as HTMLSpanElement);
 
-    Assertions.assertDomEq('Should be caret element on child', caret, SugarElement.fromDom(getParentCaretContainer(body.dom, caret.dom.firstChild)));
-    Assertions.assertDomEq('Should be caret element on self', caret, SugarElement.fromDom(getParentCaretContainer(body.dom, caret.dom)));
+    Assertions.assertDomEq('Should be caret element on child', caret, SugarElement.fromDom(getParentCaretContainer(body.dom, caret.dom.firstChild as Text) as Element));
+    Assertions.assertDomEq('Should be caret element on self', caret, SugarElement.fromDom(getParentCaretContainer(body.dom, caret.dom) as Element));
     assert.isNull(getParentCaretContainer(body.dom, SugarElement.fromTag('span').dom), 'Should not be caret element');
     assert.isNull(getParentCaretContainer(caret.dom, caret.dom), 'Should not be caret element');
   });
@@ -428,7 +428,7 @@ describe('browser.tinymce.core.fmt.CaretFormatTest', () => {
       SugarElement.fromTag('i').dom
     ];
 
-    const pos = CaretFormat.replaceWithCaretFormat(body.dom.firstChild, formats);
+    const pos = CaretFormat.replaceWithCaretFormat(body.dom.firstChild as HTMLBRElement, formats);
 
     assert.equal(pos.offset(), 0, 'Should be at first offset');
     assert.equal((pos.container() as Text).data, Zwsp.ZWSP, 'Should the zwsp text node');

--- a/modules/tinymce/src/core/test/ts/browser/fmt/ExpandRangeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/ExpandRangeTest.ts
@@ -6,6 +6,7 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as ExpandRange from 'tinymce/core/fmt/ExpandRange';
+import { Format } from 'tinymce/core/fmt/FormatTypes';
 import { RangeLikeObject } from 'tinymce/core/selection/RangeTypes';
 import { ZWSP } from 'tinymce/core/text/Zwsp';
 
@@ -18,7 +19,7 @@ describe('browser.tinymce.core.fmt.ExpandRangeTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [], true);
 
-  const expandRng = (editor: Editor, startPath: number[], startOffset: number, endPath: number[], endOffset: number, format, excludeTrailingSpaces: boolean = false) => {
+  const expandRng = (editor: Editor, startPath: number[], startOffset: number, endPath: number[], endOffset: number, format: Format[], excludeTrailingSpaces: boolean = false) => {
     const startContainer = Hierarchy.follow(TinyDom.body(editor), startPath).getOrDie();
     const endContainer = Hierarchy.follow(TinyDom.body(editor), endPath).getOrDie();
 

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FontInfoTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FontInfoTest.ts
@@ -97,30 +97,34 @@ describe('browser.tinymce.core.fmt.FontInfoTest', () => {
     const iframe = document.createElement('iframe');
     iframe.style.display = 'none';
     document.body.appendChild(iframe);
+    const iframeDoc = iframe.contentDocument as Document;
 
     iframe.addEventListener('load', () => {
-      const fontFamily = FontInfo.getFontFamily(iframe.contentDocument.body, iframe.contentDocument.body.firstChild);
+      const body = iframeDoc.body;
+      const firstChildElement = iframeDoc.body.firstChild as Element;
+      const fontFamily = FontInfo.getFontFamily(body, firstChildElement);
       assert.typeOf(fontFamily, 'string', 'Should always be a string');
-      iframe.parentNode.removeChild(iframe);
+      iframe.parentNode?.removeChild(iframe);
 
       done();
     }, false);
 
-    iframe.contentDocument.open();
-    iframe.contentDocument.write('<html><body><p>a</p></body></html>');
-    iframe.contentDocument.close();
+    iframeDoc.open();
+    iframeDoc.write('<html><body><p>a</p></body></html>');
+    iframeDoc.close();
   });
 
   it('getFontFamily should return a string when run on element in removed iframe', (done) => {
     const iframe = document.createElement('iframe');
     iframe.style.display = 'none';
     document.body.appendChild(iframe);
+    const iframeDoc = iframe.contentDocument as Document;
 
     iframe.addEventListener('load', () => {
-      const body = iframe.contentDocument.body;
-      const firstChildElement = iframe.contentDocument.body.firstChild;
+      const body = iframeDoc.body;
+      const firstChildElement = iframeDoc.body.firstChild as Element;
 
-      iframe.parentNode.removeChild(iframe);
+      iframe.parentNode?.removeChild(iframe);
 
       try {
         const fontFamily = FontInfo.getFontFamily(body, firstChildElement);
@@ -131,9 +135,9 @@ describe('browser.tinymce.core.fmt.FontInfoTest', () => {
       }
     }, false);
 
-    iframe.contentDocument.open();
-    iframe.contentDocument.write('<html><body><p>a</p></body></html>');
-    iframe.contentDocument.close();
+    iframeDoc.open();
+    iframeDoc.write('<html><body><p>a</p></body></html>');
+    iframeDoc.close();
   });
 
   it('comments should always return empty string', () => {

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatChangeVarsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatChangeVarsTest.ts
@@ -11,10 +11,10 @@ describe('browser.tinymce.core.fmt.FormatChangeVarsTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, []);
 
-  const events = {
-    general: [] as boolean[],
-    helvetica: [] as boolean[],
-    comicSans: [] as boolean[]
+  const events: Record<string, boolean[]> = {
+    general: [],
+    helvetica: [],
+    comicSans: []
   };
 
   const generalCleanup = Singleton.unbindable();

--- a/modules/tinymce/src/core/test/ts/browser/fmt/MediaAlignTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/MediaAlignTest.ts
@@ -1,4 +1,4 @@
-import { ApproxStructure } from '@ephox/agar';
+import { ApproxStructure, StringAssert } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
@@ -13,7 +13,7 @@ describe('browser.tinymce.core.fmt.MediaAlignTest', () => {
   }, [], true);
 
   const mediaApproxStructure = (tag: string, alignment: Alignment) => {
-    const alignStyles = (str: ApproxStructure.StringApi) => {
+    const alignStyles = (str: ApproxStructure.StringApi): Record<string, StringAssert> => {
       if (alignment === 'left') {
         return { float: str.is('left') };
       } else if (alignment === 'center') {

--- a/modules/tinymce/src/core/test/ts/browser/fmt/TableFormatsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/TableFormatsTest.ts
@@ -102,7 +102,7 @@ describe('browser.tinymce.core.table.TableFormatsTest', () => {
   const applyFormat = (editor: Editor, formatName: string, vars: Record<string, string>) => editor.formatter.apply(formatName, vars);
   const removeFormat = (editor: Editor, formatName: string, vars: Record<string, string>) => editor.formatter.remove(formatName, vars);
 
-  Arr.each([
+  Arr.each<{ formatName: string; vars: Record<string, string>; styles: Record<string, string> }>([
     { formatName: 'tablecellbackgroundcolor', vars: { value: 'red' }, styles: { 'background-color': 'red' }},
     { formatName: 'tablecellbordercolor', vars: { value: 'red' }, styles: { 'border-color': 'red' }},
     { formatName: 'tablecellborderstyle', vars: { value: 'dashed' }, styles: { 'border-style': 'dashed' }},

--- a/modules/tinymce/src/core/test/ts/browser/focus/EditorFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/EditorFocusTest.ts
@@ -30,7 +30,7 @@ describe('browser.tinymce.core.focus.EditorFocusTest', () => {
   };
 
   const selectBody = () => {
-    const sel = document.getSelection();
+    const sel = document.getSelection() as Selection;
     sel.removeAllRanges();
     const rng = document.createRange();
     rng.selectNode(document.body);

--- a/modules/tinymce/src/core/test/ts/browser/focus/FocusControllerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/FocusControllerTest.ts
@@ -74,7 +74,7 @@ describe('browser.tinymce.core.focus.FocusControllerTest', () => {
       it('isUIElement on editor sibling is false', () => {
         const editor = hook.editor();
         const inputElm = DOMUtils.DOM.create('input', { }, null);
-        editor.getContainer().parentNode.appendChild(inputElm);
+        editor.getContainer().parentNode?.appendChild(inputElm);
         assert.isFalse(FocusController.isUIElement(editor, inputElm), 'Should be false as not sitting inside editor');
         DOMUtils.DOM.remove(inputElm);
       });

--- a/modules/tinymce/src/core/test/ts/browser/geom/RectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/geom/RectTest.ts
@@ -6,24 +6,24 @@ import Tools from 'tinymce/core/api/util/Tools';
 
 describe('browser.tinymce.core.geom.RectTest', () => {
   it('relativePosition', () => {
-    const sourceRect = Rect.create(0, 0, 20, 30),
-      targetRect = Rect.create(10, 20, 40, 50),
-      tests = [
-        // Only test a few of them all would be 81
-        [ 'tl-tl', 10, 20, 20, 30 ],
-        [ 'tc-tc', 20, 20, 20, 30 ],
-        [ 'tr-tr', 30, 20, 20, 30 ],
-        [ 'cl-cl', 10, 30, 20, 30 ],
-        [ 'cc-cc', 20, 30, 20, 30 ],
-        [ 'cr-cr', 30, 30, 20, 30 ],
-        [ 'bl-bl', 10, 40, 20, 30 ],
-        [ 'bc-bc', 20, 40, 20, 30 ],
-        [ 'br-br', 30, 40, 20, 30 ],
-        [ 'tr-tl', 50, 20, 20, 30 ],
-        [ 'br-bl', 50, 40, 20, 30 ]
-      ];
+    const sourceRect = Rect.create(0, 0, 20, 30);
+    const targetRect = Rect.create(10, 20, 40, 50);
+    const tests: Array<[ string, number, number, number, number ]> = [
+      // Only test a few of them all would be 81
+      [ 'tl-tl', 10, 20, 20, 30 ],
+      [ 'tc-tc', 20, 20, 20, 30 ],
+      [ 'tr-tr', 30, 20, 20, 30 ],
+      [ 'cl-cl', 10, 30, 20, 30 ],
+      [ 'cc-cc', 20, 30, 20, 30 ],
+      [ 'cr-cr', 30, 30, 20, 30 ],
+      [ 'bl-bl', 10, 40, 20, 30 ],
+      [ 'bc-bc', 20, 40, 20, 30 ],
+      [ 'br-br', 30, 40, 20, 30 ],
+      [ 'tr-tl', 50, 20, 20, 30 ],
+      [ 'br-bl', 50, 40, 20, 30 ]
+    ];
 
-    Tools.each(tests, (item: [ string, number, number, number, number ]) => {
+    Tools.each(tests, (item) => {
       assert.deepEqual(
         Rect.relativePosition(sourceRect, targetRect, item[0]),
         Rect.create(item[1], item[2], item[3], item[4]),
@@ -33,20 +33,20 @@ describe('browser.tinymce.core.geom.RectTest', () => {
   });
 
   it('findBestRelativePosition', () => {
-    const sourceRect = Rect.create(0, 0, 20, 30),
-      targetRect = Rect.create(10, 20, 40, 50),
-      tests = [
-        [[ 'tl-tl' ], 5, 15, 100, 100, 'tl-tl' ],
-        [[ 'tl-tl' ], 20, 30, 100, 100, null ],
-        [[ 'tl-tl', 'tr-tl' ], 20, 20, 100, 100, 'tr-tl' ],
-        [[ 'tl-bl', 'tr-tl', 'bl-tl' ], 10, 20, 40, 100, 'bl-tl' ]
-      ];
+    const sourceRect = Rect.create(0, 0, 20, 30);
+    const targetRect = Rect.create(10, 20, 40, 50);
+    const tests: Array<[ string[], number, number, number, number, string | null ]> = [
+      [[ 'tl-tl' ], 5, 15, 100, 100, 'tl-tl' ],
+      [[ 'tl-tl' ], 20, 30, 100, 100, null ],
+      [[ 'tl-tl', 'tr-tl' ], 20, 20, 100, 100, 'tr-tl' ],
+      [[ 'tl-bl', 'tr-tl', 'bl-tl' ], 10, 20, 40, 100, 'bl-tl' ]
+    ];
 
-    Tools.each(tests, (item: [ string[], number, number, number, number, string ]) => {
+    Tools.each(tests, (item) => {
       assert.equal(
         Rect.findBestRelativePosition(sourceRect, targetRect, Rect.create(item[1], item[2], item[3], item[4]), item[0]),
         item[5],
-        item[5]
+        String(item[5])
       );
     });
   });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -4,11 +4,17 @@ import { PlatformDetection } from '@ephox/sand';
 import { assert } from 'chai';
 
 import Env from 'tinymce/core/api/Env';
-import { BlobCache } from 'tinymce/core/api/file/BlobCache';
-import DomParser from 'tinymce/core/api/html/DomParser';
-import AstNode from 'tinymce/core/api/html/Node';
-import Schema from 'tinymce/core/api/html/Schema';
+import { BlobCache, BlobInfo } from 'tinymce/core/api/file/BlobCache';
+import DomParser, { ParserArgs, ParserFilterCallback } from 'tinymce/core/api/html/DomParser';
+import AstNode, { Attributes } from 'tinymce/core/api/html/Node';
+import Schema, { SchemaElement } from 'tinymce/core/api/html/Schema';
 import HtmlSerializer from 'tinymce/core/api/html/Serializer';
+
+interface ParseTestResult {
+  readonly nodes: AstNode[];
+  readonly name: string;
+  readonly args: ParserArgs;
+}
 
 describe('browser.tinymce.core.html.DomParserTest', () => {
   const browser = PlatformDetection.detect().browser;
@@ -35,13 +41,13 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     const parser = DomParser({}, schema);
     const root = parser.parse('<B title="title" class="class">test</B>');
     assert.equal(serializer.serialize(root), '<b class="class" title="title">test</b>', 'Inline element');
-    assert.equal(root.firstChild.type, 1, 'Element type');
-    assert.equal(root.firstChild.name, 'b', 'Element name');
+    assert.equal(root.firstChild?.type, 1, 'Element type');
+    assert.equal(root.firstChild?.name, 'b', 'Element name');
     assert.deepEqual(
-      root.firstChild.attributes, [
+      root.firstChild?.attributes, [
         { name: 'title', value: 'title' },
         { name: 'class', value: 'class' },
-      ],
+      ] as unknown as Attributes,
       'Element attributes'
     );
     assert.deepEqual(countNodes(root), { 'body': 1, 'b': 1, '#text': 1 }, 'Element attributes (count)');
@@ -264,7 +270,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
   });
 
   it('addNodeFilter', () => {
-    let result;
+    let result: ParseTestResult | undefined;
 
     const parser = DomParser({}, schema);
     parser.addNodeFilter('#comment', (nodes, name, args) => {
@@ -272,17 +278,17 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     });
     parser.parse('text<!--text1-->text<!--text2-->');
 
-    assert.deepEqual(result.args, {}, 'Parser args');
-    assert.equal(result.name, '#comment', 'Parser filter result name');
-    assert.equal(result.nodes.length, 2, 'Parser filter result node');
-    assert.equal(result.nodes[0].name, '#comment', 'Parser filter result node(0) name');
-    assert.equal(result.nodes[0].value, 'text1', 'Parser filter result node(0) value');
-    assert.equal(result.nodes[1].name, '#comment', 'Parser filter result node(1) name');
-    assert.equal(result.nodes[1].value, 'text2', 'Parser filter result node(1) value');
+    assert.deepEqual(result?.args, {}, 'Parser args');
+    assert.equal(result?.name, '#comment', 'Parser filter result name');
+    assert.equal(result?.nodes.length, 2, 'Parser filter result node');
+    assert.equal(result?.nodes[0].name, '#comment', 'Parser filter result node(0) name');
+    assert.equal(result?.nodes[0].value, 'text1', 'Parser filter result node(0) value');
+    assert.equal(result?.nodes[1].name, '#comment', 'Parser filter result node(1) name');
+    assert.equal(result?.nodes[1].value, 'text2', 'Parser filter result node(1) value');
   });
 
   it('addNodeFilter multiple names', () => {
-    const results = {};
+    const results: Record<string, ParseTestResult> = {};
 
     const parser = DomParser({}, schema);
     parser.addNodeFilter('#comment,#text', (nodes, name, args) => {
@@ -307,7 +313,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
   });
 
   it('addNodeFilter with parser args', () => {
-    let result;
+    let result: ParseTestResult | undefined;
 
     const parser = DomParser({}, schema);
     parser.addNodeFilter('#comment', (nodes, name, args) => {
@@ -315,7 +321,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     });
     parser.parse('text<!--text1-->text<!--text2-->', { value: 1 });
 
-    assert.deepEqual(result.args, { value: 1 }, 'Parser args');
+    assert.deepEqual(result?.args, { value: 1 }, 'Parser args');
   });
 
   it('TINY-7847: removeNodeFilter', () => {
@@ -344,7 +350,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
   });
 
   it('addAttributeFilter', () => {
-    let result;
+    let result: ParseTestResult | undefined;
 
     const parser = DomParser({});
     parser.addAttributeFilter('src', (nodes, name, args) => {
@@ -352,13 +358,13 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     });
     parser.parse('<b>a<img src="1.gif" />b<img src="1.gif" />c</b>');
 
-    assert.deepEqual(result.args, {}, 'Parser args');
-    assert.equal(result.name, 'src', 'Parser filter result name');
-    assert.equal(result.nodes.length, 2, 'Parser filter result node');
-    assert.equal(result.nodes[0].name, 'img', 'Parser filter result node(0) name');
-    assert.equal(result.nodes[0].attr('src'), '1.gif', 'Parser filter result node(0) attr');
-    assert.equal(result.nodes[1].name, 'img', 'Parser filter result node(1) name');
-    assert.equal(result.nodes[1].attr('src'), '1.gif', 'Parser filter result node(1) attr');
+    assert.deepEqual(result?.args, {}, 'Parser args');
+    assert.equal(result?.name, 'src', 'Parser filter result name');
+    assert.equal(result?.nodes.length, 2, 'Parser filter result node');
+    assert.equal(result?.nodes[0].name, 'img', 'Parser filter result node(0) name');
+    assert.equal(result?.nodes[0].attr('src'), '1.gif', 'Parser filter result node(0) attr');
+    assert.equal(result?.nodes[1].name, 'img', 'Parser filter result node(1) name');
+    assert.equal(result?.nodes[1].attr('src'), '1.gif', 'Parser filter result node(1) attr');
   });
 
   it('addAttributeFilter multiple', () => {
@@ -913,8 +919,8 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
   it('getAttributeFilters/getNodeFilters', () => {
     const parser = DomParser();
-    const cb1 = (_nodes, _name, _args) => {};
-    const cb2 = (_nodes, _name, _args) => {};
+    const cb1: ParserFilterCallback = (_nodes, _name, _args) => {};
+    const cb2: ParserFilterCallback = (_nodes, _name, _args) => {};
 
     parser.addAttributeFilter('attr', cb1);
     parser.addNodeFilter('node', cb2);
@@ -932,7 +938,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     const base64 = 'R0lGODdhDAAMAIABAMzMzP///ywAAAAADAAMAAACFoQfqYeabNyDMkBQb81Uat85nxguUAEAOw==';
     const base64Uri = `data:image/gif;base64,${base64}`;
     const serializedHtml = serializer.serialize(parser.parse(`<p><img src="${base64Uri}" /></p>`));
-    const blobInfo = blobCache.findFirst((bi) => bi.base64() === base64);
+    const blobInfo = blobCache.findFirst((bi) => bi.base64() === base64) as BlobInfo;
     const blobUri = blobInfo.blobUri();
 
     assert.equal(
@@ -1309,8 +1315,8 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     it('empty elements should not be removed', () => {
       const customSchema = Schema({ valid_elements: 'span[style],strong' });
-      customSchema.getElementRule('span').removeEmptyAttrs = true;
-      customSchema.getElementRule('strong').removeEmpty = true;
+      (customSchema.getElementRule('span') as SchemaElement).removeEmptyAttrs = true;
+      (customSchema.getElementRule('strong') as SchemaElement).removeEmpty = true;
       const parser = DomParser({ validate: false }, customSchema);
       const html = '<p>Hello world! This should keep empty <strong></strong>elements <span></span>.</p>';
       const serializedHtml = serializer.serialize(parser.parse(html));
@@ -1320,7 +1326,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     it('empty elements should not be padded', () => {
       const customSchema = Schema({ valid_elements: 'span' });
-      customSchema.getElementRule('span').paddEmpty = true;
+      (customSchema.getElementRule('span') as SchemaElement).paddEmpty = true;
       const parser = DomParser({ validate: false }, customSchema);
       const html = '<p>Hello world! <span></span></p>';
       const serializedHtml = serializer.serialize(parser.parse(html));

--- a/modules/tinymce/src/core/test/ts/browser/html/NodeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/NodeTest.ts
@@ -4,7 +4,7 @@ import { assert } from 'chai';
 import AstNode, { Attributes } from 'tinymce/core/api/html/Node';
 
 describe('browser.tinymce.core.html.NodeTest', () => {
-  const emptyAttributes = [] as Attributes;
+  const emptyAttributes = [] as unknown as Attributes;
 
   it('construction', () => {
     let node;
@@ -20,7 +20,7 @@ describe('browser.tinymce.core.html.NodeTest', () => {
     node = new AstNode('b', 1);
     assert.equal(node.name, 'b');
     assert.equal(node.type, 1);
-    assert.deepEqual(node.attributes, []);
+    assert.deepEqual(node.attributes, emptyAttributes);
 
     node = new AstNode('#pi', 7);
     assert.equal(node.name, '#pi');
@@ -42,11 +42,11 @@ describe('browser.tinymce.core.html.NodeTest', () => {
   it('append inside empty node', () => {
     const root = new AstNode('#frag', 11);
     const node = root.append(new AstNode('b', 1));
-    assert.equal(root.firstChild.parent === root, true);
-    assert.isUndefined(root.firstChild.next);
-    assert.isUndefined(root.firstChild.prev);
-    assert.isUndefined(root.firstChild.firstChild);
-    assert.isUndefined(root.firstChild.lastChild);
+    assert.equal(root.firstChild?.parent === root, true);
+    assert.isUndefined(root.firstChild?.next);
+    assert.isUndefined(root.firstChild?.prev);
+    assert.isUndefined(root.firstChild?.firstChild);
+    assert.isUndefined(root.firstChild?.lastChild);
     assert.equal(node.parent === root, true);
     assert.isUndefined(node.next);
     assert.isUndefined(node.prev);
@@ -58,13 +58,13 @@ describe('browser.tinymce.core.html.NodeTest', () => {
     const root = new AstNode('#frag', 11);
     const node2 = root.append(new AstNode('a', 1));
     const node = root.append(new AstNode('b', 1));
-    assert.strictEqual(root.firstChild.parent, root, 'root.firstChild.parent === root');
+    assert.strictEqual(root.firstChild?.parent, root, 'root.firstChild.parent === root');
     assert.strictEqual(root.firstChild, node2, 'root.firstChild');
     assert.strictEqual(root.lastChild, node, 'root.firstChild');
-    assert.strictEqual(root.firstChild.next, node, 'root.firstChild.next');
-    assert.isUndefined(root.firstChild.prev, 'root.firstChild.prev');
-    assert.isUndefined(root.firstChild.firstChild, 'root.firstChild.firstChild');
-    assert.isUndefined(root.firstChild.lastChild, 'root.firstChild.lastChild');
+    assert.strictEqual(root.firstChild?.next, node, 'root.firstChild.next');
+    assert.isUndefined(root.firstChild?.prev, 'root.firstChild.prev');
+    assert.isUndefined(root.firstChild?.firstChild, 'root.firstChild.firstChild');
+    assert.isUndefined(root.firstChild?.lastChild, 'root.firstChild.lastChild');
     assert.strictEqual(node2.parent, root, 'node2.parent === root');
     assert.strictEqual(node2.next, node, 'node2.next');
     assert.isUndefined(node2.prev, 'node2.prev');
@@ -98,14 +98,16 @@ describe('browser.tinymce.core.html.NodeTest', () => {
 
   it('remove single child', () => {
     const root = new AstNode('#frag', 11);
-    root.append(new AstNode('p', 1));
-    const node = root.firstChild.remove();
+    const p = new AstNode('p', 1);
+    root.append(p);
+
+    const removedNode = p.remove();
     assert.isUndefined(root.firstChild);
     assert.isUndefined(root.lastChild);
-    assert.isNull(node.parent);
-    assert.isNull(node.next);
-    assert.isNull(node.prev);
-    assert.equal(node.name, 'p');
+    assert.isNull(removedNode.parent);
+    assert.isNull(removedNode.next);
+    assert.isNull(removedNode.prev);
+    assert.equal(removedNode.name, 'p');
   });
 
   it('remove middle node', () => {
@@ -240,16 +242,16 @@ describe('browser.tinymce.core.html.NodeTest', () => {
     node.attr('attr1', 'value1');
     assert.equal(node.attr('attr1'), 'value1');
     assert.isUndefined(node.attr('attr2'));
-    assert.deepEqual(node.attributes, [{ name: 'attr1', value: 'value1' }]);
-    assert.deepEqual(node.attributes.map as Record<string, string>, { attr1: 'value1' });
+    assert.deepEqual(node.attributes, [{ name: 'attr1', value: 'value1' }] as unknown as Attributes);
+    assert.deepEqual(node.attributes?.map as Record<string, string>, { attr1: 'value1' });
 
     node = new AstNode('b', 1);
     assert.deepEqual(node.attributes, emptyAttributes);
     node.attr('attr1', 'value1');
     node.attr('attr1', 'valueX');
     assert.equal(node.attr('attr1'), 'valueX');
-    assert.deepEqual(node.attributes, [{ name: 'attr1', value: 'valueX' }]);
-    assert.deepEqual(node.attributes.map as Record<string, string>, { attr1: 'valueX' });
+    assert.deepEqual(node.attributes, [{ name: 'attr1', value: 'valueX' }] as unknown as Attributes);
+    assert.deepEqual(node.attributes?.map as Record<string, string>, { attr1: 'valueX' });
 
     node = new AstNode('b', 1);
     assert.deepEqual(node.attributes, emptyAttributes);
@@ -257,8 +259,8 @@ describe('browser.tinymce.core.html.NodeTest', () => {
     node.attr('attr2', 'value2');
     assert.equal(node.attr('attr1'), 'value1');
     assert.equal(node.attr('attr2'), 'value2');
-    assert.deepEqual(node.attributes, [{ name: 'attr1', value: 'value1' }, { name: 'attr2', value: 'value2' }]);
-    assert.deepEqual(node.attributes.map as Record<string, string>, { attr1: 'value1', attr2: 'value2' });
+    assert.deepEqual(node.attributes, [{ name: 'attr1', value: 'value1' }, { name: 'attr2', value: 'value2' }] as unknown as Attributes);
+    assert.deepEqual(node.attributes?.map as Record<string, string>, { attr1: 'value1', attr2: 'value2' });
 
     node = new AstNode('b', 1);
     assert.deepEqual(node.attributes, emptyAttributes);
@@ -266,17 +268,17 @@ describe('browser.tinymce.core.html.NodeTest', () => {
     node.attr('attr1', null);
     assert.isUndefined(node.attr('attr1'));
     assert.deepEqual(node.attributes, emptyAttributes);
-    assert.deepEqual(node.attributes.map as Record<string, string>, {});
+    assert.deepEqual(node.attributes?.map as Record<string, string>, {});
 
     node = new AstNode('b', 1);
     node.attr({ a: '1', b: '2' });
-    assert.deepEqual(node.attributes, [{ name: 'a', value: '1' }, { name: 'b', value: '2' }]);
-    assert.deepEqual(node.attributes.map as Record<string, string>, { a: '1', b: '2' });
+    assert.deepEqual(node.attributes, [{ name: 'a', value: '1' }, { name: 'b', value: '2' }] as unknown as Attributes);
+    assert.deepEqual(node.attributes?.map as Record<string, string>, { a: '1', b: '2' });
 
     node = new AstNode('b', 1);
-    node.attr(null);
+    node.attr(null as any);
     assert.deepEqual(node.attributes, emptyAttributes);
-    assert.deepEqual(node.attributes.map as Record<string, string>, {});
+    assert.deepEqual(node.attributes?.map as Record<string, string>, {});
   });
 
   it('clone', () => {
@@ -311,8 +313,8 @@ describe('browser.tinymce.core.html.NodeTest', () => {
     clone = node.clone();
     assert.equal(clone.name, 'b');
     assert.equal(clone.type, 1);
-    assert.deepEqual(clone.attributes, [{ name: 'class', value: 'class' }, { name: 'title', value: 'title' }]);
-    assert.deepEqual(clone.attributes.map as Record<string, string>, { class: 'class', title: 'title' });
+    assert.deepEqual(clone.attributes, [{ name: 'class', value: 'class' }, { name: 'title', value: 'title' }] as unknown as Attributes);
+    assert.deepEqual(clone.attributes?.map as Record<string, string>, { class: 'class', title: 'title' });
   });
 
   it('unwrap', () => {
@@ -379,7 +381,7 @@ describe('browser.tinymce.core.html.NodeTest', () => {
     assert.isTrue(node1.isEmpty({ img: 1 }), 'Is empty 5');
 
     root = new AstNode('#frag', 11);
-    node1 = root.append(new AstNode('a', 1)).attr('name', 'x');
+    root.append(new AstNode('a', 1)).attr('name', 'x');
     assert.isFalse(root.isEmpty({ img: 1 }), 'Contains anchor with name attribute.');
 
     const isSpan = (node: AstNode) => {
@@ -387,11 +389,11 @@ describe('browser.tinymce.core.html.NodeTest', () => {
     };
 
     root = new AstNode('#frag', 11);
-    node1 = root.append(new AstNode('span', 1));
+    root.append(new AstNode('span', 1));
     assert.isFalse(root.isEmpty({ img: 1 }, {}, isSpan), 'Should be false since the predicate says true.');
 
     root = new AstNode('#frag', 11);
-    node1 = root.append(new AstNode('b', 1));
+    root.append(new AstNode('b', 1));
     assert.isTrue(root.isEmpty({ img: 1 }, {}, isSpan), 'Should be true since the predicate says false.');
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -2,73 +2,81 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Obj, Type } from '@ephox/katamari';
 import { assert } from 'chai';
 
-import Schema from 'tinymce/core/api/html/Schema';
+import Schema, { AttributePattern, SchemaElement } from 'tinymce/core/api/html/Schema';
 
 describe('browser.tinymce.core.html.SchemaTest', () => {
+  const getElementRule = (schema: Schema, name: string) =>
+    schema.getElementRule(name) as SchemaElement;
+
+  const getFirstAttributePattern = (schema: Schema, name: string) => {
+    const rule = getElementRule(schema, name);
+    return rule.attributePatterns?.[0] as AttributePattern;
+  };
+
   it('Valid elements global rule', () => {
     const schema = Schema({ valid_elements: '@[id|style],img[src|-style]' });
-    assert.deepEqual(schema.getElementRule('img'), { attributes: { id: {}, src: {}}, attributesOrder: [ 'id', 'src' ] });
+    assert.deepEqual(getElementRule(schema, 'img'), { attributes: { id: {}, src: {}}, attributesOrder: [ 'id', 'src' ] });
   });
 
   it('Wildcard element rule', () => {
     let schema = Schema({ valid_elements: '*[id|class]' });
-    assert.deepEqual(schema.getElementRule('b').attributes, { id: {}, class: {}});
-    assert.deepEqual(schema.getElementRule('b').attributesOrder, [ 'id', 'class' ]);
+    assert.deepEqual(getElementRule(schema, 'b').attributes, { id: {}, class: {}});
+    assert.deepEqual(getElementRule(schema, 'b').attributesOrder, [ 'id', 'class' ]);
 
     schema = Schema({ valid_elements: 'b*[id|class]' });
-    assert.deepEqual(schema.getElementRule('b').attributes, { id: {}, class: {}});
-    assert.deepEqual(schema.getElementRule('b').attributesOrder, [ 'id', 'class' ]);
-    assert.deepEqual(schema.getElementRule('body').attributes, { id: {}, class: {}});
-    assert.deepEqual(schema.getElementRule('body').attributesOrder, [ 'id', 'class' ]);
-    assert.isUndefined(schema.getElementRule('img'));
+    assert.deepEqual(getElementRule(schema, 'b').attributes, { id: {}, class: {}});
+    assert.deepEqual(getElementRule(schema, 'b').attributesOrder, [ 'id', 'class' ]);
+    assert.deepEqual(getElementRule(schema, 'body').attributes, { id: {}, class: {}});
+    assert.deepEqual(getElementRule(schema, 'body').attributesOrder, [ 'id', 'class' ]);
+    assert.isUndefined(getElementRule(schema, 'img'));
 
     schema = Schema({ valid_elements: 'b?[id|class]' });
-    assert.deepEqual(schema.getElementRule('b').attributes, { id: {}, class: {}});
-    assert.deepEqual(schema.getElementRule('b').attributesOrder, [ 'id', 'class' ]);
-    assert.deepEqual(schema.getElementRule('bx').attributes, { id: {}, class: {}});
-    assert.deepEqual(schema.getElementRule('bx').attributesOrder, [ 'id', 'class' ]);
-    assert.isUndefined(schema.getElementRule('body'));
+    assert.deepEqual(getElementRule(schema, 'b').attributes, { id: {}, class: {}});
+    assert.deepEqual(getElementRule(schema, 'b').attributesOrder, [ 'id', 'class' ]);
+    assert.deepEqual(getElementRule(schema, 'bx').attributes, { id: {}, class: {}});
+    assert.deepEqual(getElementRule(schema, 'bx').attributesOrder, [ 'id', 'class' ]);
+    assert.isUndefined(getElementRule(schema, 'body'));
 
     schema = Schema({ valid_elements: 'b+[id|class]' });
-    assert.deepEqual(schema.getElementRule('body').attributes, { id: {}, class: {}});
-    assert.deepEqual(schema.getElementRule('body').attributesOrder, [ 'id', 'class' ]);
-    assert.deepEqual(schema.getElementRule('bx').attributes, { id: {}, class: {}});
-    assert.deepEqual(schema.getElementRule('bx').attributesOrder, [ 'id', 'class' ]);
-    assert.isUndefined(schema.getElementRule('b'));
+    assert.deepEqual(getElementRule(schema, 'body').attributes, { id: {}, class: {}});
+    assert.deepEqual(getElementRule(schema, 'body').attributesOrder, [ 'id', 'class' ]);
+    assert.deepEqual(getElementRule(schema, 'bx').attributes, { id: {}, class: {}});
+    assert.deepEqual(getElementRule(schema, 'bx').attributesOrder, [ 'id', 'class' ]);
+    assert.isUndefined(getElementRule(schema, 'b'));
   });
 
   it('Wildcard attribute rule', () => {
     let schema = Schema({ valid_elements: 'b[id|class|*]' });
-    assert.deepEqual(schema.getElementRule('b').attributes, { id: {}, class: {}});
-    assert.deepEqual(schema.getElementRule('b').attributesOrder, [ 'id', 'class' ]);
-    assert.isTrue(schema.getElementRule('b').attributePatterns[0].pattern.test('x'));
+    assert.deepEqual(getElementRule(schema, 'b').attributes, { id: {}, class: {}});
+    assert.deepEqual(getElementRule(schema, 'b').attributesOrder, [ 'id', 'class' ]);
+    assert.isTrue(getFirstAttributePattern(schema, 'b').pattern.test('x'));
 
     schema = Schema({ valid_elements: 'b[id|class|x?]' });
-    assert.deepEqual(schema.getElementRule('b').attributes, { id: {}, class: {}});
-    assert.deepEqual(schema.getElementRule('b').attributesOrder, [ 'id', 'class' ]);
-    assert.isTrue(schema.getElementRule('b').attributePatterns[0].pattern.test('xy'));
-    assert.isFalse(schema.getElementRule('b').attributePatterns[0].pattern.test('xba'));
-    assert.isFalse(schema.getElementRule('b').attributePatterns[0].pattern.test('a'));
+    assert.deepEqual(getElementRule(schema, 'b').attributes, { id: {}, class: {}});
+    assert.deepEqual(getElementRule(schema, 'b').attributesOrder, [ 'id', 'class' ]);
+    assert.isTrue(getFirstAttributePattern(schema, 'b').pattern.test('xy'));
+    assert.isFalse(getFirstAttributePattern(schema, 'b').pattern.test('xba'));
+    assert.isFalse(getFirstAttributePattern(schema, 'b').pattern.test('a'));
 
     schema = Schema({ valid_elements: 'b[id|class|x+]' });
-    assert.deepEqual(schema.getElementRule('b').attributes, { id: {}, class: {}});
-    assert.deepEqual(schema.getElementRule('b').attributesOrder, [ 'id', 'class' ]);
-    assert.isFalse(schema.getElementRule('b').attributePatterns[0].pattern.test('x'));
-    assert.isTrue(schema.getElementRule('b').attributePatterns[0].pattern.test('xb'));
-    assert.isTrue(schema.getElementRule('b').attributePatterns[0].pattern.test('xba'));
+    assert.deepEqual(getElementRule(schema, 'b').attributes, { id: {}, class: {}});
+    assert.deepEqual(getElementRule(schema, 'b').attributesOrder, [ 'id', 'class' ]);
+    assert.isFalse(getFirstAttributePattern(schema, 'b').pattern.test('x'));
+    assert.isTrue(getFirstAttributePattern(schema, 'b').pattern.test('xb'));
+    assert.isTrue(getFirstAttributePattern(schema, 'b').pattern.test('xba'));
   });
 
   it('Valid attributes and attribute order', () => {
     const schema = Schema({ valid_elements: 'div,a[href|title],b[title]' });
-    assert.deepEqual(schema.getElementRule('div'), { attributes: {}, attributesOrder: [] });
-    assert.deepEqual(schema.getElementRule('a'), { attributes: { href: {}, title: {}}, attributesOrder: [ 'href', 'title' ] });
-    assert.deepEqual(schema.getElementRule('b'), { attributes: { title: {}}, attributesOrder: [ 'title' ] });
+    assert.deepEqual(getElementRule(schema, 'div'), { attributes: {}, attributesOrder: [] });
+    assert.deepEqual(getElementRule(schema, 'a'), { attributes: { href: {}, title: {}}, attributesOrder: [ 'href', 'title' ] });
+    assert.deepEqual(getElementRule(schema, 'b'), { attributes: { title: {}}, attributesOrder: [ 'title' ] });
   });
 
   it('Required any attributes', () => {
     const schema = Schema({ valid_elements: 'a![id|style|href]' });
     assert.deepEqual(
-      schema.getElementRule('a'),
+      getElementRule(schema, 'a'),
       { attributes: { href: {}, id: {}, style: {}}, attributesOrder: [ 'id', 'style', 'href' ], removeEmptyAttrs: true }
     );
   });
@@ -76,7 +84,7 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
   it('Required attributes', () => {
     const schema = Schema({ valid_elements: 'a[!href|!name]' });
     assert.deepEqual(
-      schema.getElementRule('a'),
+      getElementRule(schema, 'a'),
       {
         attributes: { href: { required: true }, name: { required: true }},
         attributesOrder: [ 'href', 'name' ], attributesRequired: [ 'href', 'name' ]
@@ -87,7 +95,7 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
   it('Default attribute values', () => {
     const schema = Schema({ valid_elements: 'img[border=0]' });
     assert.deepEqual(
-      schema.getElementRule('img'),
+      getElementRule(schema, 'img'),
       {
         attributes: { border: { defaultValue: '0' }},
         attributesOrder: [ 'border' ],
@@ -100,7 +108,7 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
     const schema = Schema({ valid_elements: 'img[border~0]' });
     schema.addValidElements('a[href~a|xlink:href~b]');
     assert.deepEqual(
-      schema.getElementRule('img'),
+      getElementRule(schema, 'img'),
       {
         attributes: { border: { forcedValue: '0' }},
         attributesOrder: [ 'border' ],
@@ -108,7 +116,7 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
       }
     );
     assert.deepEqual(
-      schema.getElementRule('a'),
+      getElementRule(schema, 'a'),
       {
         attributes: { 'href': { forcedValue: 'a' }, 'xlink:href': { forcedValue: 'b' }},
         attributesOrder: [ 'href', 'xlink:href' ],
@@ -120,7 +128,7 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
   it('Required attribute values', () => {
     const schema = Schema({ valid_elements: 'span[dir<ltr?rtl]' });
     assert.deepEqual(
-      schema.getElementRule('span'),
+      getElementRule(schema, 'span'),
       {
         attributes: { dir: { validValues: { rtl: {}, ltr: {}}}},
         attributesOrder: [ 'dir' ]
@@ -130,28 +138,28 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
 
   it('Required parents', () => {
     const schema = Schema();
-    assert.deepEqual(schema.getElementRule('tr').parentsRequired, [ 'tbody', 'thead', 'tfoot' ]);
-    assert.deepEqual(schema.getElementRule('li').parentsRequired, [ 'ul', 'ol' ]);
-    assert.isUndefined(schema.getElementRule('div').parentsRequired);
+    assert.deepEqual(getElementRule(schema, 'tr').parentsRequired, [ 'tbody', 'thead', 'tfoot' ]);
+    assert.deepEqual(getElementRule(schema, 'li').parentsRequired, [ 'ul', 'ol' ]);
+    assert.isUndefined(getElementRule(schema, 'div').parentsRequired);
   });
 
   it('Remove empty elements', () => {
     let schema = Schema({ valid_elements: '-span' });
-    assert.deepEqual(schema.getElementRule('span'), { attributes: {}, attributesOrder: [], removeEmpty: true });
+    assert.deepEqual(getElementRule(schema, 'span'), { attributes: {}, attributesOrder: [], removeEmpty: true });
 
     schema = Schema({ valid_elements: '#span' });
-    assert.deepEqual(schema.getElementRule('span'), { attributes: {}, attributesOrder: [], paddEmpty: true });
+    assert.deepEqual(getElementRule(schema, 'span'), { attributes: {}, attributesOrder: [], paddEmpty: true });
 
     // Empty table rows should not be removed
     schema = Schema();
-    assert.isUndefined(schema.getElementRule('tr').removeEmpty);
+    assert.isUndefined(getElementRule(schema, 'tr').removeEmpty);
   });
 
   it('addValidElements', () => {
     const schema = Schema({ valid_elements: '@[id|style],img[src|-style]' });
     schema.addValidElements('b[class]');
     assert.deepEqual(
-      schema.getElementRule('b'),
+      getElementRule(schema, 'b'),
       {
         attributes: { id: {}, style: {}, class: {}},
         attributesOrder: [ 'id', 'style', 'class' ]
@@ -159,7 +167,7 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
     );
     schema.addValidElements('custom-element[custom-attribute]');
     assert.deepEqual(
-      schema.getElementRule('custom-element'),
+      getElementRule(schema, 'custom-element'),
       {
         attributes: { 'id': {}, 'style': {}, 'custom-attribute': {}},
         attributesOrder: [ 'id', 'style', 'custom-attribute' ]
@@ -172,7 +180,7 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
     const schema = Schema({ valid_elements: '@[xml\\:space]' });
     schema.addValidElements('pre[xml:lang]');
     assert.deepEqual(
-      schema.getElementRule('pre'),
+      getElementRule(schema, 'pre'),
       {
         attributes: { 'xml:space': {}, 'xml:lang': {}},
         attributesOrder: [ 'xml:space', 'xml:lang' ]
@@ -183,13 +191,13 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
   it('setValidElements', () => {
     let schema = Schema({ valid_elements: '@[id|style],img[src|-style]' });
     schema.setValidElements('b[class]');
-    assert.isUndefined(schema.getElementRule('img'));
-    assert.deepEqual(schema.getElementRule('b'), { attributes: { class: {}}, attributesOrder: [ 'class' ] });
+    assert.isUndefined(getElementRule(schema, 'img'));
+    assert.deepEqual(getElementRule(schema, 'b'), { attributes: { class: {}}, attributesOrder: [ 'class' ] });
 
     schema = Schema({ valid_elements: 'img[src]' });
     schema.setValidElements('@[id|style],img[src]');
     assert.deepEqual(
-      schema.getElementRule('img'),
+      getElementRule(schema, 'img'),
       {
         attributes: { id: {}, style: {}, src: {}},
         attributesOrder: [ 'id', 'style', 'src' ]
@@ -317,16 +325,16 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
 
   it('getElementRule', () => {
     const schema = Schema();
-    assert.isObject(schema.getElementRule('b'));
-    assert.isUndefined(schema.getElementRule('bx'));
-    assert.isUndefined(schema.getElementRule(null));
+    assert.isObject(getElementRule(schema, 'b'));
+    assert.isUndefined(getElementRule(schema, 'bx'));
+    assert.isUndefined(schema.getElementRule(null as any));
   });
 
   it('addCustomElements', () => {
     const schema = Schema({ valid_elements: 'inline,block' });
     schema.addCustomElements('~inline,block');
-    assert.isObject(schema.getElementRule('inline'));
-    assert.isObject(schema.getElementRule('block'));
+    assert.isObject(getElementRule(schema, 'inline'));
+    assert.isObject(getElementRule(schema, 'block'));
     assert.isTrue(schema.isValidChild('body', 'block'));
     assert.isTrue(schema.isValidChild('block', 'inline'));
     assert.isTrue(schema.isValidChild('p', 'inline'));
@@ -497,14 +505,14 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
         custom_elements: '~foo-bar,bar-foo'
       });
 
-      const inlineRule = schema.getElementRule('foo-bar');
-      const spanRule = schema.getElementRule('span');
+      const inlineRule = getElementRule(schema, 'foo-bar');
+      const spanRule = getElementRule(schema, 'span');
       assert.deepEqual(inlineRule.attributes, spanRule.attributes, 'inline custom element rules should be copied from the span rules');
       assert.deepEqual(inlineRule.attributesOrder, spanRule.attributesOrder, 'inline custom element rules should be copied from the span rules');
       assert.deepEqual(schema.children['foo-bar'], schema.children.span);
 
-      const blockRule = schema.getElementRule('bar-foo');
-      const divRule = schema.getElementRule('div');
+      const blockRule = getElementRule(schema, 'bar-foo');
+      const divRule = getElementRule(schema, 'div');
       assert.deepEqual(blockRule.attributes, divRule.attributes, 'block custom element rules should be copied from the div rules');
       assert.deepEqual(blockRule.attributesOrder, divRule.attributesOrder, 'block custom element rules should be copied from the div rules');
       assert.deepEqual(schema.children['bar-foo'], schema.children.div);
@@ -522,19 +530,19 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
   context('paddInEmptyBlock', () => {
     it('TINY-8639: default behaviour', () => {
       const schema = Schema({});
-      const rules = Obj.mapToArray(schema.getTextInlineElements(), (_value, name) => schema.getElementRule(name.toLowerCase()));
+      const rules = Obj.mapToArray(schema.getTextInlineElements(), (_value, name) => getElementRule(schema, name.toLowerCase()));
       assert.isTrue(rules.length > 0 && Arr.forall(rules, (rule) => Type.isUndefined(rule.paddInEmptyBlock)));
     });
 
     it('TINY-8639: padd_empty_block_inline_children: false', () => {
       const schema = Schema({ padd_empty_block_inline_children: false });
-      const rules = Obj.mapToArray(schema.getTextInlineElements(), (_value, name) => schema.getElementRule(name.toLowerCase()));
+      const rules = Obj.mapToArray(schema.getTextInlineElements(), (_value, name) => getElementRule(schema, name.toLowerCase()));
       assert.isTrue(rules.length > 0 && Arr.forall(rules, (rule) => Type.isUndefined(rule.paddInEmptyBlock)));
     });
 
     it('TINY-8639: padd_empty_block_inline_children: true', () => {
       const schema = Schema({ padd_empty_block_inline_children: true });
-      const rules = Obj.mapToArray(schema.getTextInlineElements(), (_value, name) => schema.getElementRule(name.toLowerCase()));
+      const rules = Obj.mapToArray(schema.getTextInlineElements(), (_value, name) => getElementRule(schema, name.toLowerCase()));
       assert.isTrue(rules.length > 0 && Arr.forall(rules, (rule) => rule.paddInEmptyBlock === true));
     });
   });

--- a/modules/tinymce/src/core/test/ts/browser/init/ContentCssTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/ContentCssTest.ts
@@ -15,7 +15,7 @@ describe('browser.tinymce.core.init.ContentCssTest', () => {
     skinsBaseUrl = EditorManager.baseURL + '/skins/content';
   });
 
-  const testContentCss = (expectedContentCss: string[], inputContentCss: string[] | string | boolean, inline: boolean = false) => {
+  const testContentCss = (expectedContentCss: string[], inputContentCss: string[] | string | boolean | undefined, inline: boolean = false) => {
     const editor = new Editor('id', {
       content_css: inputContentCss,
       inline

--- a/modules/tinymce/src/core/test/ts/browser/init/EditorCustomThemeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/EditorCustomThemeTest.ts
@@ -20,7 +20,7 @@ describe('browser.tinymce.core.init.EditorCustomThemeTest', () => {
       iframeContainer.id = 'iframeContainer';
 
       editorContainer.appendChild(iframeContainer);
-      targetnode.parentNode.insertBefore(editorContainer, targetnode);
+      targetnode.parentNode?.insertBefore(editorContainer, targetnode);
 
       if (editor.initialized) {
         editor.dispatch('SkinLoaded');

--- a/modules/tinymce/src/core/test/ts/browser/init/EditorInitializationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/EditorInitializationTest.ts
@@ -32,7 +32,7 @@ describe('browser.tinymce.core.init.EditorInitializationTest', () => {
   });
 
   it('target (initialised properly)', (done) => {
-    const elm1 = viewBlock.get().querySelector<HTMLElement>('#elm-1');
+    const elm1 = viewBlock.get().querySelector('#elm-1') as HTMLElement;
 
     EditorManager.init({
       target: elm1,
@@ -58,8 +58,8 @@ describe('browser.tinymce.core.init.EditorInitializationTest', () => {
   });
 
   it('target (selector option takes precedence over target option)', (done) => {
-    const elm1 = document.getElementById('elm-1');
-    const elm2 = document.getElementById('elm-2');
+    const elm1 = document.getElementById('elm-1') as HTMLElement;
+    const elm2 = document.getElementById('elm-2') as HTMLElement;
 
     EditorManager.init({
       selector: '#elm-2',
@@ -81,9 +81,9 @@ describe('browser.tinymce.core.init.EditorInitializationTest', () => {
 
   it('target (each editor should have a different target)', (done) => {
     const maxCount = document.querySelectorAll('.elm-even').length;
-    const elm1 = document.getElementById('elm-1');
+    const elm1 = document.getElementById('elm-1') as HTMLElement;
     let count = 0;
-    const targets = [];
+    const targets: HTMLElement[] = [];
 
     EditorManager.init({
       selector: '.elm-even',
@@ -127,7 +127,7 @@ describe('browser.tinymce.core.init.EditorInitializationTest', () => {
 
   const getSkinCssFilenames = (): string[] => {
     return Arr.bind(SelectorFilter.descendants(SugarElement.fromDom(document), 'link'), (link) => {
-      const href = Attribute.get(link, 'href');
+      const href = Attribute.get(link, 'href') ?? '';
       const fileName = href.split('/').slice(-1).join('');
       const isSkin = href.indexOf('oxide/') > -1;
       return isSkin ? [ fileName ] : [ ];

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorIconTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorIconTest.ts
@@ -14,7 +14,7 @@ describe('browser.tinymce.core.init.InitEditorIconTest', () => {
     icons: 'custom',
     icons_url: '/project/tinymce/src/core/test/assets/icons/custom/icons.js',
     base_url: '/project/tinymce/js/tinymce',
-    setup: (editor) => {
+    setup: (editor: Editor) => {
       editor.ui.registry.addIcon('custom-icon', overrideIcon);
     }
   }, []);

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorNoThemeIframeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorNoThemeIframeTest.ts
@@ -9,7 +9,7 @@ describe('browser.tinymce.core.init.InitEditorNoThemeIframeTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     theme: false,
     base_url: '/project/tinymce/js/tinymce',
-    init_instance_callback: (editor) => {
+    init_instance_callback: (editor: Editor) => {
       editor.dispatch('SkinLoaded');
     }
   }, []);

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorNoThemeInlineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorNoThemeInlineTest.ts
@@ -11,7 +11,7 @@ describe('browser.tinymce.core.init.InitEditorNoThemeInlineTest', () => {
     theme: false,
     inline: true,
     base_url: '/project/tinymce/js/tinymce',
-    init_instance_callback: (editor) => {
+    init_instance_callback: (editor: Editor) => {
       editor.dispatch('SkinLoaded');
     }
   }, []);

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorThemeFunctionIframeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorThemeFunctionIframeTest.ts
@@ -7,7 +7,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.init.InitEditorThemeFunctionIframeTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
-    theme: (editor, target) => {
+    theme: (editor: Editor, target: HTMLElement) => {
       const elm = SugarElement.fromHtml('<div><button>B</button><div></div></div>');
 
       Insert.after(SugarElement.fromDom(target), elm);
@@ -18,7 +18,7 @@ describe('browser.tinymce.core.init.InitEditorThemeFunctionIframeTest', () => {
       };
     },
     base_url: '/project/tinymce/js/tinymce',
-    init_instance_callback: (editor) => {
+    init_instance_callback: (editor: Editor) => {
       editor.dispatch('SkinLoaded');
     }
   }, []);

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorThemeFunctionInlineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorThemeFunctionInlineTest.ts
@@ -8,7 +8,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.init.InitEditorThemeFunctionInlineTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
-    theme: (editor, target) => {
+    theme: (editor: Editor, target: HTMLElement) => {
       const elm = SugarElement.fromHtml('<div><button>B</button><div></div></div>');
 
       Insert.after(SugarElement.fromDom(target), elm);
@@ -19,7 +19,7 @@ describe('browser.tinymce.core.init.InitEditorThemeFunctionInlineTest', () => {
     },
     base_url: '/project/tinymce/js/tinymce',
     inline: true,
-    init_instance_callback: (editor) => {
+    init_instance_callback: (editor: Editor) => {
       editor.dispatch('SkinLoaded');
     }
   }, []);

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEventsOrderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEventsOrderTest.ts
@@ -19,7 +19,7 @@ describe('Init events order test', () => {
 
   TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
-    setup: (editor) => {
+    setup: (editor: Editor) => {
       editor.on('preinit addeditor scriptsloaded init visualaid loadcontent beforesetcontent setcontent postrender', addEvent);
     }
   }, []);

--- a/modules/tinymce/src/core/test/ts/browser/init/InitIframeAriaTextTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitIframeAriaTextTest.ts
@@ -13,7 +13,7 @@ describe('browser.tinymce.core.init.InitIframeAriaTextTest', () => {
     const editor = await McEditor.pFromSettings<Editor>({
       base_url: '/project/tinymce/js/tinymce'
     });
-    const iframe = SugarElement.fromDom(editor.iframeElement);
+    const iframe = SugarElement.fromDom(editor.iframeElement as HTMLIFrameElement);
     const iframeBody = TinyDom.body(editor);
     assert.equal(Attribute.get(iframe, 'title'), 'Rich Text Area');
     assert.equal(Attribute.get(iframeBody, 'aria-label'), defaultIframeTitle);
@@ -25,7 +25,7 @@ describe('browser.tinymce.core.init.InitIframeAriaTextTest', () => {
       base_url: '/project/tinymce/js/tinymce',
       iframe_aria_text: customIframeTitle
     });
-    const iframe = SugarElement.fromDom(editor.iframeElement);
+    const iframe = SugarElement.fromDom(editor.iframeElement as HTMLIFrameElement);
     const iframeBody = TinyDom.body(editor);
     assert.equal(Attribute.get(iframe, 'title'), 'Rich Text Area');
     assert.equal(Attribute.get(iframeBody, 'aria-label'), customIframeTitle);

--- a/modules/tinymce/src/core/test/ts/browser/init/InitIframeEditorWithCustomAttrsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitIframeEditorWithCustomAttrsTest.ts
@@ -17,7 +17,7 @@ describe('browser.tinymce.core.init.InitIframeEditorWithCustomAttrsTest', () => 
 
   it('Check if iframe element has the right custom attributes', () => {
     const editor = hook.editor();
-    const ifr = SugarElement.fromDom(editor.iframeElement);
+    const ifr = SugarElement.fromDom(editor.iframeElement as HTMLIFrameElement);
 
     assert.notEqual(Attribute.get(ifr, 'id'), 'x', 'Id should not be the defined x');
     assert.equal(Attribute.get(ifr, 'data-custom1'), 'a', 'Custom attribute should have the right value');

--- a/modules/tinymce/src/core/test/ts/browser/init/InitIframeEditorWithTabindexTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitIframeEditorWithTabindexTest.ts
@@ -23,7 +23,7 @@ describe('browser.tinymce.core.init.InitIframeEditorWithTabindexTest', () => {
 
   it('TINY-8315: Check if the iframe element has the right tabindex attribute', () => {
     const editor = hook.editor();
-    const ifr = SugarElement.fromDom(editor.iframeElement);
+    const ifr = SugarElement.fromDom(editor.iframeElement as HTMLIFrameElement);
     assert.equal(Attribute.get(ifr, 'tabindex'), '7', 'Tabindex attribute should have the right value');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysAnchorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysAnchorTest.ts
@@ -19,7 +19,7 @@ describe('browser.tinymce.core.keyboard.ArrowKeysAnchorTest', () => {
 
   const addGeckoBr = (s: ApproxStructure.StructApi, str: ApproxStructure.StringApi, children: StructAssert[]) => {
     if (PlatformDetection.detect().browser.isFirefox()) {
-      return [].concat(children).concat(s.element('br', { attrs: { 'data-mce-bogus': str.is('1') }}));
+      return [ ...children, s.element('br', { attrs: { 'data-mce-bogus': str.is('1') }}) ];
     } else {
       return children;
     }

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/AutocompleterTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/AutocompleterTest.ts
@@ -129,7 +129,9 @@ describe('browser.tinymce.core.keyboard.AutocompleterTest', () => {
   it('TINY-8279: mceAutocompleterClose command should fire an AutocompleterEnd event', async () => {
     const editor = hook.editor();
     const events: string[] = [];
-    const collect = (args: EditorEvent<AutocompleterEventArgs>) => events.push(args.type);
+    const collect = (args: EditorEvent<{}>) => {
+      events.push(args.type);
+    };
 
     editor.on('AutocompleterEnd', collect);
     await pOpenAutocompleter(editor, plusTriggerChar);

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/BoundaryCaretTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/BoundaryCaretTest.ts
@@ -24,7 +24,7 @@ describe('browser.tinymce.core.keyboard.BoundaryCaretTest', () => {
   const testRenderCaret = (html: string, elementPath: number[], offset: number, expectedHtml: string, expectedPath: number[], expectedOffset: number) => {
     const elm = SugarElement.fromHtml<HTMLDivElement>('<div>' + html + '</div>');
     const location = createLocation(elm, elementPath, offset);
-    const caret = Cell(null);
+    const caret = Cell<Text | null>(null);
 
     assert.isTrue(location.isSome(), 'Should be a valid location: ' + html);
 

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/BoundaryLocationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/BoundaryLocationTest.ts
@@ -29,7 +29,7 @@ describe('browser.tinymce.core.keyboard.BoundaryLocationTest', () => {
     return location;
   };
 
-  const createPosition = (elm, elementPath, offset) => {
+  const createPosition = (elm: SugarElement<Element>, elementPath: number[], offset: number) => {
     const container = Hierarchy.follow(elm, elementPath);
     return CaretPosition(container.getOrDie().dom, offset);
   };

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyAnchorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyAnchorTest.ts
@@ -20,7 +20,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyAnchorTest', () => {
 
   const addGeckoBr = (s: ApproxStructure.StructApi, str: ApproxStructure.StringApi, children: StructAssert[]) => {
     if (PlatformDetection.detect().browser.isFirefox()) {
-      return [].concat(children).concat(s.element('br', { attrs: { 'data-mce-bogus': str.is('1') }}));
+      return [ ...children, s.element('br', { attrs: { 'data-mce-bogus': str.is('1') }}) ];
     } else {
       return children;
     }

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
@@ -54,13 +54,13 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     LegacyUnit.setSelection(editor, 'h1', 2);
     pressEnter(editor, true);
     assert.equal(editor.getContent(), '<h1>ab</h1><h1>cd</h1>');
-    assert.equal(editor.selection.getRng().startContainer.parentNode.nodeName, 'H1');
+    assert.equal(editor.selection.getRng().startContainer.parentNode?.nodeName, 'H1');
   });
 
   it('Enter before text after EM', () => {
     const editor = hook.editor();
     editor.setContent('<p><em>a</em>b</p>');
-    editor.selection.setCursorLocation(editor.getBody().firstChild, 1);
+    editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 1);
     pressEnter(editor, true);
     assert.equal(editor.getContent(), '<p><em>a</em></p><p>b</p>');
     const rng = editor.selection.getRng();
@@ -70,7 +70,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
   it('Enter before first IMG in P', () => {
     const editor = hook.editor();
     editor.setContent('<p><img src="about:blank" /></p>');
-    editor.selection.setCursorLocation(editor.getBody().firstChild, 0);
+    editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 0);
     pressEnter(editor, true);
     assert.equal(editor.getContent(), '<p>\u00a0</p><p><img src="about:blank"></p>');
   });
@@ -78,7 +78,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
   it('Enter before first wrapped IMG in P', () => {
     const editor = hook.editor();
     editor.setContent('<p><strong><img src="about:blank" /></strong></p>');
-    editor.selection.setCursorLocation(editor.getBody().firstChild.firstChild, 0);
+    editor.selection.setCursorLocation(editor.getBody().firstChild?.firstChild as HTMLElement, 0);
     pressEnter(editor, true);
     assert.equal((editor.getBody().firstChild as HTMLElement).innerHTML, '<br data-mce-bogus="1">');
     assert.equal(editor.getContent(), '<p>\u00a0</p><p><strong><img src="about:blank"></strong></p>');
@@ -87,7 +87,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
   it('Enter before last IMG in P with text', () => {
     const editor = hook.editor();
     editor.setContent('<p>abc<img src="about:blank" /></p>');
-    editor.selection.setCursorLocation(editor.getBody().firstChild, 1);
+    editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 1);
     pressEnter(editor, true);
     assert.equal(editor.getContent(), '<p>abc</p><p><img src="about:blank"></p>');
     const rng = editor.selection.getRng();
@@ -98,7 +98,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
   it('Enter before last IMG in P with IMG sibling', () => {
     const editor = hook.editor();
     editor.setContent('<p><img src="about:blank" /><img src="about:blank" /></p>');
-    editor.selection.setCursorLocation(editor.getBody().firstChild, 1);
+    editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 1);
     pressEnter(editor, true);
     assert.equal(editor.getContent(), '<p><img src="about:blank"></p><p><img src="about:blank"></p>');
     const rng = editor.selection.getRng();
@@ -109,7 +109,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
   it('Enter after last IMG in P', () => {
     const editor = hook.editor();
     editor.setContent('<p>abc<img src="about:blank" /></p>');
-    editor.selection.setCursorLocation(editor.getBody().firstChild, 2);
+    editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 2);
     pressEnter(editor, true);
     assert.equal(editor.getContent(), '<p>abc<img src="about:blank"></p><p>\u00a0</p>');
   });
@@ -117,7 +117,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
   it('Enter before last INPUT in P with text', () => {
     const editor = hook.editor();
     editor.setContent('<p>abc<input type="text" /></p>');
-    editor.selection.setCursorLocation(editor.getBody().firstChild, 1);
+    editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 1);
     pressEnter(editor, true);
     assert.equal(editor.getContent(), '<p>abc</p><p><input type="text"></p>');
     const rng = editor.selection.getRng();
@@ -128,7 +128,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
   it('Enter before last INPUT in P with IMG sibling', () => {
     const editor = hook.editor();
     editor.setContent('<p><input type="text" /><input type="text" /></p>');
-    editor.selection.setCursorLocation(editor.getBody().firstChild, 1);
+    editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 1);
     pressEnter(editor, true);
     assert.equal(editor.getContent(), '<p><input type="text"></p><p><input type="text"></p>');
     const rng = editor.selection.getRng();
@@ -139,7 +139,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
   it('Enter after last INPUT in P', () => {
     const editor = hook.editor();
     editor.setContent('<p>abc<input type="text" /></p>');
-    editor.selection.setCursorLocation(editor.getBody().firstChild, 2);
+    editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 2);
     pressEnter(editor, true);
     assert.equal(editor.getContent(), '<p>abc<input type="text"></p><p>\u00a0</p>');
   });
@@ -171,7 +171,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     LegacyUnit.setSelection(editor, 'em', 2);
     pressEnter(editor, true);
     assert.equal(editor.getContent(), '<p><em>ab</em></p><p><em>cd</em></p>');
-    assert.equal(editor.selection.getRng().startContainer.parentNode.nodeName, 'EM');
+    assert.equal(editor.selection.getRng().startContainer.parentNode?.nodeName, 'EM');
   });
 
   it('Enter at beginning EM inside P', () => {
@@ -204,7 +204,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     LegacyUnit.setSelection(editor, 'strong', 2);
     pressEnter(editor, true);
     assert.equal(editor.getContent(), '<p><em><strong>ab</strong></em></p><p><em><strong>cd</strong></em></p>');
-    assert.equal(editor.selection.getRng().startContainer.parentNode.nodeName, 'STRONG');
+    assert.equal(editor.selection.getRng().startContainer.parentNode?.nodeName, 'STRONG');
   });
 
   it('Enter at beginning STRONG in EM inside P', () => {
@@ -234,7 +234,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     LegacyUnit.setSelection(editor, 'p', 2);
     pressEnter(editor, true);
     assert.equal(editor.getContent(), '<p id="a" class="b" style="color: #000;">ab</p><p class="b" style="color: #000;">cd</p>');
-    assert.equal(editor.selection.getRng().startContainer.parentNode.nodeName, 'P');
+    assert.equal(editor.selection.getRng().startContainer.parentNode?.nodeName, 'P');
   });
 
   it('Enter at a range between H1 and P', () => {
@@ -555,8 +555,8 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     const rng = editor.dom.createRng();
 
     editor.getBody().innerHTML = '<table><tbody><td>x</td></tbody></table>';
-    rng.setStartAfter(editor.getBody().lastChild);
-    rng.setEndAfter(editor.getBody().lastChild);
+    rng.setStartAfter(editor.getBody().lastChild as HTMLTableElement);
+    rng.setEndAfter(editor.getBody().lastChild as HTMLTableElement);
     editor.selection.setRng(rng);
 
     pressEnter(editor, true);
@@ -568,8 +568,8 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     const rng = editor.dom.createRng();
 
     editor.getBody().innerHTML = '<table><tbody><td>x</td></tbody></table>';
-    rng.setStartBefore(editor.getBody().lastChild);
-    rng.setEndBefore(editor.getBody().lastChild);
+    rng.setStartBefore(editor.getBody().lastChild as HTMLTableElement);
+    rng.setEndBefore(editor.getBody().lastChild as HTMLTableElement);
     editor.selection.setRng(rng);
 
     pressEnter(editor, true);
@@ -581,8 +581,8 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     const rng = editor.dom.createRng();
 
     editor.getBody().innerHTML = '<table><tbody><td>x</td></tbody></table><p>x</p>';
-    rng.setStartAfter(editor.getBody().firstChild);
-    rng.setEndAfter(editor.getBody().firstChild);
+    rng.setStartAfter(editor.getBody().firstChild as HTMLTableElement);
+    rng.setEndAfter(editor.getBody().firstChild as HTMLTableElement);
     editor.selection.setRng(rng);
 
     pressEnter(editor, true);
@@ -594,8 +594,8 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     const rng = editor.dom.createRng();
 
     editor.getBody().innerHTML = '<p>x</p><table><tbody><td>x</td></tbody></table>';
-    rng.setStartBefore(editor.getBody().lastChild);
-    rng.setStartBefore(editor.getBody().lastChild);
+    rng.setStartBefore(editor.getBody().lastChild as HTMLTableElement);
+    rng.setStartBefore(editor.getBody().lastChild as HTMLTableElement);
     editor.selection.setRng(rng);
 
     pressEnter(editor, true);
@@ -607,8 +607,8 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     const rng = editor.dom.createRng();
 
     editor.getBody().innerHTML = '<table><tbody><tr><td>x</td></tr></tbody></table>';
-    rng.setStartBefore(editor.getBody().lastChild);
-    rng.setEndBefore(editor.getBody().lastChild);
+    rng.setStartBefore(editor.getBody().lastChild as HTMLTableElement);
+    rng.setEndBefore(editor.getBody().lastChild as HTMLTableElement);
     editor.selection.setRng(rng);
 
     pressEnter(editor, true);

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/InlineUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/InlineUtilsTest.ts
@@ -35,10 +35,10 @@ describe('browser.tinymce.core.keyboard.InlineUtilsTest', () => {
     textNode.dom.splitText(offset);
   };
 
-  const createFakeEditor = (settings: RawEditorOptions): Editor => {
+  const createFakeEditor = (options: RawEditorOptions): Editor => {
     return {
       options: {
-        get: (name) => settings[name] ?? 'a[href],code,.mce-annotation'
+        get: (name: string) => options[name] ?? 'a[href],code,.mce-annotation'
       }
     } as any;
   };

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/SpaceKeyBeforeInputEventTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/SpaceKeyBeforeInputEventTest.ts
@@ -4,7 +4,7 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
-import { pressKeyAction, testBeforeInputEvent } from '../util/BeforeInputEventUtils';
+import { pressKeyAction, testBeforeInputEvent } from '../../module/test/BeforeInputEventUtils';
 
 describe('browser.tinymce.core.delete.SpaceKeyBeforeInputEventTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/SpaceKeyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/SpaceKeyTest.ts
@@ -17,7 +17,7 @@ describe('browser.tinymce.core.keyboard.SpaceKeyTest', () => {
 
   context('Space key around inline boundary elements', () => {
     it('Press space at beginning of inline boundary inserting nbsp', () => {
-      const inputEvents: Array<{ inputType: string; data: string }> = [];
+      const inputEvents: Array<{ inputType: string; data: string | null }> = [];
       const editor = hook.editor();
       const collect = ({ inputType, data }: InputEvent) => {
         inputEvents.push({ inputType, data });

--- a/modules/tinymce/src/core/test/ts/browser/newline/NewlineBeforeInputEventTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/NewlineBeforeInputEventTest.ts
@@ -3,7 +3,7 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
-import { insertNewLineAction, testBeforeInputEvent } from '../util/BeforeInputEventUtils';
+import { insertNewLineAction, testBeforeInputEvent } from '../../module/test/BeforeInputEventUtils';
 
 describe('browser.tinymce.core.delete.NewlineBeforeInputEventTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/core/test/ts/browser/paste/ImagePasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/ImagePasteTest.ts
@@ -66,7 +66,7 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
   it('TBA: pasteImages should set unique id in blobcache', async () => {
     const editor = hook.editor();
 
-    const hasCachedItem = (name) => !!editor.editorUpload.blobCache.get(name);
+    const hasCachedItem = (name: string) => !!editor.editorUpload.blobCache.get(name);
 
     const event = mockEvent('paste', [
       base64ToBlob(base64ImgSrc, 'image/gif', 'image.gif'),
@@ -79,8 +79,8 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
 
     const cachedBlob1 = editor.editorUpload.blobCache.get('mceclip0');
     const cachedBlob2 = editor.editorUpload.blobCache.get('mceclip1');
-    assert.equal(cachedBlob1.base64(), base64ImgSrc);
-    assert.equal(cachedBlob2.base64(), base64ImgSrc2);
+    assert.equal(cachedBlob1?.base64(), base64ImgSrc);
+    assert.equal(cachedBlob2?.base64(), base64ImgSrc2);
   });
 
   it('TBA: dropImages', async () => {
@@ -123,7 +123,7 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     assert.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
 
     const blobInfo = editor.editorUpload.blobCache.getByData(base64ImgSrc, 'image/jpeg');
-    assert.equal(blobInfo.filename(), 'image.jfif');
+    assert.equal(blobInfo?.filename(), 'image.jfif');
 
     editor.options.unset('images_reuse_filename');
   });

--- a/modules/tinymce/src/core/test/ts/browser/paste/InternalClipboardTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/InternalClipboardTest.ts
@@ -4,11 +4,15 @@ import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import { PastePostProcessEvent, PastePreProcessEvent } from 'tinymce/core/api/EventTypes';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import * as InternalHtml from 'tinymce/core/paste/InternalHtml';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
 
 describe('browser.tinymce.core.paste.InternalClipboardTest', () => {
-  let dataTransfer, lastPreProcessEvent, lastPostProcessEvent;
+  let dataTransfer: DataTransfer | undefined;
+  let lastPreProcessEvent: EditorEvent<PastePreProcessEvent> | undefined;
+  let lastPostProcessEvent: EditorEvent<PastePostProcessEvent> | undefined;
 
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'table',
@@ -29,8 +33,8 @@ describe('browser.tinymce.core.paste.InternalClipboardTest', () => {
   }, [ TablePlugin ]);
 
   const resetProcessEvents = () => {
-    lastPreProcessEvent = null;
-    lastPostProcessEvent = null;
+    lastPreProcessEvent = undefined;
+    lastPostProcessEvent = undefined;
   };
 
   const cutCopyDataTransferEvent = (editor: Editor, type: 'cut' | 'copy') => {
@@ -42,8 +46,8 @@ describe('browser.tinymce.core.paste.InternalClipboardTest', () => {
     Clipboard.pasteItems(TinyDom.body(editor), data);
 
   const assertClipboardData = (expectedHtml: string, expectedText: string) => {
-    assert.equal(dataTransfer.getData('text/html'), expectedHtml, 'text/html data should match');
-    assert.equal(dataTransfer.getData('text/plain'), expectedText, 'text/plain data should match');
+    assert.equal(dataTransfer?.getData('text/html'), expectedHtml, 'text/html data should match');
+    assert.equal(dataTransfer?.getData('text/plain'), expectedText, 'text/plain data should match');
   };
 
   const copy = (editor: Editor, html: string, spath: number[], soffset: number, fpath: number[], foffset: number) => {
@@ -178,18 +182,18 @@ describe('browser.tinymce.core.paste.InternalClipboardTest', () => {
 
   context('paste', () => {
     const assertLastPreProcessEvent = (expectedData: { internal: boolean; content: string }) => {
-      assert.equal(lastPreProcessEvent.internal, expectedData.internal, 'Internal property should be equal');
-      assert.equal(lastPreProcessEvent.content, expectedData.content, 'Content property should be equal');
+      assert.equal(lastPreProcessEvent?.internal, expectedData.internal, 'Internal property should be equal');
+      assert.equal(lastPreProcessEvent?.content, expectedData.content, 'Content property should be equal');
     };
 
     const assertLastPostProcessEvent = (expectedData: { internal: boolean; content: string }) => {
-      assert.equal(lastPostProcessEvent.internal, expectedData.internal, 'Internal property should be equal');
-      assert.equal(lastPostProcessEvent.node.innerHTML, expectedData.content, 'Content property should be equal');
+      assert.equal(lastPostProcessEvent?.internal, expectedData.internal, 'Internal property should be equal');
+      assert.equal(lastPostProcessEvent?.node.innerHTML, expectedData.content, 'Content property should be equal');
     };
 
     const pWaitForProcessEvents = () => Waiter.pTryUntil('Did not get any events fired', () => {
-      assert.isNotNull(lastPreProcessEvent, 'PastePreProcess event object');
-      assert.isNotNull(lastPostProcessEvent, 'PastePostProcess event object');
+      assert.isDefined(lastPreProcessEvent, 'PastePreProcess event object');
+      assert.isDefined(lastPostProcessEvent, 'PastePostProcess event object');
     });
 
     it('TBA: Paste external content', async () => {

--- a/modules/tinymce/src/core/test/ts/browser/paste/PasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/PasteTest.ts
@@ -4,6 +4,8 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import { PastePostProcessEvent, PastePreProcessEvent } from 'tinymce/core/api/EventTypes';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import * as PasteUtils from 'tinymce/core/paste/PasteUtils';
 
 describe('browser.tinymce.core.paste.PasteTest', () => {
@@ -28,7 +30,7 @@ describe('browser.tinymce.core.paste.PasteTest', () => {
 
   it('TBA: Plain text toggle event', () => {
     const editor = hook.editor();
-    const events = [];
+    const events: Array<{ state: boolean }> = [];
 
     editor.on('PastePlainTextToggle', (e) => {
       events.push({ state: e.state });
@@ -213,7 +215,7 @@ describe('browser.tinymce.core.paste.PasteTest', () => {
 
   it('TBA: paste pre process text (event)', () => {
     const editor = hook.editor();
-    const callback = (e) => {
+    const callback = (e: EditorEvent<PastePreProcessEvent>) => {
       e.content = 'PRE:' + e.content;
     };
 
@@ -232,7 +234,7 @@ describe('browser.tinymce.core.paste.PasteTest', () => {
 
   it('TBA: paste pre process html (event)', () => {
     const editor = hook.editor();
-    const callback = (e) => {
+    const callback = (e: EditorEvent<PastePreProcessEvent>) => {
       e.content = 'PRE:' + e.content;
     };
 
@@ -251,7 +253,7 @@ describe('browser.tinymce.core.paste.PasteTest', () => {
 
   it('TBA: paste post process (event)', () => {
     const editor = hook.editor();
-    const callback = (e) => {
+    const callback = (e: EditorEvent<PastePostProcessEvent>) => {
       e.node.innerHTML += ':POST';
     };
 

--- a/modules/tinymce/src/core/test/ts/browser/selection/GetSelectionContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/GetSelectionContentTest.ts
@@ -3,7 +3,7 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import { GetContentEvent } from 'tinymce/core/api/EventTypes';
+import { BeforeGetContentEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { GetSelectionContentArgs } from 'tinymce/core/content/ContentTypes';
 import { getContent } from 'tinymce/core/selection/GetSelectionContent';
@@ -16,13 +16,15 @@ describe('browser.tinymce.selection.GetSelectionContentTest', () => {
   const testDivId = 'testDiv1';
 
   const focusDiv = () => {
-    const input = document.querySelector<HTMLDivElement>('#' + testDivId);
+    const input = document.querySelector('#' + testDivId) as HTMLDivElement;
     input.focus();
   };
 
   const removeTestDiv = () => {
     const input = document.querySelector('#' + testDivId);
-    input.parentNode.removeChild(input);
+    if (input) {
+      input.parentNode?.removeChild(input);
+    }
   };
 
   const addTestDiv = () => {
@@ -42,7 +44,7 @@ describe('browser.tinymce.selection.GetSelectionContentTest', () => {
   };
 
   const assertGetContentOverrideBeforeGetContent = (label: string, editor: Editor, expectedContent: string, args: Partial<GetSelectionContentArgs> = {}) => {
-    const handler = (e: EditorEvent<GetContentEvent>) => {
+    const handler = (e: EditorEvent<BeforeGetContentEvent>) => {
       if (e.selection === true) {
         e.preventDefault();
         e.content = expectedContent;

--- a/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkInlineEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SelectionBookmarkInlineEditorTest.ts
@@ -17,7 +17,9 @@ describe('browser.tinymce.core.selection.SelectionBookmarkInlineEditorTest', () 
 
   const removeTestDiv = () => {
     const input = document.querySelector('#' + testDivId);
-    input.parentNode.removeChild(input);
+    if (input) {
+      input.parentNode?.removeChild(input);
+    }
   };
 
   const addTestDiv = () => {
@@ -35,11 +37,11 @@ describe('browser.tinymce.core.selection.SelectionBookmarkInlineEditorTest', () 
   };
 
   const focusDiv = () => {
-    const input = document.querySelector<HTMLDivElement>('#' + testDivId);
+    const input = document.querySelector('#' + testDivId) as HTMLDivElement;
     input.focus();
   };
 
-  const assertPath = (label: string, root: SugarElement, expPath: number[], expOffset: number, actElement: Node, actOffset: number) => {
+  const assertPath = (label: string, root: SugarElement<Node>, expPath: number[], expOffset: number, actElement: Node, actOffset: number) => {
     const expected = Cursors.calculateOne(root, expPath);
     const message = () => {
       const actual = SugarElement.fromDom(actElement);
@@ -129,7 +131,7 @@ describe('browser.tinymce.core.selection.SelectionBookmarkInlineEditorTest', () 
     const editor = hook.editor();
     const modifyRange = (e: EditorEvent<{ range: Range }>) => {
       const newRng = document.createRange();
-      newRng.selectNodeContents(editor.getBody().lastChild);
+      newRng.selectNodeContents(editor.getBody().lastChild as HTMLParagraphElement);
       e.range = newRng;
     };
 

--- a/modules/tinymce/src/core/test/ts/browser/selection/SetSelectionContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/SetSelectionContentTest.ts
@@ -285,13 +285,13 @@ describe('browser.tinymce.selection.SetSelectionContentTest', () => {
   it('TINY-3254: The SetContent event should contain the cleaned content', () => {
     const editor = hook.editor();
 
-    let lastSetContent: SetContentEvent;
+    let lastSetContent: SetContentEvent | undefined;
     editor.on('SetContent', (e) => {
       lastSetContent = e;
     });
 
     SetSelectionContent.setContent(editor, '<img src="" onload="alert(1)">');
 
-    assert.equal(lastSetContent.content, '<img src="">');
+    assert.equal(lastSetContent?.content, '<img src="">');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindBlockPatternsTest.ts
@@ -4,7 +4,7 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as BlockPattern from 'tinymce/core/textpatterns/core/BlockPattern';
-import { PatternSet } from 'tinymce/core/textpatterns/core/PatternTypes';
+import { DynamicPatternContext, PatternSet } from 'tinymce/core/textpatterns/core/PatternTypes';
 import { getParentBlock, resolveFromDynamicPatterns } from 'tinymce/core/textpatterns/utils/Utils';
 
 import { getPatternSetFor } from '../../module/test/TextPatternsUtils';
@@ -91,7 +91,7 @@ describe('browser.tinymce.textpatterns.FindBlockPatternsTest', () => {
         { start: '#####', format: 'h5' },
         { start: '' }
       ],
-      text_patterns_lookup: (_ctx) => [
+      text_patterns_lookup: (_ctx: DynamicPatternContext) => [
         { start: '####', format: 'h4' },
         { start: 'TBA', cmd: 'mceInsertContent', value: 'To be announced' },
         { start: '###', cmd: 'mceInsertContent', value: 'h3 heading' }

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
@@ -5,7 +5,9 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as InlinePattern from 'tinymce/core/textpatterns/core/InlinePattern';
-import { InlinePattern as InlinePatternType, InlinePatternMatch, PatternSet } from 'tinymce/core/textpatterns/core/PatternTypes';
+import {
+  DynamicPatternContext, InlinePattern as InlinePatternType, InlinePatternMatch, PatternSet
+} from 'tinymce/core/textpatterns/core/PatternTypes';
 import { PathRange } from 'tinymce/core/textpatterns/utils/PathRange';
 import { getBeforeText, getParentBlock, resolveFromDynamicPatterns } from 'tinymce/core/textpatterns/utils/Utils';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
@@ -24,9 +26,9 @@ describe('browser.tinymce.textpatterns.FindInlinePatternTest', () => {
     for (let i = 0; i < expectedMatches.length; i++) {
       const expected = expectedMatches[i];
       const actual = actualMatches[i];
-      const pattern = actual.pattern;
+      const pattern = actual.pattern as Record<string, any>;
       Obj.each(expected.pattern, (value, key) => {
-        if (Obj.has<any, string>(pattern, key)) {
+        if (Obj.has(pattern, key)) {
           assert.deepEqual(pattern[key], value, 'Pattern ' + (i + 1) + ' property `' + key + '` is not equal');
         } else {
           assert.fail('Pattern ' + (i + 1) + ' property `' + key + '` is missing');
@@ -319,7 +321,7 @@ describe('browser.tinymce.textpatterns.FindInlinePatternTest', () => {
       text_patterns: [
         { start: '*', end: '*', format: 'italic' }
       ],
-      text_patterns_lookup: (ctx) => {
+      text_patterns_lookup: (ctx: DynamicPatternContext) => {
         const parentTag = ctx.block.nodeName.toLowerCase();
         if (parentTag === 'pre') {
           return [

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/ReplacementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/ReplacementTest.ts
@@ -37,7 +37,7 @@ describe('browser.tinymce.core.textpatterns.ReplacementTest', () => {
     editor.insertContent('|');
     const content = editor.getContent();
     const normalizedContent = normalize ? content.replace(/&nbsp;/g, ' ') : content;
-    Assertions.assertHtml('Checking cursor', afterType, normalizedContent);
+    Assertions.assertHtml('Checking cursor', afterType ?? '', normalizedContent);
   };
 
   it('Apply html replacement pattern on space', () => {

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextSearchTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextSearchTest.ts
@@ -111,11 +111,11 @@ describe('browser.tinymce.core.textpatterns.TextSearchTest', () => {
     editor.setContent('<p>def</p><p>*<a href="#">a</a>bc</p>');
     TinySelections.setCursor(editor, [ 1, 2 ], 2);
 
-    const asteriskNode = editorBody.childNodes[1].firstChild;
-    const anchorNode = asteriskNode.nextSibling.firstChild;
-    const asterisk = repeatLeftUntil(editor, '*');
+    const asteriskNode = editorBody.childNodes[1].firstChild as Text;
+    const anchorNode = asteriskNode.nextSibling?.firstChild as Text;
+    const asterisk = repeatLeftUntil(editor, '*') as Text;
     Assertions.assertDomEq('Repeat left until asterisk found', SugarElement.fromDom(asteriskNode), SugarElement.fromDom(asterisk));
-    const anchor = repeatLeftUntil(editor, 'a');
+    const anchor = repeatLeftUntil(editor, 'a') as Text;
     Assertions.assertDomEq('Repeat left until anchor found', SugarElement.fromDom(anchorNode), SugarElement.fromDom(anchor));
     const boundary = repeatLeftUntil(editor, 'def');
     assert.isNull(boundary, 'Repeat left until block boundary found');
@@ -127,11 +127,11 @@ describe('browser.tinymce.core.textpatterns.TextSearchTest', () => {
     editor.setContent('<p>*<a href="#">a</a>bc</p><p>def</p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
 
-    const contentNode = editorBody.childNodes[0].lastChild;
-    const anchorNode = contentNode.previousSibling.firstChild;
-    const asterisk = repeatRightUntil(editor, 'bc');
+    const contentNode = editorBody.childNodes[0].lastChild as Text;
+    const anchorNode = contentNode.previousSibling?.firstChild as Text;
+    const asterisk = repeatRightUntil(editor, 'bc') as Text;
     Assertions.assertDomEq('Repeat right until bc found', SugarElement.fromDom(contentNode), SugarElement.fromDom(asterisk));
-    const anchor = repeatRightUntil(editor, 'a');
+    const anchor = repeatRightUntil(editor, 'a') as Text;
     Assertions.assertDomEq('Repeat right until anchor found', SugarElement.fromDom(anchorNode), SugarElement.fromDom(anchor));
     const boundary = repeatRightUntil(editor, 'def');
     assert.isNull(boundary, 'Repeat right until block boundary found');

--- a/modules/tinymce/src/core/test/ts/browser/undo/LevelsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/undo/LevelsTest.ts
@@ -4,7 +4,7 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as Levels from 'tinymce/core/undo/Levels';
-import { UndoLevelType } from 'tinymce/core/undo/UndoManagerTypes';
+import { UndoLevel, UndoLevelType } from 'tinymce/core/undo/UndoManagerTypes';
 
 describe('browser.tinymce.core.undo.LevelsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -93,7 +93,7 @@ describe('browser.tinymce.core.undo.LevelsTest', () => {
 
   it('applyToEditor to equal content with complete level', () => {
     const editor = hook.editor();
-    const level = Levels.createCompleteLevel('<p>a</p>');
+    const level = Levels.createCompleteLevel('<p>a</p>') as UndoLevel;
     level.bookmark = { start: [ 1, 0, 0 ], forward: true };
 
     editor.getBody().innerHTML = '<p>a</p>';
@@ -106,7 +106,7 @@ describe('browser.tinymce.core.undo.LevelsTest', () => {
 
   it('applyToEditor to different content with complete level', () => {
     const editor = hook.editor();
-    const level = Levels.createCompleteLevel('<p>b</p>');
+    const level = Levels.createCompleteLevel('<p>b</p>') as UndoLevel;
     level.bookmark = { start: [ 1, 0, 0 ], forward: true };
 
     editor.getBody().innerHTML = '<p>a</p>';
@@ -119,7 +119,7 @@ describe('browser.tinymce.core.undo.LevelsTest', () => {
 
   it('applyToEditor to different content with fragmented level', () => {
     const editor = hook.editor();
-    const level = Levels.createFragmentedLevel([ '<p>a</p>', '<p>b</p>' ]);
+    const level = Levels.createFragmentedLevel([ '<p>a</p>', '<p>b</p>' ]) as UndoLevel;
     level.bookmark = { start: [ 1, 0, 0 ], forward: true };
 
     editor.getBody().innerHTML = '<p>c</p>';

--- a/modules/tinymce/src/core/test/ts/browser/util/EventDispatcherTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/EventDispatcherTest.ts
@@ -245,7 +245,7 @@ describe('browser.tinymce.core.util.EventDispatcherTest', () => {
     let dispatcher: EventDispatcher<any>;
 
     dispatcher = new EventDispatcher();
-    dispatcher.on('click', function () {
+    dispatcher.on('click', function (this: EventDispatcher<any>) {
       // eslint-disable-next-line consistent-this
       lastScope = this;
     }).dispatch('click');
@@ -253,7 +253,7 @@ describe('browser.tinymce.core.util.EventDispatcherTest', () => {
 
     const scope = { test: 1 };
     dispatcher = new EventDispatcher({ scope });
-    dispatcher.on('click', function (e) {
+    dispatcher.on('click', function (this: EventDispatcher<any>, e) {
       // eslint-disable-next-line consistent-this
       lastScope = this;
       lastEvent = e;
@@ -297,8 +297,8 @@ describe('browser.tinymce.core.util.EventDispatcherTest', () => {
   });
 
   it('toggleEvent setting', () => {
-    let lastName: string;
-    let lastState: boolean;
+    let lastName: string | undefined;
+    let lastState: boolean | undefined;
 
     const dispatcher = new EventDispatcher({
       toggleEvent: (name, state) => {
@@ -316,14 +316,14 @@ describe('browser.tinymce.core.util.EventDispatcherTest', () => {
     assert.equal(lastName, 'click');
     assert.isTrue(lastState);
 
-    lastName = lastState = null;
+    lastName = lastState = undefined;
     dispatcher.on('click', listenerB);
-    assert.isNull(lastName);
-    assert.isNull(lastState);
+    assert.isUndefined(lastName);
+    assert.isUndefined(lastState);
 
     dispatcher.off('click', listenerA);
-    assert.isNull(lastName);
-    assert.isNull(lastState);
+    assert.isUndefined(lastName);
+    assert.isUndefined(lastState);
 
     dispatcher.off('click', listenerB);
     assert.equal(lastName, 'click');
@@ -332,7 +332,7 @@ describe('browser.tinymce.core.util.EventDispatcherTest', () => {
 
   it('TINY-7436: Callbacks added or removed in an earlier handler do not run while firing the same event', () => {
     const dispatcher = new EventDispatcher();
-    const logs = [];
+    const logs: string[] = [];
 
     const func1 = () => {
       logs.push('func1');

--- a/modules/tinymce/src/core/test/ts/browser/util/FakeStorageTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/FakeStorageTest.ts
@@ -17,9 +17,9 @@ describe('browser.tinymce.core.util.LocalStorageTest', () => {
     assert.equal(LocalStorage.getItem('a'), '2');
     LocalStorage.setItem('a', '3');
     assert.equal(LocalStorage.getItem('a'), '3');
-    LocalStorage.setItem('a', null);
+    LocalStorage.setItem('a', null as any);
     assert.equal(LocalStorage.getItem('a'), 'null');
-    LocalStorage.setItem('a', undefined);
+    LocalStorage.setItem('a', undefined as any);
     assert.equal(LocalStorage.getItem('a'), 'undefined');
     LocalStorage.setItem('a', new Date(0).toString());
     assert.equal(LocalStorage.getItem('a'), new Date(0).toString());
@@ -75,8 +75,8 @@ describe('browser.tinymce.core.util.LocalStorageTest', () => {
     LocalStorage.clear();
     LocalStorage.setItem('a', data + '1');
     LocalStorage.setItem('b', data);
-    assert.lengthOf(LocalStorage.getItem('a'), 1024 + 1);
-    assert.lengthOf(LocalStorage.getItem('b'), 1024);
+    assert.lengthOf(LocalStorage.getItem('a') as string, 1024 + 1);
+    assert.lengthOf(LocalStorage.getItem('b') as string, 1024);
   });
 
   it('setItem with two large keys', () => {

--- a/modules/tinymce/src/core/test/ts/browser/util/ImageUploaderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/ImageUploaderTest.ts
@@ -40,7 +40,7 @@ describe('browser.tinymce.core.util.ImageUploaderTest', () => {
     Arr.each(uploadResults, (uploadResult) => {
       assert.isFalse(uploadResult.status, 'Upload result status is false upon failure');
       assert.equal(uploadResult.url, '', 'Url is empty string upon failure');
-      assert.equal(uploadResult.error.message, errorMsg, 'Upload result error message matches failure message');
+      assert.equal(uploadResult.error?.message, errorMsg, 'Upload result error message matches failure message');
     });
   };
 

--- a/modules/tinymce/src/core/test/ts/browser/util/ObservableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/ObservableTest.ts
@@ -6,22 +6,34 @@ import Tools from 'tinymce/core/api/util/Tools';
 
 describe('browser.tinymce.core.util.ObservableTest', () => {
   it('Event bubbling/removed state', () => {
-    let lastName: string | null;
-    let lastState: boolean | null;
+    let lastName: string | undefined;
+    let lastState: boolean | undefined;
     let data = '';
 
-    const Class: any = function (parentObj) {
-      this.toggleNativeEvent = (name, state) => {
+    class Class implements Observable<any> {
+      private readonly parentObj?: Class;
+      public removed: boolean = false;
+      public hasEventListeners!: Observable<any>['hasEventListeners'];
+      public fire!: Observable<any>['fire'];
+      public dispatch!: Observable<any>['dispatch'];
+      public on!: Observable<any>['on'];
+      public off!: Observable<any>['off'];
+      public once!: Observable<any>['once'];
+
+      public constructor(parentObj?: Class) {
+        Tools.extend(this, Observable);
+        this.parentObj = parentObj;
+      }
+
+      public toggleNativeEvent = (name: string, state: boolean) => {
         lastName = name;
         lastState = state;
       };
 
-      this.parent = () => {
-        return parentObj;
+      public parent = () => {
+        return this.parentObj;
       };
-    };
-
-    Tools.extend(Class.prototype, Observable);
+    }
 
     const inst1 = new Class();
 
@@ -31,12 +43,12 @@ describe('browser.tinymce.core.util.ObservableTest', () => {
     assert.strictEqual(lastName, 'click');
     assert.isTrue(lastState);
 
-    lastName = lastState = null;
+    lastName = lastState = undefined;
     inst1.on('click', () => {
       data += 'b';
     });
-    assert.isNull(lastName);
-    assert.isNull(lastState);
+    assert.isUndefined(lastName);
+    assert.isUndefined(lastState);
 
     const inst2 = new Class(inst1);
     inst2.on('click', () => {

--- a/modules/tinymce/src/core/test/ts/browser/util/QuirksWebkitTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/QuirksWebkitTest.ts
@@ -162,8 +162,8 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<h1>a<br>b</h1><p>c</p>';
 
     const rng = editor.selection.getRng();
-    rng.setStart(editor.dom.select('h1')[0].lastChild, 1);
-    rng.setEnd(editor.dom.select('h1')[0].lastChild, 1);
+    rng.setStart(editor.dom.select('h1')[0].lastChild as Text, 1);
+    rng.setEnd(editor.dom.select('h1')[0].lastChild as Text, 1);
     editor.selection.setRng(rng);
 
     editor.execCommand('ForwardDelete');

--- a/modules/tinymce/src/core/test/ts/browser/util/ToolsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/ToolsTest.ts
@@ -6,6 +6,6 @@ import Tools from 'tinymce/core/api/util/Tools';
 describe('browser.tinymce.core.util.ToolsTest', () => {
   it('extend', () => {
     assert.deepEqual({ a: 1, b: 2, c: 3 }, Tools.extend({ a: 1 }, { b: 2 }, { c: 3 }));
-    assert.deepEqual({ a: 1, c: 3 }, Tools.extend({ a: 1 }, null, { c: 3 }));
+    assert.deepEqual({ a: 1, c: 3 }, Tools.extend({ a: 1 }, null as any, { c: 3 }));
   });
 });

--- a/modules/tinymce/src/core/test/ts/module/test/AnnotationAsserts.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/AnnotationAsserts.ts
@@ -1,4 +1,4 @@
-import { ApproxStructure, Assertions, Step } from '@ephox/agar';
+import { ApproxStructure, Assertions } from '@ephox/agar';
 import { Arr, Obj } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import { TinyAssertions } from '@ephox/wrap-mcagar';
@@ -7,18 +7,15 @@ import { assert } from 'chai';
 import * as Markings from 'tinymce/core/annotate/Markings';
 import Editor from 'tinymce/core/api/Editor';
 
-const annotate = (editor: Editor, name: string, uid: string, data: {}) => {
+const annotate = (editor: Editor, name: string, uid: string, data: {}): void => {
   editor.annotator.annotate(name, {
     uid,
     ...data
   });
 };
 
-const sAnnotate = <T>(editor: Editor, name: string, uid: string, data: {}): Step<T, T> =>
-  Step.sync(() => annotate(editor, name, uid, data));
-
 // This will result in an attribute order-insensitive HTML assertion
-const assertHtmlContent = (editor: Editor, children: string[], allowExtras?: boolean) => {
+const assertHtmlContent = (editor: Editor, children: string[], allowExtras?: boolean): void => {
   TinyAssertions.assertContentStructure(editor,
     ApproxStructure.build((s, _str, _arr) => s.element('body', {
       children: Arr.map(children, ApproxStructure.fromHtml).concat(allowExtras ? [ s.theRest() ] : [])
@@ -26,10 +23,7 @@ const assertHtmlContent = (editor: Editor, children: string[], allowExtras?: boo
   );
 };
 
-const sAssertHtmlContent = <T>(editor: Editor, children: string[], allowExtras?: boolean): Step<T, T> =>
-  Step.sync(() => assertHtmlContent(editor, children, allowExtras));
-
-const assertMarker = (editor: Editor, expected: { uid: string; name: string }, nodes: Element[]) => {
+const assertMarker = (editor: Editor, expected: { uid: string; name: string }, nodes: Element[]): void => {
   const { uid, name } = expected;
   Arr.each(nodes, (node) => {
     Assertions.assertEq('Wrapper must be in content', true, editor.getBody().contains(node));
@@ -46,7 +40,7 @@ const assertMarker = (editor: Editor, expected: { uid: string; name: string }, n
   });
 };
 
-const assertGetAll = (editor: Editor, expected: Record<string, number>, name: string) => {
+const assertGetAll = (editor: Editor, expected: Record<string, number>, name: string): void => {
   const annotations = editor.annotator.getAll(name);
   const keys = Obj.keys(annotations);
   const expectedKeys = Obj.keys(expected);
@@ -57,14 +51,11 @@ const assertGetAll = (editor: Editor, expected: Record<string, number>, name: st
   });
 };
 
-const sAssertGetAll = (editor: Editor, expected: Record<string, number>, name: string) =>
-  Step.sync(() => assertGetAll(editor, expected, name));
-
-const assertMarkings = (editor: Editor, expectedSpanAnnotations: number, expectedBlockAnnotations: number) => {
+const assertMarkings = (editor: Editor, expectedSpanAnnotations: number, expectedBlockAnnotations: number): void => {
   const annotation = Markings.annotation();
   const dataAnnotation = Markings.dataAnnotation();
   const dataAnnotationId = Markings.dataAnnotationId();
-  // Not checking active as this is not applied synchonously
+  // Not checking active as this is not applied synchronously
   // const dataAnnotationActive = Markings.dataAnnotationActive();
   const dataAnnotationClasses = Markings.dataAnnotationClasses();
   const dataAnnotationAttributes = Markings.dataAnnotationAttributes();
@@ -84,9 +75,6 @@ const assertMarkings = (editor: Editor, expectedSpanAnnotations: number, expecte
 };
 
 export {
-  sAnnotate,
-  sAssertHtmlContent,
-  sAssertGetAll,
   assertMarker,
   annotate,
   assertHtmlContent,

--- a/modules/tinymce/src/core/test/ts/module/test/BeforeInputEventUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/BeforeInputEventUtils.ts
@@ -3,8 +3,8 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import { NormalizedEvent } from 'tinymce/core/events/EventUtils';
 import * as InsertNewLine from 'tinymce/core/newline/InsertNewLine';
-import { NormalizedEvent } from 'tinymce/src/core/main/ts/events/EventUtils';
 
 export const testBeforeInputEvent = (performEditAction: (editor: Editor) => void, eventType: string) =>
   (
@@ -14,7 +14,7 @@ export const testBeforeInputEvent = (performEditAction: (editor: Editor) => void
     setupOffset: number,
     expectedHtml: string,
     cancelBeforeInput: boolean
-  ) => {
+  ): void => {
     const inputEvents: string[] = [];
     const beforeInputEvents: string[] = [];
     const collect = (event: NormalizedEvent<InputEvent, any>) => {
@@ -42,7 +42,8 @@ export const testBeforeInputEvent = (performEditAction: (editor: Editor) => void
     assert.deepEqual(beforeInputEvents, [ eventType ]);
   };
 
-export const pressKeyAction = (key: number) =>
-  (editor: Editor) => TinyContentActions.keydown(editor, key);
+export const pressKeyAction = (key: number) => (editor: Editor): void =>
+  TinyContentActions.keydown(editor, key);
 
-export const insertNewLineAction = (editor: Editor) => InsertNewLine.insert(editor, {} as EditorEvent<KeyboardEvent>);
+export const insertNewLineAction = (editor: Editor): void =>
+  InsertNewLine.insert(editor, {} as EditorEvent<KeyboardEvent>);

--- a/modules/tinymce/src/core/test/ts/module/test/CaretAsserts.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/CaretAsserts.ts
@@ -1,10 +1,11 @@
 import { Assert } from '@ephox/bedrock-client';
+import { Type } from '@ephox/katamari';
 import { assert } from 'chai';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import CaretPosition from 'tinymce/core/caret/CaretPosition';
 
-const assertCaretPosition = (actual: CaretPosition | null, expected: CaretPosition | null, message?: string) => {
+const assertCaretPosition = (actual: CaretPosition | null, expected: CaretPosition | null, message?: string): void => {
   if (expected === null) {
     assert.strictEqual(actual, expected, message || 'Expected null.');
     return;
@@ -15,24 +16,27 @@ const assertCaretPosition = (actual: CaretPosition | null, expected: CaretPositi
     return;
   }
 
-  const defaultMessage = () => `["${expected.getNode().textContent}", ${expected.offset()}] doesn't match actual position ["${actual.getNode().textContent}", ${actual.offset()}]`;
+  const defaultMessage = () => `["${expected.getNode()?.textContent}", ${expected.offset()}] doesn't match actual position ["${actual.getNode()?.textContent}", ${actual.offset()}]`;
   Assert.eq(() => message || defaultMessage(), true, expected.isEqual(actual));
 };
 
-const assertRange = (expected: Range, actual: Range) => {
+const assertRange = (expected: Range, actual: Range): void => {
   assert.strictEqual(actual.startContainer, expected.startContainer, 'startContainers should be equal');
   assert.strictEqual(actual.startOffset, expected.startOffset, 'startOffset should be equal');
   assert.strictEqual(actual.endContainer, expected.endContainer, 'endContainer should be equal');
   assert.strictEqual(actual.endOffset, expected.endOffset, 'endOffset should be equal');
 };
 
-const createRange = (startContainer: Node, startOffset: number, endContainer?: Node, endOffset?: number): Range => {
+const createRange: {
+  (startContainer: Node, startOffset: number): Range;
+  (startContainer: Node, startOffset: number, endContainer: Node, endOffset: number): Range;
+} = (startContainer: Node, startOffset: number, endContainer?: Node, endOffset?: number): Range => {
   const rng = DOMUtils.DOM.createRng();
 
   rng.setStart(startContainer, startOffset);
 
-  if (endContainer) {
-    rng.setEnd(endContainer, endOffset);
+  if (Type.isNonNullable(endContainer) && Type.isNonNullable(endOffset)) {
+    rng.setEnd(endContainer, endOffset as number);
   }
 
   return rng;

--- a/modules/tinymce/src/core/test/ts/module/test/ErrorHelpers.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/ErrorHelpers.ts
@@ -1,9 +1,14 @@
-import { Step, Waiter } from '@ephox/agar';
+import { Waiter } from '@ephox/agar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 
-export default () => {
+export interface ErrorHelper {
+  readonly pAssertErrorLogged: (label: string, message: string) => Promise<void>;
+  readonly trackErrors: (editor: Editor, name: string) => void;
+}
+
+export default (): ErrorHelper => {
   const errors: string[] = [];
 
   const handleError = (e: { message: string }) => {
@@ -14,20 +19,12 @@ export default () => {
     editor.on(name, handleError);
   };
 
-  const sAssertErrorLogged = (label: string, message: string) => Waiter.sTryUntil(label,
-    Step.sync(() => {
-      assert.include(errors, message, label);
-    }),
-    10, 1000
-  );
-
   const pAssertErrorLogged = (label: string, message: string) => Waiter.pTryUntil(label, () => {
     assert.include(errors, message, label);
   }, 10, 1000);
 
   return {
     pAssertErrorLogged,
-    sAssertErrorLogged,
     trackErrors
   };
 };

--- a/modules/tinymce/src/core/test/ts/module/test/KeyUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/KeyUtils.ts
@@ -17,9 +17,9 @@ const charCodeToKeyCode = (charCode: number): number => {
 };
 
 const type = (editor: Editor, chr: string | number | Record<string, number | string | boolean>): void => {
-  let keyCode: number;
-  let charCode: number;
-  let evt: Record<string, any>;
+  let keyCode: number | undefined;
+  let charCode: number | undefined;
+  let evt: Record<string, any> | undefined;
   let offset: number;
 
   const fakeEvent = (target: Node, type: string, evt: Record<string, any>) => {
@@ -89,7 +89,7 @@ const type = (editor: Editor, chr: string | number | Record<string, number | str
         }
       }
 
-      editor.getDoc().execCommand('Delete', false, null);
+      editor.getDoc().execCommand('Delete');
     } else if (Type.isString(chr)) {
       const rng = editor.selection.getRng();
 

--- a/modules/tinymce/src/core/test/ts/module/test/TextPatternsUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/TextPatternsUtils.ts
@@ -16,7 +16,7 @@ const setContentAndFireKeystroke = (key: number) => {
   };
 };
 
-const setContentAndPressSpace = (editor: Editor, content: string, offset = content.length, elementPath = [ 0, 0 ], blockElement = 'p') => {
+const setContentAndPressSpace = (editor: Editor, content: string, offset = content.length, elementPath = [ 0, 0 ], blockElement = 'p'): void => {
   editor.setContent(`<${blockElement}>${content}</${blockElement}>`);
   editor.focus();
   TinySelections.setCursor(editor, elementPath, offset);
@@ -24,7 +24,7 @@ const setContentAndPressSpace = (editor: Editor, content: string, offset = conte
   TinyContentActions.keyup(editor, Keys.space());
 };
 
-const bodyStruct = (children: StructAssert[]) => {
+const bodyStruct = (children: StructAssert[]): StructAssert => {
   return ApproxStructure.build((s, _str) => {
     return s.element('body', {
       children
@@ -32,7 +32,7 @@ const bodyStruct = (children: StructAssert[]) => {
   });
 };
 
-const inlineStructHelper = (tag: string, content: string) => {
+const inlineStructHelper = (tag: string, content: string): StructAssert => {
   return ApproxStructure.build((s, str) => {
     return bodyStruct([
       s.element('p', {
@@ -49,7 +49,7 @@ const inlineStructHelper = (tag: string, content: string) => {
   });
 };
 
-const inlineBlockStructHelper = (tag: string, content: string) => {
+const inlineBlockStructHelper = (tag: string, content: string): StructAssert => {
   return ApproxStructure.build((s, str) => {
     return bodyStruct([
       s.element('p', {
@@ -67,7 +67,7 @@ const inlineBlockStructHelper = (tag: string, content: string) => {
   });
 };
 
-const blockStructHelper = (tag: string, content: string) => {
+const blockStructHelper = (tag: string, content: string): StructAssert => {
   return ApproxStructure.build((s, str) => {
     return bodyStruct([
       s.element(tag, {
@@ -80,7 +80,7 @@ const blockStructHelper = (tag: string, content: string) => {
   });
 };
 
-const forcedRootBlockInlineStructHelper = (tag: string, content: string) => {
+const forcedRootBlockInlineStructHelper = (tag: string, content: string): StructAssert => {
   return ApproxStructure.build((s, str) => {
     return bodyStruct([
       s.element(tag, {
@@ -95,7 +95,7 @@ const forcedRootBlockInlineStructHelper = (tag: string, content: string) => {
   });
 };
 
-const forcedRootBlockStructHelper = (tag: string, content: string) => {
+const forcedRootBlockStructHelper = (tag: string, content: string): StructAssert => {
   return ApproxStructure.build((s, str) => {
     return bodyStruct([
       s.element(tag, {
@@ -111,7 +111,7 @@ const forcedRootBlockStructHelper = (tag: string, content: string) => {
 
 const setContentAndPressEnter = setContentAndFireKeystroke(Keys.enter());
 
-const getPatternSetFor = (hook: TinyHooks.Hook<Editor>) => Thunk.cached((): PatternSet => {
+const getPatternSetFor = (hook: TinyHooks.Hook<Editor>): () => PatternSet => Thunk.cached(() => {
   const editor = hook.editor();
   const rawPatterns = Options.getTextPatterns(editor);
   const dynamicPatternsLookup = Options.getTextPatternsLookup(editor);

--- a/modules/tinymce/src/core/test/ts/module/test/ViewBlock.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/ViewBlock.ts
@@ -40,7 +40,7 @@ const ViewBlock = (): ViewBlock => {
   };
 };
 
-export const bddSetup = (preventDuplicates?: boolean) => {
+export const bddSetup = (preventDuplicates?: boolean): ViewBlock => {
   const viewBlock = ViewBlock();
   let hasFailure = false;
 

--- a/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
@@ -13,7 +13,7 @@ describe('webdriver.tinymce.core.content.PlaceholderTest', () => {
     base_url: '/project/tinymce/js/tinymce',
     toolbar: 'undo redo | bold',
     placeholder,
-    setup: (editor) => {
+    setup: (editor: Editor) => {
       editor.on('PlaceholderToggle', () => {
         togglePlaceholderCount.set(togglePlaceholderCount.get() + 1);
       });

--- a/modules/tinymce/src/core/test/ts/webdriver/keyboard/IframeTabfocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/keyboard/IframeTabfocusTest.ts
@@ -19,12 +19,14 @@ describe('webdriver.tinymce.core.keyboard.IframeTabfocusTest', () => {
     const inputElem = document.createElement('input');
     inputElem.id = 'inputElem';
     inputElem.tabIndex = 2;
-    container.parentNode.insertBefore(inputElem, container);
+    container.parentNode?.insertBefore(inputElem, container);
   });
 
   after(() => {
     const inputElem = document.getElementById('inputElem');
-    inputElem.parentNode.removeChild(inputElem);
+    if (inputElem) {
+      inputElem.parentNode?.removeChild(inputElem);
+    }
   });
 
   it('TINY-8315: Add an input field outside the editor, focus on the editor, press the tab key and assert focus shifts to the input field', async () => {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
@@ -12,7 +12,7 @@ import TablePlugin from 'tinymce/plugins/table/Plugin';
 
 describe('browser.tinymce.plugins.table.ClipboardTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
-    plugins: 'paste table',
+    plugins: 'table',
     indent: false,
     valid_styles: {
       '*': 'width,height,vertical-align,text-align,float,border-color,background-color,border,padding,border-spacing,border-collapse'

--- a/modules/tinymce/tsconfig.strict.json
+++ b/modules/tinymce/tsconfig.strict.json
@@ -7,5 +7,12 @@
   },
   "include": [
     "src/core/main/ts/",
+    "src/core/test/ts/atomic/",
+    "src/core/test/ts/module/test/CaretAsserts.ts",
+    "src/core/test/ts/module/test/ErrorHelpers.ts",
+    "src/core/test/ts/module/test/HtmlUtils.ts",
+    "src/core/test/ts/module/test/KeyUtils.ts",
+    "src/core/test/ts/module/test/PasteStrings.ts",
+    "src/core/test/ts/module/test/ViewBlock.ts",
   ]
 }

--- a/modules/tinymce/tsconfig.strict.json
+++ b/modules/tinymce/tsconfig.strict.json
@@ -6,6 +6,7 @@
     "noEmit": true
   },
   "include": [
+    "src/core/demo/ts/",
     "src/core/main/ts/",
     "src/core/test/ts/atomic/",
     "src/core/test/ts/module/test/CaretAsserts.ts",

--- a/versions.txt
+++ b/versions.txt
@@ -1,2 +1,4 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
+
+agar@7.2.0


### PR DESCRIPTION
Related Ticket: TINY-8921

Description of Changes:

Here we go again with more strict type PRs... this one aims at getting all the tests and demos in core compiling under strict mode. Most of these changes are just casting the `firstChild` type in the tests since we can be sure it's of a specific type and won't be nullable. I also found while fixing these some core types needed further improvement so this also contains those changes. Note that I've not included the `tests` directory in the `tsconfig.strict.json` file because they include silver, the dom model and some plugins which won't compile yet.

P.S. Hopefully this is still small enough to review and I've broken it up into 3 commits in an attempt to make it easier to see the changes specifically done for core, tests and demos.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
