### PR TITLE
TINY-9203: Allow scrollbar to be either hidden or visible when on Win10/11 Firefox

### DIFF
--- a/modules/sugar/src/test/ts/browser/LocationTest.ts
+++ b/modules/sugar/src/test/ts/browser/LocationTest.ts
@@ -136,7 +136,10 @@ UnitTest.asynctest('LocationTest', (success, failure) => {
     pos = SugarLocation.viewport(body);
     Assert.eq('', 0, pos.top);
     Assert.eq('', 0, pos.left);
-    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux()) || (platform.browser.isFirefox() && platform.os.isWindows() && platform.os.version.major >= 11);
+
+    // TINY-9203: due to Win11 FF adopting native hidden scrollbar behavior and current inability to distinguish between Win10 and Win11
+    // (both os.version.major === 10), allow scrollbar to be either hidden or visible when on Win10/11 FF
+    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux()) || (platform.browser.isFirefox() && platform.os.isWindows() && platform.os.version.major >= 10);
     Assert.eq('scroll bar width, got=' + scrollBarWidth, true, scrollBarWidth > 5 && scrollBarWidth < 50 || (noVisibleScrollbarBrowser && scrollBarWidth === 0));
   };
 

--- a/modules/sugar/src/test/ts/browser/ScrollTest.ts
+++ b/modules/sugar/src/test/ts/browser/ScrollTest.ts
@@ -127,7 +127,9 @@ UnitTest.asynctest('ScrollTest', (success, failure) => {
     const cX = Math.round(center.left);
     const cY = Math.round(center.top);
 
-    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux()) || (platform.browser.isFirefox() && platform.os.isWindows() && platform.os.version.major >= 11);
+    // TINY-9203: due to Win11 FF adopting native hidden scrollbar behavior and current inability to distinguish between Win10 and Win11
+    // (both os.version.major === 10), allow scrollbar to be either hidden or visible when on Win10/11 FF
+    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux()) || (platform.browser.isFirefox() && platform.os.isWindows() && platform.os.version.major >= 10);
     Assert.eq('scroll bar width, got=' + scrollBarWidth, true, scrollBarWidth > 5 && scrollBarWidth < 50 || (noVisibleScrollbarBrowser && scrollBarWidth === 0));
 
     scrollCheck(0, 0, 0, 0, doc, 'start pos');


### PR DESCRIPTION
Related Ticket:
TINY-9203

Description of Changes:
Since:
* Win11 FF defaults to hidden scrollbars while Win10 FF does not
* Win11 appears as Win10 to sand,
* sand cannot currently be updated to use User-Agent Client Hints API to support Win11 detection as sand needs to be synchronous for now
* FF has not implemented User-Agent Client Hints API for now

the following change has been made:
* Loosen scrollbar width assertions in LocationTest and ScrollTest in the sugar module to allow the scrollbar to be either hidden (zero-width) or visible when on Win10/11 FF

Pre-checks:
* [x] ~~Changelog entry added~~ - not applicable as this PR involved fixing tests only
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
