### PR TITLE
TINY-8979: Backport URL link detection fix

### DIFF
--- a/modules/polaris/CHANGELOG.md
+++ b/modules/polaris/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Fixed incorrect `Regexes.link` URL detection for path segments that contain valid characters such as `!` and `:` #TINY-5074
+
 ## 5.0.2 - 2021-10-11
 
 ### Fixed

--- a/modules/polaris/CHANGELOG.md
+++ b/modules/polaris/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 5.0.3 - 2022-09-14
+
 ### Fixed
 - Fixed incorrect `Regexes.link` URL detection for path segments that contain valid characters such as `!` and `:` #TINY-5074
 

--- a/modules/polaris/src/main/ts/ephox/polaris/api/Regexes.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/api/Regexes.ts
@@ -28,6 +28,7 @@
   - allow up to 15 character schemes including all valid characters from the spec https://url.spec.whatwg.org/#url-scheme-string (TINY-5074)
   - changed instances of 0-9 to be \d (TINY-5074)
   - reduced duplication (TINY-5074)
+  - allow [*!;:'@$] in the path segment as they are valid characters per the spec: https://url.spec.whatwg.org/#url-path-segment-string (TINY-8069)
 
 (?:
   (?:
@@ -42,7 +43,7 @@
 (?:
   \/
   (?:
-     [-+~=.,%()\/\w]*[-+~=%()\/\w]
+     [-.~*+=!;:'%@$(),\/\w]*[-~*+=%@$()\/\w]
    )?
 )?
 (?:
@@ -61,7 +62,7 @@
 
 const link = (): RegExp =>
   // eslint-disable-next-line max-len
-  /(?:[A-Za-z][A-Za-z\d.+-]{0,14}:\/\/(?:[-.~*+=!&;:'%@?^${}(),\w]+@)?|www\.|[-;:&=+$,.\w]+@)[A-Za-z\d-]+(?:\.[A-Za-z\d-]+)*(?::\d+)?(?:\/(?:[-+~=.,%()\/\w]*[-+~=%()\/\w])?)?(?:\?(?:[-.~*+=!&;:'%@?^${}(),\/\w]+))?(?:#(?:[-.~*+=!&;:'%@?^${}(),\/\w]+))?/g;
+  /(?:[A-Za-z][A-Za-z\d.+-]{0,14}:\/\/(?:[-.~*+=!&;:'%@?^${}(),\w]+@)?|www\.|[-;:&=+$,.\w]+@)[A-Za-z\d-]+(?:\.[A-Za-z\d-]+)*(?::\d+)?(?:\/(?:[-.~*+=!;:'%@$(),\/\w]*[-~*+=%@$()\/\w])?)?(?:\?(?:[-.~*+=!&;:'%@?^${}(),\/\w]+))?(?:#(?:[-.~*+=!&;:'%@?^${}(),\/\w]+))?/g;
 
 const autolink = (): RegExp => {
   /*

--- a/modules/polaris/src/test/ts/atomic/api/RegexesTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/RegexesTest.ts
@@ -22,7 +22,9 @@ UnitTest.test('RegexesTest', () => {
     'http://xn--domain.com',
     'www.google.ca/index.htm?id=/bla/bla',
     'https://www.amazon.com.au/gp/product/B0798R2WXG/ref=s9_acsd_top_hd_bw_b5QhTfX_c_x_w?pf_rd_m=ANEGB3WVEVKZB&pf_rd_s=merchandised-search-4&pf_rd_r=KF6SD7C0M69MKF2FR9CC&pf_rd_t=101&pf_rd_p=8ad3bdba-b846-5350-9c00-72c2cb7191dd&pf_rd_i=4975211051',
-    'https://www.birddoctor.net/refId,56511/refDownload.pml'
+    'https://www.birddoctor.net/refId,56511/refDownload.pml',
+    'https://www.example.com/:w:/s/b026324c6904b2a9cb4b88d6d61c81d1?q=abc123',
+    'https://website.com/test/!test'
   ];
 
   // More cases, http://formvalidation.io/validators/uri/
@@ -253,19 +255,29 @@ UnitTest.test('RegexesTest', () => {
     }
   });
 
-  const onlyWithPathLinks = { // Ignore trailing comma and period in URL path
+  // Ignore trailing punctuation such as a comma, period and exclamation mark at the end of the URL path
+  const onlyWithPathLinks = {
     'http://google.com': 'http://google.com',
     'http://google.com.': 'http://google.com',
     'http://google.com,': 'http://google.com',
+    'http://google.com!': 'http://google.com',
+    'http://google.com;': 'http://google.com',
+    'http://google.com:': 'http://google.com',
     'http://google.com/,': 'http://google.com/',
     'http://google.com/,,': 'http://google.com/',
     'http://google.com/.': 'http://google.com/',
     'http://google.com/..': 'http://google.com/',
+    'http://google.com/!': 'http://google.com/',
+    'http://google.com/:': 'http://google.com/',
+    'http://google.com/;': 'http://google.com/',
     'http://google.com/,/': 'http://google.com/,/',
     'http://google.com/,/,': 'http://google.com/,/',
     'http://google.com/abc': 'http://google.com/abc',
     'http://google.com/abc,': 'http://google.com/abc',
     'http://google.com/abc.': 'http://google.com/abc',
+    'http://google.com/abc!': 'http://google.com/abc',
+    'http://google.com/abc;': 'http://google.com/abc',
+    'http://google.com/abc:': 'http://google.com/abc',
     'http://google.com/,ab,c': 'http://google.com/,ab,c',
     'http://google.com/ab,c': 'http://google.com/ab,c',
     'http://google.com/ab,c,': 'http://google.com/ab,c',

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `name` and `id` attributes of some elements were incorrectly removed during serialization #TINY-8773
 - Notifications would not properly reposition when toggling fullscreen mode #TINY-8701
 - Toggling fullscreen mode with the `fullscreen` plugin now also fires the `ResizeEditor` event #TINY-8701
+- The URL detection used for `autolink` and smart paste didn't work if a path segment contained valid characters such as `!` and `:` #TINY-8069
 
 ## 5.10.5 - 2022-05-25
 

--- a/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
+++ b/modules/tinymce/src/plugins/paste/main/ts/core/SmartPaste.ts
@@ -33,7 +33,7 @@ const pasteHtml = (editor: Editor, html: string): boolean => {
  */
 
 const isAbsoluteUrl = (url: string): boolean =>
-  /^https?:\/\/[\w\?\-\/+=.&%@~#]+$/i.test(url);
+  /^https?:\/\/[\w\-\/+=.,!;:&%@^~(){}?#]+$/i.test(url);
 
 const isImageUrl = (editor: Editor, url: string): boolean => {
   return isAbsoluteUrl(url) && Arr.exists(Settings.getAllowedImageFileTypes(editor), (type) =>

--- a/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
+++ b/modules/tinymce/src/plugins/paste/test/ts/browser/SmartPasteTest.ts
@@ -39,6 +39,9 @@ describe('browser.tinymce.plugins.paste.SmartPasteTest', () => {
     assert.isTrue(SmartPaste.isAbsoluteUrl('https://www.site.com/dir-name/file.gif?query=%42'));
     assert.isTrue(SmartPaste.isAbsoluteUrl('https://www.site.com/dir-name/file.gif?query=%42#a'));
     assert.isTrue(SmartPaste.isAbsoluteUrl('https://www.site.com/~abc'));
+    assert.isTrue(SmartPaste.isAbsoluteUrl('https://www.site.com/refId,56511/refDownload.pml'));
+    assert.isTrue(SmartPaste.isAbsoluteUrl('https://www.site.com/:w:/s/b026324c6904b2a9cb4b88d6d61c81d1?q=abc123'));
+    assert.isTrue(SmartPaste.isAbsoluteUrl('https://site.com/test/!test'));
     assert.isFalse(SmartPaste.isAbsoluteUrl('file.gif'));
     assert.isFalse(SmartPaste.isAbsoluteUrl(''));
   });

--- a/versions.txt
+++ b/versions.txt
@@ -1,2 +1,3 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
+

--- a/versions.txt
+++ b/versions.txt
@@ -1,3 +1,2 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
-


### PR DESCRIPTION
Related Ticket: TINY-8979

Description of Changes:
- Backport URL link detection fix
- Note: Replacement PR for https://github.com/tinymce/tinymce/pull/8122 (wrong email 😢 )

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
