### PR TITLE
TINY-8961: added expand formats to li behaviour

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improved
 - The formatter can now apply a format to a `contenteditable="false"` element by wrapping it. Configurable using the `format_noneditable_selector` option. #TINY-8905
 - The autocompleter now supports a multiple character trigger using the new `trigger` configuration #TINY-8887
-- The formatter will now expand some inline formats like color and font size to list bullets/numbers #TINY-8961
+- The formatter will now apply some inline formats like color and font size to list item elements when the entire item content is selected. #TINY-8961
 
 ### Fixed
 - The Autolink plugin did not work when the text nodes in the content were fragmented #TINY-3723

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improved
 - The formatter can now apply a format to a `contenteditable="false"` element by wrapping it. Configurable using the `format_noneditable_selector` option. #TINY-8905
 - The autocompleter now supports a multiple character trigger using the new `trigger` configuration #TINY-8887
+- The formatter will now expand some inline formats like color and font size to list bullets/numbers #TINY-8961
 
 ### Fixed
 - The Autolink plugin did not work when the text nodes in the content were fragmented #TINY-3723

--- a/modules/tinymce/src/core/main/ts/dom/NodeType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/NodeType.ts
@@ -1,4 +1,4 @@
-import { Arr } from '@ephox/katamari';
+import { Arr, Type } from '@ephox/katamari';
 
 type NullableNode = Node | null | undefined;
 
