### PR TITLE
TINY-9125: Prototyping manual tooltips

### DIFF
--- a/modules/alloy/docs/behaviours/Tooltipping.adoc
+++ b/modules/alloy/docs/behaviours/Tooltipping.adoc
@@ -1,0 +1,82 @@
+== General Overview
+
+The `Tooltipping` behaviour allows:
+
+* the entire mothership to show just one tooltip at a time through `exclusive`. This works by broadcasting a message that all Tooltipping behaviours listen to.
+* have two different modes of tooltipping:
+  * normal: does stuff
+  * follow-highlight: does other stuff.
+* be anchored in a particular position. This will default to a hotspot anchor so works well for buttons etc.
+* listeners for onHide and onShow
+
+
+The APIs available are:
+
+* hideAllExclusive: this will broadcast on the exclusivity channel to hide *all* tooltips, including this one.
+* setComponents: this uses replacing on the tooltip itself to replace the contents of the tooltip.
+
+
+=== State
+
+There are two things that are stored in the tooltipping state
+
+* timer: the timer is used to delay when certain actions (...) take place. There is only ever one scheduled action, so scheduling another action cancels the current schedule.
+* popup: this is the alloy component that will have its components replaced by calls to the setComponents API.
+
+
+
+=== Active
+
+This is where the core of the logic resides. It depends on the mode, as to which events it will listen to:
+
+* showTooltip: shows the tooltip **on the configured delay**. It does not show it immediately.
+* hideTooltip: hides the tooltip **on the configured delay**. It does not hide it immediately.
+* receiving message:
+  if the channel is exclusivity, calls hide **immediately**
+* onDetached: hide the tooltip **immediately**
+
+Now, the rest of the events depend on the mode.
+
+==== Normal mode
+
+* `focusin`: this will trigger the showTooltip event. So it will show the tooltip after the **configured delay**.
+* `postBlur`: this will trigger the hideTooltip event. So it will hide the tooltip after the **configured delay**.
+* `mouseover`: also triggers showTooltip
+* `mousout`: also triggers hideTooltip
+
+==== Follow Highlight
+
+* `highlight`: this will trigger showTooltip (so shows after delay)
+* `dehighlight`: this will trigger hideTooltip (show hides after delay)
+
+
+The Tooltip state manages stuff and things.
+
+
+Channels:
+ * exclusivity
+
+Events:
+ * tooltip.show
+ * tooltip.hide
+
+=== Functionality
+
+==== hide
+
+With the tooltip container, it:
+ * detaches the container
+ * calls onHide
+ * clears the container reference
+It also clears the timer.
+
+==== show
+
+* it won't be doing anything if it is already showing. This doesn't mean "scheduled to be showing", this means "actually showing"
+* hides all exclusive things
+* gets the sink, and builds the popup based on tooltipDom and components in the sink.
+* mouseover or mouseout **on the tooltip itself** trigger the events that schedule the show/hide
+* set the state.
+* attach the popup to the sink
+* fire the onShow
+* position the popup.

--- a/modules/alloy/src/main/ts/ephox/alloy/api/Main.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/Main.ts
@@ -32,6 +32,7 @@ import * as SliderTypes from '../ui/types/SliderTypes';
 import * as SlotContainerTypes from '../ui/types/SlotContainerTypes';
 import * as TabbarTypes from '../ui/types/TabbarTypes';
 import * as TieredMenuTypes from '../ui/types/TieredMenuTypes';
+import * as TooltippingTypes from './../behaviour/tooltipping/TooltippingTypes';
 import * as AddEventsBehaviour from './behaviour/AddEventsBehaviour';
 import { AllowBubbling } from './behaviour/AllowBubbling';
 import * as Behaviour from './behaviour/Behaviour';
