### PR TITLE
TINY-8775: Reduce spaces in urlinput when they should not be there.

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Selecting a figure with `class="image"` would incorrectly highlight the link toolbar button #TINY-8832
 - Specifying a single, non-default list style for the `advlist_bullet_styles` and `advlist_number_styles` options was not respected. #TINY-8721
 - Fixed various issues that occurred when formatting `contenteditable` elements. #TINY-8905
+- Link url field would sometimes allow users to add spaces when a title was set #TINY-8775
 - The text pattern logic threw an error when there were fragmented text nodes in a paragraph #TINY-8779
 - Dragging a `contentEditable=false` element towards the edges would not cause scrolling #TINY-8874
 - The content of the `contenteditable="false"` element could be selected with the mouse on Firefox  #TINY-8828

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, Assertions, Keyboard, Keys, Mouse, UiControls, UiFinder, Waiter } from '@ephox/agar';
 import { AlloyTriggers, Disabling, Focusing, GuiFactory, NativeEvents, Representing, TestHelpers } from '@ephox/alloy';
-import { beforeEach, describe, it } from '@ephox/bedrock-client';
+import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Future, Optional } from '@ephox/katamari';
 import { SelectorFind, SugarDocument, Value } from '@ephox/sugar';
 import { assert } from 'chai';
@@ -77,6 +77,27 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
     // Close the menu
     Keyboard.activeKeydown(doc, Keys.escape());
   };
+
+  const assertTrimSpaces = (inputString: string, expectedOutput: string) =>
+    () => {
+      const input = getInput();
+
+      UiControls.setValue(input.element, inputString);
+
+      assert.equal(Value.get(input.element), expectedOutput, 'Checking Value.get');
+      const repValue = Representing.getValue(input);
+      assert.deepEqual(
+        {
+          value: repValue.value,
+          meta: { text: repValue.meta.text },
+        },
+        {
+          value: expectedOutput,
+          meta: { text: undefined },
+        },
+        'Checking Rep.getValue'
+      );
+    };
 
   beforeEach(() => {
     hook.store().clear();
@@ -202,6 +223,14 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
     store.assertEq('Attach should be in store ... after firing attach', [ 'addToHistory', 'header1.attach' ]);
 
     closeMenu();
+  });
+
+  context('Trim spaces as expected for an URL', () => {
+    it('TINY-8775: Trim a space of it is the only thing in the input', assertTrimSpaces(' ', ''));
+    it('TINY-8775: Trim a space of it is at the start', assertTrimSpaces(' A', 'A'));
+    it('TINY-8775: Trim a space of it is at the end', assertTrimSpaces('A ', 'A'));
+    it('TINY-8775: Do not rim a space of it is in beween letters', assertTrimSpaces('A B', 'A B'));
+    it('TINY-8775: Trim all appropriate spaces', assertTrimSpaces(' A B ', 'A B'));
   });
 
   it('Click urlpicker and assert input state is updated', async () => {


### PR DESCRIPTION
Related Ticket:

Description of Changes:
URLinput elements would not always trim spaces ( it needed to be triggered by outside elements ). This should now trigger automatically.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
