### PR TITLE
TINY-9003: Fixed linter errors for new lint rules

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -882,6 +882,7 @@ const getTextPatternsLookup = option('text_patterns_lookup');
 const getNonEditableClass = option('noneditable_class');
 const getEditableClass = option('editable_class');
 const getNonEditableRegExps = option('noneditable_regexp');
+const shouldPreserveCData = option('preserve_cdata');
 
 const hasTextPatternsLookup = (editor: Editor): boolean =>
   editor.options.isSet('text_patterns_lookup');
@@ -995,5 +996,6 @@ export {
   getNonEditableClass,
   getNonEditableRegExps,
   getEditableClass,
-  hasTableTabNavigation
+  hasTableTabNavigation,
+  shouldPreserveCData
 };

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -178,7 +178,7 @@ const createParser = (editor: Editor): DomParser => {
     }
   });
 
-  if (editor.options.get('preserve_cdata')) {
+  if (Options.shouldPreserveCData(editor)) {
     parser.addNodeFilter('#cdata', (nodes: AstNode[]) => {
       let i = nodes.length;
 

--- a/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
@@ -1,7 +1,7 @@
 import { Assertions, DragnDrop, Keyboard, Keys, Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { before, beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
-import { SugarBody, SugarElement, SugarLocation } from '@ephox/sugar';
+import { SugarBody, SugarLocation } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -172,7 +172,7 @@ describe('browser.tinymce.core.DragDropOverridesTest', () => {
     const target = UiFinder.findIn(TinyDom.body(editor), 'p:contains("Draggable CEF")').getOrDie();
     const initialScrollX = editor.getWin().scrollX;
     Mouse.mouseDown(target);
-    Mouse.mouseMoveTo(SugarElement.fromDom(editor.getBody()), 298, 5); // Move the mouse close to the right edge of the editor to trigger scrolling
+    Mouse.mouseMoveTo(TinyDom.body(editor), 298, 5); // Move the mouse close to the right edge of the editor to trigger scrolling
     await Waiter.pWait(1500); // Wait a small amount of time to ensure the scrolling happens
     assert.isAbove(editor.getWin().scrollX, initialScrollX); // Make sure scrolling happened
   });
@@ -192,7 +192,7 @@ describe('browser.tinymce.core.DragDropOverridesTest', () => {
     const target = UiFinder.findIn(TinyDom.body(editor), 'p:contains("Draggable CEF")').getOrDie();
     const initialScrollX = editor.getWin().scrollX;
     Mouse.mouseDown(target);
-    Mouse.mouseMoveTo(SugarElement.fromDom(editor.getBody()), 2, 5); // Move the mouse close to the right edge of the editor to trigger scrolling
+    Mouse.mouseMoveTo(TinyDom.body(editor), 2, 5); // Move the mouse close to the right edge of the editor to trigger scrolling
     await Waiter.pWait(1500); // Wait a small amount of time to ensure the scrolling happens
     Mouse.mouseUp(target);
     assert.isBelow(editor.getWin().scrollX, initialScrollX); // Make sure scrolling happened

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -1,7 +1,6 @@
 import { afterEach, before, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions } from '@ephox/mcagar';
-import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';

--- a/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -37,7 +37,7 @@ describe('browser.tinymce.core.ForceBlocksTest', () => {
     editor.getBody().innerHTML = 'abcd';
     LegacyUnit.setSelection(editor, 'body', 2);
     pressArrowKey(editor);
-    assert.equal(editor.getContent(), '<p class="class1">abcd</p>');
+    TinyAssertions.assertContent(editor, '<p class="class1">abcd</p>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
     editor.options.unset('forced_root_block_attrs');
   });

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -1505,7 +1505,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     LegacyUnit.setSelection(editor, 'p', 2, 'p', 2);
     editor.formatter.apply('format');
-    assert.equal(editor.getContent(), '<p><b>abc</b></p>');
+    TinyAssertions.assertContent(editor, '<p><b>abc</b></p>');
   });
 
   it('Caret format inside non-ascii single block word', () => {
@@ -1516,7 +1516,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     LegacyUnit.setSelection(editor, 'p', 2, 'p', 2);
     editor.formatter.apply('format');
-    assert.equal(editor.getContent(), '<p><b>noël</b></p>');
+    TinyAssertions.assertContent(editor, '<p><b>noël</b></p>');
   });
 
   it('Caret format inside first block word', () => {
@@ -1527,7 +1527,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     LegacyUnit.setSelection(editor, 'p', 2, 'p', 2);
     editor.formatter.apply('format');
-    assert.equal(editor.getContent(), '<p><b>abc</b> 123</p>');
+    TinyAssertions.assertContent(editor, '<p><b>abc</b> 123</p>');
   });
 
   it('Caret format inside last block word', () => {
@@ -1538,7 +1538,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     LegacyUnit.setSelection(editor, 'p', 5, 'p', 5);
     editor.formatter.apply('format');
-    assert.equal(editor.getContent(), '<p>abc <b>123</b></p>');
+    TinyAssertions.assertContent(editor, '<p>abc <b>123</b></p>');
   });
 
   it('Caret format inside middle block word', () => {
@@ -1549,7 +1549,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     LegacyUnit.setSelection(editor, 'p', 5, 'p', 5);
     editor.formatter.apply('format');
-    assert.equal(editor.getContent(), '<p>abc <b>123</b> 456</p>');
+    TinyAssertions.assertContent(editor, '<p>abc <b>123</b> 456</p>');
   });
 
   it('Caret format on word separated by non breaking space', () => {
@@ -1560,7 +1560,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     LegacyUnit.setSelection(editor, 'p', 1, 'p', 1);
     editor.formatter.apply('format');
-    assert.equal(editor.getContent(), '<p><b>one</b>\u00a0two</p>');
+    TinyAssertions.assertContent(editor, '<p><b>one</b>\u00a0two</p>');
   });
 
   it('Caret format inside single inline wrapped word', () => {
@@ -1571,7 +1571,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     LegacyUnit.setSelection(editor, 'em', 1, 'em', 1);
     editor.formatter.apply('format');
-    assert.equal(editor.getContent(), '<p>abc <b><em>123</em></b> 456</p>');
+    TinyAssertions.assertContent(editor, '<p>abc <b><em>123</em></b> 456</p>');
   });
 
   it('Caret format inside word before similar format', () => {
@@ -1582,7 +1582,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     LegacyUnit.setSelection(editor, 'p', 1, 'p', 1);
     editor.formatter.apply('format');
-    assert.equal(editor.getContent(), '<p><b>abc</b> 123 <b>456</b></p>');
+    TinyAssertions.assertContent(editor, '<p><b>abc</b> 123 <b>456</b></p>');
   });
 
   it('Caret format inside last inline wrapped word', () => {
@@ -1593,7 +1593,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     LegacyUnit.setSelection(editor, 'em', 5, 'em', 5);
     editor.formatter.apply('format');
-    assert.equal(editor.getContent(), '<p>abc <em>abc <b>123</b></em> 456</p>');
+    TinyAssertions.assertContent(editor, '<p>abc <em>abc <b>123</b></em> 456</p>');
   });
 
   it('Caret format before text', () => {
@@ -1605,7 +1605,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     LegacyUnit.setSelection(editor, 'p', 0, 'p', 0);
     editor.formatter.apply('format');
     KeyUtils.type(editor, 'b');
-    assert.equal(editor.getContent(), '<p><b>b</b>a</p>');
+    TinyAssertions.assertContent(editor, '<p><b>b</b>a</p>');
   });
 
   it('Caret format after text', () => {
@@ -1617,7 +1617,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     LegacyUnit.setSelection(editor, 'p', 1, 'p', 1);
     editor.formatter.apply('format');
     KeyUtils.type(editor, 'b');
-    assert.equal(editor.getContent(), '<p>a<b>b</b></p>');
+    TinyAssertions.assertContent(editor, '<p>a<b>b</b></p>');
   });
 
   it('Caret format and no key press', () => {
@@ -1628,7 +1628,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     LegacyUnit.setSelection(editor, 'p', 0, 'p', 0);
     editor.formatter.apply('format');
-    assert.equal(editor.getContent(), '<p>a</p>');
+    TinyAssertions.assertContent(editor, '<p>a</p>');
   });
 
   it('Caret format and arrow left', () => {
@@ -1642,7 +1642,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     KeyUtils.type(editor, {
       keyCode: 37
     });
-    assert.equal(editor.getContent(), '<p>a</p>');
+    TinyAssertions.assertContent(editor, '<p>a</p>');
   });
 
   it('Caret format and arrow right', () => {
@@ -1656,7 +1656,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     KeyUtils.type(editor, {
       keyCode: 39
     });
-    assert.equal(editor.getContent(), '<p>a</p>');
+    TinyAssertions.assertContent(editor, '<p>a</p>');
   });
 
   it('Caret format and backspace', () => {
@@ -1673,7 +1673,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
 
     editor.formatter.apply('format');
     KeyUtils.type(editor, '\b');
-    assert.equal(editor.getContent(), '<p>ab</p>');
+    TinyAssertions.assertContent(editor, '<p>ab</p>');
   });
 
   it('Caret format on word in li with word in parent li before it', () => {
@@ -1684,7 +1684,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     LegacyUnit.setSelection(editor, 'ul li li', 1, 'ul li li', 1);
     editor.formatter.apply('format');
-    assert.equal(editor.getContent(), '<ul><li>one<ul><li><b>two</b></li></ul></li></ul>');
+    TinyAssertions.assertContent(editor, '<ul><li>one<ul><li><b>two</b></li></ul></li></ul>');
   });
 
   it('Format caret with multiple formats', () => {
@@ -1709,7 +1709,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
     LegacyUnit.setSelection(editor, 'p', 0, 'p', 1);
     editor.formatter.apply('format');
-    assert.equal(editor.getContent(), '<p class="test">a</p>');
+    TinyAssertions.assertContent(editor, '<p class="test">a</p>');
   });
 
   it('format inline on contentEditable: false block', () => {
@@ -1931,7 +1931,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     editor.formatter.apply('format');
     LegacyUnit.setSelection(editor, 'p', 0, 'p', 1);
     editor.formatter.apply('format');
-    assert.equal(editor.getContent(), '<p><span style="font-weight: bold;">abc</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="font-weight: bold;">abc</span></p>');
   });
 
   it('merge_with_parents', () => {
@@ -1946,7 +1946,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     editor.setContent('<p><span style="color: red">a</span></p>');
     LegacyUnit.setSelection(editor, 'span', 0, 'span', 1);
     editor.formatter.apply('format');
-    assert.equal(editor.getContent(), '<p><span style="color: red; font-weight: bold;">a</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="color: red; font-weight: bold;">a</span></p>');
   });
 
   it('Format selection from with end at beginning of block', () => {

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -2019,7 +2019,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
 
     editor.formatter.apply('fontname', { value: 'verdana' });
 
-    assert.equal(editor.getBody().innerHTML,
+    TinyAssertions.assertRawContent(editor,
       '<p>That is a <span style="font-family: verdana;" data-mce-style="font-family: verdana;"><span class="mce-spellchecker-word" data-mce-bogus="1">misespelled</span></span> text</p>');
 
     assert.equal(getContent(editor),
@@ -2028,7 +2028,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     editor.selection.select(editor.dom.select('span')[0]);
     editor.formatter.remove('fontname', { value: 'verdana' });
 
-    assert.equal(editor.getBody().innerHTML,
+    TinyAssertions.assertRawContent(editor,
       '<p>That is a <span class="mce-spellchecker-word" data-mce-bogus="1">misespelled</span> text</p>');
 
     assert.equal(getContent(editor),

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
@@ -289,7 +289,7 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { inline: 'b' });
     LegacyUnit.setSelection(editor, 'b', 1, 'b', 1);
     editor.formatter.remove('format');
-    assert.equal(editor.getContent(), '<p>abc</p>');
+    TinyAssertions.assertContent(editor, '<p>abc</p>');
   });
 
   it('Caret format at end of text', () => {
@@ -299,7 +299,7 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     LegacyUnit.setSelection(editor, 'b', 3, 'b', 3);
     editor.formatter.remove('format');
     KeyUtils.type(editor, 'd');
-    assert.equal(editor.getContent(), '<p><b>abc</b>d</p>');
+    TinyAssertions.assertContent(editor, '<p><b>abc</b>d</p>');
   });
 
   it('Caret format at end of text inside other format', () => {
@@ -309,7 +309,7 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     LegacyUnit.setSelection(editor, 'b', 3, 'b', 3);
     editor.formatter.remove('format');
     KeyUtils.type(editor, 'd');
-    assert.equal(editor.getContent(), '<p><em><b>abc</b>d</em></p>');
+    TinyAssertions.assertContent(editor, '<p><em><b>abc</b>d</em></p>');
   });
 
   it('Caret format at end of text inside other format with text after 1', () => {
@@ -319,7 +319,7 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     LegacyUnit.setSelection(editor, 'b', 3, 'b', 3);
     editor.formatter.remove('format');
     KeyUtils.type(editor, 'd');
-    assert.equal(editor.getContent(), '<p><em><b>abc</b>d</em>e</p>');
+    TinyAssertions.assertContent(editor, '<p><em><b>abc</b>d</em>e</p>');
   });
 
   it('Caret format at end of text inside other format with text after 2', () => {
@@ -329,7 +329,7 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     LegacyUnit.setSelection(editor, 'b', 3, 'b', 3);
     editor.formatter.remove('format');
     KeyUtils.type(editor, 'd');
-    assert.equal(editor.getContent(), '<p><em><b>abc</b></em><b>d</b>e</p>');
+    TinyAssertions.assertContent(editor, '<p><em><b>abc</b></em><b>d</b>e</p>');
   });
 
   it(`Toggle styles at the end of the content don' removes the format where it is not needed.`, () => {
@@ -340,7 +340,7 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     LegacyUnit.setSelection(editor, 'b', 4, 'b', 4);
     editor.formatter.remove('b');
     editor.formatter.remove('em');
-    assert.equal(editor.getContent(), '<p><em><b>abce</b></em></p>');
+    TinyAssertions.assertContent(editor, '<p><em><b>abce</b></em></p>');
   });
 
   it('Caret format on second word in table cell', () => {
@@ -349,7 +349,7 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { inline: 'b' });
     LegacyUnit.setSelection(editor, 'b', 2, 'b', 2);
     editor.formatter.remove('format');
-    assert.equal(editor.getContent(), '<table><tbody><tr><td>one two</td></tr></tbody></table>');
+    TinyAssertions.assertContent(editor, '<table><tbody><tr><td>one two</td></tr></tbody></table>');
   });
 
   it('contentEditable: false on start and contentEditable: true on end', () => {
@@ -421,7 +421,7 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { inline: 'b' });
     LegacyUnit.setSelection(editor, 'i', 1, 'i', 2);
     editor.formatter.remove('format');
-    assert.equal(editor.getContent(), '<p><b><i>a</i></b><i>b</i><b>c</b></p>');
+    TinyAssertions.assertContent(editor, '<p><b><i>a</i></b><i>b</i><b>c</b></p>');
   });
 
   it('Remove format of nested elements at end', () => {
@@ -430,7 +430,7 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { inline: 'b' });
     LegacyUnit.setSelection(editor, 'i', 0, 'i', 1);
     editor.formatter.remove('format');
-    assert.equal(editor.getContent(), '<p><b>a</b><i>b</i><b><i>c</i></b></p>');
+    TinyAssertions.assertContent(editor, '<p><b>a</b><i>b</i><b><i>c</i></b></p>');
   });
 
   it('Remove format of nested elements at end with text after ', () => {
@@ -439,7 +439,7 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { inline: 'b' });
     LegacyUnit.setSelection(editor, 'i', 0, 'i', 2);
     editor.formatter.remove('format');
-    assert.equal(editor.getContent(), '<p><b>a</b><i>bc</i>d</p>');
+    TinyAssertions.assertContent(editor, '<p><b>a</b><i>bc</i>d</p>');
   });
 
   it('Remove format bug 2', () => {
@@ -448,7 +448,7 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { inline: 'b' });
     LegacyUnit.setSelection(editor, 'b', 0, 'b', 1);
     editor.formatter.remove('format');
-    assert.equal(editor.getContent(), '<p>abc</p>');
+    TinyAssertions.assertContent(editor, '<p>abc</p>');
   });
 
   it('Remove format bug 3', () => {
@@ -457,7 +457,7 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.formatter.register('format', { inline: 'b' });
     LegacyUnit.setSelection(editor, 'i', 1, 'i', 2);
     editor.formatter.remove('format');
-    assert.equal(editor.getContent(), '<p><b><i>a</i></b><i>b</i></p>');
+    TinyAssertions.assertContent(editor, '<p><b><i>a</i></b><i>b</i></p>');
   });
 
   it('Remove format with classes', () => {

--- a/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
@@ -1,5 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -35,90 +35,90 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('test 123');
     editor.execCommand('SelectAll');
     editor.execCommand('Bold');
-    assert.equal(editor.getContent(), '<p><strong>test 123</strong></p>');
+    TinyAssertions.assertContent(editor, '<p><strong>test 123</strong></p>');
 
     editor.setContent('test 123');
     editor.execCommand('SelectAll');
     editor.execCommand('Italic');
-    assert.equal(editor.getContent(), '<p><em>test 123</em></p>');
+    TinyAssertions.assertContent(editor, '<p><em>test 123</em></p>');
 
     editor.setContent('test 123');
     editor.execCommand('SelectAll');
     editor.execCommand('Underline');
-    assert.equal(editor.getContent(), '<p><span style="text-decoration: underline;">test 123</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="text-decoration: underline;">test 123</span></p>');
 
     editor.setContent('test 123');
     editor.execCommand('SelectAll');
     editor.execCommand('Strikethrough');
-    assert.equal(editor.getContent(), '<p><s>test 123</s></p>');
+    TinyAssertions.assertContent(editor, '<p><s>test 123</s></p>');
 
     editor.setContent('test 123');
     editor.execCommand('SelectAll');
     editor.execCommand('FontName', false, 'Arial');
-    assert.equal(editor.getContent(), '<p><span style="font-family: Arial;">test 123</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="font-family: Arial;">test 123</span></p>');
 
     editor.setContent('test 123');
     editor.execCommand('SelectAll');
     editor.execCommand('FontName', false, 'Bauhaus 93');
-    assert.equal(editor.getContent(), `<p><span style="font-family: 'Bauhaus 93';">test 123</span></p>`);
+    TinyAssertions.assertContent(editor, `<p><span style="font-family: 'Bauhaus 93';">test 123</span></p>`);
 
     editor.setContent('test 123');
     editor.execCommand('SelectAll');
     editor.execCommand('FontSize', false, '7');
-    assert.equal(editor.getContent(), '<p><span style="font-size: xx-large;">test 123</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="font-size: xx-large;">test 123</span></p>');
 
     editor.setContent('test 123');
     editor.execCommand('SelectAll');
     editor.execCommand('FontSize', false, '7pt');
-    assert.equal(editor.getContent(), '<p><span style="font-size: 7pt;">test 123</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="font-size: 7pt;">test 123</span></p>');
 
     editor.setContent('test 123');
     editor.execCommand('SelectAll');
     editor.execCommand('ForeColor', false, '#FF0000');
-    assert.equal(editor.getContent(), '<p><span style="color: rgb(255, 0, 0);">test 123</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="color: rgb(255, 0, 0);">test 123</span></p>');
 
     editor.setContent('test 123');
     editor.execCommand('SelectAll');
     editor.execCommand('HiliteColor', false, '#FF0000');
-    assert.equal(editor.getContent(), '<p><span style="background-color: rgb(255, 0, 0);">test 123</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="background-color: rgb(255, 0, 0);">test 123</span></p>');
 
     editor.setContent('test 123');
     editor.execCommand('SelectAll');
     editor.execCommand('BackColor', false, '#FF0000');
-    assert.equal(editor.getContent(), '<p><span style="background-color: rgb(255, 0, 0);">test 123</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="background-color: rgb(255, 0, 0);">test 123</span></p>');
 
     editor.setContent('<p><span style="text-decoration: underline;">test 123</span></p>');
-    assert.equal(editor.getContent(), '<p><span style="text-decoration: underline;">test 123</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="text-decoration: underline;">test 123</span></p>');
 
     editor.setContent('<p><span style="text-decoration: line-through;">test 123</span></p>');
-    assert.equal(editor.getContent(), '<p><span style="text-decoration: line-through;">test 123</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="text-decoration: line-through;">test 123</span></p>');
 
     editor.setContent('<p><span style="font-family: Arial;">test 123</span></p>');
-    assert.equal(editor.getContent(), '<p><span style="font-family: Arial;">test 123</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="font-family: Arial;">test 123</span></p>');
 
     editor.setContent('<p><span style="font-size: xx-large;">test 123</span></p>');
-    assert.equal(editor.getContent(), '<p><span style="font-size: xx-large;">test 123</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="font-size: xx-large;">test 123</span></p>');
 
     editor.setContent('<p><strike>test 123</strike></p>');
-    assert.equal(editor.getContent(), '<p><s>test 123</s></p>');
+    TinyAssertions.assertContent(editor, '<p><s>test 123</s></p>');
 
     editor.setContent('<p><font face="Arial">test 123</font></p>');
-    assert.equal(editor.getContent(), '<p><span style="font-family: Arial;">test 123</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="font-family: Arial;">test 123</span></p>');
 
     editor.setContent('<p><font size="7">test 123</font></p>');
-    assert.equal(editor.getContent(), '<p><span style="font-size: 300%;">test 123</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="font-size: 300%;">test 123</span></p>');
 
     editor.setContent('<p><font face="Arial" size="7">test 123</font></p>');
-    assert.equal(editor.getContent(), '<p><span style="font-size: 300%; font-family: Arial;">test 123</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="font-size: 300%; font-family: Arial;">test 123</span></p>');
 
     editor.setContent('<font style="background-color: #ff0000" color="#ff0000">test</font><font face="Arial">test</font>');
-    assert.equal(
-      editor.getContent(),
+    TinyAssertions.assertContent(
+      editor,
       '<p><span style="color: #ff0000; background-color: #ff0000;">test</span><span style="font-family: Arial;">test</span></p>'
     );
 
     editor.setContent('<p><font face="Arial" style="color: #ff0000">test 123</font></p>');
-    assert.equal(editor.getContent(), '<p><span style="color: #ff0000; font-family: Arial;">test 123</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="color: #ff0000; font-family: Arial;">test 123</span></p>');
   });
 
   context('Formatting commands (alignInline)', () => {
@@ -127,7 +127,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
       editor.setContent('<p>test 123</p>');
       editor.execCommand('SelectAll');
       editor.execCommand('JustifyLeft');
-      assert.equal(editor.getContent(), '<p style="text-align: left;">test 123</p>');
+      TinyAssertions.assertContent(editor, '<p style="text-align: left;">test 123</p>');
       assert.isTrue(editor.queryCommandState('JustifyLeft'), 'should have JustifyLeft state true');
     });
 
@@ -136,7 +136,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
       editor.setContent('<p>test 123</p>');
       editor.execCommand('SelectAll');
       editor.execCommand('JustifyCenter');
-      assert.equal(editor.getContent(), '<p style="text-align: center;">test 123</p>');
+      TinyAssertions.assertContent(editor, '<p style="text-align: center;">test 123</p>');
       assert.isTrue(editor.queryCommandState('JustifyCenter'), 'should have JustifyCenter state true');
     });
 
@@ -145,7 +145,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
       editor.setContent('<p>test 123</p>');
       editor.execCommand('SelectAll');
       editor.execCommand('JustifyRight');
-      assert.equal(editor.getContent(), '<p style="text-align: right;">test 123</p>');
+      TinyAssertions.assertContent(editor, '<p style="text-align: right;">test 123</p>');
       assert.isTrue(editor.queryCommandState('JustifyRight'), 'should have JustifyRight state true');
     });
 
@@ -154,7 +154,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
       editor.setContent('<p>test 123</p>');
       editor.execCommand('SelectAll');
       editor.execCommand('JustifyFull');
-      assert.equal(editor.getContent(), '<p style="text-align: justify;">test 123</p>');
+      TinyAssertions.assertContent(editor, '<p style="text-align: justify;">test 123</p>');
       assert.isTrue(editor.queryCommandState('JustifyFull'), 'should have JustifyFull state true');
     });
 
