### PR TITLE
TINY-8940: Investigate and fix getAnchorElement changes

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The formatter can now apply a format to a `contenteditable="false"` element by wrapping it. Configurable using the `format_noneditable_selector` option. #TINY-8905
 
 ### Fixed
-- Fixed a regression where clicking in the editor would always show the link context toolbar when the option `link_context_toolbar` is set to true #TINY-8940
 - The Autolink plugin did not work when the text nodes in the content were fragmented #TINY-3723
 - Fixed various incorrect types on public APIs found while enabling TypeScript strict mode #TINY-8806
 - Text returned from `editor.getContent({format: 'text'})` would differ with blank lines between some browsers #TINY-8579

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The formatter can now apply a format to a `contenteditable="false"` element by wrapping it. Configurable using the `format_noneditable_selector` option. #TINY-8905
 
 ### Fixed
+- A regression where clicking in the editor would always show the link context toolbar when the option `link_context_toolbar` is set to true #TINY-8940
 - The Autolink plugin did not work when the text nodes in the content were fragmented #TINY-3723
 - Fixed various incorrect types on public APIs found while enabling TypeScript strict mode #TINY-8806
 - Text returned from `editor.getContent({format: 'text'})` would differ with blank lines between some browsers #TINY-8579

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The formatter can now apply a format to a `contenteditable="false"` element by wrapping it. Configurable using the `format_noneditable_selector` option. #TINY-8905
 
 ### Fixed
-- A regression where clicking in the editor would always show the link context toolbar when the option `link_context_toolbar` is set to true #TINY-8940
+- Fixed a regression where clicking in the editor would always show the link context toolbar when the option `link_context_toolbar` is set to true #TINY-8940
 - The Autolink plugin did not work when the text nodes in the content were fragmented #TINY-3723
 - Fixed various incorrect types on public APIs found while enabling TypeScript strict mode #TINY-8806
 - Text returned from `editor.getContent({format: 'text'})` would differ with blank lines between some browsers #TINY-8579

--- a/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
@@ -64,13 +64,13 @@ const toggleState = (editor: Editor, toggler: (e: NodeChangeEvent) => void): () 
 };
 
 const toggleActiveState = (editor: Editor) => (api: Toolbar.ToolbarToggleButtonInstanceApi | Menu.ToggleMenuItemInstanceApi): () => void => {
-  const updateState = () => api.setActive(!editor.mode.isReadOnly() && Utils.getAnchorElement(editor, editor.selection.getNode()).isSome());
+  const updateState = () => api.setActive(!editor.mode.isReadOnly() && Utils.isInAnchor(editor, editor.selection.getNode()));
   updateState();
   return toggleState(editor, updateState);
 };
 
 const toggleEnabledState = (editor: Editor) => (api: Toolbar.ToolbarButtonInstanceApi | Menu.MenuItemInstanceApi): () => void => {
-  const updateState = () => api.setEnabled(Utils.getAnchorElement(editor, editor.selection.getNode()).isSome());
+  const updateState = () => api.setEnabled(Utils.isInAnchor(editor, editor.selection.getNode()));
   updateState();
   return toggleState(editor, updateState);
 };

--- a/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
@@ -78,6 +78,9 @@ const getAnchorElement = (editor: Editor, selectedElm?: Element): Optional<HTMLA
   }
 };
 
