### PR TITLE
TINY-9230: Backspace/delete at transparent elements

### DIFF
--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -46,16 +46,18 @@ export const updateCaret = (schema: Schema, root: Element, caretParent: Element)
   );
 };
 
+export const hasBlockAttr = (el: Element): boolean => el.hasAttribute(transparentBlockAttr);
+
 export const isTransparentElementName = (schema: Schema, name: string): boolean => Obj.has(schema.getTransparentElements(), name);
 
 const isTransparentElement = (schema: Schema, node: Node | null | undefined): node is Element =>
   NodeType.isElement(node) && isTransparentElementName(schema, node.nodeName);
 
 export const isTransparentBlock = (schema: Schema, node: Node | null | undefined): node is Element =>
-  isTransparentElement(schema, node) && node.hasAttribute(transparentBlockAttr);
+  isTransparentElement(schema, node) && hasBlockAttr(node);
 
 export const isTransparentInline = (schema: Schema, node: Node | null | undefined): node is Element =>
-  isTransparentElement(schema, node) && !node.hasAttribute(transparentBlockAttr);
+  isTransparentElement(schema, node) && !hasBlockAttr(node);
 
 export const isTransparentAstBlock = (schema: Schema, node: AstNode): boolean =>
   node.type === 1 && isTransparentElementName(schema, node.name) && Type.isString(node.attr(transparentBlockAttr));

--- a/modules/tinymce/src/core/main/ts/delete/BlockMergeBoundary.ts
+++ b/modules/tinymce/src/core/main/ts/delete/BlockMergeBoundary.ts
@@ -29,7 +29,7 @@ const blockBoundary = (from: BlockPosition, to: BlockPosition): BlockBoundary =>
   to
 });
 
-const getBlockPosition = (rootNode: Node, pos: CaretPosition): Optional<BlockPosition> => {
+const getBlockPosition = (rootNode: HTMLElement, pos: CaretPosition): Optional<BlockPosition> => {
   const rootElm = SugarElement.fromDom(rootNode);
   const containerElm = SugarElement.fromDom(pos.container());
   return DeleteUtils.getParentBlock(rootElm, containerElm).map((block) => blockPosition(block, pos));
@@ -38,13 +38,13 @@ const getBlockPosition = (rootNode: Node, pos: CaretPosition): Optional<BlockPos
 const isDifferentBlocks = (blockBoundary: BlockBoundary): boolean =>
   !Compare.eq(blockBoundary.from.block, blockBoundary.to.block);
 
-const getClosestHost = (root: SugarElement<Node>, scope: SugarElement<Node>) => {
+const getClosestHost = (root: SugarElement<HTMLElement>, scope: SugarElement<Element>): SugarElement<HTMLElement> => {
   const isRoot = (node: SugarElement<Node>) => Compare.eq(node, root);
-  const isHost = (node: SugarElement<Node>) => ElementType.isTableCell(node) || NodeType.isContentEditableTrue(node.dom);
+  const isHost = (node: SugarElement<Node>): node is SugarElement<HTMLElement> => ElementType.isTableCell(node) || NodeType.isContentEditableTrue(node.dom);
   return PredicateFind.closest(scope, isHost, isRoot).filter(SugarNode.isElement).getOr(root);
 };
 
-const hasSameHost = (rootNode: Node, blockBoundary: BlockBoundary): boolean => {
+const hasSameHost = (rootNode: HTMLElement, blockBoundary: BlockBoundary): boolean => {
   const root = SugarElement.fromDom(rootNode);
   return Compare.eq(getClosestHost(root, blockBoundary.from.block), getClosestHost(root, blockBoundary.to.block));
 };
@@ -57,7 +57,7 @@ const hasValidBlocks = (blockBoundary: BlockBoundary): boolean => {
   return isValidBlock(blockBoundary.from.block) && isValidBlock(blockBoundary.to.block);
 };
 
-const skipLastBr = (rootNode: Node, forward: boolean, blockPosition: BlockPosition): BlockPosition => {
+const skipLastBr = (rootNode: HTMLElement, forward: boolean, blockPosition: BlockPosition): BlockPosition => {
   if (NodeType.isBr(blockPosition.position.getNode()) && !Empty.isEmpty(blockPosition.block)) {
     return CaretFinder.positionIn(false, blockPosition.block.dom).bind((lastPositionInBlock) => {
       if (lastPositionInBlock.isEqual(blockPosition.position)) {
@@ -71,7 +71,7 @@ const skipLastBr = (rootNode: Node, forward: boolean, blockPosition: BlockPositi
   }
 };
 
-const readFromRange = (rootNode: Node, forward: boolean, rng: Range): Optional<BlockBoundary> => {
+const readFromRange = (rootNode: HTMLElement, forward: boolean, rng: Range): Optional<BlockBoundary> => {
   const fromBlockPos = getBlockPosition(rootNode, CaretPosition.fromRangeStart(rng));
   const toBlockPos = fromBlockPos.bind((blockPos) =>
     CaretFinder.fromPosition(forward, rootNode, blockPos.position).bind((to) =>
@@ -83,7 +83,7 @@ const readFromRange = (rootNode: Node, forward: boolean, rng: Range): Optional<B
     isDifferentBlocks(blockBoundary) && hasSameHost(rootNode, blockBoundary) && isEditable(blockBoundary) && hasValidBlocks(blockBoundary));
 };
 
-const read = (rootNode: Node, forward: boolean, rng: Range): Optional<BlockBoundary> =>
+const read = (rootNode: HTMLElement, forward: boolean, rng: Range): Optional<BlockBoundary> =>
   rng.collapsed ? readFromRange(rootNode, forward, rng) : Optional.none();
 
 export {

--- a/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
@@ -25,6 +25,11 @@ describe('browser.tinymce.core.content.TransparentElementsTest', () => {
       rootState.clear();
     });
 
+    it('TINY-9230: hasBlockAttr', () => {
+      assert.isTrue(TransparentElements.hasBlockAttr(SugarElement.fromHtml<Element>('<a data-mce-block="true"></a>').dom));
+      assert.isFalse(TransparentElements.hasBlockAttr(SugarElement.fromHtml<Element>('<a></a>').dom));
+    });
+
     it('TINY-9172: Should add data-mce-block on transparent elements if the contain blocks', () => {
       const root = rootState.get().getOrDie();
 


### PR DESCRIPTION
Related Ticket: TINY-9230

Description of Changes:
* Fixes issues with deleting elements where chrome in particular is doing very strange things.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
