### PR TITLE
TINY-9402: Prepare for TinyMCE 5.10.7 release (take 2)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,9 +65,9 @@ node("primary") {
     }
 
     def browserPermutations = [
-      [ name: "win11Chrome", os: "windows-11", browser: "chrome", buckets: 1 ],
-      [ name: "win11FF", os: "windows-11", browser: "firefox", buckets: 1 ],
-      [ name: "win11Edge", os: "windows-11", browser: "MicrosoftEdge", buckets: 1 ],
+      [ name: "win10Chrome", os: "windows-10", browser: "chrome", buckets: 1 ],
+      [ name: "win10FF", os: "windows-10", browser: "firefox", buckets: 1 ],
+      [ name: "win10Edge", os: "windows-10", browser: "MicrosoftEdge", buckets: 1 ],
       [ name: "win10IE", os: "windows-10", browser: "ie", buckets: 3 ],
       [ name: "macSafari", os: "macos", browser: "safari", buckets: 1 ],
       [ name: "macChrome", os: "macos", browser: "chrome", buckets: 1 ],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,10 +65,10 @@ node("primary") {
     }
 
     def browserPermutations = [
-      [ name: "win10Chrome", os: "windows-10", browser: "chrome", buckets: 1 ],
-      [ name: "win10FF", os: "windows-10", browser: "firefox", buckets: 1 ],
-      [ name: "win10Edge", os: "windows-10", browser: "MicrosoftEdge", buckets: 1 ],
-      [ name: "win10IE", os: "windows-10", browser: "ie", buckets: 3 ],
+      [ name: "win11Chrome", os: "windows-11", browser: "chrome", buckets: 1 ],
+      [ name: "win11FF", os: "windows-11", browser: "firefox", buckets: 1 ],
+      [ name: "win11Edge", os: "windows-11", browser: "MicrosoftEdge", buckets: 1 ],
+      [ name: "win10IE", os: "windows-10", browser: "ie", buckets: 1 ],
       [ name: "macSafari", os: "macos", browser: "safari", buckets: 1 ],
       [ name: "macChrome", os: "macos", browser: "chrome", buckets: 1 ],
       [ name: "macFirefox", os: "macos", browser: "firefox", buckets: 1 ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,7 @@ node("primary") {
       [ name: "win11Chrome", os: "windows-11", browser: "chrome", buckets: 1 ],
       [ name: "win11FF", os: "windows-11", browser: "firefox", buckets: 1 ],
       [ name: "win11Edge", os: "windows-11", browser: "MicrosoftEdge", buckets: 1 ],
-      [ name: "win10IE", os: "windows-10", browser: "ie", buckets: 1 ],
+      [ name: "win10IE", os: "windows-10", browser: "ie", buckets: 3 ],
       [ name: "macSafari", os: "macos", browser: "safari", buckets: 1 ],
       [ name: "macChrome", os: "macos", browser: "chrome", buckets: 1 ],
       [ name: "macFirefox", os: "macos", browser: "firefox", buckets: 1 ]

--- a/modules/sugar/src/test/ts/browser/LocationTest.ts
+++ b/modules/sugar/src/test/ts/browser/LocationTest.ts
@@ -139,7 +139,7 @@ UnitTest.asynctest('LocationTest', (success, failure) => {
 
     // TINY-9203: due to Win11 FF adopting native hidden scrollbar behavior and current inability to distinguish between Win10 and Win11
     // (both os.version.major === 10), allow scrollbar to be either hidden or visible when on Win10/11 FF
-    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux()) || (platform.browser.isFirefox() && platform.os.isWindows() && platform.os.version.major >= 10);
+    const noVisibleScrollbarBrowser = platform.os.isOSX() || (platform.browser.isFirefox() && platform.os.isLinux()) || (platform.browser.isFirefox() && platform.os.isWindows() && platform.os.version.major >= 10);
     assert.eq(true, scrollBarWidth > 5 && scrollBarWidth < 50 || (noVisibleScrollbarBrowser && scrollBarWidth === 0), 'scroll bar width, got=' + scrollBarWidth);
   };
 

--- a/modules/sugar/src/test/ts/browser/LocationTest.ts
+++ b/modules/sugar/src/test/ts/browser/LocationTest.ts
@@ -136,7 +136,10 @@ UnitTest.asynctest('LocationTest', (success, failure) => {
     pos = SugarLocation.viewport(body);
     assert.eq(0, pos.top);
     assert.eq(0, pos.left);
-    const noVisibleScrollbarBrowser = platform.os.isOSX() || (platform.browser.isFirefox() && platform.os.isLinux());
+
+    // TINY-9203: due to Win11 FF adopting native hidden scrollbar behavior and current inability to distinguish between Win10 and Win11
+    // (both os.version.major === 10), allow scrollbar to be either hidden or visible when on Win10/11 FF
+    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux()) || (platform.browser.isFirefox() && platform.os.isWindows() && platform.os.version.major >= 10);
     assert.eq(true, scrollBarWidth > 5 && scrollBarWidth < 50 || (noVisibleScrollbarBrowser && scrollBarWidth === 0), 'scroll bar width, got=' + scrollBarWidth);
   };
 

--- a/modules/sugar/src/test/ts/browser/ScrollTest.ts
+++ b/modules/sugar/src/test/ts/browser/ScrollTest.ts
@@ -135,7 +135,9 @@ UnitTest.asynctest('ScrollTest', (success, failure) => {
     const cX = Math.round(center.left);
     const cY = Math.round(center.top);
 
-    const noVisibleScrollbarBrowser = platform.os.isOSX() || (platform.browser.isFirefox() && platform.os.isLinux());
+    // TINY-9203: due to Win11 FF adopting native hidden scrollbar behavior and current inability to distinguish between Win10 and Win11
+    // (both os.version.major === 10), allow scrollbar to be either hidden or visible when on Win10/11 FF
+    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux()) || (platform.browser.isFirefox() && platform.os.isWindows() && platform.os.version.major >= 10);
     assert.eq(true, scrollBarWidth > 5 && scrollBarWidth < 50 || (noVisibleScrollbarBrowser && scrollBarWidth === 0), 'scroll bar width, got=' + scrollBarWidth);
 
     scrollCheck(0, 0, 0, 0, doc, 'start pos');

--- a/modules/sugar/src/test/ts/browser/ScrollTest.ts
+++ b/modules/sugar/src/test/ts/browser/ScrollTest.ts
@@ -137,7 +137,7 @@ UnitTest.asynctest('ScrollTest', (success, failure) => {
 
     // TINY-9203: due to Win11 FF adopting native hidden scrollbar behavior and current inability to distinguish between Win10 and Win11
     // (both os.version.major === 10), allow scrollbar to be either hidden or visible when on Win10/11 FF
-    const noVisibleScrollbarBrowser = platform.os.isMacOS() || (platform.browser.isFirefox() && platform.os.isLinux()) || (platform.browser.isFirefox() && platform.os.isWindows() && platform.os.version.major >= 10);
+    const noVisibleScrollbarBrowser = platform.os.isOSX() || (platform.browser.isFirefox() && platform.os.isLinux()) || (platform.browser.isFirefox() && platform.os.isWindows() && platform.os.version.major >= 10);
     assert.eq(true, scrollBarWidth > 5 && scrollBarWidth < 50 || (noVisibleScrollbarBrowser && scrollBarWidth === 0), 'scroll bar width, got=' + scrollBarWidth);
 
     scrollCheck(0, 0, 0, 0, doc, 'start pos');


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Use win10 nodes to test Chrome, Edge and FF
* Backported fixes for ScrollTest.ts and LocationTest.ts

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
