### PR TITLE
TINY-9193: The caret is moved to the previous line after Enter key pressed

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `editor.selection.getRng()` API was not returning a proper range on hidden editors in Firefox. #TINY-9259
 - The `editor.selection.getBookmark()` API was not returning a proper bookmark on hidden editors in Firefox. #TINY-9259
 - Dragging a noneditable element before or after another noneditable element now works correctly. #TINY-9253
+- The caret was moved to the previous line when the inline text pattern have been executed on Enter key pressing in Firefox. #TINY-9193
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dragging a noneditable element before or after another noneditable element now works correctly. #TINY-9253
 - The restored selection after a redo or undo action was not scrolled into view. #TINY-9222
 - A newline could not be inserted when the selection was restored from a bookmark after an inline `contenteditable="false"` element. #TINY-9194
-- The caret was moved to the previous line when the inline text pattern have been executed on Enter key pressing in Firefox. #TINY-9193
+- The caret was moved to the previous line when a text pattern executed a `mceInsertContent` command on Enter key when running on Firefox. #TINY-9193
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -207,6 +207,12 @@ const deleteSelectedContent = (editor: Editor): void => {
   const startCell = dom.getParent(rng.startContainer, isTableCell);
   if (isTableCellContentSelected(dom, rng, startCell)) {
     TableDelete.deleteCellContents(editor, rng, SugarElement.fromDom(startCell as HTMLTableCellElement));
+  // TINY-9193: If the selection is over the whole text node in an element then Firefox incorrectly moves the caret to the previous line
+  } else  if (rng.startContainer === rng.endContainer && rng.endOffset - rng.startOffset === 1 && NodeType.isText(rng.startContainer.childNodes[rng.startOffset])) {
+      rng.deleteContents();
+    } else {
+      editor.getDoc().execCommand('Delete', false);
+    }
   }
 };
 

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -208,11 +208,10 @@ const deleteSelectedContent = (editor: Editor): void => {
   if (isTableCellContentSelected(dom, rng, startCell)) {
     TableDelete.deleteCellContents(editor, rng, SugarElement.fromDom(startCell as HTMLTableCellElement));
   // TINY-9193: If the selection is over the whole text node in an element then Firefox incorrectly moves the caret to the previous line
-  } else  if (rng.startContainer === rng.endContainer && rng.endOffset - rng.startOffset === 1 && NodeType.isText(rng.startContainer.childNodes[rng.startOffset])) {
-      rng.deleteContents();
-    } else {
-      editor.getDoc().execCommand('Delete', false);
-    }
+  } else if (rng.startContainer === rng.endContainer && rng.endOffset - rng.startOffset === 1 && NodeType.isText(rng.startContainer.childNodes[rng.startOffset])) {
+    rng.deleteContents();
+  } else {
+    editor.getDoc().execCommand('Delete', false);
   }
 };
 

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -11,6 +11,7 @@ import Tools from '../api/util/Tools';
 import CaretPosition from '../caret/CaretPosition';
 import { CaretWalker } from '../caret/CaretWalker';
 import * as TransparentElements from '../content/TransparentElements';
+import * as DeleteUtils from '../delete/DeleteUtils';
 import * as TableDelete from '../delete/TableDelete';
 import * as CefUtils from '../dom/CefUtils';
 import ElementUtils from '../dom/ElementUtils';
@@ -208,7 +209,7 @@ const deleteSelectedContent = (editor: Editor): void => {
   if (isTableCellContentSelected(dom, rng, startCell)) {
     TableDelete.deleteCellContents(editor, rng, SugarElement.fromDom(startCell as HTMLTableCellElement));
   } else {
-    editor.getDoc().execCommand('Delete', false);
+    DeleteUtils.deleteRangeContents(editor, rng, SugarElement.fromDom(editor.getBody()));
   }
 };
 

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -11,7 +11,6 @@ import Tools from '../api/util/Tools';
 import CaretPosition from '../caret/CaretPosition';
 import { CaretWalker } from '../caret/CaretWalker';
 import * as TransparentElements from '../content/TransparentElements';
-import * as DeleteUtils from '../delete/DeleteUtils';
 import * as TableDelete from '../delete/TableDelete';
 import * as CefUtils from '../dom/CefUtils';
 import ElementUtils from '../dom/ElementUtils';
@@ -208,8 +207,6 @@ const deleteSelectedContent = (editor: Editor): void => {
   const startCell = dom.getParent(rng.startContainer, isTableCell);
   if (isTableCellContentSelected(dom, rng, startCell)) {
     TableDelete.deleteCellContents(editor, rng, SugarElement.fromDom(startCell as HTMLTableCellElement));
-  } else {
-    DeleteUtils.deleteRangeContents(editor, rng, SugarElement.fromDom(editor.getBody()));
   }
 };
 

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -663,6 +663,14 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     TinyAssertions.assertContent(editor, '<p><foo-bar contenteditable="false" data-name="foobar"></foo-bar></p>');
   });
 
+  it('TINY-9193: it should keep the caret in the same paragraph where insertion occurred', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>foo</p><p>bar<span></span>baz</p>', { format: 'raw' });
+    TinySelections.setSelection(editor, [ 1 ], 0, [ 1 ], 1);
+    editor.insertContent('X');
+    TinyAssertions.assertRawContent(editor, '<p>foo</p><p>X<span></span>baz</p>');
+  });
+
   context('Transparent blocks', () => {
     it('TINY-9172: Insert block anchor in regular block', () => {
       const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
@@ -303,4 +303,21 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
 
     editor.options.unset('text_patterns');
   });
+
+  it('TINY-9193: should move the caret to the next line after the Enter key pressed', () => {
+    const editor = hook.editor();
+    editor.options.set('text_patterns', [
+      { start: '~', end: '~', cmd: 'mceInsertContent', value: 'world' }
+    ]);
+    editor.setContent('<p>Hello</p><p>~test~</p>');
+    TinySelections.setCursor(editor, [ 1, 0 ], 6 );
+    TinyContentActions.keystroke(editor, Keys.enter());
+    TinyAssertions.assertContentPresence(editor, {
+      p: 3
+    });
+    // actual content: <p>Hello</p><p>world</p><p>&nbsp;</p>
+    TinyAssertions.assertCursor(editor, [ 2 ], 0);
+
+    editor.options.unset('text_patterns');
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
@@ -2,6 +2,7 @@ import { ApproxStructure, Keys } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
@@ -315,6 +316,9 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
     TinyAssertions.assertContentPresence(editor, {
       p: 3
     });
+    const p = editor.getBody().childNodes;
+    assert.equal(p[0].textContent, 'Hello');
+    assert.equal(p[1].textContent, 'world');
     // actual content: <p>Hello</p><p>world</p><p>&nbsp;</p>
     TinyAssertions.assertCursor(editor, [ 2 ], 0);
 


### PR DESCRIPTION
Related Ticket: TINY-9193

Description of Changes:
* Placeholder text

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
