### PR TITLE
TINY-9283: Improved colorswatch ui functionality.

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- Added `previousSelector` optional property to `MenuMatrixMovementSpec`, to start with the selected item in focus #TINY-9283
+
 ### Removed
 - Moved `TestStore` to Agar. #TINY-9157
 

--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
-- Added `previousSelector` optional property to `MenuMatrixMovementSpec`, to start with the selected item in focus #TINY-9283
+- Added `previousSelector` optional property to `MenuMatrixMovementSpec`, to start with the selected item in focus. #TINY-9283
 - Added the `onToggled` callback for the `FloatingToolbarButton` component. #TINY-9271
 - Added the `onOpened` and `onClosed` callbacks for the `SplitFloatingToolbar` component. #TINY-9271
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/MenuSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/MenuSchema.ts
@@ -1,5 +1,5 @@
 import { FieldSchema, StructureSchema } from '@ephox/boulder';
-import { Fun, Obj } from '@ephox/katamari';
+import { Fun, Obj, Optional } from '@ephox/katamari';
 
 import { Composing } from '../../api/behaviour/Composing';
 import { Highlighting } from '../../api/behaviour/Highlighting';
@@ -42,6 +42,7 @@ const configureMatrix = (detail: MenuDetail, movementInfo: MenuMatrixMovement): 
     row: movementInfo.rowSelector,
     cell: '.' + detail.markers.item
   },
+  previousSelector: movementInfo.previousSelector,
   focusManager: detail.focusManager
 });
 
