### PR TITLE
TINY-6853: Lists applied incorrectly in table cells

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Color picker dialog now starts on the appropriate color for the cursor position. #TINY-9213
 
 ### Fixed
+- Clicking on list toolbar button inside a table cell that has anchor element when the cursor is outside the anchor element would not include the anchor element in the produce list. #TINY-6853
 - Parsing media content would cause a memory leak, which for example occurred when using the `getContent` API. #TINY-9186
 - Dragging a noneditable element toward the bottom edge would cause the page to scroll up. #TINY-9025
 - Range expanding capabilities would behave inconsistently depending on where the cursor was placed. #TINY-9029

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Color picker dialog now starts on the appropriate color for the cursor position. #TINY-9213
 
 ### Fixed
-- Clicking on list toolbar button inside a table cell that has anchor element when the cursor is outside the anchor element would not include the anchor element in the produce list. #TINY-6853
+- Clicking on list toolbar button inside a table cell that has anchor element when the cursor is outside the anchor element would not include the anchor element in the produced list. #TINY-6853
 - Parsing media content would cause a memory leak, which for example occurred when using the `getContent` API. #TINY-9186
 - Dragging a noneditable element toward the bottom edge would cause the page to scroll up. #TINY-9025
 - Range expanding capabilities would behave inconsistently depending on where the cursor was placed. #TINY-9029

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Color picker dialog now starts on the appropriate color for the cursor position. #TINY-9213
 
 ### Fixed
-- Clicking on list toolbar button inside a table cell that has anchor element when the cursor is outside the anchor element would not include the anchor element in the produced list. #TINY-6853
+- Creating a list in a table cell when the caret is in front of an anchor element would not properly include the anchor in the list. #TINY-6853
 - Parsing media content would cause a memory leak, which for example occurred when using the `getContent` API. #TINY-9186
 - Dragging a noneditable element toward the bottom edge would cause the page to scroll up. #TINY-9025
 - Range expanding capabilities would behave inconsistently depending on where the cursor was placed. #TINY-9029

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -102,7 +102,7 @@ const getEndPointNode = (editor: Editor, rng: Range, start: Boolean, root: Node)
       if (container.parentNode !== null && isInline(editor, container.parentNode)) {
         container = container.parentNode;
       }
