### PR TITLE
TINY-9226: Phase I => Simplifying positioning APIs

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Moved `TestStore` to Agar. #TINY-9157
 - Removed `positionWithin` from `Positioning` behaviour's APIs. #TINY-9226
 - Removed `showWithin` from `InlineView` sketcher's APIs. #TINY-9226
+- Removed unused custom `placer` from `Anchorage`. #TINY-9226
 
 ## 11.0.0 - 2022-09-08
 

--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 - Moved `TestStore` to Agar. #TINY-9157
 - Removed `positionWithin` from `Positioning` behaviour's APIs. #TINY-9226
+- Removed `showWithin` from `InlineView` sketcher's APIs. #TINY-9226
 
 ## 11.0.0 - 2022-09-08
 

--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 - Moved `TestStore` to Agar. #TINY-9157
+- Removed `positionWithin` from `Positioning` behaviour's APIs. #TINY-9226
 
 ## 11.0.0 - 2022-09-08
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/InlineView.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/InlineView.ts
@@ -108,11 +108,8 @@ const factory: SingleSketchFactory<InlineViewDetail, InlineViewSpec> = (detail: 
   };
 
   const showAt = (sandbox: AlloyComponent, thing: AlloySpec, placementSpec: PlacementSpec) => {
-    showWithin(sandbox, thing, placementSpec, Optional.none());
-  };
-
-  const showWithin = (sandbox: AlloyComponent, thing: AlloySpec, placementSpec: PlacementSpec, boxElement: Optional<SugarElement<HTMLElement>>) => {
-    showWithinBounds(sandbox, thing, placementSpec, () => boxElement.map((elem) => Boxes.box(elem)));
+    const getBounds = Optional.none;
+    showWithinBounds(sandbox, thing, placementSpec, getBounds);
   };
 
   const showWithinBounds = (sandbox: AlloyComponent, thing: AlloySpec, placementSpec: PlacementSpec, getBounds: () => Optional<Boxes.Bounds>) => {
@@ -164,10 +161,9 @@ const factory: SingleSketchFactory<InlineViewDetail, InlineViewSpec> = (detail: 
     }
   };
 
