### PR TITLE
TINY-6037: Add `content_css_cors` setting to global `tinymce.dom.styleSheetLoader`

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dragging a noneditable element before or after another noneditable element now works correctly. #TINY-9253
 - The restored selection after a redo or undo action was not scrolled into view. #TINY-9222
 - A newline could not be inserted when the selection was restored from a bookmark after an inline `contenteditable="false"` element. #TINY-9194
-- The global `tinymce.dom.styleSheetLoader` was not affected by the `content_css_cors` setting, preventing `crossOrigin="anonymous"` from being applied to loaded stylesheets when in inline mode. #TINY-6037
+- The global `tinymce.dom.styleSheetLoader` was not affected by the `content_css_cors` option. #TINY-6037
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dragging a noneditable element before or after another noneditable element now works correctly. #TINY-9253
 - The restored selection after a redo or undo action was not scrolled into view. #TINY-9222
 - A newline could not be inserted when the selection was restored from a bookmark after an inline `contenteditable="false"` element. #TINY-9194
+- The global `tinymce.dom.styleSheetLoader` was not affected by the `content_css_cors` setting, preventing `crossOrigin="anonymous"` from being applied to loaded stylesheets when in inline mode. #TINY-6037
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -291,6 +291,11 @@ class Editor implements EditorObservable {
       DOMUtils.DOM.styleSheetLoader._setReferrerPolicy(referrerPolicy);
     }
 
+    const contentCssCors = Options.hasContentCssCors(self);
+    if (contentCssCors) {
+      DOMUtils.DOM.styleSheetLoader._setContentCssCors(contentCssCors);
+    }
+
     AddOnManager.languageLoad = getOption('language_load');
     AddOnManager.baseURL = editorManager.baseURL;
 

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -292,7 +292,7 @@ class Editor implements EditorObservable {
     }
 
     const contentCssCors = Options.hasContentCssCors(self);
