### PR TITLE
TINY-9098: Fixed a regression that caused enter to work within noneditable elements

### DIFF
--- a/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
@@ -152,7 +152,7 @@ const setForcedBlockAttrs = (editor: Editor, node: Element) => {
 // Wraps any text nodes or inline elements in the specified forced root block name
 const wrapSelfAndSiblingsInDefaultBlock = (editor: Editor, newBlockName: string, rng: Range, container: Node, offset: number) => {
   const dom = editor.dom;
-  const editableRoot = NewLineUtils.getEditableRoot(dom, container);
+  const editableRoot = NewLineUtils.getEditableRoot(dom, container) ?? dom.getRoot();
 
   // Not in a block element or in a table cell or caption
   let parentBlock = dom.getParent(container, dom.isBlock);

--- a/modules/tinymce/src/core/main/ts/newline/NewLineAction.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineAction.ts
@@ -1,4 +1,4 @@
-import { Adt, Arr, Optional } from '@ephox/katamari';
+import { Adt, Arr, Optional, Type } from '@ephox/katamari';
 
 import Editor from '../api/Editor';
 import * as Options from '../api/Options';
@@ -67,7 +67,7 @@ const canInsertIntoEditableRoot = (editor: Editor) => {
   const forcedRootBlock = Options.getForcedRootBlock(editor);
   const rootEditable = NewLineUtils.getEditableRoot(editor.dom, editor.selection.getStart());
 
-  return rootEditable && editor.schema.isValidChild(rootEditable.nodeName, forcedRootBlock);
+  return Type.isNonNullable(rootEditable) && editor.schema.isValidChild(rootEditable.nodeName, forcedRootBlock);
 };
 
 const match = (predicates: Array<(editor: Editor, shiftKey: boolean) => boolean>, action: NewLineActionAdt) => {

--- a/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
@@ -84,7 +84,7 @@ const moveToCaretPosition = (editor: Editor, root: Node): void => {
   ScrollIntoView.scrollRangeIntoView(editor, rng);
 };
 
-const getEditableRoot = (dom: DOMUtils, node: Node): HTMLElement => {
+const getEditableRoot = (dom: DOMUtils, node: Node): HTMLElement | undefined => {
   const root = dom.getRoot();
   let editableRoot: HTMLElement | undefined;
 
@@ -98,7 +98,7 @@ const getEditableRoot = (dom: DOMUtils, node: Node): HTMLElement => {
     parent = parent.parentNode;
   }
 
-  return parent !== root && editableRoot ? editableRoot : root;
+  return parent !== root ? editableRoot : root;
 };
 
 const getParentBlock = (editor: Editor): Optional<Element> => {

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyCeFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyCeFalseTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -64,5 +64,14 @@ describe('browser.tinymce.core.keyboard.EnterKeyCeFalseTest', () => {
       '<div contenteditable="false">x</div><p><br data-mce-bogus="1"></p>'
     );
     assert.equal(editor.selection.getNode().nodeName, 'P');
+  });
+
+  it('TINY-9098: Enter key on inline cE=false should do nothing', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><span contenteditable="false">x</span></p>');
+    TinySelections.select(editor, 'span', []);
+    pressEnter(editor);
+    TinyAssertions.assertContent(editor, '<p><span contenteditable="false">x</span></p>');
+    assert.equal(editor.selection.getNode().nodeName, 'SPAN');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -80,6 +80,15 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
     });
   });
 
+  it('TINY-9098: insert newline on inline cE=false element should do nothing', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>before<span contenteditable="false">x</span>after</p>');
+    TinySelections.select(editor, 'span', []);
+    insertNewline(editor, { });
+    editor.nodeChanged();
+    TinyAssertions.assertContent(editor, '<p>before<span contenteditable="false">x</span>after</p>');
+  });
+
   context('br_newline_selector', () => {
     before(() => {
       hook.editor().options.set('br_newline_selector', 'p,div.test');

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableGridFalseTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableGridFalseTest.ts
@@ -1,4 +1,4 @@
-import { Assertions, Waiter } from '@ephox/agar';
+import { Assertions, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
@@ -18,7 +18,8 @@ describe('browser.tinymce.plugins.table.TableGridFalse', () => {
     await Waiter.pTryUntil('click table menu', () =>
       TinyUiActions.clickOnUi(editor, 'div.tox-menu div.tox-collection__item .tox-collection__item-label:contains("Table")')
     );
-    const dialog = await TinyUiActions.pWaitForDialog(editor, 'div.tox-dialog:has(div.tox-dialog__title:contains("Table Properties"))');
+    const dialog = await TinyUiActions.pWaitForDialog(editor);
+    UiFinder.exists(dialog, 'div.tox-dialog__title:contains("Table Properties")');
     Assertions.assertPresence(
       'assert presence of col and row input',
       {


### PR DESCRIPTION
Related Ticket: TINY-9098

Description of Changes:

Fixes a regression introduced in 6.2 development when I was doing the strict types as the new line logic relies on `getEditableRoot` returning a nullable value. So this swaps that back and adds other checks/fallbacks where required to handle that.

Pre-checks:
* [x] ~Changelog entry added~ N/A as this bug hasn't been released
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
