### PR TITLE
TINY-4818: Wrap invalid list child nodes within list items

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Improved
-- Direct invalid child nodes of list elements will be wrapped in list item elements. #TINY-4818
+- Direct invalid child text nodes of list elements will be wrapped in list item elements. #TINY-4818
 
 ## 6.3.0 - 2022-11-23
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Improved
+- Direct invalid child nodes of list elements will be wrapped in list item elements. #TINY-4818
+
 ## 6.3.0 - 2022-11-23
 
 ### Added

--- a/modules/tinymce/src/plugins/lists/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/Plugin.ts
@@ -3,6 +3,7 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Api from './api/Api';
 import * as Commands from './api/Commands';
 import * as Options from './api/Options';
+import * as FilterContent from './core/FilterContent';
 import * as Keyboard from './core/Keyboard';
 import * as Buttons from './ui/Buttons';
 import * as MenuItems from './ui/MenuItems';
@@ -10,6 +11,7 @@ import * as MenuItems from './ui/MenuItems';
 export default (): void => {
   PluginManager.add('lists', (editor) => {
     Options.register(editor);
+    FilterContent.setup(editor);
 
     if (!editor.hasPlugin('rtc', true)) {
       Keyboard.setup(editor);

--- a/modules/tinymce/src/plugins/lists/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/FilterContent.ts
@@ -1,0 +1,46 @@
+import { Arr } from '@ephox/katamari';
+
+import Editor from 'tinymce/core/api/Editor';
+import AstNode from 'tinymce/core/api/html/Node';
+
+const isListItem = (node: AstNode) => node.name === 'li';
+const isEmpty = (nodeBuffer: AstNode[]) => nodeBuffer.length === 0;
+
+const wrapInvalidChildren = (list: AstNode) => {
+  const insertListItem = (buffer: AstNode[], refNode?: AstNode) => {
+    const li = AstNode.create('li');
+    Arr.each(buffer, (node) => li.append(node));
+    if (refNode) {
+      list.insert(li, refNode, true);
+    } else {
+      list.append(li);
+    }
+  };
+
+  const reducer = (buffer: AstNode[], node: AstNode): AstNode[] => {
+    if (!isListItem(node)) {
+      return [ ...buffer, node ];
+    } else if (!isEmpty(buffer) && isListItem(node)) {
+      insertListItem(buffer, node);
+      return [];
+    } else {
+      return buffer;
+    }
+  };
+
+  const restBuffer = Arr.foldl(list.children(), reducer, []);
+  if (!isEmpty(restBuffer)) {
+    insertListItem(restBuffer);
+  }
+};
+
+const setup = (editor: Editor): void => {
+  editor.on('PreInit', () => {
+    const { parser } = editor;
+    parser.addNodeFilter('ul, ol', (nodes) => Arr.each(nodes, wrapInvalidChildren ));
+  });
+};
+
+export {
+  setup
+};

--- a/modules/tinymce/src/plugins/lists/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/FilterContent.ts
@@ -37,7 +37,7 @@ const wrapInvalidChildren = (list: AstNode) => {
 const setup = (editor: Editor): void => {
   editor.on('PreInit', () => {
     const { parser } = editor;
-    parser.addNodeFilter('ul, ol', (nodes) => Arr.each(nodes, wrapInvalidChildren ));
+    parser.addNodeFilter('ul,ol', (nodes) => Arr.each(nodes, wrapInvalidChildren));
   });
 };
 

--- a/modules/tinymce/src/plugins/lists/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/FilterContent.ts
@@ -3,7 +3,7 @@ import { Arr } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import AstNode from 'tinymce/core/api/html/Node';
 
-const isListItem = (node: AstNode) => node.name === 'li';
+const isTextNode = (node: AstNode) => node.type === 3;
 const isEmpty = (nodeBuffer: AstNode[]) => nodeBuffer.length === 0;
 
 const wrapInvalidChildren = (list: AstNode) => {
@@ -18,9 +18,9 @@ const wrapInvalidChildren = (list: AstNode) => {
   };
 
   const reducer = (buffer: AstNode[], node: AstNode): AstNode[] => {
-    if (!isListItem(node)) {
+    if (isTextNode(node)) {
       return [ ...buffer, node ];
-    } else if (!isEmpty(buffer) && isListItem(node)) {
+    } else if (!isEmpty(buffer) && !isTextNode(node)) {
       insertListItem(buffer, node);
       return [];
     } else {

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/FilterContentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/FilterContentTest.ts
@@ -1,0 +1,41 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/lists/Plugin';
+
+describe('browser.tinymce.plugins.lists.FilterContentTest', () => {
+  context(' wrapping the list child text nodes within list item elements', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      plugins: 'lists',
+      indent: false,
+      base_url: '/project/tinymce/js/tinymce'
+    }, [ Plugin ]);
+
+    it('TINY-4818: text node as a list first child', () => {
+      const editor = hook.editor();
+      editor.setContent('<ul>TEXT<li>a</li></ul>');
+      TinyAssertions.assertContent(editor, '<ul><li>TEXT</li><li>a</li></ul>');
+    });
+
+    it('TINY-4818: text node between the list items', () => {
+      const editor = hook.editor();
+      editor.setContent('<ul><li>a</li>TEXT<li>b</li></ul>');
+      TinyAssertions.assertContent(editor, '<ul><li>a</li><li>TEXT</li><li>b</li></ul>');
+    });
+
+    it('TINY-4818: text node as a list last child', () => {
+      const editor = hook.editor();
+      editor.setContent('<ul><li>a</li>TEXT</ul>');
+      TinyAssertions.assertContent(editor, '<ul><li>a</li><li>TEXT</li></ul>');
+    });
+
+    it('TINY-4818: complex case for ordered list', () => {
+      const editor = hook.editor();
+      editor.setContent('<ol>Text1<li>a</li><li>b</li>Text2<li>c</li>Text3</ol>');
+      TinyAssertions.assertContent(editor, '<ol><li>Text1</li><li>a</li><li>b</li><li>Text2</li><li>c</li><li>Text3</li></ol>');
+    });
+  });
+
+});
+

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/FilterContentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/FilterContentTest.ts
@@ -5,7 +5,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
 
 describe('browser.tinymce.plugins.lists.FilterContentTest', () => {
-  context(' wrapping the list child text nodes within list item elements', () => {
+  context('wrapping the list child text nodes within list item elements', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       plugins: 'lists',
       indent: false,


### PR DESCRIPTION
Related Ticket: TINY-4818

Description of Changes:
*  added content filter for lists to wrap invalid child nodes in `li` elements

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