@@ -163,7 +163,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
       editor.setContent('<pre>test 123</pre>');
       editor.execCommand('SelectAll');
       editor.execCommand('JustifyLeft');
-      assert.equal(editor.getContent(), '<pre style="text-align: left;">test 123</pre>');
+      TinyAssertions.assertContent(editor, '<pre style="text-align: left;">test 123</pre>');
       assert.isTrue(editor.queryCommandState('JustifyLeft'), 'should have JustifyLeft state true');
     });
 
@@ -172,7 +172,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
       editor.setContent('<pre>test 123</pre>');
       editor.execCommand('SelectAll');
       editor.execCommand('JustifyCenter');
-      assert.equal(editor.getContent(), '<pre style="text-align: center;">test 123</pre>');
+      TinyAssertions.assertContent(editor, '<pre style="text-align: center;">test 123</pre>');
       assert.isTrue(editor.queryCommandState('JustifyCenter'), 'should have JustifyCenter state true');
     });
 
@@ -181,7 +181,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
       editor.setContent('<pre>test 123</pre>');
       editor.execCommand('SelectAll');
       editor.execCommand('JustifyRight');
-      assert.equal(editor.getContent(), '<pre style="text-align: right;">test 123</pre>');
+      TinyAssertions.assertContent(editor, '<pre style="text-align: right;">test 123</pre>');
       assert.isTrue(editor.queryCommandState('JustifyRight'), 'should have JustifyRight state true');
     });
 
@@ -190,7 +190,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
       editor.setContent('<pre>test 123</pre>');
       editor.execCommand('SelectAll');
       editor.execCommand('JustifyFull');
-      assert.equal(editor.getContent(), '<pre style="text-align: justify;">test 123</pre>');
+      TinyAssertions.assertContent(editor, '<pre style="text-align: justify;">test 123</pre>');
       assert.isTrue(editor.queryCommandState('JustifyFull'), 'should have JustifyFull state true');
     });
 
@@ -199,7 +199,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
       editor.setContent('<img src="tinymce/ui/img/raster.gif" />');
       editor.selection.select(editor.dom.select('img')[0]);
       editor.execCommand('JustifyLeft');
-      assert.equal(editor.getContent(), '<p><img style="float: left;" src="tinymce/ui/img/raster.gif"></p>');
+      TinyAssertions.assertContent(editor, '<p><img style="float: left;" src="tinymce/ui/img/raster.gif"></p>');
     });
 
     it('TBA - img, JustifyCenter', () => {
@@ -207,8 +207,8 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
       editor.setContent('<img src="tinymce/ui/img/raster.gif" />');
       editor.selection.select(editor.dom.select('img')[0]);
       editor.execCommand('JustifyCenter');
-      assert.equal(
-        editor.getContent(),
+      TinyAssertions.assertContent(
+        editor,
         '<p><img style="margin-right: auto; margin-left: auto; display: block;" src="tinymce/ui/img/raster.gif"></p>'
       );
     });
@@ -218,7 +218,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
       editor.setContent('<img src="tinymce/ui/img/raster.gif" />');
       editor.selection.select(editor.dom.select('img')[0]);
       editor.execCommand('JustifyRight');
-      assert.equal(editor.getContent(), '<p><img style="float: right;" src="tinymce/ui/img/raster.gif"></p>');
+      TinyAssertions.assertContent(editor, '<p><img style="float: right;" src="tinymce/ui/img/raster.gif"></p>');
     });
   });
 
@@ -241,27 +241,27 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('<p>test 123</p>');
     editor.execCommand('SelectAll');
     editor.execCommand('FormatBlock', false, 'h1');
-    assert.equal(editor.getContent(), '<h1>test 123</h1>');
+    TinyAssertions.assertContent(editor, '<h1>test 123</h1>');
 
     editor.execCommand('SelectAll');
     editor.execCommand('FormatBlock', false, 'h2');
-    assert.equal(editor.getContent(), '<h2>test 123</h2>');
+    TinyAssertions.assertContent(editor, '<h2>test 123</h2>');
 
     editor.execCommand('SelectAll');
     editor.execCommand('FormatBlock', false, 'h3');
