### PR TITLE
TINY-8966: Include CSS for Footnotes plugin

### DIFF
--- a/modules/oxide/src/less/theme/content-ui.less
+++ b/modules/oxide/src/less/theme/content-ui.less
@@ -8,6 +8,7 @@
 @import 'content/codesample/codesample';
 @import 'content/contenteditable/contenteditable';
 @import 'content/cursors/cursors';
+@import 'content/footnotes/footnotes';
 @import 'content/media/media';
 @import 'content/object/object';
 @import 'content/pagebreak/pagebreak';

--- a/modules/oxide/src/less/theme/content/footnotes/footnotes.less
+++ b/modules/oxide/src/less/theme/content/footnotes/footnotes.less
@@ -1,0 +1,32 @@
+//
+// Footnotes
+//
+
+sup.mce-footnote a {
+  color: black;
+  text-decoration: none;
+}
+
+div.mce-footnotes {
+  hr {
+    margin-left: 0;
+    margin-right: auto;
+    width: 25%;
+  }
+
+  li > a:first-child {
+    color: black;
+    text-decoration: none;
+  }
+}
+
+@media print {
+  div.mce-footnotes {
+    break-inside: avoid;
+    width: 100%;
+
+    li > a:first-child {
+      display: none;
+    }
+  }
+}

--- a/modules/oxide/src/less/theme/content/footnotes/footnotes.less
+++ b/modules/oxide/src/less/theme/content/footnotes/footnotes.less
@@ -2,30 +2,29 @@
 // Footnotes
 //
 
-sup.mce-footnote a {
-  color: black;
-  text-decoration: none;
-}
-
 div.mce-footnotes {
   hr {
-    margin-left: 0;
-    margin-right: auto;
+    margin-inline-end: auto;
+    margin-inline-start: 0;
     width: 25%;
   }
 
-  li > a:first-child {
-    color: black;
+  li > a.mce-footnotes-backlink {
     text-decoration: none;
   }
 }
 
 @media print {
+  sup.mce-footnote a {
+    color: black;
+    text-decoration: none;
+  }
+
   div.mce-footnotes {
     break-inside: avoid;
-    width: 100%;
+    width: 100%; // Prevent hr shrinking in print dialog
 
-    li > a:first-child {
+    li > a.mce-footnotes-backlink {
       display: none;
     }
   }

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New promotion element has been added to the UI and can be disabled using the new `promotion` option #TINY-8840
 - New `format_noneditable_selector` option to specify the `contenteditable="false"` elements that can be wrapped in a format. #TINY-8905
 - New `search` field in the `MenuButton` that shows a search field at the top of the menu, and refetches items when the search field updates. #TINY-8952
-- New CSS for `mce-footnote` and `mce-footnotes` classes for the new Footnotes plugin. #TINY-8966
 
 ### Improved
 - The formatter can now apply a format to a `contenteditable="false"` element by wrapping it. Configurable using the `format_noneditable_selector` option. #TINY-8905

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New promotion element has been added to the UI and can be disabled using the new `promotion` option #TINY-8840
 - New `format_noneditable_selector` option to specify the `contenteditable="false"` elements that can be wrapped in a format. #TINY-8905
 - New `search` field in the `MenuButton` that shows a search field at the top of the menu, and refetches items when the search field updates. #TINY-8952
+- New CSS for `mce-footnote` and `mce-footnotes` classes for the new Footnotes plugin. #TINY-8966
 
 ### Improved
 - The formatter can now apply a format to a `contenteditable="false"` element by wrapping it. Configurable using the `format_noneditable_selector` option. #TINY-8905


### PR DESCRIPTION
Related Ticket: TINY-8966

Description of Changes:
* Added CSS to affect visuals of `mce-footnote` and `mce-footnotes` elements.

Pre-checks:
* [x] ~Changelog entry added~ N/A
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
