### PR TITLE
TINY-9223: Starting to separate out the dialog and popup sinks/motherships

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -13,9 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `ToggleView` command which makes it possible to hide or show registered custom views. #TINY-9210
 - New `color_default_foreground` and `color_default_background` options to set the initial default color for the `forecolor` and `backcolor` toolbar buttons and menu items. #TINY-9183
 
-### Changed
-- Separated the sinks and backstage setups between dialogs and other popups. #TINY-9223
-
 ### Fixed
 - Dragging a noneditable element toward the bottom edge would cause the page to scroll up. #TINY-9025
 - Range expanding capabilities would behave inconsistently depending on where the cursor was placed. #TINY-9029

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `ToggleView` command which makes it possible to hide or show registered custom views. #TINY-9210
 - New `color_default_foreground` and `color_default_background` options to set the initial default color for the `forecolor` and `backcolor` toolbar buttons and menu items. #TINY-9183
 
+### Changed
+- Separated the sinks and backstage setups between dialogs and other popups. #TINY-9223
+
 ### Fixed
 - Dragging a noneditable element toward the bottom edge would cause the page to scroll up. #TINY-9025
 - Range expanding capabilities would behave inconsistently depending on where the cursor was placed. #TINY-9029

--- a/modules/tinymce/src/themes/silver/demo/html/demo/demo-with-scrolling.html
+++ b/modules/tinymce/src/themes/silver/demo/html/demo/demo-with-scrolling.html
@@ -1,0 +1,346 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0">
+<title>silver-theme Demo (with scrolling) Page</title>
+<style>
+  .story-form div {
+    padding: 1em;
+  }
+
+  .tiny-text-scroller {
+    overflow: auto;
+    height: 500px;
+    outline: 2px solid #cadbee;
+    padding: 3em;
+    margin-left: 100px;
+  }
+</style>
+</head>
+<body>
+<h2>silver-theme Demo Page</h2>
+<div id='tiny-fixed-container' style="border: 10px solid red"></div>
+
+<h2>Step 1</h2>
+
+<div class="tiny-text-scroller" style="overflow: scroll; height: 500px;">
+  <h3>Short Story competition</h3>
+  <div class="story-form">
+    <div>
+      <label>Title</label>
+      <input />
+    </div>
+    <div>
+      <label>Category</label>
+      <select>
+        <option>Short Story</option>
+        <option>Novella</option>
+        <option>Novel</option>
+        <option>Opus</option>
+      </select>
+    </div>
+  </div>
+  <div class="tiny-text-header" style="height: 100px; background-color: cyan;"></div>
+  <div class='tiny-text'>
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+  </div>
+
+  <div class="tiny-text-footer" style="height: 100px; background-color: magenta;"></div>
+</div>
+
+
+<h2>Step 2</h2>
+
+<div class="tiny-text-scroller" style="overflow: scroll; height: 500px;">
+  <h3>Short Story competition</h3>
+  <div class="story-form">
+    <div>
+      <label>Title</label>
+      <input />
+    </div>
+    <div>
+      <label>Category</label>
+      <select>
+        <option>Short Story</option>
+        <option>Novella</option>
+        <option>Novel</option>
+        <option>Opus</option>
+      </select>
+    </div>
+  </div>
+  <div class="tiny-text-header" style="height: 100px; background-color: cyan;"></div>
+  <div class='tiny-text'>
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+  </div>
+  <div class="tiny-text-footer" style="height: 100px; background-color: magenta;"></div>
+</div>
+
+<h2>Step 3</h2>
+
+<div class="tiny-text-scroller" style="overflow: scroll; height: 500px;">
+  <h3>Short Story competition</h3>
+  <div class="story-form">
+    <div>
+      <label>Title</label>
+      <input />
+    </div>
+    <div>
+      <label>Category</label>
+      <select>
+        <option>Short Story</option>
+        <option>Novella</option>
+        <option>Novel</option>
+        <option>Opus</option>
+      </select>
+    </div>
+  <div class="tiny-text-header" style="height: 100px; background-color: cyan;"></div>
+  <div class='tiny-text'>
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+    <p>Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+      Lorem ipsum Lorem ipsum Lorem ipsum
+    </p>
+
+  </div>
+  <div class="tiny-text-footer" style="height: 100px; background-color: magenta;"></div>
+</div>
+
+<script src="../../../../../../js/tinymce/tinymce.js"></script>
+<script src="../../../../../../scratch/demos/themes/silver/demo.js"></script>
+<script>
+  demos.PlayDemo();
+</script>
+</body>
+</html>

