### PR TITLE
TINY-9462: InsertContent api is not blocking for noneditable root content

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,11 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Added
+- New `isEditable` API to `editor.selection` that returns true or false if the current selection is editable. #TINY-9462
+- New `isEditable` API to `editor.dom` that returns true or false if the specified node is editable. #TINY-9462
+
 ## Fixed
 - An element could be dropped onto the decendants of a noneditable element. #TINY-9364
 - Checkmark did not show in menu colorswatches. #TINY-9395
 - Toolbar split buttons in advlist plugin to show the correct state when the cursor is in a checklist. #TINY-5167
 - Dragging transparent elements into transparent blocks elements could produce invalid nesting of transparents. #TINY-9231
+- The `editor.insertContent` API would insert contents inside noneditable elements if the selection was inside the element. #TINY-9462
 
 ### Improved
 - Direct invalid child text nodes of list elements will be wrapped in list item elements. #TINY-4818

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,22 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## Added
+### Added
 - New `isEditable` API to `editor.selection` that returns true or false if the current selection is editable. #TINY-9462
 - New `isEditable` API to `editor.dom` that returns true or false if the specified node is editable. #TINY-9462
 
-## Fixed
+### Improved
+- Direct invalid child text nodes of list elements will be wrapped in list item elements. #TINY-4818
+
+### Fixed
 - An element could be dropped onto the decendants of a noneditable element. #TINY-9364
 - Checkmark did not show in menu colorswatches. #TINY-9395
 - Toolbar split buttons in advlist plugin to show the correct state when the cursor is in a checklist. #TINY-5167
 - Dragging transparent elements into transparent blocks elements could produce invalid nesting of transparents. #TINY-9231
 - The `editor.insertContent` API would insert contents inside noneditable elements if the selection was inside the element. #TINY-9462
 - Closing a dialog would scroll down the document in Safari. #TINY-9148
-
-### Improved
-- Direct invalid child text nodes of list elements will be wrapped in list item elements. #TINY-4818
-
-### Fixed
 - Quick toolbars were incorrectly rendered during the dragging of `contenteditable="false"` elements. #TINY-9305
 
 ## 6.3.1 - 2022-12-06

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1845,7 +1845,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      *
      * @method isEditable
      * @param {Node} scope Node to check if it's editable or not.
-     * @return {Boolean} True if it's editable, false if it's not editable.
+     * @return {Boolean} true if it's editable, false if it's not editable.
      */
     isEditable,
 

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Obj, Optionals, Strings, Type } from '@ephox/katamari';
-import { Attribute, Class, Css, Html, Insert, Remove, Selectors, SugarElement, SugarNode, Traverse, WindowVisualViewport } from '@ephox/sugar';
+import { Attribute, Class, ContentEditable, Css, Html, Insert, Remove, Selectors, SugarElement, SugarNode, Traverse, WindowVisualViewport } from '@ephox/sugar';
 
 import * as TransparentElements from '../../content/TransparentElements';
 import * as NodeType from '../../dom/NodeType';
@@ -200,6 +200,7 @@ interface DOMUtils {
   dispatch: (target: Node | Window, name: string, evt?: {}) => EventUtils;
   getContentEditable: (node: Node) => string | null;
   getContentEditableParent: (node: Node) => string | null;
+  isEditable: (node: Node) => boolean;
   destroy: () => void;
   isChildOf: (node: Node, parent: Node) => boolean;
   dumpRng: (r: Range) => string;
@@ -1122,6 +1123,16 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     return state;
   };
 
