### PR TITLE
TINY-5167: Toolbar split buttons in advlist plugin to show the correct state when the cursor is in a checklist

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - An element could be dropped onto the decendants of a noneditable element. #TINY-9364
+- Toolbar split buttons in advlist plugin to show the correct state when the cursor is in a checklist. #TINY-5167
 
 ### Improved
 - Direct invalid child text nodes of list elements will be wrapped in list item elements. #TINY-4818

--- a/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
@@ -36,8 +36,8 @@ const isWithinNonEditableList = (editor: Editor, element: Element | null): boole
 };
 
 export {
-  isTableCellNode,
-  isListNode,
+  isTableCellNode, // Exported for testing
+  isListNode, // Exported for testing
   inList,
   getSelectedStyleType,
   isWithinNonEditableList

--- a/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
@@ -2,7 +2,7 @@ import { Arr, Optional, Type } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 
-const isCustomList = (list: Element): boolean =>
+const isCustomList = (list: HTMLElement): boolean =>
   /\btox\-/.test(list.className);
 
 const isChildOfBody = (editor: Editor, elm: Node): boolean => {
@@ -16,9 +16,9 @@ const isListNode = matchNodeNames<HTMLOListElement | HTMLUListElement | HTMLDLis
 
 const isTableCellNode = matchNodeNames<HTMLTableHeaderCellElement | HTMLTableCellElement>(/^(TH|TD)$/);
 
-const inList = (editor: Editor, e: Node[], nodeName: string): boolean =>
-  Arr.findUntil(e, isListNode, isTableCellNode)
-    .exists((list) => list.nodeName === nodeName && !isCustomList(list) && isChildOfBody(editor, list));
+const inList = (editor: Editor, parents: Node[], nodeName: string): boolean =>
+  Arr.findUntil(parents, (parent) => isListNode(parent) && !isCustomList(parent), isTableCellNode)
+    .exists((list) => list.nodeName === nodeName && isChildOfBody(editor, list));
 
 const getSelectedStyleType = (editor: Editor): Optional<string> => {
   const listElm = editor.dom.getParent(editor.selection.getNode(), 'ol,ul');

--- a/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
@@ -37,6 +37,7 @@ const isWithinNonEditableList = (editor: Editor, element: Element | null): boole
 
 export {
   isTableCellNode,
+  isListNode,
   inList,
   getSelectedStyleType,
   isWithinNonEditableList

--- a/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
@@ -1,18 +1,24 @@
-import { Optional, Type } from '@ephox/katamari';
+import { Arr, Optional, Type } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
+
+const isCustomList = (list: Element): boolean =>
+  /\btox\-/.test(list.className);
 
 const isChildOfBody = (editor: Editor, elm: Node): boolean => {
   return editor.dom.isChildOf(elm, editor.getBody());
 };
 
-const isTableCellNode = (node: Node | null): boolean => {
-  return Type.isNonNullable(node) && /^(TH|TD)$/.test(node.nodeName);
-};
+const matchNodeNames = <T extends Node = Node>(regex: RegExp) =>
+  (node: Node | null): node is T => Type.isNonNullable(node) && regex.test(node.nodeName);
 
-const isListNode = (editor: Editor) => (node: Node | null): boolean => {
-  return Type.isNonNullable(node) && (/^(OL|UL|DL)$/).test(node.nodeName) && isChildOfBody(editor, node);
-};
+const isListNode = matchNodeNames<HTMLOListElement | HTMLUListElement | HTMLDListElement>(/^(OL|UL|DL)$/);
+
+const isTableCellNode = matchNodeNames<HTMLTableHeaderCellElement | HTMLTableCellElement>(/^(TH|TD)$/);
+
+const inList = (editor: Editor, e: Node[], nodeName: string): boolean =>
+  Arr.findUntil(e, isListNode, isTableCellNode)
+    .exists((list) => list.nodeName === nodeName && !isCustomList(list) && isChildOfBody(editor, list));
 
 const getSelectedStyleType = (editor: Editor): Optional<string> => {
   const listElm = editor.dom.getParent(editor.selection.getNode(), 'ol,ul');
@@ -31,7 +37,7 @@ const isWithinNonEditableList = (editor: Editor, element: Element | null): boole
 
 export {
   isTableCellNode,
-  isListNode,
+  inList,
   getSelectedStyleType,
   isWithinNonEditableList
 };

--- a/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
@@ -15,17 +15,6 @@ const enum ListType {
   UnorderedList = 'UL'
 }
 
-const findIndex = <T>(list: T[], predicate: (element: T) => boolean): number => {
-  for (let index = 0; index < list.length; index++) {
-    const element = list[index];
-
-    if (predicate(element)) {
-      return index;
-    }
-  }
-  return -1;
-};
-
 // <ListStyles>
 const styleValueToText = (styleValue: string): string => {
   return styleValue.replace(/\-/g, ' ').replace(/\b\w/g, (chr) => {
@@ -36,16 +25,9 @@ const styleValueToText = (styleValue: string): string => {
 const normalizeStyleValue = (styleValue: string | undefined): string =>
   Type.isNullable(styleValue) || styleValue === 'default' ? '' : styleValue;
 
-const isWithinList = (editor: Editor, e: EditorEvent<NodeChangeEvent>, nodeName: ListType): boolean => {
-  const tableCellIndex = findIndex(e.parents, ListUtils.isTableCellNode);
-  const parents = tableCellIndex !== -1 ? e.parents.slice(0, tableCellIndex) : e.parents;
-  const lists = Tools.grep(parents, ListUtils.isListNode(editor));
-  return lists.length > 0 && lists[0].nodeName === nodeName;
-};
-
 const makeSetupHandler = (editor: Editor, nodeName: ListType) => (api: Toolbar.ToolbarSplitButtonInstanceApi | Toolbar.ToolbarToggleButtonInstanceApi) => {
   const nodeChangeHandler = (e: EditorEvent<NodeChangeEvent>) => {
-    api.setActive(isWithinList(editor, e, nodeName));
+    api.setActive(ListUtils.inList(editor, e.parents, nodeName));
     api.setEnabled(!ListUtils.isWithinNonEditableList(editor, e.element));
   };
   editor.on('NodeChange', nodeChangeHandler);

--- a/modules/tinymce/src/plugins/advlist/test/ts/atomic/ListUtilsTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/atomic/ListUtilsTest.ts
@@ -1,0 +1,22 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
+
+import { isTableCellNode, isListNode } from 'tinymce/plugins/advlist/core/ListUtils';
+
+describe('atomic.tinymce.plugins.advlist.ListUtilsTest', () => {
+  it('isTableCellNode', () => {
+    assert.isTrue(isTableCellNode(SugarElement.fromTag('td').dom), 'td');
+    assert.isTrue(isTableCellNode(SugarElement.fromTag('th').dom), 'th');
+    assert.isFalse(isTableCellNode(SugarElement.fromHtml('<div>1</div>').dom), 'invalid div');
+    assert.isFalse(isTableCellNode(null));
+  });
+
+  it('isListNode', () => {
+    assert.isTrue(isListNode(SugarElement.fromHtml('<ol><li>1</li></ol>').dom));
+    assert.isTrue(isListNode(SugarElement.fromHtml('<ul><li>1</li></ul>').dom));
+    assert.isTrue(isListNode(SugarElement.fromHtml('<dl><li>1</li></dl>').dom));
+    assert.isFalse(isListNode(SugarElement.fromHtml('<div>2</div>').dom));
+    assert.isFalse(isListNode(null));
+  });
+});

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistOptionsAndToolbarTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistOptionsAndToolbarTest.ts
@@ -1,8 +1,8 @@
 import { ApproxStructure, Assertions, UiFinder, Waiter } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { it, before, context, describe } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
-import { McEditor, TinyAssertions, TinyUiActions } from '@ephox/wrap-mcagar';
+import { McEditor, TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import AdvListPlugin from 'tinymce/plugins/advlist/Plugin';
@@ -26,11 +26,6 @@ interface Scenario {
 }
 
 describe('browser.tinymce.plugins.advlist.AdvlistOptionsAndToolbarTest', () => {
-  before(() => {
-    AdvListPlugin();
-    ListsPlugin();
-  });
-
   const baseOptions = {
     plugins: 'lists advlist',
     toolbar: 'numlist bullist',
@@ -77,158 +72,233 @@ describe('browser.tinymce.plugins.advlist.AdvlistOptionsAndToolbarTest', () => {
     ));
   };
 
-  Arr.each([
-    {
-      label: 'TBA: Test default advlist_number_styles option behaviour',
-      options: {},
-      splitBtns: { number: true, bullet: true },
-      type: 'number',
-      expectedContent: '<ol>\n<li>a</li>\n</ol>'
-    },
-    {
-      label: 'TBA: Test default advlist_bullet_styles option behaviour',
-      options: {},
-      splitBtns: { number: true, bullet: true },
-      type: 'bullet',
-      expectedContent: '<ul>\n<li>a</li>\n</ul>'
-    },
-    {
-      label: 'TINY-8721: Test not including default in advlist_number_styles option',
-      options: {
-        advlist_number_styles: 'lower-alpha,lower-greek'
-      },
-      splitBtns: { number: true, bullet: true },
-      type: 'number',
-      expectedContent: '<ol>\n<li>a</li>\n</ol>'
-    },
-    {
-      label: 'TINY-8721: Test not including default in advlist_bullet_styles option',
-      options: {
-        advlist_bullet_styles: 'square,circle'
-      },
-      splitBtns: { number: true, bullet: true },
-      type: 'bullet',
-      expectedContent: '<ul>\n<li>a</li>\n</ul>'
-    },
-    {
-      label: 'TINY-8721: Test providing empty string for advlist_number_styles option',
-      options: {
-        advlist_number_styles: ''
-      },
-      splitBtns: { number: false, bullet: true },
-      type: 'number',
-      expectedContent: '<ol>\n<li>a</li>\n</ol>'
-    },
-    {
-      label: 'TINY-8721: Test providing empty string for advlist_bullet_styles option',
-      options: {
-        advlist_bullet_styles: ''
-      },
-      splitBtns: { number: true, bullet: false },
-      type: 'bullet',
-      expectedContent: '<ul>\n<li>a</li>\n</ul>'
-    },
-    {
-      label: 'TINY-8721: Test providing single default value for advlist_number_styles option',
-      options: {
-        advlist_number_styles: 'default'
-      },
-      splitBtns: { number: false, bullet: true },
-      type: 'number',
-      expectedContent: '<ol>\n<li>a</li>\n</ol>'
-    },
-    {
-      label: 'TINY-8721: Test providing single default value for advlist_bullet_styles option',
-      options: {
-        advlist_bullet_styles: 'default'
-      },
-      splitBtns: { number: true, bullet: false },
-      type: 'bullet',
-      expectedContent: '<ul>\n<li>a</li>\n</ul>'
-    },
-    {
-      label: 'TINY-8721: Test providing single non-default value for advlist_number_styles option',
-      options: {
-        advlist_number_styles: 'lower-alpha'
-      },
-      splitBtns: { number: false, bullet: true },
-      type: 'number',
-      expectedContent: '<ol style="list-style-type: lower-alpha;">\n<li>a</li>\n</ol>'
-    },
-    {
-      label: 'TINY-8721: Test providing single non-default value for advlist_bullet_styles option',
-      options: {
-        advlist_bullet_styles: 'square'
-      },
-      splitBtns: { number: true, bullet: false },
-      type: 'bullet',
-      expectedContent: '<ul style="list-style-type: square;">\n<li>a</li>\n</ul>'
-    },
-    {
-      label: 'TINY-8721: Test that a bullet list with a different bullet style can be removed and applied',
-      options: {
-        advlist_bullet_styles: 'square'
-      },
-      splitBtns: { number: true, bullet: false },
-      type: 'bullet',
-      initialContent: '<ul><li>a</li></ul>',
-      expectedContent: '<p>a</p>',
-      finalExpectedContent: '<ul style="list-style-type: square;">\n<li>a</li>\n</ul>'
-    },
-    {
-      label: 'TINY-8721: Test that a number list with a different number style can be removed and applied',
-      options: {
-        advlist_number_styles: 'lower-alpha'
-      },
-      splitBtns: { number: false, bullet: true },
-      type: 'number',
-      initialContent: '<ol><li>a</li></ol>',
-      expectedContent: '<p>a</p>',
-      finalExpectedContent: '<ol style="list-style-type: lower-alpha;">\n<li>a</li>\n</ol>'
-    },
-    {
-      label: 'TINY-8721: Test that a number list can be converted to a bullet list',
-      options: {
-        advlist_bullet_styles: 'circle'
-      },
-      splitBtns: { number: true, bullet: false },
-      type: 'bullet',
-      initialContent: '<ol><li>a</li></ol>',
-      expectedContent: '<ul style="list-style-type: circle;">\n<li>a</li>\n</ul>',
-      finalExpectedContent: '<p>a</p>',
-    },
-    {
-      label: 'TINY-8721: Test that a bullet list can be converted to a number list',
-      options: {
-        advlist_number_styles: 'upper-roman'
-      },
-      splitBtns: { number: false, bullet: true },
-      type: 'number',
-      initialContent: '<ul><li>a</li></ul>',
-      expectedContent: '<ol style="list-style-type: upper-roman;">\n<li>a</li>\n</ol>',
-      finalExpectedContent: '<p>a</p>',
-    },
-  ] as Scenario[], (scenario) => {
-    const { splitBtns, type } = scenario;
+  const pAssertButtonToggledState = (name: string, state: boolean) =>
+    Waiter.pTryUntil('Wait for toolbar button state', () => {
+      const button = UiFinder.findIn(SugarBody.body(), `div.tox-split-button[aria-label="${name}"]`).getOrDie();
+      return Assertions.assertStructure('', ApproxStructure.build((s, _, __) => s.element('div', {
+        children: [
+          s.element('span', {
+            exactClasses: [ 'tox-tbtn', ...(state ? [ 'tox-tbtn--enabled' ] : [] ) ]
+          }),
+          s.theRest()
+        ]
+      })), button);
+    });
 
-    it(scenario.label, async () => {
-      const editor = await McEditor.pFromSettings<Editor>({
-        ...baseOptions,
-        ...scenario.options
+  context('AdvList options and toolbar test', () => {
+    before(() => {
+      AdvListPlugin();
+      ListsPlugin();
+    });
+
+    Arr.each([
+      {
+        label: 'TBA: Test default advlist_number_styles option behaviour',
+        options: {},
+        splitBtns: { number: true, bullet: true },
+        type: 'number',
+        expectedContent: '<ol>\n<li>a</li>\n</ol>'
+      },
+      {
+        label: 'TBA: Test default advlist_bullet_styles option behaviour',
+        options: {},
+        splitBtns: { number: true, bullet: true },
+        type: 'bullet',
+        expectedContent: '<ul>\n<li>a</li>\n</ul>'
+      },
+      {
+        label: 'TINY-8721: Test not including default in advlist_number_styles option',
+        options: {
+          advlist_number_styles: 'lower-alpha,lower-greek'
+        },
+        splitBtns: { number: true, bullet: true },
+        type: 'number',
+        expectedContent: '<ol>\n<li>a</li>\n</ol>'
+      },
+      {
+        label: 'TINY-8721: Test not including default in advlist_bullet_styles option',
+        options: {
+          advlist_bullet_styles: 'square,circle'
+        },
+        splitBtns: { number: true, bullet: true },
+        type: 'bullet',
+        expectedContent: '<ul>\n<li>a</li>\n</ul>'
+      },
+      {
+        label: 'TINY-8721: Test providing empty string for advlist_number_styles option',
+        options: {
+          advlist_number_styles: ''
+        },
+        splitBtns: { number: false, bullet: true },
+        type: 'number',
+        expectedContent: '<ol>\n<li>a</li>\n</ol>'
+      },
+      {
+        label: 'TINY-8721: Test providing empty string for advlist_bullet_styles option',
+        options: {
+          advlist_bullet_styles: ''
+        },
+        splitBtns: { number: true, bullet: false },
+        type: 'bullet',
+        expectedContent: '<ul>\n<li>a</li>\n</ul>'
+      },
+      {
+        label: 'TINY-8721: Test providing single default value for advlist_number_styles option',
+        options: {
+          advlist_number_styles: 'default'
+        },
+        splitBtns: { number: false, bullet: true },
+        type: 'number',
+        expectedContent: '<ol>\n<li>a</li>\n</ol>'
+      },
+      {
+        label: 'TINY-8721: Test providing single default value for advlist_bullet_styles option',
+        options: {
+          advlist_bullet_styles: 'default'
+        },
+        splitBtns: { number: true, bullet: false },
+        type: 'bullet',
+        expectedContent: '<ul>\n<li>a</li>\n</ul>'
+      },
+      {
+        label: 'TINY-8721: Test providing single non-default value for advlist_number_styles option',
+        options: {
+          advlist_number_styles: 'lower-alpha'
+        },
+        splitBtns: { number: false, bullet: true },
+        type: 'number',
+        expectedContent: '<ol style="list-style-type: lower-alpha;">\n<li>a</li>\n</ol>'
+      },
+      {
+        label: 'TINY-8721: Test providing single non-default value for advlist_bullet_styles option',
+        options: {
+          advlist_bullet_styles: 'square'
+        },
+        splitBtns: { number: true, bullet: false },
+        type: 'bullet',
+        expectedContent: '<ul style="list-style-type: square;">\n<li>a</li>\n</ul>'
+      },
+      {
+        label: 'TINY-8721: Test that a bullet list with a different bullet style can be removed and applied',
+        options: {
+          advlist_bullet_styles: 'square'
+        },
+        splitBtns: { number: true, bullet: false },
+        type: 'bullet',
+        initialContent: '<ul><li>a</li></ul>',
+        expectedContent: '<p>a</p>',
+        finalExpectedContent: '<ul style="list-style-type: square;">\n<li>a</li>\n</ul>'
+      },
+      {
+        label: 'TINY-8721: Test that a number list with a different number style can be removed and applied',
+        options: {
+          advlist_number_styles: 'lower-alpha'
+        },
+        splitBtns: { number: false, bullet: true },
+        type: 'number',
+        initialContent: '<ol><li>a</li></ol>',
+        expectedContent: '<p>a</p>',
+        finalExpectedContent: '<ol style="list-style-type: lower-alpha;">\n<li>a</li>\n</ol>'
+      },
+      {
+        label: 'TINY-8721: Test that a number list can be converted to a bullet list',
+        options: {
+          advlist_bullet_styles: 'circle'
+        },
+        splitBtns: { number: true, bullet: false },
+        type: 'bullet',
+        initialContent: '<ol><li>a</li></ol>',
+        expectedContent: '<ul style="list-style-type: circle;">\n<li>a</li>\n</ul>',
+        finalExpectedContent: '<p>a</p>',
+      },
+      {
+        label: 'TINY-8721: Test that a bullet list can be converted to a number list',
+        options: {
+          advlist_number_styles: 'upper-roman'
+        },
+        splitBtns: { number: false, bullet: true },
+        type: 'number',
+        initialContent: '<ul><li>a</li></ul>',
+        expectedContent: '<ol style="list-style-type: upper-roman;">\n<li>a</li>\n</ol>',
+        finalExpectedContent: '<p>a</p>',
+      },
+    ] as Scenario[], (scenario) => {
+      const { splitBtns, type } = scenario;
+
+      it(scenario.label, async () => {
+        const editor = await McEditor.pFromSettings<Editor>({
+          ...baseOptions,
+          ...scenario.options
+        });
+        const initialContent = scenario.initialContent || '<p>a</p>';
+        const finalContent = scenario.finalExpectedContent || initialContent;
+
+        await pAssertListBtnStructures(splitBtns);
+        editor.setContent(initialContent);
+        editor.focus();
+
+        clickListBtn(editor, type, splitBtns[type]);
+        TinyAssertions.assertContent(editor, scenario.expectedContent);
+        clickListBtn(editor, type, splitBtns[type]);
+        TinyAssertions.assertContent(editor, finalContent);
+
+        McEditor.remove(editor);
       });
-      const initialContent = scenario.initialContent || '<p>a</p>';
-      const finalContent = scenario.finalExpectedContent || initialContent;
+    });
+  });
 
-      await pAssertListBtnStructures(splitBtns);
-      editor.setContent(initialContent);
-      editor.focus();
+  context('Toolbar Split buttons active state', () => {
+    const hook = TinyHooks.bddSetup<Editor>({
+      ...baseOptions
+    }, [ AdvListPlugin, ListsPlugin ]);
 
-      clickListBtn(editor, type, splitBtns[type]);
-      TinyAssertions.assertContent(editor, scenario.expectedContent);
-      clickListBtn(editor, type, splitBtns[type]);
-      TinyAssertions.assertContent(editor, finalContent);
+    it('TINY-5167: Ensure bullist toolbar button state shows correctly', async () => {
+      const editor = hook.editor();
+      editor.setContent('<ul><li>1<ul><li>2<ul><li>3</li></ul></li></ul></li></ul>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+      await pAssertButtonToggledState('Bullet list', true);
+      await pAssertButtonToggledState('Numbered list', false);
 
-      McEditor.remove(editor);
+      TinySelections.setCursor(editor, [ 0, 0, 1, 0, 0 ], 1);
+      await pAssertButtonToggledState('Bullet list', true);
+      await pAssertButtonToggledState('Numbered list', false);
+
+      TinySelections.setCursor(editor, [ 0, 0, 1, 0, 1, 0, 0 ], 1);
+      await pAssertButtonToggledState('Bullet list', true);
+      await pAssertButtonToggledState('Numbered list', false);
+    });
+
+    it('TINY-5167: Ensure numlist toolbar button state shows correctly', async () => {
+      const editor = hook.editor();
+      editor.setContent('<ol><li>1<ol><li>2<ol><li>3</li></ol></li></ol></li></ol>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+      await pAssertButtonToggledState('Bullet list', false);
+      await pAssertButtonToggledState('Numbered list', true);
+
+      TinySelections.setCursor(editor, [ 0, 0, 1, 0, 0 ], 1);
+      await pAssertButtonToggledState('Bullet list', false);
+      await pAssertButtonToggledState('Numbered list', true);
+
+      TinySelections.setCursor(editor, [ 0, 0, 1, 0, 1, 0, 0 ], 1);
+      await pAssertButtonToggledState('Bullet list', false);
+      await pAssertButtonToggledState('Numbered list', true);
+    });
+
+    it('TINY-5167: Ensure numlist bullist toolbar button state shows correctly with custom list class', async () => {
+      const editor = hook.editor();
+      editor.setContent('<ul class="tox-checklist"><li>1<ul class="tox-checklist"><li>2<ul class="tox-checklist"><li class="tox-checklist--checked">3</li></ul></li></ul></li></ul>');
+
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+      await pAssertButtonToggledState('Bullet list', false);
+      await pAssertButtonToggledState('Numbered list', false);
+
+      TinySelections.setCursor(editor, [ 0, 0, 1, 0, 0 ], 1);
+      await pAssertButtonToggledState('Bullet list', false);
+      await pAssertButtonToggledState('Numbered list', false);
+
+      TinySelections.setCursor(editor, [ 0, 0, 1, 0, 1, 0, 0 ], 1);
+      await pAssertButtonToggledState('Bullet list', false);
+      await pAssertButtonToggledState('Numbered list', false);
     });
   });
 });

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/ListUtilsTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/ListUtilsTest.ts
@@ -4,7 +4,7 @@ import { assert } from 'chai';
 
 import { isTableCellNode, isListNode } from 'tinymce/plugins/advlist/core/ListUtils';
 
-describe('atomic.tinymce.plugins.advlist.ListUtilsTest', () => {
+describe('browser.tinymce.plugins.advlist.ListUtilsTest', () => {
   it('isTableCellNode', () => {
     assert.isTrue(isTableCellNode(SugarElement.fromTag('td').dom), 'td');
     assert.isTrue(isTableCellNode(SugarElement.fromTag('th').dom), 'th');


### PR DESCRIPTION
Related Ticket: TINY-5167

Description of Changes:
* Toolbar split buttons in advlist plugin to show the correct state when the cursor is in a checklist

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
