### PR TITLE
TINY-8935: Fix formatter placing cursor inside a noneditable node

### DIFF
--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -1,4 +1,4 @@
-import { Arr, Obj, Type } from '@ephox/katamari';
+import { Arr, Fun, Obj, Type } from '@ephox/katamari';
 import { PredicateExists, SugarElement } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
@@ -137,17 +137,17 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
 
     const canRenameBlock = (nodeName: string, parentName: string, isEditableDescendant: boolean) => {
       const isValidBlockFormatForNode =
-            FormatUtils.isNonWrappingBlockFormat(format) &&
-            FormatUtils.isTextBlock(ed, nodeName) &&
-            FormatUtils.isValid(ed, parentName, wrapName);
+        FormatUtils.isNonWrappingBlockFormat(format) &&
+        FormatUtils.isTextBlock(ed, nodeName) &&
+        FormatUtils.isValid(ed, parentName, wrapName);
       return isEditableDescendant && isValidBlockFormatForNode;
     };
 
     const canWrapNode = (node: Node, parentName: string, isEditableDescendant: boolean, isWrappableNoneditableElm: boolean) => {
       const nodeName = node.nodeName.toLowerCase();
       const isValidWrapNode =
-            FormatUtils.isValid(ed, wrapName, nodeName) &&
-            FormatUtils.isValid(ed, parentName, wrapName);
+        FormatUtils.isValid(ed, wrapName, nodeName) &&
+        FormatUtils.isValid(ed, parentName, wrapName);
       // If it is not node specific, it means that it was not passed into 'formatter.apply` and is within the editor selection
       const isZwsp = !nodeSpecific && NodeType.isText(node) && Zwsp.isZwsp(node.data);
       const isCaret = isCaretNode(node);
@@ -335,16 +335,16 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
       if (!isCollapsed || !FormatUtils.isInlineFormat(format) || TableCellSelection.getCellsFromEditor(ed).length) {
         // Apply formatting to selection
         selection.setRng(RangeNormalizer.normalize(selection.getRng()));
-        SelectionUtils.preserve(selection, true, () => {
-          SelectionUtils.runOnRanges(ed, (selectionRng, fake) => {
-            const expandedRng = fake ? selectionRng : ExpandRange.expandRng(ed, selectionRng, formatList);
-            applyRngStyle(dom, expandedRng, false);
-          });
-        });
 
-        if (dom.getContentEditable(selection.getNode()) !== 'false') {
-          FormatUtils.moveStart(dom, selection, selection.getRng());
-        }
+        FormatUtils.adjustSelectionAfter(ed, () => {
+          SelectionUtils.preserve(selection, true, () => {
+            SelectionUtils.runOnRanges(ed, (selectionRng, fake) => {
+              const expandedRng = fake ? selectionRng : ExpandRange.expandRng(ed, selectionRng, formatList);
+              applyRngStyle(dom, expandedRng, false);
+            });
+          });
+        }, Fun.always);
+
         ed.nodeChanged();
       } else {
         CaretFormat.applyCaretFormat(ed, name, vars);

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -336,14 +336,16 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
         // Apply formatting to selection
         selection.setRng(RangeNormalizer.normalize(selection.getRng()));
 
-        FormatUtils.adjustSelectionAfter(ed, () => {
-          SelectionUtils.preserve(selection, true, () => {
+        FormatUtils.preserveSelection(
+          ed,
+          () => {
             SelectionUtils.runOnRanges(ed, (selectionRng, fake) => {
               const expandedRng = fake ? selectionRng : ExpandRange.expandRng(ed, selectionRng, formatList);
               applyRngStyle(dom, expandedRng, false);
             });
-          });
-        }, Fun.always);
+          },
+          Fun.always
+        );
 
         ed.nodeChanged();
       } else {

--- a/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
@@ -9,6 +9,7 @@ import Editor from '../api/Editor';
 import * as Options from '../api/Options';
 import * as Bookmarks from '../bookmark/Bookmarks';
 import * as NodeType from '../dom/NodeType';
+import * as SelectionUtils from '../selection/SelectionUtils';
 import * as Whitespace from '../text/Whitespace';
 import { isCaretNode } from './FormatContainer';
 import { BlockFormat, Format, FormatAttrOrStyleValue, FormatVars, InlineFormat, MixedFormat, SelectorFormat } from './FormatTypes';
@@ -35,12 +36,15 @@ const isElementDirectlySelected = (dom: DOMUtils, node: Node): boolean => {
 const isEditable = (elm: HTMLElement): boolean =>
   elm.isContentEditable === true;
 
-const adjustSelectionAfter = (editor: Editor, action: () => void, shouldMoveStart: (startNode: Node) => boolean): void => {
+// TODO: TINY-9130 Look at making SelectionUtils.preserve maintain the noneditable selection instead
+const preserveSelection = (editor: Editor, action: () => void, shouldMoveStart: (startNode: Node) => boolean): void => {
   const { selection, dom } = editor;
   const selectedNodeBeforeAction = selection.getNode();
   const isSelectedBeforeNodeNoneditable = NodeType.isContentEditableFalse(selectedNodeBeforeAction);
 
-  action();
+  SelectionUtils.preserve(selection, true, () => {
+    action();
+  });
 
   // Check previous selected node before the action still exists in the DOM
   // and is still noneditable
@@ -312,7 +316,7 @@ export {
   isNode,
   isElementNode,
   isEditable,
-  adjustSelectionAfter,
+  preserveSelection,
   getNonWhiteSpaceSibling,
   isTextBlock,
   isValid,

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -639,13 +639,9 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
 
   if (!selection.isCollapsed() || !FormatUtils.isInlineFormat(format) || TableCellSelection.getCellsFromEditor(ed).length) {
     // Remove formatting on the selection
-    FormatUtils.adjustSelectionAfter(
+    FormatUtils.preserveSelection(
       ed,
-      () => {
-        SelectionUtils.preserve(selection, true, () => {
-          SelectionUtils.runOnRanges(ed, removeRngStyle);
-        });
-      },
+      () => SelectionUtils.runOnRanges(ed, removeRngStyle),
       // Before trying to move the start of the selection, check if start element still has formatting then we are at: "<b>text|</b>text"
       // and need to move the start into the next text node
       (startNode) => FormatUtils.isInlineFormat(format) && MatchFormat.match(ed, name, vars, startNode)

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -639,15 +639,17 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
 
   if (!selection.isCollapsed() || !FormatUtils.isInlineFormat(format) || TableCellSelection.getCellsFromEditor(ed).length) {
     // Remove formatting on the selection
-    SelectionUtils.preserve(selection, true, () => {
-      SelectionUtils.runOnRanges(ed, removeRngStyle);
-    });
-
-    // Check if start element still has formatting then we are at: "<b>text|</b>text"
-    // and need to move the start into the next text node
-    if (FormatUtils.isInlineFormat(format) && MatchFormat.match(ed, name, vars, selection.getStart())) {
-      FormatUtils.moveStart(dom, selection, selection.getRng());
-    }
+    FormatUtils.adjustSelectionAfter(
+      ed,
+      () => {
+        SelectionUtils.preserve(selection, true, () => {
+          SelectionUtils.runOnRanges(ed, removeRngStyle);
+        });
+      },
+      // Before trying to move the start of the selection, check if start element still has formatting then we are at: "<b>text|</b>text"
+      // and need to move the start into the next text node
+      (startNode) => FormatUtils.isInlineFormat(format) && MatchFormat.match(ed, name, vars, startNode)
+    );
 
     ed.nodeChanged();
   } else {

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatChangeSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatChangeSelectionTest.ts
@@ -35,6 +35,7 @@ describe('browser.tinymce.core.fmt.FormatChangeSelectionTest', () => {
     editor.execCommand('italic');
     TinyAssertions.assertContent(editor, `<p>before<em><img src="about:blank"></em>after</p>`);
     TinyAssertions.assertSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 1);
+    TinyAssertions.assertContentPresence(editor, { 'img[data-mce-selected]': 1 });
   });
 
   it('TINY-8935: should keep nonwrappable, noneditable node selected after applying an inline format', () => {
@@ -49,6 +50,7 @@ describe('browser.tinymce.core.fmt.FormatChangeSelectionTest', () => {
 
     TinyAssertions.assertContent(editor, content);
     TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 2);
+    TinyAssertions.assertContentPresence(editor, { 'span[contenteditable="false"][data-mce-selected]': 1 });
   });
 
   it('TINY-8935: should keep wrappable, noneditable node selected after applying an inline format', () => {
@@ -62,6 +64,7 @@ describe('browser.tinymce.core.fmt.FormatChangeSelectionTest', () => {
 
     TinyAssertions.assertContent(editor, `<p>before <em><span contenteditable="false" data-mce-cef-wrappable="true">test</span></em> after</p>`);
     TinyAssertions.assertSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 1);
+    TinyAssertions.assertContentPresence(editor, { 'span[contenteditable="false"][data-mce-selected]': 1 });
   });
 
   it('TINY-8935: should keep wrappable, noneditable node selected after removing an inline format', () => {
@@ -75,6 +78,7 @@ describe('browser.tinymce.core.fmt.FormatChangeSelectionTest', () => {
 
     TinyAssertions.assertContent(editor, `<p>before <span contenteditable="false" data-mce-cef-wrappable="true">test</span> after</p>`);
     TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 2);
+    TinyAssertions.assertContentPresence(editor, { 'span[contenteditable="false"][data-mce-selected]': 1 });
   });
 
   it('TINY-8935: should not move the start of selection inside of the noneditable node after applying an inline format', () => {

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatChangeSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatChangeSelectionTest.ts
@@ -16,4 +16,81 @@ describe('browser.tinymce.core.fmt.FormatChangeSelectionTest', () => {
     TinyAssertions.assertContent(editor, '<p><em><strong>a </strong></em>b<em><strong> c</strong></em></p>');
     TinyAssertions.assertSelection(editor, [ 0, 1 ], 0, [ 0, 2 ], 0);
   });
+
+  it('TINY-8935: should move start of selection to an editable text node after applying an inline format', () => {
+    const editor = hook.editor();
+    editor.setContent(`<p><strong>test</strong></p>`);
+    TinySelections.select(editor, 'p', []);
+    editor.execCommand('italic');
+    TinyAssertions.assertContent(editor, `<p><em><strong>test</strong></em></p>`);
+    TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+  });
+
+  it('TINY-8935: should keep nonwrappable, noneditable node selected after applying an inline format', () => {
+    const editor = hook.editor();
+    const content = `<p>before <span contenteditable="false">test</span> after</p>`;
+
+    editor.setContent(content);
+    TinySelections.select(editor, 'span[contenteditable="false"]', []);
+    TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 2);
+
+    editor.execCommand('italic');
+
+    TinyAssertions.assertContent(editor, content);
+    TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 2);
+  });
+
+  it('TINY-8935: should keep wrappable, noneditable node selected after applying an inline format', () => {
+    const editor = hook.editor();
+
+    editor.setContent(`<p>before <span contenteditable="false" data-mce-cef-wrappable="true">test</span> after</p>`);
+    TinySelections.select(editor, 'span[contenteditable="false"]', []);
+    TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 2);
+
+    editor.execCommand('italic');
+
+    TinyAssertions.assertContent(editor, `<p>before <em><span contenteditable="false" data-mce-cef-wrappable="true">test</span></em> after</p>`);
+    TinyAssertions.assertSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 1);
+  });
+
+  it('TINY-8935: should keep wrappable, noneditable node selected after removing an inline format', () => {
+    const editor = hook.editor();
+
+    editor.setContent(`<p>before <em><span contenteditable="false" data-mce-cef-wrappable="true">test</span></em> after</p>`);
+    TinySelections.select(editor, 'span[contenteditable="false"]', []);
+    TinyAssertions.assertSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 1);
+
+    editor.execCommand('italic');
+
+    TinyAssertions.assertContent(editor, `<p>before <span contenteditable="false" data-mce-cef-wrappable="true">test</span> after</p>`);
+    TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 2);
+  });
+
+  it('TINY-8935: should not move the start of selection inside of the noneditable node after applying an inline format', () => {
+    const editor = hook.editor();
+
+    editor.setContent(`<p>before <span contenteditable="false" data-mce-cef-wrappable="true">test</span> after</p>`);
+    // Create a ranged selection so that there is not text before and some text after
+    TinySelections.setSelection(editor, [ 0, 0 ], 'before '.length, [ 0, 2 ], ' a'.length);
+
+    editor.execCommand('italic');
+
+    // start should remain on the <em> node as there is no text to move it too and can't move it into the noneditable node
+    TinyAssertions.assertContent(editor, `<p>before <em><span contenteditable="false" data-mce-cef-wrappable="true">test</span> a</em>fter</p>`);
+    TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 2);
+  });
+
+  it('TINY-8935: should not move the start of selection inside of the noneditable node after removing an inline format', () => {
+    const editor = hook.editor();
+
+    editor.setContent(`<p>before <em><span contenteditable="false" data-mce-cef-wrappable="true">test</span> a</em>fter</p>`);
+    // Create a ranged selection so that there is not text before and some text after
+    TinySelections.setSelection(editor, [ 0, 1 ], 0, [ 0, 1, 1 ], ' a'.length);
+
+    editor.execCommand('italic');
+
+    // start should remain on the span node as there is no text to move it too and can't move it into the noneditable node
+    TinyAssertions.assertContent(editor, `<p>before <span contenteditable="false" data-mce-cef-wrappable="true">test</span> after</p>`);
+    TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0, 2 ], 2);
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatChangeSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatChangeSelectionTest.ts
@@ -1,3 +1,4 @@
+import { Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
@@ -24,6 +25,16 @@ describe('browser.tinymce.core.fmt.FormatChangeSelectionTest', () => {
     editor.execCommand('italic');
     TinyAssertions.assertContent(editor, `<p><em><strong>test</strong></em></p>`);
     TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+  });
+
+  it('TINY-8935: should keep image node selected after applying an inline format', async () => {
+    const editor = hook.editor();
+    editor.setContent(`<p>before<img src="about:blank">after</p>`);
+    TinySelections.select(editor, 'img', []);
+    await Waiter.pTryUntil('image should be selected', () => TinyAssertions.assertContentPresence(editor, { 'img[data-mce-selected]': 1 }));
+    editor.execCommand('italic');
+    TinyAssertions.assertContent(editor, `<p>before<em><img src="about:blank"></em>after</p>`);
+    TinyAssertions.assertSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 1);
   });
 
   it('TINY-8935: should keep nonwrappable, noneditable node selected after applying an inline format', () => {

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
@@ -1,5 +1,6 @@
+import { Cursors } from '@ephox/agar';
 import { after, before, context, describe, it } from '@ephox/bedrock-client';
-import { Arr, Type } from '@ephox/katamari';
+import { Arr, Fun, Type } from '@ephox/katamari';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -9,6 +10,7 @@ interface Action {
   readonly expectedHtml: string;
   readonly pAssertBefore?: (editor: Editor) => Promise<void>;
   readonly pAssertAfter?: (editor: Editor) => Promise<void>;
+  readonly selectionAfter?: Cursors.CursorPath;
 }
 
 interface FormatInfo {
@@ -25,6 +27,13 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [], true);
 
+  const selectionPath = (startPath: number[], soffset: number, finishPath: number[], foffset: number): Cursors.CursorPath => ({
+    startPath,
+    soffset,
+    finishPath,
+    foffset
+  });
+
   const toggleInlineStyle = (style: string) => (editor: Editor) => {
     TinyUiActions.clickOnToolbar(editor, `[aria-label="${style}"]`);
   };
@@ -38,15 +47,26 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
 
   const pTestFormat = (format: (editor: Editor) => void) => async (editor: Editor, actions: Action[]) => {
     for (const action of actions) {
-      const { select, expectedHtml, pAssertBefore, pAssertAfter } = action;
+      const { select, expectedHtml, pAssertBefore, pAssertAfter, selectionAfter } = action;
       select(editor);
       if (Type.isNonNullable(pAssertBefore)) {
         await pAssertBefore(editor);
       }
+
       format(editor);
+
       TinyAssertions.assertContent(editor, expectedHtml);
       if (Type.isNonNullable(pAssertAfter)) {
-        await pAssertAfter(editor);
+        pAssertAfter(editor);
+      }
+      if (Type.isNonNullable(selectionAfter)) {
+        TinyAssertions.assertSelection(
+          editor,
+          selectionAfter.startPath,
+          selectionAfter.soffset,
+          selectionAfter.finishPath,
+          selectionAfter.foffset
+        );
       }
     }
   };
@@ -127,6 +147,31 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
               ]);
             });
 
+            it(`TINY-8935: select noneditable, toggle ${format.label}, keep selection, toggle ${format.label}`, async () => {
+              const editor = hook.editor();
+              editor.setContent(initialHtml);
+              await pTest(editor, [
+                {
+                  select: selectNoneditableSpan,
+                  expectedHtml: `<p>first <${format.html}>${noneditableHtml}</${format.tag}> third</p>`,
+                  pAssertAfter: async () => {
+                    await pAssertToolbar(true)(editor);
+                    TinyAssertions.assertContentPresence(editor, { 'span[contenteditable="false"][data-mce-selected]': 1 });
+                  },
+                  selectionAfter: selectionPath([ 0, 1 ], 0, [ 0, 1 ], 1)
+                },
+                {
+                  select: Fun.noop,
+                  expectedHtml: initialHtml,
+                  pAssertAfter: async () => {
+                    await pAssertToolbar(false)(editor);
+                    TinyAssertions.assertContentPresence(editor, { 'span[contenteditable="false"][data-mce-selected]': 1 });
+                  },
+                  selectionAfter: selectionPath([ 0 ], 1, [ 0 ], 2)
+                },
+              ]);
+            });
+
             it(`TINY-8842: select noneditable, toggle ${format.label}, select all, toggle ${format.label}`, async () => {
               const editor = hook.editor();
               editor.setContent(initialHtml);
@@ -178,6 +223,23 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
                 },
               ]);
             });
+
+            it(`TINY-8842: select all, toggle ${format.label}, keep selection, toggle ${format.label}`, async () => {
+              const editor = hook.editor();
+              editor.setContent(initialHtml);
+              await pTest(editor, [
+                {
+                  select: selectAll,
+                  expectedHtml: `<p><${format.html}>first ${noneditableHtml} third</${format.tag}></p>`,
+                  pAssertAfter: pAssertToolbar(true)
+                },
+                {
+                  select: Fun.noop,
+                  expectedHtml: initialHtml,
+                  pAssertAfter: pAssertToolbar(false)
+                },
+              ]);
+            });
           });
         });
       });
