### PR TITLE
TINY-8775: Reduce spaces in urlinput when they should not be there

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Selecting a figure with `class="image"` would incorrectly highlight the link toolbar button #TINY-8832
 - Specifying a single, non-default list style for the `advlist_bullet_styles` and `advlist_number_styles` options was not respected. #TINY-8721
 - Fixed various issues that occurred when formatting `contenteditable` elements. #TINY-8905
+- Link url field would sometimes allow users to add spaces when a title was set #TINY-8775
 - The text pattern logic threw an error when there were fragmented text nodes in a paragraph #TINY-8779
 - Dragging a `contentEditable=false` element towards the edges would not cause scrolling #TINY-8874
 - The content of the `contenteditable="false"` element could be selected with the mouse on Firefox  #TINY-8828

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Selecting a figure with `class="image"` would incorrectly highlight the link toolbar button #TINY-8832
 - Specifying a single, non-default list style for the `advlist_bullet_styles` and `advlist_number_styles` options was not respected. #TINY-8721
 - Fixed various issues that occurred when formatting `contenteditable` elements. #TINY-8905
-- Link url field would sometimes allow users to add spaces when a title was set #TINY-8775
+- Spaces could be incorrectly added to urlinput dialog components in certain cases #TINY-8775
 - The text pattern logic threw an error when there were fragmented text nodes in a paragraph #TINY-8779
 - Dragging a `contentEditable=false` element towards the edges would not cause scrolling #TINY-8874
 - The content of the `contenteditable="false"` element could be selected with the mouse on Firefox  #TINY-8828

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/components/urlinput/UrlInputTest.ts
@@ -1,0 +1,78 @@
+import { RealKeys, UiControls } from '@ephox/agar';
+import { GuiFactory, Representing, TestHelpers } from '@ephox/alloy';
+import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
+import { Future, Optional } from '@ephox/katamari';
+import { SelectorFind, SugarDocument, Value } from '@ephox/sugar';
+import { assert } from 'chai';
+
+import { ApiUrlData } from 'tinymce/themes/silver/backstage/UrlInputBackstage';
+import { renderUrlInput } from 'tinymce/themes/silver/ui/dialog/UrlInput';
+
+import * as TestExtras from '../../../module/TestExtras';
+
+describe('webdriver.tinymce.themes.silver.components.urlinput.UrlInputTest', () => {
+  const helpers = TestExtras.bddSetup();
+
+  const hook = TestHelpers.GuiSetup.bddSetup((store, _doc, _body) => GuiFactory.build(
+    renderUrlInput({
+      label: Optional.some('UrlInput label'),
+      name: 'col1',
+      filetype: 'file',
+      enabled: true
+    }, helpers.backstage(), {
+      getHistory: (_fileType) => [],
+      addToHistory: (_url, _filetype) => store.adder('addToHistory')(),
+      getLinkInformation: () => Optional.none(),
+      getValidationHandler: () => Optional.none(),
+      getUrlPicker: (_filetype) => Optional.some((entry: ApiUrlData) => {
+        store.adder('urlpicker')();
+        return Future.pure({ value: 'http://tiny.cloud', meta: { before: entry.value }, fieldname: 'test' });
+      })
+    }, Optional.none())
+  ));
+
+  TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [
+    '.tox-menu { background: white; }',
+    '.tox-collection__item--active { background: #cadbee }'
+  ]);
+
+  const getInput = () => {
+    const component = hook.component();
+    return component.getSystem().getByDom(
+      SelectorFind.descendant(component.element, 'input').getOrDie('Could not find input')
+    ).getOrDie();
+  };
+
+  const assertTrimSpaces = (inputKeys: any[], expectedOutput: string) =>
+    async () => {
+      const input = getInput();
+
+      await RealKeys.pSendKeysOn('body input', inputKeys);
+
+      assert.equal(Value.get(input.element), expectedOutput, 'Checking Value.get');
+      const repValue = Representing.getValue(input);
+      assert.deepEqual(
+        {
+          value: repValue.value,
+          meta: { text: repValue.meta.text },
+        },
+        {
+          value: expectedOutput,
+          meta: { text: undefined },
+        },
+        'Checking Rep.getValue'
+      );
+    };
+
+  beforeEach(() => {
+    hook.store().clear();
+    UiControls.setValue(getInput().element, '');
+  });
+
+  context('Trim spaces as expected for an URL', () => {
+    it('TINY-8775: Trim a space of it is the only thing in the input', assertTrimSpaces([ RealKeys.text(' ') ], ''));
+    it('TINY-8775: Trim a space of it is at the start', assertTrimSpaces([ RealKeys.text(' A') ], 'A'));
+    it('TINY-8775: Trim a space of it is at the end', assertTrimSpaces([ RealKeys.text('A ') ], 'A'));
+    it('TINY-8775: Trim all appropriate spaces', assertTrimSpaces([ RealKeys.text(' A B '), RealKeys.combo({}, 'arrowLeft'), RealKeys.text(' ') ], 'A B'));
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/components/urlinput/UrlInputTest.ts
@@ -70,9 +70,9 @@ describe('webdriver.tinymce.themes.silver.components.urlinput.UrlInputTest', () 
   });
 
   context('Trim spaces as expected for an URL', () => {
-    it('TINY-8775: Trim a space of it is the only thing in the input', assertTrimSpaces([ RealKeys.text(' ') ], ''));
-    it('TINY-8775: Trim a space of it is at the start', assertTrimSpaces([ RealKeys.text(' A') ], 'A'));
-    it('TINY-8775: Trim a space of it is at the end', assertTrimSpaces([ RealKeys.text('A ') ], 'A'));
+    it('TINY-8775: Trim a space if it is the only thing in the input', assertTrimSpaces([ RealKeys.text(' ') ], ''));
+    it('TINY-8775: Trim a space if it is at the start', assertTrimSpaces([ RealKeys.text(' A') ], 'A'));
+    it('TINY-8775: Trim a space if it is at the end', assertTrimSpaces([ RealKeys.text('A ') ], 'A'));
     it('TINY-8775: Trim all appropriate spaces', assertTrimSpaces([ RealKeys.text(' A B '), RealKeys.combo({}, 'arrowLeft'), RealKeys.text(' ') ], 'A B'));
   });
 });


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
UrlInput would not remove spaces on its own, and it would need to be triggered from the outside. This makes the spaces always be removed.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
