### PR TITLE
TINY-8947: prevent inline text pattern to trigger when end match and start don't

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Line separator scrolling in floating toolbars. #TINY-8948
 - A double bottom border appeared on inline mode editor for the `tinymce-5` skin. #TINY-9108
 - The editor header showed up even with no menubar and toolbar configured. #TINY-8819
-- Inline text pattern does not trigger if it matches only the end but not the start. #TINY-8947
+- Inline text pattern no longer triggers if it matches only the end but not the start. #TINY-8947
 - Matches of inline text patterns that are similar are now managed correctly. #TINY-8949
 
 ## 6.2.0 - 2022-09-08

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Line separator scrolling in floating toolbars. #TINY-8948
 - A double bottom border appeared on inline mode editor for the `tinymce-5` skin. #TINY-9108
 - The editor header showed up even with no menubar and toolbar configured. #TINY-8819
-- Inline text pattern does not trigger if it matches only the end but not the start #TINY-8947
-- Similar inline match are now managed correctly #TINY-8949
+- Inline text pattern does not trigger if it matches only the end but not the start. #TINY-8947
+- Matches of inline text patterns that are similar are now managed correctly. #TINY-8949
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Line separator scrolling in floating toolbars. #TINY-8948
 - A double bottom border appeared on inline mode editor for the `tinymce-5` skin. #TINY-9108
 - The editor header showed up even with no menubar and toolbar configured. #TINY-8819
