### PR TITLE
TINY-9402: Prepare for 5.10.7 release (take 4)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,7 @@ node("primary") {
       [ name: "win10Chrome", os: "windows-10", browser: "chrome", buckets: 1 ],
       [ name: "win11FF", os: "windows-11", browser: "firefox", buckets: 1 ],
       [ name: "win10Edge", os: "windows-10", browser: "MicrosoftEdge", buckets: 1 ],
-      // Disable EI tests as IE is unreliable
+      // Disable IE tests as IE is unreliable
       // [ name: "win10IE", os: "windows-10", browser: "ie", buckets: 3 ],
       [ name: "macSafari", os: "macos", browser: "safari", buckets: 1 ],
       [ name: "macChrome", os: "macos", browser: "chrome", buckets: 1 ],


### PR DESCRIPTION
Related Ticket: TINY-9402

Description of Changes:
* Disable IE tests because IE is unreliable

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
