### PR TITLE
TINY-8750: Backport fix to a failing test in CssTest on Chrome 102

### DIFF
--- a/modules/sugar/src/test/ts/browser/CssTest.ts
+++ b/modules/sugar/src/test/ts/browser/CssTest.ts
@@ -39,9 +39,9 @@ UnitTest.test('CssTest', () => {
     Css.copy(c, c2);
     Css.copy(m, c2);
 
-    // NOTE: Safari and Firefox 71+ seems to support styles for math ml tags, so the Css.copy(m, c2) clobbers the previous style
+    // NOTE: Safari, Firefox 71+ and Chromium 102+ seem to support styles for math ml tags, so the Css.copy(m, c2) clobbers the previous style
     const browser = PlatformDetection.detect().browser;
-    if (browser.isSafari() || browser.isFirefox() && browser.version.major >= 71) {
+    if (browser.isSafari() || browser.isFirefox() && browser.version.major >= 71 || browser.isChromium() && browser.version.major >= 102) {
       Css.copy(c, c2);
     }
 

--- a/modules/sugar/src/test/ts/browser/CssTest.ts
+++ b/modules/sugar/src/test/ts/browser/CssTest.ts
@@ -41,7 +41,7 @@ UnitTest.test('CssTest', () => {
 
     // NOTE: Safari, Firefox 71+ and Chromium 102+ seem to support styles for math ml tags, so the Css.copy(m, c2) clobbers the previous style
     const browser = PlatformDetection.detect().browser;
-    if (browser.isSafari() || browser.isFirefox() && browser.version.major >= 71 || browser.isChromium() && browser.version.major >= 102) {
+    if (browser.isSafari() || browser.isFirefox() && browser.version.major >= 71 || browser.isChrome() && browser.version.major >= 102) {
       Css.copy(c, c2);
     }
 


### PR DESCRIPTION
Related Ticket: TINY-8750

Description of Changes:
* Backports https://github.com/tinymce/tinymce/pull/7857 due to a failing test in CssTest on Chrome 102

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
