### PR TITLE
TINY-8888: Check parser filter matching in between calling each filter

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -27,10 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dragging a `contentEditable=false` element towards the edges would not cause scrolling #TINY-8874
 - The content of the `contenteditable="false"` element could be selected with the mouse on Firefox  #TINY-8828
 - Parsing large documents no longer throws a `Maximum call stack size exceeded` exception #TINY-6945
+- Node filters that removed attributes used by attribute filters could cause an exception in content parsing #TINY-8888
 
 ### Deprecated
 - The autocompleter `ch` configuration property has been deprecated and will be removed in the next major release. Use the `trigger` property instead. #TINY-8887
-
 
 ## 6.1.2 - 2022-07-29
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dragging a `contentEditable=false` element towards the edges would not cause scrolling #TINY-8874
 - The content of the `contenteditable="false"` element could be selected with the mouse on Firefox  #TINY-8828
 - Parsing large documents no longer throws a `Maximum call stack size exceeded` exception #TINY-6945
-- Node filters that removed attributes used by attribute filters could cause an exception in content parsing #TINY-8888
+- DomParser filter matching was not checked between filters, which could lead to an exception in the parser #TINY-8888
 
 ### Deprecated
 - The autocompleter `ch` configuration property has been deprecated and will be removed in the next major release. Use the `trigger` property instead. #TINY-8887

--- a/modules/tinymce/src/core/main/ts/html/FilterNode.ts
+++ b/modules/tinymce/src/core/main/ts/html/FilterNode.ts
@@ -82,7 +82,7 @@ const runFilters = (matches: FilterMatches, args: ParserArgs): void => {
 
           // Remove already removed children, and nodes that no longer match the filter
           if (Type.isNullable(node.parent) || filteringAttributes ? node.attr(match.filter.name) === undefined : node.name !== match.filter.name) {
-            nodes.splice(i);
+            nodes.splice(i, 1);
           }
         }
 

