### PR TITLE
TINY-8988: Adding Merge Tags and Footnotes to the Plugin Lists

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The `@menubar-row-separator-color` oxide variable no longer affects the divider between the Menubar and Toolbar and only controls the color of the separator lines drawn in multiline Menubars. #TINY-8632
 - The `@toolbar-separator-color` oxide variable now exclusively affects the color of the separator between the Menubar and Toolbar. #TINY-8632
-- The plugin lists in the Help dialog are no longer translated. #TINY-9019
+- The available premium plugins listed in the Help dialog are no longer translated. #TINY-9019
 
 ### Fixed
 - The Autolink plugin did not work when the text nodes in the content were fragmented #TINY-3723

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,10 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The formatter can now apply a format to a `contenteditable="false"` element by wrapping it. Configurable using the `format_noneditable_selector` option. #TINY-8905
 - The autocompleter now supports a multiple character trigger using the new `trigger` configuration #TINY-8887
 - The formatter will now apply some inline formats like color and font size to list item elements when the entire item content is selected. #TINY-8961
+- The plugin lists in the Help dialog are now sorted alphabetically. #TINY-9019
 
 ### Changed
 - The `@menubar-row-separator-color` oxide variable no longer affects the divider between the Menubar and Toolbar and only controls the color of the separator lines drawn in multiline Menubars. #TINY-8632
 - The `@toolbar-separator-color` oxide variable now exclusively affects the color of the separator between the Menubar and Toolbar. #TINY-8632
+- The plugin lists in the Help dialog are no longer translated. #TINY-9019
 
 ### Fixed
 - The Autolink plugin did not work when the text nodes in the content were fragmented #TINY-3723

--- a/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
@@ -17,6 +17,7 @@ export interface PluginUrl extends PartialPluginUrl {
   readonly slug: string;
 }
 