+const isInAnchor = (editor: Editor, selectedElm?: Element): boolean =>
+  getAnchorElement(editor, selectedElm).isSome();
+
 const getAnchorText = (selection: EditorSelection, anchorElm: Optional<HTMLAnchorElement>): string => {
   const text = anchorElm.fold(
     () => selection.getContent({ format: 'text' }),
@@ -297,6 +300,7 @@ export {
   getHref,
   isOnlyTextSelected,
   getAnchorElement,
+  isInAnchor,
   getAnchorText,
   applyRelTargetRules,
   hasProtocol

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -95,7 +95,7 @@ const setupContextToolbars = (editor: Editor): void => {
       onSetup: Actions.toggleActiveState(editor)
     },
     label: 'Link',
-    predicate: (node) => Utils.isInAnchor(editor, node) && Options.hasContextToolbar(editor),
+    predicate: (node) => Options.hasContextToolbar(editor) && Utils.isInAnchor(editor, node),
     initValue: () => {
       const elm = Utils.getAnchorElement(editor);
       return elm.fold(Fun.constant(''), Utils.getHref);

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -68,7 +68,7 @@ const setupContextToolbars = (editor: Editor): void => {
 
   const onSetupLink = (buttonApi: InlineContent.ContextFormButtonInstanceApi) => {
     const node = editor.selection.getNode();
-    buttonApi.setEnabled(Utils.getAnchorElement(editor, node).isSome());
+    buttonApi.setEnabled(!!Utils.getAnchorElement(editor, node));
     return Fun.noop;
   };
 
@@ -95,7 +95,7 @@ const setupContextToolbars = (editor: Editor): void => {
       onSetup: Actions.toggleActiveState(editor)
     },
     label: 'Link',
-    predicate: (node) => !!Utils.getAnchorElement(editor, node) && Options.hasContextToolbar(editor),
+    predicate: (node) => Utils.getAnchorElement(editor, node).isSome() && Options.hasContextToolbar(editor),
     initValue: () => {
       const elm = Utils.getAnchorElement(editor);
       return elm.fold(Fun.constant(''), Utils.getHref);
@@ -109,7 +109,7 @@ const setupContextToolbars = (editor: Editor): void => {
         onSetup: (buttonApi) => {
           const node = editor.selection.getNode();
           // TODO: Make a test for this later.
-          buttonApi.setActive(!!Utils.getAnchorElement(editor, node));
+          buttonApi.setActive(Utils.getAnchorElement(editor, node).isSome());
           return Actions.toggleActiveState(editor)(buttonApi);
         },
         onAction: (formApi) => {

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -3,6 +3,7 @@ import { Fun, Optional } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { InlineContent } from 'tinymce/core/api/ui/Ui';
 
+import * as Options from '../api/Options';
 import * as Actions from '../core/Actions';
 import * as Utils from '../core/Utils';
 
@@ -94,7 +95,7 @@ const setupContextToolbars = (editor: Editor): void => {
       onSetup: Actions.toggleActiveState(editor)
     },
     label: 'Link',
-    predicate: (node) => Utils.isInAnchor(editor, node),
+    predicate: (node) => Utils.isInAnchor(editor, node) && Options.hasContextToolbar(editor),
     initValue: () => {
       const elm = Utils.getAnchorElement(editor);
       return elm.fold(Fun.constant(''), Utils.getHref);

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -3,7 +3,6 @@ import { Fun, Optional } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { InlineContent } from 'tinymce/core/api/ui/Ui';
 
-import * as Options from '../api/Options';
 import * as Actions from '../core/Actions';
 import * as Utils from '../core/Utils';
 
@@ -68,7 +67,7 @@ const setupContextToolbars = (editor: Editor): void => {
 
   const onSetupLink = (buttonApi: InlineContent.ContextFormButtonInstanceApi) => {
     const node = editor.selection.getNode();
-    buttonApi.setEnabled(Utils.getAnchorElement(editor, node).isSome());
+    buttonApi.setEnabled(Utils.isInAnchor(editor, node));
     return Fun.noop;
   };
 
@@ -95,7 +94,7 @@ const setupContextToolbars = (editor: Editor): void => {
       onSetup: Actions.toggleActiveState(editor)
     },
     label: 'Link',
-    predicate: (node) => Utils.getAnchorElement(editor, node).isSome() && Options.hasContextToolbar(editor),
+    predicate: (node) => Utils.isInAnchor(editor, node),
     initValue: () => {
       const elm = Utils.getAnchorElement(editor);
       return elm.fold(Fun.constant(''), Utils.getHref);
@@ -109,7 +108,7 @@ const setupContextToolbars = (editor: Editor): void => {
         onSetup: (buttonApi) => {
           const node = editor.selection.getNode();
           // TODO: Make a test for this later.
-          buttonApi.setActive(Utils.getAnchorElement(editor, node).isSome());
+          buttonApi.setActive(Utils.isInAnchor(editor, node));
           return Actions.toggleActiveState(editor)(buttonApi);
         },
         onAction: (formApi) => {

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -68,7 +68,7 @@ const setupContextToolbars = (editor: Editor): void => {
 
   const onSetupLink = (buttonApi: InlineContent.ContextFormButtonInstanceApi) => {
     const node = editor.selection.getNode();
-    buttonApi.setEnabled(!!Utils.getAnchorElement(editor, node));
+    buttonApi.setEnabled(Utils.getAnchorElement(editor, node).isSome());
     return Fun.noop;
   };
 

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
@@ -2,6 +2,7 @@ import { Mouse, UiFinder } from '@ephox/agar';
 import { describe, it, before, after } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
@@ -28,6 +29,9 @@ describe('browser.tinymce.plugins.link.ContextToolbarTest', () => {
     const editorBody = TinyDom.body(editor);
     editor.setContent('<a href="http://www.google.com">google</a>');
     Mouse.trueClickOn(editorBody, 'a');
+    // I believe this does not do much, since the toolbar will never be in
+    // in the editor body. The toolbar exists in the .tox-tinymce-aux portal
+    // which exists at the top level.
     UiFinder.notExists(editorBody, '.tox-toolbar button[aria-label="Link"]');
     editor.setContent('');
   });
@@ -41,6 +45,22 @@ describe('browser.tinymce.plugins.link.ContextToolbarTest', () => {
     await TinyUiActions.pWaitForUi(editor, '.tox-toolbar button[aria-label="Remove link"]');
     await TinyUiActions.pWaitForUi(editor, '.tox-toolbar button[aria-label="Open link"]');
     await UiFinder.pWaitForState<HTMLInputElement>('check link content', SugarBody.body(), '.tox-toolbar input', (ele) => ele.dom.value === 'http://www.google.com');
+  });
+
+  it('TINY-8940: toolbar doesn\'t show on non link elements', async () => {
+    const editor = hook.editor();
+    editor.options.set('link_context_toolbar', true);
+    editor.setContent('<p>google</p>');
+    Mouse.trueClickOn(TinyDom.body(editor), 'p');
+    // You might be wondering why I did not use UiFinder.notExists.
+    // And the reason being simply it doesn't work in this case.
+    // I am not sure why, but you can put a  link in the editor content
+    // and click on it. The tollbar will show as it should, while the call
+    // UiFinder.notExists(SugarBody.body(), '.tox-toolbar') will still pass
+    // when it should fail since the toolbar does exist
+    const isNotToolbarFound = UiFinder.findIn(SugarBody.body(), '.tox-toolbar').isError();
+    assert.isTrue(isNotToolbarFound, 'There is no toolbar when clicking on non link elements');
+    editor.setContent('');
   });
 
   it('TBA: shows relative link urls', async () => {

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
@@ -29,10 +29,7 @@ describe('browser.tinymce.plugins.link.ContextToolbarTest', () => {
     const editorBody = TinyDom.body(editor);
     editor.setContent('<a href="http://www.google.com">google</a>');
     Mouse.trueClickOn(editorBody, 'a');
-    // I believe this does not do much, since the toolbar will never be in
-    // in the editor body. The toolbar exists in the .tox-tinymce-aux portal
-    // which exists at the top level.
-    UiFinder.notExists(editorBody, '.tox-toolbar button[aria-label="Link"]');
+    UiFinder.notExists(SugarBody.body(), '.tox-toolbar button[aria-label="Link"]');
     editor.setContent('');
   });
 

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
@@ -47,7 +47,7 @@ describe('browser.tinymce.plugins.link.ContextToolbarTest', () => {
     await UiFinder.pWaitForState<HTMLInputElement>('check link content', SugarBody.body(), '.tox-toolbar input', (ele) => ele.dom.value === 'http://www.google.com');
   });
 
-  it('TINY-8940: toolbar doesn\'t show on non link elements', async () => {
+  it('TINY-8940: toolbar doesn\'t show on non link elements', () => {
     const editor = hook.editor();
     editor.options.set('link_context_toolbar', true);
     editor.setContent('<p>google</p>');

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
@@ -1,8 +1,7 @@
-import { Mouse, UiFinder } from '@ephox/agar';
+import { Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it, before, after } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
-import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
@@ -44,19 +43,13 @@ describe('browser.tinymce.plugins.link.ContextToolbarTest', () => {
     await UiFinder.pWaitForState<HTMLInputElement>('check link content', SugarBody.body(), '.tox-toolbar input', (ele) => ele.dom.value === 'http://www.google.com');
   });
 
-  it('TINY-8940: toolbar doesn\'t show on non link elements', () => {
+  it('TINY-8940: toolbar doesn\'t show on non link elements', async () => {
     const editor = hook.editor();
     editor.options.set('link_context_toolbar', true);
     editor.setContent('<p>google</p>');
     Mouse.trueClickOn(TinyDom.body(editor), 'p');
-    // You might be wondering why I did not use UiFinder.notExists.
-    // And the reason being simply it doesn't work in this case.
-    // I am not sure why, but you can put a  link in the editor content
-    // and click on it. The tollbar will show as it should, while the call
-    // UiFinder.notExists(SugarBody.body(), '.tox-toolbar') will still pass
-    // when it should fail since the toolbar does exist
-    const isNotToolbarFound = UiFinder.findIn(SugarBody.body(), '.tox-toolbar').isError();
-    assert.isTrue(isNotToolbarFound, 'There is no toolbar when clicking on non link elements');
+    await Waiter.pWait(100);
+    UiFinder.notExists(SugarBody.body(), '.tox-pop__dialog .tox-toolbar');
     editor.setContent('');
   });
 

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ContextToolbarTest.ts
@@ -48,7 +48,7 @@ describe('browser.tinymce.plugins.link.ContextToolbarTest', () => {
     editor.options.set('link_context_toolbar', true);
     editor.setContent('<p>google</p>');
     Mouse.trueClickOn(TinyDom.body(editor), 'p');
-    await Waiter.pWait(100);
+    await Waiter.pWait(50);
     UiFinder.notExists(SugarBody.body(), '.tox-pop__dialog .tox-toolbar');
     editor.setContent('');
   });


### PR DESCRIPTION
Related Ticket: TINY-8940

Description of Changes:
* Fix a regression introduced in TINY-8832 where clicking in the editor would always show the link context toolbar when the option `link_context_toolbar` is set to true


Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
