### PR TITLE
TINY-9101: Allowing inserting newline based deletions to use deletion overrides

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DomParser filter matching was not checked between filters, which could lead to an exception in the parser #TINY-8888
 - Lists with `contenteditable="false"` can no longer be toggled, and `contenteditable="true"` list elements within them can no longer be indented, split into another list element, or appended to the previous list element by deletion. #TINY-8920
 - Removed extra padding for the context toolbar in the `tinymce-5` skin. #TINY-8980
+- Fixed a regression where pressing Enter caused content outside the selection to be added or deleted unexpectedly. #TINY-9101
 
 ### Deprecated
 - The autocompleter `ch` configuration property has been deprecated and will be removed in the next major release. Use the `trigger` property instead. #TINY-8887

--- a/modules/tinymce/src/core/main/ts/delete/DeleteCommands.ts
+++ b/modules/tinymce/src/core/main/ts/delete/DeleteCommands.ts
@@ -32,7 +32,7 @@ const deleteCommand = (editor: Editor, caret: Cell<Text | null>): void => {
 
   result.fold(
     () => {
-      DeleteUtils.execDeleteCommand(editor);
+      DeleteUtils.execNativeDeleteCommand(editor);
       DeleteUtils.paddEmptyBody(editor);
     },
     Fun.call
@@ -43,7 +43,7 @@ const forwardDeleteCommand = (editor: Editor, caret: Cell<Text | null>): void =>
   const result = findAction(editor, caret, true);
 
   result.fold(
-    () => DeleteUtils.execForwardDeleteCommand(editor),
+    () => DeleteUtils.execNativeForwardDeleteCommand(editor),
     Fun.call
   );
 };

--- a/modules/tinymce/src/core/main/ts/delete/DeleteCommands.ts
+++ b/modules/tinymce/src/core/main/ts/delete/DeleteCommands.ts
@@ -32,6 +32,8 @@ const deleteCommand = (editor: Editor, caret: Cell<Text | null>): void => {
 
   result.fold(
     () => {
+      // We can't use an `execEditorDeleteCommand` here, otherwise we'd get
+      // possible infinite recursion (as it would trigger `deleteCommand` again)
       DeleteUtils.execNativeDeleteCommand(editor);
       DeleteUtils.paddEmptyBody(editor);
     },

--- a/modules/tinymce/src/core/main/ts/delete/DeleteUtils.ts
+++ b/modules/tinymce/src/core/main/ts/delete/DeleteUtils.ts
@@ -18,10 +18,16 @@ const execCommandIgnoreInputEvents = (editor: Editor, command: string) => {
   editor.off('beforeinput input', inputBlocker);
 };
 
-const execDeleteCommand = (editor: Editor): void =>
+// ASSUMPTION: The editor command 'delete' doesn't have any `beforeinput` and `input` trapping
+// because those events are only triggered by native contenteditable behaviour.
+const execEditorDeleteCommand = (editor: Editor): void => {
+  editor.execCommand('delete');
+};
+
+const execNativeDeleteCommand = (editor: Editor): void =>
   execCommandIgnoreInputEvents(editor, 'Delete');
 
-const execForwardDeleteCommand = (editor: Editor): void =>
+const execNativeForwardDeleteCommand = (editor: Editor): void =>
   execCommandIgnoreInputEvents(editor, 'ForwardDelete');
 
 const isBeforeRoot = (rootNode: SugarElement<Node>) => (elm: SugarElement<Node>): boolean =>
@@ -96,8 +102,9 @@ const deleteRangeContents = (editor: Editor, rng: Range, root: SugarElement<HTML
 
 export {
   deleteRangeContents,
-  execDeleteCommand,
-  execForwardDeleteCommand,
+  execNativeDeleteCommand,
+  execNativeForwardDeleteCommand,
+  execEditorDeleteCommand,
   getParentBlock,
   paddEmptyBody,
   willDeleteLastPositionInElement

--- a/modules/tinymce/src/core/main/ts/delete/InlineBoundaryDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/InlineBoundaryDelete.ts
@@ -45,12 +45,7 @@ const deleteFromTo = (editor: Editor, caret: Cell<Text | null>, from: CaretPosit
 
   editor.undoManager.ignore(() => {
     editor.selection.setRng(rangeFromPositions(from, to));
-    // TINY-9120: The entrypoint `backspaceDelete` in this module can be triggered by the
-    // overrides in our delete execCommand, so there is a risk that firing another
-    // execCommand that goes through our overrides could result in infinite recursion.
-    // Therefore, we will leave this as just the native execCommand for now, but understand
-    // that means it isn't going to be processed by any of our delete overrides, which might
-    // cause edge cases.
+    // TODO: TINY-9120 - Investigate if this should be using our custom overrides
     execNativeDeleteCommand(editor);
 
     BoundaryLocation.readLocation(isInlineTarget, rootNode, CaretPosition.fromRangeStart(editor.selection.getRng()))

--- a/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
@@ -3,7 +3,7 @@ import { Fun, Type } from '@ephox/katamari';
 import Editor from '../api/Editor';
 import { getNewlineBehavior } from '../api/Options';
 import { EditorEvent } from '../api/util/EventDispatcher';
-import { execDeleteCommand } from '../delete/DeleteUtils';
+import { execEditorDeleteCommand } from '../delete/DeleteUtils';
 import { fireFakeBeforeInputEvent, fireFakeInputEvent } from '../keyboard/FakeInputEvents';
 import { blockbreak } from './InsertBlock';
 import { linebreak } from './InsertBr';
@@ -16,7 +16,9 @@ interface BreakType {
 
 const insertBreak = (breakType: BreakType, editor: Editor, evt?: EditorEvent<KeyboardEvent>): void => {
   if (!editor.selection.isCollapsed()) {
-    execDeleteCommand(editor);
+    // Importantly, we want to use the editor execCommand here, so that our `delete` execCommand
+    // overrides will be considered.
+    execEditorDeleteCommand(editor);
   }
   if (Type.isNonNullable(evt)) {
     const event = fireFakeBeforeInputEvent(editor, breakType.fakeEventName);

--- a/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
@@ -16,7 +16,7 @@ interface BreakType {
 
 const insertBreak = (breakType: BreakType, editor: Editor, evt?: EditorEvent<KeyboardEvent>): void => {
   if (!editor.selection.isCollapsed()) {
-    // Importantly, we want to use the editor execCommand here, so that our `delete` execCommand
+    // IMPORTANT: We want to use the editor execCommand here, so that our `delete` execCommand
     // overrides will be considered.
     execEditorDeleteCommand(editor);
   }

--- a/modules/tinymce/src/core/main/ts/newline/NewLineAction.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineAction.ts
@@ -46,18 +46,9 @@ const inBlock = (blockName: string, requiredState: boolean) => (editor: Editor, 
   return state === requiredState;
 };
 
-const inCefPreBlock = (editor: Editor) => {
-  const parentBlockOpt = NewLineUtils.getParentBlock(editor);
-  return parentBlockOpt.exists(
-    (parentBlock) => {
-      if (parentBlock.nodeName.toUpperCase() === 'PRE') {
-        const editableRoot = NewLineUtils.getEditableRoot(editor.dom, editor.selection.getStart());
-        return Type.isNullable(editableRoot);
-      } else {
-        return false;
-      }
-    }
-  );
+const inCefBlock = (editor: Editor) => {
+  const editableRoot = NewLineUtils.getEditableRoot(editor.dom, editor.selection.getStart());
+  return Type.isNullable(editableRoot);
 };
 
 const inPreBlock = (requiredState: boolean) => inBlock('pre', requiredState);
@@ -98,7 +89,8 @@ const getAction = (editor: Editor, evt?: EditorEvent<KeyboardEvent>): NewLineAct
   return LazyEvaluator.evaluateUntil([
     match([ shouldBlockNewLine ], newLineAction.none()),
     match([ inSummaryBlock() ], newLineAction.br()),
-    match([ inCefPreBlock ], newLineAction.none()),
+    // If the pre block is cef, do not try to insert a new line (or delete contents)
+    match([ inPreBlock(true), inCefBlock ], newLineAction.none()),
     match([ inPreBlock(true), shouldPutBrInPre(false), hasShiftKey ], newLineAction.br()),
     match([ inPreBlock(true), shouldPutBrInPre(false) ], newLineAction.block()),
     match([ inPreBlock(true), shouldPutBrInPre(true), hasShiftKey ], newLineAction.block()),

--- a/modules/tinymce/src/core/main/ts/newline/NewLineAction.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineAction.ts
@@ -88,13 +88,14 @@ const match = (predicates: Array<(editor: Editor, shiftKey: boolean) => boolean>
 const getAction = (editor: Editor, evt?: EditorEvent<KeyboardEvent>): NewLineActionAdt => {
   return LazyEvaluator.evaluateUntil([
     match([ shouldBlockNewLine ], newLineAction.none()),
-    match([ inSummaryBlock() ], newLineAction.br()),
     // If the pre block is cef, do not try to insert a new line (or delete contents)
     match([ inPreBlock(true), inCefBlock ], newLineAction.none()),
+    match([ inSummaryBlock() ], newLineAction.br()),
     match([ inPreBlock(true), shouldPutBrInPre(false), hasShiftKey ], newLineAction.br()),
     match([ inPreBlock(true), shouldPutBrInPre(false) ], newLineAction.block()),
     match([ inPreBlock(true), shouldPutBrInPre(true), hasShiftKey ], newLineAction.block()),
     match([ inPreBlock(true), shouldPutBrInPre(true) ], newLineAction.br()),
+    // TODO: TINY-9127 investigate if the list handling (and pre) is correct here.
     match([ inListBlock(true), hasShiftKey ], newLineAction.br()),
     match([ inListBlock(true) ], newLineAction.block()),
     match([ inBrContext ], newLineAction.br()),

--- a/modules/tinymce/src/core/main/ts/newline/NewLineAction.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineAction.ts
@@ -46,6 +46,20 @@ const inBlock = (blockName: string, requiredState: boolean) => (editor: Editor, 
   return state === requiredState;
 };
 
+const inCefPreBlock = (editor: Editor) => {
+  const parentBlockOpt = NewLineUtils.getParentBlock(editor);
+  return parentBlockOpt.exists(
+    (parentBlock) => {
+      if (parentBlock.nodeName.toUpperCase() === 'PRE') {
+        const editableRoot = NewLineUtils.getEditableRoot(editor.dom, editor.selection.getStart());
+        return Type.isNullable(editableRoot);
+      } else {
+        return false;
+      }
+    }
+  );
+};
+
 const inPreBlock = (requiredState: boolean) => inBlock('pre', requiredState);
 const inSummaryBlock = () => inBlock('summary', true);
 
@@ -84,6 +98,7 @@ const getAction = (editor: Editor, evt?: EditorEvent<KeyboardEvent>): NewLineAct
   return LazyEvaluator.evaluateUntil([
     match([ shouldBlockNewLine ], newLineAction.none()),
     match([ inSummaryBlock() ], newLineAction.br()),
+    match([ inCefPreBlock ], newLineAction.none()),
     match([ inPreBlock(true), shouldPutBrInPre(false), hasShiftKey ], newLineAction.br()),
     match([ inPreBlock(true), shouldPutBrInPre(false) ], newLineAction.block()),
     match([ inPreBlock(true), shouldPutBrInPre(true), hasShiftKey ], newLineAction.block()),

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyCeFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyCeFalseTest.ts
@@ -74,4 +74,14 @@ describe('browser.tinymce.core.keyboard.EnterKeyCeFalseTest', () => {
     TinyAssertions.assertContent(editor, '<p><span contenteditable="false">x</span></p>');
     assert.equal(editor.selection.getNode().nodeName, 'SPAN');
   });
+
+  it('TINY-9101: Enter after selecting across paragraphs before a cE=false span should not delete cE=false span', () => {
+    const editor = hook.editor();
+    editor.getBody().innerHTML = '<p>first</p><p>second<span contenteditable="false">2</span></p>';
+    // Select across the two paragraphs, but stop before the cef span
+    TinySelections.setSelection(editor, [ 0, 0 ], 'fir'.length, [ 1, 0 ], 'sec'.length);
+    pressEnter(editor);
+    TinyAssertions.assertContent(editor, '<p>fir</p><p>ond<span contenteditable="false">2</span></p>');
+    assert.equal(editor.selection.getNode().nodeName, 'P');
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyCeFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyCeFalseTest.ts
@@ -75,7 +75,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyCeFalseTest', () => {
     assert.equal(editor.selection.getNode().nodeName, 'SPAN');
   });
 
-  it('TINY-9101: Pressing Enter on a cE=false block should do nothing it', () => {
+  it('TINY-9101: Pressing Enter on a cE=false block should do nothing', () => {
     const editor = hook.editor();
     editor.getBody().innerHTML = '<p>First</p><p contenteditable="false">Second</p><p>Third</p>';
     TinySelections.select(editor, 'p:eq(1)', [ ]);
@@ -84,7 +84,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyCeFalseTest', () => {
     assert.equal(editor.selection.getNode().nodeName, 'P');
   });
 
-  it('TINY-9101: Pressing Enter on a cE=false pre should do nothing it', () => {
+  it('TINY-9101: Pressing Enter on a cE=false pre should do nothing', () => {
     const editor = hook.editor();
     editor.getBody().innerHTML = '<p>First</p><pre contenteditable="false">Second</pre><p>Third</p>';
     TinySelections.select(editor, 'pre', [ ]);

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyCeFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyCeFalseTest.ts
@@ -77,7 +77,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyCeFalseTest', () => {
 
   it('TINY-9101: Pressing Enter on a cE=false block should do nothing', () => {
     const editor = hook.editor();
-    editor.getBody().innerHTML = '<p>First</p><p contenteditable="false">Second</p><p>Third</p>';
+    editor.setContent('<p>First</p><p contenteditable="false">Second</p><p>Third</p>');
     TinySelections.select(editor, 'p:eq(1)', [ ]);
     pressEnter(editor);
     TinyAssertions.assertContent(editor, '<p>First</p><p contenteditable="false">Second</p><p>Third</p>');
@@ -86,7 +86,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyCeFalseTest', () => {
 
   it('TINY-9101: Pressing Enter on a cE=false pre should do nothing', () => {
     const editor = hook.editor();
-    editor.getBody().innerHTML = '<p>First</p><pre contenteditable="false">Second</pre><p>Third</p>';
+    editor.setContent('<p>First</p><pre contenteditable="false">Second</pre><p>Third</p>');
     TinySelections.select(editor, 'pre', [ ]);
     pressEnter(editor);
     TinyAssertions.assertContent(editor, '<p>First</p><pre contenteditable="false">Second</pre><p>Third</p>');
@@ -95,7 +95,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyCeFalseTest', () => {
 
   it('TINY-9101: Enter after selecting across paragraphs before a cE=false span should not delete cE=false span', () => {
     const editor = hook.editor();
-    editor.getBody().innerHTML = '<p>first</p><p>second<span contenteditable="false">2</span></p>';
+    editor.setContent('<p>first</p><p>second<span contenteditable="false">2</span></p>');
     // Select across the two paragraphs, but stop before the cef span
     TinySelections.setSelection(editor, [ 0, 0 ], 'fir'.length, [ 1, 0 ], 'sec'.length);
     pressEnter(editor);

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyCeFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyCeFalseTest.ts
@@ -75,6 +75,24 @@ describe('browser.tinymce.core.keyboard.EnterKeyCeFalseTest', () => {
     assert.equal(editor.selection.getNode().nodeName, 'SPAN');
   });
 
+  it('TINY-9101: Pressing Enter on a cE=false block should do nothing it', () => {
+    const editor = hook.editor();
+    editor.getBody().innerHTML = '<p>First</p><p contenteditable="false">Second</p><p>Third</p>';
+    TinySelections.select(editor, 'p:eq(1)', [ ]);
+    pressEnter(editor);
+    TinyAssertions.assertContent(editor, '<p>First</p><p contenteditable="false">Second</p><p>Third</p>');
+    assert.equal(editor.selection.getNode().nodeName, 'P');
+  });
+
+  it('TINY-9101: Pressing Enter on a cE=false pre should do nothing it', () => {
+    const editor = hook.editor();
+    editor.getBody().innerHTML = '<p>First</p><pre contenteditable="false">Second</pre><p>Third</p>';
+    TinySelections.select(editor, 'pre', [ ]);
+    pressEnter(editor);
+    TinyAssertions.assertContent(editor, '<p>First</p><pre contenteditable="false">Second</pre><p>Third</p>');
+    assert.equal(editor.selection.getNode().nodeName, 'PRE');
+  });
+
   it('TINY-9101: Enter after selecting across paragraphs before a cE=false span should not delete cE=false span', () => {
     const editor = hook.editor();
     editor.getBody().innerHTML = '<p>first</p><p>second<span contenteditable="false">2</span></p>';

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -49,8 +49,16 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
   });
 
   it('TINY-8861: press enter after pasting a code sample should not add a newline inside the code', async () => {
+    // TINY-9101: When this test was written for TINY-8861, pressing <enter> on a cef block
+    // added a newline before the cef block. This was actually a regression from TinyMCE v5,
+    // and the correct behaviour is that it should be deleted when the user selects the
+    // cef block, and presses <enter>. So as part of TINY-9101, this test needed to be
+    // signficantly rewritten. Pressing <enter> was now a destructive operation, so instead of checking
+    // that a newline wasn't added to the codesample block, we need to check that the whole block gets
+    // deleted.
     const editor = hook.editor();
 
+    editor.setContent('<p><br /></p><p><br /></p>');
     await TestUtils.pOpenDialogAndAssertInitial(hook.editor(), 'markup', '');
     TestUtils.setTextareaContent('test content');
     await TestUtils.pSubmitDialog(editor);
@@ -58,47 +66,28 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
     TinyAssertions.assertContentPresence(editor, { 'pre[data-mce-selected]': 1 });
 
     await pClickEditMenu(editor, 'Copy');
-    pressEnter(editor);
-    TinyAssertions.assertCursor(editor, [ 1 ], 0);
-    TinyAssertions.assertContentPresence(editor, { 'pre[data-mce-selected]': 0 });
 
+    // Now, move to a new paragraph and paste the codesample. After pasting, the pasted
+    // content should be selected.
+    TinySelections.setCursor(editor, [ 1 ], 1);
+    TinyAssertions.assertContentPresence(editor, { 'pre[data-mce-selected]': 0 });
     await pPaste(editor);
     TinyAssertions.assertSelection(editor, [], 1, [], 2);
-    TinyAssertions.assertContentPresence(editor, { 'pre[data-mce-selected]': 1 });
+    // We need to use "root" selections to exclude the pre that appears in the
+    // .mce-offscreen-selection div.
+    TinyAssertions.assertContentPresence(editor, {
+      'root>pre': 2,
+      'pre[data-mce-selected]': 1
+    });
 
+    // After pasting, the cef is selected. So pressing <enter> is going to delete it,
+    // and we are just left with the original.
     pressEnter(editor);
-    TinyAssertions.assertCursor(editor, [ 2 ], 0);
-    TinyAssertions.assertContentPresence(editor, { 'pre[data-mce-selected]': 0 });
-
-    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, arr) => {
-      const emptyParagraph = s.element('p', {
-        children: [
-          s.element('br', {})
-        ]
-      });
-      return s.element('body', {
-        children: [
-          emptyParagraph,
-          emptyParagraph,
-          s.element('p', {
-            attrs: {
-              // fake caret
-              'data-mce-caret': str.is('before'),
-              'data-mce-bogus': str.is('all')
-            },
-            children: [
-              s.element('br', {})
-            ]
-          }),
-          getMockPreStructure(s, str),
-          getMockPreStructure(s, str),
-          s.element('div', {
-            // fake caret
-            classes: [ arr.has('mce-visual-caret') ]
-          })
-        ]
-      });
-    }));
+    TinyAssertions.assertCursor(editor, [ 1 ], 1);
+    TinyAssertions.assertContentPresence(editor, {
+      'root>pre': 1,
+      'pre[data-mce-selected]': 0
+    });
   });
 
   // Safari cannot select the CEF in this scenario, so we can't run the test (and there is no bug)


### PR DESCRIPTION
Related Ticket: TINY-9101

Description of Changes:
* spilt execDeleteCommand into two: native and editor. Only editor will consider deletion overrides, and only newlines uses the editor variant.
* rewrote CodeSample test for pasting pre tags

Pre-checks:
* [x] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [N/A] Docs ticket created (if applicable)
