### PR TITLE
TINY-9023: added oxide content ui css for mergetags

### DIFF
--- a/modules/oxide/src/less/theme/content-ui.less
+++ b/modules/oxide/src/less/theme/content-ui.less
@@ -9,6 +9,7 @@
 @import 'content/contenteditable/contenteditable';
 @import 'content/cursors/cursors';
 @import 'content/media/media';
+@import 'content/mergetags/mergetag';
 @import 'content/object/object';
 @import 'content/pagebreak/pagebreak';
 @import 'content/pageembed/pageembed';

--- a/modules/oxide/src/less/theme/content/mergetags/mergetag.less
+++ b/modules/oxide/src/less/theme/content/mergetags/mergetag.less
@@ -1,7 +1,12 @@
+@mergetag-hover-background-color: rgba(64, 153, 255, .1);
 @mergetag-affix-text-color: #3788EC;
-@mergetag-affix-background-color: rgba(64, 153, 255, .1);
+@mergetag-affix-background-color: @mergetag-hover-background-color;
 
 .mce-content-body {
+  .mce-mergetag:hover {
+    background-color: @mergetag-hover-background-color;
+  }
+
   .mce-mergetag-affix {
     background-color: @mergetag-affix-background-color;
     color: @mergetag-affix-text-color;

--- a/modules/oxide/src/less/theme/content/mergetags/mergetag.less
+++ b/modules/oxide/src/less/theme/content/mergetags/mergetag.less
@@ -1,0 +1,17 @@
+@mergetag-prefix-color: #3788EC;
+@mergetag-prefix-background-color: rgba(64, 153, 255, .1);
+
+@mergetag-suffix-color: @mergetag-prefix-color;
+@mergetag-suffix-background-color: @mergetag-prefix-background-color;
+
+.mce-content-body {
+  .mce-mergetag-prefix {
+    background-color: @mergetag-prefix-background-color;
+    color: @mergetag-prefix-color;
+  }
+
+  .mce-mergetag-suffix {
+    background-color: @mergetag-suffix-background-color;
+    color: @mergetag-suffix-color;
+  }
+}

--- a/modules/oxide/src/less/theme/content/mergetags/mergetag.less
+++ b/modules/oxide/src/less/theme/content/mergetags/mergetag.less
@@ -1,17 +1,9 @@
-@mergetag-prefix-color: #3788EC;
-@mergetag-prefix-background-color: rgba(64, 153, 255, .1);
-
-@mergetag-suffix-color: @mergetag-prefix-color;
-@mergetag-suffix-background-color: @mergetag-prefix-background-color;
+@mergetag-affix-text-color: #3788EC;
+@mergetag-affix-background-color: rgba(64, 153, 255, .1);
 
 .mce-content-body {
-  .mce-mergetag-prefix {
-    background-color: @mergetag-prefix-background-color;
-    color: @mergetag-prefix-color;
-  }
-
-  .mce-mergetag-suffix {
-    background-color: @mergetag-suffix-background-color;
-    color: @mergetag-suffix-color;
+  .mce-mergetag-affix {
+    background-color: @mergetag-affix-background-color;
+    color: @mergetag-affix-text-color;
   }
 }

--- a/modules/oxide/src/less/theme/content/mergetags/mergetag.less
+++ b/modules/oxide/src/less/theme/content/mergetags/mergetag.less
@@ -1,5 +1,5 @@
-@mergetag-hover-background-color: rgba(64, 153, 255, .1);
-@mergetag-affix-text-color: #3788EC;
+@mergetag-hover-background-color: fade(@color-tint, 10%);
+@mergetag-affix-text-color: @color-tint;
 @mergetag-affix-background-color: @mergetag-hover-background-color;
 
 .mce-content-body {


### PR DESCRIPTION
Related Ticket: TINY-9023

Description of Changes:
* Added new mergetags ui css to visualize the merge tags while editing

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
