### PR TITLE
TINY-9186: Fix reported memory leak when parsing content

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `color_default_foreground` and `color_default_background` options to set the initial default color for the `forecolor` and `backcolor` toolbar buttons and menu items. #TINY-9183
 
 ### Fixed
-- calling getContent method would cause a memory leak. #TINY-9186
+- Parsing media content would cause a memory leak, which for example occurred when using the `getContent` API. #TINY-9186
 - Dragging a noneditable element toward the bottom edge would cause the page to scroll up. #TINY-9025
 - Range expanding capabilities would behave inconsistently depending on where the cursor was placed. #TINY-9029
 - Compilation errors were thrown when using TypeScript 4.8. #TINY-9161

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `expand` function added to `tinymce.dom.RangeUtils` to return a new range expanded around the nearest word. #TINY-9001
 
 ### Fixed
+- calling getContent method would cause a memory leak. #TINY-9186
 - Dragging a noneditable element toward the bottom edge would cause the page to scroll up. #TINY-9025
 - Range expanding capabilities would behave inconsistently depending on where the cursor was placed. #TINY-9029
 - Compilation errors were thrown when using TypeScript 4.8. #TINY-9161

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -577,7 +577,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
     const rootNode = new AstNode(rootName, 11);
     transferChildren(rootNode, element, schema.getSpecialElements());
 
-    // This next line is needed to fix memory leak in chrome and firefox.
+    // This next line is needed to fix a memory leak in chrome and firefox.
     // For more information see TINY-9186
     element.innerHTML = '';
 

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -577,6 +577,10 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
     const rootNode = new AstNode(rootName, 11);
     transferChildren(rootNode, element, schema.getSpecialElements());
 
+    // This next line is needed to fix memory leak in chrome and firefox.
+    // For more information see: https://ephocks.atlassian.net/browse/TINY-9186
+    element.innerHTML = '';
+
     // Set up whitespace fixes
     const [ whitespacePre, whitespacePost ] = whitespaceCleaner(rootNode, schema, defaultedSettings, args);
 

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -578,7 +578,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
     transferChildren(rootNode, element, schema.getSpecialElements());
 
     // This next line is needed to fix memory leak in chrome and firefox.
-    // For more information see: https://ephocks.atlassian.net/browse/TINY-9186
+    // For more information see TINY-9186
     element.innerHTML = '';
 
     // Set up whitespace fixes


### PR DESCRIPTION
Related Ticket: TINY-9186

Description of Changes:
* Fix memory leak caused in getContent method

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
