### PR TITLE
TINY-8952: Translating the placeholder text for SearchMenuField

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/searchable/SearchableMenuField.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/searchable/SearchableMenuField.ts
@@ -103,7 +103,9 @@ export const renderMenuSearcher = (spec: MenuSearcherSpec): AlloySpec => {
       Input.sketch({
         inputClasses: [ menuSearcherClass, 'tox-textfield' ],
         inputAttributes: {
-          ...(spec.placeholder.map((placeholder) => ({ placeholder })).getOr({ })),
+          ...(spec.placeholder.map((placeholder) => (
+            { placeholder: spec.i18n(placeholder) }
+          )).getOr({ })),
           // This ARIA is based on the algolia example documented in TINY-8952
           'type': 'search',
           'aria-autocomplete': 'list'

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonPlaceholderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonPlaceholderTest.ts
@@ -1,0 +1,100 @@
+import { ApproxStructure, Assertions, Keyboard, Keys, Mouse, UiFinder } from '@ephox/agar';
+import { GuiFactory, TestHelpers } from '@ephox/alloy';
+import { after, before, describe, it } from '@ephox/bedrock-client';
+import { Fun, Id, Optional } from '@ephox/katamari';
+import { SugarDocument } from '@ephox/sugar';
+
+import I18n from 'tinymce/core/api/util/I18n';
+import { renderMenuButton } from 'tinymce/themes/silver/ui/button/MenuButton';
+
+import { fetchMailMergeData } from '../../module/CommonMailMergeFetch';
+import { structMenuWith, structSearchField } from '../../module/CommonMenuTestStructures';
+import * as TestExtras from '../../module/TestExtras';
+
+describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonPlaceholderTest', () => {
+  const helpers = TestExtras.bddSetup();
+
+  TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [
+    `.tox-menu .tox-collection__item--active {
+      background-color: black;
+    }`,
+    `.tox-menu {
+      background-color: #3f878bd6;
+      color:white;
+      padding: 2em;
+    }`
+  ]);
+
+  // We use a random output translation to ensure that the translation
+  // function is being called.
+  const translateInput = 'translation-input';
+  const translateOutput = Id.generate('translation-output');
+
+  const hook = TestHelpers.GuiSetup.bddSetup(
+    (store, _doc, _body) => GuiFactory.build(
+      renderMenuButton(
+        {
+          text: Optional.some('MailMerge'),
+          icon: Optional.none(),
+          tooltip: Optional.none(),
+          onSetup: Fun.constant(Fun.noop),
+          search: Optional.some({ placeholder: Optional.some(translateInput) }),
+          fetch: fetchMailMergeData({
+            // If a search pattern is present, collapse into one menu
+            collapseSearchResults: true
+          }, store)
+        },
+        'prefix',
+        helpers.backstage(),
+        Optional.none()
+      )
+    )
+  );
+
+  before(() => {
+    // Adapted from the approach taken by SilverDialogBlockTest
+    // to test that the block message is translated.
+    I18n.add('aa', {
+      [translateInput]: translateOutput
+    });
+    I18n.setCode('aa');
+  });
+
+  after(() => {
+    I18n.setCode('en');
+  });
+
+  it('TINY-8952: Basic structure with translated placeholder', async () => {
+    const menuButtonComp = hook.component();
+
+    // Open the dropdown.
+    Mouse.click(menuButtonComp.element);
+    const tmenu = await UiFinder.pWaitFor(
+      'Searching for TieredMenu',
+      hook.body(),
+      '.tox-tiered-menu'
+    );
+
+    Assertions.assertStructure(
+      'Testing search field structure',
+      ApproxStructure.build((s, _str, _arr) => {
+        return s.element('div', {
+          children: [
+            structMenuWith({ selected: true }, [
+              structSearchField(
+                Optional.some(translateOutput)
+              ),
+              // In this test, we only care about the search field.
+              s.anything()
+            ])
+          ]
+        });
+      }),
+      tmenu
+    );
+
+    // Close the menu
+    Keyboard.activeKeystroke(hook.root(), Keys.escape(), { });
+    UiFinder.notExists(hook.body(), '.tox-tiered-menu');
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonTest.ts
@@ -24,6 +24,8 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
     }`
   ]);
 
+  const structNoPlaceholderSearch = structSearchField(Optional.none());
+
   const hook = TestHelpers.GuiSetup.bddSetup(
     (store, _doc, _body) => GuiFactory.build(
       renderMenuButton(
@@ -116,7 +118,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
         return s.element('div', {
           children: [
             structMenuWith({ selected: true }, [
-              structSearchField(''),
+              structNoPlaceholderSearch,
               structSearchResultsWith([
                 structSearchLeafItem({ selected: true }),
                 structSearchLeafItem({ selected: false }),
@@ -140,7 +142,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
         return s.element('div', {
           children: [
             structMenuWith({ selected: true }, [
-              structSearchField(''),
+              structNoPlaceholderSearch,
               structSearchResultsWith([
                 structSearchLeafItem({ selected: false }),
                 structSearchLeafItem({ selected: false }),
@@ -164,7 +166,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
         return s.element('div', {
           children: [
             structMenuWith({ selected: true }, [
-              structSearchField(''),
+              structNoPlaceholderSearch,
               structSearchResultsWith([
                 structSearchLeafItem({ selected: false }),
                 structSearchLeafItem({ selected: false }),
@@ -187,7 +189,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
         return s.element('div', {
           children: [
             structMenuWith({ selected: false }, [
-              structSearchField(''),
+              structNoPlaceholderSearch,
               structSearchResultsWith([
                 structSearchLeafItem({ selected: false }),
                 structSearchLeafItem({ selected: false }),
@@ -218,7 +220,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
         return s.element('div', {
           children: [
             structMenuWith({ selected: false }, [
-              structSearchField(''),
+              structNoPlaceholderSearch,
               structSearchResultsWith([
                 structSearchLeafItem({ selected: false }),
                 structSearchLeafItem({ selected: false }),
@@ -249,7 +251,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
         return s.element('div', {
           children: [
             structMenuWith({ selected: false }, [
-              structSearchField(''),
+              structNoPlaceholderSearch,
               structSearchResultsWith([
                 structSearchLeafItem({ selected: false }),
                 structSearchLeafItem({ selected: false }),
@@ -283,7 +285,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
         return s.element('div', {
           children: [
             structMenuWith({ selected: true }, [
-              structSearchField(''),
+              structNoPlaceholderSearch,
               structSearchResultsWith([
                 structSearchLeafItem({ selected: false }),
                 structSearchLeafItem({ selected: false }),
@@ -307,7 +309,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
         return s.element('div', {
           children: [
             structMenuWith({ selected: true }, [
-              structSearchField(''),
+              structNoPlaceholderSearch,
               structSearchResultsWith([
                 structSearchLeafItem({ selected: false }),
                 structSearchLeafItem({ selected: false }),
@@ -330,7 +332,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
         return s.element('div', {
           children: [
             structMenuWith({ selected: false }, [
-              structSearchField(''),
+              structNoPlaceholderSearch,
               structSearchResultsWith([
                 structSearchLeafItem({ selected: false }),
                 structSearchLeafItem({ selected: false }),
@@ -363,7 +365,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
         return s.element('div', {
           children: [
             structMenuWith({ selected: false }, [
-              structSearchField(''),
+              structNoPlaceholderSearch,
               structSearchResultsWith([
                 structSearchLeafItem({ selected: false }),
                 structSearchLeafItem({ selected: false }),
@@ -397,7 +399,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
         return s.element('div', {
           children: [
             structMenuWith({ selected: false }, [
-              structSearchField(''),
+              structNoPlaceholderSearch,
               structSearchResultsWith([
                 structSearchLeafItem({ selected: false }),
                 structSearchLeafItem({ selected: false }),
@@ -487,7 +489,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
         return s.element('div', {
           children: [
             structMenuWith({ selected: true }, [
-              structSearchField(''),
+              structNoPlaceholderSearch,
               structSearchResultsWith([
                 structSearchLeafItem({ selected: true }),
                 structSearchLeafItem({ selected: false })
@@ -518,7 +520,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
         return s.element('div', {
           children: [
             structMenuWith({ selected: true }, [
-              structSearchField(''),
+              structNoPlaceholderSearch,
               structSearchResultsWith([
                 structSearchLeafItem({ selected: true }),
                 structSearchLeafItem({ selected: false }),

--- a/modules/tinymce/src/themes/silver/test/ts/module/CommonMenuTestStructures.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/CommonMenuTestStructures.ts
@@ -1,6 +1,7 @@
 // This is just a set of basic menu structures for quickly creating ApproxStructures.
 
 import { ApproxStructure, StructAssert } from '@ephox/agar';
+import { Optional } from '@ephox/katamari';
 
 const structMenuWith = (state: { selected: boolean }, children: StructAssert[]): StructAssert => ApproxStructure.build(
   (s, str, arr) => s.element('div', {
@@ -26,7 +27,7 @@ const structSearchResultsWith = (menuItems: StructAssert[]): StructAssert => App
   })
 );
 
-const structSearchField = (_placeholderText: string): StructAssert => ApproxStructure.build(
+const structSearchField = (placeholderOpt: Optional<string>): StructAssert => ApproxStructure.build(
   (s, str, arr) => s.element('div', {
     classes: [ arr.has('tox-collection__item') ],
     children: [
@@ -34,7 +35,11 @@ const structSearchField = (_placeholderText: string): StructAssert => ApproxStru
         attrs: {
           'type': str.is('search'),
           'aria-controls': str.startsWith('aria-controls-search-results'),
-          'aria-autocomplete': str.is('list')
+          'aria-autocomplete': str.is('list'),
+          'placeholder': placeholderOpt.fold(
+            () => str.none('No placeholder should be set'),
+            str.is
+          )
         }
       })
     ]

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/toolbar/SearchableMenuTypingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/toolbar/SearchableMenuTypingTest.ts
@@ -121,6 +121,8 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
     )
   );
 
+  const structNoPlaceholderSearch = structSearchField(Optional.none());
+
   // TINY-9013: The <space> key is missing from KeyEffects in bedrock
   const spaceKey = RealKeys.text('\uE00D');
 
@@ -143,7 +145,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
       onActiveElement( hook.root(), assertCursorAtEndOfText('Ph') );
       await pAssertTieredMenuStructure('Typing Ph', helpers.sink(), [
         structMenuWith({ selected: true }, [
-          structSearchField(''),
+          structNoPlaceholderSearch,
           structSearchResultsWith([
             structSearchLeafItem({ selected: true }),
             structSearchLeafItem({ selected: false }),
@@ -161,7 +163,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
       );
       await pAssertTieredMenuStructure('After <left>', helpers.sink(), [
         structMenuWith({ selected: true }, [
-          structSearchField(''),
+          structNoPlaceholderSearch,
           structSearchResultsWith([
             structSearchLeafItem({ selected: true }),
             structSearchLeafItem({ selected: false }),
@@ -179,7 +181,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
       );
       await pAssertTieredMenuStructure('After <up>', helpers.sink(), [
         structMenuWith({ selected: true }, [
-          structSearchField(''),
+          structNoPlaceholderSearch,
           structSearchResultsWith([
             structSearchLeafItem({ selected: false }),
             structSearchLeafItem({ selected: false }),
@@ -199,7 +201,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
       );
       await pAssertTieredMenuStructure('After <right>', helpers.sink(), [
         structMenuWith({ selected: true }, [
-          structSearchField(''),
+          structNoPlaceholderSearch,
           structSearchResultsWith([
             structSearchLeafItem({ selected: false }),
             structSearchLeafItem({ selected: false }),
@@ -224,7 +226,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
       // by the input.
       await pAssertTieredMenuStructure('After <space> (which will trigger a refetch)', helpers.sink(), [
         structMenuWith({ selected: true }, [
-          structSearchField(''),
+          structNoPlaceholderSearch,
           structSearchResultsWith([
             structSearchLeafItem({ selected: true }),
             structSearchLeafItem({ selected: false }),
@@ -242,7 +244,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
       );
       await pAssertTieredMenuStructure('After <up>', helpers.sink(), [
         structMenuWith({ selected: true }, [
-          structSearchField(''),
+          structNoPlaceholderSearch,
           structSearchResultsWith([
             structSearchLeafItem({ selected: false }),
             structSearchLeafItem({ selected: false }),
@@ -260,7 +262,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
       );
       await pAssertTieredMenuStructure('After <enter>', helpers.sink(), [
         structMenuWith({ selected: false }, [
-          structSearchField(''),
+          structNoPlaceholderSearch,
           structSearchResultsWith([
             structSearchLeafItem({ selected: false }),
             structSearchLeafItem({ selected: false }),
@@ -291,7 +293,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
       );
       await pAssertTieredMenuStructure('After <left>', helpers.sink(), [
         structMenuWith({ selected: false }, [
-          structSearchField(''),
+          structNoPlaceholderSearch,
           structSearchResultsWith([
             structSearchLeafItem({ selected: false }),
             structSearchLeafItem({ selected: false }),
@@ -321,7 +323,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
       );
       await pAssertTieredMenuStructure('After <down>', helpers.sink(), [
         structMenuWith({ selected: false }, [
-          structSearchField(''),
+          structNoPlaceholderSearch,
           structSearchResultsWith([
             structSearchLeafItem({ selected: false }),
             structSearchLeafItem({ selected: false }),
@@ -352,7 +354,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
       );
       await pAssertTieredMenuStructure('After <escape>', helpers.sink(), [
         structMenuWith({ selected: true }, [
-          structSearchField(''),
+          structNoPlaceholderSearch,
           structSearchResultsWith([
             structSearchLeafItem({ selected: false }),
             structSearchLeafItem({ selected: false }),


### PR DESCRIPTION
Related Ticket: TINY-8952 (follow-up that was missed initially)

Description of Changes:
* placeholder text for search menu field is now translated.

Pre-checks:
* [N/A] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [N/A] Docs ticket created (if applicable)

