### PR TITLE
TINY-8872: fix infinite autoresize with content_css document

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A newline could not be inserted when the selection was restored from a bookmark after an inline `contenteditable="false"` element. #TINY-9194
 - The global `tinymce.dom.styleSheetLoader` was not affected by the `content_css_cors` option. #TINY-6037
 - The caret was moved to the previous line when a text pattern executed a `mceInsertContent` command on Enter key when running on Firefox. #TINY-9193
+- The `autoresize` plugin does not cause infinite resize when `content_css` is set to `document` #TINY-8872
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A newline could not be inserted when the selection was restored from a bookmark after an inline `contenteditable="false"` element. #TINY-9194
 - The global `tinymce.dom.styleSheetLoader` was not affected by the `content_css_cors` option. #TINY-6037
 - The caret was moved to the previous line when a text pattern executed a `mceInsertContent` command on Enter key when running on Firefox. #TINY-9193
-- The `autoresize` plugin used to cause infinite resize when `content_css` is set to `document` #TINY-8872
+- The `autoresize` plugin used to cause infinite resize when `content_css` is set to `document`. #TINY-8872
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A newline could not be inserted when the selection was restored from a bookmark after an inline `contenteditable="false"` element. #TINY-9194
 - The global `tinymce.dom.styleSheetLoader` was not affected by the `content_css_cors` option. #TINY-6037
 - The caret was moved to the previous line when a text pattern executed a `mceInsertContent` command on Enter key when running on Firefox. #TINY-9193
-- The `autoresize` plugin does not cause infinite resize when `content_css` is set to `document` #TINY-8872
+- The `autoresize` plugin used to cause infinite resize when `content_css` is set to `document` #TINY-8872
 
 ## 6.2.0 - 2022-09-08
 

