### PR TITLE
TINY-8808: Fixed strict type errors in Sand and Bridge

### DIFF
--- a/modules/bridge/src/demo/ts/dialogs/DemoDialogHelpers.ts
+++ b/modules/bridge/src/demo/ts/dialogs/DemoDialogHelpers.ts
@@ -5,13 +5,13 @@ import { DialogManager } from '../../../main/ts/ephox/bridge/api/DialogManager';
 import { Dialog, DialogInstanceApi, DialogSpec } from '../../../main/ts/ephox/bridge/components/dialog/Dialog';
 
 // This is the function that would be implemented in modern theme/silver theme for creating dialogs
-const createDemoApi = <T>(internalStructure: Dialog<T>, initalData: Partial<T>, dataValidator: StructureProcessor): DialogInstanceApi<T> => {
-  const data = Cell(initalData);
+const createDemoApi = <T>(internalStructure: Dialog<T>, initialData: Partial<T>, dataValidator: StructureProcessor): DialogInstanceApi<T> => {
+  const data = Cell(initialData);
 
   // eslint-disable-next-line no-console
   console.log({
     internalStructure,
-    initalData
+    initialData
   });
 
   return {

--- a/modules/bridge/src/demo/ts/menus/ContextMenuDemo.ts
+++ b/modules/bridge/src/demo/ts/menus/ContextMenuDemo.ts
@@ -11,7 +11,7 @@ export const registerDemoContextMenus = (): void => {
     update: () => [{
       icon: 'code',
       text: 'Code',
-      onAction: (_api) => {
+      onAction: () => {
         console.log('open source code dialog');
       }
     }]
@@ -21,7 +21,7 @@ export const registerDemoContextMenus = (): void => {
     update: () => [ 'bold', 'italic', {
       icon: 'code',
       text: 'Code',
-      onAction: (_api) => {
+      onAction: () => {
         console.log('open source code dialog');
       }
     }]

--- a/modules/bridge/src/demo/ts/plugins/AnchorItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/AnchorItems.ts
@@ -1,8 +1,8 @@
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
-  on: (_s, _f) => { },
-  off: (_s, _f) => { }
+  on: (_s: string, _f: Function) => { },
+  off: (_s: string, _f: Function) => { }
 };
 
 export const registerAnchorItems = (): void => {
@@ -10,13 +10,13 @@ export const registerAnchorItems = (): void => {
     type: 'togglebutton',
     enabled: true,
     onSetup: (buttonApi) => {
-      const f = (e) => {
+      const f = (e: any) => {
         // Set the active state based on something
         const state = e;
         buttonApi.setActive(state);
       };
       editor.on('NodeChange', f);
-      return () => editor.off('nodeChange', f);
+      return () => editor.off('NodeChange', f);
     },
     onAction: (_buttonApi) => {
       // apply anchor command

--- a/modules/bridge/src/demo/ts/plugins/AutosaveItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/AutosaveItems.ts
@@ -1,8 +1,8 @@
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
-  on: (_s, _f) => { },
-  off: (_s, _f) => { }
+  on: (_s: string, _f: Function) => { },
+  off: (_s: string, _f: Function) => { }
 };
 
 export const registerAutosaveItems = (): void => {
@@ -10,7 +10,7 @@ export const registerAutosaveItems = (): void => {
     type: 'button',
     enabled: true,
     onSetup: (buttonApi) => {
-      const editorOffCallback = (e) => {
+      const editorOffCallback = (e: any) => {
         // Set the disabled state based on something
         const state = e;
         buttonApi.setEnabled(!state);

--- a/modules/bridge/src/demo/ts/plugins/DirectionalityItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/DirectionalityItems.ts
@@ -1,8 +1,8 @@
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
-  on: (_s, _f) => { },
-  off: (_s, _f) => { }
+  on: (_s: string, _f: Function) => { },
+  off: (_s: string, _f: Function) => { }
 };
 
 export const registerDirectionalityItems = (): void => {
@@ -10,11 +10,11 @@ export const registerDirectionalityItems = (): void => {
     type: 'togglebutton',
     enabled: true,
     onSetup: (buttonApi) => {
-      const f = (e) => {
+      const f = (e: any) => {
         buttonApi.setActive(e);
       };
-      editor.on('nodeChange', f);
-      return () => editor.off('nodeChange', f);
+      editor.on('NodeChange', f);
+      return () => editor.off('NodeChange', f);
     },
     onAction: (_buttonApi) => {
       // execute command direction LTR or RTL

--- a/modules/bridge/src/demo/ts/plugins/FullscreenItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/FullscreenItems.ts
@@ -1,8 +1,8 @@
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
-  on: (_s, _f) => { },
-  off: (_s, _f) => { }
+  on: (_s: string, _f: Function) => { },
+  off: (_s: string, _f: Function) => { }
 };
 
 export const registerFullscreenItems = (): void => {
@@ -10,7 +10,7 @@ export const registerFullscreenItems = (): void => {
     type: 'togglebutton',
     enabled: true,
     onSetup: (buttonApi) => {
-      const f = (e) => {
+      const f = (e: any) => {
         buttonApi.setActive(e.something);
       };
       editor.on('FullscreenStateChanged', f);

--- a/modules/bridge/src/demo/ts/plugins/ImageItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/ImageItems.ts
@@ -1,17 +1,17 @@
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
-  on: (_s, _f) => { },
-  off: (_s, _f) => { }
+  on: (_s: string, _f: Function) => { },
+  off: (_s: string, _f: Function) => { }
 };
 
 export const registerImageItems = (): void => {
   getDemoRegistry().addToggleButton('image', {
     type: 'togglebutton',
     onSetup: (buttonApi) => {
-      const f = (e) => buttonApi.setActive(e);
-      editor.on('nodeChange', f);
-      return () => editor.off('nodeChange', f);
+      const f = (e: any) => buttonApi.setActive(e);
+      editor.on('NodeChange', f);
+      return () => editor.off('NodeChange', f);
     },
     onAction: (_buttonApi) => {
       // show image dialog

--- a/modules/bridge/src/demo/ts/plugins/MediaItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/MediaItems.ts
@@ -3,7 +3,7 @@ import { Fun } from '@ephox/katamari';
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
-  on: (_s, _f) => { }
+  on: (_s: string, _f: Function) => { }
 };
 
 export const registerMediaItems = (): void => {
@@ -11,7 +11,7 @@ export const registerMediaItems = (): void => {
     type: 'togglebutton',
     enabled: true,
     onSetup: (buttonApi) => {
-      editor.on('nodeChange', (e) => {
+      editor.on('NodeChange', (e: any) => {
         buttonApi.setActive(e);
         // sets active state based on selection
       });

--- a/modules/bridge/src/demo/ts/plugins/PasteItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/PasteItems.ts
@@ -3,7 +3,7 @@ import { Fun } from '@ephox/katamari';
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
-  on: (_s, _f) => { }
+  on: (_s: string, _f: Function) => { }
 };
 
 export const registerPasteItems = (): void => {
@@ -11,7 +11,7 @@ export const registerPasteItems = (): void => {
     type: 'togglebutton',
     enabled: true,
     onSetup: (buttonApi) => {
-      editor.on('PastePlainTextToggle', (e) => {
+      editor.on('PastePlainTextToggle', (e: any) => {
         buttonApi.setActive(e.state);
       });
       return Fun.noop;

--- a/modules/bridge/src/demo/ts/plugins/SaveItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/SaveItems.ts
@@ -3,8 +3,8 @@ import { Fun } from '@ephox/katamari';
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
-  on: (_s, _f) => { },
-  off: (_s, _f) => { },
+  on: (_s: string, _f: Function) => { },
+  off: (_s: string, _f: Function) => { },
   isDirty: Fun.always
 };
 
@@ -16,8 +16,8 @@ export const registerSaveItems = (): void => {
       const editorOffCallback = () => {
         buttonApi.setEnabled(!editor.isDirty());
       };
-      editor.on('nodeChange dirty', editorOffCallback);
-      return () => editor.off('nodeChange dirty', editorOffCallback);
+      editor.on('NodeChange dirty', editorOffCallback);
+      return () => editor.off('NodeChange dirty', editorOffCallback);
     },
     onAction: (_buttonApi) => {
       // trigger save (or cancel)

--- a/modules/bridge/src/demo/ts/plugins/TODO_AdvListItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/TODO_AdvListItems.ts
@@ -28,7 +28,7 @@ export interface ToolbarSplitButtonApi {
 */
 
 const editor = {
-  on: (_s, _f) => { }
+  on: (_s: string, _f: Function) => { }
 };
 
 export const registerAdvListItems = (): void => {
@@ -40,7 +40,7 @@ export const registerAdvListItems = (): void => {
     // FIX: disabled does not seem to be supported.
     // disabled: false,
     onSetup: (buttonApi: any) => {
-      editor.on('NodeChange', (e) => {
+      editor.on('NodeChange', (e: any) => {
         // Set the active state based on something
         const state = e;
         // FIX: This is missing.

--- a/modules/bridge/src/demo/ts/plugins/TocItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/TocItems.ts
@@ -3,7 +3,8 @@ import { Fun } from '@ephox/katamari';
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
-  on: (_s, _f) => { },
+  on: (_s: string, _f: Function) => { },
+  off: (_s: string, _f: Function) => { },
   isDirty: Fun.always
 };
 
@@ -12,7 +13,7 @@ export const registerTocItems = (): void => {
     type: 'button',
     enabled: true,
     onSetup: (buttonApi) => {
-      editor.on('LoadContent SetContent change', (e) => {
+      editor.on('LoadContent SetContent change', (e: any) => {
         buttonApi.setEnabled(!e);
       });
       return Fun.noop;

--- a/modules/bridge/src/demo/ts/plugins/VisualBlocksItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/VisualBlocksItems.ts
@@ -3,7 +3,7 @@ import { Fun } from '@ephox/katamari';
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
-  on: (_s, _f) => { },
+  on: (_s: string, _f: Function) => { },
   isDirty: Fun.always
 };
 
@@ -12,7 +12,7 @@ export const registerVisualBlocksItems = (): void => {
     type: 'togglebutton',
     enabled: true,
     onSetup: (buttonApi) => {
-      editor.on('VisualBlocks', (e) => {
+      editor.on('VisualBlocks', (e: any) => {
         buttonApi.setActive(e);
       });
       return Fun.noop;

--- a/modules/bridge/src/demo/ts/plugins/VisualCharsItems.ts
+++ b/modules/bridge/src/demo/ts/plugins/VisualCharsItems.ts
@@ -3,7 +3,7 @@ import { Fun } from '@ephox/katamari';
 import { getDemoRegistry } from '../buttons/DemoRegistry';
 
 const editor = {
-  on: (_s, _f) => { },
+  on: (_s: string, _f: Function) => { },
   isDirty: Fun.always
 };
 
@@ -12,7 +12,7 @@ export const registerVisualCharsItems = (): void => {
     type: 'togglebutton',
     enabled: true,
     onSetup: (buttonApi) => {
-      editor.on('VisualChars', (e) => {
+      editor.on('VisualChars', (e: any) => {
         buttonApi.setActive(e);
       });
       return Fun.noop;

--- a/modules/bridge/src/main/ts/ephox/bridge/api/DialogManager.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/api/DialogManager.ts
@@ -5,25 +5,25 @@ import { createUrlDialog, UrlDialog, UrlDialogInstanceApi, UrlDialogSpec } from 
 import { createDataValidator } from '../core/DialogData';
 
 interface DialogManager {
-  open: <T extends DialogData>(factory: DialogFactory<T>, structure: DialogSpec<T>) => DialogInstanceApi<T>;
-  openUrl: (factory: UrlDialogFactory, structure: UrlDialogSpec) => UrlDialogInstanceApi;
-  redial: <T extends DialogData>(structure: DialogSpec<T>) => DialogInit<T>;
+  readonly open: <T extends DialogData>(factory: DialogFactory<T>, structure: DialogSpec<T>) => DialogInstanceApi<T>;
+  readonly openUrl: (factory: UrlDialogFactory, structure: UrlDialogSpec) => UrlDialogInstanceApi;
+  readonly redial: <T extends DialogData>(structure: DialogSpec<T>) => DialogInit<T>;
 }
 
 export type DialogFactory<T extends DialogData> = (internalDialog: Dialog<T>, initialData: Partial<T>, dataValidator: StructureProcessor) => DialogInstanceApi<T>;
 export type UrlDialogFactory = (internalDialog: UrlDialog) => UrlDialogInstanceApi;
 
 export interface DialogInit<T extends DialogData> {
-  internalDialog: Dialog<T>;
-  initialData: Partial<T>;
-  dataValidator: StructureProcessor;
+  readonly internalDialog: Dialog<T>;
+  readonly initialData: Partial<T>;
+  readonly dataValidator: StructureProcessor;
 }
 
 const extract = <T>(structure: DialogSpec<T>): DialogInit<T> => {
   const internalDialog = StructureSchema.getOrDie(createDialog(structure));
   const dataValidator = createDataValidator<T>(structure);
   // We used to validate data here, but it's done when loading the dialog in tinymce
-  const initialData = structure.initialData;
+  const initialData = structure.initialData ?? {};
   return {
     internalDialog,
     dataValidator,

--- a/modules/bridge/src/main/ts/ephox/bridge/api/Registry.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/api/Registry.ts
@@ -43,14 +43,16 @@ export interface Registry {
 }
 
 export const create = (): Registry => {
-  const buttons: Record<string, ToolbarButtonSpec | ToolbarMenuButtonSpec | ToolbarSplitButtonSpec | ToolbarToggleButtonSpec> = {};
-  const menuItems: Record<string, MenuItemSpec | ToggleMenuItemSpec> = {};
+  const buttons: Record<string, ToolbarButtonSpec | GroupToolbarButtonSpec | ToolbarMenuButtonSpec | ToolbarSplitButtonSpec | ToolbarToggleButtonSpec> = {};
+  const menuItems: Record<string, MenuItemSpec | NestedMenuItemSpec | ToggleMenuItemSpec> = {};
   const popups: Record<string, AutocompleterSpec> = {};
   const icons: Record<string, string> = {};
   const contextMenus: Record<string, ContextMenuApi> = {};
   const contextToolbars: Record<string, ContextToolbarSpec | ContextFormSpec> = {};
   const sidebars: Record<string, SidebarSpec> = {};
-  const add = (collection, type: string) => (name: string, spec: any): void => collection[name.toLowerCase()] = { ...spec, type };
+  const add = <T, S extends T>(collection: Record<string, T>, type: string) => (name: string, spec: S): void => {
+    collection[name.toLowerCase()] = { ...spec, type };
+  };
   const addIcon = (name: string, svgData: string) => icons[name.toLowerCase()] = svgData;
 
   return {

--- a/modules/bridge/src/main/ts/ephox/bridge/core/DataProcessors.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/core/DataProcessors.ts
@@ -26,7 +26,7 @@ interface NamedItem {
 
 const isNamedItem = (obj: any): obj is NamedItem => Type.isString(obj.type) && Type.isString(obj.name);
 
-const dataProcessors = {
+const dataProcessors: Record<string, StructureProcessor> = {
   checkbox: checkboxDataProcessor,
   colorinput: colorInputDataProcessor,
   colorpicker: colorPickerDataProcessor,

--- a/modules/bridge/tsconfig.json
+++ b/modules/bridge/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
-    "strict": false,
     "outDir": "lib",
     "rootDir": "src",
     "baseUrl": ".",

--- a/modules/sand/src/demo/ts/ephox/sand/demo/Demo.ts
+++ b/modules/sand/src/demo/ts/ephox/sand/demo/Demo.ts
@@ -2,5 +2,5 @@ import * as PlatformDetection from 'ephox/sand/api/PlatformDetection';
 
 const platform = PlatformDetection.detect();
 
-const ephoxUi = document.querySelector('#ephox-ui');
+const ephoxUi = document.querySelector('#ephox-ui') as HTMLElement;
 ephoxUi.innerHTML = 'You are using: ' + platform.browser.current;

--- a/modules/sand/src/main/ts/ephox/sand/api/SandHTMLElement.ts
+++ b/modules/sand/src/main/ts/ephox/sand/api/SandHTMLElement.ts
@@ -10,7 +10,7 @@ const getPrototypeOf = Object.getPrototypeOf;
  * MDN no use on this one, but here's the link anyway:
  * https://developer.mozilla.org/en/docs/Web/API/HTMLElement
  */
-const sandHTMLElement = (scope: Window) => {
+const sandHTMLElement = (scope: Window | undefined) => {
   return Global.getOrDie('HTMLElement', scope) as typeof HTMLElement;
 };
 

--- a/modules/sand/src/main/ts/ephox/sand/detect/DeviceType.ts
+++ b/modules/sand/src/main/ts/ephox/sand/detect/DeviceType.ts
@@ -4,15 +4,15 @@ import { Browser } from '../core/Browser';
 import { OperatingSystem } from '../core/OperatingSystem';
 
 export interface DeviceType {
-  isiPad: () => boolean;
-  isiPhone: () => boolean;
-  isTablet: () => boolean;
-  isPhone: () => boolean;
-  isTouch: () => boolean;
-  isAndroid: () => boolean;
-  isiOS: () => boolean;
-  isWebView: () => boolean;
-  isDesktop: () => boolean;
+  readonly isiPad: () => boolean;
+  readonly isiPhone: () => boolean;
+  readonly isTablet: () => boolean;
+  readonly isPhone: () => boolean;
+  readonly isTouch: () => boolean;
+  readonly isAndroid: () => boolean;
+  readonly isiOS: () => boolean;
+  readonly isWebView: () => boolean;
+  readonly isDesktop: () => boolean;
 }
 
 export const DeviceType = (os: OperatingSystem, browser: Browser, userAgent: string, mediaMatch: (query: string) => boolean): DeviceType => {

--- a/modules/sand/src/test/ts/browser/HtmlElementTest.ts
+++ b/modules/sand/src/test/ts/browser/HtmlElementTest.ts
@@ -41,6 +41,11 @@ describe('HtmlElementTest', () => {
       document.body.appendChild(iframe);
 
       const iframeDoc = iframe.contentDocument;
+      if (iframeDoc === null) {
+        assert.fail('Iframe document is not available');
+        return;
+      }
+
       iframeDoc.open();
       iframeDoc.write('<html><body></body></html>');
       iframeDoc.close();

--- a/modules/sand/tsconfig.json
+++ b/modules/sand/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
-    "strict": false,
     "outDir": "lib",
     "rootDir": "src",
     "baseUrl": ".",


### PR DESCRIPTION
Related Ticket: TINY-8808

Description of Changes:

One more strict types PR sorry all, though it is small... I realised that this should also be done since it's part of the TinyMCE public API and also used heavily in Silver so it'd defeat the purpose a little by not having it compile under strict mode.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):