+- Inline text pattern does not trigger if it matches only the end but not the start #TINY-8947
+- Similar inline match are now managed correctly #TINY-8949
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
@@ -287,9 +287,9 @@ const getBestMatches = (matches: InlinePatternMatch[], matchesWithSortedPattenrs
 
 const findPatterns = (editor: Editor, block: Element, node: Node, offset: number, patternSet: PatternSet, normalizedMatches: boolean): InlinePatternMatch[] => {
   const matches = findPatternsRec(editor, patternSet.inlinePatterns, node, offset, block, normalizedMatches).fold(() => [], (result) => result.matches);
-  const matchesWithSortedPattenrs = findPatternsRec(editor, sortPatterns(patternSet.inlinePatterns), node, offset, block, normalizedMatches).fold(() => [], (result) => result.matches);
+  const matchesWithSortedPatterns = findPatternsRec(editor, sortPatterns(patternSet.inlinePatterns), node, offset, block, normalizedMatches).fold(() => [], (result) => result.matches);
 
-  return getBestMatches(matches, matchesWithSortedPattenrs);
+  return getBestMatches(matches, matchesWithSortedPatterns);
 };
 
 const applyMatches = (editor: Editor, matches: InlinePatternMatch[]): void => {

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
@@ -49,8 +49,8 @@ const findPatternStartFromSpot = (dom: DOMUtils, pattern: InlinePattern, block: 
   const startPattern = pattern.start;
   const startSpot = TextSearch.repeatLeft(dom, spot.container, spot.offset, matchesPattern(startPattern), block);
   return startSpot.bind((spot) => {
-    const preStartLength = block.textContent?.indexOf(startPattern) ?? 0;
-    const isCompleteMatch = spot.offset >= (preStartLength === -1 ? 0 : preStartLength) + startPattern.length;
+    const startPatternIndex = block.textContent?.indexOf(startPattern) ?? -1;
+    const isCompleteMatch = startPatternIndex !== -1 && spot.offset >= startPatternIndex + startPattern.length;
 
     if (isCompleteMatch) {
       // Complete match

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
@@ -49,7 +49,10 @@ const findPatternStartFromSpot = (dom: DOMUtils, pattern: InlinePattern, block: 
   const startPattern = pattern.start;
   const startSpot = TextSearch.repeatLeft(dom, spot.container, spot.offset, matchesPattern(startPattern), block);
   return startSpot.bind((spot) => {
-    if (spot.offset >= startPattern.length) {
+    const preStartLength = block.textContent?.indexOf(startPattern) ?? 0;
+    const isCompleteMatch = spot.offset >= (preStartLength === -1 ? 0 : preStartLength) + startPattern.length;
+
+    if (isCompleteMatch) {
       // Complete match
       const rng = dom.createRng();
       rng.setStart(spot.container, spot.offset - startPattern.length);

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts
@@ -268,21 +268,21 @@ const addMarkers = (dom: DOMUtils, matches: InlinePatternMatch[]): InlinePattern
 
 const sortPatterns = (patterns: InlinePattern[]) => Arr.sort(patterns, (a, b) => b.end.length - a.end.length);
 
-const getBestMatches = (matches: InlinePatternMatch[], matchesWithSortedPattenrs: InlinePatternMatch[]) => {
+const getBestMatches = (matches: InlinePatternMatch[], matchesWithSortedPatterns: InlinePatternMatch[]) => {
   const hasSameMatches = Arr.forall(matches, (match) =>
-    Arr.exists(matchesWithSortedPattenrs, (sortedMatch) =>
+    Arr.exists(matchesWithSortedPatterns, (sortedMatch) =>
       match.pattern.start === sortedMatch.pattern.start && match.pattern.end === sortedMatch.pattern.end
     )
   );
 
-  if (matches.length === matchesWithSortedPattenrs.length) {
+  if (matches.length === matchesWithSortedPatterns.length) {
     if (hasSameMatches) {
       return matches;
     } else {
-      return matchesWithSortedPattenrs;
+      return matchesWithSortedPatterns;
     }
   }
-  return matches.length > matchesWithSortedPattenrs.length ? matches : matchesWithSortedPattenrs;
+  return matches.length > matchesWithSortedPatterns.length ? matches : matchesWithSortedPatterns;
 };
 
 const findPatterns = (editor: Editor, block: Element, node: Node, offset: number, patternSet: PatternSet, normalizedMatches: boolean): InlinePatternMatch[] => {

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/FindInlinePatternTest.ts
@@ -100,13 +100,6 @@ describe('browser.tinymce.textpatterns.FindInlinePatternTest', () => {
       assertSimpleMatch(matches, '*', '*', [ 'italic' ], { start: [ 0, 0, 0 ], end: [ 0, 0, 1 ] }, { start: [ 0, 0, 2 ], end: [ 0, 0, 3 ] });
     });
 
-    it('TINY-8778: inline * pattern with no gap to matching token returns no match', () => {
-      const editor = hook.editor();
-      setContentAndCursor(editor, '*x***', [ 0 ], 5);
-      const matches = getInlinePattern(editor, getInlinePatternSet());
-      assertPatterns(matches, []);
-    });
-
     it('TINY-8778: inline * with uncollapsed range returns no match', () => {
       const editor = hook.editor();
       setContentAndSelection(editor, '*x*&nbsp;', [ 0 ], 3, [ 0 ], 4);

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
@@ -275,4 +275,20 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
 
     editor.options.unset('text_patterns');
   });
+
+  it('TINY-8949: the patterns should be applied to the correct element', () => {
+    const editor = hook.editor();
+    editor.options.set('text_patterns', [
+      { start: '**', end: '**', format: 'bold' },
+      { start: '***', end: '***', format: 'italic' },
+    ]);
+
+    Utils.setContentAndPressSpace(editor, 'a **test1** **test2**');
+    TinyAssertions.assertContent(editor, '<p>a **test1** <strong>test2</strong>&nbsp;</p>');
+
+    Utils.setContentAndPressSpace(editor, 'a ***test1*** ***test2***');
+    TinyAssertions.assertContent(editor, '<p>a ***test1*** <em>test2</em>&nbsp;</p>');
+
+    editor.options.unset('text_patterns');
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
@@ -249,6 +249,8 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
     TinyAssertions.assertContent(editor, '<p>a *<strong>b</strong>&nbsp;</p>');
     Utils.setContentAndPressSpace(editor, 'a ***b***');
     TinyAssertions.assertContent(editor, '<p>a <em><strong>b</strong></em>&nbsp;</p>');
+
+    editor.options.unset('text_patterns');
   });
 
   it('TINY-8949: it should take more inclusive pattern', () => {
@@ -260,6 +262,7 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
       { start: '**', end: '**', format: 'bold' },
       { start: '***', end: '***', format: 'italic' },
     ]);
+
     Utils.setContentAndPressSpace(editor, 'a ***test2***');
     TinyAssertions.assertContent(editor, '<p>a <em>test2</em>&nbsp;</p>');
 

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
@@ -273,6 +273,18 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
     Utils.setContentAndPressSpace(editor, 'a ***test3***');
     TinyAssertions.assertContent(editor, '<p>a <em>test3</em>&nbsp;</p>');
 
+    editor.options.set('text_patterns', [
+      { start: '**', end: '//', format: 'bold' }
+    ]);
+    Utils.setContentAndPressSpace(editor, 'a *test3//');
+    TinyAssertions.assertContent(editor, '<p>a *test3//&nbsp;</p>');
+
+    editor.options.set('text_patterns', [
+      { start: '*', end: '*', format: 'italic' }
+    ]);
+    Utils.setContentAndPressSpace(editor, 'a *test1* *test2*');
+    TinyAssertions.assertContent(editor, '<p>a *test1* <em>test2</em>&nbsp;</p>');
+
     editor.options.unset('text_patterns');
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
@@ -228,4 +228,26 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
 
     editor.options.unset('text_patterns');
   });
+
+  it('TINY-8947: inline text pattern is not applied when both the start and end don’t match', () => {
+    const editor = hook.editor();
+    editor.options.set('text_patterns', [
+      { start: '*', end: '*', format: 'italic' },
+    ]);
+    Utils.setContentAndPressSpace(editor, '**a*');
+    TinyAssertions.assertContent(editor, '<p>*<em>a</em>&nbsp;</p>');
+
+    editor.options.set('text_patterns', [
+      { start: '*', end: '*', format: 'italic' },
+      { start: '**', end: '**', format: 'bold' },
+    ]);
+    Utils.setContentAndPressSpace(editor, 'a **test*');
+    TinyAssertions.assertContent(editor, '<p>a *<em>test</em>&nbsp;</p>');
+    Utils.setContentAndPressSpace(editor, 'a *test**');
+    TinyAssertions.assertContent(editor, '<p>a *test**&nbsp;</p>'); // TODO: fix to have '<p>a <em>test</em>*&nbsp;</p>' as result
+    Utils.setContentAndPressSpace(editor, 'a ***b**');
+    TinyAssertions.assertContent(editor, '<p>a *<strong>b</strong>&nbsp;</p>');
+    Utils.setContentAndPressSpace(editor, 'a ***b***');
+    TinyAssertions.assertContent(editor, '<p>a <em><strong>b</strong></em>&nbsp;</p>');
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
@@ -244,10 +244,32 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
     Utils.setContentAndPressSpace(editor, 'a **test*');
     TinyAssertions.assertContent(editor, '<p>a *<em>test</em>&nbsp;</p>');
     Utils.setContentAndPressSpace(editor, 'a *test**');
-    TinyAssertions.assertContent(editor, '<p>a *test**&nbsp;</p>'); // TODO: fix to have '<p>a <em>test</em>*&nbsp;</p>' as result
+    TinyAssertions.assertContent(editor, '<p>a <em>test</em>*&nbsp;</p>');
     Utils.setContentAndPressSpace(editor, 'a ***b**');
     TinyAssertions.assertContent(editor, '<p>a *<strong>b</strong>&nbsp;</p>');
     Utils.setContentAndPressSpace(editor, 'a ***b***');
     TinyAssertions.assertContent(editor, '<p>a <em><strong>b</strong></em>&nbsp;</p>');
+  });
+
+  it('TINY-8949: it should take more inclusive pattern', () => {
+    const editor = hook.editor();
+    Utils.setContentAndPressSpace(editor, 'a ***test1***');
+    TinyAssertions.assertContent(editor, '<p>a <em><strong>test1</strong></em>&nbsp;</p>');
+
+    editor.options.set('text_patterns', [
+      { start: '**', end: '**', format: 'bold' },
+      { start: '***', end: '***', format: 'italic' },
+    ]);
+    Utils.setContentAndPressSpace(editor, 'a ***test2***');
+    TinyAssertions.assertContent(editor, '<p>a <em>test2</em>&nbsp;</p>');
+
+    editor.options.set('text_patterns', [
+      { start: '***', end: '***', format: 'italic' },
+      { start: '**', end: '**', format: 'bold' },
+    ]);
+    Utils.setContentAndPressSpace(editor, 'a ***test3***');
+    TinyAssertions.assertContent(editor, '<p>a <em>test3</em>&nbsp;</p>');
+
+    editor.options.unset('text_patterns');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-8947

Description of Changes:

- update the check for a complete match in `findPatternStartFromSpot` that ATM works only if the string starts with the pattern
- add backtracking for the matching of the patterns, it is needed because otherwise in: `*a**` instead of matching `[*a*]*` it matches `*a[**]`

adding the backtracking makes fail this case:
```
patterns = [ { start: '*', end: '*' }, { start: '**', end: '**' } ]
**a**
```
before the first pattern (`*`) gets `**a[**]` and the second one (`**`) gets `[**a**]

with the backtracking, the first pattern (`*`) is matched.

to solve this I added a system that sort the pattern based on the length of the end (since is where we start to check, but it could be improved).
the order that take the prioritization is the one that has more matches or the sorted one if there is the same amount of match but not all the match are the same (this to prevent the case described above)

I decide to preserve the possibility of manual sorting in order to don't change the existing behaviour

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
