### PR TITLE
Don't focus button on closing toolbar group

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
@@ -72,7 +72,6 @@ const makeSandbox = (button: AlloyComponent, spec: FloatingToolbarButtonSpec, de
   const onClose = () => {
     // Toggle and focus the button
     Toggling.off(button);
-    Focusing.focus(button);
     ariaOwner.unlink(button.element);
   };
 


### PR DESCRIPTION
Related Ticket: 

Steps to replicate:
1. https://fiddle.tiny.cloud/oqiaab
2. Click the button button - paragraph format
3. Click numbered list
4. Click inside the editor to focus the numbered list

Actual Result:
Focus is set to the numbered list button in the toolbar

Expected Result:
Focus should be set in the editor

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
