### PR TITLE
TINY-9226: Phase II => Introducing new UI setting

### DIFF
--- a/modules/mcagar/CHANGELOG.md
+++ b/modules/mcagar/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Added
 - Add new `pWaitForEventToStopFiring` function to the `TinyContentActions` helper methods to allow tests to wait until an event stops being triggered.
+- Exposed `getUiRoot` from `TinyUiActions` for easier ShadowDOM support. #TINY-9226
 
 ## 8.1.0 - 2022-09-08
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyUiActions.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyUiActions.ts
@@ -110,5 +110,7 @@ export {
   pWaitForDialog,
   pWaitForPopup,
   pWaitForUi,
-  pTriggerContextMenu
+  pTriggerContextMenu,
+
+  getUiRoot
 };

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyUiActions.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyUiActions.ts
@@ -9,7 +9,7 @@ import { TinyDom } from '../TinyDom';
 const getUiDoc = (editor: Editor) =>
   SugarShadowDom.getRootNode(TinyDom.targetElement(editor));
 
-const getUiRoot = (editor: Editor) =>
+const getUiRoot = (editor: Editor): SugarElement<HTMLElement | ShadowRoot> =>
   SugarShadowDom.getContentContainer(getUiDoc(editor));
 
 const getToolbarRoot = (editor: Editor) => {

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+(Post 6.3) - temporary
+
+### Added
+- New `ui_of_tomorrow` setting for TBA
+
 ## Unreleased
 
 ### Added

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -221,6 +221,7 @@ interface BaseEditorOptions {
   toolbar_sticky?: boolean;
   toolbar_sticky_offset?: number;
   typeahead_urls?: boolean;
+  ui_of_tomorrow?: boolean;
   url_converter?: URLConverter;
   url_converter_scope?: any;
   urlconverter_callback?: URLConverterCallback;
@@ -324,6 +325,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   toolbar_sticky_offset: number;
   text_patterns: Pattern[];
   text_patterns_lookup: DynamicPatternsLookup;
+  ui_of_tomorrow: boolean;
   visual: boolean;
   visual_anchor_class: string;
   visual_table_class: string;

--- a/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
@@ -18,8 +18,10 @@ describe('browser.tinymce.core.init.ShadowDomEditorTest', () => {
   const isShadowDomSkin = (ss: StyleSheet) => ss.href !== null && Strings.contains(ss.href, 'skin.shadowdom.min.css');
 
   Arr.each([
-    { type: 'normal', settings: { }},
-    { type: 'inline', settings: { inline: true }}
+    { type: 'normal', settings: { }, numSinks: 1 },
+    { type: 'inline', settings: { inline: true }, numSinks: 1 },
+    { type: 'normal-tomorrow', settings: { ui_of_tomorrow: true }, numSinks: 2 },
+    { type: 'inline-tomorrow', settings: { ui_of_tomorrow: true, inline: true }, numSinks: 2 }
   ], (tester) => {
     context(`${tester.type} editor`, () => {
       const hook = TinyHooks.bddSetupInShadowRoot<Editor>({
@@ -40,7 +42,11 @@ describe('browser.tinymce.core.init.ShadowDomEditorTest', () => {
         editor.nodeChanged();
         await UiFinder.pWaitForVisible('Wait for editor to be visible', shadowRoot, '.tox-editor-header');
         assert.lengthOf(SelectorFilter.descendants(SugarBody.body(), '.tox-tinymce-aux'), 0, 'Should be no aux divs in the document');
-        assert.lengthOf(SelectorFilter.descendants(shadowRoot, '.tox-tinymce-aux'), 1, 'Should be 1 aux div in the shadow root');
+        assert.lengthOf(
+          SelectorFilter.descendants(shadowRoot, '.tox-tinymce-aux'),
+          tester.numSinks,
+          `Should be ${tester.numSinks} aux div in the shadow root`
+        );
       });
     });
 

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -15,7 +15,7 @@ import * as Backstage from './backstage/Backstage';
 import * as DomEvents from './Events';
 import * as Iframe from './modes/Iframe';
 import * as Inline from './modes/Inline';
-import { LazyUiReferences, ReadyUiReferences } from './modes/UiReferences';
+import { LazyUiReferences, ReadyUiReferences, SinkAndMothership } from './modes/UiReferences';
 import * as ReadOnly from './ReadOnly';
 import * as ContextToolbar from './ui/context/ContextToolbar';
 import * as FormatControls from './ui/core/FormatControls';
@@ -499,12 +499,17 @@ const setup = (editor: Editor): RenderInfo => {
     return mode.render(editor, uiRefs, rawUiConfig, backstages.popup, args);
   };
 
+  const reuseDialogUiForPopuUi = (dialogUi: SinkAndMothership) => {
+    lazyPopupMothership.set(dialogUi.mothership);
+    return dialogUi;
+  };
+
   const renderUI = (): ModeRenderInfo => {
     const mainUi = renderMainUi();
     const dialogUi = renderDialogUi();
     // If dialogUi and popupUi are the same, LazyUiReferences should handle deduplicating then
     // get calling getUiMotherships
-    const popupUi = Options.isUiOfTomorrow(editor) ? renderPopupUi() : dialogUi;
+    const popupUi = Options.isUiOfTomorrow(editor) ? renderPopupUi() : reuseDialogUiForPopuUi(dialogUi);
 
     lazyUiRefs.dialogUi.set(dialogUi);
     lazyUiRefs.popupUi.set(popupUi);

--- a/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
@@ -210,6 +210,11 @@ const register = (editor: Editor): void => {
     processor: 'object'
   });
 
+  registerOption('ui_of_tomorrow', {
+    processor: 'boolean',
+    default: false
+  });
+
   registerOption('file_picker_callback', {
     processor: 'function'
   });
@@ -400,6 +405,9 @@ const isStickyToolbar = (editor: Editor): boolean => {
   return (isStickyToolbar || editor.inline) && !useFixedContainer(editor) && !isDistractionFree(editor);
 };
 
+const isUiOfTomorrow = (editor: Editor): boolean =>
+  !useFixedContainer(editor) && editor.options.get('ui_of_tomorrow');
+
 const getMenus = (editor: Editor): Record<string, { title: string; items: string }> => {
   const menu = editor.options.get('menu');
   return Obj.map(menu, (menu) => ({ ...menu, items: menu.items }));
@@ -429,6 +437,7 @@ export {
   getMultipleToolbarsOption,
   getUiContainer,
   useFixedContainer,
+  isUiOfTomorrow,
   getToolbarMode,
   isDraggableModal,
   isDistractionFree,

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -84,11 +84,13 @@ const setupEvents = (editor: Editor, uiRefs: ReadyUiReferences) => {
   });
 };
 
-// TINY-9226: When introducing two sinks, the dialog mothership should be attached to the ui
-// root, and the popup mothership should be attached *after* (or before) the main mothership
-const attachUiMotherships = (uiRoot: SugarElement<HTMLElement | ShadowRoot>, uiRefs: ReadyUiReferences) => {
-  // We only have one sink currently, until TINY-9226 is completed.
-  // Add the dialog sink to the ui root
+// TINY-9226: When set, the `ui_of_tomorrow` option will create two different sinks (one for popups and one for sinks)
+// and the popup sink will be placed adjacent to the editor. This will make it having the same scrolling ancestry.
+const attachUiMotherships = (editor: Editor, uiRoot: SugarElement<HTMLElement | ShadowRoot>, uiRefs: ReadyUiReferences) => {
+  if (Options.isUiOfTomorrow(editor)) {
+    Attachment.attachSystemAfter(uiRefs.mainUi.mothership.element, uiRefs.popupUi.mothership);
+  }
+  // In UiRefs, dialogUi and popupUi refer to the same thing if ui_of_tomorrow is false
   Attachment.attachSystem(uiRoot, uiRefs.dialogUi.mothership);
 };
 
@@ -103,7 +105,7 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
   const uiRoot = SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(eTargetNode));
 
   Attachment.attachSystemAfter(eTargetNode, mainUi.mothership);
-  attachUiMotherships(uiRoot, uiRefs);
+  attachUiMotherships(editor, uiRoot, uiRefs);
 
   editor.on('PostRender', () => {
     // Set the sidebar before the toolbar and menubar

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverUiOfTomorrowTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverUiOfTomorrowTest.ts
@@ -1,0 +1,218 @@
+import { Keys, UiFinder } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { Class, Insert, Remove, SelectorFind, Selectors, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.SilverUiOfTomorrowTest', () => {
+  const sharedSettings = {
+    menubar: 'file',
+    toolbar: 'undo bold',
+    base_url: '/project/tinymce/js/tinymce'
+  };
+
+  const selectors = {
+    sink: '.tox-silver-sink',
+    fileMenu: '[role=menuitem]:contains("File")',
+    menu: '[role=menu]',
+    dialog: '[role=dialog]',
+    editorParent: 'div.test-editor-parent'
+  };
+
+  // These tests are going to create editor inside another divs, so that we can
+  // test whether the sinks are being put in the correct place.
+  const setupElement = (inline: boolean) => {
+
+    const grandparent = SugarElement.fromTag('div');
+    Class.add(grandparent, 'test-editor-grandparent');
+    const parent = SugarElement.fromTag('div');
+    Class.add(parent, 'test-editor-parent');
+    const target = inline ? SugarElement.fromTag('div') : SugarElement.fromTag('textarea');
+
+    Insert.append(parent, target);
+    Insert.append(grandparent, parent);
+
+    // The Loader is going to try to insert `target` into the body if it isn't already in the body,
+    // so we insert grandparent here.
+    Insert.append(SugarBody.body(), grandparent);
+
+    // We remove the outer most div, not just the target element
+    const teardown = () => {
+      Remove.remove(grandparent);
+    };
+
+    return {
+      element: target,
+      teardown
+    };
+  };
+
+  const assertIsDialogSinkInBody = (sink: SugarElement<Element>): void => {
+    assert.isTrue(Class.has(sink, 'tox-silver-sink'), 'Sink should have sink class');
+    assert.isFalse(Class.has(sink, 'tox-silver-popup-sink'), 'Sink should not have popup sink class');
+    assertParentIs(sink, 'body');
+  };
+
+  const assertIsPopupSinkIn = (sink: SugarElement<Element>, selector: string): void => {
+    assert.isTrue(Class.has(sink, 'tox-silver-sink'), 'Sink should have sink class');
+    assert.isTrue(Class.has(sink, 'tox-silver-popup-sink'), 'Sink should have popup sink class');
+    assertParentIs(sink, selector);
+  };
+
+  // Just finished writing this and using it in the test.
+  const assertParentIs = (element: SugarElement<Element>, selector: string): void => {
+    const parent = Traverse.parent(element).getOrDie(
+      `Could not find the parent when testing if parent matched selector: "${selector}"`
+    );
+    assert.isTrue(
+      Selectors.is(parent, selector),
+      `Parent of element did not match selector: "${selector}"`
+    );
+  };
+
+  const pAssertOneSinkMode = async (editor: Editor): Promise<void> => {
+    // For inline mode, we need to focus the editor to get the sink
+    editor.focus();
+    await TinyUiActions.pWaitForUi(editor, selectors.sink);
+    const uiRoot = TinyUiActions.getUiRoot(editor);
+    const sinks = UiFinder.findAllIn(uiRoot, selectors.sink);
+    assert.equal(1, sinks.length, 'There should be one sink in ui_is_tomorrow=false mode');
+    assertIsDialogSinkInBody(sinks[0]);
+  };
+
+  const pAssertTwoSinksMode = async (editor: Editor): Promise<void> => {
+    // For inline mode, we need to focus the editor to get the sink
+    editor.focus();
+    await TinyUiActions.pWaitForUi(editor, selectors.sink);
+    const uiRoot = TinyUiActions.getUiRoot(editor);
+    const sinks = UiFinder.findAllIn(uiRoot, selectors.sink);
+    assert.equal(2, sinks.length, 'There should be two sinks in ui_is_tomorrow=true mode');
+    // TODO: Double-check this ordering.
+    assertIsDialogSinkInBody(sinks[1]);
+    assertIsPopupSinkIn(sinks[0], selectors.editorParent);
+  };
+
+  const pGetSinkWithPopup = async (editor: Editor): Promise<SugarElement<Element>> => {
+    await TinyUiActions.pWaitForUi(editor, selectors.fileMenu);
+    TinyUiActions.clickOnMenu(editor, selectors.fileMenu);
+    const menu = await TinyUiActions.pWaitForPopup(editor, selectors.menu);
+    return SelectorFind.ancestor(menu, selectors.sink).getOrDie(
+      'Could not find containing sink of menu'
+    );
+  };
+
+  const pGetSinkWithDialog = async (editor: Editor): Promise<SugarElement<Element>> => {
+    editor.windowManager.open({
+      title: 'Test Dialog',
+      body: {
+        type: 'panel',
+        items: [
+          {
+            name: 'alpha',
+            type: 'input'
+          }
+        ]
+      },
+      buttons: [ ]
+    });
+    const dialog = await TinyUiActions.pWaitForDialog(editor);
+    return SelectorFind.ancestor(dialog, selectors.sink).getOrDie(
+      'Could not find containing sink of dialog'
+    );
+  };
+
+  const closeMenu = (editor: Editor): void => {
+    const uiRoot = TinyUiActions.getUiRoot(editor);
+    TinyUiActions.keystroke(editor, Keys.escape());
+    UiFinder.notExists(uiRoot, selectors.menu);
+  };
+
+  const closeDialog = (editor: Editor): void => {
+    const uiRoot = TinyUiActions.getUiRoot(editor);
+    TinyUiActions.keystroke(editor, Keys.escape());
+    UiFinder.notExists(uiRoot, selectors.dialog);
+  };
+
+  context('ui_of_tomorrow = false', () => {
+    Arr.each([
+      { name: 'inline', settings: { inline: true }},
+      { name: 'normal', settings: { inline: false }}
+    ], (tester) => {
+      context(tester.name, () => {
+        const hook = TinyHooks.bddSetupFromElement<Editor>(
+          {
+            ...tester.settings,
+            ui_of_tomorrow: false,
+            ...sharedSettings,
+          },
+          () => setupElement(tester.settings.inline),
+          []
+        );
+
+        it('Check basic structure (1 sink, parent is body)', async () => {
+          const editor = hook.editor();
+          await pAssertOneSinkMode(editor);
+        });
+
+        it('Check popup menu sink location - dialog sink (there is no popup sink)', async () => {
+          const editor = hook.editor();
+          editor.focus();
+          const sink = await pGetSinkWithPopup(editor);
+          assertIsDialogSinkInBody(sink);
+          closeMenu(editor);
+        });
+
+        it('Check dialog sink location - dialog sink', async () => {
+          const editor = hook.editor();
+          editor.focus();
+          const sink = await pGetSinkWithDialog(editor);
+          assertIsDialogSinkInBody(sink);
+          closeDialog(editor);
+        });
+      });
+    });
+  });
+
+  context('ui_of_tomorrow = true', () => {
+    Arr.each([
+      { name: 'inline', settings: { inline: true }},
+      { name: 'normal', settings: { inline: false }}
+    ], (tester) => {
+      context(tester.name, () => {
+        const hook = TinyHooks.bddSetupFromElement<Editor>(
+          {
+            ...tester.settings,
+            ui_of_tomorrow: true,
+            ...sharedSettings
+          },
+          () => setupElement(tester.settings.inline),
+          []
+        );
+
+        it('Check basic structure', async () => {
+          const editor = hook.editor();
+          await pAssertTwoSinksMode(editor);
+        });
+
+        it('Check popup menu sink location', async () => {
+          const editor = hook.editor();
+          editor.focus();
+          const sink = await pGetSinkWithPopup(editor);
+          assertIsPopupSinkIn(sink, selectors.editorParent);
+          closeMenu(editor);
+        });
+
+        it('Check dialog sink location', async () => {
+          const editor = hook.editor();
+          editor.focus();
+          const sink = await pGetSinkWithDialog(editor);
+          assertIsDialogSinkInBody(sink);
+          closeDialog(editor);
+        });
+      });
+    });
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverUiOfTomorrowTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverUiOfTomorrowTest.ts
@@ -152,12 +152,12 @@ describe('browser.tinymce.themes.silver.editor.SilverUiOfTomorrowTest', () => {
           []
         );
 
-        it('Check basic structure (1 sink, parent is body)', async () => {
+        it('TINY-9226: Check basic structure (1 sink, parent is body)', async () => {
           const editor = hook.editor();
           await pAssertOneSinkMode(editor);
         });
 
-        it('Check popup menu sink location - dialog sink (there is no popup sink)', async () => {
+        it('TINY-9226: Check popup menu sink location - dialog sink (there is no popup sink)', async () => {
           const editor = hook.editor();
           editor.focus();
           const sink = await pGetSinkWithPopup(editor);
@@ -165,7 +165,7 @@ describe('browser.tinymce.themes.silver.editor.SilverUiOfTomorrowTest', () => {
           closeMenu(editor);
         });
 
-        it('Check dialog sink location - dialog sink', async () => {
+        it('TINY-9226: Check dialog sink location - dialog sink', async () => {
           const editor = hook.editor();
           editor.focus();
           const sink = await pGetSinkWithDialog(editor);
@@ -192,12 +192,12 @@ describe('browser.tinymce.themes.silver.editor.SilverUiOfTomorrowTest', () => {
           []
         );
 
-        it('Check basic structure', async () => {
+        it('TINY-9226: Check basic structure', async () => {
           const editor = hook.editor();
           await pAssertTwoSinksMode(editor);
         });
 
-        it('Check popup menu sink location', async () => {
+        it('TINY-9226: Check popup menu sink location', async () => {
           const editor = hook.editor();
           editor.focus();
           const sink = await pGetSinkWithPopup(editor);
@@ -205,7 +205,7 @@ describe('browser.tinymce.themes.silver.editor.SilverUiOfTomorrowTest', () => {
           closeMenu(editor);
         });
 
-        it('Check dialog sink location', async () => {
+        it('TINY-9226: Check dialog sink location', async () => {
           const editor = hook.editor();
           editor.focus();
           const sink = await pGetSinkWithDialog(editor);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
@@ -1,5 +1,6 @@
 import { Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
 import { Css, Height, Remove, Scroll, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
@@ -46,161 +47,194 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogPositionTest', 
   };
 
   context('Top toolbar positioning', () => {
-    const hook = TinyHooks.bddSetup<Editor>({
-      base_url: '/project/tinymce/js/tinymce',
-      resize: 'both',
-      height: 400,
-      width: 650,
-      toolbar_sticky: false,
-      toolbar_mode: 'wrap'
-    }, []);
+    Arr.each([
+      { name: 'normal', settings: { ui_of_tomorrow: false }},
+      { name: 'normal-tomorrow', settings: { ui_of_tomorrow: true }}
+    ], (tester) => {
+      context(tester.name, () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          resize: 'both',
+          height: 400,
+          width: 650,
+          toolbar_sticky: false,
+          toolbar_mode: 'wrap',
+          ...tester.settings
+        }, []);
 
-    it('Test position when resizing', async () => {
-      const editor = hook.editor();
-      const resizeHandle = UiFinder.findIn(SugarBody.body(), '.tox-statusbar__resize-handle').getOrDie();
-      const dialog = openDialog(editor);
-      await pAssertPos(dialog, 'absolute', 158, -306);
+        it('Test position when resizing', async () => {
+          const editor = hook.editor();
+          const resizeHandle = UiFinder.findIn(SugarBody.body(), '.tox-statusbar__resize-handle').getOrDie();
+          const dialog = openDialog(editor);
+          await pAssertPos(dialog, 'absolute', 158, -306);
 
-      // Shrink the editor to 300px
-      Mouse.mouseDown(resizeHandle);
-      resizeToPos(650, 400, 500, 300);
-      await pAssertPos(dialog, 'absolute', 5, -166); // Toolbar wraps so y diff is 100 + toolbar height
+          // Shrink the editor to 300px
+          Mouse.mouseDown(resizeHandle);
+          resizeToPos(650, 400, 500, 300);
+          await pAssertPos(dialog, 'absolute', 5, -166); // Toolbar wraps so y diff is 100 + toolbar height
 
-      // Enlarge the editor to 500px
-      Mouse.mouseDown(resizeHandle);
-      resizeToPos(500, 300, 750, 500);
-      await pAssertPos(dialog, 'absolute', 258, -406);
+          // Enlarge the editor to 500px
+          Mouse.mouseDown(resizeHandle);
+          resizeToPos(500, 300, 750, 500);
+          await pAssertPos(dialog, 'absolute', 258, -406);
 
-      // Resize back to the original size
-      Mouse.mouseDown(resizeHandle);
-      resizeToPos(750, 500, 650, 400);
-      await pAssertPos(dialog, 'absolute', 158, -306);
+          // Resize back to the original size
+          Mouse.mouseDown(resizeHandle);
+          resizeToPos(750, 500, 650, 400);
+          await pAssertPos(dialog, 'absolute', 158, -306);
 
-      DialogUtils.close(editor);
-    });
+          DialogUtils.close(editor);
+        });
 
-    it('Test position when scrolling', async () => {
-      const editor = hook.editor();
-      const dialog = openDialog(editor);
+        it('Test position when scrolling', async () => {
+          const editor = hook.editor();
+          const dialog = openDialog(editor);
 
-      // Enlarge the editor to 2000px
-      Height.set(TinyDom.container(editor), 2000);
-      editor.dispatch('ResizeEditor');
-      await pAssertPos(dialog, 'absolute', 158, -1901);
+          // Enlarge the editor to 2000px
+          Height.set(TinyDom.container(editor), 2000);
+          editor.dispatch('ResizeEditor');
+          await pAssertPos(dialog, 'absolute', 158, -1901);
 
-      // Scroll to 1500px and assert docked
-      Scroll.to(0, 1500);
-      await pAssertPos(dialog, 'fixed', 158, 0);
+          // Scroll to 1500px and assert docked
+          Scroll.to(0, 1500);
+          await pAssertPos(dialog, 'fixed', 158, 0);
 
-      // Scroll back to top and assert not docked
-      Scroll.to(0, 0);
-      await pAssertPos(dialog, 'absolute', 158, -1906);
+          // Scroll back to top and assert not docked
+          Scroll.to(0, 0);
+          await pAssertPos(dialog, 'absolute', 158, -1906);
 
-      DialogUtils.close(editor);
-    });
+          DialogUtils.close(editor);
+        });
 
-    it('Test initial position when initially scrolled', async () => {
-      const editor = hook.editor();
+        it('Test initial position when initially scrolled', async () => {
+          const editor = hook.editor();
 
-      // Enlarge the editor to 2000px
-      Height.set(TinyDom.container(editor), 2000);
-      editor.dispatch('ResizeEditor');
+          // Enlarge the editor to 2000px
+          Height.set(TinyDom.container(editor), 2000);
+          editor.dispatch('ResizeEditor');
 
-      // Scroll to 1500px, open the dialog and assert docked
-      Scroll.to(0, 1500);
-      const dialog = openDialog(editor);
-      await pAssertPos(dialog, 'fixed', 158, 0);
+          // Scroll to 1500px, open the dialog and assert docked
+          Scroll.to(0, 1500);
+          const dialog = openDialog(editor);
+          await pAssertPos(dialog, 'fixed', 158, 0);
 
-      // Scroll back to top and assert not docked
-      Scroll.to(0, 0);
-      await pAssertPos(dialog, 'absolute', 158, -1906);
+          // Scroll back to top and assert not docked
+          Scroll.to(0, 0);
+          await pAssertPos(dialog, 'absolute', 158, -1906);
 
-      DialogUtils.close(editor);
+          DialogUtils.close(editor);
+        });
+      });
     });
   });
 
   context('Bottom toolbar positioning', () => {
-    const hook = TinyHooks.bddSetup<Editor>({
-      base_url: '/project/tinymce/js/tinymce',
-      height: 400,
-      width: 600,
-      toolbar_sticky: true,
-      toolbar_location: 'bottom'
-    }, []);
+    Arr.each([
+      { name: 'normal', settings: { ui_of_tomorrow: false }},
+      { name: 'normal-tomorrow', settings: { ui_of_tomorrow: true }}
+    ], (tester) => {
+      context(tester.name, () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          height: 400,
+          width: 600,
+          toolbar_sticky: true,
+          toolbar_location: 'bottom',
+          ...tester.settings
+        }, []);
 
-    PageScroll.bddSetup(hook.editor, 1000);
+        PageScroll.bddSetup(hook.editor, 1000);
 
-    it('Position of dialog should be constant when toolbar bottom docks', async () => {
-      const editor = hook.editor();
+        it('Position of dialog should be constant when toolbar bottom docks', async () => {
+          const editor = hook.editor();
 
-      // Scroll so that the editor is fully in view
-      scrollRelativeEditor(editor, 'top', -100);
-      const dialog = openDialog(editor);
-      await pAssertPos(dialog, 'absolute', 108, -1387);
+          // Scroll so that the editor is fully in view
+          scrollRelativeEditor(editor, 'top', -100);
+          const dialog = openDialog(editor);
+          await pAssertPos(dialog, 'absolute', 108, -1387);
 
-      // Scroll so that bottom of window overlaps bottom of editor
-      scrollRelativeEditor(editor, 'bottom', -200);
-      await pAssertPos(dialog, 'absolute', 108, -1387);
+          // Scroll so that bottom of window overlaps bottom of editor
+          scrollRelativeEditor(editor, 'bottom', -200);
+          await pAssertPos(dialog, 'absolute', 108, -1387);
 
-      // Scroll so that top of window overlaps top of editor
-      scrollRelativeEditor(editor, 'top', 200);
-      await pAssertPos(dialog, 'fixed', 108, 0);
+          // Scroll so that top of window overlaps top of editor
+          scrollRelativeEditor(editor, 'top', 200);
+          await pAssertPos(dialog, 'fixed', 108, 0);
 
-      DialogUtils.close(editor);
-    });
+          DialogUtils.close(editor);
+        });
 
-    it('Test position when resizing', async () => {
-      const editor = hook.editor();
-      const resizeHandle = UiFinder.findIn(SugarBody.body(), '.tox-statusbar__resize-handle').getOrDie();
+        it('Test position when resizing', async () => {
+          const editor = hook.editor();
+          const resizeHandle = UiFinder.findIn(SugarBody.body(), '.tox-statusbar__resize-handle').getOrDie();
 
-      scrollRelativeEditor(editor, 'top', -100);
-      const dialog = openDialog(editor);
-      await pAssertPos(dialog, 'absolute', 108, -1387);
+          scrollRelativeEditor(editor, 'top', -100);
+          const dialog = openDialog(editor);
+          await pAssertPos(dialog, 'absolute', 108, -1387);
 
-      // Shrink the editor to 300px
-      Mouse.mouseDown(resizeHandle);
-      resizeToPos(600, 400, 600, 300);
-      await pAssertPos(dialog, 'absolute', 108, -1287);
+          // Shrink the editor to 300px
+          Mouse.mouseDown(resizeHandle);
+          resizeToPos(600, 400, 600, 300);
+          await pAssertPos(dialog, 'absolute', 108, -1287);
 
-      DialogUtils.close(editor);
+          DialogUtils.close(editor);
+        });
+      });
     });
   });
 
   context('Bottom toolbar with inline editor positioning', () => {
-    const hook = TinyHooks.bddSetupFromElement<Editor>({
-      theme: 'silver',
-      base_url: '/project/tinymce/js/tinymce',
-      inline: true,
-      toolbar_location: 'bottom'
-    }, () => {
-      const div = SugarElement.fromHtml<HTMLDivElement>('<div style="width: 600px; height: 400px;"></div>');
-      return {
-        element: div,
-        teardown: () => Remove.remove(div)
-      };
-    }, []);
+    Arr.each([
+      { name: 'inline', settings: { ui_of_tomorrow: false }, sinkSeparatedByScrollDiv: false },
+      { name: 'inline-tomorrow', settings: { ui_of_tomorrow: true }, sinkSeparatedByScrollDiv: true }
+    ], (tester) => {
+      context(tester.name, () => {
+        const hook = TinyHooks.bddSetupFromElement<Editor>({
+          theme: 'silver',
+          base_url: '/project/tinymce/js/tinymce',
+          inline: true,
+          toolbar_location: 'bottom',
+          ...tester.settings
+        }, () => {
+          const div = SugarElement.fromHtml<HTMLDivElement>('<div style="width: 600px; height: 400px;"></div>');
+          return {
+            element: div,
+            teardown: () => Remove.remove(div)
+          };
+        }, []);
 
-    PageScroll.bddSetup(hook.editor, 1000);
+        // This scroll div is inserted before and after the target, so the popup sink that
+        // gets added for inline mode in ui_of_tomorrow: true is separated from the dialog sink
+        // by the height of one scroll div
+        const scrollDivHeight = 1000;
+        PageScroll.bddSetup(hook.editor, scrollDivHeight);
 
-    it('Position of dialog should be constant when toolbar bottom docks', async () => {
-      const editor = hook.editor();
+        it('Position of dialog should be constant when toolbar bottom docks', async () => {
+          const editor = hook.editor();
 
-      // Scroll so that the editor is fully in view
-      scrollRelativeEditor(editor, 'top', -100);
-      editor.focus();
-      await TinyUiActions.pWaitForPopup(editor, '.tox-tinymce-inline');
-      const dialog = openDialog(editor);
-      await pAssertPos(dialog, 'absolute', 106, -1388);
+          // When in two sink mode (ui_of_tomorrow), we need to consider the height of the scrollDiv when
+          // comparing *absolute* positions.
+          const yDelta = tester.sinkSeparatedByScrollDiv ? scrollDivHeight : 0;
 
-      // Scroll so that bottom of window overlaps bottom of editor
-      scrollRelativeEditor(editor, 'bottom', -200);
-      await pAssertPos(dialog, 'absolute', 106, -1388);
+          // Scroll so that the editor is fully in view
+          scrollRelativeEditor(editor, 'top', -100);
+          editor.focus();
+          await TinyUiActions.pWaitForPopup(editor, '.tox-tinymce-inline');
+          const dialog = openDialog(editor);
+          await pAssertPos(dialog, 'absolute', 106, -1388 + yDelta);
 
-      // Scroll so that top of window overlaps top of editor
-      scrollRelativeEditor(editor, 'top', 200);
-      await pAssertPos(dialog, 'fixed', 106, 0);
+          // Scroll so that bottom of window overlaps bottom of editor
+          scrollRelativeEditor(editor, 'bottom', -200);
+          await pAssertPos(dialog, 'absolute', 106, -1388 + yDelta);
 
-      DialogUtils.close(editor);
+          // Scroll so that top of window overlaps top of editor
+          scrollRelativeEditor(editor, 'top', 200);
+          // We don't need to consider the height of the scrollDiv for things with fixed positioning
+          await pAssertPos(dialog, 'fixed', 106, 0);
+
+          DialogUtils.close(editor);
+        });
+      });
     });
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/headless/modes/UiReferencesTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/modes/UiReferencesTest.ts
@@ -1,0 +1,73 @@
+import { Gui, GuiFactory } from '@ephox/alloy';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { Class, Classes } from '@ephox/sugar';
+import { assert } from 'chai';
+
+import { LazyUiReferences, SinkAndMothership } from 'tinymce/themes/silver/modes/UiReferences';
+
+describe('headless.modes.UiReferencesTest', () => {
+  context('getUiMotherships', () => {
+
+    const makeSinkAndMothership = (className: string): SinkAndMothership => {
+      const mothership = Gui.create();
+      Class.add(mothership.element, className);
+      // It's not used as a sink in this test, so it doesn't need Positioning.
+      const sink = GuiFactory.build({
+        dom: {
+          tag: 'div'
+        }
+      });
+
+      return {
+        mothership,
+        sink
+      };
+    };
+
+    const assertClasses = (expected: string[][], motherships: Gui.GuiSystem[]) => {
+      const actual = Arr.map(motherships, (m) => Classes.get(m.element));
+      assert.deepEqual(actual, expected, 'Checking classes of motherships');
+    };
+
+    it('No UIs set', () => {
+      const lazyRefs = LazyUiReferences();
+      assert.deepEqual(lazyRefs.getUiMotherships(), [ ], 'There should be no motherships');
+    });
+
+    it('DialogUi set but not PopupUp', () => {
+      const lazyRefs = LazyUiReferences();
+      lazyRefs.dialogUi.set(
+        makeSinkAndMothership('alpha')
+      );
+      assertClasses([[ 'alpha' ]], lazyRefs.getUiMotherships());
+    });
+
+    it('PopupUi set but not DialogUi', () => {
+      const lazyRefs = LazyUiReferences();
+      lazyRefs.popupUi.set(
+        makeSinkAndMothership('beta')
+      );
+      assertClasses([[ 'beta' ]], lazyRefs.getUiMotherships());
+    });
+
+    it('PopupUi set and DialogUi set, but same component', () => {
+      const lazyRefs = LazyUiReferences();
+      const shared = makeSinkAndMothership('shared');
+      lazyRefs.dialogUi.set(shared);
+      lazyRefs.popupUi.set(shared);
+      assertClasses([[ 'shared' ]], lazyRefs.getUiMotherships());
+    });
+
+    it('PopupUi set and DialogUi set, and different components', () => {
+      const lazyRefs = LazyUiReferences();
+      lazyRefs.dialogUi.set(
+        makeSinkAndMothership('alpha')
+      );
+      lazyRefs.popupUi.set(
+        makeSinkAndMothership('beta')
+      );
+      assertClasses([[ 'alpha' ], [ 'beta' ]], lazyRefs.getUiMotherships());
+    });
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/headless/modes/UiReferencesTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/modes/UiReferencesTest.ts
@@ -30,12 +30,12 @@ describe('headless.modes.UiReferencesTest', () => {
       assert.deepEqual(actual, expected, 'Checking classes of motherships');
     };
 
-    it('No UIs set', () => {
+    it('TINY-9226: No UIs set', () => {
       const lazyRefs = LazyUiReferences();
       assert.deepEqual(lazyRefs.getUiMotherships(), [ ], 'There should be no motherships');
     });
 
-    it('DialogUi set but not PopupUp', () => {
+    it('TINY-9226: DialogUi set but not PopupUp', () => {
       const lazyRefs = LazyUiReferences();
       lazyRefs.dialogUi.set(
         makeSinkAndMothership('alpha')
@@ -43,7 +43,7 @@ describe('headless.modes.UiReferencesTest', () => {
       assertClasses([[ 'alpha' ]], lazyRefs.getUiMotherships());
     });
 
-    it('PopupUi set but not DialogUi', () => {
+    it('TINY-9226: PopupUi set but not DialogUi', () => {
       const lazyRefs = LazyUiReferences();
       lazyRefs.popupUi.set(
         makeSinkAndMothership('beta')
@@ -51,7 +51,7 @@ describe('headless.modes.UiReferencesTest', () => {
       assertClasses([[ 'beta' ]], lazyRefs.getUiMotherships());
     });
 
-    it('PopupUi set and DialogUi set, but same component', () => {
+    it('TINY-9226: PopupUi set and DialogUi set, but same component', () => {
       const lazyRefs = LazyUiReferences();
       const shared = makeSinkAndMothership('shared');
       lazyRefs.dialogUi.set(shared);
@@ -59,7 +59,7 @@ describe('headless.modes.UiReferencesTest', () => {
       assertClasses([[ 'shared' ]], lazyRefs.getUiMotherships());
     });
 
-    it('PopupUi set and DialogUi set, and different components', () => {
+    it('TINY-9226: PopupUi set and DialogUi set, and different components', () => {
       const lazyRefs = LazyUiReferences();
       lazyRefs.dialogUi.set(
         makeSinkAndMothership('alpha')


### PR DESCRIPTION
Related Ticket: TINY-9226

Description of Changes:
* creates a new setting (placeholder name: ui_of_tomorrow) that enables the "two sink / adjacent sink" mode
* updates some tests to work with both modes

Pre-checks:
* [N/A] Changelog entry added - deferring for merge into develop
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [N/A] Docs ticket created (if applicable) - we don't know the name of the setting yet

GitHub issues (if applicable):
