### PR TITLE
TINY-9213: Color picker dialog now defaults to approriate color 

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 - Transparent elements, like anchors, can now contain block elements. #TINY-9172
-- Color picker dialog now starts on the appropriate color for the cursor position #TINY-9213
+- Color picker dialog now starts on the appropriate color for the cursor position. #TINY-9213
 
 ### Fixed
 - Parsing media content would cause a memory leak, which for example occurred when using the `getContent` API. #TINY-9186

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 - Transparent elements, like anchors, can now contain block elements. #TINY-9172
+- Color picker dialog now starts on the approriate color for the cursor position #TINY-9213
 
 ### Fixed
 - Parsing media content would cause a memory leak, which for example occurred when using the `getContent` API. #TINY-9186

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 - Transparent elements, like anchors, can now contain block elements. #TINY-9172
-- Color picker dialog now starts on the approriate color for the cursor position #TINY-9213
+- Color picker dialog now starts on the appropriate color for the cursor position #TINY-9213
 
 ### Fixed
 - Parsing media content would cause a memory leak, which for example occurred when using the `getContent` API. #TINY-9186

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -1,5 +1,5 @@
 import { HexColour, RgbaColour } from '@ephox/acid';
-import { Cell, Fun, Optional, Strings, Type } from '@ephox/katamari';
+import { Cell, Fun, Optional } from '@ephox/katamari';
 import { Css, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -18,21 +18,9 @@ export interface ColorSwatchDialogData {
 
 type ColorFormat = 'forecolor' | 'hilitecolor';
 
-const hasStyleApi = (node: Node): node is (Node & ElementCSSInlineStyle) =>
-  Type.isNonNullable((node as HTMLElement).style);
-
 const getCurrentColor = (editor: Editor, format: ColorFormat): Optional<string> => {
-  let color: string | undefined;
-
-  editor.dom.getParents(editor.selection.getStart(), (elm) => {
-    const value = hasStyleApi(elm) ? elm.style[format === 'forecolor' ? 'color' : 'backgroundColor'] : null;
-
-    if (value) {
-      color = color ? color : value;
-    }
-  });
-
-  return Optional.from(color);
+  const cssRgbValue = Css.get(SugarElement.fromDom(editor.selection.getStart()), format === 'hilitecolor' ? 'background-color' : 'color');
+  return RgbaColour.fromString(cssRgbValue).map((rgba) => '#' + HexColour.fromRgba(rgba).value);
 };
 
 const applyFormat = (editor: Editor, format: ColorFormat, value: string) => {
@@ -84,15 +72,13 @@ const getAdditionalColors = (hasCustom: boolean): Menu.ChoiceMenuItemSpec[] => {
 const applyColor = (editor: Editor, format: ColorFormat, value: string, onChoice: (v: string) => void) => {
   if (value === 'custom') {
     const dialog = colorPickerDialog(editor);
-    const cssRgbValue = Css.get(SugarElement.fromDom(editor.selection.getStart()), format === 'hilitecolor' ? 'background-color' : 'color');
-    const hexvalue = RgbaColour.fromString(cssRgbValue).map((rgba) => '#' + HexColour.fromRgba(rgba).value).getOr(Options.fallbackColor);
     dialog((colorOpt) => {
       colorOpt.each((color) => {
         ColorCache.addColor(format, color);
         editor.execCommand('mceApplyTextcolor', format as any, color);
         onChoice(color);
       });
-    }, hexvalue);
+    }, getCurrentColor(editor, format).getOr(Options.fallbackColor));
   } else if (value === 'remove') {
     onChoice('');
     editor.execCommand('mceRemoveTextcolor', format as any);
@@ -120,12 +106,10 @@ const registerTextColorButton = (editor: Editor, name: string, format: ColorForm
     presets: 'color',
     icon: name === 'forecolor' ? 'text-color' : 'highlight-bg-color',
     select: (value) => {
-      const optCurrentRgb = getCurrentColor(editor, format);
-      return optCurrentRgb.bind((currentRgb) => RgbaColour.fromString(currentRgb).map((rgba) => {
-        const currentHex = HexColour.fromRgba(rgba).value;
-        // note: value = '#FFFFFF', currentHex = 'ffffff'
-        return Strings.contains(value.toLowerCase(), currentHex);
-      })).getOr(false);
+      const optCurrenthex = getCurrentColor(editor, format);
+      return optCurrenthex.map((currentHex) => {
+        return value.toUpperCase() === currentHex;
+      }).getOr(false);
     },
     columns: Options.getColorCols(editor, format),
     fetch: getFetch(Options.getColors(editor, format), format, Options.hasCustomColors(editor)),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -1,5 +1,5 @@
 import { HexColour, RgbaColour } from '@ephox/acid';
-import { Cell, Fun, Optional } from '@ephox/katamari';
+import { Cell, Fun, Optional, Optionals } from '@ephox/katamari';
 import { Css, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -106,10 +106,8 @@ const registerTextColorButton = (editor: Editor, name: string, format: ColorForm
     presets: 'color',
     icon: name === 'forecolor' ? 'text-color' : 'highlight-bg-color',
     select: (value) => {
-      const optCurrenthex = getCurrentColor(editor, format);
-      return optCurrenthex.map((currentHex) => {
-        return value.toUpperCase() === currentHex;
-      }).getOr(false);
+      const optCurrentHex = getCurrentColor(editor, format);
+      return Optionals.is(optCurrentHex, value.toUpperCase());
     },
     columns: Options.getColorCols(editor, format),
     fetch: getFetch(Options.getColors(editor, format), format, Options.hasCustomColors(editor)),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -1,5 +1,6 @@
 import { HexColour, RgbaColour } from '@ephox/acid';
 import { Cell, Fun, Optional, Strings, Type } from '@ephox/katamari';
+import { Css, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog, Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
@@ -83,13 +84,15 @@ const getAdditionalColors = (hasCustom: boolean): Menu.ChoiceMenuItemSpec[] => {
 const applyColor = (editor: Editor, format: ColorFormat, value: string, onChoice: (v: string) => void) => {
   if (value === 'custom') {
     const dialog = colorPickerDialog(editor);
+    const cssRgbValue = Css.get(SugarElement.fromDom(editor.selection.getStart()), format === 'hilitecolor' ? 'background-color' : 'color');
+    const hexvalue = RgbaColour.fromString(cssRgbValue).map((rgba) => '#' + HexColour.fromRgba(rgba).value).getOr(Options.fallbackColor);
     dialog((colorOpt) => {
       colorOpt.each((color) => {
         ColorCache.addColor(format, color);
         editor.execCommand('mceApplyTextcolor', format as any, color);
         onChoice(color);
       });
-    }, Options.fallbackColor);
+    }, hexvalue);
   } else if (value === 'remove') {
     onChoice('');
     editor.execCommand('mceRemoveTextcolor', format as any);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -30,6 +30,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         const backgroundDialog = await TinyUiActions.pWaitForDialog(editor);
         const backgroundDialogResult = UiFinder.findIn<HTMLInputElement>(backgroundDialog, 'label:contains("#") + input').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(backgroundDialogResult.dom.value, '80FF80'));
+        TinyUiActions.cancelDialog(editor);
       });
 
       it('TINY-9213: Color detected on color, foreground', async () => {
@@ -41,6 +42,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         const textDialog = await TinyUiActions.pWaitForDialog(editor);
         const textDialogResult = UiFinder.findIn<HTMLInputElement>(textDialog, 'label:contains("#") + input').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(textDialogResult.dom.value, 'FFC0CB'));
+        TinyUiActions.cancelDialog(editor);
       });
     });
 
@@ -151,6 +153,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         const backgroundDialog = await TinyUiActions.pWaitForDialog(editor);
         const backgroundDialogResult = UiFinder.findIn<HTMLInputElement>(backgroundDialog, 'label:contains("#") + input').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(backgroundDialogResult.dom.value, '00FF00'));
+        TinyUiActions.cancelDialog(editor);
       });
 
       it('TINY-9213: Color detected on color, foreground', async () => {
@@ -162,6 +165,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         const textDialog = await TinyUiActions.pWaitForDialog(editor);
         const textDialogResult = UiFinder.findIn<HTMLInputElement>(textDialog, 'label:contains("#") + input').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(textDialogResult.dom.value, 'FF00FF'));
+        TinyUiActions.cancelDialog(editor);
       });
 
       it('TINY-6952: Submitting an invalid hex color code will show an alert with an error message', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -13,6 +13,37 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
     { label: 'Iframe Editor', setup: TinyHooks.bddSetup },
     { label: 'Shadow Dom Editor', setup: TinyHooks.bddSetupInShadowRoot }
   ], (tester) => {
+    context(`${tester.label}, Test of different color types`, () => {
+      const hook = tester.setup<Editor>({
+        base_url: '/project/tinymce/js/tinymce',
+        toolbar: 'forecolor backcolor',
+        content_style: 'p{color: pink; background-color: hsl(120, 100%, 75%);}'
+      }, []);
+
+      it('TINY-9213: Color detected on color, background', async () => {
+        const editor = hook.editor();
+        editor.setContent('<p>Text</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 2);
+        TinyUiActions.clickOnToolbar(editor, '[aria-label="Background color"] > .tox-tbtn + .tox-split-button__chevron');
+        await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+        TinyUiActions.clickOnUi(editor, 'button[title="Custom color"]');
+        const backgroundDialog = await TinyUiActions.pWaitForDialog(editor);
+        const backgroundDialogResult = UiFinder.findIn<HTMLInputElement>(backgroundDialog, 'label:contains("#") + input').getOrDie();
+        await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(backgroundDialogResult.dom.value, '80FF80'));
+      });
+
+      it('TINY-9213: Color detected on color, foreground', async () => {
+        const editor = hook.editor();
+        editor.setContent('<p>Text</p>');
+        TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
+        await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+        TinyUiActions.clickOnUi(editor, 'button[title="Custom color"]');
+        const textDialog = await TinyUiActions.pWaitForDialog(editor);
+        const textDialogResult = UiFinder.findIn<HTMLInputElement>(textDialog, 'label:contains("#") + input').getOrDie();
+        await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(textDialogResult.dom.value, 'FFC0CB'));
+      });
+    });
+
     context(tester.label, () => {
       const hook = tester.setup<Editor>({
         base_url: '/project/tinymce/js/tinymce',
@@ -119,7 +150,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         TinyUiActions.clickOnUi(editor, 'button[title="Custom color"]');
         const backgroundDialog = await TinyUiActions.pWaitForDialog(editor);
         const backgroundDialogResult = UiFinder.findIn<HTMLInputElement>(backgroundDialog, 'label:contains("#") + input').getOrDie();
-        await Waiter.pTryUntil('Dialog should start with the right color', () => backgroundDialogResult.dom.value === '00FF00');
+        await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(backgroundDialogResult.dom.value, '00FF00'));
       });
 
       it('TINY-9213: Color detected on color, foreground', async () => {
@@ -130,7 +161,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         TinyUiActions.clickOnUi(editor, 'button[title="Custom color"]');
         const textDialog = await TinyUiActions.pWaitForDialog(editor);
         const textDialogResult = UiFinder.findIn<HTMLInputElement>(textDialog, 'label:contains("#") + input').getOrDie();
-        await Waiter.pTryUntil('Dialog should start with the right color', () => textDialogResult.dom.value === 'FF00FF');
+        await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(textDialogResult.dom.value, 'FF00FF'));
       });
 
       it('TINY-6952: Submitting an invalid hex color code will show an alert with an error message', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -2,7 +2,7 @@ import { UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
 import { SelectorFilter, SugarElement, SugarShadowDom } from '@ephox/sugar';
-import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -15,7 +15,8 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
   ], (tester) => {
     context(tester.label, () => {
       const hook = tester.setup<Editor>({
-        base_url: '/project/tinymce/js/tinymce'
+        base_url: '/project/tinymce/js/tinymce',
+        toolbar: 'forecolor backcolor'
       }, []);
       const dialogSelector = 'div[role="dialog"]';
       let currentColor = '';
@@ -107,6 +108,29 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         await pSetHexWhite(editor);
         await pCancelDialog(editor);
         assertColorBlack();
+      });
+
+      it('TINY-9213: Color detected on color, background', async () => {
+        const editor = hook.editor();
+        editor.setContent('<p style="color: #FF00FF;background-color: #00FF00;">Text</p>', { format: 'raw' });
+        TinySelections.setCursor(editor, [ 0, 0 ], 2);
+        TinyUiActions.clickOnToolbar(editor, '[aria-label="Background color"] > .tox-tbtn + .tox-split-button__chevron');
+        await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+        TinyUiActions.clickOnUi(editor, 'button[title="Custom color"]');
+        const backgroundDialog = await TinyUiActions.pWaitForDialog(editor);
+        const backgroundDialogResult = UiFinder.findIn<HTMLInputElement>(backgroundDialog, 'label:contains("#") + input').getOrDie();
+        await Waiter.pTryUntil('Dialog should start with the right color', () => backgroundDialogResult.dom.value === '00FF00');
+      });
+
+      it('TINY-9213: Color detected on color, foreground', async () => {
+        const editor = hook.editor();
+        editor.setContent('<p style="color: #FF00FF;background-color: #00FF00;">Text</p>', { format: 'raw' });
+        TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
+        await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+        TinyUiActions.clickOnUi(editor, 'button[title="Custom color"]');
+        const textDialog = await TinyUiActions.pWaitForDialog(editor);
+        const textDialogResult = UiFinder.findIn<HTMLInputElement>(textDialog, 'label:contains("#") + input').getOrDie();
+        await Waiter.pTryUntil('Dialog should start with the right color', () => textDialogResult.dom.value === 'FF00FF');
       });
 
       it('TINY-6952: Submitting an invalid hex color code will show an alert with an error message', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/GetCurrentColorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/GetCurrentColorTest.ts
@@ -20,13 +20,13 @@ describe('browser.tinymce.themes.silver.editor.color.GetCurrentColorTest', () =>
     const editor = hook.editor();
     editor.setContent('<p style="color: blue;">hello <span style="color: red;">world</span></p>');
     TinySelections.setCursor(editor, [ 0, 1, 0 ], 2);
-    assertCurrentColor(editor, 'forecolor', 'should return red', 'red');
+    assertCurrentColor(editor, 'forecolor', 'should return red', '#FF0000');
   });
 
   it('TBA: getCurrentColor should return the first found backcolor, not the parent color', () => {
     const editor = hook.editor();
     editor.setContent('<p style="background-color: red;">hello <span style="background-color: blue;">world</span></p>');
     TinySelections.setCursor(editor, [ 0, 1, 0 ], 2);
-    assertCurrentColor(editor, 'hilitecolor', 'should return blue', 'blue');
+    assertCurrentColor(editor, 'hilitecolor', 'should return blue', '#0000FF');
   });
 });


### PR DESCRIPTION

Related Ticket: 

Description of Changes:
Color picker dialog uses cursor position for color.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
