### PR TITLE
TINY-9183: Add new options to set default fore/background color button value

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -69,6 +69,8 @@ interface BaseEditorOptions {
   cache_suffix?: string;
   color_cols?: number;
   color_map?: string[];
+  color_foreground_default?: string;
+  color_background_default?: string;
   content_css?: boolean | string | string[];
   content_css_cors?: boolean;
   content_security_policy?: string;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -16,8 +16,6 @@ export interface ColorSwatchDialogData {
 
 type ColorFormat = 'forecolor' | 'hilitecolor';
 
-const fallbackColor = '#000000';
-
 const hasStyleApi = (node: Node): node is (Node & ElementCSSInlineStyle) =>
   Type.isNonNullable((node as HTMLElement).style);
 
@@ -90,7 +88,7 @@ const applyColor = (editor: Editor, format: ColorFormat, value: string, onChoice
         editor.execCommand('mceApplyTextcolor', format as any, color);
         onChoice(color);
       });
-    }, fallbackColor);
+    }, format === 'forecolor' ? 'black' : 'white');
   } else if (value === 'remove') {
     onChoice('');
     editor.execCommand('mceRemoveTextcolor', format as any);
@@ -236,8 +234,10 @@ const colorPickerDialog = (editor: Editor) => (callback: ColorInputCallback, val
 
 const register = (editor: Editor): void => {
   registerCommands(editor);
-  const lastForeColor = Cell(fallbackColor);
-  const lastBackColor = Cell(fallbackColor);
+  const fallbackColorForeground = Options.getDefaultForegroundColor(editor);
+  const fallbackColorBackground = Options.getDefaultBackgroundColor(editor);
+  const lastForeColor = Cell( fallbackColorForeground || 'black');
+  const lastBackColor = Cell( fallbackColorBackground || 'white');
   registerTextColorButton(editor, 'forecolor', 'forecolor', 'Text color', lastForeColor);
   registerTextColorButton(editor, 'backcolor', 'hilitecolor', 'Background color', lastBackColor);
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
@@ -82,11 +82,21 @@ const register = (editor: Editor): void => {
     processor: 'boolean',
     default: true
   });
+
+  registerOption('color_foreground_default', {
+    processor: 'string',
+  });
+
+  registerOption('color_background_default', {
+    processor: 'string',
+  });
 };
 
 const getColorCols = option('color_cols');
 const hasCustomColors = option('custom_colors');
 const getColors = option<Menu.ChoiceMenuItemSpec[]>('color_map');
+const getDefaultForegroundColor = option('color_foreground_default');
+const getDefaultBackgroundColor = option('color_background_default');
 
 const getCurrentColors = (): Menu.ChoiceMenuItemSpec[] => Arr.map(colorCache.state(), (color) => ({
   type: 'choiceitem',
@@ -106,5 +116,7 @@ export {
   hasCustomColors,
   getColors,
   getCurrentColors,
+  getDefaultBackgroundColor,
+  getDefaultForegroundColor,
   addColor
 };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
@@ -1,14 +1,10 @@
 import { ApproxStructure } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () => {
-  const hook = TinyHooks.bddSetupLight<Editor>({
-    toolbar: 'forecolor backcolor fontsize',
-    base_url: '/project/tinymce/js/tinymce'
-  }, [], true);
 
   const forecolorStruct = (color: string) => ApproxStructure.build((s, str) => {
     return s.element('body', {
@@ -55,37 +51,65 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 5);
   };
 
-  it('TINY-7836: Initial color is set to black for both buttons', () => {
-    const editor = hook.editor();
-    setupContent(editor);
-    TinyUiActions.clickOnUi(editor, 'div[title="Text color"] .tox-tbtn');
-    TinyAssertions.assertContentStructure(editor, forecolorStruct('rgb(0, 0, 0)'));
-    setupContent(editor);
-    TinyUiActions.clickOnUi(editor, 'div[title="Background color"] .tox-tbtn');
-    TinyAssertions.assertContentStructure(editor, backcolorStruct('rgb(0, 0, 0)'));
+  context('No default background or foreground set', () => {
+
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      toolbar: 'forecolor backcolor fontsize',
+      base_url: '/project/tinymce/js/tinymce'
+    }, [], true);
+
+    it('TINY-7836: Initial color is set to black for text color and to white for background color', () => {
+      const editor = hook.editor();
+      setupContent(editor);
+      TinyUiActions.clickOnUi(editor, 'div[title="Text color"] .tox-tbtn');
+      TinyAssertions.assertContentStructure(editor, forecolorStruct('black'));
+      setupContent(editor);
+      TinyUiActions.clickOnUi(editor, 'div[title="Background color"] .tox-tbtn');
+      TinyAssertions.assertContentStructure(editor, backcolorStruct('white'));
+    });
+
+    it('TBA: forecolor', async () => {
+      const editor = hook.editor();
+      setupContent(editor);
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      TinyUiActions.clickOnUi(editor, 'div[data-mce-color="#2DC26B"]');
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      TinyUiActions.clickOnUi(editor, 'div[data-mce-color="#236FA1"]');
+      TinyAssertions.assertContentStructure(editor, forecolorStruct('rgb(35, 111, 161)'));
+    });
+
+    it('TBA: backcolor', async () => {
+      const editor = hook.editor();
+      setupContent(editor);
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Background color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      TinyUiActions.clickOnUi(editor, 'div[data-mce-color="#2DC26B"]');
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Background color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      TinyUiActions.clickOnUi(editor, 'div[data-mce-color="#236FA1"]');
+      TinyAssertions.assertContentStructure(editor, backcolorStruct('rgb(35, 111, 161)'));
+    });
   });
 
-  it('TBA: forecolor', async () => {
-    const editor = hook.editor();
-    setupContent(editor);
-    TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
-    await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-    TinyUiActions.clickOnUi(editor, 'div[data-mce-color="#2DC26B"]');
-    TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
-    await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-    TinyUiActions.clickOnUi(editor, 'div[data-mce-color="#236FA1"]');
-    TinyAssertions.assertContentStructure(editor, forecolorStruct('rgb(35, 111, 161)'));
+  context('Custom default background and foreground set', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      toolbar: 'forecolor backcolor fontsize',
+      base_url: '/project/tinymce/js/tinymce',
+      color_foreground_default: 'yellow',
+      color_background_default: 'cyan'
+    }, [], true);
+
+    it('TINY-9183: Initial color is set to yellow for text color and to cyan for background color', () => {
+      const editor = hook.editor();
+      setupContent(editor);
+      TinyUiActions.clickOnUi(editor, 'div[title="Text color"] .tox-tbtn');
+      TinyAssertions.assertContentStructure(editor, forecolorStruct('yellow'));
+      setupContent(editor);
+      TinyUiActions.clickOnUi(editor, 'div[title="Background color"] .tox-tbtn');
+      TinyAssertions.assertContentStructure(editor, backcolorStruct('cyan'));
+    });
   });
 
-  it('TBA: backcolor', async () => {
-    const editor = hook.editor();
-    setupContent(editor);
-    TinyUiActions.clickOnToolbar(editor, '[aria-label="Background color"] > .tox-tbtn + .tox-split-button__chevron');
-    await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-    TinyUiActions.clickOnUi(editor, 'div[data-mce-color="#2DC26B"]');
-    TinyUiActions.clickOnToolbar(editor, '[aria-label="Background color"] > .tox-tbtn + .tox-split-button__chevron');
-    await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-    TinyUiActions.clickOnUi(editor, 'div[data-mce-color="#236FA1"]');
-    TinyAssertions.assertContentStructure(editor, backcolorStruct('rgb(35, 111, 161)'));
-  });
 });


### PR DESCRIPTION
Related Ticket: TINY-9183

Description of Changes:
*  Add new options to set default fore/background color button value


Pre-checks:
* [ ] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
