### PR TITLE
TINY-9474: Visualchars applies to noneditable content

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `editor.insertContent` API would insert contents inside noneditable elements if the selection was inside the element. #TINY-9462
 - Closing a dialog would scroll down the document in Safari. #TINY-9148
 - Quick toolbars were incorrectly rendered during the dragging of `contenteditable="false"` elements. #TINY-9305
+- Visual characters was rendered inside noneditable elements. #TINY-9474
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `editor.insertContent` API would insert contents inside noneditable elements if the selection was inside the element. #TINY-9462
 - Closing a dialog would scroll down the document in Safari. #TINY-9148
 - Quick toolbars were incorrectly rendered during the dragging of `contenteditable="false"` elements. #TINY-9305
-- Visual characters was rendered inside noneditable elements. #TINY-9474
+- Visual characters were rendered inside noneditable elements. #TINY-9474
 - Removed a workaround for ensuring stylesheets are loaded in an outdated version of webkit. #TINY-9433
 
 ## 6.3.1 - 2022-12-06

--- a/modules/tinymce/src/plugins/visualchars/main/ts/core/Nodes.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/core/Nodes.ts
@@ -26,8 +26,8 @@ const isChildEditable = (node: SugarElement<Node>, currentState: boolean) => {
   return currentState;
 };
 
-// inlined sugars PredicateFilter.descendants for file size but also make it only act on editable nodes
-const filterDescendants = <T extends Node>(scope: SugarElement<Node>, predicate: (x: SugarElement<Node>) => x is SugarElement<T>, editable: boolean): SugarElement<T>[] => {
+// inlined sugars PredicateFilter.descendants for file size but also make it only act on editable nodes it changes the current editable state when it traveses down
+const filterEditableDescendants = <T extends Node>(scope: SugarElement<Node>, predicate: (x: SugarElement<Node>) => x is SugarElement<T>, editable: boolean): SugarElement<T>[] => {
   let result: SugarElement<T>[] = [];
   const dom = scope.dom;
   const children = Arr.map(dom.childNodes, SugarElement.fromDom);
@@ -36,7 +36,7 @@ const filterDescendants = <T extends Node>(scope: SugarElement<Node>, predicate:
     if (editable && !isContentEditableFalse(x) && predicate(x)) {
       result = result.concat([ x ]);
     }
-    result = result.concat(filterDescendants(x, predicate, isChildEditable(x, editable)));
+    result = result.concat(filterEditableDescendants(x, predicate, isChildEditable(x, editable)));
   });
   return result;
 };
@@ -57,7 +57,7 @@ const replaceWithSpans = (text: string): string =>
 
 export {
   isMatch,
-  filterDescendants,
+  filterEditableDescendants,
   findParentElm,
   replaceWithSpans
 };

--- a/modules/tinymce/src/plugins/visualchars/main/ts/core/Nodes.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/core/Nodes.ts
@@ -1,5 +1,5 @@
 import { Arr, Type } from '@ephox/katamari';
-import { SugarElement, SugarNode } from '@ephox/sugar';
+import { ContentEditable, SugarElement, SugarNode } from '@ephox/sugar';
 
 import * as Data from './Data';
 import * as Html from './Html';
@@ -11,17 +11,32 @@ const isMatch = (n: SugarElement<Node>): n is SugarElement<Text> => {
     Data.regExp.test(value);
 };
 
