### PR TITLE
TINY-9222: Fix scrolling to the cursor after undo or redo actions

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `editor.selection.getRng()` API was not returning a proper range on hidden editors in Firefox. #TINY-9259
 - The `editor.selection.getBookmark()` API was not returning a proper bookmark on hidden editors in Firefox. #TINY-9259
 - Dragging a noneditable element before or after another noneditable element now works correctly. #TINY-9253
-- Scrolling to the cursor after undo/redo. #TINY-9222
+- The restored selection after a redo or undo action was not scrolled into view. #TINY-9222
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `editor.selection.getRng()` API was not returning a proper range on hidden editors in Firefox. #TINY-9259
 - The `editor.selection.getBookmark()` API was not returning a proper bookmark on hidden editors in Firefox. #TINY-9259
 - Dragging a noneditable element before or after another noneditable element now works correctly. #TINY-9253
+- Scrolling to the cursor after undo/redo. #TINY-9222
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/src/core/main/ts/undo/Levels.ts
+++ b/modules/tinymce/src/core/main/ts/undo/Levels.ts
@@ -65,6 +65,8 @@ const applyToEditor = (editor: Editor, level: UndoLevel, before: boolean): void 
   if (bookmark) {
     editor.selection.moveToBookmark(bookmark);
   }
+
+  editor.selection.scrollIntoView();
 };
 
 const getLevelContent = (level: NewUndoLevel): string => {

--- a/modules/tinymce/src/core/main/ts/undo/Levels.ts
+++ b/modules/tinymce/src/core/main/ts/undo/Levels.ts
@@ -64,9 +64,8 @@ const applyToEditor = (editor: Editor, level: UndoLevel, before: boolean): void 
 
   if (bookmark) {
     editor.selection.moveToBookmark(bookmark);
+    editor.selection.scrollIntoView();
   }
-
-  editor.selection.scrollIntoView();
 };
 
 const getLevelContent = (level: NewUndoLevel): string => {

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -689,7 +689,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     editor.focus();
 
     const height = 5000;
-    editor.resetContent(`<p class="first">top paragraph</p><p style="height: ${height}px"></p><p class="last">last paragraph</p>`);
+    editor.setContent(`<p class="first">top paragraph</p><p style="height: ${height}px"></p><p class="last">last paragraph</p>`);
     TinySelections.select(editor, 'p.last', [ 0 ]);
     TinyContentActions.type(editor, 'updated ');
 

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -685,11 +685,9 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
 
   it('TINY-9222: Scroll to the cursor after undo and redo', () => {
     const editor = hook.editor();
-    editor.undoManager.clear();
-    editor.focus();
 
     const height = 5000;
-    editor.setContent(`<p class="first">top paragraph</p><p style="height: ${height}px"></p><p class="last">last paragraph</p>`);
+    editor.resetContent(`<p class="first">top paragraph</p><p style="height: ${height}px"></p><p class="last">last paragraph</p>`);
     TinySelections.select(editor, 'p.last', [ 0 ]);
     TinyContentActions.type(editor, 'updated ');
 

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -688,8 +688,8 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     editor.undoManager.clear();
     editor.focus();
 
-    const HEIGHT = 5000;
-    editor.resetContent(`<p class="first">top paragraph</p><p style="height: ${HEIGHT}px"></p><p class="last">last paragraph</p>`);
+    const height = 5000;
+    editor.resetContent(`<p class="first">top paragraph</p><p style="height: ${height}px"></p><p class="last">last paragraph</p>`);
     TinySelections.select(editor, 'p.last', [ 0 ]);
     TinyContentActions.type(editor, 'updated ');
 
@@ -700,7 +700,7 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
       Scroll.to(0, 0, doc);
       editor.undoManager[action]();
       Scroll.intoViewIfNeeded(UiFinder.findIn(doc, 'p.last').getOrDie(), SugarElement.fromDom(doc.dom.scrollingElement as Element));
-      assert.isAtLeast(Scroll.get(doc).top + editorHeight, HEIGHT, `should scroll to the cursor after ${action}`);
+      assert.isAtLeast(Scroll.get(doc).top + editorHeight, height, `should scroll to the cursor after ${action}`);
     };
 
     Arr.each([ 'undo', 'redo' ], checkScroll);

--- a/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UndoManagerTest.ts
@@ -1,8 +1,8 @@
-import { Keys, UiFinder } from '@ephox/agar';
+import { Keys } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { SugarElement, Scroll } from '@ephox/sugar';
+import { Scroll } from '@ephox/sugar';
 import { TinyDom, LegacyUnit, TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -699,7 +699,6 @@ describe('browser.tinymce.core.UndoManagerTest', () => {
     const checkScroll = (action: 'undo' | 'redo') => {
       Scroll.to(0, 0, doc);
       editor.undoManager[action]();
-      Scroll.intoViewIfNeeded(UiFinder.findIn(doc, 'p.last').getOrDie(), SugarElement.fromDom(doc.dom.scrollingElement as Element));
       assert.isAtLeast(Scroll.get(doc).top + editorHeight, height, `should scroll to the cursor after ${action}`);
     };
 


### PR DESCRIPTION
Related Ticket: TINY-9222

Description of Changes:
* Fixed scrolling to the new cursor position after undo or redo action. This is fixed in `undo/Levels.ts:applyToEditor` since this function is called both from `undo` and `redo` actions. However it is also called in `undoManager.extra` function which I do not fully comprehend.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