-    assert.equal(editor.getContent(), '<h3>test 123</h3>');
+    TinyAssertions.assertContent(editor, '<h3>test 123</h3>');
 
     editor.execCommand('SelectAll');
     editor.execCommand('FormatBlock', false, 'h4');
-    assert.equal(editor.getContent(), '<h4>test 123</h4>');
+    TinyAssertions.assertContent(editor, '<h4>test 123</h4>');
 
     editor.execCommand('SelectAll');
     editor.execCommand('FormatBlock', false, 'h5');
-    assert.equal(editor.getContent(), '<h5>test 123</h5>');
+    TinyAssertions.assertContent(editor, '<h5>test 123</h5>');
 
     editor.execCommand('SelectAll');
     editor.execCommand('FormatBlock', false, 'h6');
-    assert.equal(editor.getContent(), '<h6>test 123</h6>');
+    TinyAssertions.assertContent(editor, '<h6>test 123</h6>');
 
     editor.execCommand('SelectAll');
 
@@ -271,15 +271,15 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
       // t.log('Failed: ' + ex.message);
     }
 
-    assert.equal(editor.getContent(), '<div>test 123</div>');
+    TinyAssertions.assertContent(editor, '<div>test 123</div>');
 
     editor.execCommand('SelectAll');
     editor.execCommand('FormatBlock', false, 'address');
-    assert.equal(editor.getContent(), '<address>test 123</address>');
+    TinyAssertions.assertContent(editor, '<address>test 123</address>');
 
     editor.execCommand('SelectAll');
     editor.execCommand('FormatBlock', false, 'pre');
