### PR TITLE
TINY-8921: Fixed strict type errors in the model

### DIFF
--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- The `TableFill.cellOperations` function incorrectly declared the mutate element types as generic when they should have been a `CellElement`.
+
 ## 11.0.3 - 2022-06-29
 
 ### Fixed

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableFill.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableFill.ts
@@ -1,6 +1,7 @@
 import { Arr, Obj, Optional } from '@ephox/katamari';
 import { Attribute, Compare, Css, CursorPosition, Insert, Replication, SelectorFilter, SugarElement, SugarNode } from '@ephox/sugar';
 
+import { CellElement } from '../util/TableTypes';
 import { CellData, Generators, SimpleGenerators } from './Generators';
 
 const transferableAttributes: Record<string, string[]> = {
@@ -74,7 +75,7 @@ const cloneAppropriateAttributes = <T extends HTMLElement>(original: SugarElemen
   );
 };
 
-const cellOperations = (mutate: <T>(e1: SugarElement<T>, e2: SugarElement<T>) => void, doc: SugarElement<Document>, formatsToClone: Optional<string[]>): Generators => {
+const cellOperations = (mutate: (e1: SugarElement<CellElement>, e2: SugarElement<CellElement>) => void, doc: SugarElement<Document>, formatsToClone: Optional<string[]>): Generators => {
   const cloneCss = <T extends HTMLElement> (prev: CellData, clone: SugarElement<T>) => {
     // inherit the style and width, dont inherit the row height
     Css.copy(prev.element, clone);

--- a/modules/tinymce/.eslintrc.json
+++ b/modules/tinymce/.eslintrc.json
@@ -17,7 +17,7 @@
     },
     // Re-enable things that are passing for explicit module boundary types
     {
-      "files": [ "src/core/**/*.ts" ],
+      "files": [ "src/core/**/*.ts", "src/models/**/*.ts" ],
       "rules": {
         "@typescript-eslint/explicit-module-boundary-types": [ "error", { "allowArgumentsExplicitlyTypedAsAny": true }]
       }

--- a/modules/tinymce/src/models/dom/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/models/dom/demo/ts/demo/Demo.ts
@@ -1,10 +1,10 @@
-import Editor from 'tinymce/core/api/Editor';
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
 
-declare let tinymce: any;
+declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'div.tinymce',
-  setup: (ed: Editor) => {
+  setup: (ed) => {
     ed.on('init', () => {
       const runtimeModel = ed.model;
       // eslint-disable-next-line no-console

--- a/modules/tinymce/src/models/dom/main/ts/Model.ts
+++ b/modules/tinymce/src/models/dom/main/ts/Model.ts
@@ -11,6 +11,6 @@ const DomModel = (editor: Editor): Model => {
   };
 };
 
-export default () => {
+export default (): void => {
   ModelManager.add('dom', DomModel);
 };

--- a/modules/tinymce/src/models/dom/main/ts/table/actions/Clipboard.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/actions/Clipboard.ts
@@ -21,10 +21,10 @@ const extractSelected = (cells: SugarElement<HTMLTableCellElement>[]): Optional<
   );
 };
 
-const serializeElements = (editor: Editor, elements: SugarElement[]): string =>
+const serializeElements = (editor: Editor, elements: SugarElement<HTMLElement>[]): string =>
   Arr.map(elements, (elm) => editor.selection.serializer.serialize(elm.dom, {})).join('');
 
-const getTextContent = (elements: SugarElement[]): string =>
+const getTextContent = (elements: SugarElement<HTMLElement>[]): string =>
   Arr.map(elements, (element) => element.dom.innerText).join('');
 
 const registerEvents = (editor: Editor, actions: TableActions): void => {

--- a/modules/tinymce/src/models/dom/main/ts/table/actions/InsertTable.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/actions/InsertTable.ts
@@ -30,7 +30,7 @@ const fireEvents = (editor: Editor, table: SugarElement<HTMLTableElement>): void
 const isPercentage = (width: string): boolean =>
   Type.isString(width) && width.indexOf('%') !== -1;
 
-const insert = (editor: Editor, columns: number, rows: number, colHeaders: number, rowHeaders: number): HTMLTableElement => {
+const insert = (editor: Editor, columns: number, rows: number, colHeaders: number, rowHeaders: number): HTMLTableElement | null => {
   const defaultStyles = Options.getTableDefaultStyles(editor);
   const options: TableRender.RenderOptions = {
     styles: defaultStyles,
@@ -62,7 +62,7 @@ const insert = (editor: Editor, columns: number, rows: number, colHeaders: numbe
     fireEvents(editor, table);
     selectFirstCellInTable(editor, table);
     return table.dom;
-  }).getOr(null);
+  }).getOrNull();
 };
 
 const insertTable = (editor: Editor, rows: number, columns: number, options: Record<string, number> = {}): HTMLTableElement | null => {

--- a/modules/tinymce/src/models/dom/main/ts/table/actions/TableActions.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/actions/TableActions.ts
@@ -26,7 +26,7 @@ export type AdvancedPasteTableAction = TableAction<RunOperation.TargetPasteRows>
 export type LookupAction = (table: SugarElement<HTMLTableElement>, target: RunOperation.TargetSelection) => string;
 
 type GuardFn = (table: SugarElement<HTMLTableElement>) => boolean;
-type MutateFn = <T>(e1: SugarElement<T>, e2: SugarElement<T>) => void;
+type MutateFn = (e1: SugarElement<HTMLTableCellElement | HTMLTableColElement>, e2: SugarElement<HTMLTableCellElement | HTMLTableColElement>) => void;
 
 export interface TableActions {
   readonly deleteRow: CombinedTargetsTableAction;
@@ -59,10 +59,10 @@ export const TableActions = (editor: Editor, resizeHandler: TableResizeHandler, 
     SugarNode.name(Utils.getBody(editor)) === 'table';
 
   const lastRowGuard = (table: SugarElement<HTMLTableElement>): boolean =>
-    isTableBody(editor) === false || TableGridSize.getGridSize(table).rows > 1;
+    !isTableBody(editor) || TableGridSize.getGridSize(table).rows > 1;
 
   const lastColumnGuard = (table: SugarElement<HTMLTableElement>): boolean =>
-    isTableBody(editor) === false || TableGridSize.getGridSize(table).columns > 1;
+    !isTableBody(editor) || TableGridSize.getGridSize(table).columns > 1;
 
   // Optional.none gives the default cloneFormats.
   const cloneFormats = Options.getTableCloneElements(editor);
@@ -118,7 +118,7 @@ export const TableActions = (editor: Editor, resizeHandler: TableResizeHandler, 
         section: getTableSectionType(table)
       };
       return guard(table) ? operation(table, target, generators, behaviours).bind((result) => {
-        // Update the resize bars after the table opeation
+        // Update the resize bars after the table operation
         resizeHandler.refresh(table.dom);
 
         // INVESTIGATE: Should "noEvents" prevent these from firing as well?

--- a/modules/tinymce/src/models/dom/main/ts/table/api/Events.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/Events.ts
@@ -43,11 +43,11 @@ const fireTableSelectionClear = (editor: Editor): void => {
   editor.dispatch('TableSelectionClear');
 };
 
-const fireObjectResizeStart = (editor: Editor, target: HTMLElement, width: number, height: number, origin: string) => {
+const fireObjectResizeStart = (editor: Editor, target: HTMLElement, width: number, height: number, origin: string): void => {
   editor.dispatch('ObjectResizeStart', { target, width, height, origin });
 };
 
-const fireObjectResized = (editor: Editor, target: HTMLElement, width: number, height: number, origin: string) => {
+const fireObjectResized = (editor: Editor, target: HTMLElement, width: number, height: number, origin: string): void => {
   editor.dispatch('ObjectResized', { target, width, height, origin });
 };
 

--- a/modules/tinymce/src/models/dom/main/ts/table/api/Options.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/Options.ts
@@ -9,8 +9,8 @@ export type TableColumnResizing = 'preservetable' | 'resizetable';
 export type TableHeaderType = 'section' | 'cells' | 'sectionCells' | 'auto';
 
 const option: {
-  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K] | undefined;
-  <T>(name: string): (editor: Editor) => T | undefined;
+  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K];
+  <T>(name: string): (editor: Editor) => T;
 } = (name: string) => (editor: Editor) =>
   editor.options.get(name);
 

--- a/modules/tinymce/src/models/dom/main/ts/table/api/TableCellSelectionHandler.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/TableCellSelectionHandler.ts
@@ -21,7 +21,7 @@ export interface TableCellSelectionHandler {
 }
 
 const hasInternalTarget = (e: Event): boolean =>
-  Class.has(SugarElement.fromDom(e.target as Node), 'ephox-snooker-resizer-bar') === false;
+  !Class.has(SugarElement.fromDom(e.target as Node), 'ephox-snooker-resizer-bar');
 
 export const TableCellSelectionHandler = (editor: Editor, resizeHandler: TableResizeHandler): TableCellSelectionHandler => {
   const cellSelection = Selections(

--- a/modules/tinymce/src/models/dom/main/ts/table/api/TableResizeHandler.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/TableResizeHandler.ts
@@ -16,7 +16,7 @@ export interface TableResizeHandler {
   readonly show: () => void;
 }
 
-const isTable = (node: Node) => Type.isNonNullable(node) && (node as Element).tagName === 'TABLE';
+const isTable = (node: Node) => Type.isNonNullable(node) && node.nodeName === 'TABLE';
 
 const barResizerPrefix = 'bar-';
 const isResizable = (elm: SugarElement<Element>) => Attribute.get(elm, 'data-mce-resize') !== 'false';

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/DragResizeTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/DragResizeTest.ts
@@ -36,7 +36,7 @@ describe('browser.tinymce.models.dom.table.DragResizeTest', () => {
     Mouse.mouseOver(elem);
   };
 
-  const state = Cell(null);
+  const state = Cell<{ h: number; w: number } | null>(null);
 
   const setStateFrom = (editor: Editor, path: number[]) => {
     const element = Hierarchy.follow(TinyDom.body(editor), path).getOrDie('could not find element') as SugarElement<HTMLElement>;
@@ -63,8 +63,11 @@ describe('browser.tinymce.models.dom.table.DragResizeTest', () => {
     const height = Height.get(element);
     const width = Width.get(element);
 
-    const changedHeight = state.get().h + change.dh;
-    const changedWidth = state.get().w + change.dw;
+    const currentState = state.get() as { h: number; w: number };
+    assert.isNotNull(currentState);
+
+    const changedHeight = currentState.h + change.dh;
+    const changedWidth = currentState.w + change.dw;
 
     assert.approximately(changedHeight, height, 4, 'height is ' + height + ' but expected ' + changedHeight);
     assert.approximately(changedWidth, width, 4, 'width is ' + width + ' but expected ' + changedWidth);

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/InsertRowTableResizeTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/InsertRowTableResizeTest.ts
@@ -17,7 +17,7 @@ describe('browser.tinymce.models.dom.table.InsertRowTableResizeTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     width: 400,
     base_url: '/project/tinymce/js/tinymce',
-    setup: (editor) => {
+    setup: (editor: Editor) => {
       editor.on('ObjectResized', () => objectResizedCounter++);
     }
   }, [], true);

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/ResizeTableTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/ResizeTableTest.ts
@@ -125,7 +125,7 @@ describe('browser.tinymce.models.dom.table.ResizeTableTest', () => {
 
   const assertWidthAfterResize = (width: number | null, widths: WidthMeasurements, approx: boolean = false) => {
     if (approx) {
-      assert.approximately(widths.widthAfter.raw, width, pixelDiffThreshold, `table raw width after resizing is ~${width}`);
+      assert.approximately(widths.widthAfter.raw ?? 0, width ?? 0, pixelDiffThreshold, `table raw width after resizing is ~${width}`);
     } else {
       assert.equal(widths.widthAfter.raw, width, `table raw width after resizing is ${width}`);
     }
@@ -133,10 +133,10 @@ describe('browser.tinymce.models.dom.table.ResizeTableTest', () => {
 
   const assertEventData = (state: Cell<EditorEvent<ObjectResizeEvent> | null>, expectedEventName: string) => {
     const event = state.get();
-    assert.equal(event.target.nodeName, 'TABLE', 'Should be table element');
-    assert.equal(event.type, expectedEventName, 'Should be expected resize event');
-    assert.typeOf(event.width, 'number', 'Should have width');
-    assert.typeOf(event.height, 'number', 'Should have height');
+    assert.equal(event?.target.nodeName, 'TABLE', 'Should be table element');
+    assert.equal(event?.type, expectedEventName, 'Should be expected resize event');
+    assert.typeOf(event?.width, 'number', 'Should have width');
+    assert.typeOf(event?.height, 'number', 'Should have height');
     assert.lengthOf(tableModifiedEvents, 1, 'Should have a table modified event');
     assert.isFalse(tableModifiedEvents[0].structure, 'Should not have structure modified');
     assert.isTrue(tableModifiedEvents[0].style, 'Should have style modified');
@@ -327,9 +327,11 @@ describe('browser.tinymce.models.dom.table.ResizeTableTest', () => {
       const firstColWidth = widths.colWidthsAfter[0];
       const lastColWidth = widths.colWidthsAfter[1];
       // Note: Use 96px as the padding + borders are about 14px which adds up to ~110px per cell
-      assert.approximately(firstColWidth.raw, 96, pixelDiffThreshold, `First column raw width ${firstColWidth.raw + firstColWidth.unit} should be ~96px`);
+      const rawFirstColWidth = firstColWidth.raw ?? 0;
+      assert.approximately(rawFirstColWidth, 96, pixelDiffThreshold, `First column raw width ${rawFirstColWidth + String(firstColWidth.unit)} should be ~96px`);
       assert.equal(firstColWidth.unit, 'px', 'First column unit width');
-      assert.approximately(lastColWidth.raw, 96, pixelDiffThreshold, `Last column raw width ${lastColWidth.raw + lastColWidth.unit} should be ~96px`);
+      const rawLastColWidth = lastColWidth.raw ?? 0;
+      assert.approximately(rawLastColWidth, 96, pixelDiffThreshold, `Last column raw width ${rawLastColWidth + String(lastColWidth.unit)} should be ~96px`);
       assert.equal(lastColWidth.unit, 'px', 'Last column unit width');
     });
   });
@@ -365,12 +367,13 @@ describe('browser.tinymce.models.dom.table.ResizeTableTest', () => {
       assertEventData(lastObjectResizedEvent, 'objectresized');
       const lastColWidth = widths.colWidthsAfter[1];
       // Note: Use 106px as the padding + borders are about 14px
-      assert.approximately(lastColWidth.raw, 106, pixelDiffThreshold, `Last column raw width ${lastColWidth.raw + lastColWidth.unit} should be ~106px`);
+      const rawLastColWidth = lastColWidth.raw ?? 0;
+      assert.approximately(rawLastColWidth, 106, pixelDiffThreshold, `Last column raw width ${rawLastColWidth + String(lastColWidth.unit)} should be ~106px`);
       assert.equal(lastColWidth.unit, 'px', 'Last column unit width');
       const firstColWidthBefore = widths.colWidthsBefore[0];
       const firstColWidthAfter = widths.colWidthsAfter[0];
       // Allow for a 1px variation here due to potential rounding issues
-      assert.approximately(firstColWidthAfter.px, firstColWidthBefore.px, 1, `First column raw width ${firstColWidthBefore.px + firstColWidthBefore.unit} should be unchanged`);
+      assert.approximately(firstColWidthAfter.px, firstColWidthBefore.px, 1, `First column raw width ${firstColWidthBefore.px + String(firstColWidthBefore.unit)} should be unchanged`);
       assert.equal(firstColWidthAfter.unit, 'px', 'First column unit width');
     });
   });
@@ -395,9 +398,11 @@ describe('browser.tinymce.models.dom.table.ResizeTableTest', () => {
       assertEventData(lastObjectResizedEvent, 'objectresized');
       const firstColWidth = widths.colWidthsAfter[0];
       const lastColWidth = widths.colWidthsAfter[1];
-      assert.approximately(firstColWidth.raw, 95, percentDiffThreshold, `First column raw width ${firstColWidth.raw + firstColWidth.unit} should be ~95%`);
+      const rawFirstColWidth = firstColWidth.raw ?? 0;
+      assert.approximately(rawFirstColWidth, 95, percentDiffThreshold, `First column raw width ${rawFirstColWidth + String(firstColWidth.unit)} should be ~95%`);
       assert.equal(firstColWidth.unit, '%', 'First column unit width');
-      assert.approximately(lastColWidth.raw, 5, percentDiffThreshold, `Last column raw width ${lastColWidth.raw + lastColWidth.unit} should be ~5%`);
+      const rawLastColWidth = lastColWidth.raw ?? 0;
+      assert.approximately(rawLastColWidth, 5, percentDiffThreshold, `Last column raw width ${rawLastColWidth + String(lastColWidth.unit)} should be ~5%`);
       assert.equal(lastColWidth.unit, '%', 'Last column unit width');
     });
   });

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/TableSectionApiTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/TableSectionApiTest.ts
@@ -167,7 +167,7 @@ describe('browser.tinymce.models.dom.table.TableSectionApiTest', () => {
 </tbody>
 </table>`;
 
-  let events = [];
+  let events: Array<{ type: string; structure?: boolean; style?: boolean }> = [];
   const logModifiedEvent = (event: EditorEvent<TableModifiedEvent>) => {
     events.push({
       type: event.type,

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/TwoCellsSelectionTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/TwoCellsSelectionTest.ts
@@ -49,7 +49,7 @@ describe('browser.tinymce.models.dom.table.TwoCellsSelectionTest', () => {
     TinyAssertions.assertContentPresence(editor, {
       'td[data-mce-selected]': 2
     });
-    assert.equal(editor.selection.getSel().rangeCount, 1, 'there should only be 1 selection range');
+    assert.equal(editor.selection.getSel()?.rangeCount, 1, 'there should only be 1 selection range');
   });
 
   it('TINY-3897: Select 2 cells in same row via mouse and merge them together', () => {

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/MergeCellCommandTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/MergeCellCommandTest.ts
@@ -5,15 +5,17 @@ import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import { TableEventData } from 'tinymce/core/api/EventTypes';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
-type TableModifiedEvent = EditorEvent<TableEventData>;
+interface PartialTableModifiedEvent {
+  readonly type: string;
+  readonly structure: boolean;
+  readonly style: boolean;
+}
 
 interface MergeCellTest {
   readonly before: string;
   readonly after: string;
-  readonly expectedEvents: TableModifiedEvent[];
+  readonly expectedEvents: PartialTableModifiedEvent[];
 }
 
 describe('browser.tinymce.models.dom.table.command.MergeCellCommandTest', () => {
@@ -23,8 +25,8 @@ describe('browser.tinymce.models.dom.table.command.MergeCellCommandTest', () => 
     setup: (ed: Editor) => ed.on('TableModified', logModifiedEvent),
   }, []);
 
-  let modifiedEvents = [];
-  const logModifiedEvent = (event: TableModifiedEvent) => {
+  let modifiedEvents: PartialTableModifiedEvent[] = [];
+  const logModifiedEvent = (event: PartialTableModifiedEvent) => {
     modifiedEvents.push({
       type: event.type,
       structure: event.structure,
@@ -33,7 +35,7 @@ describe('browser.tinymce.models.dom.table.command.MergeCellCommandTest', () => 
   };
 
   const clearEvents = () => modifiedEvents = [];
-  const defaultEvent = { type: 'tablemodified', structure: true, style: false } as TableModifiedEvent;
+  const defaultEvent: PartialTableModifiedEvent = { type: 'tablemodified', structure: true, style: false };
 
   const testMerge = (editor: Editor, test: MergeCellTest) => {
     clearEvents();
@@ -49,7 +51,8 @@ describe('browser.tinymce.models.dom.table.command.MergeCellCommandTest', () => 
     return html.replace(/<p>(&nbsp;|<br[^>]+>)<\/p>$/, '');
   };
 
-  const getWidth = (elem: SugarElement<Element>) => Dimension.parse(Css.getRaw(elem, 'width').getOrDie(), [ 'relative' ]).getOrDie().value;
+  const getWidth = (elem: SugarElement<Element>) =>
+    Dimension.parse(Css.getRaw(elem, 'width').getOrDie(), [ 'relative' ]).getOrDie().value;
 
   it('TBA: Should merge all cells into one', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/models/dom/test/ts/module/table/TableSizingModeCommandUtil.ts
+++ b/modules/tinymce/src/models/dom/test/ts/module/table/TableSizingModeCommandUtil.ts
@@ -11,11 +11,11 @@ type SizingMode = 'relative' | 'fixed' | 'responsive';
 
 interface Scenario {
   readonly mode: SizingMode;
-  readonly tableWidth: number;
+  readonly tableWidth: number | null;
   readonly cols: number;
   readonly rows: number;
-  readonly expectedTableWidth: number;
-  readonly expectedWidths: number[][];
+  readonly expectedTableWidth: number | null;
+  readonly expectedWidths: Array<number | null>[];
   readonly newMode: SizingMode;
 }
 
@@ -36,15 +36,15 @@ const getUnit = (mode: SizingMode): 'px' | '%' | null => {
   }
 };
 
-const generateWidth = (mode: SizingMode, tableWidth: number, cols: number) => {
-  if (mode === 'responsive') {
+const generateWidth = (mode: SizingMode, tableWidth: number | null, cols: number) => {
+  if (mode === 'responsive' || tableWidth === null) {
     return '';
   } else {
     return `width: ${tableWidth / cols}${getUnit(mode)}`;
   }
 };
 
-const generateTable = (mode: SizingMode, width: number, rows: number, cols: number, useColumns: boolean) => {
+const generateTable = (mode: SizingMode, width: number | null, rows: number, cols: number, useColumns: boolean) => {
   const tableWidth = generateWidth(mode, width, 1);
   const cellWidth = generateWidth(mode, width, cols);
 
@@ -69,7 +69,7 @@ const generateTable = (mode: SizingMode, width: number, rows: number, cols: numb
 
 const defaultEvents = [{ type: 'tablemodified', structure: true, style: false }];
 
-const tableSizingModeScenarioTest = (editor: Editor, withColGroups: boolean, scenario: Scenario, expectedEvents: PartialTableModifiedEvent[] = defaultEvents) => {
+const tableSizingModeScenarioTest = (editor: Editor, withColGroups: boolean, scenario: Scenario, expectedEvents: PartialTableModifiedEvent[] = defaultEvents): void => {
   let events: PartialTableModifiedEvent[] = [];
   editor.on('TableModified', (event: EditorEvent<{ structure: boolean; style: boolean }>) => events.push({
     type: event.type,

--- a/modules/tinymce/tsconfig.strict.json
+++ b/modules/tinymce/tsconfig.strict.json
@@ -15,5 +15,7 @@
     "src/core/test/ts/module/test/KeyUtils.ts",
     "src/core/test/ts/module/test/PasteStrings.ts",
     "src/core/test/ts/module/test/ViewBlock.ts",
+    "src/models/dom/demo/ts/",
+    "src/models/dom/main/ts/"
   ]
 }


### PR DESCRIPTION
Related Ticket: TINY-8921

Description of Changes:

This PR is a lot smaller than that last thankfully and aims at fixing all the strict type errors in the DOM model. Note that I've not included the `tests` directory in the `tsconfig.strict.json` file because they include silver and some plugins which won't compile yet.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
