### PR TITLE
TINY-7981: getContent text no longer untoggles radio inputs.

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The editor header showed up even with no menubar and toolbar configured. #TINY-8819
 - Inline text pattern no longer triggers if it matches only the end but not the start. #TINY-8947
 - Matches of inline text patterns that are similar are now managed correctly. #TINY-8949
+- Using `editor.selection.getContent({ format: 'text' })` or `editor.getContent({ format: 'text' })` would sometimes deselect selected radio buttons #TINY-9213
 - The context toolbar prevented the user from placing the cursor at the edges of the editor. #TINY-8890
 - The Quick Insert context toolbar provided by the `quickbars` plugin showed when the cursor was in a fake block caret. #TINY-9190
 - The `editor.selection.getRng()` API was not returning a proper range on hidden editors in Firefox. #TINY-9259

--- a/modules/tinymce/src/core/main/ts/selection/GetSelectionContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/selection/GetSelectionContentImpl.ts
@@ -3,6 +3,7 @@ import { SugarElement } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import { Content, ContentFormat, GetSelectionContentArgs } from '../content/ContentTypes';
+import { cleanupBogusElements, cleanupInputNames } from '../content/GetContentImpl';
 import { postProcessGetContent, preProcessGetContent } from '../content/PrePostProcess';
 import * as CharType from '../text/CharType';
 import * as Zwsp from '../text/Zwsp';
@@ -26,10 +27,15 @@ const getTextContent = (editor: Editor): string =>
 
     const contextNodeName = getContextNodeName(parentBlockOpt);
 
+    const rangeClone = SugarElement.fromDom(rng.cloneContents());
+    cleanupBogusElements(rangeClone);
+    cleanupInputNames(rangeClone);
+
     const bin = editor.dom.add(body, contextNodeName, {
       'data-mce-bogus': 'all',
       'style': 'overflow: hidden; opacity: 0;'
-    }, rng.cloneContents());
+    }, rangeClone.dom);
+
     const text = getInnerText(bin);
 
     // textContent will not strip leading/trailing spaces since it doesn't consider how it'll render

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorGetContentTextFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorGetContentTextFormatTest.ts
@@ -10,10 +10,32 @@ describe('browser.tinymce.core.content.EditorGetContentTextFormatTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, []);
 
-  it('get text format content should trim zwsp', () => {
+  const assertSelectedRadioButtons = (editor: Editor, nrOfInputs: number, shouldBeSelected: number) => {
+    const inputs = editor.getBody().getElementsByTagName('input');
+    let selected = 0;
+    for (let index = 0; index < inputs.length; index++) {
+      if (inputs[index].checked) {
+        selected++;
+      }
+    }
+
+    assert.equal(inputs.length, nrOfInputs, 'Should have the right amount of inputs');
+    assert.equal(selected, shouldBeSelected, 'Should have exactly one radio button');
+  };
+
+  it('TDA: get text format content should trim zwsp', () => {
     const editor = hook.editor();
     editor.setContent('<p>' + Zwsp.ZWSP + 'a</p>');
     const html = editor.getContent({ format: 'text' });
     assert.equal(html, 'a', 'Should be expected html');
+  });
+
+  it('TINY-7981: inputs should not be deselected', () => {
+    const editor = hook.editor();
+    // eslint-disable-next-line max-len
+    editor.setContent('<p><label><input name="group-name" type="radio" value="1">Option 1</label><label><input checked="checked" name="group-name" type="radio" value="2">Option 2</label><label><input name="group-name" type="radio" value="3">Option 3</label></p>');
+    const html = editor.getContent({ format: 'text' });
+    assert.equal(html, 'Option 1Option 2Option 3', 'Should be expected text');
+    assertSelectedRadioButtons(editor, 3, 1);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/selection/GetSelectionContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/GetSelectionContentTest.ts
@@ -15,6 +15,19 @@ describe('browser.tinymce.selection.GetSelectionContentTest', () => {
   }, []);
   const testDivId = 'testDiv1';
 
+  const assertSelectedRadioButtons = (editor: Editor, nrOfInputs: number, shouldBeSelected: number) => {
+    const inputs = editor.getBody().getElementsByTagName('input');
+    let selected = 0;
+    for (let index = 0; index < inputs.length; index++) {
+      if (inputs[index].checked) {
+        selected++;
+      }
+    }
+
+    assert.equal(inputs.length, nrOfInputs, 'Should have the right amount of inputs');
+    assert.equal(selected, shouldBeSelected, 'Should have exactly one radio button');
+  };
+
   const focusDiv = () => {
     const input = document.querySelector('#' + testDivId) as HTMLDivElement;
     input.focus();
@@ -121,6 +134,15 @@ describe('browser.tinymce.selection.GetSelectionContentTest', () => {
     editor.setContent('<p>          This      Has\n     Spaces</p>');
     TinySelections.setSelection(editor, [ ], 0, [ ], 1);
     assertGetContent('Should be some content', editor, 'This Has Spaces', { format: 'text' });
+  });
+
+  it('TINY-7981: inputs should not be deselected', () => {
+    const editor = hook.editor();
+    // eslint-disable-next-line max-len
+    editor.setContent('<p><label><input name="group-name" type="radio" value="1">Option 1</label><label><input checked="checked" name="group-name" type="radio" value="2">Option 2</label><label><input name="group-name" type="radio" value="3">Option 3</label></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 3);
+    assertGetContent('Should be some content', editor, 'Option 1Option 2Option 3', { format: 'text' });
+    assertSelectedRadioButtons(editor, 3, 1);
   });
 
   it('TBA: Should be text content without non-visible leading/trailing spaces', () => {


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
Due to naming we would untoggle elements when the wrapper was attached to the dom.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
