### PR TITLE
TINY-9226: Phase III => Constraining the popup sink bounds

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/alien/Boxes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/Boxes.ts
@@ -1,3 +1,4 @@
+import { Arr } from '@ephox/katamari';
 import { Height, SugarElement, SugarLocation, Width, WindowVisualViewport } from '@ephox/sugar';
 
 import * as OuterPosition from '../frame/OuterPosition';
@@ -78,6 +79,14 @@ const constrain = (original: Bounds, constraint: Bounds): Bounds => {
   );
 };
 
+const constrainByMany = (original: Bounds, constraints: Bounds[]): Bounds => {
+  return Arr.foldl(
+    constraints,
+    (acc, c) => constrain(acc, c),
+    original
+  );
+};
+
 const win = (): Bounds => WindowVisualViewport.getBounds(window);
 
 export {
@@ -87,5 +96,6 @@ export {
   box,
   absolute,
   win,
-  constrain
+  constrain,
+  constrainByMany
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/alien/Boxes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/Boxes.ts
@@ -63,6 +63,21 @@ const absolute = (element: SugarElement<HTMLElement>): Bounds => {
   return bounds(position.left, position.top, width, height);
 };
 
+const constrain = (original: Bounds, constraint: Bounds): Bounds => {
+  const left = Math.max(original.x, constraint.x);
+  const top = Math.max(original.y, constraint.y);
+  const right = Math.min(original.right, constraint.right);
+  const bottom = Math.min(original.bottom, constraint.bottom);
+  const width = right - left;
+  const height = bottom - top;
+  return bounds(
+    left,
+    top,
+    width,
+    height
+  );
+};
+
 const win = (): Bounds => WindowVisualViewport.getBounds(window);
 
 export {
@@ -71,5 +86,6 @@ export {
   bounds,
   box,
   absolute,
-  win
+  win,
+  constrain
 };

--- a/modules/alloy/src/test/ts/atomic/alien/BoxesTest.ts
+++ b/modules/alloy/src/test/ts/atomic/alien/BoxesTest.ts
@@ -1,11 +1,21 @@
 import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr, Optional } from '@ephox/katamari';
 import { assert } from 'chai';
 import fc from 'fast-check';
 
 import * as Boxes from 'ephox/alloy/alien/Boxes';
 
-// TODO: Add more tests.
 describe('atomic.alloy.alien.BoxesTest', () => {
+  const arbBounds: fc.Arbitrary<Boxes.Bounds> =
+    fc.tuple(
+      fc.nat(1000),
+      fc.nat(1000),
+      fc.nat(1000),
+      fc.nat(1000)
+    ).map(([ x, y, width, height ]) =>
+      Boxes.bounds(x, y, width, height)
+    );
+
   context('Boxes.constrain', () => {
     it('TINY-9226: Constraint equals box', () => {
       const actual = Boxes.constrain(
@@ -31,17 +41,7 @@ describe('atomic.alloy.alien.BoxesTest', () => {
     });
 
     context('Properties', () => {
-      const arbBounds: fc.Arbitrary<Boxes.Bounds> = fc.nat(1000).chain((x) =>
-        fc.nat(1000).chain((y) =>
-          fc.nat(1000).chain((width) =>
-            fc.nat(1000).map((height) =>
-              Boxes.bounds(x, y, width, height)
-            )
-          )
-        )
-      );
-
-      it('basic property - no outside constraints', () => {
+      it('TINY-9226: basic property - no outside constraints', () => {
         fc.assert(
           fc.property(arbBounds, arbBounds, (original, constraint) => {
             const actual = Boxes.constrain(original, constraint);
@@ -49,6 +49,76 @@ describe('atomic.alloy.alien.BoxesTest', () => {
             assert.isAtMost(actual.right, constraint.right);
             assert.isAtLeast(actual.y, constraint.y);
             assert.isAtMost(actual.bottom, constraint.bottom);
+          })
+        );
+      });
+    });
+  });
+
+  context('Boxes.constrainByMany', () => {
+    it('TINY-9226: Sanity test', () => {
+      const actual = Boxes.constrainByMany(
+        Boxes.bounds(100, 100, 500, 300),
+        [
+          Boxes.bounds(50, 50, 350, 200),
+          Boxes.bounds(0, 0, 1000, 1000),
+          Boxes.bounds(0, 0, 200, 1000)
+        ]
+      );
+      assert.deepEqual(
+        actual,
+        Boxes.bounds(100, 100, 200 - 100, 250 - 100)
+      );
+    });
+
+    context('Properties', () => {
+      const sortNumbers = (xs: number[]): number[] => {
+        return Arr.sort(xs, (a, b) => {
+          if (a < b) {
+            return -1;
+          } else if (b < a) {
+            return +1;
+          } else {
+            return 0;
+          }
+        });
+      };
+
+      it('TINY-9226: no constrants', () => {
+        fc.assert(
+          fc.property(arbBounds, (original) => {
+            const actual = Boxes.constrainByMany(original, [ ]);
+            assert.deepEqual(actual, original);
+          })
+        );
+      });
+      it('TINY-9226: basic property', () => {
+        fc.assert(
+          fc.property(arbBounds, arbBounds, fc.array(arbBounds), (original, first, rest) => {
+            const constraints = [ first ].concat(rest);
+            const all = [ original ].concat(constraints);
+            const actual = Boxes.constrainByMany(original, constraints);
+            const optLargestLeft = Arr.last(sortNumbers(Arr.map(all, (c) => c.x)));
+            const optLargestTop = Arr.last(sortNumbers(Arr.map(all, (c) => c.y)));
+            const optSmallestRight = Arr.head(sortNumbers(Arr.map(all, (c) => c.right)));
+            const optSmallestBottom = Arr.head(sortNumbers(Arr.map(all, (c) => c.bottom)));
+
+            const assertOpt = (label: string, optValue: Optional<number>, actualValue: number): void => {
+              optValue.fold(
+                () => assert.fail('There were no candidates. Actual value: ' + actualValue),
+                (v) => assert.equal(
+                  actualValue,
+                  v,
+                  `Property ${label}. Expected: ${v}, Actual: ${actualValue}, \n
+                   All: ${JSON.stringify(all, null, 2)}`
+                )
+              );
+            };
+
+            assertOpt('left', optLargestLeft, actual.x);
+            assertOpt('right', optSmallestRight, actual.right);
+            assertOpt('top', optLargestTop, actual.y);
+            assertOpt('bottom', optSmallestBottom, actual.bottom);
           })
         );
       });

--- a/modules/alloy/src/test/ts/atomic/alien/BoxesTest.ts
+++ b/modules/alloy/src/test/ts/atomic/alien/BoxesTest.ts
@@ -1,0 +1,57 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { assert } from 'chai';
+import fc from 'fast-check';
+
+import * as Boxes from 'ephox/alloy/alien/Boxes';
+
+// TODO: Add more tests.
+describe('atomic.alloy.alien.BoxesTest', () => {
+  context('Boxes.constrain', () => {
+    it('TINY-9226: Constraint equals box', () => {
+      const actual = Boxes.constrain(
+        Boxes.bounds(0, 0, 1000, 500),
+        Boxes.bounds(0, 0, 1000, 500)
+      );
+
+      assert.deepEqual(
+        actual,
+        Boxes.bounds(0, 0, 1000, 500)
+      );
+    });
+
+    it('TINY-9226: Constraint larger than box', () => {
+      const original = Boxes.bounds(100, 100, 800, 300);
+      const constraint = Boxes.bounds(0, 0, 1000, 500);
+      const actual = Boxes.constrain(original, constraint);
+
+      assert.deepEqual(
+        actual,
+        original
+      );
+    });
+
+    context('Properties', () => {
+      const arbBounds: fc.Arbitrary<Boxes.Bounds> = fc.nat(1000).chain((x) =>
+        fc.nat(1000).chain((y) =>
+          fc.nat(1000).chain((width) =>
+            fc.nat(1000).map((height) =>
+              Boxes.bounds(x, y, width, height)
+            )
+          )
+        )
+      );
+
+      it('basic property - no outside constraints', () => {
+        fc.assert(
+          fc.property(arbBounds, arbBounds, (original, constraint) => {
+            const actual = Boxes.constrain(original, constraint);
+            assert.isAtLeast(actual.x, constraint.x);
+            assert.isAtMost(actual.right, constraint.right);
+            assert.isAtLeast(actual.y, constraint.y);
+            assert.isAtMost(actual.bottom, constraint.bottom);
+          })
+        );
+      });
+    });
+  });
+});

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -1,5 +1,5 @@
 import {
-  AlloyComponent, AlloyEvents, AlloyParts, AlloySpec, Behaviour, Disabling, Gui, GuiFactory, Keying, Memento, Positioning, SimpleSpec, SystemEvents, VerticalDir
+  AlloyComponent, AlloyEvents, AlloyParts, AlloySpec, Behaviour, Boxes, Disabling, Gui, GuiFactory, Keying, Memento, Positioning, SimpleSpec, SystemEvents, VerticalDir
 } from '@ephox/alloy';
 import { Arr, Merger, Obj, Optional, Result, Singleton } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
@@ -63,10 +63,14 @@ export interface RenderArgs {
   readonly height: string;
 }
 
+export interface ThemeRenderSetup {
+  readonly getPopupSinkBounds: () => Boxes.Bounds;
+}
+
 const getLazyMothership = (label: string, singleton: Singleton.Value<Gui.GuiSystem>) =>
   singleton.get().getOrDie(`UI for ${label} has not been rendered`);
 
-const setup = (editor: Editor): RenderInfo => {
+const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
   const isInline = editor.inline;
   const mode = isInline ? Inline : Iframe;
 
@@ -320,7 +324,12 @@ const setup = (editor: Editor): RenderInfo => {
       },
       behaviours: Behaviour.derive([
         Positioning.config({
-          useFixed: () => header.isDocked(lazyHeader)
+          useFixed: () => header.isDocked(lazyHeader),
+
+          // TINY-9226: We want to limit the popup sink's bounds based on its scrolling environment. We don't
+          // want it to try to position things outside of its scrolling viewport, because they will
+          // just appear offscreen (hidden by the current scroll values)
+          getBounds: () => setupForTheme.getPopupSinkBounds()
         })
       ])
     };

--- a/modules/tinymce/src/themes/silver/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Theme.ts
@@ -42,17 +42,21 @@ export default (): void => {
     // the getPopupSinkBounds cell is required.
     const renderUI = (): RenderResult => {
       const renderResult = renderModeUI();
-      const optScrollingContext = ScrollingContext.detect(popups.getMothership().element);
-      optScrollingContext.each(
-        (sc) => popupSinkBounds.set(
-          () => {
-            // At this stage, it looks like we need to calculate the bounds each time, just in
-            // case the scrolling context details have changed since the last time. The bounds considers
-            // the Boxes.box sizes, which might change over time.
-            return ScrollingContext.getBoundsFrom(sc);
-          }
-        )
-      );
+
+      if (Options.isUiOfTomorrow(editor)) {
+        const optScrollingContext = ScrollingContext.detect(popups.getMothership().element);
+        optScrollingContext.each(
+          (sc) => popupSinkBounds.set(
+            () => {
+              // At this stage, it looks like we need to calculate the bounds each time, just in
+              // case the scrolling context details have changed since the last time. The bounds considers
+              // the Boxes.box sizes, which might change over time.
+              return ScrollingContext.getBoundsFrom(sc);
+            }
+          )
+        );
+      }
+
       return renderResult;
     };
 

--- a/modules/tinymce/src/themes/silver/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Theme.ts
@@ -1,11 +1,13 @@
-import { Fun } from '@ephox/katamari';
+import { Boxes } from '@ephox/alloy';
+import { Cell, Fun } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
-import ThemeManager, { Theme } from 'tinymce/core/api/ThemeManager';
+import ThemeManager, { RenderResult, Theme } from 'tinymce/core/api/ThemeManager';
 
 import NotificationManagerImpl from './alien/NotificationManagerImpl';
 import * as Options from './api/Options';
 import { Autocompleter } from './Autocompleter';
+import * as ScrollingContext from './modes/ScrollingContext';
 import * as Render from './Render';
 import * as ColorOptions from './ui/core/color/Options';
 import * as WindowManager from './ui/dialog/WindowManager';
@@ -22,7 +24,37 @@ const registerOptions = (editor: Editor) => {
 export default (): void => {
   ThemeManager.add('silver', (editor): Theme => {
     registerOptions(editor);
-    const { dialogs, popups, renderUI }: RenderInfo = Render.setup(editor);
+
+    // When using the ui_of_tomorrow, the popup sink is placed as a sibling to the
+    // editor, which means that it might be subject to any scrolling environments
+    // that the editor has. Therefore, we want to make the popup sink have an overall
+    // bounds that is depeendent on its scrolling environment. We don't know that ahead
+    // of time, so we use a cell whose value will change if there is a scrolling context.
+    const popupSinkBounds = Cell<() => Boxes.Bounds>(() => Boxes.win());
+
+    const { dialogs, popups, renderUI: renderModeUI }: RenderInfo = Render.setup(editor, {
+      // consult the cell to find out the bounds for the popup sink. When renderUI is
+      // called, this cell might have its value changed.
+      getPopupSinkBounds: () => popupSinkBounds.get()()
+    });
+
+    // We wrap the `renderModeUI` function being returned by Render so that we can update
+    // the getPopupSinkBounds cell is required.
+    const renderUI = (): RenderResult => {
+      const renderResult = renderModeUI();
+      const optScrollingContext = ScrollingContext.detect(popups.getMothership().element);
+      optScrollingContext.each(
+        (sc) => popupSinkBounds.set(
+          () => {
+            // At this stage, it looks like we need to calculate the bounds each time, just in
+            // case the scrolling context details have changed since the last time. The bounds considers
+            // the Boxes.box sizes, which might change over time.
+            return ScrollingContext.getBoundsFrom(sc);
+          }
+        )
+      );
+      return renderResult;
+    };
 
     Autocompleter.register(editor, popups.backstage.shared);
 

--- a/modules/tinymce/src/themes/silver/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Theme.ts
@@ -1,5 +1,5 @@
 import { Boxes } from '@ephox/alloy';
-import { Cell, Fun } from '@ephox/katamari';
+import { Fun } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import ThemeManager, { RenderResult, Theme } from 'tinymce/core/api/ThemeManager';
@@ -28,32 +28,32 @@ export default (): void => {
     // When using the ui_of_tomorrow, the popup sink is placed as a sibling to the
     // editor, which means that it might be subject to any scrolling environments
     // that the editor has. Therefore, we want to make the popup sink have an overall
-    // bounds that is depeendent on its scrolling environment. We don't know that ahead
-    // of time, so we use a cell whose value will change if there is a scrolling context.
-    const popupSinkBounds = Cell<() => Boxes.Bounds>(() => Boxes.win());
+    // bounds that is dependent on its scrolling environment. We don't know that ahead
+    // of time, so we use a mutable variable whose value will change if there is a scrolling context.
+    let popupSinkBounds = () => Boxes.win();
 
     const { dialogs, popups, renderUI: renderModeUI }: RenderInfo = Render.setup(editor, {
-      // consult the cell to find out the bounds for the popup sink. When renderUI is
-      // called, this cell might have its value changed.
-      getPopupSinkBounds: () => popupSinkBounds.get()()
+      // consult the mutable variable to find out the bounds for the popup sink. When renderUI is
+      // called, this mutable variable might be reassigned
+      getPopupSinkBounds: () => popupSinkBounds()
     });
 
     // We wrap the `renderModeUI` function being returned by Render so that we can update
-    // the getPopupSinkBounds cell is required.
+    // the getPopupSinkBounds mutable variable if required.
     const renderUI = (): RenderResult => {
       const renderResult = renderModeUI();
 
       if (Options.isUiOfTomorrow(editor)) {
         const optScrollingContext = ScrollingContext.detect(popups.getMothership().element);
         optScrollingContext.each(
-          (sc) => popupSinkBounds.set(
-            () => {
+          (sc) => {
+            popupSinkBounds = () => {
               // At this stage, it looks like we need to calculate the bounds each time, just in
               // case the scrolling context details have changed since the last time. The bounds considers
               // the Boxes.box sizes, which might change over time.
               return ScrollingContext.getBoundsFrom(sc);
-            }
-          )
+            };
+          }
         );
       }
 

--- a/modules/tinymce/src/themes/silver/main/ts/modes/ScrollingContext.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/ScrollingContext.ts
@@ -24,31 +24,31 @@ export const isScroller = (elem: SugarElement<Node> | any): boolean => {
 // NOTE: Calculating the list of scrolling ancestors each time this function is called might
 // be unnecessary. It will depend on its usage.
 export const detect = (poupSinkElem: SugarElement<HTMLElement>): Optional<ScrollingContext> => {
-  // We don't want to include popuSinkElem in the list of scrollers, so we just use "ancestors"
+  // We don't want to include popupSinkElem in the list of scrollers, so we just use "ancestors"
   const scrollers: SugarElement<HTMLElement>[] = PredicateFilter.ancestors(poupSinkElem, isScroller) as SugarElement<HTMLElement>[];
 
-  const closestScroller = Arr.head(scrollers);
-  return closestScroller.map(
-    (element) => ({
-      element,
-      // A list of all scrolling elements above the nearest scroller,
-      // ordered from closest to popup -> closest to top of document
-      others: scrollers.slice(1)
-    })
-  );
+  return Arr.head(scrollers)
+    .map(
+      (element) => ({
+        element,
+        // A list of all scrolling elements above the nearest scroller,
+        // ordered from closest to popup -> closest to top of document
+        others: scrollers.slice(1)
+      })
+    );
 };
 
 // Using all the scrolling viewports in the ancestry, limit the absolute
 // coordinates of window so that the bounds are limited by all the scrolling
 // viewports.
 export const getBoundsFrom = (sc: ScrollingContext): Bounds => {
-  const stencils = [
+  const scrollableBoxes = [
     ...Arr.map(sc.others, Boxes.box),
     Boxes.win()
   ];
-  return Arr.foldl(
-    stencils,
-    (acc, stencil) => Boxes.constrain(acc, stencil),
-    Boxes.box(sc.element)
+
+  return Boxes.constrainByMany(
+    Boxes.box(sc.element),
+    scrollableBoxes
   );
 };

--- a/modules/tinymce/src/themes/silver/main/ts/modes/ScrollingContext.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/ScrollingContext.ts
@@ -1,0 +1,54 @@
+import { Bounds, Boxes } from '@ephox/alloy';
+import { Arr, Optional, Strings } from '@ephox/katamari';
+import { Css, PredicateFilter, SugarElement, SugarNode } from '@ephox/sugar';
+
+export interface ScrollingContext {
+  readonly element: SugarElement<HTMLElement>;
+  readonly others: SugarElement<HTMLElement>[];
+}
+
+// TINY-9385: Investigate exactly what makes an element possibly
+// scrollable. This approach does not seem exhaustive. What about:
+// overflow-x, overflow-y etc.
+const nonScrollingOverflows = [ 'visible', 'hidden' ];
+
+export const isScroller = (elem: SugarElement<Node> | any): boolean => {
+  if (SugarNode.isHTMLElement(elem)) {
+    const overflow = Css.get(elem, 'overflow');
+    return Strings.trim(overflow).length > 0 && !Arr.contains(nonScrollingOverflows, overflow);
+  } else {
+    return false;
+  }
+};
+
+// NOTE: Calculating the list of scrolling ancestors each time this function is called might
+// be unnecessary. It will depend on its usage.
+export const detect = (poupSinkElem: SugarElement<HTMLElement>): Optional<ScrollingContext> => {
+  // We don't want to include popuSinkElem in the list of scrollers, so we just use "ancestors"
+  const scrollers: SugarElement<HTMLElement>[] = PredicateFilter.ancestors(poupSinkElem, isScroller) as SugarElement<HTMLElement>[];
+
+  const closestScroller = Arr.head(scrollers);
+  return closestScroller.map(
+    (element) => ({
+      element,
+      // A list of all scrolling elements above the nearest scroller,
+      // ordered from closest to popup -> closest to top of document
+      others: scrollers.slice(1)
+    })
+  );
+};
+
+// Using all the scrolling viewports in the ancestry, limit the absolute
+// coordinates of window so that the bounds are limited by all the scrolling
+// viewports.
+export const getBoundsFrom = (sc: ScrollingContext): Bounds => {
+  const stencils = [
+    ...Arr.map(sc.others, Boxes.box),
+    Boxes.win()
+  ];
+  return Arr.foldl(
+    stencils,
+    (acc, stencil) => Boxes.constrain(acc, stencil),
+    Boxes.box(sc.element)
+  );
+};

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverPopupSinkBoundsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverPopupSinkBoundsTest.ts
@@ -1,0 +1,135 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { Class, Css, Insert, Remove, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.SilverPopupSinkBoundsTest', () => {
+  const numItems = 100;
+  const sharedSettings = {
+    toolbar: 'undo bold',
+    base_url: '/project/tinymce/js/tinymce',
+    setup: (editor: Editor) => {
+      // Define lots and lots and lots of menu items
+      Arr.range(numItems, (x) => {
+        editor.ui.registry.addMenuItem(
+          `menu-item-${x}`,
+          {
+            type: 'menuitem',
+            text: `Item ${x}`
+          }
+        );
+      });
+    },
+    menubar: 'custom',
+    menu: {
+      custom: {
+        title: 'Custom menu',
+        items: Arr.range(numItems, (x) => `menu-item-${x}`).join(' ')
+      }
+    },
+  };
+
+  // These tests are going to create editor inside another divs, so that we can
+  // test whether the sinks are being put in the correct place.
+  const setupElement = (inline: boolean) => {
+
+    const scrollingContainer = SugarElement.fromTag('div');
+    Class.add(scrollingContainer, 'test-scrolling-viewport');
+    Css.set(scrollingContainer, 'overflow', 'scroll');
+    Css.set(scrollingContainer, 'height', '300px');
+
+    const banner = SugarElement.fromTag('div');
+    Css.setAll(banner, {
+      'width': '100%',
+      'height': '150px',
+      'background-color': 'purple'
+    });
+
+    const target = inline ? SugarElement.fromTag('div') : SugarElement.fromTag('textarea');
+
+    Insert.append(scrollingContainer, banner);
+    Insert.append(scrollingContainer, target);
+
+    // The Loader is going to try to insert `target` into the body if it isn't already in the body,
+    // so we insert grandparent here.
+    Insert.append(SugarBody.body(), scrollingContainer);
+
+    // We remove the outer most div, not just the target element
+    const teardown = () => {
+      Remove.remove(scrollingContainer);
+    };
+
+    return {
+      element: target,
+      teardown
+    };
+  };
+
+  const pOpenAndMeasureMenu = async (editor: Editor): Promise<DOMRect> => {
+    TinyUiActions.clickOnMenu(editor, 'span:contains("Custom")');
+
+    const menu = await TinyUiActions.pWaitForUi(editor, '[role=menu]');
+    return menu.dom.getBoundingClientRect();
+  };
+
+  const measureWrapper = (editor: Editor): DOMRect => {
+    const wrapper = Traverse.parent(
+      SugarElement.fromDom(editor.targetElm)
+    ).getOrDie('Could not find the wrapper') as SugarElement<HTMLElement>;
+    return wrapper.dom.getBoundingClientRect();
+  };
+
+  context('ui_of_tomorrow = false', () => {
+    const hook = TinyHooks.bddSetupFromElement<Editor>(
+      {
+        ...sharedSettings,
+        ui_of_tomorrow: false
+      },
+      () => setupElement(false),
+      []
+    );
+
+    it('TINY-9226: popup just needs to be inside window', async () => {
+      const editor = hook.editor();
+      assert.isFalse(editor.isHidden());
+
+      const marginOfError = 5;
+
+      const menuRect = await pOpenAndMeasureMenu(editor);
+      const wrapperRect = measureWrapper(editor);
+      // Compare the menu to the window
+      assert.isAbove(menuRect.top, -marginOfError, 'Menu should not appear above window');
+      assert.isBelow(menuRect.bottom, window.innerHeight, 'Menu should not below window');
+
+      // Compare the menu to the wrapper
+      assert.isAbove(menuRect.bottom, wrapperRect.bottom, 'Menu should extend outside wrapper');
+    });
+  });
+
+  context('ui_of_tomorrow = true', () => {
+    const hook = TinyHooks.bddSetupFromElement<Editor>(
+      {
+        ...sharedSettings,
+        ui_of_tomorrow: true
+      },
+      () => setupElement(false),
+      []
+    );
+
+    it('TINY-9226: popup needs to be inside scrolling container', async () => {
+      const editor = hook.editor();
+      assert.isFalse(editor.isHidden());
+
+      const marginOfError = 5;
+      const menuRect = await pOpenAndMeasureMenu(editor);
+      const wrapperRect = measureWrapper(editor);
+
+      // Compare the menu to the scrolling container
+      assert.isAbove(menuRect.top, wrapperRect.top - marginOfError, 'Menu should not appear above scrolling container');
+      assert.isBelow(menuRect.bottom, wrapperRect.bottom + marginOfError, 'Menu should not below scrolling container');
+    });
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/headless/modes/ScrollingContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/modes/ScrollingContextTest.ts
@@ -1,35 +1,97 @@
+import { Cursors } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { SugarElement } from '@ephox/sugar';
+import { Css, InsertAll, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import * as ScrollingContext from 'tinymce/themes/silver/modes/ScrollingContext';
 
 describe('headless.modes.ScrollingContextTest', () => {
   context('isScroller', () => {
-    it('overflow default - not a scroller', () => {
+    it('TINY-9226: overflow default - not a scroller', () => {
       const div = SugarElement.fromHtml('<div>A</div>');
       assert.isFalse(ScrollingContext.isScroller(div), 'Should not be a scroller');
     });
 
-    it('overflow: visible - not a scroller', () => {
+    it('TINY-9226: overflow: visible - not a scroller', () => {
       const div = SugarElement.fromHtml('<div style="overflow: visible;">A</div>');
       assert.isFalse(ScrollingContext.isScroller(div), 'Should not be a scroller');
     });
 
-    it('overflow: auto - a scroller', () => {
+    it('TINY-9226: overflow: auto - a scroller', () => {
       const div = SugarElement.fromHtml('<div style="overflow: auto;">A</div>');
       assert.isTrue(ScrollingContext.isScroller(div), 'Should be a scroller');
     });
 
-    it('overflow: scroll - a scroller', () => {
+    it('TINY-9226: overflow: scroll - a scroller', () => {
       const div = SugarElement.fromHtml('<div style="overflow: scroll;">A</div>');
       assert.isTrue(ScrollingContext.isScroller(div), 'Should be a scroller');
     });
   });
 
-  // context('detect', () => {
+  context('detect', () => {
 
-  // });
+    const makeWith = (nodeName: string, styles: Record<string, string>, children: SugarElement<Node>[]): SugarElement<Node> => {
+      const parent = SugarElement.fromTag(nodeName);
+      Css.setAll(parent, styles);
+      InsertAll.append(parent, children);
+      return parent;
+    };
+
+    it('TINY-9226: no scrolling contexts', () => {
+      const situation = makeWith('div', { }, [
+        makeWith('div', { }, [
+          makeWith('div', { }, [
+            makeWith('div', { }, [
+
+            ])
+          ])
+        ])
+      ]);
+
+      const target = Cursors.follow(situation, [ 0, 0, 0 ]).getOrDie() as SugarElement<HTMLElement>;
+
+      const optActual = ScrollingContext.detect(target);
+      assert.isTrue(optActual.isNone(), 'There should be no scrolling context');
+    });
+
+    it('TINY-9226: several scrolling contexts', () => {
+      const situation = makeWith('div', {
+        overflow: 'auto'
+      }, [
+        makeWith('div', {
+          overflow: 'auto'
+        }, [
+          makeWith('div', {
+            overflow: 'scroll'
+          }, [
+            makeWith('div', { }, [
+
+            ])
+          ])
+        ])
+      ]);
+
+      const follow = (path: number[]): SugarElement<HTMLElement> =>
+        Cursors.follow(situation, path).getOrDie() as SugarElement<HTMLElement>;
+
+      const target = follow([ 0, 0, 0 ]);
+
+      const optActual = ScrollingContext.detect(target);
+      optActual.fold(
+        () => assert.fail('Should have found a scrolling context'),
+        (actual) => assert.deepEqual(
+          actual,
+          {
+            element: follow([ 0, 0 ]),
+            others: [
+              follow([ 0 ]),
+              follow([ ])
+            ]
+          }
+        )
+      );
+    });
+  });
 
   // context('getBoundsFrom', () => {
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/modes/ScrollingContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/modes/ScrollingContextTest.ts
@@ -1,5 +1,6 @@
 import { Cursors } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { Css, InsertAll, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
@@ -93,7 +94,7 @@ describe('headless.modes.ScrollingContextTest', () => {
     });
   });
 
-  // context('getBoundsFrom', () => {
-
-  // });
+  context('getBoundsFrom', () => {
+    it.skip('TINY-9226: Sanity test', () => Fun.noop);
+  });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/headless/modes/ScrollingContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/modes/ScrollingContextTest.ts
@@ -1,0 +1,37 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
+
+import * as ScrollingContext from 'tinymce/themes/silver/modes/ScrollingContext';
+
+describe('headless.modes.ScrollingContextTest', () => {
+  context('isScroller', () => {
+    it('overflow default - not a scroller', () => {
+      const div = SugarElement.fromHtml('<div>A</div>');
+      assert.isFalse(ScrollingContext.isScroller(div), 'Should not be a scroller');
+    });
+
+    it('overflow: visible - not a scroller', () => {
+      const div = SugarElement.fromHtml('<div style="overflow: visible;">A</div>');
+      assert.isFalse(ScrollingContext.isScroller(div), 'Should not be a scroller');
+    });
+
+    it('overflow: auto - a scroller', () => {
+      const div = SugarElement.fromHtml('<div style="overflow: auto;">A</div>');
+      assert.isTrue(ScrollingContext.isScroller(div), 'Should be a scroller');
+    });
+
+    it('overflow: scroll - a scroller', () => {
+      const div = SugarElement.fromHtml('<div style="overflow: scroll;">A</div>');
+      assert.isTrue(ScrollingContext.isScroller(div), 'Should be a scroller');
+    });
+  });
+
+  // context('detect', () => {
+
+  // });
+
+  // context('getBoundsFrom', () => {
+
+  // });
+});


### PR DESCRIPTION
Related Ticket: TINY-9226

Description of Changes:
* restrict the popup sink to show within visible areas of the (possibly nested) scrollable viewports

Pre-checks:
* [N/A] Changelog entry added - deferring
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [N/A] Docs ticket created (if applicable) - no documentation required.

GitHub issues (if applicable):