@@ -13,6 +13,13 @@ const isNodeType = <T extends Node>(type: number) => {
 const isRestrictedNode = (node: NullableNode): boolean => !!node && !Object.getPrototypeOf(node);
 
 const isElement = isNodeType<HTMLElement>(1);
+
+const matchNodeName = <T extends Node>(name: string): (node: NullableNode) => node is T => {
+  const lowercasedName = name.toLowerCase();
+
+  return (node: NullableNode): node is T =>
+    Type.isNonNullable(node) && node.nodeName.toLowerCase() === lowercasedName;
+};
 
 const matchNodeNames = <T extends Node>(names: string[]): (node: NullableNode) => node is T => {
   const lowercasedNames = names.map((s) => s.toLowerCase());
@@ -94,14 +101,15 @@ const isPi = isNodeType<ProcessingInstruction>(7);
 const isComment = isNodeType<Comment>(8);
 const isDocument = isNodeType<Document>(9);
 const isDocumentFragment = isNodeType<DocumentFragment>(11);
-const isBr = matchNodeNames<HTMLBRElement>([ 'br' ]);
-const isImg = matchNodeNames<HTMLImageElement>([ 'img' ]);
+const isBr = matchNodeName<HTMLBRElement>('br');
+const isImg = matchNodeName<HTMLImageElement>('img');
 const isContentEditableTrue = hasContentEditableState('true');
 const isContentEditableFalse = hasContentEditableState('false');
 
 const isTableCell = matchNodeNames<HTMLTableCellElement>([ 'td', 'th' ]);
 const isTableCellOrCaption = matchNodeNames<HTMLTableCellElement>([ 'td', 'th', 'caption' ]);
 const isMedia = matchNodeNames<HTMLElement>([ 'video', 'audio', 'object', 'embed' ]);
+const isListItem = matchNodeName<HTMLBRElement>('li');
 
 export {
   isText,
@@ -127,5 +135,6 @@ export {
   isBogus,
   isBogusAll,
   isTable,
-  isTextareaOrInput
+  isTextareaOrInput,
+  isListItem
 };

--- a/modules/tinymce/src/core/main/ts/dom/NodeType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/NodeType.ts
@@ -15,19 +15,19 @@ const isRestrictedNode = (node: NullableNode): boolean => !!node && !Object.getP
 const isElement = isNodeType<HTMLElement>(1);
 
 const matchNodeName = <T extends Node>(name: string): (node: NullableNode) => node is T => {
-  const lowercasedName = name.toLowerCase();
+  const lowerCasedName = name.toLowerCase();
 
   return (node: NullableNode): node is T =>
-    Type.isNonNullable(node) && node.nodeName.toLowerCase() === lowercasedName;
+    Type.isNonNullable(node) && node.nodeName.toLowerCase() === lowerCasedName;
 };
 
 const matchNodeNames = <T extends Node>(names: string[]): (node: NullableNode) => node is T => {
-  const lowercasedNames = names.map((s) => s.toLowerCase());
+  const lowerCasedNames = names.map((s) => s.toLowerCase());
 
   return (node: NullableNode): node is T => {
     if (node && node.nodeName) {
       const nodeName = node.nodeName.toLowerCase();
-      return Arr.contains(lowercasedNames, nodeName);
+      return Arr.contains(lowerCasedNames, nodeName);
     }
 
     return false;

--- a/modules/tinymce/src/core/main/ts/fmt/ListItemFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ListItemFormat.ts
@@ -1,0 +1,50 @@
+import { Arr, Obj, Optional, Type } from '@ephox/katamari';
+
+import DOMUtils from '../api/dom/DOMUtils';
+import EditorSelection from '../api/dom/Selection';
+import Formatter from '../api/Formatter';
+import * as CaretFinder from '../caret/CaretFinder';
+import CaretPosition from '../caret/CaretPosition';
+import * as NodeType from '../dom/NodeType';
+import { Format, InlineFormat } from './FormatTypes';
+import * as FormatUtils from './FormatUtils';
+
+export const listItemStyles = [ 'fontWeight', 'fontStyle', 'color', 'fontSize', 'fontFamily' ];
+
+const hasListStyles = (fmt: InlineFormat) => Type.isObject(fmt.styles) && Arr.exists(Obj.keys(fmt.styles), (name) => Arr.contains(listItemStyles, name));
+
+const findExpandedListItemFormat = (formats: Format[]) =>
+  Arr.find(formats, (fmt) => FormatUtils.isInlineFormat(fmt) && fmt.inline === 'span' && hasListStyles(fmt));
+
+export const getExpandedListItemFormat = (formatter: Formatter, format: string): Optional<Format> => {
+  const formatList = formatter.get(format);
+
+  return Type.isArray(formatList) ? findExpandedListItemFormat(formatList) : Optional.none();
+};
+
+const isRngStartAtStartOfElement = (rng: Range, elm: Element) => CaretFinder.prevPosition(elm, CaretPosition.fromRangeStart(rng)).isNone();
+const isRngEndAtEndOfElement = (rng: Range, elm: Element) => CaretFinder.nextPosition(elm, CaretPosition.fromRangeEnd(rng)).isNone();
+const isEditableListItem = (dom: DOMUtils) => (elm: Element) => NodeType.isListItem(elm) && dom.getContentEditableParent(elm) !== 'false';
+
+const getFullySelectedBlocks = (selection: EditorSelection) => {
+  const blocks = selection.getSelectedBlocks();
+  const rng = selection.getRng();
+
+  if (selection.isCollapsed()) {
+    return [];
+  } if (blocks.length === 1) {
+    return isRngStartAtStartOfElement(rng, blocks[0]) && isRngEndAtEndOfElement(rng, blocks[0]) ? blocks : [];
+  } else {
+    const first = Arr.head(blocks).filter((elm) => isRngStartAtStartOfElement(rng, elm)).toArray();
+    const last = Arr.last(blocks).filter((elm) => isRngEndAtEndOfElement(rng, elm)).toArray();
+    const middle = blocks.slice(1, -1);
+
+    return first.concat(middle).concat(last);
+  }
+};
+
+export const getFullySelectedListItems = (selection: EditorSelection): Element[] =>
+  Arr.filter(getFullySelectedBlocks(selection), isEditableListItem(selection.dom));
+
+export const getPartiallySelectedListItems = (selection: EditorSelection): Element[] =>
+  Arr.filter(selection.getSelectedBlocks(), isEditableListItem(selection.dom));

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -20,6 +20,7 @@ import * as ExpandRange from './ExpandRange';
 import { Format, FormatAttrOrStyleValue, FormatVars } from './FormatTypes';
 import { normalizeStyleValue } from './FormatUtils';
 import * as FormatUtils from './FormatUtils';
+import * as ListItemFormat from './ListItemFormat';
 import * as MatchFormat from './MatchFormat';
 import { mergeSiblings } from './MergeUtils';
 
@@ -192,8 +193,46 @@ const processFormatAttrOrStyle = (name: string | number, value: FormatAttrOrStyl
   }
 };
 
-const removeFormatInternal = (ed: Editor, format: Format, vars?: FormatVars, node?: Node, compareNode?: Node | null): RemoveFormatAdt => {
+const removeEmptyStyleAttributeIfNeeded = (dom: DOMUtils, elm: Element) => {
+  if (dom.getAttrib(elm, 'style') === '') {
+    elm.removeAttribute('style');
+    elm.removeAttribute('data-mce-style');
+  }
+};
+
+const removeStyles = (dom: DOMUtils, elm: Element, format: Format, vars: FormatVars | undefined, compareNode: Node | null | undefined) => {
   let stylesModified = false;
+
+  each(format.styles as any, (value: FormatAttrOrStyleValue | string, name: string | number) => {
+    const { name: styleName, value: styleValue } = processFormatAttrOrStyle(name, value, vars);
+    const normalizedStyleValue = normalizeStyleValue(styleValue, styleName);
+
+    if (format.remove_similar || Type.isNull(styleValue) || !NodeType.isElement(compareNode) || isEq(FormatUtils.getStyle(dom, compareNode, styleName), normalizedStyleValue)) {
+      dom.setStyle(elm, styleName, '');
+    }
+
+    stylesModified = true;
+  });
+
+  if (stylesModified) {
+    removeEmptyStyleAttributeIfNeeded(dom, elm);
+  }
+};
+
+const removeListStyleFormats = (editor: Editor, name: string, vars: FormatVars | undefined) => {
+  if (name === 'removeformat') {
+    Arr.each(ListItemFormat.getPartiallySelectedListItems(editor.selection), (li) => {
+      Arr.each(ListItemFormat.listItemStyles, (name) => editor.dom.setStyle(li, name, ''));
+      removeEmptyStyleAttributeIfNeeded(editor.dom, li);
+    });
+  } else {
+    ListItemFormat.getExpandedListItemFormat(editor.formatter, name).each((liFmt) => {
+      Arr.each(ListItemFormat.getPartiallySelectedListItems(editor.selection), (li) => removeStyles(editor.dom, li, liFmt, vars, null));
+    });
+  }
+};
+
+const removeFormatInternal = (ed: Editor, format: Format, vars?: FormatVars, node?: Node, compareNode?: Node | null): RemoveFormatAdt => {
   const dom = ed.dom;
   const elementUtils = ElementUtils(ed);
 
@@ -226,23 +265,7 @@ const removeFormatInternal = (ed: Editor, format: Format, vars?: FormatVars, nod
 
   // Should we compare with format attribs and styles
   if (format.remove !== 'all') {
-    // Remove styles
-    each(format.styles as any, (value: FormatAttrOrStyleValue | string, name: string | number) => {
-      const { name: styleName, value: styleValue } = processFormatAttrOrStyle(name, value, vars);
-      const normalizedStyleValue = normalizeStyleValue(styleValue, styleName);
-
-      if (format.remove_similar || Type.isNull(styleValue) || !NodeType.isElement(compareNode) || isEq(FormatUtils.getStyle(dom, compareNode, styleName), normalizedStyleValue)) {
-        dom.setStyle(elm, styleName, '');
-      }
-
-      stylesModified = true;
-    });
-
-    // Remove style attribute if it's empty
-    if (stylesModified && dom.getAttrib(elm, 'style') === '') {
-      elm.removeAttribute('style');
-      elm.removeAttribute('data-mce-style');
-    }
+    removeStyles(dom, elm, format, vars, compareNode);
 
     // Remove attributes
     each(format.attributes as any, (value: FormatAttrOrStyleValue | string, name: string | number) => {
@@ -630,6 +653,11 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
   } else {
     CaretFormat.removeCaretFormat(ed, name, vars, similar);
   }
+
+  if (!node) {
+    removeListStyleFormats(ed, name, vars);
+  }
+
   Events.fireFormatRemove(ed, name, node, vars);
 };
 

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -654,9 +654,7 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
     CaretFormat.removeCaretFormat(ed, name, vars, similar);
   }
 
-  if (!node) {
-    removeListStyleFormats(ed, name, vars);
-  }
+  removeListStyleFormats(ed, name, vars);
 
   Events.fireFormatRemove(ed, name, node, vars);
 };

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatEmptyLineTest.ts
@@ -342,10 +342,10 @@ describe('browser.tinymce.core.fmt.FormatEmptyLineTest', () => {
         rawHtml: true,
         expectedHtml:
           '<p><strong>a</strong></p>\n' +
-          '<ul>\n<li><strong>&nbsp;</strong></li>\n</ul>',
+          '<ul>\n<li style="font-weight: bold;"><strong>&nbsp;</strong></li>\n</ul>',
         expectedRawHtml:
           '<p><strong>a</strong></p>' +
-          '<ul><li><strong><br data-mce-bogus="1"></strong></li></ul>',
+          '<ul><li style="font-weight: bold;" data-mce-style="font-weight: bold;"><strong><br data-mce-bogus="1"></strong></li></ul>',
         select: selectAll,
         apply: toggleInlineStyle('Bold'),
         remove: toggleInlineStyle('Bold')

--- a/modules/tinymce/src/core/test/ts/browser/fmt/ListItemFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/ListItemFormatTest.ts
@@ -32,10 +32,10 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
     TinyAssertions.assertContent(editor, expected);
   };
 
-  context('Apply inline formats to list elements', () => {
+  context('Apply inline formats to LIs', () => {
     const testApplyInlineListFormat = testListFormat((editor, format, vars) => editor.formatter.apply(format, vars));
 
-    context('Apply inline format to single list element', () => {
+    context('Apply inline format to a single LI', () => {
       it('TINY-8961: applying bold to the entire contents of a LI should also apply that bold to the LI', () =>
         testApplyInlineListFormat({
           format: 'bold',
@@ -130,8 +130,8 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
       );
     });
 
-    context('Apply inline formats to multiple list elements', () => {
-      it('TINY-8961: applying bold to 3 fully selected list items', () =>
+    context('Apply inline formats to multiple LIs', () => {
+      it('TINY-8961: applying bold to 3 fully selected LIs should also apply bold to the LIs', () =>
         testApplyInlineListFormat({
           format: 'bold',
           input: '<ul><li>abc</li><li>def</li><li>ghj</li></ul>',
@@ -140,7 +140,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
         })
       );
 
-      it('TINY-8961: applying bold to a partially selected start li and 2 fully selected list items', () =>
+      it('TINY-8961: applying bold to a partially selected start LI and 2 fully selected LIs should also apply bold to the fully selected LIs', () =>
         testApplyInlineListFormat({
           format: 'bold',
           input: '<ul><li>abc</li><li>def</li><li>ghj</li></ul>',
@@ -149,7 +149,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
         })
       );
 
-      it('TINY-8961: applying bold to 2 fully selected list items and a partially selected end li', () =>
+      it('TINY-8961: applying bold to 2 fully selected LIs and a partially selected end LI should also apply bold to the 2 fully selected LIs', () =>
         testApplyInlineListFormat({
           format: 'bold',
           input: '<ul><li>abc</li><li>def</li><li>ghj</li></ul>',
@@ -158,7 +158,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
         })
       );
 
-      it('TINY-8961: applying bold to a fully selected list item and partially selected start and end lis', () =>
+      it('TINY-8961: applying bold to a fully selected LI and partially selected start and end LIs should only apply bold to the fully selected LI', () =>
         testApplyInlineListFormat({
           format: 'bold',
           input: '<ul><li>abc</li><li>def</li><li>ghj</li></ul>',
@@ -169,7 +169,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
     });
 
     context('Apply inline formats at caret', () => {
-      it('TINY-8961: applying bold at caret in middle of word should not apply bold to parent list item', () =>
+      it('TINY-8961: applying bold at caret in middle of word should not apply bold to parent LI', () =>
         testApplyInlineListFormat({
           format: 'bold',
           input: '<ul><li>abc</li></ul>',
@@ -178,7 +178,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
         })
       );
 
-      it('TINY-8961: applying bold at caret at the end of a word should not apply bold to parent list item', () =>
+      it('TINY-8961: applying bold at caret at the end of a word should not apply bold to parent LI', () =>
         testApplyInlineListFormat({
           format: 'bold',
           input: '<ul><li>abc</li></ul>',
@@ -189,7 +189,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
     });
 
     context('Apply inline formats on noneditable lists', () => {
-      it('TINY-8961: applying bold on li elements in a noneditable parent should not get bold styles', () =>
+      it('TINY-8961: applying bold on LIs in a noneditable parent should not get bold styles', () =>
         testApplyInlineListFormat({
           format: 'bold',
           input: '<p>a</p><ul contenteditable="false"><li>b</li><li>c</li></ul><p>d</p>',
@@ -200,10 +200,10 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
     });
   });
 
-  context('Remove inline formats from list elements', () => {
+  context('Remove inline formats from LIs', () => {
     const testRemoveInlineListFormat = testListFormat((editor, format, vars) => editor.formatter.remove(format, vars));
 
-    context('Remove inline formats from single list element', () => {
+    context('Remove inline formats from single LI', () => {
       it('TINY-8961: removing bold from the entire contents of a LI should also remove that bold from the LI', () =>
         testRemoveInlineListFormat({
           format: 'bold',
@@ -253,8 +253,8 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
       );
     });
 
-    context('Remove inline formats from multiple list elements', () => {
-      it('TINY-8961: removing bold to 3 fully selected list items', () =>
+    context('Remove inline formats from multiple LIs', () => {
+      it('TINY-8961: removing bold to 3 fully selected LIs', () =>
         testRemoveInlineListFormat({
           format: 'bold',
           input: '<ul><li style="font-weight: bold;"><strong>abc</strong></li><li style="font-weight: bold;"><strong>def</strong></li><li style="font-weight: bold;"><strong>ghj</strong></li></ul>',
@@ -263,7 +263,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
         })
       );
 
-      it('TINY-8961: removing bold from a partially selected start li and 2 fully selected list items', () =>
+      it('TINY-8961: removing bold from a partially selected start LI and 2 fully selected LIs', () =>
         testRemoveInlineListFormat({
           format: 'bold',
           input: '<ul><li style="font-weight: bold;"><strong>abc</strong></li><li style="font-weight: bold;"><strong>def</strong></li><li style="font-weight: bold;"><strong>ghj</strong></li></ul>',
@@ -272,7 +272,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
         })
       );
 
-      it('TINY-8961: removing bold from 2 fully selected list items and a partially selected end li', () =>
+      it('TINY-8961: removing bold from 2 fully selected LIs and a partially selected end li', () =>
         testRemoveInlineListFormat({
           format: 'bold',
           input: '<ul><li style="font-weight: bold;"><strong>abc</strong></li><li style="font-weight: bold;"><strong>def</strong></li><li><strong>ghj</strong></li></ul>',
@@ -281,7 +281,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
         })
       );
 
-      it('TINY-8961: removing bold from a fully selected list item and partially selected start and end lis', () =>
+      it('TINY-8961: removing bold from a fully selected LI and partially selected start and end LIs', () =>
         testRemoveInlineListFormat({
           format: 'bold',
           input: '<ul><li><strong>abc</strong></li><li style="font-weight: bold;"><strong>def</strong></li><li><strong>ghj</strong></li></ul>',
@@ -292,7 +292,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
     });
 
     context('Removing inline formats at caret', () => {
-      it('TINY-8961: removing bold at caret in middle of word should remove bold from parent list item', () =>
+      it('TINY-8961: removing bold at caret in middle of word should remove bold from parent LI', () =>
         testRemoveInlineListFormat({
           format: 'bold',
           input: '<ul><li style="font-weight: bold"><strong>abc</strong></li></ul>',
@@ -301,7 +301,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
         })
       );
 
-      it('TINY-8961: removing bold at caret at end of word should remove bold from parent list item', () =>
+      it('TINY-8961: removing bold at caret at end of word should remove bold from parent LI', () =>
         testRemoveInlineListFormat({
           format: 'bold',
           input: '<ul><li style="font-weight: bold"><strong>abc</strong></li></ul>',
@@ -312,7 +312,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
     });
 
     context('Remove inline formats on noneditable lists', () => {
-      it('TINY-8961: remove bold on li elements in a noneditable parent should not remove bold styles', () =>
+      it('TINY-8961: remove bold on LI elements in a noneditable parent should not remove bold styles', () =>
         testRemoveInlineListFormat({
           format: 'bold',
           input: '<p><strong>a</strong></p><ul contenteditable="false"><li style="font-weight: bold;">b</li><li style="font-weight: bold;">c</li></ul><p><strong>d</strong></p>',
@@ -323,7 +323,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
     });
 
     context('Remove all formats', () => {
-      it('TINY-8961: remove all formats should only remove the li specific styles on a partially selected li', () =>
+      it('TINY-8961: remove all formats should only remove the LI specific styles on a partially selected LI', () =>
         testRemoveInlineListFormat({
           format: 'removeformat',
           input: '<ul><li style="font-size: 30px; font-weight: bold; color: red; font-style: italic; text-decoration: underline;">abc</li></ul>',

--- a/modules/tinymce/src/core/test/ts/browser/fmt/ListItemFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/ListItemFormatTest.ts
@@ -1,0 +1,336 @@
+
+import { Cursors } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Type } from '@ephox/katamari';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import { FormatVars } from 'tinymce/core/fmt/FormatTypes';
+
+interface ListItemFormatCase {
+  readonly format: string;
+  readonly value?: string;
+  readonly input: string;
+  readonly selection: Cursors.CursorPath;
+  readonly expected: string;
+}
+
+describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [], true);
+
+  const testListFormat = (f: (editor: Editor, format: string, vars: FormatVars | undefined) => void) => (testCase: ListItemFormatCase) => {
+    const { format, selection, expected } = testCase;
+    const editor = hook.editor();
+    const vars = Type.isString(testCase.value) ? { value: testCase.value } : undefined;
+
+    editor.setContent(testCase.input);
+    TinySelections.setSelection(editor, selection.startPath, selection.soffset, selection.finishPath, selection.foffset);
+    f(editor, format, vars);
+    TinyAssertions.assertContent(editor, expected);
+  };
+
+  context('Apply inline formats to list elements', () => {
+    const testApplyInlineListFormat = testListFormat((editor, format, vars) => editor.formatter.apply(format, vars));
+
+    context('Apply inline format to single list element', () => {
+      it('TINY-8961: applying bold to the entire contents of a LI should also apply that bold to the LI', () =>
+        testApplyInlineListFormat({
+          format: 'bold',
+          input: '<ul><li>abc</li></ul>',
+          selection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0 ], foffset: 3 },
+          expected: '<ul><li style="font-weight: bold;"><strong>abc</strong></li></ul>'
+        })
+      );
+
+      it('TINY-8961: applying italic to the entire contents of a LI should also apply that italic to the LI', () =>
+        testApplyInlineListFormat({
+          format: 'italic',
+          input: '<ul><li>abc</li></ul>',
+          selection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0 ], foffset: 3 },
+          expected: '<ul><li style="font-style: italic;"><em>abc</em></li></ul>'
+        })
+      );
+
+      it('TINY-8961: applying text color to the entire contents of a LI should also apply that color to the LI', () =>
+        testApplyInlineListFormat({
+          format: 'forecolor',
+          value: 'red',
+          input: '<ul><li>abc</li></ul>',
+          selection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0 ], foffset: 3 },
+          expected: '<ul><li style="color: red;"><span style="color: red;">abc</span></li></ul>'
+        })
+      );
+
+      it('TINY-8961: applying font size to the entire contents of a LI should also apply that font size to the LI', () =>
+        testApplyInlineListFormat({
+          format: 'fontsize',
+          value: '30px',
+          input: '<ul><li>abc</li></ul>',
+          selection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0 ], foffset: 3 },
+          expected: '<ul><li style="font-size: 30px;"><span style="font-size: 30px;">abc</span></li></ul>'
+        })
+      );
+
+      it('TINY-8961: applying font family to the entire contents of a LI should also apply that font family to the LI', () =>
+        testApplyInlineListFormat({
+          format: 'fontname',
+          value: 'Arial',
+          input: '<ul><li>abc</li></ul>',
+          selection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0 ], foffset: 3 },
+          expected: '<ul><li style="font-family: Arial;"><span style="font-family: Arial;">abc</span></li></ul>'
+        })
+      );
+
+      it('TINY-8961: applying bold to a fully selected LI with deep nested content should apply bold to the LI', () =>
+        testApplyInlineListFormat({
+          format: 'bold',
+          input: '<ul><li><em><span id="x">abc</span></em></li></ul>',
+          selection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0 ], foffset: 3 },
+          expected: '<ul><li style="font-weight: bold;"><strong><em><span id="x">abc</span></em></strong></li></ul>',
+        })
+      );
+
+      it('TINY-8961: applying bold to a partially selected start of a LI should not apply bold to the LI', () =>
+        testApplyInlineListFormat({
+          format: 'bold',
+          input: '<ul><li>abc</li></ul>',
+          selection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0 ], foffset: 2 },
+          expected: '<ul><li><strong>ab</strong>c</li></ul>'
+        })
+      );
+
+      it('TINY-8961: applying bold to a partially selected end of a LI should not apply bold to the LI', () =>
+        testApplyInlineListFormat({
+          format: 'bold',
+          input: '<ul><li>abc</li></ul>',
+          selection: { startPath: [ 0, 0, 0 ], soffset: 1, finishPath: [ 0, 0, 0 ], foffset: 3 },
+          expected: '<ul><li>a<strong>bc</strong></li></ul>'
+        })
+      );
+
+      it('TINY-8961: applying bold to a partially selected LI should not apply bold to the LI', () =>
+        testApplyInlineListFormat({
+          format: 'bold',
+          input: '<ul><li>abc</li></ul>',
+          selection: { startPath: [ 0, 0, 0 ], soffset: 1, finishPath: [ 0, 0, 0 ], foffset: 2 },
+          expected: '<ul><li>a<strong>b</strong>c</li></ul>'
+        })
+      );
+
+      it('TINY-8961: applying underline to the entire contents of a LI should not apply that to the LI since it will not be rendered', () =>
+        testApplyInlineListFormat({
+          format: 'underline',
+          input: '<ul><li>abc</li></ul>',
+          selection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0 ], foffset: 3 },
+          expected: '<ul><li><span style="text-decoration: underline;">abc</span></li></ul>'
+        })
+      );
+    });
+
+    context('Apply inline formats to multiple list elements', () => {
+      it('TINY-8961: applying bold to 3 fully selected list items', () =>
+        testApplyInlineListFormat({
+          format: 'bold',
+          input: '<ul><li>abc</li><li>def</li><li>ghj</li></ul>',
+          selection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 2, 0 ], foffset: 3 },
+          expected: '<ul><li style="font-weight: bold;"><strong>abc</strong></li><li style="font-weight: bold;"><strong>def</strong></li><li style="font-weight: bold;"><strong>ghj</strong></li></ul>'
+        })
+      );
+
+      it('TINY-8961: applying bold to a partially selected start li and 2 fully selected list items', () =>
+        testApplyInlineListFormat({
+          format: 'bold',
+          input: '<ul><li>abc</li><li>def</li><li>ghj</li></ul>',
+          selection: { startPath: [ 0, 0, 0 ], soffset: 1, finishPath: [ 0, 2, 0 ], foffset: 3 },
+          expected: '<ul><li>a<strong>bc</strong></li><li style="font-weight: bold;"><strong>def</strong></li><li style="font-weight: bold;"><strong>ghj</strong></li></ul>'
+        })
+      );
+
+      it('TINY-8961: applying bold to 2 fully selected list items and a partially selected end li', () =>
+        testApplyInlineListFormat({
+          format: 'bold',
+          input: '<ul><li>abc</li><li>def</li><li>ghj</li></ul>',
+          selection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 2, 0 ], foffset: 2 },
+          expected: '<ul><li style="font-weight: bold;"><strong>abc</strong></li><li style="font-weight: bold;"><strong>def</strong></li><li><strong>gh</strong>j</li></ul>'
+        })
+      );
+
+      it('TINY-8961: applying bold to a fully selected list item and partially selected start and end lis', () =>
+        testApplyInlineListFormat({
+          format: 'bold',
+          input: '<ul><li>abc</li><li>def</li><li>ghj</li></ul>',
+          selection: { startPath: [ 0, 0, 0 ], soffset: 1, finishPath: [ 0, 2, 0 ], foffset: 2 },
+          expected: '<ul><li>a<strong>bc</strong></li><li style="font-weight: bold;"><strong>def</strong></li><li><strong>gh</strong>j</li></ul>'
+        })
+      );
+    });
+
+    context('Apply inline formats at caret', () => {
+      it('TINY-8961: applying bold at caret in middle of word should not apply bold to parent list item', () =>
+        testApplyInlineListFormat({
+          format: 'bold',
+          input: '<ul><li>abc</li></ul>',
+          selection: { startPath: [ 0, 0, 0 ], soffset: 1, finishPath: [ 0, 0, 0 ], foffset: 1 },
+          expected: '<ul><li><strong>abc</strong></li></ul>',
+        })
+      );
+
+      it('TINY-8961: applying bold at caret at the end of a word should not apply bold to parent list item', () =>
+        testApplyInlineListFormat({
+          format: 'bold',
+          input: '<ul><li>abc</li></ul>',
+          selection: { startPath: [ 0, 0, 0 ], soffset: 3, finishPath: [ 0, 0, 0 ], foffset: 3 },
+          expected: '<ul><li>abc</li></ul>',
+        })
+      );
+    });
+
+    context('Apply inline formats on noneditable lists', () => {
+      it('TINY-8961: applying bold on li elements in a noneditable parent should not get bold styles', () =>
+        testApplyInlineListFormat({
+          format: 'bold',
+          input: '<p>a</p><ul contenteditable="false"><li>b</li><li>c</li></ul><p>d</p>',
+          selection: { startPath: [ 0, 0 ], soffset: 0, finishPath: [ 2, 0 ], foffset: 1 },
+          expected: '<p><strong>a</strong></p><ul contenteditable="false"><li>b</li><li>c</li></ul><p><strong>d</strong></p>',
+        })
+      );
+    });
+  });
+
+  context('Remove inline formats from list elements', () => {
+    const testRemoveInlineListFormat = testListFormat((editor, format, vars) => editor.formatter.remove(format, vars));
+
+    context('Remove inline formats from single list element', () => {
+      it('TINY-8961: removing bold from the entire contents of a LI should also remove that bold from the LI', () =>
+        testRemoveInlineListFormat({
+          format: 'bold',
+          input: '<ul><li style="font-weight: bold;"><strong>abc</strong></li></ul>',
+          selection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0 ], foffset: 3 },
+          expected: '<ul><li>abc</li></ul>',
+        })
+      );
+
+      it('TINY-8961: removing italic from the entire contents of a LI should also remove that italic from the LI', () =>
+        testRemoveInlineListFormat({
+          format: 'italic',
+          input: '<ul><li style="font-style: italic;"><em>abc</em></li></ul>',
+          selection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0 ], foffset: 3 },
+          expected: '<ul><li>abc</li></ul>',
+        })
+      );
+
+      it('TINY-8961: removing text color from the entire contents of a LI should also remove that color from the LI', () =>
+        testRemoveInlineListFormat({
+          format: 'forecolor',
+          value: 'red',
+          input: '<ul><li style="color: red;"><span style="color: red;">abc</span></li></ul>',
+          selection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0 ], foffset: 3 },
+          expected: '<ul><li>abc</li></ul>'
+        })
+      );
+
+      it('TINY-8961: removing font size from the entire contents of a LI should also remove that font size from the LI', () =>
+        testRemoveInlineListFormat({
+          format: 'fontsize',
+          value: '30px',
+          input: '<ul><li style="font-size: 30px;"><span style="font-size: 30px;">abc</span></li></ul>',
+          selection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0 ], foffset: 3 },
+          expected: '<ul><li>abc</li></ul>'
+        })
+      );
+
+      it('TINY-8961: removing font family from the entire contents of a LI should also remove that font family from the LI', () =>
+        testRemoveInlineListFormat({
+          format: 'fontname',
+          value: 'Arial',
+          input: '<ul><li style="font-family: Arial;"><span style="font-family: Arial;">abc</span></li></ul>',
+          selection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0 ], foffset: 3 },
+          expected: '<ul><li>abc</li></ul>'
+        })
+      );
+    });
+
+    context('Remove inline formats from multiple list elements', () => {
+      it('TINY-8961: removing bold to 3 fully selected list items', () =>
+        testRemoveInlineListFormat({
+          format: 'bold',
+          input: '<ul><li style="font-weight: bold;"><strong>abc</strong></li><li style="font-weight: bold;"><strong>def</strong></li><li style="font-weight: bold;"><strong>ghj</strong></li></ul>',
+          selection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 2, 0, 0 ], foffset: 3 },
+          expected: '<ul><li>abc</li><li>def</li><li>ghj</li></ul>',
+        })
+      );
+
+      it('TINY-8961: removing bold from a partially selected start li and 2 fully selected list items', () =>
+        testRemoveInlineListFormat({
+          format: 'bold',
+          input: '<ul><li style="font-weight: bold;"><strong>abc</strong></li><li style="font-weight: bold;"><strong>def</strong></li><li style="font-weight: bold;"><strong>ghj</strong></li></ul>',
+          selection: { startPath: [ 0, 0, 0, 0 ], soffset: 1, finishPath: [ 0, 2, 0, 0 ], foffset: 3 },
+          expected: '<ul><li><strong>a</strong>bc</li><li>def</li><li>ghj</li></ul>'
+        })
+      );
+
+      it('TINY-8961: removing bold from 2 fully selected list items and a partially selected end li', () =>
+        testRemoveInlineListFormat({
+          format: 'bold',
+          input: '<ul><li style="font-weight: bold;"><strong>abc</strong></li><li style="font-weight: bold;"><strong>def</strong></li><li><strong>ghj</strong></li></ul>',
+          selection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 2, 0, 0 ], foffset: 2 },
+          expected: '<ul><li>abc</li><li>def</li><li>gh<strong>j</strong></li></ul>'
+        })
+      );
+
+      it('TINY-8961: removing bold from a fully selected list item and partially selected start and end lis', () =>
+        testRemoveInlineListFormat({
+          format: 'bold',
+          input: '<ul><li><strong>abc</strong></li><li style="font-weight: bold;"><strong>def</strong></li><li><strong>ghj</strong></li></ul>',
+          selection: { startPath: [ 0, 0, 0, 0 ], soffset: 1, finishPath: [ 0, 2, 0, 0 ], foffset: 2 },
+          expected: '<ul><li><strong>a</strong>bc</li><li>def</li><li>gh<strong>j</strong></li></ul>'
+        })
+      );
+    });
+
+    context('Removing inline formats at caret', () => {
+      it('TINY-8961: removing bold at caret in middle of word should remove bold from parent list item', () =>
+        testRemoveInlineListFormat({
+          format: 'bold',
+          input: '<ul><li style="font-weight: bold"><strong>abc</strong></li></ul>',
+          selection: { startPath: [ 0, 0, 0, 0 ], soffset: 1, finishPath: [ 0, 0, 0, 0 ], foffset: 1 },
+          expected: '<ul><li>abc</li></ul>',
+        })
+      );
+
+      it('TINY-8961: removing bold at caret at end of word should remove bold from parent list item', () =>
+        testRemoveInlineListFormat({
+          format: 'bold',
+          input: '<ul><li style="font-weight: bold"><strong>abc</strong></li></ul>',
+          selection: { startPath: [ 0, 0, 0, 0 ], soffset: 3, finishPath: [ 0, 0, 0, 0 ], foffset: 3 },
+          expected: '<ul><li><strong>abc</strong></li></ul>',
+        })
+      );
+    });
+
+    context('Remove inline formats on noneditable lists', () => {
+      it('TINY-8961: remove bold on li elements in a noneditable parent should not remove bold styles', () =>
+        testRemoveInlineListFormat({
+          format: 'bold',
+          input: '<p><strong>a</strong></p><ul contenteditable="false"><li style="font-weight: bold;">b</li><li style="font-weight: bold;">c</li></ul><p><strong>d</strong></p>',
+          selection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 2, 0, 0 ], foffset: 1 },
+          expected: '<p>a</p><ul contenteditable="false"><li style="font-weight: bold;">b</li><li style="font-weight: bold;">c</li></ul><p>d</p>',
+        })
+      );
+    });
+
+    context('Remove all formats', () => {
+      it('TINY-8961: remove all formats should only remove the li specific styles on a partially selected li', () =>
+        testRemoveInlineListFormat({
+          format: 'removeformat',
+          input: '<ul><li style="font-size: 30px; font-weight: bold; color: red; font-style: italic; text-decoration: underline;">abc</li></ul>',
+          selection: { startPath: [ 0, 0, 0 ], soffset: 1, finishPath: [ 0, 0, 0 ], foffset: 2 },
+          expected: '<ul><li style="text-decoration: underline;">abc</li></ul>',
+        })
+      );
+    });
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/fmt/ListItemFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/ListItemFormatTest.ts
@@ -254,7 +254,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
     });
 
     context('Remove inline formats from multiple LIs', () => {
-      it('TINY-8961: removing bold to 3 fully selected LIs', () =>
+      it('TINY-8961: removing bold from 3 fully selected LIs', () =>
         testRemoveInlineListFormat({
           format: 'bold',
           input: '<ul><li style="font-weight: bold;"><strong>abc</strong></li><li style="font-weight: bold;"><strong>def</strong></li><li style="font-weight: bold;"><strong>ghj</strong></li></ul>',
@@ -263,7 +263,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
         })
       );
 
-      it('TINY-8961: removing bold from a partially selected start LI and 2 fully selected LIs', () =>
+      it('TINY-8961: removing bold from a partially selected start LI and 2 fully selected LIs should remove bold from all 3 LIs', () =>
         testRemoveInlineListFormat({
           format: 'bold',
           input: '<ul><li style="font-weight: bold;"><strong>abc</strong></li><li style="font-weight: bold;"><strong>def</strong></li><li style="font-weight: bold;"><strong>ghj</strong></li></ul>',
@@ -272,7 +272,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
         })
       );
 
-      it('TINY-8961: removing bold from 2 fully selected LIs and a partially selected end li', () =>
+      it('TINY-8961: removing bold from 2 fully selected LIs and a partially selected end LI should remove bold from all 3 LIs', () =>
         testRemoveInlineListFormat({
           format: 'bold',
           input: '<ul><li style="font-weight: bold;"><strong>abc</strong></li><li style="font-weight: bold;"><strong>def</strong></li><li><strong>ghj</strong></li></ul>',
@@ -281,7 +281,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
         })
       );
 
-      it('TINY-8961: removing bold from a fully selected LI and partially selected start and end LIs', () =>
+      it('TINY-8961: removing bold from a fully selected LI and partially selected start and end LIs should remove bold from all 3 LIs', () =>
         testRemoveInlineListFormat({
           format: 'bold',
           input: '<ul><li><strong>abc</strong></li><li style="font-weight: bold;"><strong>def</strong></li><li><strong>ghj</strong></li></ul>',


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Formats that have style properties that are possible to apply to list bullets/numbers are now expanded to that list number.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