-    if (contentCssCors !== undefined) {
+    if (Type.isNonNullable(contentCssCors)) {
       DOMUtils.DOM.styleSheetLoader._setContentCssCors(contentCssCors);
     }
 

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -292,7 +292,7 @@ class Editor implements EditorObservable {
     }
 
     const contentCssCors = Options.hasContentCssCors(self);
-    if (contentCssCors) {
+    if (contentCssCors !== undefined) {
       DOMUtils.DOM.styleSheetLoader._setContentCssCors(contentCssCors);
     }
 

--- a/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
@@ -15,6 +15,7 @@ interface StyleSheetLoader {
   unload: (url: string) => void;
   unloadAll: (urls: string[]) => void;
   _setReferrerPolicy: (referrerPolicy: ReferrerPolicy) => void;
+  _setContentCssCors: (contentCssCors: boolean) => void;
 }
 
 export interface StyleSheetLoaderSettings {
@@ -42,6 +43,10 @@ const StyleSheetLoader = (documentOrShadowRoot: Document | ShadowRoot, settings:
 
   const _setReferrerPolicy = (referrerPolicy: ReferrerPolicy) => {
     settings.referrerPolicy = referrerPolicy;
+  };
+
+  const _setContentCssCors = (contentCssCors: boolean) => {
+    settings.contentCssCors = contentCssCors;
   };
 
   const addStyle = (element: SugarElement<HTMLStyleElement>) => {
@@ -233,7 +238,8 @@ const StyleSheetLoader = (documentOrShadowRoot: Document | ShadowRoot, settings:
     loadAll,
     unload,
     unloadAll,
-    _setReferrerPolicy
+    _setReferrerPolicy,
+    _setContentCssCors
   };
 };
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/ContentCssCorsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ContentCssCorsTest.ts
@@ -1,7 +1,8 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { afterEach, context, describe, it } from '@ephox/bedrock-client';
 import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
+import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.dom.ContentCssCorsTest', () => {
@@ -11,20 +12,118 @@ describe('browser.tinymce.core.dom.ContentCssCorsTest', () => {
     toolbar: false
   };
 
-  const assertCorsLinkPresence = (editor: Editor, expected: boolean) => {
-    const corsLinks = editor.getDoc().querySelectorAll('link[crossorigin="anonymous"]');
-    assert.equal(corsLinks.length > 0, expected, 'should have link with crossorigin="anonymous"');
+  const inlineSettings = {
+    ...settings,
+    inline: true
   };
 
-  it('assert crossorigin link presence with setting set', async () => {
-    const editor = await McEditor.pFromSettings<Editor>({ ...settings, content_css_cors: true });
-    assertCorsLinkPresence(editor, true);
-    McEditor.remove(editor);
+  const assertCorsLinkPresence = (editor: Editor, expected: number) => {
+    // Classic mode has two stylesheets in the document head, content.css and content.min.css.
+    // Inline mode shares stylesheets with the outer document, and should have two different stylesheets by default, skin.min.css and content.inline.min.css.
+    const corsLinks = editor.getDoc().querySelectorAll('link[crossorigin="anonymous"]');
+    assert.equal(corsLinks.length, expected, `should have ${expected} link(s) with crossorigin="anonymous"`);
+  };
+
+  afterEach(() => {
+    // Clean up by resetting the globals contentCssCors
+    DOMUtils.DOM.styleSheetLoader._setContentCssCors(false);
   });
 
-  it('assert crossorigin link presence with no setting set', async () => {
-    const editor = await McEditor.pFromSettings<Editor>(settings);
-    assertCorsLinkPresence(editor, false);
-    McEditor.remove(editor);
+  context('Classic mode: Editor StyleSheetLoader is separate from global (tinymce)', () => {
+    it('assert crossorigin link presence with setting set', async () => {
+      const editor = await McEditor.pFromSettings<Editor>({ ...settings, content_css_cors: true });
+      assertCorsLinkPresence(editor, 2);
+      McEditor.remove(editor);
+    });
+
+    it('assert crossorigin link presence with no setting set', async () => {
+      const editor = await McEditor.pFromSettings<Editor>(settings);
+      assertCorsLinkPresence(editor, 0);
+      McEditor.remove(editor);
+    });
+  });
+
+  context('Inline mode: Global (tinymce) StyleSheetLoader is shared amongst multiple inline editors', () => {
+    it('TINY-6037: assert crossorigin link presence with no setting set in inline mode', async () => {
+      const inlineEditor1 = await McEditor.pFromSettings<Editor>({ ...inlineSettings });
+      const inlineEditor2 = await McEditor.pFromSettings<Editor>({ ...inlineSettings });
+
+      assertCorsLinkPresence(inlineEditor1, 0);
+      assertCorsLinkPresence(inlineEditor2, 0);
+
+      McEditor.remove(inlineEditor1);
+      McEditor.remove(inlineEditor2);
+    });
+
+    it('TINY-6037: assert crossorigin link presence with setting set in inline mode', async () => {
+      const inlineEditor1 = await McEditor.pFromSettings<Editor>({ ...inlineSettings, content_css_cors: true });
+      const inlineEditor2 = await McEditor.pFromSettings<Editor>({ ...inlineSettings, content_css_cors: false });
+
+      assertCorsLinkPresence(inlineEditor1, 2);
+      assertCorsLinkPresence(inlineEditor2, 2);
+
+      McEditor.remove(inlineEditor1);
+      McEditor.remove(inlineEditor2);
+    });
+
+    it('TINY-6037: assert crossorigin link presence with setting false in inline mode', async () => {
+      const inlineEditor1 = await McEditor.pFromSettings<Editor>({ ...inlineSettings, content_css_cors: false });
+      const inlineEditor2 = await McEditor.pFromSettings<Editor>({ ...inlineSettings, content_css_cors: true });
+
+      assertCorsLinkPresence(inlineEditor1, 0);
+      assertCorsLinkPresence(inlineEditor2, 0);
+
+      McEditor.remove(inlineEditor1);
+      McEditor.remove(inlineEditor2);
+    });
+  });
+
+  context('Classic and inline editors: Global (tinymce) StyleSheetLoader is shared amongst multiple inline editors, but classic editor has separate stylesheetloader', () => {
+    it('TINY-6037: assert crossorigin links with setting true in first classic editor, and false in second inline editor', async () => {
+      const classicEditor = await McEditor.pFromSettings<Editor>({ ...settings, content_css_cors: true });
+      const inlineEditor = await McEditor.pFromSettings<Editor>({ ...inlineSettings, content_css_cors: false });
+
+      assertCorsLinkPresence(classicEditor, 2);
+      // Oxide skin will have crossOrigin="anonymous" after being loaded by classicEditor
+      assertCorsLinkPresence(inlineEditor, 1);
+
+      McEditor.remove(classicEditor);
+      McEditor.remove(inlineEditor);
+    });
+
+    it('TINY-6037: assert crossorigin links with setting set only in first classic editor', async () => {
+      const classicEditor = await McEditor.pFromSettings<Editor>({ ...settings, content_css_cors: true });
+      const inlineEditor = await McEditor.pFromSettings<Editor>({ ...inlineSettings });
+
+      assertCorsLinkPresence(classicEditor, 2);
+      // Oxide skin will have crossOrigin="anonymous" after being loaded by classicEditor
+      assertCorsLinkPresence(inlineEditor, 1);
+
+      McEditor.remove(classicEditor);
+      McEditor.remove(inlineEditor);
+    });
+
+    it('TINY-6037: assert crossorigin links with setting true in first inline editor, and false in second classic editor', async () => {
+      const inlineEditor = await McEditor.pFromSettings<Editor>({ ...inlineSettings, content_css_cors: true });
+      const classicEditor = await McEditor.pFromSettings<Editor>({ ...settings, content_css_cors: false });
+
+      assertCorsLinkPresence(inlineEditor, 2);
+      // Global styleSheetLoader shouldn't affect classic editor styleSheetLoader
+      assertCorsLinkPresence(classicEditor, 0);
+
+      McEditor.remove(classicEditor);
+      McEditor.remove(inlineEditor);
+    });
+
+    it('TINY-6037: assert crossorigin links with no setting in first classic and second inline editors', async () => {
+      const classicEditor = await McEditor.pFromSettings<Editor>({ ...settings });
+      const inlineEditor = await McEditor.pFromSettings<Editor>({ ...inlineSettings });
+
+      assertCorsLinkPresence(classicEditor, 0);
+      assertCorsLinkPresence(inlineEditor, 0);
+
+      McEditor.remove(classicEditor);
+      McEditor.remove(inlineEditor);
+    });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-6037

Description of Changes:
* Setting the `content_css_cors` option will now update the global `tinymce.dom.styleSheetLoader` with the given setting
* This allows the `crossOrigin="anonymous"` attribute to be added to stylesheets loaded in inline mode
* This was not possible before as inline editors share the global `styleSheetLoader`, rather than separate ones for each editor, which never has this setting updated.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
