### PR TITLE
TINY-9335: Block Links - Selection allows 'Text to Display' in Link Dialog

### DIFF
--- a/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
@@ -105,14 +105,19 @@ const isOnlyTextSelected = (editor: Editor): boolean => {
   const isElement = (elm: Node): elm is Element =>
     elm.nodeType === 1 && !isAnchor(elm) && !Obj.has(inlineTextElements, elm.nodeName.toLowerCase());
 
+  // If selection is inside a block anchor then always treat it as non text only
+  const isInBlockAnchor = getAnchorElement(editor).exists((anchor) => anchor.hasAttribute('data-mce-block'));
+  if (isInBlockAnchor) {
+    return false;
+  }
+
   const rng = editor.selection.getRng();
   if (!rng.collapsed) {
     // Collect all non inline text elements in the range and make sure no elements were found
     const elements = collectNodesInRange(rng, isElement);
     return elements.length === 0;
   } else {
-    // If collapsed then make sure we're not in a block anchor
-    return getAnchorElement(editor).forall((anchor) => !anchor.hasAttribute('data-mce-block'));
+    return true;
   }
 };
 

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
@@ -162,5 +162,13 @@ describe('browser.tinymce.plugins.link.SelectedTextLinkTest', () => {
       await pOpenDialog(editor, false);
       await TestLinkUi.pClickCancel(editor);
     });
+
+    it('TINY-9335: Expanded selections inside a block link should not have text to display', async () => {
+      const editor = hook.editor();
+      editor.setContent('<div><a href="#"><p>block</p></a></div>');
+      TinySelections.setSelection(editor, [ 0, 0, 0, 0 ], 1, [ 0, 0, 0, 0 ], 3);
+      await pOpenDialog(editor, false);
+      await TestLinkUi.pClickCancel(editor);
+    });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9335

Description of Changes:
* Text to display will now be hidden if the selection is expanded within a block anchor

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
