### PR TITLE
TINY-8984: Preparation for 6.3 community release

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ Tiny Technologies, Inc. supports the following community versions of TinyMCE:
 | Version | Supported                      |
 |---------| ------------------------------ |
 | 5.10.x  | &#10004;                       |
-| 6.2.x   | &#10004;                       |
+| 6.3.x   | &#10004;                       |
 | Other   | &#10006;                       |
 
 For supported enterprise versions of TinyMCE, refer to the enterprise [Supported TinyMCE versions documentation](https://www.tiny.cloud/docs/tinymce/6/support/#supportedversionsandplatforms).

--- a/modules/acid/package.json
+++ b/modules/acid/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@ephox/acid",
   "description": "Color library including Alloy UI component for a color picker",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
     "directory": "modules/acid"
   },
   "dependencies": {
-    "@ephox/alloy": "^11.0.1",
-    "@ephox/boulder": "^7.1.1",
-    "@ephox/katamari": "^9.1.1",
-    "@ephox/sugar": "^9.1.1",
+    "@ephox/alloy": "^12.0.0",
+    "@ephox/boulder": "^7.1.2",
+    "@ephox/katamari": "^9.1.2",
+    "@ephox/sugar": "^9.1.2",
     "tslib": "^2.0.0"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",

--- a/modules/agar/CHANGELOG.md
+++ b/modules/agar/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 7.3.0 - 2022-11-23
+
 ### Added
 - Added `TestStore` API, which was moved from Alloy and requires types. #TINY-9157
 - Added `exactAttrs`, `exactClasses` and `exactStyles` to `ApproxStructures.element`. #TINY-9102

--- a/modules/agar/package.json
+++ b/modules/agar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/agar",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "description": "Testing infrastructure",
   "repository": {
     "type": "git",
@@ -26,16 +26,16 @@
   "dependencies": {
     "@ephox/bedrock-client": "11 || 12 || 13",
     "@ephox/bedrock-common": "11 || 12 || 13",
-    "@ephox/jax": "^7.0.5",
-    "@ephox/sand": "^6.0.5",
-    "@ephox/sugar": "^9.1.1",
+    "@ephox/jax": "^7.0.6",
+    "@ephox/sand": "^6.0.6",
+    "@ephox/sugar": "^9.1.2",
     "@types/sizzle": "^2.3.3",
     "fast-check": "^2.0.0",
     "sizzle": "^2.3.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^4.0.5"
+    "@ephox/katamari-assertions": "^4.0.6"
   },
   "files": [
     "lib/main",

--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 12.0.0 - 2022-11-23
+
 ### Added
 - Added `previousSelector` optional property to `MenuMatrixMovementSpec`, to start with the selected item in focus. #TINY-9283
 - Added the `onToggled` callback for the `FloatingToolbarButton` component. #TINY-9271

--- a/modules/alloy/package.json
+++ b/modules/alloy/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@ephox/alloy",
-  "version": "11.0.1",
+  "version": "12.0.0",
   "description": "Ui Framework",
   "dependencies": {
-    "@ephox/agar": "^7.2.1",
-    "@ephox/boulder": "^7.1.1",
-    "@ephox/katamari": "^9.1.1",
-    "@ephox/sand": "^6.0.5",
-    "@ephox/sugar": "^9.1.1",
+    "@ephox/agar": "^7.3.0",
+    "@ephox/boulder": "^7.1.2",
+    "@ephox/katamari": "^9.1.2",
+    "@ephox/sand": "^6.0.6",
+    "@ephox/sugar": "^9.1.2",
     "tslib": "^2.0.0"
   },
   "files": [

--- a/modules/boss/package.json
+++ b/modules/boss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/boss",
   "description": "Generic wrapper to document models - DomUniverse vs TestUniverse",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -19,12 +19,12 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^9.1.1",
-    "@ephox/sugar": "^9.1.1",
+    "@ephox/katamari": "^9.1.2",
+    "@ephox/sugar": "^9.1.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^4.0.5"
+    "@ephox/katamari-assertions": "^4.0.6"
   },
   "scripts": {
     "prepublishOnly": "tsc -b",

--- a/modules/boulder/package.json
+++ b/modules/boulder/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@ephox/boulder",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "Basic javascript object validation",
   "dependencies": {
-    "@ephox/katamari": "^9.1.1"
+    "@ephox/katamari": "^9.1.2"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^4.0.5"
+    "@ephox/katamari-assertions": "^4.0.6"
   },
   "scripts": {
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",

--- a/modules/bridge/CHANGELOG.md
+++ b/modules/bridge/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 4.2.0 - 2022-11-23
+
 ### Added
 - Added optional `storageKey` property to `colorinput` component and `colorswatch` fancy menu item. #TINY-9184
 - New `view` component. #TINY-9210

--- a/modules/bridge/package.json
+++ b/modules/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/bridge",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "Ui API for TinyMCE 5",
   "repository": {
     "type": "git",
@@ -13,8 +13,8 @@
     "lint": "eslint --config ../../.eslintrc.json src/**/*.ts"
   },
   "dependencies": {
-    "@ephox/boulder": "^7.1.1",
-    "@ephox/katamari": "^9.1.1",
+    "@ephox/boulder": "^7.1.2",
+    "@ephox/katamari": "^9.1.2",
     "tslib": "^2.0.0"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",

--- a/modules/darwin/package.json
+++ b/modules/darwin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/darwin",
   "description": "This project's purpose is to handle selection and cursor navigation.",
-  "version": "8.0.6",
+  "version": "8.0.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -19,12 +19,12 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^9.1.1",
-    "@ephox/phoenix": "^8.0.5",
-    "@ephox/robin": "^10.0.5",
-    "@ephox/sand": "^6.0.5",
-    "@ephox/snooker": "^11.0.6",
-    "@ephox/sugar": "^9.1.1",
+    "@ephox/katamari": "^9.1.2",
+    "@ephox/phoenix": "^8.0.6",
+    "@ephox/robin": "^10.0.6",
+    "@ephox/sand": "^6.0.6",
+    "@ephox/snooker": "^11.0.7",
+    "@ephox/sugar": "^9.1.2",
     "tslib": "^2.0.0"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",

--- a/modules/dragster/package.json
+++ b/modules/dragster/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/dragster",
   "description": "This project handles dragging.",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -19,9 +19,9 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^9.1.1",
-    "@ephox/porkbun": "^7.0.5",
-    "@ephox/sugar": "^9.1.1",
+    "@ephox/katamari": "^9.1.2",
+    "@ephox/porkbun": "^7.0.6",
+    "@ephox/sugar": "^9.1.2",
     "tslib": "^2.0.0"
   },
   "scripts": {

--- a/modules/jax/package.json
+++ b/modules/jax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/jax",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "description": "AJAX library",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
-    "@ephox/katamari": "^9.1.1",
+    "@ephox/katamari": "^9.1.2",
     "tslib": "^2.0.0"
   },
   "files": [

--- a/modules/katamari-assertions/package.json
+++ b/modules/katamari-assertions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/katamari-assertions",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "Bedrock test assertions for Katamari",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   "dependencies": {
     "@ephox/bedrock-client": "11 || 12 || 13",
     "@ephox/dispute": "^1.0.3",
-    "@ephox/katamari": "^9.1.1",
+    "@ephox/katamari": "^9.1.2",
     "tslib": "^2.0.0"
   },
   "files": [

--- a/modules/katamari/package.json
+++ b/modules/katamari/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/katamari",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "description": "Basic data type library",
   "repository": {
     "type": "git",

--- a/modules/mcagar/CHANGELOG.md
+++ b/modules/mcagar/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 8.2.0 - 2022-11-23
+
 ## Added
 - Add new `pWaitForEventToStopFiring` function to the `TinyContentActions` helper methods to allow tests to wait until an event stops being triggered.
 

--- a/modules/mcagar/package.json
+++ b/modules/mcagar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/mcagar",
-  "version": "8.1.1",
+  "version": "8.2.0",
   "description": "Tinymce agar wrapper",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
-    "@ephox/agar": "^7.2.1",
-    "@ephox/katamari": "^9.1.1",
-    "@ephox/sand": "^6.0.5",
-    "@ephox/sugar": "^9.1.1",
+    "@ephox/agar": "^7.3.0",
+    "@ephox/katamari": "^9.1.2",
+    "@ephox/sand": "^6.0.6",
+    "@ephox/sugar": "^9.1.2",
     "fast-check": "^2.0.0",
     "tslib": "^2.0.0"
   },

--- a/modules/oxide-icons-default/package.json
+++ b/modules/oxide-icons-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/oxide-icons-default",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "The default icon pack for TinyMCE",
   "repository": {
     "type": "git",

--- a/modules/oxide/package.json
+++ b/modules/oxide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/oxide",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "TinyMCE 5 Oxide skin",
   "repository": {
     "type": "git",

--- a/modules/phoenix/package.json
+++ b/modules/phoenix/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/phoenix",
   "description": "DOM node text gathering library, rose from the ashes of some other projects we can't remember the names of now (edit: seek, sherlock, gift)",
-  "version": "8.0.5",
+  "version": "8.0.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -19,14 +19,14 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/boss": "^6.0.5",
-    "@ephox/katamari": "^9.1.1",
-    "@ephox/polaris": "^6.0.5",
-    "@ephox/sugar": "^9.1.1",
+    "@ephox/boss": "^6.0.6",
+    "@ephox/katamari": "^9.1.2",
+    "@ephox/polaris": "^6.0.6",
+    "@ephox/sugar": "^9.1.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^4.0.5"
+    "@ephox/katamari-assertions": "^4.0.6"
   },
   "scripts": {
     "test-manual": "bedrock -d src/test",

--- a/modules/polaris/package.json
+++ b/modules/polaris/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/polaris",
   "description": "This project does data manipulation on arrays and strings.",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -19,11 +19,11 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^9.1.1",
+    "@ephox/katamari": "^9.1.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^4.0.5"
+    "@ephox/katamari-assertions": "^4.0.6"
   },
   "scripts": {
     "prepublishOnly": "tsc -b",

--- a/modules/porkbun/package.json
+++ b/modules/porkbun/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/porkbun",
   "description": "Event framework for JavaScript",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -19,7 +19,7 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^9.1.1"
+    "@ephox/katamari": "^9.1.2"
   },
   "scripts": {
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",

--- a/modules/robin/package.json
+++ b/modules/robin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/robin",
   "description": "This project is for grouping sibling DOM nodes together by boundary points, for example the list of elements and nodes representing a word.",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -19,15 +19,15 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/boss": "^6.0.5",
-    "@ephox/katamari": "^9.1.1",
-    "@ephox/phoenix": "^8.0.5",
-    "@ephox/polaris": "^6.0.5",
-    "@ephox/sugar": "^9.1.1",
+    "@ephox/boss": "^6.0.6",
+    "@ephox/katamari": "^9.1.2",
+    "@ephox/phoenix": "^8.0.6",
+    "@ephox/polaris": "^6.0.6",
+    "@ephox/sugar": "^9.1.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^4.0.5"
+    "@ephox/katamari-assertions": "^4.0.6"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",

--- a/modules/sand/package.json
+++ b/modules/sand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/sand",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "description": "Platform detection library",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
-    "@ephox/katamari": "^9.1.1",
+    "@ephox/katamari": "^9.1.2",
     "tslib": "^2.0.0"
   },
   "main": "./lib/main/ts/ephox/sand/api/Main.js",

--- a/modules/snooker/package.json
+++ b/modules/snooker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/snooker",
   "description": "This project implements the table model.",
-  "version": "11.0.6",
+  "version": "11.0.7",
   "files": [
     "lib/main",
     "lib/demo",
@@ -19,11 +19,11 @@
     "directory": "modules/snooker"
   },
   "dependencies": {
-    "@ephox/dragster": "^7.0.5",
-    "@ephox/katamari": "^9.1.1",
-    "@ephox/porkbun": "^7.0.5",
-    "@ephox/robin": "^10.0.5",
-    "@ephox/sugar": "^9.1.1",
+    "@ephox/dragster": "^7.0.6",
+    "@ephox/katamari": "^9.1.2",
+    "@ephox/porkbun": "^7.0.6",
+    "@ephox/robin": "^10.0.6",
+    "@ephox/sugar": "^9.1.2",
     "tslib": "^2.0.0"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",

--- a/modules/sugar/package.json
+++ b/modules/sugar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/sugar",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "description": "Basic DOM manipulation",
   "repository": {
     "type": "git",
@@ -22,11 +22,11 @@
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
-    "@ephox/katamari": "^9.1.1",
-    "@ephox/sand": "^6.0.5"
+    "@ephox/katamari": "^9.1.2",
+    "@ephox/sand": "^6.0.6"
   },
   "devDependencies": {
-    "@ephox/katamari-assertions": "^4.0.5"
+    "@ephox/katamari-assertions": "^4.0.6"
   },
   "files": [
     "lib/main",

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 6.3.0 - 2022-11-23
+
 ### Added
 - New `expand` function added to `tinymce.selection` which expands the selection around the nearest word. #TINY-9001
 - New `expand` function added to `tinymce.dom.RangeUtils` to return a new range expanded around the nearest word. #TINY-9001

--- a/versions.txt
+++ b/versions.txt
@@ -1,7 +1,2 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
-
-alloy@12.0.0
-agar@7.3.0
-bridge@4.2.0
-mcagar@8.2.0


### PR DESCRIPTION
Related ticket: TINY-8984

Description of Changes:
* Added changelog dates for monorepo libraries being released per `versions.txt`
* Bump monorepo libraries to their respective versions and cleaned `versions.txt`.
* Update SECURITY.md and CHANGELOG.md

Note: The TinyMCE changelog/package.json was already up to date due to previous PRs.

Monorepo version changes:
```
 - @ephox/acid: 5.0.5 => 5.0.6
 - @ephox/agar: 7.2.1 => 7.3.0
 - @ephox/alloy: 11.0.1 => 12.0.0
 - @ephox/boss: 6.0.5 => 6.0.6
 - @ephox/boulder: 7.1.1 => 7.1.2
 - @ephox/bridge: 4.1.1 => 4.2.0
 - @ephox/darwin: 8.0.6 => 8.0.7
 - @ephox/dragster: 7.0.5 => 7.0.6
 - @ephox/jax: 7.0.5 => 7.0.6
 - @ephox/katamari-assertions: 4.0.5 => 4.0.6
 - @ephox/katamari: 9.1.1 => 9.1.2
 - @ephox/mcagar: 8.1.1 => 8.2.0
 - @tinymce/oxide-icons-default: 2.1.1 => 2.1.2
 - @tinymce/oxide: 2.2.1 => 2.3.0
 - @ephox/phoenix: 8.0.5 => 8.0.6
 - @ephox/polaris: 6.0.5 => 6.0.6
 - @ephox/porkbun: 7.0.5 => 7.0.6
 - @ephox/robin: 10.0.5 => 10.0.6
 - @ephox/sand: 6.0.5 => 6.0.6
 - @ephox/snooker: 11.0.6 => 11.0.7
 - @ephox/sugar: 9.1.1 => 9.1.2
```


Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
