### PR TITLE
TINY-9102: Added exactAttrs, exactClasses and exactStyles to ApproxStructures.element

### DIFF
--- a/modules/agar/CHANGELOG.md
+++ b/modules/agar/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added `TestStore` API, which was moved from Alloy and requires types. #TINY-9157
-- Added `elementWithSpecifics` to `structApi`. #TINY-9102
+- Added `elementWithExactMatch` to `structApi`. #TINY-9102
 
 ## 7.2.0 - 2022-09-08
 

--- a/modules/agar/CHANGELOG.md
+++ b/modules/agar/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added `TestStore` API, which was moved from Alloy and requires types. #TINY-9157
-- Added `elementWithExactMatch` to `structApi`. #TINY-9102
+- Added `exactAttrs`, `exactClasses` and `exactStyles` to `ApproxStructures.element`. #TINY-9102
 
 ## 7.2.0 - 2022-09-08
 

--- a/modules/agar/CHANGELOG.md
+++ b/modules/agar/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added `TestStore` API, which was moved from Alloy and requires types. #TINY-9157
+- Added `elementWithSpecifics` to `structApi`. #TINY-9102
 
 ## 7.2.0 - 2022-09-08
 

--- a/modules/agar/src/main/ts/ephox/agar/api/ApproxStructure.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/ApproxStructure.ts
@@ -18,7 +18,7 @@ export type Builder<T> = (struct: StructApi, str: StringApi, arr: ArrayApi) => T
 
 const structApi = {
   element: ApproxStructures.element,
-  elementWithSpecifics: ApproxStructures.elementWithSpecifics,
+  elementWithExactMatch: ApproxStructures.elementWithExactMatch,
   text: ApproxStructures.text,
   anything: ApproxStructures.anything,
   either: ApproxStructures.either,

--- a/modules/agar/src/main/ts/ephox/agar/api/ApproxStructure.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/ApproxStructure.ts
@@ -18,7 +18,6 @@ export type Builder<T> = (struct: StructApi, str: StringApi, arr: ArrayApi) => T
 
 const structApi = {
   element: ApproxStructures.element,
-  elementWithExactMatch: ApproxStructures.elementWithExactMatch,
   text: ApproxStructures.text,
   anything: ApproxStructures.anything,
   either: ApproxStructures.either,

--- a/modules/agar/src/main/ts/ephox/agar/api/ApproxStructure.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/ApproxStructure.ts
@@ -18,6 +18,7 @@ export type Builder<T> = (struct: StructApi, str: StringApi, arr: ArrayApi) => T
 
 const structApi = {
   element: ApproxStructures.element,
+  elementWithSpecifics: ApproxStructures.elementWithSpecifics,
   text: ApproxStructures.text,
   anything: ApproxStructures.anything,
   either: ApproxStructures.either,

--- a/modules/agar/src/main/ts/ephox/agar/assertions/ApproxStructures.ts
+++ b/modules/agar/src/main/ts/ephox/agar/assertions/ApproxStructures.ts
@@ -298,7 +298,7 @@ const assertClassesSpecific = (expectedClasses: string[], actual: SugarElement<E
   );
 
   if (!isClassesEqual) {
-    throw new Error('Attribute names were not matching. actual: ' + actualClasses.join(', ') + ', expected: ' + expectedClasses.join(', '));
+    throw new Error('Class names were not matching. actual: ' + actualClasses.join(', ') + ', expected: ' + expectedClasses.join(', '));
   }
 };
 

--- a/modules/agar/src/main/ts/ephox/agar/assertions/ApproxStructures.ts
+++ b/modules/agar/src/main/ts/ephox/agar/assertions/ApproxStructures.ts
@@ -254,7 +254,7 @@ const assertAttrs = (expectedAttrs: Record<string, StringAssert>, actual: SugarE
 
 const assertExactMatchAttrs = (expectedAttrs: Record<string, StringAssert>, actual: SugarElement<Element>) => {
   const allDefinedAttrs = Obj.keys(expectedAttrs);
-  const actualDefinedAttrs = Obj.keys(Obj.bifilter(Attribute.clone(actual), (_value, key) => !Arr.contains([ 'style', 'class' ], key)).t);
+  const actualDefinedAttrs = Arr.filter(Obj.keys(Attribute.clone(actual)), (attr) => attr !== 'class' && attr !== 'style');
 
   const isEqual = assertEqualArray(
     allDefinedAttrs,
@@ -262,7 +262,7 @@ const assertExactMatchAttrs = (expectedAttrs: Record<string, StringAssert>, actu
   );
 
   if (!isEqual) {
-    throw new Error('Attribute names were not matching. actual: ' + actualDefinedAttrs.join(', ') + ', expected: ' + allDefinedAttrs.join(', '));
+    throw new Error(`Attribute names were not matching. actual: [${actualDefinedAttrs.join(', ')}], expected: [${allDefinedAttrs.join(', ')}]`);
   }
 
   assertAttrs(expectedAttrs, actual);
@@ -287,7 +287,7 @@ const assertExactMatchClasses = (expectedClasses: string[], actual: SugarElement
   );
 
   if (!isEqual) {
-    throw new Error('Class names were not matching. actual: ' + actualClasses.join(', ') + ', expected: ' + expectedClasses.join(', '));
+    throw new Error(`Class names were not matching. actual:  [${actualClasses.join(', ')}], expected: [${expectedClasses.join(', ')}]`);
   }
 };
 
@@ -314,7 +314,7 @@ const assertExactMatchStyles = (expectedStyles: Record<string, StringAssert>, ac
   );
 
   if (!isEqual) {
-    throw new Error('Style names were not matching. actual: ' + actualDefinedStyles.join(', ') + ', expected: ' + allDefinedStyles.join(', '));
+    throw new Error(`Style names were not matching. actual: [${actualDefinedStyles.join(', ')}], expected: [${allDefinedStyles.join(', ')}]`);
   }
 
   assertStyles(expectedStyles, actual);

--- a/modules/agar/src/test/ts/browser/ApproxStructureTest.ts
+++ b/modules/agar/src/test/ts/browser/ApproxStructureTest.ts
@@ -170,7 +170,7 @@ describe('browser.agar.ApproxStructureTest', () => {
 
     it('TINY-9102: ApproxStructure build', () => {
       check(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithSpecifics('div', {
+        s.elementWithExactMatch('div', {
           attrs: {
             'selected': str.is('double'),
             'data-key': str.contains('test')
@@ -182,12 +182,12 @@ describe('browser.agar.ApproxStructureTest', () => {
             display: str.is('block')
           },
           children: [
-            s.elementWithSpecifics('div', {
+            s.elementWithExactMatch('div', {
               attrs: {
                 selected: str.is('true')
               },
               children: [
-                s.elementWithSpecifics('span', {
+                s.elementWithExactMatch('span', {
                   attrs: {
                     'data-ephox-id': str.startsWith('bl')
                   },
@@ -207,12 +207,12 @@ describe('browser.agar.ApproxStructureTest', () => {
     it('TINY-9102: ApproxStructure either', () => {
       const struct1 = ApproxStructure.build((s, _str, _arr) =>
         s.either([
-          s.elementWithSpecifics('span', {
+          s.elementWithExactMatch('span', {
             classes: [
               'hello'
             ]
           }),
-          s.elementWithSpecifics('div', {
+          s.elementWithExactMatch('div', {
             classes: [
               'fizzbuzz'
             ]
@@ -225,15 +225,15 @@ describe('browser.agar.ApproxStructureTest', () => {
 
     it('TINY-9102: ApproxStructure oneOrMore and zeroOrOne', () => {
       const struct2 = ApproxStructure.build((s, _str, _arr) =>
-        s.elementWithSpecifics('div', {
+        s.elementWithExactMatch('div', {
           children: [
-            s.oneOrMore(s.elementWithSpecifics('span', {
+            s.oneOrMore(s.elementWithExactMatch('span', {
               classes: [
                 'hello'
               ]
             })),
-            s.elementWithSpecifics('div', {}),
-            s.zeroOrOne(s.elementWithSpecifics('span', {
+            s.elementWithExactMatch('div', {}),
+            s.zeroOrOne(s.elementWithExactMatch('span', {
               classes: [
                 'bye'
               ]
@@ -255,14 +255,14 @@ describe('browser.agar.ApproxStructureTest', () => {
       ]);
 
       Assertions.assertStructure('Test', ApproxStructure.build((s, str, _arr) =>
-        s.elementWithSpecifics('div', {
+        s.elementWithExactMatch('div', {
           children: [
             s.text(str.is('hello world'), true)
           ]
         })), container);
 
       Assertions.assertStructure('Test', ApproxStructure.build((s, str, _arr) =>
-        s.elementWithSpecifics('div', {
+        s.elementWithExactMatch('div', {
           children: [
             s.text(str.is('hello'), false),
             s.text(str.is(' world'), true)
@@ -275,7 +275,7 @@ describe('browser.agar.ApproxStructureTest', () => {
         '</div>';
 
       checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithSpecifics('div', {
+        s.elementWithExactMatch('div', {
           attrs: {
             'selected': str.is('double'),
             'data-key': str.contains('test'),
@@ -296,7 +296,7 @@ describe('browser.agar.ApproxStructureTest', () => {
         '</div>';
 
       checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithSpecifics('div', {
+        s.elementWithExactMatch('div', {
           attrs: {
             'selected': str.is('double'),
             'data-key': str.contains('test')
@@ -315,7 +315,7 @@ describe('browser.agar.ApproxStructureTest', () => {
         '</div>';
 
       checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithSpecifics('div', {
+        s.elementWithExactMatch('div', {
           attrs: {
             'selected': str.is('double'),
             'data-key': str.contains('test')
@@ -337,7 +337,7 @@ describe('browser.agar.ApproxStructureTest', () => {
         '</div>';
 
       checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithSpecifics('div', {
+        s.elementWithExactMatch('div', {
           attrs: {
             'selected': str.is('double'),
             'data-key': str.contains('test'),
@@ -351,7 +351,7 @@ describe('browser.agar.ApproxStructureTest', () => {
             display: str.is('block')
           },
           children: [
-            s.elementWithSpecifics('div', {
+            s.elementWithExactMatch('div', {
               attrs: {
                 selected: str.is('true')
               },
@@ -367,7 +367,7 @@ describe('browser.agar.ApproxStructureTest', () => {
         '</div>';
 
       checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithSpecifics('div', {
+        s.elementWithExactMatch('div', {
           attrs: {
             'selected': str.is('double'),
             'data-key': str.contains('test')
@@ -379,7 +379,7 @@ describe('browser.agar.ApproxStructureTest', () => {
             display: str.is('block')
           },
           children: [
-            s.elementWithSpecifics('div', {
+            s.elementWithExactMatch('div', {
               attrs: {
                 selected: str.is('true')
               },
@@ -398,7 +398,7 @@ describe('browser.agar.ApproxStructureTest', () => {
         '</div>';
 
       checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithSpecifics('div', {
+        s.elementWithExactMatch('div', {
           attrs: {
             'selected': str.is('double'),
             'data-key': str.contains('test')
@@ -411,13 +411,160 @@ describe('browser.agar.ApproxStructureTest', () => {
             width: str.is('20px')
           },
           children: [
-            s.elementWithSpecifics('div', {
+            s.elementWithExactMatch('div', {
               attrs: {
                 selected: str.is('true')
               },
               styles: {
                 display: str.is('inline-block')
               }
+            })
+          ]
+        })), html);
+    });
+
+    it('TINY-9102: ApproxStructure throws error when there are fewer attributes', () => {
+      const html = '<div extra-attribute2="extra2" extra-attribute="extra" data-key="test-1" selected="double" class="test1 root" style="display: block;">' +
+        '</div>';
+
+      checkThrowError(ApproxStructure.build((s, str, _arr) =>
+        s.elementWithExactMatch('div', {
+          attrs: {
+            'selected': str.is('double'),
+            'data-key': str.contains('test'),
+            'extra-attribute': str.startsWith('ex'),
+          },
+          classes: [
+            'test1', 'root'
+          ],
+          styles: {
+            display: str.is('block')
+          },
+        })), html);
+    });
+
+    it('TINY-9102: ApproxStructure throws error when there are fewer classes', () => {
+      const html = '<div data-key="test-1" selected="double" class="extra-class test1 root" style="display: block;">' +
+        '</div>';
+
+      checkThrowError(ApproxStructure.build((s, str, _arr) =>
+        s.elementWithExactMatch('div', {
+          attrs: {
+            'selected': str.is('double'),
+            'data-key': str.contains('test')
+          },
+          classes: [
+            'test1'
+          ],
+          styles: {
+            display: str.is('block')
+          },
+        })), html);
+    });
+
+    it('TINY-9102: ApproxStructure throws error when there are fewer styles', () => {
+      const html = '<div data-key="test-1" selected="double" class="test1 root" style="display: block; width: 20px;">' +
+        '</div>';
+
+      checkThrowError(ApproxStructure.build((s, str, _arr) =>
+        s.elementWithExactMatch('div', {
+          attrs: {
+            'selected': str.is('double'),
+            'data-key': str.contains('test')
+          },
+          classes: [
+            'test1', 'root'
+          ],
+          styles: {
+            display: str.is('block'),
+          },
+        })), html);
+    });
+
+    it('TINY-9102: ApproxStructure throws error when there are fewer attributes (children)', () => {
+      const html = '<div extra-attribute2="extra2" extra-attribute="extra" data-key="test-1" selected="double" class="test1 root" style="display: block;">' +
+        '<div selected="true" attr="hello">' +
+        '</div>' +
+        '</div>';
+
+      checkThrowError(ApproxStructure.build((s, str, _arr) =>
+        s.elementWithExactMatch('div', {
+          attrs: {
+            'selected': str.is('double'),
+            'data-key': str.contains('test'),
+            'extra-attribute': str.startsWith('ex'),
+            'extra-attribute2': str.is('extra2'),
+          },
+          classes: [
+            'test1', 'root'
+          ],
+          styles: {
+            display: str.is('block')
+          },
+          children: [
+            s.elementWithExactMatch('div', {
+              attrs: {
+                selected: str.is('true')
+              },
+            })
+          ]
+        })), html);
+    });
+
+    it('TINY-9102: ApproxStructure throws error when there are fewer classes (children)', () => {
+      const html = '<div data-key="test-1" selected="double" class="extra-class test1 root" style="display: block;">' +
+        '<div selected="true" classes="hello there">' +
+        '</div>' +
+        '</div>';
+
+      checkThrowError(ApproxStructure.build((s, str, _arr) =>
+        s.elementWithExactMatch('div', {
+          attrs: {
+            'selected': str.is('double'),
+            'data-key': str.contains('test')
+          },
+          classes: [
+            'test1', 'root', 'extra-class'
+          ],
+          styles: {
+            display: str.is('block')
+          },
+          children: [
+            s.elementWithExactMatch('div', {
+              attrs: {
+                selected: str.is('true')
+              },
+              classes: []
+            })
+          ]
+        })), html);
+    });
+
+    it('TINY-9102: ApproxStructure throws error when there are fewer styles (children)', () => {
+      const html = '<div data-key="test-1" selected="double" class="test1 root" style="display: block; width: 20px;">' +
+        '<div selected="true" style="display: block">' +
+        '</div>' +
+        '</div>';
+
+      checkThrowError(ApproxStructure.build((s, str, _arr) =>
+        s.elementWithExactMatch('div', {
+          attrs: {
+            'selected': str.is('double'),
+            'data-key': str.contains('test')
+          },
+          classes: [
+            'test1', 'root'
+          ],
+          styles: {
+            display: str.is('block'),
+            width: str.is('20px')
+          },
+          children: [
+            s.elementWithExactMatch('div', {
+              attrs: {
+                selected: str.is('true')
+              },
+              styles: { }
             })
           ]
         })), html);

--- a/modules/agar/src/test/ts/browser/ApproxStructureTest.ts
+++ b/modules/agar/src/test/ts/browser/ApproxStructureTest.ts
@@ -1,4 +1,4 @@
-import { Assert, context, describe, it } from '@ephox/bedrock-client';
+import { Assert, describe, it } from '@ephox/bedrock-client';
 import { InsertAll, SugarElement } from '@ephox/sugar';
 
 import * as ApproxStructure from 'ephox/agar/api/ApproxStructure';
@@ -6,568 +6,612 @@ import * as Assertions from 'ephox/agar/api/Assertions';
 import { StructAssert } from 'ephox/agar/assertions/ApproxStructures';
 
 describe('browser.agar.ApproxStructureTest', () => {
-  context('Non specific ApproxStructure', () => {
-    const html = '<div data-key="test-1" selected="double" class="test1 root" style="display: block;">' +
-      '<div selected="true">' +
-      '<span data-ephox-id="blah" class="disabled">span</span>' +
-      '</div>' +
-      'words' +
-      '<span></span>' +
-      '</div>';
+  const html = '<div data-key="test-1" selected="double" class="test1 root" style="display: block;">' +
+    '<div selected="true">' +
+    '<span data-ephox-id="blah" class="disabled">span</span>' +
+    '</div>' +
+    'words' +
+    '<span></span>' +
+    '</div>';
 
-    const check = (expected: StructAssert, input: string) => {
-      const target = SugarElement.fromHtml(input);
-      Assertions.assertStructure('Test', expected, target);
-    };
+  const check = (expected: StructAssert, input: string) => {
+    const target = SugarElement.fromHtml(input);
+    Assertions.assertStructure('Test', expected, target);
+  };
 
-    it('TINY-9102: ApproxStructure build', () => {
-      check(ApproxStructure.build((s, str, arr) =>
-        s.element('div', {
-          attrs: {
-            'selected': str.is('double'),
-            'car': str.none('no car attribute'),
-            'data-key': str.contains('test')
-          },
-          classes: [
-            arr.has('test1'),
-            arr.not('dog'),
-            arr.hasPrefix('tes')
-          ],
-          styles: {
-            display: str.is('block')
-          },
-          children: [
-            s.element('div', {
-              attrs: {
-                selected: str.is('true')
-              },
-              children: [
-                s.element('span', {
-                  attrs: {
-                    'data-ephox-id': str.startsWith('bl')
-                  },
-                  classes: [
-                    arr.not('enabled'),
-                    arr.has('disabled')
-                  ],
-                  html: str.is('span')
-                })
-              ]
-            }),
-            s.text(
-              str.is('words')
-            ),
-            s.anything()
-          ]
-        })), html);
-    });
+  const checkThrowError = (expected: StructAssert, input: string) => {
+    const target = SugarElement.fromHtml(input);
+    Assert.throwsError('Test', () => Assertions.assertStructure('Test', expected, target));
+  };
 
-    it('TINY-9102: ApproxStructure fromHtml', () => {
-      check(ApproxStructure.fromHtml(html), html);
-    });
-
-    it('TINY-9102: ApproxStructure theRest', () => {
-      check(ApproxStructure.build((s, str, _arr) =>
-        s.element('div', {
-          children: [
-            s.element('div', {
-              attrs: {
-                selected: str.is('true')
-              }
-            }),
-            s.theRest()
-          ]
-        })), html);
-    });
-
-    it('TINY-9102: ApproxStructure either', () => {
-      const struct1 = ApproxStructure.build((s, str, arr) =>
-        s.either([
-          s.element('span', {
-            classes: [
-              arr.has('hello'),
-              arr.not('fizzbuzz')
+  it('TINY-9102: ApproxStructure build', () => {
+    check(ApproxStructure.build((s, str, arr) =>
+      s.element('div', {
+        attrs: {
+          'selected': str.is('double'),
+          'car': str.none('no car attribute'),
+          'data-key': str.contains('test')
+        },
+        classes: [
+          arr.has('test1'),
+          arr.not('dog'),
+          arr.hasPrefix('tes')
+        ],
+        styles: {
+          display: str.is('block')
+        },
+        children: [
+          s.element('div', {
+            attrs: {
+              selected: str.is('true')
+            },
+            children: [
+              s.element('span', {
+                attrs: {
+                  'data-ephox-id': str.startsWith('bl')
+                },
+                classes: [
+                  arr.not('enabled'),
+                  arr.has('disabled')
+                ],
+                html: str.is('span')
+              })
             ]
           }),
-          s.element('div', {
-            classes: [
-              arr.has('fizzbuzz'),
-              arr.not('hello')
-            ]
-          })
-        ]));
-
-      check(struct1, '<span class="hello"></span>');
-      check(struct1, '<div class="fizzbuzz"></span>');
-    });
-
-    it('TINY-9102: ApproxStructure oneOrMore and zeroOrOne', () => {
-      const struct2 = ApproxStructure.build((s, str, arr) =>
-        s.element('div', {
-          children: [
-            s.oneOrMore(s.element('span', {
-              classes: [
-                arr.has('hello')
-              ]
-            })),
-            s.element('div', {}),
-            s.zeroOrOne(s.element('span', {
-              classes: [
-                arr.has('bye')
-              ]
-            }))
-          ]
-        }));
-
-      check(struct2, '<div><span class="hello"></span><div></div></div>');
-      check(struct2, '<div><span class="hello"></span><div></div><span class="bye"></span></div>');
-      check(struct2, '<div><span class="hello"></span><span class="hello"></span><span class="hello"></span><span class="hello"></span><div></div><span class="bye"></span></div>');
-    });
-
-    it('TINY-9102: ApproxStructure text combineSiblings', () => {
-      const container = SugarElement.fromTag('div');
-      InsertAll.append(container, [
-        SugarElement.fromText('hello'),
-        SugarElement.fromText(' '),
-        SugarElement.fromText('world')
-      ]);
-
-      Assertions.assertStructure('Test', ApproxStructure.build((s, str, _arr) =>
-        s.element('div', {
-          children: [
-            s.text(str.is('hello world'), true)
-          ]
-        })), container);
-
-      Assertions.assertStructure('Test', ApproxStructure.build((s, str, _arr) =>
-        s.element('div', {
-          children: [
-            s.text(str.is('hello'), false),
-            s.text(str.is(' world'), true)
-          ]
-        })), container);
-    });
+          s.text(
+            str.is('words')
+          ),
+          s.anything()
+        ]
+      })), html);
   });
 
-  context('Specific ApproxStructure', () => {
-    const html = '<div data-key="test-1" selected="double" class="test1 root" style="display: block;">' +
-      '<div selected="true">' +
-      '<span data-ephox-id="blah" class="disabled">span</span>' +
-      '</div>' +
-      'words' +
-      '<span></span>' +
+  it('TINY-9102: ApproxStructure fromHtml', () => {
+    check(ApproxStructure.fromHtml(html), html);
+  });
+
+  it('TINY-9102: ApproxStructure theRest', () => {
+    check(ApproxStructure.build((s, str, _arr) =>
+      s.element('div', {
+        children: [
+          s.element('div', {
+            attrs: {
+              selected: str.is('true')
+            }
+          }),
+          s.theRest()
+        ]
+      })), html);
+  });
+
+  it('TINY-9102: ApproxStructure either', () => {
+    const struct1 = ApproxStructure.build((s, str, arr) =>
+      s.either([
+        s.element('span', {
+          classes: [
+            arr.has('hello'),
+            arr.not('fizzbuzz')
+          ]
+        }),
+        s.element('div', {
+          classes: [
+            arr.has('fizzbuzz'),
+            arr.not('hello')
+          ]
+        })
+      ]));
+
+    check(struct1, '<span class="hello"></span>');
+    check(struct1, '<div class="fizzbuzz"></span>');
+  });
+
+  it('TINY-9102: ApproxStructure oneOrMore and zeroOrOne', () => {
+    const struct2 = ApproxStructure.build((s, str, arr) =>
+      s.element('div', {
+        children: [
+          s.oneOrMore(s.element('span', {
+            classes: [
+              arr.has('hello')
+            ]
+          })),
+          s.element('div', {}),
+          s.zeroOrOne(s.element('span', {
+            classes: [
+              arr.has('bye')
+            ]
+          }))
+        ]
+      }));
+
+    check(struct2, '<div><span class="hello"></span><div></div></div>');
+    check(struct2, '<div><span class="hello"></span><div></div><span class="bye"></span></div>');
+    check(struct2, '<div><span class="hello"></span><span class="hello"></span><span class="hello"></span><span class="hello"></span><div></div><span class="bye"></span></div>');
+  });
+
+  it('TINY-9102: ApproxStructure text combineSiblings', () => {
+    const container = SugarElement.fromTag('div');
+    InsertAll.append(container, [
+      SugarElement.fromText('hello'),
+      SugarElement.fromText(' '),
+      SugarElement.fromText('world')
+    ]);
+
+    Assertions.assertStructure('Test', ApproxStructure.build((s, str, _arr) =>
+      s.element('div', {
+        children: [
+          s.text(str.is('hello world'), true)
+        ]
+      })), container);
+
+    Assertions.assertStructure('Test', ApproxStructure.build((s, str, _arr) =>
+      s.element('div', {
+        children: [
+          s.text(str.is('hello'), false),
+          s.text(str.is(' world'), true)
+        ]
+      })), container);
+  });
+
+  it('TINY-9102: ApproxStructure build mix and match', () => {
+    check(ApproxStructure.build((s, str, arr) =>
+      s.element('div', {
+        attrs: {
+          'selected': str.is('double'),
+          'data-key': str.contains('test')
+        },
+        exactClasses: [
+          'test1', 'root'
+        ],
+        exactStyles: {
+          display: str.is('block')
+        },
+        children: [
+          s.element('div', {
+            exactAttrs: {
+              selected: str.is('true')
+            },
+            children: [
+              s.element('span', {
+                attrs: {
+                  'data-ephox-id': str.startsWith('bl')
+                },
+                classes: [ arr.has('disabled') ],
+                html: str.is('span')
+              })
+            ]
+          }),
+          s.text(
+            str.is('words')
+          ),
+          s.anything()
+        ]
+      })), html);
+  });
+
+  it('TINY-9102: ApproxStructure throws error when there are extra attributes', () => {
+    const html = '<div extra-attribute2="extra2" extra-attribute="extra" data-key="test-1" selected="double" class="test1 root" style="display: block;">' +
       '</div>';
 
-    const check = (expected: StructAssert, input: string) => {
-      const target = SugarElement.fromHtml(input);
-      Assertions.assertStructure('Test', expected, target);
-    };
+    checkThrowError(ApproxStructure.build((s, str, arr) =>
+      s.element('div', {
+        exactAttrs: {
+          'selected': str.is('double'),
+          'data-key': str.contains('test'),
+          'extra-attribute': str.startsWith('ex'),
+          'non-existent-attribute': str.is('non'),
+        },
+        classes: [
+          arr.has('test1'),
+          arr.has('root')
+        ],
+        styles: {
+          display: str.is('block')
+        },
+      })), html);
+  });
 
-    const checkThrowError = (expected: StructAssert, input: string) => {
-      const target = SugarElement.fromHtml(input);
-      Assert.throwsError('Test', () => Assertions.assertStructure('Test', expected, target));
-    };
+  it('TINY-9102: ApproxStructure throws error when there are extra classes', () => {
+    const html = '<div data-key="test-1" selected="double" class="extra-class test1 root" style="display: block;">' +
+      '</div>';
 
-    it('TINY-9102: ApproxStructure build', () => {
-      check(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithExactMatch('div', {
-          attrs: {
-            'selected': str.is('double'),
-            'data-key': str.contains('test')
-          },
-          classes: [
-            'test1', 'root'
-          ],
-          styles: {
-            display: str.is('block')
-          },
-          children: [
-            s.elementWithExactMatch('div', {
-              attrs: {
-                selected: str.is('true')
-              },
-              children: [
-                s.elementWithExactMatch('span', {
-                  attrs: {
-                    'data-ephox-id': str.startsWith('bl')
-                  },
-                  classes: [ 'disabled' ],
-                  html: str.is('span')
-                })
-              ]
-            }),
-            s.text(
-              str.is('words')
-            ),
-            s.anything()
-          ]
-        })), html);
-    });
+    checkThrowError(ApproxStructure.build((s, str, _arr) =>
+      s.element('div', {
+        attrs: {
+          'selected': str.is('double'),
+          'data-key': str.contains('test')
+        },
+        exactClasses: [
+          'test1', 'root', 'non-existent-class'
+        ],
+        styles: {
+          display: str.is('block')
+        },
+      })), html);
+  });
 
-    it('TINY-9102: ApproxStructure either', () => {
-      const struct1 = ApproxStructure.build((s, _str, _arr) =>
-        s.either([
-          s.elementWithExactMatch('span', {
-            classes: [
+  it('TINY-9102: ApproxStructure throws error when there are extra styles', () => {
+    const html = '<div data-key="test-1" selected="double" class="test1 root" style="display: block; width: 20px;">' +
+      '</div>';
+
+    checkThrowError(ApproxStructure.build((s, str, arr) =>
+      s.element('div', {
+        attrs: {
+          'selected': str.is('double'),
+          'data-key': str.contains('test')
+        },
+        classes: [
+          arr.has('test1'),
+          arr.has('root')
+        ],
+        exactStyles: {
+          display: str.is('block'),
+          height: str.is('20px')
+        },
+      })), html);
+  });
+
+  it('TINY-9102: ApproxStructure throws error when there are fewer attributes', () => {
+    const html = '<div extra-attribute2="extra2" extra-attribute="extra" data-key="test-1" selected="double" class="test1 root" style="display: block;">' +
+      '</div>';
+
+    checkThrowError(ApproxStructure.build((s, str, arr) =>
+      s.element('div', {
+        exactAttrs: {
+          'selected': str.is('double'),
+          'data-key': str.contains('test'),
+          'extra-attribute': str.startsWith('ex'),
+        },
+        classes: [
+          arr.has('test1'),
+          arr.has('root')
+        ],
+        styles: {
+          display: str.is('block')
+        },
+      })), html);
+  });
+
+  it('TINY-9102: ApproxStructure throws error when there are fewer classes', () => {
+    const html = '<div data-key="test-1" selected="double" class="extra-class test1 root" style="display: block;">' +
+      '</div>';
+
+    checkThrowError(ApproxStructure.build((s, str, _arr) =>
+      s.element('div', {
+        attrs: {
+          'selected': str.is('double'),
+          'data-key': str.contains('test')
+        },
+        exactClasses: [
+          'test1'
+        ],
+        styles: {
+          display: str.is('block')
+        },
+      })), html);
+  });
+
+  it('TINY-9102: ApproxStructure throws error when there are fewer styles', () => {
+    const html = '<div data-key="test-1" selected="double" class="test1 root" style="display: block; width: 20px;">' +
+      '</div>';
+
+    checkThrowError(ApproxStructure.build((s, str, arr) =>
+      s.element('div', {
+        attrs: {
+          'selected': str.is('double'),
+          'data-key': str.contains('test')
+        },
+        classes: [
+          arr.has('test1'),
+          arr.has('root')
+        ],
+        exactStyles: {
+          display: str.is('block'),
+        },
+      })), html);
+  });
+
+  it('TINY-9102: ApproxStructure throws error when there are extra attributes (children)', () => {
+    const html = '<div extra-attribute2="extra2" extra-attribute="extra" data-key="test-1" selected="double" class="test1 root" style="display: block;">' +
+      '<div selected="true" attr="hello">' +
+      '</div>' +
+      '</div>';
+
+    checkThrowError(ApproxStructure.build((s, str, arr) =>
+      s.element('div', {
+        attrs: {
+          'selected': str.is('double'),
+          'data-key': str.contains('test'),
+          'extra-attribute': str.startsWith('ex'),
+          'extra-attribute2': str.is('extra2'),
+        },
+        classes: [
+          arr.has('test1'),
+          arr.has('root')
+        ],
+        styles: {
+          display: str.is('block')
+        },
+        children: [
+          s.element('div', {
+            exactAttrs: {
+              'selected': str.is('true'),
+              'attr': str.is('hello'),
+              'extra-attribute': str.is('extra')
+            },
+          })
+        ]
+      })), html);
+  });
+
+  it('TINY-9102: ApproxStructure throws error when there are extra classes (children)', () => {
+    const html = '<div data-key="test-1" selected="double" class="extra-class test1 root" style="display: block;">' +
+      '<div selected="true" classes="hello there">' +
+      '</div>' +
+      '</div>';
+
+    checkThrowError(ApproxStructure.build((s, str, arr) =>
+      s.element('div', {
+        attrs: {
+          'selected': str.is('double'),
+          'data-key': str.contains('test')
+        },
+        classes: [
+          arr.has('test1'),
+          arr.has('root'),
+          arr.has('extra-class')
+        ],
+        styles: {
+          display: str.is('block')
+        },
+        children: [
+          s.element('div', {
+            attrs: {
+              selected: str.is('true')
+            },
+            exactClasses: [
+              'hello', 'there', '1'
+            ]
+          })
+        ]
+      })), html);
+  });
+
+  it('TINY-9102: ApproxStructure throws error when there are extra styles (children)', () => {
+    const html = '<div data-key="test-1" selected="double" class="test1 root" style="display: block; width: 20px;">' +
+      '<div selected="true" style="display: block">' +
+      '</div>' +
+      '</div>';
+
+    checkThrowError(ApproxStructure.build((s, str, arr) =>
+      s.element('div', {
+        attrs: {
+          'selected': str.is('double'),
+          'data-key': str.contains('test')
+        },
+        classes: [
+          arr.has('test1'),
+          arr.has('root')
+        ],
+        styles: {
+          display: str.is('block'),
+          width: str.is('20px')
+        },
+        children: [
+          s.element('div', {
+            attrs: {
+              selected: str.is('true')
+            },
+            exactStyles: {
+              display: str.is('block'),
+              width: str.is('20px')
+            }
+          })
+        ]
+      })), html);
+  });
+
+  it('TINY-9102: ApproxStructure throws error when there are fewer attributes (children)', () => {
+    const html = '<div extra-attribute2="extra2" extra-attribute="extra" data-key="test-1" selected="double" class="test1 root" style="display: block;">' +
+      '<div selected="true" attr="hello">' +
+      '</div>' +
+      '</div>';
+
+    checkThrowError(ApproxStructure.build((s, str, arr) =>
+      s.element('div', {
+        attrs: {
+          'selected': str.is('double'),
+          'data-key': str.contains('test'),
+          'extra-attribute': str.startsWith('ex'),
+          'extra-attribute2': str.is('extra2'),
+        },
+        classes: [
+          arr.has('test1'),
+          arr.has('root')
+        ],
+        styles: {
+          display: str.is('block')
+        },
+        children: [
+          s.element('div', {
+            exactAttrs: {
+              selected: str.is('true')
+            },
+          })
+        ]
+      })), html);
+  });
+
+  it('TINY-9102: ApproxStructure throws error when there are fewer classes (children)', () => {
+    const html = '<div data-key="test-1" selected="double" class="extra-class test1 root" style="display: block;">' +
+      '<div selected="true" classes="hello there">' +
+      '</div>' +
+      '</div>';
+
+    checkThrowError(ApproxStructure.build((s, str, arr) =>
+      s.element('div', {
+        attrs: {
+          'selected': str.is('double'),
+          'data-key': str.contains('test')
+        },
+        classes: [
+          arr.has('test1'),
+          arr.has('root'),
+          arr.has('extra-class')
+        ],
+        styles: {
+          display: str.is('block')
+        },
+        children: [
+          s.element('div', {
+            exactAttrs: {
+              selected: str.is('true')
+            },
+            exactClasses: [
               'hello'
             ]
-          }),
-          s.elementWithExactMatch('div', {
-            classes: [
-              'fizzbuzz'
-            ]
-          }),
-        ]));
+          })
+        ]
+      })), html);
+  });
 
-      check(struct1, '<span class="hello"></span>');
-      check(struct1, '<div class="fizzbuzz"></span>');
-    });
+  it('TINY-9102: ApproxStructure throws error when there are fewer styles (children)', () => {
+    const html = '<div data-key="test-1" selected="double" class="test1 root" style="display: block; width: 20px;">' +
+      '<div selected="true" style="display: block; width: 20px;">' +
+      '</div>' +
+      '</div>';
 
-    it('TINY-9102: ApproxStructure oneOrMore and zeroOrOne', () => {
-      const struct2 = ApproxStructure.build((s, _str, _arr) =>
-        s.elementWithExactMatch('div', {
-          children: [
-            s.oneOrMore(s.elementWithExactMatch('span', {
-              classes: [
-                'hello'
-              ]
-            })),
-            s.elementWithExactMatch('div', {}),
-            s.zeroOrOne(s.elementWithExactMatch('span', {
-              classes: [
-                'bye'
-              ]
-            }))
-          ]
-        }));
+    checkThrowError(ApproxStructure.build((s, str, arr) =>
+      s.element('div', {
+        attrs: {
+          'selected': str.is('double'),
+          'data-key': str.contains('test')
+        },
+        classes: [
+          arr.has('test1'),
+          arr.has('root')
+        ],
+        styles: {
+          display: str.is('block'),
+          width: str.is('20px')
+        },
+        children: [
+          s.element('div', {
+            exactAttrs: {
+              selected: str.is('true')
+            },
+            exactStyles: {
+              display: str.is('block'),
+            }
+          })
+        ]
+      })), html);
+  });
 
-      check(struct2, '<div><span class="hello"></span><div></div></div>');
-      check(struct2, '<div><span class="hello"></span><div></div><span class="bye"></span></div>');
-      check(struct2, '<div><span class="hello"></span><span class="hello"></span><span class="hello"></span><span class="hello"></span><div></div><span class="bye"></span></div>');
-    });
+  it('TINY-9102: ApproxStructure should use exact attrs when the exact and non exact attrs are specified', () => {
+    const html = '<div data-key="test-1" selected="double" class="test1 root" style="display: block; width: 20px;">' +
+      '<div selected="true" style="display: block; width: 20px;">' +
+      '</div>' +
+      '</div>';
 
-    it('TINY-9102: ApproxStructure text combineSiblings', () => {
-      const container = SugarElement.fromTag('div');
-      InsertAll.append(container, [
-        SugarElement.fromText('hello'),
-        SugarElement.fromText(' '),
-        SugarElement.fromText('world')
-      ]);
+    checkThrowError(ApproxStructure.build((s, str, arr) =>
+      s.element('div', {
+        exactAttrs: {
+          selected: str.is('double')
+        },
+        attrs: {
+          'selected': str.is('double'),
+          'data-key': str.contains('test')
+        },
+        classes: [
+          arr.has('test1'),
+          arr.has('root')
+        ],
+        styles: {
+          display: str.is('block'),
+          width: str.is('20px')
+        },
+        children: [
+          s.element('div', {
+            attrs: {
+              selected: str.is('true')
+            },
+            styles: {
+              display: str.is('block'),
+            }
+          })
+        ]
+      })), html);
+  });
 
-      Assertions.assertStructure('Test', ApproxStructure.build((s, str, _arr) =>
-        s.elementWithExactMatch('div', {
-          children: [
-            s.text(str.is('hello world'), true)
-          ]
-        })), container);
+  it('TINY-9102: ApproxStructure should use exact classes when the exact and non exact classes are specified', () => {
+    const html = '<div data-key="test-1" selected="double" class="test1 root" style="display: block; width: 20px;">' +
+      '<div selected="true" style="display: block; width: 20px;">' +
+      '</div>' +
+      '</div>';
 
-      Assertions.assertStructure('Test', ApproxStructure.build((s, str, _arr) =>
-        s.elementWithExactMatch('div', {
-          children: [
-            s.text(str.is('hello'), false),
-            s.text(str.is(' world'), true)
-          ]
-        })), container);
-    });
+    checkThrowError(ApproxStructure.build((s, str, arr) =>
+      s.element('div', {
+        attrs: {
+          'selected': str.is('double'),
+          'data-key': str.contains('test')
+        },
+        exactClasses: [
+          'test1'
+        ],
+        classes: [
+          arr.has('test1'),
+          arr.has('root')
+        ],
+        styles: {
+          display: str.is('block'),
+          width: str.is('20px')
+        },
+        children: [
+          s.element('div', {
+            attrs: {
+              selected: str.is('true')
+            },
+            styles: {
+              display: str.is('block'),
+            }
+          })
+        ]
+      })), html);
+  });
 
-    it('TINY-9102: ApproxStructure throws error when there are extra attributes', () => {
-      const html = '<div extra-attribute2="extra2" extra-attribute="extra" data-key="test-1" selected="double" class="test1 root" style="display: block;">' +
-        '</div>';
+  it('TINY-9102: ApproxStructure should use exact styles when the exact and non exact styles are specified', () => {
+    const html = '<div data-key="test-1" selected="double" class="test1 root" style="display: block; width: 20px;">' +
+      '<div selected="true" style="display: block; width: 20px;">' +
+      '</div>' +
+      '</div>';
 
-      checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithExactMatch('div', {
-          attrs: {
-            'selected': str.is('double'),
-            'data-key': str.contains('test'),
-            'extra-attribute': str.startsWith('ex'),
-            'non-existent-attribute': str.is('non'),
-          },
-          classes: [
-            'test1', 'root'
-          ],
-          styles: {
-            display: str.is('block')
-          },
-        })), html);
-    });
-
-    it('TINY-9102: ApproxStructure throws error when there are extra classes', () => {
-      const html = '<div data-key="test-1" selected="double" class="extra-class test1 root" style="display: block;">' +
-        '</div>';
-
-      checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithExactMatch('div', {
-          attrs: {
-            'selected': str.is('double'),
-            'data-key': str.contains('test')
-          },
-          classes: [
-            'test1', 'root', 'non-existent-class'
-          ],
-          styles: {
-            display: str.is('block')
-          },
-        })), html);
-    });
-
-    it('TINY-9102: ApproxStructure throws error when there are extra styles', () => {
-      const html = '<div data-key="test-1" selected="double" class="test1 root" style="display: block; width: 20px;">' +
-        '</div>';
-
-      checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithExactMatch('div', {
-          attrs: {
-            'selected': str.is('double'),
-            'data-key': str.contains('test')
-          },
-          classes: [
-            'test1', 'root'
-          ],
-          styles: {
-            display: str.is('block'),
-            height: str.is('20px')
-          },
-        })), html);
-    });
-
-    it('TINY-9102: ApproxStructure throws error when there are extra attributes (children)', () => {
-      const html = '<div extra-attribute2="extra2" extra-attribute="extra" data-key="test-1" selected="double" class="test1 root" style="display: block;">' +
-        '<div selected="true" attr="hello">' +
-        '</div>' +
-        '</div>';
-
-      checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithExactMatch('div', {
-          attrs: {
-            'selected': str.is('double'),
-            'data-key': str.contains('test'),
-            'extra-attribute': str.startsWith('ex'),
-            'extra-attribute2': str.is('extra2'),
-          },
-          classes: [
-            'test1', 'root'
-          ],
-          styles: {
-            display: str.is('block')
-          },
-          children: [
-            s.elementWithExactMatch('div', {
-              attrs: {
-                selected: str.is('true')
-              },
-            })
-          ]
-        })), html);
-    });
-
-    it('TINY-9102: ApproxStructure throws error when there are extra classes (children)', () => {
-      const html = '<div data-key="test-1" selected="double" class="extra-class test1 root" style="display: block;">' +
-        '<div selected="true" classes="hello there">' +
-        '</div>' +
-        '</div>';
-
-      checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithExactMatch('div', {
-          attrs: {
-            'selected': str.is('double'),
-            'data-key': str.contains('test')
-          },
-          classes: [
-            'test1', 'root', 'extra-class'
-          ],
-          styles: {
-            display: str.is('block')
-          },
-          children: [
-            s.elementWithExactMatch('div', {
-              attrs: {
-                selected: str.is('true')
-              },
-              classes: [
-                'hello'
-              ]
-            })
-          ]
-        })), html);
-    });
-
-    it('TINY-9102: ApproxStructure throws error when there are extra styles (children)', () => {
-      const html = '<div data-key="test-1" selected="double" class="test1 root" style="display: block; width: 20px;">' +
-        '<div selected="true" style="display: block">' +
-        '</div>' +
-        '</div>';
-
-      checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithExactMatch('div', {
-          attrs: {
-            'selected': str.is('double'),
-            'data-key': str.contains('test')
-          },
-          classes: [
-            'test1', 'root'
-          ],
-          styles: {
-            display: str.is('block'),
-            width: str.is('20px')
-          },
-          children: [
-            s.elementWithExactMatch('div', {
-              attrs: {
-                selected: str.is('true')
-              },
-              styles: {
-                display: str.is('inline-block')
-              }
-            })
-          ]
-        })), html);
-    });
-
-    it('TINY-9102: ApproxStructure throws error when there are fewer attributes', () => {
-      const html = '<div extra-attribute2="extra2" extra-attribute="extra" data-key="test-1" selected="double" class="test1 root" style="display: block;">' +
-        '</div>';
-
-      checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithExactMatch('div', {
-          attrs: {
-            'selected': str.is('double'),
-            'data-key': str.contains('test'),
-            'extra-attribute': str.startsWith('ex'),
-          },
-          classes: [
-            'test1', 'root'
-          ],
-          styles: {
-            display: str.is('block')
-          },
-        })), html);
-    });
-
-    it('TINY-9102: ApproxStructure throws error when there are fewer classes', () => {
-      const html = '<div data-key="test-1" selected="double" class="extra-class test1 root" style="display: block;">' +
-        '</div>';
-
-      checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithExactMatch('div', {
-          attrs: {
-            'selected': str.is('double'),
-            'data-key': str.contains('test')
-          },
-          classes: [
-            'test1'
-          ],
-          styles: {
-            display: str.is('block')
-          },
-        })), html);
-    });
-
-    it('TINY-9102: ApproxStructure throws error when there are fewer styles', () => {
-      const html = '<div data-key="test-1" selected="double" class="test1 root" style="display: block; width: 20px;">' +
-        '</div>';
-
-      checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithExactMatch('div', {
-          attrs: {
-            'selected': str.is('double'),
-            'data-key': str.contains('test')
-          },
-          classes: [
-            'test1', 'root'
-          ],
-          styles: {
-            display: str.is('block'),
-          },
-        })), html);
-    });
-
-    it('TINY-9102: ApproxStructure throws error when there are fewer attributes (children)', () => {
-      const html = '<div extra-attribute2="extra2" extra-attribute="extra" data-key="test-1" selected="double" class="test1 root" style="display: block;">' +
-        '<div selected="true" attr="hello">' +
-        '</div>' +
-        '</div>';
-
-      checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithExactMatch('div', {
-          attrs: {
-            'selected': str.is('double'),
-            'data-key': str.contains('test'),
-            'extra-attribute': str.startsWith('ex'),
-            'extra-attribute2': str.is('extra2'),
-          },
-          classes: [
-            'test1', 'root'
-          ],
-          styles: {
-            display: str.is('block')
-          },
-          children: [
-            s.elementWithExactMatch('div', {
-              attrs: {
-                selected: str.is('true')
-              },
-            })
-          ]
-        })), html);
-    });
-
-    it('TINY-9102: ApproxStructure throws error when there are fewer classes (children)', () => {
-      const html = '<div data-key="test-1" selected="double" class="extra-class test1 root" style="display: block;">' +
-        '<div selected="true" classes="hello there">' +
-        '</div>' +
-        '</div>';
-
-      checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithExactMatch('div', {
-          attrs: {
-            'selected': str.is('double'),
-            'data-key': str.contains('test')
-          },
-          classes: [
-            'test1', 'root', 'extra-class'
-          ],
-          styles: {
-            display: str.is('block')
-          },
-          children: [
-            s.elementWithExactMatch('div', {
-              attrs: {
-                selected: str.is('true')
-              },
-              classes: []
-            })
-          ]
-        })), html);
-    });
-
-    it('TINY-9102: ApproxStructure throws error when there are fewer styles (children)', () => {
-      const html = '<div data-key="test-1" selected="double" class="test1 root" style="display: block; width: 20px;">' +
-        '<div selected="true" style="display: block">' +
-        '</div>' +
-        '</div>';
-
-      checkThrowError(ApproxStructure.build((s, str, _arr) =>
-        s.elementWithExactMatch('div', {
-          attrs: {
-            'selected': str.is('double'),
-            'data-key': str.contains('test')
-          },
-          classes: [
-            'test1', 'root'
-          ],
-          styles: {
-            display: str.is('block'),
-            width: str.is('20px')
-          },
-          children: [
-            s.elementWithExactMatch('div', {
-              attrs: {
-                selected: str.is('true')
-              },
-              styles: { }
-            })
-          ]
-        })), html);
-    });
+    checkThrowError(ApproxStructure.build((s, str, arr) =>
+      s.element('div', {
+        attrs: {
+          'selected': str.is('double'),
+          'data-key': str.contains('test')
+        },
+        classes: [
+          arr.has('test1'),
+          arr.has('root')
+        ],
+        exactStyles: {
+          display: str.is('block'),
+        },
+        styles: {
+          display: str.is('block'),
+          width: str.is('20px')
+        },
+        children: [
+          s.element('div', {
+            attrs: {
+              selected: str.is('true')
+            },
+            styles: {
+              display: str.is('block'),
+            }
+          })
+        ]
+      })), html);
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9102

Description of Changes:
* Added `elementWithSpecifics` to `structApi` (`ApproxStructure`) for strict comparison of styles, attributes and classes

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
