### PR TITLE
TINY-9140: Fix `editor.insertContent` API not respecting the `no_events` arg

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed extra padding for the context toolbar in the `tinymce-5` skin. #TINY-8980
 - Fixed a regression where pressing Enter caused content outside the selection to be added or deleted unexpectedly. #TINY-9101
 - Fixed a bug where pressing Enter deleted selected "contenteditable="false" pre elements. #TINY-9101
+- The `editor.insertContent()` API did not respect the `no_events` argument. #TINY-9140
 
 ### Deprecated
 - The autocompleter `ch` configuration property has been deprecated and will be removed in the next major release. Use the `trigger` property instead. #TINY-8887

--- a/modules/tinymce/src/core/main/ts/content/ContentTypes.ts
+++ b/modules/tinymce/src/core/main/ts/content/ContentTypes.ts
@@ -40,6 +40,7 @@ export interface SetSelectionContentArgs extends SetContentArgs {
 }
 
 export interface InsertContentDetails {
+  readonly no_events?: boolean;
   readonly paste?: boolean;
   readonly merge?: boolean;
   readonly data?: {

--- a/modules/tinymce/src/core/main/ts/content/InsertContent.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContent.ts
@@ -50,7 +50,7 @@ const trimOrPad = (editor: Editor, value: string): string => {
 const insertAtCaret = (editor: Editor, value: string | DetailsWithContent): void => {
   const { content, details } = processValue(value);
 
-  preProcessSetContent(editor, { content: trimOrPad(editor, content), format: 'html', set: false, selection: true, paste: details.paste }).each((args) => {
+  preProcessSetContent(editor, { ...details, content: trimOrPad(editor, content), format: 'html', set: false, selection: true }).each((args) => {
     const insertedContent = Rtc.insertContent(editor, args.content, details);
     postProcessSetContent(editor, insertedContent, args);
     editor.addVisual();

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -241,6 +241,13 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
           assertEventsContentType();
         });
 
+        it('TINY-9140: Insert content without firing events', () => {
+          const editor = hook.editor();
+          editor.setContent('<p>html</p>', { no_events: true });
+          assertEventsFiredInOrder([]);
+          assertEventsContentType();
+        });
+
         it('TINY-7996: Set tree content with content altered in BeforeSetContent', () => {
           const editor = hook.editor();
           editor.setContent('<p>tree</p>');


### PR DESCRIPTION
Related Ticket: TINY-9140

Description of Changes:
* Fix `editor.insertContent` not respecting `no_events` . All other set/get content calls look to respect the event so this just makes them consistent.

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [X] Docs ticket created (if applicable)

GitHub issues (if applicable):
