### PR TITLE
TINY-9180: Improve discoverability of the question mark read more link

### DIFF
--- a/modules/oxide/src/less/theme/components/accessibility-checker/accessibility-checker.less
+++ b/modules/oxide/src/less/theme/components/accessibility-checker/accessibility-checker.less
@@ -5,22 +5,18 @@
 @accessibility-issue-info-heading-text-color: contrast(@dialog-background-color, @color-white, @color-tint);
 @accessibility-issue-info-body-text-color: contrast(@dialog-background-color, @color-white, @text-color);
 @accessibility-issue-info-background-color: contrast(@dialog-background-color, fade(@color-tint, 10%), fade(@color-tint, 50%));
-@accessibility-issue-info-border-color: contrast(@dialog-background-color, fade(@color-tint, 40%), @color-tint);
 
 @accessibility-issue-warn-heading-text-color: contrast(@dialog-background-color, @color-white, #cc8500);
 @accessibility-issue-warn-body-text-color: contrast(@dialog-background-color, @color-white, @text-color);
 @accessibility-issue-warn-background-color: contrast(@dialog-background-color, fade(orange, 10%), fade(orange, 50%));
-@accessibility-issue-warn-border-color: contrast(@dialog-background-color, fade(orange, 50%), fade(orange, 80%));
 
 @accessibility-issue-error-heading-text-color: contrast(@dialog-background-color, @color-white, @color-error);
 @accessibility-issue-error-body-text-color: contrast(@dialog-background-color, @color-white, @text-color);
 @accessibility-issue-error-background-color: contrast(@dialog-background-color, fade(@color-error, 10%), fade(@color-error, 50%));
-@accessibility-issue-error-border-color: contrast(@dialog-background-color, fade(@color-error, 40%), fade(@color-error, 80%));
 
 @accessibility-issue-success-heading-text-color: contrast(@dialog-background-color, @color-white, @color-success);
 @accessibility-issue-success-body-text-color: contrast(@dialog-background-color, @color-white, @text-color);
 @accessibility-issue-success-background-color: contrast(@dialog-background-color, fade(@color-success, 10%), fade(@color-success, 50%));
-@accessibility-issue-success-border-color: contrast(@dialog-background-color, fade(@color-success, 40%), fade(@color-success, 80%));
 
 .tox {
   .accessibility-issue {
@@ -35,7 +31,6 @@
 
   .accessibility-issue__description {
     align-items: stretch;
-    border: 1px solid @border-color;
     border-radius: @panel-border-radius;
     display: flex;
     justify-content: space-between;
@@ -48,11 +43,6 @@
         display: flex;
         margin-bottom: @pad-xs;
       }
-    }
-
-    > *:last-child:not(:only-child) {
-      border-color: @border-color;
-      border-style: solid;
     }
   }
 
@@ -67,12 +57,7 @@
     .accessibility-issue--info {
       .accessibility-issue__description {
         background-color: @accessibility-issue-info-background-color;
-        border-color: @accessibility-issue-info-border-color;
         color: @accessibility-issue-info-body-text-color;
-
-        > *:last-child {
-          border-color: @accessibility-issue-info-border-color;
-        }
       }
 
       .tox-form__group h2 {
@@ -92,12 +77,7 @@
     .accessibility-issue--warn {
       .accessibility-issue__description {
         background-color: @accessibility-issue-warn-background-color;
-        border-color: @accessibility-issue-warn-border-color;
         color: @accessibility-issue-warn-body-text-color;
-
-        > *:last-child {
-          border-color: @accessibility-issue-warn-border-color;
-        }
       }
 
       .tox-form__group h2 {
@@ -117,12 +97,7 @@
     .accessibility-issue--error {
       .accessibility-issue__description {
         background-color: @accessibility-issue-error-background-color;
-        border-color: @accessibility-issue-error-border-color;
         color: @accessibility-issue-error-body-text-color;
-
-        > *:last-child {
-          border-color: @accessibility-issue-error-border-color;
-        }
       }
 
       .tox-form__group h2 {
@@ -142,12 +117,7 @@
     .accessibility-issue--success {
       .accessibility-issue__description {
         background-color: @accessibility-issue-success-background-color;
-        border-color: @accessibility-issue-success-border-color;
         color: @accessibility-issue-success-body-text-color;
-
-        > *:last-child {
-          border-color: @accessibility-issue-success-border-color;
-        }
       }
 
       .tox-form__group h2 {
@@ -186,11 +156,6 @@
 
     .accessibility-issue__description {
       padding: @pad-xs @pad-xs @pad-xs @pad-sm;
-
-      > *:last-child {
-        border-left-width: 1px;
-        padding-left: @pad-xs;
-      }
     }
   }
 }
@@ -209,11 +174,6 @@
 
     .accessibility-issue__description {
       padding: @pad-xs @pad-sm @pad-xs @pad-xs;
-
-      > *:last-child {
-        border-right-width: 1px;
-        padding-right: @pad-xs;
-      }
     }
   }
 }

--- a/modules/oxide/src/less/theme/components/accessibility-checker/accessibility-checker.less
+++ b/modules/oxide/src/less/theme/components/accessibility-checker/accessibility-checker.less
@@ -42,6 +42,10 @@
         align-items: center;
         display: flex;
         margin-bottom: @pad-xs;
+
+        .tox-icon svg {
+          display: block;
+        }
       }
     }
   }

--- a/modules/oxide/src/less/theme/components/accessibility-checker/accessibility-checker.less
+++ b/modules/oxide/src/less/theme/components/accessibility-checker/accessibility-checker.less
@@ -4,17 +4,23 @@
 
 @accessibility-issue-info-heading-text-color: contrast(@dialog-background-color, @color-white, @color-tint);
 @accessibility-issue-info-body-text-color: contrast(@dialog-background-color, @color-white, @text-color);
-@accessibility-issue-info-background-color: contrast(@dialog-background-color, fade(@color-tint, 10%), fade(@color-tint, 50%));
+@accessibility-issue-info-background-color: contrast(@dialog-background-color, fade(darken(@color-tint, 3%), 10%), fade(darken(@color-tint, 3%), 40%));
 
-@accessibility-issue-warn-heading-text-color: contrast(@dialog-background-color, @color-white, #cc8500);
+@accessibility-issue-warn-heading-text-color: contrast(@dialog-background-color, @color-white, darken(#cc8500, 12%));
 @accessibility-issue-warn-body-text-color: contrast(@dialog-background-color, @color-white, @text-color);
-@accessibility-issue-warn-background-color: contrast(@dialog-background-color, fade(orange, 10%), fade(orange, 50%));
+@accessibility-issue-warn-background-color: contrast(@dialog-background-color, fade(orange, 8%), fade(orange, 50%));
+@accessibility-issue-warn-icon-background-color: #FFE89D;
+@accessibility-issue-warn-icon-hover-background-color: #F2D574;
+@accessibility-issue-warn-icon-active-background-color: #E8C657;
 
 @accessibility-issue-error-heading-text-color: contrast(@dialog-background-color, @color-white, @color-error);
 @accessibility-issue-error-body-text-color: contrast(@dialog-background-color, @color-white, @text-color);
 @accessibility-issue-error-background-color: contrast(@dialog-background-color, fade(@color-error, 10%), fade(@color-error, 50%));
+@accessibility-issue-error-icon-background-color: #F2BFBF;
+@accessibility-issue-error-icon-hover-background-color: #E9A4A4;
+@accessibility-issue-error-icon-active-background-color: #EE9494;
 
-@accessibility-issue-success-heading-text-color: contrast(@dialog-background-color, @color-white, @color-success);
+@accessibility-issue-success-heading-text-color: contrast(@dialog-background-color, @color-white, darken(@color-success, 15%));
 @accessibility-issue-success-body-text-color: contrast(@dialog-background-color, @color-white, @text-color);
 @accessibility-issue-success-background-color: contrast(@dialog-background-color, fade(@color-success, 10%), fade(@color-success, 50%));
 
@@ -72,8 +78,18 @@
         fill: @accessibility-issue-info-heading-text-color;
       }
 
-      a .tox-icon {
-        color: @accessibility-issue-info-heading-text-color;
+      a.tox-button--naked.tox-button--icon {
+        background-color: @button-background-color;
+        color: @color-white;
+
+        &:hover,
+        &:focus {
+          background-color: @button-hover-background-color;
+        }
+
+        &:active {
+          background-color: @button-active-background-color;
+        }
       }
     }
 
@@ -92,8 +108,21 @@
         fill: @accessibility-issue-warn-heading-text-color;
       }
 
-      a .tox-icon {
-        color: @accessibility-issue-warn-heading-text-color;
+      /* stylelint-disable-next-line no-descending-specificity */
+      a.tox-button--naked.tox-button--icon {
+        background-color: @accessibility-issue-warn-icon-background-color;
+        color: @color-black;
+
+        &:hover,
+        &:focus {
+          background-color: @accessibility-issue-warn-icon-hover-background-color;
+          color: @color-black;
+        }
+
+        &:active {
+          background-color: @accessibility-issue-warn-icon-active-background-color;
+          color: @color-black;
+        }
       }
     }
 
@@ -112,8 +141,21 @@
         fill: @accessibility-issue-error-heading-text-color;
       }
 
-      a .tox-icon {
-        color: @accessibility-issue-error-heading-text-color;
+      /* stylelint-disable-next-line no-descending-specificity */
+      a.tox-button--naked.tox-button--icon {
+        background-color: @accessibility-issue-error-icon-background-color;
+        color: @color-black;
+
+        &:hover,
+        &:focus {
+          background-color: @accessibility-issue-error-icon-hover-background-color;
+          color: @color-black;
+        }
+
+        &:active {
+          background-color: @accessibility-issue-error-icon-active-background-color;
+          color: @color-black;
+        }
       }
     }
 
@@ -122,6 +164,10 @@
       .accessibility-issue__description {
         background-color: @accessibility-issue-success-background-color;
         color: @accessibility-issue-success-body-text-color;
+
+        > *:last-child {
+          display: none;
+        }
       }
 
       .tox-form__group h2 {
@@ -130,10 +176,6 @@
 
       .tox-icon svg {
         fill: @accessibility-issue-success-heading-text-color;
-      }
-
-      a .tox-icon {
-        color: @accessibility-issue-success-heading-text-color;
       }
     }
   }

--- a/modules/oxide/src/less/theme/components/accessibility-checker/accessibility-checker.less
+++ b/modules/oxide/src/less/theme/components/accessibility-checker/accessibility-checker.less
@@ -164,8 +164,9 @@
     }
   }
 