--- a/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
@@ -167,7 +167,7 @@ const setup = (editor: Editor, oldSize: Cell<number>): void => {
     } else if (resizeCounter < 3) {
       resize(editor, oldSize, e, getExtraMarginBottom);
       resizeCounter += 1;
-    } else if (resizeCounter === 3 && !checkDone) {
+    } else if (resizeCounter >= 3 && !checkDone) {
       const body = editor.getBody();
       const bodyRect = body.getBoundingClientRect();
       const doc = editor.getDoc();

--- a/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
@@ -127,11 +127,12 @@ const resize = (editor: Editor, oldSize: Cell<number>, trigger?: EditorEvent<unk
 
 const setup = (editor: Editor, oldSize: Cell<number>): void => {
   let getExtraMarginBottom = () => Options.getAutoResizeBottomMargin(editor);
-  let resizeCounter = 0;
+  let resizeCounter: number;
   let sizeAfterFirstResize: number;
   let checkDone = false;
 
   editor.on('init', (e) => {
+    resizeCounter = 0;
     const overflowPadding = Options.getAutoResizeOverflowPadding(editor);
     const dom = editor.dom;
 
@@ -163,7 +164,10 @@ const setup = (editor: Editor, oldSize: Cell<number>): void => {
       sizeAfterFirstResize = editor.getContainer().offsetHeight;
       resize(editor, oldSize, e, getExtraMarginBottom);
       resizeCounter += 1;
-    } else if (resizeCounter === 2 && !checkDone) {
+    } else if (resizeCounter < 3) {
+      resize(editor, oldSize, e, getExtraMarginBottom);
+      resizeCounter += 1;
+    } else if (resizeCounter === 3 && !checkDone) {
       const body = editor.getBody();
       const bodyRect = body.getBoundingClientRect();
       const doc = editor.getDoc();

--- a/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
@@ -73,8 +73,6 @@ const resize = (editor: Editor, oldSize: Cell<number>, trigger?: EditorEvent<unk
   const marginTop = parseCssValueToInt(dom, docEle, 'margin-top', true);
   const marginBottom = parseCssValueToInt(dom, docEle, 'margin-bottom', true);
   let contentHeight = docEle.offsetHeight + marginTop + marginBottom + resizeBottomMargin;
-  // eslint-disable-next-line no-console
-  console.log(`CALC: docEle.offsetHeight: ${docEle.offsetHeight} + marginTop: ${marginTop} + marginBottom: ${marginBottom} + resizeBottomMargin: ${resizeBottomMargin}`);
 
   // Make sure we have a valid height
   if (contentHeight < 0) {

--- a/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
@@ -73,6 +73,8 @@ const resize = (editor: Editor, oldSize: Cell<number>, trigger?: EditorEvent<unk
   const marginTop = parseCssValueToInt(dom, docEle, 'margin-top', true);
   const marginBottom = parseCssValueToInt(dom, docEle, 'margin-bottom', true);
   let contentHeight = docEle.offsetHeight + marginTop + marginBottom + resizeBottomMargin;
+  // eslint-disable-next-line no-console
+  console.log(`CALC: docEle.offsetHeight: ${docEle.offsetHeight} + marginTop: ${marginTop} + marginBottom: ${marginBottom} + resizeBottomMargin: ${resizeBottomMargin}`);
 
   // Make sure we have a valid height
   if (contentHeight < 0) {
@@ -164,16 +166,15 @@ const setup = (editor: Editor, oldSize: Cell<number>): void => {
       sizeAfterFirstResize = editor.getContainer().offsetHeight;
       resize(editor, oldSize, e, getExtraMarginBottom);
       resizeCounter += 1;
-    } else if (resizeCounter < 3) {
-      resize(editor, oldSize, e, getExtraMarginBottom);
-      resizeCounter += 1;
-    } else if (resizeCounter >= 3 && !checkDone) {
-      const body = editor.getBody();
-      const bodyRect = body.getBoundingClientRect();
+    } else if (resizeCounter >= 2 && !checkDone) {
+      const dom = editor.dom;
       const doc = editor.getDoc();
-      const currentExtraMarginBottom = doc.documentElement.offsetHeight - (body.offsetHeight + bodyRect.top);
-
-      getExtraMarginBottom = sizeAfterFirstResize < editor.getContainer().offsetHeight ? Fun.constant(currentExtraMarginBottom) : getExtraMarginBottom;
+      const isLooping = sizeAfterFirstResize < editor.getContainer().offsetHeight;
+      if (isLooping) {
+        dom.setStyles(doc.documentElement, { 'min-height': 0 });
+        dom.setStyles(editor.getBody(), { 'min-height': 'inherit' });
+      }
+      getExtraMarginBottom = isLooping ? Fun.constant(0) : getExtraMarginBottom;
       checkDone = true;
     }
 

--- a/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
@@ -64,7 +64,15 @@ const resize = (editor: Editor, oldSize: Cell<number>, trigger?: EditorEvent<unk
   }
 
   const docEle = doc.documentElement;
-  const resizeBottomMargin = Options.getAutoResizeBottomMargin(editor);
+  let resizeBottomMargin = Options.getAutoResizeBottomMargin(editor);
+
+  if (dom.getStyle(docEle, 'min-height', true) === '100%' || dom.getStyle(docEle, 'height', true) === '100%') {
+    const body = editor.getBody();
+    const bodyRect = body.getBoundingClientRect();
+    const doc = editor.getDoc();
+    resizeBottomMargin = doc.documentElement.offsetHeight - (body.offsetHeight + bodyRect.top);
+  }
+
   const minHeight = Options.getMinHeight(editor) ?? editor.getElement().offsetHeight;
   let resizeHeight = minHeight;
 
@@ -134,12 +142,19 @@ const setup = (editor: Editor, oldSize: Cell<number>): void => {
       height: 'auto'
     });
 
-    dom.setStyles(editor.getBody(), {
-      'paddingLeft': overflowPadding,
-      'paddingRight': overflowPadding,
-      // IE & Edge have a min height of 150px by default on the body, so override that
-      'min-height': 0
-    });
+    if (Env.browser.isEdge() || Env.browser.isIE()) {
+      dom.setStyles(editor.getBody(), {
+        'paddingLeft': overflowPadding,
+        'paddingRight': overflowPadding,
+        // IE & Edge have a min height of 150px by default on the body, so override that
+        'min-height': 0
+      });
+    } else {
+      dom.setStyles(editor.getBody(), {
+        paddingLeft: overflowPadding,
+        paddingRight: overflowPadding
+      });
+    }
   });
 
   editor.on('NodeChange SetContent keyup FullscreenStateChanged ResizeContent', (e) => {

--- a/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
@@ -129,7 +129,6 @@ const setup = (editor: Editor, oldSize: Cell<number>): void => {
   let getExtraMarginBottom = () => Options.getAutoResizeBottomMargin(editor);
   let resizeCounter: number;
   let sizeAfterFirstResize: number;
-  let checkDone = false;
 
   editor.on('init', (e) => {
     resizeCounter = 0;
@@ -164,19 +163,19 @@ const setup = (editor: Editor, oldSize: Cell<number>): void => {
       sizeAfterFirstResize = editor.getContainer().offsetHeight;
       resize(editor, oldSize, e, getExtraMarginBottom);
       resizeCounter += 1;
-    } else if (resizeCounter >= 2 && !checkDone) {
-      const dom = editor.dom;
-      const doc = editor.getDoc();
+    } else if (resizeCounter === 2) {
+      // After the first check, this code checks if the editor's container is resized again, if so it means that the resize is in a loop
+      // in this case, the CSS is changed to let the document and body adapt to the height of the content
       const isLooping = sizeAfterFirstResize < editor.getContainer().offsetHeight;
       if (isLooping) {
+        const dom = editor.dom;
+        const doc = editor.getDoc();
         dom.setStyles(doc.documentElement, { 'min-height': 0 });
         dom.setStyles(editor.getBody(), { 'min-height': 'inherit' });
       }
       getExtraMarginBottom = isLooping ? Fun.constant(0) : getExtraMarginBottom;
-      checkDone = true;
-    }
-
-    if (checkDone) {
+      resizeCounter += 1;
+    } else {
       resize(editor, oldSize, e, getExtraMarginBottom);
     }
   });

--- a/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
+++ b/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
@@ -207,11 +207,10 @@ describe('browser.tinymce.plugins.autoresize.AutoresizePluginTest', () => {
       assert.isAtMost(resizeEventsCount.get(), 10, 'Should have fired a ResizeEditor event at most 10 time');
     });
 
-    // this is not working because of a bug in the `setContent`
-    it.skip('TINY-9123: it should continue to resize if the content expands or contract', async () => {
+    it('TINY-9123: it should continue to resize if the content expands or contract', async () => {
       const editor = hook.editor();
       const content = '<p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p>';
-      editor.setContent('<div style="height: 10px;">' + content + '</div>');
+      editor.setContent('<div>' + content + '</div>');
       await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightBelow(editor, 610), 10, 3000);
       TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 12);
       editor.execCommand('FontSize', false, '36pt');

--- a/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
+++ b/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
@@ -200,7 +200,7 @@ describe('browser.tinymce.plugins.autoresize.AutoresizePluginTest', () => {
       resizeEventsCount.set(0);
     });
 
-    it('TINY-9123: it should not continue to resize in some specific condition', async () => {
+    it('TINY-9123: it should not continue to resize when the CSS forces the content to have a margin-bottom lesser than autoresize_bottom_margin', async () => {
       const editor = hook.editor();
       editor.setContent('<div style="height: 250px;">a</div>');
       await Waiter.pWait(2000);

--- a/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
+++ b/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
@@ -9,23 +9,6 @@ import AutoresizePlugin from 'tinymce/plugins/autoresize/Plugin';
 import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
 
 describe('browser.tinymce.plugins.autoresize.AutoresizePluginTest', () => {
-
-  const resizeEventsCount = Cell(0);
-  const hook = TinyHooks.bddSetup<Editor>({
-    plugins: 'autoresize fullscreen',
-    menubar: false,
-    toolbar: 'autoresize',
-    base_url: '/project/tinymce/js/tinymce',
-    autoresize_bottom_margin: 50,
-    // Override the content css margins, so they don't come into play
-    content_style: 'body { margin: 0; margin-top: 10px; }',
-    setup: (editor: Editor) => {
-      editor.on('ResizeEditor', () => {
-        resizeEventsCount.set(resizeEventsCount.get() + 1);
-      });
-    }
-  }, [ AutoresizePlugin, FullscreenPlugin ], true);
-
   const assertEditorHeightAbove = (editor: Editor, minHeight: number) => {
     const editorHeight = editor.getContainer().offsetHeight;
     assert.isAtLeast(editorHeight, minHeight, `editor height should be above: ${editorHeight}>=${minHeight}`);
@@ -53,131 +36,149 @@ describe('browser.tinymce.plugins.autoresize.AutoresizePluginTest', () => {
     assert.equal(body.style.overflowY === 'hidden', !state, `scroll state: ${state}`);
   };
 
-  beforeEach(() => {
-    resizeEventsCount.set(0);
-  });
+  context('common tests', () => {
+    const resizeEventsCount = Cell(0);
+    const hook = TinyHooks.bddSetup<Editor>({
+      plugins: 'autoresize fullscreen',
+      menubar: false,
+      toolbar: 'autoresize',
+      base_url: '/project/tinymce/js/tinymce',
+      autoresize_bottom_margin: 50,
+      // Override the content css margins, so they don't come into play
+      content_style: 'body { margin: 0; margin-top: 10px; }',
+      setup: (editor: Editor) => {
+        editor.on('ResizeEditor', () => {
+          resizeEventsCount.set(resizeEventsCount.get() + 1);
+        });
+      }
+    }, [ AutoresizePlugin, FullscreenPlugin ], true);
 
-  it('TBA: Should not have a resize handle visible by default', async () => {
-    const editor = hook.editor();
-    const statusbar = await TinyUiActions.pWaitForUi(editor, '.tox-statusbar');
-    Assertions.assertStructure('Check the statusbar does not have a resize handle', ApproxStructure.build((s, str, arr) => {
-      return s.element('div', {
-        children: [
-          s.element('div', {
-            classes: [ arr.has('tox-statusbar__text-container') ],
-            children: [
-              s.element('div', { classes: [ arr.has('tox-statusbar__path') ] }),
-              s.element('span', { classes: [ arr.has('tox-statusbar__branding') ] })
-            ]
-          })
-        ]
-      });
-    }), statusbar);
-  });
+    beforeEach(() => {
+      resizeEventsCount.set(0);
+    });
 
-  it('TBA: Fullscreen toggle scroll state', () => {
-    const editor = hook.editor();
-    editor.execCommand('mceFullScreen');
-    assertScroll(editor, true);
-    editor.execCommand('mceFullScreen');
-    assertScroll(editor, false);
-  });
+    it('TBA: Should not have a resize handle visible by default', async () => {
+      const editor = hook.editor();
+      const statusbar = await TinyUiActions.pWaitForUi(editor, '.tox-statusbar');
+      Assertions.assertStructure('Check the statusbar does not have a resize handle', ApproxStructure.build((s, str, arr) => {
+        return s.element('div', {
+          children: [
+            s.element('div', {
+              classes: [ arr.has('tox-statusbar__text-container') ],
+              children: [
+                s.element('div', { classes: [ arr.has('tox-statusbar__path') ] }),
+                s.element('span', { classes: [ arr.has('tox-statusbar__branding') ] })
+              ]
+            })
+          ]
+        });
+      }), statusbar);
+    });
 
-  it('TBA: Editor size increase based on content size', async () => {
-    const editor = hook.editor();
-    editor.setContent('<div style="height: 5000px;">a</div>');
-    // Content height + bottom margin = 5050
-    await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5050), 10, 3000);
-    await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightAbove(editor, 5050), 10, 3000);
-    assert.isAtLeast(resizeEventsCount.get(), 1, 'Should have fired a ResizeEditor event');
-  });
+    it('TBA: Fullscreen toggle scroll state', () => {
+      const editor = hook.editor();
+      editor.execCommand('mceFullScreen');
+      assertScroll(editor, true);
+      editor.execCommand('mceFullScreen');
+      assertScroll(editor, false);
+    });
 
-  it('TBA: Editor size increase with floated content', async () => {
-    const editor = hook.editor();
-    editor.setContent('<div style="height: 5500px; float: right;">a</div>');
-    // Content height + bottom margin = 5550
-    await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5550), 10, 3000);
-    await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightAbove(editor, 5550), 10, 3000);
-    assert.isAtLeast(resizeEventsCount.get(), 1, 'Should have fired a ResizeEditor event');
-  });
+    it('TBA: Editor size increase based on content size', async () => {
+      const editor = hook.editor();
+      editor.setContent('<div style="height: 5000px;">a</div>');
+      // Content height + bottom margin = 5050
+      await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5050), 10, 3000);
+      await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightAbove(editor, 5050), 10, 3000);
+      assert.isAtLeast(resizeEventsCount.get(), 1, 'Should have fired a ResizeEditor event');
+    });
 
-  it('TBA: Editor size decrease based on content size', async () => {
-    const editor = hook.editor();
-    editor.setContent('<div style="height: 1000px;">a</div>');
-    await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 1050), 10, 3000);
-    await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightBelow(editor, 1200), 10, 3000);
-    assert.isAtLeast(resizeEventsCount.get(), 1, 'Should have fired a ResizeEditor event');
-  });
+    it('TBA: Editor size increase with floated content', async () => {
+      const editor = hook.editor();
+      editor.setContent('<div style="height: 5500px; float: right;">a</div>');
+      // Content height + bottom margin = 5550
+      await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5550), 10, 3000);
+      await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightAbove(editor, 5550), 10, 3000);
+      assert.isAtLeast(resizeEventsCount.get(), 1, 'Should have fired a ResizeEditor event');
+    });
 
-  it('TBA: Editor size increase with async loaded content', async () => {
-    const editor = hook.editor();
-    // Note: Use a min-height here to account for different browsers rendering broken images differently
-    editor.setContent('<div style="min-height: 35px;"><img src="#" /></div><div style="height: 5500px;"></div>');
-    await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5585), 10, 3000);
-    // Update the img element to load an image
-    const image = editor.dom.select('img')[0];
-    editor.dom.setAttrib(image, 'src', 'http://moxiecode.cachefly.net/tinymce/v9/images/logo.png');
-    // Content height + div image height (84px) + bottom margin = 5634
-    await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5634), 10, 3000);
-    await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightAbove(editor, 5634), 10, 3000);
-  });
+    it('TBA: Editor size decrease based on content size', async () => {
+      const editor = hook.editor();
+      editor.setContent('<div style="height: 1000px;">a</div>');
+      await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 1050), 10, 3000);
+      await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightBelow(editor, 1200), 10, 3000);
+      assert.isAtLeast(resizeEventsCount.get(), 1, 'Should have fired a ResizeEditor event');
+    });
 
