### PR TITLE
TINY-9148: Fix scrolling to the bottom after closing a dialog in Safari

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- Changed positioning behaviour position style from `relative` to `absolute` to avoid Safari autoscroll. #TINY-9148
+
 ## 12.0.0 - 2022-11-23
 
 ### Added

--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Changed
-- Changed positioning behaviour position style from `relative` to `absolute` to avoid Safari autoscroll. #TINY-9148
+- Changed `useFixed` function to `usePositioningType` to allow usage of `absolute` positioning which fixes autoscrolling in Safari. #TINY-9148
 
 ## 12.0.0 - 2022-11-23
 

--- a/modules/alloy/package.json
+++ b/modules/alloy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/alloy",
-  "version": "12.0.1",
+  "version": "13.0.0",
   "description": "Ui Framework",
   "dependencies": {
     "@ephox/agar": "^7.3.1",

--- a/modules/alloy/src/demo/ts/ephox/alloy/demo/DemoSink.ts
+++ b/modules/alloy/src/demo/ts/ephox/alloy/demo/DemoSink.ts
@@ -10,7 +10,7 @@ const make = (): AlloyComponent => GuiFactory.build(
   Container.sketch({
     containerBehaviours: Behaviour.derive([
       Positioning.config({
-        useFixed: Fun.always
+        usePositioningType: Fun.constant('fixed')
       })
     ])
   })

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/ActivePosition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/ActivePosition.ts
@@ -1,12 +1,12 @@
 import { DomDefinitionDetail } from '../../dom/DomDefinition';
 import * as DomModification from '../../dom/DomModification';
-import { PositioningConfig, PositioningType  } from './PositioningTypes';
+import { PositioningConfig, PositioningType } from './PositioningTypes';
 
 const getStyles = (positioningType: PositioningType): Record<string, string> => {
   if (positioningType === 'relative') {
     return { position: 'relative' };
   } else if (positioningType === 'absolute') {
-    // Elements with `position: absolute` and without any content collapse, 
+    // Elements with `position: absolute` and without any content collapse,
     // so theirs width equals 0. That differs from `position: relative` behaviour,
     // which preserves containers width.
     return { position: 'absolute', width: '100%' };
@@ -15,7 +15,7 @@ const getStyles = (positioningType: PositioningType): Record<string, string> => 
   }
 };
 
-const exhibit = (base: DomDefinitionDetail, posConfig: PositioningConfig): DomModification.DomModification => 
+const exhibit = (base: DomDefinitionDetail, posConfig: PositioningConfig): DomModification.DomModification =>
   DomModification.nu({
     classes: [ ],
     styles: getStyles(posConfig.usePositioningType()),

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/ActivePosition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/ActivePosition.ts
@@ -5,7 +5,7 @@ import { PositioningConfig } from './PositioningTypes';
 const exhibit = (base: DomDefinitionDetail, posConfig: PositioningConfig): DomModification.DomModification =>
   DomModification.nu({
     classes: [ ],
-    styles: posConfig.useFixed() ? { } : { position: 'relative' }
+    styles: posConfig.useFixed() ? { } : { position: 'absolute', width: '100%' }
   });
 
 export {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/ActivePosition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/ActivePosition.ts
@@ -6,6 +6,9 @@ const getStyles = (positioningType: PositioningType): Record<string, string> => 
   if (positioningType === 'relative') {
     return { position: 'relative' };
   } else if (positioningType === 'absolute') {
+    // Elements with `position: absolute` and without any content collapse, 
+    // so theirs width equals 0. That differs from `position: relative` behaviour,
+    // which preserves containers width.
     return { position: 'absolute', width: '100%' };
   } else {
     return { };

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/ActivePosition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/ActivePosition.ts
@@ -1,15 +1,21 @@
 import { DomDefinitionDetail } from '../../dom/DomDefinition';
 import * as DomModification from '../../dom/DomModification';
-import { PositioningConfig } from './PositioningTypes';
+import { PositioningConfig, PositioningType  } from './PositioningTypes';
 
-const exhibit = (base: DomDefinitionDetail, posConfig: PositioningConfig): DomModification.DomModification =>
+const getStyles = (positioningType: PositioningType): Record<string, string> => {
+  if (positioningType === 'relative') {
+    return { position: 'relative' };
+  } else if (positioningType === 'absolute') {
+    return { position: 'absolute', width: '100%' };
+  } else {
+    return { };
+  }
+};
+
+const exhibit = (base: DomDefinitionDetail, posConfig: PositioningConfig): DomModification.DomModification => 
   DomModification.nu({
     classes: [ ],
-    styles: {
-      fixed: { },
-      relative: { position: 'relative' },
-      absolute: { position: 'absolute', width: '100%' }
-    }[posConfig.usePositioningType()]
+    styles: getStyles(posConfig.usePositioningType()),
   });
 
 export {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/ActivePosition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/ActivePosition.ts
@@ -5,7 +5,11 @@ import { PositioningConfig } from './PositioningTypes';
 const exhibit = (base: DomDefinitionDetail, posConfig: PositioningConfig): DomModification.DomModification =>
   DomModification.nu({
     classes: [ ],
-    styles: posConfig.useFixed() ? { } : { position: 'absolute', width: '100%' }
+    styles: {
+      fixed: { },
+      relative: { position: 'relative' },
+      absolute: { position: 'absolute', width: '100%' }
+    }[posConfig.usePositioningType()]
   });
 
 export {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
@@ -15,6 +15,9 @@ import { Transition } from '../../positioning/view/Transitions';
 import { PlacementDetail, PlacementSpec, PositioningConfig, PositioningState } from './PositioningTypes';
 import { PlacementSchema } from './PositionSchema';
 
+const isFixed = (posConfig: PositioningConfig): boolean =>
+  posConfig.usePositioningType() === 'fixed';
+
 const getFixedOrigin = (): Origins.OriginAdt => {
   // Don't use window.innerWidth/innerHeight here, as we don't want to include scrollbars
   // since the right/bottom position is based on the edge of the scrollbar not the window
@@ -63,9 +66,7 @@ const positionWithinBounds = (component: AlloyComponent, posConfig: PositioningC
     // We need to calculate the origin (esp. the bounding client rect) *after* we have done
     // all the preprocessing of the component and placee. Otherwise, the relative positions
     // (bottom and right) will be using the wrong dimensions
-    const origin = posConfig.usePositioningType() === 'fixed'
-      ? getFixedOrigin()
-      : getRelativeOrigin(component);
+    const origin = isFixed(posConfig) ? getFixedOrigin() : getRelativeOrigin(component);
 
     const placer = anchorage.placement;
 
@@ -98,7 +99,7 @@ const positionWithinBounds = (component: AlloyComponent, posConfig: PositioningC
 };
 
 const getMode = (component: AlloyComponent, pConfig: PositioningConfig, _pState: PositioningState): string =>
-  pConfig.usePositioningType() === 'fixed' ? 'fixed' : 'absolute';
+  isFixed(pConfig) ? 'fixed' : 'absolute';
 
 const reset = (component: AlloyComponent, pConfig: PositioningConfig, posState: PositioningState, placee: AlloyComponent): void => {
   const element = placee.element;

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
@@ -63,7 +63,9 @@ const positionWithinBounds = (component: AlloyComponent, posConfig: PositioningC
     // We need to calculate the origin (esp. the bounding client rect) *after* we have done
     // all the preprocessing of the component and placee. Otherwise, the relative positions
     // (bottom and right) will be using the wrong dimensions
-    const origin = posConfig.useFixed() ? getFixedOrigin() : getRelativeOrigin(component);
+    const origin = posConfig.usePositioningType() === 'fixed'
+      ? getFixedOrigin()
+      : getRelativeOrigin(component);
 
     const placer = anchorage.placement;
 
@@ -96,7 +98,7 @@ const positionWithinBounds = (component: AlloyComponent, posConfig: PositioningC
 };
 
 const getMode = (component: AlloyComponent, pConfig: PositioningConfig, _pState: PositioningState): string =>
-  pConfig.useFixed() ? 'fixed' : 'absolute';
+  pConfig.usePositioningType() === 'fixed' ? 'fixed' : 'absolute';
 
 const reset = (component: AlloyComponent, pConfig: PositioningConfig, posState: PositioningState, placee: AlloyComponent): void => {
   const element = placee.element;

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionSchema.ts
@@ -1,5 +1,5 @@
-import { FieldSchema, ValueType } from '@ephox/boulder';
-import { Fun } from '@ephox/katamari';
+import { FieldSchema, ValueType, StructureSchema } from '@ephox/boulder';
+import { Arr, Fun, Result } from '@ephox/katamari';
 
 import AnchorSchema from '../../positioning/mode/AnchorSchema';
 
@@ -9,7 +9,14 @@ const TransitionSchema = [
 ];
 
 export const PositionSchema = [
-  FieldSchema.defaulted('usePositioningType', Fun.constant('relative')),
+  FieldSchema.defaultedOf(
+    'usePositioningType',
+    Fun.constant('relative'),
+    StructureSchema.valueOf((val) =>
+      Arr.contains([ 'fixed', 'relative', 'absolute' ], val())
+        ? Result.value(val)
+        : Result.error('Invalid value for usePositioningType'))),
+
   FieldSchema.option('getBounds')
 ];
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionSchema.ts
@@ -15,7 +15,7 @@ export const PositionSchema = [
     StructureSchema.valueOf((val) =>
       Arr.contains([ 'fixed', 'relative', 'absolute' ], val())
         ? Result.value(val)
-        : Result.error('Invalid value for usePositioningType'))),
+        : Result.error(`Invalid value ${val()} for usePositioningType`))),
 
   FieldSchema.option('getBounds')
 ];

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionSchema.ts
@@ -9,7 +9,7 @@ const TransitionSchema = [
 ];
 
 export const PositionSchema = [
-  FieldSchema.defaulted('useFixed', Fun.never),
+  FieldSchema.defaulted('usePositioningType', Fun.constant('relative')),
   FieldSchema.option('getBounds')
 ];
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositioningTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositioningTypes.ts
@@ -38,13 +38,15 @@ export interface PositioningBehaviour extends Behaviour.AlloyBehaviour<Positioni
   readonly reset: (component: AlloyComponent, placee: AlloyComponent) => void;
 }
 
+export type PositioningType = 'fixed' | 'relative' | 'absolute';
+
 export interface PositioningConfigSpec extends Behaviour.BehaviourConfigSpec {
-  readonly useFixed?: () => boolean;
+  readonly usePositioningType?: () => PositioningType;
   readonly getBounds?: () => Bounds;
 }
 
 export interface PositioningConfig extends Behaviour.BehaviourConfigDetail {
-  readonly useFixed: () => boolean;
+  readonly usePositioningType: () => PositioningType;
   readonly getBounds: Optional<() => Bounds>;
 }
 

--- a/modules/alloy/src/main/ts/ephox/alloy/parts/InternalSink.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/parts/InternalSink.ts
@@ -16,7 +16,7 @@ const partType = Fun.constant(PartType.optional({
     behaviours: Behaviour.derive([
       Positioning.config({
         // TODO: Make an internal sink also be able to be used with relative layouts
-        useFixed: Fun.always
+        usePositioningType: Fun.constant('fixed')
       })
     ]),
     events: AlloyEvents.derive([

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/DropdownListTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/DropdownListTest.ts
@@ -27,7 +27,7 @@ UnitTest.asynctest('Dropdown List', (success, failure) => {
     Container.sketch({
       containerBehaviours: Behaviour.derive([
         Positioning.config({
-          useFixed: Fun.always
+          usePositioningType: Fun.constant('fixed')
         })
       ])
     })

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/DropdownMenuTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/DropdownMenuTest.ts
@@ -26,7 +26,7 @@ UnitTest.asynctest('DropdownMenuTest', (success, failure) => {
     Container.sketch({
       containerBehaviours: Behaviour.derive([
         Positioning.config({
-          useFixed: Fun.always
+          usePositioningType: Fun.constant('fixed')
         })
       ])
     })

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/DropdownRefetchTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/DropdownRefetchTest.ts
@@ -31,7 +31,7 @@ UnitTest.asynctest('DropdownRefetchTest', (success, failure) => {
     Container.sketch({
       containerBehaviours: Behaviour.derive([
         Positioning.config({
-          useFixed: Fun.always
+          usePositioningType: Fun.constant('fixed')
         })
       ])
     })

--- a/modules/alloy/src/test/ts/browser/ui/dropdown/SplitDropdownTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dropdown/SplitDropdownTest.ts
@@ -23,7 +23,7 @@ UnitTest.asynctest('SplitDropdown List', (success, failure) => {
     Container.sketch({
       containerBehaviours: Behaviour.derive([
         Positioning.config({
-          useFixed: Fun.always
+          usePositioningType: Fun.constant('fixed')
         })
       ])
     })

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/Sinks.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/Sinks.ts
@@ -24,7 +24,7 @@ const fixedSink = (): AlloyComponent => GuiFactory.build(
     uid: 'fixed-sink',
     containerBehaviours: Behaviour.derive([
       Positioning.config({
-        useFixed: Fun.always
+        usePositioningType: Fun.constant('fixed')
       })
     ])
   })
@@ -41,7 +41,7 @@ const relativeSink = (): AlloyComponent => GuiFactory.build(
     uid: 'relative-sink',
     containerBehaviours: Behaviour.derive([
       Positioning.config({
-        useFixed: Fun.always
+        usePositioningType: Fun.constant('fixed')
       })
     ])
   })

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogTest.ts
@@ -1,5 +1,7 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { Scroll } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/searchreplace/Plugin';
@@ -10,6 +12,7 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceDialogTest', () => 
   const hook = TinyHooks.bddSetupInShadowRoot<Editor>({
     plugins: 'searchreplace',
     menubar: false,
+    height: 2000,
     toolbar: 'searchreplace',
     base_url: '/project/tinymce/js/tinymce',
   }, [ Plugin ]);
@@ -111,5 +114,14 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceDialogTest', () => 
     await Utils.pAssertFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'fish');
     findAndAssertFound(editor, 3);
     TinyUiActions.closeDialog(editor);
+  });
+
+  it('TINY-9148: Scroll should remain in place after the dialog is closed', async () => {
+    const editor = hook.editor();
+    const doc = TinyDom.document(editor);
+    const initialScroll = Scroll.get(doc);
+    await Utils.pOpenDialog(editor);
+    TinyUiActions.closeDialog(editor);
+    assert.equal(initialScroll.top, Scroll.get(doc).top);
   });
 });

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -279,7 +279,9 @@ const setup = (editor: Editor): RenderInfo => {
       },
       behaviours: Behaviour.derive([
         Positioning.config({
-          useFixed: () => header.isDocked(lazyHeader)
+          // TINY-9148: Using absolute positioning here because Safari
+          // tries to focus the sink after it's content is changed with relative positioning.
+          usePositioningType: () => header.isDocked(lazyHeader) ? 'fixed' :  'absolute'
         })
       ])
     };

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -280,7 +280,7 @@ const setup = (editor: Editor): RenderInfo => {
       behaviours: Behaviour.derive([
         Positioning.config({
           // TINY-9148: Using absolute positioning here because Safari
-          // tries to focus the sink after it's content is changed with relative positioning.
+          // tries to focus the sink after its content is changed with relative positioning.
           usePositioningType: () => header.isDocked(lazyHeader) ? 'fixed' : 'absolute'
         })
       ])

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -281,7 +281,7 @@ const setup = (editor: Editor): RenderInfo => {
         Positioning.config({
           // TINY-9148: Using absolute positioning here because Safari
           // tries to focus the sink after it's content is changed with relative positioning.
-          usePositioningType: () => header.isDocked(lazyHeader) ? 'fixed' :  'absolute'
+          usePositioningType: () => header.isDocked(lazyHeader) ? 'fixed' : 'absolute'
         })
       ])
     };

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestExtras.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestExtras.ts
@@ -35,7 +35,7 @@ export const TestExtras = (): TestExtras => {
     dom: DomFactory.fromHtml('<div class="mce-silver-sink test-dialogs-sink"></div>'),
     behaviours: Behaviour.derive([
       Positioning.config({
-        useFixed: Fun.always
+        usePositioningType: Fun.constant('fixed')
       })
     ])
   });
@@ -44,7 +44,7 @@ export const TestExtras = (): TestExtras => {
     dom: DomFactory.fromHtml('<div class="mce-silver-sink test-popups-sink"></div>'),
     behaviours: Behaviour.derive([
       Positioning.config({
-        useFixed: Fun.always
+        usePositioningType: Fun.constant('fixed')
       })
     ])
   });

--- a/versions.txt
+++ b/versions.txt
@@ -1,2 +1,4 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
+
+alloy@13.0.0


### PR DESCRIPTION
Related Ticket: TINY-9148

Description of Changes:
* Changes `position` style value from `relative` to `absolute` in alloy's positioning behaviour.

The issue is that after removing the dialog from the sink Safari tries to focus the sink if it's positioning is `relative`, thus scrolling the page down. Using `absolute` value for positioning helps prevent the scrolling and keeps the sink in the same place. 

That's a bit of a radical change though. Maybe use it only in Safari?

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
