### PR TITLE
TINY-9217: Toolbar menu button as inputs

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/TypeaheadSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/TypeaheadSchema.ts
@@ -55,7 +55,7 @@ const schema = Fun.constant([
     Focusing, Representing, Streaming, Keying, Toggling, Coupling
   ]),
 
-  FieldSchema.customField('lazyTypeaheadComp', () => Cell(Optional.none)),
+  FieldSchema.customField('lazyTypeaheadComp', () => Cell(Optional.none())),
 
   FieldSchema.customField('previewing', () => Cell(true))
 ].concat(

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/PlayDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/PlayDemo.ts
@@ -13,7 +13,7 @@ export default (): void => {
     selector: 'div.tiny-text',
     inline: false,
     theme: 'silver',
-    toolbar: [ 'link', 'styles', 'stylestypeahead', 'MagicButton', 'code', 'undo', 'redo', 'preview', '|', 'help', 'link', '|', 'align', 'alignleft', 'alignright', 'aligncenter',
+    toolbar: [ 'styles', 'MagicButton', 'code', 'undo', 'redo', 'preview', '|', 'help', 'link', '|', 'align', 'alignleft', 'alignright', 'aligncenter',
       'alignjustify', 'alignnone', '|', 'bold', 'italic', 'underline', 'strikethrough', 'subscript', 'superscript', '|', 'blockquote',
       'outdent', 'indent', '|', 'cut', 'copy', 'paste', '|', 'help', 'selectall', 'visualaid', 'newdocument', 'removeformat', 'remove', '|', 'menu-button-1', '|', 'mailmerge', 'mailmerge-NoCollapse'
     ].join(' '),

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/PlayDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/PlayDemo.ts
@@ -13,7 +13,7 @@ export default (): void => {
     selector: 'div.tiny-text',
     inline: false,
     theme: 'silver',
-    toolbar: [ 'styles', 'MagicButton', 'code', 'undo', 'redo', 'preview', '|', 'help', 'link', '|', 'align', 'alignleft', 'alignright', 'aligncenter',
+    toolbar: [ 'link', 'styles', 'stylestypeahead', 'MagicButton', 'code', 'undo', 'redo', 'preview', '|', 'help', 'link', '|', 'align', 'alignleft', 'alignright', 'aligncenter',
       'alignjustify', 'alignnone', '|', 'bold', 'italic', 'underline', 'strikethrough', 'subscript', 'superscript', '|', 'blockquote',
       'outdent', 'indent', '|', 'cut', 'copy', 'paste', '|', 'help', 'selectall', 'visualaid', 'newdocument', 'removeformat', 'remove', '|', 'menu-button-1', '|', 'mailmerge', 'mailmerge-NoCollapse'
     ].join(' '),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -27,15 +27,18 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
 
   const customEvents = Id.generate('custom-number-input-events');
 
+  const isValidValue = (value: number): boolean => value >= 1;
+
   const changeValue = (f: (v: number) => number): void => {
     const text = currentValue.get();
     const unit = text.match(/\D+$/)?.join('');
     const value = parseInt(text.match(/^\d+/)?.join('') || '0', 10);
-    const newValue = `${f(value)}${unit}`;
+    const newValue = f(value);
+    const newValueWithUnit = `${isValidValue(newValue) ? newValue : value}${unit}`;
 
-    spec.onAction(newValue);
-    currentValue.set(newValue);
-    currentComp.get().each((comp) => Representing.setValue(comp, newValue));
+    spec.onAction(newValueWithUnit);
+    currentValue.set(newValueWithUnit);
+    currentComp.get().each((comp) => Representing.setValue(comp, newValueWithUnit));
   };
 
   const buttonStyles = {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -1,4 +1,4 @@
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Button, Input, Representing, SketchSpec } from '@ephox/alloy';
+import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Button, Input, NativeEvents, Representing, SketchSpec } from '@ephox/alloy';
 import { Cell, Fun, Id, Optional } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -7,13 +7,13 @@ import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 import { onControlAttached, onControlDetached } from '../../controls/Controls';
 import { updateMenuText, UpdateMenuTextEvent } from '../../dropdown/CommonDropdown';
 import { onSetupEvent } from '../ControlUtils';
-import { SelectSpec } from './BespokeSelect';
+import { NumberInputSpec } from './FontSizeBespoke';
 
 interface BespokeSelectApi {
   readonly getComponent: () => AlloyComponent;
 }
 
-const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec): SketchSpec => {
+const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage, spec: NumberInputSpec): SketchSpec => {
   const currentValue = Cell('');
   const currentComp: Cell<Optional<AlloyComponent>> = Cell(Optional.none());
 
@@ -33,9 +33,15 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
     const value = parseInt(text.match(/^\d+/)?.join('') || '0', 10);
     const newValue = `${f(value)}${unit}`;
 
-    spec.onAction({ format: newValue } as any);
+    spec.onAction(newValue);
     currentValue.set(newValue);
     currentComp.get().each((comp) => Representing.setValue(comp, newValue));
+  };
+
+  const buttonStyles = {
+    'width': '20px',
+    'text-align': 'center',
+    'background-color': 'grey'
   };
 
   return {
@@ -50,11 +56,7 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
       Button.sketch({
         dom: {
           tag: 'button',
-          styles: {
-            'width': '20px',
-            'text-align': 'center',
-            'background-color': 'grey'
-          },
+          styles: buttonStyles,
           innerHtml: '-',
         },
         action: () => changeValue((n) => n - 1)
@@ -73,18 +75,17 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
             AlloyEvents.run<UpdateMenuTextEvent>(updateMenuText, (comp, se) => {
               Representing.setValue(comp, se.event.text);
               currentValue.set(se.event.text);
+            }),
+            AlloyEvents.run(NativeEvents.change(), (_comp, se) => {
+              spec.onAction(se.event.target.dom.value);
             })
-          ]),
+          ])
         ])
       }),
       Button.sketch({
         dom: {
           tag: 'button',
-          styles: {
-            'width': '20px',
-            'text-align': 'center',
-            'background-color': 'grey'
-          },
+          styles: buttonStyles,
           innerHtml: '+'
         },
         action: () => changeValue((n) => n + 1)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -1,5 +1,6 @@
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Button, Input, NativeEvents, Representing, SketchSpec } from '@ephox/alloy';
+import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Button, Focusing, Input, Keying, NativeEvents, Representing, SketchSpec } from '@ephox/alloy';
 import { Cell, Fun, Id, Optional } from '@ephox/katamari';
