### PR TITLE
TINY-9106: Fix promotion button height difference between hidpi and regular screens

### DIFF
--- a/modules/oxide/src/less/theme/components/menubar/promotion.less
+++ b/modules/oxide/src/less/theme/components/menubar/promotion.less
@@ -5,13 +5,13 @@
 @promotion-background-color: #E8F1F8;
 @promotion-background-hover-color: #B4D7FF;
 @promotion-background-active-color: #D9EDF7;
+@promotion-button-height: @menubar-select-font-size * 1.9;
 @promotion-text-color: #086BE6;
 
 .tox {
   .tox-promotion {
     background: @menubar-background;
     background-color: @menubar-background-color;
-    cursor: pointer;
     grid-column: 2;
     grid-row: 1;
     padding-inline-end: 8px;
@@ -20,11 +20,14 @@
   }
 
   .tox-promotion-link {
+    align-items: unsafe center;
     background-color: @promotion-background-color;
     border-radius: 5px;
     color: @promotion-text-color;
-    display: block;
+    cursor: pointer;
+    display: flex;
     font-size: @menubar-select-font-size;
+    height: @promotion-button-height;
     padding: 4px 8px;
     white-space: nowrap;
 


### PR DESCRIPTION
Related Ticket: TINY-9106

Description of Changes:
* Fix promotion button height and center it’s content regardless of content’s height
* Moved `cursor: pointer` property from promotion wrapper to button itself

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set