### PR TITLE
DOC-1757: Improve documentation of overrideDefaults editor method

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -128,7 +128,7 @@ const EditorManager: EditorManager = {
   baseURL: null as any,
 
   /**
-   * Default options for TinyMCE.
+   * Object which contains required, and user-specific, default values for cloud-related options.
    *
    * @property defaultOptions
    * @type Object

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -278,11 +278,11 @@ const EditorManager: EditorManager = {
   },
 
   /**
-   * Overrides the default options for editor instances. The <code>overrideDefaults</code> method replaces any of the defaults set by a previous call to the <code>overrideDefaults</code> function.
+   * Overrides the default options for editor instances. The <code>overrideDefaults</code> method replaces the <code>defaultOptions</code>, including any set by a previous call to the <code>overrideDefaults</code> method.
    * <br /><br />
    * When using the Tiny Cloud, some of these defaults are required for the cloud-based editor to function.
    * <br /><br />
-   * Therefore, when using <code>overrideDefaults</code> with the cloud-based editor, combine the previous defaults, <code>tinymce.defaultOptions</code>, with the new options that you want to integrate.
+   * Therefore, when using <code>overrideDefaults</code> with the cloud-based editor, any newly integrated options must be combined with the options in <code>tinymce.defaultOptions</code>.
    *
    * @method overrideDefaults
    * @param {Object} defaultOptions Default options object.

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -278,7 +278,7 @@ const EditorManager: EditorManager = {
   },
 
   /**
-   * Overrides the default options for editor instances. <code>overrideDefaults</code> replaces any of the defaults set by a previous call to the <code>overrideDefaults</code> function.
+   * Overrides the default options for editor instances. The <code>overrideDefaults</code> method replaces any of the defaults set by a previous call to the <code>overrideDefaults</code> function.
    * <br /><br />
    * When using the Tiny Cloud, some of these defaults are required for the cloud-based editor to function.
    * <br /><br />
@@ -288,7 +288,7 @@ const EditorManager: EditorManager = {
    * @param {Object} defaultOptions Default options object.
    * @example
    * const customOptions = {
-   *   promotion: true
+   *   toolbar_sticky: true
    * };
    *
    * tinymce.overrideDefaults({

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -126,7 +126,15 @@ const EditorManager: EditorManager = {
 
   baseURI: null as any,
   baseURL: null as any,
+
+  /**
+   * Default options for TinyMCE.
+   *
+   * @property defaultOptions
+   * @type Object
+   */
   defaultOptions: {},
+
   documentBaseURL: null as any,
   suffix: null as any,
 
@@ -272,7 +280,7 @@ const EditorManager: EditorManager = {
   /**
    * Overrides the default options for editor instances. <code>overrideDefaults</code> replaces any of the defaults set by a previous call to the <code>overrideDefaults</code> function.
    * <br /><br />
-   * When using the cloud, some of these defaults are required for the cloud-based editor to function.
+   * When using the Tiny Cloud, some of these defaults are required for the cloud-based editor to function.
    * <br /><br />
    * Therefore, when using <code>overrideDefaults</code> with the cloud-based editor, combine the previous defaults, <code>tinymce.defaultOptions</code>, with the new options that you want to integrate.
    *

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -128,7 +128,7 @@ const EditorManager: EditorManager = {
   baseURL: null as any,
 
   /**
-   * Object containing the options that will be passed by default to the `init` method upon each initialization of an editor.
+   * Object containing the default options that will be shallow merged with the options object passed to the `init` method upon each initialization of an editor.
    *
    * @property defaultOptions
    * @type Object

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -270,10 +270,23 @@ const EditorManager: EditorManager = {
   },
 
   /**
-   * Overrides the default options for editor instances.
+   * Overrides the default options for editor instances. <code>overrideDefaults</code> replaces any of the defaults set by a previous call to the <code>overrideDefaults</code> function.
+   * <br /><br />
+   * When using the cloud, some of these defaults are required for the cloud-based editor to function.
+   * <br /><br />
+   * Therefore, when using <code>overrideDefaults</code> with the cloud-based editor, combine the previous defaults, <code>tinymce.defaultOptions</code>, with the new options that you want to integrate.
    *
    * @method overrideDefaults
-   * @param {Object} defaultOptions Defaults options object.
+   * @param {Object} defaultOptions Default options object.
+   * @example
+   * const customOptions = {
+   *   promotion: true
+   * };
+   *
+   * tinymce.overrideDefaults({
+   *   ...tinymce.defaultOptions,
+   *   ...customOptions
+   * });
    */
   overrideDefaults(defaultOptions) {
     const baseUrl = defaultOptions.base_url;

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -128,7 +128,7 @@ const EditorManager: EditorManager = {
   baseURL: null as any,
 
   /**
-   * Object which contains required, and user-specific, default values for cloud-related options.
+   * Object containing the options that will be passed by default to the `init` method upon each initialization of an editor.
    *
    * @property defaultOptions
    * @type Object

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -128,7 +128,7 @@ const EditorManager: EditorManager = {
   baseURL: null as any,
 
   /**
-   * Object containing the default options that will be shallow merged with the options object passed to the `init` method upon each initialization of an editor.
+   * Object containing the options that will be passed by default to the <code>init</code> method upon each initialization of an editor. These defaults will be shallow merged with other options passed to <code>init</code>.
    *
    * @property defaultOptions
    * @type Object


### PR DESCRIPTION
Related Ticket: DOC-1757

Previous PR: https://github.com/tinymce/tinymce-docs/pull/2554

Description of Changes:
* Update EditorManager API docs to improve description of `overrideDefaults` method, with example
* Document the `defaultOptions` property
* Credit to @kemister85 and @lnewson for the new documentation

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