+import { Focus, SugarElement, Traverse } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
@@ -53,7 +54,8 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
       tag: 'div',
       styles: {
         display: 'flex'
-      }
+      },
+      classes: [ 'number-input-wrapper' ]
     },
     components: [
       Button.sketch({
@@ -93,7 +95,31 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
         },
         action: () => changeValue((n, s) => n + s)
       })
-    ]
+    ],
+    behaviours: Behaviour.derive([
+      Focusing.config({}),
+      Keying.config({
+        mode: 'special',
+        onEnter: (comp) => {
+          if (Focus.hasFocus(comp.element)) {
+            Traverse.child(comp.element, 1).each((inputElement) => {
+              Focus.focus(inputElement as SugarElement<HTMLElement>);
+            });
+            return Optional.some(true);
+          } else {
+            return Optional.none();
+          }
+        },
+        onEscape: (wrapperComp) => {
+          if (Focus.hasFocus(wrapperComp.element)) {
+            return Optional.none();
+          } else {
+            Focusing.focus(wrapperComp);
+            return Optional.some(true);
+          }
+        }
+      })
+    ])
   };
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -27,12 +27,12 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
 
   const customEvents = Id.generate('custom-number-input-events');
 
-  const isValidValue = (value: number): boolean => value >= 1;
+  const isValidValue = (value: number): boolean => value >= 0;
 
   const changeValue = (f: (v: number) => number): void => {
     const text = currentValue.get();
     const unit = text.match(/\D+$/)?.join('');
-    const value = parseInt(text.match(/^\d+/)?.join('') || '0', 10);
+    const value = parseFloat(text.match(/^[\d\.]+/)?.join('') || '0');
     const newValue = f(value);
     const newValueWithUnit = `${isValidValue(newValue) ? newValue : value}${unit}`;
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -1,0 +1,96 @@
+import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Button, Input, Representing, SketchSpec } from '@ephox/alloy';
+import { Cell, Fun, Id, Optional } from '@ephox/katamari';
+
+import Editor from 'tinymce/core/api/Editor';
+import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
+
+import { onControlAttached, onControlDetached } from '../../controls/Controls';
+import { updateMenuText, UpdateMenuTextEvent } from '../../dropdown/CommonDropdown';
+import { onSetupEvent } from '../ControlUtils';
+import { SelectSpec } from './BespokeSelect';
+
+interface BespokeSelectApi {
+  readonly getComponent: () => AlloyComponent;
+}
+
+const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec): SketchSpec => {
+  const currentValue = Cell('');
+  const currentComp: Cell<Optional<AlloyComponent>> = Cell(Optional.none());
+
+  const onSetup = onSetupEvent(editor, 'NodeChange', (api: BespokeSelectApi) => {
+    const comp = api.getComponent();
+    currentComp.set(Optional.some(comp));
+    spec.updateText(comp);
+  });
+  const getApi = (comp: AlloyComponent): BespokeSelectApi => ({ getComponent: Fun.constant(comp) });
+  const editorOffCell = Cell(Fun.noop);
+
+  const customEvents = Id.generate('custom-number-input-events');
+
+  const changeValue = (f: (v: number) => number): void => {
+    const text = currentValue.get();
+    const unit = text.match(/\D+$/)?.join('');
+    const value = parseInt(text.match(/^\d+/)?.join('') || '0', 10);
+    const newValue = `${f(value)}${unit}`;
+
+    spec.onAction({ format: newValue } as any);
+    currentValue.set(newValue);
+    currentComp.get().each((comp) => Representing.setValue(comp, newValue));
+  };
+
+  return {
+    uid: Id.generate('number-input-wrapper'),
+    dom: {
+      tag: 'div',
+      styles: {
+        display: 'flex'
+      }
+    },
+    components: [
+      Button.sketch({
+        dom: {
+          tag: 'button',
+          styles: {
+            'width': '20px',
+            'text-align': 'center',
+            'background-color': 'grey'
+          },
+          innerHtml: '-',
+        },
+        action: () => changeValue((n) => n - 1)
+      }),
+      Input.sketch({
+        inputStyles: {
+          'width': '75px',
+          'text-align': 'center'
+        },
+        inputBehaviours: Behaviour.derive([
+          AddEventsBehaviour.config(customEvents, [
+            onControlAttached({ onSetup, getApi }, editorOffCell),
+            onControlDetached({ getApi }, editorOffCell)
+          ]),
+          AddEventsBehaviour.config('menubutton-update-display-text', [
+            AlloyEvents.run<UpdateMenuTextEvent>(updateMenuText, (comp, se) => {
+              Representing.setValue(comp, se.event.text);
+              currentValue.set(se.event.text);
+            })
+          ]),
+        ])
+      }),
+      Button.sketch({
+        dom: {
+          tag: 'button',
+          styles: {
+            'width': '20px',
+            'text-align': 'center',
+            'background-color': 'grey'
+          },
+          innerHtml: '+'
+        },
+        action: () => changeValue((n) => n + 1)
+      })
+    ]
+  };
+};
+
+export { createBespokeNumberInput };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -29,11 +29,11 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
 
   const isValidValue = (value: number): boolean => value >= 0;
 
