### PR TITLE
TINY-8921: Fixed strict type errors in the A-L plugins

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -251,9 +251,14 @@ export interface NormalizedEditorOptions extends BaseEditorOptions {
 }
 
 export interface EditorOptions extends NormalizedEditorOptions {
+  a11y_advanced_options: boolean;
+  allow_unsafe_link_target: boolean;
   anchor_bottom: string;
   anchor_top: string;
+  automatic_uploads: boolean;
   block_formats: string;
+  body_class: string;
+  body_id: string;
   br_newline_selector: string;
   color_cols: number;
   content_css: string[];

--- a/modules/tinymce/src/plugins/advlist/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/advlist/demo/ts/demo/Demo.ts
@@ -1,4 +1,6 @@
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',

--- a/modules/tinymce/src/plugins/advlist/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/api/Options.ts
@@ -2,8 +2,8 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorOptions } from 'tinymce/core/api/OptionTypes';
 
 const option: {
-  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K] | undefined;
-  <T>(name: string): (editor: Editor) => T | undefined;
+  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K];
+  <T>(name: string): (editor: Editor) => T;
 } = (name: string) => (editor: Editor) =>
   editor.options.get(name);
 

--- a/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
@@ -1,4 +1,4 @@
-import { Optional } from '@ephox/katamari';
+import { Optional, Type } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -7,11 +7,11 @@ const isChildOfBody = (editor: Editor, elm: Node): boolean => {
 };
 
 const isTableCellNode = (node: Node | null): boolean => {
-  return node && /^(TH|TD)$/.test(node.nodeName);
+  return Type.isNonNullable(node) && /^(TH|TD)$/.test(node.nodeName);
 };
 
 const isListNode = (editor: Editor) => (node: Node | null): boolean => {
-  return node && (/^(OL|UL|DL)$/).test(node.nodeName) && isChildOfBody(editor, node);
+  return Type.isNonNullable(node) && (/^(OL|UL|DL)$/).test(node.nodeName) && isChildOfBody(editor, node);
 };
 
 const getSelectedStyleType = (editor: Editor): Optional<string> => {

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistPluginTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistPluginTest.ts
@@ -40,7 +40,7 @@ describe('browser.tinymce.plugins.advlist.AdvlistPluginTest', () => {
       const expectedElm = editor.dom.select(definition.expectedSelection[0])[0];
 
       TinyAssertions.assertContent(editor, definition.expectedContent);
-      LegacyUnit.equalDom(rng.startContainer.parentNode, expectedElm, 'Selection elements should be equal');
+      LegacyUnit.equalDom(rng.startContainer.parentNode as Node, expectedElm, 'Selection elements should be equal');
       assert.equal(rng.startOffset, definition.expectedSelection[1], 'Selection offset should be equal');
     });
   };

--- a/modules/tinymce/src/plugins/anchor/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/anchor/demo/ts/demo/Demo.ts
@@ -1,4 +1,6 @@
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',

--- a/modules/tinymce/src/plugins/anchor/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/api/Options.ts
@@ -2,8 +2,8 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorOptions } from 'tinymce/core/api/OptionTypes';
 
 const option: {
-  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K] | undefined;
-  <T>(name: string): (editor: Editor) => T | undefined;
+  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K];
+  <T>(name: string): (editor: Editor) => T;
 } = (name: string) => (editor: Editor) =>
   editor.options.get(name);
 

--- a/modules/tinymce/src/plugins/anchor/main/ts/core/Anchor.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/core/Anchor.ts
@@ -43,7 +43,7 @@ const createAnchor = (editor: Editor, id: string): void => {
       // Remove any empty named anchors in the selection as they cannot be removed by the formatter since they are cef
       removeEmptyNamedAnchorsInSelection(editor);
       // Format is set up to truncate any partially selected named anchors so that they are not completely removed
-      editor.formatter.remove('namedAnchor', null, null, true);
+      editor.formatter.remove('namedAnchor', undefined, undefined, true);
       // Insert new anchor using the formatter - will wrap selected content in anchor
       editor.formatter.apply('namedAnchor', { value: id });
       // Need to add visual classes to anchors if required

--- a/modules/tinymce/src/plugins/anchor/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/core/FilterContent.ts
@@ -5,10 +5,10 @@ import { isEmptyString } from './Utils';
 
 // Note: node.firstChild check is for the 'allow_html_in_named_anchor' setting
 // Only want to add contenteditable attributes if there is no text within the anchor
-const isNamedAnchorNode = (node: AstNode | undefined) =>
-  node && isEmptyString(node.attr('href')) && !isEmptyString(node.attr('id') || node.attr('name'));
+const isNamedAnchorNode = (node: AstNode): boolean =>
+  isEmptyString(node.attr('href')) && !isEmptyString(node.attr('id') || node.attr('name'));
 
-const isEmptyNamedAnchorNode = (node: AstNode | undefined) =>
+const isEmptyNamedAnchorNode = (node: AstNode): boolean =>
   isNamedAnchorNode(node) && !node.firstChild;
 
 const setContentEditable = (state: string | null) => (nodes: AstNode[]): void => {

--- a/modules/tinymce/src/plugins/anchor/main/ts/core/Formats.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/core/Formats.ts
@@ -1,4 +1,5 @@
 import Editor from 'tinymce/core/api/Editor';
+import { Format } from 'tinymce/core/fmt/FormatTypes';
 
 import * as Utils from './Utils';
 
@@ -12,7 +13,7 @@ const registerFormats = (editor: Editor): void => {
     attributes: {
       id: '%value'
     },
-    onmatch: (node: Node, _fmt, _itemName: string) => {
+    onmatch: (node: Node, _fmt: Format, _itemName: string) => {
       return Utils.isNamedAnchor(node);
     }
   });

--- a/modules/tinymce/src/plugins/anchor/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/core/Utils.ts
@@ -1,19 +1,19 @@
 const namedAnchorSelector = 'a:not([href])';
 
-const isEmptyString = (str: string): boolean => !str;
+const isEmptyString = (str: string | undefined): boolean => !str;
 
 const getIdFromAnchor = (elm: HTMLAnchorElement): string => {
   const id = elm.getAttribute('id') || elm.getAttribute('name');
   return id || '';
 };
 
-const isAnchor = (elm: Node | null): elm is HTMLAnchorElement =>
-  elm && elm.nodeName.toLowerCase() === 'a';
+const isAnchor = (elm: Node): elm is HTMLAnchorElement =>
+  elm.nodeName.toLowerCase() === 'a';
 
-const isNamedAnchor = (elm: Node | null): elm is HTMLAnchorElement =>
+const isNamedAnchor = (elm: Node): elm is HTMLAnchorElement =>
   isAnchor(elm) && !elm.getAttribute('href') && getIdFromAnchor(elm) !== '';
 
-const isEmptyNamedAnchor = (elm: Node | null): elm is HTMLAnchorElement =>
+const isEmptyNamedAnchor = (elm: Node): elm is HTMLAnchorElement =>
   isNamedAnchor(elm) && !elm.firstChild;
 
 export {

--- a/modules/tinymce/src/plugins/anchor/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/ui/Buttons.ts
@@ -1,17 +1,19 @@
 import Editor from 'tinymce/core/api/Editor';
 
 const register = (editor: Editor): void => {
+  const onAction = () => editor.execCommand('mceAnchor');
+
   editor.ui.registry.addToggleButton('anchor', {
     icon: 'bookmark',
     tooltip: 'Anchor',
-    onAction: () => editor.execCommand('mceAnchor'),
+    onAction,
     onSetup: (buttonApi) => editor.selection.selectorChangedWithUnbind('a:not([href])', buttonApi.setActive).unbind
   });
 
   editor.ui.registry.addMenuItem('anchor', {
     icon: 'bookmark',
     text: 'Anchor...',
-    onAction: () => editor.execCommand('mceAnchor')
+    onAction
   });
 };
 

--- a/modules/tinymce/src/plugins/anchor/test/ts/module/Helpers.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/module/Helpers.ts
@@ -12,11 +12,7 @@ const pAddAnchor = async (editor: Editor, id: string, useCommand: boolean = fals
 };
 
 const pAssertAnchorPresence = (editor: Editor, numAnchors: number, selector: string = 'a.mce-item-anchor'): Promise<void> => {
-  const expected = {};
-  expected[selector] = numAnchors;
-  return Waiter.pTryUntil('wait for anchor',
-    () => TinyAssertions.assertContentPresence(editor, expected)
-  );
+  return Waiter.pTryUntil('wait for anchor', () => TinyAssertions.assertContentPresence(editor, { [selector]: numAnchors }));
 };
 
 export {

--- a/modules/tinymce/src/plugins/autolink/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/autolink/demo/ts/demo/Demo.ts
@@ -1,4 +1,6 @@
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',

--- a/modules/tinymce/src/plugins/autolink/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/autolink/main/ts/api/Options.ts
@@ -4,8 +4,8 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorOptions } from 'tinymce/core/api/OptionTypes';
 
 const option: {
-  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K] | undefined;
-  <T>(name: string): (editor: Editor) => T | undefined;
+  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K];
+  <T>(name: string): (editor: Editor) => T;
 } = (name: string) => (editor: Editor) =>
   editor.options.get(name);
 
@@ -29,9 +29,9 @@ const register = (editor: Editor): void => {
 };
 
 const getAutoLinkPattern = option<RegExp>('autolink_pattern');
-const getDefaultLinkTarget = option<string>('link_default_target');
+const getDefaultLinkTarget = option<string | undefined>('link_default_target');
 const getDefaultLinkProtocol = option<string>('link_default_protocol');
-const allowUnsafeLinkTarget = option<boolean>('allow_unsafe_link_target');
+const allowUnsafeLinkTarget = option('allow_unsafe_link_target');
 
 export {
   register,

--- a/modules/tinymce/src/plugins/autolink/main/ts/core/Keys.ts
+++ b/modules/tinymce/src/plugins/autolink/main/ts/core/Keys.ts
@@ -18,7 +18,7 @@ const parseCurrentLine = (editor: Editor, offset: number): ParseResult | null =>
 
   // Never create a link when we are inside a link
   if (dom.getParent(selection.getNode(), 'a[href]') !== null) {
-    return;
+    return null;
   }
 
   const rng = selection.getRng();
@@ -42,7 +42,7 @@ const parseCurrentLine = (editor: Editor, offset: number): ParseResult | null =>
   }, root);
 
   if (!endSpot) {
-    return;
+    return null;
   }
 
   // Walk backwards until we find a boundary or a bracket/space

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
@@ -122,7 +122,7 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
   it('TBA: Url inside blank formatting wrapper', () => {
     const editor = hook.editor();
     editor.setContent('<p><br></p>');
-    editor.selection.setCursorLocation(editor.getBody().firstChild, 0);
+    editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 0);
     editor.execCommand('Bold');
     // inserting url via typeUrl() results in different behaviour, so lets simply type it in, char by char
     KeyUtils.typeString(editor, 'http://www.domain.com ');
@@ -213,7 +213,7 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
 
   it('TINY-8896: should fire a createlink ExecCommand event when converting a URL to a link', () => {
     const editor = hook.editor();
-    const events = [];
+    const events: string[] = [];
     const logEvent = (e: EditorEvent<ExecCommandEvent>) => {
       events.push(`${e.type.toLowerCase()}-${e.command.toLowerCase()}`);
     };

--- a/modules/tinymce/src/plugins/autolink/test/ts/module/test/KeyUtils.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/module/test/KeyUtils.ts
@@ -1,4 +1,4 @@
-import { Arr, Fun, Obj, Unicode } from '@ephox/katamari';
+import { Arr, Fun, Obj, Type, Unicode } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -15,14 +15,14 @@ const charCodeToKeyCode = (charCode: number): number => {
   return Obj.get(lookup, String.fromCharCode(charCode)).getOr(charCode);
 };
 
-const needsShiftModifier = (charCode: number): boolean => {
+const needsShiftModifier = (charCode: number | undefined): boolean => {
   const lookup: Record<string, boolean> = {
     '(': true, ')': true, '{': true, '}': true, '+': true, '_': true, ':': true, '"': true,
     '<': true, '>': true, '?': true, '!': true, '@': true, '#': true, '$': true, '%': true,
     '^': true, '&': true, '*': true, '|': true
   };
 
-  return Obj.has(lookup, String.fromCharCode(charCode));
+  return Type.isNumber(charCode) && Obj.has(lookup, String.fromCharCode(charCode));
 };
 
 const needsNbsp = (rng: Range, chr: string): boolean => {
@@ -39,9 +39,9 @@ const needsNbsp = (rng: Range, chr: string): boolean => {
 };
 
 const type = (editor: Editor, chr: string | number | Record<string, number | string | boolean>): void => {
-  let keyCode: number;
-  let charCode: number;
-  let evt: Record<string, any>;
+  let keyCode: number | undefined;
+  let charCode: number | undefined;
+  let evt: Record<string, any> | undefined;
   let offset: number;
 
   const fakeEvent = (type: string, evt: Record<string, any>) => {
@@ -130,7 +130,7 @@ const type = (editor: Editor, chr: string | number | Record<string, number | str
         }
       }
 
-      editor.getDoc().execCommand('Delete', false, null);
+      editor.getDoc().execCommand('Delete');
     }
   } else if (typeof chr === 'string') {
     const rng = editor.selection.getRng();

--- a/modules/tinymce/src/plugins/autoresize/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/autoresize/demo/ts/demo/Demo.ts
@@ -1,4 +1,6 @@
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',

--- a/modules/tinymce/src/plugins/autoresize/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/api/Options.ts
@@ -2,8 +2,8 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorOptions } from 'tinymce/core/api/OptionTypes';
 
 const option: {
-  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K] | undefined;
-  <T>(name: string): (editor: Editor) => T | undefined;
+  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K];
+  <T>(name: string): (editor: Editor) => T;
 } = (name: string) => (editor: Editor) =>
   editor.options.get(name);
 

--- a/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
@@ -30,7 +30,7 @@ const toggleScrolling = (editor: Editor, state: boolean): void => {
 };
 
 const parseCssValueToInt = (dom: DOMUtils, elm: Element, name: string, computed: boolean): number => {
-  const value = parseInt(dom.getStyle(elm, name, computed), 10);
+  const value = parseInt(dom.getStyle(elm, name, computed) ?? '', 10);
   // The value maybe be an empty string, so in that case treat it as being 0
   return isNaN(value) ? 0 : value;
 };

--- a/modules/tinymce/src/plugins/autosave/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/autosave/demo/ts/demo/Demo.ts
@@ -1,4 +1,6 @@
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',

--- a/modules/tinymce/src/plugins/autosave/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/api/Options.ts
@@ -6,8 +6,8 @@ import { EditorOptions } from 'tinymce/core/api/OptionTypes';
 import * as Time from '../core/Time';
 
 const option: {
-  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K] | undefined;
-  <T>(name: string): (editor: Editor) => T | undefined;
+  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K];
+  <T>(name: string): (editor: Editor) => T;
 } = (name: string) => (editor: Editor) =>
   editor.options.get(name);
 