--- a/modules/tinymce/src/core/main/ts/html/FilterNode.ts
+++ b/modules/tinymce/src/core/main/ts/html/FilterNode.ts
@@ -81,7 +81,8 @@ const runFilters = (matches: FilterMatches, args: ParserArgs): void => {
           const node = nodes[i];
 
           // Remove already removed children, and nodes that no longer match the filter
-          if (Type.isNullable(node.parent) || filteringAttributes ? node.attr(match.filter.name) === undefined : node.name !== match.filter.name) {
+          const valueMatches = filteringAttributes ? node.attr(match.filter.name) !== undefined : node.name === match.filter.name;
+          if (!valueMatches || Type.isNullable(node.parent)) {
             nodes.splice(i, 1);
           }
         }

--- a/modules/tinymce/src/core/main/ts/html/FilterNode.ts
+++ b/modules/tinymce/src/core/main/ts/html/FilterNode.ts
@@ -77,13 +77,12 @@ const runFilters = (matches: FilterMatches, args: ParserArgs): void => {
 
       Arr.each(match.filter.callbacks, (callback) => {
         // very very carefully mutate the nodes array based on whether the filter still matches them
-        for (let i = 0; i < nodes.length; i++) {
+        for (let i = nodes.length - 1; i >= 0; i--) {
           const node = nodes[i];
 
           // Remove already removed children, and nodes that no longer match the filter
           if (Type.isNullable(node.parent) || filteringAttributes ? node.attr(match.filter.name) === undefined : node.name !== match.filter.name) {
             nodes.splice(i);
-            i--;
           }
         }
 

--- a/modules/tinymce/src/core/main/ts/html/FilterNode.ts
+++ b/modules/tinymce/src/core/main/ts/html/FilterNode.ts
@@ -70,19 +70,21 @@ const findMatchingNodes = (nodeFilters: ParserFilter[], attributeFilters: Parser
 
 // Run all necessary node filters and attribute filters, based on a match set
 const runFilters = (matches: FilterMatches, args: ParserArgs): void => {
-  const run = (matchRecord: Record<string, FilterMatch>) => {
+  const run = (matchRecord: Record<string, FilterMatch>, filteringAttributes: boolean) => {
     Obj.each(matchRecord, (match) => {
-      // Remove already removed children
-      const nodes = Arr.filter(match.nodes, (node) => Type.isNonNullable(node.parent));
+      // Remove already removed children, and nodes that no longer contain the attribute to be matched
+      const nodes = Arr.filter(match.nodes, (node) => Type.isNonNullable(node.parent) && (!filteringAttributes || node.attr(match.filter.name) !== undefined));
 
-      Arr.each(match.filter.callbacks, (callback) => {
-        callback(nodes, match.filter.name, args);
-      });
+      if (nodes.length > 0) {
+        Arr.each(match.filter.callbacks, (callback) => {
+          callback(nodes, match.filter.name, args);
+        });
+      }
     });
   };
 
-  run(matches.nodes);
-  run(matches.attributes);
+  run(matches.nodes, false);
+  run(matches.attributes, true);
 };
 
 const filter = (nodeFilters: ParserFilter[], attributeFilters: ParserFilter[], node: AstNode, args: ParserArgs = {}): void => {

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -431,10 +431,12 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       nodes[0].attr('src', null);
     });
     let ranIdFilter = false;
-    parser.addAttributeFilter('src', () => {
+    parser.addAttributeFilter('src', (nodes) => {
       ranIdFilter = true;
+      assert.lengthOf(nodes, 1);
+      assert.equal(node[0].attr('src'), '2.gif');
     });
-    parser.parse('<b>a<img src="1.gif" />b<img src="1.gif" />c</b>');
+    parser.parse('<b>a<img src="1.gif" />b<img src="2.gif" />c</b>');
     assert.isTrue(ranIdFilter, 'second filter should run, because only one src attribute was removed');
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1,4 +1,4 @@
-import { context, describe, it } from '@ephox/bedrock-client';
+import { Assert, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { assert } from 'chai';
@@ -390,6 +390,17 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     assert.equal(results.href.nodes[0].attr('href'), '1.gif', 'Parser filter result node(0) attr');
     assert.equal(results.href.nodes[1].name, 'a', 'Parser filter result node(1) name');
     assert.equal(results.href.nodes[1].attr('href'), '2.gif', 'Parser filter result node(1) attr');
+  });
+
+  it('TINY-8888: mutating addNodeFilter', () => {
+    const parser = DomParser({});
+    parser.addNodeFilter('img', (nodes) => {
+      Arr.each(nodes, (node) => node.attr('src', null));
+    });
+    parser.addAttributeFilter('src', () => {
+      Assert.fail('second src filter should not run, because src was removed');
+    });
+    parser.parse('<b>a<img src="1.gif" />b<img src="1.gif" />c</b>');
   });
 
   it('TINY-7847: removeAttributeFilter', () => {

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -425,6 +425,19 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     parser.parse('<b>a<img src="1.gif" />b</b>');
   });
 
+  it('TINY-8888: mutating addAttributeFilter only removes matching nodes', () => {
+    const parser = DomParser({});
+    parser.addAttributeFilter('src', (nodes) => {
+      nodes[0].attr('src', null);
+    });
+    let ranIdFilter = false;
+    parser.addAttributeFilter('src', () => {
+      ranIdFilter = true;
+    });
+    parser.parse('<b>a<img src="1.gif" />b<img src="1.gif" />c</b>');
+    assert.isTrue(ranIdFilter, 'second filter should run, because only one src attribute was removed');
+  });
+
   it('TINY-7847: removeAttributeFilter', () => {
     const parser = DomParser({});
     const numFilters = parser.getAttributeFilters().length;

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1,4 +1,4 @@
-import { Assert, context, describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { assert } from 'chai';
@@ -398,7 +398,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       Arr.each(nodes, (node) => node.attr('src', null));
     });
     parser.addAttributeFilter('src', () => {
-      Assert.fail('second src filter should not run, because src was removed');
+      assert.fail('second src filter should not run, because src was removed');
     });
     parser.parse('<b>a<img src="1.gif" />b</b>');
   });
@@ -409,7 +409,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       Arr.each(nodes, (node) => node.remove());
     });
     parser.addNodeFilter('img', () => {
-      Assert.fail('second img filter should not run, because img was removed');
+      assert.fail('second img filter should not run, because img was removed');
     });
     parser.parse('<b>a<img src="1.gif" />b</b>');
   });
@@ -420,7 +420,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       Arr.each(nodes, (node) => node.attr('src', null));
     });
     parser.addAttributeFilter('src', () => {
-      Assert.fail('second src filter should not run, because src was removed');
+      assert.fail('second src filter should not run, because src was removed');
     });
     parser.parse('<b>a<img src="1.gif" />b</b>');
   });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -392,7 +392,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     assert.equal(results.href.nodes[1].attr('href'), '2.gif', 'Parser filter result node(1) attr');
   });
 