--- a/modules/tinymce/src/themes/silver/main/ts/Events.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Events.ts
@@ -6,20 +6,23 @@ import Editor from 'tinymce/core/api/Editor';
 import { AfterProgressStateEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
-const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMothership: Gui.GuiSystem): void => {
+const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMotherships: Gui.GuiSystem[]): void => {
   const broadcastEvent = (name: string, evt: EventArgs) => {
-    Arr.each([ mothership, uiMothership ], (ship) => {
-      ship.broadcastEvent(name, evt);
+    Arr.each([ mothership, ...uiMotherships ], (m) => {
+      m.broadcastEvent(name, evt);
     });
   };
 
   const broadcastOn = (channel: string, message: Record<string, any>) => {
-    Arr.each([ mothership, uiMothership ], (ship) => {
-      ship.broadcastOn([ channel ], message);
+    Arr.each([ mothership, ...uiMotherships ], (m) => {
+      m.broadcastOn([ channel ], message);
     });
   };
 
-  const fireDismissPopups = (evt: EventArgs) => broadcastOn(Channels.dismissPopups(), { target: evt.target });
+  const fireDismissPopups = (evt: EventArgs) => broadcastOn(
+    Channels.dismissPopups(),
+    { target: evt.target }
+  );
 
   // Document touch events
   const doc = SugarDocument.getDocument();
@@ -101,10 +104,8 @@ const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMothership: Gui.GuiS
   });
 
   editor.on('detach', () => {
-    Attachment.detachSystem(mothership);
-    Attachment.detachSystem(uiMothership);
-    mothership.destroy();
-    uiMothership.destroy();
+    Arr.each([ mothership, ...uiMotherships ], Attachment.detachSystem);
+    Arr.each([ mothership, ...uiMotherships ], (m) => m.destroy());
   });
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ReadOnly.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ReadOnly.ts
@@ -1,10 +1,11 @@
 import { Behaviour, Channels, Disabling, Receiving } from '@ephox/alloy';
 import { FieldSchema, StructureSchema } from '@ephox/boulder';
+import { Arr } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 
 import * as Options from './api/Options';
-import { RenderUiComponents } from './Render';
+import { ReadyUiReferences } from './modes/UiReferences';
 
 export const ReadOnlyChannel = 'silver.readonly';
 
@@ -16,28 +17,31 @@ const ReadOnlyDataSchema = StructureSchema.objOf([
   FieldSchema.requiredBoolean('readonly')
 ]);
 
-const broadcastReadonly = (uiComponents: RenderUiComponents, readonly: boolean): void => {
-  const outerContainer = uiComponents.outerContainer;
+const broadcastReadonly = (uiRefs: ReadyUiReferences, readonly: boolean): void => {
+  const outerContainer = uiRefs.mainUi.outerContainer;
   const target = outerContainer.element;
 
+  const motherships = [ uiRefs.mainUi.mothership ].concat(uiRefs.uiMotherships);
   if (readonly) {
-    uiComponents.mothership.broadcastOn([ Channels.dismissPopups() ], { target });
-    uiComponents.uiMothership.broadcastOn([ Channels.dismissPopups() ], { target });
+    Arr.each(motherships, (m) => {
+      m.broadcastOn([ Channels.dismissPopups() ], { target });
+    });
   }
 
-  uiComponents.mothership.broadcastOn([ ReadOnlyChannel ], { readonly });
-  uiComponents.uiMothership.broadcastOn([ ReadOnlyChannel ], { readonly });
+  Arr.each(motherships, (m) => {
+    m.broadcastOn([ ReadOnlyChannel ], { readonly });
+  });
 };
 
-const setupReadonlyModeSwitch = (editor: Editor, uiComponents: RenderUiComponents): void => {
+const setupReadonlyModeSwitch = (editor: Editor, uiRefs: ReadyUiReferences): void => {
   editor.on('init', () => {
     // Force an update of the ui components disabled states if in readonly mode
     if (editor.mode.isReadOnly()) {
-      broadcastReadonly(uiComponents, true);
+      broadcastReadonly(uiRefs, true);
     }
   });
 
-  editor.on('SwitchMode', () => broadcastReadonly(uiComponents, editor.mode.isReadOnly()));
+  editor.on('SwitchMode', () => broadcastReadonly(uiRefs, editor.mode.isReadOnly()));
 
   if (Options.isReadOnly(editor)) {
     editor.mode.set('readonly');

--- a/modules/tinymce/src/themes/silver/main/ts/ReadOnly.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ReadOnly.ts
@@ -21,7 +21,7 @@ const broadcastReadonly = (uiRefs: ReadyUiReferences, readonly: boolean): void =
   const outerContainer = uiRefs.mainUi.outerContainer;
   const target = outerContainer.element;
 
-  const motherships = [ uiRefs.mainUi.mothership ].concat(uiRefs.uiMotherships);
+  const motherships = [ uiRefs.mainUi.mothership, ...uiRefs.uiMotherships ];
   if (readonly) {
     Arr.each(motherships, (m) => {
       m.broadcastOn([ Channels.dismissPopups() ], { target });

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -95,7 +95,7 @@ const setup = (editor: Editor): RenderInfo => {
 
   const lazyHeader = () => lazyUiRefs.mainUi.get()
     .map((ui) => ui.outerContainer)
-    .bind((oc) => editor.inline ? Optional.some(oc) : OuterContainer.getHeader(oc));
+    .bind(OuterContainer.getHeader);
 
   const lazyDialogSinkResult = () => Result.fromOption(
     lazyUiRefs.dialogUi.get().map((ui) => ui.sink),

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -444,7 +444,7 @@ const setup = (editor: Editor): RenderInfo => {
     };
 
     setupShortcutsAndCommands(uiRefs.mainUi.outerContainer);
-    Events.setup(editor, uiRefs.mainUi.mothership, uiRefs.dialogUi.mothership);
+    Events.setup(editor, uiRefs.mainUi.mothership, uiRefs.uiMotherships);
 
     // This backstage needs to kept in sync with the one passed to the Header part.
     header.setup(editor, backstages.popup.shared, lazyHeader);

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -39,11 +39,11 @@ export interface ModeRenderInfo {
 }
 
 export interface RenderInfo {
-  readonly forPopups: {
+  readonly popups: {
     readonly getMothership: () => Gui.GuiSystem;
     readonly backstage: Backstage.UiFactoryBackstage;
   };
-  readonly forDialogs: {
+  readonly dialogs: {
     readonly getMothership: () => Gui.GuiSystem;
     readonly backstage: Backstage.UiFactoryBackstage;
   };
@@ -105,7 +105,7 @@ const setup = (editor: Editor): RenderInfo => {
 
   const lazyPopupSinkResult = () => Result.fromOption(
     lazyUiRefs.popupUi.get().map((ui) => ui.sink),
-    '(adjacent) UI has not been rendered'
+    '(popup) UI has not been rendered'
   );
 
   const lazyAnchorBar = lazyUiRefs.lazyGetInOuterOrDie(
@@ -430,6 +430,7 @@ const setup = (editor: Editor): RenderInfo => {
   };
 
   const renderUIWithRefs = (uiRefs: ReadyUiReferences): ModeRenderInfo => {
+    const { mainUi, popupUi, uiMotherships } = uiRefs;
     Obj.map(Options.getToolbarGroups(editor), (toolbarGroupButtonConfig, name) => {
       editor.ui.registry.addGroupToolbarButton(name, toolbarGroupButtonConfig);
     });
@@ -448,8 +449,8 @@ const setup = (editor: Editor): RenderInfo => {
       views
     };
 
-    setupShortcutsAndCommands(uiRefs.mainUi.outerContainer);
-    Events.setup(editor, uiRefs.mainUi.mothership, uiRefs.uiMotherships);
+    setupShortcutsAndCommands(mainUi.outerContainer);
+    Events.setup(editor, mainUi.mothership, uiMotherships);
 
     // This backstage needs to kept in sync with the one passed to the Header part.
     header.setup(editor, backstages.popup.shared, lazyHeader);
@@ -458,11 +459,11 @@ const setup = (editor: Editor): RenderInfo => {
     SilverContextMenu.setup(editor, backstages.popup.shared.getSink, backstages.popup);
     Sidebar.setup(editor);
     Throbber.setup(editor, lazyThrobber, backstages.popup.shared);
-    ContextToolbar.register(editor, contextToolbars, uiRefs.popupUi.sink, { backstage: backstages.popup });
-    TableSelectorHandles.setup(editor, uiRefs.popupUi.sink);
+    ContextToolbar.register(editor, contextToolbars, popupUi.sink, { backstage: backstages.popup });
+    TableSelectorHandles.setup(editor, popupUi.sink);
 
     const elm = editor.getElement();
-    const height = setEditorSize(uiRefs.mainUi.outerContainer);
+    const height = setEditorSize(mainUi.outerContainer);
 
     const args: RenderArgs = { targetNode: elm, height };
     // The only components that use backstages.dialog currently are the Modal dialogs.
@@ -491,13 +492,13 @@ const setup = (editor: Editor): RenderInfo => {
 
   // We don't have uiRefs here, so we have to rely on cells unfortunately.
   return {
-    forPopups: {
+    popups: {
       backstage: backstages.popup,
       // TINY-9226: We haven't enabled the separate popup mothership yet, so this needs to
       // point to the dialog mothership
       getMothership: (): Gui.GuiSystem => getLazyMothership('popups', lazyDialogMothership)
     },
-    forDialogs: {
+    dialogs: {
       backstage: backstages.dialog,
       getMothership: (): Gui.GuiSystem => getLazyMothership('dialogs', lazyDialogMothership)
     },

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -38,9 +38,14 @@ export interface ModeRenderInfo {
 }
 
 export interface RenderInfo {
-  readonly getMothership: () => Gui.GuiSystem;
-  readonly getUiMothership: () => Gui.GuiSystem;
-  readonly backstage: Backstage.UiFactoryBackstage;
+  readonly forPopups: {
+    readonly getMothership: () => Gui.GuiSystem;
+    readonly backstage: Backstage.UiFactoryBackstage;
+  };
+  readonly forDialogs: {
+    readonly getMothership: () => Gui.GuiSystem;
+    readonly backstage: Backstage.UiFactoryBackstage;
+  };
   readonly renderUI: () => ModeRenderInfo;
 }
 
@@ -427,10 +432,17 @@ const setup = (editor: Editor): RenderInfo => {
     return mode.render(editor, uiComponents, rawUiConfig, backstage, args);
   };
 
-  const getMothership = (): Gui.GuiSystem => getLazyMothership(lazyMothership);
-  const getUiMothership = (): Gui.GuiSystem => getLazyMothership(lazyUiMothership);
-
-  return { getMothership, getUiMothership, backstage, renderUI };
+  return {
+    forPopups: {
+      backstage,
+      getMothership: (): Gui.GuiSystem => getLazyMothership(lazyUiMothership)
+    },
+    forDialogs: {
+      backstage,
+      getMothership: (): Gui.GuiSystem => getLazyMothership(lazyUiMothership)
+    },
+    renderUI
+  };
 };
 
 export {

--- a/modules/tinymce/src/themes/silver/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Theme.ts
@@ -22,16 +22,24 @@ const registerOptions = (editor: Editor) => {
 export default (): void => {
   ThemeManager.add('silver', (editor): Theme => {
     registerOptions(editor);
-    const { getUiMothership, backstage, renderUI }: RenderInfo = Render.setup(editor);
+    const { forDialogs, forPopups, renderUI }: RenderInfo = Render.setup(editor);
 
-    Autocompleter.register(editor, backstage.shared);
+    Autocompleter.register(editor, forPopups.backstage.shared);
 
-    const windowMgr = WindowManager.setup({ editor, backstage });
+    // TINY-9223: TODO: Add support for inline dialogs using popup sinks through backstage.
+    const windowMgr = WindowManager.setup({ editor, backstage: forDialogs.backstage });
+
+    // The NotificationManager uses the popup mothership (and sink)
+    const getNotificationManagerImpl = () => NotificationManagerImpl(
+      editor,
+      { backstage: forPopups.backstage },
+      forPopups.getMothership()
+    );
 
     return {
       renderUI,
       getWindowManagerImpl: Fun.constant(windowMgr),
-      getNotificationManagerImpl: () => NotificationManagerImpl(editor, { backstage }, getUiMothership())
+      getNotificationManagerImpl
     };
   });
 };

--- a/modules/tinymce/src/themes/silver/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Theme.ts
@@ -26,8 +26,13 @@ export default (): void => {
 
     Autocompleter.register(editor, forPopups.backstage.shared);
 
-    // TINY-9223: TODO: Add support for inline dialogs using popup sinks through backstage.
-    const windowMgr = WindowManager.setup({ editor, backstage: forDialogs.backstage });
+    const windowMgr = WindowManager.setup({
+      editor,
+      backstages: {
+        popup: forPopups.backstage,
+        dialog: forDialogs.backstage
+      }
+    });
 
     // The NotificationManager uses the popup mothership (and sink)
     const getNotificationManagerImpl = () => NotificationManagerImpl(

--- a/modules/tinymce/src/themes/silver/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Theme.ts
@@ -22,23 +22,23 @@ const registerOptions = (editor: Editor) => {
 export default (): void => {
   ThemeManager.add('silver', (editor): Theme => {
     registerOptions(editor);
-    const { forDialogs, forPopups, renderUI }: RenderInfo = Render.setup(editor);
+    const { dialogs, popups, renderUI }: RenderInfo = Render.setup(editor);
 
-    Autocompleter.register(editor, forPopups.backstage.shared);
+    Autocompleter.register(editor, popups.backstage.shared);
 
     const windowMgr = WindowManager.setup({
       editor,
       backstages: {
-        popup: forPopups.backstage,
-        dialog: forDialogs.backstage
+        popup: popups.backstage,
+        dialog: dialogs.backstage
       }
     });
 
     // The NotificationManager uses the popup mothership (and sink)
     const getNotificationManagerImpl = () => NotificationManagerImpl(
       editor,
-      { backstage: forPopups.backstage },
-      forPopups.getMothership()
+      { backstage: popups.backstage },
+      popups.getMothership()
     );
 
     return {

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -50,7 +50,7 @@ const init = (lazySinks: { popup: () => Result<AlloyComponent, string>; dialog: 
   const contextMenuState = Cell(false);
   const toolbar = HeaderBackstage(editor);
 
-  const providers: UiFactoryBackstage['shared']['providers'] = {
+  const providers: UiFactoryBackstageProviders = {
     icons: () => editor.ui.registry.getAll().icons,
     menuItems: () => editor.ui.registry.getAll().menuItems,
     translate: I18n.translate,
@@ -92,8 +92,8 @@ const init = (lazySinks: { popup: () => Result<AlloyComponent, string>; dialog: 
     ...commonBackstage,
     shared: {
       ...commonBackstage.shared,
-      interpreter: (s) => UiFactory.interpretWithoutForm(s, {}, popupBackstage),
-      getSink: lazySinks.popup
+      interpreter: (s) => UiFactory.interpretWithoutForm(s, {}, dialogBackstage),
+      getSink: lazySinks.dialog
     }
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -41,32 +41,66 @@ export interface UiFactoryBackstage {
   readonly setContextMenuState: (state: boolean) => void;
 }
 
-const init = (lazySink: () => Result<AlloyComponent, string>, editor: Editor, lazyAnchorbar: () => AlloyComponent): UiFactoryBackstage => {
+export interface UiFactoryBackstagePair {
+  readonly popup: UiFactoryBackstage;
+  readonly dialog: UiFactoryBackstage;
+}
+
+const init = (lazySinks: { popup: () => Result<AlloyComponent, string>; dialog: () => Result<AlloyComponent, string> }, editor: Editor, lazyAnchorbar: () => AlloyComponent): UiFactoryBackstagePair => {
   const contextMenuState = Cell(false);
   const toolbar = HeaderBackstage(editor);
-  const backstage: UiFactoryBackstage = {
-    shared: {
-      providers: {
-        icons: () => editor.ui.registry.getAll().icons,
-        menuItems: () => editor.ui.registry.getAll().menuItems,
-        translate: I18n.translate,
-        isDisabled: () => editor.mode.isReadOnly() || !editor.ui.isEnabled(),
-        getOption: editor.options.get
-      },
-      interpreter: (s) => UiFactory.interpretWithoutForm(s, {}, backstage),
-      anchors: Anchors.getAnchors(editor, lazyAnchorbar, toolbar.isPositionedAtTop),
-      header: toolbar,
-      getSink: lazySink
-    },
-    urlinput: UrlInputBackstage(editor),
-    styles: initStyleFormatBackstage(editor),
-    colorinput: ColorInputBackstage(editor),
-    dialog: DialogBackstage(editor),
-    isContextMenuOpen: () => contextMenuState.get(),
-    setContextMenuState: (state) => contextMenuState.set(state)
+
+  const providers: UiFactoryBackstage['shared']['providers'] = {
+    icons: () => editor.ui.registry.getAll().icons,
+    menuItems: () => editor.ui.registry.getAll().menuItems,
+    translate: I18n.translate,
+    isDisabled: () => editor.mode.isReadOnly() || !editor.ui.isEnabled(),
+    getOption: editor.options.get
   };
 
-  return backstage;
+  const urlinput = UrlInputBackstage(editor);
+  const styles = initStyleFormatBackstage(editor);
+  const colorinput = ColorInputBackstage(editor);
+  const dialogSettings = DialogBackstage(editor);
+  const isContextMenuOpen = () => contextMenuState.get();
+  const setContextMenuState = (state: boolean) => contextMenuState.set(state);
+
+  const commonBackstage = {
+    shared: {
+      providers,
+      anchors: Anchors.getAnchors(editor, lazyAnchorbar, toolbar.isPositionedAtTop),
+      header: toolbar,
+    },
+    urlinput,
+    styles,
+    colorinput,
+    dialog: dialogSettings,
+    isContextMenuOpen,
+    setContextMenuState
+  };
+
+  const popupBackstage: UiFactoryBackstage = {
+    ...commonBackstage,
+    shared: {
+      ...commonBackstage.shared,
+      interpreter: (s) => UiFactory.interpretWithoutForm(s, {}, popupBackstage),
+      getSink: lazySinks.popup
+    }
+  };
+
+  const dialogBackstage: UiFactoryBackstage = {
+    ...commonBackstage,
+    shared: {
+      ...commonBackstage.shared,
+      interpreter: (s) => UiFactory.interpretWithoutForm(s, {}, popupBackstage),
+      getSink: lazySinks.popup
+    }
+  };
+
+  return {
+    popup: popupBackstage,
+    dialog: dialogBackstage
+  };
 };
 
 export { init };

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -68,7 +68,7 @@ const setupEvents = (editor: Editor, uiRefs: ReadyUiReferences) => {
   });
   editor.on('show', () => {
     Arr.each(uiRefs.uiMotherships, (m) => {
-      Css.set(m.element, 'display', 'none');
+      Css.remove(m.element, 'display');
     });
   });
 

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -22,6 +22,7 @@ const detection = PlatformDetection.detect();
 const isiOS12 = detection.os.isiOS() && detection.os.version.major <= 12;
 
 const setupEvents = (editor: Editor, uiRefs: ReadyUiReferences) => {
+  const { uiMotherships } = uiRefs;
   const dom = editor.dom;
   let contentWindow = editor.getWin();
   const initialDocEle = editor.getDoc().documentElement;
@@ -62,12 +63,12 @@ const setupEvents = (editor: Editor, uiRefs: ReadyUiReferences) => {
 
   // We want to hide ALL UI motherships here.
   editor.on('hide', () => {
-    Arr.each(uiRefs.uiMotherships, (m) => {
+    Arr.each(uiMotherships, (m) => {
       Css.set(m.element, 'display', 'none');
     });
   });
   editor.on('show', () => {
-    Arr.each(uiRefs.uiMotherships, (m) => {
+    Arr.each(uiMotherships, (m) => {
       Css.remove(m.element, 'display');
     });
   });
@@ -92,8 +93,8 @@ const attachUiMotherships = (uiRoot: SugarElement<HTMLElement | ShadowRoot>, uiR
 };
 
 const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): ModeRenderInfo => {
-  const lastToolbarWidth = Cell(0);
   const { mainUi, uiMotherships } = uiRefs;
+  const lastToolbarWidth = Cell(0);
   const outerContainer = mainUi.outerContainer;
 
   loadIframeSkin(editor);
@@ -101,7 +102,7 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
   const eTargetNode = SugarElement.fromDom(args.targetNode);
   const uiRoot = SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(eTargetNode));
 
-  Attachment.attachSystemAfter(eTargetNode, uiRefs.mainUi.mothership);
+  Attachment.attachSystemAfter(eTargetNode, mainUi.mothership);
   attachUiMotherships(uiRoot, uiRefs);
 
   editor.on('PostRender', () => {

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -83,6 +83,14 @@ const setupEvents = (editor: Editor, uiRefs: ReadyUiReferences) => {
   });
 };
 
+// TINY-9226: When introducing two sinks, the dialog mothership should be attached to the ui
+// root, and the popup mothership should be attached *after* (or before) the main mothership
+const attachUiMotherships = (uiRoot: SugarElement<HTMLElement | ShadowRoot>, uiRefs: ReadyUiReferences) => {
+  // We only have one sink currently, until TINY-9226 is completed.
+  // Add the dialog sink to the ui root
+  Attachment.attachSystem(uiRoot, uiRefs.dialogUi.mothership);
+};
+
 const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): ModeRenderInfo => {
   const lastToolbarWidth = Cell(0);
   const { mainUi, uiMotherships } = uiRefs;
@@ -93,12 +101,8 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
   const eTargetNode = SugarElement.fromDom(args.targetNode);
   const uiRoot = SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(eTargetNode));
 
-  Attachment.attachSystemAfter(eTargetNode, mainUi.mothership);
-  // TINY-9223: This is where we would insert the popup mothership at a different location
-  // from the dialog mothership. But for now, we just treat them the same.
-  Arr.each(uiMotherships, (m) => {
-    Attachment.attachSystem(uiRoot, m);
-  });
+  Attachment.attachSystemAfter(eTargetNode, uiRefs.mainUi.mothership);
+  attachUiMotherships(uiRoot, uiRefs);
 
   editor.on('PostRender', () => {
     // Set the sidebar before the toolbar and menubar

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -72,6 +72,14 @@ const setupEvents = (editor: Editor, targetElm: SugarElement, ui: InlineHeader, 
   });
 };
 
+// TINY-9226: When introducing two sinks, the dialog mothership should be attached to the ui
+// root, and the popup mothership should be attached *after* the target node (for inline)
+const attachUiMotherships = (uiRoot: SugarElement<HTMLElement | ShadowRoot>, uiRefs: ReadyUiReferences) => {
+  // We only have one sink currently, until TINY-9226 is completed.
+  // Add the dialog sink to the ui root
+  Attachment.attachSystem(uiRoot, uiRefs.dialogUi.mothership);
+};
+
 const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): ModeRenderInfo => {
   const floatContainer = Singleton.value<AlloyComponent>();
   const targetElm = SugarElement.fromDom(args.targetNode);
@@ -90,7 +98,7 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
 
     const uiContainer = getUiContainer(editor);
     Attachment.attachSystem(uiContainer, uiRefs.mainUi.mothership);
-    Attachment.attachSystem(uiContainer, uiRefs.dialogUi.mothership);
+    attachUiMotherships(uiContainer, uiRefs);
 
     setToolbar(editor, uiRefs, rawUiConfig, backstage);
 

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -81,6 +81,7 @@ const attachUiMotherships = (uiRoot: SugarElement<HTMLElement | ShadowRoot>, uiR
 };
 
 const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): ModeRenderInfo => {
+  const { mainUi } = uiRefs;
   const floatContainer = Singleton.value<AlloyComponent>();
   const targetElm = SugarElement.fromDom(args.targetNode);
   const ui = InlineHeader(editor, targetElm, uiRefs, backstage, floatContainer);
@@ -94,16 +95,16 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
       return;
     }
 
-    floatContainer.set(OuterContainer.getHeader(uiRefs.mainUi.outerContainer).getOrDie());
+    floatContainer.set(OuterContainer.getHeader(mainUi.outerContainer).getOrDie());
 
     const uiContainer = getUiContainer(editor);
-    Attachment.attachSystem(uiContainer, uiRefs.mainUi.mothership);
+    Attachment.attachSystem(uiContainer, mainUi.mothership);
     attachUiMotherships(uiContainer, uiRefs);
 
     setToolbar(editor, uiRefs, rawUiConfig, backstage);
 
     OuterContainer.setMenubar(
-      uiRefs.mainUi.outerContainer,
+      mainUi.outerContainer,
       identifyMenus(editor, rawUiConfig)
     );
 
@@ -137,11 +138,11 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
     setEnabled: (state) => {
       ReadOnly.broadcastReadonly(uiRefs, !state);
     },
-    isEnabled: () => !Disabling.isDisabled(uiRefs.mainUi.outerContainer)
+    isEnabled: () => !Disabling.isDisabled(mainUi.outerContainer)
   };
 
   return {
-    editorContainer: uiRefs.mainUi.outerContainer.element.dom,
+    editorContainer: mainUi.outerContainer.element.dom,
     api
   };
 };

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -10,12 +10,13 @@ import * as Events from '../api/Events';
 import { getUiContainer, isToolbarPersist } from '../api/Options';
 import { UiFactoryBackstage } from '../backstage/Backstage';
 import * as ReadOnly from '../ReadOnly';
-import { ModeRenderInfo, RenderArgs, RenderUiComponents, RenderUiConfig } from '../Render';
+import { ModeRenderInfo, RenderArgs, RenderUiConfig } from '../Render';
 import OuterContainer from '../ui/general/OuterContainer';
 import { InlineHeader } from '../ui/header/InlineHeader';
 import { identifyMenus } from '../ui/menus/menubar/Integration';
 import { inline as loadInlineSkin } from '../ui/skin/Loader';
 import { setToolbar } from './Toolbars';
+import { ReadyUiReferences } from './UiReferences';
 
 const getTargetPosAndBounds = (targetElm: SugarElement, isToolbarTop: boolean) => {
   const bounds = Boxes.box(targetElm);
@@ -71,11 +72,10 @@ const setupEvents = (editor: Editor, targetElm: SugarElement, ui: InlineHeader, 
   });
 };
 
-const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): ModeRenderInfo => {
-  const { mothership, uiMothership, outerContainer } = uiComponents;
+const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): ModeRenderInfo => {
   const floatContainer = Singleton.value<AlloyComponent>();
   const targetElm = SugarElement.fromDom(args.targetNode);
-  const ui = InlineHeader(editor, targetElm, uiComponents, backstage, floatContainer);
+  const ui = InlineHeader(editor, targetElm, uiRefs, backstage, floatContainer);
   const toolbarPersist = isToolbarPersist(editor);
 
   loadInlineSkin(editor);
@@ -86,16 +86,16 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
       return;
     }
 
-    floatContainer.set(OuterContainer.getHeader(outerContainer).getOrDie());
+    floatContainer.set(OuterContainer.getHeader(uiRefs.mainUi.outerContainer).getOrDie());
 
     const uiContainer = getUiContainer(editor);
-    Attachment.attachSystem(uiContainer, mothership);
-    Attachment.attachSystem(uiContainer, uiMothership);
+    Attachment.attachSystem(uiContainer, uiRefs.mainUi.mothership);
+    Attachment.attachSystem(uiContainer, uiRefs.dialogUi.mothership);
 
-    setToolbar(editor, uiComponents, rawUiConfig, backstage);
+    setToolbar(editor, uiRefs, rawUiConfig, backstage);
 
     OuterContainer.setMenubar(
-      outerContainer,
+      uiRefs.mainUi.outerContainer,
       identifyMenus(editor, rawUiConfig)
     );
 
@@ -121,19 +121,19 @@ const render = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: R
     }
   });
 
-  ReadOnly.setupReadonlyModeSwitch(editor, uiComponents);
+  ReadOnly.setupReadonlyModeSwitch(editor, uiRefs);
 
   const api: Partial<EditorUiApi> = {
     show: render,
     hide: ui.hide,
     setEnabled: (state) => {
-      ReadOnly.broadcastReadonly(uiComponents, !state);
+      ReadOnly.broadcastReadonly(uiRefs, !state);
     },
-    isEnabled: () => !Disabling.isDisabled(outerContainer)
+    isEnabled: () => !Disabling.isDisabled(uiRefs.mainUi.outerContainer)
   };
 
   return {
-    editorContainer: outerContainer.element.dom,
+    editorContainer: uiRefs.mainUi.outerContainer.element.dom,
     api
   };
 };

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Toolbars.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Toolbars.ts
@@ -10,7 +10,7 @@ import { ReadyUiReferences } from './UiReferences';
 
 // Set toolbar(s) depending on if multiple toolbars is configured or not
 const setToolbar = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage): void => {
-  const comp = uiRefs.mainUi.outerContainer;
+  const outerContainer = uiRefs.mainUi.outerContainer;
   const toolbarConfig = rawUiConfig.toolbar;
   const toolbarButtonsConfig = rawUiConfig.buttons;
 
@@ -20,10 +20,10 @@ const setToolbar = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: Rend
       const config = { toolbar: t, buttons: toolbarButtonsConfig, allowToolbarGroups: rawUiConfig.allowToolbarGroups };
       return identifyButtons(editor, config, backstage, Optional.none());
     });
-    OuterContainer.setToolbars(comp, toolbars);
+    OuterContainer.setToolbars(outerContainer, toolbars);
   } else {
     OuterContainer.setToolbar(
-      comp,
+      outerContainer,
       identifyButtons(editor, rawUiConfig, backstage, Optional.none())
     );
   }

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Toolbars.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Toolbars.ts
@@ -3,13 +3,14 @@ import { Optional, Type } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 
 import { UiFactoryBackstage } from '../backstage/Backstage';
-import { RenderUiComponents, RenderUiConfig } from '../Render';
+import { RenderUiConfig } from '../Render';
 import OuterContainer from '../ui/general/OuterContainer';
 import { identifyButtons } from '../ui/toolbar/Integration';
+import { ReadyUiReferences } from './UiReferences';
 
 // Set toolbar(s) depending on if multiple toolbars is configured or not
-const setToolbar = (editor: Editor, uiComponents: RenderUiComponents, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage): void => {
-  const comp = uiComponents.outerContainer;
+const setToolbar = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage): void => {
+  const comp = uiRefs.mainUi.outerContainer;
   const toolbarConfig = rawUiConfig.toolbar;
   const toolbarButtonsConfig = rawUiConfig.buttons;
 

--- a/modules/tinymce/src/themes/silver/main/ts/modes/UiReferences.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/UiReferences.ts
@@ -1,0 +1,62 @@
+import { AlloyComponent, Gui } from '@ephox/alloy';
+import { Optional, Singleton } from '@ephox/katamari';
+
+export interface SinkAndMothership {
+  readonly sink: AlloyComponent;
+  readonly mothership: Gui.GuiSystem;
+}
+
+export interface MainUi {
+  readonly mothership: Gui.GuiSystem;
+  readonly outerContainer: AlloyComponent;
+}
+
+export interface ReadyUiReferences {
+  readonly dialogUi: SinkAndMothership;
+  readonly popupUi: SinkAndMothership;
+  readonly mainUi: MainUi;
+  readonly uiMotherships: Gui.GuiSystem[];
+}
+
+export interface LazyUiReferences {
+  readonly dialogUi: Singleton.Value<SinkAndMothership>;
+  readonly popupUi: Singleton.Value<SinkAndMothership>;
+  readonly mainUi: Singleton.Value<MainUi>;
+
+  // dialog + popup, if popup is different.
+  readonly getUiMotherships: () => Array<Gui.GuiSystem>;
+
+  readonly setupDialogUi: (ui: { sink: AlloyComponent; mothership: Gui.GuiSystem }) => void;
+
+  readonly lazyGetInOuterOrDie: <A>(label: string, f: (oc: AlloyComponent) => Optional<A>) => () => A;
+}
+
+export const LazyUiReferences = (): LazyUiReferences => {
+  const dialogUi = Singleton.value<SinkAndMothership>();
+  const popupUi = Singleton.value<SinkAndMothership>();
+  const mainUi = Singleton.value<{ mothership: Gui.GuiSystem; outerContainer: AlloyComponent }>();
+
+  const setupDialogUi = (ui: SinkAndMothership): void => {
+    dialogUi.set(ui);
+  };
+
+  const lazyGetInOuterOrDie = <A>(label: string, f: (oc: AlloyComponent) => Optional<A>): () => A =>
+    () => mainUi.get().bind(
+      (oc) => f(oc.outerContainer)
+    ).getOrDie(
+      `Could not find ${label} element in OuterContainer`
+    );
+
+  return {
+    dialogUi,
+    popupUi,
+    mainUi,
+
+    getUiMotherships: () => [
+      ...dialogUi.get().map((e) => e.mothership).toArray(),
+      ...popupUi.get().map((a) => a.mothership).toArray()
+    ],
+    setupDialogUi,
+    lazyGetInOuterOrDie
+  };
+};

--- a/modules/tinymce/src/themes/silver/main/ts/modes/UiReferences.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/UiReferences.ts
@@ -23,7 +23,10 @@ export interface LazyUiReferences {
   readonly popupUi: Singleton.Value<SinkAndMothership>;
   readonly mainUi: Singleton.Value<MainUi>;
 
-  // dialog + popup, if popup is different.
+  // TINY-9226: We abstract over all "UI Motherships" for things like
+  // * showing / hiding on editor focus/blur
+  // * destroying on remove
+  // * broadcasting events for dismissing popups on mousedown etc.
   readonly getUiMotherships: () => Array<Gui.GuiSystem>;
 
   readonly setupDialogUi: (ui: { sink: AlloyComponent; mothership: Gui.GuiSystem }) => void;
@@ -52,9 +55,9 @@ export const LazyUiReferences = (): LazyUiReferences => {
     popupUi,
     mainUi,
 
+    // TINY-9226: We need to return the popup mothership here once it has been added to the code
     getUiMotherships: () => [
-      ...dialogUi.get().map((e) => e.mothership).toArray(),
-      ...popupUi.get().map((a) => a.mothership).toArray()
+      ...dialogUi.get().map((e) => e.mothership).toArray()
     ],
     setupDialogUi,
     lazyGetInOuterOrDie

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
@@ -31,6 +31,7 @@ export const InlineHeader = (
   backstage: UiFactoryBackstage,
   floatContainer: Singleton.Value<AlloyComponent>
 ): InlineHeader => {
+  const { mainUi, uiMotherships } = uiRefs;
   const DOM = DOMUtils.DOM;
   const useFixedToolbarContainer = Options.useFixedContainer(editor);
   const isSticky = Options.isStickyToolbar(editor);
@@ -55,7 +56,7 @@ export const InlineHeader = (
   const calcMode = (container: AlloyComponent): 'top' | 'bottom' => {
     switch (Options.getToolbarLocation(editor)) {
       case ToolbarLocation.auto:
-        const toolbar = OuterContainer.getToolbar(uiRefs.mainUi.outerContainer);
+        const toolbar = OuterContainer.getToolbar(mainUi.outerContainer);
         const offset = calcToolbarOffset(toolbar);
         const toolbarHeight = Height.get(container.element) - offset;
         const targetBounds = Boxes.box(targetElm);
@@ -115,7 +116,7 @@ export const InlineHeader = (
 
   const updateChromePosition = () => {
     floatContainer.on((container) => {
-      const toolbar = OuterContainer.getToolbar(uiRefs.mainUi.outerContainer);
+      const toolbar = OuterContainer.getToolbar(mainUi.outerContainer);
       const offset = calcToolbarOffset(toolbar);
 
       // The float container/editor may not have been rendered yet, which will cause it to have a non integer based positions
@@ -125,7 +126,7 @@ export const InlineHeader = (
         Math.max(targetBounds.y - Height.get(container.element) + offset, 0) :
         targetBounds.bottom;
 
-      Css.setAll(uiRefs.mainUi.outerContainer.element, {
+      Css.setAll(mainUi.outerContainer.element, {
         position: 'absolute',
         top: Math.round(top) + 'px',
         left: Math.round(targetBounds.x) + 'px'
@@ -134,7 +135,7 @@ export const InlineHeader = (
   };
 
   const repositionPopups = () => {
-    Arr.each(uiRefs.uiMotherships, (m) => {
+    Arr.each(uiMotherships, (m) => {
       m.broadcastOn([ Channels.repositionPopups() ], { });
     });
   };
@@ -158,7 +159,7 @@ export const InlineHeader = (
 
     // Refresh split toolbar
     if (isSplitToolbar) {
-      OuterContainer.refreshToolbar(uiRefs.mainUi.outerContainer);
+      OuterContainer.refreshToolbar(mainUi.outerContainer);
     }
 
     // Positioning
@@ -197,9 +198,9 @@ export const InlineHeader = (
 
   const show = () => {
     visible.set(true);
-    Css.set(uiRefs.mainUi.outerContainer.element, 'display', 'flex');
+    Css.set(mainUi.outerContainer.element, 'display', 'flex');
     DOM.addClass(editor.getBody(), 'mce-edit-focus');
-    Arr.each(uiRefs.uiMotherships, (m) => {
+    Arr.each(uiMotherships, (m) => {
       Css.remove(m.element, 'display');
     });
     updateMode(false);
@@ -208,12 +209,9 @@ export const InlineHeader = (
 
   const hide = () => {
     visible.set(false);
-    // In what situation would `outerContainer` not be set?
-    if (uiRefs.mainUi.outerContainer) {
-      Css.set(uiRefs.mainUi.outerContainer.element, 'display', 'none');
-      DOM.removeClass(editor.getBody(), 'mce-edit-focus');
-    }
-    Arr.each(uiRefs.uiMotherships, (m) => {
+    Css.set(mainUi.outerContainer.element, 'display', 'none');
+    DOM.removeClass(editor.getBody(), 'mce-edit-focus');
+    Arr.each(uiMotherships, (m) => {
       Css.set(m.element, 'display', 'none');
     });
   };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/StickyHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/StickyHeader.ts
@@ -190,8 +190,14 @@ const getBehaviours = (editor: Editor, sharedBackstage: UiFactoryBackstageShared
       updateIframeContentFlow(comp);
     }
     updateEditorClasses(editor, Docking.isDocked(comp));
+
+    // TINY-9223: This will only reposition the popups in the same mothership as the StickyHeader
+    // and its sink. If we need to reposition the popups in all motherships (in the two sink
+    // model) then we'll need a reference to all motherships here.
     comp.getSystem().broadcastOn( [ Channels.repositionPopups() ], { });
-    lazySink().each((sink) => sink.getSystem().broadcastOn( [ Channels.repositionPopups() ], { }));
+    lazySink().each(
+      (sink) => sink.getSystem().broadcastOn( [ Channels.repositionPopups() ], { })
+    );
   };
 
   const additionalBehaviours = editor.inline ? [ ] : getIframeBehaviours();

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -193,9 +193,11 @@ const renderSlidingMoreToolbar = (toolbarSpec: MoreDrawerToolbarSpec): SketchSpe
       overflowToggledClass: ToolbarButtonClasses.Ticked
     },
     onOpened: (comp) => {
+      // TINY-9223: This will only broadcast to the same mothership as the toolbar
       comp.getSystem().broadcastOn([ Channels.toolbarHeightChange() ], { type: 'opened' });
     },
     onClosed: (comp) => {
+      // TINY-9223: This will only broadcast to the same mothership as the toolbar
       comp.getSystem().broadcastOn([ Channels.toolbarHeightChange() ], { type: 'closed' });
     }
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
@@ -75,6 +75,9 @@ const renderModalDialog = <T>(spec: DialogSpec, initialData: T, dialogEvents: Al
     ...spec,
     lazySink: backstage.shared.getSink,
     extraBehaviours: [
+      // Because this doesn't define `renderComponents`, all this does is update the state.
+      // We use the state for the initialData. The other parts (body etc.) render the
+      // components based on what reflecting receives.
       Reflecting.config({
         channel: `${dialogChannel}-${spec.id}`,
         updateState,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogInstanceApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogInstanceApi.ts
@@ -117,8 +117,16 @@ const getDialogApi = <T extends Dialog.DialogData>(
     withRoot((root) => {
       const id = access.getId();
       const dialogInit = doRedial(d);
+      // TINY-9223: We only need to broadcast to the mothership containing the dialog
       root.getSystem().broadcastOn([ `${dialogChannel}-${id}` ], dialogInit);
 
+      // NOTE: Reflecting does not have any smart handling of nested reflecting components,
+      // and the order of receiving a broadcast is non-deterministic. Here we use separate
+      // channels for each section (title, body, footer), and make those broadcasts *after*
+      // we've already sent the overall dialog broadcast. The overall dialog broadcast
+      // doesn't actually change the components ... its Reflecting config just stores state,
+      // but these Reflecting configs (title, body, footer) do change the components based on
+      // the received broadcasts.
       root.getSystem().broadcastOn([ `${titleChannel}-${id}` ], dialogInit.internalDialog);
       root.getSystem().broadcastOn([ `${bodyChannel}-${id}` ], dialogInit.internalDialog);
       root.getSystem().broadcastOn([ `${footerChannel}-${id}` ], dialogInit.internalDialog);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageSinkTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageSinkTest.ts
@@ -1,0 +1,188 @@
+import { Assertions, Keyboard, Keys, Mouse, UiFinder } from '@ephox/agar';
+import { AlloyComponent, Attachment, Behaviour, Gui, GuiFactory, Positioning, Representing } from '@ephox/alloy';
+import { after, before, context, describe, it } from '@ephox/bedrock-client';
+import { Fun, Optional, Result } from '@ephox/katamari';
+import { Classes, SugarBody, Traverse } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import EditorManager from 'tinymce/core/api/EditorManager';
+import * as Backstage from 'tinymce/themes/silver/backstage/Backstage';
+import * as Options from 'tinymce/themes/silver/ui/core/color/Options';
+
+describe('browser.tinymce.themes.silver.editor.backstage.BackstageSinkTest', () => {
+  // We setup an editor without a complete silver theme, so that we can
+  // test backstage more directly. Because there isn't a theme, we need to
+  // do a few things
+  //  (1) register the options that the colorinput uses. This is because this test
+  // is checking the backstage instance passed into the ui factory interpreter, and
+  // colorinput was the component chosen for testing that. URLInput would have been another,
+  // or just a menu button. The chosen component just needs to use the sink.
+  //  (2) load the oxide skin. The colorinput relies on some pseudo elements for size,
+  // so we need the skin
+  //  (3) dispatch "SkinLoaded" event. This is required for the mcagar loader to consider
+  // that the editor is ready for testing. Without this, the test won't complete.
+  //
+  // NOTE: If this approach is causing problems, we can just load silver normally, and create a duplicate
+  // backstage, but this approach removes the number of extraneous elements.
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    setup: (ed: Editor) => {
+      Options.register(ed);
+      ed.on('init', () => {
+        const skinUrl = EditorManager.baseURL + '/skins/ui/oxide/skin.min.css';
+        ed.ui.styleSheetLoader.load(skinUrl).then(
+          () => {
+            ed.dispatch('SkinLoaded');
+          }
+        );
+      });
+    },
+    theme: false
+  }, [], true);
+
+  const buildSink = (extraClass: string) => GuiFactory.build({
+    dom: {
+      tag: 'div',
+      classes: [ extraClass, 'backstage-test-sink' ]
+    },
+    behaviours: Behaviour.derive([
+      Positioning.config({})
+    ])
+  });
+
+  const popupSink = buildSink('popup-sink');
+  const dialogSink = buildSink('dialog-sink');
+
+  const mothership = Gui.create();
+  Classes.add(mothership.element, [ 'tox' ]);
+  mothership.add(popupSink);
+  mothership.add(dialogSink);
+
+  before(() => {
+    Attachment.attachSystem(SugarBody.body(), mothership);
+  });
+
+  after(() => {
+    Attachment.detachSystem(mothership);
+    mothership.destroy();
+  });
+
+  const buildAndAddColorInput = (backstage: Backstage.UiFactoryBackstage): AlloyComponent => {
+    const colorInputSpec = backstage.shared.interpreter({
+      type: 'colorinput',
+      label: Optional.some('color'),
+      name: 'color'
+    });
+
+    const colorInputComp = GuiFactory.build(colorInputSpec);
+    mothership.add(colorInputComp);
+    Representing.setValue(colorInputComp, '#000000');
+    return colorInputComp;
+  };
+
+  const assertCompEmpty = (label: string, comp: AlloyComponent) => {
+    Assertions.assertEq(
+      `Ensure that ${label} is empty`,
+      0,
+      Traverse.childNodesCount(comp.element)
+    );
+  };
+
+  context('themeless - init', () => {
+    context('testing sinks', () => {
+      let lazyBackstages: () => Backstage.UiFactoryBackstagePair = Fun.die(
+        'backstages have not yet been setup'
+      );
+
+      before(() => {
+        const editor = hook.editor();
+        lazyBackstages = () => Backstage.init(
+          {
+            popup: () => Result.value(popupSink),
+            dialog: () => Result.value(dialogSink)
+          },
+          editor,
+          Fun.die('No lazy anchor bar in this test')
+        );
+      });
+
+      context('backstage - popup', () => {
+        it('getSink', () => {
+          const backstage = lazyBackstages().popup;
+
+          const actual = backstage.shared.getSink().getOrDie();
+          Assertions.assertEq(
+            'Checking class list of popup sink',
+            [ 'popup-sink', 'backstage-test-sink' ],
+            Classes.get(actual.element)
+          );
+        });
+
+        it('backstage sink being used by colorinput', async () => {
+          const backstage = lazyBackstages().popup;
+
+          const colorInputComp = buildAndAddColorInput(backstage);
+
+          // Check that the sink is empty first.
+          assertCompEmpty('Popup sink', popupSink);
+
+          // Now, trigger the color inputs dropdown picker, and check it appears in popup sink.
+          Mouse.clickOn(mothership.element, '[aria-label="Color swatch"]');
+          const swatch = await UiFinder.pWaitFor<Element>(
+            'Waiting for color picker in popup sink',
+            popupSink.element,
+            '.tox-swatch'
+          );
+
+          // Close the color picker.
+          Keyboard.keystroke(Keys.escape(), { }, swatch);
+
+          // Check that the sink is empty again, because the picker has closed
+          assertCompEmpty('Popup sink', popupSink);
+
+          mothership.remove(colorInputComp);
+        });
+      });
+
+      context('backstage - dialog', () => {
+        it('getSink', () => {
+          const backstage = lazyBackstages().dialog;
+
+          const actual = backstage.shared.getSink().getOrDie();
+          Assertions.assertEq(
+            'Checking class list of dialog sink',
+            [ 'dialog-sink', 'backstage-test-sink' ],
+            Classes.get(actual.element)
+          );
+        });
+
+        it('backstage sink being used by colorinput', async () => {
+          // The colorinput uses getSink
+          const backstage = lazyBackstages().dialog;
+
+          const colorInputComp = buildAndAddColorInput(backstage);
+
+          // Check that the sink is empty first.
+          assertCompEmpty('Dialog sink', dialogSink);
+
+          // Now, trigger its dropdown, and check which sink it is appearing inside.
+          Mouse.clickOn(mothership.element, '[aria-label="Color swatch"]');
+          const swatch = await UiFinder.pWaitFor<Element>(
+            'Waiting for color picker in dialog sink',
+            dialogSink.element,
+            '.tox-swatch'
+          );
+
+          // Close the color picker.
+          Keyboard.keystroke(Keys.escape(), { }, swatch);
+
+          // Check that the sink is empty again, because the picker has closed
+          assertCompEmpty('Dialog sink', dialogSink);
+
+          mothership.remove(colorInputComp);
+        });
+      });
+    });
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageTest.ts
@@ -1,0 +1,5 @@
+import { describe } from '@ephox/bedrock-client';
+
+describe('browser.editor.backstage.BackstageTest', () => {
+
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageTest.ts
@@ -1,5 +1,0 @@
-import { describe } from '@ephox/bedrock-client';
-
-describe('browser.editor.backstage.BackstageTest', () => {
-
-});

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/colorinput/ColorInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/colorinput/ColorInputTest.ts
@@ -13,7 +13,7 @@ type StringAssert = ReturnType<ApproxStructure.StringApi['is']>;
 type ArrayAssert = ReturnType<ApproxStructure.ArrayApi['has']>;
 
 describe('headless.tinymce.themes.silver.components.colorinput.ColorInputTest', () => {
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
 
   const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(
     Container.sketch({
@@ -24,7 +24,7 @@ describe('headless.tinymce.themes.silver.components.colorinput.ColorInputTest', 
         renderColorInput({
           name: 'alpha',
           label: Optional.some('test-color-input')
-        }, helpers.extras().backstages.popup.shared, {
+        }, extrasHook.access().extras.backstages.popup.shared, {
           colorPicker: (_callback, _value) => {},
           hasCustomColors: Fun.always,
           getColors: () => [
@@ -69,11 +69,17 @@ describe('headless.tinymce.themes.silver.components.colorinput.ColorInputTest', 
 
   const pOpenPicker = async () => {
     Mouse.clickOn(getLegend().element, 'root:span');
-    await UiFinder.pWaitFor('Waiting for colorswatch to show up!', helpers.sink(), '.tox-swatches');
+    await UiFinder.pWaitFor(
+      'Waiting for colorswatch to show up!',
+      extrasHook.access().getPopupSink(),
+      '.tox-swatches'
+    );
   };
 
   const assertFocusedValue = (label: string, expected: string) => {
-    const value = FocusTools.getActiveValue(helpers.sink());
+    const value = FocusTools.getActiveValue(
+      extrasHook.access().getPopupSink()
+    );
     assert.equal(value, expected, 'Checking value of focused element');
   };
 
@@ -154,7 +160,10 @@ describe('headless.tinymce.themes.silver.components.colorinput.ColorInputTest', 
     Keyboard.activeKeydown(doc, Keys.enter());
     await FocusTools.pTryOnSelector('Focus should be back on colorinput button (after escape)', doc, '.colorinput-container input');
     assertFocusedValue('After pressing <enter> in hex', '#18BC9B');
-    UiFinder.notExists(helpers.sink(), '.tox-swatches');
+    UiFinder.notExists(
+      extrasHook.access().getPopupSink(),
+      '.tox-swatches'
+    );
   });
 
   it('TBA: Check that pressing escape inside the picker refocuses the colorinput button', async () => {
@@ -163,7 +172,10 @@ describe('headless.tinymce.themes.silver.components.colorinput.ColorInputTest', 
     await FocusTools.pTryOnSelector('Focus should be on a swatch', doc, 'div.tox-swatch');
     Keyboard.activeKeyup(doc, Keys.escape());
     await FocusTools.pTryOnSelector('Focus should be back on colorinput button (after escape)', doc, '.colorinput-container > div:not(.mce-silver-sink) span');
-    UiFinder.notExists(helpers.sink(), '.tox-swatches');
+    UiFinder.notExists(
+      extrasHook.access().getPopupSink(),
+      '.tox-swatches'
+    );
   });
 
   it('TBA: Check that validating an empty string passes (first time)', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/colorinput/ColorInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/colorinput/ColorInputTest.ts
@@ -24,7 +24,7 @@ describe('headless.tinymce.themes.silver.components.colorinput.ColorInputTest', 
         renderColorInput({
           name: 'alpha',
           label: Optional.some('test-color-input')
-        }, helpers.shared(), {
+        }, helpers.extras().backstages.popup.shared, {
           colorPicker: (_callback, _value) => {},
           hasCustomColors: Fun.always,
           getColors: () => [

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/listbox/ListBoxTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/listbox/ListBoxTest.ts
@@ -11,7 +11,7 @@ import * as RepresentingUtils from '../../../module/RepresentingUtils';
 import * as TestExtras from '../../../module/TestExtras';
 
 describe('headless.tinymce.themes.silver.components.listbox.ListBoxTest', () => {
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
 
   const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(
     renderListBox({
@@ -25,7 +25,7 @@ describe('headless.tinymce.themes.silver.components.listbox.ListBoxTest', () => 
           { value: 'three', text: 'Three' }
         ] }
       ]
-    }, helpers.extras().backstages.popup, Optional.none())
+    }, extrasHook.access().extras.backstages.popup, Optional.none())
   ));
 
   const assertValue = (component: AlloyComponent, expected: string) => {
@@ -92,7 +92,7 @@ describe('headless.tinymce.themes.silver.components.listbox.ListBoxTest', () => 
     const component = hook.component();
     const doc = hook.root();
     const gui = hook.gui();
-    const sink = helpers.sink();
+    const sink = extrasHook.access().getPopupSink();
     Representing.setValue(component, 'three');
 
     Mouse.clickOn(gui.element, '.tox-listbox');

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/listbox/ListBoxTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/listbox/ListBoxTest.ts
@@ -25,7 +25,7 @@ describe('headless.tinymce.themes.silver.components.listbox.ListBoxTest', () => 
           { value: 'three', text: 'Three' }
         ] }
       ]
-    }, helpers.backstage(), Optional.none())
+    }, helpers.extras().backstages.popup, Optional.none())
   ));
 
   const assertValue = (component: AlloyComponent, expected: string) => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
@@ -12,7 +12,7 @@ import { renderUrlInput } from 'tinymce/themes/silver/ui/dialog/UrlInput';
 import * as TestExtras from '../../../module/TestExtras';
 
 describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () => {
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
 
   const hook = TestHelpers.GuiSetup.bddSetup((store, _doc, _body) => GuiFactory.build(
     renderUrlInput({
@@ -20,7 +20,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
       name: 'col1',
       filetype: 'file',
       enabled: true
-    }, helpers.extras().backstages.popup, {
+    }, extrasHook.access().extras.backstages.popup, {
       getHistory: (_fileType) => [],
       addToHistory: (_url, _filetype) => store.adder('addToHistory')(),
       getLinkInformation: () => Optional.some({
@@ -49,7 +49,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
         return Future.pure({ value: 'http://tiny.cloud', meta: { before: entry.value }, fieldname: 'test' });
       })
     }, Optional.none())
-  ), helpers.uiMothership);
+  ), () => extrasHook.access().getPopupMothership());
 
   TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [
     '.tox-menu { background: white; }',
@@ -64,7 +64,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
   };
 
   const pOpenMenu = async () => {
-    const sink = helpers.sink();
+    const sink = extrasHook.access().getPopupSink();
     const doc = hook.root();
     Focusing.focus(getInput());
     Keyboard.activeKeydown(doc, Keys.down());
@@ -138,7 +138,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
   });
 
   it('Type "He", select an item and assert input state is updated', async () => {
-    const sink = helpers.sink();
+    const sink = extrasHook.access().getPopupSink();
     const store = hook.store();
     const doc = hook.root();
     const input = getInput();

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
@@ -20,7 +20,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
       name: 'col1',
       filetype: 'file',
       enabled: true
-    }, helpers.backstage(), {
+    }, helpers.extras().backstages.popup, {
       getHistory: (_fileType) => [],
       addToHistory: (_url, _filetype) => store.adder('addToHistory')(),
       getLinkInformation: () => Optional.some({

--- a/modules/tinymce/src/themes/silver/test/ts/headless/sketchers/SilverMenubarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/sketchers/SilverMenubarTest.ts
@@ -10,7 +10,7 @@ import SilverMenubar from 'tinymce/themes/silver/ui/menus/menubar/SilverMenubar'
 import * as TestExtras from '../../module/TestExtras';
 
 describe('headless.tinymce.themes.silver.sketchers.SilverMenubar Test', () => {
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
 
   const hook = TestHelpers.GuiSetup.bddSetup((store, _doc, _body) => GuiFactory.build({
     dom: {
@@ -25,7 +25,7 @@ describe('headless.tinymce.themes.silver.sketchers.SilverMenubar Test', () => {
         },
         onEscape: store.adder('Menubar.escape'),
         onSetup: store.adder('Menubar.setup'),
-        backstage: helpers.extras().backstages.popup
+        backstage: extrasHook.access().extras.backstages.popup
       })
     ]
   }));
@@ -44,7 +44,10 @@ describe('headless.tinymce.themes.silver.sketchers.SilverMenubar Test', () => {
     );
 
   const assertActiveToggleItemHasOneCheckmark = (itemText: string) => {
-    UiFinder.findIn(helpers.sink(), '.tox-selected-menu [role=menuitemcheckbox]:contains("' + itemText + '")').getOrDie();
+    UiFinder.findIn(
+      extrasHook.access().getPopupSink(),
+      '.tox-selected-menu [role=menuitemcheckbox]:contains("' + itemText + '")'
+    ).getOrDie();
     const checkMarks = Selectors.all('.tox-collection__item-checkmark');
     assert.lengthOf(checkMarks, 1, 'only one check mark is displayed for active toggled menu items');
   };
@@ -67,17 +70,20 @@ describe('headless.tinymce.themes.silver.sketchers.SilverMenubar Test', () => {
     // Wait for menu to appear
     Waiter.pTryUntil(
       'Waiting for menu to be in DOM',
-      () => UiFinder.exists(helpers.sink(), '.tox-menu')
+      () => UiFinder.exists(extrasHook.access().getPopupSink(), '.tox-menu')
     );
 
   const pWaitForMenuToDisappear = () =>
     Waiter.pTryUntil(
       'Waiting for menu to NO LONGER be in DOM',
-      () => UiFinder.notExists(helpers.sink(), '.tox-menu')
+      () => UiFinder.notExists(extrasHook.access().getPopupSink(), '.tox-menu')
     );
 
   const assertMenuItemGroups = (label: string, groups: string[][], hasIcons: boolean, hasCheckmark: boolean) => {
-    const menu = UiFinder.findIn(helpers.sink(), '.tox-selected-menu').getOrDie();
+    const menu = UiFinder.findIn(
+      extrasHook.access().getPopupSink(),
+      '.tox-selected-menu'
+    ).getOrDie();
     Assertions.assertStructure(
       label + '. Checking contents of menu',
       ApproxStructure.build((s, str, arr) => s.element('div', {
@@ -269,7 +275,7 @@ describe('headless.tinymce.themes.silver.sketchers.SilverMenubar Test', () => {
     it('AP-307: Once a menu is expanded, hovering on buttons should switch which menu is expanded', async () => {
       const doc = hook.root();
       const menubar = getMenubar();
-      const sink = helpers.sink();
+      const sink = extrasHook.access().getPopupSink();
       Mouse.hoverOn(menubar.element, 'button[role="menuitem"]:contains("Basic Menu Button")');
       await Waiter.pWait(100);
       UiFinder.notExists(sink, '[role="menu"]');

--- a/modules/tinymce/src/themes/silver/test/ts/headless/sketchers/SilverMenubarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/sketchers/SilverMenubarTest.ts
@@ -25,7 +25,7 @@ describe('headless.tinymce.themes.silver.sketchers.SilverMenubar Test', () => {
         },
         onEscape: store.adder('Menubar.escape'),
         onSetup: store.adder('Menubar.setup'),
-        backstage: helpers.backstage()
+        backstage: helpers.extras().backstages.popup
       })
     ]
   }));

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonPlaceholderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonPlaceholderTest.ts
@@ -45,7 +45,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonPlaceholder
           }, store)
         },
         'prefix',
-        helpers.extras().backstages.popup,
+        helpers.access().extras.backstages.popup,
         Optional.none()
       )
     )

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonPlaceholderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonPlaceholderTest.ts
@@ -45,7 +45,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonPlaceholder
           }, store)
         },
         'prefix',
-        helpers.backstage(),
+        helpers.extras().backstages.popup,
         Optional.none()
       )
     )

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonTest.ts
@@ -41,7 +41,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
           }, store)
         },
         'prefix',
-        helpers.backstage(),
+        helpers.extras().backstages.popup,
         Optional.none()
       )
     )

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonTest.ts
@@ -11,7 +11,7 @@ import { structMenuWith, structSearchField, structSearchLeafItem, structSearchPa
 import * as TestExtras from '../../module/TestExtras';
 
 describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () => {
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
 
   TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [
     `.tox-menu .tox-collection__item--active {
@@ -41,7 +41,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
           }, store)
         },
         'prefix',
-        helpers.extras().backstages.popup,
+        extrasHook.access().extras.backstages.popup,
         Optional.none()
       )
     )
@@ -52,13 +52,13 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
     // So find the field.
     const inputField: SugarElement<HTMLElement> = await UiFinder.pWaitForVisible(
       'Waiting for search widget to appear (testing aria consistency)',
-      helpers.uiMothership().element,
+      extrasHook.access().getPopupSink(),
       '.tox-menu input'
     );
 
     const activeResults = await UiFinder.pWaitForVisible(
       'Waiting for selected menu to appear',
-      helpers.uiMothership().element,
+      extrasHook.access().getPopupSink(),
       '.tox-selected-menu .tox-collection--results__js, .tox-selected-menu.tox-collection--results__js'
     );
 
@@ -74,7 +74,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
     // Invariant: aria-activedescendant points to active item
     const activeItem = await UiFinder.pWaitForVisible(
       'Waiting for selected item to appear',
-      helpers.uiMothership().element,
+      extrasHook.access().getPopupSink(),
       '.tox-selected-menu .tox-collection__item--active'
     );
     const inputFieldDescendant = Attribute.get(inputField, 'aria-activedescendant');
@@ -455,7 +455,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
     const updateInputAndEmit = (newValue: string): void => {
       FocusTools.setActiveValue(hook.root(), newValue);
       FocusTools.getFocused(hook.root()).each((input) => {
-        helpers.uiMothership().getByDom(input).each((inputComp) => {
+        extrasHook.access().getPopupMothership().getByDom(input).each((inputComp) => {
           AlloyTriggers.emit(inputComp, NativeEvents.input());
         });
       });
@@ -473,7 +473,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
     updateInputAndEmit('Pho');
     await UiFinder.pWaitForVisible(
       'Waiting for the Phone.Home to appear',
-      helpers.uiMothership().element,
+      extrasHook.access().getPopupSink(),
       'div:contains(Phone.Home)'
     );
 
@@ -505,7 +505,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
     updateInputAndEmit('P');
     await UiFinder.pWaitForVisible(
       'Waiting for the Person.Email to appear',
-      helpers.uiMothership().element,
+      extrasHook.access().getPopupSink(),
       'div:contains(Person.Email)'
     );
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
@@ -108,7 +108,7 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
               store.adder('onItemAction.3')();
               api.setActive(true);
             }
-          }, helpers.shared())
+          }, helpers.extras().backstages.popup.shared)
         ]
       },
 
@@ -138,7 +138,7 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
               store.adder('onSetup.4')();
               return Fun.noop;
             }
-          }, 'tox-mbtn', helpers.backstage(), Optional.none())
+          }, 'tox-mbtn', helpers.extras().backstages.popup, Optional.none())
         ]
       }
     ]

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
@@ -15,7 +15,7 @@ import TestProviders from '../../module/TestProviders';
 describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
   const shouldDisable = Cell(false);
   const shouldActivate = Cell(false);
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
 
   const hook = TestHelpers.GuiSetup.bddSetup((store, _doc, _body) => GuiFactory.build({
     dom: {
@@ -108,7 +108,7 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
               store.adder('onItemAction.3')();
               api.setActive(true);
             }
-          }, helpers.extras().backstages.popup.shared)
+          }, extrasHook.access().extras.backstages.popup.shared)
         ]
       },
 
@@ -138,7 +138,7 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
               store.adder('onSetup.4')();
               return Fun.noop;
             }
-          }, 'tox-mbtn', helpers.extras().backstages.popup, Optional.none())
+          }, 'tox-mbtn', extrasHook.access().extras.backstages.popup, Optional.none())
         ]
       }
     ]

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/CustomDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/CustomDialogTest.ts
@@ -14,10 +14,10 @@ const GuiSetup = TestHelpers.GuiSetup;
 
 describe('headless.tinymce.themes.silver.window.CustomDialogTest', () => {
   const store = TestStore();
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
   let windowManager: WindowManagerImpl;
   before(() => {
-    windowManager = WindowManager.setup(helpers.extras());
+    windowManager = WindowManager.setup(extrasHook.access().extras);
   });
 
   GuiSetup.bddAddStyles(SugarDocument.getDocument(), [

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogReuseTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogReuseTest.ts
@@ -13,11 +13,11 @@ import * as TestExtras from '../../module/TestExtras';
 
 describe('headless.tinymce.themes.silver.window.SilverDialogReuseTest', () => {
   const store = TestStore();
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
   let windowManager: WindowManagerImpl;
   let dialogApi: Dialog.DialogInstanceApi<any>;
   before(() => {
-    windowManager = WindowManager.setup(helpers.extras());
+    windowManager = WindowManager.setup(extrasHook.access().extras);
   });
 
   afterEach(() => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogTest.ts
@@ -11,11 +11,11 @@ import * as TestExtras from '../../module/TestExtras';
 
 describe('headless.tinymce.themes.silver.window.SilverDialogTest', () => {
   const store = TestStore();
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
   let windowManager: WindowManagerImpl;
   let dialogApi: Dialog.DialogInstanceApi<any>;
   before(() => {
-    windowManager = WindowManager.setup(helpers.extras());
+    windowManager = WindowManager.setup(extrasHook.access().extras);
   });
 
   const openDialogAndAssertInitialData = () => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverUrlDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverUrlDialogTest.ts
@@ -10,11 +10,11 @@ import * as TestExtras from '../../module/TestExtras';
 
 describe('headless.tinymce.themes.silver.window.SilverUrlDialogTest', () => {
   const store = TestStore();
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
   let windowManager: WindowManagerImpl;
   let dialogApi: Dialog.UrlDialogInstanceApi;
   before(() => {
-    windowManager = WindowManager.setup(helpers.extras());
+    windowManager = WindowManager.setup(extrasHook.access().extras);
   });
 
   const openDialog = () => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/TabbedDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/TabbedDialogTest.ts
@@ -9,10 +9,10 @@ import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 import * as TestExtras from '../../module/TestExtras';
 
 describe('headless.tinymce.themes.silver.window.TabbedDialogTest', () => {
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
   let windowManager: WindowManagerImpl;
   before(() => {
-    windowManager = WindowManager.setup(helpers.extras());
+    windowManager = WindowManager.setup(extrasHook.access().extras);
   });
 
   const assertFormContents = (label: string, tabview: SugarElement<HTMLElement>, f: ApproxStructure.Builder<StructAssert>) => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerAlertTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerAlertTest.ts
@@ -10,10 +10,10 @@ import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 import * as TestExtras from '../../module/TestExtras';
 
 describe('headless.tinymce.themes.silver.window.WindowManagerAlertTest', () => {
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
   let windowManager: WindowManagerImpl;
   before(() => {
-    windowManager = WindowManager.setup(helpers.extras());
+    windowManager = WindowManager.setup(extrasHook.access().extras);
   });
 
   const pTeardown = async () => {
@@ -36,7 +36,7 @@ describe('headless.tinymce.themes.silver.window.WindowManagerAlertTest', () => {
   it('Check the basic structure of the alert dialog', async () => {
     createAlert('The alert dialog loads with the basic structure', Fun.noop);
     await pWaitForDialog();
-    const sink = helpers.sink();
+    const sink = extrasHook.access().getDialogSink();
     Assertions.assertStructure('A basic alert dialog should have these components',
       ApproxStructure.build((s, str, arr) => s.element('div', {
         classes: [ arr.has('mce-silver-sink') ],

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerConfirmTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerConfirmTest.ts
@@ -10,10 +10,10 @@ import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 import * as TestExtras from '../../module/TestExtras';
 
 describe('headless.tinymce.themes.silver.window.WindowManagerConfirmTest', () => {
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
   let windowManager: WindowManagerImpl;
   before(() => {
-    windowManager = WindowManager.setup(helpers.extras());
+    windowManager = WindowManager.setup(extrasHook.access().extras);
   });
 
   const pTeardown = async () => {
@@ -36,7 +36,7 @@ describe('headless.tinymce.themes.silver.window.WindowManagerConfirmTest', () =>
   it('Check the basic structure of the confirm dialog', async () => {
     createConfirm('The confirm dialog loads with the basic structure', Fun.noop);
     await pWaitForDialog();
-    const sink = helpers.sink();
+    const sink = extrasHook.access().getDialogSink();
     Assertions.assertStructure('A basic confirm dialog should have these components',
       ApproxStructure.build((s, str, arr) => s.element('div', {
         classes: [ arr.has('mce-silver-sink') ],

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerRedialTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerRedialTest.ts
@@ -11,10 +11,10 @@ import * as TestExtras from '../../module/TestExtras';
 
 describe('headless.tinymce.themes.silver.window.WindowManagerRedialTest', () => {
   const store = TestStore();
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
   let windowManager: WindowManagerImpl;
   before(() => {
-    windowManager = WindowManager.setup(helpers.extras());
+    windowManager = WindowManager.setup(extrasHook.access().extras);
   });
 
   const dialogA: Dialog.DialogSpec<{}> = {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerTest.ts
@@ -15,13 +15,22 @@ describe('headless.tinymce.themes.silver.window.WindowManagerTest', () => {
   let windowManager: WindowManagerImpl;
   let windowManagerWithDragging: WindowManagerImpl;
   before(() => {
-    windowManager = WindowManager.setup(helpers.extras());
+    const testExtras = helpers.extras();
+    windowManager = WindowManager.setup(testExtras);
     windowManagerWithDragging = WindowManager.setup({
-      editor: helpers.extras().editor,
-      backstage: {
-        ...helpers.extras().backstage,
+      editor: testExtras.editor,
+      backstages: {
+        popup: {
+          ...testExtras.backstages.popup,
+          dialog: {
+            isDraggableModal: Fun.always
+          }
+        },
         dialog: {
-          isDraggableModal: Fun.always
+          ...testExtras.backstages.dialog,
+          dialog: {
+            isDraggableModal: Fun.always
+          }
         }
       }
     });

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerTest.ts
@@ -11,11 +11,11 @@ import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 import * as TestExtras from '../../module/TestExtras';
 
 describe('headless.tinymce.themes.silver.window.WindowManagerTest', () => {
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
   let windowManager: WindowManagerImpl;
   let windowManagerWithDragging: WindowManagerImpl;
   before(() => {
-    const testExtras = helpers.extras();
+    const testExtras = extrasHook.access().extras;
     windowManager = WindowManager.setup(testExtras);
     windowManagerWithDragging = WindowManager.setup({
       editor: testExtras.editor,
@@ -62,7 +62,7 @@ describe('headless.tinymce.themes.silver.window.WindowManagerTest', () => {
   };
 
   const assertSinkStructure = (asserter: (sink: SugarElement<HTMLElement>) => void) => {
-    const sink = helpers.sink();
+    const sink = extrasHook.access().getPopupSink();
     asserter(sink);
   };
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestExtras.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestExtras.ts
@@ -31,8 +31,8 @@ export const TestExtras = (): TestExtras => {
     throw Error('old sinks found, a previous test did not call helpers.destroy() leaving artifacts, found: ' + oldSink.length);
   }
 
-  const sink = GuiFactory.build({
-    dom: DomFactory.fromHtml('<div class="mce-silver-sink"></div>'),
+  const dialogSink = GuiFactory.build({
+    dom: DomFactory.fromHtml('<div class="mce-silver-sink test-dialogs-sink"></div>'),
     behaviours: Behaviour.derive([
       Positioning.config({
         useFixed: Fun.always
@@ -40,17 +40,41 @@ export const TestExtras = (): TestExtras => {
     ])
   });
 
-  const uiMothership = Gui.create();
-  Class.add(uiMothership.element, 'tox');
+  const popupSink = GuiFactory.build({
+    dom: DomFactory.fromHtml('<div class="mce-silver-sink test-popups-sink"></div>'),
+    behaviours: Behaviour.derive([
+      Positioning.config({
+        useFixed: Fun.always
+      })
+    ])
+  });
+
+  const dialogMothership = Gui.create();
+  Class.add(dialogMothership.element, 'tox');
+  Class.add(dialogMothership.element, 'test-dialogs-mothership');
+
+  const popupMothership = Gui.create();
+  Class.add(popupMothership.element, 'tox');
+  Class.add(popupMothership.element, 'test-popups-mothership');
 
   const backstages = {
-    popup: TestBackstage(sink),
-    dialog: TestBackstage(sink)
+    popup: TestBackstage(popupSink),
+    dialog: TestBackstage(dialogSink)
   };
   const options: Record<string, any> = {};
 
+  const editorOn: Editor['on'] = (_name, _callback) => {
+    return { } as any;
+  };
+
+  const editorOff: Editor['off'] = (_name, _callback) => {
+    return { } as any;
+  };
+
   const mockEditor = {
     setContent: (_content) => {},
+    on: editorOn,
+    off: editorOff,
     insertContent: (_content: string, _args?: any) => {},
     execCommand: (_cmd: string, _ui?: boolean, _value?: any) => {},
     ui: {
@@ -66,16 +90,20 @@ export const TestExtras = (): TestExtras => {
     backstages
   };
 
-  uiMothership.add(sink);
-  Attachment.attachSystem(SugarBody.body(), uiMothership);
+  dialogMothership.add(dialogSink);
+  popupMothership.add(popupSink);
+  Attachment.attachSystem(SugarBody.body(), dialogMothership);
+  Attachment.attachSystem(SugarBody.body(), popupMothership);
 
-  const getPopupSink = () => sink.element;
-  const getDialogSink = () => sink.element;
-  const getPopupMothership = Fun.constant(uiMothership);
+  const getPopupSink = () => popupSink.element;
+  const getDialogSink = () => dialogSink.element;
+  const getPopupMothership = Fun.constant(popupMothership);
 
   const destroy = () => {
-    uiMothership.remove(sink);
-    uiMothership.destroy();
+    dialogMothership.remove(dialogSink);
+    dialogMothership.destroy();
+    popupMothership.remove(popupSink);
+    popupMothership.destroy();
   };
 
   return {

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestExtras.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestExtras.ts
@@ -4,16 +4,14 @@ import { Fun, Obj, Optional } from '@ephox/katamari';
 import { Class, SugarBody, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
-import { UiFactoryBackstage, UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
+import { UiFactoryBackstagePair } from 'tinymce/themes/silver/backstage/Backstage';
 
 import TestBackstage from './TestBackstage';
 
 export interface TestExtras {
-  readonly backstage: UiFactoryBackstage;
-  readonly shared: UiFactoryBackstageShared;
   readonly extras: {
     readonly editor: Editor;
-    readonly backstage: UiFactoryBackstage;
+    readonly backstages: UiFactoryBackstagePair;
   };
   readonly destroy: () => void;
   readonly uiMothership: Gui.GuiSystem;
@@ -22,11 +20,9 @@ export interface TestExtras {
 }
 
 interface BddTestExtras {
-  readonly backstage: () => UiFactoryBackstage;
-  readonly shared: () => UiFactoryBackstageShared;
   readonly extras: () => {
     readonly editor: Editor;
-    readonly backstage: UiFactoryBackstage;
+    readonly backstages: UiFactoryBackstagePair;
   };
   readonly uiMothership: () => Gui.GuiSystem;
   readonly mockEditor: () => Editor;
@@ -52,7 +48,10 @@ export const TestExtras = (): TestExtras => {
   const uiMothership = Gui.create();
   Class.add(uiMothership.element, 'tox');
 
-  const backstage = TestBackstage(sink);
+  const backstages = {
+    popup: TestBackstage(sink),
+    dialog: TestBackstage(sink)
+  };
   const options: Record<string, any> = {};
 
   const mockEditor = {
@@ -69,7 +68,7 @@ export const TestExtras = (): TestExtras => {
 
   const extras = {
     editor: mockEditor,
-    backstage
+    backstages
   };
 
   uiMothership.add(sink);
@@ -81,8 +80,6 @@ export const TestExtras = (): TestExtras => {
   };
 
   return {
-    backstage,
-    shared: backstage.shared,
     extras,
     destroy,
     uiMothership,
@@ -117,8 +114,6 @@ export const bddSetup = (): BddTestExtras => {
     .getOrDie('The setup hooks have not run yet');
 
   return {
-    backstage: get('backstage'),
-    shared: get('shared'),
     extras: get('extras'),
     uiMothership: get('uiMothership'),
     mockEditor: get('mockEditor'),

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/components/urlinput/UrlInputTest.ts
@@ -19,7 +19,7 @@ describe('webdriver.tinymce.themes.silver.components.urlinput.UrlInputTest', () 
       name: 'col1',
       filetype: 'file',
       enabled: true
-    }, helpers.backstage(), {
+    }, helpers.extras().backstages.popup, {
       getHistory: (_fileType) => [],
       addToHistory: (_url, _filetype) => store.adder('addToHistory')(),
       getLinkInformation: () => Optional.none(),

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/components/urlinput/UrlInputTest.ts
@@ -11,7 +11,7 @@ import { renderUrlInput } from 'tinymce/themes/silver/ui/dialog/UrlInput';
 import * as TestExtras from '../../../module/TestExtras';
 
 describe('webdriver.tinymce.themes.silver.components.urlinput.UrlInputTest', () => {
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
 
   const hook = TestHelpers.GuiSetup.bddSetup((store, _doc, _body) => GuiFactory.build(
     renderUrlInput({
@@ -19,7 +19,7 @@ describe('webdriver.tinymce.themes.silver.components.urlinput.UrlInputTest', () 
       name: 'col1',
       filetype: 'file',
       enabled: true
-    }, helpers.extras().backstages.popup, {
+    }, extrasHook.access().extras.backstages.popup, {
       getHistory: (_fileType) => [],
       addToHistory: (_url, _filetype) => store.adder('addToHistory')(),
       getLinkInformation: () => Optional.none(),

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/DialogFocusTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/DialogFocusTest.ts
@@ -11,7 +11,7 @@ import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 import * as TestExtras from '../../module/TestExtras';
 
 describe('webdriver.tinymce.themes.silver.dialogs.DialogFocusTest', () => {
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
 
   let windowManager: WindowManagerImpl;
   before(function () {
@@ -21,7 +21,7 @@ describe('webdriver.tinymce.themes.silver.dialogs.DialogFocusTest', () => {
       this.skip();
     }
 
-    windowManager = WindowManager.setup(helpers.extras());
+    windowManager = WindowManager.setup(extrasHook.access().extras);
   });
 
   TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
@@ -12,10 +12,10 @@ import * as TestExtras from '../../module/TestExtras';
 
 describe('webdriver.tinymce.themes.silver.dialogs.IFrameDialogTest', () => {
   const isFirefox = PlatformDetection.detect().browser.isFirefox();
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
   let windowManager: WindowManagerImpl;
   before(() => {
-    windowManager = WindowManager.setup(helpers.extras());
+    windowManager = WindowManager.setup(extrasHook.access().extras);
   });
 
   TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/toolbar/SearchableMenuTypingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/toolbar/SearchableMenuTypingTest.ts
@@ -11,7 +11,7 @@ import { structMenuWith, structSearchField, structSearchLeafItem, structSearchPa
 import * as TestExtras from '../../module/TestExtras';
 
 describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () => {
-  const helpers = TestExtras.bddSetup();
+  const extrasHook = TestExtras.bddSetup();
 
   TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [
     `.tox-menu .tox-collection__item--active {
@@ -115,7 +115,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
           }, store)
         },
         'prefix',
-        helpers.extras().backstages.popup,
+        extrasHook.access().extras.backstages.popup,
         Optional.none()
       )
     )
@@ -143,7 +143,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
       // Type "Ph" into the input
       await pSendKeysToActiveInput(hook.root(), [ RealKeys.text('Ph') ]);
       onActiveElement( hook.root(), assertCursorAtEndOfText('Ph') );
-      await pAssertTieredMenuStructure('Typing Ph', helpers.sink(), [
+      await pAssertTieredMenuStructure('Typing Ph', extrasHook.access().getPopupSink(), [
         structMenuWith({ selected: true }, [
           structNoPlaceholderSearch,
           structSearchResultsWith([
@@ -161,7 +161,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
         hook.root(),
         assertTextState({ text: 'Ph', start: 'P'.length, end: 'P'.length })
       );
-      await pAssertTieredMenuStructure('After <left>', helpers.sink(), [
+      await pAssertTieredMenuStructure('After <left>', extrasHook.access().getPopupSink(), [
         structMenuWith({ selected: true }, [
           structNoPlaceholderSearch,
           structSearchResultsWith([
@@ -179,7 +179,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
         hook.root(),
         assertTextState({ text: 'Ph', start: 'P'.length, end: 'P'.length })
       );
-      await pAssertTieredMenuStructure('After <up>', helpers.sink(), [
+      await pAssertTieredMenuStructure('After <up>', extrasHook.access().getPopupSink(), [
         structMenuWith({ selected: true }, [
           structNoPlaceholderSearch,
           structSearchResultsWith([
@@ -199,7 +199,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
         hook.root(),
         assertCursorAtEndOfText('Ph')
       );
-      await pAssertTieredMenuStructure('After <right>', helpers.sink(), [
+      await pAssertTieredMenuStructure('After <right>', extrasHook.access().getPopupSink(), [
         structMenuWith({ selected: true }, [
           structNoPlaceholderSearch,
           structSearchResultsWith([
@@ -224,7 +224,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
       // will reset back to the first item. So it's not easy to double-check it
       // didn't expand, but we are at least checking that it is being interpreted
       // by the input.
-      await pAssertTieredMenuStructure('After <space> (which will trigger a refetch)', helpers.sink(), [
+      await pAssertTieredMenuStructure('After <space> (which will trigger a refetch)', extrasHook.access().getPopupSink(), [
         structMenuWith({ selected: true }, [
           structNoPlaceholderSearch,
           structSearchResultsWith([
@@ -242,7 +242,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
         hook.root(),
         assertCursorAtEndOfText('Ph ')
       );
-      await pAssertTieredMenuStructure('After <up>', helpers.sink(), [
+      await pAssertTieredMenuStructure('After <up>', extrasHook.access().getPopupSink(), [
         structMenuWith({ selected: true }, [
           structNoPlaceholderSearch,
           structSearchResultsWith([
@@ -260,7 +260,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
         hook.root(),
         assertCursorAtEndOfText('Ph ')
       );
-      await pAssertTieredMenuStructure('After <enter>', helpers.sink(), [
+      await pAssertTieredMenuStructure('After <enter>', extrasHook.access().getPopupSink(), [
         structMenuWith({ selected: false }, [
           structNoPlaceholderSearch,
           structSearchResultsWith([
@@ -291,7 +291,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
         hook.root(),
         assertTextState({ text: 'Ph ', start: 'Ph'.length, end: 'Ph'.length })
       );
-      await pAssertTieredMenuStructure('After <left>', helpers.sink(), [
+      await pAssertTieredMenuStructure('After <left>', extrasHook.access().getPopupSink(), [
         structMenuWith({ selected: false }, [
           structNoPlaceholderSearch,
           structSearchResultsWith([
@@ -321,7 +321,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
         hook.root(),
         assertTextState({ text: 'Ph ', start: 'Ph'.length, end: 'Ph'.length })
       );
-      await pAssertTieredMenuStructure('After <down>', helpers.sink(), [
+      await pAssertTieredMenuStructure('After <down>', extrasHook.access().getPopupSink(), [
         structMenuWith({ selected: false }, [
           structNoPlaceholderSearch,
           structSearchResultsWith([
@@ -352,7 +352,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
         hook.root(),
         assertTextState({ text: 'Ph ', start: 'Ph'.length, end: 'Ph'.length })
       );
-      await pAssertTieredMenuStructure('After <escape>', helpers.sink(), [
+      await pAssertTieredMenuStructure('After <escape>', extrasHook.access().getPopupSink(), [
         structMenuWith({ selected: true }, [
           structNoPlaceholderSearch,
           structSearchResultsWith([

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/toolbar/SearchableMenuTypingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/toolbar/SearchableMenuTypingTest.ts
@@ -115,7 +115,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
           }, store)
         },
         'prefix',
-        helpers.backstage(),
+        helpers.extras().backstages.popup,
         Optional.none()
       )
     )


### PR DESCRIPTION
Related Ticket: TINY-9223

Description of Changes:
* passing through different sinks and motherships for modal dialogs vs other popups. This is in preparation for supporting tinymce within a scrollable element. Note: there is still just one mothership and sink, but the code has been separated to (theoretically) support more than one more easily. This also doesn't include the code to make Positioning work with the popup sink - that's going to be TINY-9226.

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [N/A] Docs ticket created (if applicable) - it's internal

GitHub issues (if applicable):
