### PR TITLE
TINY-8997: Fixed urlinput components updating the value when highlighting dropdown values

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -6,9 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Improved
+- The `GuiSetup` BDD test helpers now provide a way to create a custom `GuiSystem`.
+
 ### Fixed
 - The `lazyViewport` property incorrectly marked the passed component as optional for the `Docking` behaviour.
 - The `TypeaheadSpec` type did not correctly extend `InputSpec`.
+- The `TypeaheadSpec` type had a typo in the `populateFromBrowse` property.
 
 ## 10.1.0 - 2022-06-29
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/TypeaheadTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/TypeaheadTypes.ts
@@ -65,7 +65,7 @@ export interface TypeaheadSpec extends CompositeSketchSpec, InputSpec {
   model?: {
     getDisplayText?: (itemData: TypeaheadData) => string;
     selectsOver?: boolean;
-    populateFromBrowser?: boolean;
+    populateFromBrowse?: boolean;
   };
 
   parts: {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
@@ -146,7 +146,7 @@ export const renderUrlInput = (
     model: {
       getDisplayText: (itemData) => itemData.value,
       selectsOver: false,
-      populateFromBrowser: false
+      populateFromBrowse: false
     },
 
     markers: {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
@@ -1,5 +1,5 @@
 import { ApproxStructure, Assertions, Keyboard, Keys, Mouse, UiControls, UiFinder, Waiter } from '@ephox/agar';
-import { AlloyTriggers, Disabling, Focusing, GuiFactory, NativeEvents, Representing, TestHelpers } from '@ephox/alloy';
+import { Disabling, Focusing, GuiFactory, Representing, TestHelpers } from '@ephox/alloy';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Future, Optional } from '@ephox/katamari';
 import { SelectorFind, SugarDocument, Value } from '@ephox/sugar';
@@ -35,7 +35,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
           {
             type: 'header' as LinkTargetType,
             title: 'Header2',
-            url: '#h_2abefd32',
+            url: '#header2',
             level: 0,
             attach: store.adder('header2.attach')
           }
@@ -49,7 +49,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
         return Future.pure({ value: 'http://tiny.cloud', meta: { before: entry.value }, fieldname: 'test' });
       })
     }, Optional.none())
-  ));
+  ), helpers.uiMothership);
 
   TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [
     '.tox-menu { background: white; }',
@@ -75,7 +75,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
   const closeMenu = () => {
     const doc = hook.root();
     // Close the menu
-    Keyboard.activeKeydown(doc, Keys.escape());
+    Keyboard.activeKeystroke(doc, Keys.escape());
   };
 
   beforeEach(() => {
@@ -140,8 +140,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
     const input = getInput();
 
     await pOpenMenu();
-    UiControls.setValue(input.element, 'He');
-    AlloyTriggers.emit(input, NativeEvents.input());
+    UiControls.setValue(input.element, 'He', 'input');
     await Waiter.pTryUntil(
       'Waiting for the menu to update',
       () => {
@@ -160,7 +159,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
             classes: [ arr.has('tox-collection__group') ],
             children: [
               s.element('div', {
-                classes: [ arr.has('tox-collection__item') ],
+                classes: [ arr.has('tox-collection__item'), arr.has('tox-collection__item--active') ],
                 children: [
                   s.element('div', { html: str.is('Header1') })
                 ]
@@ -200,8 +199,6 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
     // Check that attach fires
     repValue.meta.attach();
     store.assertEq('Attach should be in store ... after firing attach', [ 'addToHistory', 'header1.attach' ]);
-
-    closeMenu();
   });
 
   it('Click urlpicker and assert input state is updated', async () => {
@@ -232,5 +229,31 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
       meta: { before: '#header' },
       fieldname: 'test'
     }, 'Checking Rep.getValue');
+  });
+
+  it('TINY-8997: Should not populate the input value when highlighting a dropdown item', async () => {
+    const input = getInput();
+
+    UiControls.setValue(input.element, '');
+    const menu = await pOpenMenu();
+
+    Mouse.hoverOn(menu, '.tox-collection__item:contains(Header2)');
+    assert.equal(UiControls.getValue(input.element), '');
+
+    Mouse.clickOn(menu, '.tox-collection__item:contains(Header1)');
+    assert.equal(Value.get(input.element), '#header', 'Checking Value.get');
+
+    const repValue = Representing.getValue(input);
+    assert.deepEqual(
+      {
+        value: repValue.value,
+        meta: { text: repValue.meta.text }
+      },
+      {
+        value: '#header',
+        meta: { text: 'Header1' }
+      },
+      'Checking Rep.getValue'
+    );
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
@@ -72,10 +72,14 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
     return UiFinder.findIn(sink, '[role="menu"]').getOrDie();
   };
 
+  const assertMenuIsClosed = () =>
+    UiFinder.notExists(hook.body(), '.tox-menu');
+
   const closeMenu = () => {
     const doc = hook.root();
-    // Close the menu
+    // Close the menu and verify it did actually close
     Keyboard.activeKeystroke(doc, Keys.escape());
+    assertMenuIsClosed();
   };
 
   beforeEach(() => {
@@ -180,6 +184,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
     store.assertEq('nothing in store ... before selecting item', []);
     Keyboard.activeKeydown(doc, Keys.enter());
     assert.equal(Value.get(input.element), '#header', 'Checking Value.get');
+    assertMenuIsClosed();
     const repValue = Representing.getValue(input);
     assert.deepEqual(
       {
@@ -242,6 +247,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
 
     Mouse.clickOn(menu, '.tox-collection__item:contains(Header1)');
     assert.equal(Value.get(input.element), '#header', 'Checking Value.get');
+    assertMenuIsClosed();
 
     const repValue = Representing.getValue(input);
     assert.deepEqual(

--- a/versions.txt
+++ b/versions.txt
@@ -3,5 +3,6 @@
 
 mcagar@8.1.0
 agar@7.2.0
+alloy@10.2.0
 katamari@9.1.0
 sugar@9.1.0


### PR DESCRIPTION
Related Ticket: TINY-8997

Description of Changes:

This fixes a regression I accidentally introduced when doing the strict types due to the alloy types being incorrect for the `TypeaheadSpec`. As part of this, I also had to add a way to specify a custom gui for the alloy `TestHelpers` because the URL input was never working properly because the `input` element and menu were in different GUI motherships. This then meant that all the logic in https://github.com/tinymce/tinymce/blob/16676bc48409eb440ad1e2bb3021d62c24d975fa/modules/alloy/src/main/ts/ephox/alloy/ui/schema/TypeaheadSchema.ts was never running since the `getByUid` would always return a `Result.error`.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
