### PR TITLE
TINY-9402: Prepare for TinyMCE 5.10.7 release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,9 +65,9 @@ node("primary") {
     }
 
     def browserPermutations = [
-      [ name: "win10Chrome", os: "windows-10", browser: "chrome", buckets: 1 ],
-      [ name: "win10FF", os: "windows-10", browser: "firefox", buckets: 1 ],
-      [ name: "win10Edge", os: "windows-10", browser: "MicrosoftEdge", buckets: 1 ],
+      [ name: "win11Chrome", os: "windows-11", browser: "chrome", buckets: 1 ],
+      [ name: "win11FF", os: "windows-11", browser: "firefox", buckets: 1 ],
+      [ name: "win11Edge", os: "windows-11", browser: "MicrosoftEdge", buckets: 1 ],
       [ name: "win10IE", os: "windows-10", browser: "ie", buckets: 3 ],
       [ name: "macSafari", os: "macos", browser: "safari", buckets: 1 ],
       [ name: "macChrome", os: "macos", browser: "chrome", buckets: 1 ],

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 5.10.7 - 2022-12-06
+
 ### Fixed
 - HTML in messages for the `WindowManager.alert` and `WindowManager.confirm` APIs were not properly sanitized. #TINY-3548
 

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "5.10.6",
+  "version": "5.10.7",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related Ticket: TINY-9402

Description of Changes:
* Bumped package.json and updated changelog

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