-  const changeValue = (f: (v: number) => number): void => {
+  const changeValue = (f: (v: number, step: number) => number): void => {
     const text = currentValue.get();
-    const unit = text.match(/\D+$/)?.join('');
+    const unit = text.match(/\D+$/)?.join('') || '';
     const value = parseFloat(text.match(/^[\d\.]+/)?.join('') || '0');
-    const newValue = f(value);
+    const newValue = f(value, spec.getConfigFromUnit(unit).step);
     const newValueWithUnit = `${isValidValue(newValue) ? newValue : value}${unit}`;
 
     spec.onAction(newValueWithUnit);
@@ -62,7 +62,7 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
           styles: buttonStyles,
           innerHtml: '-',
         },
-        action: () => changeValue((n) => n - 1)
+        action: () => changeValue((n, s) => n - s)
       }),
       Input.sketch({
         inputStyles: {
@@ -91,7 +91,7 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
           styles: buttonStyles,
           innerHtml: '+'
         },
-        action: () => changeValue((n) => n + 1)
+        action: () => changeValue((n, s) => n + s)
       })
     ]
   };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -68,6 +68,10 @@ export interface SelectSpec {
   readonly dataset: SelectDataset;
 }
 
+export interface SelectTypeaheadSpec extends SelectSpec {
+  readonly onTypeaheadSelection: (item: FormatterFormatItem) => void;
+}
+
 interface BespokeSelectApi {
   readonly getComponent: () => AlloyComponent;
 }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -68,7 +68,10 @@ export interface SelectSpec {
   readonly dataset: SelectDataset;
 }
 