@@ -271,7 +272,7 @@ export {
   SubmenuAnchorSpec,
   DraggingTypes,
   Layouts,
-
+  TooltippingTypes,
   FocusInsideModes,
 
   TestHelpers

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/ActiveTooltipping.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/ActiveTooltipping.ts
@@ -62,12 +62,12 @@ const events = (tooltipConfig: TooltippingConfig, state: TooltippingState): Allo
       AlloyEvents.run(ShowTooltipEvent, (comp) => {
         state.resetTimer(() => {
           show(comp);
-        }, tooltipConfig.delay);
+        }, tooltipConfig.delayForShow());
       }),
       AlloyEvents.run(HideTooltipEvent, (comp) => {
         state.resetTimer(() => {
           hide(comp);
-        }, tooltipConfig.delay);
+        }, tooltipConfig.delayForHide());
       }),
       AlloyEvents.run<ReceivingEvent>(SystemEvents.receive(), (comp, message) => {
         // TODO: Think about the types for this, or find a better way for this

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingSchema.ts
@@ -11,7 +11,8 @@ export default [
   FieldSchema.required('tooltipDom'),
   FieldSchema.defaulted('exclusive', true),
   FieldSchema.defaulted('tooltipComponents', []),
-  FieldSchema.defaulted('delay', 300),
+  FieldSchema.defaultedFunction('delayForShow', Fun.constant(300)),
+  FieldSchema.defaultedFunction('delayForHide', Fun.constant(300)),
   FieldSchema.defaultedStringEnum('mode', 'normal', [ 'normal', 'follow-highlight' ]),
   FieldSchema.defaulted('anchor', (comp: AlloyComponent): AnchorSpec => ({
     type: 'hotspot',

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingTypes.ts
@@ -18,7 +18,8 @@ export interface TooltippingConfig extends BehaviourConfigDetail {
   tooltipComponents: AlloySpec[];
   exclusive: boolean;
   mode: 'normal' | 'follow-highlight';
-  delay: number;
+  delayForShow: () => number;
+  delayForHide: () => number;
   anchor: (comp: AlloyComponent) => AnchorSpec;
   onShow: (comp: AlloyComponent, tooltip: AlloyComponent) => void;
   onHide: (comp: AlloyComponent, tooltip: AlloyComponent) => void;
@@ -30,7 +31,8 @@ export interface TooltippingConfigSpec extends BehaviourConfigSpec {
   tooltipComponents?: AlloySpec[];
   exclusive?: boolean;
   mode?: 'normal' | 'follow-highlight';
-  delay?: number;
+  delayForShow?: () => number;
+  delayForHide?: () => number;
   anchor?: (comp: AlloyComponent) => AnchorSpec;
   onShow?: (comp: AlloyComponent, tooltip: AlloyComponent) => void;
   onHide?: (comp: AlloyComponent, tooltip: AlloyComponent) => void;

--- a/modules/alloy/src/test/ts/browser/behaviour/TooltippingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/TooltippingTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, Assertions, Chain, FocusTools, Keyboard, Keys, Logger, Mouse, Step, StructAssert, UiFinder, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
-import { Arr, Result } from '@ephox/katamari';
+import { Arr, Fun, Result } from '@ephox/katamari';
 import { SelectorFind } from '@ephox/sugar';
 
 import * as Behaviour from 'ephox/alloy/api/behaviour/Behaviour';
@@ -44,7 +44,8 @@ UnitTest.asynctest('Tooltipping Behaviour', (success, failure) => {
       containerBehaviours: Behaviour.derive([
         Tooltipping.config({
           lazySink,
-          delay: 10,
+          delayForShow: Fun.constant(10),
+          delayForHide: Fun.constant(10),
           tooltipDom: {
             tag: 'span'
           },

--- a/modules/tinymce/src/themes/silver/demo/html/demo/demo.html
+++ b/modules/tinymce/src/themes/silver/demo/html/demo/demo.html
@@ -6,6 +6,12 @@
 <style>
    .tox-tooltip {
     z-index: 10000000000;
+    /* The pointer-events: none is designed to make mouse events bleed through the tooltip
+     * to the underlying items. For example, a mouse hovering over a tooltip that hovers over
+     * another item should trigger the hover of the item obscured by the tooltip, even though
+     * the tooltip is on top
+     */
+    pointer-events: none;
    }
 </style>
 </head>

--- a/modules/tinymce/src/themes/silver/demo/html/demo/demo.html
+++ b/modules/tinymce/src/themes/silver/demo/html/demo/demo.html
@@ -3,6 +3,11 @@
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0">
 <title>silver-theme Demo Page</title>
+<style>
+   .tox-tooltip {
+    z-index: 10000000000;
+   }
+</style>
 </head>
 <body style="">
 <h2>silver-theme Demo Page</h2>

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/ButtonSetupDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/ButtonSetupDemo.ts
@@ -189,6 +189,7 @@ export default {
 
     ed.ui.registry.addMenuButton('MailMerge', {
       text: 'MailMerge',
+      tooltip: 'MailMerge tooltip',
       search: true,
       fetch: mailMergeFetch(true)
     });

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -13,6 +13,7 @@ import { ColorInputBackstage, UiFactoryBackstageForColorInput } from './ColorInp
 import { DialogBackstage, UiFactoryBackstageForDialog } from './DialogBackstage';
 import { HeaderBackstage, UiFactoryBackstageForHeader } from './HeaderBackstage';
 import { init as initStyleFormatBackstage, UiFactoryBackstageForStyleFormats } from './StyleFormatsBackstage';
+import { TooltipsBackstage, TooltipsProvider } from './TooltipsBackstage';
 import { UiFactoryBackstageForUrlInput, UrlInputBackstage } from './UrlInputBackstage';
 
 export interface UiFactoryBackstageProviders {
@@ -21,6 +22,7 @@ export interface UiFactoryBackstageProviders {
   readonly translate: (text: Untranslated) => TranslatedString;
   readonly isDisabled: () => boolean;
   readonly getOption: Editor['options']['get'];
+  readonly tooltips: TooltipsProvider;
 }
 
 export interface UiFactoryBackstageShared {
@@ -51,7 +53,8 @@ const init = (lazySink: () => Result<AlloyComponent, string>, editor: Editor, la
         menuItems: () => editor.ui.registry.getAll().menuItems,
         translate: I18n.translate,
         isDisabled: () => editor.mode.isReadOnly() || !editor.ui.isEnabled(),
-        getOption: editor.options.get
+        getOption: editor.options.get,
+        tooltips: TooltipsBackstage(lazySink)
       },
       interpreter: (s) => UiFactory.interpretWithoutForm(s, {}, backstage),
       anchors: Anchors.getAnchors(editor, lazyAnchorbar, toolbar.isPositionedAtTop),

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/TooltipsBackstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/TooltipsBackstage.ts
@@ -1,0 +1,61 @@
+import { AlloyComponent, GuiFactory, TooltippingTypes } from '@ephox/alloy';
+import { Fun, Result } from '@ephox/katamari';
+
+export interface TooltipsProvider {
+  readonly getConfig: (spec: { tooltipText: string }) => TooltippingTypes.TooltippingConfigSpec;
+}
+
+export const TooltipsBackstage = (
+  getSink: () => Result<AlloyComponent, any>
+): TooltipsProvider => {
+
+  const tooltipDelay = 800;
+
+  let numActiveTooltips = 0;
+
+  const alreadyShowingTooltips = () => numActiveTooltips > 0;
+
+  const getConfig = (spec: { tooltipText: string }) => ({
+    delayForShow: () => alreadyShowingTooltips() ? 0 : tooltipDelay,
+    delayForHide: Fun.constant(tooltipDelay),
+    exclusive: true,
+    lazySink: getSink,
+    /*
+      <div class="tox-tooltip tox-tooltip--down">
+  <div class="tox-tooltip__body">Are you hanging on the edge of your seat? </div>
+  <i class="tox-tooltip__arrow"></i>
+  </div>*/
+    tooltipDom: {
+      tag: 'div',
+      classes: [ 'tox-tooltip', 'tox-tooltip--up' ]
+    },
+    tooltipComponents: [
+      {
+        dom: {
+          tag: 'div',
+          classes: [ 'tox-tooltip__body' ]
+        },
+        components: [
+          GuiFactory.text(spec.tooltipText)
+        ]
+      },
+      {
+        dom: {
+          tag: 'i',
+          classes: [ 'tox-tooltip__arrow' ]
+        }
+      }
+    ],
+    onShow: () => {
+      numActiveTooltips++;
+    },
+    onHide: () => {
+      numActiveTooltips--;
+    }
+  });
+
+  return {
+    getConfig
+  };
+
+};

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
@@ -1,7 +1,7 @@
 import {
   AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, AlloyTriggers, Behaviour, CustomEvent, Disabling,
   FormCoupledInputs as AlloyFormCoupledInputs,
-  FormField as AlloyFormField, GuiFactory, Input as AlloyInput, NativeEvents, Representing, SketchSpec, Tabstopping
+  FormField as AlloyFormField, GuiFactory, Input as AlloyInput, NativeEvents, Representing, SketchSpec, Tabstopping, Tooltipping
 } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Id, Unicode } from '@ephox/katamari';
@@ -30,10 +30,7 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
   const pLock = AlloyFormCoupledInputs.parts.lock({
     dom: {
       tag: 'button',
-      classes: [ 'tox-lock', 'tox-button', 'tox-button--naked', 'tox-button--icon' ],
-      attributes: {
-        title: providersBackstage.translate(spec.label.getOr('Constrain proportions'))  // TODO: tooltips AP-213
-      }
+      classes: [ 'tox-lock', 'tox-button', 'tox-button--naked', 'tox-button--icon' ]
     },
     components: [
       makeIcon('lock'),
@@ -44,7 +41,12 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
         disabled: () => !spec.enabled || providersBackstage.isDisabled()
       }),
       ReadOnly.receivingConfig(),
-      Tabstopping.config({})
+      Tabstopping.config({}),
+      Tooltipping.config(
+        providersBackstage.tooltips.getConfig({
+          tooltipText: providersBackstage.translate(spec.label.getOr('Constrain proportions'))
+        })
+      )
     ])
   });
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -1,6 +1,6 @@
 import {
   AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, AlloyTriggers, Behaviour, Button as AlloyButton, FormField as AlloyFormField, GuiFactory, Memento,
-  RawDomSchema, SimpleOrSketchSpec, SketchSpec, Tabstopping
+  RawDomSchema, SimpleOrSketchSpec, SketchSpec, Tabstopping, Tooltipping
 } from '@ephox/alloy';
 import { Dialog, Toolbar } from '@ephox/bridge';
 import { Fun, Merger, Optional } from '@ephox/katamari';
@@ -33,17 +33,27 @@ const renderCommonSpec = (
   extraBehaviours: Behaviours = [],
   dom: RawDomSchema,
   components: AlloySpec[],
+  tooltip: Optional<string>,
   providersBackstage: UiFactoryBackstageProviders
 ): AlloyButtonSpec => {
   const action = actionOpt.fold(() => ({}), (action) => ({
     action
   }));
 
+  const optTooltipping = tooltip.map(
+    (t) => Tooltipping.config(
+      providersBackstage.tooltips.getConfig({
+        tooltipText: t
+      })
+    )
+  );
+
   const common = {
     buttonBehaviours: Behaviour.derive([
       DisablingConfigs.button(() => !spec.enabled || providersBackstage.isDisabled()),
       ReadOnly.receivingConfig(),
       Tabstopping.config({}),
+      ...optTooltipping.toArray(),
       AddEventsBehaviour.config('button press', [
         AlloyEvents.preventDefault('click'),
         AlloyEvents.preventDefault('mousedown')
@@ -59,6 +69,8 @@ const renderCommonSpec = (
   return Merger.deepMerge(domFinal, { components });
 };
 
+// An IconButton just seems to be a button that *cannot* have text, but
+// can have a tooltip. It's only used for the More Drawer button at the moment.
 export const renderIconButtonSpec = (
   spec: IconButtonWrapper,
   action: Optional<(comp: AlloyComponent) => void>,
@@ -78,17 +90,7 @@ export const renderIconButtonSpec = (
   const components = componentRenderPipeline([
     icon
   ]);
-  return renderCommonSpec(spec, action, extraBehaviours, dom, components, providersBackstage);
-};
-
-export const renderIconButton = (
-  spec: IconButtonWrapper,
-  action: (comp: AlloyComponent) => void,
-  providersBackstage: UiFactoryBackstageProviders,
-  extraBehaviours: Behaviours = []
-): SketchSpec => {
-  const iconButtonSpec = renderIconButtonSpec(spec, Optional.some(action), providersBackstage, extraBehaviours);
-  return AlloyButton.sketch(iconButtonSpec);
+  return renderCommonSpec(spec, action, extraBehaviours, dom, components, spec.tooltip, providersBackstage);
 };
 
 const calculateClassesFromButtonType = (buttonType: 'primary' | 'secondary' | 'toolbar') => {
@@ -105,13 +107,15 @@ const calculateClassesFromButtonType = (buttonType: 'primary' | 'secondary' | 't
 
 // Maybe the list of extraBehaviours is better than doing a Merger.deepMerge that
 // we do elsewhere? Not sure.
-export const renderButtonSpec = (
+const renderButtonSpec = (
   spec: ButtonSpec,
   action: Optional<(comp: AlloyComponent) => void>,
   providersBackstage: UiFactoryBackstageProviders,
   extraBehaviours: Behaviours = [],
   extraClasses: string[] = []
 ): AlloyButtonSpec => {
+  // It's a bit confusing that this is called text. It seems to be a tooltip. Although I can see
+  // that it's used if there is no icon
   const translatedText = providersBackstage.translate(spec.text);
 
   const icon = spec.icon.map((iconName) => renderIconFromPack(iconName, providersBackstage.icons));
@@ -131,14 +135,25 @@ export const renderButtonSpec = (
 
   const dom = {
     tag: 'button',
-    classes,
-    attributes: {
-      title: translatedText // TODO: tooltips AP-213
-    }
+    classes
   };
-  return renderCommonSpec(spec, action, extraBehaviours, dom, components, providersBackstage);
+
+  // Only provide a tooltip if we are using an icon. This is because above, a button is only an icon
+  // or text, and not both.
+  const optTooltip = spec.icon.map(Fun.constant(translatedText));
+
+  return renderCommonSpec(
+    spec,
+    action,
+    extraBehaviours,
+    dom,
+    components,
+    optTooltip,
+    providersBackstage
+  );
 };
 
+// This actually seems to be a button on the dialog for UrlInput only (browse). Interesting.
 export const renderButton = (
   spec: ButtonSpec,
   action: (comp: AlloyComponent) => void,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Tooltips.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Tooltips.ts
@@ -1,16 +1,19 @@
-import { GuiFactory, Tooltipping } from '@ephox/alloy';
-
-import { UiFactoryBackstageShared } from '../../backstage/Backstage';
+import { AlloyComponent, GuiFactory, Tooltipping } from '@ephox/alloy';
+import { Fun, Result } from '@ephox/katamari';
 
 type TooltippingBehaviour = ReturnType<typeof Tooltipping['config']>;
 
 // TODO: Consider using this once we fix the delayed attempt to appear after it's gone problem.
 
+// FIX this with a proper design / architecture.
+let numActiveTooltips = 0;
+
 // TODO: Make the arrow configurable.
-const upConfig = (item: { text: string }, sharedBackstage: UiFactoryBackstageShared): TooltippingBehaviour => Tooltipping.config({
-  delay: 200,
+const upConfig = (item: { text: string }, getSink: () => Result<AlloyComponent, any>): TooltippingBehaviour => Tooltipping.config({
+  delayForShow: () => numActiveTooltips > 0 ? 0 : 800,
+  delayForHide: Fun.constant(800),
   exclusive: true,
-  lazySink: sharedBackstage.getSink,
+  lazySink: getSink,
   /*
     <div class="tox-tooltip tox-tooltip--down">
 <div class="tox-tooltip__body">Are you hanging on the edge of your seat? </div>
@@ -36,7 +39,13 @@ const upConfig = (item: { text: string }, sharedBackstage: UiFactoryBackstageSha
         classes: [ 'tox-tooltip__arrow' ]
       }
     }
-  ]
+  ],
+  onShow: () => {
+    numActiveTooltips++;
+  },
+  onHide: () => {
+    numActiveTooltips--;
+  }
 });
 
 export {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/AutocompleteMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/AutocompleteMenuItem.ts
@@ -89,6 +89,7 @@ const renderAutocompleteItem = (
     onAction: (_api) => onItemValueHandler(spec.value, spec.meta),
     onSetup: Fun.constant(Fun.noop),
     triggersSubmenu: false,
+    // TINY-9125: Hmm. This is going to be a problem.
     itemBehaviours: tooltipBehaviour(spec.meta, sharedBackstage)
   }, structure, itemResponse, sharedBackstage.providers);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CardMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CardMenuItem.ts
@@ -4,7 +4,6 @@ import { Arr, Optional } from '@ephox/katamari';
 import { SelectorFilter } from '@ephox/sugar';
 
 import { UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
-import { renderItemDomStructure } from 'tinymce/themes/silver/ui/menus/item/structure/ItemStructure';
 
 import * as ItemClasses from '../ItemClasses';
 import ItemResponse from '../ItemResponse';
@@ -60,7 +59,12 @@ export const renderCardMenuItem = (
   });
 
   const structure = {
-    dom: renderItemDomStructure(spec.label),
+    // TINY-9125: we used to create attributes.title here, but we aren't any more
+    // What is CardMenuItem being used for, anyway?
+    dom: {
+      tag: 'div',
+      classes: [ ItemClasses.navClass, ItemClasses.selectableClass ]
+    },
     optComponents: [
       Optional.some({
         dom: {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ChoiceItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ChoiceItem.ts
@@ -1,4 +1,4 @@
-import { AlloyComponent, Disabling, ItemTypes, Toggling } from '@ephox/alloy';
+import { AlloyComponent, Disabling, ItemTypes, Toggling, Tooltipping } from '@ephox/alloy';
 import { Menu, Toolbar } from '@ephox/bridge';
 import { Fun, Merger, Optional } from '@ephox/katamari';
 
@@ -45,6 +45,14 @@ const renderChoiceItem = (
     value: spec.value
   }, providersBackstage, renderIcons);
 
+  const optTooltipping = spec.text
+    .filter(Fun.constant(!useText))
+    .map((t) => Tooltipping.config(
+      providersBackstage.tooltips.getConfig({
+        tooltipText: providersBackstage.translate(t)
+      })
+    ));
+
   return Merger.deepMerge(
     renderCommonItem({
       data: buildData(spec),
@@ -56,7 +64,9 @@ const renderChoiceItem = (
         return Fun.noop;
       },
       triggersSubmenu: false,
-      itemBehaviours: [ ]
+      itemBehaviours: [
+        ...optTooltipping.toArray()
+      ]
     }, structure, itemResponse, providersBackstage),
     {
       toggling: {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/NestedMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/NestedMenuItem.ts
@@ -1,4 +1,4 @@
-import { AlloyComponent, Disabling, ItemTypes } from '@ephox/alloy';
+import { AlloyComponent, Disabling, ItemTypes, Tooltipping } from '@ephox/alloy';
 import { Menu } from '@ephox/bridge';
 import { Fun, Optional } from '@ephox/katamari';
 
@@ -17,6 +17,15 @@ const renderNestedItem = (spec: Menu.NestedMenuItem, itemResponse: ItemResponse,
     setEnabled: (state: boolean) => Disabling.set(component, !state)
   });
 
+  // Dupe
+  const optTooltipping = spec.text.map(
+    (t) => Tooltipping.config(
+      providersBackstage.tooltips.getConfig({
+        tooltipText: providersBackstage.translate(t)
+      })
+    )
+  );
+
   const structure = renderItemStructure({
     presets: 'normal',
     iconContent: spec.icon,
@@ -34,7 +43,9 @@ const renderNestedItem = (spec: Menu.NestedMenuItem, itemResponse: ItemResponse,
     onAction: Fun.noop,
     onSetup: spec.onSetup,
     triggersSubmenu: true,
-    itemBehaviours: [ ]
+    itemBehaviours: [
+      ...optTooltipping.toArray()
+    ]
   }, structure, itemResponse, providersBackstage);
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/NormalMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/NormalMenuItem.ts
@@ -1,4 +1,4 @@
-import { AlloyComponent, Disabling, ItemTypes } from '@ephox/alloy';
+import { AlloyComponent, Disabling, ItemTypes, Tooltipping } from '@ephox/alloy';
 import { Menu } from '@ephox/bridge';
 import { Optional } from '@ephox/katamari';
 
@@ -14,6 +14,15 @@ const renderNormalItem = (spec: Menu.MenuItem, itemResponse: ItemResponse, provi
     isEnabled: () => !Disabling.isDisabled(component),
     setEnabled: (state: boolean) => Disabling.set(component, !state)
   });
+
+  // Dupe
+  const optTooltipping = spec.text.map(
+    (t) => Tooltipping.config(
+      providersBackstage.tooltips.getConfig({
+        tooltipText: providersBackstage.translate(t)
+      })
+    )
+  );
 
   const structure = renderItemStructure({
     presets: 'normal',
@@ -33,7 +42,9 @@ const renderNormalItem = (spec: Menu.MenuItem, itemResponse: ItemResponse, provi
     onAction: spec.onAction,
     onSetup: spec.onSetup,
     triggersSubmenu: false,
-    itemBehaviours: [ ]
+    itemBehaviours: [
+      ...optTooltipping.toArray()
+    ]
   }, structure, itemResponse, providersBackstage);
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ToggleMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ToggleMenuItem.ts
@@ -1,4 +1,4 @@
-import { AlloyComponent, Disabling, ItemTypes, Toggling } from '@ephox/alloy';
+import { AlloyComponent, Disabling, ItemTypes, Toggling, Tooltipping } from '@ephox/alloy';
 import { Menu } from '@ephox/bridge';
 import { Merger, Optional } from '@ephox/katamari';
 
@@ -25,6 +25,15 @@ const renderToggleMenuItem = (
     setEnabled: (state: boolean) => Disabling.set(component, !state)
   });
 
+  // Dupe
+  const optTooltipping = spec.text.map(
+    (t) => Tooltipping.config(
+      providersBackstage.tooltips.getConfig({
+        tooltipText: providersBackstage.translate(t)
+      })
+    )
+  );
+
   // BespokeSelects use meta to pass through styling information. Bespokes should only
   // be togglemenuitems hence meta is only passed through in this MenuItem.
   const structure = renderItemStructure({
@@ -47,7 +56,9 @@ const renderToggleMenuItem = (
       onAction: spec.onAction,
       onSetup: spec.onSetup,
       triggersSubmenu: false,
-      itemBehaviours: [ ]
+      itemBehaviours: [
+        ...optTooltipping.toArray()
+      ]
     }, structure, itemResponse, providersBackstage),
     {
       toggling: {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -2,8 +2,6 @@ import { AlloySpec, RawDomSchema } from '@ephox/alloy';
 import { Toolbar } from '@ephox/bridge';
 import { Fun, Obj, Optional, Type } from '@ephox/katamari';
 
-import I18n from 'tinymce/core/api/util/I18n';
-
 import { UiFactoryBackstageProviders } from '../../../../backstage/Backstage';
 import * as Icons from '../../../icons/Icons';
 import * as ItemClasses from '../ItemClasses';
@@ -31,39 +29,41 @@ const renderColorStructure = (item: ItemStructureSpec, providerBackstage: UiFact
   const colorPickerCommand = 'custom';
   const removeColorCommand = 'remove';
 
-  const itemText = item.ariaLabel;
   const itemValue = item.value;
   const iconSvg = item.iconContent.map((name) => Icons.getOr(name, providerBackstage.icons, fallbackIcon));
+
+  const attributes = item.ariaLabel.map(
+    (al) => ({
+      'aria-label': providerBackstage.translate(al)
+    })
+  ).getOr({ });
 
   const getDom = (): RawDomSchema => {
     const common = ItemClasses.colorClass;
     const icon = iconSvg.getOr('');
-    const attributes = itemText.map((text) => ({ title: providerBackstage.translate(text) } as Record<string, string>)).getOr({ });
 
-    const baseDom = {
-      tag: 'div',
-      attributes,
-      classes: [ common ]
-    };
+    // TINY-9125 Need to pass through the tooltip here.
 
     if (itemValue === colorPickerCommand) {
       return {
-        ...baseDom,
         tag: 'button',
-        classes: [ ...baseDom.classes, 'tox-swatches__picker-btn' ],
+        attributes,
+        classes: [ common, 'tox-swatches__picker-btn' ],
         innerHtml: icon
       };
     } else if (itemValue === removeColorCommand) {
       return {
-        ...baseDom,
-        classes: [ ...baseDom.classes, 'tox-swatch--remove' ],
+        tag: 'div',
+        attributes,
+        classes: [ common, 'tox-swatch--remove' ],
         innerHtml: icon
       };
     } else if (Type.isNonNullable(itemValue)) {
       return {
-        ...baseDom,
+        tag: 'div',
+        classes: [ common ],
         attributes: {
-          ...baseDom.attributes,
+          ...attributes,
           'data-mce-color': itemValue
         },
         styles: {
@@ -71,29 +71,17 @@ const renderColorStructure = (item: ItemStructureSpec, providerBackstage: UiFact
         }
       };
     } else {
-      return baseDom;
+      return {
+        tag: 'div',
+        classes: [ common ],
+        attributes
+      };
     }
   };
 
   return {
     dom: getDom(),
     optComponents: [ ]
-  };
-};
-
-const renderItemDomStructure = (ariaLabel: Optional<string>): RawDomSchema => {
-  const domTitle = ariaLabel.map((label): { attributes?: { title: string }} => ({
-    attributes: {
-      // TODO: AP-213 change this temporary solution to use tooltips, ensure its aria readable still.
-      // for icon only implementations we need either a title or aria label to satisfy aria requirements.
-      title: I18n.translate(label)
-    }
-  })).getOr({});
-
-  return {
-    tag: 'div',
-    classes: [ ItemClasses.navClass, ItemClasses.selectableClass ],
-    ...domTitle
   };
 };
 
@@ -120,7 +108,11 @@ const renderNormalItemStructure = (info: ItemStructureSpec, providersBackstage: 
   );
 
   const menuItem = {
-    dom: renderItemDomStructure(info.ariaLabel),
+    // TINY-9125: used to pass through attributes.title here.
+    dom: {
+      tag: 'div',
+      classes: [ ItemClasses.navClass, ItemClasses.selectableClass ]
+    },
     optComponents: [
       leftIcon,
       content,
@@ -141,4 +133,4 @@ const renderItemStructure = (info: ItemStructureSpec, providersBackstage: UiFact
   }
 };
 
-export { renderItemStructure, renderItemDomStructure };
+export { renderItemStructure };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
@@ -1,4 +1,4 @@
-import { Dragging, Focusing, Keying, SimpleSpec, Tabstopping } from '@ephox/alloy';
+import { Dragging, Focusing, Keying, SimpleSpec, Tabstopping, Tooltipping } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { SugarPosition } from '@ephox/sugar';
 
@@ -36,9 +36,6 @@ export const renderResizeHandler = (editor: Editor, providersBackstage: UiFactor
   return Optional.some(Icons.render('resize-handle', {
     tag: 'div',
     classes: [ 'tox-statusbar__resize-handle' ],
-    attributes: {
-      title: providersBackstage.translate('Resize'), // TODO: tooltips AP-213
-    },
     behaviours: [
       Dragging.config({
         mode: 'mouse',
@@ -54,7 +51,12 @@ export const renderResizeHandler = (editor: Editor, providersBackstage: UiFactor
         onDown: () => keyboardHandler(editor, resizeType, 0, 1),
       }),
       Tabstopping.config({}),
-      Focusing.config({})
+      Focusing.config({}),
+      Tooltipping.config(
+        providersBackstage.tooltips.getConfig({
+          tooltipText: providersBackstage.translate('Resize')
+        })
+      )
     ]
   }, providersBackstage.icons));
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ButtonEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ButtonEvents.ts
@@ -27,7 +27,8 @@ const onToolbarButtonExecute = <T>(info: OnMenuItemExecuteType<T>): AlloyEvents.
 
 const toolbarButtonEventOrder: Record<string, string[]> = {
   // TODO: use the constants provided by behaviours.
-  [SystemEvents.execute()]: [ 'disabling', 'alloy.base.behaviour', 'toggling', 'toolbar-button-events' ]
+  [SystemEvents.execute()]: [ 'disabling', 'alloy.base.behaviour', 'toggling', 'toolbar-button-events', 'tooltipping' ],
+  [SystemEvents.detachedFromDom()]: [ 'toolbar-button-events', 'tooltipping' ]
 };
 
 export { onToolbarButtonExecute, toolbarButtonEventOrder, runWithApi };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -1,6 +1,7 @@
 import {
   AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Button as AlloyButton, Disabling, FloatingToolbarButton, Focusing,
   Keying, NativeEvents, Reflecting, Replacing, SketchSpec, SplitDropdown as AlloySplitDropdown, SystemEvents, TieredData, TieredMenuTypes, Toggling,
+  Tooltipping,
   Unselecting
 } from '@ephox/alloy';
 import { Toolbar } from '@ephox/bridge';
@@ -73,8 +74,7 @@ const getToggleApi = (component: AlloyComponent): Toolbar.ToolbarToggleButtonIns
 });
 
 const getTooltipAttributes = (tooltip: Optional<string>, providersBackstage: UiFactoryBackstageProviders) => tooltip.map<{}>((tooltip) => ({
-  'aria-label': providersBackstage.translate(tooltip),
-  'title': providersBackstage.translate(tooltip)
+  'aria-label': providersBackstage.translate(tooltip)
 })).getOr({});
 
 const focusButtonEvent = Id.generate('focus-button');
@@ -172,6 +172,15 @@ const renderCommonToolbarButton = <T>(spec: GeneralToolbarButton<T>, specialisat
           onControlAttached(specialisation, editorOffCell),
           onControlDetached(specialisation, editorOffCell)
         ]),
+        ...(
+          spec.tooltip.map(
+            (t) => Tooltipping.config(
+              providersBackstage.tooltips.getConfig({
+                tooltipText: t
+              })
+            )
+          ).toArray()
+        ),
         // Enable toolbar buttons by default
         DisablingConfigs.toolbarButton(() => !spec.enabled || providersBackstage.isDisabled()),
         ReadOnly.receivingConfig()

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
@@ -1,5 +1,5 @@
 import {
-  AlloySpec, AlloyTriggers, Behaviour, Button, Container, DomFactory, Dragging, GuiFactory, ModalDialog, Reflecting, SketchSpec
+  AlloySpec, AlloyTriggers, Behaviour, Button, Container, DomFactory, Dragging, GuiFactory, ModalDialog, Reflecting, SketchSpec, Tooltipping
 } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { SelectorFind } from '@ephox/sugar';
@@ -22,8 +22,7 @@ const renderClose = (providersBackstage: UiFactoryBackstageProviders) => Button.
     classes: [ 'tox-button', 'tox-button--icon', 'tox-button--naked' ],
     attributes: {
       'type': 'button',
-      'aria-label': providersBackstage.translate('Close'),
-      'title': providersBackstage.translate('Close') // TODO tooltips: AP-213
+      'aria-label': providersBackstage.translate('Close')
     }
   },
   components: [
@@ -31,7 +30,14 @@ const renderClose = (providersBackstage: UiFactoryBackstageProviders) => Button.
   ],
   action: (comp) => {
     AlloyTriggers.emit(comp, formCancelEvent);
-  }
+  },
+  buttonBehaviours: Behaviour.derive([
+    Tooltipping.config(
+      providersBackstage.tooltips.getConfig({
+        tooltipText: providersBackstage.translate('Close')
+      })
+    )
+  ])
 });
 
 const renderTitle = (

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
@@ -1,6 +1,8 @@
+import { TooltippingTypes } from '@ephox/alloy';
 import { Fun } from '@ephox/katamari';
 
 import I18n from 'tinymce/core/api/util/I18n';
+import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 
 const defaultOptions: Record<string, any> = {
   images_file_types: 'jpeg,jpg,jpe,jfi,jif,jfif,png,gif,bmp,webp'
@@ -11,5 +13,10 @@ export default {
   menuItems: (): Record<string, any> => ({}),
   translate: I18n.translate,
   isDisabled: Fun.never,
-  getOption: <T>(name: string): T | undefined => defaultOptions[name]
-};
+  getOption: <T>(name: string): T | undefined => defaultOptions[name],
+  tooltips: {
+    getConfig: (): TooltippingTypes.TooltippingConfigSpec => {
+      return { } as any;
+    }
+  }
+} as UiFactoryBackstageProviders;


### PR DESCRIPTION
* has some naive concept of "in tooltip mode", where tooltips will show up immediately instead of on a delay
* most on anything that had a title. Its weird opening up menu items that have text and seeing a tooltip that says the same thing
* not on buttons that only have text. Not sure if we want to preserve that
* operates by mouse and focus
* lots of duplication as I'm still working out where to put things.
* css hackery

Unresolved problem

- [ ] autocompleter already uses Tooltipping for its items to work with mentions. We'll need to think how we want that to play with other autocompleters that need tooltips like emoticons

Other things

- [ ] when should we show a tooltip if the text is already visible? 
- [ ] if the tooltip obscures another item, it interferes with the obscured items mouse listeners. This is particularly evident when in a menu, and a hotspot anchor shows the tooltip just below covering the next item. Moving the mouse over that item (and over the tooltip) doesn't highlight the item. From testing on Ubuntu Chrome and Firefox, this might be solved with `pointer-events: none` on the tooltip container :tada: 

- [ ] hard-coded arrows in the tooltip dom classes