### PR TITLE
TINY-9111: Revert changes for how selected nested noneditable element is formatted

### DIFF
--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -319,6 +319,16 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
     });
   };
 
+  // TODO: TINY-9142: Remove this to make nested noneditable formatting work
+  const targetNode = FormatUtils.isNode(node) ? node : selection.getNode();
+  if (dom.getContentEditable(targetNode) === 'false' && !FormatUtils.isWrappableNoneditable(ed, targetNode)) {
+    // node variable is used by other functions above in the same scope so need to set it here
+    node = targetNode;
+    applyNodeStyle(formatList, node);
+    Events.fireFormatApply(ed, name, node, vars);
+    return;
+  }
+
   if (format) {
     if (node) {
       if (FormatUtils.isNode(node)) {

--- a/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
@@ -14,7 +14,8 @@ import * as Whitespace from '../text/Whitespace';
 import { isCaretNode } from './FormatContainer';
 import { BlockFormat, Format, FormatAttrOrStyleValue, FormatVars, InlineFormat, MixedFormat, SelectorFormat } from './FormatTypes';
 
-const isNode = (node: any): node is Node => !!(node).nodeType;
+const isNode = (node: any): node is Node =>
+  Type.isNumber(node?.nodeType);
 
 const isElementNode = (node: Node): node is Element =>
   NodeType.isElement(node) && !Bookmarks.isBookmarkNode(node) && !isCaretNode(node) && !NodeType.isBogus(node);

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
@@ -320,7 +320,7 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
               await pTest(editor, [
                 {
                   select: selectNoneditableSpan,
-                  expectedHtml: `<p>first ${noneditableBeforeHtml}<span contenteditable="true"><${format.html}>editable</${format.tag}></span>${noneditableAfterHtml} third</p>`,
+                  expectedHtml: initialHtml,
                   pAssertAfter: async () => {
                     await pAssertToolbar(false)(editor);
                     TinyAssertions.assertContentPresence(editor, { 'span[contenteditable="false"][data-mce-selected]': 1 });
@@ -739,12 +739,23 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
     });
 
     context('noneditable inline elements with selector formats', () => {
-      it('TINY-8687: applying a selector format to an inline element should apply it to the matching parent block', () => {
+      // TODO: TINY-9142 Reenable when Jira is done
+      it.skip('TINY-8687: should apply selector format to matching parent block when a noneditable inline element is selected', () => {
         const editor = hook.editor();
         editor.setContent(`<p>a<span contenteditable="false">CEF</span>b</p>`);
         TinySelections.select(editor, 'span', []);
         editor.formatter.apply('alignright');
         TinyAssertions.assertContent(editor, `<p style="text-align: right;">a<span contenteditable="false">CEF</span>b</p>`);
+      });
+
+      it('TINY-8687: should apply selector format to matching parent block when selection is within a nested noneditable inline element', () => {
+        const editor = hook.editor();
+        editor.setContent(`<p>a<span contenteditable="false">C<span contenteditable="true">E</span>F</span>b</p>`);
+        TinySelections.select(editor, 'span', []);
+        TinySelections.setCursor(editor, [ 0, 1, 1, 0 ], 0);
+        editor.formatter.apply('alignright');
+        TinyAssertions.assertContent(editor, `<p style="text-align: right;">a<span contenteditable="false">C<span contenteditable="true">E</span>F</span>b</p>`);
+        TinyAssertions.assertCursor(editor, [ 0, 1, 1, 0 ], 0);
       });
     });
   });


### PR DESCRIPTION
Related Ticket: TINY-9111

Description of Changes:
* It was found during QA that when a noneditable element was directly selected and had editable children, applying a format would format the editable children. Whilst this may have been fine, there was then no way to toggle the format off again when the nonediatble element was directly selected. Because of this, part of the code deleted from #7968 has been put back so that the 6-stable behaviour is maintained.

It might be better if the editable children of the noneditable element could be formatted even if the noneditable element was selected so that it is consistent with how a ranged selection works. Although, this would require various changes to MatchFormat and RemoveFormat so is best left for another ticket if we wanted to do it.

Pre-checks:
* [X] ~Changelog entry added~ (just reverting some changes that hadn't been released yet)
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [X] Docs ticket created (if applicable)

GitHub issues (if applicable):
