### PR TITLE
fix: newline behavior for heading and paragraphs tags

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The content of the `contenteditable="false"` element could be selected with the mouse on Firefox  #TINY-8828
 - Parsing large documents no longer throws a `Maximum call stack size exceeded` exception #TINY-6945
 - DomParser filter matching was not checked between filters, which could lead to an exception in the parser #TINY-8888
+- Enabling the `Enter` key to insert `line-break` for inline editors
 
 ### Deprecated
 - The autocompleter `ch` configuration property has been deprecated and will be removed in the next major release. Use the `trigger` property instead. #TINY-8887

--- a/modules/tinymce/src/core/main/ts/newline/NewLineAction.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineAction.ts
@@ -46,8 +46,14 @@ const inBlock = (blockName: string, requiredState: boolean) => (editor: Editor, 
   return state === requiredState;
 };
 
+const inBlocks = (blockNames: string[], requiredState: boolean) => (editor: Editor, _shiftKey: boolean) => {
+  return blockNames.some((blockName) => inBlock(blockName, requiredState)(editor, _shiftKey));
+};
+
 const inPreBlock = (requiredState: boolean) => inBlock('pre', requiredState);
 const inSummaryBlock = () => inBlock('summary', true);
+const inParagraphBlock = () => inBlock('p', true);
+const inHeadingBlock = () => inBlocks([ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ], true);
 
 const shouldPutBrInPre = (requiredState: boolean) => {
   return (editor: Editor, _shiftKey: boolean) => {
@@ -84,6 +90,8 @@ const getAction = (editor: Editor, evt?: EditorEvent<KeyboardEvent>): NewLineAct
   return LazyEvaluator.evaluateUntil([
     match([ shouldBlockNewLine ], newLineAction.none()),
     match([ inSummaryBlock() ], newLineAction.br()),
+    match([ inParagraphBlock() ], newLineAction.br()),
+    match([ inHeadingBlock() ], newLineAction.br()),
     match([ inPreBlock(true), shouldPutBrInPre(false), hasShiftKey ], newLineAction.br()),
     match([ inPreBlock(true), shouldPutBrInPre(false) ], newLineAction.block()),
     match([ inPreBlock(true), shouldPutBrInPre(true), hasShiftKey ], newLineAction.block()),


### PR DESCRIPTION
Related Ticket: https://github.com/tinymce/tinymce/issues/8040

Description of Changes:
- Enabling the `Enter` key to insert `line-break` for inline editors.
- I have forced the behavior to be `line-break` for the inline editors whenever we have `P` and `h*` tags as root blocks  as we cannot insert the `Block` break inside them.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable): https://github.com/tinymce/tinymce/issues/8040
