### PR TITLE
TINY-9231: Drag/drop on block links into other links

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - An element could be dropped onto the decendants of a noneditable element. #TINY-9364
 - Toolbar split buttons in advlist plugin to show the correct state when the cursor is in a checklist. #TINY-5167
+- Dragging transparent elements into transparent blocks elements could produce invalid nesting of transparents. #TINY-9231
 
 ### Improved
 - Direct invalid child text nodes of list elements will be wrapped in list item elements. #TINY-4818

--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -84,7 +84,7 @@ const split = (parentElm: Element, splitElm: Node) => {
 const splitInvalidChildren = (schema: Schema, scope: Element, transparentBlocks: Element[]): void => {
   const blocksElements = schema.getBlockElements();
   const rootNode = SugarElement.fromDom(scope);
-  const isBlock = (el: SugarElement) => SugarNode.name(el) in blocksElements;
+  const isBlock = (el: SugarElement): el is SugarElement<Element> => SugarNode.name(el) in blocksElements;
   const isRoot = (el: SugarElement) => Compare.eq(el, rootNode);
 
   Arr.each(SugarElements.fromDom(transparentBlocks), (transparentBlock) => {
@@ -110,7 +110,7 @@ const splitInvalidChildren = (schema: Schema, scope: Element, transparentBlocks:
 };
 
 const unwrapInvalidChildren = (schema: Schema, scope: Element, transparentBlocks: Element[]) => {
-  Arr.each(transparentBlocks.concat(isTransparentBlock(schema, scope ) ? [ scope ] : []), (block) =>
+  Arr.each([ ...transparentBlocks, ...(isTransparentBlock(schema, scope) ? [ scope ] : []) ], (block) =>
     Arr.each(SelectorFilter.descendants(SugarElement.fromDom(block), block.nodeName.toLowerCase()), (elm) => {
       if (isTransparentInline(schema, elm.dom)) {
         Remove.unwrap(elm);

--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -109,17 +109,20 @@ const splitInvalidChildren = (schema: Schema, scope: Element, transparentBlocks:
   });
 };
 
-const unwrapInvalidChildren = (transparentBlocks: Element[]) => {
-  Arr.each(transparentBlocks, (block) =>
-    Arr.each(SelectorFilter.descendants(SugarElement.fromDom(block), block.nodeName.toLowerCase()), Remove.unwrap)
+const unwrapInvalidChildren = (schema: Schema, scope: Element, transparentBlocks: Element[]) => {
+  Arr.each(transparentBlocks.concat(isTransparentBlock(schema, scope ) ? [ scope ] : []), (block) =>
+    Arr.each(SelectorFilter.descendants(SugarElement.fromDom(block), block.nodeName.toLowerCase()), (elm) => {
+      if (isTransparentInline(schema, elm.dom)) {
+        Remove.unwrap(elm);
+      }
+    })
   );
 };
 
 export const updateChildren = (schema: Schema, scope: Element): void => {
-  const transparentBlocks = updateBlockStateOnChildren(schema, scope).concat(isTransparentBlock(schema, scope ) ? [ scope ] : []);
-
-  unwrapInvalidChildren(transparentBlocks);
+  const transparentBlocks = updateBlockStateOnChildren(schema, scope);
   splitInvalidChildren(schema, scope, transparentBlocks);
+  unwrapInvalidChildren(schema, scope, transparentBlocks);
 };
 
 export const updateElement = (schema: Schema, target: Element): void => {

--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -1,5 +1,5 @@
 import { Arr, Obj, Type } from '@ephox/katamari';
-import { Compare, PredicateFilter, PredicateFind, SugarElement, SugarElements, SugarNode, Traverse } from '@ephox/sugar';
+import { Compare, PredicateFilter, PredicateFind, Remove, SelectorFilter, SugarElement, SugarElements, SugarNode, Traverse } from '@ephox/sugar';
 
 import AstNode from '../api/html/Node';
 import Schema, { SchemaMap } from '../api/html/Schema';
@@ -109,8 +109,16 @@ const splitInvalidChildren = (schema: Schema, scope: Element, transparentBlocks:
   });
 };
 
+const unwrapInvalidChildren = (transparentBlocks: Element[]) => {
+  Arr.each(transparentBlocks, (block) =>
+    Arr.each(SelectorFilter.descendants(SugarElement.fromDom(block), block.nodeName.toLowerCase()), Remove.unwrap)
+  );
+};
+
 export const updateChildren = (schema: Schema, scope: Element): void => {
-  const transparentBlocks = updateBlockStateOnChildren(schema, scope);
+  const transparentBlocks = updateBlockStateOnChildren(schema, scope).concat(isTransparentBlock(schema, scope ) ? [ scope ] : []);
+
+  unwrapInvalidChildren(transparentBlocks);
   splitInvalidChildren(schema, scope, transparentBlocks);
 };
 

--- a/modules/tinymce/src/core/main/ts/paste/DragDrop.ts
+++ b/modules/tinymce/src/core/main/ts/paste/DragDrop.ts
@@ -1,9 +1,12 @@
-import { Arr, Cell, Type } from '@ephox/katamari';
+import { Arr, Cell, Obj, Type } from '@ephox/katamari';
 
+import DOMUtils from '../api/dom/DOMUtils';
 import RangeUtils from '../api/dom/RangeUtils';
 import Editor from '../api/Editor';
+import Schema from '../api/html/Schema';
 import * as Options from '../api/Options';
 import Delay from '../api/util/Delay';
+import * as TransparentElements from '../content/TransparentElements';
 import * as Clipboard from './Clipboard';
 import * as InternalHtml from './InternalHtml';
 import * as PasteUtils from './PasteUtils';
@@ -27,6 +30,16 @@ const setFocusedRange = (editor: Editor, rng: Range | undefined): void => {
 const hasImage = (dataTransfer: DataTransfer): boolean =>
   Arr.exists(dataTransfer.files, (file) => /^image\//.test(file.type));
 
+const isTransparentBlockDrop = (dom: DOMUtils, schema: Schema, target: Element, dropContent: Clipboard.ClipboardContents) => {
+  const parentTransparent = dom.getParent(target, (node) => TransparentElements.isTransparentBlock(schema, node));
+  if (parentTransparent && Obj.has(dropContent, 'text/html')) {
+    const fragment = new DOMParser().parseFromString(dropContent['text/html'], 'text/html').body;
+    return !Type.isNull(fragment.querySelector(parentTransparent.nodeName.toLowerCase()));
+  } else {
+    return false;
+  }
+};
+
 const setup = (editor: Editor, draggingInternallyState: Cell<boolean>): void => {
   // Block all drag/drop events
   if (Options.shouldPasteBlockDrop(editor)) {
@@ -48,7 +61,7 @@ const setup = (editor: Editor, draggingInternallyState: Cell<boolean>): void => 
   }
 
   editor.on('drop', (e) => {
-    if (e.isDefaultPrevented() || draggingInternallyState.get()) {
+    if (e.isDefaultPrevented()) {
       return;
     }
 
@@ -66,6 +79,11 @@ const setup = (editor: Editor, draggingInternallyState: Cell<boolean>): void => 
 
     const internalContent = dropContent[InternalHtml.internalHtmlMime()];
     const content = internalContent || dropContent['text/html'] || dropContent['text/plain'];
+    const transparentElementDrop = isTransparentBlockDrop(editor.dom, editor.schema, e.target, dropContent);
+
+    if (draggingInternallyState.get() && !transparentElementDrop) {
+      return;
+    }
 
     if (content) {
       e.preventDefault();
@@ -80,6 +98,7 @@ const setup = (editor: Editor, draggingInternallyState: Cell<boolean>): void => 
           setFocusedRange(editor, rng);
 
           const trimmedContent = PasteUtils.trimHtml(content);
+
           if (dropContent['text/html']) {
             Clipboard.pasteHtml(editor, trimmedContent, internal);
           } else {

--- a/modules/tinymce/src/core/test/ts/browser/EditorAutoFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorAutoFocusTest.ts
@@ -11,7 +11,7 @@ import { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
 describe('browser.tinymce.core.EditorAutoFocusTest', () => {
   before(() => {
     Insert.append(SugarBody.body(), SugarElement.fromHtml(`<div id="abc">
-      <div style="margin-top: 500px" class="tinymce" id="mce_0">Editor_0</div>
+      <div class="tinymce" id="mce_0">Editor_0</div>
       <div style="margin-top: 500px" class="tinymce" id="mce_1">Editor_1</div>
       <div style="margin-top: 500px" class="tinymce" id="mce_2">Editor_2</div>
     </div>`));
@@ -22,6 +22,7 @@ describe('browser.tinymce.core.EditorAutoFocusTest', () => {
   });
 
   afterEach(() => {
+    window.scrollTo(0, 0);
     EditorManager.remove();
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/EditorAutoFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorAutoFocusTest.ts
@@ -12,8 +12,8 @@ describe('browser.tinymce.core.EditorAutoFocusTest', () => {
   before(() => {
     Insert.append(SugarBody.body(), SugarElement.fromHtml(`<div id="abc">
       <div class="tinymce" id="mce_0">Editor_0</div>
-      <div style="margin-top: 500px" class="tinymce" id="mce_1">Editor_1</div>
-      <div style="margin-top: 500px" class="tinymce" id="mce_2">Editor_2</div>
+      <div style="margin-top: ${window.innerHeight}px"><div class="tinymce" id="mce_1">Editor_1</div></div>
+      <div style="margin-top: ${window.innerHeight}px"><div class="tinymce" id="mce_2">Editor_2</div></div>
     </div>`));
   });
 
@@ -71,10 +71,12 @@ describe('browser.tinymce.core.EditorAutoFocusTest', () => {
 
       it('TINY-8785: should autofocus the second editor', async () => {
         await pTestEditorAutoFocus('mce_1', tester.settings);
+        assert.isAtLeast(window.scrollY, 10);
       });
 
       it('TINY-8785: should autofocus the third editor', async () => {
         await pTestEditorAutoFocus('mce_2', tester.settings);
+        assert.isAtLeast(window.scrollY, 10);
       });
     });
   });

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -691,13 +691,13 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
       TinyAssertions.assertContent(editor, '<div><a href="#1">a</a><a href="#2"><p>b</p></a>c</div>');
     });
 
-    it('TINY-9172: Insert inline anchor in transparent block should split the block', () => {
+    it('TINY-9172: Insert inline anchor in anchor block should unwrap the inline anchor', () => {
       const editor = hook.editor();
 
       editor.setContent('<a href="#1"><div>ac</div></a>');
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
       editor.insertContent('<a href="#2">b</a>');
-      TinyAssertions.assertContent(editor, '<div><a href="#1">a</a><a href="#2">b</a>c</div>');
+      TinyAssertions.assertContent(editor, '<a href="#1"><div>abc</div></a>');
     });
 
     it('TINY-9172: Insert block in anchor should work and annotate the element with data-mce-block', () => {

--- a/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
@@ -55,6 +55,18 @@ describe('browser.tinymce.core.content.TransparentElementsTest', () => {
       });
     });
 
+    it('TINY-9231: Should unwrap invalid children', () => {
+      withScratchDiv('', (root) => {
+        const anchor = SugarElement.fromHtml('<a href="#1"></a>');
+        Html.set(anchor, '<p><a href="#2">link</a></p>');
+        Insert.append(root, anchor);
+
+        assert.equal(Html.get(root), '<a href="#1"><p><a href="#2">link</a></p></a>', 'Check that the setup worked');
+        TransparentElements.updateChildren(schema, root.dom);
+        assert.equal(Html.get(root), '<a href="#1" data-mce-block="true"><p>link</p></a>', 'Should unwrap the inner anchor');
+      });
+    });
+
     it('TINY-9172: Should add data-mce-block on transparent block elements that wrap blocks and also remove data-mce-selected="inline-boundary"', () => testUpdateChildren({
       input: '<div><a href="#" data-mce-selected="inline-boundary"><p>link</p></a></div>',
       expected: '<div><a href="#" data-mce-block="true"><p>link</p></a></div>'

--- a/modules/tinymce/src/core/test/ts/browser/paste/DragDropTransparentsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/DragDropTransparentsTest.ts
@@ -1,0 +1,38 @@
+import { DragnDrop, Waiter } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarElement } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.paste.DragDropTransparentElementsTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [], true);
+
+  const pWaitForContent = (editor: Editor, expected: string) =>
+    Waiter.pTryUntil('Should be expected content', () => TinyAssertions.assertContent(editor, expected));
+
+  it('TINY-9231: should unwrap inline anchors if dropping in a block anchor', async () => {
+    const editor = hook.editor();
+
+    editor.setContent('<a href="#"><p>block link</p></a>');
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+    const target = SugarElement.fromDom(editor.selection.getNode());
+    DragnDrop.dropItems([{ data: '<a href="#">link</a>', type: 'text/html' }], target);
+    await pWaitForContent(editor, '<a href="#"><p>linkblock link</p></a>');
+  });
+
+  it('TINY-9231: should unwrap inline anchors if dropping in a block anchor (internal)', async () => {
+    const editor = hook.editor();
+
+    editor.setContent('<a href="#"><p>block link</p></a>');
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+    const target = SugarElement.fromDom(editor.selection.getNode());
+    editor.fire('dragstart');
+    DragnDrop.dropItems([{ data: '<a href="#">link</a>', type: 'text/html' }], target);
+    editor.fire('dragend');
+    await pWaitForContent(editor, '<a href="#"><p>linkblock link</p></a>');
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/StickyHeaderInitialPlacementTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/StickyHeaderInitialPlacementTest.ts
@@ -11,7 +11,7 @@ describe('browser.tinymce.themes.silver.editor.header.StickyHeaderInitialPlaceme
 
   Arr.each([
     { location: ToolbarLocation.top, height: 2000, expectDocked: false },
-    { location: ToolbarLocation.bottom, height: 500, expectDocked: false },
+    { location: ToolbarLocation.bottom, height: 200, expectDocked: false },
     { location: ToolbarLocation.bottom, height: 2000, expectDocked: true }
   ], (test) => {
     it(`Test toolbar initial placement with toolbar_location: ${test.location} and height: ${test.height}`, async () => {


### PR DESCRIPTION
Related Ticket: TINY-9231

Description of Changes:
* Fix for drag/dropping transparents into transparents

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