-export interface SelectTypeaheadSpec extends SelectSpec {
+export interface SelectTypeaheadSpec {
+  readonly dataset: SelectDataset;
+  readonly onAction: (item: FormatterFormatItem) => (api: Menu.ToggleMenuItemInstanceApi) => void;
+  readonly updateText: (comp: AlloyComponent) => void;
   readonly onTypeaheadSelection: (item: FormatterFormatItem) => void;
 }
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeTypeahead.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeTypeahead.ts
@@ -1,0 +1,124 @@
+import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Focusing, GuiFactory, Keying, Memento, Replacing, SketchSpec, Typeahead } from '@ephox/alloy';
+import { TypeaheadData } from '@ephox/alloy/src/main/ts/ephox/alloy/ui/types/TypeaheadTypes';
+import { Arr, Cell, Fun, Future, Optional } from '@ephox/katamari';
+import { Focus, Traverse } from '@ephox/sugar';
+
+import Editor from 'tinymce/core/api/Editor';
+import { Menu } from 'tinymce/core/api/ui/Ui';
+import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
+
+import { renderLabel } from '../../button/ButtonSlices';
+import { onControlAttached, onControlDetached } from '../../controls/Controls';
+import { updateMenuText, UpdateMenuTextEvent } from '../../dropdown/CommonDropdown';
+import ItemResponse from '../../menus/item/ItemResponse';
+import * as MenuParts from '../../menus/menu/MenuParts';
+import * as NestedMenus from '../../menus/menu/NestedMenus';
+import { SingleMenuItemSpec } from '../../menus/menu/SingleMenuTypes';
+import { onSetupEvent } from '../ControlUtils';
+import { SelectSpec } from './BespokeSelect';
+
+interface BespokeSelectApi {
+  readonly getComponent: () => AlloyComponent;
+}
+
+const createTypeaheadButton = (editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec): SketchSpec => {
+  const optMemDisplayText = spec.text.map(
+    (text) => Memento.record(renderLabel(text, '', backstage.shared.providers))
+  );
+  const data: SingleMenuItemSpec[] = spec.dataset.type === 'basic'
+    ? []
+    : Arr.map(spec.dataset.getData(), (item): Menu.ToggleMenuItemSpec => ({ type: 'togglemenuitem', text: item.title, onAction: (api) => {
+      // it seems to work only with click :(
+      if (item.type === 'formatter') {
+        spec.onAction(item)(api);
+      }
+    } }));
+
+  const onSetup = onSetupEvent(editor, 'NodeChange', (api: BespokeSelectApi) => {
+    const comp = api.getComponent();
+    spec.updateText(comp);
+  });
+  const getApi = (comp: AlloyComponent): BespokeSelectApi => ({ getComponent: Fun.constant(comp) });
+  const editorOffCell = Cell(Fun.noop);
+
+  const typeahead = Typeahead.sketch({
+    minChars: 1,
+    responseTime: 0.1,
+    markers: {
+      openClass: 'typeahead-is-open',
+    },
+    parts: {
+      menu: MenuParts.part(false, 1, 'normal')
+    },
+    model: {
+      selectsOver: true,
+      getDisplayText: (itemData: TypeaheadData) => itemData.meta && itemData.meta.text ? itemData.meta.text : 'No.text',
+      populateFromBrowse: true,
+    },
+    typeaheadBehaviours: Behaviour.derive([
+      AddEventsBehaviour.config('typeaheadevents', [
+        onControlAttached({ onSetup, getApi }, editorOffCell),
+        onControlDetached({ getApi }, editorOffCell)
+      ]),
+      AddEventsBehaviour.config('menubutton-update-display-text', [
+        AlloyEvents.run<UpdateMenuTextEvent>(updateMenuText, (comp, se) => {
+          optMemDisplayText.bind((mem) => mem.getOpt(comp)).each((displayText) => {
+            Replacing.set(displayText, [ GuiFactory.text(backstage.shared.providers.translate(se.event.text)) ]);
+          });
+        })
+      ])
+    ]),
+    fetch: (_typeaheadComp) => {
+      const optTieredData = NestedMenus.build(
+        data,
+        ItemResponse.CLOSE_ON_EXECUTE,
+        backstage,
+        {
+          isHorizontalMenu: false,
+          search: Optional.none()
+        }
+      );
+      return Future.pure(optTieredData);
+    },
+    onExecute: (sandbox, item, value) => {
+      // it seems to not work
+      // eslint-disable-next-line no-console
+      console.log('onExecute: ', sandbox, item, value);
+    },
+    lazySink: backstage.shared.getSink
+  });
+
+  return {
+    uid: 'fake-uid-typeahead-wrapper',
+    dom: {
+      tag: 'div',
+      classes: [ 'typeahead-wrapper' ],
+    },
+    components: [
+      // ...componentRenderPipeline([ optMemDisplayText.map((mem) => mem.asSpec()) ]),
+      typeahead
+    ],
+    behaviours: Behaviour.derive([
+      Focusing.config({}),
+      Keying.config({
+        mode: 'special',
+        onEnter: (comp) => {
+          Traverse.firstChild(comp.element).each((firstChild) => {
+            Focus.focus(firstChild as any);
+          });
+          return Optional.some(true);
+        },
+        onEscape: (wrapperComp) => {
+          if (Focus.hasFocus(wrapperComp.element)) {
+            return Optional.none();
+          } else {
+            Focusing.focus(wrapperComp);
+            return Optional.some(true);
+          }
+        }
+      })
+    ])
+  };
+};
+
+export { createTypeaheadButton };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
@@ -101,8 +101,12 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const getSpecTypeahead = (editor: Editor): SelectTypeaheadSpec => {
+  const spec = getSpec(editor);
+
   return {
-    ...getSpec(editor),
+    dataset: spec.dataset,
+    onAction: spec.onAction,
+    updateText: spec.updateText,
     onTypeaheadSelection: (rawItem) => editor.undoManager.transact(() => {
       editor.focus();
       editor.execCommand('FontName', false, rawItem.format);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
@@ -5,7 +5,8 @@ import Editor from 'tinymce/core/api/Editor';
 
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
-import { createMenuItems, createSelectButton, FormatterFormatItem, PreviewSpec, SelectedFormat, SelectSpec } from './BespokeSelect';
+import { createMenuItems, createSelectButton, FormatterFormatItem, PreviewSpec, SelectedFormat, SelectSpec, SelectTypeaheadSpec } from './BespokeSelect';
+import { createTypeaheadButton } from './BespokeTypeahead';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 
 // A list of fonts that must be in a font family for the font to be recognised as the system stack
@@ -99,8 +100,21 @@ const getSpec = (editor: Editor): SelectSpec => {
   };
 };
 
+const getSpecTypeahead = (editor: Editor): SelectTypeaheadSpec => {
+  return {
+    ...getSpec(editor),
+    onTypeaheadSelection: (rawItem) => editor.undoManager.transact(() => {
+      editor.focus();
+      editor.execCommand('FontName', false, rawItem.format);
+    })
+  };
+};
+
 const createFontFamilyButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
   createSelectButton(editor, backstage, getSpec(editor));
+
+const createFontFamilyTypeaheadButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
+  createTypeaheadButton(editor, backstage, getSpecTypeahead(editor));
 
 // TODO: Test this!
 const createFontFamilyMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
@@ -111,4 +125,4 @@ const createFontFamilyMenu = (editor: Editor, backstage: UiFactoryBackstage): vo
   });
 };
 