-    assert.equal(editor.getContent(), '<pre>test 123</pre>');
+    TinyAssertions.assertContent(editor, '<pre>test 123</pre>');
   });
 
   it('createLink', () => {
@@ -287,7 +287,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('test 123');
     editor.execCommand('SelectAll');
     editor.execCommand('createLink', false, 'http://www.site.com');
-    assert.equal(editor.getContent(), '<p><a href="http://www.site.com">test 123</a></p>');
+    TinyAssertions.assertContent(editor, '<p><a href="http://www.site.com">test 123</a></p>');
   });
 
   it('mceInsertLink (relative)', () => {
@@ -295,7 +295,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('test 123');
     editor.execCommand('SelectAll');
     editor.execCommand('mceInsertLink', false, 'test');
-    assert.equal(editor.getContent(), '<p><a href="test">test 123</a></p>');
+    TinyAssertions.assertContent(editor, '<p><a href="test">test 123</a></p>');
   });
 
   it('mceInsertLink (link absolute)', () => {
@@ -303,7 +303,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('<p>test 123</p>');
     editor.execCommand('SelectAll');
     editor.execCommand('mceInsertLink', false, 'http://www.site.com');
-    assert.equal(editor.getContent(), '<p><a href="http://www.site.com">test 123</a></p>');
+    TinyAssertions.assertContent(editor, '<p><a href="http://www.site.com">test 123</a></p>');
   });
 
   it('mceInsertLink (link encoded)', () => {
@@ -311,7 +311,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('<p>test 123</p>');
     editor.execCommand('SelectAll');
     editor.execCommand('mceInsertLink', false, '"&<>');
-    assert.equal(editor.getContent(), '<p><a href="&quot;&amp;&lt;&gt;">test 123</a></p>');
+    TinyAssertions.assertContent(editor, '<p><a href="&quot;&amp;&lt;&gt;">test 123</a></p>');
   });
 
   it('mceInsertLink (link encoded and with class)', () => {
@@ -319,7 +319,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('<p>test 123</p>');
     editor.execCommand('SelectAll');
     editor.execCommand('mceInsertLink', false, { href: '"&<>', class: 'test' });
-    assert.equal(editor.getContent(), '<p><a class="test" href="&quot;&amp;&lt;&gt;">test 123</a></p>');
+    TinyAssertions.assertContent(editor, '<p><a class="test" href="&quot;&amp;&lt;&gt;">test 123</a></p>');
   });
 
   it('mceInsertLink (link with space)', () => {
@@ -327,7 +327,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('<p>test 123</p>');
     editor.execCommand('SelectAll');
     editor.execCommand('mceInsertLink', false, { href: 'foo bar' });
-    assert.equal(editor.getContent(), '<p><a href="foo%20bar">test 123</a></p>');
+    TinyAssertions.assertContent(editor, '<p><a href="foo%20bar">test 123</a></p>');
   });
 
   it('mceInsertLink (link floated img)', () => {
@@ -335,7 +335,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('<p><img style="float: right;" src="about:blank" /></p>');
     editor.execCommand('SelectAll');
     editor.execCommand('mceInsertLink', false, 'link');
-    assert.equal(editor.getContent(), '<p><a href="link"><img style="float: right;" src="about:blank"></a></p>');
+    TinyAssertions.assertContent(editor, '<p><a href="link"><img style="float: right;" src="about:blank"></a></p>');
   });
 
   it('mceInsertLink (link adjacent text)', () => {
@@ -348,7 +348,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.selection.setRng(rng);
 
     editor.execCommand('mceInsertLink', false, 'link');
-    assert.equal(editor.getContent(), '<p><a href="#">a</a><a href="link">b</a></p>');
+    TinyAssertions.assertContent(editor, '<p><a href="#">a</a><a href="link">b</a></p>');
   });
 
   it('mceInsertLink (link text inside text)', () => {
@@ -357,7 +357,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     LegacyUnit.setSelection(editor, 'em', 1, 'em', 2);
 
     editor.execCommand('mceInsertLink', false, 'link');
-    assert.equal(editor.getContent(), '<p><a href="link"><em>abc</em></a></p>');
+    TinyAssertions.assertContent(editor, '<p><a href="link"><em>abc</em></a></p>');
   });
 
   it('mceInsertLink (link around existing links)', () => {
@@ -366,7 +366,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.execCommand('SelectAll');
 
     editor.execCommand('mceInsertLink', false, 'link');
-    assert.equal(editor.getContent(), '<p><a href="link">12</a></p>');
+    TinyAssertions.assertContent(editor, '<p><a href="link">12</a></p>');
   });
 
   it('mceInsertLink (link around existing links with different attrs)', () => {
@@ -375,7 +375,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.execCommand('SelectAll');
 
     editor.execCommand('mceInsertLink', false, 'link');
-    assert.equal(editor.getContent(), '<p><a href="link">12</a></p>');
+    TinyAssertions.assertContent(editor, '<p><a href="link">12</a></p>');
   });
 
   it('mceInsertLink (link around existing complex contents with links)', () => {
@@ -387,8 +387,8 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.execCommand('SelectAll');
 
     editor.execCommand('mceInsertLink', false, 'link');
-    assert.equal(
-      editor.getContent(),
+    TinyAssertions.assertContent(
+      editor,
       '<p><a href="link"><span id="s1"><strong><em>1</em>' +
       '</strong></span><span id="s2"><em><strong>2</strong></em></span></a></p>'
     );
@@ -401,7 +401,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.execCommand('SelectAll');
 
     editor.execCommand('mceInsertLink', false, 'link');
-    assert.equal(editor.getContent(), '<p><a href="link">test</a></p>');
+    TinyAssertions.assertContent(editor, '<p><a href="link">test</a></p>');
   });
 
   it('mceInsertLink bug #7331', () => {
@@ -412,7 +412,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     rng.setEnd(editor.getBody(), 1);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertLink', false, { href: 'x' });
-    assert.equal(editor.getContent(), '<table><tbody><tr><td>A</td></tr><tr><td><a href=\"x\">B</a></td></tr></tbody></table>');
+    TinyAssertions.assertContent(editor, '<table><tbody><tr><td>A</td></tr><tr><td><a href=\"x\">B</a></td></tr></tbody></table>');
   });
 
   it('unlink', () => {
@@ -420,7 +420,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('<p><a href="test">test</a> <a href="test">123</a></p>');
     editor.execCommand('SelectAll');
     editor.execCommand('unlink');
-    assert.equal(editor.getContent(), '<p>test 123</p>');
+    TinyAssertions.assertContent(editor, '<p>test 123</p>');
   });
 
   it('unlink - unselected a[href] with childNodes', () => {
@@ -428,7 +428,7 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('<p><a href="test"><strong><em>test</em></strong></a></p>');
     LegacyUnit.setSelection(editor, 'em', 0);
     editor.execCommand('unlink');
-    assert.equal(editor.getContent(), '<p><strong><em>test</em></strong></p>');
+    TinyAssertions.assertContent(editor, '<p><strong><em>test</em></strong></p>');
   });
 
   it('subscript/superscript', () => {
@@ -436,24 +436,24 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('<p>test 123</p>');
     editor.execCommand('SelectAll');
     editor.execCommand('subscript');
-    assert.equal(editor.getContent(), '<p><sub>test 123</sub></p>');
+    TinyAssertions.assertContent(editor, '<p><sub>test 123</sub></p>');
 
     editor.setContent('<p>test 123</p>');
     editor.execCommand('SelectAll');
     editor.execCommand('superscript');
-    assert.equal(editor.getContent(), '<p><sup>test 123</sup></p>');
+    TinyAssertions.assertContent(editor, '<p><sup>test 123</sup></p>');
 
     editor.setContent('<p>test 123</p>');
     editor.execCommand('SelectAll');
     editor.execCommand('subscript');
     editor.execCommand('subscript');
-    assert.equal(editor.getContent(), '<p>test 123</p>');
+    TinyAssertions.assertContent(editor, '<p>test 123</p>');
 
     editor.setContent('<p>test 123</p>');
     editor.execCommand('SelectAll');
     editor.execCommand('superscript');
     editor.execCommand('superscript');
-    assert.equal(editor.getContent(), '<p>test 123</p>');
+    TinyAssertions.assertContent(editor, '<p>test 123</p>');
   });
 
   it('indent/outdent', () => {
@@ -461,25 +461,25 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('<p>test 123</p>');
     editor.execCommand('SelectAll');
     editor.execCommand('Indent');
-    assert.equal(editor.getContent(), '<p style="padding-left: 40px;">test 123</p>');
+    TinyAssertions.assertContent(editor, '<p style="padding-left: 40px;">test 123</p>');
 
     editor.setContent('<p>test 123</p>');
     editor.execCommand('SelectAll');
     editor.execCommand('Indent');
     editor.execCommand('Indent');
-    assert.equal(editor.getContent(), '<p style="padding-left: 80px;">test 123</p>');
+    TinyAssertions.assertContent(editor, '<p style="padding-left: 80px;">test 123</p>');
 
     editor.setContent('<p>test 123</p>');
     editor.execCommand('SelectAll');
     editor.execCommand('Indent');
     editor.execCommand('Indent');
     editor.execCommand('Outdent');
-    assert.equal(editor.getContent(), '<p style="padding-left: 40px;">test 123</p>');
+    TinyAssertions.assertContent(editor, '<p style="padding-left: 40px;">test 123</p>');
 
     editor.setContent('<p>test 123</p>');
     editor.execCommand('SelectAll');
     editor.execCommand('Outdent');
-    assert.equal(editor.getContent(), '<p>test 123</p>');
+    TinyAssertions.assertContent(editor, '<p>test 123</p>');
   });
 
   it('indent/outdent table always uses margin', () => {
@@ -487,25 +487,25 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('<table><tbody><tr><td>test</td></tr></tbody></table>');
     editor.execCommand('SelectAll');
     editor.execCommand('Indent');
-    assert.equal(editor.getContent(), '<table style="margin-left: 40px;"><tbody><tr><td>test</td></tr></tbody></table>');
+    TinyAssertions.assertContent(editor, '<table style="margin-left: 40px;"><tbody><tr><td>test</td></tr></tbody></table>');
 
     editor.setContent('<table><tbody><tr><td>test</td></tr></tbody></table>');
     editor.execCommand('SelectAll');
     editor.execCommand('Indent');
     editor.execCommand('Indent');
-    assert.equal(editor.getContent(), '<table style="margin-left: 80px;"><tbody><tr><td>test</td></tr></tbody></table>');
+    TinyAssertions.assertContent(editor, '<table style="margin-left: 80px;"><tbody><tr><td>test</td></tr></tbody></table>');
 
     editor.setContent('<table><tbody><tr><td>test</td></tr></tbody></table>');
     editor.execCommand('SelectAll');
     editor.execCommand('Indent');
     editor.execCommand('Indent');
     editor.execCommand('Outdent');
-    assert.equal(editor.getContent(), '<table style="margin-left: 40px;"><tbody><tr><td>test</td></tr></tbody></table>');
+    TinyAssertions.assertContent(editor, '<table style="margin-left: 40px;"><tbody><tr><td>test</td></tr></tbody></table>');
 
     editor.setContent('<table><tbody><tr><td>test</td></tr></tbody></table>');
     editor.execCommand('SelectAll');
     editor.execCommand('Outdent');
-    assert.equal(editor.getContent(), '<table><tbody><tr><td>test</td></tr></tbody></table>');
+    TinyAssertions.assertContent(editor, '<table><tbody><tr><td>test</td></tr></tbody></table>');
   });
 
   it('RemoveFormat', () => {
@@ -513,17 +513,17 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.setContent('<p><em>test</em> <strong>123</strong> <a href="123">123</a> 123</p>');
     editor.execCommand('SelectAll');
     editor.execCommand('RemoveFormat');
-    assert.equal(editor.getContent(), '<p>test 123 <a href="123">123</a> 123</p>');
+    TinyAssertions.assertContent(editor, '<p>test 123 <a href="123">123</a> 123</p>');
 
     editor.setContent('<p><em><em>test</em> <strong>123</strong> <a href="123">123</a> 123</em></p>');
     editor.execCommand('SelectAll');
     editor.execCommand('RemoveFormat');
-    assert.equal(editor.getContent(), '<p>test 123 <a href="123">123</a> 123</p>');
+    TinyAssertions.assertContent(editor, '<p>test 123 <a href="123">123</a> 123</p>');
 
     editor.setContent('<p><em>test<span id="x">test <strong>123</strong></span><a href="123">123</a> 123</em></p>');
     editor.selection.select(editor.dom.get('x') as HTMLSpanElement);
     editor.execCommand('RemoveFormat');
-    assert.equal(editor.getContent(), '<p><em>test</em><span id="x">test 123</span><em><a href="123">123</a> 123</em></p>');
+    TinyAssertions.assertContent(editor, '<p><em>test</em><span id="x">test 123</span><em><a href="123">123</a> 123</em></p>');
 
     editor.setContent(
       '<p><dfn>dfn tag </dfn> <code>code tag </code> <samp>samp tag</samp> ' +
@@ -532,6 +532,6 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     );
     editor.execCommand('SelectAll');
     editor.execCommand('RemoveFormat');
-    assert.equal(editor.getContent(), '<p>dfn tag code tag samp tag kbd tag var tag cite tag mark tag q tag strike tag s tag small tag</p>');
+    TinyAssertions.assertContent(editor, '<p>dfn tag code tag samp tag kbd tag var tag cite tag mark tag q tag strike tag s tag small tag</p>');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/MiscCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/MiscCommandsTest.ts
@@ -1,7 +1,7 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarElement } from '@ephox/sugar';
-import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -53,7 +53,7 @@ describe('browser.tinymce.core.MiscCommandsTest', () => {
     rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 2);
     editor.selection.setRng(rng);
     editor.execCommand('InsertHorizontalRule');
-    assert.equal(editor.getContent(), '<p>1</p><hr><p>3</p>');
+    TinyAssertions.assertContent(editor, '<p>1</p><hr><p>3</p>');
     rng = normalizeRng(editor.selection.getRng());
     assert.isTrue(rng.collapsed);
     Assertions.assertDomEq('Nodes are not equal', SugarElement.fromDom(editor.getBody().lastChild as HTMLParagraphElement), SugarElement.fromDom(rng.startContainer));

--- a/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/SelectionOverridesTest.ts
@@ -247,7 +247,7 @@ describe('browser.tinymce.core.SelectionOverridesTest', () => {
 
     assert.isFalse(caretContainer.hasAttribute('data-mce-bogus'), 'Bogus attribute should have been removed');
     assert.isFalse(caretContainer.hasAttribute('data-mce-caret'), 'Caret attribute should have been removed');
-    assert.equal(editor.getContent(), '<p>\u00a0</p><p contenteditable="false">a</p>');
+    TinyAssertions.assertContent(editor, '<p>\u00a0</p><p contenteditable="false">a</p>');
   });
 
   it('showBlockCaretContainer after ce=false element', () => {
@@ -266,7 +266,7 @@ describe('browser.tinymce.core.SelectionOverridesTest', () => {
 
     assert.isFalse(caretContainer.hasAttribute('data-mce-bogus'), 'Bogus attribute should have been removed');
     assert.isFalse(caretContainer.hasAttribute('data-mce-caret'), 'Caret attribute should have been removed');
-    assert.equal(editor.getContent(), '<p contenteditable="false">a</p><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<p contenteditable="false">a</p><p>\u00a0</p>');
   });
 
   it('set range in short ended element', () => {

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -386,7 +386,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
 
     editor.execCommand('FormatBlock', false, 'h1');
     editor.undoManager.undo();
-    assert.equal(editor.getContent(), '<p>some</p>');
+    TinyAssertions.assertContent(editor, '<p>some</p>');
   });
 
   it('BeforeAddUndo event', () => {
@@ -441,7 +441,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
 
     assert.isFalse(editor.isDirty(), 'Dirty state should be false');
     KeyUtils.type(editor, 'b');
-    assert.equal(editor.getContent(), '<p>ab</p>');
+    TinyAssertions.assertContent(editor, '<p>ab</p>');
     assert.isTrue(editor.isDirty(), 'Dirty state should be true');
   });
 
@@ -454,7 +454,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
 
     assert.isFalse(editor.isDirty(), 'Dirty state should be false');
     KeyUtils.type(editor, { keyCode: 65, charCode: 66, shiftKey: true });
-    assert.equal(editor.getContent(), '<p>aB</p>');
+    TinyAssertions.assertContent(editor, '<p>aB</p>');
     assert.isTrue(editor.isDirty(), 'Dirty state should be true');
   });
 
@@ -467,7 +467,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
 
     assert.isFalse(editor.isDirty(), 'Dirty state should be false');
     KeyUtils.type(editor, { keyCode: 65, charCode: 66, ctrlKey: true, altKey: true });
-    assert.equal(editor.getContent(), '<p>aB</p>');
+    TinyAssertions.assertContent(editor, '<p>aB</p>');
     assert.isTrue(editor.isDirty(), 'Dirty state should be true');
   });
 
@@ -510,7 +510,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     assert.isFalse(editor.undoManager.typing);
     KeyUtils.type(editor, { keyCode: 66, charCode: 66 });
     assert.isTrue(editor.undoManager.typing);
-    assert.equal(editor.getContent(), '<p>aB</p>');
+    TinyAssertions.assertContent(editor, '<p>aB</p>');
     editor.execCommand('mceInsertContent', false, 'C');
     assert.isFalse(editor.undoManager.typing);
     assert.lengthOf(editor.undoManager.data, 3);
@@ -529,7 +529,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     assert.isFalse(editor.undoManager.typing);
     KeyUtils.type(editor, { keyCode: 66, charCode: 66 });
     assert.isTrue(editor.undoManager.typing);
-    assert.equal(editor.getContent(), '<p>aB</p>');
+    TinyAssertions.assertContent(editor, '<p>aB</p>');
     editor.undoManager.transact(() => {
       const p = editor.dom.select('p')[0];
       (p.firstChild as Text).data = 'aBC';
@@ -556,7 +556,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
 
     assert.isTrue(editor.undoManager.typing);
     assert.lengthOf(editor.undoManager.data, 0);
-    assert.equal(editor.getContent(), '<p><em><strong>a</strong></em></p>');
+    TinyAssertions.assertContent(editor, '<p><em><strong>a</strong></em></p>');
   });
 
   it('TINY-7373: undo filter for mceFocus is case insensitive', () => {

--- a/modules/tinymce/src/core/test/ts/browser/api/EditorCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/api/EditorCommandsTest.ts
@@ -6,7 +6,7 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { ExecCommandEvent } from 'tinymce/core/api/EventTypes';
-import { EditorEvent } from 'tinymce/core/api/PublicApi';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 interface CommandTestState<T, U> {
   readonly command?: string;

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentEventsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentEventsTest.ts
@@ -49,7 +49,7 @@ describe('browser.tinymce.core.content.EditorContentEventsTest', () => {
 
     clearEvents();
     overrideGetContent('<h1>new content</h1>');
-    assert.equal(editor.getContent(), '<h1>new content</h1>');
+    TinyAssertions.assertContent(editor, '<h1>new content</h1>');
     assertEvents([ 'beforegetcontent', 'getcontent' ]);
 
     clearEvents();
@@ -62,7 +62,7 @@ describe('browser.tinymce.core.content.EditorContentEventsTest', () => {
     const editor = hook.editor();
 
     clearEvents();
-    assert.equal(editor.getContent({ no_events: true }), '<p>Some initial content</p>');
+    TinyAssertions.assertContent(editor, '<p>Some initial content</p>', { no_events: true });
     assertEvents([]);
 
     clearEvents();

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentCommandTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentCommandTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -50,7 +50,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<p>abc</p>');
-    assert.equal(editor.getContent(), '<p>1</p><p>abc</p><p>4</p>');
+    TinyAssertions.assertContent(editor, '<p>1</p><p>abc</p><p>4</p>');
     rng = normalizeRng(editor.selection.getRng());
     assert.isTrue(rng.collapsed);
     assert.equal(rng.startContainer.nodeName, 'P');
@@ -69,7 +69,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     rng.setEnd(editor.getBody(), 0);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, 'x');
-    assert.equal(editor.getContent(), '<p>x</p><hr>');
+    TinyAssertions.assertContent(editor, '<p>x</p><hr>');
   });
 
   it('mceInsertContent HR at end of H1', () => {
@@ -79,7 +79,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.execCommand('mceInsertContent', false, '<hr>');
     LegacyUnit.equalDom(editor.selection.getNode(), editor.getBody().lastChild as HTMLHeadingElement);
     assert.equal(editor.selection.getNode().nodeName, 'H1');
-    assert.equal(editor.getContent(), '<h1>abc</h1><hr><h1>\u00a0</h1>');
+    TinyAssertions.assertContent(editor, '<h1>abc</h1><hr><h1>\u00a0</h1>');
   });
 
   it('mceInsertContent HR at end of H1 with P sibling', () => {
@@ -89,7 +89,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.execCommand('mceInsertContent', false, '<hr>');
     LegacyUnit.equalDom(editor.selection.getNode(), editor.getBody().lastChild as HTMLParagraphElement);
     assert.equal(editor.selection.getNode().nodeName, 'P');
-    assert.equal(editor.getContent(), '<h1>abc</h1><hr><p>def</p>');
+    TinyAssertions.assertContent(editor, '<h1>abc</h1><hr><p>def</p>');
   });
 
   it('mceInsertContent HR at end of H1 with inline elements with P sibling', () => {
@@ -99,7 +99,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.execCommand('mceInsertContent', false, '<hr>');
     LegacyUnit.equalDom(editor.selection.getNode(), editor.getBody().lastChild as HTMLParagraphElement);
     assert.equal(editor.selection.getNode().nodeName, 'P');
-    assert.equal(editor.getContent(), '<h1><strong>abc</strong></h1><hr><p>def</p>');
+    TinyAssertions.assertContent(editor, '<h1><strong>abc</strong></h1><hr><p>def</p>');
   });
 
   it('mceInsertContent empty block', () => {
@@ -109,7 +109,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.execCommand('mceInsertContent', false, '<p></p>');
     LegacyUnit.equalDom(editor.selection.getNode(), editor.getBody().childNodes[1]);
     assert.equal(editor.selection.getNode().nodeName, 'P');
-    assert.equal(editor.getContent(), '<h1>a</h1><p>\u00a0</p><h1>bc</h1>');
+    TinyAssertions.assertContent(editor, '<h1>a</h1><p>\u00a0</p><h1>bc</h1>');
   });
 
   it('mceInsertContent table at end of H1 with P sibling', () => {
@@ -118,7 +118,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     LegacyUnit.setSelection(editor, 'h1', 3);
     editor.execCommand('mceInsertContent', false, '<table><tr><td></td></tr></table>');
     assert.equal(editor.selection.getNode().nodeName, 'TD');
-    assert.equal(editor.getContent(), '<h1>abc</h1><table><tbody><tr><td>\u00a0</td></tr></tbody></table><p>def</p>');
+    TinyAssertions.assertContent(editor, '<h1>abc</h1><table><tbody><tr><td>\u00a0</td></tr></tbody></table><p>def</p>');
   });
 
   it('mceInsertContent - p inside whole p', () => {
@@ -131,7 +131,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 4);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<p>abc</p>');
-    assert.equal(editor.getContent(), '<p>abc</p>');
+    TinyAssertions.assertContent(editor, '<p>abc</p>');
     rng = normalizeRng(editor.selection.getRng());
     assert.isTrue(rng.collapsed);
     assert.equal(rng.startContainer.nodeName, 'P');
@@ -151,7 +151,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     rng.setEnd(editor.dom.select('pre')[0].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<pre>abc</pre>');
-    assert.equal(editor.getContent(), '<pre>1</pre><pre>abc</pre><pre>4</pre>');
+    TinyAssertions.assertContent(editor, '<pre>1</pre><pre>abc</pre><pre>4</pre>');
     rng = normalizeRng(editor.selection.getRng());
     assert.isTrue(rng.collapsed);
     assert.equal(rng.startContainer.nodeName, 'PRE');
@@ -171,7 +171,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     rng.setEnd(editor.dom.select('h1')[0].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<h1>abc</h1>');
-    assert.equal(editor.getContent(), '<h1>1</h1><h1>abc</h1><h1>4</h1>');
+    TinyAssertions.assertContent(editor, '<h1>1</h1><h1>abc</h1><h1>4</h1>');
     rng = normalizeRng(editor.selection.getRng());
     assert.isTrue(rng.collapsed);
     assert.equal(rng.startContainer.nodeName, 'H1');
@@ -191,7 +191,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     rng.setEnd(editor.dom.select('li')[0].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<li>abc</li>');
-    assert.equal(editor.getContent(), '<ul><li>1</li><li>abc</li><li>4</li></ul>');
+    TinyAssertions.assertContent(editor, '<ul><li>1</li><li>abc</li><li>4</li></ul>');
     rng = normalizeRng(editor.selection.getRng());
     assert.isTrue(rng.collapsed);
     assert.equal(rng.startContainer.nodeName, 'LI');
@@ -205,7 +205,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     const editor = hook.editor();
     editor.setContent('');
     editor.execCommand('mceInsertContent', false, '<p>abc</p>');
-    assert.equal(editor.getContent(), '<p>abc</p>');
+    TinyAssertions.assertContent(editor, '<p>abc</p>');
     const rng = normalizeRng(editor.selection.getRng());
     assert.isTrue(rng.collapsed);
     assert.equal(rng.startContainer.nodeName, 'P');
@@ -263,7 +263,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 1);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<img src="about:blank" />');
-    assert.equal(editor.getContent(), '<p><img src="about:blank"></p>');
+    TinyAssertions.assertContent(editor, '<p><img src="about:blank"></p>');
     rng = normalizeRng(editor.selection.getRng());
     assert.isTrue(rng.collapsed);
     assert.equal(rng.startContainer.nodeName, 'P');
@@ -281,8 +281,8 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 1);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<strike>strike</strike><font size="7">font</font>');
-    assert.equal(
-      editor.getContent(),
+    TinyAssertions.assertContent(
+      editor,
       '<p><s>strike</s><span style="font-size: 300%;">font</span></p>'
     );
   });
@@ -297,7 +297,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     rng.setEnd(editor.dom.select('p')[0].firstChild as Text, 2);
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, '<hr />');
-    assert.equal(editor.getContent(), '<p>1</p><hr><p>3</p>');
+    TinyAssertions.assertContent(editor, '<p>1</p><hr><p>3</p>');
     rng = normalizeRng(editor.selection.getRng());
     assert.isTrue(rng.collapsed);
     LegacyUnit.equalDom(rng.startContainer, editor.getBody().lastChild as HTMLParagraphElement);
@@ -322,7 +322,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.getBody().innerHTML = '<table><tr><td>X</td></tr></table>';
     LegacyUnit.setSelection(editor, 'td', 0, 'td', 0);
     editor.execCommand('mceInsertContent', false, 'test<b>123</b><!-- a -->');
-    assert.equal(editor.getContent(), '<table><tbody><tr><td>test<strong>123</strong><!-- a -->X</td></tr></tbody></table>');
+    TinyAssertions.assertContent(editor, '<table><tbody><tr><td>test<strong>123</strong><!-- a -->X</td></tr></tbody></table>');
   });
 
   it('mceInsertContent - invalid insertion with spans on page', () => {
@@ -336,7 +336,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.selection.setRng(rng);
     editor.execCommand('mceInsertContent', false, insertedContent);
 
-    assert.equal(editor.getContent(), insertedContent + startingContent);
+    TinyAssertions.assertContent(editor, insertedContent + startingContent);
   });
 
   it('mceInsertContent - text with space before at start of block', () => {
@@ -344,7 +344,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.getBody().innerHTML = '<p>a</p>';
     LegacyUnit.setSelection(editor, 'p', 0);
     editor.execCommand('mceInsertContent', false, ' b');
-    assert.equal(editor.getContent(), '<p>\u00a0ba</p>');
+    TinyAssertions.assertContent(editor, '<p>\u00a0ba</p>');
   });
 
   it('mceInsertContent - text with space after at end of block', () => {
@@ -352,7 +352,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.getBody().innerHTML = '<p>a</p>';
     LegacyUnit.setSelection(editor, 'p', 1);
     editor.execCommand('mceInsertContent', false, 'b ');
-    assert.equal(editor.getContent(), '<p>ab\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<p>ab\u00a0</p>');
   });
 
   it('mceInsertContent - text with space before/after at middle of block', () => {
@@ -360,7 +360,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.getBody().innerHTML = '<p>ac</p>';
     LegacyUnit.setSelection(editor, 'p', 1);
     editor.execCommand('mceInsertContent', false, ' b ');
-    assert.equal(editor.getContent(), '<p>a b c</p>');
+    TinyAssertions.assertContent(editor, '<p>a b c</p>');
   });
 
   it('mceInsertContent - inline element with space before/after at middle of block', () => {
@@ -368,7 +368,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.getBody().innerHTML = '<p>ac</p>';
     LegacyUnit.setSelection(editor, 'p', 1);
     editor.execCommand('mceInsertContent', false, ' <em>b</em> ');
-    assert.equal(editor.getContent(), '<p>a <em>b</em> c</p>');
+    TinyAssertions.assertContent(editor, '<p>a <em>b</em> c</p>');
   });
 
   it('mceInsertContent - block element with space before/after at middle of block', () => {
@@ -376,7 +376,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.getBody().innerHTML = '<p>ac</p>';
     LegacyUnit.setSelection(editor, 'p', 1);
     editor.execCommand('mceInsertContent', false, ' <p>b</p> ');
-    assert.equal(editor.getContent(), '<p>a</p><p>b</p><p>c</p>');
+    TinyAssertions.assertContent(editor, '<p>a</p><p>b</p><p>c</p>');
   });
 
   it('mceInsertContent - strong in strong', () => {
@@ -384,7 +384,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.getBody().innerHTML = '<strong>ac</strong>';
     LegacyUnit.setSelection(editor, 'strong', 1);
     editor.execCommand('mceInsertContent', false, { content: '<strong>b</strong>', merge: true });
-    assert.equal(editor.getContent(), '<p><strong>abc</strong></p>');
+    TinyAssertions.assertContent(editor, '<p><strong>abc</strong></p>');
   });
 
   it('mceInsertContent - span in span same style color', () => {
@@ -392,7 +392,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.getBody().innerHTML = '<span style="color:#ff0000">ac</strong>';
     LegacyUnit.setSelection(editor, 'span', 1);
     editor.execCommand('mceInsertContent', false, { content: '<span style="color:#ff0000">b</span>', merge: true });
-    assert.equal(editor.getContent(), '<p><span style="color: #ff0000;">abc</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="color: #ff0000;">abc</span></p>');
   });
 
   it('mceInsertContent - span in span different style color', () => {
@@ -400,7 +400,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.getBody().innerHTML = '<span style="color:#ff0000">ac</strong>';
     LegacyUnit.setSelection(editor, 'span', 1);
     editor.execCommand('mceInsertContent', false, { content: '<span style="color:#00ff00">b</span>', merge: true });
-    assert.equal(editor.getContent(), '<p><span style="color: #ff0000;">a<span style="color: #00ff00;">b</span>c</span></p>');
+    TinyAssertions.assertContent(editor, '<p><span style="color: #ff0000;">a<span style="color: #00ff00;">b</span>c</span></p>');
   });
 
   it('mceInsertContent - select with option element', () => {
@@ -408,7 +408,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.getBody().innerHTML = '<p>1</p>';
     LegacyUnit.setSelection(editor, 'p', 1);
     editor.execCommand('mceInsertContent', false, '2<select><option selected="selected">3</option></select>');
-    assert.equal(editor.getContent(), '<p>12<select><option selected="selected">3</option></select></p>');
+    TinyAssertions.assertContent(editor, '<p>12<select><option selected="selected">3</option></select></p>');
   });
 
   it('mceInsertContent - insert P in span style element #7090', () => {
@@ -416,7 +416,7 @@ describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
     editor.setContent('<p><span style="color: red">1</span></p><p>3</p>');
     LegacyUnit.setSelection(editor, 'span', 1);
     editor.execCommand('mceInsertContent', false, '<p>2</p>');
-    assert.equal(editor.getContent(), '<p><span style="color: red;">1</span></p><p>2</p><p>3</p>');
+    TinyAssertions.assertContent(editor, '<p><span style="color: red;">1</span></p><p>2</p><p>3</p>');
   });
 
   it('mceInsertContent - insert char at char surrounded by spaces', () => {

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -156,7 +156,7 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     editor.setContent('<p>a</p>');
     editor.selection.setCursorLocation(editor.dom.select('p')[0].firstChild as Text, 0);
     InsertContent.insertAtCaret(editor, { content: '<p>b</p>', paste: true });
-    assert.equal(editor.getContent(), '<h1>c</h1>');
+    TinyAssertions.assertContent(editor, '<h1>c</h1>');
     assert.equal(args?.content, '<h1>b</h1>');
     assert.equal(args?.type, 'setcontent');
     assert.isTrue(args?.paste);

--- a/modules/tinymce/src/core/test/ts/browser/fmt/HooksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/HooksTest.ts
@@ -1,6 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
-import { assert } from 'chai';
+import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as Hooks from 'tinymce/core/fmt/Hooks';
@@ -20,7 +19,7 @@ describe('browser.tinymce.core.fmt.HooksTest', () => {
       editor.getBody().innerHTML = setupHtml;
       LegacyUnit.setSelection(editor, ...setupSelection);
       Hooks.postProcess('pre', editor);
-      assert.equal(editor.getContent(), expected);
+      TinyAssertions.assertContent(editor, expected);
     };
 
     assertPreHook(

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/AutocompleterTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/AutocompleterTest.ts
@@ -6,7 +6,7 @@ import { TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcaga
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import { EditorEvent } from 'tinymce/core/api/PublicApi';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { AutocompleterEventArgs, AutocompleteLookupData } from 'tinymce/core/autocomplete/AutocompleteTypes';
 
 describe('browser.tinymce.core.keyboard.AutocompleterTest', () => {

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyListsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyListsTest.ts
@@ -38,7 +38,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ol><li><br></li><li>a</li></ol>';
     LegacyUnit.setSelection(editor, 'li', 0);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<p>\u00a0</p><ol><li>a</li></ol>');
+    TinyAssertions.assertContent(editor, '<p>\u00a0</p><ol><li>a</li></ol>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -47,7 +47,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ol><li>a</li><li><br></li></ol>';
     LegacyUnit.setSelection(editor, 'li:last-of-type', 0);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<ol><li>a</li></ol><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<ol><li>a</li></ol><p>\u00a0</p>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -83,7 +83,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ol><li>a</li><li><br></li><li>b</li></ol>';
     LegacyUnit.setSelection(editor, 'li:nth-child(2)', 0);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<ol><li>a</li></ol><p>\u00a0</p><ol><li>b</li></ol>');
+    TinyAssertions.assertContent(editor, '<ol><li>a</li></ol><p>\u00a0</p><ol><li>b</li></ol>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -106,7 +106,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.focus();
     pressEnter(editor);
 
-    assert.equal(editor.getContent(),
+    TinyAssertions.assertContent(editor,
       '<ol>' +
       '<li>a</li>' +
       '<li>' +
@@ -138,7 +138,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.focus();
     pressEnter(editor);
 
-    assert.equal(editor.getContent(),
+    TinyAssertions.assertContent(editor,
       '<ol>' +
       '<li>a' +
       '<ol>' +
@@ -173,7 +173,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.focus();
     pressEnter(editor);
 
-    assert.equal(editor.getContent(),
+    TinyAssertions.assertContent(editor,
       '<ol>' +
       '<li>a' +
       '<ol>' +
@@ -206,7 +206,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.focus();
     pressEnter(editor);
 
-    assert.equal(editor.getContent(),
+    TinyAssertions.assertContent(editor,
       '<ol>' +
       '<li>a</li>' +
       '<li>\u00a0' +
@@ -237,7 +237,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.focus();
     pressEnter(editor);
 
-    assert.equal(editor.getContent(),
+    TinyAssertions.assertContent(editor,
       '<ol>' +
       '<li>a</li>' +
       '<li>\u00a0</li>' +
@@ -267,7 +267,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.focus();
     pressEnter(editor);
 
-    assert.equal(editor.getContent(),
+    TinyAssertions.assertContent(editor,
       '<ol>' +
       '<li>a</li>' +
       '<ol>' +
@@ -299,7 +299,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.focus();
     pressEnter(editor);
 
-    assert.equal(editor.getContent(),
+    TinyAssertions.assertContent(editor,
       '<ol>' +
       '<li>a</li>' +
       '<ol>' +
@@ -317,7 +317,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<dl><dt>a</dt></dl>';
     LegacyUnit.setSelection(editor, 'dt', 0);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<dl><dt>\u00a0</dt><dt>a</dt></dl>');
+    TinyAssertions.assertContent(editor, '<dl><dt>\u00a0</dt><dt>a</dt></dl>');
     assert.equal(editor.selection.getNode().nodeName, 'DT');
   });
 
@@ -326,7 +326,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<dl><dd>a</dd></dl>';
     LegacyUnit.setSelection(editor, 'dd', 0);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<dl><dd>\u00a0</dd><dd>a</dd></dl>');
+    TinyAssertions.assertContent(editor, '<dl><dd>\u00a0</dd><dd>a</dd></dl>');
     assert.equal(editor.selection.getNode().nodeName, 'DD');
   });
 
@@ -335,7 +335,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<dl><dt>a</dt><dt>b</dt><dt>c</dt></dl>';
     LegacyUnit.setSelection(editor, 'dt:nth-child(2)', 0);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<dl><dt>a</dt><dt>\u00a0</dt><dt>b</dt><dt>c</dt></dl>');
+    TinyAssertions.assertContent(editor, '<dl><dt>a</dt><dt>\u00a0</dt><dt>b</dt><dt>c</dt></dl>');
     assert.equal(editor.selection.getNode().nodeName, 'DT');
   });
 
@@ -344,7 +344,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<dl><dd>a</dd><dd>b</dd><dd>c</dd></dl>';
     LegacyUnit.setSelection(editor, 'dd:nth-child(2)', 0);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<dl><dd>a</dd><dd>\u00a0</dd><dd>b</dd><dd>c</dd></dl>');
+    TinyAssertions.assertContent(editor, '<dl><dd>a</dd><dd>\u00a0</dd><dd>b</dd><dd>c</dd></dl>');
     assert.equal(editor.selection.getNode().nodeName, 'DD');
   });
 
@@ -353,7 +353,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<dl><dt>a</dt></dl>';
     LegacyUnit.setSelection(editor, 'dt', 1);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<dl><dt>a</dt><dt>\u00a0</dt></dl>');
+    TinyAssertions.assertContent(editor, '<dl><dt>a</dt><dt>\u00a0</dt></dl>');
     assert.equal(editor.selection.getNode().nodeName, 'DT');
   });
 
@@ -362,7 +362,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<dl><dd>a</dd></dl>';
     LegacyUnit.setSelection(editor, 'dd', 1);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<dl><dd>a</dd><dd>\u00a0</dd></dl>');
+    TinyAssertions.assertContent(editor, '<dl><dd>a</dd><dd>\u00a0</dd></dl>');
     assert.equal(editor.selection.getNode().nodeName, 'DD');
   });
 
@@ -371,7 +371,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<dl><dt>a</dt><dt></dt></dl>';
     LegacyUnit.setSelection(editor, 'dt:nth-child(2)', 0);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<dl><dt>a</dt></dl><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<dl><dt>a</dt></dl><p>\u00a0</p>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -380,7 +380,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<dl><dd>a</dd><dd></dd></dl>';
     LegacyUnit.setSelection(editor, 'dd:nth-child(2)', 0);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<dl><dd>a</dd></dl><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<dl><dd>a</dd></dl><p>\u00a0</p>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -389,7 +389,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ol><li><p>abcd</p></li></ol>';
     LegacyUnit.setSelection(editor, 'p', 0);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<ol><li>\u00a0</li><li><p>abcd</p></li></ol>');
+    TinyAssertions.assertContent(editor, '<ol><li>\u00a0</li><li><p>abcd</p></li></ol>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -398,7 +398,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ol><li><p>abcd</p></li></ol>';
     LegacyUnit.setSelection(editor, 'p', 2);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<ol><li><p>ab</p></li><li><p>cd</p></li></ol>');
+    TinyAssertions.assertContent(editor, '<ol><li><p>ab</p></li><li><p>cd</p></li></ol>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -407,7 +407,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ol><li><p>abcd</p></li></ol>';
     LegacyUnit.setSelection(editor, 'p', 4);
     pressEnter(editor);
-    assert.equal(editor.getContent(), '<ol><li><p>abcd</p></li><li>\u00a0</li></ol>');
+    TinyAssertions.assertContent(editor, '<ol><li><p>abcd</p></li><li>\u00a0</li></ol>');
     assert.equal(editor.selection.getNode().nodeName, 'LI');
   });
 
@@ -416,7 +416,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ol><li><p>abcd</p></li></ol>';
     LegacyUnit.setSelection(editor, 'p', 0);
     pressEnter(editor, { shiftKey: true });
-    assert.equal(editor.getContent(), '<ol><li><p><br>abcd</p></li></ol>');
+    TinyAssertions.assertContent(editor, '<ol><li><p><br>abcd</p></li></ol>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -425,7 +425,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ol><li><p>abcd</p></li></ol>';
     LegacyUnit.setSelection(editor, 'p', 2);
     pressEnter(editor, { shiftKey: true });
-    assert.equal(editor.getContent(), '<ol><li><p>ab<br>cd</p></li></ol>');
+    TinyAssertions.assertContent(editor, '<ol><li><p>ab<br>cd</p></li></ol>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -434,8 +434,8 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ol><li><p>abcd</p></li></ol>';
     LegacyUnit.setSelection(editor, 'p', 4);
     pressEnter(editor, { shiftKey: true });
-    assert.equal(
-      editor.getContent(),
+    TinyAssertions.assertContent(
+      editor,
       '<ol><li><p>abcd<br><br></p></li></ol>'
     );
     assert.equal(editor.selection.getNode().nodeName, 'P');
@@ -446,7 +446,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ol><li><p>abcd</p></li></ol>';
     LegacyUnit.setSelection(editor, 'p', 0);
     pressEnter(editor, { ctrlKey: true });
-    assert.equal(editor.getContent(), '<ol><li><p>\u00a0</p><p>abcd</p></li></ol>');
+    TinyAssertions.assertContent(editor, '<ol><li><p>\u00a0</p><p>abcd</p></li></ol>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -455,7 +455,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ol><li><p>abcd</p></li></ol>';
     LegacyUnit.setSelection(editor, 'p', 2);
     pressEnter(editor, { ctrlKey: true });
-    assert.equal(editor.getContent(), '<ol><li><p>ab</p><p>cd</p></li></ol>');
+    TinyAssertions.assertContent(editor, '<ol><li><p>ab</p><p>cd</p></li></ol>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -464,7 +464,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ol><li><p>abcd</p></li></ol>';
     LegacyUnit.setSelection(editor, 'p', 4);
     pressEnter(editor, { ctrlKey: true });
-    assert.equal(editor.getContent(), '<ol><li><p>abcd</p><p>\u00a0</p></li></ol>');
+    TinyAssertions.assertContent(editor, '<ol><li><p>abcd</p><p>\u00a0</p></li></ol>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyListsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyListsTest.ts
@@ -56,7 +56,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ol><li>a</li><li><br></li><li>b</li></ol>';
     editor.selection.setCursorLocation(editor.dom.select('li:nth-child(2)')[0], 0);
     pressEnter(editor, { shiftKey: true });
-    assert.equal(editor.getBody().innerHTML, '<ol><li>a</li><li><br><br></li><li>b</li></ol>');
+    TinyAssertions.assertRawContent(editor, '<ol><li>a</li><li><br><br></li><li>b</li></ol>');
     assert.equal(editor.selection.getNode().nodeName, 'LI');
   });
 
@@ -65,7 +65,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ol><li><br></li><li>a</li></ol>';
     editor.selection.setCursorLocation(editor.dom.select('li')[0], 0);
     pressEnter(editor, { shiftKey: true });
-    assert.equal(editor.getBody().innerHTML, '<ol><li><br><br></li><li>a</li></ol>');
+    TinyAssertions.assertRawContent(editor, '<ol><li><br><br></li><li>a</li></ol>');
     assert.equal(editor.selection.getNode().nodeName, 'LI');
   });
 
@@ -74,7 +74,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyListsTest', () => {
     editor.getBody().innerHTML = '<ol><li>a</li><li><br></li></ol>';
     editor.selection.setCursorLocation(editor.dom.select('li')[1], 0);
     pressEnter(editor, { shiftKey: true });
-    assert.equal(editor.getBody().innerHTML, '<ol><li>a</li><li><br><br></li></ol>');
+    TinyAssertions.assertRawContent(editor, '<ol><li>a</li><li><br><br></li></ol>');
     assert.equal(editor.selection.getNode().nodeName, 'LI');
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
@@ -44,7 +44,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<h1>abc</h1>');
     LegacyUnit.setSelection(editor, 'h1', 3);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<h1>abc</h1><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<h1>abc</h1><p>\u00a0</p>');
     assert.equal(editor.selection.getRng().startContainer.nodeName, 'P');
   });
 
@@ -53,7 +53,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<h1>abcd</h1>');
     LegacyUnit.setSelection(editor, 'h1', 2);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<h1>ab</h1><h1>cd</h1>');
+    TinyAssertions.assertContent(editor, '<h1>ab</h1><h1>cd</h1>');
     assert.equal(editor.selection.getRng().startContainer.parentNode?.nodeName, 'H1');
   });
 
@@ -62,7 +62,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<p><em>a</em>b</p>');
     editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 1);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p><em>a</em></p><p>b</p>');
+    TinyAssertions.assertContent(editor, '<p><em>a</em></p><p>b</p>');
     const rng = editor.selection.getRng();
     assert.equal(rng.startContainer.nodeValue, 'b');
   });
@@ -72,7 +72,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<p><img src="about:blank" /></p>');
     editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 0);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>\u00a0</p><p><img src="about:blank"></p>');
+    TinyAssertions.assertContent(editor, '<p>\u00a0</p><p><img src="about:blank"></p>');
   });
 
   it('Enter before first wrapped IMG in P', () => {
@@ -81,7 +81,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.selection.setCursorLocation(editor.getBody().firstChild?.firstChild as HTMLElement, 0);
     pressEnter(editor, true);
     assert.equal((editor.getBody().firstChild as HTMLElement).innerHTML, '<br data-mce-bogus="1">');
-    assert.equal(editor.getContent(), '<p>\u00a0</p><p><strong><img src="about:blank"></strong></p>');
+    TinyAssertions.assertContent(editor, '<p>\u00a0</p><p><strong><img src="about:blank"></strong></p>');
   });
 
   it('Enter before last IMG in P with text', () => {
@@ -89,7 +89,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<p>abc<img src="about:blank" /></p>');
     editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 1);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>abc</p><p><img src="about:blank"></p>');
+    TinyAssertions.assertContent(editor, '<p>abc</p><p><img src="about:blank"></p>');
     const rng = editor.selection.getRng();
     assert.equal(rng.startContainer.nodeName, 'P');
     assert.equal(rng.startContainer.childNodes[rng.startOffset].nodeName, 'IMG');
@@ -100,7 +100,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<p><img src="about:blank" /><img src="about:blank" /></p>');
     editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 1);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p><img src="about:blank"></p><p><img src="about:blank"></p>');
+    TinyAssertions.assertContent(editor, '<p><img src="about:blank"></p><p><img src="about:blank"></p>');
     const rng = editor.selection.getRng();
     assert.equal(rng.startContainer.nodeName, 'P');
     assert.equal(rng.startContainer.childNodes[rng.startOffset].nodeName, 'IMG');
@@ -111,7 +111,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<p>abc<img src="about:blank" /></p>');
     editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 2);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>abc<img src="about:blank"></p><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<p>abc<img src="about:blank"></p><p>\u00a0</p>');
   });
 
   it('Enter before last INPUT in P with text', () => {
@@ -119,7 +119,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<p>abc<input type="text" /></p>');
     editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 1);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>abc</p><p><input type="text"></p>');
+    TinyAssertions.assertContent(editor, '<p>abc</p><p><input type="text"></p>');
     const rng = editor.selection.getRng();
     assert.equal(rng.startContainer.nodeName, 'P');
     assert.equal(rng.startContainer.childNodes[rng.startOffset].nodeName, 'INPUT');
@@ -130,7 +130,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<p><input type="text" /><input type="text" /></p>');
     editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 1);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p><input type="text"></p><p><input type="text"></p>');
+    TinyAssertions.assertContent(editor, '<p><input type="text"></p><p><input type="text"></p>');
     const rng = editor.selection.getRng();
     assert.equal(rng.startContainer.nodeName, 'P');
     assert.equal(rng.startContainer.childNodes[rng.startOffset].nodeName, 'INPUT');
@@ -141,7 +141,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<p>abc<input type="text" /></p>');
     editor.selection.setCursorLocation(editor.getBody().firstChild as HTMLParagraphElement, 2);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>abc<input type="text"></p><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<p>abc<input type="text"></p><p>\u00a0</p>');
   });
 
   it('Enter at end of P', () => {
@@ -149,7 +149,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<p>abc</p>');
     LegacyUnit.setSelection(editor, 'p', 3);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>abc</p><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<p>abc</p><p>\u00a0</p>');
     assert.equal(editor.selection.getRng().startContainer.nodeName, 'P');
   });
 
@@ -170,7 +170,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<p><em>abcd</em></p>');
     LegacyUnit.setSelection(editor, 'em', 2);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p><em>ab</em></p><p><em>cd</em></p>');
+    TinyAssertions.assertContent(editor, '<p><em>ab</em></p><p><em>cd</em></p>');
     assert.equal(editor.selection.getRng().startContainer.parentNode?.nodeName, 'EM');
   });
 
