### PR TITLE
TINY-9337: Remove focusing after toggling the toolbar

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
@@ -26,12 +26,11 @@ import * as Sketcher from './Sketcher';
 import { Toolbar } from './Toolbar';
 import { CompositeSketchFactory } from './UiSketcher';
 
-
 const onClose = (
   button: AlloyComponent,
   toolbar: AlloyComponent,
   ariaControls: AriaControls.AriaManager,
-  options?: { skipFocus: boolean },
+  options?: { skipFocus: boolean }
 ) => {
   Sandboxing.close(toolbar);
   if (!options?.skipFocus) {
@@ -39,7 +38,7 @@ const onClose = (
     Focusing.focus(button);
   }
   ariaControls.unlink(button.element);
-}
+};
 
 const toggle = (
   button: AlloyComponent,
@@ -93,7 +92,7 @@ const makeSandbox = (
   button: AlloyComponent,
   spec: FloatingToolbarButtonSpec,
   detail: FloatingToolbarButtonDetail,
-  ariaControls: AriaControls.AriaManager,
+  ariaControls: AriaControls.AriaManager
 ) => ({
   dom: {
     tag: 'div',
@@ -141,46 +140,47 @@ const factory: CompositeSketchFactory<FloatingToolbarButtonDetail, FloatingToolb
   const ariaControls = AriaControls.manager();
 
   return {
-  ...Button.sketch({
-    ...externals.button(),
-    action: (button) => {
-      toggle(button, externals, detail, spec, ariaControls);
-    },
-    buttonBehaviours: SketchBehaviours.augment(
-      { dump: externals.button().buttonBehaviours },
-      [
-        Coupling.config({
-          others: {
-            toolbarSandbox: (button) => {
-              return makeSandbox(button, spec, detail, ariaControls);
+    ...Button.sketch({
+      ...externals.button(),
+      action: (button) => {
+        toggle(button, externals, detail, spec, ariaControls);
+      },
+      buttonBehaviours: SketchBehaviours.augment(
+        { dump: externals.button().buttonBehaviours },
+        [
+          Coupling.config({
+            others: {
+              toolbarSandbox: (button) => {
+                return makeSandbox(button, spec, detail, ariaControls);
+              }
             }
-          }
-        })
-      ]
-    )
-  }),
-  apis: {
-    setGroups: (button: AlloyComponent, groups: AlloySpec[]) => {
-      Sandboxing.getState(Coupling.getCoupled(button, 'toolbarSandbox')).each((toolbar) => {
-        setGroups(button, toolbar, detail, spec.layouts, groups);
-      });
-    },
-    reposition: (button: AlloyComponent) => {
-      Sandboxing.getState(Coupling.getCoupled(button, 'toolbarSandbox')).each((toolbar) => {
-        position(button, toolbar, detail, spec.layouts);
-      });
-    },
-    toggle: (button: AlloyComponent, options: { skipFocus: boolean }) => {
-      toggle(button, externals, detail, spec, ariaControls, options);
-    },
-    getToolbar: (button: AlloyComponent) => {
-      return Sandboxing.getState(Coupling.getCoupled(button, 'toolbarSandbox'));
-    },
-    isOpen: (button: AlloyComponent) => {
-      return Sandboxing.isOpen(Coupling.getCoupled(button, 'toolbarSandbox'));
+          })
+        ]
+      )
+    }),
+    apis: {
+      setGroups: (button: AlloyComponent, groups: AlloySpec[]) => {
+        Sandboxing.getState(Coupling.getCoupled(button, 'toolbarSandbox')).each((toolbar) => {
+          setGroups(button, toolbar, detail, spec.layouts, groups);
+        });
+      },
+      reposition: (button: AlloyComponent) => {
+        Sandboxing.getState(Coupling.getCoupled(button, 'toolbarSandbox')).each((toolbar) => {
+          position(button, toolbar, detail, spec.layouts);
+        });
+      },
+      toggle: (button: AlloyComponent, options: { skipFocus: boolean }) => {
+        toggle(button, externals, detail, spec, ariaControls, options);
+      },
+      getToolbar: (button: AlloyComponent) => {
+        return Sandboxing.getState(Coupling.getCoupled(button, 'toolbarSandbox'));
+      },
+      isOpen: (button: AlloyComponent) => {
+        return Sandboxing.isOpen(Coupling.getCoupled(button, 'toolbarSandbox'));
+      }
     }
-  }
-  }};
+  };
+};
 
 const FloatingToolbarButton: FloatingToolbarButtonSketcher = Sketcher.composite<FloatingToolbarButtonSpec, FloatingToolbarButtonDetail, FloatingToolbarButtonApis>({
   name: 'FloatingToolbarButton',

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
@@ -33,8 +33,8 @@ const onClose = (
   options?: { skipFocus: boolean }
 ) => {
   Sandboxing.close(toolbar);
+  Toggling.off(button);
   if (!options?.skipFocus) {
-    Toggling.off(button);
     Focusing.focus(button);
   }
   ariaControls.unlink(button.element);

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
@@ -28,15 +28,19 @@ import { CompositeSketchFactory } from './UiSketcher';
 
 const shouldSkipFocus = Singleton.value<boolean>();
 
-const toggle = (button: AlloyComponent, externals: Record<string, any>, options?: { skipFocus: boolean }) => {
-  shouldSkipFocus.set(options?.skipFocus || false);
+const toggleWithoutFocusing = (button: AlloyComponent, externals: Record<string, any>) => {
+  shouldSkipFocus.set(true);
+  toggle(button, externals);
+  shouldSkipFocus.clear();
+};
+
+const toggle = (button: AlloyComponent, externals: Record<string, any>) => {
   const toolbarSandbox = Coupling.getCoupled(button, 'toolbarSandbox');
   if (Sandboxing.isOpen(toolbarSandbox)) {
     Sandboxing.close(toolbarSandbox);
   } else {
     Sandboxing.open(toolbarSandbox, externals.toolbar());
   }
-  shouldSkipFocus.clear();
 };
 
 const position = (button: AlloyComponent, toolbar: AlloyComponent, detail: FloatingToolbarButtonDetail, layouts: Layouts | undefined) => {
@@ -162,6 +166,9 @@ const factory: CompositeSketchFactory<FloatingToolbarButtonDetail, FloatingToolb
     toggle: (button: AlloyComponent) => {
       toggle(button, externals);
     },
+    toggleWithoutFocusing: (button: AlloyComponent) => {
+      toggleWithoutFocusing(button, externals);
+    },
     getToolbar: (button: AlloyComponent) => {
       return Sandboxing.getState(Coupling.getCoupled(button, 'toolbarSandbox'));
     },
@@ -183,8 +190,11 @@ const FloatingToolbarButton: FloatingToolbarButtonSketcher = Sketcher.composite<
     reposition: (apis, button) => {
       apis.reposition(button);
     },
-    toggle: (apis, button, options) => {
-      apis.toggle(button, options);
+    toggle: (apis, button) => {
+      apis.toggle(button);
+    },
+    toggleWithoutFocusing: (apis, button) => {
+      apis.toggleWithoutFocusing(button);
     },
     getToolbar: (apis, button) => apis.getToolbar(button),
     isOpen: (apis, button) => apis.isOpen(button)

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
@@ -69,10 +69,11 @@ const makeSandbox = (button: AlloyComponent, spec: FloatingToolbarButtonSpec, de
   const ariaControls = AriaControls.manager();
 
   const onOpen = (sandbox: AlloyComponent, toolbar: AlloyComponent) => {
+    const skipFocus = shouldSkipFocus.get().getOr(false);
     detail.fetch().get((groups) => {
       setGroups(button, toolbar, detail, spec.layouts, groups);
       ariaControls.link(button.element);
-      if (!shouldSkipFocus.get()) {
+      if (!skipFocus) {
         Keying.focusIn(toolbar);
       }
     });
@@ -81,7 +82,7 @@ const makeSandbox = (button: AlloyComponent, spec: FloatingToolbarButtonSpec, de
   const onClose = () => {
     // Toggle and focus the button
     Toggling.off(button);
-    if (!shouldSkipFocus.get()) {
+    if (!shouldSkipFocus.get().getOr(false)) {
       Focusing.focus(button);
     }
     ariaControls.unlink(button.element);

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitFloatingToolbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitFloatingToolbar.ts
@@ -88,9 +88,7 @@ const factory: CompositeSketchFactory<SplitFloatingToolbarDetail, SplitFloatingT
         });
       },
       toggleWithoutFocusing: (toolbar: AlloyComponent) => {
-        memFloatingToolbarButton.getOpt(toolbar).each((floatingToolbarButton) => {
-          FloatingToolbarButton.toggleWithoutFocusing(floatingToolbarButton);
-        });
+        memFloatingToolbarButton.getOpt(toolbar).each(FloatingToolbarButton.toggleWithoutFocusing);
       },
       isOpen: (toolbar: AlloyComponent) =>
         memFloatingToolbarButton.getOpt(toolbar).map(FloatingToolbarButton.isOpen).getOr(false),

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitFloatingToolbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitFloatingToolbar.ts
@@ -82,9 +82,14 @@ const factory: CompositeSketchFactory<SplitFloatingToolbarDetail, SplitFloatingT
         refresh(toolbar, memFloatingToolbarButton, detail);
       },
       refresh: (toolbar: AlloyComponent) => refresh(toolbar, memFloatingToolbarButton, detail),
-      toggle: (toolbar: AlloyComponent, options?: { skipFocus: boolean }) => {
+      toggle: (toolbar: AlloyComponent) => {
         memFloatingToolbarButton.getOpt(toolbar).each((floatingToolbarButton) => {
-          FloatingToolbarButton.toggle(floatingToolbarButton, options);
+          FloatingToolbarButton.toggle(floatingToolbarButton);
+        });
+      },
+      toggleWithoutFocusing: (toolbar: AlloyComponent) => {
+        memFloatingToolbarButton.getOpt(toolbar).each((floatingToolbarButton) => {
+          FloatingToolbarButton.toggleWithoutFocusing(floatingToolbarButton);
         });
       },
       isOpen: (toolbar: AlloyComponent) =>
@@ -119,8 +124,11 @@ const SplitFloatingToolbar: SplitFloatingToolbarSketcher = Sketcher.composite<Sp
     reposition: (apis, toolbar) => {
       apis.reposition(toolbar);
     },
-    toggle: (apis, toolbar, options) => {
-      apis.toggle(toolbar, options);
+    toggle: (apis, toolbar) => {
+      apis.toggle(toolbar);
+    },
+    toggleWithoutFocusing: (apis, toolbar) => {
+      apis.toggle(toolbar);
     },
     isOpen: (apis, toolbar) => apis.isOpen(toolbar),
     getOverflow: (apis, toolbar) => apis.getOverflow(toolbar)

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitFloatingToolbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitFloatingToolbar.ts
@@ -120,7 +120,7 @@ const SplitFloatingToolbar: SplitFloatingToolbarSketcher = Sketcher.composite<Sp
       apis.reposition(toolbar);
     },
     toggle: (apis, toolbar, options) => {
-      apis.toggle(toolbar);
+      apis.toggle(toolbar, options);
     },
     isOpen: (apis, toolbar) => apis.isOpen(toolbar),
     getOverflow: (apis, toolbar) => apis.getOverflow(toolbar)

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitFloatingToolbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitFloatingToolbar.ts
@@ -82,9 +82,9 @@ const factory: CompositeSketchFactory<SplitFloatingToolbarDetail, SplitFloatingT
         refresh(toolbar, memFloatingToolbarButton, detail);
       },
       refresh: (toolbar: AlloyComponent) => refresh(toolbar, memFloatingToolbarButton, detail),
-      toggle: (toolbar: AlloyComponent) => {
+      toggle: (toolbar: AlloyComponent, options?: { skipFocus: boolean }) => {
         memFloatingToolbarButton.getOpt(toolbar).each((floatingToolbarButton) => {
-          FloatingToolbarButton.toggle(floatingToolbarButton);
+          FloatingToolbarButton.toggle(floatingToolbarButton, options);
         });
       },
       isOpen: (toolbar: AlloyComponent) =>
@@ -119,7 +119,7 @@ const SplitFloatingToolbar: SplitFloatingToolbarSketcher = Sketcher.composite<Sp
     reposition: (apis, toolbar) => {
       apis.reposition(toolbar);
     },
-    toggle: (apis, toolbar) => {
+    toggle: (apis, toolbar, options) => {
       apis.toggle(toolbar);
     },
     isOpen: (apis, toolbar) => apis.isOpen(toolbar),

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/FloatingToolbarButtonTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/FloatingToolbarButtonTypes.ts
@@ -26,7 +26,7 @@ export interface FloatingToolbarButtonDetail extends CompositeSketchDetail, HasL
 export interface FloatingToolbarButtonApis {
   setGroups: (floatingToolbarButton: AlloyComponent, groups: AlloySpec[]) => Optional<AlloyComponent>;
   reposition: (floatingToolbarButton: AlloyComponent) => void;
-  toggle: (floatingToolbarButton: AlloyComponent) => void;
+  toggle: (floatingToolbarButton: AlloyComponent, options?: { skipFocus: boolean }) => void;
   getToolbar: (floatingToolbarButton: AlloyComponent) => Optional<AlloyComponent>;
   isOpen: (floatingToolbarButton: AlloyComponent) => boolean;
 }

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/FloatingToolbarButtonTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/FloatingToolbarButtonTypes.ts
@@ -26,7 +26,8 @@ export interface FloatingToolbarButtonDetail extends CompositeSketchDetail, HasL
 export interface FloatingToolbarButtonApis {
   setGroups: (floatingToolbarButton: AlloyComponent, groups: AlloySpec[]) => Optional<AlloyComponent>;
   reposition: (floatingToolbarButton: AlloyComponent) => void;
-  toggle: (floatingToolbarButton: AlloyComponent, options?: { skipFocus: boolean }) => void;
+  toggle: (floatingToolbarButton: AlloyComponent) => void;
+  toggleWithoutFocusing: (floatingToolbarButton: AlloyComponent) => void;
   getToolbar: (floatingToolbarButton: AlloyComponent) => Optional<AlloyComponent>;
   isOpen: (floatingToolbarButton: AlloyComponent) => boolean;
 }

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitToolbarBaseTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitToolbarBaseTypes.ts
@@ -18,7 +18,7 @@ export interface SplitToolbarBaseDetail extends CompositeSketchDetail {
 export interface SplitToolbarBaseApis {
   setGroups: (toolbar: AlloyComponent, groups: SketchSpec[]) => void;
   refresh: (toolbar: AlloyComponent) => void;
-  toggle: (toolbar: AlloyComponent) => void;
+  toggle: (toolbar: AlloyComponent, options?: { skipFocus: boolean }) => void;
   isOpen: (toolbar: AlloyComponent) => boolean;
 }
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitToolbarBaseTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitToolbarBaseTypes.ts
@@ -18,7 +18,8 @@ export interface SplitToolbarBaseDetail extends CompositeSketchDetail {
 export interface SplitToolbarBaseApis {
   setGroups: (toolbar: AlloyComponent, groups: SketchSpec[]) => void;
   refresh: (toolbar: AlloyComponent) => void;
-  toggle: (toolbar: AlloyComponent, options?: { skipFocus: boolean }) => void;
+  toggle: (toolbar: AlloyComponent) => void;
+  toggleWithoutFocusing: (toolbar: AlloyComponent) => void;
   isOpen: (toolbar: AlloyComponent) => boolean;
 }
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `color_default_foreground` and `color_default_background` options to set the initial default color for the `forecolor` and `backcolor` toolbar buttons and menu items. #TINY-9183
 - New `getTransparentElements` function added to `tinymce.html.Schema` to return a map object of transparent HTML elements. #TINY-9172
 - Added `ToggleToolbarDrawer` event to subscribe to toolbar’s opening and closing. #TINY-9271
+- Added `skipFocus` option to the `ToggleToolbarDrawer` command to preserve focus. #TINY-9337
 
 ### Changed
 - Transparent elements, like anchors, are now allowed in the root of the editor body if they contain blocks. #TINY-9172

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -425,8 +425,8 @@ const setup = (editor: Editor): RenderInfo => {
       OuterContainer.focusToolbar(outerContainer);
     });
 
-    editor.addCommand('ToggleToolbarDrawer', () => {
-      OuterContainer.toggleToolbarDrawer(outerContainer);
+    editor.addCommand('ToggleToolbarDrawer', (_ui, options?: { skipFocus: boolean }) => {
+      OuterContainer.toggleToolbarDrawer(outerContainer, options);
     });
 
     editor.addQueryStateHandler('ToggleToolbarDrawer', () => OuterContainer.isToolbarDrawerToggled(outerContainer));

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -426,7 +426,11 @@ const setup = (editor: Editor): RenderInfo => {
     });
 
     editor.addCommand('ToggleToolbarDrawer', (_ui, options?: { skipFocus: boolean }) => {
-      OuterContainer[options?.skipFocus ? 'toggleToolbarDrawerWithoutFocusing' : 'toggleToolbarDrawer'](outerContainer);
+      if (options?.skipFocus) {
+        OuterContainer.toggleToolbarDrawerWithoutFocusing(outerContainer);
+      } else {
+        OuterContainer.toggleToolbarDrawer(outerContainer);
+      }
     });
 
     editor.addQueryStateHandler('ToggleToolbarDrawer', () => OuterContainer.isToolbarDrawerToggled(outerContainer));

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -426,7 +426,7 @@ const setup = (editor: Editor): RenderInfo => {
     });
 
     editor.addCommand('ToggleToolbarDrawer', (_ui, options?: { skipFocus: boolean }) => {
-      OuterContainer.toggleToolbarDrawer(outerContainer, options);
+      OuterContainer[options?.skipFocus ? 'toggleToolbarDrawerWithoutFocusing' : 'toggleToolbarDrawer'](outerContainer);
     });
 
     editor.addQueryStateHandler('ToggleToolbarDrawer', () => OuterContainer.isToolbarDrawerToggled(outerContainer));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -65,7 +65,8 @@ interface OuterContainerApis {
   readonly setToolbar: (comp: AlloyComponent, groups: ToolbarGroup[]) => void;
   readonly setToolbars: (comp: AlloyComponent, toolbars: ToolbarGroup[][]) => void;
   readonly refreshToolbar: (comp: AlloyComponent) => void;
-  readonly toggleToolbarDrawer: (comp: AlloyComponent, options?: { skipFocus: boolean }) => void;
+  readonly toggleToolbarDrawer: (comp: AlloyComponent) => void;
+  readonly toggleToolbarDrawerWithoutFocusing: (comp: AlloyComponent) => void;
   readonly isToolbarDrawerToggled: (comp: AlloyComponent) => boolean;
   readonly getThrobber: (comp: AlloyComponent) => Optional<AlloyComponent>;
   readonly focusToolbar: (comp: AlloyComponent) => void;
@@ -81,7 +82,8 @@ interface OuterContainerApis {
 interface ToolbarApis {
   readonly setGroups: (toolbar: AlloyComponent, groups: SketchSpec[]) => void;
   readonly refresh: (toolbar: AlloyComponent) => void;
-  readonly toggle?: (toolbar: AlloyComponent, options?: { skipFocus: boolean }) => void;
+  readonly toggle: (toolbar: AlloyComponent) => void;
+  readonly toggleWithoutFocusing: (toolbar: AlloyComponent) => void;
   readonly isOpen?: (toolbar: AlloyComponent) => boolean;
 }
 
@@ -129,9 +131,14 @@ const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, Out
       const toolbar = Composite.parts.getPart(comp, detail, 'toolbar');
       toolbar.each((toolbar) => toolbar.getApis<ToolbarApis>().refresh(toolbar));
     },
-    toggleToolbarDrawer: (comp, options) => {
+    toggleToolbarDrawer: (comp) => {
       Composite.parts.getPart(comp, detail, 'toolbar').each((toolbar) => {
-        Optionals.mapFrom(toolbar.getApis<ToolbarApis>().toggle, (toggle) => toggle(toolbar, options));
+        Optionals.mapFrom(toolbar.getApis<ToolbarApis>().toggle, (toggle) => toggle(toolbar));
+      });
+    },
+    toggleToolbarDrawerWithoutFocusing: (comp) => {
+      Composite.parts.getPart(comp, detail, 'toolbar').each((toolbar) => {
+        Optionals.mapFrom(toolbar.getApis<ToolbarApis>().toggleWithoutFocusing, (toggleWithoutFocusing) => toggleWithoutFocusing(toolbar));
       });
     },
     isToolbarDrawerToggled: (comp) => {
@@ -421,8 +428,11 @@ export default Sketcher.composite<OuterContainerSketchSpec, OuterContainerSketch
     refreshToolbar: (apis, comp) => {
       return apis.refreshToolbar(comp);
     },
-    toggleToolbarDrawer: (apis, comp, options) => {
-      apis.toggleToolbarDrawer(comp, options);
+    toggleToolbarDrawer: (apis, comp) => {
+      apis.toggleToolbarDrawer(comp);
+    },
+    toggleToolbarDrawerWithoutFocusing: (apis, comp) => {
+      apis.toggleToolbarDrawerWithoutFocusing(comp);
     },
     isToolbarDrawerToggled: (apis, comp) => {
       return apis.isToolbarDrawerToggled(comp);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -65,7 +65,7 @@ interface OuterContainerApis {
   readonly setToolbar: (comp: AlloyComponent, groups: ToolbarGroup[]) => void;
   readonly setToolbars: (comp: AlloyComponent, toolbars: ToolbarGroup[][]) => void;
   readonly refreshToolbar: (comp: AlloyComponent) => void;
-  readonly toggleToolbarDrawer: (comp: AlloyComponent) => void;
+  readonly toggleToolbarDrawer: (comp: AlloyComponent, options?: { skipFocus: boolean }) => void;
   readonly isToolbarDrawerToggled: (comp: AlloyComponent) => boolean;
   readonly getThrobber: (comp: AlloyComponent) => Optional<AlloyComponent>;
   readonly focusToolbar: (comp: AlloyComponent) => void;
@@ -81,7 +81,7 @@ interface OuterContainerApis {
 interface ToolbarApis {
   readonly setGroups: (toolbar: AlloyComponent, groups: SketchSpec[]) => void;
   readonly refresh: (toolbar: AlloyComponent) => void;
-  readonly toggle?: (toolbar: AlloyComponent) => void;
+  readonly toggle?: (toolbar: AlloyComponent, options?: { skipFocus: boolean }) => void;
   readonly isOpen?: (toolbar: AlloyComponent) => boolean;
 }
 
@@ -129,9 +129,9 @@ const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, Out
       const toolbar = Composite.parts.getPart(comp, detail, 'toolbar');
       toolbar.each((toolbar) => toolbar.getApis<ToolbarApis>().refresh(toolbar));
     },
-    toggleToolbarDrawer: (comp) => {
+    toggleToolbarDrawer: (comp, options) => {
       Composite.parts.getPart(comp, detail, 'toolbar').each((toolbar) => {
-        Optionals.mapFrom(toolbar.getApis<ToolbarApis>().toggle, (toggle) => toggle(toolbar));
+        Optionals.mapFrom(toolbar.getApis<ToolbarApis>().toggle, (toggle) => toggle(toolbar, options));
       });
     },
     isToolbarDrawerToggled: (comp) => {
@@ -421,8 +421,8 @@ export default Sketcher.composite<OuterContainerSketchSpec, OuterContainerSketch
     refreshToolbar: (apis, comp) => {
       return apis.refreshToolbar(comp);
     },
-    toggleToolbarDrawer: (apis, comp) => {
-      apis.toggleToolbarDrawer(comp);
+    toggleToolbarDrawer: (apis, comp, options) => {
+      apis.toggleToolbarDrawer(comp, options);
     },
     isToolbarDrawerToggled: (apis, comp) => {
       return apis.isToolbarDrawerToggled(comp);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -1,6 +1,7 @@
-import { TestStore, Waiter } from '@ephox/agar';
+import { TestStore, Waiter, FocusTools } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
+import { SugarDocument } from '@ephox/sugar';
 import { McEditor, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -120,12 +121,14 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest',
         });
         await UiUtils.pWaitForEditorToRender();
         editor.focus();
-        const initialFocusedElement = document.activeElement;
+
+        const doc = SugarDocument.getDocument();
+        FocusTools.isOnSelector('Root element is focused', doc, 'iframe');
         editor.execCommand('ToggleToolbarDrawer', false, { skipFocus: true });
         await TinyUiActions.pWaitForUi(editor, '.tox-toolbar__overflow');
-        assert.equal(initialFocusedElement, document.activeElement, 'Focus should be preserved');
+        await FocusTools.pTryOnSelector('Focus should be preserved', doc, 'iframe');
         editor.execCommand('ToggleToolbarDrawer', false, { skipFocus: true });
-        assert.equal(initialFocusedElement, document.activeElement, 'Focus should be preserved');
+        await FocusTools.pTryOnSelector('Focus should be preserved', doc, 'iframe');
         McEditor.remove(editor);
       });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -107,4 +107,27 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest',
       });
     });
   });
+
+  context(`Should preserve focus if skipFocus: true option was passed`, () => {
+    Arr.each<ToolbarMode>([ 'floating', 'sliding' ], (toolbarMode) => {
+      it(`TINY-9337: Preserves focus in ${toolbarMode}`, async () => {
+        const editor = await McEditor.pFromSettings<Editor>({
+          menubar: false,
+          statusbar: false,
+          width: 200,
+          toolbar_mode: toolbarMode,
+          base_url: '/project/tinymce/js/tinymce'
+        });
+        await UiUtils.pWaitForEditorToRender();
+        editor.focus();
+        const initialFocusedElement = document.activeElement;
+        editor.execCommand('ToggleToolbarDrawer', false, { skipFocus: true });
+        await TinyUiActions.pWaitForUi(editor, '.tox-toolbar__overflow');
+        assert.equal(initialFocusedElement, document.activeElement, 'Focus should be preserved');
+        editor.execCommand('ToggleToolbarDrawer', false, { skipFocus: true });
+        assert.equal(initialFocusedElement, document.activeElement, 'Focus should be preserved');
+        McEditor.remove(editor);
+      });
+    });
+  });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -110,7 +110,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest',
 
   context(`Should preserve focus if skipFocus: true option was passed`, () => {
     Arr.each<ToolbarMode>([ 'floating', 'sliding' ], (toolbarMode) => {
-      it(`TINY-9337: Preserves focus in ${toolbarMode}`, async () => {
+      it(`TINY-9337: Preserves focus in ${toolbarMode} if skipFocus is true`, async () => {
         const editor = await McEditor.pFromSettings<Editor>({
           menubar: false,
           statusbar: false,
@@ -126,6 +126,29 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest',
         assert.equal(initialFocusedElement, document.activeElement, 'Focus should be preserved');
         editor.execCommand('ToggleToolbarDrawer', false, { skipFocus: true });
         assert.equal(initialFocusedElement, document.activeElement, 'Focus should be preserved');
+        McEditor.remove(editor);
+      });
+
+      it(`TINY-9337: Does not preserve focus in ${toolbarMode} if skipFocus is false`, async () => {
+        const editor = await McEditor.pFromSettings<Editor>({
+          menubar: false,
+          statusbar: false,
+          width: 200,
+          toolbar_mode: toolbarMode,
+          base_url: '/project/tinymce/js/tinymce'
+        });
+        await UiUtils.pWaitForEditorToRender();
+        editor.focus();
+        const initialFocusedElement = document.activeElement;
+        editor.execCommand('ToggleToolbarDrawer', false, { skipFocus: false });
+        await TinyUiActions.pWaitForUi(editor, '.tox-toolbar__overflow');
+        await Waiter.pTryUntil('Wait for toolbar to be completely open', () => {
+          assert.notEqual(initialFocusedElement, document.activeElement, 'Focus should not be preserved');
+        });
+        editor.execCommand('ToggleToolbarDrawer', false, { skipFocus: false });
+        await Waiter.pTryUntil('Wait for toolbar to be completely closed', () => {
+          assert.notEqual(initialFocusedElement, document.activeElement, 'Focus should not be preserved');
+        });
         McEditor.remove(editor);
       });
     });


### PR DESCRIPTION
Related Ticket: TINY-9337

Description of Changes:
* Removed focusing after toggling the toolbar in `FloatingToolbarButton`.

The focusing was added in the initial `FloatingToolbarButton` commit in 2019. I am not sure what are the consequences of removing it, but it definitely conflicts with `skip_focus` argument in `execCommend`.

Other solutions would be to refactor the `execCommand` in order to pass down `skip_focus` argument to all commands, but that feels like a major public API change.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-9337]: https://ephocks.atlassian.net/browse/TINY-9337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