-  const apis = {
+  const apis: InlineViewApis = {
     setContent,
     showAt,
-    showWithin,
     showWithinBounds,
     showMenuAt,
     showMenuWithinBounds,
@@ -245,9 +241,6 @@ const InlineView: InlineViewSketcher = Sketcher.single<InlineViewSpec, InlineVie
   apis: {
     showAt: (apis, component, anchor, thing) => {
       apis.showAt(component, anchor, thing);
-    },
-    showWithin: (apis, component, anchor, thing, boxElement) => {
-      apis.showWithin(component, anchor, thing, boxElement);
     },
     showWithinBounds: (apis, component, anchor, thing, bounds) => {
       apis.showWithinBounds(component, anchor, thing, bounds);

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
@@ -1,8 +1,8 @@
 import { StructureSchema } from '@ephox/boulder';
 import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
-import { Css, SugarElement, SugarLocation } from '@ephox/sugar';
+import { Css, SugarLocation } from '@ephox/sugar';
 
-import { Bounds, box } from '../../alien/Boxes';
+import * as Boxes from '../../alien/Boxes';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as AriaFocus from '../../aria/AriaFocus';
 import * as Anchor from '../../positioning/layout/Anchor';
@@ -31,21 +31,17 @@ const getRelativeOrigin = (component: AlloyComponent): Origins.OriginAdt => {
   return Origins.relative(position.left, position.top, bounds.width, bounds.height);
 };
 
-const place = (component: AlloyComponent, origin: Origins.OriginAdt, anchoring: Anchoring, getBounds: Optional<() => Bounds>, placee: AlloyComponent, lastPlace: Optional<PlacerResult>, transition: Optional<Transition>): PlacerResult => {
+const place = (_component: AlloyComponent, origin: Origins.OriginAdt, anchoring: Anchoring, optBounds: Optional<Boxes.Bounds>, placee: AlloyComponent, lastPlace: Optional<PlacerResult>, transition: Optional<Transition>): PlacerResult => {
   const anchor = Anchor.box(anchoring.anchorBox, origin);
-  return SimpleLayout.simple(anchor, placee.element, anchoring.bubble, anchoring.layouts, lastPlace, getBounds, anchoring.overrides, transition);
+  return SimpleLayout.simple(anchor, placee.element, anchoring.bubble, anchoring.layouts, lastPlace, optBounds, anchoring.overrides, transition);
 };
 
 const position = (component: AlloyComponent, posConfig: PositioningConfig, posState: PositioningState, placee: AlloyComponent, placementSpec: PlacementSpec): void => {
-  positionWithin(component, posConfig, posState, placee, placementSpec, Optional.none());
+  const optWithinBounds = Optional.none();
+  positionWithinBounds(component, posConfig, posState, placee, placementSpec, optWithinBounds);
 };
 
-const positionWithin = (component: AlloyComponent, posConfig: PositioningConfig, posState: PositioningState, placee: AlloyComponent, placementSpec: PlacementSpec, boxElement: Optional<SugarElement<HTMLElement>>): void => {
-  const boundsBox = boxElement.map(box);
-  return positionWithinBounds(component, posConfig, posState, placee, placementSpec, boundsBox);
-};
-
-const positionWithinBounds = (component: AlloyComponent, posConfig: PositioningConfig, posState: PositioningState, placee: AlloyComponent, placementSpec: PlacementSpec, bounds: Optional<Bounds>): void => {
+const positionWithinBounds = (component: AlloyComponent, posConfig: PositioningConfig, posState: PositioningState, placee: AlloyComponent, placementSpec: PlacementSpec, optWithinBounds: Optional<Boxes.Bounds>): void => {
   const placeeDetail: PlacementDetail = StructureSchema.asRawOrDie('placement.info', StructureSchema.objOf(PlacementSchema), placementSpec);
   const anchorage = placeeDetail.anchor;
   const element = placee.element;
@@ -65,11 +61,19 @@ const positionWithinBounds = (component: AlloyComponent, posConfig: PositioningC
     // (bottom and right) will be using the wrong dimensions
     const origin = posConfig.useFixed() ? getFixedOrigin() : getRelativeOrigin(component);
 
-    const getBounds = bounds.map(Fun.constant).or(posConfig.getBounds);
-
     anchorage.placement(component, anchorage, origin).each((anchoring) => {
+      // If "within bounds" is specified, it overrides any Positioning config. Otherwise, we
+      // use the Positioning config. We don't try to combine automatically here because they are
+      // sometimes serving different purposes. If the Positioning config getBounds needs to be
+      // combined with the optWithinBounds bounds, then it is the responsibility of the calling
+      // code to combine them, and pass in the combined value as optWithinBounds. The optWithinBounds
+      // will *always* override the Positioning config.
+      const optBounds: Optional<Boxes.Bounds> = optWithinBounds.orThunk(
+        () => posConfig.getBounds.map(Fun.apply)
+      );
+
       // Place the element and then update the state for the placee
-      const newState = place(component, origin, anchoring, getBounds, placee, placeeState, placeeDetail.transition);
+      const newState = place(component, origin, anchoring, optBounds, placee, placeeState, placeeDetail.transition);
       posState.set(placee.uid, newState);
     });
 
@@ -104,7 +108,6 @@ const reset = (component: AlloyComponent, pConfig: PositioningConfig, posState: 
 
 export {
   position,
-  positionWithin,
   positionWithinBounds,
   getMode,
   reset

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
@@ -65,14 +65,11 @@ const positionWithinBounds = (component: AlloyComponent, posConfig: PositioningC
     // (bottom and right) will be using the wrong dimensions
     const origin = posConfig.useFixed() ? getFixedOrigin() : getRelativeOrigin(component);
 
-    const placer = anchorage.placement;
-
     const getBounds = bounds.map(Fun.constant).or(posConfig.getBounds);
 
-    placer(component, anchorage, origin).each((anchoring) => {
+    anchorage.placement(component, anchorage, origin).each((anchoring) => {
       // Place the element and then update the state for the placee
-      const doPlace = anchoring.placer.getOr(place);
-      const newState = doPlace(component, origin, anchoring, getBounds, placee, placeeState, placeeDetail.transition);
+      const newState = place(component, origin, anchoring, getBounds, placee, placeeState, placeeDetail.transition);
       posState.set(placee.uid, newState);
     });
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositioningTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositioningTypes.ts
@@ -1,5 +1,4 @@
 import { Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
 
 import { Bounds } from '../../alien/Boxes';
 import * as Behaviour from '../../api/behaviour/Behaviour';
@@ -32,7 +31,6 @@ export interface PlacementDetail {
 export interface PositioningBehaviour extends Behaviour.AlloyBehaviour<PositioningConfigSpec, PositioningConfig> {
   readonly config: (config: PositioningConfigSpec) => Behaviour.NamedConfiguredBehaviour<PositioningConfigSpec, PositioningConfig>;
   readonly position: (component: AlloyComponent, placee: AlloyComponent, spec: PlacementSpec) => void;
-  readonly positionWithin: (component: AlloyComponent, placee: AlloyComponent, spec: PlacementSpec, boxElement: Optional<SugarElement<HTMLElement>>) => void;
   readonly positionWithinBounds: (component: AlloyComponent, placee: AlloyComponent, spec: PlacementSpec, bounds: Optional<Bounds>) => void;
   readonly getMode: (component: AlloyComponent) => string;
   readonly reset: (component: AlloyComponent, placee: AlloyComponent) => void;

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositioningTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositioningTypes.ts
@@ -31,7 +31,7 @@ export interface PlacementDetail {
 export interface PositioningBehaviour extends Behaviour.AlloyBehaviour<PositioningConfigSpec, PositioningConfig> {
   readonly config: (config: PositioningConfigSpec) => Behaviour.NamedConfiguredBehaviour<PositioningConfigSpec, PositioningConfig>;
   readonly position: (component: AlloyComponent, placee: AlloyComponent, spec: PlacementSpec) => void;
-  readonly positionWithinBounds: (component: AlloyComponent, placee: AlloyComponent, spec: PlacementSpec, bounds: Optional<Bounds>) => void;
+  readonly positionWithinBounds: (component: AlloyComponent, placee: AlloyComponent, spec: PlacementSpec, optWithinBounds: Optional<Bounds>) => void;
   readonly getMode: (component: AlloyComponent) => string;
   readonly reset: (component: AlloyComponent, placee: AlloyComponent) => void;
 }

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Origins.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Origins.ts
@@ -84,16 +84,19 @@ const toBox = (origin: OriginAdt, element: SugarElement<HTMLElement>): Boxes.Bou
   return Boxes.bounds(position.left, position.top, width, height);
 };
 
-const viewport = (origin: OriginAdt, getBounds: Optional<() => Boxes.Bounds>): Boxes.Bounds => getBounds.fold(() =>
-/* There are no bounds supplied */
-  origin.fold(Boxes.win, Boxes.win, Boxes.bounds)
-, (b) =>
-/* Use any bounds supplied or remove the scroll position of the bounds for fixed. */
-  origin.fold(b, b, () => {
-    const bounds = b();
-    const pos = translate(origin, bounds.x, bounds.y);
-    return Boxes.bounds(pos.left, pos.top, bounds.width, bounds.height);
-  })
+const viewport = (origin: OriginAdt, optBounds: Optional<Boxes.Bounds>): Boxes.Bounds => optBounds.fold(
+  /* There are no bounds supplied */
+  () => origin.fold(Boxes.win, Boxes.win, Boxes.bounds),
+  (bounds) =>
+    /* Use any bounds supplied or remove the scroll position of the bounds for fixed. */
+    origin.fold(
+      Fun.constant(bounds),
+      Fun.constant(bounds),
+      () => {
+        const pos = translate(origin, bounds.x, bounds.y);
+        return Boxes.bounds(pos.left, pos.top, bounds.width, bounds.height);
+      }
+    )
 );
 
 const translate = (origin: OriginAdt, x: number, y: number): SugarPosition => {

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/SimpleLayout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/SimpleLayout.ts
@@ -31,7 +31,7 @@ const simple = (
   bubble: Bubble,
   layouts: LayoutTypes.AnchorLayout[],
   lastPlacement: Optional<PlacerResult>,
-  getBounds: Optional<() => Bounds>,
+  optBounds: Optional<Bounds>,
   overrideOptions: AnchorOverrides,
   transition: Optional<Transition>
 ): PlacerResult => {
@@ -43,7 +43,7 @@ const simple = (
   const origin = anchor.origin;
 
   const options: ReparteeOptions = {
-    bounds: Origins.viewport(origin, getBounds),
+    bounds: Origins.viewport(origin, optBounds),
     origin,
     preference: layouts,
     maxHeightFunction,

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/Anchoring.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/Anchoring.ts
@@ -140,7 +140,6 @@ export interface Anchoring {
   bubble: Bubble;
   overrides: AnchorOverrides;
   layouts: AnchorLayout[];
-  placer: Optional<AnchorPlacement>;
 }
 
 const nu: (spec: Anchoring) => Anchoring = Fun.identity;

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/ContentAnchorCommon.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/ContentAnchorCommon.ts
@@ -52,8 +52,7 @@ const calcNewAnchor = (optBox: Optional<Boxes.BoxByPoint>, rootPoint: CssPositio
       anchorBox,
       bubble: anchorInfo.bubble.getOr(Bubble.fallback()),
       overrides: anchorInfo.overrides,
-      layouts,
-      placer: Optional.none()
+      layouts
     });
   });
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/HotspotAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/HotspotAnchor.ts
@@ -28,8 +28,7 @@ const placement = (component: AlloyComponent, anchorInfo: HotspotAnchor, origin:
       anchorBox,
       bubble: anchorInfo.bubble.getOr(Bubble.fallback()),
       overrides: anchorInfo.overrides,
-      layouts,
-      placer: Optional.none()
+      layouts
     })
   );
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/MakeshiftAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/MakeshiftAnchor.ts
@@ -30,8 +30,7 @@ const placement = (component: AlloyComponent, anchorInfo: MakeshiftAnchor, origi
       anchorBox,
       bubble: anchorInfo.bubble,
       overrides: anchorInfo.overrides,
-      layouts,
-      placer: Optional.none()
+      layouts
     })
   );
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SubmenuAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SubmenuAnchor.ts
@@ -28,8 +28,7 @@ const placement = (component: AlloyComponent, submenuInfo: SubmenuAnchor, origin
       anchorBox,
       bubble: Bubble.fallback(),
       overrides: submenuInfo.overrides,
-      layouts,
-      placer: Optional.none()
+      layouts
     })
   );
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/InlineViewTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/InlineViewTypes.ts
@@ -59,7 +59,6 @@ export interface InlineMenuSpec {
 
 export interface InlineViewApis {
   showAt: (component: AlloyComponent, thing: AlloySpec, placementSpec: PlacementSpec) => void;
-  showWithin: (component: AlloyComponent, thing: AlloySpec, placementSpec: PlacementSpec, boxElement: Optional<SugarElement<HTMLElement>>) => void;
   showWithinBounds: (component: AlloyComponent, thing: AlloySpec, placementSpec: PlacementSpec, getBounds: () => Optional<Bounds>) => void;
   showMenuAt: (component: AlloyComponent, placementSpec: PlacementSpec, menuSpec: InlineMenuSpec) => void;
   showMenuWithinBounds: (component: AlloyComponent, placementSpec: PlacementSpec, menuSpec: InlineMenuSpec, getBounds: () => Optional<Bounds>) => void;

--- a/modules/alloy/src/test/ts/browser/position/HotspotCustomBoundsPositionTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/HotspotCustomBoundsPositionTest.ts
@@ -76,14 +76,14 @@ UnitTest.asynctest('HotspotPositionTest', (success, failure) => {
 
           NamedChain.direct('hotspot', cSetupAnchor, 'anchor'),
 
-          PositionTestUtils.cTestSinkWithinBounds('Relative, not scrolled', 'relative', win),
+          PositionTestUtils.cTestSinkWithinBounds('Relative, not scrolled', 'relative', Fun.constant(win)),
           cAssertLayoutDirection('top'),
-          PositionTestUtils.cTestSinkWithinBounds('Fixed, not scrolled', 'fixed', win),
+          PositionTestUtils.cTestSinkWithinBounds('Fixed, not scrolled', 'fixed', Fun.constant(win)),
           cAssertLayoutDirection('top'),
 
-          PositionTestUtils.cTestSinkWithinBounds('Relative, bounds 50px from top', 'relative', bounds100PixelsFromTop),
+          PositionTestUtils.cTestSinkWithinBounds('Relative, bounds 50px from top', 'relative', Fun.constant(bounds100PixelsFromTop)),
           cAssertLayoutDirection('bottom'),
-          PositionTestUtils.cTestSinkWithinBounds('Fixed, bounds 50px from top', 'fixed', bounds100PixelsFromTop),
+          PositionTestUtils.cTestSinkWithinBounds('Fixed, bounds 50px from top', 'fixed', Fun.constant(bounds100PixelsFromTop)),
           cAssertLayoutDirection('bottom')
         ])
       ])

--- a/modules/alloy/src/test/ts/browser/position/NodeInFramePositionTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/NodeInFramePositionTest.ts
@@ -3,6 +3,7 @@ import { UnitTest } from '@ephox/bedrock-client';
 import { Optional, Result } from '@ephox/katamari';
 import { Css, DomEvent, SelectorFind, SimRange, SugarElement, WindowSelection } from '@ephox/sugar';
 
+import * as Boxes from 'ephox/alloy/alien/Boxes';
 import { AlloyComponent } from 'ephox/alloy/api/component/ComponentApi';
 import * as GuiFactory from 'ephox/alloy/api/component/GuiFactory';
 import * as GuiSetup from 'ephox/alloy/api/testhelpers/GuiSetup';
@@ -115,29 +116,30 @@ UnitTest.asynctest('SelectionInFramePositionTest', (success, failure) => {
             ]
           ),
 
-          PositionTestUtils.cTestSinkWithin(
+          PositionTestUtils.cTestSinkWithinBounds(
             'Relative, Selected: 3rd paragraph, no page scroll, no editor scroll, positioned within frame',
             'relative',
-            frame),
+            () => Boxes.box(frame)
+          ),
 
-          PositionTestUtils.cTestSinkWithin(
+          PositionTestUtils.cTestSinkWithinBounds(
             'Fixed, Selected: 3rd paragraph, no page scroll, no editor scroll, positioned within frame',
             'fixed',
-            frame
+            () => Boxes.box(frame)
           ),
 
           PositionTestUtils.cScrollDown('classic', '2000px'),
 
-          PositionTestUtils.cTestSinkWithin(
+          PositionTestUtils.cTestSinkWithinBounds(
             'Relative, Selected: 3rd paragraph, 2000px scroll, no editor scroll, positioned within frame',
             'relative',
-            frame
+            () => Boxes.box(frame)
           ),
 
-          PositionTestUtils.cTestSinkWithin(
+          PositionTestUtils.cTestSinkWithinBounds(
             'Fixed, Selected: 3rd paragraph, 2000px scroll, no editor scroll, positioned within frame',
             'fixed',
-            frame
+            () => Boxes.box(frame)
           )
         ])
       ])

--- a/modules/alloy/src/test/ts/browser/position/SelectionInFramePositionTest.ts
+++ b/modules/alloy/src/test/ts/browser/position/SelectionInFramePositionTest.ts
@@ -4,6 +4,7 @@ import { Optional, Result } from '@ephox/katamari';
 import { Css, DomEvent, Scroll, SelectorFind, SimRange, SugarElement, SugarNode, SugarPosition, Traverse, WindowSelection } from '@ephox/sugar';
 import { assert } from 'chai';
 
+import * as Boxes from 'ephox/alloy/alien/Boxes';
 import * as GuiFactory from 'ephox/alloy/api/component/GuiFactory';
 import * as GuiSetup from 'ephox/alloy/api/testhelpers/GuiSetup';
 import { Container } from 'ephox/alloy/api/ui/Container';
@@ -143,19 +144,20 @@ UnitTest.asynctest('SelectionInFramePositionTest', (success, failure) => {
             'Relative, Selected: 3rd paragraph, no page scroll, no editor scroll',
             'relative'
           ),
-          PositionTestUtils.cTestSinkWithin(
+          PositionTestUtils.cTestSinkWithinBounds(
             'Relative, Selected: 3rd paragraph, no page scroll, no editor scroll, positioned within frame',
             'relative',
-            frame),
+            () => Boxes.box(frame)
+          ),
 
           PositionTestUtils.cTestSink(
             'Fixed, Selected: 3rd paragraph, no page scroll, no editor scroll',
             'fixed'
           ),
-          PositionTestUtils.cTestSinkWithin(
+          PositionTestUtils.cTestSinkWithinBounds(
             'Fixed, Selected: 3rd paragraph, no page scroll, no editor scroll, positioned within frame',
             'fixed',
-            frame
+            () => Boxes.box(frame)
           ),
 
           PositionTestUtils.cScrollDown('classic', '2000px'),
@@ -163,20 +165,20 @@ UnitTest.asynctest('SelectionInFramePositionTest', (success, failure) => {
             'Relative, Selected: 3rd paragraph, 2000px scroll, no editor scroll',
             'relative'
           ),
-          PositionTestUtils.cTestSinkWithin(
+          PositionTestUtils.cTestSinkWithinBounds(
             'Relative, Selected: 3rd paragraph, 2000px scroll, no editor scroll, positioned within frame',
             'relative',
-            frame
+            () => Boxes.box(frame)
           ),
 
           PositionTestUtils.cTestSink(
             'Fixed, Selected: 3rd paragraph, 2000px scroll, no editor scroll',
             'fixed'
           ),
-          PositionTestUtils.cTestSinkWithin(
+          PositionTestUtils.cTestSinkWithinBounds(
             'Fixed, Selected: 3rd paragraph, 2000px scroll, no editor scroll, positioned within frame',
             'fixed',
-            frame
+            () => Boxes.box(frame)
           ),
 
           ChainUtils.cLogging(

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/PositionTestUtils.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/PositionTestUtils.ts
@@ -1,6 +1,6 @@
 import { Chain, Guard, NamedChain, Waiter } from '@ephox/agar';
 import { Optional, Result } from '@ephox/katamari';
-import { Css, Scroll, SugarElement, Traverse } from '@ephox/sugar';
+import { Css, Scroll, Traverse } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import { Bounds } from 'ephox/alloy/alien/Boxes';
@@ -18,11 +18,6 @@ const addPopupToSinkCommon = (popup: AlloyComponent, sink: AlloyComponent, posit
 
 const addPopupToSink = (popup: AlloyComponent, placementSpec: PlacementSpec, sink: AlloyComponent) => {
   const positioner = () => Positioning.position(sink, popup, placementSpec);
-  addPopupToSinkCommon(popup, sink, positioner);
-};
-
-const addPopupToSinkWithin = (popup: AlloyComponent, placementSpec: PlacementSpec, sink: AlloyComponent, elem: SugarElement<HTMLElement>) => {
-  const positioner = () => Positioning.positionWithin(sink, popup, placementSpec, Optional.some(elem));
   addPopupToSinkCommon(popup, sink, positioner);
 };
 
@@ -54,11 +49,6 @@ const pTestSink = async (sinkName: string, sink: AlloyComponent, popup: AlloyCom
   await pTestPopupPosition(sinkName, popup, sink);
 };
 
-const pTestSinkWithin = async (sinkName: string, sink: AlloyComponent, popup: AlloyComponent, placementSpec: PlacementSpec, elem: SugarElement<HTMLElement>): Promise<void> => {
-  addPopupToSinkWithin(popup, placementSpec, sink, elem);
-  await pTestPopupPosition(sinkName, popup, sink);
-};
-
 const pTestSinkWithinBounds = async (sinkName: string, sink: AlloyComponent, popup: AlloyComponent, placementSpec: PlacementSpec, bounds: Bounds): Promise<void> => {
   addPopupToSinkWithinBounds(popup, placementSpec, sink, bounds);
   await pTestPopupPosition(sinkName, popup, sink);
@@ -74,13 +64,8 @@ const cAddPopupToSink = (sinkName: string): NamedChain => NamedChain.bundle((dat
   return Result.value(data);
 });
 
-const cAddPopupToSinkWithin = (sinkName: string, elem: SugarElement<HTMLElement>): NamedChain => NamedChain.bundle((data) => {
-  addPopupToSinkWithin(data.popup, { anchor: data.anchor }, data[sinkName], elem);
-  return Result.value(data);
-});
-
-const cAddPopupToSinkWithinBounds = (sinkName: string, bounds: Bounds): NamedChain => NamedChain.bundle((data) => {
-  addPopupToSinkWithinBounds(data.popup, { anchor: data.anchor }, data[sinkName], bounds);
+const cAddPopupToSinkWithinBounds = (sinkName: string, getBounds: () => Bounds): NamedChain => NamedChain.bundle((data) => {
+  addPopupToSinkWithinBounds(data.popup, { anchor: data.anchor }, data[sinkName], getBounds());
   return Result.value(data);
 });
 
@@ -129,18 +114,10 @@ const cTestSink = (label: string, sinkName: string): NamedChain => ChainUtils.cL
   ]
 );
 
-const cTestSinkWithin = (label: string, sinkName: string, elem: SugarElement<HTMLElement>): NamedChain => ChainUtils.cLogging(
+const cTestSinkWithinBounds = (label: string, sinkName: string, getBounds: () => Bounds): NamedChain => ChainUtils.cLogging(
   label,
   [
-    cAddPopupToSinkWithin(sinkName, elem),
-    cTestSinkPopupPosition(sinkName)
-  ]
-);
-
-const cTestSinkWithinBounds = (label: string, sinkName: string, bounds: Bounds): NamedChain => ChainUtils.cLogging(
-  label,
-  [
-    cAddPopupToSinkWithinBounds(sinkName, bounds),
+    cAddPopupToSinkWithinBounds(sinkName, getBounds),
     cTestSinkPopupPosition(sinkName)
   ]
 );
@@ -155,10 +132,8 @@ const cScrollDown = (componentName: string, amount: string): NamedChain => Chain
 
 export {
   cTestSink,
-  cTestSinkWithin,
   cTestSinkWithinBounds,
   cScrollDown,
   pTestSink,
-  pTestSinkWithin,
   pTestSinkWithinBounds
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
@@ -52,6 +52,13 @@ const inlineAdditionalBehaviours = (editor: Editor, isStickyToolbar: boolean, is
   }
 };
 
+const getInlineDialogBounds = (): Optional<Boxes.Bounds> => {
+  // At the moment the inline dialog is just put anywhere in the body, and docking is what is used to make
+  // sure that it stays onscreen
+  const bounds = Boxes.box(SugarBody.body());
+  return Optional.some(bounds);
+};
+
 const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
   const editor = extras.editor;
   const isStickyToolbar = Options.isStickyToolbar(editor);
@@ -180,11 +187,11 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
       inlineDialog.set(inlineDialogComp);
 
       // Position the inline dialog
-      InlineView.showWithin(
+      InlineView.showWithinBounds(
         inlineDialogComp,
         GuiFactory.premade(dialogUi.dialog),
         { anchor },
-        Optional.some(SugarBody.body())
+        getInlineDialogBounds
       );
 
       // Refresh the docking position if not using a sticky toolbar


### PR DESCRIPTION
Related Ticket: TINY-9226

Description of Changes:
* some renames and dethunking
* removed unnecessary complexity in Anchorage with a custom 'placer'
* removing all positionWithin equivalent APIs in favour of just positionWithinBounds. The reason is that positionWithinBounds allows for more complex calculations, and by using positionWithin, we make it much easier to forget the more complex bounds arrangements that might be required in certain places. So ideally, the calling code should always be making the decision on how complex the bounds should be. These functions probably don't need to be removed, but they aren't extensively used, and it helps to reduce the number of functions to consider when looking at scrolling contexts and environments.

Pre-checks:
* [X] Changelog entry added  - no user-facing changes in tinymce, alloy has changelog entries
* [N/A] Tests have been added (if applicable) - code was just deleted. Existing behaviour should be preserved.
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [N/A] Docs ticket created (if applicable)

GitHub issues (if applicable):
