### PR TITLE
TINY-8687: added support for aligning media plugin and ephox embed elements

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The autocompleter now supports a multiple character trigger using the new `trigger` configuration #TINY-8887
 - The formatter will now apply some inline formats like color and font size to list item elements when the entire item content is selected. #TINY-8961
 - The plugin lists in the Help dialog are now sorted alphabetically. #TINY-9019
+- Alignment can now be applied to more types of embedded media elements. #TINY-8687
 
 ### Changed
 - The `@menubar-row-separator-color` oxide variable no longer affects the divider between the Menubar and Toolbar and only controls the color of the separator lines drawn in multiline Menubars. #TINY-8632

--- a/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
@@ -56,6 +56,13 @@ const get = (editor: Editor): Formats => {
           dom.setStyle(table as HTMLTableElement, 'float', null);
         },
         preview: 'font-family font-size'
+      },
+      {
+        selector: '.mce-preview-object,[data-ephox-embed-iri]',
+        ceFalseOverride: true,
+        styles: {
+          float: 'left'
+        }
       }
     ],
 
@@ -93,6 +100,25 @@ const get = (editor: Editor): Formats => {
           marginRight: 'auto'
         },
         preview: 'font-family font-size'
+      },
+      {
+        selector: '.mce-preview-object',
+        ceFalseOverride: true,
+        styles: {
+          display: 'table', // Needs to be `table` to properly render while editing
+          marginLeft: 'auto',
+          marginRight: 'auto'
+        },
+        preview: false
+      },
+      {
+        selector: '[data-ephox-embed-iri]',
+        ceFalseOverride: true,
+        styles: {
+          marginLeft: 'auto',
+          marginRight: 'auto'
+        },
+        preview: false
       }
     ],
 
@@ -132,6 +158,14 @@ const get = (editor: Editor): Formats => {
           dom.setStyle(table as HTMLTableElement, 'float', null);
         },
         preview: 'font-family font-size'
+      },
+      {
+        selector: '.mce-preview-object,[data-ephox-embed-iri]',
+        ceFalseOverride: true,
+        styles: {
+          float: 'right'
+        },
+        preview: false
       }
     ],
 

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
@@ -676,5 +676,15 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
         },
       ]);
     });
+
+    context('noneditable inline elements with selector formats', () => {
+      it('TINY-8687: applying a selector format to an inline element should apply it to the matching parent block', () => {
+        const editor = hook.editor();
+        editor.setContent(`<p>a<span contenteditable="false">CEF</span>b</p>`);
+        TinySelections.select(editor, 'span', []);
+        editor.formatter.apply('alignright');
+        TinyAssertions.assertContent(editor, `<p style="text-align: right;">a<span contenteditable="false">CEF</span>b</p>`);
+      });
+    });
   });
 });

