### PR TITLE
TINY-8591: Add EditorManager page to documentation

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -22,19 +22,6 @@ interface PreInit {
 
 declare const window: Window & { tinymce?: PreInit; tinyMCEPreInit?: PreInit };
 
-// NOTE: the class tag is commented out for the include in `modules/tinymce/tools/docs/tinymce.js`
-/**
- * This class used as a factory for manager for tinymce.Editor instances.
- *
- * @example
- * tinymce.EditorManager.init({});
- *
- * /@class tinymce.EditorManager
- * @mixes tinymce.util.Observable
- * @static
- * @private
- */
-
 const DOM = DOMUtils.DOM;
 const each = Tools.each;
 let boundGlobalEvents = false;

--- a/modules/tinymce/tools/docs/tinymce.EditorManager.js
+++ b/modules/tinymce/tools/docs/tinymce.EditorManager.js
@@ -1,10 +1,10 @@
 /**
  * This is the base class for the link:../tinymce.root/[`tinymce`] global.
-*
-* This class is a factory for link:../tinymce.editor/[`tinymce.Editor`] instances.
-*
-* And the link:../tinymce.root/[`tinymce`] global is the only
-* EditorManager instance the class is expected to create.
+ *
+ * This class is a factory for link:../tinymce.editor/[`tinymce.Editor`] instances.
+ *
+ * And the link:../tinymce.root/[`tinymce`] global is the only
+ * EditorManager instance the class is expected to create.
  *
  * @example
  * tinymce.EditorManager.init({});

--- a/modules/tinymce/tools/docs/tinymce.EditorManager.js
+++ b/modules/tinymce/tools/docs/tinymce.EditorManager.js
@@ -1,0 +1,11 @@
+/**
+ * This is the base class for the <a href="tinymce.root.html>TinyMCE</a> global, a factory for tinymce.Editor instances.
+ *
+ * It is not generally used directly - the global <a href="tinymce.root.html>TinyMCE</a> is the only one expected to be created.
+ *
+ * @example
+ * tinymce.EditorManager.init({});
+ *
+ * @class tinymce.EditorManager
+ * @static
+ */

--- a/modules/tinymce/tools/docs/tinymce.EditorManager.js
+++ b/modules/tinymce/tools/docs/tinymce.EditorManager.js
@@ -1,7 +1,7 @@
 /**
- * This is the base class for the <a href="tinymce.root.html>TinyMCE</a> global, a factory for tinymce.Editor instances.
+ * This is the base class for the link:../tinymce.root/[`tinymce`] global, a factory for link:../tinymce.editor/[`tinymce.Editor`] instances.
  *
- * It is not generally used directly - the global <a href="tinymce.root.html>TinyMCE</a> is the only one expected to be created.
+ * It is not generally used directly - the global link:../tinymce.root/[`tinymce`] is the only one expected to be created.
  *
  * @example
  * tinymce.EditorManager.init({});

--- a/modules/tinymce/tools/docs/tinymce.EditorManager.js
+++ b/modules/tinymce/tools/docs/tinymce.EditorManager.js
@@ -1,7 +1,7 @@
 /**
  * This is the base class for the link:../tinymce.root/[`tinymce`] global, a factory for link:../tinymce.editor/[`tinymce.Editor`] instances.
  *
- * It is not generally used directly - the global link:../tinymce.root/[`tinymce`] is the only one expected to be created.
+ * The global link:../tinymce.root/[`tinymce`] is the only one expected to be created.
  *
  * @example
  * tinymce.EditorManager.init({});

--- a/modules/tinymce/tools/docs/tinymce.EditorManager.js
+++ b/modules/tinymce/tools/docs/tinymce.EditorManager.js
@@ -1,7 +1,10 @@
 /**
- * This is the base class for the link:../tinymce.root/[`tinymce`] global, a factory for link:../tinymce.editor/[`tinymce.Editor`] instances.
- *
- * The global link:../tinymce.root/[`tinymce`] is the only one expected to be created.
+ * This is the base class for the link:../tinymce.root/[`tinymce`] global.
+*
+* This class is a factory for link:../tinymce.editor/[`tinymce.Editor`] instances.
+*
+* And the link:../tinymce.root/[`tinymce`] global is the only
+* EditorManager instance the class is expected to create.
  *
  * @example
  * tinymce.EditorManager.init({});

--- a/modules/tinymce/tools/docs/tinymce.js
+++ b/modules/tinymce/tools/docs/tinymce.js
@@ -19,6 +19,12 @@
  * @include ../../src/core/main/ts/api/EditorManager.ts
  */
 
+
+/**
+ * Include EditorManager API reference.
+ *
+ * @include tinymce.EditorManager.js
+ */
 /**
  * Root level namespace this contains classes directly related to the TinyMCE editor.
  *


### PR DESCRIPTION
Related Ticket: TINY-8591

Description of Changes:
* Uncommented the `@class` reference to generate a page for `EditorManager`
* Did this with a new page, instead of in `EditorManager.ts`, otherwise all of the references it adds are deleted from the `tinymce` root page.

Take a look at the branch on staging and see what we think:
http://docs-feature-62-tiny-8591.staging.tiny.cloud/docs/tinymce/6/apis/tinymce.editormanager/

The generated code isn’t great, this text is also used for the description so it ends up with `&#x60;` literals in the description. I've made a branch with the files checked in:
https://github.com/tinymce/tinymce-docs/compare/feature/6.2/TINY-8591

But I couldn’t figure out another way to do it with the way our moxiedoc/asciidoc code generation works.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