-  it('TBA: Editor size content set to 10 and autoresize_bottom_margin set to 100', async () => {
-    const editor = hook.editor();
-    editor.options.set('autoresize_bottom_margin', 100);
-    editor.setContent('<div style="height: 10px;">a</div>');
-    await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 110), 10, 3000);
-    editor.options.unset('autoresize_bottom_margin');
-  });
+    it('TBA: Editor size increase with async loaded content', async () => {
+      const editor = hook.editor();
+      // Note: Use a min-height here to account for different browsers rendering broken images differently
+      editor.setContent('<div style="min-height: 35px;"><img src="#" /></div><div style="height: 5500px;"></div>');
+      await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5585), 10, 3000);
+      // Update the img element to load an image
+      const image = editor.dom.select('img')[0];
+      editor.dom.setAttrib(image, 'src', 'http://moxiecode.cachefly.net/tinymce/v9/images/logo.png');
+      // Content height + div image height (84px) + bottom margin = 5634
+      await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5634), 10, 3000);
+      await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightAbove(editor, 5634), 10, 3000);
+    });
 
-  it('TBA: Editor size increase content to 1000 based and restrict by max height', async () => {
-    const editor = hook.editor();
-    editor.options.set('max_height', 200);
-    editor.setContent('<div style="height: 1000px;">a</div>');
-    await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightBelow(editor, 200), 10, 3000);
-    editor.options.unset('max_height');
-  });
+    it('TBA: Editor size content set to 10 and autoresize_bottom_margin set to 100', async () => {
+      const editor = hook.editor();
+      editor.options.set('autoresize_bottom_margin', 100);
+      editor.setContent('<div style="height: 10px;">a</div>');
+      await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 110), 10, 3000);
+      editor.options.unset('autoresize_bottom_margin');
+    });
 
