### PR TITLE
TINY-9172: Implement block level links

### DIFF
--- a/modules/oxide/src/less/theme/content-ui.less
+++ b/modules/oxide/src/less/theme/content-ui.less
@@ -21,6 +21,7 @@
 @import 'content/selection/selection';
 @import 'content/spellchecker/spellchecker';
 @import 'content/table-of-contents/table-of-contents';
+@import 'content/transparent/transparent';
 @import 'content/table/table';
 @import 'content/visualblocks/visualblocks';
 @import 'content/visualchars/visualchars';

--- a/modules/oxide/src/less/theme/content/transparent/transparent.less
+++ b/modules/oxide/src/less/theme/content/transparent/transparent.less
@@ -1,0 +1,8 @@
+//
+// Transparent
+//
+
+// Transparent elements in a block position needs to render as block inside the editor to avoid selection and input quirks
+[data-mce-block] {
+  display: block;
+}

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,10 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `color_default_foreground` and `color_default_background` options to set the initial default color for the `forecolor` and `backcolor` toolbar buttons and menu items. #TINY-9183
 
 ### Changed
-- Transparent elements like anchors are now allowed in the root of the editor body. #TINY-9172
+- Transparent elements, like anchors, are now allowed in the root of the editor body if they contain blocks. #TINY-9172
 
 ### Improved
-- Transparent elements like anchors can now contain block elements. #TINY-9172
+- Transparent elements, like anchors, can now contain block elements. #TINY-9172
 
 ### Fixed
 - Dragging a noneditable element toward the bottom edge would cause the page to scroll up. #TINY-9025

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - New `expand` function added to `tinymce.selection` which expands the selection around the nearest word. #TINY-9001
 - New `expand` function added to `tinymce.dom.RangeUtils` to return a new range expanded around the nearest word. #TINY-9001
+- New `getTransparentElements` function added to `tinymce.html.Schema` to return a map object of transparent HTML elements. #TINY-9172
 
 ### Fixed
 - Dragging a noneditable element toward the bottom edge would cause the page to scroll up. #TINY-9025
@@ -17,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Line separator scrolling in floating toolbars. #TINY-8948
 - A double bottom border appeared on inline mode editor for the `tinymce-5` skin. #TINY-9108
 - The editor header showed up even with no menubar and toolbar configured. #TINY-8819
+
+### Changed
+- Transparent elements like anchors are now allowed in the root of the editor body. #TINY-9172
+- Transparent elements like anchors can now contain block elements. #TINY-9172
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Compilation errors were thrown when using TypeScript 4.8. #TINY-9161
 - Line separator scrolling in floating toolbars. #TINY-8948
 - A double bottom border appeared on inline mode editor for the `tinymce-5` skin. #TINY-9108
+- The editor header showed up even with no menubar and toolbar configured. #TINY-8819
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,17 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `ToggleView` command which makes it possible to hide or show registered custom views. #TINY-9210
 - New `color_default_foreground` and `color_default_background` options to set the initial default color for the `forecolor` and `backcolor` toolbar buttons and menu items. #TINY-9183
 
+### Changed
+- Transparent elements like anchors are now allowed in the root of the editor body. #TINY-9172
+
+### Improved
+- Transparent elements like anchors can now contain block elements. #TINY-9172
+
 ### Fixed
 - Dragging a noneditable element toward the bottom edge would cause the page to scroll up. #TINY-9025
 - Range expanding capabilities would behave inconsistently depending on where the cursor was placed. #TINY-9029
 - Compilation errors were thrown when using TypeScript 4.8. #TINY-9161
 - Line separator scrolling in floating toolbars. #TINY-8948
 - A double bottom border appeared on inline mode editor for the `tinymce-5` skin. #TINY-9108
-- The editor header showed up even with no menubar and toolbar configured. #TINY-8819
-
-### Changed
-- Transparent elements like anchors are now allowed in the root of the editor body. #TINY-9172
-- Transparent elements like anchors can now contain block elements. #TINY-9172
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/src/core/main/ts/ForceBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/ForceBlocks.ts
@@ -55,7 +55,8 @@ const createRootBlock = (editor: Editor): HTMLElement =>
 
 const addRootBlocks = (editor: Editor) => {
   const dom = editor.dom, selection = editor.selection;
-  const schema = editor.schema, blockElements = schema.getBlockElements();
+  const schema = editor.schema;
+  const blockElements = { ...schema.getBlockElements(), ...schema.getTransparentElements() };
   const startNode = selection.getStart();
   const rootNode = editor.getBody();
   let rootBlockNode: Node | undefined | null;

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1,6 +1,7 @@
 import { Arr, Fun, Obj, Optionals, Strings, Type } from '@ephox/katamari';
 import { Attribute, Class, Css, Html, Insert, Remove, Selectors, SugarElement, SugarNode, Traverse, WindowVisualViewport } from '@ephox/sugar';
 
+import * as TransparentElements from '../../content/TransparentElements';
 import * as NodeType from '../../dom/NodeType';
 import * as Position from '../../dom/Position';
 import * as StyleSheetLoaderRegistry from '../../dom/StyleSheetLoaderRegistry';
@@ -353,7 +354,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     if (Type.isString(node)) {
       return Obj.has(blockElementsMap, node);
     } else {
-      return NodeType.isElement(node) && Obj.has(blockElementsMap, node.nodeName);
+      return NodeType.isElement(node) && Obj.has(blockElementsMap, node.nodeName) && !TransparentElements.isTransparentInline(schema, node);
     }
   };
 

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1,6 +1,7 @@
 import { Arr, Fun, Obj, Optionals, Strings, Type } from '@ephox/katamari';
 import { Attribute, Class, Css, Html, Insert, Remove, Selectors, SugarElement, SugarNode, Traverse, WindowVisualViewport } from '@ephox/sugar';
 
+import * as TransparentElements from '../../content/TransparentElements';
 import * as NodeType from '../../dom/NodeType';
 import * as Position from '../../dom/Position';
 import * as StyleSheetLoaderRegistry from '../../dom/StyleSheetLoaderRegistry';
@@ -353,7 +354,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     if (Type.isString(node)) {
       return Obj.has(blockElementsMap, node);
     } else {
-      return NodeType.isElement(node) && Obj.has(blockElementsMap, node.nodeName);
+      return NodeType.isElement(node) && (Obj.has(blockElementsMap, node.nodeName) || TransparentElements.isTransparentBlock(schema, node));
     }
   };
 

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1,7 +1,6 @@
 import { Arr, Fun, Obj, Optionals, Strings, Type } from '@ephox/katamari';
 import { Attribute, Class, Css, Html, Insert, Remove, Selectors, SugarElement, SugarNode, Traverse, WindowVisualViewport } from '@ephox/sugar';
 
-import * as TransparentElements from '../../content/TransparentElements';
 import * as NodeType from '../../dom/NodeType';
 import * as Position from '../../dom/Position';
 import * as StyleSheetLoaderRegistry from '../../dom/StyleSheetLoaderRegistry';