@@ -203,7 +203,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<p><em><strong>abcd</strong></em></p>');
     LegacyUnit.setSelection(editor, 'strong', 2);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p><em><strong>ab</strong></em></p><p><em><strong>cd</strong></em></p>');
+    TinyAssertions.assertContent(editor, '<p><em><strong>ab</strong></em></p><p><em><strong>cd</strong></em></p>');
     assert.equal(editor.selection.getRng().startContainer.parentNode?.nodeName, 'STRONG');
   });
 
@@ -224,7 +224,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<p>abc</p>');
     LegacyUnit.setSelection(editor, 'p', 0);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>\u00a0</p><p>abc</p>');
+    TinyAssertions.assertContent(editor, '<p>\u00a0</p><p>abc</p>');
     assert.equal(editor.selection.getRng().startContainer.nodeValue, 'abc');
   });
 
@@ -233,7 +233,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<p id="a" class="b" style="color:#000">abcd</p>');
     LegacyUnit.setSelection(editor, 'p', 2);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p id="a" class="b" style="color: #000;">ab</p><p class="b" style="color: #000;">cd</p>');
+    TinyAssertions.assertContent(editor, '<p id="a" class="b" style="color: #000;">ab</p><p class="b" style="color: #000;">cd</p>');
     assert.equal(editor.selection.getRng().startContainer.parentNode?.nodeName, 'P');
   });
 
