### PR TITLE
TINY-9200: Fix broken tests on Firefox

### DIFF
--- a/modules/snooker/src/test/ts/browser/ResizeTest.ts
+++ b/modules/snooker/src/test/ts/browser/ResizeTest.ts
@@ -219,7 +219,7 @@ describe('ResizeTest', () => {
     const table = SugarElement.fromHtml<HTMLTableElement>(`<table style="border-collapse: collapse; width: 800px;">
     <tbody>
     <tr>
-    <td style="width: 400px;">thisisareallylongsentencewithoutspacesthatcausescontenttooverflow</td>
+    <td style="width: 400px;"><span style="display: inline-block; width: 483px"></span></td>
     <td style="width: 400px;">B</td>
     </tr>
     <tr>

--- a/modules/snooker/src/test/ts/browser/TableSizeTest.ts
+++ b/modules/snooker/src/test/ts/browser/TableSizeTest.ts
@@ -11,9 +11,9 @@ const tOptional = OptionalInstances.tOptional;
 
 describe('TableSizeTest', () => {
   const pixelTableHtml = '<table style="width: 400px; border-collapse: collapse;"><tbody><tr><td style="width: 200px"></td><td style="width: 200px"></td></tr></tbody></table>';
-  const overflowingPixelTableHtml = '<table style="width: 400px; border-collapse: collapse;"><tbody><tr><td style="width: 200px">thisisareallylongsentencewithoutspacesthatcausescontenttooverflow</td><td style="width: 200px"></td></tr></tbody></table>';
+  const overflowingPixelTableHtml = '<table style="width: 400px; border-collapse: collapse;"><tbody><tr><td style="width: 200px"><span style="display: inline-block; width: 483px"></span></td><td style="width: 200px"></td></tr></tbody></table>';
   const percentTableHtml = '<table style="width: 80%; border-collapse: collapse;"><tbody><tr><td style="width: 50%"></td><td style="width: 50%"></td></tr></tbody></table>';
-  const overflowingPercentTableHtml = '<table style="width: 80%; border-collapse: collapse;"><tbody><tr><td style="width: 50%">thisisareallylongsentencewithoutspacesthatcausescontenttooverflow</td><td style="width: 50%"></td></tr></tbody></table>';
+  const overflowingPercentTableHtml = '<table style="width: 80%; border-collapse: collapse;"><tbody><tr><td style="width: 50%"><span style="display: inline-block; width: 483px"></span></td><td style="width: 50%"></td></tr></tbody></table>';
   const noneTableHtml = '<table><tbody><tr><td></td><td></td></tr></tbody></table>';
 
   context('getTableSize', () => {

--- a/modules/sugar/src/test/ts/browser/LocationTest.ts
+++ b/modules/sugar/src/test/ts/browser/LocationTest.ts
@@ -136,7 +136,7 @@ UnitTest.asynctest('LocationTest', (success, failure) => {
     pos = SugarLocation.viewport(body);
     Assert.eq('', 0, pos.top);
     Assert.eq('', 0, pos.left);
-    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux());
+    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux()) && (platform.os.isWindows() && platform.os.version.major >= 11);
     Assert.eq('scroll bar width, got=' + scrollBarWidth, true, scrollBarWidth > 5 && scrollBarWidth < 50 || (noVisibleScrollbarBrowser && scrollBarWidth === 0));
   };
 

--- a/modules/sugar/src/test/ts/browser/LocationTest.ts
+++ b/modules/sugar/src/test/ts/browser/LocationTest.ts
@@ -136,8 +136,8 @@ UnitTest.asynctest('LocationTest', (success, failure) => {
     pos = SugarLocation.viewport(body);
     Assert.eq('', 0, pos.top);
     Assert.eq('', 0, pos.left);
-    const noScrollBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux());
-    Assert.eq('scroll bar width, got=' + scrollBarWidth, true, scrollBarWidth > 5 && scrollBarWidth < 50 || (noScrollBrowser && scrollBarWidth === 0));
+    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux());
+    Assert.eq('scroll bar width, got=' + scrollBarWidth, true, scrollBarWidth > 5 && scrollBarWidth < 50 || (noVisibleScrollbarBrowser && scrollBarWidth === 0));
   };
 
   const disconnectedChecks = () => {

--- a/modules/sugar/src/test/ts/browser/LocationTest.ts
+++ b/modules/sugar/src/test/ts/browser/LocationTest.ts
@@ -136,7 +136,7 @@ UnitTest.asynctest('LocationTest', (success, failure) => {
     pos = SugarLocation.viewport(body);
     Assert.eq('', 0, pos.top);
     Assert.eq('', 0, pos.left);
-    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux()) && (platform.os.isWindows() && platform.os.version.major >= 11);
+    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux()) || (platform.browser.isFirefox() && platform.os.isWindows() && platform.os.version.major >= 11);
     Assert.eq('scroll bar width, got=' + scrollBarWidth, true, scrollBarWidth > 5 && scrollBarWidth < 50 || (noVisibleScrollbarBrowser && scrollBarWidth === 0));
   };
 

--- a/modules/sugar/src/test/ts/browser/LocationTest.ts
+++ b/modules/sugar/src/test/ts/browser/LocationTest.ts
@@ -136,7 +136,8 @@ UnitTest.asynctest('LocationTest', (success, failure) => {
     pos = SugarLocation.viewport(body);
     Assert.eq('', 0, pos.top);
     Assert.eq('', 0, pos.left);
-    Assert.eq('scroll bar width, got=' + scrollBarWidth, true, scrollBarWidth > 5 && scrollBarWidth < 50 || (platform.os.isMacOS() && scrollBarWidth === 0));
+    const noScrollBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux());
+    Assert.eq('scroll bar width, got=' + scrollBarWidth, true, scrollBarWidth > 5 && scrollBarWidth < 50 || (noScrollBrowser && scrollBarWidth === 0));
   };
 
   const disconnectedChecks = () => {

--- a/modules/sugar/src/test/ts/browser/ScrollTest.ts
+++ b/modules/sugar/src/test/ts/browser/ScrollTest.ts
@@ -127,7 +127,7 @@ UnitTest.asynctest('ScrollTest', (success, failure) => {
     const cX = Math.round(center.left);
     const cY = Math.round(center.top);
 
-    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux()) && (platform.os.isWindows() && platform.os.version.major >= 11);
+    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux()) || (platform.browser.isFirefox() && platform.os.isWindows() && platform.os.version.major >= 11);
     Assert.eq('scroll bar width, got=' + scrollBarWidth, true, scrollBarWidth > 5 && scrollBarWidth < 50 || (noVisibleScrollbarBrowser && scrollBarWidth === 0));
 
     scrollCheck(0, 0, 0, 0, doc, 'start pos');

--- a/modules/sugar/src/test/ts/browser/ScrollTest.ts
+++ b/modules/sugar/src/test/ts/browser/ScrollTest.ts
@@ -127,8 +127,8 @@ UnitTest.asynctest('ScrollTest', (success, failure) => {
     const cX = Math.round(center.left);
     const cY = Math.round(center.top);
 
-    const noScrollBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux());
-    Assert.eq('scroll bar width, got=' + scrollBarWidth, true, scrollBarWidth > 5 && scrollBarWidth < 50 || (noScrollBrowser && scrollBarWidth === 0));
+    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux());
+    Assert.eq('scroll bar width, got=' + scrollBarWidth, true, scrollBarWidth > 5 && scrollBarWidth < 50 || (noVisibleScrollbarBrowser && scrollBarWidth === 0));
 
     scrollCheck(0, 0, 0, 0, doc, 'start pos');
 

--- a/modules/sugar/src/test/ts/browser/ScrollTest.ts
+++ b/modules/sugar/src/test/ts/browser/ScrollTest.ts
@@ -127,7 +127,7 @@ UnitTest.asynctest('ScrollTest', (success, failure) => {
     const cX = Math.round(center.left);
     const cY = Math.round(center.top);
 
-    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux());
+    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux()) && (platform.os.isWindows() && platform.os.version.major >= 11);
     Assert.eq('scroll bar width, got=' + scrollBarWidth, true, scrollBarWidth > 5 && scrollBarWidth < 50 || (noVisibleScrollbarBrowser && scrollBarWidth === 0));
 
     scrollCheck(0, 0, 0, 0, doc, 'start pos');

--- a/modules/sugar/src/test/ts/browser/ScrollTest.ts
+++ b/modules/sugar/src/test/ts/browser/ScrollTest.ts
@@ -127,7 +127,8 @@ UnitTest.asynctest('ScrollTest', (success, failure) => {
     const cX = Math.round(center.left);
     const cY = Math.round(center.top);
 
-    Assert.eq('scroll bar width, got=' + scrollBarWidth, true, scrollBarWidth > 5 && scrollBarWidth < 50 || (platform.os.isMacOS() && scrollBarWidth === 0));
+    const noScrollBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux());
+    Assert.eq('scroll bar width, got=' + scrollBarWidth, true, scrollBarWidth > 5 && scrollBarWidth < 50 || (noScrollBrowser && scrollBarWidth === 0));
 
     scrollCheck(0, 0, 0, 0, doc, 'start pos');
 

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationStylingTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationStylingTest.ts
@@ -97,7 +97,7 @@ describe('browser.tinymce.core.annotate.AnnotationStylingTest', () => {
 
       if (checkOtherNodes) {
         const parents = SelectorFilter.ancestors(elm, '*', (e) => Compare.eq(e, body));
-        const children = SelectorFilter.children(elm, '*');
+        const children = SelectorFilter.children(elm, '*:not(source)');
         const isFigCaption = SugarNode.isTag('figcaption');
 
         Arr.each(parents, (e) => assert.deepEqual(getOutline(e), noOutline, 'parent should not have outline'));

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationStylingTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationStylingTest.ts
@@ -97,7 +97,7 @@ describe('browser.tinymce.core.annotate.AnnotationStylingTest', () => {
 
       if (checkOtherNodes) {
         const parents = SelectorFilter.ancestors(elm, '*', (e) => Compare.eq(e, body));
-        const children = SelectorFilter.children(elm, '*:not(source)');
+        const children = SelectorFilter.children(elm, '*:not(source)'); // Source is a hidden element and Firefox returns empty strings for runtime style properties
         const isFigCaption = SugarNode.isTag('figcaption');
 
         Arr.each(parents, (e) => assert.deepEqual(getOutline(e), noOutline, 'parent should not have outline'));

--- a/modules/tinymce/src/models/dom/test/ts/module/table/TableTestUtils.ts
+++ b/modules/tinymce/src/models/dom/test/ts/module/table/TableTestUtils.ts
@@ -53,6 +53,7 @@ const assertWidth = (editor: Editor, elm: HTMLElement, expectedWidth: number | n
   if (expectedWidth === null) {
     assert.isNull(widthData.raw, `${nodeName} width should not be set`);
   } else {
+    // This does a approximately check with a delta of 4 to compensate for Firefox sometimes being off by 4 pixels depending on version and platform see TINY-9200 for details
     assert.approximately(widthData.raw ?? -1, expectedWidth, 4, `${nodeName} width is ${expectedWidth} ~= ${widthData.raw}`);
   }
   assert.equal(widthData.unit, expectedUnit, `${nodeName} unit is ${expectedUnit}`);

--- a/modules/tinymce/src/models/dom/test/ts/module/table/TableTestUtils.ts
+++ b/modules/tinymce/src/models/dom/test/ts/module/table/TableTestUtils.ts
@@ -53,7 +53,7 @@ const assertWidth = (editor: Editor, elm: HTMLElement, expectedWidth: number | n
   if (expectedWidth === null) {
     assert.isNull(widthData.raw, `${nodeName} width should not be set`);
   } else {
-    assert.approximately(widthData.raw ?? -1, expectedWidth, 2, `${nodeName} width is ${expectedWidth} ~= ${widthData.raw}`);
+    assert.approximately(widthData.raw ?? -1, expectedWidth, 4, `${nodeName} width is ${expectedWidth} ~= ${widthData.raw}`);
   }
   assert.equal(widthData.unit, expectedUnit, `${nodeName} unit is ${expectedUnit}`);
 };


### PR DESCRIPTION
Related Ticket: TINY-9200

Description of Changes:
Tests started to fail since Firefox was updated to a newer version
* Changed the `ResizeTest.ts` and `TableSizeTest.ts` for snooker to have an inline block with exact pixels to expand the TD rather than just text that could cause issues with kerning, oses etc the intent of the test is still the same.
* Added a fix for Firefox scrollbars. By default Firefox 100+ on Linux has no scrollbars visible. Makes local testing a bit easier.
* Removed `source` from the children elements for the `AnnotationStylingTest.ts` test since it now return an empty string instead of a proper rgb value. It is a hidden element so it kind of makes sense to return nothing.
* Increased the fuzzy asserts from 2 to 4 to compensate for rendering changes in latest Firefox.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