+// These lists are automatically sorted when generating the dialog.
 const urls = Arr.map<PartialPluginUrl, PluginUrl>([
   { key: 'advlist', name: 'Advanced List' },
   { key: 'anchor', name: 'Anchor' },
@@ -56,11 +57,13 @@ const urls = Arr.map<PartialPluginUrl, PluginUrl>([
   { key: 'casechange', name: 'Case Change', type: PluginType.Premium },
   { key: 'checklist', name: 'Checklist', type: PluginType.Premium },
   { key: 'editimage', name: 'Enhanced Image Editing', type: PluginType.Premium },
+  { key: 'footnotes', name: 'Footnotes', type: PluginType.Premium },
   { key: 'mediaembed', name: 'Enhanced Media Embed', type: PluginType.Premium, slug: 'introduction-to-mediaembed' },
   { key: 'export', name: 'Export', type: PluginType.Premium },
   { key: 'formatpainter', name: 'Format Painter', type: PluginType.Premium },
   { key: 'linkchecker', name: 'Link Checker', type: PluginType.Premium },
   { key: 'mentions', name: 'Mentions', type: PluginType.Premium },
+  { key: 'mergetags', name: 'Merge Tags', type: PluginType.Premium },
   { key: 'pageembed', name: 'Page Embed', type: PluginType.Premium },
   { key: 'permanentpen', name: 'Permanent Pen', type: PluginType.Premium },
   { key: 'powerpaste', name: 'PowerPaste', type: PluginType.Premium, slug: 'introduction-to-powerpaste' },

--- a/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
@@ -50,7 +50,6 @@ const tab = (editor: Editor): Dialog.TabSpec & { name: string } => {
   const getPluginData = (editor: Editor, key: string): PluginData => Arr.find(PluginUrls.urls, (x) => {
     return x.key === key;
   }).fold(() => {
-    // This is an unknown plugin, so see if there is any metadata, or fallback to its name
     return identifyUnknownPlugin(editor, key);
   }, (x) => {
     // We know this plugin, so use our stored details.

--- a/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
@@ -7,13 +7,24 @@ import I18n from 'tinymce/core/api/util/I18n';
 import * as Options from '../api/Options';
 import * as PluginUrls from '../data/PluginUrls';
 
+interface PluginData {
+  // The name is just used for sorting alphabetically.
+  readonly name: string;
+  readonly html: string;
+}
+
 const tab = (editor: Editor): Dialog.TabSpec & { name: string } => {
   const availablePlugins = () => {
     const premiumPlugins = Arr.filter(PluginUrls.urls, ({ type }) => {
       return type === PluginUrls.PluginType.Premium;
     });
-    const premiumPluginList = Arr.map(premiumPlugins, (plugin) => '<li>' + I18n.translate(plugin.name) + '</li>').join('');
 
+    const sortedPremiumPlugins = Arr.sort(
+      Arr.map(premiumPlugins, (p) => p.name),
+      (s1, s2) => s1.localeCompare(s2)
+    );
+
+    const premiumPluginList = Arr.map(sortedPremiumPlugins, (pluginName) => `<li>${pluginName}</li>`).join('');
     return '<div data-mce-tabstop="1" tabindex="-1">' +
       '<p><b>' + I18n.translate('Premium plugins:') + '</b></p>' +
       '<ul>' +
@@ -26,14 +37,26 @@ const tab = (editor: Editor): Dialog.TabSpec & { name: string } => {
   const makeLink = (p: { name: string; url: string }): string =>
     `<a href="${p.url}" target="_blank" rel="noopener">${p.name}</a>`;
 
-  const maybeUrlize = (editor: Editor, key: string) => Arr.find(PluginUrls.urls, (x) => {
+  const identifyUnknownPlugin = (editor: Editor, key: string): PluginData => {
+    const getMetadata = editor.plugins[key].getMetadata;
+    if (Type.isFunction(getMetadata)) {
+      const metadata = getMetadata();
+      return { name: metadata.name, html: makeLink(metadata) };
+    } else {
+      return { name: key, html: key };
+    }
+  };
+
+  const getPluginData = (editor: Editor, key: string): PluginData => Arr.find(PluginUrls.urls, (x) => {
     return x.key === key;
   }).fold(() => {
-    const getMetadata = editor.plugins[key].getMetadata;
-    return typeof getMetadata === 'function' ? makeLink(getMetadata()) : key;
+    // This is an unknown plugin, so see if there is any metadata, or fallback to its name
+    return identifyUnknownPlugin(editor, key);
   }, (x) => {
+    // We know this plugin, so use our stored details.
     const name = x.type === PluginUrls.PluginType.Premium ? `${x.name}*` : x.name;
-    return makeLink({ name, url: `https://www.tiny.cloud/docs/tinymce/6/${x.slug}/` });
+    const html = makeLink({ name, url: `https://www.tiny.cloud/docs/tinymce/6/${x.slug}/` });
+    return { name, html };
   });
 
   const getPluginKeys = (editor: Editor) => {
@@ -47,8 +70,13 @@ const tab = (editor: Editor): Dialog.TabSpec & { name: string } => {
 
   const pluginLister = (editor: Editor) => {
     const pluginKeys = getPluginKeys(editor);
-    const pluginLis = Arr.map(pluginKeys, (key) => {
-      return '<li>' + maybeUrlize(editor, key) + '</li>';
+    const sortedPluginData = Arr.sort(
+      Arr.map(pluginKeys, (k) => getPluginData(editor, k)),
+      (pd1, pd2) => pd1.name.localeCompare(pd2.name)
+    );
+
+    const pluginLis = Arr.map(sortedPluginData, (key) => {
+      return '<li>' + key.html + '</li>';
     });
     const count = pluginLis.length;
     const pluginsString = pluginLis.join('');

--- a/modules/tinymce/src/plugins/help/test/ts/browser/MetadataTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/MetadataTest.ts
@@ -8,7 +8,7 @@ import { selectors } from '../module/Selectors';
 import FakePlugin from '../module/test/FakePlugin';
 import NoMetaFakePlugin from '../module/test/NoMetaFakePlugin';
 
-describe('Browser Test: .MetadataTest', () => {
+describe('browser.tinymce.plugins.help.MetadataTest', () => {
   const hook = TinyHooks.bddSetupLight({
     plugins: 'help fake nometafake',
     toolbar: 'help',

--- a/modules/tinymce/src/plugins/help/test/ts/browser/PluginTabsOrderTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/PluginTabsOrderTest.ts
@@ -1,0 +1,63 @@
+import { Keyboard, Keys, Mouse, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { SelectorFilter, SugarBody, SugarDocument, TextContent } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import HelpPlugin from 'tinymce/plugins/help/Plugin';
+
+import { selectors } from '../module/Selectors';
+import FakePlugin from '../module/test/FakePlugin';
+import NoMetaFakePlugin from '../module/test/NoMetaFakePlugin';
+
+describe('Browser Test: .PluginTabsOrderTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'help fake nometafake',
+    toolbar: 'help',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ HelpPlugin, FakePlugin, NoMetaFakePlugin ]);
+
+  const doc = SugarDocument.getDocument();
+  const body = SugarBody.body();
+
+  const pExtractItemsFrom = async (label: string, selector: string): Promise<string[]> => {
+    const list = await UiFinder.pWaitFor(
+      `Could not find list for ${label} defined by selector: ${selector}`,
+      body,
+      selector
+    );
+
+    return Arr.map(
+      // We want to exclude the "read-more link at the bottom"
+      SelectorFilter.children(list, `li:not(.${selectors.pluginsTabLists.readMoreClass})`),
+      (x) => TextContent.get(x) ?? ''
+    );
+  };
+
+  const pTestPluginItems = async (label: string, editor: Editor, selector: string): Promise<void> => {
+    TinyUiActions.clickOnToolbar(editor, selectors.toolbarHelpButton);
+    const dialog = await UiFinder.pWaitFor('Could not find help dialog', body, selectors.dialog);
+    Mouse.clickOn(dialog, selectors.pluginsTab);
+    const rawEntries = await pExtractItemsFrom(label, selector);
+    assert.deepEqual(
+      rawEntries,
+      Arr.sort(rawEntries, (s1, s2) => s1.localeCompare(s2)),
+      `${label} were not sorted alphabetically`
+    );
+
+    // Close the dialog after a successful assertion.
+    Keyboard.activeKeystroke(doc, Keys.escape(), { });
+  };
+
+  it('TINY-9019: Installed Plugin Lists are alphabetically ordered', async () => {
+    const editor = hook.editor();
+    await pTestPluginItems('Installed Plugins', editor, selectors.pluginsTabLists.installed);
+  });
+
+  it('TINY-9019: Available Plugin Lists are alphabetically ordered', async () => {
+    const editor = hook.editor();
+    await pTestPluginItems('Available Plugins', editor, selectors.pluginsTabLists.available);
+  });
+});

--- a/modules/tinymce/src/plugins/help/test/ts/browser/PluginTabsOrderTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/PluginTabsOrderTest.ts
@@ -1,7 +1,7 @@
-import { Keyboard, Keys, Mouse, UiFinder } from '@ephox/agar';
+import { Keys, Mouse } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { SelectorFilter, SugarBody, SugarDocument, TextContent } from '@ephox/sugar';
+import { SelectorFilter, TextContent } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -12,20 +12,16 @@ import { selectors } from '../module/Selectors';
 import FakePlugin from '../module/test/FakePlugin';
 import NoMetaFakePlugin from '../module/test/NoMetaFakePlugin';
 
-describe('Browser Test: .PluginTabsOrderTest', () => {
+describe('browser.tinymce.plugins.help.PluginTabsOrderTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'help fake nometafake',
     toolbar: 'help',
     base_url: '/project/tinymce/js/tinymce'
   }, [ HelpPlugin, FakePlugin, NoMetaFakePlugin ]);
 
-  const doc = SugarDocument.getDocument();
-  const body = SugarBody.body();
-
-  const pExtractItemsFrom = async (label: string, selector: string): Promise<string[]> => {
-    const list = await UiFinder.pWaitFor(
-      `Could not find list for ${label} defined by selector: ${selector}`,
-      body,
+  const pExtractItemsFrom = async (editor: Editor, selector: string): Promise<string[]> => {
+    const list = await TinyUiActions.pWaitForUi(
+      editor,
       selector
     );
 
@@ -38,9 +34,9 @@ describe('Browser Test: .PluginTabsOrderTest', () => {
 
   const pTestPluginItems = async (label: string, editor: Editor, selector: string): Promise<void> => {
     TinyUiActions.clickOnToolbar(editor, selectors.toolbarHelpButton);
-    const dialog = await UiFinder.pWaitFor('Could not find help dialog', body, selectors.dialog);
+    const dialog = await TinyUiActions.pWaitForUi(editor, selectors.dialog);
     Mouse.clickOn(dialog, selectors.pluginsTab);
-    const rawEntries = await pExtractItemsFrom(label, selector);
+    const rawEntries = await pExtractItemsFrom(editor, selector);
     assert.deepEqual(
       rawEntries,
       Arr.sort(rawEntries, (s1, s2) => s1.localeCompare(s2)),
@@ -48,7 +44,7 @@ describe('Browser Test: .PluginTabsOrderTest', () => {
     );
 
     // Close the dialog after a successful assertion.
-    Keyboard.activeKeystroke(doc, Keys.escape(), { });
+    TinyUiActions.keystroke(editor, Keys.escape(), { });
   };
 
   it('TINY-9019: Installed Plugin Lists are alphabetically ordered', async () => {

--- a/modules/tinymce/src/plugins/help/test/ts/module/Selectors.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/module/Selectors.ts
@@ -1,5 +1,10 @@
 export const selectors = {
   dialog: '[role="dialog"]',
   toolbarHelpButton: 'button',
-  pluginsTab: '[role="tab"]:contains(Plugins)'
+  pluginsTab: '[role="tab"]:contains(Plugins)',
+  pluginsTabLists: {
+    installed: '[role=document] div:eq(0) ul',
+    available: '[role=document] div:eq(1) ul',
+    readMoreClass: 'tox-help__more-link'
+  }
 };


### PR DESCRIPTION
Related Ticket: TINY-8988 and TINY-9019

Description of Changes:
* added mergetags and footnotes to the available plugin lists
* sorted the available and installed plugin lists that are displayed

Pre-checks:
* [x] Changelog entry added (for sorting)
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [N/A] Docs ticket created (if applicable)