@@ -242,7 +242,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<h1>abcd</h1><p>efgh</p>');
     LegacyUnit.setSelection(editor, 'h1', 2, 'p', 2);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<h1>ab</h1><h1>gh</h1>');
+    TinyAssertions.assertContent(editor, '<h1>ab</h1><h1>gh</h1>');
     assert.equal(editor.selection.getNode().nodeName, 'H1');
   });
 
@@ -251,7 +251,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<ul><li>abcd</li><li>efgh</li></ul>');
     LegacyUnit.setSelection(editor, 'li:nth-child(1)', 2, 'li:nth-child(2)', 2);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<ul><li>ab</li><li>gh</li></ul>');
+    TinyAssertions.assertContent(editor, '<ul><li>ab</li><li>gh</li></ul>');
     assert.equal(editor.selection.getNode().nodeName, 'LI');
   });
 
@@ -260,7 +260,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<hgroup><h1>abc</h1></hgroup>');
     LegacyUnit.setSelection(editor, 'h1', 3);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<hgroup><h1>abc</h1><h1>\u00a0</h1></hgroup>');
+    TinyAssertions.assertContent(editor, '<hgroup><h1>abc</h1><h1>\u00a0</h1></hgroup>');
     assert.equal(editor.selection.getRng().startContainer.nodeName, 'H1');
   });
 
@@ -293,7 +293,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = 'abcd';
     LegacyUnit.setSelection(editor, 'body', 2);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>ab</p><p>cd</p>');
+    TinyAssertions.assertContent(editor, '<p>ab</p><p>cd</p>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -302,7 +302,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = 'abcd';
     LegacyUnit.setSelection(editor, 'body', 0);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>\u00a0</p><p>abcd</p>');
+    TinyAssertions.assertContent(editor, '<p>\u00a0</p><p>abcd</p>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -311,7 +311,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = 'abcd';
     LegacyUnit.setSelection(editor, 'body', 4);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>abcd</p><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<p>abcd</p><p>\u00a0</p>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -320,7 +320,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '';
     LegacyUnit.setSelection(editor, 'body', 0);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>\u00a0</p><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<p>\u00a0</p><p>\u00a0</p>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -330,7 +330,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<blockquote><p>abc</p><p><br></p></blockquote>';
     LegacyUnit.setSelection(editor, 'p:last-of-type', 0);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<blockquote><p>abc</p></blockquote><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<blockquote><p>abc</p></blockquote><p>\u00a0</p>');
     editor.options.set('forced_root_block', 'p');
   });
 
@@ -340,7 +340,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<blockquote><p><br></p><p>abc</p></blockquote>';
     LegacyUnit.setSelection(editor, 'p', 0);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>\u00a0</p><blockquote><p>abc</p></blockquote>');
+    TinyAssertions.assertContent(editor, '<p>\u00a0</p><blockquote><p>abc</p></blockquote>');
     editor.options.set('forced_root_block', 'p');
   });
 
@@ -350,12 +350,12 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<blockquote><p>abc</p><p><br></p><p>123</p></blockquote>';
     LegacyUnit.setSelection(editor, 'p:nth-child(2)', 0);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<blockquote><p>abc</p></blockquote><p>\u00a0</p><blockquote><p>123</p></blockquote>');
+    TinyAssertions.assertContent(editor, '<blockquote><p>abc</p></blockquote><p>\u00a0</p><blockquote><p>123</p></blockquote>');
 
     editor.getBody().innerHTML = '<blockquote><p>abc</p><p>\u00a0</p><p><br></p><p>123</p></blockquote>';
     LegacyUnit.setSelection(editor, 'p:nth-child(3)', 0);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<blockquote><p>abc</p><p>\u00a0</p></blockquote><p>\u00a0</p><blockquote><p>123</p></blockquote>');
+    TinyAssertions.assertContent(editor, '<blockquote><p>abc</p><p>\u00a0</p></blockquote><p>\u00a0</p><blockquote><p>123</p></blockquote>');
     editor.options.set('forced_root_block', 'p');
   });
 
