### PR TITLE
TINY-9089: added fix for trailing br element

### DIFF
--- a/modules/tinymce/src/core/main/ts/fmt/ListItemFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ListItemFormat.ts
@@ -23,7 +23,12 @@ export const getExpandedListItemFormat = (formatter: Formatter, format: string):
 };
 
 const isRngStartAtStartOfElement = (rng: Range, elm: Element) => CaretFinder.prevPosition(elm, CaretPosition.fromRangeStart(rng)).isNone();
-const isRngEndAtEndOfElement = (rng: Range, elm: Element) => CaretFinder.nextPosition(elm, CaretPosition.fromRangeEnd(rng)).isNone();
+
+const isRngEndAtEndOfElement = (rng: Range, elm: Element) => {
+  return CaretFinder.nextPosition(elm, CaretPosition.fromRangeEnd(rng))
+    .exists((pos) => !NodeType.isBr(pos.getNode()) || CaretFinder.nextPosition(elm, pos).isSome()) === false;
+};
+
 const isEditableListItem = (dom: DOMUtils) => (elm: Element) => NodeType.isListItem(elm) && dom.getContentEditableParent(elm) !== 'false';
 
 const getFullySelectedBlocks = (selection: EditorSelection) => {


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Fixes a case that happens on Firefox found by QA

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
