### PR TITLE
TINY-8948: fix scrolling of separator lines in multiline toolbars

### DIFF
--- a/modules/oxide/src/less/theme/components/toolbar/toolbar.less
+++ b/modules/oxide/src/less/theme/components/toolbar/toolbar.less
@@ -27,6 +27,7 @@
   .tox-toolbar,
   .tox-toolbar__primary,
   .tox-toolbar__overflow {
+    background-attachment: local;
     background-color: @toolbar-background-color;
     background-image: @_toolbar-row-separator-image;
     background-position: @_toolbar-row-separator-image-position;

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fix line separator scrolling in floating toolbars #TINY-8948
+
 ## 6.2.0 - 2022-09-08
 
 ### Added

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Fix line separator scrolling in floating toolbars #TINY-8948
+- Fix line separator scrolling in floating toolbars. #TINY-8948
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Fix line separator scrolling in floating toolbars. #TINY-8948
+- Line separator scrolling in floating toolbars. #TINY-8948
 
 ## 6.2.0 - 2022-09-08
 


### PR DESCRIPTION
Related Ticket: TINY-8948

Description of Changes:
* Specified `background-attachment: local` for toolbar so that separator lines would scroll with it’s contents

Pre-checks:
* [x] Changelog entry added
* [X] ~Tests have been added (if applicable)~
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set