-export { createFontFamilyButton, createFontFamilyMenu };
+export { createFontFamilyButton, createFontFamilyTypeaheadButton, createFontFamilyMenu };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -5,6 +5,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
+import { createBespokeNumberInput } from './BespokeNumberInput';
 import { createMenuItems, createSelectButton, FormatterFormatItem, SelectedFormat, SelectSpec } from './BespokeSelect';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import * as FormatRegister from './utils/FormatRegister';
@@ -110,6 +111,9 @@ const getSpec = (editor: Editor): SelectSpec => {
 const createFontSizeButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
   createSelectButton(editor, backstage, getSpec(editor));
 
+const createFontSizeInputButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
+  createBespokeNumberInput(editor, backstage, getSpec(editor));
+
 // TODO: Test this!
 const createFontSizeMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
   const menuItems = createMenuItems(editor, backstage, getSpec(editor));
@@ -119,4 +123,4 @@ const createFontSizeMenu = (editor: Editor, backstage: UiFactoryBackstage): void
   });
 };
 
-export { createFontSizeButton, createFontSizeMenu };
+export { createFontSizeButton, createFontSizeInputButton, createFontSizeMenu };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -108,20 +108,40 @@ const getSpec = (editor: Editor): SelectSpec => {
   };
 };
 