@@ -204,16 +266,11 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
                 {
                   select: selectNoneditableSpan,
                   expectedHtml: initialHtml,
-                  pAssertAfter: pAssertToolbar(false)
-                },
-                {
-                  select: selectAll,
-                  expectedHtml: [
-                    `<p><${format.html}>first </${format.tag}>` +
-                    noneditableHtml,
-                    `<${format.html}> third</${format.tag}></p>`,
-                  ].join(''),
-                  pAssertAfter: pAssertToolbar(true)
+                  pAssertAfter: async () => {
+                    await pAssertToolbar(false)(editor);
+                    TinyAssertions.assertContentPresence(editor, { 'span[contenteditable="false"][data-mce-selected]': 1 });
+                  },
+                  selectionAfter: selectionPath([ 0 ], 1, [ 0 ], 2)
                 },
               ]);
             });
@@ -264,7 +321,11 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
                 {
                   select: selectNoneditableSpan,
                   expectedHtml: `<p>first ${noneditableBeforeHtml}<span contenteditable="true"><${format.html}>editable</${format.tag}></span>${noneditableAfterHtml} third</p>`,
-                  pAssertAfter: pAssertToolbar(false)
+                  pAssertAfter: async () => {
+                    await pAssertToolbar(false)(editor);
+                    TinyAssertions.assertContentPresence(editor, { 'span[contenteditable="false"][data-mce-selected]': 1 });
+                  },
+                  selectionAfter: selectionPath([ 0 ], 1, [ 0 ], 2)
                 },
               ]);
             });


### PR DESCRIPTION
Related Ticket: TINY-8935

Description of Changes:
* Fixes a regression that was caused when adding support for wrapping noneditable elements. After either applying or removing a format, the selection is kept on the noneditable element if it was already selected. Additionally, there is some extra checks to prevent placing the cursor inside a noneditable element.
 
Pre-checks:
* [X] Changelog entry added (This was never released so not including a changelog entry)
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [X] Docs ticket created (if applicable)

GitHub issues (if applicable):