@@ -108,7 +109,8 @@ const schema = Fun.constant([
       ],
       matrix: [
         Fields.output('config', configureMatrix),
-        FieldSchema.required('rowSelector')
+        FieldSchema.required('rowSelector'),
+        FieldSchema.defaulted('previousSelector', Optional.none),
       ],
       menu: [
         FieldSchema.defaulted('moveOnTab', true),

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/MenuTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/MenuTypes.ts
@@ -1,3 +1,6 @@
+import { Optional } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
+
 import { AlloyBehaviourRecord } from '../../api/behaviour/Behaviour';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { SketchBehaviours } from '../../api/component/SketchBehaviours';
@@ -19,6 +22,7 @@ export interface MenuGridMovementSpec {
 export interface MenuMatrixMovementSpec {
   mode: 'matrix';
   rowSelector: string;
+  previousSelector?: (comp: AlloyComponent) => Optional<SugarElement<HTMLElement>>;
 }
 
 export interface MenuNormalMovementSpec {
@@ -42,6 +46,7 @@ export interface MenuMatrixMovement {
   mode: 'matrix';
   config: (detail: MenuDetail, movementInfo: MenuMovement) => MatrixConfigSpec;
   rowSelector: string;
+  previousSelector: (comp: AlloyComponent) => Optional<SugarElement<HTMLElement>>;
 }
 
 export interface MenuNormalMovement {

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/MatrixMenuTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/MatrixMenuTest.ts
@@ -1,5 +1,5 @@
-import { ApproxStructure, Assertions, Chain, Keyboard, Keys, NamedChain, StructAssert, UiFinder } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
+import { ApproxStructure, Assertions, Keyboard, Keys, UiFinder } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
@@ -14,126 +14,122 @@ import * as GuiSetup from 'ephox/alloy/api/testhelpers/GuiSetup';
 import { Menu } from 'ephox/alloy/api/ui/Menu';
 import * as MenuEvents from 'ephox/alloy/menu/util/MenuEvents';
 import * as TestDropdownMenu from 'ephox/alloy/test/dropdown/TestDropdownMenu';
+import { MenuMovementSpec } from 'ephox/alloy/ui/types/MenuTypes';
 
-UnitTest.asynctest('MatrixMenuTest', (success, failure) => {
+describe('browser.ui.dropdown.MatrixMenuTest', () => {
+  const assertSelectedStates = (label: string, expected: boolean[], menu: SugarElement<HTMLElement>) =>
+    Assertions.assertStructure(
+      label,
+      ApproxStructure.build((s, _str, arr) => s.element('ol', {
+        classes: [
+          arr.has('test-menu')
+        ],
+        children: [
+          s.element('div', {
+            classes: [ arr.has('row-class') ],
+            children: [
+              s.element('li', { classes: [ (expected[0] ? arr.has : arr.not)('selected-item') ] }),
+              s.element('li', { classes: [ (expected[1] ? arr.has : arr.not)('selected-item') ] })
+            ]
+          }),
+          s.element('div', {
+            classes: [ arr.has('row-class') ],
+            children: [
+              s.element('li', { classes: [ (expected[2] ? arr.has : arr.not)('selected-item') ] }),
+              s.element('li', { classes: [ (expected[3] ? arr.has : arr.not)('selected-item') ] })
+            ]
+          })
+        ]
+      })
+      ), menu);
 
-  GuiSetup.setup((store, _doc, _body) => GuiFactory.build(
-    Menu.sketch({
-      value: 'test-menu-1',
-      items: Arr.map([
-        { type: 'item', data: { value: 'alpha', meta: { }}, hasSubmenu: false },
-        { type: 'item', data: { value: 'beta', meta: { }}, hasSubmenu: false },
-        { type: 'item', data: { value: 'gamma', meta: { }}, hasSubmenu: false },
-        { type: 'item', data: { value: 'delta', meta: { }}, hasSubmenu: false }
-      ], TestDropdownMenu.renderItem),
-      dom: {
-        tag: 'ol',
-        classes: [ 'test-menu' ]
-      },
+  const makeGuiHook = (movementSpec: MenuMovementSpec) => {
+    return GuiSetup.bddSetup(
+      (store, _doc, _body) => GuiFactory.build(
+        Menu.sketch({
+          value: 'test-menu-1',
+          items: Arr.map([
+            { type: 'item', data: { value: 'alpha', meta: { }}, hasSubmenu: false },
+            { type: 'item', data: { value: 'beta', meta: { }}, hasSubmenu: false },
+            { type: 'item', data: { value: 'gamma', meta: { }}, hasSubmenu: false },
+            { type: 'item', data: { value: 'delta', meta: { }}, hasSubmenu: false }
+          ], TestDropdownMenu.renderItem),
+          dom: {
+            tag: 'ol',
+            classes: [ 'test-menu' ]
+          },
 
-      movement: {
-        mode: 'matrix',
+          movement: movementSpec,
 
-        rowSelector: '.row-class'
-      },
+          components: [
+            Menu.parts.items({
+              preprocess: (items: AlloySpec[]) => {
+                const chunks = Arr.chunk(items, 2);
+                return Arr.map(chunks, (c) => ({
+                  dom: {
+                    tag: 'div',
+                    classes: [ 'row-class' ]
+                  },
+                  components: c
+                }));
+              }
+            })
+          ],
 
-      components: [
-        Menu.parts.items({
-          preprocess: (items: AlloySpec[]) => {
-            const chunks = Arr.chunk(items, 2);
-            return Arr.map(chunks, (c) => ({
-              dom: {
-                tag: 'div',
-                classes: [ 'row-class' ]
-              },
-              components: c
-            }));
-          }
+          markers: {
+            item: TestDropdownMenu.markers().item,
+            selectedItem: TestDropdownMenu.markers().selectedItem
+          },
+
+          menuBehaviours: Behaviour.derive([
+            AddEventsBehaviour.config('menu-test-behaviour', [
+              AlloyEvents.run(MenuEvents.focus(), store.adder('menu.events.focus'))
+            ])
+          ])
         })
-      ],
+      )
+    );
+  };
+  context('No previous selector', () => {
 
-      markers: {
-        item: TestDropdownMenu.markers().item,
-        selectedItem: TestDropdownMenu.markers().selectedItem
-      },
-
-      menuBehaviours: Behaviour.derive([
-        AddEventsBehaviour.config('menu-test-behaviour', [
-          AlloyEvents.run(MenuEvents.focus(), store.adder('menu.events.focus'))
-        ])
-      ])
-    })
-  ), (_doc, _body, _gui, component, store) => {
-    // TODO: Flesh out test.
-    const cAssertStructure = (label: string, expected: StructAssert) => Chain.op((element: SugarElement<HTMLOListElement>) => {
-      Assertions.assertStructure(label, expected, element);
+    const hook = makeGuiHook({
+      mode: 'matrix',
+      rowSelector: '.row-class'
     });
 
-    const cTriggerFocusItem = Chain.op((target: SugarElement<HTMLLIElement>) => {
-      AlloyTriggers.dispatch(component, target, SystemEvents.focusItem());
+    it('basic navigation', () => {
+
+      const menuComponent = hook.component();
+      const store = hook.store();
+
+      // Find the alpha and beta list items
+      const alphaItem = UiFinder.findIn(menuComponent.element, 'li[data-value="alpha"]').getOrDie();
+      const betaItem = UiFinder.findIn(menuComponent.element, 'li[data-value="beta"]').getOrDie();
+
+      store.assertEq('Before focusItem event', [ ]);
+
+      AlloyTriggers.dispatch(menuComponent, alphaItem, SystemEvents.focusItem());
+      // Focus item on alpha should select alpha (the first item)
+      assertSelectedStates('After focusing on alpha', [ true, false, false, false ], menuComponent.element);
+      store.assertEq('After focusItem event', [ 'menu.events.focus' ]);
+
+      store.clear();
+      // Focus item on beta should select beta (the second item)
+      AlloyTriggers.dispatch(menuComponent, betaItem, SystemEvents.focusItem());
+      assertSelectedStates('After focusing on beta', [ false, true, false, false ], menuComponent.element);
+      store.assertEq('After focusItem event (on beta)', [ 'menu.events.focus' ]);
+
+      store.clear();
+      Keyboard.keydown(Keys.down(), { }, menuComponent.element);
+      assertSelectedStates('After pressing down on beta to get to delta (goes down one row)', [ false, false, false, true ], menuComponent.element);
+      store.assertEq('After pressing down on beta', [ 'menu.events.focus' ]);
+
+      store.clear();
+      Keyboard.keydown(Keys.left(), { }, menuComponent.element);
+      assertSelectedStates('After pressing left on delta to get to gamma (goes back one column)', [ false, false, true, false ], menuComponent.element);
+      store.assertEq('After pressing left on delta', [ 'menu.events.focus' ]);
+
+      store.clear();
     });
-
-    const cAssertSelectedStates = (label: string, expected: boolean[]) => NamedChain.direct('menu', cAssertStructure(label, ApproxStructure.build((s, _str, arr) => s.element('ol', {
-      classes: [
-        arr.has('test-menu')
-      ],
-      children: [
-        s.element('div', {
-          classes: [ arr.has('row-class') ],
-          children: [
-            s.element('li', { classes: [ (expected[0] ? arr.has : arr.not)('selected-item') ] }),
-            s.element('li', { classes: [ (expected[1] ? arr.has : arr.not)('selected-item') ] })
-          ]
-        }),
-        s.element('div', {
-          classes: [ arr.has('row-class') ],
-          children: [
-            s.element('li', { classes: [ (expected[2] ? arr.has : arr.not)('selected-item') ] }),
-            s.element('li', { classes: [ (expected[3] ? arr.has : arr.not)('selected-item') ] })
-          ]
-        })
-      ]
-    }))), '_');
-
-    return [
-      Chain.asStep({}, [
-        NamedChain.asChain([
-          NamedChain.writeValue('menu', component.element),
-          NamedChain.direct('menu', UiFinder.cFindIn('li[data-value="alpha"]'), 'alpha'),
-          NamedChain.direct('menu', UiFinder.cFindIn('li[data-value="beta"]'), 'beta'),
-
-          store.cAssertEq('Before focusItem event', [ ]),
-
-          NamedChain.direct('alpha', cTriggerFocusItem, '_'),
-
-          cAssertSelectedStates('After focusing item on alpha', [ true, false, false, false ]),
-
-          store.cAssertEq('After focusItem event (alpha)', [ 'menu.events.focus' ]),
-
-          store.cClear,
-          NamedChain.direct('beta', cTriggerFocusItem, '_'),
-          cAssertSelectedStates('After focusing item on beta', [ false, true, false, false ]),
-          store.cAssertEq('After focusItem event (beta)', [ 'menu.events.focus' ]),
-          store.cClear,
-
-          NamedChain.direct('menu', Chain.op((menu) => {
-            Keyboard.keydown(Keys.down(), { }, menu);
-          }), '_'),
-
-          cAssertSelectedStates('After pressing down on menu (with beta focus)', [ false, false, false, true ]),
-          store.cAssertEq('After pressing down on beta', [ 'menu.events.focus' ]),
-          store.cClear,
-
-          NamedChain.direct('menu', Chain.op((menu) => {
-            Keyboard.keydown(Keys.left(), { }, menu);
-          }), '_'),
-
-          cAssertSelectedStates('After pressing left on menu (with delta focus)', [ false, false, true, false ]),
-          store.cAssertEq('After pressing left on delta', [ 'menu.events.focus' ]),
-          store.cClear
-
-        ])
-      ])
-    ];
-  }, success, failure);
+  });
 });

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/MatrixMenuTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/MatrixMenuTest.ts
@@ -133,7 +133,7 @@ describe('browser.ui.dropdown.MatrixMenuTest', () => {
       rowSelector: '.row-class'
     });
 
-    it('TBA: Basic Focusing', () => {
+    it('TINY-9283: Basic Focusing', () => {
       const menuComponent = hook.component();
       const store = hook.store();
 
@@ -148,7 +148,7 @@ describe('browser.ui.dropdown.MatrixMenuTest', () => {
       setFocusOnItem(store, menuComponent, betaItem, 1, 'After focusing on beta');
     });
 
-    it('TBA: Keyboard navigation', () => {
+    it('TINY-9283: Keyboard navigation', () => {
       const menuComponent = hook.component();
       const store = hook.store();
 
@@ -169,7 +169,7 @@ describe('browser.ui.dropdown.MatrixMenuTest', () => {
       previousSelector: (component) => Optional.some(UiFinder.findIn<HTMLElement>(component.element, 'li[data-value="beta"]').getOrDie())
     });
 
-    it('Position starts as expected', () => {
+    it('TINY-9283: Position starts as expected', () => {
       const menuComponent = hook.component();
       const store = hook.store();
       assertInitialFocusIsOnElement(store, menuComponent, 1, 'Focus should be on beta');

--- a/modules/oxide/src/less/theme/components/color-swatch/color-swatch.less
+++ b/modules/oxide/src/less/theme/components/color-swatch/color-swatch.less
@@ -70,6 +70,27 @@
       background: @toolbar-button-hover-background-color;
     }
   }
+
+  div.tox-swatch:not(.tox-swatch--remove) {
+    svg {
+      display: none;
+      fill: @swatch-picker-button-icon-fill;
+      height: @swatch-picker-button-icon-height;
+      margin: calc((@swatch-size - @swatch-picker-button-icon-height) / 2) calc((@swatch-size - @swatch-picker-button-icon-width) / 2);
+      width: @swatch-picker-button-icon-width;
+
+      path {
+        fill: #fff;
+        paint-order: stroke;
+        stroke: #222f3e;
+        stroke-width: 2px;
+      }
+    }
+
+    &[aria-checked="true"] svg {
+      display: block;
+    }
+  }
 }
 
 .tox:not([dir=rtl]) {

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -19,12 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Transparent elements, like anchors, are now allowed in the root of the editor body if they contain blocks. #TINY-9172
-- Colorswatch keyboard navigation now starts on currently selected color if present in the colorswatch. Otherwise defaults to current behavior #TINY-9283
+- Colorswatch keyboard navigation now starts on currently selected color if present in the colorswatch. #TINY-9283
 - `setContent` is now allowed to accept any custom keys and values as a second options argument. #TINY-9143
 
 ### Improved
 - Transparent elements, like anchors, can now contain block elements. #TINY-9172
-- Colorswatch now displays a checkmark for selected color #TINY-9283
+- Colorswatch now displays a checkmark for selected color. #TINY-9283
 - Color picker dialog now starts on the appropriate color for the cursor position. #TINY-9213
 
 ### Fixed

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -18,10 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Transparent elements, like anchors, are now allowed in the root of the editor body if they contain blocks. #TINY-9172
+- Colorswatch keyboard navigation now starts on currently selected color if present in the colorswatch. Otherwise defaults to current behavior #TINY-9283
 - `setContent` is now allowed to accept any custom keys and values as a second options argument. #TINY-9143
 
 ### Improved
 - Transparent elements, like anchors, can now contain block elements. #TINY-9172
+- Colorswatch now displays a checkmark for selected color #TINY-9283
 - Color picker dialog now starts on the appropriate color for the cursor position. #TINY-9213
 
 ### Fixed

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
@@ -18,6 +18,7 @@ const mapColors = (colorMap: string[]): Menu.ChoiceMenuItemSpec[] => {
     colors.push({
       text: colorMap[i + 1],
       value: '#' + Transformations.anyToHex(colorMap[i]).value,
+      icon: 'checkmark',
       type: 'choiceitem'
     });
   }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -68,7 +68,8 @@ const renderColorStructure = (item: ItemStructureSpec, providerBackstage: UiFact
         },
         styles: {
           'background-color': itemValue
-        }
+        },
+        innerHtml: icon
       };
     } else {
       return baseDom;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuMovement.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuMovement.ts
@@ -1,5 +1,7 @@
 import { KeyingConfigSpec, MenuTypes } from '@ephox/alloy';
 import { Toolbar } from '@ephox/bridge';
+import { Optional } from '@ephox/katamari';
+import { SelectorFind } from '@ephox/sugar';
 
 import { colorClass, selectableClass } from '../item/ItemClasses';
 import { markers as getMenuMarkers } from './MenuParts';
@@ -21,8 +23,14 @@ export const deriveMenuMovement = (columns: number | 'auto', presets: Toolbar.Pr
     const rowClass = presets === 'color' ? 'tox-swatches__row' : 'tox-collection__group';
     return {
       mode: 'matrix',
-      rowSelector: '.' + rowClass
-    } as MenuTypes.MenuMatrixMovementSpec;
+      rowSelector: '.' + rowClass,
+      previousSelector: (menu) => {
+        // We only want the navigation to start on the selected item if we are in color-mode (The colorswatch)
+        return presets === 'color'
+          ? SelectorFind.descendant(menu.element, '[aria-checked=true]')
+          : Optional.none();
+      }
+    };
   }
 };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
@@ -149,7 +149,7 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
     closeSwatchButtonMenu();
   });
 
-  it('TINY-9283: ', async () => {
+  it('TINY-9283: selected color is successfully marked', async () => {
     const editor = hook.editor();
     editor.setContent('<p>black</p><p style="color: rgb(224, 62, 45);">red</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2, true);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
@@ -3,7 +3,7 @@ import { TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
-import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Menu } from 'tinymce/core/api/ui/Ui';
@@ -11,13 +11,14 @@ import { Menu } from 'tinymce/core/api/ui/Ui';
 describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
   const store = TestStore();
   const hook = TinyHooks.bddSetup<Editor>({
-    toolbar: 'swatch-button',
+    toolbar: 'swatch-button forecolor',
     base_url: '/project/tinymce/js/tinymce',
     setup: (ed: Editor) => {
       ed.ui.registry.addSplitButton('swatch-button', {
         type: 'splitbutton',
         presets: 'color',
         columns: 2,
+        tooltip: 'swatch-button',
         fetch: (callback) => {
           const items = Arr.map([
             'green',
@@ -58,7 +59,7 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
   const structColors = (values: string[]): ApproxStructure.Builder<StructAssert[]> =>
     (s, str, arr) => Arr.map(values, (v) => structColor(v)(s, str, arr));
 
-  const focusOnColor = (expected: string) => {
+  const assertFocusIsOnColor = (expected: string) => {
     const focused = FocusTools.getFocused(SugarDocument.getDocument()).getOrDie();
     Assertions.assertStructure(
       'Checking focus is on ' + expected,
@@ -67,16 +68,34 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
     );
   };
 
+  const openAndGetMenu = (title: string) =>
+    () => {
+      Mouse.clickOn(SugarBody.body(), `[title="${title}"] .tox-split-button__chevron`);
+      return Waiter.pTryUntil('Waiting for menu', () =>
+        UiFinder.findIn(SugarBody.body(), '[role="menu"]').getOrDie()
+      );
+    };
+
+  const closeMenu = (title: string) =>
+    () => {
+      Mouse.clickOn(SugarBody.body(), `[title="${title}"] .tox-split-button__chevron`);
+      return Waiter.pTryUntil('Waiting for menu', () =>
+        UiFinder.notExists(SugarBody.body(), '[role="menu"]')
+      );
+    };
+
+  const openAndGetSwatchButtonMenu = openAndGetMenu('swatch-button');
+  const closeSwatchButtonMenu = closeMenu('swatch-button');
+  const openAndGetForecolorMenu = openAndGetMenu('Text color');
+  const closeForecolorMenu = closeMenu('Text color');
+
   TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [
     ':focus { transform: scale(0.8) }'
   ]);
 
   it('Check structure of color swatch', async () => {
     const editor = hook.editor();
-    Mouse.clickOn(SugarBody.body(), '.tox-split-button__chevron');
-    const menu = await Waiter.pTryUntil('Waiting for menu', () =>
-      UiFinder.findIn(SugarBody.body(), '[role="menu"]').getOrDie()
-    );
+    const menu = await openAndGetSwatchButtonMenu();
     Assertions.assertStructure(
       'Checking menu structure for color swatches',
       ApproxStructure.build((s, str, arr) => s.element('div', {
@@ -122,10 +141,27 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
       menu
     );
 
-    focusOnColor('green');
+    assertFocusIsOnColor('green');
     TinyUiActions.keydown(editor, Keys.down());
-    focusOnColor('blue');
+    assertFocusIsOnColor('blue');
     TinyUiActions.keydown(editor, Keys.right());
-    focusOnColor('black');
+    assertFocusIsOnColor('black');
+    closeSwatchButtonMenu();
+  });
+
+  it('TINY-9283: ', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>black</p><p style="color: rgb(224, 62, 45);">red</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2, true);
+
+    await openAndGetForecolorMenu();
+    assertFocusIsOnColor('rgb(0, 0, 0)');
+    closeForecolorMenu();
+
+    TinySelections.setSelection(editor, [ 1, 0 ], 1, [ 1, 0 ], 2, true);
+
+    await openAndGetForecolorMenu();
+    assertFocusIsOnColor('rgb(224, 62, 45)');
+    closeForecolorMenu();
   });
 });


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
Colorswatch now displays the selected color ( if applicable ) with a checkmark, navigation starts at the current color ( if applicable )

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
