### PR TITLE
TINY-8980: fix toolbar padding in tinymce-5 skin

### DIFF
--- a/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
@@ -136,7 +136,7 @@
     padding: 0;
   }
 
-  // Distraction-free mode
+  // Context toolbar
   .tox-pop .tox-pop__dialog .tox-toolbar { padding: 0; }
 
   // Add a top border when toolbar_location is bottom

--- a/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
@@ -136,6 +136,9 @@
     padding: 0;
   }
 
+  // Distraction-free mode
+  .tox-pop .tox-pop__dialog .tox-toolbar { padding: 0; }
+
   // Add a top border when toolbar_location is bottom
   &:not(.tox-tinymce-inline) .tox-editor-header:not(:first-child) .tox-menubar {
     border-top: 1px solid @menubar-separator-color;

--- a/modules/oxide/src/less/theme/components/toolbar/toolbar.less
+++ b/modules/oxide/src/less/theme/components/toolbar/toolbar.less
@@ -127,7 +127,7 @@
   padding: @pad-xs 0;
 }
 
-// Distraction-free mode
+// Context toolbar
 .tox-pop .tox-pop__dialog {
   /* stylelint-disable-next-line no-descending-specificity */
   .tox-toolbar {

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parsing large documents no longer throws a `Maximum call stack size exceeded` exception #TINY-6945
 - DomParser filter matching was not checked between filters, which could lead to an exception in the parser #TINY-8888
 - Lists with `contenteditable="false"` can no longer be toggled, and `contenteditable="true"` list elements within them can no longer be indented, split into another list element, or appended to the previous list element by deletion. #TINY-8920
+- Removed extra padding for Quick Toolbar in `tinymce-5` skin #TINY-8980
 
 ### Deprecated
 - The autocompleter `ch` configuration property has been deprecated and will be removed in the next major release. Use the `trigger` property instead. #TINY-8887

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parsing large documents no longer throws a `Maximum call stack size exceeded` exception #TINY-6945
 - DomParser filter matching was not checked between filters, which could lead to an exception in the parser #TINY-8888
 - Lists with `contenteditable="false"` can no longer be toggled, and `contenteditable="true"` list elements within them can no longer be indented, split into another list element, or appended to the previous list element by deletion. #TINY-8920
-- Removed extra padding for Quick Toolbar in `tinymce-5` skin #TINY-8980
+- Removed extra padding for the context toolbar in the `tinymce-5` skin. #TINY-8980
 
 ### Deprecated
 - The autocompleter `ch` configuration property has been deprecated and will be removed in the next major release. Use the `trigger` property instead. #TINY-8887


### PR DESCRIPTION
Related Ticket: TINY-8980

Description of Changes:
* Removed extra padding for floating Toolbar in tinymce-5 skin

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set