### PR TITLE
TINY-9053: Exposing more types of TextPatterns 

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/textpatterns/TextPatterns.ts
+++ b/modules/tinymce/src/core/main/ts/api/textpatterns/TextPatterns.ts
@@ -1,7 +1,14 @@
-import { RawPattern, RawDynamicPatternsLookup, DynamicPatternContext } from '../../textpatterns/core/PatternTypes';
+import { RawPattern, RawDynamicPatternsLookup, DynamicPatternContext, DynamicPatternsLookup, Pattern, BlockCmdPattern, BlockFormatPattern, InlineCmdPattern, InlinePattern, InlineFormatPattern } from '../../textpatterns/core/PatternTypes';
 
 export {
+  Pattern,
   RawPattern,
+  DynamicPatternsLookup,
   RawDynamicPatternsLookup,
-  DynamicPatternContext
+  DynamicPatternContext,
+  BlockCmdPattern,
+  BlockFormatPattern,
+  InlineCmdPattern,
+  InlinePattern,
+  InlineFormatPattern
 };

--- a/modules/tinymce/src/core/main/ts/api/textpatterns/TextPatterns.ts
+++ b/modules/tinymce/src/core/main/ts/api/textpatterns/TextPatterns.ts
@@ -1,4 +1,4 @@
-import { RawPattern, RawDynamicPatternsLookup, DynamicPatternContext, DynamicPatternsLookup, Pattern, BlockCmdPattern, BlockFormatPattern, InlineCmdPattern, InlinePattern, InlineFormatPattern } from '../../textpatterns/core/PatternTypes';
+import { RawPattern, RawDynamicPatternsLookup, DynamicPatternContext, DynamicPatternsLookup, Pattern, BlockCmdPattern, BlockFormatPattern, InlineCmdPattern, InlinePattern, InlineFormatPattern, BlockPattern } from '../../textpatterns/core/PatternTypes';
 
 export {
   Pattern,
@@ -7,6 +7,7 @@ export {
   RawDynamicPatternsLookup,
   DynamicPatternContext,
   BlockCmdPattern,
+  BlockPattern,
   BlockFormatPattern,
   InlineCmdPattern,
   InlinePattern,

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/PatternTypes.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/PatternTypes.ts
@@ -53,7 +53,7 @@ export type Pattern = InlinePattern | BlockPattern;
 
 export interface DynamicPatternContext {
   readonly text: string; // the string from the start of the block to the cursor
-  readonly block: Element; // the parent block node
+  readonly block: Element; // the parent block element
 }
 
 export type DynamicPatternsLookup = (ctx: DynamicPatternContext) => Pattern[];

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/PatternTypes.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/PatternTypes.ts
@@ -53,7 +53,7 @@ export type Pattern = InlinePattern | BlockPattern;
 
 export interface DynamicPatternContext {
   readonly text: string; // the string from the start of the block to the cursor
-  readonly block: Node; // the parent block node
+  readonly block: Element; // the parent block node
 }
 
 export type DynamicPatternsLookup = (ctx: DynamicPatternContext) => Pattern[];

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsPublicApiTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsPublicApiTest.ts
@@ -12,7 +12,13 @@ describe('browser.tinymce.textpatterns.TextPatternsPublicApiTest', () => {
   const makePlugin = () => {
     PluginManager.add('custom-plugin', (editor) => {
 
-      const replacementLookup: TextPatterns.RawDynamicPatternsLookup = (_ctx: TextPatterns.DynamicPatternContext): TextPatterns.RawPattern[] => {
+      const replacementLookup: TextPatterns.RawDynamicPatternsLookup = (ctx: TextPatterns.DynamicPatternContext): TextPatterns.RawPattern[] => {
+        // Use `setAttribute` on the context's block to ensure it is of type Element
+        ctx.block.setAttribute(
+          'data-textpattern-text',
+          ctx.text
+        );
+
         return [
           // block format
           {

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsPublicApiTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsPublicApiTest.ts
@@ -1,0 +1,117 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+
+// eslint-disable-next-line @tinymce/no-publicapi-module-imports
+import { Editor, PluginManager, TextPatterns } from 'tinymce/core/api/PublicApi';
+
+// The purpose of this test is to ensure that we have all the types required
+// for managing TextPatterns exposed through PublicApi
+describe('browser.tinymce.textpatterns.TextPatternsPublicApiTest', () => {
+  // This function `make needs to be defined before creating hook.
+  const makePlugin = () => {
+    PluginManager.add('custom-plugin', (editor) => {
+
+      const replacementLookup: TextPatterns.RawDynamicPatternsLookup = (_ctx: TextPatterns.DynamicPatternContext): TextPatterns.RawPattern[] => {
+        return [
+          // block format
+          {
+            start: '#',
+            format: 'h1'
+          },
+          // block cmd
+          {
+            start: '*',
+            cmd: 'InsertOrderedList'
+          },
+          // inline format
+          {
+            start: '__',
+            end: '__',
+            format: 'italics'
+          },
+          // inline cmd
+          {
+            start: '**',
+            end: '**',
+            cmd: 'Bold'
+          }
+        ];
+      };
+
+      editor.options.set('text_patterns_lookup', replacementLookup);
+
+      editor.ui.registry.addButton(
+        'list-lookups',
+        {
+          text: 'List lookups',
+          onAction: () => {
+            const existingLookup: TextPatterns.DynamicPatternsLookup = editor.options.get('text_patterns_lookup');
+
+            const lookups: TextPatterns.Pattern[] = existingLookup({
+              block: document.createElement('div'),
+              text: 'some-text'
+            });
+
+            // This extracted value is meaningless. It's just testing that we have access to
+            // all the types we need to classify the various formats. We do test to see if
+            // the values go into the content, though.
+            const information: string[] = Arr.bind(lookups, (l) => {
+              // case match on the types of patterns.
+              switch (l.type) {
+                case 'block-command': {
+                  const bl: TextPatterns.BlockCmdPattern = l;
+                  return [ `block-command: ${bl.cmd}` ];
+                }
+                case 'block-format': {
+                  const bf: TextPatterns.BlockFormatPattern = l;
+                  return [ `block-format: ${bf.format}` ];
+                }
+                case 'inline-command': {
+                  // We use both types here just to check we can.
+                  const ip: TextPatterns.InlinePattern = l;
+                  const ic: TextPatterns.InlineCmdPattern = l;
+                  // The equality here is just to force `ip` to be used.
+                  return ip === ic ? [ `inline-command: ${ic.cmd}` ] : [ ];
+                }
+                case 'inline-format': {
+                  const inf: TextPatterns.InlineFormatPattern = l;
+                  return [ `inline-format: ${inf.format.join(',')}` ];
+                }
+                default: {
+                  return [ ];
+                }
+              }
+            });
+
+            editor.setContent(
+              Arr.map(information, (inf) => `<p>${inf}</p>`).join('\n')
+            );
+          }
+        }
+      );
+
+      return {};
+    });
+  };
+
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    plugins: [ 'custom-plugin' ],
+    toolbar: 'list-lookups'
+  }, [ makePlugin ]);
+
+  it('TINY-9053: all required types for managing text patterns are exported through PublicApi', () => {
+    const editor = hook.editor();
+    TinyUiActions.clickOnToolbar(editor, 'button');
+    TinyAssertions.assertContent(
+      editor,
+      [
+        '<p>block-format: h1</p>',
+        '<p>block-command: InsertOrderedList</p>',
+        '<p>inline-format: italics</p>',
+        '<p>inline-command: Bold</p>'
+      ].join('\n')
+    );
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsPublicApiTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsPublicApiTest.ts
@@ -66,8 +66,9 @@ describe('browser.tinymce.textpatterns.TextPatternsPublicApiTest', () => {
               // case match on the types of patterns.
               switch (l.type) {
                 case 'block-command': {
+                  const bp: TextPatterns.BlockPattern = l;
                   const bl: TextPatterns.BlockCmdPattern = l;
-                  return [ `block-command: ${bl.cmd}` ];
+                  return bp === bl ? [ `block-command: ${bl.cmd}` ] : [ ];
                 }
                 case 'block-format': {
                   const bf: TextPatterns.BlockFormatPattern = l;


### PR DESCRIPTION
Related Ticket: TINY-9053

Description of Changes:
* exposed more types through TextPatterns in PublicApi
* created a test that uses just PublicApi to check that managing text pattern lookups are more managable

Questions
- does this need documentation changes? 
- is there a precedent for how verbose our changelog entry is for this? Does it need to list every type exposed? 

Pre-checks:
* [x] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