-  it('TBA: Editor size decrease content to 10 and set min height to 500', async () => {
-    const editor = hook.editor();
-    editor.options.set('min_height', 500);
-    editor.setContent('<div style="height: 10px;">a</div>');
-    await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightAbove(editor, 500), 10, 3000);
-    editor.options.unset('min_height');
-  });
+    it('TBA: Editor size increase content to 1000 based and restrict by max height', async () => {
+      const editor = hook.editor();
+      editor.options.set('max_height', 200);
+      editor.setContent('<div style="height: 1000px;">a</div>');
+      await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightBelow(editor, 200), 10, 3000);
+      editor.options.unset('max_height');
+    });
 
-  it('TBA: Editor keeps selection in view when resizing', async () => {
-    const editor = hook.editor();
-    editor.setContent('');
-    window.scrollTo(0, 0);
-    // Set content will keep the selection at the start, whereas insert will keep it after the inserted content
-    editor.insertContent('<div style="height: 5000px;">a</div><div style="height: 50px">b</div>');
-    await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5100), 10, 3000);
-    await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightAbove(editor, 5100), 10, 3000);
-    assertScrollPositionGreaterThan(window, 3500);
-  });
+    it('TBA: Editor size decrease content to 10 and set min height to 500', async () => {
+      const editor = hook.editor();
+      editor.options.set('min_height', 500);
+      editor.setContent('<div style="height: 10px;">a</div>');
+      await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightAbove(editor, 500), 10, 3000);
+      editor.options.unset('min_height');
+    });
 