+  const isEditable = (node: Node) => {
+    if (Type.isNonNullable(node)) {
+      const scope = NodeType.isElement(node) ? node : node.parentElement;
+      const isRootEditable = getContentEditable(getRoot()) === 'true';
+      return Type.isNonNullable(scope) && ContentEditable.isEditable(SugarElement.fromDom(scope), isRootEditable);
+    } else {
+      return false;
+    }
+  };
+
   const destroy = () => {
     // Unbind all events bound to window/document by editor instance
     if (boundEvents.length > 0) {
@@ -1828,6 +1839,15 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     // Returns the content editable state of a node
     getContentEditable,
     getContentEditableParent,
+
+    /**
+     * Returns true or false if the specified node is editable within the context of it's parents.
+     *
+     * @method isEditable
+     * @param {Node} scope Node to check if it's editable or not.
+     * @return {Boolean} True if it's editable, false if it's not editable.
+     */
+    isEditable,
 
     /**
      * Destroys all internal references to the DOM to solve memory leak issues.

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1840,13 +1840,6 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     getContentEditable,
     getContentEditableParent,
 
-    /**
-     * Returns true or false if the specified node is editable within the context of it's parents.
-     *
-     * @method isEditable
-     * @param {Node} scope Node to check if it's editable or not.
-     * @return {Boolean} true if it's editable, false if it's not editable.
-     */
     isEditable,
 
     /**

--- a/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
@@ -257,12 +257,6 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
     return !sel || rng.collapsed;
   };
 
-  /**
-   * Returns true if both the endpoints of the selection range is editable and false if one if them isn't editable.
-   *
-   * @method isEditable
-   * @return {Boolean} true or false if the selection range is editable or not.
-   */
   const isEditable = (): boolean => {
     const rng = getRng();
 

--- a/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
@@ -69,6 +69,7 @@ interface EditorSelection {
   moveToBookmark: (bookmark: Bookmark) => void;
   select: (node: Node, content?: boolean) => Node;
   isCollapsed: () => boolean;
+  isEditable: () => boolean;
   isForward: () => boolean;
   setNode: (elm: Element) => Element;
   getNode: () => HTMLElement;
@@ -254,6 +255,22 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
     }
 
     return !sel || rng.collapsed;
+  };
+
+  /**
+   * Returns true if both the endpoints of the selection range is editable and false if one if them isn't editable.
+   *
+   * @method isEditable
+   * @return {Boolean} true or false if the selection range is editable or not.
+   */
+  const isEditable = (): boolean => {
+    const rng = getRng();
+
+    if (rng.startContainer === rng.endContainer) {
+      return dom.isEditable(rng.startContainer);
+    } else {
+      return dom.isEditable(rng.startContainer) && dom.isEditable(rng.endContainer);
+    }
   };
 
   /**
@@ -567,6 +584,7 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
     moveToBookmark,
     select,
     isCollapsed,
+    isEditable,
     isForward,
     setNode,
     getNode,

--- a/modules/tinymce/src/core/main/ts/content/InsertContent.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContent.ts
@@ -48,13 +48,15 @@ const trimOrPad = (editor: Editor, value: string): string => {
 };
 
 const insertAtCaret = (editor: Editor, value: string | DetailsWithContent): void => {
-  const { content, details } = processValue(value);
+  if (editor.selection.isEditable()) {
+    const { content, details } = processValue(value);
 
-  preProcessSetContent(editor, { ...details, content: trimOrPad(editor, content), format: 'html', set: false, selection: true }).each((args) => {
-    const insertedContent = Rtc.insertContent(editor, args.content, details);
-    postProcessSetContent(editor, insertedContent, args);
-    editor.addVisual();
-  });
+    preProcessSetContent(editor, { ...details, content: trimOrPad(editor, content), format: 'html', set: false, selection: true }).each((args) => {
+      const insertedContent = Rtc.insertContent(editor, args.content, details);
+      postProcessSetContent(editor, insertedContent, args);
+      editor.addVisual();
+    });
+  }
 };
 
 export { insertAtCaret };

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -739,4 +739,40 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
       TinyAssertions.assertContent(editor, '<p><a href="#1">a</a></p><p>b</p><p>c</p><p><a href="#1">d</a></p>');
     });
   });
+
+  context('Noneditable parents', () => {
+    it('TINY-9462: insertContent in noneditable element should be a noop', () => {
+      const editor = hook.editor();
+      const content = '<div contenteditable="false">text</div>';
+
+      editor.setContent(content);
+      // Shifted since fake caret is before div
+      TinySelections.setSelection(editor, [ 1, 0 ], 1, [ 1, 0 ], 2);
+      editor.insertContent('hello');
+      TinyAssertions.assertContent(editor, content);
+    });
+
+    it('TINY-9462: insertContent in normal element in noneditable root should be a noop', () => {
+      const editor = hook.editor();
+      const content = '<div>text</div>';
+
+      editor.getBody().contentEditable = 'false';
+      editor.setContent(content);
+      TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
+      editor.insertContent('hello');
+      TinyAssertions.assertContent(editor, content);
+      editor.getBody().contentEditable = 'true';
+    });
+
+    it('TINY-9462: insertContent in editable element in noneditable root should insert content', () => {
+      const editor = hook.editor();
+
+      editor.getBody().contentEditable = 'false';
+      editor.setContent('<div contenteditable="true">text</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
+      editor.insertContent('hello');
+      TinyAssertions.assertContent(editor, '<div contenteditable="true">thelloxt</div>');
+      editor.getBody().contentEditable = 'true';
+    });
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-9462

Description of Changes:
* Fixes so insertContent becomes a noop if the selection range is noneditable
* Adds a new editor.selection.isEditable public api needed for this and other future PRs
* Adds a new editor.dom.isEditable public api needed for this and other future PRs
* Fixes some issues with the changelog like duplicate categories and incorrect ordering and heading level

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable) DOC-1888

GitHub issues (if applicable):