-  .tox-dialog__body-content .accessibility-issue__header h1,
+  .tox-dialog__body-content .accessibility-issue__header .tox-form__group h1,
   .tox-dialog__body-content .tox-form__group .accessibility-issue__description h2 {
+    font-size: @font-size-sm;
     margin-top: 0;
     // Inherits other styles from dialog body content heading
   }


### PR DESCRIPTION
Related Ticket: TINY-9180

Description of Changes:
* Setting icon alignment to be middle 
* Decrease font size of 'issue' and 'warning/error'
* Remove borders around descriptions
* Set warning and success title colours to meet the contrast ratio
* Setting the background colour of the 'question mark' button

Pre-checks:
* [x] ~~Changelog entry added~~ (Do we need changelog entry for changes made to premium plugin?)
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

Screenshot of UI changes: 
- The `info` state is to demo

**Light Mode:**
![SCR-20221013-b5l](https://user-images.githubusercontent.com/111734091/195469344-0b578a62-a25d-4d7c-9298-643bc003b174.png)
![SCR-20221013-ayn](https://user-images.githubusercontent.com/111734091/195469351-ce475075-bcfc-477c-900c-5fd43d824306.png)
![SCR-20221013-ayx](https://user-images.githubusercontent.com/111734091/195469356-67f757df-ed86-4fe6-9442-6e90d9d80d4b.png)
![SCR-20221013-az3](https://user-images.githubusercontent.com/111734091/195469361-3cd6594e-0761-4eb0-b017-0f17a7ca492c.png)

**Dark Mode:**
![SCR-20221013-b5b](https://user-images.githubusercontent.com/111734091/195469517-575edd8c-3ee1-4ae8-8ef5-047579249019.png)
![SCR-20221013-b3q](https://user-images.githubusercontent.com/111734091/195469532-87583c30-39b6-4456-95e1-007b3ec344d4.png)
![SCR-20221013-b3u](https://user-images.githubusercontent.com/111734091/195469536-806c0bb5-ece8-46b3-94ac-68333317b804.png)
![SCR-20221013-b41](https://user-images.githubusercontent.com/111734091/195469541-c0c49141-3edf-4ca4-9141-c3996c8fdd06.png)

GitHub issues (if applicable):
