### PR TITLE
TINY-8886: Update prismjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ephox/oxide-icons-tools": "^2.2.2",
     "@ephox/swag": "^4.4.0",
     "@ephox/wrap-jsverify": "^2.0.1",
-    "@ephox/wrap-prismjs": "^1.25.0",
+    "@ephox/wrap-prismjs": "^1.29.1-patchfix.3558",
     "@ephox/wrap-promise-polyfill": "^2.2.1",
     "@tinymce/eslint-plugin": "^1.9.1",
     "@tinymce/moxiedoc": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -305,10 +305,10 @@
   resolved "https://registry.yarnpkg.com/@ephox/wrap-jsverify/-/wrap-jsverify-2.0.1.tgz#8984b292eeab3bd570eab773541650d257793d4d"
   integrity sha512-RSSsUFBV9uVUPzmCRvYXZBEZhVahYXs/j0JVgCy0CrbS98nV60BeYd97QB37sr05Lv7haLWzKf9XAcVAO7M8Ng==
 
-"@ephox/wrap-prismjs@^1.25.0":
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/@ephox/wrap-prismjs/-/wrap-prismjs-1.29.0.tgz#a4b3cd0b54ea5358a59d0c93b84168d9cf961007"
-  integrity sha512-kx85Fi93aj7FH8SFr3H2Fy3BgVG63AuTCggM8iUzbuNlJSQqhn1jvA52xo4ACAraZMvXHN9GZhjblTksN/lS4A==
+"@ephox/wrap-prismjs@^1.29.1-patchfix.3558":
+  version "1.29.1-patchfix.3558"
+  resolved "https://registry.yarnpkg.com/@ephox/wrap-prismjs/-/wrap-prismjs-1.29.1-patchfix.3558.tgz#1268bda3eeb792b774b93fc421666f518810e308"
+  integrity sha512-zXIdFxvTOdiwfzz6VUEP57UgxigXZyTxlpEoWQN0Jhr/Kudq3JMJW288kzhcwhxitRI5DM6A8TpkXxYuqoJYpA==
 
 "@ephox/wrap-promise-polyfill@^2.2.0", "@ephox/wrap-promise-polyfill@^2.2.1":
   version "2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,9 +306,9 @@
   integrity sha512-RSSsUFBV9uVUPzmCRvYXZBEZhVahYXs/j0JVgCy0CrbS98nV60BeYd97QB37sr05Lv7haLWzKf9XAcVAO7M8Ng==
 
 "@ephox/wrap-prismjs@^1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@ephox/wrap-prismjs/-/wrap-prismjs-1.25.0.tgz#a77f94d6a04346e42c1bd318622ae06fd84528b6"
-  integrity sha512-o0c0kPF0iejJbVFgmHp4U3sCpmRmFEhHvuEpf57eFscuhtKaOEHpaAyBVcwPbnPKeGEJ6dH1q/kMVLhQANh06A==
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/@ephox/wrap-prismjs/-/wrap-prismjs-1.29.0.tgz#a4b3cd0b54ea5358a59d0c93b84168d9cf961007"
+  integrity sha512-kx85Fi93aj7FH8SFr3H2Fy3BgVG63AuTCggM8iUzbuNlJSQqhn1jvA52xo4ACAraZMvXHN9GZhjblTksN/lS4A==
 
 "@ephox/wrap-promise-polyfill@^2.2.0", "@ephox/wrap-promise-polyfill@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
Related Ticket: TINY-8886

Description of Changes:
* Small version bump to include security patches
* We don't actually use the vulnerable code, but there's no harm in upgrading (primjs is [in maintenance mode](https://github.com/PrismJS/prism/blob/59e5a3471377057de1f401ba38337aca27b80e03/README.md?plain=1#L18-L20) until v2 is released)

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