-      while (container.nextSibling !== null && ( isInline(editor, container.nextSibling) || NodeType.isTextNode(container.nextSibling) ) ) {
+      while (container.nextSibling !== null && (isInline(editor, container.nextSibling) || NodeType.isTextNode(container.nextSibling))) {
         container = container.nextSibling;
       }
     }

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -77,7 +77,7 @@ const getEndPointNode = (editor: Editor, rng: Range, start: Boolean, root: Node)
     const dir = forward ? 'next' : 'prev';
     let node;
     while ((node = walker[dir]())) {
-      if (NodeType.isVoid(editor, node) || Unicode.isZwsp(node.textContent as string) || node.textContent?.length === 0) {
+      if (!(NodeType.isVoid(editor, node) || Unicode.isZwsp(node.textContent as string) || node.textContent?.length === 0)) {
         return Optional.some(node);
       }
     }

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -89,7 +89,7 @@ const getEndPointNode = (editor: Editor, rng: Range, start: Boolean, root: Node)
       }
     }
     if (!Unicode.isZwsp(container.textContent as string)) {
-      if ( container.parentNode !== null && isInline(SugarElement.fromDom(container.parentNode))) {
+      if (container.parentNode !== null && isInline(SugarElement.fromDom(container.parentNode))) {
         container = container.parentNode;
       }
       while (container.previousSibling !== null && (isInline(SugarElement.fromDom(container.previousSibling)) || NodeType.isTextNode(container.previousSibling))) {

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -1,12 +1,10 @@
 import { Optional, Type, Unicode } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
 
 import BookmarkManager from 'tinymce/core/api/dom/BookmarkManager';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
+import DomTreeWalker from 'tinymce/core/api/dom/TreeWalker';
 import Editor from 'tinymce/core/api/Editor';
-import { DomTreeWalker } from 'tinymce/core/api/PublicApi';
 import Tools from 'tinymce/core/api/util/Tools';
-import { isVoid } from 'tinymce/core/dom/ElementType';
 
 import { fireListEvent } from '../api/Events';
 import * as Bookmark from '../core/Bookmark';
@@ -79,7 +77,7 @@ const getEndPointNode = (editor: Editor, rng: Range, start: Boolean, root: Node)
     const dir = forward ? 'next' : 'prev';
     let node;
     while ((node = walker[dir]())) {
-      if (isVoid(SugarElement.fromDom(node) ) || Unicode.isZwsp(node.textContent as string) || node.textContent?.length === 0) {
+      if (NodeType.isVoid(editor, node) || Unicode.isZwsp(node.textContent as string) || node.textContent?.length === 0) {
         return Optional.some(node);
       }
     }

--- a/modules/tinymce/src/plugins/lists/main/ts/core/NodeType.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/NodeType.ts
@@ -39,6 +39,9 @@ const isTextBlock = (editor: Editor, node: Node | null): node is HTMLElement =>
 const isBlock = (node: Node | null, blockElements: Record<string, any>): boolean =>
   Type.isNonNullable(node) && node.nodeName in blockElements;
 
+const isVoid = (editor: Editor, node: Node | null): boolean =>
+  Type.isNonNullable(node) && node.nodeName in editor.schema.getVoidElements();
+
 const isBogusBr = (dom: DOMUtils, node: Node): node is HTMLBRElement => {
   if (!isBr(node)) {
     return false;
@@ -76,5 +79,6 @@ export {
   isBlock,
   isBogusBr,
   isEmpty,
-  isChildOfBody
+  isChildOfBody,
+  isVoid
 };

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ToggleListInTableCell.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ToggleListInTableCell.ts
@@ -1,0 +1,79 @@
+import { Keys } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/lists/Plugin';
+
+describe('browser.tinymce.plugins.lists.ToggleListWithEmptyLiTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    indent: false,
+    plugins: 'lists table',
+    toolbar: 'bullist',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const wrapInsideTable = (content: string): string =>
+    `<table style="border-collapse: collapse; width: 100%;" border="1"><colgroup><col style="width: 50%;"><col style="width: 50%;"></colgroup><tbody><tr><td>${content}</td></tr></tbody></table>`;
+
+  const wrapInsideTableWithList = (content: string): string =>
+    `<table style="border-collapse: collapse; width: 100%;" border="1"><colgroup><col style="width: 50%;"><col style="width: 50%;"></colgroup><tbody><tr><td><ul><li>${content}</li></ul></td></tr></tbody></table>`;
+
+  it('TINY-6853: toggle list inside table cell with anchor outside of anchor to the left of the anchor should include the anchor in the list', () => {
+    const editor = hook.editor();
+    const content = '<a href="#">link</a>';
+    editor.setContent(wrapInsideTable(content));
+    TinySelections.setCursor(editor, [ 0, 1, 0, 0, 0 ], 0);
+    // Needed to move the cursor outside of the link
+    TinyContentActions.keydown(editor, Keys.left());
+    TinyContentActions.keyup(editor, Keys.left());
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Bullet list"]');
+    TinyAssertions.assertContent(editor, wrapInsideTableWithList(content));
+  });
+  it('TINY-6853: toggle list inside table cell with anchor outside of anchor to the right of the anchor should include the anchor in the list', () => {
+    const editor = hook.editor();
+    const content = '<a href="#">link</a>';
+    editor.setContent(wrapInsideTable(content));
+    TinySelections.setCursor(editor, [ 0, 1, 0, 0, 0 ], 1);
+    // Needed to move the cursor outside of the link
+    TinyContentActions.keydown(editor, Keys.right());
+    TinyContentActions.keyup(editor, Keys.right());
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Bullet list"]');
+    TinyAssertions.assertContent(editor, wrapInsideTableWithList(content));
+  });
+  it('TINY-6853: toggle list inside table cell with anchor and other inline elements before the anchor should include all the inline elements in the list', () => {
+    const editor = hook.editor();
+    const content = 'abc <em>def</em> <a href="#">link</a>';
+    editor.setContent(wrapInsideTable(content));
+    TinySelections.setCursor(editor, [ 0, 1, 0, 0, 0 ], 1);
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Bullet list"]');
+    TinyAssertions.assertContent(editor, wrapInsideTableWithList(content));
+  });
+  it('TINY-6853: toggle list inside table cell with anchor and other inline elements after the anchor should include all the inline elements in the list', () => {
+    const editor = hook.editor();
+    const content = '<a href="#">link</a> abc <em>def</em>';
+    editor.setContent(wrapInsideTable(content));
+    TinySelections.setCursor(editor, [ 0, 1, 0, 0, 2, 0 ], 1);
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Bullet list"]');
+    TinyAssertions.assertContent(editor, wrapInsideTableWithList(content));
+  });
+  it('TINY-6853: toggle list inside table cell with anchor and other inline elements around the anchor should include all the inline elements in the list', () => {
+    const editor = hook.editor();
+    const content = 'abc <em>def</em> <a href="#">link</a> efg <em>hij</em>';
+    editor.setContent(wrapInsideTable(content));
+    TinySelections.setCursor(editor, [ 0, 1, 0, 0, 1, 0 ], 1);
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Bullet list"]');
+    TinyAssertions.assertContent(editor, wrapInsideTableWithList(content));
+  });
+  it('TINY-6853: toggle list inside table cell with cursor between two anchors should include both anchors in the list', () => {
+    const editor = hook.editor();
+    const content = '<a href="#">a</a><a href="#">b</a>';
+    editor.setContent(wrapInsideTable(content));
+    TinySelections.setCursor(editor, [ 0, 1, 0, 0, 1 ], 0);
+    // Needed to move the cursor outside of the link
+    TinyContentActions.keydown(editor, Keys.left());
+    TinyContentActions.keyup(editor, Keys.left());
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Bullet list"]');
+    TinyAssertions.assertContent(editor, wrapInsideTableWithList(content));
+  });
+});

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ToggleListInTableCell.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ToggleListInTableCell.ts
@@ -74,8 +74,7 @@ describe('browser.tinymce.plugins.lists.ToggleListWithEmptyLiTest', () => {
     editor.setContent(wrapInsideTable(content));
     TinySelections.setCursor(editor, [ 0, 1, 0, 0, 1 ], 0);
     // Needed to move the cursor outside of the link
-    TinyContentActions.keydown(editor, Keys.left());
-    TinyContentActions.keyup(editor, Keys.left());
+    TinyContentActions.keystroke(editor, Keys.left());
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Bullet list"]');
     TinyAssertions.assertContent(editor, wrapInsideTableWithList(content));
   });

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ToggleListInTableCell.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ToggleListInTableCell.ts
@@ -30,6 +30,15 @@ describe('browser.tinymce.plugins.lists.ToggleListWithEmptyLiTest', () => {
     TinyAssertions.assertContent(editor, wrapInsideTableWithList(content));
   });
 
+  it('TINY-6853: toggle list inside table cell with anchor containing an img tag outside of anchor to the left of the anchor should include the anchor in the list', () => {
+    const editor = hook.editor();
+    const content = '<a href="#"><strong><em><img src="#"></em></strong></a>';
+    editor.setContent(wrapInsideTable(content));
+    TinySelections.setCursor(editor, [ 0, 1, 0, 0, 0 ], 0);
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Bullet list"]');
+    TinyAssertions.assertContent(editor, wrapInsideTableWithList(content));
+  });
+
   it('TINY-6853: toggle list inside table cell with anchor outside of anchor to the right of the anchor should include the anchor in the list', () => {
     const editor = hook.editor();
     const content = '<a href="#">link</a>';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ToggleListInTableCell.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ToggleListInTableCell.ts
@@ -25,22 +25,22 @@ describe('browser.tinymce.plugins.lists.ToggleListWithEmptyLiTest', () => {
     editor.setContent(wrapInsideTable(content));
     TinySelections.setCursor(editor, [ 0, 1, 0, 0, 0 ], 0);
     // Needed to move the cursor outside of the link
-    TinyContentActions.keydown(editor, Keys.left());
-    TinyContentActions.keyup(editor, Keys.left());
+    TinyContentActions.keystroke(editor, Keys.left());
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Bullet list"]');
     TinyAssertions.assertContent(editor, wrapInsideTableWithList(content));
   });
+
   it('TINY-6853: toggle list inside table cell with anchor outside of anchor to the right of the anchor should include the anchor in the list', () => {
     const editor = hook.editor();
     const content = '<a href="#">link</a>';
     editor.setContent(wrapInsideTable(content));
     TinySelections.setCursor(editor, [ 0, 1, 0, 0, 0 ], 1);
     // Needed to move the cursor outside of the link
-    TinyContentActions.keydown(editor, Keys.right());
-    TinyContentActions.keyup(editor, Keys.right());
+    TinyContentActions.keystroke(editor, Keys.right());
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Bullet list"]');
     TinyAssertions.assertContent(editor, wrapInsideTableWithList(content));
   });
+
   it('TINY-6853: toggle list inside table cell with anchor and other inline elements before the anchor should include all the inline elements in the list', () => {
     const editor = hook.editor();
     const content = 'abc <em>def</em> <a href="#">link</a>';
@@ -49,6 +49,7 @@ describe('browser.tinymce.plugins.lists.ToggleListWithEmptyLiTest', () => {
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Bullet list"]');
     TinyAssertions.assertContent(editor, wrapInsideTableWithList(content));
   });
+
   it('TINY-6853: toggle list inside table cell with anchor and other inline elements after the anchor should include all the inline elements in the list', () => {
     const editor = hook.editor();
     const content = '<a href="#">link</a> abc <em>def</em>';
@@ -57,6 +58,7 @@ describe('browser.tinymce.plugins.lists.ToggleListWithEmptyLiTest', () => {
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Bullet list"]');
     TinyAssertions.assertContent(editor, wrapInsideTableWithList(content));
   });
+
   it('TINY-6853: toggle list inside table cell with anchor and other inline elements around the anchor should include all the inline elements in the list', () => {
     const editor = hook.editor();
     const content = 'abc <em>def</em> <a href="#">link</a> efg <em>hij</em>';
@@ -65,6 +67,7 @@ describe('browser.tinymce.plugins.lists.ToggleListWithEmptyLiTest', () => {
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Bullet list"]');
     TinyAssertions.assertContent(editor, wrapInsideTableWithList(content));
   });
+
   it('TINY-6853: toggle list inside table cell with cursor between two anchors should include both anchors in the list', () => {
     const editor = hook.editor();
     const content = '<a href="#">a</a><a href="#">b</a>';
@@ -76,4 +79,5 @@ describe('browser.tinymce.plugins.lists.ToggleListWithEmptyLiTest', () => {
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Bullet list"]');
     TinyAssertions.assertContent(editor, wrapInsideTableWithList(content));
   });
+
 });


### PR DESCRIPTION
Related Ticket: TINY-6853

Description of Changes:
* Toggling list inside a table cell with that has an anchor element in it, now includes the anchor element in the produced list

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
