### PR TITLE
TINY-8827: Update ContextToolbar to close Quicklink toolbar on a single ESC keypress

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improved
 - Transparent elements, like anchors, can now contain block elements. #TINY-9172
 - Color picker dialog now starts on the appropriate color for the cursor position. #TINY-9213
+- Quicklink context toolbar now closes on a single ESC keypress. #TINY-8827
 
 ### Fixed
 - Parsing media content would cause a memory leak, which for example occurred when using the `getContent` API. #TINY-9186

--- a/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
@@ -182,4 +182,15 @@ describe('browser.tinymce.plugins.link.QuickLinkTest', () => {
     TinyUiActions.keydown(editor, Keys.enter());
     UiFinder.notExists(SugarBody.body(), '.tox-pop__dialog');
   });
+
+  it('TINY-8827: Closes Quicklink toolbar on escape keyup', async () => {
+    const editor = hook.editor();
+    editor.setContent('');
+    TinyContentActions.keystroke(editor, 'K'.charCodeAt(0), metaKey);
+    await TinyUiActions.pWaitForPopup(editor, '.tox-pop__dialog .tox-toolbar');
+    await FocusTools.pTryOnSelector('Selector should be in context form input', doc, '.tox-toolbar input');
+    await Waiter.pWait(100);
+    TinyUiActions.keyup(editor, Keys.escape());
+    UiFinder.notExists(SugarBody.body(), '.tox-pop__dialog');
+  });
 });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
@@ -47,11 +47,15 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
   const lastElement = Singleton.value<SugarElement<Element>>();
   const lastTrigger = Singleton.value<TriggerCause>();
   const lastContextPosition = Singleton.value<InlineContent.ContextPosition>();
+  const lastToolbarKey = Singleton.value<string>();
 
   const contextbar = GuiFactory.build(
     renderContextToolbar({
       sink,
       onEscape: () => {
+        if (lastToolbarKey.get().getOr('default') === 'quicklink') {
+          close();
+        }
         editor.focus();
         return Optional.some(true);
       }
@@ -95,6 +99,7 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
     lastElement.clear();
     lastTrigger.clear();
     lastContextPosition.clear();
+    lastToolbarKey.clear();
     InlineView.hide(contextbar);
   };
 
@@ -257,6 +262,7 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
       const scopes = getScopes();
       // TODO: Have this stored in a better structure
       Obj.get(scopes.lookupTable, e.toolbarKey).each((ctx) => {
+        lastToolbarKey.set(e.toolbarKey);
         // ASSUMPTION: this is only used to open one specific toolbar at a time, hence [ctx]
         launchContext([ ctx ], Optionals.someIf(e.target !== editor, e.target));
         // Forms launched via this way get immediate focus


### PR DESCRIPTION
Related Ticket: TINY-8827

Description of Changes:
* Updated `ContextToolbar.ts` to close Quicklink toolbar on a single ESC keypress. It is not very elegant, but I couldn't figure out a better solution. Let me know if there is one.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
