### PR TITLE
TINY-9450: Added typography plugin to the default menubar

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,10 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Added
-- Typography added to the default menubar tools list. #TINY-9450
-
-### Fixed
+## Fixed
 - An element could be dropped onto the decendants of a noneditable element. #TINY-9364
 - Checkmark did not show in menu colorswatches. #TINY-9395
 - Toolbar split buttons in advlist plugin to show the correct state when the cursor is in a checklist. #TINY-5167

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## Fixed
+### Added
+- Typography added to the default menubar tools list. #TINY-9450
+
+### Fixed
 - An element could be dropped onto the decendants of a noneditable element. #TINY-9364
 - Checkmark did not show in menu colorswatches. #TINY-9395
 - Toolbar split buttons in advlist plugin to show the correct state when the cursor is in a checklist. #TINY-5167

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
@@ -25,7 +25,7 @@ const defaultMenus: Record<string, MenuSpec> = {
   view: { title: 'View', items: 'code | visualaid visualchars visualblocks | spellchecker | preview fullscreen | showcomments' },
   insert: { title: 'Insert', items: 'image link media addcomment pageembed template codesample inserttable | charmap emoticons hr | pagebreak nonbreaking anchor tableofcontents footnotes | mergetags | insertdatetime' },
   format: { title: 'Format', items: 'bold italic underline strikethrough superscript subscript codeformat | styles blocks fontfamily fontsize align lineheight | forecolor backcolor | language | removeformat' },
-  tools: { title: 'Tools', items: 'spellchecker spellcheckerlanguage | autocorrect capitalization | a11ycheck code wordcount' },
+  tools: { title: 'Tools', items: 'spellchecker spellcheckerlanguage | autocorrect capitalization | a11ycheck code wordcount typography' },
   table: { title: 'Table', items: 'inserttable | cell row column | advtablesort | tableprops deletetable' },
   help: { title: 'Help', items: 'help' }
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
@@ -25,7 +25,7 @@ const defaultMenus: Record<string, MenuSpec> = {
   view: { title: 'View', items: 'code | visualaid visualchars visualblocks | spellchecker | preview fullscreen | showcomments' },
   insert: { title: 'Insert', items: 'image link media addcomment pageembed template codesample inserttable | charmap emoticons hr | pagebreak nonbreaking anchor tableofcontents footnotes | mergetags | insertdatetime' },
   format: { title: 'Format', items: 'bold italic underline strikethrough superscript subscript codeformat | styles blocks fontfamily fontsize align lineheight | forecolor backcolor | language | removeformat' },
-  tools: { title: 'Tools', items: 'spellchecker spellcheckerlanguage | autocorrect capitalization | a11ycheck code wordcount typography' },
+  tools: { title: 'Tools', items: 'spellchecker spellcheckerlanguage | autocorrect capitalization | a11ycheck code typography wordcount' },
   table: { title: 'Table', items: 'inserttable | cell row column | advtablesort | tableprops deletetable' },
   help: { title: 'Help', items: 'help' }
 };


### PR DESCRIPTION
Related Ticket: TINY-9450

Description of Changes:
* Added typography plugin to the default menubar.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
