### PR TITLE
TINY-9025: Dragging CEF element toward the bottom edge no longer causes the page to scroll up

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `expand` function added to `tinymce.dom.RangeUtils` to return a new range expanded around the nearest word. #TINY-9001
 
 ### Fixed
+- Dragging CEF element toward the bottom edge would cause the page to scroll up. #TINY-9025
 - Range expanding capabilities would behave inconsistently depending on where the cursor was placed. #TINY-9029
 - Compilation errors were thrown when using TypeScript 4.8. #TINY-9161
 - Line separator scrolling in floating toolbars. #TINY-8948

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `expand` function added to `tinymce.dom.RangeUtils` to return a new range expanded around the nearest word. #TINY-9001
 
 ### Fixed
-- Dragging CEF element toward the bottom edge would cause the page to scroll up. #TINY-9025
+- Dragging a noneditable element toward the bottom edge would cause the page to scroll up. #TINY-9025
 - Range expanding capabilities would behave inconsistently depending on where the cursor was placed. #TINY-9029
 - Compilation errors were thrown when using TypeScript 4.8. #TINY-9161
 - Line separator scrolling in floating toolbars. #TINY-8948

--- a/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
@@ -269,7 +269,7 @@ const move = (state: Singleton.Value<State>, editor: Editor) => {
     }
 
     if (state.dragging) {
-      const mouseEventOriginatedFromWithinTheEditor = e.currentTarget === editor.getDoc().firstElementChild;
+      const mouseEventOriginatedFromWithinTheEditor = e.currentTarget === editor.getDoc().documentElement;
       const targetPos = applyRelPos(state, MousePosition.calc(editor, e));
       appendGhostToBody(state.ghost, editor.getBody());
       moveGhost(state.ghost, targetPos, state.width, state.height, state.maxX, state.maxY, e.clientY, e.clientX, editor.getContentAreaContainer(), editor.getWin(), state_, mouseEventOriginatedFromWithinTheEditor);

--- a/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
@@ -130,7 +130,8 @@ const moveGhost = (
   mouseX: number,
   contentAreaContainer: HTMLElement,
   win: Window,
-  state: Singleton.Value<State>
+  state: Singleton.Value<State>,
+  mouseEventOriginatedFromWithinTheEditor: boolean
 ) => {
   let overflowX = 0, overflowY = 0;
 
@@ -163,7 +164,7 @@ const moveGhost = (
 
   state.on((state) => {
     state.intervalId.clear();
-    if (state.dragging) {
+    if (state.dragging && mouseEventOriginatedFromWithinTheEditor) {
       // This basically means that the mouse is close to the bottom edge
       // (within MouseRange pixels of the bottom edge)
       if (mouseY + mouseRangeToTriggerScrollInsideEditor >= clientHeight) {
@@ -268,9 +269,16 @@ const move = (state: Singleton.Value<State>, editor: Editor) => {
     }
 
     if (state.dragging) {
+      console.log({
+        mouseY: e.clientY,
+        origin: e.currentTarget,
+        editorOringin: editor.getDoc().firstElementChild,
+        fromEditor: e.currentTarget === editor.getDoc().firstElementChild
+      });
+      const mouseEventOriginatedFromWithinTheEditor = e.currentTarget === editor.getDoc().firstElementChild;
       const targetPos = applyRelPos(state, MousePosition.calc(editor, e));
       appendGhostToBody(state.ghost, editor.getBody());
-      moveGhost(state.ghost, targetPos, state.width, state.height, state.maxX, state.maxY, e.clientY, e.clientX, editor.getContentAreaContainer(), editor.getWin(), state_);
+      moveGhost(state.ghost, targetPos, state.width, state.height, state.maxX, state.maxY, e.clientY, e.clientX, editor.getContentAreaContainer(), editor.getWin(), state_, mouseEventOriginatedFromWithinTheEditor);
       throttledPlaceCaretAt.throttle(e.clientX, e.clientY);
     }
   });

--- a/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
@@ -269,12 +269,6 @@ const move = (state: Singleton.Value<State>, editor: Editor) => {
     }
 
     if (state.dragging) {
-      console.log({
-        mouseY: e.clientY,
-        origin: e.currentTarget,
-        editorOringin: editor.getDoc().firstElementChild,
-        fromEditor: e.currentTarget === editor.getDoc().firstElementChild
-      });
       const mouseEventOriginatedFromWithinTheEditor = e.currentTarget === editor.getDoc().firstElementChild;
       const targetPos = applyRelPos(state, MousePosition.calc(editor, e));
       appendGhostToBody(state.ghost, editor.getBody());

--- a/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
@@ -257,6 +257,31 @@ describe('browser.tinymce.core.DragDropOverridesTest', () => {
       });
     });
 
+    it('TINY-9025: Dragging CEF element outside the editor should not cause scrolling', async () => {
+      const editor = hook.editor();
+      editor.setContent(`
+      <p>CEF can get dragged before this one</p>
+      <p class="hidden" style="height: 1500px"></p>
+      <p id="separator" style="height: 100px"></p>
+      <p contenteditable="false" style="height: 200px; background-color: black; color: white">Draggable CEF</p>
+    `);
+      window.scroll({
+        top: window.innerHeight + 2000
+      });
+      const target = UiFinder.findIn(TinyDom.body(editor), 'p:contains("Draggable CEF")').getOrDie();
+      const initialScrollY = window.scrollY;
+      editor.getWin().scroll({
+        top: editor.getWin().innerHeight
+      })
+      Mouse.mouseDown(target);
+      window.dispatchEvent(new MouseEvent('mousemove', {
+        clientY: window.innerHeight,
+      }));
+      await Waiter.pWait(100);
+      Mouse.mouseUp(target);
+      assert.strictEqual(window.scrollY, initialScrollY);
+    });
+
     it('TINY-8874: Dragging CEF element towards the right edge causes scrolling', async () => {
       const editor = hook.editor();
       editor.setContent(`

--- a/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
@@ -272,7 +272,7 @@ describe('browser.tinymce.core.DragDropOverridesTest', () => {
       const initialScrollY = window.scrollY;
       editor.getWin().scroll({
         top: editor.getWin().innerHeight
-      })
+      });
       Mouse.mouseDown(target);
       window.dispatchEvent(new MouseEvent('mousemove', {
         clientY: window.innerHeight,


### PR DESCRIPTION
Related Ticket: TINY-9025

Description of Changes:
*  Dragging CEF element toward the bottom edge no longer causes the page to scroll up

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
