### PR TITLE
TINY-9020: More spacing linter rules enabled and fixed

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,8 +23,6 @@
     "one-var": "off",
     "prefer-rest-params": "off",
     "prefer-spread": "off",
-    "@tinymce/no-unimported-promise": "off",
-    "max-len": ["warn", 260],
-    "semi-spacing": "error"
+    "max-len": ["warn", 260]
   }
 }

--- a/modules/agar/src/main/ts/ephox/agar/api/TestLogs.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/TestLogs.ts
@@ -1,6 +1,10 @@
 import { Arr } from '@ephox/katamari';
 
-export enum TestLogEntryState { Original, Started, Finished }
+export enum TestLogEntryState {
+  Original,
+  Started,
+  Finished
+}
 
 export interface TestLogEntry {
   message: string;

--- a/modules/agar/src/main/ts/ephox/agar/arbitrary/TagDecorator.ts
+++ b/modules/agar/src/main/ts/ephox/agar/arbitrary/TagDecorator.ts
@@ -2,7 +2,7 @@ import * as fc from 'fast-check';
 
 import * as WeightedChoice from './WeightedChoice';
 
-export interface Decorator<T> extends WeightedChoice.WeightedItem{
+export interface Decorator<T> extends WeightedChoice.WeightedItem {
   property: string;
   value: fc.Arbitrary<T>;
 }

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/DomFactory.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/DomFactory.ts
@@ -34,7 +34,7 @@ const fromHtml = (html: string): RawDomSchema => {
   };
 };
 
-const sketch = <T>(sketcher: { sketch: (spec: { dom: RawDomSchema } & T) => SketchSpec}, html: string, config: T): SketchSpec =>
+const sketch = <T>(sketcher: { sketch: (spec: { dom: RawDomSchema } & T) => SketchSpec }, html: string, config: T): SketchSpec =>
   sketcher.sketch({
     dom: fromHtml(html),
     ...config

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/GuiFactory.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/GuiFactory.ts
@@ -12,6 +12,11 @@ import * as Component from './Component';
 import { AlloyComponent } from './ComponentApi';
 import { AlloySpec, PremadeSpec, SimpleOrSketchSpec, SketchSpec } from './SpecTypes';
 
+export interface ExternalElement {
+  uid?: string;
+  element: SugarElement<Node>;
+}
+
 const buildSubcomponents = (spec: SimpleOrSketchSpec, obsoleted: Optional<SugarElement<Node>>): AlloyComponent[] => {
   const components = Obj.get(spec, 'components').getOr([ ]);
 
@@ -51,8 +56,6 @@ const text = (textContent: string): PremadeSpec => {
   });
 };
 
-// Rename.
-export interface ExternalElement { uid?: string; element: SugarElement<Node> }
 const external = (spec: ExternalElement): PremadeSpec => {
   const extSpec: { uid: Optional<string>; element: SugarElement<Node> } = StructureSchema.asRawOrDie('external.component', StructureSchema.objOfOnly([
     FieldSchema.required('element'),

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/GuiFactory.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/GuiFactory.ts
@@ -13,8 +13,8 @@ import { AlloyComponent } from './ComponentApi';
 import { AlloySpec, PremadeSpec, SimpleOrSketchSpec, SketchSpec } from './SpecTypes';
 
 export interface ExternalElement {
-  uid?: string;
-  element: SugarElement<Node>;
+  readonly uid?: string;
+  readonly element: SugarElement<Node>;
 }
 
 const buildSubcomponents = (spec: SimpleOrSketchSpec, obsoleted: Optional<SugarElement<Node>>): AlloyComponent[] => {

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/UiSketcher.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/UiSketcher.ts
@@ -37,7 +37,7 @@ const composite = <D extends CompositeSketchDetail, S extends CompositeSketchSpe
   return factory(detail, components, specWithUid, subs.externals());
 };
 
-const hasUid = <S>(spec: S): spec is S & {uid: string} => Obj.has(spec as any, 'uid');
+const hasUid = <S>(spec: S): spec is S & { uid: string } => Obj.has(spec as any, 'uid');
 
 const supplyUid = <S>(spec: S): S & { uid: string } => {
   return hasUid(spec) ? spec : {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/BehaviourTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/BehaviourTypes.ts
@@ -11,7 +11,9 @@ import { BehaviourState, BehaviourStateInitialiser } from './BehaviourState';
 export type BehaviourApiFunc<D extends BehaviourConfigDetail, S extends BehaviourState> = (component: AlloyComponent, bConfig: D, bState: S, ...rest: any[]) => any;
 
 export type BehaviourRecord = Record<string, ConfiguredBehaviour<any, any, any> | undefined>;
-export interface BehaviourApisRecord<D extends BehaviourConfigDetail, S extends BehaviourState> { [key: string]: BehaviourApiFunc<D, S> }
+export interface BehaviourApisRecord<D extends BehaviourConfigDetail, S extends BehaviourState> {
+  [key: string]: BehaviourApiFunc<D, S>;
+}
 export type BehaviourExtraRecord<E> = { [K in keyof E]: Function };
 
 export type BehaviourInfo<D extends BehaviourConfigDetail, S extends BehaviourState> = Record<string, () => Optional<BehaviourConfigAndState<D, S>>>;

--- a/modules/alloy/src/main/ts/ephox/alloy/menu/layered/LayeredState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/menu/layered/LayeredState.ts
@@ -9,7 +9,11 @@ export type MenuDirectory = Record<string, string[]>;
 
 // A tuple of (item, menu). This can be used to refresh the menu and position them next to the right
 // triggering items.
-export interface LayeredItemTrigger { triggeringItem: AlloyComponent; triggeredMenu: AlloyComponent; triggeringPath: string[] }
+export interface LayeredItemTrigger {
+  triggeringItem: AlloyComponent;
+  triggeredMenu: AlloyComponent;
+  triggeringPath: string[];
+}
 
 export interface LayeredState {
   setContents: (sPrimary: string, sMenus: Record<string, MenuPreparation>, sExpansions: Record<string, string>, dir: MenuDirectory) => void;

--- a/modules/alloy/src/main/ts/ephox/alloy/menu/layered/LayeredState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/menu/layered/LayeredState.ts
@@ -10,9 +10,9 @@ export type MenuDirectory = Record<string, string[]>;
 // A tuple of (item, menu). This can be used to refresh the menu and position them next to the right
 // triggering items.
 export interface LayeredItemTrigger {
-  triggeringItem: AlloyComponent;
-  triggeredMenu: AlloyComponent;
-  triggeringPath: string[];
+  readonly triggeringItem: AlloyComponent;
+  readonly triggeredMenu: AlloyComponent;
+  readonly triggeringPath: string[];
 }
 
 export interface LayeredState {

--- a/modules/alloy/src/main/ts/ephox/alloy/sandbox/Reposition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/sandbox/Reposition.ts
@@ -41,7 +41,7 @@ const receivingConfig = (rawSpec: RepositionReceivingSpec): NamedConfiguredBehav
 const receivingChannel = (rawSpec: RepositionReceivingSpec): Record<string, ReceivingChannelSpec> => {
   const detail: RepositionReceivingDetail = StructureSchema.asRawOrDie('Reposition', schema, rawSpec);
   return {
-    [ Channels.repositionPopups() ]: {
+    [Channels.repositionPopups()]: {
       onReceive: (sandbox: AlloyComponent) => {
         if (Sandboxing.isOpen(sandbox)) {
           detail.fireEventInstead.fold(

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/FormFieldSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/FormFieldSchema.ts
@@ -40,7 +40,7 @@ const parts: () => PartType.PartTypeAdt[] = Fun.constant([
     name: 'aria-descriptor'
   }),
 
-  PartType.required<FormFieldDetail, { factory: { sketch: (spec: Record<string, any>) => Record<string, any> } }>({
+  PartType.required<FormFieldDetail, { factory: { sketch: (spec: Record<string, any>) => Record<string, any> }}>({
     factory: {
       sketch: (spec) => {
         const excludeFactory = Objects.exclude(spec, [ 'factory' ]);

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/single/TieredMenuSpec.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/single/TieredMenuSpec.ts
@@ -213,7 +213,10 @@ const make: SingleSketchFactory<TieredMenuDetail, TieredMenuSpec> = (detail, _ra
       }
     }));
 
-  enum ExpandHighlightDecision { HighlightSubmenu, HighlightParent }
+  enum ExpandHighlightDecision {
+    HighlightSubmenu,
+    HighlightParent
+  }
 
   const buildIfRequired = (container: AlloyComponent, menuName: string, menuPrep: MenuPreparation) => {
     if (menuPrep.type === 'notbuilt') {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/TieredMenuTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/TieredMenuTypes.ts
@@ -88,7 +88,11 @@ export type PartialMenuSpec = Partial<MenuSpec> & {
 
 export type TieredMenuRecord = Record<string, PartialMenuSpec>;
 
-export enum HighlightOnOpen { HighlightMenuAndItem, HighlightJustMenu, HighlightNone }
+export enum HighlightOnOpen {
+  HighlightMenuAndItem,
+  HighlightJustMenu,
+  HighlightNone
+}
 
 export interface TieredData {
   primary: string;

--- a/modules/alloy/src/test/ts/browser/api/CustomComponentTest.ts
+++ b/modules/alloy/src/test/ts/browser/api/CustomComponentTest.ts
@@ -49,7 +49,7 @@ UnitTest.asynctest('CustomComponentTest', (success, failure) => {
       ],
       name: 'behaviourB',
       active: {
-        exhibit: (_base, info: { attr: string}) => {
+        exhibit: (_base, info: { attr: string }) => {
           const extra = {
             attributes: {
               'behaviour-b-exhibit': info.attr

--- a/modules/alloy/src/test/ts/browser/behaviour/PinchingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/PinchingTest.ts
@@ -30,7 +30,7 @@ UnitTest.asynctest('Browser Test: behaviour.PinchingTest', (success, failure) =>
     ])
   }), (_doc, _body, _gui, component, store) => {
 
-    const sSendTouchmove = (touches: Array<{ clientX: number; clientY: number}>) => Step.sync(() => {
+    const sSendTouchmove = (touches: Array<{ clientX: number; clientY: number }>) => Step.sync(() => {
       AlloyTriggers.emitWith(component, NativeEvents.touchmove(), {
         raw: { touches }
       });

--- a/modules/alloy/src/test/ts/browser/behaviour/representing/RepresentingDatasetTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/representing/RepresentingDatasetTest.ts
@@ -40,7 +40,7 @@ UnitTest.asynctest('RepresentingTest (mode: dataset)', (success, failure) => {
       ])
     })
   ), (doc, _body, gui, component, _store) => {
-    const sAssertRepValue = (label: string, expected: { value: string; meta: { text: string } }) => Step.sync(() => {
+    const sAssertRepValue = (label: string, expected: { value: string; meta: { text: string }}) => Step.sync(() => {
       const v = Representing.getValue(component);
       Assertions.assertEq(label, expected, v);
     });

--- a/modules/alloy/src/test/ts/browser/events/EventRegistryTest.ts
+++ b/modules/alloy/src/test/ts/browser/events/EventRegistryTest.ts
@@ -7,7 +7,12 @@ import * as DescribedHandler from 'ephox/alloy/events/DescribedHandler';
 import { ElementAndHandler, EventRegistry } from 'ephox/alloy/events/EventRegistry';
 import * as Tagger from 'ephox/alloy/registry/Tagger';
 
-interface ExpectedType { id?: string; handler: string; target?: string; purpose?: string }
+interface ExpectedType {
+  readonly id?: string;
+  readonly handler: string;
+  readonly target?: string;
+  readonly purpose?: string;
+}
 
 UnitTest.asynctest('EventRegistryTest', (success, failure) => {
   const body = SugarElement.fromDom(document.body);

--- a/modules/alloy/src/test/ts/browser/parts/PartSchemasTest.ts
+++ b/modules/alloy/src/test/ts/browser/parts/PartSchemasTest.ts
@@ -52,7 +52,7 @@ UnitTest.test('Atomic Test: parts.SchemasTest', () => {
   // checkSuccessWithNone, the non-optional parts are expected, and the optional = None
   // checkSuccessWithSome, the non-optional parts are expected, and the optional is optExpected
 
-  const checkSuccess = (label: string, expected: { external?: { entirety: string } }, parts: PartType.PartTypeAdt[], input: { external?: string }) => {
+  const checkSuccess = (label: string, expected: { external?: { entirety: string }}, parts: PartType.PartTypeAdt[], input: { external?: string }) => {
     const schemas = AlloyParts.schemas(parts);
     const output = StructureSchema.asRawOrDie(
       label,

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/BoundsUtils.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/BoundsUtils.ts
@@ -19,7 +19,7 @@ const boundsArb = (minBounds = 0, maxBounds = 2000): fc.Arbitrary<Boxes.Bounds> 
 
 const boxArb = boundsArb;
 
-const boxAndBoundsArb = (minBounds = 0, maxBounds = 2000): fc.Arbitrary<{ box: Boxes.Bounds; bounds: Boxes.Bounds}> =>
+const boxAndBoundsArb = (minBounds = 0, maxBounds = 2000): fc.Arbitrary<{ box: Boxes.Bounds; bounds: Boxes.Bounds }> =>
   boundsArb(minBounds, maxBounds).chain((bounds) =>
     boxArb(minBounds, maxBounds).map((box) => ({
       box,

--- a/modules/boulder/src/main/ts/ephox/boulder/alien/SimpleResult.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/alien/SimpleResult.ts
@@ -3,7 +3,10 @@ import { Arr, Result } from '@ephox/katamari';
 // An experiment to make a more efficient boulder.
 export type SimpleResult<E, A> = SimpleError<E> | SimpleValue<A>;
 
-export enum SimpleResultType { Error, Value }
+export enum SimpleResultType {
+  Error,
+  Value
+}
 
 export interface SimpleError<E> {
   stype: SimpleResultType.Error;

--- a/modules/boulder/src/main/ts/ephox/boulder/alien/SimpleResult.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/alien/SimpleResult.ts
@@ -9,13 +9,13 @@ export enum SimpleResultType {
 }
 
 export interface SimpleError<E> {
-  stype: SimpleResultType.Error;
-  serror: E;
+  readonly stype: SimpleResultType.Error;
+  readonly serror: E;
 }
 
 export interface SimpleValue<A> {
-  stype: SimpleResultType.Value;
-  svalue: A;
+  readonly stype: SimpleResultType.Value;
+  readonly svalue: A;
 }
 
 const fold = <B, E, A>(res: SimpleResult<E, A>, onError: (err: E) => B, onValue: (val: A) => B): B =>

--- a/modules/boulder/src/main/ts/ephox/boulder/core/ObjChanger.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/core/ObjChanger.ts
@@ -12,8 +12,8 @@ const narrow = <T extends Record<string, any>, F extends Array<keyof T>>(obj: T,
   return r;
 };
 
-const indexOnKey = <T extends Record<string, any>, K extends keyof T>(array: ArrayLike<T>, key: K): {[A in T[K]]: T} => {
-  const obj = { } as {[A in T[K]]: T};
+const indexOnKey = <T extends Record<string, any>, K extends keyof T>(array: ArrayLike<T>, key: K): { [A in T[K]]: T } => {
+  const obj = { } as { [A in T[K]]: T };
   Arr.each(array, (a) => {
     // FIX: Work out what to do here.
     const keyValue: string | number = a[key];

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
@@ -27,8 +27,8 @@ export const each = <T extends {}>(obj: T, f: ObjCallback<T>): void => {
   }
 };
 
-export const map = <T extends {}, R>(obj: T, f: ObjMorphism<T, R>): {[k in keyof T]: R} => {
-  return tupleMap<{[k in keyof T]: R}, T>(obj, (x, i) => ({
+export const map = <T extends {}, R>(obj: T, f: ObjMorphism<T, R>): { [k in keyof T]: R } => {
+  return tupleMap<{ [k in keyof T]: R }, T>(obj, (x, i) => ({
     k: i,
     v: f(x, i)
   }));

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Resolve.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Resolve.ts
@@ -24,7 +24,7 @@ export const step = <T extends {}, K extends keyof T>(o: T, part: K): T[K] => {
 };
 
 /** forge :: ([String], JsObj?) -> JsObj */
-export const forge = <T extends string[]>(parts: T, target?: {}): {[ K in T[number]]: {}} => {
+export const forge = <T extends string[]>(parts: T, target?: {}): { [ K in T[number]]: {}} => {
   let o = target !== undefined ? target : Global;
   for (let i = 0; i < parts.length; ++i) {
     o = step(o, parts[i]);
@@ -33,7 +33,7 @@ export const forge = <T extends string[]>(parts: T, target?: {}): {[ K in T[numb
 };
 
 /** namespace :: (String, JsObj?) -> JsObj */
-export const namespace = (name: string, target?: {}): { [key: string]: {} } => {
+export const namespace = (name: string, target?: {}): { [key: string]: {}} => {
   const parts = name.split('.');
   return forge(parts, target);
 };

--- a/modules/katamari/src/main/ts/ephox/katamari/async/AsyncValues.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/async/AsyncValues.ts
@@ -9,7 +9,7 @@ import * as Arr from '../api/Arr';
  *   get: (callback) => { callback(10); }
  * }
  */
-export const par = <A, T, C> (asyncValues: ArrayLike<(A & {get: (callback: (value: T) => void) => void})>, nu: (worker: (callback: (values: T[]) => void) => void) => C): C => {
+export const par = <A, T, C> (asyncValues: ArrayLike<(A & { get: (callback: (value: T) => void) => void })>, nu: (worker: (callback: (values: T[]) => void) => void) => C): C => {
   return nu((callback) => {
     const r: T[] = [];
     let count = 0;
@@ -27,7 +27,7 @@ export const par = <A, T, C> (asyncValues: ArrayLike<(A & {get: (callback: (valu
     if (asyncValues.length === 0) {
       callback([]);
     } else {
-      Arr.each(asyncValues, (asyncValue: A & {get: (callback: (value: T) => void) => void}, i) => {
+      Arr.each(asyncValues, (asyncValue: A & { get: (callback: (value: T) => void) => void }, i) => {
         asyncValue.get(cb(i));
       });
     }

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyScenarios.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyScenarios.ts
@@ -15,7 +15,8 @@ interface ArbScenarioOptions {
 }
 
 interface AsyncPropertyOptions {
-  readonly scenario: ArbScenarioOptions; property: fc.Parameters;
+  readonly scenario: ArbScenarioOptions;
+  readonly property: fc.Parameters;
 }
 
 interface Scenario {
@@ -24,10 +25,10 @@ interface Scenario {
 }
 
 export interface TinyScenarios {
-  genScenario: (genContent: ContentGenerator, selectionExclusions: SelectionExclusions) => fc.Arbitrary<Scenario>;
-  arbScenario: (genContent: ContentGenerator, options: ArbScenarioOptions) => fc.Arbitrary<Scenario>;
+  readonly genScenario: (genContent: ContentGenerator, selectionExclusions: SelectionExclusions) => fc.Arbitrary<Scenario>;
+  readonly arbScenario: (genContent: ContentGenerator, options: ArbScenarioOptions) => fc.Arbitrary<Scenario>;
 
-  sAsyncProperty: <T>(label: string, generator: ContentGenerator, step: Step<Scenario, any>, options: AsyncPropertyOptions) => Step<T, T>;
+  readonly sAsyncProperty: <T>(label: string, generator: ContentGenerator, step: Step<Scenario, any>, options: AsyncPropertyOptions) => Step<T, T>;
 }
 
 export const TinyScenarios = (editor: Editor): TinyScenarios => {

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyScenarios.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyScenarios.ts
@@ -5,9 +5,18 @@ import * as fc from 'fast-check';
 import { Editor } from '../../alien/EditorTypes';
 
 type ContentGenerator = fc.Arbitrary<SugarElement<HTMLElement>>;
-interface SelectionExclusions { containers: (container: SugarElement<Node>) => boolean }
-interface ArbScenarioOptions { exclusions: SelectionExclusions }
-interface AsyncPropertyOptions { scenario: ArbScenarioOptions; property: fc.Parameters }
+
+interface SelectionExclusions {
+  readonly containers: (container: SugarElement<Node>) => boolean;
+}
+
+interface ArbScenarioOptions {
+  readonly exclusions: SelectionExclusions;
+}
+
+interface AsyncPropertyOptions {
+  readonly scenario: ArbScenarioOptions; property: fc.Parameters;
+}
 
 interface Scenario {
   readonly input: string;

--- a/modules/phoenix/src/test/ts/atomic/api/extract/ExtractTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/api/extract/ExtractTest.ts
@@ -49,14 +49,14 @@ UnitTest.test('api.Extract.(from,all,extract,extractTo)', () => {
 
   //
   // const extract = (universe, child, offset) => {
-  const checkExtract = (expected: {id: string; offset: number}, childId: string, offset: number) => {
+  const checkExtract = (expected: { id: string; offset: number }, childId: string, offset: number) => {
     const child = Finder.get(doc, childId);
     const actual = Extract.extract(doc, child, offset);
     Assert.eq('', expected.id, actual.element.id);
     Assert.eq('', expected.offset, actual.offset);
   };
 
-  const checkExtractTo = (expected: {id: string; offset: number}, childId: string, offset: number, pred: (e: any) => boolean) => {
+  const checkExtractTo = (expected: { id: string; offset: number }, childId: string, offset: number, pred: (e: any) => boolean) => {
     const child = Finder.get(doc, childId);
     const actual = Extract.extractTo(doc, child, offset, pred);
     Assert.eq('', expected.id, actual.element.id);

--- a/modules/snooker/src/test/ts/atomic/model/FitmentIVTest.ts
+++ b/modules/snooker/src/test/ts/atomic/model/FitmentIVTest.ts
@@ -11,6 +11,12 @@ interface InvTest {
   readonly test: () => void;
 }
 
+interface Spec {
+  readonly rows: number;
+  readonly cols: number;
+  readonly grid: Structs.ElementNew[][];
+}
+
 UnitTest.test('FitmentIVTest', () => {
   const en = (fakeElement: any, isNew: boolean) =>
     Structs.elementnew(fakeElement as SugarElement<any>, isNew, false);
@@ -173,10 +179,6 @@ UnitTest.test('FitmentIVTest', () => {
         cols: gridSpecB.cols
       }
     };
-
-    interface Spec {
-      rows: number; cols: number; grid: Structs.ElementNew[][];
-    }
 
     const queryliser2000 = (
       result: Result<Structs.RowCells[], string>,

--- a/modules/snooker/src/test/ts/atomic/model/FitmentIVTest.ts
+++ b/modules/snooker/src/test/ts/atomic/model/FitmentIVTest.ts
@@ -7,6 +7,10 @@ import * as Structs from 'ephox/snooker/api/Structs';
 import * as Fitment from 'ephox/snooker/test/Fitment';
 import * as TableMerge from 'ephox/snooker/test/TableMerge';
 
+interface InvTest {
+  readonly test: () => void;
+}
+
 UnitTest.test('FitmentIVTest', () => {
   const en = (fakeElement: any, isNew: boolean) =>
     Structs.elementnew(fakeElement as SugarElement<any>, isNew, false);
@@ -45,7 +49,6 @@ UnitTest.test('FitmentIVTest', () => {
   const rand = (min: number, max: number) =>
     Math.floor(Math.random() * (max - min + 1)) + min;
 
-  interface InvTest { test: () => void }
   const inVariantRunner = <T extends InvTest> (label: string, mvTest: () => T, timelimit: number): number => {
     let times = 0;
     const startTime = Date.now();
@@ -171,7 +174,9 @@ UnitTest.test('FitmentIVTest', () => {
       }
     };
 
-    interface Spec { rows: number; cols: number; grid: Structs.ElementNew[][] }
+    interface Spec {
+      rows: number; cols: number; grid: Structs.ElementNew[][];
+    }
 
     const queryliser2000 = (
       result: Result<Structs.RowCells[], string>,

--- a/modules/snooker/src/test/ts/browser/CopySelectedTest.ts
+++ b/modules/snooker/src/test/ts/browser/CopySelectedTest.ts
@@ -538,7 +538,7 @@ UnitTest.test('CopySelectedTest', () => {
     ],
     {
       beforeCopy: {
-        [ LOCKED_COL_ATTR ]: '0',
+        [LOCKED_COL_ATTR]: '0',
         'data-snooker-col-series': 'numbers'
       },
       afterCopy: [ LOCKED_COL_ATTR, 'data-snooker-col-series' ]
@@ -560,7 +560,7 @@ UnitTest.test('CopySelectedTest', () => {
     ],
     {
       beforeCopy: {
-        [ LOCKED_COL_ATTR ]: '0',
+        [LOCKED_COL_ATTR]: '0',
         'data-snooker-col-series': 'numbers'
       },
       afterCopy: [ LOCKED_COL_ATTR, 'data-snooker-col-series' ]

--- a/modules/snooker/src/test/ts/browser/resize/RecalculationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/resize/RecalculationsTest.ts
@@ -24,7 +24,7 @@ UnitTest.test('RecalculationsTest', () => {
     }>;
   }
 
-  const expectedParts = (columns: {element: string; width: number}[], widths: {element: string; width: number}[], heights: {element: string; height: number}[]): Parts => ({
+  const expectedParts = (columns: Array<{ element: string; width: number }>, widths: Array<{ element: string; width: number }>, heights: Array<{ element: string; height: number }>): Parts => ({
     columns,
     widths,
     heights

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/Assertions.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/Assertions.ts
@@ -241,8 +241,8 @@ const checkMerge = (
   label: string,
   expected: string,
   input: string,
-  selection: {section: number; row: number; column: number}[],
-  bounds: {startRow: number; startCol: number; finishRow: number; finishCol: number}
+  selection: Array<{ section: number; row: number; column: number }>,
+  bounds: { startRow: number; startCol: number; finishRow: number; finishCol: number }
 ): void => {
   const table = SugarElement.fromHtml<HTMLTableElement>(input);
   const expectedDom = SugarElement.fromHtml(expected);

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/Bridge.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/Bridge.ts
@@ -7,7 +7,7 @@ import { TargetMergable } from 'ephox/snooker/model/RunOperation';
 
 // Mock/Stub out helper functions
 
-const targetStub = (selection: { section: number; row: number; column: number}[], bounds: { startRow: number; startCol: number; finishRow: number; finishCol: number}, table: SugarElement<HTMLTableElement>): TargetMergable => {
+const targetStub = (selection: Array<{ section: number; row: number; column: number }>, bounds: { startRow: number; startCol: number; finishRow: number; finishCol: number }, table: SugarElement<HTMLTableElement>): TargetMergable => {
   const cells = Optionals.cat(Arr.map(selection, (path) => {
     return Hierarchy.follow(table, [ path.section, path.row, path.column ]) as Optional<SugarElement<HTMLTableCellElement>>;
   }));

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/TableMerge.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/TableMerge.ts
@@ -7,6 +7,14 @@ import * as Structs from 'ephox/snooker/api/Structs';
 import * as TableMerge from 'ephox/snooker/model/TableMerge';
 import * as Fitment from 'ephox/snooker/test/Fitment';
 
+interface Spec {
+  readonly rows: number;
+  readonly cols: number;
+  readonly grid: Structs.ElementNew[][];
+}
+
+type Asserter = (result: Result<Structs.RowCells[], string>, s: Structs.Address, specA: Spec, specB: Spec) => void;
+
 const mapToStructGrid = (grid: Structs.ElementNew[][]): Structs.RowCells[] => {
   return Arr.map(grid, (row) => {
     return Structs.rowcells('tr' as any, row, 'tbody', false);
@@ -55,8 +63,6 @@ const mergeTest = (
   });
 };
 
-interface Spec { rows: number; cols: number; grid: Structs.ElementNew[][] }
-type Asserter = (result: Result<Structs.RowCells[], string>, s: Structs.Address, specA: Spec, specB: Spec) => void;
 const mergeIVTest = (
   asserter: Asserter,
   startAddress: Structs.Address,

--- a/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/AddOnManager.ts
@@ -90,7 +90,11 @@ import I18n from './util/I18n';
  * @class tinymce.AddOnManager
  */
 
-export interface UrlObject { prefix: string; resource: string; suffix: string }
+export interface UrlObject {
+  prefix: string;
+  resource: string;
+  suffix: string;
+}
 
 type WaitState = 'added' | 'loaded';
 
@@ -139,7 +143,7 @@ const AddOnManager = <T>(): AddOnManager<T> => {
       return;
     }
 
-    ScriptLoader.ScriptLoader.add(urls[ name ] + '/langs/' + language + '.js');
+    ScriptLoader.ScriptLoader.add(urls[name] + '/langs/' + language + '.js');
   };
 
   const requireLangPack = (name: string, languages?: string) => {

--- a/modules/tinymce/src/core/main/ts/api/EventTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/EventTypes.ts
@@ -11,7 +11,11 @@ import { Dialog } from './ui/Ui';
 import { NativeEventMap } from './util/EventDispatcher';
 import { InstanceApi } from './WindowManager';
 
-export interface ExecCommandEvent { command: string; ui: boolean; value?: any }
+export interface ExecCommandEvent {
+  command: string;
+  ui: boolean;
+  value?: any;
+}
 
 export interface BeforeGetContentEvent extends GetContentArgs {
   selection?: boolean;
@@ -35,42 +39,96 @@ export interface SaveContentEvent extends GetContentEvent {
   save: boolean;
 }
 
-export interface NewBlockEvent { newBlock: Element }
+export interface NewBlockEvent {
+  newBlock: Element;
+}
 
-export interface NodeChangeEvent { element: Element; parents: Node[]; selectionChange?: boolean; initial?: boolean }
+export interface NodeChangeEvent {
+  element: Element;
+  parents: Node[];
+  selectionChange?: boolean;
+  initial?: boolean;
+}
 
-export interface FormatEvent { format: string; vars?: FormatVars; node?: Node | RangeLikeObject | null }
+export interface FormatEvent {
+  format: string;
+  vars?: FormatVars;
+  node?: Node | RangeLikeObject | null;
+}
 
-export interface ObjectResizeEvent { target: HTMLElement; width: number; height: number; origin: string }
+export interface ObjectResizeEvent {
+  target: HTMLElement;
+  width: number;
+  height: number;
+  origin: string;
+}
 
-export interface ObjectSelectedEvent { target: Node; targetClone?: Node }
+export interface ObjectSelectedEvent {
+  target: Node;
+  targetClone?: Node;
+}
 
-export interface ScrollIntoViewEvent { elm: HTMLElement; alignToTop: boolean | undefined }
+export interface ScrollIntoViewEvent {
+  elm: HTMLElement;
+  alignToTop: boolean | undefined;
+}
 
-export interface SetSelectionRangeEvent { range: Range; forward: boolean | undefined }
+export interface SetSelectionRangeEvent {
+  range: Range;
+  forward: boolean | undefined;
+}
 
-export interface ShowCaretEvent { target: Node; direction: number; before: boolean }
+export interface ShowCaretEvent {
+  target: Node;
+  direction: number;
+  before: boolean;
+}
 
-export interface SwitchModeEvent { mode: string }
+export interface SwitchModeEvent {
+  mode: string;
+}
 
-export interface ChangeEvent { level: UndoLevel; lastLevel: UndoLevel | undefined }
-export interface AddUndoEvent extends ChangeEvent { originalEvent: Event | undefined }
-export interface UndoRedoEvent { level: UndoLevel }
+export interface ChangeEvent {
+  level: UndoLevel;
+  lastLevel: UndoLevel | undefined;
+}
+export interface AddUndoEvent extends ChangeEvent {
+  originalEvent: Event | undefined;
+}
+export interface UndoRedoEvent {
+  level: UndoLevel;
+}
 
-export interface WindowEvent<T extends Dialog.DialogData> { dialog: InstanceApi<T> }
+export interface WindowEvent<T extends Dialog.DialogData> {
+  dialog: InstanceApi<T>;
+}
 
-export interface ProgressStateEvent { state: boolean; time?: number }
+export interface ProgressStateEvent {
+  state: boolean; time?: number;
+}
 
-export interface AfterProgressStateEvent { state: boolean }
+export interface AfterProgressStateEvent {
+  state: boolean;
+}
 
-export interface PlaceholderToggleEvent { state: boolean }
+export interface PlaceholderToggleEvent {
+  state: boolean;
+}
 
-export interface LoadErrorEvent { message: string }
+export interface LoadErrorEvent {
+  message: string;
+}
 
-export interface PreProcessEvent extends ParserArgs { node: Element }
-export interface PostProcessEvent extends ParserArgs { content: string }
+export interface PreProcessEvent extends ParserArgs {
+  node: Element;
+}
+export interface PostProcessEvent extends ParserArgs {
+  content: string;
+}
 
-export interface PastePlainTextToggleEvent { state: boolean }
+export interface PastePlainTextToggleEvent {
+  state: boolean;
+}
 export interface PastePreProcessEvent {
   content: string;
   readonly internal: boolean;
@@ -81,8 +139,12 @@ export interface PastePostProcessEvent {
   readonly internal: boolean;
 }
 
-export interface NewTableRowEvent { node: HTMLTableRowElement }
-export interface NewTableCellEvent { node: HTMLTableCellElement }
+export interface NewTableRowEvent {
+  node: HTMLTableRowElement;
+}
+export interface NewTableCellEvent {
+  node: HTMLTableCellElement;
+}
 
 export interface TableEventData {
   readonly structure: boolean;

--- a/modules/tinymce/src/core/main/ts/api/EventTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/EventTypes.ts
@@ -92,9 +92,11 @@ export interface ChangeEvent {
   level: UndoLevel;
   lastLevel: UndoLevel | undefined;
 }
+
 export interface AddUndoEvent extends ChangeEvent {
   originalEvent: Event | undefined;
 }
+
 export interface UndoRedoEvent {
   level: UndoLevel;
 }
@@ -104,7 +106,8 @@ export interface WindowEvent<T extends Dialog.DialogData> {
 }
 
 export interface ProgressStateEvent {
-  state: boolean; time?: number;
+  state: boolean;
+  time?: number;
 }
 
 export interface AfterProgressStateEvent {
@@ -122,6 +125,7 @@ export interface LoadErrorEvent {
 export interface PreProcessEvent extends ParserArgs {
   node: Element;
 }
+
 export interface PostProcessEvent extends ParserArgs {
   content: string;
 }
@@ -129,6 +133,7 @@ export interface PostProcessEvent extends ParserArgs {
 export interface PastePlainTextToggleEvent {
   state: boolean;
 }
+
 export interface PastePreProcessEvent {
   content: string;
   readonly internal: boolean;
@@ -142,6 +147,7 @@ export interface PastePostProcessEvent {
 export interface NewTableRowEvent {
   node: HTMLTableRowElement;
 }
+
 export interface NewTableCellEvent {
   node: HTMLTableCellElement;
 }
@@ -150,6 +156,7 @@ export interface TableEventData {
   readonly structure: boolean;
   readonly style: boolean;
 }
+
 export interface TableModifiedEvent extends TableEventData {
   readonly table: HTMLTableElement;
 }

--- a/modules/tinymce/src/core/main/ts/api/html/Entities.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Entities.ts
@@ -2,7 +2,9 @@ import { SugarElement } from '@ephox/sugar';
 
 import Tools from '../util/Tools';
 
-export interface EntitiesMap { [name: string]: string }
+export interface EntitiesMap {
+  [name: string]: string;
+}
 
 interface Entities {
   encodeRaw: (text: string, attr?: boolean) => string;

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -65,8 +65,13 @@ export interface SchemaElement extends ElementRule {
   pattern?: RegExp;
 }
 
-export interface SchemaMap { [name: string]: {} }
-export interface SchemaRegExpMap { [name: string]: RegExp }
+export interface SchemaMap {
+  [name: string]: {};
+}
+
+export interface SchemaRegExpMap {
+  [name: string]: RegExp;
+}
 
 interface Schema {
   type: SchemaType;

--- a/modules/tinymce/src/core/main/ts/api/util/URI.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/URI.ts
@@ -79,7 +79,7 @@ export const isInvalidUri = (settings: SafeUriOptions, uri: string, tagName?: st
 
 class URI {
 
-  public static parseDataUri(uri: string): { type: string | undefined; data: string} {
+  public static parseDataUri(uri: string): { type: string | undefined; data: string } {
     let type;
 
     const uriComponents = decodeURIComponent(uri).split(',');

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
@@ -5,7 +5,7 @@ import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@
 
 import Editor from 'tinymce/core/api/Editor';
 
-const applyForDeleteAndBackspace = (fn: (pair: {label: string; key: () => number}) => void) =>
+const applyForDeleteAndBackspace = (fn: (pair: { label: string; key: () => number }) => void) =>
   Arr.each([
     { label: 'Delete', key: Keys.delete },
     { label: 'Backspace', key: Keys.backspace }

--- a/modules/tinymce/src/models/dom/main/ts/table/api/Clipboard.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/Clipboard.ts
@@ -34,7 +34,7 @@ const clearData = (type: string): void => {
 const setRows = (rowsOpt: Optional<SugarElement<RowElement>[]>): void => {
   rowsOpt.fold(
     clearRows,
-    (rows) => setData({ [ tableTypeRow ]: rows })
+    (rows) => setData({ [tableTypeRow]: rows })
   );
 };
 
@@ -47,7 +47,7 @@ const clearRows = (): void =>
 const setColumns = (columnsOpt: Optional<SugarElement<RowElement>[]>): void => {
   columnsOpt.fold(
     clearColumns,
-    (columns) => setData({ [ tableTypeColumn ]: columns })
+    (columns) => setData({ [tableTypeColumn]: columns })
   );
 };
 

--- a/modules/tinymce/src/plugins/image/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/Dialog.ts
@@ -328,7 +328,7 @@ const createBlobCache = (editor: Editor) => (file: File, blobUri: string, dataUr
     blobUri,
     name: file.name?.replace(/\.[^\.]+$/, ''),
     filename: file.name,
-    base64: dataUrl.split(',')[ 1 ]
+    base64: dataUrl.split(',')[1]
   });
 
 const addToBlobCache = (editor: Editor) => (blobInfo: BlobInfo): void => {

--- a/modules/tinymce/src/plugins/image/test/ts/browser/A11yImageTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/A11yImageTest.ts
@@ -66,7 +66,7 @@ describe('browser.tinymce.plugins.image.A11yImageTest', () => {
     UiFinder.notExists(SugarBody.body(), 'div[role="dialog"]');
   });
 
-  it ('FOAM-11: Image with alt text', async () => {
+  it('FOAM-11: Image with alt text', async () => {
     const editor = hook.editor();
     await pCreateTestOnEmptyEditor(
       editor,

--- a/modules/tinymce/src/plugins/table/main/ts/api/Clipboard.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Clipboard.ts
@@ -34,7 +34,7 @@ const clearData = (type: string): void => {
 const setRows = (rowsOpt: Optional<SugarElement<RowElement>[]>): void => {
   rowsOpt.fold(
     clearRows,
-    (rows) => setData({ [ tableTypeRow ]: rows })
+    (rows) => setData({ [tableTypeRow]: rows })
   );
 };
 
@@ -47,7 +47,7 @@ const clearRows = (): void =>
 const setColumns = (columnsOpt: Optional<SugarElement<RowElement>[]>): void => {
   columnsOpt.fold(
     clearColumns,
-    (columns) => setData({ [ tableTypeColumn ]: columns })
+    (columns) => setData({ [tableTypeColumn]: columns })
   );
 };
 

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/ButtonSetupDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/ButtonSetupDemo.ts
@@ -85,7 +85,7 @@ export default {
     // flag passed in determines whether to collapse all the items into a single
     // menu when a search pattern is present.
     const mailMergeFetch = (collapseIfSearch: boolean): Toolbar.ToolbarMenuButton['fetch'] => (callback, fetchContext) => {
-      const makeMailMerge = (info: { value: string; title?: string}) => ({
+      const makeMailMerge = (info: { value: string; title?: string }) => ({
         type: 'menuitem',
         text: info.title ?? info.value,
         onAction: () => {
@@ -148,7 +148,7 @@ export default {
           )
         ] as any);
       } else {
-        const allMerges: Array<{value: string; title?: string}> = [
+        const allMerges: Array<{ value: string; title?: string }> = [
           currentDateMerge,
           tocMerge,
           phoneHomeMerge,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarLookup.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarLookup.ts
@@ -80,12 +80,12 @@ const matchStartNode = (elem: SugarElement<Element>, nodeCandidates: ContextType
   const nodeMatches = matchTargetWith(elem, nodeCandidates);
 
   if (nodeMatches.contextForms.length > 0) {
-    return Optional.some({ elem, toolbars: [ nodeMatches.contextForms[ 0 ] ] });
+    return Optional.some({ elem, toolbars: [ nodeMatches.contextForms[0] ] });
   } else {
     const editorMatches = matchTargetWith(elem, editorCandidates);
 
     if (editorMatches.contextForms.length > 0) {
-      return Optional.some({ elem, toolbars: [ editorMatches.contextForms[ 0 ] ] });
+      return Optional.some({ elem, toolbars: [ editorMatches.contextForms[0] ] });
     } else if (nodeMatches.contextToolbars.length > 0 || editorMatches.contextToolbars.length > 0) {
       const toolbars = filterByPositionForStartNode(nodeMatches.contextToolbars.concat(editorMatches.contextToolbars));
       return Optional.some({ elem, toolbars });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -80,7 +80,10 @@ interface BespokeMenuItems {
   readonly getStyleItems: () => FormatItem[];
 }
 
-const enum IrrelevantStyleItemResponse { Hide, Disable }
+const enum IrrelevantStyleItemResponse {
+  Hide,
+  Disable
+}
 
 const generateSelectItems = (_editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec) => {
   const generateItem = (rawItem: FormatItem, response: IrrelevantStyleItemResponse, invalid: boolean, value: Optional<SelectedFormat>): Optional<Menu.NestedMenuItemContents> => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/SelectDatasets.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/SelectDatasets.ts
@@ -38,7 +38,10 @@ const buildBasicStaticDataset = (data: Array<BasicSelectItem>): BasicSelectDatas
   data
 });
 
-export enum Delimiter { SemiColon, Space }
+export enum Delimiter {
+  SemiColon,
+  Space
+}
 
 const split = (rawFormats: string, delimiter: Delimiter): string[] => {
   if (delimiter === Delimiter.SemiColon) {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleFormat.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleFormat.ts
@@ -102,7 +102,7 @@ const mapFormats = (userFormats: AllowedFormat[]): CustomFormatMapping =>
 const registerCustomFormats = (editor: Editor, userFormats: AllowedFormat[]): StyleFormatType[] => {
   const result = mapFormats(userFormats);
 
-  const registerFormats = (customFormats: {name: string; format: StyleFormat}[]) => {
+  const registerFormats = (customFormats: Array<{ name: string; format: StyleFormat }>) => {
     Arr.each(customFormats, (fmt) => {
       // Only register the custom format with the editor, if it's not already registered
       if (!editor.formatter.has(fmt.name)) {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/StickyHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/StickyHeader.ts
@@ -170,7 +170,7 @@ const isDocked = (lazyHeader: () => Optional<AlloyComponent>): boolean => lazyHe
 const getIframeBehaviours = () => [
   Receiving.config({
     channels: {
-      [ EditorChannels.toolbarHeightChange() ]: {
+      [EditorChannels.toolbarHeightChange()]: {
         onReceive: updateIframeContentFlow
       }
     }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/ItemResponse.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/ItemResponse.ts
@@ -1,3 +1,6 @@
-enum ItemResponse { CLOSE_ON_EXECUTE, BUBBLE_TO_SANDBOX }
+enum ItemResponse {
+  CLOSE_ON_EXECUTE,
+  BUBBLE_TO_SANDBOX
+}
 
 export default ItemResponse;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -82,7 +82,7 @@ const renderColorStructure = (item: ItemStructureSpec, providerBackstage: UiFact
 };
 
 const renderItemDomStructure = (ariaLabel: Optional<string>): RawDomSchema => {
-  const domTitle = ariaLabel.map((label): {attributes?: {title: string}} => ({
+  const domTitle = ariaLabel.map((label): { attributes?: { title: string }} => ({
     attributes: {
       // TODO: AP-213 change this temporary solution to use tooltips, ensure its aria readable still.
       // for icon only implementations we need either a title or aria label to satisfy aria requirements.

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/SingleMenu.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/SingleMenu.ts
@@ -17,7 +17,10 @@ import { SingleMenuItemSpec } from './SingleMenuTypes';
 
 type PartialMenuSpec = MenuUtils.PartialMenuSpec;
 
-export enum FocusMode { ContentFocus, UiFocus }
+export enum FocusMode {
+  ContentFocus,
+  UiFocus
+}
 
 const createMenuItemFromBridge = (
   item: SingleMenuItemSpec,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
@@ -30,7 +30,7 @@ const defaultMenus: Record<string, MenuSpec> = {
   help: { title: 'Help', items: 'help' }
 };
 
-const make = (menu: {title: string; items: string[]}, registry: MenuRegistry, editor: Editor): MenubarItemSpec => {
+const make = (menu: { title: string; items: string[] }, registry: MenuRegistry, editor: Editor): MenubarItemSpec => {
   const removedMenuItems = Options.getRemovedMenuItems(editor).split(/[ ,]/);
   return {
     text: menu.title,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogBody.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogBody.ts
@@ -48,7 +48,7 @@ const renderBody = (spec: WindowBodySpec, dialogId: string, contentId: Optional<
       tag: 'div',
       classes: [ 'tox-dialog__content-js' ],
       attributes: {
-        ...contentId.map((x): {id?: string} => ({ id: x })).getOr({}),
+        ...contentId.map((x): { id?: string } => ({ id: x })).getOr({}),
         ...ariaAttrs ? ariaAttributes : {}
       }
     },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogInstanceApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogInstanceApi.ts
@@ -72,7 +72,7 @@ const getDialogApi = <T extends Dialog.DialogData>(
       Representing.setValue(form, newInternalData);
       Obj.each(menuItemStates, (v, k) => {
         if (Obj.has(mergedData, k)) {
-          v.set(mergedData[ k ]);
+          v.set(mergedData[k]);
         }
       });
     });

--- a/modules/tinymce/src/themes/silver/test/ts/module/CommonMailMergeFetch.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/CommonMailMergeFetch.ts
@@ -3,7 +3,7 @@ import { Menu, Toolbar } from '@ephox/bridge';
 import { Arr } from '@ephox/katamari';
 
 export const fetchMailMergeData = (settings: { collapseSearchResults: boolean }, store: TestHelpers.TestStore): Toolbar.ToolbarMenuButtonSpec['fetch'] => (callback, fetchContext) => {
-  const makeMailMerge = (info: { value: string; title?: string}): Menu.MenuItemSpec => ({
+  const makeMailMerge = (info: { value: string; title?: string }): Menu.MenuItemSpec => ({
     type: 'menuitem',
     text: info.title ?? info.value,
     onAction: () => {
@@ -67,7 +67,7 @@ export const fetchMailMergeData = (settings: { collapseSearchResults: boolean },
       )
     ]);
   } else {
-    const allMerges: Array<{value: string; title?: string}> = [
+    const allMerges: Array<{ value: string; title?: string }> = [
       currentDateMerge,
       tocMerge,
       phoneHomeMerge,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@ephox/bedrock-server": "^13.3.0",
     "@ephox/oxide-icons-tools": "^3.1.0",
     "@ephox/swag": "^4.5.0",
-    "@tinymce/eslint-plugin": "^2.1.0",
+    "@tinymce/eslint-plugin": "^2.2.0",
     "@tinymce/moxiedoc": "^0.2.1",
     "@types/chai": "^4.3.3",
     "@types/dompurify": "^2.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1352,10 +1352,10 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@tinymce/eslint-plugin@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@tinymce/eslint-plugin/-/eslint-plugin-2.1.0.tgz#d124121da51b6d2fb5f47c9656c26643a3b3089c"
-  integrity sha512-YrqnVxUtkBvkpcRHD0d8+RVgQdoDypIy610dpNJCyl1XVHZ8BHP1lDkADkCzRGvUoZXIgPLP3xUvnKydLINYJg==
+"@tinymce/eslint-plugin@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@tinymce/eslint-plugin/-/eslint-plugin-2.2.0.tgz#c3928d84b5bc3631c86e5643549f90b8b5c56ff2"
+  integrity sha512-EpRrl708xVmcieCzAumfCxlLkRPGgCSQtfMZN8VHj2NHsVG1SzAfyYwcQXumEha32pgF8OLmD05QlauWDqnJYw==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^5.0.0"
     "@typescript-eslint/parser" "^5.0.0"


### PR DESCRIPTION
Related Ticket: TINY-9020

Description of Changes:
* Upgraded to eslint-plugin 2.2.0 to pull in new spacing rules
* Fixed various issues for the rules (used the autofixer and then did a little manual cleanup)

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