-  it('TINY-7291: Editor does not scroll to the top when changing font size over multiple paragraphs (NodeChange trigger)', () => {
-    const editor = hook.editor();
-    editor.setContent('<div style="height: 5000px;">a</div><p>Paragraph 1</p><p>Paragraph 2</p>');
-    window.scrollTo(0, 5000);
-    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 2, 0 ], 11);
-    editor.execCommand('FontSize', false, '20pt');
-    assertScrollPositionGreaterThan(window, 3500);
-  });
+    it('TBA: Editor keeps selection in view when resizing', async () => {
+      const editor = hook.editor();
+      editor.setContent('');
+      window.scrollTo(0, 0);
+      // Set content will keep the selection at the start, whereas insert will keep it after the inserted content
+      editor.insertContent('<div style="height: 5000px;">a</div><div style="height: 50px">b</div>');
+      await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5100), 10, 3000);
+      await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightAbove(editor, 5100), 10, 3000);
+      assertScrollPositionGreaterThan(window, 3500);
+    });
 
-  it('TINY-7291: Editor does not scroll to the top on undo/redo (SetContent & NodeChange trigger)', () => {
-    const editor = hook.editor();
-    editor.resetContent('<div style="height: 5000px;">a</div><p>Some content</p>');
-    window.scrollTo(0, 5000);
-    TinySelections.setCursor(editor, [ 1, 0 ], 12);
-    TinyContentActions.type(editor, '. More content...');
-    editor.undoManager.add();
-    assertScrollPositionGreaterThan(window, 3500);
-    editor.execCommand('Undo');
-    assertScrollPositionGreaterThan(window, 3500);
-    editor.execCommand('Redo');
-    assertScrollPositionGreaterThan(window, 3500);
+    it('TINY-7291: Editor does not scroll to the top when changing font size over multiple paragraphs (NodeChange trigger)', () => {
+      const editor = hook.editor();
+      editor.setContent('<div style="height: 5000px;">a</div><p>Paragraph 1</p><p>Paragraph 2</p>');
+      window.scrollTo(0, 5000);
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 2, 0 ], 11);
+      editor.execCommand('FontSize', false, '20pt');
+      assertScrollPositionGreaterThan(window, 3500);
+    });
+
+    it('TINY-7291: Editor does not scroll to the top on undo/redo (SetContent & NodeChange trigger)', () => {
+      const editor = hook.editor();
+      editor.resetContent('<div style="height: 5000px;">a</div><p>Some content</p>');
+      window.scrollTo(0, 5000);
+      TinySelections.setCursor(editor, [ 1, 0 ], 12);
+      TinyContentActions.type(editor, '. More content...');
+      editor.undoManager.add();
+      assertScrollPositionGreaterThan(window, 3500);
+      editor.execCommand('Undo');
+      assertScrollPositionGreaterThan(window, 3500);
+      editor.execCommand('Redo');
+      assertScrollPositionGreaterThan(window, 3500);
+    });
   });
 
   context('TINY-9123', () => {
@@ -187,20 +188,38 @@ describe('browser.tinymce.plugins.autoresize.AutoresizePluginTest', () => {
       menubar: false,
       toolbar: 'autoresize',
       base_url: '/project/tinymce/js/tinymce',
-      autoresize_bottom_margin: 50,
-      // Override the content css margins, so they don't come into play
-      content_style: 'html { min-height: 100%; } body { margin: 0; margin-top: 10px; min-height: calc(100vh - 10px) }',
+      content_style: 'html { min-height: 100%; } body { max-width: 820px; margin: 10px auto 0; min-height: calc(100vh - 10px) }',
       setup: (editor: Editor) => {
         editor.on('ResizeEditor', () => {
           resizeEventsCount.set(resizeEventsCount.get() + 1);
         });
       }
     }, [ AutoresizePlugin, FullscreenPlugin ], true);
+
+    beforeEach(() => {
+      resizeEventsCount.set(0);
+    });
+
     it('TINY-9123: it should not continue to resaize in some specific condition', async () => {
       const editor = hook.editor();
       editor.setContent('<div style="height: 250px;">a</div>');
       await Waiter.pWait(2000);
       assert.isAtMost(resizeEventsCount.get(), 10, 'Should have fired a ResizeEditor event at most 10 time');
+    });
+
+    // this is not working because of a bug in the `setContent`
+    it.skip('TINY-9123: it should continue to resaize if the content expands or contract', async () => {
+      const editor = hook.editor();
+      const content = '<p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p>';
+      editor.setContent('<div style="height: 10px;">' + content + '</div>');
+      await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightBelow(editor, 610), 10, 3000);
+      TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 12);
+      editor.execCommand('FontSize', false, '36pt');
+      await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightAbove(editor, 610), 10, 3000);
+      TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 12);
+      editor.execCommand('FontSize', false, '12pt');
+      await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightBelow(editor, 610), 10, 3000);
+      assert.isAtLeast(resizeEventsCount.get(), 1, 'Should have fired a ResizeEditor event');
     });
   });
 

