### PR TITLE
TINY-8921: Fixed strict type errors in the silver theme demos and tests

### DIFF
--- a/modules/tinymce/.eslintrc.json
+++ b/modules/tinymce/.eslintrc.json
@@ -17,7 +17,7 @@
     },
     // Re-enable things that are passing for explicit module boundary types
     {
-      "files": [ "src/core/**/*.ts", "src/models/**/*.ts" ],
+      "files": [ "src/core/**/*.ts", "src/models/**/*.ts", "src/themes/**/*.ts" ],
       "rules": {
         "@typescript-eslint/explicit-module-boundary-types": [ "error", { "allowArgumentsExplicitlyTypedAsAny": true }]
       }

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/ButtonSetupDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/ButtonSetupDemo.ts
@@ -2,7 +2,7 @@
 import Editor from 'tinymce/core/api/Editor';
 
 export default {
-  setup: (ed: Editor) => {
+  setup: (ed: Editor): void => {
     ed.ui.registry.addButton('basic-button-1', {
       text: 'basic-button-1',
       onAction: () => {

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/FormatSelectDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/FormatSelectDemo.ts
@@ -1,7 +1,8 @@
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
 
-declare let tinymce: any;
+declare let tinymce: TinyMCE;
 
-export default () => {
+export default (): void => {
 
   tinymce.init({
     selector: 'textarea.tiny-text',

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/MenuItemDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/MenuItemDemo.ts
@@ -1,14 +1,14 @@
 import { Fun } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
 
 import * as MockDemo from './MockDemo';
 
-declare let tinymce: any;
+declare let tinymce: TinyMCE;
 
 /* eslint-disable no-console */
 
-export default () => {
+export default (): void => {
   const DemoState = MockDemo.mockFeatureState();
   const DemoState2 = MockDemo.mockFeatureState();
 
@@ -26,7 +26,7 @@ export default () => {
       File: [ 'x1', 'x2', 'x3', '|', 't1', '|', 'd1' ]
     },
 
-    setup: (ed: Editor) => {
+    setup: (ed) => {
       ed.ui.registry.addMenuItem('x1', {
         icon: 'drop',
         text: 'Text with icon',

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/MockDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/MockDemo.ts
@@ -1,6 +1,12 @@
-const mockFeatureState = () => {
+interface MockState {
+  readonly get: () => boolean;
+  readonly set: (nu: boolean) => void;
+  readonly toggle: () => boolean;
+}
+
+const mockFeatureState = (): MockState => {
   // Why we need this mock?
-  // Alloy toggle is stateless, it needs somthing to tell it what state it should be
+  // Alloy toggle is stateless, it needs something to tell it what state it should be
 
   let demoState = false;
 
@@ -11,7 +17,7 @@ const mockFeatureState = () => {
   };
 
   const toggle = (): boolean => {
-    const nuState = demoState === true ? false : true;
+    const nuState = !demoState;
     set(nuState);
     return get();
   };

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/PlayDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/PlayDemo.ts
@@ -1,13 +1,13 @@
 /* eslint-disable no-console */
 import { Fun } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
 
 import ButtonSetupDemo from './ButtonSetupDemo';
 
-declare let tinymce: any;
+declare let tinymce: TinyMCE;
 
-export default () => {
+export default (): void => {
   tinymce.init({
     // TODO: Investigate. Should thisget the styles (e.g. margin) of the div/textarea?
     selector: 'div.tiny-text',
@@ -96,7 +96,7 @@ export default () => {
       // }
     ],
 
-    setup: (ed: Editor) => {
+    setup: (ed) => {
       ButtonSetupDemo.setup(ed);
 
       ed.ui.registry.addButton('MagicButton', {

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/SidebarDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/SidebarDemo.ts
@@ -1,12 +1,12 @@
 /* eslint-disable no-console */
 import { SugarElement } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import { Editor, TinyMCE } from 'tinymce/core/api/PublicApi';
 
 // import ButtonSetupDemo from './ButtonSetupDemo';
-declare let tinymce: any;
+declare let tinymce: TinyMCE;
 
-export default () => {
+export default (): void => {
   const makeSidebar = (ed: Editor, name: string, background: string, width: number) => {
     ed.ui.registry.addSidebar(name, {
       icon: 'comment',
@@ -40,7 +40,7 @@ export default () => {
     // statusbar: false,
     resize: 'both',
 
-    setup: (ed: Editor) => {
+    setup: (ed) => {
       makeSidebar(ed, 'sidebar1', 'green', 200);
       makeSidebar(ed, 'sidebar2', 'red', 300);
       makeSidebar(ed, 'sidebar3', 'blue', 150);

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/ToolbarButtonDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/ToolbarButtonDemo.ts
@@ -1,16 +1,16 @@
 /* eslint-disable no-console */
 import { Fun } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
+import { Editor, TinyMCE } from 'tinymce/core/api/PublicApi';
 
 import * as MockDemo from './MockDemo';
 
-declare let tinymce: any;
+declare let tinymce: TinyMCE;
 
-export default () => {
+export default (): void => {
   const DemoState2 = MockDemo.mockFeatureState();
-  const generateButton = (editor: Editor, buttonType: 'button', name, num) => {
-    const names = [];
+  const generateButton = (editor: Editor, buttonType: 'button', name: string, num: number) => {
+    const names: string[] = [];
 
     for (let i = 0; i <= num; i++) {
       editor.ui.registry.addButton(`${name}-${i}`, {
@@ -40,7 +40,7 @@ export default () => {
       'autosave' // Required to prevent users losing content when they press back
     ],
 
-    setup: (ed: Editor) => {
+    setup: (ed) => {
       ed.on('skinLoaded', () => {
         // Notification fields for equality: type, text, progressBar, timeout
         ed.notificationManager.open({

--- a/modules/tinymce/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputConvertTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputConvertTest.ts
@@ -42,7 +42,7 @@ describe('atomic.tinymce.themes.silver.components.sizeinput.SizeInputConvertTest
           (unit2Value) => convertUnit(nuSize(unit2Value, unit2), unit1)
         ).getOrNull();
         assert.isNotNull(outValue);
-        assert.approximately(outValue, value, 0.000001);
+        assert.approximately(outValue as number, value, 0.000001);
       }
     ));
   });

--- a/modules/tinymce/src/themes/silver/test/ts/atomic/menus/MenuConversionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/atomic/menus/MenuConversionTest.ts
@@ -37,7 +37,7 @@ describe('atomic.tinymce.themes.silver.menus.MenuConversionTest', () => {
     'submenu-2': submenu2
   };
 
-  const expandAndAssertEq = (items: string | Array<Menu.NestedMenuItemContents>, expected) => {
+  const expandAndAssertEq = (items: string | Array<Menu.NestedMenuItemContents>, expected: MenuConversion.ExpandedMenus) => {
     assert.deepEqual(MenuConversion.expand(items, menuItems), expected);
   };
 

--- a/modules/tinymce/src/themes/silver/test/ts/atomic/sizing/ResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/atomic/sizing/ResizeTest.ts
@@ -8,7 +8,7 @@ import { getDimensions, ResizeTypes } from 'tinymce/themes/silver/ui/sizing/Resi
 import * as Utils from 'tinymce/themes/silver/ui/sizing/Utils';
 
 const mockEditor = (containerHeight: number, contentAreaHeight: number): Editor => {
-  const options = {
+  const options: Record<string, number> = {
     min_height: 400,
     max_height: 600,
     min_width: 400,
@@ -17,7 +17,7 @@ const mockEditor = (containerHeight: number, contentAreaHeight: number): Editor 
 
   return {
     options: {
-      get: (param) => options[param]
+      get: (param: string) => options[param]
     },
     getContainer: () => ({ offsetHeight: containerHeight }),
     getContentAreaContainer: () => ({ offsetHeight: contentAreaHeight })
@@ -30,7 +30,7 @@ describe('atomic.tinymce.themes.silver.sizing.ResizeTest', () => {
     assert.equal(actual, expected, label);
   };
 
-  const assertDimensions = (label: string, topDelta: number, leftDelta: number, resizeType: ResizeTypes, width, expected) => {
+  const assertDimensions = (label: string, topDelta: number, leftDelta: number, resizeType: ResizeTypes, width: number, expected: { height: number; width?: number }) => {
     const containerHeight = 500; // mid way between min and max in mockEditor
     const chromeHeight = 100; // just need something smaller
     const editor = mockEditor(containerHeight, containerHeight - chromeHeight);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ContextFormTest.ts
@@ -20,9 +20,9 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
           onSetup: (buttonApi) => {
             const f = (evt: { active?: boolean; disable?: boolean }) => {
               if (Obj.has(evt, 'disable')) {
-                buttonApi.setEnabled(!evt.disable);
+                buttonApi.setEnabled(!evt.disable as boolean);
               } else if (Obj.has(evt, 'active')) {
-                buttonApi.setActive(evt.active);
+                buttonApi.setActive(evt.active as boolean);
               }
             };
 
@@ -34,7 +34,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
           }
         },
 
-        predicate: (node) => node.nodeName && node.nodeName.toLowerCase() === 'a',
+        predicate: (node) => node.nodeName.toLowerCase() === 'a',
         commands: [
           {
             type: 'contextformbutton',
@@ -69,9 +69,9 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
             onSetup: (buttonApi) => {
               const f = (evt: { active?: boolean; disable?: boolean }) => {
                 if (Obj.has(evt, 'disable')) {
-                  buttonApi.setEnabled(!evt.disable);
+                  buttonApi.setEnabled(!evt.disable as boolean);
                 } else if (Obj.has(evt, 'active')) {
-                  buttonApi.setActive(evt.active);
+                  buttonApi.setActive(evt.active as boolean);
                 }
               };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
@@ -11,7 +11,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.SilverEditorTest', () => {
   const os = PlatformDetection.detect().os;
-  const store = Cell([ ]);
+  const store = Cell<string[]>([ ]);
   const hook = TinyHooks.bddSetup<Editor>({
     toolbar: 'custom1 customtoggle1 dropdown1-with-text dropdown1-with-icon splitbutton1-with-text splitbutton2-with-icon',
     menubar: 'menutest',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
@@ -13,7 +13,7 @@ import * as UiUtils from '../../module/UiUtils';
 
 describe('browser.tinymce.themes.silver.editor.SilverInlineEditorTest', () => {
   const os = PlatformDetection.detect().os;
-  const store = Cell([ ]);
+  const store = Cell<string[]>([ ]);
   const hook = TinyHooks.bddSetup<Editor>({
     inline: true,
     toolbar: 'custom1 customtoggle1 dropdown1-with-text dropdown1-with-icon splitbutton1-with-text splitbutton2-with-icon',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverRenderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverRenderTest.ts
@@ -25,7 +25,7 @@ describe('browser.tinymce.themes.silver.editor.SilverRenderTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'test',
     base_url: '/project/tinymce/js/tinymce',
-    setup: (editor) => {
+    setup: (editor: Editor) => {
       editor.on('PostRender init', (e) => {
         initStates[e.type] = getRenderState(editor);
       });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -65,7 +65,8 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
               callback([
                 {
                   type: 'choiceitem',
-                  text: 'text'
+                  text: 'text',
+                  value: 'item'
                 }
               ]);
             },

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteCancelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteCancelTest.ts
@@ -41,11 +41,11 @@ describe('browser.tinymce.themes.silver.editor.autocomplete.AutocompleteCancelTe
     }
   }, [], true);
 
-  const expectedSimplePara = (content: string) => (s, str): StructAssert => s.element('p', {
+  const expectedSimplePara = (content: string): ApproxStructure.Builder<StructAssert> => (s, str, _arr) => s.element('p', {
     children: [ s.text(str.is(content), true) ]
   });
 
-  const expectedAutocompletePara = (content: string) => (s, str): StructAssert => s.element('p', {
+  const expectedAutocompletePara = (content: string): ApproxStructure.Builder<StructAssert> => (s, str, _arr) => s.element('p', {
     children: [
       s.element('span', {
         attrs: {
@@ -80,7 +80,7 @@ describe('browser.tinymce.themes.silver.editor.autocomplete.AutocompleteCancelTe
     setContentAndTrigger(editor, ':a', ':'.charCodeAt(0), template, elementPath);
     await TinyUiActions.pWaitForPopup(editor, '.tox-autocompleter div[role="menu"]');
     await pAssertContent('Check initial content with autocompleter active', editor, (s, str, arr) => {
-      return expected ? expected(s, str, arr) : [ expectedAutocompletePara(':a')(s, str) ];
+      return expected ? expected(s, str, arr) : [ expectedAutocompletePara(':a')(s, str, arr) ];
     });
   };
 
@@ -98,14 +98,14 @@ describe('browser.tinymce.themes.silver.editor.autocomplete.AutocompleteCancelTe
 
   it('Checking escape in menu cancels the autocompleter', () => pTestAutocompleter({
     action: (editor) => TinyContentActions.keydown(editor, Keys.escape()),
-    assertion: (s, str) => [ expectedSimplePara(':a')(s, str) ]
+    assertion: (s, str, arr) => [ expectedSimplePara(':a')(s, str, arr) ]
   }));
 
   it('Checking inserting a new line cancels the autocompleter', () => pTestAutocompleter({
     action: (editor) => insertContentAndTrigger(editor, 'aa'),
     postAction: (editor) => TinyContentActions.keydown(editor, Keys.enter()),
-    assertion: (s, str) => [
-      expectedSimplePara(':aaa')(s, str),
+    assertion: (s, str, arr) => [
+      expectedSimplePara(':aaa')(s, str, arr),
       s.element('p', {})
     ]
   }));
@@ -126,68 +126,68 @@ describe('browser.tinymce.themes.silver.editor.autocomplete.AutocompleteCancelTe
   }));
 
   it('Checking pressing down cancels the autocompleter', () => pTestAutocompleter({
-    setup: (editor) => pTriggerAndAssertInitialContent(editor, '<p></p><p>CONTENT</p><p></p>', [ 1, 0 ], (s, str) => [
+    setup: (editor) => pTriggerAndAssertInitialContent(editor, '<p></p><p>CONTENT</p><p></p>', [ 1, 0 ], (s, str, arr) => [
       s.element('p', {}),
-      expectedAutocompletePara(':a')(s, str),
+      expectedAutocompletePara(':a')(s, str, arr),
       s.element('p', {})
     ]),
     action: (editor) => insertContentAndTrigger(editor, 'aa'),
     postAction: (editor) => TinyContentActions.keydown(editor, Keys.down()),
-    assertion: (s, str) => [
+    assertion: (s, str, arr) => [
       s.element('p', {}),
-      expectedSimplePara(':aaa')(s, str),
+      expectedSimplePara(':aaa')(s, str, arr),
       s.element('p', {})
     ]
   }));
 
   it('Checking pressing up cancels the autocompleter', () => pTestAutocompleter({
-    setup: (editor) => pTriggerAndAssertInitialContent(editor, '<p></p><p>CONTENT</p><p></p>', [ 1, 0 ], (s, str) => [
+    setup: (editor) => pTriggerAndAssertInitialContent(editor, '<p></p><p>CONTENT</p><p></p>', [ 1, 0 ], (s, str, arr) => [
       s.element('p', {}),
-      expectedAutocompletePara(':a')(s, str),
+      expectedAutocompletePara(':a')(s, str, arr),
       s.element('p', {})
     ]),
     action: (editor) => insertContentAndTrigger(editor, 'aa'),
     postAction: (editor) => TinyContentActions.keydown(editor, Keys.up()),
-    assertion: (s, str) => [
+    assertion: (s, str, arr) => [
       s.element('p', {}),
-      expectedSimplePara(':aaa')(s, str),
+      expectedSimplePara(':aaa')(s, str, arr),
       s.element('p', {})
     ]
   }));
 
   it('Checking inserting at least 10 chars after no matches cancels the autocompleter', () => pTestAutocompleter({
     action: (editor) => insertContentAndTrigger(editor, 'aaaaaaaaaa'),
-    assertion: (s, str) => [ expectedSimplePara(':aaaaaaaaaaa')(s, str) ]
+    assertion: (s, str, arr) => [ expectedSimplePara(':aaaaaaaaaaa')(s, str, arr) ]
   }));
 
   it('Checking changing to different node cancels the autocompleter', async () => {
     const editor = hook.editor();
-    await pTriggerAndAssertInitialContent(editor, '<p>CONTENT</p><p>new node</p>', [ 0, 0 ], (s, str) => [
-      expectedAutocompletePara(':a')(s, str),
+    await pTriggerAndAssertInitialContent(editor, '<p>CONTENT</p><p>new node</p>', [ 0, 0 ], (s, str, arr) => [
+      expectedAutocompletePara(':a')(s, str, arr),
       s.element('p', {})
     ]);
     insertContentAndTrigger(editor, 'aa');
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
     await pWaitForAutocompleteToClose();
-    await pAssertContent('Check autocompleter was not cancelled', editor, (s, str) => [
-      expectedAutocompletePara(':aaa')(s, str),
+    await pAssertContent('Check autocompleter was not cancelled', editor, (s, str, arr) => [
+      expectedAutocompletePara(':aaa')(s, str, arr),
       s.element('p', {})
     ]);
     TinySelections.setCursor(editor, [ 1, 0 ], 0);
-    await pAssertContent('Check autocompleter was cancelled', editor, (s, str) => [
-      expectedSimplePara(':aaa')(s, str),
+    await pAssertContent('Check autocompleter was cancelled', editor, (s, str, arr) => [
+      expectedSimplePara(':aaa')(s, str, arr),
       s.element('p', {})
     ]);
   });
 
   it('Checking clicking outside cancels the autocompleter', () => pTestAutocompleter({
-    setup: (editor) => pTriggerAndAssertInitialContent(editor, '<p>CONTENT</p><p>new node</p>', [ 0, 0 ], (s, str) => [
-      expectedAutocompletePara(':a')(s, str),
+    setup: (editor) => pTriggerAndAssertInitialContent(editor, '<p>CONTENT</p><p>new node</p>', [ 0, 0 ], (s, str, arr) => [
+      expectedAutocompletePara(':a')(s, str, arr),
       s.element('p', {})
     ]),
     action: (editor) => Mouse.trueClickOn(TinyDom.body(editor), 'p:contains(new node)'),
-    assertion: (s, str) => [
-      expectedSimplePara(':a')(s, str),
+    assertion: (s, str, arr) => [
+      expectedSimplePara(':a')(s, str, arr),
       s.element('p', { })
     ]
   }));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
@@ -653,6 +653,7 @@ describe('browser.tinymce.themes.silver.editor.autocomplete.AutocompleteTest', (
     additionalContent: 'als s',
     structure: {
       type: 'list',
+      hasIcons: false,
       groups: [
         [
           (s, str, arr) => s.element('div', {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorSettingsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorSettingsTest.ts
@@ -8,7 +8,7 @@ import LocalStorage from 'tinymce/core/api/util/LocalStorage';
 import * as Options from 'tinymce/themes/silver/ui/core/color/Options';
 
 interface ExpectedColor {
-  readonly type: string;
+  readonly type: 'choiceitem';
   readonly text: string;
   readonly value: string;
   readonly delta?: number;
@@ -34,11 +34,11 @@ describe('browser.tinymce.themes.silver.editor.color.ColorSettingsTest', () => {
   };
 
   const assertColors = (input: string[], expected: ExpectedColor[]) => {
-    const extractColor = (color: string) => {
-      const m = /^#([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})$/.exec(color);
+    const extractColor = (color: string | undefined) => {
+      const m = /^#([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})$/.exec(color ?? '') ?? [];
       return [ parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16) ];
     };
-    const assertColor = (expectedColor: string, actualColor: string, delta: number = 0) => {
+    const assertColor = (expectedColor: string, actualColor: string | undefined, delta: number = 0) => {
       const expectedRgb = extractColor(expectedColor);
       const actualRgb = extractColor(actualColor);
       assert.isTrue((
@@ -68,7 +68,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorSettingsTest', () => {
     assert.equal(sqrt, expected, 'Calced cols should be the same');
   };
 
-  const mappedColors = [
+  const mappedColors: ExpectedColor[] = [
     {
       text: 'Black',
       value: '#1ABC9C',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorCommandsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorCommandsTest.ts
@@ -6,7 +6,7 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.color.TextColorCommandsTest', () => {
-  const state = Cell(null);
+  const state = Cell<string | null>(null);
   const hook = TinyHooks.bddSetupLight<Editor>({
     toolbar: 'forecolor backcolor',
     base_url: '/project/tinymce/js/tinymce'

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
@@ -22,7 +22,7 @@ interface TestBounds {
 interface Scenario {
   readonly options: RawEditorOptions;
   readonly position: InlineContent.ContextPosition;
-  readonly scroll?: {
+  readonly scroll: {
     readonly relativeTop: boolean;
     readonly delta: number;
   };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarDistractionFreePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarDistractionFreePositionTest.ts
@@ -33,7 +33,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarDist
         onAction: Fun.noop
       });
       ed.ui.registry.addContextToolbar('test-toolbar', {
-        predicate: (node) => node.nodeName && node.nodeName.toLowerCase() === 'a',
+        predicate: (node) => node.nodeName.toLowerCase() === 'a',
         items: 'alpha'
       });
     }

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
@@ -83,7 +83,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarIFra
     assert.approximately(styles, value, diff, `Assert toolbar position - ${position} ${styles}px ~= ${value}px`);
   });
 
-  const pAssertFullscreenPosition = (position: string, value: number, diff = 5) => Waiter.pTryUntil('Wait for toolbar to be positioned', () => {
+  const pAssertFullscreenPosition = (position: 'top' | 'bottom', value: number, diff = 5) => Waiter.pTryUntil('Wait for toolbar to be positioned', () => {
     const ele = UiFinder.findIn(SugarBody.body(), '.tox-pop').getOrDie();
     // The context toolbar is positioned relative to the sink, so the value can change between browsers due to different default styles
     // as such we can't reliably test using the actual top/bottom position, so use the bounding client rect instead.

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupTest.ts
@@ -20,7 +20,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLook
 
       // Setup a container to click to outside the editor
       ed.on('init', () => {
-        const parent = ed.getContentAreaContainer().parentNode;
+        const parent = ed.getContentAreaContainer().parentNode as Node;
         const textarea = document.createElement('textarea');
         textarea.id = 'content-click-area';
         parent.appendChild(textarea);
@@ -48,7 +48,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLook
       ed.ui.registry.addContextToolbar('test-node-toolbar', {
         predicate: (node) => {
           recordNode('node', node);
-          return node.nodeName && node.nodeName.toLowerCase() === 'a';
+          return node.nodeName.toLowerCase() === 'a';
         },
         items: 'node',
         scope: 'node'
@@ -57,7 +57,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLook
         predicate: (node) => {
           recordNode('parent', node);
           const childNode = node.childNodes[0];
-          return childNode && childNode.nodeName && childNode.nodeName.toLowerCase() === 'strong';
+          return childNode && childNode.nodeName.toLowerCase() === 'strong';
         },
         items: 'parentnode',
         scope: 'node'
@@ -65,7 +65,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLook
       ed.ui.registry.addContextToolbar('test-editor-toolbar', {
         predicate: (node) => {
           recordNode('editor', node);
-          return node.nodeName && node.nodeName.toLowerCase() === 'span';
+          return node.nodeName.toLowerCase() === 'span';
         },
         items: 'editor',
         scope: 'editor'
@@ -152,7 +152,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLook
     await UiFinder.pWaitForVisible('Waiting for parent node toolbar to appear', SugarBody.body(), '.tox-tbtn:contains(Parent)');
     assertNames([ 'em', 'strong', 'p' ], [ 'em', 'strong', 'p' ], [ 'em' ]);
     resetNames();
-    SelectorFind.descendant(SugarBody.body(), '#content-click-area').each(Focus.focus);
+    SelectorFind.descendant<HTMLTextAreaElement>(SugarBody.body(), '#content-click-area').each(Focus.focus);
     await Waiter.pTryUntil('Wait for toolbar to hide', () => UiFinder.notExists(SugarBody.body(), '.tox-pop'));
     assertNames([], [], []);
     editor.focus();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
@@ -16,7 +16,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
         onAction: store.adder('alpha-exec')
       });
       ed.ui.registry.addContextToolbar('test-toolbar', {
-        predicate: (node) => node.nodeName && node.nodeName.toLowerCase() === 'a',
+        predicate: (node) => node.nodeName.toLowerCase() === 'a',
         items: 'alpha'
       });
     }

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/RemoveContextToolbarOnFocusoutTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/RemoveContextToolbarOnFocusoutTest.ts
@@ -36,7 +36,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.RemoveContextToolb
       onAction: Fun.noop
     });
     ed.ui.registry.addContextToolbar('test-toolbar', {
-      predicate: (node) => node.nodeName && node.nodeName.toLowerCase() === 'a',
+      predicate: (node) => node.nodeName.toLowerCase() === 'a',
       items: 'alpha'
     });
   };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
@@ -50,7 +50,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ReadonlyToolbarResizeTest
       ), overlord);
     });
 
-  const pAssertToolbarDrawerButtonState = (label: string, f: (s, str, arr) => StructAssert[]) =>
+  const pAssertToolbarDrawerButtonState = (label: string, f: ApproxStructure.Builder<StructAssert[]>) =>
     Waiter.pTryUntil('Waiting for toolbar state', () => {
       const overflow = UiFinder.findIn(SugarBody.body(), '.tox-toolbar__overflow').getOrDie();
       Assertions.assertStructure(label, ApproxStructure.build((s, str, arr) =>

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarShowOptionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarShowOptionTest.ts
@@ -24,7 +24,7 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarShowOptionTest', () => {
     return {
       base_url: '/project/tinymce/js/tinymce',
       toolbar: 'sidebarone sidebartwo',
-      setup: (ed) => {
+      setup: (ed: Editor) => {
         ed.ui.registry.addSidebar('sidebarone', {
           tooltip: 'side bar one',
           icon: 'comment',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
@@ -18,7 +18,7 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     toolbar: 'mysidebar1 mysidebar2 mysidebar3',
-    setup: (editor) => {
+    setup: (editor: Editor) => {
       const logEvent = (name: string) => (api: Sidebar.SidebarInstanceApi) => {
         const index = Traverse.findIndex(SugarElement.fromDom(api.element())).getOr(-1);
         const entry: EventLog = { name, index };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberEditorTest.ts
@@ -72,7 +72,7 @@ describe('browser.tinymce.themes.silver.throbber.ThrobberEditorTest', () => {
 
     it('TINY-7373: should set correct tabindex on iframe when the throbber is disabled', async () => {
       const editor = hook.editor();
-      const iframe = editor.iframeElement;
+      const iframe = editor.iframeElement as HTMLIFrameElement;
       iframe.tabIndex = 1;
       assertTabIndex(editor, '1', '');
       await pToggleThrobber(editor, () => assertTabIndex(editor, '-1', '1'));

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/colorpicker/ColorPickerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/colorpicker/ColorPickerTest.ts
@@ -53,7 +53,8 @@ describe('headless.tinymce.themes.silver.components.colorpicker.ColorPickerTest'
     return Waiter.pTryUntil('Assert hue of palette matches expected', () => {
       const canvas = UiFinder.findIn<HTMLCanvasElement>(component.element, 'canvas').getOrDie();
       // get 1px square from top right of palette canvas
-      const imageData = canvas.dom.getContext('2d').getImageData(100, 0, 1, 1).data;
+      const canvasContext = canvas.dom.getContext('2d') as CanvasRenderingContext2D;
+      const imageData = canvasContext.getImageData(100, 0, 1, 1).data;
       const rgb = { red: imageData[0], green: imageData[1], blue: imageData[2], alpha: (imageData[3] / 255) * 100 };
       const hsv = HsvColour.fromRgb(rgb);
       assert.equal(hsv.hue, expected);

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/customeditor/CustomEditorSchemaTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/customeditor/CustomEditorSchemaTest.ts
@@ -31,7 +31,7 @@ describe('headless.tinymce.themes.silver.components.customeditor.CustomEditorSch
       ...base,
       scriptId: 'scriptId',
       scriptUrl: 'scriptUrl',
-      init: (_el) => {
+      init: (_el: HTMLElement) => {
         return {
           setValue: Fun.noop,
           getValue: Fun.constant(''),
@@ -59,7 +59,7 @@ describe('headless.tinymce.themes.silver.components.customeditor.CustomEditorSch
 
     assert.isTrue(StructureSchema.asRaw('.', schema, {
       ...base,
-      init: (_el) => {
+      init: (_el: HTMLElement) => {
         return {
           setValue: Fun.noop,
           getValue: Fun.constant(''),

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
@@ -90,7 +90,8 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
               callback([
                 {
                   type: 'choiceitem',
-                  text: 'Item 1'
+                  text: 'Item 1',
+                  value: 'item1'
                 }
               ]);
             },

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerRedialTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerRedialTest.ts
@@ -83,7 +83,7 @@ describe('headless.tinymce.themes.silver.window.WindowManagerRedialTest', () => 
     onClose: store.adder('onCloseB'),
     onAction: (dialogApi, actionData) => {
       if (actionData.name === 'Dest.DialogC') {
-        dialogApi.redial(dialogC);
+        dialogApi.redial(dialogC as Dialog.DialogSpec<{}>);
       }
     }
   };

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerTest.ts
@@ -31,7 +31,7 @@ describe('headless.tinymce.themes.silver.window.WindowManagerTest', () => {
     try {
       windowManager.open(conf, {}, Fun.noop);
       assert.fail('This should throw a configuration error');
-    } catch (err) {
+    } catch (err: any) {
       asserter(err);
     }
   };
@@ -264,8 +264,8 @@ describe('headless.tinymce.themes.silver.window.WindowManagerTest', () => {
       dialogBody
     );
 
-    const inputElement: HTMLInputElement = document.querySelector('input.tox-textfield');
-    assert.equal(inputElement.value, conf.initialData.fooname, 'The input value should equal the initial data');
+    const inputElement = document.querySelector('input.tox-textfield') as HTMLInputElement;
+    assert.equal(inputElement.value, conf.initialData?.fooname, 'The input value should equal the initial data');
 
     const nuData = { fooname: 'Bonjour Universe' };
     instanceApi.setData(nuData);
@@ -275,7 +275,7 @@ describe('headless.tinymce.themes.silver.window.WindowManagerTest', () => {
 
     try {
       instanceApi.setData(badData);
-    } catch (error) {
+    } catch (error: any) {
       const message = error.message.split('\n');
       assert.equal('Failed path: (data > fooname)', message[1], 'Calling setData, with invalid data should throw: ');
       assert.equal('Expected type: string but got: object', message[2], 'Calling setData, with invalid data should throw: ');

--- a/modules/tinymce/src/themes/silver/test/ts/module/AutocompleterUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/AutocompleterUtils.ts
@@ -1,80 +1,103 @@
 import { ApproxStructure, Assertions, StructAssert, UiFinder, Waiter } from '@ephox/agar';
 import { Arr, Type } from '@ephox/katamari';
-import { SugarBody } from '@ephox/sugar';
+import { SugarBody, SugarElement } from '@ephox/sugar';
+
+interface TitleWithTextItem {
+  readonly title: string;
+  readonly text: string;
+}
+
+interface TitleWithIconItem {
+  readonly title: string;
+  readonly icon: string;
+}
+
+interface TitleWithTextAndIconItem extends TitleWithTextItem, TitleWithIconItem {}
+
+type GroupItem = TitleWithTextAndIconItem | TitleWithTextItem | TitleWithIconItem | ApproxStructure.Builder<StructAssert>;
 
 interface AutocompleterListStructure {
-  type: 'list';
-  hasIcons?: boolean;
-  groups: Array<{ title: string; text: string; icon?: string; boldText?: string} | ((s, str, arr) => StructAssert)>[];
+  readonly type: 'list';
+  readonly hasIcons: false;
+  readonly groups: Array<TitleWithTextItem | ApproxStructure.Builder<StructAssert>>[];
+}
+
+interface AutocompleterIconListStructure {
+  readonly type: 'list';
+  readonly hasIcons: true;
+  readonly groups: Array<TitleWithTextAndIconItem | ApproxStructure.Builder<StructAssert>>[];
 }
 
 interface AutocompleterGridStructure {
-  type: 'grid';
-  groups: Array<{ title: string; icon?: string; boldText?: string } | ((s, str, arr) => StructAssert)>[];
+  readonly type: 'grid';
+  readonly groups: Array<TitleWithIconItem | ApproxStructure.Builder<StructAssert>>[];
 }
 
-type AutocompleterStructure = AutocompleterListStructure | AutocompleterGridStructure;
+type AutocompleterStructure = AutocompleterListStructure | AutocompleterIconListStructure | AutocompleterGridStructure;
 
-const structWithTitleAndIconAndText = (d) => (s, str, arr) => s.element('div', {
-  classes: [ arr.has('tox-collection__item') ],
-  attrs: {
-    title: str.is(d.title)
-  },
-  children: [
-    s.element('div', {
-      classes: [ arr.has('tox-collection__item-icon') ],
-      children: [
-        s.text(str.is(d.icon))
-      ]
-    }),
-    s.element('div', {
-      classes: [ arr.has('tox-collection__item-label') ],
-      html: str.is(d.text)
-    })
-  ]
-});
+const structWithTitleAndIconAndText = (d: TitleWithTextAndIconItem): ApproxStructure.Builder<StructAssert> =>
+  (s, str, arr) => s.element('div', {
+    classes: [ arr.has('tox-collection__item') ],
+    attrs: {
+      title: str.is(d.title)
+    },
+    children: [
+      s.element('div', {
+        classes: [ arr.has('tox-collection__item-icon') ],
+        children: [
+          s.text(str.is(d.icon))
+        ]
+      }),
+      s.element('div', {
+        classes: [ arr.has('tox-collection__item-label') ],
+        html: str.is(d.text)
+      })
+    ]
+  });
 
-const structWithTitleAndText = (d) => (s, str, arr) => s.element('div', {
-  classes: [ arr.has('tox-collection__item') ],
-  attrs: {
-    title: str.is(d.title)
-  },
-  children: [
-    s.element('div', {
-      classes: [ arr.has('tox-collection__item-label') ],
-      html: str.is(d.text)
-    })
-  ]
-});
+const structWithTitleAndText = (d: TitleWithTextItem): ApproxStructure.Builder<StructAssert> =>
+  (s, str, arr) => s.element('div', {
+    classes: [ arr.has('tox-collection__item') ],
+    attrs: {
+      title: str.is(d.title)
+    },
+    children: [
+      s.element('div', {
+        classes: [ arr.has('tox-collection__item-label') ],
+        html: str.is(d.text)
+      })
+    ]
+  });
 
-const structWithTitleAndIcon = (d) => (s, str, arr) => s.element('div', {
-  classes: [ arr.has('tox-collection__item') ],
-  attrs: {
-    title: str.is(d.title)
-  },
-  children: [
-    s.element('div', {
-      classes: [ arr.has('tox-collection__item-icon') ],
-      children: [
-        s.text(str.is(d.icon))
-      ]
-    })
-  ]
-});
+const structWithTitleAndIcon = (d: TitleWithIconItem): ApproxStructure.Builder<StructAssert> =>
+  (s, str, arr) => s.element('div', {
+    classes: [ arr.has('tox-collection__item') ],
+    attrs: {
+      title: str.is(d.title)
+    },
+    children: [
+      s.element('div', {
+        classes: [ arr.has('tox-collection__item-icon') ],
+        children: [
+          s.text(str.is(d.icon))
+        ]
+      })
+    ]
+  });
 
-const pWaitForAutocompleteToOpen = () => UiFinder.pWaitForVisible(
+const pWaitForAutocompleteToOpen = (): Promise<SugarElement<HTMLElement>> => UiFinder.pWaitForVisible(
   'Wait for autocompleter to appear',
   SugarBody.body(),
   '.tox-autocompleter div[role="menu"]'
 );
 
-const pWaitForAutocompleteToClose = () => Waiter.pTryUntil(
+const pWaitForAutocompleteToClose = (): Promise<void> => Waiter.pTryUntil(
   'Autocompleter should disappear',
   () => UiFinder.notExists(SugarBody.body(), '.tox-autocompleter div[role="menu"]'),
   50
 );
 
-const pAssertAutocompleterStructure = async (structure: AutocompleterStructure) => {
+const pAssertAutocompleterStructure = async (structure: AutocompleterStructure): Promise<void> => {
   const autocompleter = UiFinder.findIn(SugarBody.body(), '.tox-autocompleter').getOrDie();
   await Waiter.pTryUntil(
     'Waiting for autocompleter structure to match',
@@ -91,19 +114,19 @@ const pAssertAutocompleterStructure = async (structure: AutocompleterStructure) 
                   // TINY-6476: Ensure the menu is positioned not the wrapper
                   position: str.is('absolute')
                 },
-                children: Arr.map(structure.groups, (group) => s.element('div', {
+                children: Arr.map<GroupItem[], StructAssert>(structure.groups, (group) => s.element('div', {
                   classes: [ arr.has('tox-collection__group') ],
                   children: Arr.map(group, (d) => {
-                    if (structure.type === 'list') {
-                      if (Type.isFunction(d)) {
-                        return d(s, str, arr);
-                      } else if (structure.hasIcons) {
-                        return structWithTitleAndIconAndText(d)(s, str, arr);
+                    if (Type.isFunction(d)) {
+                      return d(s, str, arr);
+                    } else if (structure.type === 'list') {
+                      if (structure.hasIcons) {
+                        return structWithTitleAndIconAndText(d as TitleWithTextAndIconItem)(s, str, arr);
                       } else {
-                        return structWithTitleAndText(d)(s, str, arr);
+                        return structWithTitleAndText(d as TitleWithTextItem)(s, str, arr);
                       }
                     } else {
-                      return structWithTitleAndIcon(d)(s, str, arr);
+                      return structWithTitleAndIcon(d as TitleWithIconItem)(s, str, arr);
                     }
                   })
                 }))

--- a/modules/tinymce/src/themes/silver/test/ts/module/ContextMenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/ContextMenuUtils.ts
@@ -5,12 +5,12 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 
-const pOpenContextMenu = async (editor: Editor, selector: string) => {
+const pOpenContextMenu = async (editor: Editor, selector: string): Promise<void> => {
   await TinyUiActions.pTriggerContextMenu(editor, selector, '.tox-silver-sink .tox-menu.tox-collection [role="menuitem"]');
   await Waiter.pWait(0);
 };
 
-const assertContentMenuPosition = (left: number, top: number, diff: number = 3) => {
+const assertContentMenuPosition = (left: number, top: number, diff: number = 3): void => {
   const menu = UiFinder.findIn(SugarBody.body(), '.tox-silver-sink .tox-menu.tox-collection').getOrDie();
   const topStyle = parseInt(Css.getRaw(menu, 'top').getOr('0').replace('px', ''), 10);
   const leftStyle = parseInt(Css.getRaw(menu, 'left').getOr('0').replace('px', ''), 10);
@@ -19,7 +19,7 @@ const assertContentMenuPosition = (left: number, top: number, diff: number = 3) 
 };
 
 // Wait for dialog to open and close dialog
-const pWaitForAndCloseDialog = async (editor: Editor) => {
+const pWaitForAndCloseDialog = async (editor: Editor): Promise<void> => {
   await TinyUiActions.pWaitForDialog(editor);
   TinyUiActions.cancelDialog(editor);
   await Waiter.pTryUntil(

--- a/modules/tinymce/src/themes/silver/test/ts/module/DialogUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/DialogUtils.ts
@@ -10,7 +10,7 @@ import { WindowParams } from 'tinymce/core/api/WindowManager';
 const open = <T>(editor: Editor, spec: Dialog.DialogSpec<T>, params: WindowParams): Dialog.DialogInstanceApi<T> =>
   editor.windowManager.open(spec, params);
 
-const openWithStore = <T>(editor: Editor, spec: Dialog.DialogSpec<T>, params: WindowParams, store: TestHelpers.TestStore) => {
+const openWithStore = <T>(editor: Editor, spec: Dialog.DialogSpec<T>, params: WindowParams, store: TestHelpers.TestStore): Dialog.DialogInstanceApi<T> => {
   const dialogSpec = {
     onSubmit: store.adder('onSubmit'),
     onClose: store.adder('onClose'),
@@ -22,7 +22,7 @@ const openWithStore = <T>(editor: Editor, spec: Dialog.DialogSpec<T>, params: Wi
   return open(editor, dialogSpec, params);
 };
 
-const close = (editor: Editor) => {
+const close = (editor: Editor): void => {
   TinyUiActions.closeDialog(editor);
   UiFinder.notExists(SugarBody.body(), 'div[role=dialog]');
 };

--- a/modules/tinymce/src/themes/silver/test/ts/module/DomUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/DomUtils.ts
@@ -3,12 +3,12 @@ import { AlloyComponent, AlloyTriggers } from '@ephox/alloy';
 import { Traverse, Value } from '@ephox/sugar';
 import { assert } from 'chai';
 
-const assertValue = (label: string, component: AlloyComponent, selector: string, expected: string) => {
+const assertValue = (label: string, component: AlloyComponent, selector: string, expected: string): void => {
   const elem = UiFinder.findIn<HTMLSelectElement>(component.element, selector).getOrDie();
   assert.equal(Value.get(elem), expected, label + ' - checking value of ' + selector);
 };
 
-const triggerEventOnFocused = (component: AlloyComponent, eventName: string) => {
+const triggerEventOnFocused = (component: AlloyComponent, eventName: string): void => {
   const doc = Traverse.owner(component.element);
   const focused = FocusTools.getFocused(doc).getOrDie();
   const input = component.getSystem().getByDom(focused).getOrDie();

--- a/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
@@ -19,27 +19,27 @@ const getToolbarSelector = (type: ToolbarMode, opening: boolean) => {
   return type === ToolbarMode.sliding ? slidingClass : floatingClass;
 };
 
-const pOpenMenuWithSelector = async (label: string, selector: string) => {
+const pOpenMenuWithSelector = async (label: string, selector: string): Promise<void> => {
   Mouse.clickOn(SugarBody.body(), selector);
   await UiFinder.pWaitForVisible(`Waiting for menu: ${label}`, SugarBody.body(), '[role="menu"]');
 };
 
-const pOpenMore = async (type: ToolbarMode) => {
+const pOpenMore = async (type: ToolbarMode): Promise<void> => {
   Mouse.clickOn(SugarBody.body(), 'button[title="More..."]');
   await UiFinder.pWaitForVisible('Waiting for more drawer to open', SugarBody.body(), getToolbarSelector(type, true));
 };
 
-const pCloseMore = async (type: ToolbarMode) => {
+const pCloseMore = async (type: ToolbarMode): Promise<void> => {
   Mouse.clickOn(SugarBody.body(), 'button[title="More..."]');
   await Waiter.pTryUntil('Waiting for more drawer to close', () => UiFinder.notExists(SugarBody.body(), getToolbarSelector(type, false)));
 };
 
-const pOpenAlignMenu = (label: string) => {
+const pOpenAlignMenu = (label: string): Promise<void> => {
   const selector = 'button[aria-label="Align"]';
   return pOpenMenuWithSelector(label, selector);
 };
 
-const pOpenMenu = (label: string, menuText: string) => {
+const pOpenMenu = (label: string, menuText: string): Promise<void> => {
   const menuTextParts = menuText.indexOf(':') > -1 ? menuText.split(':') : [ menuText ];
   const btnText = menuTextParts[0];
   const pseudo = menuTextParts.length > 1 ? ':' + menuTextParts[1] : '';
@@ -47,12 +47,12 @@ const pOpenMenu = (label: string, menuText: string) => {
   return pOpenMenuWithSelector(label, selector);
 };
 
-const pOpenNestedMenus = (menus: OpenNestedMenus[]) =>
+const pOpenNestedMenus = (menus: OpenNestedMenus[]): Promise<void> =>
   Arr.foldl(menus, (p, menu) => p.then(async () => {
     await pOpenMenuWithSelector(menu.label, menu.selector);
   }), Promise.resolve());
 
-const assertMoreDrawerInViewport = (type: ToolbarMode) => {
+const assertMoreDrawerInViewport = (type: ToolbarMode): void => {
   const toolbar = UiFinder.findIn<HTMLDivElement>(SugarBody.body(), getToolbarSelector(type, true)).getOrDie();
   const winBox = Boxes.win();
   const drawerBox = Boxes.box(toolbar);

--- a/modules/tinymce/src/themes/silver/test/ts/module/PageScroll.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/PageScroll.ts
@@ -8,7 +8,7 @@ import Editor from 'tinymce/core/api/Editor';
 const createScrollDiv = (height: number) =>
   SugarElement.fromHtml<HTMLElement>(`<div style="height: ${height}px;" tabindex="0" class="scroll-div"></div>`);
 
-const setup = (editor: Editor, amount: number) => {
+const setup = (editor: Editor, amount: number): VoidFunction => {
   const target = editor.inline ? TinyDom.body(editor) : TinyDom.container(editor);
 
   const divBefore = createScrollDiv(amount);
@@ -23,7 +23,7 @@ const setup = (editor: Editor, amount: number) => {
   };
 };
 
-const bddSetup = (lazyEditor: () => Editor, amount: number) => {
+const bddSetup = (lazyEditor: () => Editor, amount: number): void => {
   let teardownScroll: () => void = Fun.noop;
   before(() => {
     teardownScroll = setup(lazyEditor(), amount);

--- a/modules/tinymce/src/themes/silver/test/ts/module/RepresentingUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/RepresentingUtils.ts
@@ -1,21 +1,21 @@
 import { AlloyComponent, Composing, Representing } from '@ephox/alloy';
 import { assert } from 'chai';
 
-const assertComposedValue = (component: AlloyComponent, expected: any) => {
+const assertComposedValue = (component: AlloyComponent, expected: any): void => {
   const c = Composing.getCurrent(component).getOrDie('Trying to get the composed component');
   assert.deepEqual(Representing.getValue(c), expected, 'Representing value');
 };
 
-const assertValue = (component: AlloyComponent, expected: any) => {
+const assertValue = (component: AlloyComponent, expected: any): void => {
   assert.deepEqual(Representing.getValue(component), expected, 'Representing value');
 };
 
-const setComposedValue = (component: AlloyComponent, newValue: any) => {
+const setComposedValue = (component: AlloyComponent, newValue: any): void => {
   const c = Composing.getCurrent(component).getOrDie('Trying to get the composed component');
   Representing.setValue(c, newValue);
 };
 
-const assertRoundtrip = (component: AlloyComponent, newValue: any) => {
+const assertRoundtrip = (component: AlloyComponent, newValue: any): void => {
   Representing.setValue(component, newValue);
   assertValue(component, newValue);
 };

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -12,7 +12,7 @@ import * as MenuUtils from './MenuUtils';
 import * as PageScroll from './PageScroll';
 import * as StickyUtils from './StickyHeaderUtils';
 
-const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLocation) => {
+const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLocation): void => {
   const isToolbarTop = toolbarLocation === ToolbarLocation.top;
 
   context('Test editor with toolbar_mode: ' + toolbarMode, () => {

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderUtils.ts
@@ -34,7 +34,7 @@ const expectedScrollEventBound = (s: ApproxStructure.StructApi, str: ApproxStruc
   })
 ];
 
-const pAssertHeaderDocked = async (assertDockedTop: boolean) => {
+const pAssertHeaderDocked = async (assertDockedTop: boolean): Promise<void> => {
   const header = UiFinder.findIn(SugarBody.body(), '.tox-editor-header').getOrDie();
   await Waiter.pTryUntil(
     'Wait for header structure',
@@ -98,13 +98,13 @@ const expectedInFullView = (s: ApproxStructure.StructApi, str: ApproxStructure.S
   })
 ];
 
-const scrollRelativeEditor = (delta: number, scrollRelativeTop: boolean) => {
+const scrollRelativeEditor = (delta: number, scrollRelativeTop: boolean): void => {
   const container = UiFinder.findIn(SugarBody.body(), '.tox-tinymce').getOrDie();
   container.dom.scrollIntoView(scrollRelativeTop);
   Scroll.to(0, window.pageYOffset + (scrollRelativeTop ? delta : -delta));
 };
 
-const pAssertSinkVisibility = async (label: string, expectedVisibility: 'hidden' | 'visible') => {
+const pAssertSinkVisibility = async (label: string, expectedVisibility: 'hidden' | 'visible'): Promise<void> => {
   const sink = UiFinder.findIn(SugarBody.body(), '.tox-tinymce-aux').getOrDie();
   await Waiter.pTryUntil(`Wait for sink visibility to be ${expectedVisibility}`, () => {
     const visibility = Css.get(sink, 'visibility');
@@ -112,7 +112,7 @@ const pAssertSinkVisibility = async (label: string, expectedVisibility: 'hidden'
   });
 };
 
-const pAssertMenuStructure = (label: string, container: SugarElement<HTMLElement>, position: string) => Waiter.pTryUntil(
+const pAssertMenuStructure = (label: string, container: SugarElement<HTMLElement>, position: string): Promise<void> => Waiter.pTryUntil(
   `Wait until menus become ${position} positioned`,
   () => Assertions.assertStructure(
     label,
@@ -127,7 +127,7 @@ const pAssertMenuStructure = (label: string, container: SugarElement<HTMLElement
 );
 
 // Assume editor height 400
-const pTestMenuScroll = async (top: boolean) => {
+const pTestMenuScroll = async (top: boolean): Promise<void> => {
   const menu = UiFinder.findIn<HTMLElement>(SugarBody.body(), '[role="menu"]').getOrDie();
   await pAssertMenuStructure('Checking the opened menus default positioning', menu, 'absolute');
   scrollRelativeEditor(200, top);
@@ -141,7 +141,7 @@ const pTestMenuScroll = async (top: boolean) => {
   await pAssertMenuStructure('When the editor is in full view, menus and toolbars should not be sticky', menu, 'absolute');
 };
 
-const pAssertEditorContainer = async (isToolbarTop: boolean, expectedPart: ApproxStructure.Builder<StructAssert[]>) => {
+const pAssertEditorContainer = async (isToolbarTop: boolean, expectedPart: ApproxStructure.Builder<StructAssert[]>): Promise<void> => {
   const container = UiFinder.findIn(SugarBody.body(), '.tox-editor-container').getOrDie();
   await Waiter.pTryUntil('Wait for editor structure',
     () => Assertions.assertStructure(
@@ -157,7 +157,7 @@ const pAssertEditorContainer = async (isToolbarTop: boolean, expectedPart: Appro
   );
 };
 
-const pScrollAndAssertStructure = async (isToolbarTop: boolean, scrollYDelta: number, expectedPart: ApproxStructure.Builder<StructAssert[]>) => {
+const pScrollAndAssertStructure = async (isToolbarTop: boolean, scrollYDelta: number, expectedPart: ApproxStructure.Builder<StructAssert[]>): Promise<void> => {
   scrollRelativeEditor(scrollYDelta, isToolbarTop);
   const container = UiFinder.findIn(SugarBody.body(), '.tox-editor-container').getOrDie();
   await Waiter.pTryUntil('Wait until editor docking updated',
@@ -174,7 +174,7 @@ const pScrollAndAssertStructure = async (isToolbarTop: boolean, scrollYDelta: nu
   );
 };
 
-const assertEditorClasses = (docked: boolean) => {
+const assertEditorClasses = (docked: boolean): void => {
   const container = UiFinder.findIn(SugarBody.body(), '.tox-tinymce').getOrDie();
   Assertions.assertStructure('Check root container classes', ApproxStructure.build((s, _str, arr) => s.element('div', {
     classes: [
@@ -184,7 +184,7 @@ const assertEditorClasses = (docked: boolean) => {
   })), container);
 };
 
-const pAssertHeaderPosition = async (toolbarLocation: ToolbarLocation, value: number) => {
+const pAssertHeaderPosition = async (toolbarLocation: ToolbarLocation, value: number): Promise<void> => {
   const isToolbarTop = toolbarLocation === ToolbarLocation.top;
   scrollRelativeEditor(-100, isToolbarTop);
   await Waiter.pWait(100);
@@ -212,7 +212,7 @@ const pCloseMenus = (numOpenedMenus: number) => {
   }), Promise.resolve());
 };
 
-const pOpenMenuAndTestScrolling = async (pOpenMenu: () => Promise<void>, numMenusToClose: number, top: boolean) => {
+const pOpenMenuAndTestScrolling = async (pOpenMenu: () => Promise<void>, numMenusToClose: number, top: boolean): Promise<void> => {
   await pOpenMenu();
   await pTestMenuScroll(top);
   await pCloseMenus(numMenusToClose);

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestExtras.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestExtras.ts
@@ -53,7 +53,7 @@ export const TestExtras = (): TestExtras => {
   Class.add(uiMothership.element, 'tox');
 
   const backstage = TestBackstage(sink);
-  const options = {};
+  const options: Record<string, any> = {};
 
   const mockEditor = {
     setContent: (_content) => {},

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
@@ -2,7 +2,7 @@ import { Fun } from '@ephox/katamari';
 
 import I18n from 'tinymce/core/api/util/I18n';
 
-const defaultOptions = {
+const defaultOptions: Record<string, any> = {
   images_file_types: 'jpeg,jpg,jpe,jfi,jif,jfif,png,gif,bmp,webp'
 };
 
@@ -11,5 +11,5 @@ export default {
   menuItems: (): Record<string, any> => ({}),
   translate: I18n.translate,
   isDisabled: Fun.never,
-  getOption: (name: string) => defaultOptions[name]
+  getOption: <T>(name: string): T | undefined => defaultOptions[name]
 };

--- a/modules/tinymce/src/themes/silver/test/ts/module/ToolbarUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/ToolbarUtils.ts
@@ -9,7 +9,7 @@ import { ToolbarMode } from 'tinymce/themes/silver/api/Options';
 
 import { pCloseMore, pOpenMore } from './MenuUtils';
 
-const pAssertFloatingToolbarPosition = async (editor: Editor, getTop: () => number, expectedLeft: number, expectedRight: number) => {
+const pAssertFloatingToolbarPosition = async (editor: Editor, getTop: () => number, expectedLeft: number, expectedRight: number): Promise<void> => {
   const toolbar = await TinyUiActions.pWaitForUi(editor, '.tox-toolbar__overflow') as SugarElement<HTMLElement>;
   await Waiter.pTryUntil('Wait for toolbar position', () => {
     const top = getTop();
@@ -22,13 +22,13 @@ const pAssertFloatingToolbarPosition = async (editor: Editor, getTop: () => numb
   });
 };
 
-const pAssertFloatingToolbarHeight = async (editor: Editor, expectedHeight: number) => {
+const pAssertFloatingToolbarHeight = async (editor: Editor, expectedHeight: number): Promise<void> => {
   const toolbar = await TinyUiActions.pWaitForUi(editor, '.tox-toolbar__overflow') as SugarElement<HTMLElement>;
   const height = Height.get(toolbar);
   assert.approximately(height, expectedHeight, 1, `Drawer height ${height}px should be ~${expectedHeight}px`);
 };
 
-const pOpenFloatingToolbarAndAssertPosition = async (editor: Editor, getTop: () => number, pActions?: () => Promise<void>) => {
+const pOpenFloatingToolbarAndAssertPosition = async (editor: Editor, getTop: () => number, pActions?: () => Promise<void>): Promise<void> => {
   await pOpenMore(ToolbarMode.floating);
   await pAssertFloatingToolbarPosition(editor, getTop, 105, 531);
   if (Type.isNonNullable(pActions)) {

--- a/modules/tinymce/src/themes/silver/test/ts/module/UiUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/UiUtils.ts
@@ -5,12 +5,12 @@ import { TinyDom } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
-const countNumber = (container: SugarElement<Node>, selector: string) => {
+const countNumber = (container: SugarElement<Node>, selector: string): number => {
   const ts = UiFinder.findAllIn(container, selector);
   return ts.length;
 };
 
-const extractOnlyOne = (container: SugarElement<Node>, selector: string) => {
+const extractOnlyOne = (container: SugarElement<Node>, selector: string): SugarElement<HTMLElement> => {
   const ts = UiFinder.findAllIn<HTMLElement>(container, selector);
   if (ts.length === 1) {
     return ts[0];
@@ -19,7 +19,7 @@ const extractOnlyOne = (container: SugarElement<Node>, selector: string) => {
   }
 };
 
-const resizeToPos = (sx: number, sy: number, dx: number, dy: number, delta: number = 10) => {
+const resizeToPos = (sx: number, sy: number, dx: number, dy: number, delta: number = 10): void => {
   // Simulate moving the mouse, by making a number of movements
   const numMoves = sy === dy ? Math.abs(dx - sx) / delta : Math.abs(dy - sy) / delta;
   // Determine the deltas based on the number of moves to make
@@ -37,13 +37,13 @@ const resizeToPos = (sx: number, sy: number, dx: number, dy: number, delta: numb
   Mouse.mouseUp(blocker);
 };
 
-const scrollRelativeEditor = (editor: Editor, relative: 'top' | 'bottom' = 'top', deltaY: number) => {
+const scrollRelativeEditor = (editor: Editor, relative: 'top' | 'bottom' = 'top', deltaY: number): void => {
   const target = editor.inline ? TinyDom.body(editor) : TinyDom.container(editor);
   target.dom.scrollIntoView(relative === 'top');
   Scroll.to(0, window.pageYOffset + deltaY);
 };
 
-const pWaitForEditorToRender = () =>
+const pWaitForEditorToRender = (): Promise<void> =>
   Waiter.pTryUntil('Editor has rendered', () => UiFinder.exists(SugarBody.body(), '.tox-editor-header'));
 
 export {

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
@@ -73,7 +73,7 @@ describe('webdriver.tinymce.themes.silver.dialogs.IFrameDialogTest', () => {
       'check iframe is loaded',
       SugarDocument.getDocument(),
       '.tox-dialog .tox-dialog__body iframe',
-      (iframe) => iframe.dom.contentDocument.readyState === 'complete'
+      (iframe) => iframe.dom.contentDocument?.readyState === 'complete'
     );
 
     const input = await FocusTools.pTryOnSelector('focus should be on the input initially', SugarDocument.getDocument(), 'input');

--- a/modules/tinymce/tsconfig.strict.json
+++ b/modules/tinymce/tsconfig.strict.json
@@ -17,6 +17,7 @@
     "src/core/test/ts/module/test/ViewBlock.ts",
     "src/models/dom/demo/ts/",
     "src/models/dom/main/ts/",
+    "src/themes/silver/demo/ts/",
     "src/themes/silver/main/ts/"
   ]
 }


### PR DESCRIPTION
Related Ticket: TINY-8921

Description of Changes:

This PR is a somewhat smaller than that last thankfully and aims at fixing all the strict type errors in the silver theme demo and tests. Note that I've not included the `tests` directory in the `tsconfig.strict.json` file because they include silver and some plugins which won't compile yet.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