@@ -354,7 +353,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     if (Type.isString(node)) {
       return Obj.has(blockElementsMap, node);
     } else {
-      return NodeType.isElement(node) && Obj.has(blockElementsMap, node.nodeName) && !TransparentElements.isTransparentInline(schema, node);
+      return NodeType.isElement(node) && Obj.has(blockElementsMap, node.nodeName);
     }
   };
 

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -14,6 +14,7 @@ interface ElementSettings {
   text_inline_elements?: string;
   void_elements?: string;
   whitespace_elements?: string;
+  transparent_elements?: string;
 }
 
 export interface SchemaSettings extends ElementSettings {
@@ -90,6 +91,7 @@ interface Schema {
   getNonEmptyElements: () => SchemaMap;
   getMoveCaretBeforeOnEnterElements: () => SchemaMap;
   getWhitespaceElements: () => SchemaMap;
+  getTransparentElements: () => SchemaMap;
   getSpecialElements: () => SchemaRegExpMap;
   isValidChild: (name: string, child: string) => boolean;
   isValid: (name: string, attr?: string) => boolean;
@@ -215,9 +217,10 @@ const compileSchema = (type: SchemaType): SchemaLookupTable => {
 
   // Add HTML5 items to globalAttributes, blockContent, phrasingContent
   if (type !== 'html4') {
+    const transparentContent = 'a ins del canvas map';
     globalAttributes += ' contenteditable contextmenu draggable dropzone ' +
       'hidden spellcheck translate';
-    blockContent += ' article aside details dialog figure main header footer hgroup section nav';
+    blockContent += ' article aside details dialog figure main header footer hgroup section nav ' + transparentContent;
     phrasingContent += ' audio canvas command datalist mark meter output picture ' +
       'progress time wbr video ruby bdi keygen';
   }
@@ -267,7 +270,7 @@ const compileSchema = (type: SchemaType): SchemaLookupTable => {
   add('ul', '', 'li');
   add('li', 'value', flowContent);
   add('dl', '', 'dt dd');
-  add('a', 'href target rel media hreflang type', phrasingContent);
+  add('a', 'href target rel media hreflang type', flowContent);
   add('q', 'cite', phrasingContent);
   add('ins del', 'cite datetime', flowContent);
   add('img', 'src sizes srcset alt usemap ismap width height');
@@ -404,9 +407,6 @@ const compileSchema = (type: SchemaType): SchemaLookupTable => {
 
   // TODO: LI:s can only have value if parent is OL
 
-  // TODO: Handle transparent elements
-  // a ins del canvas map
-
   lookupCache[type] = schema;
 
   return schema;
@@ -497,6 +497,8 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
     'datalist select optgroup figcaption details summary', textBlockElementsMap);
   const textInlineElementsMap = createLookupTable('text_inline_elements', 'span strong b em i font s strike u var cite ' +
     'dfn code mark q sup sub samp');
+
+  const transparentElementsMap = createLookupTable('transparent_elements', 'a ins del canvas map');
 
   // See https://html.spec.whatwg.org/multipage/parsing.html#parsing-html-fragments
   each(('script noscript iframe noframes noembed title style textarea xmp plaintext').split(' '), (name) => {
@@ -995,6 +997,14 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
   const getWhitespaceElements = Fun.constant(whitespaceElementsMap);
 
   /**
+   * Returns a map with elements that should be treated as transparent.
+   *
+   * @method getTransparentElements
+   * @return {Object} Name/value lookup map for special elements.
+   */
+  const getTransparentElements = Fun.constant(transparentElementsMap);
+
+  /**
    * Returns a map with special elements. These are elements that needs to be parsed
    * in a special way such as script, style, textarea etc. The map object values
    * are regexps used to find the end of the element.
@@ -1124,6 +1134,7 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
     getNonEmptyElements,
     getMoveCaretBeforeOnEnterElements,
     getWhitespaceElements,
+    getTransparentElements,
     getSpecialElements,
     isValidChild,
     isValid,

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -16,7 +16,7 @@ import ElementUtils from '../dom/ElementUtils';
 import * as NodeType from '../dom/NodeType';
 import * as PaddingBr from '../dom/PaddingBr';
 import * as FilterNode from '../html/FilterNode';
-import { cleanInvalidNodes } from '../html/InvalidNodes';
+import * as InvalidNodes from '../html/InvalidNodes';
 import * as RangeNormalizer from '../selection/RangeNormalizer';
 import * as SelectionUtils from '../selection/SelectionUtils';
 import { InsertContentDetails } from './ContentTypes';
@@ -325,10 +325,10 @@ export const insertHtmlAtCaret = (editor: Editor, value: string, details: Insert
       }
     }
     const toExtract = fragment.children();
-    const parent = fragment.parent?.name ?? root.name;
+    const parent = fragment.parent ?? root;
     fragment.unwrap();
-    const invalidChildren = Arr.filter(toExtract, (node) => !editor.schema.isValidChild(parent, node.name));
-    cleanInvalidNodes(invalidChildren, editor.schema);
+    const invalidChildren = Arr.filter(toExtract, (node) => InvalidNodes.isInvalid(editor.schema, node, parent));
+    InvalidNodes.cleanInvalidNodes(invalidChildren, editor.schema);
     FilterNode.filter(parser.getNodeFilters(), parser.getAttributeFilters(), root);
     value = serializer.serialize(root);
 

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -345,6 +345,7 @@ export const insertHtmlAtCaret = (editor: Editor, value: string, details: Insert
   moveSelectionToMarker(editor, dom.get('mce_marker'));
   unmarkFragmentElements(editor.getBody());
   trimBrsFromTableCell(dom, selection.getStart());
-  TransparentElements.update(editor.schema, editor.getBody(), true);
+  TransparentElements.updateCaret(editor.schema, editor.getBody(), selection.getStart());
+
   return value;
 };

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -10,6 +10,7 @@ import * as StyleUtils from '../api/html/StyleUtils';
 import Tools from '../api/util/Tools';
 import CaretPosition from '../caret/CaretPosition';
 import { CaretWalker } from '../caret/CaretWalker';
+import * as TransparentElements from '../content/TransparentElements';
 import * as TableDelete from '../delete/TableDelete';
 import * as CefUtils from '../dom/CefUtils';
 import ElementUtils from '../dom/ElementUtils';
@@ -344,5 +345,6 @@ export const insertHtmlAtCaret = (editor: Editor, value: string, details: Insert
   moveSelectionToMarker(editor, dom.get('mce_marker'));
   unmarkFragmentElements(editor.getBody());
   trimBrsFromTableCell(dom, selection.getStart());
+  TransparentElements.update(editor.schema, editor.getBody(), true);
   return value;
 };

--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -1,0 +1,30 @@
+import { Arr, Type } from '@ephox/katamari';
+
+import AstNode from '../api/html/Node';
+import Schema from '../api/html/Schema';
+import * as NodeType from '../dom/NodeType';
+
+export const update = (schema: Schema, root: Element, inEditorRoot: boolean): void => {
+  const transparentSelector = Object.keys(schema.getTransparentElements()).join(',');
+  const blocksSelector = Object.keys(schema.getBlockElements()).join(',');
+
+  Arr.each(root.querySelectorAll(transparentSelector), (anchor) => {
+    if ((inEditorRoot && anchor.parentElement === root) || anchor.querySelectorAll(blocksSelector).length > 0) {
+      anchor.setAttribute('data-mce-block', 'true');
+    } else {
+      anchor.removeAttribute('data-mce-block');
+    }
+  });
+};
+
+export const isTransparentBlock = (schema: Schema, node: Node): boolean =>
+  NodeType.isElement(node) && node.nodeName in schema.getTransparentElements() && node.hasAttribute('data-mce-block');
+
+export const isTransparentInline = (schema: Schema, node: Node): boolean =>
+  NodeType.isElement(node) && node.nodeName in schema.getTransparentElements() && !node.hasAttribute('data-mce-block');
+
+export const isTransparentAstBlock = (schema: Schema, node: AstNode): boolean =>
+  node.type === 1 && node.name in schema.getTransparentElements() && Type.isString(node.attr('data-mce-block'));
+
+export const isTransparentAstInline = (schema: Schema, node: AstNode): boolean =>
+  node.type === 1 && node.name in schema.getTransparentElements() && Type.isUndefined(node.attr('data-mce-block'));

--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -13,6 +13,10 @@ export const update = (schema: Schema, root: Element, inEditorRoot: boolean): vo
   Arr.each(root.querySelectorAll(transparentSelector), (anchor) => {
     if ((inEditorRoot && anchor.parentElement === root) || anchor.querySelectorAll(blocksSelector).length > 0) {
       anchor.setAttribute(transparentBlockAttr, 'true');
+
+      if (anchor.getAttribute('data-mce-selected') === 'inline-boundary') {
+        anchor.removeAttribute('data-mce-selected');
+      }
     } else {
       anchor.removeAttribute(transparentBlockAttr);
     }

--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -47,7 +47,7 @@ export const updateCaret = (schema: Schema, root: Element, caretParent: Element)
   );
 };
 
-export const isTransparentElementName = (schema: Schema, name: string): boolean => name in schema.getTransparentElements();
+export const isTransparentElementName = (schema: Schema, name: string): boolean => Obj.has(schema.getTransparentElements(), name);
 
 const isTransparentElement = (schema: Schema, node: Node | null | undefined): node is Element =>
   NodeType.isElement(node) && isTransparentElementName(schema, node.nodeName);

--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -21,7 +21,7 @@ const updateTransparent = (blocksSelector: string, transparent: Element) => {
   }
 };
 
-const updateAt = (schema: Schema, scope: Element) => {
+export const updateChildren = (schema: Schema, scope: Element): void => {
   const transparentSelector = makeSelectorFromSchemaMap(schema.getTransparentElements());
   const blocksSelector = makeSelectorFromSchemaMap(schema.getBlockElements());
 
@@ -36,8 +36,6 @@ export const updateElement = (schema: Schema, target: Element): void => {
   }
 };
 
-export const updateChildren = (schema: Schema, root: Element): void => updateAt(schema, root);
-
 export const updateCaret = (schema: Schema, root: Element, caretParent: Element): void => {
   const isRoot = (el: SugarElement<Node>) => Compare.eq(el, SugarElement.fromDom(root));
   const parents = Traverse.parents(SugarElement.fromDom(caretParent), isRoot);
@@ -45,7 +43,7 @@ export const updateCaret = (schema: Schema, root: Element, caretParent: Element)
   // case <body><p><b><i>|</i></b></p></body> it would use the P as the scope
   Arr.get(parents, parents.length - 2).filter(SugarNode.isElement).fold(
     () => updateChildren(schema, root),
-    (scope) => updateAt(schema, scope.dom)
+    (scope) => updateChildren(schema, scope.dom)
   );
 };
 

--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -13,7 +13,7 @@ export const update = (schema: Schema, root: Element, inEditorRoot: boolean): vo
   const blocksSelector = makeSelectorFromSchemaMap(schema.getBlockElements());
 
   Arr.each(root.querySelectorAll(transparentSelector), (anchor) => {
-    if ((inEditorRoot && anchor.parentElement === root) || anchor.matches(`:has(${blocksSelector})`)) {
+    if ((inEditorRoot && anchor.parentElement === root) || anchor.querySelectorAll(blocksSelector).length > 0) {
       anchor.setAttribute(transparentBlockAttr, 'true');
 
       if (anchor.getAttribute('data-mce-selected') === 'inline-boundary') {

--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -19,14 +19,19 @@ export const update = (schema: Schema, root: Element, inEditorRoot: boolean): vo
   });
 };
 
-export const isTransparentBlock = (schema: Schema, node: Node): boolean =>
-  NodeType.isElement(node) && node.nodeName in schema.getTransparentElements() && node.hasAttribute(transparentBlockAttr);
+export const isTransparentElementName = (schema: Schema, name: string): boolean => name in schema.getTransparentElements();
 
-export const isTransparentInline = (schema: Schema, node: Node): boolean =>
-  NodeType.isElement(node) && node.nodeName in schema.getTransparentElements() && !node.hasAttribute(transparentBlockAttr);
+const isTransparentElement = (schema: Schema, node: Node | null | undefined): node is Element =>
+  NodeType.isElement(node) && isTransparentElementName(schema, node.nodeName);
+
+export const isTransparentBlock = (schema: Schema, node: Node | null | undefined): node is Element =>
+  isTransparentElement(schema, node) && node.hasAttribute(transparentBlockAttr);
+
+export const isTransparentInline = (schema: Schema, node: Node | null | undefined): node is Element =>
+  isTransparentElement(schema, node) && !node.hasAttribute(transparentBlockAttr);
 
 export const isTransparentAstBlock = (schema: Schema, node: AstNode): boolean =>
-  node.type === 1 && node.name in schema.getTransparentElements() && Type.isString(node.attr(transparentBlockAttr));
+  node.type === 1 && isTransparentElementName(schema, node.name) && Type.isString(node.attr(transparentBlockAttr));
 
 export const isTransparentAstInline = (schema: Schema, node: AstNode): boolean =>
-  node.type === 1 && node.name in schema.getTransparentElements() && Type.isUndefined(node.attr(transparentBlockAttr));
+  node.type === 1 && isTransparentElementName(schema, node.name) && Type.isUndefined(node.attr(transparentBlockAttr));

--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -1,17 +1,19 @@
-import { Arr, Type } from '@ephox/katamari';
+import { Arr, Obj, Type } from '@ephox/katamari';
 
 import AstNode from '../api/html/Node';
-import Schema from '../api/html/Schema';
+import Schema, { SchemaMap } from '../api/html/Schema';
 import * as NodeType from '../dom/NodeType';
 
 export const transparentBlockAttr = 'data-mce-block';
 
+const makeSelectorFromSchemaMap = (map: SchemaMap) => Arr.filter(Obj.keys(map), (key) => /^[a-z]+$/.test(key)).join(',');
+
 export const update = (schema: Schema, root: Element, inEditorRoot: boolean): void => {
-  const transparentSelector = Object.keys(schema.getTransparentElements()).join(',');
-  const blocksSelector = Object.keys(schema.getBlockElements()).join(',');
+  const transparentSelector = makeSelectorFromSchemaMap(schema.getTransparentElements());
+  const blocksSelector = makeSelectorFromSchemaMap(schema.getBlockElements());
 
   Arr.each(root.querySelectorAll(transparentSelector), (anchor) => {
-    if ((inEditorRoot && anchor.parentElement === root) || anchor.querySelectorAll(blocksSelector).length > 0) {
+    if ((inEditorRoot && anchor.parentElement === root) || anchor.matches(`:has(${blocksSelector})`)) {
       anchor.setAttribute(transparentBlockAttr, 'true');
 
       if (anchor.getAttribute('data-mce-selected') === 'inline-boundary') {

--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -10,7 +10,7 @@ export const transparentBlockAttr = 'data-mce-block';
 const makeSelectorFromSchemaMap = (map: SchemaMap) => Arr.filter(Obj.keys(map), (key) => /^[a-z]+$/.test(key)).join(',');
 
 const updateTransparent = (blocksSelector: string, transparent: Element) => {
-  if (transparent.querySelectorAll(blocksSelector).length > 0) {
+  if (Type.isNonNullable(transparent.querySelector(blocksSelector))) {
     transparent.setAttribute(transparentBlockAttr, 'true');
 
     if (transparent.getAttribute('data-mce-selected') === 'inline-boundary') {

--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -29,9 +29,8 @@ export const updateChildren = (schema: Schema, scope: Element): void => {
 };
 
 export const updateElement = (schema: Schema, target: Element): void => {
-  const blocksSelector = makeSelectorFromSchemaMap(schema.getBlockElements());
-
   if (isTransparentElement(schema, target)) {
+    const blocksSelector = makeSelectorFromSchemaMap(schema.getBlockElements());
     updateTransparent(blocksSelector, target);
   }
 };

--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -1,4 +1,5 @@
 import { Arr, Obj, Type } from '@ephox/katamari';
+import { Compare, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import AstNode from '../api/html/Node';
 import Schema, { SchemaMap } from '../api/html/Schema';
@@ -8,11 +9,11 @@ export const transparentBlockAttr = 'data-mce-block';
 
 const makeSelectorFromSchemaMap = (map: SchemaMap) => Arr.filter(Obj.keys(map), (key) => /^[a-z]+$/.test(key)).join(',');
 
-export const update = (schema: Schema, root: Element, inEditorRoot: boolean): void => {
+const updateAt = (schema: Schema, root: Element, scope: Element, inEditorRoot: boolean) => {
   const transparentSelector = makeSelectorFromSchemaMap(schema.getTransparentElements());
   const blocksSelector = makeSelectorFromSchemaMap(schema.getBlockElements());
 
-  Arr.each(root.querySelectorAll(transparentSelector), (transparent) => {
+  Arr.each(scope.querySelectorAll(transparentSelector), (transparent) => {
     if ((inEditorRoot && transparent.parentElement === root) || transparent.querySelectorAll(blocksSelector).length > 0) {
       transparent.setAttribute(transparentBlockAttr, 'true');
 
@@ -23,6 +24,19 @@ export const update = (schema: Schema, root: Element, inEditorRoot: boolean): vo
       transparent.removeAttribute(transparentBlockAttr);
     }
   });
+};
+
+export const update = (schema: Schema, root: Element, inEditorRoot: boolean): void => updateAt(schema, root, root, inEditorRoot);
+
+export const updateCaret = (schema: Schema, root: Element, caretParent: Element): void => {
+  const isRoot = (el: SugarElement<Node>) => Compare.eq(el, SugarElement.fromDom(root));
+  const parents = Traverse.parents(SugarElement.fromDom(caretParent), isRoot);
+  // Check the element just above below the root so in if caretParent is I in this
+  // case <body><p><b><i>|</i></b></p></body> it would use the P as the scope
+  Arr.get(parents, parents.length - 2).filter(SugarNode.isElement).fold(
+    () => update(schema, root, true),
+    (scope) => updateAt(schema, root, scope.dom, true)
+  );
 };
 
 export const isTransparentElementName = (schema: Schema, name: string): boolean => name in schema.getTransparentElements();

--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -12,15 +12,15 @@ export const update = (schema: Schema, root: Element, inEditorRoot: boolean): vo
   const transparentSelector = makeSelectorFromSchemaMap(schema.getTransparentElements());
   const blocksSelector = makeSelectorFromSchemaMap(schema.getBlockElements());
 
-  Arr.each(root.querySelectorAll(transparentSelector), (anchor) => {
-    if ((inEditorRoot && anchor.parentElement === root) || anchor.querySelectorAll(blocksSelector).length > 0) {
-      anchor.setAttribute(transparentBlockAttr, 'true');
+  Arr.each(root.querySelectorAll(transparentSelector), (transparent) => {
+    if ((inEditorRoot && transparent.parentElement === root) || transparent.querySelectorAll(blocksSelector).length > 0) {
+      transparent.setAttribute(transparentBlockAttr, 'true');
 
-      if (anchor.getAttribute('data-mce-selected') === 'inline-boundary') {
-        anchor.removeAttribute('data-mce-selected');
+      if (transparent.getAttribute('data-mce-selected') === 'inline-boundary') {
+        transparent.removeAttribute('data-mce-selected');
       }
     } else {
-      anchor.removeAttribute(transparentBlockAttr);
+      transparent.removeAttribute(transparentBlockAttr);
     }
   });
 };

--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -4,27 +4,29 @@ import AstNode from '../api/html/Node';
 import Schema from '../api/html/Schema';
 import * as NodeType from '../dom/NodeType';
 
+export const transparentBlockAttr = 'data-mce-block';
+
 export const update = (schema: Schema, root: Element, inEditorRoot: boolean): void => {
   const transparentSelector = Object.keys(schema.getTransparentElements()).join(',');
   const blocksSelector = Object.keys(schema.getBlockElements()).join(',');
 
   Arr.each(root.querySelectorAll(transparentSelector), (anchor) => {
     if ((inEditorRoot && anchor.parentElement === root) || anchor.querySelectorAll(blocksSelector).length > 0) {
-      anchor.setAttribute('data-mce-block', 'true');
+      anchor.setAttribute(transparentBlockAttr, 'true');
     } else {
-      anchor.removeAttribute('data-mce-block');
+      anchor.removeAttribute(transparentBlockAttr);
     }
   });
 };
 
 export const isTransparentBlock = (schema: Schema, node: Node): boolean =>
-  NodeType.isElement(node) && node.nodeName in schema.getTransparentElements() && node.hasAttribute('data-mce-block');
+  NodeType.isElement(node) && node.nodeName in schema.getTransparentElements() && node.hasAttribute(transparentBlockAttr);
 
 export const isTransparentInline = (schema: Schema, node: Node): boolean =>
-  NodeType.isElement(node) && node.nodeName in schema.getTransparentElements() && !node.hasAttribute('data-mce-block');
+  NodeType.isElement(node) && node.nodeName in schema.getTransparentElements() && !node.hasAttribute(transparentBlockAttr);
 
 export const isTransparentAstBlock = (schema: Schema, node: AstNode): boolean =>
-  node.type === 1 && node.name in schema.getTransparentElements() && Type.isString(node.attr('data-mce-block'));
+  node.type === 1 && node.name in schema.getTransparentElements() && Type.isString(node.attr(transparentBlockAttr));
 
 export const isTransparentAstInline = (schema: Schema, node: AstNode): boolean =>
-  node.type === 1 && node.name in schema.getTransparentElements() && Type.isUndefined(node.attr('data-mce-block'));
+  node.type === 1 && node.name in schema.getTransparentElements() && Type.isUndefined(node.attr(transparentBlockAttr));

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
@@ -178,7 +178,7 @@ const register = (htmlParser: DomParser, settings: DomSerializerSettings, dom: D
   // Remove internal data attributes
   htmlParser.addAttributeFilter(
     'data-mce-src,data-mce-href,data-mce-style,' +
-    'data-mce-selected,data-mce-expando,' +
+    'data-mce-selected,data-mce-expando,data-mce-block,' +
     'data-mce-type,data-mce-resize,data-mce-placeholder',
 
     (nodes, name) => {

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -135,11 +135,11 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
     const isMatchingWrappingBlock = (node: Node) =>
       FormatUtils.isWrappingBlockFormat(format) && MatchFormat.matchNode(ed, node, name, vars);
 
-    const canRenameBlock = (nodeName: string, parentName: string, isEditableDescendant: boolean) => {
+    const canRenameBlock = (node: Node, parentName: string, isEditableDescendant: boolean) => {
       const isValidBlockFormatForNode =
-        FormatUtils.isNonWrappingBlockFormat(format) &&
-        FormatUtils.isTextBlock(ed.schema, nodeName) &&
-        FormatUtils.isValid(ed, parentName, wrapName);
+            FormatUtils.isNonWrappingBlockFormat(format) &&
+            FormatUtils.isTextBlock(ed.schema, node) &&
+            FormatUtils.isValid(ed, parentName, wrapName);
       return isEditableDescendant && isValidBlockFormatForNode;
     };
 
@@ -164,7 +164,6 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
         let hasContentEditableState = false;
         let lastContentEditable = contentEditable;
         let isWrappableNoneditableElm = false;
-        const nodeName = node.nodeName.toLowerCase();
         const parentNode = node.parentNode as Node;
         const parentName = parentNode.nodeName.toLowerCase();
 
@@ -194,7 +193,7 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
           return;
         }
 
-        if (canRenameBlock(nodeName, parentName, isEditableDescendant)) {
+        if (canRenameBlock(node, parentName, isEditableDescendant)) {
           const elm = dom.rename(node as Element, wrapName);
           setElementFormat(elm);
           newWrappers.push(elm);

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -137,9 +137,9 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
 
     const canRenameBlock = (node: Node, parentName: string, isEditableDescendant: boolean) => {
       const isValidBlockFormatForNode =
-            FormatUtils.isNonWrappingBlockFormat(format) &&
-            FormatUtils.isTextBlock(ed.schema, node) &&
-            FormatUtils.isValid(ed, parentName, wrapName);
+        FormatUtils.isNonWrappingBlockFormat(format) &&
+        FormatUtils.isTextBlock(ed.schema, node) &&
+        FormatUtils.isValid(ed, parentName, wrapName);
       return isEditableDescendant && isValidBlockFormatForNode;
     };
 

--- a/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
@@ -122,9 +122,8 @@ const getNonWhiteSpaceSibling = (node: Node | null, next?: boolean, inc?: boolea
   return undefined;
 };
 
-const isTextBlock = (schema: Schema, node: Node): boolean => {
-  return !!schema.getTextBlockElements()[node.nodeName.toLowerCase()] || TransparentElements.isTransparentBlock(schema, node);
-};
+const isTextBlock = (schema: Schema, node: Node): boolean =>
+  !!schema.getTextBlockElements()[node.nodeName.toLowerCase()] || TransparentElements.isTransparentBlock(schema, node);
 
 const isValid = (ed: Editor, parent: string, child: string): boolean => {
   return ed.schema.isValidChild(parent, child);

--- a/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
@@ -9,6 +9,7 @@ import Editor from '../api/Editor';
 import Schema from '../api/html/Schema';
 import * as Options from '../api/Options';
 import * as Bookmarks from '../bookmark/Bookmarks';
+import * as TransparentElements from '../content/TransparentElements';
 import * as NodeType from '../dom/NodeType';
 import * as SelectionUtils from '../selection/SelectionUtils';
 import * as Whitespace from '../text/Whitespace';
@@ -121,12 +122,8 @@ const getNonWhiteSpaceSibling = (node: Node | null, next?: boolean, inc?: boolea
   return undefined;
 };
 
-const isTextBlock = (schema: Schema, name: string | Node): boolean => {
-  if (isNode(name)) {
-    name = name.nodeName;
-  }
-
-  return !!schema.getTextBlockElements()[name.toLowerCase()];
+const isTextBlock = (schema: Schema, node: Node): boolean => {
+  return !!schema.getTextBlockElements()[node.nodeName.toLowerCase()] || TransparentElements.isTransparentBlock(schema, node);
 };
 
 const isValid = (ed: Editor, parent: string, child: string): boolean => {

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -240,7 +240,8 @@ const removeFormatInternal = (ed: Editor, format: Format, vars?: FormatVars, nod
 
   // Root level block transparents should get converted into regular text blocks
   if (FormatUtils.isInlineFormat(format) && TransparentElements.isTransparentElementName(schema, format.inline) && TransparentElements.isTransparentBlock(schema, node) && node.parentElement === ed.getBody()) {
-    return removeResult.rename(Options.getForcedRootBlock(ed));
+    removeNode(ed, node, format);
+    return removeResult.removed();
   }
 
   // Check if node is noneditable and can have the format removed from it

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -8,6 +8,7 @@ import * as Events from '../api/Events';
 import * as Options from '../api/Options';
 import Tools from '../api/util/Tools';
 import * as Bookmarks from '../bookmark/Bookmarks';
+import * as TransparentElements from '../content/TransparentElements';
 import ElementUtils from '../dom/ElementUtils';
 import * as NodeType from '../dom/NodeType';
 import { RangeLikeObject } from '../selection/RangeTypes';
@@ -235,6 +236,12 @@ const removeListStyleFormats = (editor: Editor, name: string, vars: FormatVars |
 const removeFormatInternal = (ed: Editor, format: Format, vars?: FormatVars, node?: Node, compareNode?: Node | null): RemoveFormatAdt => {
   const dom = ed.dom;
   const elementUtils = ElementUtils(ed);
+  const schema = ed.schema;
+
+  // Root level block transparents should get converted into regular text blocks
+  if (FormatUtils.isInlineFormat(format) && TransparentElements.isTransparentElementName(schema, format.inline) && TransparentElements.isTransparentBlock(schema, node) && node.parentElement === ed.getBody()) {
+    return removeResult.rename(Options.getForcedRootBlock(ed));
+  }
 
   // Check if node is noneditable and can have the format removed from it
   if (!format.ceFalseOverride && node && dom.getContentEditableParent(node) === 'false') {

--- a/modules/tinymce/src/core/main/ts/html/InvalidNodes.ts
+++ b/modules/tinymce/src/core/main/ts/html/InvalidNodes.ts
@@ -149,4 +149,28 @@ const cleanInvalidNodes = (nodes: AstNode[], schema: Schema, onCreate: (newNode:
   }
 };
 
-export { cleanInvalidNodes };
+const hasClosest = (node: AstNode, parentName: string): boolean => {
+  let tempNode: AstNode | null | undefined = node;
+  while (tempNode) {
+    if (tempNode.name === parentName) {
+      return true;
+    }
+    tempNode = tempNode.parent;
+  }
+  return false;
+};
+
+const isInvalid = (schema: Schema, node: AstNode, parent: AstNode | null | undefined = node.parent): boolean => {
+  // Check if the node is a valid child of the parent node. If the child is
+  // unknown we don't collect it since it's probably a custom element
+  if (parent && schema.children[node.name] && !schema.isValidChild(parent.name, node.name)) {
+    return true;
+  // Anchors are a special case and cannot be nested
+  } else if (parent && node.name === 'a' && hasClosest(parent, 'a')) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
+export { cleanInvalidNodes, isInvalid };

--- a/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
@@ -4,6 +4,7 @@ import Env from '../api/Env';
 import DomParser, { DomParserSettings } from '../api/html/DomParser';
 import AstNode from '../api/html/Node';
 import Tools from '../api/util/Tools';
+import * as TransparentElements from '../content/TransparentElements';
 import { dataUriToBlobInfo } from '../file/BlobCacheUtils';
 import { isEmpty, paddEmptyNode } from './ParserUtils';
 
@@ -47,6 +48,8 @@ const register = (parser: DomParser, settings: DomParserSettings): void => {
       // Remove brs from body element as well
       blockElements.body = 1;
 
+      const isBlock = (node: AstNode) => node.name in blockElements && TransparentElements.isTransparentAstInline(schema, node);
+
       // Must loop forwards since it will otherwise remove all brs in <p>a<br><br><br></p>
       for (let i = 0, l = nodes.length; i < l; i++) {
         let node: AstNode | null = nodes[i];
@@ -83,7 +86,7 @@ const register = (parser: DomParser, settings: DomParserSettings): void => {
                 if (elementRule.removeEmpty) {
                   parent.remove();
                 } else if (elementRule.paddEmpty) {
-                  paddEmptyNode(settings, args, blockElements, parent);
+                  paddEmptyNode(args, isBlock, parent);
                 }
               }
             }

--- a/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
@@ -1,11 +1,11 @@
 import { Type, Unicode } from '@ephox/katamari';
 
-import { DomParserSettings, ParserArgs } from '../api/html/DomParser';
+import { ParserArgs } from '../api/html/DomParser';
 import AstNode from '../api/html/Node';
 import Schema, { SchemaMap } from '../api/html/Schema';
 
-const paddEmptyNode = (settings: DomParserSettings, args: ParserArgs, blockElements: SchemaMap, node: AstNode): void => {
-  if (args.insert && blockElements[node.name]) {
+const paddEmptyNode = (args: ParserArgs, isBlock: (node: AstNode) => boolean, node: AstNode): void => {
+  if (args.insert && isBlock(node)) {
     const astNode = new AstNode('br', 1);
     astNode.attr('data-mce-bogus', '1');
     node.empty().append(astNode);
@@ -30,8 +30,8 @@ const isPadded = (schema: Schema, node: AstNode): boolean => {
 const isEmpty = (schema: Schema, nonEmptyElements: SchemaMap, whitespaceElements: SchemaMap, node: AstNode): boolean =>
   node.isEmpty(nonEmptyElements, whitespaceElements, (node) => isPadded(schema, node));
 
-const isLineBreakNode = (node: AstNode | null | undefined, blockElements: SchemaMap): boolean =>
-  Type.isNonNullable(node) && (node.name in blockElements || node.name === 'br');
+const isLineBreakNode = (node: AstNode | null | undefined, isBlock: (node: AstNode) => boolean): boolean =>
+  Type.isNonNullable(node) && (isBlock(node) || node.name === 'br');
 
 export {
   paddEmptyNode,

--- a/modules/tinymce/src/core/main/ts/keyboard/InlineUtils.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/InlineUtils.ts
@@ -7,11 +7,12 @@ import * as Options from '../api/Options';
 import * as CaretContainer from '../caret/CaretContainer';
 import CaretPosition from '../caret/CaretPosition';
 import * as CaretUtils from '../caret/CaretUtils';
+import * as TransparentElements from '../content/TransparentElements';
 import * as NodeType from '../dom/NodeType';
 import * as Bidi from '../text/Bidi';
 
 const isInlineTarget = (editor: Editor, elm: Node): elm is Element =>
-  Selectors.is(SugarElement.fromDom(elm), Options.getInlineBoundarySelector(editor));
+  Selectors.is(SugarElement.fromDom(elm), Options.getInlineBoundarySelector(editor)) && !TransparentElements.isTransparentBlock(editor.schema, elm);
 
 const isRtl = (element: Element): boolean =>
   DOMUtils.DOM.getStyle(element, 'direction', true) === 'rtl' || Bidi.hasStrongRtl(element.textContent ?? '');

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -402,7 +402,7 @@ const Quirks = (editor: Editor): Quirks => {
    */
   const addBrAfterLastLinks = () => {
     const fixLinks = () => {
-      each(dom.select('a'), (node) => {
+      each(dom.select('a:not([data-mce-block])'), (node) => {
         let parentNode: Node | null = node.parentNode;
         const root = dom.getRoot();
 

--- a/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
@@ -79,25 +79,25 @@ describe('browser.tinymce.core.EditorTest', () => {
     editor.options.set('relative_urls', true);
     editor.documentBaseURI = new URI('http://www.site.com/dirA/dirB/dirC/');
 
-    editor.setContent('<a href="test.html">test</a>');
+    editor.setContent('<p><a href="test.html">test</a></p>');
     assert.equal(editor.getContent(), '<p><a href="test.html">test</a></p>', 'urls - relativeURLs');
 
-    editor.setContent('<a href="../test.html">test</a>');
+    editor.setContent('<p><a href="../test.html">test</a></p>');
     assert.equal(editor.getContent(), '<p><a href="../test.html">test</a></p>', 'urls - relativeURLs');
 
-    editor.setContent('<a href="test/test.html">test</a>');
+    editor.setContent('<p><a href="test/test.html">test</a></p>');
     assert.equal(editor.getContent(), '<p><a href="test/test.html">test</a></p>', 'urls - relativeURLs');
 
-    editor.setContent('<a href="/test.html">test</a>');
+    editor.setContent('<p><a href="/test.html">test</a></p>');
     assert.equal(editor.getContent(), '<p><a href="../../../test.html">test</a></p>', 'urls - relativeURLs');
 
-    editor.setContent('<a href="http://www.somesite.com/test/file.htm">test</a>');
+    editor.setContent('<p><a href="http://www.somesite.com/test/file.htm">test</a></p>');
     assert.equal(editor.getContent(), '<p><a href="http://www.somesite.com/test/file.htm">test</a></p>', 'urls - relativeURLs');
 
-    editor.setContent('<a href="//www.site.com/test/file.htm">test</a>');
+    editor.setContent('<p><a href="//www.site.com/test/file.htm">test</a></p>');
     assert.equal(editor.getContent(), '<p><a href="../../../test/file.htm">test</a></p>', 'urls - relativeURLs');
 
-    editor.setContent('<a href="//www.somesite.com/test/file.htm">test</a>');
+    editor.setContent('<p><a href="//www.somesite.com/test/file.htm">test</a></p>');
     assert.equal(editor.getContent(), '<p><a href="//www.somesite.com/test/file.htm">test</a></p>', 'urls - relativeURLs');
   });
 
@@ -107,37 +107,37 @@ describe('browser.tinymce.core.EditorTest', () => {
     editor.options.set('remove_script_host', true);
     editor.documentBaseURI = new URI('http://www.site.com/dirA/dirB/dirC/');
 
-    editor.setContent('<a href="test.html">test</a>');
+    editor.setContent('<p><a href="test.html">test</a></p>');
     assert.equal(editor.getContent(), '<p><a href="/dirA/dirB/dirC/test.html">test</a></p>', 'urls - absoluteURLs');
 
-    editor.setContent('<a href="../test.html">test</a>');
+    editor.setContent('<p><a href="../test.html">test</a></p>');
     assert.equal(editor.getContent(), '<p><a href="/dirA/dirB/test.html">test</a></p>', 'urls - absoluteURLs');
 
-    editor.setContent('<a href="test/test.html">test</a>');
+    editor.setContent('<p><a href="test/test.html">test</a></p>');
     assert.equal(editor.getContent(), '<p><a href="/dirA/dirB/dirC/test/test.html">test</a></p>', 'urls - absoluteURLs');
 
-    editor.setContent('<a href="http://www.somesite.com/test/file.htm">test</a>');
+    editor.setContent('<p><a href="http://www.somesite.com/test/file.htm">test</a></p>');
     assert.equal(editor.getContent(), '<p><a href="http://www.somesite.com/test/file.htm">test</a></p>', 'urls - absoluteURLs');
 
     editor.options.set('relative_urls', false);
     editor.options.set('remove_script_host', false);
 
-    editor.setContent('<a href="test.html">test</a>');
+    editor.setContent('<p><a href="test.html">test</a></p>');
     assert.equal(editor.getContent(), '<p><a href="http://www.site.com/dirA/dirB/dirC/test.html">test</a></p>', 'urls - absoluteURLs');
 
-    editor.setContent('<a href="../test.html">test</a>');
+    editor.setContent('<p><a href="../test.html">test</a></p>');
     assert.equal(editor.getContent(), '<p><a href="http://www.site.com/dirA/dirB/test.html">test</a></p>', 'urls - absoluteURLs');
 
-    editor.setContent('<a href="test/test.html">test</a>');
+    editor.setContent('<p><a href="test/test.html">test</a></p>');
     assert.equal(editor.getContent(), '<p><a href="http://www.site.com/dirA/dirB/dirC/test/test.html">test</a></p>', 'urls - absoluteURLs');
 
-    editor.setContent('<a href="http://www.somesite.com/test/file.htm">test</a>');
+    editor.setContent('<p><a href="http://www.somesite.com/test/file.htm">test</a></p>');
     assert.equal(editor.getContent(), '<p><a href="http://www.somesite.com/test/file.htm">test</a></p>', 'urls - absoluteURLs');
 
-    editor.setContent('<a href="//www.site.com/test/file.htm">test</a>');
+    editor.setContent('<p><a href="//www.site.com/test/file.htm">test</a></p>');
     assert.equal(editor.getContent(), '<p><a href="//www.site.com/test/file.htm">test</a></p>', 'urls - absoluteURLs');
 
-    editor.setContent('<a href="//www.somesite.com/test/file.htm">test</a>');
+    editor.setContent('<p><a href="//www.somesite.com/test/file.htm">test</a></p>');
     assert.equal(editor.getContent(), '<p><a href="//www.somesite.com/test/file.htm">test</a></p>', 'urls - absoluteURLs');
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
@@ -120,7 +120,7 @@ describe('browser.tinymce.core.ForceBlocksTest', () => {
 
   it('TINY-9172: Do not wrap root level transparent elements', () => {
     const editor = hook.editor();
-    const transparentElements = Arr.filter(Obj.keys(editor.schema.getTransparentElements()), (name) => /^[a-z]+$/.test(name.toLowerCase()));
+    const transparentElements = Arr.filter(Obj.keys(editor.schema.getTransparentElements()), (name) => /^[a-z]+$/.test(name));
     const transparentElementsHtml = Arr.map(transparentElements, (name) => `<${name}>text</${name}>`).join('');
     const innerHtml = transparentElementsHtml + 'text';
     const expectedInnerHtml = transparentElementsHtml + '<p>text</p>';

--- a/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
@@ -106,6 +106,8 @@ describe('browser.tinymce.core.ForceBlocksTest', () => {
     assert.equal(HtmlUtils.cleanHtml(body.innerHTML), '<div>abcd</div><div>abcd</div>');
     assert.equal(editor.selection.getNode().nodeName, 'DIV');
     assert.lengthOf(body.childNodes, 2);
+
+    editor.options.unset('forced_root_block');
   });
 
   it('Do not wrap bookmark spans', () => {

--- a/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
@@ -120,7 +120,7 @@ describe('browser.tinymce.core.ForceBlocksTest', () => {
 
   it('TINY-9172: Do not wrap root level transparent elements', () => {
     const editor = hook.editor();
-    const transparentElements = Arr.unique(Arr.map(Obj.keys(editor.schema.getTransparentElements()), (s) => s.toLowerCase()));
+    const transparentElements = Arr.filter(Obj.keys(editor.schema.getTransparentElements()), (name) => /^[a-z]+$/.test(name.toLowerCase()));
     const transparentElementsHtml = Arr.map(transparentElements, (name) => `<${name}>text</${name}>`).join('');
     const innerHtml = transparentElementsHtml + 'text';
     const expectedInnerHtml = transparentElementsHtml + '<p>text</p>';

--- a/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
@@ -1,5 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+import { Arr, Obj } from '@ephox/katamari';
+import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -113,5 +114,18 @@ describe('browser.tinymce.core.ForceBlocksTest', () => {
     LegacyUnit.setSelection(editor, 'body', 0);
     pressArrowKey(editor);
     assert.equal(HtmlUtils.cleanHtml(editor.getBody().innerHTML), '<span data-mce-type="bookmark">a</span>');
+  });
+
+  it('TINY-9172: Do not wrap root level transparent elements', () => {
+    const editor = hook.editor();
+    const transparentElements = Arr.unique(Arr.map(Obj.keys(editor.schema.getTransparentElements()), (s) => s.toLowerCase()));
+    const transparentElementsHtml = Arr.map(transparentElements, (name) => `<${name}>text</${name}>`).join('');
+    const innerHtml = transparentElementsHtml + 'text';
+    const expectedInnerHtml = transparentElementsHtml + '<p>text</p>';
+
+    editor.getBody().innerHTML = innerHtml;
+    TinySelections.setCursor(editor, [ 0, 0 ], 0);
+    pressArrowKey(editor);
+    assert.equal(HtmlUtils.cleanHtml(editor.getBody().innerHTML), expectedInnerHtml);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
@@ -431,6 +431,14 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     TinyAssertions.assertContent(editor, '<p><strong><em>test</em></strong></p>');
   });
 
+  it('TINY-9172: unlink block links', () => {
+    const editor = hook.editor();
+    editor.setContent('<a href="test">test</a><div><a href="#"><p>test</p></a></div>');
+    editor.execCommand('SelectAll');
+    editor.execCommand('unlink');
+    TinyAssertions.assertContent(editor, '<p>test</p><div><p>test</p></div>');
+  });
+
   it('subscript/superscript', () => {
     const editor = hook.editor();
     editor.setContent('<p>test 123</p>');

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -670,7 +670,7 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
     editor.insertContent('<a href="#"><p>b</p></a>');
     TinyAssertions.assertContent(editor, '<div><a href="#"><p>b</p></a>a</div>');
-    assert.equal('true', editor.dom.select('a')[0].getAttribute('data-mce-block'), 'Should have data-mce-block set to true');
+    assert.isTrue(editor.dom.select('a[data-mce-block="true"]').length === 1, 'Should have data-mce-block set to true');
   });
 
   it('TINY-9172: Insert block anchor in transparent block should split the block', () => {
@@ -689,5 +689,15 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     TinySelections.setCursor(editor, [ 0, 0 ], 1);
     editor.insertContent('<a href="#2">b</a>');
     TinyAssertions.assertContent(editor, '<a href="#1">a</a><a href="#2">b</a><a href="#1">c</a>');
+  });
+
+  it('TINY-9172: Insert block in anchor should work and annotate the element with data-mce-block', () => {
+    const editor = hook.editor();
+
+    editor.setContent('<div><a href="#1">ac</a></div>');
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+    editor.insertContent('<p>b</p>');
+    TinyAssertions.assertContent(editor, '<div><a href="#1">a<p>b</p>c</a></div>');
+    assert.isTrue(editor.dom.select('a[data-mce-block="true"]').length === 1, 'Should have data-mce-block set to true');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -1,5 +1,4 @@
-import { ApproxStructure } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -664,62 +663,63 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     TinyAssertions.assertContent(editor, '<p><foo-bar contenteditable="false" data-name="foobar"></foo-bar></p>');
   });
 
-  it('TINY-9172: Insert block anchor in regular block', () => {
-    const editor = hook.editor();
+  context('Transparent blocks', () => {
+    it('TINY-9172: Insert block anchor in regular block', () => {
+      const editor = hook.editor();
 
-    editor.setContent('<div>a</div>');
-    TinySelections.setCursor(editor, [ 0, 0 ], 0);
-    editor.insertContent('<a href="#"><p>b</p></a>');
-    TinyAssertions.assertContent(editor, '<div><a href="#"><p>b</p></a>a</div>');
-    assert.isTrue(editor.dom.select('a[data-mce-block="true"]').length === 1, 'Should have data-mce-block set to true');
-  });
+      editor.setContent('<div>a</div>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+      editor.insertContent('<a href="#"><p>b</p></a>');
+      TinyAssertions.assertContent(editor, '<div><a href="#"><p>b</p></a>a</div>');
+      assert.isTrue(editor.dom.select('a[data-mce-block="true"]').length === 1, 'Should have data-mce-block set to true');
+    });
 
-  it('TINY-9172: Insert block anchor in transparent block should split the block', () => {
-    const editor = hook.editor();
+    it('TINY-9172: Insert block anchor in transparent block should split the block', () => {
+      const editor = hook.editor();
 
-    editor.setContent('<a href="#1"><div>ac</div></a>');
-    TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
-    editor.insertContent('<a href="#2"><p>b</p></a>');
-    TinyAssertions.assertContent(editor, '<div><a href="#1">a</a><a href="#2"><p>b</p></a>c</div>');
-  });
+      editor.setContent('<a href="#1"><div>ac</div></a>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+      editor.insertContent('<a href="#2"><p>b</p></a>');
+      TinyAssertions.assertContent(editor, '<div><a href="#1">a</a><a href="#2"><p>b</p></a>c</div>');
+    });
 
-  it('TINY-9172: Insert inline anchor in transparent block should split the block', () => {
-    const editor = hook.editor();
+    it('TINY-9172: Insert inline anchor in transparent block should split the block', () => {
+      const editor = hook.editor();
 
-    editor.setContent('<a href="#1"><div>ac</div></a>');
-    TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
-    editor.insertContent('<a href="#2">b</a>');
-    TinyAssertions.assertContent(editor, '<div><a href="#1">a</a><a href="#2">b</a>c</div>');
-  });
+      editor.setContent('<a href="#1"><div>ac</div></a>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+      editor.insertContent('<a href="#2">b</a>');
+      TinyAssertions.assertContent(editor, '<div><a href="#1">a</a><a href="#2">b</a>c</div>');
+    });
 
-  it('TINY-9172: Insert block in anchor should work and annotate the element with data-mce-block', () => {
-    const editor = hook.editor();
+    it('TINY-9172: Insert block in anchor should work and annotate the element with data-mce-block', () => {
+      const editor = hook.editor();
 
-    editor.setContent('<div><a href="#1">ac</a></div>');
-    TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
-    editor.insertContent('<p>b</p>');
-    TinyAssertions.assertContent(editor, '<div><a href="#1">a<p>b</p>c</a></div>');
-    assert.isTrue(editor.dom.select('a[data-mce-block="true"]').length === 1, 'Should have data-mce-block set to true');
-  });
+      editor.setContent('<div><a href="#1">ac</a></div>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+      editor.insertContent('<p>b</p>');
+      TinyAssertions.assertContent(editor, '<div><a href="#1">a<p>b</p>c</a></div>');
+      assert.isTrue(editor.dom.select('a[data-mce-block="true"]').length === 1, 'Should have data-mce-block set to true');
+    });
 
-  it('TINY-9172: Insert block in regular anchor should annotate the block with data-mce-block', () => {
-    const editor = hook.editor();
+    it('TINY-9172: Insert block in regular anchor should annotate the block with data-mce-block', () => {
+      const editor = hook.editor();
 
-    editor.setContent('<div><a href="#1">ac</a></div>');
-    TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
-    editor.insertContent('<p>b</p>');
-    TinyAssertions.assertContent(editor, '<div><a href="#1">a<p>b</p>c</a></div>');
-    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, _arr) =>
-      s.element('body', {
-        children: [
-          s.element('div', {
-            children: [
-              s.element('a', { attrs: { 'data-mce-block': str.is('true') }}),
-              s.zeroOrOne(s.element('br', {}))
-            ]
-          })
-        ]
-      })
-    ));
+      editor.setContent('<div><a href="#1">ac</a></div>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+      editor.insertContent('<p>b</p>');
+      TinyAssertions.assertContent(editor, '<div><a href="#1">a<p>b</p>c</a></div>');
+      TinyAssertions.assertContentPresence(editor, { 'a[data-mce-block]': 1 });
+    });
+
+    it('TINY-9172: Insert block mixed with inlines in regular anchor should annotate the block with data-mce-block', () => {
+      const editor = hook.editor();
+
+      editor.setContent('<div><a href="#1">ad</a></div>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+      editor.insertContent('<p>b</p><strong><em>c</em></strong>');
+      TinyAssertions.assertContent(editor, '<div><a href="#1">a<p>b</p><strong><em>c</em></strong>d</a></div>');
+      TinyAssertions.assertContentPresence(editor, { 'a[data-mce-block]': 1 });
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -714,7 +714,8 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
         children: [
           s.element('div', {
             children: [
-              s.element('a', { attrs: { 'data-mce-block': str.is('true') }})
+              s.element('a', { attrs: { 'data-mce-block': str.is('true') }}),
+              s.zeroOrOne(s.element('br', {}))
             ]
           })
         ]

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -662,4 +662,32 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     editor.insertContent('<foo-bar contenteditable="false" data-name="foobar"></foo-bar>');
     TinyAssertions.assertContent(editor, '<p><foo-bar contenteditable="false" data-name="foobar"></foo-bar></p>');
   });
+
+  it('TINY-9172: Insert block anchor in regual block', () => {
+    const editor = hook.editor();
+
+    editor.setContent('<div>a</div>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 0);
+    editor.insertContent('<a href="#"><p>b</p></a>');
+    TinyAssertions.assertContent(editor, '<div><a href="#"><p>b</p></a>a</div>');
+    assert.equal('true', editor.dom.select('a')[0].getAttribute('data-mce-block'), 'Should have data-mce-block set to true');
+  });
+
+  it('TINY-9172: Insert block anchor in transparent block should split the block', () => {
+    const editor = hook.editor();
+
+    editor.setContent('<a href="#1">ac</a>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    editor.insertContent('<a href="#2"><p>b</p></a>');
+    TinyAssertions.assertContent(editor, '<a href="#1">a</a><a href="#2"><p>b</p></a><a href="#1">c</a>');
+  });
+
+  it('TINY-9172: Insert inline anchor in transparent block should split the block', () => {
+    const editor = hook.editor();
+
+    editor.setContent('<a href="#1">ac</a>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    editor.insertContent('<a href="#2">b</a>');
+    TinyAssertions.assertContent(editor, '<a href="#1">a</a><a href="#2">b</a><a href="#1">c</a>');
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -677,19 +677,19 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
   it('TINY-9172: Insert block anchor in transparent block should split the block', () => {
     const editor = hook.editor();
 
-    editor.setContent('<a href="#1">ac</a>');
-    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    editor.setContent('<a href="#1"><div>ac</div></a>');
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
     editor.insertContent('<a href="#2"><p>b</p></a>');
-    TinyAssertions.assertContent(editor, '<a href="#1">a</a><a href="#2"><p>b</p></a><a href="#1">c</a>');
+    TinyAssertions.assertContent(editor, '<div><a href="#1">a</a><a href="#2"><p>b</p></a>c</div>');
   });
 
   it('TINY-9172: Insert inline anchor in transparent block should split the block', () => {
     const editor = hook.editor();
 
-    editor.setContent('<a href="#1">ac</a>');
-    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    editor.setContent('<a href="#1"><div>ac</div></a>');
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
     editor.insertContent('<a href="#2">b</a>');
-    TinyAssertions.assertContent(editor, '<a href="#1">a</a><a href="#2">b</a><a href="#1">c</a>');
+    TinyAssertions.assertContent(editor, '<div><a href="#1">a</a><a href="#2">b</a>c</div>');
   });
 
   it('TINY-9172: Insert block in anchor should work and annotate the element with data-mce-block', () => {

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -664,7 +664,7 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     TinyAssertions.assertContent(editor, '<p><foo-bar contenteditable="false" data-name="foobar"></foo-bar></p>');
   });
 
-  it('TINY-9172: Insert block anchor in regual block', () => {
+  it('TINY-9172: Insert block anchor in regular block', () => {
     const editor = hook.editor();
 
     editor.setContent('<div>a</div>');

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -1,3 +1,4 @@
+import { ApproxStructure } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
@@ -699,5 +700,25 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     editor.insertContent('<p>b</p>');
     TinyAssertions.assertContent(editor, '<div><a href="#1">a<p>b</p>c</a></div>');
     assert.isTrue(editor.dom.select('a[data-mce-block="true"]').length === 1, 'Should have data-mce-block set to true');
+  });
+
+  it('TINY-9172: Insert block in regular anchor should annotate the block with data-mce-block', () => {
+    const editor = hook.editor();
+
+    editor.setContent('<div><a href="#1">ac</a></div>');
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+    editor.insertContent('<p>b</p>');
+    TinyAssertions.assertContent(editor, '<div><a href="#1">a<p>b</p>c</a></div>');
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, _arr) =>
+      s.element('body', {
+        children: [
+          s.element('div', {
+            children: [
+              s.element('a', { attrs: { 'data-mce-block': str.is('true') }})
+            ]
+          })
+        ]
+      })
+    ));
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
@@ -42,6 +42,19 @@ describe('browser.tinymce.core.content.TransparentElementsTest', () => {
     });
   });
 
+  context('isTransparentElementName', () => {
+    it('TINY-9172: Should return true for any transparent element name', () => {
+      Arr.each(transparentElements, (name) => {
+        assert.isTrue(TransparentElements.isTransparentElementName(schema, name));
+      });
+    });
+
+    it('TINY-9172: Should return false for any non transparent element names', () => {
+      assert.isFalse(TransparentElements.isTransparentElementName(schema, 'p'));
+      assert.isFalse(TransparentElements.isTransparentElementName(schema, 'span'));
+    });
+  });
+
   context('isTransparentBlock', () => {
     it('TINY-9172: Should return true for any transparent element with data-mce-block', () => {
       Arr.each(transparentElements, (name) => {

--- a/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
@@ -40,6 +40,14 @@ describe('browser.tinymce.core.content.TransparentElementsTest', () => {
       TransparentElements.update(schema, root.dom, false);
       assert.equal(Html.get(root), '<a href="#">link</a><div><a href="#" data-mce-block="true"><p>link</p></a></div><div><a href="#">link</a></div>');
     });
+
+    it('TINY-9172: Should add data-mce-block on transparent block elements that wrap blocks and also remove data-mce-selected="inline-boundary"', () => {
+      const root = rootState.get().getOrDie();
+
+      Html.set(root, '<div><a href="#" data-mce-selected="inline-boundary"><p>link</p></a></div>');
+      TransparentElements.update(schema, root.dom, false);
+      assert.equal(Html.get(root), '<div><a href="#" data-mce-block="true"><p>link</p></a></div>');
+    });
   });
 
   context('isTransparentElementName', () => {

--- a/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
@@ -25,19 +25,11 @@ describe('browser.tinymce.core.content.TransparentElementsTest', () => {
       rootState.clear();
     });
 
-    it('TINY-9172: Should add data-mce-block on transparent block elements', () => {
+    it('TINY-9172: Should add data-mce-block on transparent elements if the contain blocks', () => {
       const root = rootState.get().getOrDie();
 
       Html.set(root, '<a href="#">link</a><div><a href="#"><p>link</p></a></div><div><a href="#">link</a></div>');
-      TransparentElements.update(schema, root.dom, true);
-      assert.equal(Html.get(root), '<a href="#" data-mce-block="true">link</a><div><a href="#" data-mce-block="true"><p>link</p></a></div><div><a href="#">link</a></div>');
-    });
-
-    it('TINY-9172: Should add data-mce-block on transparent block elements that wrap blocks but not at root level', () => {
-      const root = rootState.get().getOrDie();
-
-      Html.set(root, '<a href="#">link</a><div><a href="#"><p>link</p></a></div><div><a href="#">link</a></div>');
-      TransparentElements.update(schema, root.dom, false);
+      TransparentElements.updateChildren(schema, root.dom);
       assert.equal(Html.get(root), '<a href="#">link</a><div><a href="#" data-mce-block="true"><p>link</p></a></div><div><a href="#">link</a></div>');
     });
 
@@ -45,7 +37,7 @@ describe('browser.tinymce.core.content.TransparentElementsTest', () => {
       const root = rootState.get().getOrDie();
 
       Html.set(root, '<div><a href="#" data-mce-selected="inline-boundary"><p>link</p></a></div>');
-      TransparentElements.update(schema, root.dom, false);
+      TransparentElements.updateChildren(schema, root.dom);
       assert.equal(Html.get(root), '<div><a href="#" data-mce-block="true"><p>link</p></a></div>');
     });
 
@@ -64,10 +56,10 @@ describe('browser.tinymce.core.content.TransparentElementsTest', () => {
     it('TINY-9172: Should update anchor closest to root', () => {
       const root = rootState.get().getOrDie();
 
-      Html.set(root, '<a href="#" data-mce-block="true">link</a>');
+      Html.set(root, '<a href="#"><p>link</p></a>');
       const scope = Hierarchy.follow(root, [ 0 ]).filter(SugarNode.isElement).getOrDie();
       TransparentElements.updateCaret(schema, root.dom, scope.dom);
-      assert.equal( Html.get(root), '<a href="#" data-mce-block="true">link</a>');
+      assert.equal(Html.get(root), '<a href="#" data-mce-block="true"><p>link</p></a>');
     });
 
   });

--- a/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
@@ -9,7 +9,7 @@ import * as TransparentElements from 'tinymce/core/content/TransparentElements';
 
 describe('browser.tinymce.core.content.TransparentElementsTest', () => {
   const schema = Schema();
-  const transparentElements = Arr.unique(Arr.map(Obj.keys(schema.getTransparentElements()), (key) => key.toLowerCase()));
+  const transparentElements = Arr.filter(Obj.keys(schema.getTransparentElements()), (name) => /^[a-z]+$/.test(name.toLowerCase()));
 
   context('update', () => {
     const rootState = Singleton.value<SugarElement<HTMLElement>>();

--- a/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
@@ -9,7 +9,7 @@ import * as TransparentElements from 'tinymce/core/content/TransparentElements';
 
 describe('browser.tinymce.core.content.TransparentElementsTest', () => {
   const schema = Schema();
-  const transparentElements = Arr.filter(Obj.keys(schema.getTransparentElements()), (name) => /^[a-z]+$/.test(name.toLowerCase()));
+  const transparentElements = Arr.filter(Obj.keys(schema.getTransparentElements()), (name) => /^[a-z]+$/.test(name));
 
   context('update', () => {
     const rootState = Singleton.value<SugarElement<HTMLElement>>();

--- a/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
@@ -62,6 +62,14 @@ describe('browser.tinymce.core.content.TransparentElementsTest', () => {
       assert.equal(Html.get(root), '<a href="#" data-mce-block="true"><p>link</p></a>');
     });
 
+    it('TINY-9172: Should update anchor even if target element is in another branch', () => {
+      const root = rootState.get().getOrDie();
+
+      Html.set(root, '<div><a href="#"><p>link</p></a><b><i>target</i></b></div>');
+      const scope = Hierarchy.follow(root, [ 0, 1, 0 ]).filter(SugarNode.isElement).getOrDie();
+      TransparentElements.updateCaret(schema, root.dom, scope.dom);
+      assert.equal(Html.get(root), '<div><a href="#" data-mce-block="true"><p>link</p></a><b><i>target</i></b></div>');
+    });
   });
 
   context('isTransparentElementName', () => {

--- a/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, context, describe, it } from '@ephox/bedrock-client';
+import { Arr, Obj, Singleton } from '@ephox/katamari';
+import { Html, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
+
+import AstNode from 'tinymce/core/api/html/Node';
+import Schema from 'tinymce/core/api/html/Schema';
+import * as TransparentElements from 'tinymce/core/content/TransparentElements';
+
+describe('browser.tinymce.core.content.TransparentElementsTest', () => {
+  const schema = Schema();
+  const transparentElements = Arr.unique(Arr.map(Obj.keys(schema.getTransparentElements()), (key) => key.toLowerCase()));
+
+  context('update', () => {
+    const rootState = Singleton.value<SugarElement<HTMLElement>>();
+
+    beforeEach(() => {
+      const root = SugarElement.fromTag('div');
+      Insert.append(SugarBody.body(), root);
+      rootState.set(root);
+    });
+
+    afterEach(() => {
+      rootState.get().each((root) => Remove.remove(root));
+      rootState.clear();
+    });
+
+    it('TINY-9172: Should add data-mce-block on transparent block elements', () => {
+      const root = rootState.get().getOrDie();
+
+      Html.set(root, '<a href="#">link</a><div><a href="#"><p>link</p></a></div><div><a href="#">link</a></div>');
+      TransparentElements.update(schema, root.dom, true);
+      assert.equal(Html.get(root), '<a href="#" data-mce-block="true">link</a><div><a href="#" data-mce-block="true"><p>link</p></a></div><div><a href="#">link</a></div>');
+    });
+
+    it('TINY-9172: Should add data-mce-block on transparent block elements that wrap blocks but not at root level', () => {
+      const root = rootState.get().getOrDie();
+
+      Html.set(root, '<a href="#">link</a><div><a href="#"><p>link</p></a></div><div><a href="#">link</a></div>');
+      TransparentElements.update(schema, root.dom, false);
+      assert.equal(Html.get(root), '<a href="#">link</a><div><a href="#" data-mce-block="true"><p>link</p></a></div><div><a href="#">link</a></div>');
+    });
+  });
+
+  context('isTransparentBlock', () => {
+    it('TINY-9172: Should return true for any transparent element with data-mce-block', () => {
+      Arr.each(transparentElements, (name) => {
+        const elm = document.createElement(name);
+        elm.setAttribute('data-mce-block', 'true');
+        assert.isTrue(TransparentElements.isTransparentBlock(schema, elm));
+      });
+    });
+
+    it('TINY-9172: Should return false for any transparent element without data-mce-block', () => {
+      Arr.each(transparentElements, (name) => {
+        assert.isFalse(TransparentElements.isTransparentBlock(schema, document.createElement(name)));
+      });
+    });
+
+    it('TINY-9172: Should return false for any non element', () => {
+      assert.isFalse(TransparentElements.isTransparentBlock(schema, document.createTextNode('')));
+      assert.isFalse(TransparentElements.isTransparentBlock(schema, document.createComment('')));
+    });
+
+    it('TINY-9172: Should return false for any non transparent element', () => {
+      assert.isFalse(TransparentElements.isTransparentBlock(schema, document.createElement('p')));
+      assert.isFalse(TransparentElements.isTransparentBlock(schema, document.createElement('span')));
+    });
+  });
+
+  context('isTransparentInline', () => {
+    it('TINY-9172: Should return false for any transparent element with data-mce-block', () => {
+      Arr.each(transparentElements, (name) => {
+        const elm = document.createElement(name);
+        elm.setAttribute('data-mce-block', 'true');
+        assert.isFalse(TransparentElements.isTransparentInline(schema, elm));
+      });
+    });
+
+    it('TINY-9172: Should return true for any transparent element without data-mce-block', () => {
+      Arr.each(transparentElements, (name) => {
+        assert.isTrue(TransparentElements.isTransparentInline(schema, document.createElement(name)));
+      });
+    });
+
+    it('TINY-9172: Should return false for any non element', () => {
+      assert.isFalse(TransparentElements.isTransparentInline(schema, document.createTextNode('')));
+      assert.isFalse(TransparentElements.isTransparentInline(schema, document.createComment('')));
+    });
+
+    it('TINY-9172: Should return false for any non transparent element', () => {
+      assert.isFalse(TransparentElements.isTransparentInline(schema, document.createElement('p')));
+      assert.isFalse(TransparentElements.isTransparentInline(schema, document.createElement('span')));
+    });
+  });
+
+  context('isTransparentAstBlock', () => {
+    it('TINY-9172: Should return true for any transparent element with data-mce-block', () => {
+      Arr.each(transparentElements, (name) => {
+        const elm = AstNode.create(name);
+        elm.attr('data-mce-block', 'true');
+        assert.isTrue(TransparentElements.isTransparentAstBlock(schema, elm));
+      });
+    });
+
+    it('TINY-9172: Should return false for any transparent element without data-mce-block', () => {
+      Arr.each(transparentElements, (name) =>
+        assert.isFalse(TransparentElements.isTransparentAstBlock(schema, AstNode.create(name)))
+      );
+    });
+
+    it('TINY-9172: Should return false for any non element', () => {
+      assert.isFalse(TransparentElements.isTransparentAstBlock(schema, AstNode.create('#text')));
+      assert.isFalse(TransparentElements.isTransparentAstBlock(schema, AstNode.create('#comment')));
+    });
+
+    it('TINY-9172: Should return false for any non transparent element', () => {
+      assert.isFalse(TransparentElements.isTransparentAstBlock(schema, AstNode.create('p')));
+      assert.isFalse(TransparentElements.isTransparentAstBlock(schema, AstNode.create('span')));
+    });
+  });
+
+  context('isTransparentAstInline', () => {
+    it('TINY-9172: Should return false for any transparent element with data-mce-block', () => {
+      Arr.each(transparentElements, (name) => {
+        const elm = AstNode.create(name);
+        elm.attr('data-mce-block', 'true');
+        assert.isFalse(TransparentElements.isTransparentAstInline(schema, elm));
+      });
+    });
+
+    it('TINY-9172: Should return true for any transparent element without data-mce-block', () => {
+      Arr.each(transparentElements, (name) =>
+        assert.isTrue(TransparentElements.isTransparentAstInline(schema, AstNode.create(name)))
+      );
+    });
+
+    it('TINY-9172: Should return false for any non element', () => {
+      assert.isFalse(TransparentElements.isTransparentAstInline(schema, AstNode.create('#text')));
+      assert.isFalse(TransparentElements.isTransparentAstInline(schema, AstNode.create('#comment')));
+    });
+
+    it('TINY-9172: Should return false for any non transparent element', () => {
+      assert.isFalse(TransparentElements.isTransparentAstInline(schema, AstNode.create('p')));
+      assert.isFalse(TransparentElements.isTransparentAstInline(schema, AstNode.create('span')));
+    });
+  });
+});
+

--- a/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
@@ -181,4 +181,3 @@ describe('browser.tinymce.core.content.TransparentElementsTest', () => {
     });
   });
 });
-

--- a/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
@@ -509,6 +509,9 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
     assert.isTrue(DOM.isBlock('DIV'));
     assert.isFalse(DOM.isBlock('SPAN'));
     assert.isTrue(DOM.isBlock('div'));
+    assert.isFalse(DOM.isBlock('a'), 'Anchor name should not be block');
+    assert.isTrue(DOM.isBlock(DOM.create('a', { 'data-mce-block': 'true' } )), 'Anchor with data-mce-block should be block');
+    assert.isFalse(DOM.isBlock(DOM.create('a')), 'Anchor without data-mce-block should not be block');
   });
 
   it('remove', () => {

--- a/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
@@ -830,10 +830,10 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
   it('TINY-9172: Should remove the internal data-mce-block attribute for transparent block elements', () => {
     const ser = DomSerializer({ });
 
-    setTestHtml('<a href="#" data-mce-block="true">block</a>');
+    setTestHtml('<a href="#" data-mce-block="true"><p>block</p></a>');
     assert.equal(
       ser.serialize(getTestElement(), { getInner: true }),
-      '<a href="#">block</a>'
+      '<a href="#"><p>block</p></a>'
     );
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
@@ -826,4 +826,14 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     assert.lengthOf(ser.getNodeFilters(), numNodeFilters, 'Number of node filters');
     assert.lengthOf(ser.getAttributeFilters(), numAttrFilters, 'Number of attribute filters');
   });
+
+  it('TINY-9172: Should remove the internal data-mce-block attribute for transparent block elements', () => {
+    const ser = DomSerializer({ });
+
+    setTestHtml('<a href="#" data-mce-block="true">block</a>');
+    assert.equal(
+      ser.serialize(getTestElement(), { getInner: true }),
+      '<a href="#">block</a>'
+    );
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -496,13 +496,13 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     parser = DomParser({}, Schema({ valid_elements: 'span,a[name],img' }));
     root = parser.parse('<span></span><a name="anchor"></a>');
-    assert.equal(serializer.serialize(root), '<span></span><a name="anchor"></a>', 'Leave a with name attribute');
+    assert.equal(serializer.serialize(root), '<span></span><a name="anchor" data-mce-block="true"></a>', 'Leave a with name attribute');
 
     parser = DomParser({}, Schema({ valid_elements: 'span,a[href],img[src]' }));
     root = parser.parse('<span></span><a href="#"><img src="about:blank" /></a>');
     assert.equal(
       serializer.serialize(root),
-      '<span></span><a href="#"><img src="about:blank"></a>',
+      '<span></span><a href="#" data-mce-block="true"><img src="about:blank"></a>',
       'Leave elements with img in it'
     );
   });
@@ -635,7 +635,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     const parser = DomParser({ allow_html_in_named_anchor: false }, schema);
     const root = parser.parse('<a name="x">a</a><a href="x">x</a>');
-    assert.equal(serializer.serialize(root), '<a name="x"></a>a<a href="x">x</a>');
+    assert.equal(serializer.serialize(root), '<a name="x" data-mce-block="true"></a>a<a href="x" data-mce-block="true">x</a>');
   });
 
   it('Parse contents with html5 anchors and allow_html_in_named_anchor: false', () => {
@@ -643,7 +643,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     const parser = DomParser({ allow_html_in_named_anchor: false }, schema);
     const root = parser.parse('<a id="x">a</a><a href="x">x</a>');
-    assert.equal(serializer.serialize(root), '<a id="x"></a>a<a href="x">x</a>');
+    assert.equal(serializer.serialize(root), '<a id="x" data-mce-block="true"></a>a<a href="x" data-mce-block="true">x</a>');
   });
 
   it('Parse contents with html4 anchors and allow_html_in_named_anchor: true', () => {
@@ -651,7 +651,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     const parser = DomParser({ allow_html_in_named_anchor: true }, schema);
     const root = parser.parse('<a name="x">a</a><a href="x">x</a>');
-    assert.equal(serializer.serialize(root), '<a name="x">a</a><a href="x">x</a>');
+    assert.equal(serializer.serialize(root), '<a name="x" data-mce-block="true">a</a><a href="x" data-mce-block="true">x</a>');
   });
 
   it('Parse contents with html5 anchors and allow_html_in_named_anchor: true', () => {
@@ -659,7 +659,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     const parser = DomParser({ allow_html_in_named_anchor: true }, schema);
     const root = parser.parse('<a id="x">a</a><a href="x">x</a>');
-    assert.equal(serializer.serialize(root), '<a id="x">a</a><a href="x">x</a>');
+    assert.equal(serializer.serialize(root), '<a id="x" data-mce-block="true">a</a><a href="x" data-mce-block="true">x</a>');
   });
 
   it('Parse contents with html5 self closing datalist options', () => {
@@ -836,8 +836,8 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     const serializedHtml = serializer.serialize(parser.parse(html));
 
     assert.equal(serializedHtml,
-      '<a href="javascript:alert(1)">1</a>' +
-      '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">3</a>'
+      '<a href="javascript:alert(1)" data-mce-block="true">1</a>' +
+      '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+" data-mce-block="true">3</a>'
     );
   });
 
@@ -849,9 +849,9 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     const serializedHtml = serializer.serialize(parser.parse(html));
 
     assert.equal(serializedHtml,
-      '<a>1</a>' +
-      '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">2</a>' +
-      '<a href="data:image/svg+xml;base64,x">3</a>'
+      '<a data-mce-block="true">1</a>' +
+      '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+" data-mce-block="true">2</a>' +
+      '<a href="data:image/svg+xml;base64,x" data-mce-block="true">3</a>'
     );
   });
 
@@ -863,7 +863,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     assert.equal(
       serializedHtml,
-      '<a>1</a>' +
+      '<a data-mce-block="true">1</a>' +
       '<img>'
     );
   });
@@ -891,23 +891,23 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     assert.equal(
       serializedHtml,
-      '<a>1</a>' +
-      '<a>2</a>' +
-      '<a>3</a>' +
-      '<a>4</a>' +
-      '<a>5</a>' +
-      '<a>6</a>' +
-      '<a>7</a>' +
-      '<a>8</a>' +
-      '<a>9</a>' +
+      '<a data-mce-block="true">1</a>' +
+      '<a data-mce-block="true">2</a>' +
+      '<a data-mce-block="true">3</a>' +
+      '<a data-mce-block="true">4</a>' +
+      '<a data-mce-block="true">5</a>' +
+      '<a data-mce-block="true">6</a>' +
+      '<a data-mce-block="true">7</a>' +
+      '<a data-mce-block="true">8</a>' +
+      '<a data-mce-block="true">9</a>' +
       '<object>10</object>' +
       '<button>11</button>' +
       '<form>12</form>' +
       '<table><tbody><tr><td>13</td></tr></tbody></table>' +
-      '<a>14</a>' +
-      '<a>15</a>' +
+      '<a data-mce-block="true">14</a>' +
+      '<a data-mce-block="true">15</a>' +
       '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">' +
-      '<a href="%E3%82%AA%E3%83%BC%E3%83">Invalid url</a>'
+      '<a href="%E3%82%AA%E3%83%BC%E3%83" data-mce-block="true">Invalid url</a>'
     );
   });
 
@@ -922,7 +922,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     ));
     assert.equal(serializedHtml,
       '<iframe></iframe>' +
-      '<a>1</a>' +
+      '<a data-mce-block="true">1</a>' +
       '<object></object>' +
       '<img src="data:image/svg+xml;base64,x">' +
       '<video></video>'
@@ -940,7 +940,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     ));
     assert.equal(serializedHtml,
       '<iframe src="data:image/svg+xml;base64,x"></iframe>' +
-      '<a href="data:image/svg+xml;base64,x">1</a>' +
+      '<a href="data:image/svg+xml;base64,x" data-mce-block="true">1</a>' +
       '<object data="data:image/svg+xml;base64,x"></object>' +
       '<img src="data:image/svg+xml;base64,x">' +
       '<video poster="data:image/svg+xml;base64,x"></video>'
@@ -958,7 +958,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     ));
     assert.equal(serializedHtml,
       '<iframe></iframe>' +
-      '<a>1</a>' +
+      '<a data-mce-block="true">1</a>' +
       '<object></object>' +
       '<img>' +
       '<video></video>'

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -496,13 +496,13 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     parser = DomParser({}, Schema({ valid_elements: 'span,a[name],img' }));
     root = parser.parse('<span></span><a name="anchor"></a>');
-    assert.equal(serializer.serialize(root), '<span></span><a name="anchor" data-mce-block="true"></a>', 'Leave a with name attribute');
+    assert.equal(serializer.serialize(root), '<span></span><a name="anchor"></a>', 'Leave a with name attribute');
 
     parser = DomParser({}, Schema({ valid_elements: 'span,a[href],img[src]' }));
     root = parser.parse('<span></span><a href="#"><img src="about:blank" /></a>');
     assert.equal(
       serializer.serialize(root),
-      '<span></span><a href="#" data-mce-block="true"><img src="about:blank"></a>',
+      '<span></span><a href="#"><img src="about:blank"></a>',
       'Leave elements with img in it'
     );
   });
@@ -635,7 +635,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     const parser = DomParser({ allow_html_in_named_anchor: false }, schema);
     const root = parser.parse('<a name="x">a</a><a href="x">x</a>');
-    assert.equal(serializer.serialize(root), '<a name="x" data-mce-block="true"></a>a<a href="x" data-mce-block="true">x</a>');
+    assert.equal(serializer.serialize(root), '<a name="x"></a>a<a href="x">x</a>');
   });
 
   it('Parse contents with html5 anchors and allow_html_in_named_anchor: false', () => {
@@ -643,7 +643,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     const parser = DomParser({ allow_html_in_named_anchor: false }, schema);
     const root = parser.parse('<a id="x">a</a><a href="x">x</a>');
-    assert.equal(serializer.serialize(root), '<a id="x" data-mce-block="true"></a>a<a href="x" data-mce-block="true">x</a>');
+    assert.equal(serializer.serialize(root), '<a id="x"></a>a<a href="x">x</a>');
   });
 
   it('Parse contents with html4 anchors and allow_html_in_named_anchor: true', () => {
@@ -651,7 +651,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     const parser = DomParser({ allow_html_in_named_anchor: true }, schema);
     const root = parser.parse('<a name="x">a</a><a href="x">x</a>');
-    assert.equal(serializer.serialize(root), '<a name="x" data-mce-block="true">a</a><a href="x" data-mce-block="true">x</a>');
+    assert.equal(serializer.serialize(root), '<a name="x">a</a><a href="x">x</a>');
   });
 
   it('Parse contents with html5 anchors and allow_html_in_named_anchor: true', () => {
@@ -659,7 +659,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     const parser = DomParser({ allow_html_in_named_anchor: true }, schema);
     const root = parser.parse('<a id="x">a</a><a href="x">x</a>');
-    assert.equal(serializer.serialize(root), '<a id="x" data-mce-block="true">a</a><a href="x" data-mce-block="true">x</a>');
+    assert.equal(serializer.serialize(root), '<a id="x">a</a><a href="x">x</a>');
   });
 
   it('Parse contents with html5 self closing datalist options', () => {
@@ -836,8 +836,8 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     const serializedHtml = serializer.serialize(parser.parse(html));
 
     assert.equal(serializedHtml,
-      '<a href="javascript:alert(1)" data-mce-block="true">1</a>' +
-      '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+" data-mce-block="true">3</a>'
+      '<a href="javascript:alert(1)">1</a>' +
+      '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">3</a>'
     );
   });
 
@@ -849,9 +849,9 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     const serializedHtml = serializer.serialize(parser.parse(html));
 
     assert.equal(serializedHtml,
-      '<a data-mce-block="true">1</a>' +
-      '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+" data-mce-block="true">2</a>' +
-      '<a href="data:image/svg+xml;base64,x" data-mce-block="true">3</a>'
+      '<a>1</a>' +
+      '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">2</a>' +
+      '<a href="data:image/svg+xml;base64,x">3</a>'
     );
   });
 
@@ -863,7 +863,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     assert.equal(
       serializedHtml,
-      '<a data-mce-block="true">1</a>' +
+      '<a>1</a>' +
       '<img>'
     );
   });
@@ -891,23 +891,23 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
     assert.equal(
       serializedHtml,
-      '<a data-mce-block="true">1</a>' +
-      '<a data-mce-block="true">2</a>' +
-      '<a data-mce-block="true">3</a>' +
-      '<a data-mce-block="true">4</a>' +
-      '<a data-mce-block="true">5</a>' +
-      '<a data-mce-block="true">6</a>' +
-      '<a data-mce-block="true">7</a>' +
-      '<a data-mce-block="true">8</a>' +
-      '<a data-mce-block="true">9</a>' +
+      '<a>1</a>' +
+      '<a>2</a>' +
+      '<a>3</a>' +
+      '<a>4</a>' +
+      '<a>5</a>' +
+      '<a>6</a>' +
+      '<a>7</a>' +
+      '<a>8</a>' +
+      '<a>9</a>' +
       '<object>10</object>' +
       '<button>11</button>' +
       '<form>12</form>' +
       '<table><tbody><tr><td>13</td></tr></tbody></table>' +
-      '<a data-mce-block="true">14</a>' +
-      '<a data-mce-block="true">15</a>' +
+      '<a>14</a>' +
+      '<a>15</a>' +
       '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">' +
-      '<a href="%E3%82%AA%E3%83%BC%E3%83" data-mce-block="true">Invalid url</a>'
+      '<a href="%E3%82%AA%E3%83%BC%E3%83">Invalid url</a>'
     );
   });
 
@@ -922,7 +922,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     ));
     assert.equal(serializedHtml,
       '<iframe></iframe>' +
-      '<a data-mce-block="true">1</a>' +
+      '<a>1</a>' +
       '<object></object>' +
       '<img src="data:image/svg+xml;base64,x">' +
       '<video></video>'
@@ -940,7 +940,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     ));
     assert.equal(serializedHtml,
       '<iframe src="data:image/svg+xml;base64,x"></iframe>' +
-      '<a href="data:image/svg+xml;base64,x" data-mce-block="true">1</a>' +
+      '<a href="data:image/svg+xml;base64,x">1</a>' +
       '<object data="data:image/svg+xml;base64,x"></object>' +
       '<img src="data:image/svg+xml;base64,x">' +
       '<video poster="data:image/svg+xml;base64,x"></video>'
@@ -958,7 +958,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     ));
     assert.equal(serializedHtml,
       '<iframe></iframe>' +
-      '<a data-mce-block="true">1</a>' +
+      '<a>1</a>' +
       '<object></object>' +
       '<img>' +
       '<video></video>'
@@ -1428,10 +1428,10 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
         assert.equal(serializedHtml, html);
       });
 
-      it('TINY-9172: root level transparents should get data-mce-block attribute', () => {
+      it('TINY-9172: root level transparents should not get data-mce-block attribute', () => {
         const parser = DomParser();
         const html = Arr.map(getTransparentElements(parser.schema), (name) => `<${name}>text</${name}>`).join('');
-        const expectedHtml = Arr.map(getTransparentElements(parser.schema), (name) => `<${name} data-mce-block="true">text</${name}>`).join('');
+        const expectedHtml = Arr.map(getTransparentElements(parser.schema), (name) => `<${name}>text</${name}>`).join('');
         const serializedHtml = serializer.serialize(parser.parse(html));
 
         assert.equal(serializedHtml, expectedHtml);

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1417,12 +1417,13 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       assert.equal(serializedHtml, html);
     });
 
-    context('transparent elements', () => {
+    context('Transparent elements', () => {
       const getTransparentElements = (schema: Schema) => Arr.unique(Arr.map(Obj.keys(schema.getTransparentElements()), (s) => s.toLowerCase()));
 
       it('TINY-9172: inline transparents should not get data-mce-block attribute', () => {
         const parser = DomParser();
-        const html = '<p>' + Arr.map(getTransparentElements(parser.schema), (name) => `<${name}>text</${name}>`).join('') + '</p>';
+        const innerHtml = Arr.map(getTransparentElements(parser.schema), (name) => `<${name}>text</${name}>`).join('');
+        const html = `<p>${innerHtml}</p>`;
         const serializedHtml = serializer.serialize(parser.parse(html));
 
         assert.equal(serializedHtml, html);
@@ -1439,8 +1440,10 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
       it('TINY-9172: transparents wrapping blocks should get data-mce-block attribute', () => {
         const parser = DomParser();
-        const html = '<div>' + Arr.map(getTransparentElements(parser.schema), (name) => `<${name}><p>text</p></${name}>`).join('') + '</div>';
-        const expectedHtml = '<div>' + Arr.map(getTransparentElements(parser.schema), (name) => `<${name} data-mce-block="true"><p>text</p></${name}>`).join('') + '</div>';
+        const innerHtml = Arr.map(getTransparentElements(parser.schema), (name) => `<${name}><p>text</p></${name}>`).join('');
+        const html = `<div>${innerHtml}</div>`;
+        const expectedInnerHtml = Arr.map(getTransparentElements(parser.schema), (name) => `<${name} data-mce-block="true"><p>text</p></${name}>`).join('');
+        const expectedHtml = `<div>${expectedInnerHtml}</div>`;
         const serializedHtml = serializer.serialize(parser.parse(html));
 
         assert.equal(serializedHtml, expectedHtml);

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -286,6 +286,14 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
     });
   });
 
+  it('getTransparentElements', () => {
+    const schema = Schema();
+    assert.deepEqual(schema.getTransparentElements(), {
+      MAP: {}, CANVAS: {}, DEL: {}, INS: {}, A: {},
+      map: {}, canvas: {}, del: {}, ins: {}, a: {}
+    });
+  });
+
   it('getTextInlineElements', () => {
     const schema = Schema();
     assert.deepEqual(schema.getTextInlineElements(), {

--- a/modules/tinymce/src/core/test/ts/browser/init/InitContentBodySelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitContentBodySelectionTest.ts
@@ -30,7 +30,7 @@ describe('browser.tinymce.core.init.InitContentBodySelectionTest', () => {
   });
 
   context('TINY-4139: More complex content tests', () => {
-    initAndAssertContent('Test a (which should be wrapped in a p on init)', '<a href="www.google.com">Initial Content</a>', [ 0, 0, 0 ], 1);
+    initAndAssertContent('Test a (which should be wrapped in a p on init)', '<a href="www.google.com">Initial Content</a>', [ 0, 0 ], 0);
     initAndAssertContent('Test a in paragraph', '<p><a href="www.google.com">Initial Content</a></p>', [ 0, 0, 0 ], 1);
     initAndAssertContent('Test list', '<ul><li>Initial Content</li></ul>', [ 0, 0, 0 ]);
     initAndAssertContent('Test image (which should be wrapped in a p on init)', '<img src="https://www.google.com/logos/google.jpg" alt="My alt text" width="354" height="116" />', [ 0 ]);

--- a/modules/tinymce/src/core/test/ts/browser/init/InitContentBodySelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitContentBodySelectionTest.ts
@@ -30,7 +30,7 @@ describe('browser.tinymce.core.init.InitContentBodySelectionTest', () => {
   });
 
   context('TINY-4139: More complex content tests', () => {
-    initAndAssertContent('Test a (which should be wrapped in a p on init)', '<a href="www.google.com">Initial Content</a>', [ 0, 0 ], 0);
+    initAndAssertContent('Test a (which should be wrapped in a p on init)', '<a href="www.google.com">Initial Content</a>', [ 0, 0, 0 ], 1);
     initAndAssertContent('Test a in paragraph', '<p><a href="www.google.com">Initial Content</a></p>', [ 0, 0, 0 ], 1);
     initAndAssertContent('Test list', '<ul><li>Initial Content</li></ul>', [ 0, 0, 0 ]);
     initAndAssertContent('Test image (which should be wrapped in a p on init)', '<img src="https://www.google.com/logos/google.jpg" alt="My alt text" width="354" height="116" />', [ 0 ]);

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysInlineBoundariesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysInlineBoundariesTest.ts
@@ -378,11 +378,11 @@ describe('browser.tinymce.core.keyboard.ArrowKeysInlineBoundariesTest', () => {
   context('Block links', () => {
     it('TINY-9172: Arrow right at beginning of block link should do nothing', () => {
       const editor = hook.editor();
-      editor.setContent('<a href="#">x</a>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+      editor.setContent('<a href="#"><p>x</p></a>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
       editor.nodeChanged();
       TinyContentActions.keystroke(editor, Keys.right());
-      TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
+      TinyAssertions.assertCursor(editor, [ 0, 0, 0 ], 0);
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysInlineBoundariesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysInlineBoundariesTest.ts
@@ -375,4 +375,14 @@ describe('browser.tinymce.core.keyboard.ArrowKeysInlineBoundariesTest', () => {
     });
   });
 
+  context('Block links', () => {
+    it('TINY-9172: Arrow right at beginning of block link should do nothing', () => {
+      const editor = hook.editor();
+      editor.setContent('<a href="#">x</a>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+      editor.nodeChanged();
+      TinyContentActions.keystroke(editor, Keys.right());
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
+    });
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/InlineUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/InlineUtilsTest.ts
@@ -4,6 +4,7 @@ import { Hierarchy, SugarElement, SugarNode } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import Schema from 'tinymce/core/api/html/Schema';
 import { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
 import CaretPosition from 'tinymce/core/caret/CaretPosition';
 import * as InlineUtils from 'tinymce/core/keyboard/InlineUtils';
@@ -39,7 +40,8 @@ describe('browser.tinymce.core.keyboard.InlineUtilsTest', () => {
     return {
       options: {
         get: (name: string) => options[name] ?? 'a[href],code,.mce-annotation'
-      }
+      },
+      schema: Schema()
     } as any;
   };
 

--- a/modules/tinymce/src/core/test/ts/browser/util/QuirksFirefoxTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/QuirksFirefoxTest.ts
@@ -1,0 +1,61 @@
+import { ApproxStructure } from '@ephox/agar';
+import { before, context, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Env from 'tinymce/core/api/Env';
+
+describe('browser.tinymce.core.util.QuirksFirefoxTest', () => {
+  before(function () {
+    if (!Env.browser.isFirefox()) {
+      this.skip();
+    }
+  });
+
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    add_unload_trigger: false,
+    indent: false,
+    disable_nodechange: true,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [], true);
+
+  context('addBrAfterLastLinks', () => {
+    it('TINY-9172: Should add bogus br after link', () => {
+      const editor = hook.editor();
+      editor.setContent('<div><a href="#">test</a></div>');
+      TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+        return s.element('body', {
+          children: [
+            s.element('div', {
+              children: [
+                s.element('a', { attrs: { href: str.is('#') }, children: [ s.text(str.is('test')) ] }),
+                s.element('br', { attrs: { 'data-mce-bogus': str.is('1') }})
+              ]
+            })
+          ]
+        });
+      }));
+    });
+
+    it('TINY-9172: Should add not add bogus br after block link', () => {
+      const editor = hook.editor();
+      editor.setContent('<div><a href="#"><p>test</p></a></div>');
+      TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+        return s.element('body', {
+          children: [
+            s.element('div', {
+              children: [
+                s.element('a', {
+                  attrs: { 'href': str.is('#'), 'data-mce-block': str.is('true') },
+                  children: [
+                    s.element('p', { children: [ s.text(str.is('test')) ] })
+                  ]
+                })
+              ]
+            })
+          ]
+        });
+      }));
+    });
+  });
+});

--- a/modules/tinymce/src/plugins/link/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/link/demo/ts/demo/Demo.ts
@@ -5,7 +5,7 @@ declare let tinymce: TinyMCE;
 tinymce.init({
   selector: 'textarea.tinymce',
   plugins: 'link code',
-  toolbar: 'link code',
+  toolbar: 'link unlink code',
   menubar: 'view insert tools custom',
   link_quicklink: true,
   link_list: [
@@ -18,7 +18,13 @@ tinymce.init({
   height: 600,
   setup: (ed) => {
     ed.on('init', () => {
-      ed.setContent('<h1>Heading</h1><p><a name="anchor1"></a>anchor here.');
+      ed.setContent(`
+        <h1>Heading</h1>
+        <p><a name="anchor1"></a>anchor here.</p>
+        <a href="#">Block link</a>
+        <div><a href="#"><p>Block link</p></a></div>
+        <p><a href="#">Inline link</a></p>
+      `);
     });
   }
 });

--- a/modules/tinymce/src/plugins/link/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/link/demo/ts/demo/Demo.ts
@@ -21,8 +21,9 @@ tinymce.init({
       ed.setContent(`
         <h1>Heading</h1>
         <p><a name="anchor1"></a>anchor here.</p>
-        <a href="#">Block link</a>
+        <a href="#"><p>Block root link</p></a>
         <div><a href="#"><p>Block link</p></a></div>
+        <a href="#">Inline root link</a>
         <p><a href="#">Inline link</a></p>
       `);
     });

--- a/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
@@ -105,9 +105,17 @@ const isOnlyTextSelected = (editor: Editor): boolean => {
   const isElement = (elm: Node): elm is Element =>
     elm.nodeType === 1 && !isAnchor(elm) && !Obj.has(inlineTextElements, elm.nodeName.toLowerCase());
 
-  // Collect all non inline text elements in the range and make sure no elements were found
-  const elements = collectNodesInRange(editor.selection.getRng(), isElement);
-  return elements.length === 0;
+  const rng = editor.selection.getRng();
+  if (!rng.collapsed) {
+    // Collect all non inline text elements in the range and make sure no elements were found
+    const elements = collectNodesInRange(rng, isElement);
+    return elements.length === 0;
+  } else {
+    // If collapsed then make sure we're not in a block anchor
+    return getAnchorElement(editor).forall((anchor) => {
+      return editor.dom.getParent(rng.startContainer, isElement, anchor) === null;
+    });
+  }
 };
 
 const isImageFigure = (elm: Element | null): elm is HTMLElement =>

--- a/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
@@ -112,9 +112,7 @@ const isOnlyTextSelected = (editor: Editor): boolean => {
     return elements.length === 0;
   } else {
     // If collapsed then make sure we're not in a block anchor
-    return getAnchorElement(editor).forall((anchor) => {
-      return editor.dom.getParent(rng.startContainer, isElement, anchor) === null;
-    });
+    return getAnchorElement(editor).forall((anchor) => !anchor.hasAttribute('data-mce-block'));
   }
 };
 

--- a/modules/tinymce/src/plugins/link/test/ts/browser/AllowUnsafeLinkTargetTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/AllowUnsafeLinkTargetTest.ts
@@ -52,7 +52,7 @@ describe('browser.tinymce.plugins.link.AllowUnsafeLinkTargetTest', () => {
   it(`TBA: allow_unsafe_link_target=false: node filter normalizes and secures rel on SetContent`, () => {
     const editor = hook.editor();
     editor.options.set('allow_unsafe_link_target', false);
-    editor.setContent('<a href="http://www.google.com" target="_blank" rel="nofollow alternate">Google</a>');
+    editor.setContent('<p><a href="http://www.google.com" target="_blank" rel="nofollow alternate">Google</a></p>');
     TinyAssertions.assertContent(editor, '<p><a href="http://www.google.com" target="_blank" rel="alternate nofollow noopener">Google</a></p>');
   });
 
@@ -64,7 +64,7 @@ describe('browser.tinymce.plugins.link.AllowUnsafeLinkTargetTest', () => {
       { title: 'Test rel', value: 'alternate nofollow' },
       { title: 'Table of contents', value: 'toc' }
     ]);
-    editor.setContent('<a href="http://www.google.com" target="_blank" rel="nofollow alternate">Google</a>');
+    editor.setContent('<p><a href="http://www.google.com" target="_blank" rel="nofollow alternate">Google</a></p>');
     TinySelections.select(editor, 'p', [ 0 ]);
     await TestLinkUi.pOpenLinkDialog(editor);
     TestLinkUi.assertDialogContents({

--- a/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
@@ -1,4 +1,4 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -8,7 +8,8 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: 'unlink',
-    base_url: '/project/tinymce/js/tinymce'
+    base_url: '/project/tinymce/js/tinymce',
+    indent: false
   }, [ Plugin ]);
 
   it('TBA: Removing a link with a collapsed selection', async () => {
@@ -45,5 +46,25 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
     TinyUiActions.clickOnToolbar(editor, 'button[title="Remove link"]');
     TinyAssertions.assertContentPresence(editor, { a: 0 });
     TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 4 ], 2);
+  });
+
+  context('Block links', () => {
+    it('TINY-9172: Removing root level link should convert it to regular text block', () => {
+      const editor = hook.editor();
+      editor.setContent('<a href="#">tiny</a>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      TinyUiActions.clickOnToolbar(editor, 'button[title="Remove link"]');
+      TinyAssertions.assertContent(editor, '<p>tiny</p>');
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+    });
+
+    it('TINY-9172: Removing wrapped block link should unwrap', () => {
+      const editor = hook.editor();
+      editor.setContent('<div><a href="#"><p>tiny</p></a></div>');
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0 ], 1);
+      TinyUiActions.clickOnToolbar(editor, 'button[title="Remove link"]');
+      TinyAssertions.assertContent(editor, '<div><p>tiny</p></div>');
+      TinyAssertions.assertCursor(editor, [ 0, 0, 0 ], 1);
+    });
   });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
@@ -51,8 +51,8 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
   context('Block links', () => {
     it('TINY-9172: Removing root level link should convert it to regular text block', () => {
       const editor = hook.editor();
-      editor.setContent('<a href="#">tiny</a>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      editor.setContent('<a href="#"><p>tiny</p></a>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
       TinyUiActions.clickOnToolbar(editor, 'button[title="Remove link"]');
       TinyAssertions.assertContent(editor, '<p>tiny</p>');
       TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
@@ -149,8 +149,8 @@ describe('browser.tinymce.plugins.link.SelectedTextLinkTest', () => {
   context('Block links', () => {
     it('TINY-9172: Collapsed selection in root block link should not have text to display', async () => {
       const editor = hook.editor();
-      editor.setContent('<a href="#">root</a>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      editor.setContent('<a href="#"><p>root</p></a>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
       await pOpenDialog(editor, false);
       await TestLinkUi.pClickCancel(editor);
     });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
@@ -1,5 +1,5 @@
 import { FocusTools, Keys, UiFinder } from '@ephox/agar';
-import { describe, it, before, after } from '@ephox/bedrock-client';
+import { describe, it, before, after, context } from '@ephox/bedrock-client';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
@@ -8,7 +8,7 @@ import Plugin from 'tinymce/plugins/link/Plugin';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
-describe('browser.tinymce.plugins.link.SelectedTextLinkTest', () => {
+describe.only('browser.tinymce.plugins.link.SelectedTextLinkTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: '',
@@ -143,6 +143,24 @@ describe('browser.tinymce.plugins.link.SelectedTextLinkTest', () => {
       'a[href="http://something"]': 1,
       'a': 2,
       'p': 1
+    });
+  });
+
+  context('Block links', () => {
+    it('TINY-9172: Collapsed selection in root block link should not have text to display', async () => {
+      const editor = hook.editor();
+      editor.setContent('<a href="#">root</a>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      await pOpenDialog(editor, false);
+      await TestLinkUi.pClickCancel(editor);
+    });
+
+    it('TINY-9172: Collapsed selection in wrapped block link should not have text to display', async () => {
+      const editor = hook.editor();
+      editor.setContent('<div><a href="#"><p>block</p></a></div>');
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0 ], 1);
+      await pOpenDialog(editor, false);
+      await TestLinkUi.pClickCancel(editor);
     });
   });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
@@ -8,7 +8,7 @@ import Plugin from 'tinymce/plugins/link/Plugin';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
-describe.only('browser.tinymce.plugins.link.SelectedTextLinkTest', () => {
+describe('browser.tinymce.plugins.link.SelectedTextLinkTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: '',

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UpdateLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UpdateLinkTest.ts
@@ -1,7 +1,7 @@
-import { FocusTools, Keys } from '@ephox/agar';
-import { describe, it, before, afterEach } from '@ephox/bedrock-client';
+import { FocusTools, Keys, Waiter } from '@ephox/agar';
+import { describe, it, before, afterEach, context } from '@ephox/bedrock-client';
 import { SugarDocument } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
@@ -78,6 +78,30 @@ describe('browser.tinymce.plugins.link.UpdateLinkTest', () => {
       'a[href]': 0,
       'a[title="shouldbekept"]': 1,
       'a:contains("tiny")': 1
+    });
+  });
+
+  context('Block links', () => {
+    it('TINY-9172: Should update a root block link', async () => {
+      const editor = hook.editor();
+      editor.setContent('<a href="#1">tiny</a>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      editor.execCommand('mceLink');
+      await TinyUiActions.pWaitForDialog(editor);
+      FocusTools.setActiveValue(SugarDocument.getDocument(), '#2');
+      TinyUiActions.submitDialog(editor);
+      Waiter.pTryUntil('Wait for content to change', () => TinyAssertions.assertContent(editor, '<a href="#2">tiny</a>'));
+    });
+
+    it('TINY-9172: Should update a wrapped block link', async () => {
+      const editor = hook.editor();
+      editor.setContent('<div><a href="#1"><p>tiny</p></a></div>');
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0 ], 1);
+      editor.execCommand('mceLink');
+      await TinyUiActions.pWaitForDialog(editor);
+      FocusTools.setActiveValue(SugarDocument.getDocument(), '#2');
+      TinyUiActions.submitDialog(editor);
+      Waiter.pTryUntil('Wait for content to change', () => TinyAssertions.assertContent(editor, '<div><a href="#2"><p>tiny</p></a></div>'));
     });
   });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UpdateLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UpdateLinkTest.ts
@@ -85,13 +85,13 @@ describe('browser.tinymce.plugins.link.UpdateLinkTest', () => {
   context('Block links', () => {
     it('TINY-9172: Should update a root block link', async () => {
       const editor = hook.editor();
-      editor.setContent('<a href="#1">tiny</a>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      editor.setContent('<a href="#1"><p>tiny</p></a>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
       editor.execCommand('mceLink');
       await TinyUiActions.pWaitForDialog(editor);
       FocusTools.setActiveValue(SugarDocument.getDocument(), '#2');
       TinyUiActions.submitDialog(editor);
-      await Waiter.pTryUntil('Wait for content to change', () => TinyAssertions.assertContent(editor, '<a href="#2">tiny</a>'));
+      await Waiter.pTryUntil('Wait for content to change', () => TinyAssertions.assertContent(editor, '<a href="#2"><p>tiny</p></a>'));
     });
 
     it('TINY-9172: Should update a wrapped block link', async () => {

--- a/modules/tinymce/src/plugins/link/test/ts/browser/UpdateLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/UpdateLinkTest.ts
@@ -12,7 +12,8 @@ describe('browser.tinymce.plugins.link.UpdateLinkTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: '',
-    base_url: '/project/tinymce/js/tinymce'
+    base_url: '/project/tinymce/js/tinymce',
+    indent: false
   }, [ Plugin ]);
 
   before(() => {
@@ -90,7 +91,7 @@ describe('browser.tinymce.plugins.link.UpdateLinkTest', () => {
       await TinyUiActions.pWaitForDialog(editor);
       FocusTools.setActiveValue(SugarDocument.getDocument(), '#2');
       TinyUiActions.submitDialog(editor);
-      Waiter.pTryUntil('Wait for content to change', () => TinyAssertions.assertContent(editor, '<a href="#2">tiny</a>'));
+      await Waiter.pTryUntil('Wait for content to change', () => TinyAssertions.assertContent(editor, '<a href="#2">tiny</a>'));
     });
 
     it('TINY-9172: Should update a wrapped block link', async () => {
@@ -101,7 +102,7 @@ describe('browser.tinymce.plugins.link.UpdateLinkTest', () => {
       await TinyUiActions.pWaitForDialog(editor);
       FocusTools.setActiveValue(SugarDocument.getDocument(), '#2');
       TinyUiActions.submitDialog(editor);
-      Waiter.pTryUntil('Wait for content to change', () => TinyAssertions.assertContent(editor, '<div><a href="#2"><p>tiny</p></a></div>'));
+      await Waiter.pTryUntil('Wait for content to change', () => TinyAssertions.assertContent(editor, '<div><a href="#2"><p>tiny</p></a></div>'));
     });
   });
 });

--- a/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
@@ -37,7 +37,7 @@ describe('browser.tinymce.plugins.media.ContentFormatsTest', () => {
   it('TBA: Embed retained as is', () => {
     const editor = hook.editor();
     editor.setContent(
-      '<embed src="320x240.ogg" width="100" height="200">text<a href="#">link</a></embed>'
+      '<p><embed src="320x240.ogg" width="100" height="200">text<a href="#">link</a></embed></p>'
     );
 
     TinyAssertions.assertContent(editor,
@@ -48,7 +48,7 @@ describe('browser.tinymce.plugins.media.ContentFormatsTest', () => {
   it('TBA: Video retained as is', () => {
     const editor = hook.editor();
     editor.setContent(
-      '<video src="320x240.ogg" autoplay loop controls>text<a href="#">link</a></video>'
+      '<p><video src="320x240.ogg" autoplay loop controls>text<a href="#">link</a></video></p>'
     );
 
     TinyAssertions.assertContent(editor,
@@ -60,7 +60,7 @@ describe('browser.tinymce.plugins.media.ContentFormatsTest', () => {
   it.skip('TBA: Iframe retained as is', () => {
     const editor = hook.editor();
     editor.setContent(
-      '<iframe src="320x240.ogg" allowfullscreen>text<a href="#">link</a></iframe>'
+      '<p><iframe src="320x240.ogg" allowfullscreen>text<a href="#">link</a></iframe></p>'
     );
 
     TinyAssertions.assertContent(editor,

--- a/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
@@ -37,7 +37,7 @@ describe('browser.tinymce.plugins.media.ContentFormatsTest', () => {
   it('TBA: Embed retained as is', () => {
     const editor = hook.editor();
     editor.setContent(
-      '<p><embed src="320x240.ogg" width="100" height="200">text<a href="#">link</a></embed></p>'
+      '<embed src="320x240.ogg" width="100" height="200">text<a href="#">link</a></embed>'
     );
 
     TinyAssertions.assertContent(editor,

--- a/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
@@ -48,7 +48,7 @@ describe('browser.tinymce.plugins.media.ContentFormatsTest', () => {
   it('TBA: Video retained as is', () => {
     const editor = hook.editor();
     editor.setContent(
-      '<p><video src="320x240.ogg" autoplay loop controls>text<a href="#">link</a></video></p>'
+      '<video src="320x240.ogg" autoplay loop controls>text<a href="#">link</a></video>'
     );
 
     TinyAssertions.assertContent(editor,
@@ -60,7 +60,7 @@ describe('browser.tinymce.plugins.media.ContentFormatsTest', () => {
   it.skip('TBA: Iframe retained as is', () => {
     const editor = hook.editor();
     editor.setContent(
-      '<p><iframe src="320x240.ogg" allowfullscreen>text<a href="#">link</a></iframe></p>'
+      '<iframe src="320x240.ogg" allowfullscreen>text<a href="#">link</a></iframe>'
     );
 
     TinyAssertions.assertContent(editor,

--- a/modules/tinymce/src/plugins/visualchars/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/visualchars/test/ts/browser/PluginTest.ts
@@ -30,6 +30,8 @@ describe('browser.tinymce.plugins.visualchars.PluginTest', () => {
     await Waiter.pTryUntil('wait for visual chars to appear', () => assertNbspStruct(editor));
     TinyUiActions.clickOnToolbar(editor, 'button');
     await Waiter.pTryUntil('wait for visual chars to appear', () => assertSpanStruct(editor));
+    TinyUiActions.clickOnToolbar(editor, 'button');
+    await Waiter.pTryUntil('wait for visual chars to appear', () => assertNbspStruct(editor));
   });
 
   it('TINY-4507: Set content with HTML like content, click visual chars button and assert span char is present in whitespaces, click the button again and assert no span is present in the whitespace', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/RemoveContextToolbarOnFocusoutTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/RemoveContextToolbarOnFocusoutTest.ts
@@ -44,7 +44,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.RemoveContextToolb
   it('iframe editor focusout should remove context toolbar', async () => {
     const editor = await McEditor.pFromHtml<Editor>(html, { setup, base_url: '/project/tinymce/js/tinymce' });
     editor.focus();
-    TinySelections.setCursor(editor, [ 0, 1, 0 ], 1);
+    TinySelections.setCursor(editor, [ 1, 0 ], 1);
     await pWaitForContextToolbarState(true);
     focusInput();
     await pWaitForContextToolbarState(false);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/RemoveContextToolbarOnFocusoutTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/RemoveContextToolbarOnFocusoutTest.ts
@@ -44,7 +44,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.RemoveContextToolb
   it('iframe editor focusout should remove context toolbar', async () => {
     const editor = await McEditor.pFromHtml<Editor>(html, { setup, base_url: '/project/tinymce/js/tinymce' });
     editor.focus();
-    TinySelections.setCursor(editor, [ 1, 0 ], 1);
+    TinySelections.setCursor(editor, [ 0, 1, 0 ], 1);
     await pWaitForContextToolbarState(true);
     focusInput();
     await pWaitForContextToolbarState(false);


### PR DESCRIPTION
Related Ticket: TINY-9172

Description of Changes:
* Transparent elements are now accepted at editor root
* Transparent elements are now allowed to contain other blocks
* Transparent elements in the root gets annotated with `data-mce-block` if they have blocks
* Transparent elements that contain blocks gets annotated with `data-mce-block`
* Lots of new tests for this new behavior of transparent elements

This is just the first batch known issues have been logged.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
