### PR TITLE
TINY-8936: Reverted the undo level part of the fixes done for f5c2ce9

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 6.1.2 - 2022-07-29
+
+### Fixed
+- Reverted the undo level fix in the `autolink` plugin as it caused duplicated content in some edge cases. #TINY-8936
+
 ## 6.1.1 - 2022-07-27
 
 ### Fixed

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
@@ -201,25 +201,4 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     assert.deepEqual(events, [ 'beforeexeccommand-createlink', 'execcommand-createlink' ], 'The createlink ExecCommand events should have fired');
     editor.off('BeforeExecCommand ExecCommand', logEvent);
   });
-
-  it('TINY-8896: should add an undo level for the link conversion', () => {
-    const editor = hook.editor();
-    assertIsLink(editor, 'http://www.domain.com', 'http://www.domain.com');
-    TinyAssertions.assertCursor(editor, [ 0 ], 2);
-    editor.undoManager.undo();
-    TinyAssertions.assertContent(editor, '<p>http://www.domain.com&nbsp;</p>');
-    TinyAssertions.assertCursor(editor, [ 0, 0 ], 'http://www.domain.com\u00a0'.length);
-
-    typeAnEclipsedURL(editor, 'http://www.domain.com', 'http://www.domain.com');
-    TinyAssertions.assertCursor(editor, [ 0 ], 3);
-    editor.undoManager.undo();
-    TinyAssertions.assertContent(editor, '<p>(http://www.domain.com)</p>');
-    TinyAssertions.assertCursor(editor, [ 0, 0 ], '(http://www.domain.com)'.length);
-
-    typeNewlineURL(editor, 'http://www.domain.com', 'http://www.domain.com');
-    TinyAssertions.assertCursor(editor, [ 1 ], 0);
-    editor.undoManager.undo();
-    TinyAssertions.assertContent(editor, '<p>http://www.domain.com</p><p>&nbsp;</p>');
-    TinyAssertions.assertCursor(editor, [ 1 ], 0);
-  });
 });


### PR DESCRIPTION
Related Ticket: TINY-8936

Description of Changes:

Reverts the undo level fixes so this works the same as it did in 5.x and we'll re-evaluate and provide a better fix for 6.2.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