+interface Config {
+  step: number;
+}
+
 export interface NumberInputSpec {
   onAction: (format: string) => void;
   updateText: (comp: AlloyComponent) => void;
+  getConfigFromUnit: (unit: string) => Config;
 }
 
-const getNumberInputSpec = (editor: Editor): NumberInputSpec => ({
-  ...getSpec(editor),
-  onAction: (format) => {
-    editor.undoManager.transact(() => {
-      editor.focus();
-      editor.execCommand('FontSize', false, format);
-    });
-  }
-});
+const getNumberInputSpec = (editor: Editor): NumberInputSpec => {
+  const getConfigFromUnit = (unit: string): Config => {
+    const baseConfig = { step: 1 };
+
+    const configs: Record<string, Config> = {
+      em: { step: 0.1 },
+      px: { step: 1 },
+      pt: { step: 1 }
+    };
+
+    return configs[unit] || baseConfig;
+  };
+
+  return {
+    updateText: getSpec(editor).updateText,
+    getConfigFromUnit,
+    onAction: (format) => {
+      editor.undoManager.transact(() => {
+        editor.focus();
+        editor.execCommand('FontSize', false, format);
+      });
+    }
+  };
+};
 
 const createFontSizeButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
   createSelectButton(editor, backstage, getSpec(editor));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -108,11 +108,26 @@ const getSpec = (editor: Editor): SelectSpec => {
   };
 };
 
+export interface NumberInputSpec {
+  onAction: (format: string) => void;
+  updateText: (comp: AlloyComponent) => void;
+}
+
+const getNumberInputSpec = (editor: Editor): NumberInputSpec => ({
+  ...getSpec(editor),
+  onAction: (format) => {
+    editor.undoManager.transact(() => {
+      editor.focus();
+      editor.execCommand('FontSize', false, format);
+    });
+  }
+});
+
 const createFontSizeButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
   createSelectButton(editor, backstage, getSpec(editor));
 
 const createFontSizeInputButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createBespokeNumberInput(editor, backstage, getSpec(editor));
+  createBespokeNumberInput(editor, backstage, getNumberInputSpec(editor));
 
 // TODO: Test this!
 const createFontSizeMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
@@ -9,6 +9,7 @@ import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
 import { onActionToggleFormat } from '../ControlUtils';
 import { createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
+import { createTypeaheadButton } from './BespokeTypeahead';
 import { AdvancedSelectDataset, BasicSelectItem, SelectDataset } from './SelectDatasets';
 import { getStyleFormats, isFormatReference, isNestedFormat, StyleFormatType } from './StyleFormat';
 import { findNearest } from './utils/FormatDetection';
@@ -64,6 +65,11 @@ const createStylesButton = (editor: Editor, backstage: UiFactoryBackstage): Sket
   return createSelectButton(editor, backstage, getSpec(editor, dataset));
 };
 