@@ -365,7 +365,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<p></p><p></p><p>X</p>';
     LegacyUnit.setSelection(editor, 'p', 0);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>\u00a0</p><p>\u00a0</p><p>\u00a0</p><p>X</p>');
+    TinyAssertions.assertContent(editor, '<p>\u00a0</p><p>\u00a0</p><p>\u00a0</p><p>X</p>');
   });
 
   it('Enter at end of H1 with forced_root_block_attrs', () => {
@@ -374,7 +374,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<h1>a</h1>';
     LegacyUnit.setSelection(editor, 'h1', 1);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<h1>a</h1><p class="class1">\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<h1>a</h1><p class="class1">\u00a0</p>');
     editor.options.unset('forced_root_block_attrs');
   });
 
@@ -383,7 +383,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<p>abc</p>';
     LegacyUnit.setSelection(editor, 'p', 0);
     pressEnter(editor, false, { shiftKey: true });
-    assert.equal(editor.getContent(), '<p><br>abc</p>');
+    TinyAssertions.assertContent(editor, '<p><br>abc</p>');
   });
 
   it('Shift+Enter in the middle of P', () => {
@@ -391,7 +391,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<p>abcd</p>';
     LegacyUnit.setSelection(editor, 'p', 2);
     pressEnter(editor, false, { shiftKey: true });
-    assert.equal(editor.getContent(), '<p>ab<br>cd</p>');
+    TinyAssertions.assertContent(editor, '<p>ab<br>cd</p>');
   });
 
   it('Shift+Enter at the end of P', () => {
@@ -399,7 +399,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<p>abcd</p>';
     LegacyUnit.setSelection(editor, 'p', 4);
     pressEnter(editor, false, { shiftKey: true });
-    assert.equal(editor.getContent(), '<p>abcd<br><br></p>');
+    TinyAssertions.assertContent(editor, '<p>abcd<br><br></p>');
   });
 
   it('Shift+Enter in the middle of B with a BR after it', () => {
@@ -407,7 +407,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<p><strong>abcd</strong><br></p>';
     LegacyUnit.setSelection(editor, 'strong', 2);
     pressEnter(editor, false, { shiftKey: true });
-    assert.equal(editor.getContent(), '<p><strong>ab<br>cd</strong></p>');
+    TinyAssertions.assertContent(editor, '<p><strong>ab<br>cd</strong></p>');
   });
 
   it('Shift+Enter at the end of B with a BR after it', () => {
@@ -415,7 +415,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<p><strong>abcd</strong><br></p>';
     LegacyUnit.setSelection(editor, 'strong', 4);
     pressEnter(editor, false, { shiftKey: true });
-    assert.equal(editor.getContent(), '<p><strong>abcd<br></strong></p>');
+    TinyAssertions.assertContent(editor, '<p><strong>abcd<br></strong></p>');
   });
 
   it('Enter in beginning of PRE', () => {
@@ -423,7 +423,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<pre>abc</pre>';
     LegacyUnit.setSelection(editor, 'pre', 0);
     pressEnter(editor, false);
-    assert.equal(editor.getContent(), '<pre><br>abc</pre>');
+    TinyAssertions.assertContent(editor, '<pre><br>abc</pre>');
   });
 
   it('Enter in the middle of PRE', () => {
@@ -431,7 +431,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<pre>abcd</pre>';
     LegacyUnit.setSelection(editor, 'pre', 2);
     pressEnter(editor, false);
-    assert.equal(editor.getContent(), '<pre>ab<br>cd</pre>');
+    TinyAssertions.assertContent(editor, '<pre>ab<br>cd</pre>');
   });
 
   it('Enter at the end of PRE', () => {
@@ -439,7 +439,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<pre>abcd</pre>';
     LegacyUnit.setSelection(editor, 'pre', 4);
     pressEnter(editor, false);
-    assert.equal(editor.getContent(), '<pre>abcd<br><br></pre>');
+    TinyAssertions.assertContent(editor, '<pre>abcd<br><br></pre>');
   });
 
   it('Enter in beginning of PRE and br_in_pre: false', () => {
@@ -448,7 +448,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<pre>abc</pre>';
     LegacyUnit.setSelection(editor, 'pre', 0);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<pre>\u00a0</pre><pre>abc</pre>');
+    TinyAssertions.assertContent(editor, '<pre>\u00a0</pre><pre>abc</pre>');
     editor.options.unset('br_in_pre');
   });
 
@@ -458,7 +458,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<pre>abcd</pre>';
     LegacyUnit.setSelection(editor, 'pre', 2);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<pre>ab</pre><pre>cd</pre>');
+    TinyAssertions.assertContent(editor, '<pre>ab</pre><pre>cd</pre>');
     editor.options.unset('br_in_pre');
   });
 
@@ -468,7 +468,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<pre>abcd</pre>';
     LegacyUnit.setSelection(editor, 'pre', 4);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<pre>abcd</pre><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<pre>abcd</pre><p>\u00a0</p>');
     editor.options.unset('br_in_pre');
   });
 
@@ -477,7 +477,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<pre>abc</pre>';
     LegacyUnit.setSelection(editor, 'pre', 0);
     pressEnter(editor, true, { shiftKey: true });
-    assert.equal(editor.getContent(), '<pre>\u00a0</pre><pre>abc</pre>');
+    TinyAssertions.assertContent(editor, '<pre>\u00a0</pre><pre>abc</pre>');
   });
 
   it('Shift+Enter in the middle of PRE', () => {
@@ -485,7 +485,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<pre>abcd</pre>';
     LegacyUnit.setSelection(editor, 'pre', 2);
     pressEnter(editor, true, { shiftKey: true });
-    assert.equal(editor.getContent(), '<pre>ab</pre><pre>cd</pre>');
+    TinyAssertions.assertContent(editor, '<pre>ab</pre><pre>cd</pre>');
   });
 
   it('Shift+Enter at the end of PRE', () => {
@@ -493,7 +493,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<pre>abcd</pre>';
     LegacyUnit.setSelection(editor, 'pre', 4);
     pressEnter(editor, true, { shiftKey: true });
-    assert.equal(editor.getContent(), '<pre>abcd</pre><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<pre>abcd</pre><p>\u00a0</p>');
   });
 
   it('Enter at the end of DIV layer', () => {
@@ -502,7 +502,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<div style="position: absolute; top: 1px; left: 2px;">abcd</div>');
     LegacyUnit.setSelection(editor, 'div', 4);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<div style="position: absolute; top: 1px; left: 2px;"><p>abcd</p><p>\u00a0</p></div>');
+    TinyAssertions.assertContent(editor, '<div style="position: absolute; top: 1px; left: 2px;"><p>abcd</p><p>\u00a0</p></div>');
     editor.options.unset('br_in_pre');
   });
 
@@ -512,7 +512,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<p><em><span style="font-size: 13px;">X</span></em></p>';
     LegacyUnit.setSelection(editor, 'span', 1);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p><em><span style="font-size: 13px;">X</span></em></p><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<p><em><span style="font-size: 13px;">X</span></em></p><p>\u00a0</p>');
     editor.options.unset('keep_styles');
   });
 
@@ -522,7 +522,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<p class="red" style="color: #ff0000;"><span style="font-size: 13px;">X</span></p>';
     LegacyUnit.setSelection(editor, 'span', 1);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p class="red" style="color: #ff0000;"><span style="font-size: 13px;">X</span></p><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<p class="red" style="color: #ff0000;"><span style="font-size: 13px;">X</span></p><p>\u00a0</p>');
     editor.options.unset('keep_styles');
   });
 
@@ -531,7 +531,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<p>a<br>b</p>';
     LegacyUnit.setSelection(editor, 'p', 1);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>a</p><p><br>b</p>');
+    TinyAssertions.assertContent(editor, '<p>a</p><p><br>b</p>');
 
     const rng = editor.selection.getRng();
     assert.equal(rng.startContainer.nodeName, 'P');
@@ -546,7 +546,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     rng.setEndBefore(editor.dom.select('br')[0]);
     editor.selection.setRng(rng);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<div>a<span>b</span>c</div><p>\u00a0</p><p>\u00a0</p><div>d</div>');
+    TinyAssertions.assertContent(editor, '<div>a<span>b</span>c</div><p>\u00a0</p><p>\u00a0</p><div>d</div>');
   });
 
   // Only test these on modern browsers
@@ -560,7 +560,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.selection.setRng(rng);
 
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<table><tbody><tr><td>x</td></tr></tbody></table><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<table><tbody><tr><td>x</td></tr></tbody></table><p>\u00a0</p>');
   });
 
   it('Enter before table element', () => {
@@ -573,7 +573,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.selection.setRng(rng);
 
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>\u00a0</p><table><tbody><tr><td>x</td></tr></tbody></table>');
+    TinyAssertions.assertContent(editor, '<p>\u00a0</p><table><tbody><tr><td>x</td></tr></tbody></table>');
   });
 
   it('Enter behind table followed by a p', () => {
@@ -586,7 +586,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.selection.setRng(rng);
 
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<table><tbody><tr><td>x</td></tr></tbody></table><p>\u00a0</p><p>x</p>');
+    TinyAssertions.assertContent(editor, '<table><tbody><tr><td>x</td></tr></tbody></table><p>\u00a0</p><p>x</p>');
   });
 
   it('Enter before table element preceded by a p', () => {
@@ -599,7 +599,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.selection.setRng(rng);
 
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>x</p><p>\u00a0</p><table><tbody><tr><td>x</td></tr></tbody></table>');
+    TinyAssertions.assertContent(editor, '<p>x</p><p>\u00a0</p><table><tbody><tr><td>x</td></tr></tbody></table>');
   });
 
   it('Enter twice before table element', () => {
@@ -613,7 +613,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
 
     pressEnter(editor, true);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>\u00a0</p><p>\u00a0</p><table><tbody><tr><td>x</td></tr></tbody></table>');
+    TinyAssertions.assertContent(editor, '<p>\u00a0</p><p>\u00a0</p><table><tbody><tr><td>x</td></tr></tbody></table>');
   });
 
   it('Enter after span with space', () => {
@@ -621,7 +621,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.setContent('<p><strong>abc </strong></p>');
     LegacyUnit.setSelection(editor, 'strong', 3);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p><strong>abc</strong></p><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<p><strong>abc</strong></p><p>\u00a0</p>');
 
     const rng = editor.selection.getRng();
     assert.equal(rng.startContainer.nodeName, 'STRONG');
@@ -633,7 +633,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<ul><li><p><br /></p></li><li><p>b</p></li><li>c</li></ul>';
     LegacyUnit.setSelection(editor, 'p', 0);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<p>\u00a0</p><ul><li><p>b</p></li><li>c</li></ul>');
+    TinyAssertions.assertContent(editor, '<p>\u00a0</p><ul><li><p>b</p></li><li>c</li></ul>');
   });
 
   it('Enter inside middle li with block inside', () => {
@@ -641,7 +641,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<ul><li>a</li><li><p><br /></p></li><li>c</li></ul>';
     LegacyUnit.setSelection(editor, 'p', 0);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<ul><li>a</li></ul><p>\u00a0</p><ul><li>c</li></ul>');
+    TinyAssertions.assertContent(editor, '<ul><li>a</li></ul><p>\u00a0</p><ul><li>c</li></ul>');
   });
 
   it('Enter inside last li with block inside', () => {
@@ -649,7 +649,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<ul><li>a</li><li>b</li><li><p><br /></p></li></ul>';
     LegacyUnit.setSelection(editor, 'p', 0);
     pressEnter(editor, true);
-    assert.equal(editor.getContent(), '<ul><li>a</li><li>b</li></ul><p>\u00a0</p>');
+    TinyAssertions.assertContent(editor, '<ul><li>a</li><li>b</li></ul><p>\u00a0</p>');
   });
 
   it('Enter inside summary element', () => {
@@ -657,7 +657,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     editor.getBody().innerHTML = '<details><summary>ab</summary></details>';
     LegacyUnit.setSelection(editor, 'summary', 1);
     pressEnter(editor, false);
-    assert.equal(editor.getContent(), '<details><summary>a<br>b</summary></details>');
+    TinyAssertions.assertContent(editor, '<details><summary>a<br>b</summary></details>');
   });
 
   it('Enter on expanded range', () => {

--- a/modules/tinymce/src/core/test/ts/browser/util/QuirksWebkitTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/QuirksWebkitTest.ts
@@ -51,7 +51,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<h1>a<input type="text"></h1><p>b<span style="color:red">c</span></p>';
     LegacyUnit.setSelection(editor, 'p', 0);
     editor.execCommand('Delete');
-    assert.equal(editor.getContent(), '<h1>a<input type="text">b<span style="color: red;">c</span></h1>');
+    TinyAssertions.assertContent(editor, '<h1>a<input type="text">b<span style="color: red;">c</span></h1>');
     assert.equal(editor.selection.getNode().nodeName, 'H1');
   });
 
@@ -60,7 +60,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<h1>a</h1><p>b<span style="color:red">c</span></p>';
     LegacyUnit.setSelection(editor, 'p', 0);
     editor.execCommand('Delete');
-    assert.equal(editor.getContent(), '<h1>ab<span style="color: red;">c</span></h1>');
+    TinyAssertions.assertContent(editor, '<h1>ab<span style="color: red;">c</span></h1>');
     assert.equal(editor.selection.getStart().nodeName, 'H1');
   });
 
@@ -69,7 +69,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<h1 contentEditable="false">a</h1><p>b<span style="color:red">c</span></p>';
     LegacyUnit.setSelection(editor, 'p', 0);
     editor.execCommand('Delete');
-    assert.equal(editor.getContent(), '<h1 contenteditable="false">a</h1><p>b<span style="color: red;">c</span></p>');
+    TinyAssertions.assertContent(editor, '<h1 contenteditable="false">a</h1><p>b<span style="color: red;">c</span></p>');
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
@@ -78,7 +78,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<h1>a<br></h1><p>b<span style="color:red">c</span></p>';
     LegacyUnit.setSelection(editor, 'p', 0);
     editor.execCommand('Delete');
-    assert.equal(editor.getContent(), '<h1>ab<span style="color: red;">c</span></h1>');
+    TinyAssertions.assertContent(editor, '<h1>ab<span style="color: red;">c</span></h1>');
     assert.equal(editor.selection.getStart().nodeName, 'H1');
   });
 
