### PR TITLE
TINY-9141: Decrease background opacity for merge tags in dark UI

### DIFF
--- a/modules/oxide/src/less/theme/content/mergetags/mergetag.less
+++ b/modules/oxide/src/less/theme/content/mergetags/mergetag.less
@@ -1,4 +1,4 @@
-@mergetag-hover-background-color: fade(@color-tint, 10%);
+@mergetag-hover-background-color: if(@content-ui-darkmode, fade(@color-tint, 30%), fade(@color-tint, 10%));
 @mergetag-affix-text-color: @color-tint;
 @mergetag-affix-background-color: @mergetag-hover-background-color;
 


### PR DESCRIPTION
Related Ticket: TINY-9141

Description of Changes:
* Change merge tag background colors based on `content-ui-darkmode` less variable

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set