### PR TITLE
TINY-9216: Add working example for toolbar button with updateable text

### DIFF
--- a/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarToggleButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarToggleButton.ts
@@ -15,6 +15,8 @@ export interface BaseToolbarToggleButton<I extends BaseToolbarButtonInstanceApi>
 export interface BaseToolbarToggleButtonInstanceApi extends BaseToolbarButtonInstanceApi {
   isActive: () => boolean;
   setActive: (state: boolean) => void;
+  setText: (text: string) => void;
+  setIcon: (icon: string) => void;
 }
 
 export interface ToolbarToggleButtonSpec extends BaseToolbarToggleButtonSpec<ToolbarToggleButtonInstanceApi> {

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-select-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-select-button.less
@@ -18,7 +18,11 @@
   .tox-tbtn__select-label {
     cursor: default;
     font-weight: @toolbar-button-font-weight;
+    height: initial;
     margin: 0 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .tox-tbtn__select-chevron {

--- a/modules/tinymce/src/plugins/code/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/code/demo/ts/demo/Demo.ts
@@ -1,3 +1,4 @@
+
 import { TinyMCE } from 'tinymce/core/api/PublicApi';
 
 declare let tinymce: TinyMCE;
@@ -5,8 +6,16 @@ declare let tinymce: TinyMCE;
 tinymce.init({
   selector: 'textarea.tinymce',
   plugins: 'code',
-  toolbar: 'code',
-  height: 600
+  toolbar: 'test-update-text fontsize align alignleft code',
+  height: 600,
+  setup: (editor) => {
+    editor.ui.registry.addToggleButton('test-update-text', {
+      text: 'Before',
+      onAction: (api) => {
+        api.setText('After');
+      },
+    });
+  }
 });
 
 export {};

--- a/modules/tinymce/src/plugins/code/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/code/demo/ts/demo/Demo.ts
@@ -6,13 +6,13 @@ declare let tinymce: TinyMCE;
 tinymce.init({
   selector: 'textarea.tinymce',
   plugins: 'code',
-  toolbar: 'test-update-text fontsize align alignleft code',
+  toolbar: 'test-update-text fontsize align alignleft code fontfamily',
   height: 600,
   setup: (editor) => {
     editor.ui.registry.addToggleButton('test-update-text', {
       text: 'Before',
       onAction: (api) => {
-        api.setText('After');
+        api.setText('After After After AfterAfterAfterAfterAfterAfterAfter');
       },
     });
   }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ButtonEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ButtonEvents.ts
@@ -1,4 +1,4 @@
-import { AlloyEvents, AlloyTriggers, CustomEvent, EventFormat, SystemEvents } from '@ephox/alloy';
+import { AlloyEvents, AlloyTriggers, CustomEvent, EventFormat, NativeEvents, SystemEvents } from '@ephox/alloy';
 import { Id } from '@ephox/katamari';
 
 import { GetApiType, runWithApi } from '../../controls/Controls';
@@ -27,7 +27,19 @@ const onToolbarButtonExecute = <T>(info: OnMenuItemExecuteType<T>): AlloyEvents.
 
 const toolbarButtonEventOrder: Record<string, string[]> = {
   // TODO: use the constants provided by behaviours.
-  [SystemEvents.execute()]: [ 'disabling', 'alloy.base.behaviour', 'toggling', 'toolbar-button-events' ]
+  [SystemEvents.execute()]: [
+    'disabling', 'alloy.base.behaviour', 'toggling', 'toolbar-button-events'
+  ],
+  [SystemEvents.attachedToDom()]: [
+    'toolbar-button-events',
+    'common-button-display-events'
+  ],
+
+  [NativeEvents.mousedown()]: [
+    'focusing',
+    'alloy.base.behaviour',
+    'common-button-display-events'
+  ]
 };
 
 export { onToolbarButtonExecute, toolbarButtonEventOrder, runWithApi };

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
@@ -95,16 +95,16 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
                 }
               ]);
             },
-            onSetup: (_api: Toolbar.ToolbarToggleButtonInstanceApi) => {
+            onSetup: (_api: Toolbar.ToolbarSplitButtonInstanceApi) => {
               store.adder('onSetup.3')();
               return Fun.noop;
             },
-            onAction: (api: Toolbar.ToolbarToggleButtonInstanceApi) => {
+            onAction: (api: Toolbar.ToolbarSplitButtonInstanceApi) => {
               store.adder('onToggleAction.3')();
               api.setEnabled(!shouldDisable.get());
               api.setActive(shouldActivate.get());
             },
-            onItemAction: (api: Toolbar.ToolbarToggleButtonInstanceApi, _value: string) => {
+            onItemAction: (api: Toolbar.ToolbarSplitButtonInstanceApi, _value: string) => {
               store.adder('onItemAction.3')();
               api.setActive(true);
             }


### PR DESCRIPTION
Related Ticket: TINY-9216

Description of Changes:
*  Add working example for toolbar button with updateable text

To test the example:
1. open the code plugin example page
2. click on the button with the text `Before`
3. Notice how the text updates to become `After`

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
