### PR TITLE
TINY-9222: Fix scrolling to the cursor after undo or redo actions

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The context toolbar prevented the user from placing the cursor at the edges of the editor. #TINY-8890
 - The `editor.selection.getRng()` API was not returning a proper range on hidden editors in Firefox. #TINY-9259
 - The `editor.selection.getBookmark()` API was not returning a proper bookmark on hidden editors in Firefox. #TINY-9259
+- Scrolling to the cursor after undo/redo. #TINY-9222
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/src/core/main/ts/undo/Levels.ts
+++ b/modules/tinymce/src/core/main/ts/undo/Levels.ts
@@ -65,6 +65,8 @@ const applyToEditor = (editor: Editor, level: UndoLevel, before: boolean): void 
   if (bookmark) {
     editor.selection.moveToBookmark(bookmark);
   }
+
+  editor.selection.scrollIntoView();
 };
 
 const getLevelContent = (level: NewUndoLevel): string => {


### PR DESCRIPTION
Related Ticket: TINY-9222

Description of Changes:
* Fixed scrolling to the new cursor position after undo or redo action. This is fixed in `undo/Levels.ts:applyToEditor` since this function is called both from `undo` and `redo` actions. However it is also called in `undoManager.extra` function which I do not fully comprehend.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