-  it('TINY-8888: mutating addNodeFilter', () => {
+  it('TINY-8888: mutating addNodeFilter -> addAttributeFilter', () => {
     const parser = DomParser({});
     parser.addNodeFilter('img', (nodes) => {
       Arr.each(nodes, (node) => node.attr('src', null));
@@ -400,7 +400,29 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     parser.addAttributeFilter('src', () => {
       Assert.fail('second src filter should not run, because src was removed');
     });
-    parser.parse('<b>a<img src="1.gif" />b<img src="1.gif" />c</b>');
+    parser.parse('<b>a<img src="1.gif" />b</b>');
+  });
+
+  it('TINY-8888: mutating addNodeFilter -> addNodeFilter', () => {
+    const parser = DomParser({});
+    parser.addNodeFilter('img', (nodes) => {
+      Arr.each(nodes, (node) => node.remove());
+    });
+    parser.addNodeFilter('img', () => {
+      Assert.fail('second img filter should not run, because img was removed');
+    });
+    parser.parse('<b>a<img src="1.gif" />b</b>');
+  });
+
+  it('TINY-8888: mutating addAttributeFilter -> addAttributeFilter', () => {
+    const parser = DomParser({});
+    parser.addAttributeFilter('src', (nodes) => {
+      Arr.each(nodes, (node) => node.attr('src', null));
+    });
+    parser.addAttributeFilter('src', () => {
+      Assert.fail('second src filter should not run, because src was removed');
+    });
+    parser.parse('<b>a<img src="1.gif" />b</b>');
   });
 
   it('TINY-7847: removeAttributeFilter', () => {

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -434,7 +434,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     parser.addAttributeFilter('src', (nodes) => {
       ranIdFilter = true;
       assert.lengthOf(nodes, 1);
-      assert.equal(node[0].attr('src'), '2.gif');
+      assert.equal(nodes[0].attr('src'), '2.gif');
     });
     parser.parse('<b>a<img src="1.gif" />b<img src="2.gif" />c</b>');
     assert.isTrue(ranIdFilter, 'second filter should run, because only one src attribute was removed');


### PR DESCRIPTION
Related Ticket: TINY-8888

Description of Changes:
* The logic that calls filters did not expect that filters could remove things that a later filter was matched on.
* The logged issue happened when a node filter removed the `src` attribute from an `iframe`, our internal `src` attribute filter [received an unexpected `undefined` and triggered an exception](https://github.com/tinymce/tinymce/blob/ece3bf774b9ae20910d073af5351f162c4fb52d5/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts#L40).
* The fix is to check the filter still matches the node array before _every_ filter callback is executed.
* To keep the performance impact to a minimum, this uses careful mutation of the node array rather than copying the contents. Our expectation is that the case where a filter no longer matches is rare, so the majority case should not need to pay the copying penalty of a `filter` that allows all nodes.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable): Fixes #7959
