### PR TITLE
TINY-9395: menu colorswatch fixup

### DIFF
--- a/modules/bridge/CHANGELOG.md
+++ b/modules/bridge/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Added optional `select`-property to `colorswatch`-type `fancymenuitem` to allow setting colors as selected. #TINY-9395
 
 ## 4.2.0 - 2022-11-23
 

--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/FancyMenuItem.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/FancyMenuItem.ts
@@ -23,6 +23,7 @@ export interface InsertTableMenuItemSpec extends BaseFancyMenuItemSpec<'insertta
 
 export interface ColorSwatchMenuItemSpec extends BaseFancyMenuItemSpec<'colorswatch'> {
   fancytype: 'colorswatch';
+  select?: (value: string) => boolean;
   initData?: {
     allowCustomColors?: boolean;
     colors?: ChoiceMenuItemSpec[];
@@ -46,6 +47,7 @@ export interface InsertTableMenuItem extends BaseFancyMenuItem<'inserttable'> {
 
 export interface ColorSwatchMenuItem extends BaseFancyMenuItem<'colorswatch'> {
   fancytype: 'colorswatch';
+  select: Optional<(value: string) => boolean>;
   initData: {
     allowCustomColors: boolean;
     colors: Optional<ChoiceMenuItemSpec[]>;
@@ -66,6 +68,7 @@ const insertTableFields = [
 ].concat(baseFields);
 
 const colorSwatchFields = [
+  FieldSchema.optionFunction('select'),
   FieldSchema.defaultedObjOf('initData', {}, [
     FieldSchema.defaultedBoolean('allowCustomColors', true),
     FieldSchema.defaultedString('storageKey', 'default'),

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - An element could be dropped onto the decendants of a noneditable element. #TINY-9364
-- Checkmark did not show in menu colorswatches #TINY-9395
+- Checkmark did not show in menu colorswatches. #TINY-9395
 
 ### Improved
 - Direct invalid child text nodes of list elements will be wrapped in list item elements. #TINY-4818

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - An element could be dropped onto the decendants of a noneditable element. #TINY-9364
+- Checkmark did not show in menu colorswatches #TINY-9395
 
 ### Improved
 - Direct invalid child text nodes of list elements will be wrapped in list item elements. #TINY-4818

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -100,15 +100,18 @@ const setIconColor = (splitButtonApi: Toolbar.ToolbarSplitButtonInstanceApi, nam
   splitButtonApi.setIconFill(id, newColor);
 };
 
+const select = (editor: Editor, format: ColorFormat) =>
+  (value: string) => {
+    const optCurrentHex = getCurrentColor(editor, format);
+    return Optionals.is(optCurrentHex, value.toUpperCase());
+  };
+
 const registerTextColorButton = (editor: Editor, name: string, format: ColorFormat, tooltip: string, lastColor: Cell<string>) => {
   editor.ui.registry.addSplitButton(name, {
     tooltip,
     presets: 'color',
     icon: name === 'forecolor' ? 'text-color' : 'highlight-bg-color',
-    select: (value) => {
-      const optCurrentHex = getCurrentColor(editor, format);
-      return Optionals.is(optCurrentHex, value.toUpperCase());
-    },
+    select: select(editor, format),
     columns: Options.getColorCols(editor, format),
     fetch: getFetch(Options.getColors(editor, format), format, Options.hasCustomColors(editor)),
     onAction: (_splitButtonApi) => {
@@ -150,6 +153,7 @@ const registerTextColorMenuItem = (editor: Editor, name: string, format: ColorFo
       {
         type: 'fancymenuitem',
         fancytype: 'colorswatch',
+        select: select(editor, format),
         initData: {
           storageKey: format,
         },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
@@ -24,7 +24,7 @@ export const renderColorSwatchItem = (spec: Menu.ColorSwatchMenuItem, backstage:
     columns,
     presets,
     ItemResponse.CLOSE_ON_EXECUTE,
-    Fun.never,
+    spec.select.getOr(Fun.never),
     backstage.shared.providers
   );
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
@@ -109,7 +109,7 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
     TinyUiActions.clickOnUi(editor, submenuButton);
     return TinyUiActions.pWaitForUi(editor, '.tox-swatches-menu');
   };
-  const closeAndGetMenuColorMenu = (editor: Editor) =>
+  const closeMenuColorMenu = (editor: Editor) =>
     TinyUiActions.clickOnMenu(editor, 'button:contains("Color")');
   const openAndGetBackcolorMenu = openAndGetMenu('Background color');
   const closeBackcolorMenu = closeMenu('Background color');
@@ -235,7 +235,14 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
       menu
     );
 
-    closeAndGetMenuColorMenu(editor);
+    closeMenuColorMenu(editor);
+
+    editor.setContent('<p style="background-color: rgb(224, 62, 45);">red</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2, true);
+
+    await pOpenAndGetMenuColorMenu(editor);
+    assertFocusIsOnColor('rgb(224, 62, 45)');
+    closeMenuColorMenu(editor);
   });
 
   it('TINY-9283: selected color is successfully marked', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
@@ -49,6 +49,7 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
     },
     color_map_background: [
       '#FFFFFF', 'white',
+      'rgb(224, 62, 45)', 'red',
       '#000000', 'black',
     ],
     menu: {
@@ -102,7 +103,7 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
   const closeForecolorMenu = closeMenu('Text color');
   const pOpenAndGetMenuColorMenu = async (editor: Editor) => {
     const mainButton = 'button:contains("Color")';
-    const submenuButton = 'div[title="Background color"]';
+    const submenuButton = '[role="menu"] div[title="Background color"]';
     TinyUiActions.clickOnMenu(editor, mainButton);
     await TinyUiActions.pWaitForUi(editor, submenuButton);
     TinyUiActions.clickOnUi(editor, submenuButton);
@@ -196,6 +197,15 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
                     classes: [ arr.has('tox-swatch') ],
                     styles: {
                       'background-color': str.is('rgb(255, 255, 255)')
+                    },
+                    attrs: {
+                      'aria-checked': str.is('false')
+                    }
+                  }),
+                  s.element('div', {
+                    classes: [ arr.has('tox-swatch') ],
+                    styles: {
+                      'background-color': str.is('rgb(224, 62, 45)')
                     },
                     attrs: {
                       'aria-checked': str.is('false')

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
@@ -1,12 +1,13 @@
 import { ApproxStructure, Assertions, FocusTools, Keys, Mouse, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
-import { describe, it } from '@ephox/bedrock-client';
+import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Menu } from 'tinymce/core/api/ui/Ui';
+import LocalStorage from 'tinymce/core/api/util/LocalStorage';
 
 describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
   const store = TestStore();
@@ -45,7 +46,18 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
         onAction: store.adder('onAction'),
         onItemAction: store.adder('onItemAction')
       });
-    }
+    },
+    color_map_background: [
+      '#FFFFFF', 'white',
+      '#000000', 'black',
+    ],
+    menu: {
+      color: {
+        title: 'Color',
+        items: 'backcolor'
+      }
+    },
+    menubar: 'color'
   }, []);
 
   const structColor = (value: string): ApproxStructure.Builder<StructAssert> =>
@@ -88,10 +100,24 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
   const closeSwatchButtonMenu = closeMenu('swatch-button');
   const openAndGetForecolorMenu = openAndGetMenu('Text color');
   const closeForecolorMenu = closeMenu('Text color');
+  const pOpenAndGetMenuColorMenu = async (editor: Editor) => {
+    const mainButton = 'button:contains("Color")';
+    const submenuButton = 'div[title="Background color"]';
+    TinyUiActions.clickOnMenu(editor, mainButton);
+    await TinyUiActions.pWaitForUi(editor, submenuButton);
+    TinyUiActions.clickOnUi(editor, submenuButton);
+    return TinyUiActions.pWaitForUi(editor, '.tox-swatches-menu');
+  };
+  const closeAndGetMenuColorMenu = (editor: Editor) =>
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Color")');
 
   TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [
     ':focus { transform: scale(0.8) }'
   ]);
+
+  before(() => {
+    LocalStorage.clear();
+  });
 
   it('Check structure of color swatch', async () => {
     const editor = hook.editor();
@@ -147,6 +173,57 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
     TinyUiActions.keydown(editor, Keys.right());
     assertFocusIsOnColor('black');
     closeSwatchButtonMenu();
+  });
+
+  it('TINY-9395: Check structure of menu color swatch', async () => {
+    const editor = hook.editor();
+    const menu = await pOpenAndGetMenuColorMenu(editor);
+
+    Assertions.assertStructure(
+      'Checking menu structure for color swatches',
+      ApproxStructure.build((s, str, arr) => s.element('div', {
+        classes: [ arr.has('tox-menu') ],
+        children: [
+          s.element('div', {
+            classes: [ arr.has('tox-swatches') ],
+            children: [
+              s.element('div', {
+                classes: [ arr.has('tox-swatches__row') ],
+                children: [
+                  s.element('div', {
+                    classes: [ arr.has('tox-swatch') ],
+                    styles: {
+                      'background-color': str.is('rgb(255, 255, 255)')
+                    },
+                    attrs: {
+                      'aria-checked': str.is('false')
+                    }
+                  }),
+                  s.element('div', {
+                    classes: [ arr.has('tox-swatch') ],
+                    styles: {
+                      'background-color': str.is('rgb(0, 0, 0)')
+                    },
+                    attrs: {
+                      'aria-checked': str.is('true')
+                    }
+                  }),
+                  s.element('div', {
+                    classes: [ arr.has('tox-swatch') ],
+                  }),
+                  s.element('button', {
+                    classes: [ arr.has('tox-swatch') ],
+                  }),
+                ]
+              }),
+            ]
+          })
+        ]
+      })),
+      menu
+    );
+
+    closeAndGetMenuColorMenu(editor);
   });
 
   it('TINY-9283: selected color is successfully marked', async () => {


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
 Checkmark missing from the menu colorswatch

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
