### PR TITLE
Do not show the textselection quickbar for videos

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dragging a noneditable element before or after another noneditable element now works correctly. #TINY-9253
 - The restored selection after a redo or undo action was not scrolled into view. #TINY-9222
 - A newline could not be inserted when the selection was restored from a bookmark after an inline `contenteditable="false"` element. #TINY-9194
+- Fixed `quickbars` selection toolbar appearing on video elements.
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/src/plugins/quickbars/main/ts/selection/Toolbars.ts
+++ b/modules/tinymce/src/plugins/quickbars/main/ts/selection/Toolbars.ts
@@ -5,6 +5,7 @@ import * as Options from '../api/Options';
 const addToEditor = (editor: Editor): void => {
   const isEditable = (node: Element): boolean => editor.dom.getContentEditableParent(node) !== 'false';
   const isImage = (node: Element): boolean => node.nodeName === 'IMG' || node.nodeName === 'FIGURE' && /image/i.test(node.className);
+  const isVideo = (node: Element): boolean => node.nodeName === 'VIDEO';
 
   const imageToolbarItems = Options.getImageToolbarItems(editor);
   if (imageToolbarItems.length > 0) {
@@ -18,7 +19,7 @@ const addToEditor = (editor: Editor): void => {
   const textToolbarItems = Options.getTextSelectionToolbarItems(editor);
   if (textToolbarItems.length > 0) {
     editor.ui.registry.addContextToolbar('textselection', {
-      predicate: (node) => !isImage(node) && !editor.selection.isCollapsed() && isEditable(node),
+      predicate: (node) => !isImage(node) && !isVideo(node) && !editor.selection.isCollapsed() && isEditable(node),
       items: textToolbarItems,
       position: 'selection',
       scope: 'editor'

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/SelectionToolbarTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/SelectionToolbarTest.ts
@@ -91,4 +91,12 @@ describe('browser.tinymce.plugins.quickbars.SelectionToolbarTest', () => {
     await pSetImageAndAssertToolbarState(editor, true, Alignment.Center);
     await pSetImageAndAssertToolbarState(editor, true, Alignment.Right);
   });
+
+  it('TBA: Text selection toolbar is not shown for videos', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><video controls="controls"></video></p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 1);
+    await Waiter.pWait(50);
+    UiFinder.notExists(SugarBody.body(), '.tox-pop__dialog .tox-toolbar');
+  });
 });


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Do not show the textselection quickbar when selecting a video

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