+const createStylesTypeahead = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec => {
+  const dataset: AdvancedSelectDataset = { type: 'advanced', ...backstage.styles };
+  return createTypeaheadButton(editor, backstage, getSpec(editor, dataset));
+};
+
 const createStylesMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
   const dataset: AdvancedSelectDataset = { type: 'advanced', ...backstage.styles };
   const menuItems = createMenuItems(editor, backstage, getSpec(editor, dataset));
@@ -73,4 +79,4 @@ const createStylesMenu = (editor: Editor, backstage: UiFactoryBackstage): void =
   });
 };
 
-export { createStylesButton, createStylesMenu };
+export { createStylesButton, createStylesTypeahead, createStylesMenu };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
@@ -63,16 +63,6 @@ const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
 const getSpecTypeahead = (editor: Editor, dataset: SelectDataset): SelectTypeaheadSpec => {
   const fallbackFormat = 'Paragraph';
 
-  const isSelectedFor = (format: string) => () => editor.formatter.match(format);
-
-  const getPreviewFor = (format: string) => () => {
-    const fmt = editor.formatter.get(format);
-    return fmt !== undefined ? Optional.some({
-      tag: fmt.length > 0 ? (fmt[0] as InlineFormat).inline || (fmt[0] as BlockFormat).block || 'div' : 'div',
-      styles: editor.dom.parseStyle(editor.formatter.getCssText(format))
-    }) : Optional.none();
-  };
-
   const updateSelectMenuText = (comp: AlloyComponent) => {
     const getFormatItems = (fmt: StyleFormatType): BasicSelectItem[] => {
       if (isNestedFormat(fmt)) {
@@ -92,18 +82,10 @@ const getSpecTypeahead = (editor: Editor, dataset: SelectDataset): SelectTypeahe
   };
 
   return {
-    tooltip: 'Formats',
-    text: Optional.some(fallbackFormat),
-    icon: Optional.none(),
-    isSelectedFor,
-    getCurrentValue: Optional.none,
-    getPreviewFor,
+    dataset,
     onAction: onActionToggleFormat(editor),
     onTypeaheadSelection: (rawItem) => onActionToggleFormat(editor)(rawItem)(),
-    updateText: updateSelectMenuText,
-    shouldHide: Options.shouldAutoHideStyleFormats(editor) || false,
-    isInvalid: (item) => !editor.formatter.canApply(item.format),
-    dataset
+    updateText: updateSelectMenuText
   };
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
@@ -87,8 +87,7 @@ const getSpecTypeahead = (editor: Editor, dataset: SelectDataset): SelectTypeahe
     const detectedFormat = findNearest(editor, Fun.constant(flattenedItems));
     const text = detectedFormat.fold(Fun.constant(fallbackFormat), (fmt) => fmt.title);
     AlloyTriggers.emitWith(comp, updateMenuText, {
-      text,
-      // format: detectedFormat
+      text
     });
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -61,7 +61,8 @@ const renderToolbarGroupCommon = (toolbarGroup: ToolbarGroup) => {
       itemSelector: '*:not(.tox-split-button) > .tox-tbtn:not([disabled]), ' +
                     '.tox-split-button:not([disabled]), ' +
                     '.tox-toolbar-nav-js:not([disabled]), ' +
-                    '.typeahead-wrapper:not([disabled])'
+                    '.typeahead-wrapper:not([disabled]), ' +
+                    '.number-input-wrapper:not([disabled])'
     },
     tgroupBehaviours: Behaviour.derive([
       Tabstopping.config({}),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -60,7 +60,8 @@ const renderToolbarGroupCommon = (toolbarGroup: ToolbarGroup) => {
       // nav within a group breaks if disabled buttons are first in their group so skip them
       itemSelector: '*:not(.tox-split-button) > .tox-tbtn:not([disabled]), ' +
                     '.tox-split-button:not([disabled]), ' +
-                    '.tox-toolbar-nav-js:not([disabled])'
+                    '.tox-toolbar-nav-js:not([disabled]), ' +
+                    '.typeahead-wrapper:not([disabled])'
     },
     tgroupBehaviours: Behaviour.derive([
       Tabstopping.config({}),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
@@ -11,7 +11,7 @@ import { ToolbarConfig } from '../../Render';
 import { renderMenuButton } from '../button/MenuButton';
 import { createAlignButton } from '../core/complex/AlignBespoke';
 import { createBlocksButton } from '../core/complex/BlocksBespoke';
-import { createFontFamilyButton } from '../core/complex/FontFamilyBespoke';
+import { createFontFamilyButton, createFontFamilyTypeaheadButton } from '../core/complex/FontFamilyBespoke';
 import { createFontSizeButton } from '../core/complex/FontSizeBespoke';
 import { createStylesButton, createStylesTypeahead } from '../core/complex/StylesBespoke';
 import { ToolbarButtonClasses } from './button/ButtonClasses';
@@ -117,6 +117,7 @@ const bespokeButtons: Record<string, (editor: Editor, backstage: UiFactoryBackst
   stylestypeahead: createStylesTypeahead,
   fontsize: createFontSizeButton,
   fontfamily: createFontFamilyButton,
+  fontfamilytypeahead: createFontFamilyTypeaheadButton,
   blocks: createBlocksButton,
   align: createAlignButton
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
@@ -12,7 +12,7 @@ import { renderMenuButton } from '../button/MenuButton';
 import { createAlignButton } from '../core/complex/AlignBespoke';
 import { createBlocksButton } from '../core/complex/BlocksBespoke';
 import { createFontFamilyButton, createFontFamilyTypeaheadButton } from '../core/complex/FontFamilyBespoke';
-import { createFontSizeButton } from '../core/complex/FontSizeBespoke';
+import { createFontSizeButton, createFontSizeInputButton } from '../core/complex/FontSizeBespoke';
 import { createStylesButton, createStylesTypeahead } from '../core/complex/StylesBespoke';
 import { ToolbarButtonClasses } from './button/ButtonClasses';
 import { renderFloatingToolbarButton, renderSplitButton, renderToolbarButton, renderToolbarToggleButton } from './button/ToolbarButtons';
@@ -116,6 +116,7 @@ const bespokeButtons: Record<string, (editor: Editor, backstage: UiFactoryBackst
   styles: createStylesButton,
   stylestypeahead: createStylesTypeahead,
   fontsize: createFontSizeButton,
+  fontsizeinput: createFontSizeInputButton,
   fontfamily: createFontFamilyButton,
   fontfamilytypeahead: createFontFamilyTypeaheadButton,
   blocks: createBlocksButton,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
@@ -13,7 +13,7 @@ import { createAlignButton } from '../core/complex/AlignBespoke';
 import { createBlocksButton } from '../core/complex/BlocksBespoke';
 import { createFontFamilyButton } from '../core/complex/FontFamilyBespoke';
 import { createFontSizeButton } from '../core/complex/FontSizeBespoke';
-import { createStylesButton } from '../core/complex/StylesBespoke';
+import { createStylesButton, createStylesTypeahead } from '../core/complex/StylesBespoke';
 import { ToolbarButtonClasses } from './button/ButtonClasses';
 import { renderFloatingToolbarButton, renderSplitButton, renderToolbarButton, renderToolbarToggleButton } from './button/ToolbarButtons';
 import { ToolbarGroup } from './CommonToolbar';
@@ -114,6 +114,7 @@ const extractFrom = (spec: ToolbarButton & { type: string }, backstage: UiFactor
 
 const bespokeButtons: Record<string, (editor: Editor, backstage: UiFactoryBackstage) => SketchSpec> = {
   styles: createStylesButton,
+  stylestypeahead: createStylesTypeahead,
   fontsize: createFontSizeButton,
   fontfamily: createFontFamilyButton,
   blocks: createBlocksButton,


### PR DESCRIPTION
Related Ticket: TINY-9217

Description of Changes:
This spike includes two new components:
  [BespokeTypeahead](modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeTypeahead.ts) -> this could be used as a replacement for any toolbar menu select
  [BespokeNumberInput](modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts) -> this can be used as a number input with a unit, units also give the possibility to define specific behaviors for different units, by now is defined only in the step but it could also be used for others behavior like minimum or maximum value

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