--- a/modules/tinymce/src/plugins/autosave/main/ts/core/BeforeUnload.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/core/BeforeUnload.ts
@@ -6,7 +6,7 @@ import * as Options from '../api/Options';
 
 const setup = (editor: Editor): void => {
   editor.editorManager.on('BeforeUnload', (e) => {
-    let msg: string;
+    let msg: string | undefined;
 
     Tools.each(EditorManager.get(), (editor) => {
       // Store a draft for each editor instance

--- a/modules/tinymce/src/plugins/autosave/main/ts/core/Storage.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/core/Storage.ts
@@ -24,7 +24,7 @@ const isEmpty = (editor: Editor, html?: string): boolean => {
 };
 
 const hasDraft = (editor: Editor): boolean => {
-  const time = parseInt(LocalStorage.getItem(Options.getAutoSavePrefix(editor) + 'time'), 10) || 0;
+  const time = parseInt(LocalStorage.getItem(Options.getAutoSavePrefix(editor) + 'time') ?? '0', 10) || 0;
 
   if (new Date().getTime() - time > Options.getAutoSaveRetention(editor)) {
     removeDraft(editor, false);
@@ -59,7 +59,7 @@ const restoreDraft = (editor: Editor): void => {
   const prefix = Options.getAutoSavePrefix(editor);
 
   if (hasDraft(editor)) {
-    editor.setContent(LocalStorage.getItem(prefix + 'draft'), { format: 'raw' });
+    editor.setContent(LocalStorage.getItem(prefix + 'draft') ?? '', { format: 'raw' });
     Events.fireRestoreDraft(editor);
   }
 };

--- a/modules/tinymce/src/plugins/autosave/main/ts/core/Time.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/core/Time.ts
@@ -5,8 +5,7 @@ const parse = (timeString: string): number => {
   };
 
   const parsedTime = /^(\d+)([ms]?)$/.exec(timeString);
-
-  return (parsedTime[2] ? multiples[parsedTime[2]] : 1) * parseInt(timeString, 10);
+  return (parsedTime && parsedTime[2] ? multiples[parsedTime[2]] : 1) * parseInt(timeString, 10);
 };
 
 export {

--- a/modules/tinymce/src/plugins/autosave/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/ui/Buttons.ts
@@ -15,21 +15,21 @@ const register = (editor: Editor): void => {
   //       Is it safe to start this process when the plugin is registered?
   Storage.startStoreDraft(editor);
 
+  const onAction = () => {
+    Storage.restoreLastDraft(editor);
+  };
+
   editor.ui.registry.addButton('restoredraft', {
     tooltip: 'Restore last draft',
     icon: 'restore-draft',
-    onAction: () => {
-      Storage.restoreLastDraft(editor);
-    },
+    onAction,
     onSetup: makeSetupHandler(editor)
   });
 
   editor.ui.registry.addMenuItem('restoredraft', {
     text: 'Restore last draft',
     icon: 'restore-draft',
-    onAction: () => {
-      Storage.restoreLastDraft(editor);
-    },
+    onAction,
     onSetup: makeSetupHandler(editor)
   });
 };

--- a/modules/tinymce/src/plugins/charmap/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/charmap/demo/ts/demo/Demo.ts
@@ -1,4 +1,6 @@
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',

--- a/modules/tinymce/src/plugins/charmap/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/api/Options.ts
@@ -6,8 +6,8 @@ import { EditorOptions } from 'tinymce/core/api/OptionTypes';
 type UserChar = [ number, string ];
 
 const option: {
-  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K] | undefined;
-  <T>(name: string): (editor: Editor) => T | undefined;
+  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K];
+  <T>(name: string): (editor: Editor) => T;
 } = (name: string) => (editor: Editor) =>
   editor.options.get(name);
 
@@ -26,8 +26,8 @@ const register = (editor: Editor): void => {
   });
 };
 
-const getCharMap = option<UserChar[] | (() => UserChar[])>('charmap');
-const getCharMapAppend = option<UserChar[] | (() => UserChar[])>('charmap_append');
+const getCharMap = option<UserChar[] | (() => UserChar[]) | undefined>('charmap');
+const getCharMapAppend = option<UserChar[] | (() => UserChar[]) | undefined>('charmap_append');
 
 export {
   register,

--- a/modules/tinymce/src/plugins/charmap/main/ts/core/CharMap.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/core/CharMap.ts
@@ -12,7 +12,7 @@ export const UserDefined = 'User Defined';
 export type Char = [ number, string ];
 
 export interface CharMap {
-  name: string;
+  readonly name: string;
   characters: Char[];
 }
 
@@ -390,7 +390,7 @@ const extendCharMap = (editor: Editor, charmap: CharMap[]): CharMap[] => {
   if (userCharMapAppend) {
     const userDefinedGroup = Tools.grep(charmap, (cg) => cg.name === UserDefined);
     if (userDefinedGroup.length) {
-      userDefinedGroup[0].characters = [].concat(userDefinedGroup[0].characters).concat(getCharsFromOption(userCharMapAppend));
+      userDefinedGroup[0].characters = [ ...userDefinedGroup[0].characters, ...getCharsFromOption(userCharMapAppend) ];
       return charmap;
     }
     return charmap.concat({ name: UserDefined, characters: getCharsFromOption(userCharMapAppend) });

--- a/modules/tinymce/src/plugins/charmap/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/ui/Buttons.ts
@@ -1,16 +1,18 @@
 import Editor from 'tinymce/core/api/Editor';
 
 const register = (editor: Editor): void => {
+  const onAction = () => editor.execCommand('mceShowCharmap');
+
   editor.ui.registry.addButton('charmap', {
     icon: 'insert-character',
     tooltip: 'Special character',
-    onAction: () => editor.execCommand('mceShowCharmap')
+    onAction
   });
 
   editor.ui.registry.addMenuItem('charmap', {
     icon: 'insert-character',
     text: 'Special character...',
-    onAction: () => editor.execCommand('mceShowCharmap')
+    onAction
   });
 };
 

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapPluginTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapPluginTest.ts
@@ -96,13 +96,13 @@ describe('browser.tinymce.plugins.charmap.CharMapPluginTest', () => {
 
   it('TBA: Insert character', () => {
     const editor = hook.editor();
-    let lastEvt: EditorEvent<{ chr: string }>;
+    let lastEvt: EditorEvent<{ chr: string }> | undefined;
 
     editor.on('InsertCustomChar', (e) => {
       lastEvt = e;
     });
 
     editor.plugins.charmap.insertChar('A');
-    assert.equal(lastEvt.chr, 'A');
+    assert.equal(lastEvt?.chr, 'A');
   });
 });

--- a/modules/tinymce/src/plugins/charmap/test/ts/module/Helpers.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/module/Helpers.ts
@@ -1,7 +1,7 @@
 import { SugarElement } from '@ephox/sugar';
 
 // TODO: Move into shared library
-const fakeEvent = (elm: SugarElement<Node>, name: string) => {
+const fakeEvent = (elm: SugarElement<Node>, name: string): void => {
   const evt = document.createEvent('HTMLEvents');
   evt.initEvent(name, true, true);
   elm.dom.dispatchEvent(evt);

--- a/modules/tinymce/src/plugins/code/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/code/demo/ts/demo/Demo.ts
@@ -1,4 +1,6 @@
-declare const tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',

--- a/modules/tinymce/src/plugins/code/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/code/main/ts/ui/Dialog.ts
@@ -3,7 +3,7 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Content from '../core/Content';
 
 const open = (editor: Editor): void => {
-  const editorContent: string = Content.getContent(editor);
+  const editorContent = Content.getContent(editor);
 
   editor.windowManager.open({
     title: 'Source Code',
@@ -38,11 +38,6 @@ const open = (editor: Editor): void => {
       api.close();
     }
   });
-
-  // TODO - ask Spocke about this. Works without, is maybe an outdated comment?
-  // Gecko has a major performance issue with textarea
-  // contents so we need to set it when all reflows are done
-  // win.find('#code').value(Content.getContent(editor));
 };
 
 export {

--- a/modules/tinymce/src/plugins/code/test/ts/browser/CodeSanityTest.ts
+++ b/modules/tinymce/src/plugins/code/test/ts/browser/CodeSanityTest.ts
@@ -15,12 +15,12 @@ describe('browser.tinymce.plugins.code.CodeSanityTest', () => {
   const toolbarButtonSelector = '[role="toolbar"] button[aria-label="Source code"]';
 
   const setTextareaContent = (content: string) => {
-    const textarea: HTMLTextAreaElement = document.querySelector('div[role="dialog"] textarea');
+    const textarea = document.querySelector('div[role="dialog"] textarea') as HTMLTextAreaElement;
     textarea.value = content;
   };
 
   const assertTextareaContent = (expected: string) => {
-    const textarea: HTMLTextAreaElement = document.querySelector('div[role="dialog"] textarea');
+    const textarea = document.querySelector('div[role="dialog"] textarea') as HTMLTextAreaElement;
     assert.equal(textarea.value, expected, 'Should have correct value');
   };
 

--- a/modules/tinymce/src/plugins/codesample/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/codesample/demo/ts/demo/Demo.ts
@@ -1,4 +1,6 @@
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',

--- a/modules/tinymce/src/plugins/codesample/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/api/Options.ts
@@ -4,8 +4,8 @@ import { EditorOptions } from 'tinymce/core/api/OptionTypes';
 import { LanguageSpec } from '../core/Languages';
 
 const option: {
-  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K] | undefined;
-  <T>(name: string): (editor: Editor) => T | undefined;
+  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K];
+  <T>(name: string): (editor: Editor) => T;
 } = (name: string) => (editor: Editor) =>
   editor.options.get(name);
 
@@ -22,7 +22,7 @@ const register = (editor: Editor): void => {
   });
 };
 
-const getLanguages = option<LanguageSpec[]>('codesample_languages');
+const getLanguages = option<LanguageSpec[] | undefined>('codesample_languages');
 const useGlobalPrismJS = option<boolean>('codesample_global_prismjs');
 
 export {

--- a/modules/tinymce/src/plugins/codesample/main/ts/core/CodeSample.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/core/CodeSample.ts
@@ -1,4 +1,4 @@
-import { Fun, Optional, Optionals } from '@ephox/katamari';
+import { Optional } from '@ephox/katamari';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
@@ -6,9 +6,9 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Prism from '../prism/Prism';
 import * as Utils from '../util/Utils';
 
-const getSelectedCodeSample = (editor: Editor): Optional<Element> => {
+const getSelectedCodeSample = (editor: Editor): Optional<HTMLPreElement> => {
   const node = editor.selection ? editor.selection.getNode() : null;
-  return Optionals.someIf(Utils.isCodeSample(node), node);
+  return Utils.isCodeSample(node) ? Optional.some(node) : Optional.none();
 };
 
 const insertCodeSample = (editor: Editor, language: string, code: string): void => {
@@ -34,7 +34,7 @@ const insertCodeSample = (editor: Editor, language: string, code: string): void 
 
 const getCurrentCode = (editor: Editor): string => {
   const node = getSelectedCodeSample(editor);
-  return node.fold(Fun.constant(''), (n) => n.textContent);
+  return node.bind((n) => Optional.from(n.textContent)).getOr('');
 };
 
 export {

--- a/modules/tinymce/src/plugins/codesample/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/core/FilterContent.ts
@@ -18,7 +18,7 @@ const setup = (editor: Editor): void => {
       dom.setAttrib(elm, 'data-mce-highlighted', null);
 
       // Empty the pre element
-      let child: Node;
+      let child: Node | null;
       while ((child = elm.firstChild)) {
         elm.removeChild(child);
       }

--- a/modules/tinymce/src/plugins/codesample/main/ts/util/Utils.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/util/Utils.ts
@@ -1,5 +1,7 @@
-const isCodeSample = (elm: Element | null): boolean => {
-  return elm && elm.nodeName === 'PRE' && elm.className.indexOf('language-') !== -1;
+import { Type } from '@ephox/katamari';
+
+const isCodeSample = (elm: Element | null): elm is HTMLPreElement => {
+  return Type.isNonNullable(elm) && elm.nodeName === 'PRE' && elm.className.indexOf('language-') !== -1;
 };
 
 const trimArg = <T>(predicateFn: (a: T) => boolean) => {

--- a/modules/tinymce/src/plugins/codesample/test/ts/module/CodeSampleTestUtils.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/module/CodeSampleTestUtils.ts
@@ -8,20 +8,20 @@ import Editor from 'tinymce/core/api/Editor';
 const dialogSelector = 'div.tox-dialog';
 const toolbarButtonSelector = 'button[aria-label="Insert/edit code sample"]';
 
-const setLanguage = (newLanguage: string) => {
-  const select: HTMLSelectElement = document.querySelector('div[role="dialog"] select');
+const setLanguage = (newLanguage: string): void => {
+  const select = document.querySelector('div[role="dialog"] select') as HTMLSelectElement;
   select.value = newLanguage;
 };
 
-const setTextareaContent = (content: string) => {
-  const textarea: HTMLTextAreaElement = document.querySelector('div[role="dialog"] textarea');
+const setTextareaContent = (content: string): void => {
+  const textarea = document.querySelector('div[role="dialog"] textarea') as HTMLTextAreaElement;
   textarea.value = content;
 };
 
-const assertCodeSampleDialog = (expectedLanguage: string, expectedContent: string) => {
-  const select: HTMLSelectElement = document.querySelector('div[role="dialog"] select');
+const assertCodeSampleDialog = (expectedLanguage: string, expectedContent: string): void => {
+  const select = document.querySelector('div[role="dialog"] select') as HTMLSelectElement;
   assert.equal(select.value, expectedLanguage, 'Asserting language dropdown is ' + expectedLanguage);
-  const textarea: HTMLTextAreaElement = document.querySelector('div[role="dialog"] textarea');
+  const textarea = document.querySelector('div[role="dialog"] textarea') as HTMLTextAreaElement;
   assert.equal(textarea.value, expectedContent, 'Asserting textarea content is ' + expectedContent);
 };
 
@@ -52,23 +52,23 @@ const assertPreText = (container: SugarElement<Node>, selector: string, expected
   assert.equal(text, expected, 'Assert ' + selector + ' has innerText ' + expected);
 };
 
-const pOpenDialogAndAssertInitial = async (editor: Editor, language: string, content: string) => {
+const pOpenDialogAndAssertInitial = async (editor: Editor, language: string, content: string): Promise<void> => {
   TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
   await UiFinder.pWaitForVisible('Waited for dialog to be visible', SugarBody.body(), dialogSelector);
   assertCodeSampleDialog(language, content);
 };
 
-const pSubmitDialog = async (editor: Editor) => {
+const pSubmitDialog = async (editor: Editor): Promise<void> => {
   TinyUiActions.submitDialog(editor, dialogSelector);
   await Waiter.pTryUntil('Dialog should close', () => UiFinder.notExists(SugarBody.body(), dialogSelector));
 };
 
-const pCancelDialog = async (editor: Editor) => {
+const pCancelDialog = async (editor: Editor): Promise<void> => {
   TinyUiActions.cancelDialog(editor, dialogSelector);
   await Waiter.pTryUntil('Dialog should close', () => UiFinder.notExists(SugarBody.body(), dialogSelector));
 };
 
-const pAssertEditorContents = async (editorBody: SugarElement<HTMLElement>, language: string, content: string, selector: string) => {
+const pAssertEditorContents = async (editorBody: SugarElement<HTMLElement>, language: string, content: string, selector: string): Promise<void> => {
   /*
    * Since the syntax highlighting wraps tokens in spans which would be annoying to assert, we assert
    * the overall structure of the editor's content, then exact match the textContent of the pre tag

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -1,4 +1,4 @@
-import { ApproxStructure, Keys, RealClipboard, RealMouse } from '@ephox/agar';
+import { ApproxStructure, Keys, RealClipboard, RealMouse, StructAssert } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
@@ -32,7 +32,7 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
     }
   };
 
-  const getMockPreStructure = (s, str) =>
+  const getMockPreStructure = (s: ApproxStructure.StructApi, str: ApproxStructure.StringApi): StructAssert =>
     s.element('pre', {
       attrs: {
         'class': str.is('language-markup'),

--- a/modules/tinymce/src/plugins/directionality/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/directionality/demo/ts/demo/Demo.ts
@@ -1,4 +1,6 @@
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',

--- a/modules/tinymce/src/plugins/emoticons/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/emoticons/demo/ts/demo/Demo.ts
@@ -1,4 +1,6 @@
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',

--- a/modules/tinymce/src/plugins/emoticons/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/api/Options.ts
@@ -10,8 +10,8 @@ export interface UserEmojiEntry {
 const DEFAULT_ID = 'tinymce.plugins.emoticons';
 
 const option: {
-  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K] | undefined;
-  <T>(name: string): (editor: Editor) => T | undefined;
+  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K];
+  <T>(name: string): (editor: Editor) => T;
 } = (name: string) => (editor: Editor) =>
   editor.options.get(name);
 

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/ImageEmojiTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/ImageEmojiTest.ts
@@ -34,7 +34,7 @@ describe('browser.tinymce.plugins.emoticons.ImageEmojiTest', () => {
       'Wait until dog is the first choice (search should filter)',
       () => {
         const item = UiFinder.findIn(SugarBody.body(), '.tox-collection__item:first').getOrDie();
-        const attr = Attribute.get(item, 'data-collection-item-value');
+        const attr = Attribute.get(item, 'data-collection-item-value') as string;
         const img = SugarElement.fromHtml<HTMLImageElement>(attr);
         const src = Attribute.get(img, 'src');
         assert.equal(src, 'https://twemoji.maxcdn.com/v/13.0.1/72x72/1f436.png', 'Search should show a dog');

--- a/modules/tinymce/src/plugins/emoticons/test/ts/module/test/Utils.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/module/test/Utils.ts
@@ -1,7 +1,7 @@
 import { SugarElement } from '@ephox/sugar';
 
 // TODO: Move into shared library (eg agar)
-const fakeEvent = (elm: SugarElement<Node>, name: string) => {
+const fakeEvent = (elm: SugarElement<Node>, name: string): void => {
   const evt = document.createEvent('HTMLEvents');
   evt.initEvent(name, true, true);
   elm.dom.dispatchEvent(evt);

--- a/modules/tinymce/src/plugins/fullscreen/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/fullscreen/demo/ts/demo/Demo.ts
@@ -1,4 +1,6 @@
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
@@ -7,6 +9,7 @@ tinymce.init({
   height: 600,
   fullscreen_native: true
 });
+
 tinymce.init({
   selector: 'textarea.tinymce2',
   plugins: 'fullscreen code',

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/api/Options.ts
@@ -2,8 +2,8 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorOptions } from 'tinymce/core/api/OptionTypes';
 
 const option: {
-  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K] | undefined;
-  <T>(name: string): (editor: Editor) => T | undefined;
+  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K];
+  <T>(name: string): (editor: Editor) => T;
 } = (name: string) => (editor: Editor) =>
   editor.options.get(name);
 

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
@@ -98,8 +98,8 @@ const toggleFullscreen = (editor: Editor, fullscreenState: Cell<ScrollInfo | nul
 
   const editorContainerStyle = editorContainer.style;
 
-  const iframe = editor.iframeElement;
-  const iframeStyle = iframe.style;
+  const iframe = editor.iframeElement as HTMLIFrameElement;
+  const iframeStyle = iframe?.style;
 
   const handleClasses = (handler: (elm: string | Element | Element[], cls: string) => void) => {
     handler(body, 'tox-fullscreen');

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/core/Thor.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/core/Thor.ts
@@ -53,7 +53,7 @@ const restoreStyles = (dom: DOMUtils): void => {
   const clobberedEls = SelectorFilter.all('[' + attr + ']');
   Arr.each(clobberedEls, (element) => {
     const restore = Attribute.get(element, attr);
-    if (restore !== 'no-styles') {
+    if (restore && restore !== 'no-styles') {
       Css.setAll(element, dom.parseStyle(restore));
     } else {
       Attribute.remove(element, 'style');

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/ui/Buttons.ts
@@ -4,14 +4,16 @@ import Editor from 'tinymce/core/api/Editor';
 import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
-const makeSetupHandler = (editor: Editor, fullscreenState: Cell<object>) => (api: Toolbar.ToolbarToggleButtonInstanceApi | Menu.ToggleMenuItemInstanceApi) => {
+import { ScrollInfo } from '../core/Actions';
+
+const makeSetupHandler = (editor: Editor, fullscreenState: Cell<ScrollInfo | null>) => (api: Toolbar.ToolbarToggleButtonInstanceApi | Menu.ToggleMenuItemInstanceApi) => {
   api.setActive(fullscreenState.get() !== null);
   const editorEventCallback = (e: EditorEvent<{ state: boolean }>) => api.setActive(e.state);
   editor.on('FullscreenStateChanged', editorEventCallback);
   return () => editor.off('FullscreenStateChanged', editorEventCallback);
 };
 
-const register = (editor: Editor, fullscreenState: Cell<object>): void => {
+const register = (editor: Editor, fullscreenState: Cell<ScrollInfo | null>): void => {
   const onAction = () => editor.execCommand('mceFullScreen');
 
   editor.ui.registry.addToggleMenuItem('fullscreen', {

--- a/modules/tinymce/src/plugins/help/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/help/demo/ts/demo/Demo.ts
@@ -1,4 +1,6 @@
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',

--- a/modules/tinymce/src/plugins/help/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/api/Api.ts
@@ -1,3 +1,5 @@
+import { Id } from '@ephox/katamari';
+
 import { Dialog } from 'tinymce/core/api/ui/Ui';
 
 import { CustomTabSpecs } from '../Plugin';
@@ -8,8 +10,9 @@ export interface Api {
 
 const get = (customTabs: CustomTabSpecs): Api => {
   const addTab = (spec: Dialog.TabSpec): void => {
+    const name = spec.name ?? Id.generate('tab-name');
     const currentCustomTabs = customTabs.get();
-    currentCustomTabs[spec.name] = spec;
+    currentCustomTabs[name] = spec;
     customTabs.set(currentCustomTabs);
   };
 

--- a/modules/tinymce/src/plugins/help/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/api/Options.ts
@@ -5,8 +5,8 @@ import { Dialog } from 'tinymce/core/api/ui/Ui';
 export type HelpTabsSetting = (string | Dialog.TabSpec)[];
 
 const option: {
-  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K] | undefined;
-  <T>(name: string): (editor: Editor) => T | undefined;
+  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K];
+  <T>(name: string): (editor: Editor) => T;
 } = (name: string) => (editor: Editor) =>
   editor.options.get(name);
 
@@ -18,7 +18,7 @@ const register = (editor: Editor): void => {
   });
 };
 
-const getHelpTabs = option<HelpTabsSetting>('help_tabs');
+const getHelpTabs = option<HelpTabsSetting | undefined>('help_tabs');
 const getForcedPlugins = option('forced_plugins');
 
 export {

--- a/modules/tinymce/src/plugins/help/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/Dialog.ts
@@ -1,4 +1,4 @@
-import { Arr, Obj, Optional, Optionals } from '@ephox/katamari';
+import { Arr, Id, Obj, Optional, Optionals, Type } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
@@ -16,9 +16,9 @@ interface TabData {
 }
 
 const parseHelpTabsSetting = (tabsFromSettings: Options.HelpTabsSetting, tabs: TabSpecs): TabData => {
-  const newTabs = {};
+  const newTabs: Record<string, any> = {};
   const names = Arr.map(tabsFromSettings, (t) => {
-    if (typeof t === 'string') {
+    if (Type.isString(t)) {
       // Code below shouldn't care if a tab name doesn't have a spec.
       // If we find it does, we'll need to make this smarter.
       // CustomTabsTest has a case for this.
@@ -27,8 +27,9 @@ const parseHelpTabsSetting = (tabsFromSettings: Options.HelpTabsSetting, tabs: T
       }
       return t;
     } else {
-      newTabs[t.name] = t;
-      return t.name;
+      const name = t.name ?? Id.generate('tab-name');
+      newTabs[name] = t;
+      return name;
     }
   });
   return { tabs: newTabs, names };
@@ -67,7 +68,6 @@ const parseCustomTabs = (editor: Editor, customTabs: CustomTabSpecs): TabData =>
 };
 
 const init = (editor: Editor, customTabs: CustomTabSpecs) => (): void => {
-  // const tabSpecs: Record<string, Types.Dialog.TabApi> = customTabs.get();
   const { tabs, names } = parseCustomTabs(editor, customTabs);
   const foundTabs: Optional<Dialog.TabSpec>[] = Arr.map(names, (name) => Obj.get(tabs, name));
   const dialogTabs: Dialog.TabSpec[] = Optionals.cat(foundTabs);

--- a/modules/tinymce/src/plugins/help/main/ts/ui/KeyboardNavTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/KeyboardNavTab.ts
@@ -67,7 +67,7 @@ const description = `<h1>Editor UI keyboard navigation</h1>
 <p>When a tabbed dialog is opened, the first button in the tab menu is focused. Pressing tab will navigate to the first interactive component in that tab, and will cycle through the tab’s components, the footer buttons, then back to the tab button. To switch to another tab, focus the tab button for the current tab, then use the arrow keys to cycle through the tab buttons.</p>`;
 /* eslint-enable max-len */
 
-const tab = (): Dialog.TabSpec => {
+const tab = (): Dialog.TabSpec & { name: string } => {
   const body: Dialog.BodyComponentSpec = {
     type: 'htmlpanel',
     presets: 'document',

--- a/modules/tinymce/src/plugins/help/main/ts/ui/KeyboardShortcutsTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/KeyboardShortcutsTab.ts
@@ -10,7 +10,7 @@ export interface ShortcutActionPairType {
   action: string;
 }
 
-const tab = (): Dialog.TabSpec => {
+const tab = (): Dialog.TabSpec & { name: string } => {
   const shortcutList = Arr.map(KeyboardShortcuts.shortcuts, (shortcut: ShortcutActionPairType) => {
     const shortcutText = Arr.map(shortcut.shortcuts, ConvertShortcut.convertText).join(' or ');
     return [ shortcut.action, shortcutText ];

--- a/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
@@ -7,7 +7,7 @@ import I18n from 'tinymce/core/api/util/I18n';
 import * as Options from '../api/Options';
 import * as PluginUrls from '../data/PluginUrls';
 
-const tab = (editor: Editor): Dialog.TabSpec => {
+const tab = (editor: Editor): Dialog.TabSpec & { name: string } => {
   const availablePlugins = () => {
     const premiumPlugins = Arr.filter(PluginUrls.urls, ({ key, type }) => {
       return key !== 'autocorrect' && type === PluginUrls.PluginType.Premium;

--- a/modules/tinymce/src/plugins/help/main/ts/ui/VersionTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/VersionTab.ts
@@ -2,7 +2,7 @@ import EditorManager from 'tinymce/core/api/EditorManager';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
 import I18n from 'tinymce/core/api/util/I18n';
 
-const tab = (): Dialog.TabSpec => {
+const tab = (): Dialog.TabSpec & { name: string } => {
   const getVersion = (major: string, minor: string) => major.indexOf('@') === 0 ? 'X.X.X' : major + '.' + minor;
   const version = getVersion(EditorManager.majorVersion, EditorManager.minorVersion);
   const changeLogLink = '<a href="https://www.tiny.cloud/docs/tinymce/6/changelog/?utm_campaign=editor_referral&utm_medium=help_dialog&utm_source=tinymce" rel="noopener" target="_blank">TinyMCE ' + version + '</a>';

--- a/modules/tinymce/src/plugins/help/test/ts/module/PluginAssert.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/module/PluginAssert.ts
@@ -1,7 +1,7 @@
 import { Assertions, Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { SugarDocument } from '@ephox/sugar';
 
-export const pAssert = async (message: string, expected: Record<string, number>, waitOnSelector: string, clickOnSelector: string) => {
+export const pAssert = async (message: string, expected: Record<string, number>, waitOnSelector: string, clickOnSelector: string): Promise<void> => {
   const dialog = await UiFinder.pWaitFor('Could not find dialog', SugarDocument.getDocument(), waitOnSelector);
   Mouse.clickOn(dialog, clickOnSelector);
   await Waiter.pTryUntil(

--- a/modules/tinymce/src/plugins/help/test/ts/module/test/FakePlugin.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/module/test/FakePlugin.ts
@@ -3,7 +3,7 @@ import { Fun } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import PluginManager from 'tinymce/core/api/PluginManager';
 
-export default () => {
+export default (): void => {
   const Plugin = (_editor: Editor, _url: string) => {
     return {
       getMetadata: Fun.constant({

--- a/modules/tinymce/src/plugins/help/test/ts/module/test/NoMetaFakePlugin.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/module/test/NoMetaFakePlugin.ts
@@ -2,6 +2,6 @@ import { Fun } from '@ephox/katamari';
 
 import PluginManager from 'tinymce/core/api/PluginManager';
 
-export default () => {
+export default (): void => {
   PluginManager.add('nometafake', Fun.noop);
 };

--- a/modules/tinymce/src/plugins/image/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/image/demo/ts/demo/Demo.ts
@@ -1,4 +1,6 @@
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
@@ -19,13 +21,13 @@ tinymce.init({
   file_picker_callback: (callback, _value, _meta) => {
     callback('https://www.google.com/logos/google.jpg', { alt: 'My alt text', caption: true });
   },
-  images_upload_handler: (blobInfo, success, _failure, _progress) => {
+  images_upload_handler: (blobInfo, _progress) => new Promise((success) => {
     // eslint-disable-next-line no-console
     console.log(blobInfo);
     setTimeout(() => {
       success('https://www.google.com/logos/google.jpg');
     }, 5000);
-  },
+  }),
   height: 600
 });
 

--- a/modules/tinymce/src/plugins/image/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/api/Options.ts
@@ -8,8 +8,8 @@ import { UserListItem } from '../ui/DialogTypes';
 type UserImageListCallback = (callback: (imageList: UserListItem[]) => void) => void;
 
 const option: {
-  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K] | undefined;
-  <T>(name: string): (editor: Editor) => T | undefined;
+  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K];
+  <T>(name: string): (editor: Editor) => T;
 } = (name: string) => (editor: Editor) =>
   editor.options.get(name);
 
@@ -68,7 +68,7 @@ const hasDimensions = option<boolean>('image_dimensions');
 const hasAdvTab = option<boolean>('image_advtab');
 const hasUploadTab = option<boolean>('image_uploadtab');
 const getPrependUrl = option<string>('image_prepend_url');
-const getClassList = option<UserListItem[]>('image_class_list');
+const getClassList = option<UserListItem[] | undefined>('image_class_list');
 const hasDescription = option<boolean>('image_description');
 const hasImageTitle = option<boolean>('image_title');
 const hasImageCaption = option<boolean>('image_caption');

--- a/modules/tinymce/src/plugins/image/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/core/FilterContent.ts
@@ -1,10 +1,12 @@
+import { Type } from '@ephox/katamari';
+
 import Editor from 'tinymce/core/api/Editor';
 import AstNode from 'tinymce/core/api/html/Node';
 import Tools from 'tinymce/core/api/util/Tools';
 
 const hasImageClass = (node: AstNode): boolean => {
   const className = node.attr('class');
-  return className && /\bimage\b/.test(className);
+  return Type.isNonNullable(className) && /\bimage\b/.test(className);
 };
 
 const toggleContentEditableState = (state: boolean) => (nodes: AstNode[]): void => {

--- a/modules/tinymce/src/plugins/image/main/ts/core/ImageSelection.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/core/ImageSelection.ts
@@ -6,7 +6,7 @@ import { SchemaMap } from 'tinymce/core/api/html/Schema';
 import { create, defaultData, ImageData, isFigure, read, write } from './ImageData';
 import * as Utils from './Utils';
 
-const normalizeCss = (editor: Editor, cssText: string): string => {
+const normalizeCss = (editor: Editor, cssText: string | undefined): string => {
   const css = editor.dom.styles.parse(cssText);
   const mergedCss = Utils.mergeMargins(css);
   const compressed = editor.dom.styles.parse(editor.dom.styles.serialize(mergedCss));

--- a/modules/tinymce/src/plugins/image/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/core/Utils.ts
@@ -149,7 +149,7 @@ const blobToDataUri = (blob: Blob): Promise<string> => new Promise((resolve, rej
     resolve(reader.result as string);
   };
   reader.onerror = () => {
-    reject(reader.error.message);
+    reject(reader.error?.message);
   };
   reader.readAsDataURL(blob);
 });

--- a/modules/tinymce/src/plugins/image/main/ts/ui/DialogInfo.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/DialogInfo.ts
@@ -9,7 +9,7 @@ import * as Utils from '../core/Utils';
 import { ImageDialogInfo, ListItem } from './DialogTypes';
 
 const collect = (editor: Editor): Promise<ImageDialogInfo> => {
-  const urlListSanitizer = ListUtils.sanitizer((item) => editor.convertURL(item.value || item.url, 'src'));
+  const urlListSanitizer = ListUtils.sanitizer((item) => editor.convertURL(item.value || item.url || '', 'src'));
 
   const futureImageList = new Promise<Optional<ListItem[]>>((completer) => {
     Utils.createImageList(editor, (imageList) => {

--- a/modules/tinymce/src/plugins/image/main/ts/ui/DialogTypes.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/DialogTypes.ts
@@ -33,27 +33,29 @@ export interface ImageDialogInfo {
   readonly prependURL: Optional<string>;
 }
 
+export interface ImageMeta {
+  text?: string;
+  width?: string;
+  height?: string;
+  alt?: string | null;
+  title?: string;
+  class?: string;
+  style?: string;
+  caption?: boolean;
+  vspace?: string;
+  border?: string;
+  hspace?: string;
+  borderstyle?: string;
+  isDecorative?: boolean;
+}
+
 export interface ImageDialogData {
   src: {
     value: string;
-    meta?: {
-      text?: string;
-      width?: string;
-      height?: string;
-      alt?: string;
-      title?: string;
-      class?: string;
-      style?: string;
-      caption?: boolean;
-      vspace?: string;
-      border?: string;
-      hspace?: string;
-      borderstyle?: string;
-      isDecorative?: boolean;
-    };
+    meta?: ImageMeta;
   };
   images: string;
-  alt: string;
+  alt: string | null;
   title: string;
   dimensions: {
     width: string;

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -15,7 +15,7 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     image_title: true,
-    file_picker_callback: (callback, _value, _meta) => {
+    file_picker_callback: (callback: (url: string, meta: Record<string, any>) => void) => {
       callback('https://www.google.com/logos/google.jpg', { width: '200' });
     }
   }, [ Plugin ]);

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
@@ -13,7 +13,7 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
     toolbar: 'image',
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
-    setup: (editor) => {
+    setup: (editor: Editor) => {
       editor.ui.registry.addContextToolbar('test-image', {
         predicate: (node) => node.nodeName.toLowerCase() === 'img',
         items: 'image'

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImageResizeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImageResizeTest.ts
@@ -12,7 +12,7 @@ describe('browser.tinymce.plugins.image.ImageResizeTest', () => {
     plugins: 'image',
     toolbar: 'image',
     base_url: '/project/tinymce/js/tinymce',
-    file_picker_callback: (callback) => {
+    file_picker_callback: (callback: (url: string) => void) => {
       // eslint-disable-next-line no-console
       console.log('file picker pressed');
       callback('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');

--- a/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageDataTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageDataTest.ts
@@ -16,9 +16,9 @@ interface ImageDataExt {
 }
 
 describe('browser.tinymce.plugins.image.core.ImageDataTest', () => {
-  const normalizeCss = (cssText: string) => {
+  const normalizeCss = (cssText: string | undefined) => {
     const css = DOMUtils.DOM.styles.parse(cssText);
-    const newCss = {};
+    const newCss: Record<string, string> = {};
 
     Arr.each(Obj.keys(css).sort(), (key) => {
       newCss[key] = css[key];

--- a/modules/tinymce/src/plugins/image/test/ts/module/Helpers.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/module/Helpers.ts
@@ -1,5 +1,5 @@
 import { Assertions, Mouse, UiFinder } from '@ephox/agar';
-import { Obj, Type } from '@ephox/katamari';
+import { Obj, Optional, Type } from '@ephox/katamari';
 import { Attribute, Checked, Class, Focus, SugarBody, SugarElement, Traverse, Value } from '@ephox/sugar';
 import { assert } from 'chai';
 
@@ -65,14 +65,13 @@ const setFieldValue = (selector: string, value: string | boolean): SugarElement<
 };
 
 const setTabFieldValues = (data: Partial<ImageDialogData>, tabSelectors: Record<string, string>): void => {
-  Obj.each(tabSelectors, (value, key: keyof Omit<ImageDialogData, 'dimensions'>) => {
-    if (Obj.has(data, key)) {
-      const obj = data[key];
-      const newValue = isObjWithValue(obj) ? obj.value : obj;
-      setFieldValue(tabSelectors[key], newValue);
-    } else if (Obj.has(data, 'dimensions') && Obj.has(data.dimensions as Record<string, string>, key)) {
-      setFieldValue(tabSelectors[key], data.dimensions[key]);
-    }
+  Obj.each(tabSelectors, (value, key) => {
+    Obj.get(data, key as keyof Omit<ImageDialogData, 'dimensions'>)
+      .orThunk(() => Obj.has(data, 'dimensions') ? Obj.get(data.dimensions as Record<string, string>, key) : Optional.none())
+      .each((obj) => {
+        const newValue = isObjWithValue(obj) ? obj.value : obj;
+        setFieldValue(tabSelectors[key], newValue);
+      });
   });
 };
 

--- a/modules/tinymce/src/plugins/importcss/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/importcss/demo/ts/demo/Demo.ts
@@ -1,6 +1,8 @@
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
 
-const elm: any = document.querySelector('.tinymce');
+declare let tinymce: TinyMCE;
+
+const elm = document.querySelector('.tinymce') as HTMLTextAreaElement;
 elm.value = 'The format menu should show "red"';
 
 tinymce.init({

--- a/modules/tinymce/src/plugins/importcss/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/importcss/main/ts/api/Options.ts
@@ -11,8 +11,8 @@ type FileFilter = string | RegExp | ((value: string, imported?: boolean) => bool
 type SelectorFilter = string | RegExp | ((value: string) => boolean) | undefined;
 
 const option: {
-  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K] | undefined;
-  <T>(name: string): (editor: Editor) => T | undefined;
+  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K];
+  <T>(name: string): (editor: Editor) => T;
 } = (name: string) => (editor: Editor) =>
   editor.options.get(name);
 
@@ -56,11 +56,11 @@ const register = (editor: Editor): void => {
 
 const shouldMergeClasses = option<boolean>('importcss_merge_classes');
 const shouldImportExclusive = option<boolean>('importcss_exclusive');
-const getSelectorConverter = option<SelectorConvertor>('importcss_selector_converter');
-const getSelectorFilter = option<SelectorFilter>('importcss_selector_filter');
-const getCssGroups = option<UserDefinedGroup[]>('importcss_groups');
+const getSelectorConverter = option<SelectorConvertor | undefined>('importcss_selector_converter');
+const getSelectorFilter = option<SelectorFilter | undefined>('importcss_selector_filter');
+const getCssGroups = option<UserDefinedGroup[] | undefined>('importcss_groups');
 const shouldAppend = option<boolean>('importcss_append');
-const getFileFilter = option<FileFilter>('importcss_file_filter');
+const getFileFilter = option<FileFilter | undefined>('importcss_file_filter');
 const getSkin = option('skin');
 const getSkinUrl = option('skin_url');
 

--- a/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
+++ b/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
@@ -12,7 +12,7 @@ import * as Options from '../api/Options';
 import { generate, SelectorFormatItem } from './SelectorModel';
 
 type Filter = (value: string, imported?: boolean) => boolean;
-type SelectorConvertor = () => StyleFormat | undefined;
+type SelectorConvertor = (selector: string, group: Group | null) => StyleFormat | undefined;
 
 export interface UserDefinedGroup {
   readonly title: string;
@@ -20,7 +20,7 @@ export interface UserDefinedGroup {
   readonly selector_converter?: SelectorConvertor;
 }
 
-interface Group extends UserDefinedGroup {
+export interface Group extends UserDefinedGroup {
   readonly original: UserDefinedGroup;
   readonly selectors: Record<string, boolean>;
   readonly filter: Filter | undefined;
@@ -28,7 +28,7 @@ interface Group extends UserDefinedGroup {
 
 const internalEditorStyle = /^\.(?:ephox|tiny-pageembed|mce)(?:[.-]+\w+)+$/;
 
-const removeCacheSuffix = (url: string): string => {
+const removeCacheSuffix = (url: string | null): string | null => {
   const cacheSuffix = Env.cacheSuffix;
 
   if (Type.isString(url)) {
@@ -73,11 +73,12 @@ const getSelectors = (editor: Editor, doc: Document, fileFilter: Filter | undefi
   const contentCSSUrls: Record<string, boolean> = {};
 
   const append = (styleSheet: CSSStyleSheet, imported?: boolean) => {
-    let href = styleSheet.href, rules: CSSRuleList | undefined;
+    let href = styleSheet.href;
+    let rules: CSSRuleList | undefined;
 
     href = removeCacheSuffix(href);
 
-    if (!href || !fileFilter(href, imported) || isSkinContentCss(editor, href)) {
+    if (!href || fileFilter && !fileFilter(href, imported) || isSkinContentCss(editor, href)) {
       return;
     }
 
@@ -109,7 +110,7 @@ const getSelectors = (editor: Editor, doc: Document, fileFilter: Filter | undefi
   });
 
   if (!fileFilter) {
-    fileFilter = (href: string, imported: boolean) => {
+    fileFilter = (href: string, imported?: boolean) => {
       return imported || contentCSSUrls[href];
     };
   }
@@ -126,7 +127,7 @@ const getSelectors = (editor: Editor, doc: Document, fileFilter: Filter | undefi
 };
 
 const defaultConvertSelectorToFormat = (editor: Editor, selectorText: string): StyleFormat | undefined => {
-  let format;
+  let format: Record<string, any> = {};
 
   // Parse simple element.class1, .class1
   const selector = /^(?:([a-z0-9\-_]+))?(\.[a-z0-9_\-\.]+)$/i.exec(selectorText);
@@ -170,7 +171,7 @@ const defaultConvertSelectorToFormat = (editor: Editor, selectorText: string): S
     format.attributes = { class: classes };
   }
 
-  return format;
+  return format as StyleFormat;
 };
 
 const getGroupsBySelector = (groups: Group[], selector: string): Group[] => {
@@ -179,7 +180,7 @@ const getGroupsBySelector = (groups: Group[], selector: string): Group[] => {
   });
 };
 
-const compileUserDefinedGroups = (groups: UserDefinedGroup[]): Group[] => {
+const compileUserDefinedGroups = (groups: UserDefinedGroup[] | undefined): Group[] => {
   return Tools.map(groups, (group) => {
     return Tools.extend({}, group, {
       original: group,
@@ -189,16 +190,16 @@ const compileUserDefinedGroups = (groups: UserDefinedGroup[]): Group[] => {
   });
 };
 
-const isExclusiveMode = (editor: Editor, group: Group): boolean => {
+const isExclusiveMode = (editor: Editor, group: Group | null): group is null => {
   // Exclusive mode can only be disabled when there are groups allowing the same style to be present in multiple groups
   return group === null || Options.shouldImportExclusive(editor);
 };
 
-const isUniqueSelector = (editor: Editor, selector: string, group: Group, globallyUniqueSelectors: Record<string, boolean>): boolean => {
+const isUniqueSelector = (editor: Editor, selector: string, group: Group | null, globallyUniqueSelectors: Record<string, boolean>): boolean => {
   return !(isExclusiveMode(editor, group) ? selector in globallyUniqueSelectors : selector in group.selectors);
 };
 
-const markUniqueSelector = (editor: Editor, selector: string, group: Group, globallyUniqueSelectors: Record<string, boolean>): void => {
+const markUniqueSelector = (editor: Editor, selector: string, group: Group | null, globallyUniqueSelectors: Record<string, boolean>): void => {
   if (isExclusiveMode(editor, group)) {
     globallyUniqueSelectors[selector] = true;
   } else {
@@ -206,13 +207,14 @@ const markUniqueSelector = (editor: Editor, selector: string, group: Group, glob
   }
 };
 
-const convertSelectorToFormat = (editor: Editor, plugin: Plugin, selector: string, group: Group): StyleFormat | undefined => {
+const convertSelectorToFormat = (editor: Editor, plugin: Plugin, selector: string, group: Group | null): StyleFormat | undefined => {
   let selectorConverter: SelectorConvertor;
 
+  const converter = Options.getSelectorConverter(editor);
   if (group && group.selector_converter) {
     selectorConverter = group.selector_converter;
-  } else if (Options.getSelectorConverter(editor)) {
-    selectorConverter = Options.getSelectorConverter(editor);
+  } else if (converter) {
+    selectorConverter = converter;
   } else {
     selectorConverter = () => {
       return defaultConvertSelectorToFormat(editor, selector);
@@ -230,7 +232,7 @@ const setup = (editor: Editor): void => {
     const selectorFilter = compileFilter(Options.getSelectorFilter(editor));
     const groups = compileUserDefinedGroups(Options.getCssGroups(editor));
 
-    const processSelector = (selector: string, group: Group): SelectorFormatItem | null => {
+    const processSelector = (selector: string, group: Group | null): SelectorFormatItem | null => {
       if (isUniqueSelector(editor, selector, group, globallyUniqueSelectors)) {
         markUniqueSelector(editor, selector, group, globallyUniqueSelectors);
 

--- a/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssGroupsPluginTest.ts
+++ b/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssGroupsPluginTest.ts
@@ -6,6 +6,7 @@ import { McEditor, TinyDom, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
+import { Group } from 'tinymce/plugins/importcss/core/ImportCss';
 import Plugin from 'tinymce/plugins/importcss/Plugin';
 
 import { Navigation, pProcessNavigation } from '../module/MenuNavigationTestUtils';
@@ -81,7 +82,7 @@ describe('browser.tinymce.plugins.importcss.ImportCssGroupsTest', () => {
         { title: 'Other', custom: '.DDD' }
       ],
 
-      importcss_selector_converter: (selector, group) => ({
+      importcss_selector_converter: (selector: string, group: Group & { custom: string }) => ({
         title: selector + group.custom,
         classes: [ 'converted' ],
         inline: 'span'
@@ -111,7 +112,7 @@ describe('browser.tinymce.plugins.importcss.ImportCssGroupsTest', () => {
         {
           title: 'Advanced',
           filter: /.adv/,
-          selector_converter: (selector, group) => {
+          selector_converter: (selector: string, group: Group | null) => {
             // eslint-disable-next-line no-console
             console.log('selector', selector, 'group', group);
             return {
@@ -124,7 +125,7 @@ describe('browser.tinymce.plugins.importcss.ImportCssGroupsTest', () => {
         },
         {
           title: 'Other',
-          selector_converter: (selector, _group) => ({
+          selector_converter: (selector: string, _group: Group | null) => ({
             title: selector + '.OtherGroup',
             selector: 'p',
             classes: selector.split('.')[1]

--- a/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssPluginTest.ts
+++ b/modules/tinymce/src/plugins/importcss/test/ts/browser/ImportCssPluginTest.ts
@@ -8,11 +8,18 @@ import Editor from 'tinymce/core/api/Editor';
 import { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
 import Plugin from 'tinymce/plugins/importcss/Plugin';
 
-interface MenuDetails {
-  readonly tag?: string;
+interface MenuTagDetails {
+  readonly tag: string;
   readonly html: string;
-  readonly submenu: boolean;
+  readonly submenu: false;
 }
+
+interface MenuSubmenuDetails {
+  readonly html: string;
+  readonly submenu: true;
+}
+
+type MenuDetails = MenuTagDetails | MenuSubmenuDetails;
 
 interface Assertion {
   readonly choice: Optional<string>;
@@ -41,7 +48,7 @@ describe('browser.tinymce.plugins.importcss.ImportCssTest', () => {
               } : {
                 classes: [ arr.has('tox-collection__item-label') ],
                 children: [
-                  s.element(exp.tag, { html: str.is(exp.html) })
+                  s.element((exp as MenuTagDetails).tag, { html: str.is(exp.html) })
                 ]
               })
             ].concat(exp.submenu ? [ s.anything() ] : [ s.element('div', { classes: [ arr.has('tox-collection__item-checkmark') ] }) ])
@@ -211,7 +218,7 @@ describe('browser.tinymce.plugins.importcss.ImportCssTest', () => {
     {
       content_css: [ '/project/tinymce/src/plugins/importcss/test/css/basic.css' ],
       importcss_append: false,
-      importcss_selector_filter: (sel) => sel.indexOf('p') > -1 || sel.indexOf('inline') > -1
+      importcss_selector_filter: (sel: string) => sel.indexOf('p') > -1 || sel.indexOf('inline') > -1
     }
   ));
 
@@ -267,7 +274,7 @@ describe('browser.tinymce.plugins.importcss.ImportCssTest', () => {
         '/project/tinymce/src/plugins/importcss/test/css/other-adv.css'
       ],
       importcss_append: false,
-      importcss_file_filter: (href) => href.indexOf('adv') > -1
+      importcss_file_filter: (href: string) => href.indexOf('adv') > -1
     }
   ));
 

--- a/modules/tinymce/src/plugins/insertdatetime/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/demo/ts/demo/Demo.ts
@@ -1,4 +1,6 @@
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',

--- a/modules/tinymce/src/plugins/insertdatetime/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/main/ts/api/Options.ts
@@ -2,8 +2,8 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorOptions } from 'tinymce/core/api/OptionTypes';
 
 const option: {
-  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K] | undefined;
-  <T>(name: string): (editor: Editor) => T | undefined;
+  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K];
+  <T>(name: string): (editor: Editor) => T;
 } = (name: string) => (editor: Editor) =>
   editor.options.get(name);
 

--- a/modules/tinymce/src/plugins/insertdatetime/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/main/ts/core/Actions.ts
@@ -42,8 +42,7 @@ const getDateTime = (editor: Editor, fmt: string, date: Date = new Date()): stri
 
 const updateElement = (editor: Editor, timeElm: HTMLTimeElement, computerTime: string, userTime: string) => {
   const newTimeElm = editor.dom.create('time', { datetime: computerTime }, userTime);
-  timeElm.parentNode.insertBefore(newTimeElm, timeElm);
-  editor.dom.remove(timeElm);
+  editor.dom.replace(newTimeElm, timeElm);
   editor.selection.select(newTimeElm, true);
   editor.selection.collapse(false);
 };

--- a/modules/tinymce/src/plugins/link/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/link/demo/ts/demo/Demo.ts
@@ -1,4 +1,6 @@
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',

--- a/modules/tinymce/src/plugins/link/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/api/Options.ts
@@ -9,8 +9,8 @@ import { AssumeExternalTargets } from './Types';
 type UserLinkListCallback = (callback: (items: UserListItem[]) => void) => void;
 
 const option: {
-  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K] | undefined;
-  <T>(name: string): (editor: Editor) => T | undefined;
+  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K];
+  <T>(name: string): (editor: Editor) => T;
 } = (name: string) => (editor: Editor) =>
   editor.options.get(name);
 
@@ -86,8 +86,8 @@ const register = (editor: Editor): void => {
 
 const assumeExternalTargets = option<AssumeExternalTargets>('link_assume_external_targets');
 const hasContextToolbar = option<boolean>('link_context_toolbar');
-const getLinkList = option<string | UserListItem[] | UserLinkListCallback>('link_list');
-const getDefaultLinkTarget = option<string>('link_default_target');
+const getLinkList = option<string | UserListItem[] | UserLinkListCallback | undefined>('link_list');
+const getDefaultLinkTarget = option<string | undefined>('link_default_target');
 const getDefaultLinkProtocol = option<string>('link_default_protocol');
 const getTargetList = option<boolean | UserListItem[]>('link_target_list');
 const getRelList = option<UserListItem[]>('link_rel_list');

--- a/modules/tinymce/src/plugins/link/main/ts/ui/DialogChanges.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/DialogChanges.ts
@@ -23,7 +23,7 @@ const findTextByValue = (value: string, catalog: ListItem[]): Optional<ListValue
     }
   });
 
-const getDelta = (persistentText: string, fieldName: string, catalog: ListItem[], data: Partial<LinkDialogData>): Optional<DialogDelta> => {
+const getDelta = (persistentText: string, fieldName: 'link' | 'anchor', catalog: ListItem[], data: Partial<LinkDialogData>): Optional<DialogDelta> => {
   const value = data[fieldName];
   const hasPersistentText = persistentText.length > 0;
   return value !== undefined ? findTextByValue(value, catalog).map((i) => ({
@@ -55,10 +55,10 @@ const init = (initialData: LinkDialogData, linkCatalog: LinkDialogCatalog): Dial
   };
 
   const getTitleFromUrlChange = (url: LinkDialogUrlData): Optional<string> =>
-    Optionals.someIf(persistentData.title.length <= 0, Optional.from(url.meta.title).getOr(''));
+    Optionals.someIf(persistentData.title.length <= 0, Optional.from(url.meta?.title).getOr(''));
 
   const getTextFromUrlChange = (url: LinkDialogUrlData): Optional<string> =>
-    Optionals.someIf(persistentData.text.length <= 0, Optional.from(url.meta.text).getOr(url.value));
+    Optionals.someIf(persistentData.text.length <= 0, Optional.from(url.meta?.text).getOr(url.value));
 
   const onUrlChange = (data: LinkDialogData): Optional<Partial<LinkDialogData>> => {
     const text = getTextFromUrlChange(data.url);
@@ -74,9 +74,9 @@ const init = (initialData: LinkDialogData, linkCatalog: LinkDialogCatalog): Dial
     }
   };
 
-  const onCatalogChange = (data: LinkDialogData, change: { name: string }): Optional<Partial<LinkDialogData>> => {
-    const catalog = findCatalog(linkCatalog, change.name).getOr([ ]);
-    return getDelta(persistentData.text, change.name, catalog, data);
+  const onCatalogChange = (data: LinkDialogData, change: 'link' | 'anchor'): Optional<Partial<LinkDialogData>> => {
+    const catalog = findCatalog(linkCatalog, change).getOr([ ]);
+    return getDelta(persistentData.text, change, catalog, data);
   };
 
   const onChange = (getData: () => LinkDialogData, change: { name: string }): Optional<Partial<LinkDialogData>> => {
@@ -84,7 +84,7 @@ const init = (initialData: LinkDialogData, linkCatalog: LinkDialogCatalog): Dial
     if (name === 'url') {
       return onUrlChange(getData());
     } else if (Arr.contains([ 'anchor', 'link' ], name)) {
-      return onCatalogChange(getData(), change);
+      return onCatalogChange(getData(), name as 'anchor' | 'link');
     } else if (name === 'text' || name === 'title') {
       // Update the persistent text/title state, as a user has input custom text
       persistentData[name] = getData()[name];

--- a/modules/tinymce/src/plugins/link/main/ts/ui/DialogTypes.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/DialogTypes.ts
@@ -76,6 +76,6 @@ interface LinkUrlMeta {
 }
 
 export interface AttachState {
-  readonly href?: string;
-  readonly attach?: () => void;
+  readonly href: string;
+  readonly attach: () => void;
 }

--- a/modules/tinymce/src/plugins/link/main/ts/ui/sections/AnchorListOptions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/sections/AnchorListOptions.ts
@@ -7,8 +7,8 @@ import { ListItem } from '../DialogTypes';
 // NOTE: you currently need anchors in the content for this field to appear
 
 const getAnchors = (editor: Editor): Optional<ListItem[]> => {
-  const anchorNodes = editor.dom.select('a:not([href])');
-  const anchors = Arr.bind(anchorNodes, (anchor: HTMLAnchorElement) => {
+  const anchorNodes = editor.dom.select<HTMLAnchorElement>('a:not([href])');
+  const anchors = Arr.bind(anchorNodes, (anchor) => {
     const id = anchor.name || anchor.id;
     return id ? [{ text: id, value: '#' + id }] : [ ];
   });

--- a/modules/tinymce/src/plugins/link/main/ts/ui/sections/LinkListOptions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/sections/LinkListOptions.ts
@@ -16,7 +16,7 @@ const parseJson = (text: string): Optional<ListItem[]> => {
 };
 
 const getLinks = (editor: Editor): Promise<Optional<ListItem[]>> => {
-  const extractor = (item: UserListItem) => editor.convertURL(item.value || item.url, 'href');
+  const extractor = (item: UserListItem) => editor.convertURL(item.value || item.url || '', 'href');
 
   const linkList = Options.getLinkList(editor);
   return new Promise<Optional<UserListItem[]>>((resolve) => {

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DialogSectionsTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DialogSectionsTest.ts
@@ -31,7 +31,7 @@ describe('browser.tinymce.plugins.link.DialogSectionsTest', () => {
   });
 
   const getStr = (sections: TestSection[]) => {
-    const r = {};
+    const r: Record<string, string> = {};
     Arr.each(sections, (section) => {
       r[section.option.key] = section.option.value.getOr('{ default }');
     });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/LinkDialogOverrideTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/LinkDialogOverrideTest.ts
@@ -22,7 +22,7 @@ describe('browser.tinymce.plugins.link.LinkDialogOverrideTest', () => {
             if (spec.title === 'Insert/Edit Link') {
               const newSpec = Tools.extend({}, spec, {
                 onChange: (api: Dialog.DialogInstanceApi<LinkDialogData>, details: Dialog.DialogChangeDetails<LinkDialogData>) => {
-                  spec.onChange(api, details);
+                  spec.onChange?.(api, details);
                   if (details.name === 'url' || details.name === 'link' || details.name === 'anchor') {
                     const data = api.getData();
                     api.setEnabled('save', data.url.value.length > 0);
@@ -30,7 +30,8 @@ describe('browser.tinymce.plugins.link.LinkDialogOverrideTest', () => {
                 }
               });
               const api = originalWindowManager.open(newSpec);
-              if (spec.initialData.url.value.length === 0) {
+              const urlValue = spec.initialData?.url?.value ?? '';
+              if (urlValue.length === 0) {
                 api.setEnabled('save', false);
               }
 

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ListOptionsTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ListOptionsTest.ts
@@ -5,6 +5,7 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
+import { UserListItem } from 'tinymce/plugins/link/ui/DialogTypes';
 import { AnchorListOptions } from 'tinymce/plugins/link/ui/sections/AnchorListOptions';
 import { ClassListOptions } from 'tinymce/plugins/link/ui/sections/ClassListOptions';
 import { LinkListOptions } from 'tinymce/plugins/link/ui/sections/LinkListOptions';
@@ -63,7 +64,7 @@ describe('browser.tinymce.plugins.link.ListOptionsTest', () => {
 
   it('TBA: Checking link list generation', async () => {
     const editor = hook.editor();
-    editor.options.set('link_list', (callback) => {
+    editor.options.set('link_list', (callback: (value: UserListItem[]) => void) => {
       callback([
         {
           title: 'Alpha',

--- a/modules/tinymce/src/plugins/link/test/ts/browser/PreventDefaultTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/PreventDefaultTest.ts
@@ -14,7 +14,7 @@ describe('browser.tinymce.plugins.link.PreventDefaultTest', () => {
     plugins: 'link',
     toolbar: 'link openlink unlink',
     base_url: '/project/tinymce/js/tinymce',
-    setup: (ed) => {
+    setup: (ed: Editor) => {
       const hasOnlyAltModifier = (e: KeyboardEvent) => {
         return (
           e.altKey === true &&
@@ -24,15 +24,11 @@ describe('browser.tinymce.plugins.link.PreventDefaultTest', () => {
         );
       };
 
-      ed.on(
-        'keydown',
-        (event) => {
-          if (event.keyCode === 13 && hasOnlyAltModifier(event)) {
-            event.preventDefault();
-          }
-        },
-        true
-      );
+      ed.on('keydown', (event) => {
+        if (event.keyCode === 13 && hasOnlyAltModifier(event)) {
+          event.preventDefault();
+        }
+      }, true);
     },
   }, [ Plugin ]);
 

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UrlProtocolTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UrlProtocolTest.ts
@@ -16,9 +16,6 @@ describe('browser.tinymce.plugins.link.UrlProtocolTest', () => {
   }, [ Plugin ]);
 
   const pTestProtocolConfirm = async (editor: Editor, url: string, expectedProtocol: string) => {
-    const presence = {};
-    presence[`a[href="${expectedProtocol}${url}"]:contains("Something")`] = 1;
-
     editor.setContent('<p>Something</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], ''.length, [ 0, 0 ], 'Something'.length);
     await TestLinkUi.pOpenLinkDialog(editor);
@@ -33,13 +30,10 @@ describe('browser.tinymce.plugins.link.UrlProtocolTest', () => {
     await TestLinkUi.pClickSave(editor);
     await TinyUiActions.pWaitForDialog(editor, '[role="dialog"].tox-confirm-dialog');
     await TestLinkUi.pClickConfirmYes(editor);
-    await TestLinkUi.pAssertContentPresence(editor, presence);
+    await TestLinkUi.pAssertContentPresence(editor, { [`a[href="${expectedProtocol}${url}"]:contains("Something")`]: 1 });
   };
 
   const pTestNoProtocolConfirm = async (editor: Editor, url: string) => {
-    const presence = {};
-    presence[`a[href="${url}"]:contains("Something")`] = 1;
-
     editor.setContent('<p>Something</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], ''.length, [ 0, 0 ], 'Something'.length);
     await TestLinkUi.pOpenLinkDialog(editor);
@@ -53,7 +47,7 @@ describe('browser.tinymce.plugins.link.UrlProtocolTest', () => {
     });
     await TestLinkUi.pClickSave(editor);
     UiFinder.notExists(SugarBody.body(), '[role="dialog"]');
-    await TestLinkUi.pAssertContentPresence(editor, presence);
+    await TestLinkUi.pAssertContentPresence(editor, { [`a[href="${url}"]:contains("Something")`]: 1 });
   };
 
   it('TBA: Test regex for non relative ftp link', async () => {

--- a/modules/tinymce/src/plugins/link/test/ts/module/TestLinkUi.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/module/TestLinkUi.ts
@@ -16,16 +16,16 @@ const selectors = {
   linklist: 'label.tox-label:contains(Link list) + div.tox-listboxfield > .tox-listbox'
 };
 
-const pOpenLinkDialog = async (editor: Editor) => {
+const pOpenLinkDialog = async (editor: Editor): Promise<void> => {
   TinyUiActions.clickOnToolbar(editor, '[aria-label="Insert/edit link"]');
   await TinyUiActions.pWaitForDialog(editor);
 };
 
-const clickOnConfirmDialog = (editor: Editor, state: boolean) => {
+const clickOnConfirmDialog = (editor: Editor, state: boolean): void => {
   TinyUiActions.clickOnUi(editor, '[role="dialog"].tox-confirm-dialog button:contains("' + (state ? 'Yes' : 'No') + '")');
 };
 
-const fireEvent = (elem: SugarElement, event: string) => {
+const fireEvent = (elem: SugarElement, event: string): void => {
   const evt = new Event(event, {
     bubbles: true,
     cancelable: true
@@ -41,13 +41,13 @@ const assertInputValue = (label: string, selector: string, expected: string | bo
   if (input.dom.type === 'checkbox') {
     assert.equal(input.dom.checked, expected, `The input value for ${label} should be: ${expected}`);
   } else if (Class.has(input, 'tox-listbox')) {
-    assert.equal(Attribute.get(input, 'data-value'), expected, `The input value for ${label} should be: ${expected}`);
+    assert.equal(Attribute.get(input, 'data-value'), String(expected), `The input value for ${label} should be: ${expected}`);
   } else {
     assert.equal(Value.get(input), expected, `The input value for ${label} should be: ${expected}`);
   }
 };
 
-const assertDialogContents = (expected: Record<string, any>) => {
+const assertDialogContents = (expected: Record<string, any>): void => {
   Obj.mapToArray(selectors, (value, key) => {
     if (Obj.has(expected, key)) {
       assertInputValue(key, value, expected[key]);
@@ -55,55 +55,55 @@ const assertDialogContents = (expected: Record<string, any>) => {
   });
 };
 
-const pInsertLink = async (editor: Editor, url: string) => {
+const pInsertLink = async (editor: Editor, url: string): Promise<void> => {
   await pOpenLinkDialog(editor);
   FocusTools.setActiveValue(doc, url);
   await pClickSave(editor);
 };
 
-const pAssertContentPresence = (editor: Editor, presence: Record<string, number>) =>
+const pAssertContentPresence = (editor: Editor, presence: Record<string, number>): Promise<void> =>
   Waiter.pTryUntil('Waiting for content to have expected presence', () => TinyAssertions.assertContentPresence(editor, presence));
 
-const pWaitForDialogClose = () => Waiter.pTryUntil(
+const pWaitForDialogClose = (): Promise<void> => Waiter.pTryUntil(
   'Waiting for dialog to go away',
   () => UiFinder.notExists(SugarBody.body(), '[role="dialog"]:not(.tox-confirm-dialog)')
 );
 
-const pWaitForConfirmClose = () => Waiter.pTryUntil(
+const pWaitForConfirmClose = (): Promise<void> => Waiter.pTryUntil(
   'Waiting for confirm dialog to go away',
   () => UiFinder.notExists(SugarBody.body(), '[role="dialog"].tox-confirm-dialog')
 );
 
-const pClickSave = async (editor: Editor) => {
+const pClickSave = async (editor: Editor): Promise<void> => {
   TinyUiActions.submitDialog(editor);
   await pWaitForDialogClose();
 };
 
-const pClickCancel = async (editor: Editor) => {
+const pClickCancel = async (editor: Editor): Promise<void> => {
   TinyUiActions.cancelDialog(editor);
   await pWaitForDialogClose();
 };
 
-const pClickConfirmYes = async (editor: Editor) => {
+const pClickConfirmYes = async (editor: Editor): Promise<void> => {
   clickOnConfirmDialog(editor, true);
   await pWaitForConfirmClose();
 };
 
-const pClickConfirmNo = async (editor: Editor) => {
+const pClickConfirmNo = async (editor: Editor): Promise<void> => {
   clickOnConfirmDialog(editor, false);
   await pWaitForConfirmClose();
 };
 
-const pFindInDialog = async <T extends Element>(editor: Editor, selector: string) => {
+const pFindInDialog = async <T extends Element>(editor: Editor, selector: string): Promise<SugarElement<T>> => {
   const dialog = await TinyUiActions.pWaitForDialog(editor);
   return UiFinder.findIn<T>(dialog, selector).getOrDie();
 };
 
-const clearHistory = () => {
+const clearHistory = (): void => {
   localStorage.removeItem('tinymce-url-history');
 };
 
-const pSetListBoxItem = async (editor: Editor, group: string, itemText: string) => {
+const pSetListBoxItem = async (editor: Editor, group: string, itemText: string): Promise<void> => {
   const element = await pFindInDialog(editor, 'label:contains("' + group + '") + .tox-listboxfield .tox-listbox');
   Mouse.click(element);
   const list = await UiFinder.pWaitForVisible('Wait for list to open', SugarBody.body(), '.tox-menu.tox-collection--list');
@@ -112,7 +112,7 @@ const pSetListBoxItem = async (editor: Editor, group: string, itemText: string) 
   Mouse.click(parent);
 };
 
-const pSetInputFieldValue = async (editor: Editor, group: string, newValue: string) => {
+const pSetInputFieldValue = async (editor: Editor, group: string, newValue: string): Promise<void> => {
   const element = await pFindInDialog<HTMLInputElement>(editor, 'label:contains("' + group + '") + input');
   UiControls.setValue(element, newValue);
   fireEvent(element, 'input');

--- a/modules/tinymce/src/plugins/lists/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/lists/demo/ts/demo/Demo.ts
@@ -1,4 +1,6 @@
-declare let tinymce: any;
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',

--- a/modules/tinymce/src/plugins/lists/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/Plugin.ts
@@ -11,7 +11,7 @@ export default (): void => {
   PluginManager.add('lists', (editor) => {
     Options.register(editor);
 
-    if (editor.hasPlugin('rtc', true) === false) {
+    if (!editor.hasPlugin('rtc', true)) {
       Keyboard.setup(editor);
       Commands.register(editor);
     } else {

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/Update.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/Update.ts
@@ -11,12 +11,14 @@ interface ListUpdate {
 
 export const updateList = (editor: Editor, update: ListUpdate): void => {
   const parentList = getParentList(editor);
-  editor.undoManager.transact(() => {
-    if (Type.isObject(update.styles)) {
-      editor.dom.setStyles(parentList, update.styles);
-    }
-    if (Type.isObject(update.attrs)) {
-      Obj.each(update.attrs, (v, k) => editor.dom.setAttrib(parentList, k, v));
-    }
-  });
+  if (parentList) {
+    editor.undoManager.transact(() => {
+      if (Type.isObject(update.styles)) {
+        editor.dom.setStyles(parentList, update.styles);
+      }
+      if (Type.isObject(update.attrs)) {
+        Obj.each(update.attrs, (v, k) => editor.dom.setAttrib(parentList, k, v));
+      }
+    });
+  }
 };

--- a/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/api/Commands.ts
@@ -10,7 +10,7 @@ import * as Dialog from '../ui/Dialog';
 
 const queryListCommandState = (editor: Editor, listName: string) => (): boolean => {
   const parentList = getParentList(editor);
-  return parentList && parentList.nodeName === listName;
+  return Type.isNonNullable(parentList) && parentList.nodeName === listName;
 };
 
 const registerDialog = (editor: Editor): void => {

--- a/modules/tinymce/src/plugins/lists/main/ts/api/Events.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/api/Events.ts
@@ -3,5 +3,5 @@ import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import { ListAction } from '../core/ListAction';
 
-export const fireListEvent = (editor: Editor, action: ListAction, element: Node): EditorEvent<{ action: ListAction; element: Node }> =>
+export const fireListEvent = (editor: Editor, action: ListAction, element: Node | null): EditorEvent<{ action: ListAction; element: Node | null }> =>
   editor.dispatch('ListMutation', { action, element });

--- a/modules/tinymce/src/plugins/lists/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/api/Options.ts
@@ -2,8 +2,8 @@ import Editor from 'tinymce/core/api/Editor';
 import { EditorOptions } from 'tinymce/core/api/OptionTypes';
 
 const option: {
-  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K] | undefined;
-  <T>(name: string): (editor: Editor) => T | undefined;
+  <K extends keyof EditorOptions>(name: K): (editor: Editor) => EditorOptions[K];
+  <T>(name: string): (editor: Editor) => T;
 } = (name: string) => (editor: Editor) =>
   editor.options.get(name);
 

--- a/modules/tinymce/src/plugins/lists/main/ts/core/NodeType.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/NodeType.ts
@@ -1,13 +1,17 @@
+import { Type } from '@ephox/katamari';
+
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
 
 const matchNodeName = <T extends Node = Node>(name: string) =>
-  (node: Node | null): node is T => node && node.nodeName.toLowerCase() === name;
+  (node: Node | null): node is T => Type.isNonNullable(node) && node.nodeName.toLowerCase() === name;
 
 const matchNodeNames = <T extends Node = Node>(regex: RegExp) =>
-  (node: Node | null): node is T => node && regex.test(node.nodeName);
+  (node: Node | null): node is T => Type.isNonNullable(node) && regex.test(node.nodeName);
 
-const isTextNode = (node: Node | null): node is Text => node && node.nodeType === 3;
+const isTextNode = (node: Node | null): node is Text => Type.isNonNullable(node) && node.nodeType === 3;
+
+const isElement = (node: Node | null): node is Element => Type.isNonNullable(node) && node.nodeType === 1;
 
 const isListNode = matchNodeNames<HTMLOListElement | HTMLUListElement | HTMLDListElement>(/^(OL|UL|DL)$/);
 
@@ -24,16 +28,16 @@ const isTableCellNode = matchNodeNames<HTMLTableHeaderCellElement | HTMLTableCel
 const isBr = matchNodeName<HTMLBRElement>('br');
 
 const isFirstChild = (node: Node): boolean =>
-  node.parentNode.firstChild === node;
+  node.parentNode?.firstChild === node;
 
 const isLastChild = (node: Node): boolean =>
-  node.parentNode.lastChild === node;
+  node.parentNode?.lastChild === node;
 
-const isTextBlock = (editor: Editor, node: Node): node is HTMLElement =>
-  node && !!editor.schema.getTextBlockElements()[node.nodeName];
+const isTextBlock = (editor: Editor, node: Node | null): node is HTMLElement =>
+  Type.isNonNullable(node) && node.nodeName in editor.schema.getTextBlockElements();
 
 const isBlock = (node: Node | null, blockElements: Record<string, any>): boolean =>
-  node && node.nodeName in blockElements;
+  Type.isNonNullable(node) && node.nodeName in blockElements;
 
 const isBogusBr = (dom: DOMUtils, node: Node): node is HTMLBRElement => {
   if (!isBr(node)) {
@@ -58,6 +62,7 @@ const isChildOfBody = (dom: DOMUtils, elm: Element): boolean =>
 
 export {
   isTextNode,
+  isElement,
   isListNode,
   isOlUlNode,
   isOlNode,

--- a/modules/tinymce/src/plugins/lists/main/ts/core/NormalizeLists.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/NormalizeLists.ts
@@ -9,7 +9,7 @@ const normalizeList = (dom: DOMUtils, list: HTMLUListElement | HTMLOListElement)
   const parentNode = list.parentElement;
 
   // Move UL/OL to previous LI if it's the only child of a LI
-  if (parentNode.nodeName === 'LI' && parentNode.firstChild === list) {
+  if (parentNode && parentNode.nodeName === 'LI' && parentNode.firstChild === list) {
     const sibling = parentNode.previousSibling;
     if (sibling && sibling.nodeName === 'LI') {
       sibling.appendChild(list);

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
@@ -1,4 +1,4 @@
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Optional, Type } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import Schema from 'tinymce/core/api/html/Schema';
@@ -9,14 +9,14 @@ import * as NodeType from './NodeType';
 const listNames = [ 'OL', 'UL', 'DL' ];
 const listSelector = listNames.join(',');
 
-const getParentList = (editor: Editor, node?: Node): HTMLElement => {
+const getParentList = (editor: Editor, node?: Node): HTMLElement | null => {
   const selectionStart = node || editor.selection.getStart(true);
 
   return editor.dom.getParent(selectionStart, listSelector, getClosestListHost(editor, selectionStart));
 };
 
-const isParentListSelected = (parentList: HTMLElement, selectedBlocks: Element[]): boolean =>
-  parentList && selectedBlocks.length === 1 && selectedBlocks[0] === parentList;
+const isParentListSelected = (parentList: HTMLElement | null, selectedBlocks: Element[]): boolean =>
+  Type.isNonNullable(parentList) && selectedBlocks.length === 1 && selectedBlocks[0] === parentList;
 
 const findSubLists = (parentList: HTMLElement): HTMLElement[] =>
   Arr.filter(parentList.querySelectorAll(listSelector), NodeType.isListNode);
@@ -26,7 +26,7 @@ const getSelectedSubLists = (editor: Editor): HTMLElement[] => {
   const selectedBlocks = editor.selection.getSelectedBlocks();
 
   if (isParentListSelected(parentList, selectedBlocks)) {
-    return findSubLists(parentList);
+    return findSubLists(parentList as HTMLElement);
   } else {
     return Arr.filter(selectedBlocks, (elm): elm is HTMLElement => {
       return NodeType.isListNode(elm) && parentList !== elm;
@@ -57,7 +57,7 @@ const getClosestEditingHost = (editor: Editor, elm: Element): HTMLElement => {
   return parentTableCell.length > 0 ? parentTableCell[0] : editor.getBody();
 };
 
-const isListHost = (schema: Schema, node: Node) =>
+const isListHost = (schema: Schema, node: Node): boolean =>
   !NodeType.isListNode(node) && !NodeType.isListItemNode(node) && Arr.exists(listNames, (listName) => schema.isValidChild(node.nodeName, listName));
 
 const getClosestListHost = (editor: Editor, elm: Node): HTMLElement => {

--- a/modules/tinymce/src/plugins/lists/main/ts/core/SplitList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/SplitList.ts
@@ -9,9 +9,12 @@ const DOM = DOMUtils.DOM;
 
 const splitList = (editor: Editor, list: Element, li: Element): void => {
   const removeAndKeepBookmarks = (targetNode: Node) => {
-    Tools.each(bookmarks, (node) => {
-      targetNode.parentNode.insertBefore(node, li.parentNode);
-    });
+    const parent = targetNode.parentNode;
+    if (parent) {
+      Tools.each(bookmarks, (node) => {
+        parent.insertBefore(node, li.parentNode);
+      });
+    }
 
     DOM.remove(targetNode);
   };
@@ -37,7 +40,7 @@ const splitList = (editor: Editor, list: Element, li: Element): void => {
   DOM.insertAfter(newBlock, list);
 
   const parent = li.parentElement;
-  if (NodeType.isEmpty(editor.dom, parent)) {
+  if (parent && NodeType.isEmpty(editor.dom, parent)) {
     removeAndKeepBookmarks(parent);
   }
 

--- a/modules/tinymce/src/plugins/lists/main/ts/core/TextBlock.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/TextBlock.ts
@@ -9,7 +9,9 @@ const createTextBlock = (editor: Editor, contentNode: Node): DocumentFragment =>
   const fragment = dom.createFragment();
   const blockName = Options.getForcedRootBlock(editor);
   const blockAttrs = Options.getForcedRootBlockAttrs(editor);
-  let node: Node, textBlock: Element, hasContentNode: boolean;
+  let node: Node | null;
+  let textBlock: Element | null;
+  let hasContentNode = false;
 
   textBlock = dom.create(blockName, blockAttrs);
 
@@ -38,7 +40,7 @@ const createTextBlock = (editor: Editor, contentNode: Node): DocumentFragment =>
   }
 
   // BR is needed in empty blocks
-  if (!hasContentNode) {
+  if (!hasContentNode && textBlock) {
     textBlock.appendChild(dom.create('br', { 'data-mce-bogus': '1' }));
   }
 

--- a/modules/tinymce/src/plugins/lists/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/ui/Dialog.ts
@@ -29,7 +29,7 @@ const open = (editor: Editor): void => {
     initialData: {
       start: parseDetail({
         start: editor.dom.getAttrib(currentList, 'start', '1'),
-        listStyleType: Optional.some(editor.dom.getStyle(currentList, 'list-style-type'))
+        listStyleType: Optional.from(editor.dom.getStyle(currentList, 'list-style-type'))
       })
     },
     buttons: [

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyTest.ts
@@ -328,7 +328,7 @@ describe('browser.tinymce.plugins.lists.ApplyTest', () => {
     );
 
     LegacyUnit.setSelection(editor, 'ul li', 1);
-    editor.execCommand('InsertOrderedList', null, { 'list-style-type': 'lower-alpha' });
+    editor.execCommand('InsertOrderedList', false, { 'list-style-type': 'lower-alpha' });
 
     TinyAssertions.assertContent(
       editor,
@@ -356,7 +356,7 @@ describe('browser.tinymce.plugins.lists.ApplyTest', () => {
     );
 
     LegacyUnit.setSelection(editor, 'p', 1);
-    editor.execCommand('InsertOrderedList', null, { 'list-style-type': 'lower-alpha' });
+    editor.execCommand('InsertOrderedList', false, { 'list-style-type': 'lower-alpha' });
 
     TinyAssertions.assertContent(
       editor,
@@ -762,8 +762,8 @@ describe('browser.tinymce.plugins.lists.ApplyTest', () => {
     );
 
     const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('td')[0].firstChild, 0);
-    rng.setEnd(editor.dom.select('td')[0].firstChild, 0);
+    rng.setStart(editor.dom.select('td')[0].firstChild as Text, 0);
+    rng.setEnd(editor.dom.select('td')[0].firstChild as Text, 0);
     editor.selection.setRng(rng);
 
     editor.execCommand('InsertUnorderedList');

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteInlineTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteInlineTest.ts
@@ -42,7 +42,7 @@ describe('browser.tinymce.plugins.lists.BackspaceDeleteInlineTest', () => {
   it('TBA: Backspace at beginning of LI on body UL', () => {
     const editor = hook.editor();
     const body = editor.getBody();
-    editor.selection.setCursorLocation(body.firstChild.firstChild, 0);
+    editor.selection.setCursorLocation(body.firstChild?.firstChild as HTMLUListElement, 0);
     editor.plugins.lists.backspaceDelete();
     assert.lengthOf(editor.dom.select('#lists ul'), 3);
     assert.lengthOf(editor.dom.select('#lists li'), 3);
@@ -51,7 +51,7 @@ describe('browser.tinymce.plugins.lists.BackspaceDeleteInlineTest', () => {
   it('TBA: Delete at end of LI on body UL', () => {
     const editor = hook.editor();
     const body = editor.getBody();
-    editor.selection.setCursorLocation(body.firstChild.firstChild, 1);
+    editor.selection.setCursorLocation(body.firstChild?.firstChild as HTMLUListElement, 1);
     editor.plugins.lists.backspaceDelete(true);
     assert.lengthOf(editor.dom.select('#lists ul'), 3);
     assert.lengthOf(editor.dom.select('#lists li'), 3);


### PR DESCRIPTION
Related Ticket: TINY-8921

Description of Changes:

This PR aims at fixing all the strict type errors in the A-L plugins. Note that I've not included any extra directories in the `tsconfig.strict.json` file because that will be done in the next PR whereby everything is using strict mode.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