--- a/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
+++ b/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
@@ -199,7 +199,7 @@ describe('browser.tinymce.plugins.autoresize.AutoresizePluginTest', () => {
     it('TINY-9123: it should not continue to resaize in some specific condition', async () => {
       const editor = hook.editor();
       editor.setContent('<div style="height: 250px;">a</div>');
-      await Waiter.pWait(1000);
+      await Waiter.pWait(2000);
       assert.isAtMost(resizeEventsCount.get(), 10, 'Should have fired a ResizeEditor event at most 10 time');
     });
   });

--- a/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
+++ b/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
@@ -200,7 +200,7 @@ describe('browser.tinymce.plugins.autoresize.AutoresizePluginTest', () => {
       resizeEventsCount.set(0);
     });
 
-    it('TINY-9123: it should not continue to resaize in some specific condition', async () => {
+    it('TINY-9123: it should not continue to resize in some specific condition', async () => {
       const editor = hook.editor();
       editor.setContent('<div style="height: 250px;">a</div>');
       await Waiter.pWait(2000);
@@ -208,7 +208,7 @@ describe('browser.tinymce.plugins.autoresize.AutoresizePluginTest', () => {
     });
 
     // this is not working because of a bug in the `setContent`
-    it.skip('TINY-9123: it should continue to resaize if the content expands or contract', async () => {
+    it.skip('TINY-9123: it should continue to resize if the content expands or contract', async () => {
       const editor = hook.editor();
       const content = '<p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p>';
       editor.setContent('<div style="height: 10px;">' + content + '</div>');


### PR DESCRIPTION
Related Ticket: TINY-8872

Description of Changes:
the problem was that `document` skin has a CSS that aligns the bottom of the content to the bottom of the editor, but not setting `autoresize_bottom_margin` the editor takes the default of `50`, so each time the resize function calculated the size it also adds `autoresize_bottom_margin` but since the CSS sets the bottom of the content to something less than the `autoresize_bottom_margin` resize go in a loop.

The idea is to check if the resize function goes in a loop and if so, the resize function considers the `margin bottom` as always 0 instead of `autoresize_bottom_margin`, and the min-height of HTML and Body are changed

P.S. we could put in the documentation that `autoresize_bottom_margin` should not be set as a value greater than the one set by CSS

to solve it
Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
