### PR TITLE
TINY-9143: Add tests for insert content and get content events

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 - Transparent elements, like anchors, can now contain block elements. #TINY-9172
+- Tests for insert content and get content events. #TINY-9143
 
 ### Fixed
 - Parsing media content would cause a memory leak, which for example occurred when using the `getContent` API. #TINY-9186

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -18,10 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Transparent elements, like anchors, are now allowed in the root of the editor body if they contain blocks. #TINY-9172
+- `setContent` is now allowed to accept any custom keys and values as a second options argument. #TINY-9143
 
 ### Improved
 - Transparent elements, like anchors, can now contain block elements. #TINY-9172
-- Tests for insert content and get content events. #TINY-9143
 
 ### Fixed
 - Parsing media content would cause a memory leak, which for example occurred when using the `getContent` API. #TINY-9186

--- a/modules/tinymce/src/core/main/ts/content/ContentTypes.ts
+++ b/modules/tinymce/src/core/main/ts/content/ContentTypes.ts
@@ -22,6 +22,7 @@ export interface SetContentArgs {
   paste?: boolean;
   load?: boolean;
   initial?: boolean;
+  [key: string]: any;
 }
 
 export interface SetContentResult {

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentEventsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentEventsTest.ts
@@ -123,4 +123,28 @@ describe('browser.tinymce.core.content.EditorContentEventsTest', () => {
     assertEvents([]);
     TinyAssertions.assertContent(editor, '<p>Selection content</p>');
   });
+
+  const data = { hello: 'world', test: 132 };
+  Arr.each([ 'BeforeSetContent', 'SetContent' ], (action) => {
+    it(`TINY-9143: Can pass custom data object to "${action}" event`, () => {
+      const editor = hook.editor();
+      editor.setContent('<p>initial</p>');
+      editor.once(action, (e) => {
+        assert.equal(data.hello, e.hello);
+        assert.equal(data.test, e.test);
+      });
+      editor.setContent('<p>new</p>', data);
+    });
+  });
+  Arr.each([ 'BeforeGetContent', 'GetContent' ], (action) => {
+    it(`TINY-9143: Can pass custom data object to "${action}" event`, () => {
+      const editor = hook.editor();
+      editor.setContent('<p>initial</p>');
+      editor.once(action, (e) => {
+        assert.equal(data.hello, e.hello);
+        assert.equal(data.test, e.test);
+      });
+      editor.getContent(data);
+    });
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentEventsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentEventsTest.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { Arr } from '@ephox/katamari';
+import { Arr, Singleton } from '@ephox/katamari';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import { SetContentEvent, GetContentEvent } from 'tinymce/core/api/EventTypes';
 import { ContentFormat } from 'tinymce/core/content/ContentTypes';
 
 describe('browser.tinymce.core.content.EditorContentEventsTest', () => {
@@ -128,23 +129,25 @@ describe('browser.tinymce.core.content.EditorContentEventsTest', () => {
   Arr.each([ 'BeforeSetContent', 'SetContent' ], (action) => {
     it(`TINY-9143: Can pass custom data object to "${action}" event`, () => {
       const editor = hook.editor();
+      const lastEventState = Singleton.value<SetContentEvent>();
       editor.setContent('<p>initial</p>');
-      editor.once(action, (e) => {
-        assert.equal(data.hello, e.hello);
-        assert.equal(data.test, e.test);
-      });
+      editor.once(action, (e) => lastEventState.set(e));
       editor.setContent('<p>new</p>', data);
+      const lastEvent = lastEventState.get().getOrDie('Should be set');
+      assert.equal(lastEvent.hello, data.hello);
+      assert.equal(lastEvent.test, data.test);
     });
   });
   Arr.each([ 'BeforeGetContent', 'GetContent' ], (action) => {
     it(`TINY-9143: Can pass custom data object to "${action}" event`, () => {
       const editor = hook.editor();
+      const lastEventState = Singleton.value<GetContentEvent>();
       editor.setContent('<p>initial</p>');
-      editor.once(action, (e) => {
-        assert.equal(data.hello, e.hello);
-        assert.equal(data.test, e.test);
-      });
+      editor.once(action, (e) => lastEventState.set(e));
       editor.getContent(data);
+      const lastEvent = lastEventState.get().getOrDie('Should be set');
+      assert.equal(lastEvent.hello, data.hello);
+      assert.equal(lastEvent.test, data.test);
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -269,6 +269,25 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
           const tree = editor.getContent({ format: 'tree' });
           assert.equal(toHtml(tree), '<p>replaced</p>', 'Should be replaced html');
         });
+
+        const INITIAL_CONTENT = '<p>initial</p>';
+        const NEW_CONTENT = '<p>new content</p>';
+        const MANIPULATED_CONTENT = '<p>manipulated</p>';
+        Arr.each([
+          [ 'setContent', MANIPULATED_CONTENT ],
+          [ 'insertContent', MANIPULATED_CONTENT + '\n' + INITIAL_CONTENT ]
+        ] as const, ([ action, result ]) => {
+          it(`TINY-9143: Can manipulate content in "BeforeSetContent" callback when called from "${action}" function`, () => {
+            const editor = hook.editor();
+            editor.setContent(INITIAL_CONTENT);
+            editor.once('BeforeSetContent', (e) => {
+              assert.equal(e.content, NEW_CONTENT);
+              e.content = MANIPULATED_CONTENT;
+            });
+            editor[action](NEW_CONTENT);
+            TinyAssertions.assertContent(editor, result);
+          });
+        });
       });
     }
   );

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -270,21 +270,21 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
           assert.equal(toHtml(tree), '<p>replaced</p>', 'Should be replaced html');
         });
 
-        const INITIAL_CONTENT = '<p>initial</p>';
-        const NEW_CONTENT = '<p>new content</p>';
-        const MANIPULATED_CONTENT = '<p>manipulated</p>';
+        const initialContent = '<p>initial</p>';
+        const newContent = '<p>new content</p>';
+        const manipulatedContent = '<p>manipulated</p>';
         Arr.each([
-          [ 'setContent', MANIPULATED_CONTENT ],
-          [ 'insertContent', MANIPULATED_CONTENT + '\n' + INITIAL_CONTENT ]
+          [ 'setContent', manipulatedContent ],
+          [ 'insertContent', manipulatedContent + '\n' + initialContent ]
         ] as const, ([ action, result ]) => {
           it(`TINY-9143: Can manipulate content in "BeforeSetContent" callback when called from "${action}" function`, () => {
             const editor = hook.editor();
-            editor.setContent(INITIAL_CONTENT);
+            editor.setContent(initialContent);
             editor.once('BeforeSetContent', (e) => {
-              assert.equal(e.content, NEW_CONTENT);
-              e.content = MANIPULATED_CONTENT;
+              assert.equal(e.content, newContent);
+              e.content = manipulatedContent;
             });
-            editor[action](NEW_CONTENT);
+            editor[action](newContent);
             TinyAssertions.assertContent(editor, result);
           });
         });


### PR DESCRIPTION
Related Ticket: TINY-9143

Description of Changes:
* Added tests to check if content manipulation in `BeforeSetContent` callback is possible;
* Added tests to check if custom data object can be passed to all get content and set content events.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
