### PR TITLE
TINY-9308: Focus editor before reversing selection in visualchars PluginTest

### DIFF
--- a/modules/tinymce/src/plugins/visualchars/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/visualchars/test/ts/browser/PluginTest.ts
@@ -56,6 +56,7 @@ describe('browser.tinymce.plugins.visualchars.PluginTest', () => {
     editor.setContent('<p>abc&nbsp;&nbsp;</p>');
 
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
+    editor.focus();
     editor.selection.setRng(editor.selection.getRng(), false);
 
     TinyUiActions.clickOnToolbar(editor, 'button');

--- a/modules/tinymce/src/plugins/visualchars/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/visualchars/test/ts/browser/PluginTest.ts
@@ -14,7 +14,7 @@ describe('browser.tinymce.plugins.visualchars.PluginTest', () => {
     plugins: 'visualchars',
     toolbar: 'visualchars',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin ]);
+  }, [ Plugin ], true);
 
   it('TBA: Set content, click visual chars button and assert span char is present in whitespaces, click the button again and assert no span is present in the whitespace', async () => {
     const editor = hook.editor();
@@ -56,7 +56,6 @@ describe('browser.tinymce.plugins.visualchars.PluginTest', () => {
     editor.setContent('<p>abc&nbsp;&nbsp;</p>');
 
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
-    editor.focus();
     editor.selection.setRng(editor.selection.getRng(), false);
 
     TinyUiActions.clickOnToolbar(editor, 'button');


### PR DESCRIPTION
Related Ticket: 
TINY-9308

Description of Changes:
* Add `editor.focus()` before an `editor.setRng` that reverses current selection to address browser quirk in Firefox where editor loses focus when toolbar button is clicked

Pre-checks:
* [x] ~~Changelog entry added~~ - not applicable as involves fixing tests
* [x] ~~Tests have been added (if applicable)~~ - not applicable as involves fixing existing tests
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
