### PR TITLE
Save the content updated by the event handler.

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -748,12 +748,12 @@ class Editor implements EditorObservable {
 
     const saveArgs = { ...getArgs, content: html } as SaveContentEvent;
     if (!saveArgs.no_events) {
-      self.dispatch('SaveContent', saveArgs);
+      saveArgs.content = self.dispatch('SaveContent', saveArgs).content;
     }
 
     // Always run this internal event
     if (saveArgs.format === 'raw') {
-      self.dispatch('RawSaveContent', saveArgs);
+      saveArgs.content = self.dispatch('RawSaveContent', saveArgs).content;
     }
 
     html = saveArgs.content;

--- a/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
@@ -243,6 +243,30 @@ describe('browser.tinymce.core.EditorTest', () => {
     assert.isUndefined(lastEvent, 'show/hide/isHidden and events');
   });
 
+  it('TBA: SaveContent adn RawSaveContent events', () => {
+    const editor = hook.editor();
+    const elm: any = document.getElementById(editor.id);
+
+    editor.on('SaveContent', (e) => {
+      e.content = e.content.replace(/abc/, 'xyz');
+    });
+    editor.on('RawSaveContent', (e) => {
+      e.content = e.content.replace(/def/, '123');
+    });
+
+    editor.setContent('abcdef');
+    editor.save();
+    assert.equal(elm.value, '<p>xyzdef</p>', 'save updated content in SaveContent');
+
+    editor.setContent('abcdef');
+    editor.save({ format: 'raw' });
+    assert.equal(elm.value, '<p>xyz123</p>', 'save updated content in SaveContent and RawSaveContent');
+
+    editor.setContent('abcdef');
+    editor.save({ no_events: true, format: 'raw' });
+    assert.equal(elm.value, '<p>abc123</p>', 'save updated content in RawSaveContent');
+  });
+
   it('TBA: hide save content and hidden state while saving', () => {
     const editor = hook.editor();
     let lastEvent: EditorEvent<SaveContentEvent> | undefined;


### PR DESCRIPTION
Related Ticket: 

Description of Changes:

If "content" is updated in "SaveContent" or "RawSaveContent", the updated "content" should be saved.
This behavior is also used in the following code.
https://github.com/tinymce/tinymce/blob/47f4372be1286754d1dcef8762c7eb0a645e5d24/modules/tinymce/src/core/main/ts/api/EditorUpload.ts#L247-L249

Pre-checks:
* [ ] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
