### PR TITLE
TINY-8811: Fixed strict type errors in katamari

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/menu/build/ItemType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/menu/build/ItemType.ts
@@ -14,7 +14,7 @@ import * as SystemEvents from '../../api/events/SystemEvents';
 import { TogglingConfigSpec } from '../../behaviour/toggling/TogglingTypes';
 import * as Fields from '../../data/Fields';
 import * as ButtonBase from '../../ui/common/ButtonBase';
-import { NormalItemDetail } from '../../ui/types/ItemTypes';
+import { ItemTogglingConfigSpec, NormalItemDetail } from '../../ui/types/ItemTypes';
 import * as ItemEvents from '../util/ItemEvents';
 
 type ItemRole = 'menuitem' | 'menuitemcheckbox' | 'menuitemradio';
@@ -24,12 +24,12 @@ const getItemRole = (detail: NormalItemDetail): ItemRole =>
     .map((toggling) => toggling.exclusive ? 'menuitemradio' : 'menuitemcheckbox')
     .getOr('menuitem');
 
-const getTogglingSpec = (tConfig: Partial<TogglingConfigSpec> & { exclusive?: boolean }): TogglingConfigSpec => ({
+const getTogglingSpec = (tConfig: Partial<ItemTogglingConfigSpec>): TogglingConfigSpec => ({
   aria: {
     mode: 'checked'
   },
   // Filter out the additional properties that are not in Toggling Behaviour's configuration (e.g. exclusive)
-  ...Obj.filter(tConfig as { [K in keyof TogglingConfigSpec]: TogglingConfigSpec[K] }, (_value, name) => name !== 'exclusive'),
+  ...Obj.filter(tConfig, (_value, name) => name !== 'exclusive'),
   onToggled: (component, state) => {
     if (Type.isFunction(tConfig.onToggled)) {
       tConfig.onToggled(component, state);

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/ItemTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/ItemTypes.ts
@@ -14,6 +14,10 @@ export interface ItemDataTuple {
   };
 }
 
+export interface ItemTogglingConfigSpec extends TogglingConfigSpec {
+  readonly exclusive?: boolean;
+}
+
 export type ItemSpec = WidgetItemSpec | SeparatorItemSpec | NormalItemSpec;
 
 export interface WidgetItemSpec {
@@ -56,7 +60,7 @@ export interface NormalItemSpec {
   data: ItemDataTuple;
   components?: AlloySpec[];
   dom: RawDomSchema;
-  toggling?: Partial<TogglingConfigSpec> & { exclusive?: boolean };
+  toggling?: Partial<ItemTogglingConfigSpec>;
   itemBehaviours?: AlloyBehaviourRecord;
   ignoreFocus?: boolean;
   domModification?: DomModificationSpec;
@@ -68,7 +72,7 @@ export interface NormalItemDetail extends ItemDetail {
   data: ItemDataTuple;
   components: AlloySpec[];
   dom: RawDomSchema;
-  toggling: Optional<Partial<TogglingConfigSpec> & { exclusive?: boolean }>;
+  toggling: Optional<Partial<ItemTogglingConfigSpec>>;
   itemBehaviours: SketchBehaviours;
   ignoreFocus?: boolean;
   domModification: DomModification;

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/form/TestForm.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/form/TestForm.ts
@@ -1,5 +1,5 @@
 import { Assertions, Step } from '@ephox/agar';
-import { Obj } from '@ephox/katamari';
+import { Obj, Optional } from '@ephox/katamari';
 
 import { Representing } from 'ephox/alloy/api/behaviour/Representing';
 import { AlloyComponent } from 'ephox/alloy/api/component/ComponentApi';
@@ -11,7 +11,7 @@ interface TestForm {
 
 const helper = (component: AlloyComponent): TestForm => {
   const sAssertRep = <T>(expected: Record<string, string>) => Step.sync<T>(() => {
-    const val = Representing.getValue(component);
+    const val: Record<string, Optional<string>> = Representing.getValue(component);
     Assertions.assertEq(
       'Checking form value',
       expected,

--- a/modules/boulder/src/main/ts/ephox/boulder/core/ObjChanger.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/core/ObjChanger.ts
@@ -26,7 +26,7 @@ const exclude = <T extends Record<string, any>, F extends Array<keyof T>>(obj: T
   const r = { } as Omit<T, F[number]>;
   Obj.each(obj, (v, k) => {
     if (!Arr.contains(fields, k)) {
-      r[k] = v;
+      r[k as string] = v;
     }
   });
   return r;

--- a/modules/katamari-assertions/tsconfig.json
+++ b/modules/katamari-assertions/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
-    "strict": false,
-    "noImplicitThis": true,
-    "strictBindCallApply": true,
-    "strictNullChecks": true,
     "outDir": "lib",
     "rootDir": "src",
     "baseUrl": ".",

--- a/modules/katamari/CHANGELOG.md
+++ b/modules/katamari/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Improved
 - The `Strings.contains` API now accepts optional `start` and `end` parameters to set the range for searching within the string.
+- The `Obj` APIs now use `keyof T` instead of `string` for the object key type.
 
 ## 9.0.0 - 2022-03-03
 

--- a/modules/katamari/CHANGELOG.md
+++ b/modules/katamari/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Improved
 - The `Strings.contains` API now accepts optional `start` and `end` parameters to set the range for searching within the string.
 - The `Obj` APIs now use `keyof T` instead of `string` for the object key type.
+- The `Obj.filter` API better handles type guard predicates so the return type matches the type guard.
 
 ## 9.0.0 - 2022-03-03
 

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Adt.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Adt.ts
@@ -3,9 +3,9 @@ import * as Obj from './Obj';
 import * as Type from './Type';
 
 export interface Adt {
-  fold: <T> (...caseHandlers: ((...data: any[]) => T)[]) => T;
-  match: <T> (branches: { [branch: string]: (...data: any[]) => T }) => T;
-  log: (label: string) => void;
+  readonly fold: <T> (...caseHandlers: ((...data: any[]) => T)[]) => T;
+  readonly match: <T> (branches: { [branch: string]: (...data: any[]) => T }) => T;
+  readonly log: (label: string) => void;
 }
 
 /*

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
@@ -238,11 +238,14 @@ export const reverse = <T>(xs: ArrayLike<T>): T[] => {
 
 export const difference = <T>(a1: ArrayLike<T>, a2: ArrayLike<T>): T[] => filter(a1, (x) => !contains(a2, x));
 
-export const mapToObject = <T extends keyof any, U>(xs: ArrayLike<T>, f: (x: T, i: number) => U): Record<T, U> => {
-  const r = {} as Record<T, U>;
+export const mapToObject: {
+  <T extends string, U>(xs: ArrayLike<T>, f: (x: T, i: number) => U): Record<T, U>;
+  <T, R extends Record<string, any>>(xs: ArrayLike<T>, f: (x: T, i: number) => R[keyof R]): R;
+} = <T, R extends Record<string, any>>(xs: ArrayLike<T>, f: (x: T, i: number) => R[keyof R]): R => {
+  const r = {} as R;
   for (let i = 0, len = xs.length; i < len; i++) {
     const x = xs[i];
-    r[String(x)] = f(x, i);
+    r[String(x) as keyof R] = f(x, i);
   }
   return r;
 };

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Cell.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Cell.ts
@@ -1,6 +1,6 @@
 export interface Cell<T> {
-  get: () => T;
-  set: (value: T) => void;
+  readonly get: () => T;
+  readonly set: (value: T) => void;
 }
 
 export const Cell = <T>(initial: T): Cell<T> => {

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Future.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Future.ts
@@ -1,13 +1,13 @@
 import { LazyValue } from './LazyValue';
 
 export interface Future<T> {
-  map: <U> (mapper: (v: T) => U) => Future<U>;
-  bind: <U> (binder: (v: T) => Future<U>) => Future<U>;
-  anonBind: <U> (thunk: Future<U>) => Future<U>;
-  toLazy: () => LazyValue<T>;
-  toCached: () => Future<T>;
-  toPromise: () => Promise<T>;
-  get: (callback: (v: T) => void) => void;
+  readonly map: <U> (mapper: (v: T) => U) => Future<U>;
+  readonly bind: <U> (binder: (v: T) => Future<U>) => Future<U>;
+  readonly anonBind: <U> (thunk: Future<U>) => Future<U>;
+  readonly toLazy: () => LazyValue<T>;
+  readonly toCached: () => Future<T>;
+  readonly toPromise: () => Promise<T>;
+  readonly get: (callback: (v: T) => void) => void;
 }
 
 const errorReporter = (err: any) => {

--- a/modules/katamari/src/main/ts/ephox/katamari/api/FutureResult.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/FutureResult.ts
@@ -2,13 +2,13 @@ import { Future } from './Future';
 import { Result } from './Result';
 
 export interface FutureResult<A, E> extends Future<Result<A, E>> {
-  toCached: () => FutureResult<A, E>;
-  bindFuture: <B>(f: (value: A) => Future<Result<B, E>>) => FutureResult<B, E>;
-  bindResult: <B>(f: (value: A) => Result<B, E>) => FutureResult<B, E>;
-  mapResult: <B>(f: (value: A) => B) => FutureResult<B, E>;
-  mapError: <B>(f: (error: E) => B) => FutureResult<A, B>;
-  foldResult: <X>(whenError: (error: E) => X, whenValue: (value: A) => X) => Future<X>;
-  withTimeout: (timeout: number, errorThunk: () => E) => FutureResult<A, E>;
+  readonly toCached: () => FutureResult<A, E>;
+  readonly bindFuture: <B>(f: (value: A) => Future<Result<B, E>>) => FutureResult<B, E>;
+  readonly bindResult: <B>(f: (value: A) => Result<B, E>) => FutureResult<B, E>;
+  readonly mapResult: <B>(f: (value: A) => B) => FutureResult<B, E>;
+  readonly mapError: <B>(f: (error: E) => B) => FutureResult<A, B>;
+  readonly foldResult: <X>(whenError: (error: E) => X, whenValue: (value: A) => X) => Future<X>;
+  readonly withTimeout: (timeout: number, errorThunk: () => E) => FutureResult<A, E>;
 }
 
 const wrap = <A = any, E = any> (delegate: Future<Result<A, E>>): FutureResult<A, E> => {

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Maybes.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Maybes.ts
@@ -314,7 +314,7 @@ export const is = <T>(other: T, comparator: (a: T, b: T) => boolean = Fun.triple
 export const equals: {
   <T, U>(lhs: Maybe<T>, rhs: Maybe<U>, comparator: (lhs: T, rhs: U) => boolean): boolean;
   <T>(lhs: Maybe<T>, rhs: Maybe<T>, comparator?: (lhs: T, rhs: T) => boolean): boolean;
-} = (lhs, rhs, comparator = Fun.tripleEquals) => {
+} = <T>(lhs: Maybe<T>, rhs: Maybe<T>, comparator: (lhs: T, rhs: T) => boolean = Fun.tripleEquals) => {
   if (isJust(lhs) && isJust(rhs)) {
     return comparator(lhs.value, rhs.value);
   } else {

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
@@ -54,7 +54,7 @@ const internalFilter = <T extends {}>(obj: T, pred: ObjPredicate<T>, onTrue: Obj
 };
 
 export const bifilter = <T extends {}>(obj: T, pred: ObjPredicate<T>): { t: Record<string, T[keyof T]>; f: Record<string, T[keyof T]> } => {
-  const t: Record<string, T[keyof T]> = {} ;
+  const t: Record<string, T[keyof T]> = {};
   const f: Record<string, T[keyof T]> = {};
   internalFilter(obj, pred, objAcc(t), objAcc(f));
   return { t, f };

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
@@ -6,6 +6,7 @@ import { Optional } from './Optional';
 type ObjKeys<T extends {}> = Extract<keyof T, string>;
 type ObjCallback<T extends {}> = (value: T[keyof T], key: ObjKeys<T>) => void;
 type ObjMorphism<T extends {}, R> = (value: T[keyof T], key: ObjKeys<T>) => R;
+type ObjGuardPredicate<T extends {}, U extends T[keyof T]> = (value: T[keyof T], key: ObjKeys<T>) => value is U;
 type ObjPredicate<T extends {}> = (value: T[keyof T], key: ObjKeys<T>) => boolean;
 
 // There are many variations of Object iteration that are faster than the 'for-in' style:
@@ -59,7 +60,10 @@ export const bifilter = <T extends {}>(obj: T, pred: ObjPredicate<T>): { t: Reco
   return { t, f };
 };
 
-export const filter = <T extends {}>(obj: T, pred: ObjPredicate<T>): Record<string, T[keyof T]> => {
+export const filter: {
+  <T extends {}, U extends T[keyof T]>(obj: T, pred: ObjGuardPredicate<T, U>): Record<string, U>;
+  <T extends {}>(obj: T, pred: ObjPredicate<T>): Record<string, T[keyof T]>;
+} = <T extends {}>(obj: T, pred: ObjPredicate<T>): Record<string, T[keyof T]> => {
   const t: Record<string, T[keyof T]> = {};
   internalFilter(obj, pred, objAcc(t), Fun.noop);
   return t;

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Optionals.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Optionals.ts
@@ -13,8 +13,8 @@ export const is = <T>(lhs: Optional<T>, rhs: T, comparator: (a: T, b: T) => bool
  * `Some` (and the values are equal under the comparator) or they're both `None`.
  */
 export const equals: {
-  <A, B>(lhs: Optional<A>, rhs: Optional<B>, comparator: (a: A, b: B) => boolean);
-  <T>(lhs: Optional<T>, rhs: Optional<T>);
+  <A, B>(lhs: Optional<A>, rhs: Optional<B>, comparator: (a: A, b: B) => boolean): boolean;
+  <T>(lhs: Optional<T>, rhs: Optional<T>): boolean;
 } = <A, B>(lhs: Optional<A>, rhs: Optional<B>, comparator: (a: A, b: B) => boolean = Fun.tripleEquals as any): boolean =>
   lift2(lhs, rhs, comparator).getOr(lhs.isNone() && rhs.isNone());
 

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Resolve.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Resolve.ts
@@ -16,9 +16,9 @@ export const resolve = <T>(p: string, scope?: {}): T | undefined => {
 };
 
 /** step :: (JsObj, String) -> JsObj */
-export const step = <T extends Record<string, any>>(o: {}, part: string): T => {
+export const step = <T extends {}, K extends keyof T>(o: T, part: K): T[K] => {
   if (o[part] === undefined || o[part] === null) {
-    o[part] = {};
+    o[part] = {} as T[K];
   }
   return o[part];
 };

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Strings.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Strings.ts
@@ -9,8 +9,8 @@ const checkRange = (str: string, substr: string, start: number): boolean =>
  * Any template fields of the form ${name} are replaced by the string or number specified as obj["name"]
  * Based on Douglas Crockford's 'supplant' method for template-replace of strings. Uses different template format.
  */
-export const supplant = (str: string, obj: {[key: string]: string | number}): string => {
-  const isStringOrNumber = (a) => {
+export const supplant = (str: string, obj: Record<string, string | number>): string => {
+  const isStringOrNumber = (a: unknown): a is string | number => {
     const t = typeof a;
     return t === 'string' || t === 'number';
   };

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Unique.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Unique.ts
@@ -2,7 +2,7 @@ import * as Arr from './Arr';
 import * as Obj from './Obj';
 
 export const stringArray = (a: string[]): string[] => {
-  const all = {};
+  const all: Record<string, {}> = {};
   Arr.each(a, (key) => {
     all[key] = {};
   });

--- a/modules/katamari/src/test/ts/atomic/api/arr/ArrBindTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ArrBindTest.ts
@@ -7,9 +7,9 @@ import * as Fun from 'ephox/katamari/api/Fun';
 
 describe('atomic.katamari.api.arr.ArrBindTest', () => {
   it('unit tests', () => {
-    const len = (x) => [ x.length ];
+    const len = (x: unknown[]): number[] => [ x.length ];
 
-    const check = (expected, input: any[], f) => {
+    const check = <T, U>(expected: U[], input: T[][], f: (x: T[]) => U[]) => {
       assert.deepEqual(Arr.bind(input, f), expected);
       assert.deepEqual(Arr.bind(Object.freeze(input.slice()), f), expected);
     };

--- a/modules/katamari/src/test/ts/atomic/api/arr/ArrEachTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ArrEachTest.ts
@@ -4,23 +4,23 @@ import * as fc from 'fast-check';
 
 import * as Arr from 'ephox/katamari/api/Arr';
 
-interface Z<T> {
-  index: number;
-  value: T;
+interface TestResult<T> {
+  readonly index: number;
+  readonly value: T;
 }
 
 describe('atomic.katamari.api.arr.ArrEachTest', () => {
   context('Arr.each', () => {
     it('unit test', () => {
-      const checkLHelper = <T>(expected: Z<T>[], input: ArrayLike<T>) => {
-        const values: Array<Z<T>> = [];
+      const checkLHelper = <T>(expected: TestResult<T>[], input: ArrayLike<T>) => {
+        const values: Array<TestResult<T>> = [];
         Arr.each(input, (x, i) => {
           values.push({ index: i, value: x });
         });
         assert.deepEqual(values, expected);
       };
 
-      const checkL = (expected, input: any[]) => {
+      const checkL = <T>(expected: TestResult<T>[], input: T[]) => {
         checkLHelper(expected, input);
         checkLHelper(expected, Object.freeze(input.slice()));
       };
@@ -49,15 +49,15 @@ describe('atomic.katamari.api.arr.ArrEachTest', () => {
 
   context('Arr.eachr', () => {
     it('unit test', () => {
-      const checkRHelper = <T>(expected: Z<T>[], input: ArrayLike<T>) => {
-        const values: Array<Z<T>> = [];
+      const checkRHelper = <T>(expected: TestResult<T>[], input: ArrayLike<T>) => {
+        const values: Array<TestResult<T>> = [];
         Arr.eachr(input, (x, i) => {
           values.push({ index: i, value: x });
         });
         assert.deepEqual(values, expected);
       };
 
-      const checkR = (expected, input: any[]) => {
+      const checkR = <T>(expected: TestResult<T>[], input: T[]) => {
         checkRHelper(expected, input);
         checkRHelper(expected, Object.freeze(input.slice()));
       };

--- a/modules/katamari/src/test/ts/atomic/api/arr/ArrFindTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ArrFindTest.ts
@@ -50,7 +50,7 @@ describe('atomic.katamari.api.arr.ArrFindTest', () => {
   it('finds a value in the array', () => {
     fc.assert(fc.property(fc.array(fc.integer()), fc.integer(), fc.array(fc.integer()), (prefix, i, suffix) => {
       const arr = prefix.concat([ i ]).concat(suffix);
-      const pred = (x) => x === i;
+      const pred = (x: number) => x === i;
       const result = Arr.find(arr, pred);
       assertSome(result, i);
     }));

--- a/modules/katamari/src/test/ts/atomic/api/arr/ArrMapTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ArrMapTest.ts
@@ -5,13 +5,13 @@ import * as fc from 'fast-check';
 import * as Arr from 'ephox/katamari/api/Arr';
 import * as Fun from 'ephox/katamari/api/Fun';
 
-const dbl = (x) => x * 2;
+const dbl = (x: number) => x * 2;
 
-const plus3 = (x) => x + 3;
+const plus3 = (x: number) => x + 3;
 
 describe('atomic.katamari.api.arr.ArrMapTest', () => {
   it('unit tests', () => {
-    const checkA = (expected, input, f) => {
+    const checkA = <T, U>(expected: U[], input: T[], f: (x: T, i: number) => U) => {
       assert.deepEqual(Arr.map(input, f), expected);
       assert.deepEqual(Arr.map(Object.freeze(input.slice()), f), expected);
     };

--- a/modules/katamari/src/test/ts/atomic/api/arr/ArrMapToObjectTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ArrMapToObjectTest.ts
@@ -9,8 +9,8 @@ import * as Unique from 'ephox/katamari/api/Unique';
 describe('atomic.katamari.api.arr.ArrMapToObjectTest', () => {
   it('maps to object', () => {
 
-    const checkToObject = (expected, input: any[], f) => {
-      assert.deepEqual(expected, Arr.mapToObject(input, f));
+    const checkToObject = <T, U>(expected: U, input: T[], f: (x: T) => U[keyof U]) => {
+      assert.deepEqual(expected, Arr.mapToObject<T, U>(input, f));
       assert.deepEqual(expected, Arr.mapToObject(Object.freeze(input.slice()), f));
     };
 
@@ -22,7 +22,7 @@ describe('atomic.katamari.api.arr.ArrMapToObjectTest', () => {
     checkToObject({ 1: 4, 2: 5 }, [ 1, 2 ], (x) => 3 + x);
 
     fc.assert(fc.property(fc.array(fc.asciiString()), (keys) => {
-      const f = (x) => x + '_cat';
+      const f = (x: string) => x + '_cat';
       const inputKeys = Arr.sort(Unique.stringArray(keys));
       const output = Arr.mapToObject(inputKeys, f);
       const outputKeys = Arr.sort(Obj.keys(output));

--- a/modules/katamari/src/test/ts/atomic/api/arr/ArrRangeTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ArrRangeTest.ts
@@ -8,7 +8,7 @@ import * as Fun from 'ephox/katamari/api/Fun';
 describe('atomic.katamari.api.arr.ArrRangeTest', () => {
 
   it('unit tests', () => {
-    const check = (expected, input, f) => {
+    const check = <R>(expected: R[], input: number, f: (i: number) => R) => {
       const actual = Arr.range(input, f);
       assert.deepEqual(actual, expected);
     };

--- a/modules/katamari/src/test/ts/atomic/api/arr/ContainsTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ContainsTest.ts
@@ -7,7 +7,7 @@ import * as Fun from 'ephox/katamari/api/Fun';
 
 describe('atomic.katamari.api.arr.ContainsTest', () => {
   it('unit test', () => {
-    const check = (expected, input: any[], value) => {
+    const check = <T>(expected: boolean, input: T[], value: T) => {
       assert.deepEqual(Arr.contains(input, value), expected);
       assert.deepEqual(Arr.contains(Object.freeze(input.slice()), value), expected);
     };

--- a/modules/katamari/src/test/ts/atomic/api/arr/DifferenceTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/DifferenceTest.ts
@@ -6,7 +6,7 @@ import * as Arr from 'ephox/katamari/api/Arr';
 
 describe('atomic.katamari.api.arr.DifferenceTest', () => {
   it('unit tests', () => {
-    const check = <T>(expected, a1: T[], a2: T[]) => {
+    const check = <T>(expected: T[], a1: T[], a2: T[]) => {
       const readonlyA1 = Object.freeze(a1.slice());
       const readonlyA2 = Object.freeze(a2.slice());
       assert.deepEqual(Arr.difference(a1, a2), expected);

--- a/modules/katamari/src/test/ts/atomic/api/arr/ExistsTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ExistsTest.ts
@@ -5,7 +5,7 @@ import fc from 'fast-check';
 import * as Arr from 'ephox/katamari/api/Arr';
 import { never, always } from 'ephox/katamari/api/Fun';
 
-const eqc = (x) => (a) => x === a;
+const eqc = <T>(x: T) => (a: T) => x === a;
 const bottom = () => {
   throw new Error('error');
 };

--- a/modules/katamari/src/test/ts/atomic/api/arr/FindIndexTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/FindIndexTest.ts
@@ -47,7 +47,7 @@ describe('atomic.katamari.api.arr.FindIndexTest', () => {
 
   it('finds elements that pass the predicate', () => {
     fc.assert(fc.property(fc.array(fc.integer()), (arr) => {
-      const pred = (x) => x % 3 === 0;
+      const pred = (x: number) => x % 3 === 0;
       assert.isTrue(Arr.findIndex(arr, pred).forall((x) => pred(arr[x])));
     }));
   });
@@ -60,14 +60,14 @@ describe('atomic.katamari.api.arr.FindIndexTest', () => {
 
   it('is consistent with find', () => {
     fc.assert(fc.property(fc.array(fc.integer()), (arr) => {
-      const pred = (x) => x % 5 === 0;
+      const pred = (x: number) => x % 5 === 0;
       assertOptional(Arr.findIndex(arr, pred).map((x) => arr[x]), Arr.find(arr, pred));
     }));
   });
 
   it('is consistent with exists', () => {
     fc.assert(fc.property(fc.array(fc.integer()), (arr) => {
-      const pred = (x) => x % 6 === 0;
+      const pred = (x: number) => x % 6 === 0;
       assert.equal(Arr.findIndex(arr, pred).isSome(), Arr.exists(arr, pred));
     }));
   });

--- a/modules/katamari/src/test/ts/atomic/api/arr/FoldTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/FoldTest.ts
@@ -7,23 +7,23 @@ import * as Fun from 'ephox/katamari/api/Fun';
 
 describe('atomic.katamari.api.arr.FoldTest', () => {
   it('unit tests', () => {
-    const checkl = (expected, input: any[], f, acc) => {
+    const checkl = <T, A>(expected: A, input: T[], f: (acc: A, x: T, i: number) => A, acc: A) => {
       assert.deepEqual(Arr.foldl(input, f, acc), expected);
       assert.deepEqual(Arr.foldl(Object.freeze(input.slice()), f, acc), expected);
     };
 
-    const checkr = (expected, input, f, acc) => {
+    const checkr = <T, A>(expected: A, input: T[], f: (acc: A, x: T, i: number) => A, acc: A) => {
       assert.deepEqual(Arr.foldr(input, f, acc), expected);
       assert.deepEqual(Arr.foldr(Object.freeze(input.slice()), f, acc), expected);
     };
 
-    checkl(0, [], Fun.noop, 0);
+    checkl(0, [], Fun.die('should not be called'), 0);
     checkl(6, [ 1, 2, 3 ], (acc, x) => acc + x, 0);
     checkl(13, [ 1, 2, 3 ], (acc, x) => acc + x, 7);
     // foldl with cons and [] should reverse the list
     checkl([ 3, 2, 1 ], [ 1, 2, 3 ], (acc, x) => [ x ].concat(acc), []);
 
-    checkr(0, [], Fun.noop, 0);
+    checkr(0, [], Fun.die('should not be called'), 0);
     checkr(6, [ 1, 2, 3 ], (acc, x) => acc + x, 0);
     checkr(13, [ 1, 2, 3 ], (acc, x) => acc + x, 7);
     // foldr with cons and [] should be identity
@@ -33,8 +33,8 @@ describe('atomic.katamari.api.arr.FoldTest', () => {
   it('foldl concat [ ] xs === reverse(xs)', () => {
     fc.assert(fc.property(
       fc.array(fc.integer()),
-      (arr: number[]) => {
-        const output: number[] = Arr.foldl(arr, (b: number[], a: number) => [ a ].concat(b), []);
+      (arr) => {
+        const output = Arr.foldl(arr, (b: number[], a: number) => [ a ].concat(b), []);
         assert.deepEqual(output, Arr.reverse(arr));
       }
     ));
@@ -43,7 +43,7 @@ describe('atomic.katamari.api.arr.FoldTest', () => {
   it('foldr concat [ ] xs === xs', () => {
     fc.assert(fc.property(
       fc.array(fc.integer()),
-      (arr: number[]) => {
+      (arr) => {
         const output = Arr.foldr(arr, (b: number[], a: number) => [ a ].concat(b), []);
         assert.deepEqual(output, arr);
       }

--- a/modules/katamari/src/test/ts/atomic/api/arr/ForallTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ForallTest.ts
@@ -7,9 +7,9 @@ import * as Fun from 'ephox/katamari/api/Fun';
 
 describe('atomic.katamari.api.arr.ForallTest', () => {
   it('unit tests', () => {
-    const isOne = (i) => i === 1;
+    const isOne = (i: number) => i === 1;
 
-    const check = (expected, input, f) => {
+    const check = <T>(expected: boolean, input: T[], f: (x: T, i: number) => boolean) => {
       assert.deepEqual(Arr.forall(input, f), expected);
       assert.deepEqual(Arr.forall(Object.freeze(input.slice()), f), expected);
     };

--- a/modules/katamari/src/test/ts/atomic/api/arr/GroupByTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/GroupByTest.ts
@@ -8,7 +8,7 @@ import * as Fun from 'ephox/katamari/api/Fun';
 describe('atomic.katamari.api.arr.GroupByTest', () => {
 
   it('unit tests', () => {
-    const check = (input: unknown[], expected) => {
+    const check = <T>(input: T[], expected: T[][]) => {
       const f = Fun.identity;
       assert.deepEqual(Arr.groupBy(input, f), expected);
       assert.deepEqual(Arr.groupBy(Object.freeze(input.slice()), f), expected);

--- a/modules/katamari/src/test/ts/atomic/api/arr/IndexOfTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/IndexOfTest.ts
@@ -8,20 +8,20 @@ import { assertNone, assertSome } from 'ephox/katamari/test/AssertOptional';
 describe('atomic.katamari.api.arr.ArrLastTest', () => {
 
   it('unit tests', () => {
-    const checkNoneHelper = (xs, x) => {
+    const checkNoneHelper = <T>(xs: ReadonlyArray<T>, x: any) => {
       assertNone(Arr.indexOf(xs, x));
     };
 
-    const checkNone = (xs: any[], x) => {
+    const checkNone = <T>(xs: T[], x: any) => {
       checkNoneHelper(xs, x);
       checkNoneHelper(Object.freeze(xs.slice()), x);
     };
 
-    const checkHelper = (expected, xs, x) => {
+    const checkHelper = <T>(expected: number, xs: ReadonlyArray<T>, x: T) => {
       assertSome(Arr.indexOf(xs, x), expected);
     };
 
-    const check = (expected, xs: any[], x) => {
+    const check = <T>(expected: number, xs: T[], x: T) => {
       checkHelper(expected, xs, x);
       checkHelper(expected, Object.freeze(xs.slice()), x);
     };

--- a/modules/katamari/src/test/ts/atomic/api/arr/IntersperseTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/IntersperseTest.ts
@@ -8,16 +8,16 @@ import { arbNegativeInteger } from 'ephox/katamari/test/arb/ArbDataTypes';
 
 describe('atomic.katamari.api.arr.IntersperseTest', () => {
   it('unit tests', () => {
-    const check = (expected, input, delimiter) => {
+    const check = <T>(expected: T[], input: T[], delimiter: T) => {
       const actual = Jam.intersperse(input, delimiter);
       assert.deepEqual(actual, expected);
     };
 
-    const checkErr = (expected, input, delimiter) => {
+    const checkErr = (expected: string, input: any, delimiter: number) => {
       try {
         Jam.intersperse(input, delimiter);
-        assert.fail('Excpected exception: ' + expected + ' from input: ' + input + ' with delimiter: ' + delimiter);
-      } catch (e) {
+        assert.fail('Expected exception: ' + expected + ' from input: ' + input + ' with delimiter: ' + delimiter);
+      } catch (e: any) {
         assert.deepEqual(e.message, expected);
       }
     };

--- a/modules/katamari/src/test/ts/atomic/api/arr/ObjKeysTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ObjKeysTest.ts
@@ -7,8 +7,8 @@ import * as Obj from 'ephox/katamari/api/Obj';
 
 describe('atomic.katamari.api.arr.ObjKeysTest', () => {
   it('unit tests', () => {
-    const check = (expKeys, input) => {
-      const c = (expected, v) => {
+    const check = (expKeys: string[], input: Record<string, unknown>) => {
+      const c = (expected: string[], v: string[]) => {
         v.sort();
         assert.deepEqual(v, expected);
       };

--- a/modules/katamari/src/test/ts/atomic/api/arr/ObjValuesTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ObjValuesTest.ts
@@ -5,8 +5,8 @@ import * as Obj from 'ephox/katamari/api/Obj';
 
 describe('atomic.katamari.api.arr.ObjValuesTest', () => {
   it('unit test', () => {
-    const check = (expValues, input) => {
-      const c = (expected, v) => {
+    const check = <T>(expValues: T[], input: Record<string, T>) => {
+      const c = (expected: T[], v: T[]) => {
         v.sort();
         assert.deepEqual(v, expected);
       };

--- a/modules/katamari/src/test/ts/atomic/api/arr/PartitionTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/PartitionTest.ts
@@ -7,8 +7,8 @@ import * as Fun from 'ephox/katamari/api/Fun';
 
 describe('atomic.katamari.api.arr.PartitionTest', () => {
   it('unit tests', () => {
-    const check = (input: unknown[], expected) => {
-      const f = (n) => n.indexOf('yes') > -1;
+    const check = (input: string[], expected: { pass: string[]; fail: string[] }) => {
+      const f = (n: string) => n.indexOf('yes') > -1;
       assert.deepEqual(Arr.partition(input, f), expected);
       assert.deepEqual(Arr.partition(Object.freeze(input.slice()), f), expected);
     };
@@ -57,7 +57,7 @@ describe('atomic.katamari.api.arr.PartitionTest', () => {
     fc.assert(fc.property(
       fc.array(fc.integer()),
       (arr) => {
-        const predicate = (x) => x % 3 === 0;
+        const predicate = (x: number) => x % 3 === 0;
         const output = Arr.partition(arr, predicate);
         return Arr.forall(output.fail, (x) => !predicate(x)) && Arr.forall(output.pass, predicate);
       }

--- a/modules/katamari/src/test/ts/atomic/api/arr/ReverseTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ReverseTest.ts
@@ -6,7 +6,7 @@ import * as Arr from 'ephox/katamari/api/Arr';
 
 describe('atomic.katamari.api.arr.ReverseTest', () => {
   it('unit tests', () => {
-    const check = (expected, input) => {
+    const check = <T>(expected: T[], input: T[]) => {
       assert.deepEqual(Arr.reverse(input), expected);
       assert.deepEqual(Arr.reverse(Object.freeze(input.slice())), expected);
     };

--- a/modules/katamari/src/test/ts/atomic/api/arr/UniqueTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/UniqueTest.ts
@@ -9,7 +9,7 @@ describe('atomic.katamari.api.arr.UniqueTest', () => {
   it('unit tests', () => {
     const expected = [ 'three', 'two', 'one' ];
 
-    const check = (input) => {
+    const check = (input: string[]) => {
       assert.deepEqual(Unique.stringArray(input), expected);
     };
 

--- a/modules/katamari/src/test/ts/atomic/api/async/FutureResultTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/async/FutureResultTest.ts
@@ -66,7 +66,7 @@ describe('atomic.katamari.ap.async.FutureResultTest', () => {
   }))));
 
   it('value mapResult', () => {
-    const f = (x) => x + 3;
+    const f = (x: number) => x + 3;
     return fc.assert(fc.asyncProperty(fc.integer(), (i) => new Promise((resolve, reject) => {
       FutureResult.value(i).mapResult(f).get((ii) => {
         eqAsync('eq', Result.value(f(i)), ii, reject, tResult());
@@ -90,7 +90,7 @@ describe('atomic.katamari.ap.async.FutureResultTest', () => {
   }))));
 
   it('err mapError', () => {
-    const f = (x) => x + 3;
+    const f = (x: number) => x + 3;
     return fc.assert(fc.asyncProperty(fc.integer(), (i) => new Promise((resolve, reject) => {
       FutureResult.error(i).mapError(f).get((ii) => {
         eqAsync('eq', Result.error(f(i)), ii, reject, tResult());
@@ -100,7 +100,7 @@ describe('atomic.katamari.ap.async.FutureResultTest', () => {
   });
 
   it('value bindFuture value', () => fc.assert(fc.asyncProperty(fc.integer(), (i) => new Promise((resolve, reject) => {
-    const f = (x) => x % 4;
+    const f = (x: number) => x % 4;
     FutureResult.value(i).bindFuture((x) => FutureResult.value(f(x))).get((actual) => {
       eqAsync('bind result', Result.value(f(i)), actual, reject, tResult(tNumber));
       resolve();

--- a/modules/katamari/src/test/ts/atomic/api/async/LazyValueTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/async/LazyValueTest.ts
@@ -31,9 +31,9 @@ describe('atomic.katamari.api.async.LazyValueTest', () => {
   }));
 
   it('map', () => new Promise<void>((resolve, reject) => {
-    const f = (x) => x + 'hello';
+    const f = (x: string) => x + 'hello';
 
-    const lazy = LazyValue.nu((callback) => {
+    const lazy = LazyValue.nu<string>((callback) => {
       setTimeout(() => {
         callback('extra');
       }, 10);

--- a/modules/katamari/src/test/ts/atomic/api/data/ResultErrorTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/data/ResultErrorTest.ts
@@ -43,7 +43,7 @@ describe('atomic.katamari.api.data.ResultErrorTest', () => {
     assertNone(Result.error(4).toOptional());
   });
 
-  const getErrorOrDie = (res) => res.fold(Fun.identity, Fun.die('Was not an error!'));
+  const getErrorOrDie = <T, E>(res: Result<T, E>): E => res.fold(Fun.identity, Fun.die('Was not an error!'));
 
   it('error.is === false', () => {
     fc.assert(fc.property(fc.integer(), fc.string(), (i, s) => {
@@ -104,7 +104,7 @@ describe('atomic.katamari.api.data.ResultErrorTest', () => {
 
   it('error.mapError(f) === f(error)', () => {
     fc.assert(fc.property(fc.integer(), (i) => {
-      const f = (x) => x % 3;
+      const f = (x: number) => x % 3;
       assertResult(Result.error(i).mapError(f), Result.error(f(i)));
     }));
   });

--- a/modules/katamari/src/test/ts/atomic/api/fun/FunTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/fun/FunTest.ts
@@ -6,9 +6,9 @@ import * as Fun from 'ephox/katamari/api/Fun';
 
 describe('atomic.katamari.api.fun.FunTest', () => {
   it('unit tests', () => {
-    const add2 = (n) => n + 2;
+    const add2 = (n: number) => n + 2;
 
-    const squared = (n) => n * n;
+    const squared = (n: number) => n * n;
 
     const add2squared = Fun.compose(squared, add2);
 
@@ -31,7 +31,7 @@ describe('atomic.katamari.api.fun.FunTest', () => {
     assert.isFalse(Fun.never());
     assert.isTrue(Fun.always());
 
-    const c = (...args) => args;
+    const c = <T>(...args: T[]): T[] => args;
 
     assert.deepEqual(Fun.curry(c)(), []);
     assert.deepEqual(Fun.curry(c, 'a')(), [ 'a' ]);
@@ -96,7 +96,7 @@ describe('atomic.katamari.api.fun.FunTest', () => {
 
   it('Check curry', () => {
     fc.assert(fc.property(fc.json(), fc.json(), fc.json(), fc.json(), (a, b, c, d) => {
-      const f = (a, b, c, d) => [ a, b, c, d ];
+      const f = (a: string, b: string, c: string, d: string) => [ a, b, c, d ];
 
       assert.deepEqual([ a, b, c, d ], Fun.curry(f, a)(b, c, d));
       assert.deepEqual([ a, b, c, d ], Fun.curry(f, a, b)(c, d));

--- a/modules/katamari/src/test/ts/atomic/api/obj/BiFilterTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/obj/BiFilterTest.ts
@@ -9,18 +9,18 @@ import * as Obj from 'ephox/katamari/api/Obj';
 describe('atomic.katamari.api.obj.BiFilterTest', () => {
 
   it('unit tests', () => {
-    const even = (x) => x % 2 === 0;
+    const even = (x: number) => x % 2 === 0;
 
-    const check = (trueObj, falseObj, input, f) => {
+    const check = <T>(trueObj: Record<string, T>, falseObj: Record<string, T>, input: Record<string, T>, f: (val: T) => boolean) => {
       const filtered = Obj.bifilter(input, f);
       assert.deepEqual(filtered.t, trueObj);
       assert.deepEqual(filtered.f, falseObj);
     };
 
-    check({}, { a: '1' }, { a: '1' }, even);
-    check({ b: '2' }, {}, { b: '2' }, even);
-    check({ b: '2' }, { a: '1' }, { a: '1', b: '2' }, even);
-    check({ b: '2', d: '4' }, { a: '1', c: '3' }, { a: '1', b: '2', c: '3', d: '4' }, even);
+    check({}, { a: 1 }, { a: 1 }, even);
+    check({ b: 2 }, {}, { b: 2 }, even);
+    check({ b: 2 }, { a: 1 }, { a: 1, b: 2 }, even);
+    check({ b: 2, d: 4 }, { a: 1, c: 3 }, { a: 1, b: 2, c: 3, d: 4 }, even);
   });
 
   it('Check that if the filter always returns false, then everything is in "f"', () => {
@@ -51,10 +51,10 @@ describe('atomic.katamari.api.obj.BiFilterTest', () => {
     fc.assert(fc.property(
       fc.dictionary(fc.asciiString(1, 30), fc.integer()),
       (obj) => {
-        const predicate = (x) => x % 2 === 0;
+        const predicate = (x: number) => x % 2 === 0;
         const output = Obj.bifilter(obj, predicate);
 
-        const matches = (k) => predicate(obj[k]);
+        const matches = (k: string) => predicate(obj[k]);
 
         const falseKeys = Obj.keys(output.f);
         const trueKeys = Obj.keys(output.t);

--- a/modules/katamari/src/test/ts/atomic/api/obj/ObjEachTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/obj/ObjEachTest.ts
@@ -26,8 +26,8 @@ describe('atomic.katamari.api.obj.ObjEachTest', () => {
   it('Each + set should equal the same object', () => {
     fc.assert(fc.property(
       fc.dictionary(fc.asciiString(), fc.json()),
-      (obj: Record<string, any>) => {
-        const values = {};
+      (obj) => {
+        const values: Record<string, string> = {};
         const output = Obj.each(obj, (x, i) => {
           values[i] = x;
         });

--- a/modules/katamari/src/test/ts/atomic/api/obj/ObjFindTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/obj/ObjFindTest.ts
@@ -8,17 +8,17 @@ import * as Obj from 'ephox/katamari/api/Obj';
 
 describe('atomic.katamari.api.obj.ObjFindTest', () => {
   it('ObjFindTest', () => {
-    const checkNone = (input, pred) => {
+    const checkNone = <T>(input: Record<string, T>, pred: (val: T, key: string, obj: Record<string, T>) => boolean) => {
       const actual = Obj.find(input, pred);
-      return actual.isNone();
+      assert.isTrue(actual.isNone());
     };
 
-    const checkObj = (expected, input, pred) => {
+    const checkObj = <T>(expected: T, input: Record<string, T>, pred: (val: T, key: string, obj: Record<string, T>) => boolean) => {
       const actual = Obj.find(input, pred).getOrDie('should have value');
       assert.deepEqual(actual, expected);
     };
 
-    checkNone({}, (v, _k) => {
+    checkNone<number>({}, (v, _k) => {
       return v > 0;
     });
     checkObj(3, { test: 3 }, (_v, k) => {

--- a/modules/katamari/src/test/ts/atomic/api/obj/ObjMapTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/obj/ObjMapTest.ts
@@ -8,20 +8,20 @@ import * as Obj from 'ephox/katamari/api/Obj';
 
 describe('atomic.katamari.api.obj.ObjMapTest', () => {
   it('unit test', () => {
-    const dbl = (x) => x * 2;
+    const dbl = (x: number) => x * 2;
 
-    const addDot = (x) => x + '.';
+    const addDot = (x: string) => x + '.';
 
-    const tupleF = (x, i) => ({
+    const tupleF = (x: string, i: string) => ({
       k: i + 'b',
       v: x + 'b'
     });
 
-    const check = (expected, input, f) => {
+    const check = <T, U>(expected: Record<string, U>, input: Record<string, T>, f: (val: T) => U) => {
       assert.deepEqual(Obj.map(input, f), expected);
     };
 
-    const checkT = (expected, input, f) => {
+    const checkT = <T, R>(expected: Record<string, R>, input: Record<string, T>, f: (val: T, key: string) => { k: string; v: R }) => {
       assert.deepEqual(Obj.tupleMap(input, f), expected);
     };
 
@@ -33,9 +33,9 @@ describe('atomic.katamari.api.obj.ObjMapTest', () => {
     checkT({ ab: 'ab' }, { a: 'a' }, tupleF);
     checkT({ ab: 'ab', bb: 'bb', cb: 'cb' }, { a: 'a', b: 'b', c: 'c' }, tupleF);
 
-    const stringify = (x, i) => i + ' :: ' + x;
+    const stringify = (x: string, i: string) => i + ' :: ' + x;
 
-    const checkMapToArray = (expected, input, f) => {
+    const checkMapToArray = (expected: string[], input: Record<string, string>, f: (x: string, i: string) => string) => {
       assert.deepEqual(Obj.mapToArray(input, f), expected);
     };
 

--- a/modules/katamari/src/test/ts/atomic/api/obj/ResolveTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/obj/ResolveTest.ts
@@ -34,7 +34,7 @@ describe('atomic.katamari.api.obj.ResolveTest', () => {
   });
 
   it('resolve', () => {
-    const check = (expected, path, scope) => {
+    const check = (expected: any, path: string, scope: any) => {
       const actual = Resolve.resolve(path, scope);
       assert.deepEqual(actual, expected);
     };

--- a/modules/katamari/src/test/ts/atomic/api/optional/OptionalsEqualTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/optional/OptionalsEqualTest.ts
@@ -52,7 +52,7 @@ describe('atomic.katamari.api.optional.OptionalsEqualTest', () => {
     assert.isTrue(Optionals.equals(Optional.some(5), Optional.some(5)));
     assert.isFalse(Optionals.equals(Optional.some(5.1), Optional.some(5.3)));
 
-    const comparator = (a, b) => Math.round(a) === Math.round(b);
+    const comparator = (a: number, b: number) => Math.round(a) === Math.round(b);
 
     assert.isTrue(Optionals.equals(Optional.some(5.1), Optional.some(5.3), comparator));
     assert.isFalse(Optionals.equals(Optional.some(5.1), Optional.some(5.9), comparator));

--- a/modules/katamari/src/test/ts/atomic/api/optional/OptionalsMapFromTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/optional/OptionalsMapFromTest.ts
@@ -14,7 +14,7 @@ describe('atomic.katamari.api.optional.OptionalsMapFromTest', () => {
   });
 
   it('Optionals.mapFrom === Optionals.map().from()', () => {
-    const f = (x) => x + 1;
+    const f = (x: number) => x + 1;
 
     const check = (input: number | null | undefined) => {
       assertOptional(Optionals.mapFrom(input, f), Optional.from(input).map(f));

--- a/modules/katamari/src/test/ts/atomic/api/str/EndsWithTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/str/EndsWithTest.ts
@@ -6,7 +6,7 @@ import * as Strings from 'ephox/katamari/api/Strings';
 
 describe('atomic.katamari.api.str.EndsWithTest', () => {
   it('Unit tests', () => {
-    const check = (expected, str, suffix) => {
+    const check = (expected: boolean, str: string, suffix: string) => {
       const actual = Strings.endsWith(str, suffix);
       assert.equal(actual, expected);
     };

--- a/modules/katamari/src/test/ts/atomic/api/str/StartsWithTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/str/StartsWithTest.ts
@@ -6,7 +6,7 @@ import * as Strings from 'ephox/katamari/api/Strings';
 
 describe('atomic.katamari.api.str.StartsWithTest', () => {
   it('unit tests', () => {
-    const check = (expected, str, prefix) => {
+    const check = (expected: boolean, str: string, prefix: string) => {
       const actual = Strings.startsWith(str, prefix);
       assert.equal(actual, expected);
     };

--- a/modules/katamari/src/test/ts/atomic/api/str/StringMatchTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/str/StringMatchTest.ts
@@ -4,9 +4,15 @@ import fc from 'fast-check';
 
 import { StringMatch } from 'ephox/katamari/api/StringMatch';
 
+interface Scenario {
+  readonly expected: boolean;
+  readonly input: string;
+  readonly match: StringMatch;
+}
+
 describe('atomic.katamari.api.str.StringMatchTest', () => {
   it('unit tests', () => {
-    const check = (testcase) => {
+    const check = (testcase: Scenario) => {
       assert.equal(StringMatch.matches(testcase.match, testcase.input), testcase.expected);
       assert.equal(StringMatch.matches(
         StringMatch.not(testcase.match),

--- a/modules/katamari/src/test/ts/atomic/api/struct/AdtTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/struct/AdtTest.ts
@@ -6,7 +6,7 @@ import { Adt } from 'ephox/katamari/api/Adt';
 import * as Arr from 'ephox/katamari/api/Arr';
 import * as Fun from 'ephox/katamari/api/Fun';
 
-const checkInvalid = (message, f) => {
+const checkInvalid = (message: string, f: () => void) => {
   let error = false;
   try {
     f();
@@ -24,7 +24,7 @@ const checkInvalid = (message, f) => {
   }
 };
 
-const checkInvalidGenerate = (cases, message) => {
+const checkInvalidGenerate = (cases: any, message: string) => {
   checkInvalid('generate() did not throw an error. Input: "' + message + '"', () => {
     Adt.generate(cases);
   });
@@ -64,10 +64,10 @@ describe('atomic.katamari.api.struct.AdtTest', () => {
     const blockStr = 'block';
 
     // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-    const tag = function (target, block) {
-      assert.deepEqual(arguments.length, 2);
-      assert.deepEqual(target, targetStr);
-      assert.deepEqual(block, blockStr);
+    const tag = function (target: string, block: string) {
+      assert.equal(arguments.length, 2);
+      assert.equal(target, targetStr);
+      assert.equal(block, blockStr);
     };
 
     let die = () => {
@@ -143,7 +143,7 @@ describe('atomic.katamari.api.struct.AdtTest', () => {
         const branches = Arr.mapToObject(original, () => Fun.identity);
         subject.match(branches);
         return false;
-      } catch (err) {
+      } catch (err: any) {
         return err.message.indexOf('nothing') > -1;
       }
     }));
@@ -234,7 +234,7 @@ describe('atomic.katamari.api.struct.AdtTest', () => {
           right: Fun.identity
         });
         return false;
-      } catch (err) {
+      } catch (err: any) {
         return err.message.indexOf('nothing') > -1;
       }
     }));

--- a/modules/katamari/src/test/ts/atomic/api/struct/ContractsTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/struct/ContractsTest.ts
@@ -54,7 +54,7 @@ describe('atomic.katamari.api.struct.ContractsTest', () => {
       });
 
       assert.fail('Expected failure: ' + expected);
-    } catch (err) {
+    } catch (err: any) {
       assert.equal(err.message, expected);
     }
   });
@@ -69,7 +69,7 @@ describe('atomic.katamari.api.struct.ContractsTest', () => {
       });
 
       assert.fail('Expected failure: ' + expected);
-    } catch (err) {
+    } catch (err: any) {
       assert.equal(err.message, expected);
     }
   });
@@ -85,7 +85,7 @@ describe('atomic.katamari.api.struct.ContractsTest', () => {
       });
 
       assert.fail('Expected failure: ' + expected);
-    } catch (err) {
+    } catch (err: any) {
       assert.equal(err.message, expected);
     }
   });
@@ -112,7 +112,7 @@ describe('atomic.katamari.api.struct.ContractsTest', () => {
       });
 
       assert.fail('Expected failure: ' + expected);
-    } catch (err) {
+    } catch (err: any) {
       assert.equal(err.message, expected);
     }
   });

--- a/modules/katamari/src/test/ts/browser/TypeBrowserTest.ts
+++ b/modules/katamari/src/test/ts/browser/TypeBrowserTest.ts
@@ -6,7 +6,7 @@ describe('browser.katamari.TypeBrowserTest', () => {
   it('Type cross window test', () => new Promise<void>((success, failure) => {
 
     const runTest = (frameEval: (script: string) => any) => {
-      const check = (expected: boolean, method: string, input: string) => {
+      const check = (expected: boolean, method: 'isArray' | 'isString' | 'isNumber' | 'isFunction' | 'isObject' | 'isPlainObject', input: string) => {
         const frameValue = frameEval(input);
         if (expected !== Type[method](frameValue)) {
           const failMessage = `Type method ${method} did not return ${expected} for frame value '${input}'`;

--- a/modules/katamari/tsconfig.json
+++ b/modules/katamari/tsconfig.json
@@ -1,11 +1,6 @@
 {
   "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
-    "strict": false,
-    "noImplicitThis": true,
-    "strictBindCallApply": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
     "outDir": "lib",
     "rootDir": "src",
     "baseUrl": ".",

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -5,7 +5,7 @@ import { PastePostProcessEvent, PastePreProcessEvent } from './EventTypes';
 import { Formats } from './fmt/Format';
 import { AllowedFormat } from './fmt/StyleFormat';
 import { SchemaType } from './html/Schema';
-import { EditorUiApi } from './ui/Ui';
+import { EditorUiApi, Toolbar } from './ui/Ui';
 
 export type EntityEncoding = 'named' | 'numeric' | 'raw' | 'named,numeric' | 'named+numeric' | 'numeric,named' | 'numeric+named';
 
@@ -208,6 +208,7 @@ interface BaseEditorOptions {
   toolbar7?: string;
   toolbar8?: string;
   toolbar9?: string;
+  toolbar_groups?: Record<string, Toolbar.GroupToolbarButtonSpec>;
   toolbar_location?: ToolbarLocation;
   toolbar_mode?: ToolbarMode;
   toolbar_sticky?: boolean;
@@ -302,6 +303,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   readonly: boolean;
   removed_menuitems: string;
   toolbar: boolean | string | string[] | Array<ToolbarGroup>;
+  toolbar_groups: Record<string, Toolbar.GroupToolbarButtonSpec>;
   toolbar_location: ToolbarLocation;
   toolbar_mode: ToolbarMode;
   toolbar_persist: boolean;


### PR DESCRIPTION
Related Ticket: TINY-8811

Description of Changes:

This enables strict mode for katamari and katamari-assertions and fixes the various compilation errors. Most of the changes are either in tests or in `Obj` since we cannot index an object using `string` and it needs to be `keyof object`. This also includes the `T extends {}` generic fix that will be needed to upgrade to TS 4.8 when it's released later this month.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