-// inlined sugars PredicateFilter.descendants for file size
-const filterDescendants = <T extends Node>(scope: SugarElement<Node>, predicate: (x: SugarElement<Node>) => x is SugarElement<T>): SugarElement<T>[] => {
+const isContentEditableFalse = (node: SugarElement<Node>) => SugarNode.isHTMLElement(node) && ContentEditable.getRaw(node) === 'false';
+
+const isChildEditable = (node: SugarElement<Node>, currentState: boolean) => {
+  if (SugarNode.isHTMLElement(node)) {
+    const value = ContentEditable.getRaw(node);
+    if (value === 'true') {
+      return true;
+    } else if (value === 'false') {
+      return false;
+    }
+  }
+
+  return currentState;
+};
+
+// inlined sugars PredicateFilter.descendants for file size but also make it only act on editable nodes
+const filterDescendants = <T extends Node>(scope: SugarElement<Node>, predicate: (x: SugarElement<Node>) => x is SugarElement<T>, editable: boolean): SugarElement<T>[] => {
   let result: SugarElement<T>[] = [];
   const dom = scope.dom;
   const children = Arr.map(dom.childNodes, SugarElement.fromDom);
 
   Arr.each(children, (x) => {
-    if (predicate(x)) {
+    if (editable && !isContentEditableFalse(x) && predicate(x)) {
       result = result.concat([ x ]);
     }
-    result = result.concat(filterDescendants(x, predicate));
+    result = result.concat(filterDescendants(x, predicate, isChildEditable(x, editable)));
   });
   return result;
 };

--- a/modules/tinymce/src/plugins/visualchars/main/ts/core/VisualChars.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/core/VisualChars.ts
@@ -11,7 +11,7 @@ const isWrappedNbsp = (node: Node): node is HTMLSpanElement =>
 
 const show = (editor: Editor, rootElm: Element): void => {
   const dom = editor.dom;
-  const nodeList = Nodes.filterDescendants(SugarElement.fromDom(rootElm), Nodes.isMatch);
+  const nodeList = Nodes.filterDescendants(SugarElement.fromDom(rootElm), Nodes.isMatch, editor.dom.isEditable(rootElm));
 
   Arr.each(nodeList, (n) => {
     const parent = n.dom.parentNode as Node;

--- a/modules/tinymce/src/plugins/visualchars/main/ts/core/VisualChars.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/core/VisualChars.ts
@@ -11,7 +11,7 @@ const isWrappedNbsp = (node: Node): node is HTMLSpanElement =>
 
 const show = (editor: Editor, rootElm: Element): void => {
   const dom = editor.dom;
-  const nodeList = Nodes.filterDescendants(SugarElement.fromDom(rootElm), Nodes.isMatch, editor.dom.isEditable(rootElm));
+  const nodeList = Nodes.filterEditableDescendants(SugarElement.fromDom(rootElm), Nodes.isMatch, editor.dom.isEditable(rootElm));
 
   Arr.each(nodeList, (n) => {
     const parent = n.dom.parentNode as Node;

--- a/modules/tinymce/src/plugins/visualchars/test/ts/atomic/NodesTest.ts
+++ b/modules/tinymce/src/plugins/visualchars/test/ts/atomic/NodesTest.ts
@@ -28,7 +28,7 @@ describe('atomic.tinymce.plugins.visualchars.NodesTest', () => {
         '<p>c</p>' +
         '<p>d' + Unicode.softHyphen + '</p>'
       );
-      assert.equal(Nodes.filterDescendants(SugarElement.fromDom(div), Nodes.isMatch, true).length, 2);
+      assert.equal(Nodes.filterEditableDescendants(SugarElement.fromDom(div), Nodes.isMatch, true).length, 2);
 
       // 4 matches
       div.innerHTML = (
@@ -37,7 +37,7 @@ describe('atomic.tinymce.plugins.visualchars.NodesTest', () => {
         '<p>c' + Unicode.nbsp + '</p>' +
         '<p>d' + Unicode.softHyphen + '</p>'
       );
-      assert.equal(Nodes.filterDescendants(SugarElement.fromDom(div), Nodes.isMatch, true).length, 4);
+      assert.equal(Nodes.filterEditableDescendants(SugarElement.fromDom(div), Nodes.isMatch, true).length, 4);
     });
 
     it('should only return editable nodes for initial editable state', () => {
@@ -58,7 +58,7 @@ describe('atomic.tinymce.plugins.visualchars.NodesTest', () => {
       `;
       const div = SugarElement.fromHtml(`<div>${innerHtml}</div>`);
 
-      assert.deepEqual(Arr.map(Nodes.filterDescendants(div, SugarNode.isElement, true), Html.getOuter), [
+      assert.deepEqual(Arr.map(Nodes.filterEditableDescendants(div, SugarNode.isElement, true), Html.getOuter), [
         '<b>editable 1</b>',
         '<b>editable 2</b>',
         '<i>editable 3</i>',
@@ -85,7 +85,7 @@ describe('atomic.tinymce.plugins.visualchars.NodesTest', () => {
       `;
       const div = SugarElement.fromHtml(`<div>${innerHtml}</div>`);
 
-      assert.deepEqual(Arr.map(Nodes.filterDescendants(div, SugarNode.isElement, false), Html.getOuter), [
+      assert.deepEqual(Arr.map(Nodes.filterEditableDescendants(div, SugarNode.isElement, false), Html.getOuter), [
         '<b>editable 1</b>',
         '<i>editable 2</i>',
         '<b>editable 3</b>'

--- a/modules/tinymce/src/plugins/visualchars/test/ts/atomic/NodesTest.ts
+++ b/modules/tinymce/src/plugins/visualchars/test/ts/atomic/NodesTest.ts
@@ -1,7 +1,7 @@
 import { Assertions } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { Unicode } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import { Arr, Unicode } from '@ephox/katamari';
+import { Html, SugarElement, SugarNode } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import * as Nodes from 'tinymce/plugins/visualchars/core/Nodes';
@@ -28,7 +28,7 @@ describe('atomic.tinymce.plugins.visualchars.NodesTest', () => {
         '<p>c</p>' +
         '<p>d' + Unicode.softHyphen + '</p>'
       );
-      assert.equal(2, Nodes.filterDescendants(SugarElement.fromDom(div), Nodes.isMatch).length);
+      assert.equal(Nodes.filterDescendants(SugarElement.fromDom(div), Nodes.isMatch, true).length, 2);
 
       // 4 matches
       div.innerHTML = (
@@ -37,8 +37,59 @@ describe('atomic.tinymce.plugins.visualchars.NodesTest', () => {
         '<p>c' + Unicode.nbsp + '</p>' +
         '<p>d' + Unicode.softHyphen + '</p>'
       );
-      assert.equal(4, Nodes.filterDescendants(SugarElement.fromDom(div), Nodes.isMatch).length);
+      assert.equal(Nodes.filterDescendants(SugarElement.fromDom(div), Nodes.isMatch, true).length, 4);
+    });
+
+    it('should only return editable nodes for initial editable state', () => {
+      const innerHtml = `
+        <b>editable 1</b>
+        <span contenteditable="false">
+          <b><i>noneditable</i></b>
+          <span contenteditable="true">
+            <b>editable 2</b>
+            <i>editable 3</i>
+          </span>
+          <i>noneditable</i>
+          <span contenteditable="true">
+            <b>editable 4</b>
+          </span>
+        </span>
+        <i>editable 5</i>
+      `;
+      const div = SugarElement.fromHtml(`<div>${innerHtml}</div>`);
+
+      assert.deepEqual(Arr.map(Nodes.filterDescendants(div, SugarNode.isElement, true), Html.getOuter), [
+        '<b>editable 1</b>',
+        '<b>editable 2</b>',
+        '<i>editable 3</i>',
+        '<b>editable 4</b>',
+        '<i>editable 5</i>'
+      ]);
+    });
+
+    it('should only return editable nodes for initial noneditable state', () => {
+      const innerHtml = `
+        <b>noneditable</b>
+        <span contenteditable="false">
+          <b><i>noneditable</i></b>
+          <span contenteditable="true">
+            <b>editable 1</b>
+            <i>editable 2</i>
+          </span>
+          <i>noneditable</i>
+          <span contenteditable="true">
+            <b>editable 3</b>
+          </span>
+        </span>
+        <i>noneditable</i>
+      `;
+      const div = SugarElement.fromHtml(`<div>${innerHtml}</div>`);
+
+      assert.deepEqual(Arr.map(Nodes.filterDescendants(div, SugarNode.isElement, false), Html.getOuter), [
+        '<b>editable 1</b>',
+        '<i>editable 2</i>',
+        '<b>editable 3</b>'
+      ]);
     });
   });
-
 });

--- a/modules/tinymce/src/plugins/visualchars/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/visualchars/test/ts/browser/PluginTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyHooks, TinyUiActions, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinyUiActions, TinySelections, TinyAssertions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -74,5 +74,31 @@ describe('browser.tinymce.plugins.visualchars.PluginTest', () => {
     ])));
 
     assert.isFalse(editor.selection.isForward(), 'should still be backwards');
+  });
+
+  it('TINY-9474: should not process noneditable elements', async () => {
+    const editor = hook.editor();
+
+    editor.setContent('<p contenteditable="false">abc&nbsp;&nbsp;</p><p>123&nbsp;&nbsp;</p>');
+    TinyUiActions.clickOnToolbar(editor, 'button');
+    await Waiter.pTryUntil('wait for visual chars to appear', () => {
+      TinyAssertions.assertContentPresence(editor, {
+        'span.mce-nbsp': 2
+      });
+    });
+  });
+
+  it('TINY-9474: should not process noneditable elements in a noneditable root', async () => {
+    const editor = hook.editor();
+
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<p>abc&nbsp;&nbsp;</p><p contenteditable="true">123&nbsp;&nbsp;</p>');
+    TinyUiActions.clickOnToolbar(editor, 'button');
+    await Waiter.pTryUntil('wait for visual chars to appear', () => {
+      TinyAssertions.assertContentPresence(editor, {
+        'span.mce-nbsp': 2
+      });
+    });
+    editor.getBody().contentEditable = 'true';
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9474

Description of Changes:
* Prevents visual characters spans from being rendered within a noneditable context.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-9474]: https://ephocks.atlassian.net/browse/TINY-9474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