### PR TITLE
TINY-9259: get more selection apis working on hidden editors

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inline text pattern no longer triggers if it matches only the end but not the start. #TINY-8947
 - Matches of inline text patterns that are similar are now managed correctly. #TINY-8949
 - The context toolbar prevented the user from placing the cursor at the edges of the editor. #TINY-8890
+- The `editor.selection.getRng()` api was not returning a proper range on hidden editors in Firefox. #TINY-9259
+- The `editor.selection.getBookmark()` api was not returning a proper bookmark on hidden editors in Firefox. #TINY-9259
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -26,8 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inline text pattern no longer triggers if it matches only the end but not the start. #TINY-8947
 - Matches of inline text patterns that are similar are now managed correctly. #TINY-8949
 - The context toolbar prevented the user from placing the cursor at the edges of the editor. #TINY-8890
-- The `editor.selection.getRng()` api was not returning a proper range on hidden editors in Firefox. #TINY-9259
-- The `editor.selection.getBookmark()` api was not returning a proper bookmark on hidden editors in Firefox. #TINY-9259
+- The `editor.selection.getRng()` API was not returning a proper range on hidden editors in Firefox. #TINY-9259
+- The `editor.selection.getBookmark()` API was not returning a proper bookmark on hidden editors in Firefox. #TINY-9259
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/src/core/main/ts/selection/SelectionBookmark.ts
+++ b/modules/tinymce/src/core/main/ts/selection/SelectionBookmark.ts
@@ -2,6 +2,7 @@ import { Optional } from '@ephox/katamari';
 import { Compare, SimRange, SimSelection, SugarElement, SugarNode, SugarText, Traverse } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
+import Env from '../api/Env';
 import * as NodeType from '../dom/NodeType';
 
 const clamp = (offset: number, element: SugarElement<Node>): number => {
@@ -30,7 +31,8 @@ const isOrContains = (root: SugarElement<Node>, elm: SugarElement<Node>): boolea
 const isRngInRoot = (root: SugarElement<Node>) => (rng: SimRange): boolean =>
   isOrContains(root, rng.start) && isOrContains(root, rng.finish);
 
-const shouldStore = (editor: Editor) => editor.inline;
+// TINY-9259: We need to store the selection on Firefox since if the editor is hidden the selection.getRng() api will not work as expected.
+const shouldStore = (editor: Editor) => editor.inline || Env.browser.isFirefox();
 
 const nativeRangeToSelectionRange = (r: Range): SimRange =>
   SimSelection.range(SugarElement.fromDom(r.startContainer), r.startOffset, SugarElement.fromDom(r.endContainer), r.endOffset);

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/BookmarksTest.ts
@@ -224,6 +224,18 @@ describe('browser.tinymce.core.bookmark.BookmarksTest', () => {
     TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
   }));
 
+  it('TINY-9259: Should be able to get bookmark on hidden editor', bookmarkTest((editor) => {
+    editor.focus();
+    editor.setContent('<p>ab</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    editor.getContainer().style.display = 'none';
+    const bm = editor.selection.getBookmark();
+    editor.getContainer().style.display = '';
+    TinySelections.setCursor(editor, [ 0, 0 ], 0);
+    editor.selection.moveToBookmark(bm);
+    TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+  }));
+
   context('Get bookmark should work if the first element of the content is a comment', () => {
     const outsideButton: SugarElement<HTMLButtonElement> = SugarElement.fromHtml('<button id="getBookmarkButton">Get Bookmark</button>');
     const setupElement = () => {

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
@@ -1212,6 +1212,17 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     TinyAssertions.assertSelection(editor, [ 0, 0 ], 2, [ 0, 0 ], 6);
   });
 
+  it('TINY-9259: Should be able to get selection range on hidden editors', () => {
+    const editor = hook.editor();
+
+    editor.focus();
+    editor.setContent('<p>ab</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    editor.getContainer().style.display = 'none';
+    TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+    editor.getContainer().style.display = '';
+  });
+
   /*
   // TODO: Re-implement this test as a separate test if needed by destroying an editor etc
   it('getRng should return null if win.document is not defined or null', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -2,7 +2,7 @@ import { ApproxStructure, Assertions, StructAssert, TestStore, UiFinder, Waiter 
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { Attribute, Css, Html, SugarBody } from '@ephox/sugar';
-import { TinyApis, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyApis, TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -306,6 +306,17 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       apis.hasFocus(false);
       toggleView('myview1');
       apis.hasFocus(true);
+    });
+
+    it('TINY-9259: Should retain range selection when main view is hidden', () => {
+      const editor = hook.editor();
+
+      editor.setContent('<p>ab</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      toggleView('myview1');
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+      toggleView('myview1');
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
     });
   });
 


### PR DESCRIPTION
Related Ticket: TINY-9259

Description of Changes:
* Getting more selection apis working for hidden editors on Firefox

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