--- a/modules/tinymce/src/plugins/media/test/ts/browser/MediaAlignmentTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/MediaAlignmentTest.ts
@@ -1,0 +1,89 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/media/Plugin';
+
+describe('browser.tinymce.plugins.media.core.MediaAlignmentTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: [ 'media' ],
+    toolbar: 'media',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ]);
+
+  const testCommand = (cmd: string) => (inputHtml: string, expectedHtml: string) => {
+    const editor = hook.editor();
+
+    editor.setContent(inputHtml);
+    TinySelections.select(editor, '.mce-preview-object,[data-ephox-embed-iri]', []);
+    editor.execCommand(cmd);
+
+    TinyAssertions.assertContent(editor, expectedHtml);
+  };
+
+  const testAlignLeft = testCommand('JustifyLeft');
+  const testAlignCenter = testCommand('JustifyCenter');
+  const testAlignRight = testCommand('JustifyRight');
+
+  context('apply alignment to video elements', () => {
+    it('TINY-8687: align video element without styles to the left', () => testAlignLeft(
+      '<p><video src="about:blank" width="300" height="250"></video></p>',
+      '<p><video style="float: left;" src="about:blank" width="300" height="250"></video></p>'
+    ));
+
+    it('TINY-8687: align video element without styles to the center', () => testAlignCenter(
+      '<p><video src="about:blank" width="300" height="250"></video></p>',
+      '<p><video style="display: table; margin-left: auto; margin-right: auto;" src="about:blank" width="300" height="250"></video></p>'
+    ));
+
+    it('TINY-8687: align video element without styles to the right', () => testAlignRight(
+      '<p><video src="about:blank" width="300" height="250"></video></p>',
+      '<p><video style="float: right;" src="about:blank" width="300" height="250"></video></p>'
+    ));
+
+    it('TINY-8687: aligning a video element with styles to the left should retain existing styles', () => testAlignLeft(
+      '<p><video style="color: red;" src="about:blank" width="300" height="250"></video></p>',
+      '<p><video style="color: red; float: left;" src="about:blank" width="300" height="250"></video></p>'
+    ));
+  });
+
+  context('apply alignment to ephox embed elements', () => {
+    it('TINY-8687: align ephox embed element without styles to the left', () => testAlignLeft(
+      '<div contenteditable="false" data-ephox-embed-iri="embed-iri"><iframe src="about:blank"></iframe></div>',
+      '<div style="float: left;" contenteditable="false" data-ephox-embed-iri="embed-iri"><iframe src="about:blank"></iframe></div>'
+    ));
+
+    it('TINY-8687: align ephox embed element without styles to the center', () => testAlignCenter(
+      '<div contenteditable="false" data-ephox-embed-iri="embed-iri"><iframe src="about:blank"></iframe></div>',
+      '<div style="margin-left: auto; margin-right: auto;" contenteditable="false" data-ephox-embed-iri="embed-iri"><iframe src="about:blank"></iframe></div>'
+    ));
+
+    it('TINY-8687: align ephox embed element without styles to the right', () => testAlignRight(
+      '<div contenteditable="false" data-ephox-embed-iri="embed-iri"><iframe src="about:blank"></iframe></div>',
+      '<div style="float: right;" contenteditable="false" data-ephox-embed-iri="embed-iri"><iframe src="about:blank"></iframe></div>'
+    ));
+  });
+
+  context('remove alignment from video', () => {
+    it('TINY-8687: remove align left from video element without styles', () => testAlignLeft(
+      '<p><video style="float: left;" src="about:blank" width="300" height="250"></video></p>',
+      '<p><video src="about:blank" width="300" height="250"></video></p>'
+    ));
+
+    it('TINY-8687: remove align center from video element without styles', () => testAlignCenter(
+      '<p><video style="display: table; margin-left: auto; margin-right: auto;" src="about:blank" width="300" height="250"></video></p>',
+      '<p><video src="about:blank" width="300" height="250"></video></p>'
+    ));
+
+    it('TINY-8687: remove align right from video element without styles', () => testAlignRight(
+      '<p><video style="float: right;" src="about:blank" width="300" height="250"></video></p>',
+      '<p><video src="about:blank" width="300" height="250"></video></p>'
+    ));
+
+    it('TINY-8687: removing alignment left from a video element with styles should retain the existing styles', () => testAlignLeft(
+      '<p><video style="color: red; float: left;" src="about:blank" width="300" height="250"></video></p>',
+      '<p><video style="color: red;" src="about:blank" width="300" height="250"></video></p>'
+    ));
+  });
+});
+


### PR DESCRIPTION
Related Ticket: TINY-8687

Description of Changes:
* Adds two new alignment formats for media plugin wrapping elements and for ephox embeded elements (enhanced media plugin)
* Tested a few variants of this one was using classes instead like the figure element another one was trying to have the display be `block` in import/exporting but `table` internally both became messy. So this is the simplest solution and the customer can override this alignment if they want to in one spot with the `formats` config option.
* The case where you select an inline editable element seems to work with other changes we made recently to cef so I just added an extra test for that

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
