### PR TITLE
TINY-8773: Prevent stripping of "name" and "id" attributes on iframe and img elements

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- The `name` and `id` attributes of any `img` or `iframe` elements were incorrectly removed #TINY-8773
+
 ## 5.10.5 - 2022-05-25
 
 ### Fixed

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- The `name` and `id` attributes of any `img` or `iframe` elements were incorrectly removed #TINY-8773
+- The `name` and `id` attributes of some elements were incorrectly removed during serialization #TINY-8773
 
 ## 5.10.5 - 2022-05-25
 

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "5.10.5",
+  "version": "5.10.6",
   "private": true,
   "repository": {
     "type": "git",

--- a/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
@@ -211,7 +211,7 @@ const checkBogusAttribute = (regExp: RegExp, attrString: string): string | null 
  */
 const SaxParser = (settings?: SaxParserSettings, schema = Schema()): SaxParser => {
   settings = settings || {};
-  const doc = settings.document ?? document;
+  const doc = (settings.document ?? document).implementation.createHTMLDocument('parser');
   const form = doc.createElement('form');
 
   if (settings.fix_self_closing !== false) {

--- a/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
@@ -107,6 +107,8 @@ const filteredClobberElements = Tools.makeMap('button,fieldset,form,iframe,img,i
 
 const isValidPrefixAttrName = (name: string): boolean => name.indexOf('data-') === 0 || name.indexOf('aria-') === 0;
 
+const lazyTempDocument = Thunk.cached(() => document.implementation.createHTMLDocument('parser'));
+
 /**
  * Returns the index of the matching end tag for a specific start tag. This can
  * be used to skip all children of a parent element from being processed.
@@ -211,7 +213,6 @@ const checkBogusAttribute = (regExp: RegExp, attrString: string): string | null 
  */
 const SaxParser = (settings?: SaxParserSettings, schema = Schema()): SaxParser => {
   settings = settings || {};
-  const lazyTempDocument = Thunk.cached(() => document.implementation.createHTMLDocument('parser'));
   const doc = lazyTempDocument();
   const form = doc.createElement('form');
 

--- a/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/SaxParser.ts
@@ -5,7 +5,7 @@
  * For commercial licenses see https://www.tiny.cloud/
  */
 
-import { Fun, Obj, Strings, Type } from '@ephox/katamari';
+import { Fun, Obj, Strings, Thunk, Type } from '@ephox/katamari';
 
 import { Base64Extract, extractBase64DataUris, restoreDataUris } from '../../html/Base64Uris';
 import Tools from '../util/Tools';
@@ -211,7 +211,8 @@ const checkBogusAttribute = (regExp: RegExp, attrString: string): string | null 
  */
 const SaxParser = (settings?: SaxParserSettings, schema = Schema()): SaxParser => {
   settings = settings || {};
-  const doc = (settings.document ?? document).implementation.createHTMLDocument('parser');
+  const lazyTempDocument = Thunk.cached(() => document.implementation.createHTMLDocument('parser'));
+  const doc = lazyTempDocument();
   const form = doc.createElement('form');
 
   if (settings.fix_self_closing !== false) {

--- a/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
@@ -305,13 +305,6 @@ describe('browser.tinymce.core.html.SaxParserTest', () => {
     parser.parse('<div id="divid" src="test" name="my_div"></div>');
     assert.equal(writer.getContent(), '<div id="divid" src="test" name="my_div"></div>', 'Parse div elements with name and id attributes.');
     assert.deepEqual(counter.counts, { start: 1, end: 1 }, 'Parse div elements with name and id attributes. (counts).');
-
-    counter = createCounter(writer);
-    parser = SaxParser(counter, schema);
-    writer.reset();
-    parser.parse('<image id="test2" src="test" name="testimage2"></image');
-    assert.equal(writer.getContent(), '<image id="test2" src="test" name="testimage2"></image>', 'Parse image elements with quoted name and id attributes.');
-    assert.deepEqual(counter.counts, { start: 1, end: 1 }, 'Parse image elements with name and id attributes. (counts).');
   });
 
   it('Parse style elements', () => {

--- a/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
@@ -290,14 +290,28 @@ describe('browser.tinymce.core.html.SaxParserTest', () => {
     writer.reset();
     parser.parse('<iframe id="someid" src="test" name="my_iframe"></iframe>');
     assert.equal(writer.getContent(), '<iframe id="someid" src="test" name="my_iframe"></iframe>', 'Parse iframe elements with name and id attributes.');
-    assert.deepEqual(counter.counts, { start: 1, end: 1 }, 'Parse iframe elements with quoted name and id attributes. (counts).');
+    assert.deepEqual(counter.counts, { start: 1, end: 1 }, 'Parse iframe elements with name and id attributes. (counts).');
 
     counter = createCounter(writer);
     parser = SaxParser(counter, schema);
     writer.reset();
     parser.parse('<img id="test1" src="test" name="testimage" />');
     assert.equal(writer.getContent(), '<img id="test1" src="test" name="testimage" />', 'Parse img elements with quoted name and id attributes.');
-    assert.deepEqual(counter.counts, { start: 1 }, 'Parse img elements with quoted name and id attributes. (counts).');
+    assert.deepEqual(counter.counts, { start: 1 }, 'Parse img elements with name and id attributes. (counts).');
+
+    counter = createCounter(writer);
+    parser = SaxParser(counter, schema);
+    writer.reset();
+    parser.parse('<div id="divid" src="test" name="my_div"></div>');
+    assert.equal(writer.getContent(), '<div id="divid" src="test" name="my_div"></div>', 'Parse div elements with name and id attributes.');
+    assert.deepEqual(counter.counts, { start: 1, end: 1 }, 'Parse div elements with name and id attributes. (counts).');
+
+    counter = createCounter(writer);
+    parser = SaxParser(counter, schema);
+    writer.reset();
+    parser.parse('<image id="test2" src="test" name="testimage2"></image');
+    assert.equal(writer.getContent(), '<image id="test2" src="test" name="testimage2"></image>', 'Parse image elements with quoted name and id attributes.');
+    assert.deepEqual(counter.counts, { start: 1, end: 1 }, 'Parse image elements with name and id attributes. (counts).');
   });
 
   it('Parse style elements', () => {

--- a/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SaxParserTest.ts
@@ -284,6 +284,20 @@ describe('browser.tinymce.core.html.SaxParserTest', () => {
     parser.parse('<p title="gre>gererg"/>');
     assert.equal(writer.getContent(), '<p title="gre&gt;gererg"></p>', 'Parse elements with quoted > characters.');
     assert.deepEqual(counter.counts, { start: 1, end: 1 }, 'Parse elements with quoted > characters (counts).');
+
+    counter = createCounter(writer);
+    parser = SaxParser(counter, schema);
+    writer.reset();
+    parser.parse('<iframe id="someid" src="test" name="my_iframe"></iframe>');
+    assert.equal(writer.getContent(), '<iframe id="someid" src="test" name="my_iframe"></iframe>', 'Parse iframe elements with name and id attributes.');
+    assert.deepEqual(counter.counts, { start: 1, end: 1 }, 'Parse iframe elements with quoted name and id attributes. (counts).');
+
+    counter = createCounter(writer);
+    parser = SaxParser(counter, schema);
+    writer.reset();
+    parser.parse('<img id="test1" src="test" name="testimage" />');
+    assert.equal(writer.getContent(), '<img id="test1" src="test" name="testimage" />', 'Parse img elements with quoted name and id attributes.');
+    assert.deepEqual(counter.counts, { start: 1 }, 'Parse img elements with quoted name and id attributes. (counts).');
   });
 
   it('Parse style elements', () => {


### PR DESCRIPTION
Related Ticket: TINY-8773

Description of Changes:
* Regression introduced in clobbering check #TINY-7756
* Filter through new document for each attribute, rather than same document
* SaxParser method now works same as in 6.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
