### PR TITLE
TINY-9108: Fix double bottom border on inline mode editor in `tinymce-5` skin

### DIFF
--- a/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
@@ -77,6 +77,10 @@
     margin-bottom: -1px;
   }
 
+  &.tox-tinymce-inline .tox-editor-container {
+    overflow: hidden;
+  }
+
   &:not(.tox-tinymce-inline).tox-tinymce--toolbar-bottom .tox-editor-header {
     border-top: none;
     box-shadow: none;

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fix double bottom border on inline mode editor in `tinymce-5` skin #TINY-9108
+
 ### Added
 - New `text_patterns_lookup` option to provide additional text patterns dynamically #TINY-8778
 - New promotion element has been added to the UI and can be disabled using the new `promotion` option #TINY-8840

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Fix double bottom border on inline mode editor in `tinymce-5` skin #TINY-9108
+- Fix double bottom border on inline mode editor in `tinymce-5` skin. #TINY-9108
 
 ### Added
 - New `text_patterns_lookup` option to provide additional text patterns dynamically #TINY-8778

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Line separator scrolling in floating toolbars. #TINY-8948
-- Double bottom border on inline mode editor in `tinymce-5` skin. #TINY-9108
+- A double bottom border appeared on inline mode editor for the `tinymce-5` skin. #TINY-9108
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Fix double bottom border on inline mode editor in `tinymce-5` skin. #TINY-9108
+- Double bottom border on inline mode editor in `tinymce-5` skin. #TINY-9108
 
 ## 6.2.0 - 2022-09-08
 


### PR DESCRIPTION
Related Ticket: TINY-9108

Description of Changes:
* Reverted overflow value for inline mode editor in `tinymce-5` skin

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set