### PR TITLE
TINY-9290: fixed bug where names with numbers was not working correctly

### DIFF
--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -7,7 +7,9 @@ import * as NodeType from '../dom/NodeType';
 
 export const transparentBlockAttr = 'data-mce-block';
 
-const makeSelectorFromSchemaMap = (map: SchemaMap) => Arr.filter(Obj.keys(map), (key) => /^[a-z]+$/.test(key)).join(',');
+export const elementNames = (map: SchemaMap): string[] => Arr.filter(Obj.keys(map), (key) => !/[A-Z]/.test(key));
+
+const makeSelectorFromSchemaMap = (map: SchemaMap) => elementNames(map).join(',');
 
 const updateTransparent = (blocksSelector: string, transparent: Element) => {
   if (Type.isNonNullable(transparent.querySelector(blocksSelector))) {

--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -7,6 +7,8 @@ import * as NodeType from '../dom/NodeType';
 
 export const transparentBlockAttr = 'data-mce-block';
 
+// Returns the lowercase element names form a SchemaMap by excluding anyone that has uppercase letters.
+// This method is to avoid having to specify all possible valid characters other than lowercase a-z such as '-' or ':' etc.
 export const elementNames = (map: SchemaMap): string[] => Arr.filter(Obj.keys(map), (key) => !/[A-Z]/.test(key));
 
 const makeSelectorFromSchemaMap = (map: SchemaMap) => elementNames(map).join(',');

--- a/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
@@ -1,9 +1,10 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { Arr, Obj } from '@ephox/katamari';
+import { Arr } from '@ephox/katamari';
 import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import * as TransparentElements from 'tinymce/core/content/TransparentElements';
 
 import * as HtmlUtils from '../module/test/HtmlUtils';
 
@@ -121,7 +122,7 @@ describe('browser.tinymce.core.ForceBlocksTest', () => {
   context('Transparent elements', () => {
     it('TINY-9172: Do not wrap root level transparent elements if they blocks inside', () => {
       const editor = hook.editor();
-      const transparentElements = Arr.filter(Obj.keys(editor.schema.getTransparentElements()), (name) => /^[a-z]+$/.test(name));
+      const transparentElements = TransparentElements.elementNames(editor.schema.getTransparentElements());
       const transparentElementsHtml = Arr.map(transparentElements, (name) => `<${name} data-mce-block="true"><p>text</p></${name}>`).join('');
       const innerHtml = 'text' + transparentElementsHtml;
       const expectedInnerHtml = '<p>text</p>' + transparentElementsHtml;
@@ -134,7 +135,7 @@ describe('browser.tinymce.core.ForceBlocksTest', () => {
 
     it('TINY-9172: Wrap root level transparent elements if they do not have blocks inside', () => {
       const editor = hook.editor();
-      const transparentElements = Arr.filter(Obj.keys(editor.schema.getTransparentElements()), (name) => /^[a-z]+$/.test(name));
+      const transparentElements = TransparentElements.elementNames(editor.schema.getTransparentElements());
       const transparentElementsHtml = Arr.map(transparentElements, (name) => `<${name}>text</${name}>`).join('');
       const innerHtml = 'text' + transparentElementsHtml;
       const expectedInnerHtml = `<p>text${transparentElementsHtml}</p>`;


### PR DESCRIPTION
Related Ticket: TINY-9290

Description of Changes:
* The node name matches was incorrect since they didn't match H1 so they are changed to look for things that are not uppercase instead.
* Changed all duplicates of the function in tests by exposing the function also makes it testable.
* Improved tests so that all text blocks elements are tested would be more difficult to test all block elements since UL etc require a child element to be valid.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