@@ -87,7 +87,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<h1>a<br></h1><p><span style="color:red">b</span></p>';
     LegacyUnit.setSelection(editor, 'span', 0);
     editor.execCommand('Delete');
-    assert.equal(editor.getContent(), '<h1>a<span style="color: red;">b</span></h1>');
+    TinyAssertions.assertContent(editor, '<h1>a<span style="color: red;">b</span></h1>');
     assert.equal(editor.selection.getNode().nodeName, 'H1');
   });
 
@@ -96,7 +96,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<h1>a</h1><p><span style="color:red">b</span></p>';
     LegacyUnit.setSelection(editor, 'span', 0);
     editor.execCommand('Delete');
-    assert.equal(editor.getContent(), '<h1>a<span style="color: red;">b</span></h1>');
+    TinyAssertions.assertContent(editor, '<h1>a<span style="color: red;">b</span></h1>');
     assert.equal(editor.selection.getNode().nodeName, 'H1');
   });
 
@@ -126,7 +126,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<h1>a</h1><p><span style="color:red">b</span></p>';
     LegacyUnit.setSelection(editor, 'h1', 1);
     editor.execCommand('ForwardDelete');
-    assert.equal(editor.getContent(), '<h1>a<span style="color: red;">b</span></h1>');
+    TinyAssertions.assertContent(editor, '<h1>a<span style="color: red;">b</span></h1>');
     assert.equal(editor.selection.getNode().nodeName, 'H1');
   });
 
@@ -135,7 +135,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<h1>a<br></h1><p><span style="color:red">b</span></p>';
     LegacyUnit.setSelection(editor, 'h1', 1);
     editor.execCommand('ForwardDelete');
-    assert.equal(editor.getContent(), '<h1>a<span style="color: red;">b</span></h1>');
+    TinyAssertions.assertContent(editor, '<h1>a<span style="color: red;">b</span></h1>');
     assert.equal(editor.selection.getNode().nodeName, 'H1');
   });
 
@@ -144,7 +144,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<h1>a<br><br></h1><p><span style="color:red">b</span></p>';
     LegacyUnit.setSelection(editor, 'h1', 1);
     editor.execCommand('ForwardDelete');
-    assert.equal(editor.getContent(), '<h1>a</h1><p><span style="color: red;">b</span></p>');
+    TinyAssertions.assertContent(editor, '<h1>a</h1><p><span style="color: red;">b</span></p>');
     assert.equal(editor.selection.getStart().nodeName, 'H1');
   });
 
@@ -153,7 +153,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<h1>a</h1><p><input type="text"><span style="color:red">b</span></p>';
     LegacyUnit.setSelection(editor, 'h1', 1);
     editor.execCommand('ForwardDelete');
-    assert.equal(editor.getContent(), '<h1>a<input type="text"><span style="color: red;">b</span></h1>');
+    TinyAssertions.assertContent(editor, '<h1>a<input type="text"><span style="color: red;">b</span></h1>');
     assert.equal(editor.selection.getStart().nodeName, 'H1');
   });
 
@@ -185,7 +185,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<h1>a</h1><p contentEditable="false">b</p>';
     LegacyUnit.setSelection(editor, 'h1', 1);
     editor.execCommand('ForwardDelete');
-    assert.equal(editor.getContent(), '<h1>a</h1><p contenteditable="false">b</p>');
+    TinyAssertions.assertContent(editor, '<h1>a</h1><p contenteditable="false">b</p>');
   });
 
   it('ForwardDelete from end of H1 into P with style span inside', () => {
@@ -193,7 +193,7 @@ describe('browser.tinymce.core.util.QuirksWebkitTest', () => {
     editor.getBody().innerHTML = '<h1>a</h1><p>b<span style="color: #010203">c</span></p>';
     LegacyUnit.setSelection(editor, 'h1', 1);
     editor.execCommand('ForwardDelete');
-    assert.equal(editor.getContent(), '<h1>ab<span style="color: #010203;">c</span></h1>');
+    TinyAssertions.assertContent(editor, '<h1>ab<span style="color: #010203;">c</span></h1>');
     assert.equal(editor.selection.getStart().nodeName, 'H1');
   });
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/TableSectionApiTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/TableSectionApiTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { Selectors, SugarElement } from '@ephox/sugar';
+import { Selectors } from '@ephox/sugar';
 import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -207,7 +207,7 @@ describe('browser.tinymce.models.dom.table.TableSectionApiTest', () => {
   const defaultEvents = [ 'tablemodified' ];
   const switchType = (editor: Editor, startContent: string, expectedContent: string, command: string, type: string, expectedEvents: string[] = defaultEvents, selector = 'tr#one td') => {
     editor.setContent(startContent);
-    const row = UiFinder.findIn(SugarElement.fromDom(editor.getBody()), selector).getOrDie();
+    const row = UiFinder.findIn(TinyDom.body(editor), selector).getOrDie();
     editor.selection.select(row.dom);
     clearEvents();
     editor.execCommand(command, false, { type });

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
@@ -7,7 +7,7 @@ import { McEditor, TinyContentActions, TinyDom, TinyHooks, TinyUiActions } from 
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import { NotificationApi } from 'tinymce/core/api/PublicApi';
+import { NotificationApi } from 'tinymce/core/api/NotificationManager';
 import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DialogOpenTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DialogOpenTest.ts
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { ExecCommandEvent } from 'tinymce/core/api/EventTypes';
-import { EditorEvent } from 'tinymce/core/api/PublicApi';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import Plugin from 'tinymce/plugins/link/Plugin';
 
 describe('browser.tinymce.plugins.link.DialogOpenTest', () => {

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteTest.ts
@@ -668,8 +668,8 @@ describe('browser.tinymce.plugins.lists.BackspaceDeleteTest', () => {
     LegacyUnit.setSelection(editor, 'p', 0);
     editor.plugins.lists.backspaceDelete();
 
-    assert.equal(
-      editor.getContent(),
+    TinyAssertions.assertContent(
+      editor,
       '<ul>' +
         '<li>12</li>' +
         '<li>3</li>' +

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
@@ -6,7 +6,7 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { ExecCommandEvent } from 'tinymce/core/api/EventTypes';
-import { EditorEvent } from 'tinymce/core/api/PublicApi';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import Plugin from 'tinymce/plugins/lists/Plugin';
 
 describe('browser.tinymce.plugins.lists.ListPropertiesTest', () => {

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePluginTest.ts
@@ -207,6 +207,6 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplacePluginTest', () => 
     assert.lengthOf(editor.getBody().getElementsByTagName('span'), 2);
     editor.plugins.searchreplace.done();
     assert.lengthOf(editor.getBody().getElementsByTagName('span'), 0);
-    assert.equal(editor.getBody().innerHTML, content);
+    TinyAssertions.assertRawContent(editor, content);
   });
 });

--- a/modules/tinymce/src/plugins/table/main/ts/selection/TableSelection.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/TableSelection.ts
@@ -10,7 +10,7 @@ import { Arr, Fun, Optionals } from '@ephox/katamari';
 import { TableLookup } from '@ephox/snooker';
 import { Attribute, Compare, SelectorFind, SugarElement, SugarElements, SugarNode } from '@ephox/sugar';
 
-import { Editor } from 'tinymce/core/api/PublicApi';
+import Editor from 'tinymce/core/api/Editor';
 
 import { ephemera } from './Ephemera';
 

--- a/modules/tinymce/src/plugins/visualchars/test/ts/module/test/Utils.ts
+++ b/modules/tinymce/src/plugins/visualchars/test/ts/module/test/Utils.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, StructAssert } from '@ephox/agar';
 import { Unicode } from '@ephox/katamari';
-import { TinyAssertions } from '@ephox/mcagar';
+import { TinyAssertions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 

--- a/modules/tinymce/src/themes/silver/main/ts/Autocompleter.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Autocompleter.ts
@@ -3,8 +3,8 @@ import { InlineContent } from '@ephox/bridge';
 import { Arr, Cell, Optional } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
+import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
-import { DOMUtils } from 'tinymce/core/api/PublicApi';
 import { AutocompleteLookupData } from 'tinymce/core/autocomplete/AutocompleteTypes';
 
 import { AutocompleterEditorEvents, AutocompleterUiApi } from './autocomplete/AutocompleteEditorEvents';

--- a/modules/tinymce/src/themes/silver/main/ts/api/Events.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Events.ts
@@ -1,4 +1,5 @@
 import Editor from 'tinymce/core/api/Editor';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 const fireSkinLoaded = (editor: Editor): void => {
   editor.dispatch('SkinLoaded');
@@ -24,11 +25,23 @@ const fireTextColorChange = (editor: Editor, data: { name: string; color: string
   editor.dispatch('TextColorChange', data);
 };
 
+const fireAfterProgressState = (editor: Editor, state: boolean): void => {
+  editor.dispatch('AfterProgressState', { state });
+};
+
+const fireResolveName = (editor: Editor, node: Node): EditorEvent<{ name: string; target: Node }> =>
+  editor.dispatch('ResolveName', {
+    name: node.nodeName.toLowerCase(),
+    target: node
+  });
+
 export {
   fireSkinLoaded,
   fireSkinLoadError,
   fireResizeEditor,
   fireScrollContent,
   fireResizeContent,
-  fireTextColorChange
+  fireTextColorChange,
+  fireAfterProgressState,
+  fireResolveName
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ElementPath.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ElementPath.ts
@@ -3,6 +3,7 @@ import { Arr } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 
+import * as Events from '../../api/Events';
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as ReadOnly from '../../ReadOnly';
 import { DisablingConfigs } from '../alien/DisablingConfigs';
@@ -75,10 +76,7 @@ const renderElementPath = (editor: Editor, settings: ElementPathSettings, provid
     while (i-- > 0) {
       const parent = parents[i];
       if (parent.nodeType === 1 && !isHidden(parent as Element)) {
-        const args = editor.dispatch('ResolveName', {
-          name: parent.nodeName.toLowerCase(),
-          target: parent
-        });
+        const args = Events.fireResolveName(editor, parent);
 
         if (!args.isDefaultPrevented()) {
           newPath.push({ name: args.name, element: parent });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/throbber/Throbber.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/throbber/Throbber.ts
@@ -8,6 +8,7 @@ import { ExecCommandEvent } from 'tinymce/core/api/EventTypes';
 import Delay from 'tinymce/core/api/util/Delay';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
+import * as Events from '../../api/Events';
 import { UiFactoryBackstageProviders, UiFactoryBackstageShared } from '../../backstage/Backstage';
 
 const getBusySpec = (providerBackstage: UiFactoryBackstageProviders) => (_root: AlloyComponent, _behaviours: Behaviour.AlloyBehaviourRecord): AlloySpec => ({
@@ -147,7 +148,7 @@ const setup = (editor: Editor, lazyThrobber: () => AlloyComponent, sharedBacksta
     if (state !== throbberState.get()) {
       throbberState.set(state);
       toggleThrobber(editor, lazyThrobber(), state, sharedBackstage.providers);
-      editor.dispatch('AfterProgressState', { state });
+      Events.fireAfterProgressState(editor, state);
     }
   };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorWidthTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorWidthTest.ts
@@ -87,7 +87,7 @@ describe('browser.tinymce.themes.silver.editor.SilverInlineEditorWidthTest', () 
 
   it('Check max-width is 400px when set via element', testRender({
     setup: (ed: Editor) => {
-      Css.set(SugarElement.fromDom(ed.getElement()), 'width', '400px');
+      Css.set(TinyDom.targetElement(ed), 'width', '400px');
     }
   }, 400));
 
@@ -107,6 +107,6 @@ describe('browser.tinymce.themes.silver.editor.SilverInlineEditorWidthTest', () 
     width: 400
   }, 400, async (editor) => {
     await pOpenMore(ToolbarMode.sliding);
-    assertWidth(SugarElement.fromDom(editor.getContainer()), 400, 300);
+    assertWidth(TinyDom.container(editor), 400, 300);
   }));
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
@@ -1,7 +1,7 @@
 import { Bounds, Boxes } from '@ephox/alloy';
 import { after, before, context, describe, it } from '@ephox/bedrock-client';
 import { InlineContent } from '@ephox/bridge';
-import { Css, Scroll, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
+import { Css, Scroll, SelectorFind, SugarBody } from '@ephox/sugar';
 import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -55,8 +55,8 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarBoun
   });
 
   const getBounds = (editor: Editor): TestBounds => {
-    const container = SugarElement.fromDom(editor.getContainer());
-    const contentAreaContainer = SugarElement.fromDom(editor.getContentAreaContainer());
+    const container = TinyDom.container(editor);
+    const contentAreaContainer = TinyDom.contentAreaContainer(editor);
     const header = SelectorFind.descendant<HTMLElement>(SugarBody.body(), '.tox-editor-header').getOrDie();
 
     return {

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/DisabledNestedMenuItemTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/DisabledNestedMenuItemTest.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import { Editor } from 'tinymce/core/api/PublicApi';
+import Editor from 'tinymce/core/api/Editor';
 
 describe('webdriver.tinymce.themes.silver.editor.menubar.DisabledNestedMenuItemTest', () => {
 

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/throbber/ThrobberTabbingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/throbber/ThrobberTabbingTest.ts
@@ -2,7 +2,7 @@ import { FocusTools, RealKeys, UiFinder } from '@ephox/agar';
 import { after, before, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { Insert, Remove, SelectorFind, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
-import { TinyHooks } from '@ephox/wrap-mcagar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -17,7 +17,7 @@ describe('webdriver.tinymce.themes.silver.throbber.ThrobberTabbingTest', () => {
 
   before(() => {
     const editor = hook.editor();
-    const target = SugarElement.fromDom(editor.getElement());
+    const target = TinyDom.targetElement(editor);
     const inputBefore = SugarElement.fromHtml('<div><input id="beforeInput" /></div>');
     const inputAfter = SugarElement.fromHtml('<div><input id="afterInput" /></div>');
     Insert.before(target, inputBefore);


### PR DESCRIPTION
Related Ticket: TINY-9003

Description of Changes:

This fixes the errors discovered by the new linter rules I've implemented in https://github.com/tinymce/eslint-plugin/pull/30. I have however disabled/not fixed the events rule errors within tinymce because there are a lot of failures so it'd be better cleaned up as a separate PR (have logged TINY-9004 for that).

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
