### PR TITLE
TINY-9449: Cursor position search should not descend into the CEF

### DIFF
--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableFill.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableFill.ts
@@ -60,7 +60,6 @@ const cloneFormats = (oldCell: SugarElement<Element>, newCell: SugarElement<Elem
     // Add the matched ancestors to the new cell, then return the new cell.
     return Arr.foldr(parents, (last, parent) => {
       const clonedFormat = Replication.shallow(parent);
-      Attribute.remove(clonedFormat, 'contenteditable');
       Insert.append(last, clonedFormat);
       return clonedFormat;
     }, newCell);

--- a/modules/snooker/src/test/ts/browser/CloneFormatsTest.ts
+++ b/modules/snooker/src/test/ts/browser/CloneFormatsTest.ts
@@ -12,7 +12,7 @@ UnitTest.test('CloneFormatsTest', () => {
   const noCloneTableFill = TableFill.cellOperations(Fun.noop, doc, noCloneFormats);
 
   const cellElement = SugarElement.fromTag('td');
-  const cellContent = SugarElement.fromHtml('<strong contenteditable="false"><em>stuff</em></strong>');
+  const cellContent = SugarElement.fromHtml('<strong><em contenteditable="false">stuff</em></strong>');
   Insert.append(cellElement, cellContent);
   const cell: CellData = {
     element: cellElement,
@@ -22,7 +22,7 @@ UnitTest.test('CloneFormatsTest', () => {
 
   const clonedCell = cloneTableFill.cell(cell);
 
-  Assert.eq('', '<td><strong><em><br></em></strong></td>', Html.getOuter(clonedCell));
+  Assert.eq('', '<td><strong><br></strong></td>', Html.getOuter(clonedCell));
 
   const noClonedCell = noCloneTableFill.cell(cell);
   Assert.eq('', '<td><br></td>', Html.getOuter(noClonedCell));

--- a/modules/snooker/src/test/ts/browser/CloneFormatsTest.ts
+++ b/modules/snooker/src/test/ts/browser/CloneFormatsTest.ts
@@ -11,19 +11,25 @@ UnitTest.test('CloneFormatsTest', () => {
   const cloneTableFill = TableFill.cellOperations(Fun.noop, doc, Optional.none());
   const noCloneTableFill = TableFill.cellOperations(Fun.noop, doc, noCloneFormats);
 
-  const cellElement = SugarElement.fromTag('td');
-  const cellContent = SugarElement.fromHtml('<strong><em contenteditable="false">stuff</em></strong>');
-  Insert.append(cellElement, cellContent);
-  const cell: CellData = {
-    element: cellElement,
-    colspan: 1,
-    rowspan: 1
+  const createCell = (content: string): CellData => {
+    const cellElement = SugarElement.fromTag('td');
+    const cellContent = SugarElement.fromHtml(content);
+    Insert.append(cellElement, cellContent);
+    return {
+      element: cellElement,
+      colspan: 1,
+      rowspan: 1
+    };
   };
 
-  const clonedCell = cloneTableFill.cell(cell);
+  const testClonedCell = (content: string, expected: string) => {
+    const cell = createCell(content);
+    const clonedCell = cloneTableFill.cell(cell);
+    Assert.eq('', expected, Html.getOuter(clonedCell));
+    const noClonedCell = noCloneTableFill.cell(cell);
+    Assert.eq('', '<td><br></td>', Html.getOuter(noClonedCell));
+  };
 
-  Assert.eq('', '<td><strong><br></strong></td>', Html.getOuter(clonedCell));
-
-  const noClonedCell = noCloneTableFill.cell(cell);
-  Assert.eq('', '<td><br></td>', Html.getOuter(noClonedCell));
+  testClonedCell('<strong contenteditable="false"><em>stuff</em></strong>', '<td><br></td>');
+  testClonedCell('<strong><em contenteditable="false">stuff</em></strong>', '<td><strong><br></strong></td>');
 });

--- a/modules/sugar/CHANGELOG.md
+++ b/modules/sugar/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- `Awareness.isCursorPosition` API now returns `true` for passed `contenteditable=false` elements.
+
 ## 9.1.0 - 2022-09-08
 
 ### Improved

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/Awareness.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/Awareness.ts
@@ -21,7 +21,7 @@ const isTextNodeWithCursorPosition = (el: SugarElement<Node>) => SugarText.getOp
   text.trim().length !== 0 || text.indexOf(Unicode.nbsp) > -1
 ).isSome();
 
-const isContentEditableFalse = (elem: SugarElement<Node>) => SugarNode.isHTMLElement(elem) && (elem.dom.contentEditable === 'false');
+const isContentEditableFalse = (elem: SugarElement<Node>) => SugarNode.isHTMLElement(elem) && (Attribute.get(elem, 'contenteditable') === 'false');
 
 const elementsWithCursorPosition = [ 'img', 'br' ];
 const isCursorPosition = (elem: SugarElement<Node>): boolean => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/Awareness.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/Awareness.ts
@@ -21,10 +21,12 @@ const isTextNodeWithCursorPosition = (el: SugarElement<Node>) => SugarText.getOp
   text.trim().length !== 0 || text.indexOf(Unicode.nbsp) > -1
 ).isSome();
 
+const isContentEditableFalse = (elem: SugarElement<Node>) => SugarNode.isHTMLElement(elem) && !elem.dom.isContentEditable;
+
 const elementsWithCursorPosition = [ 'img', 'br' ];
 const isCursorPosition = (elem: SugarElement<Node>): boolean => {
   const hasCursorPosition = isTextNodeWithCursorPosition(elem);
-  return hasCursorPosition || Arr.contains(elementsWithCursorPosition, SugarNode.name(elem));
+  return hasCursorPosition || Arr.contains(elementsWithCursorPosition, SugarNode.name(elem)) || isContentEditableFalse(elem);
 };
 
 export {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/Awareness.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/Awareness.ts
@@ -3,6 +3,7 @@ import { Arr, Unicode } from '@ephox/katamari';
 import { SugarElement } from '../node/SugarElement';
 import * as SugarNode from '../node/SugarNode';
 import * as SugarText from '../node/SugarText';
+import * as Attribute from '../properties/Attribute';
 import * as Traverse from '../search/Traverse';
 
 const getEnd = (element: SugarElement<Node>): number =>

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/Awareness.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/Awareness.ts
@@ -21,7 +21,7 @@ const isTextNodeWithCursorPosition = (el: SugarElement<Node>) => SugarText.getOp
   text.trim().length !== 0 || text.indexOf(Unicode.nbsp) > -1
 ).isSome();
 
-const isContentEditableFalse = (elem: SugarElement<Node>) => SugarNode.isHTMLElement(elem) && !elem.dom.isContentEditable;
+const isContentEditableFalse = (elem: SugarElement<Node>) => SugarNode.isHTMLElement(elem) && (elem.dom.contentEditable === 'false');
 
 const elementsWithCursorPosition = [ 'img', 'br' ];
 const isCursorPosition = (elem: SugarElement<Node>): boolean => {

--- a/modules/sugar/src/test/ts/browser/CursorPositionTest.ts
+++ b/modules/sugar/src/test/ts/browser/CursorPositionTest.ts
@@ -56,4 +56,13 @@ UnitTest.test('Browser Test: CursorPositionTest', () => {
 
   // INVESTIGATE: Not sure if offset here should be 0 or 1.
   Assert.eq('', true, Edge.isAtRightEdge(container, child4, 0));
+
+  const container2 = SugarElement.fromTag('p');
+  const child2_1 = SugarElement.fromHtml('<span contenteditable="false">AAA</span>');
+  const child2_2 = SugarElement.fromText('BBB');
+  const child2_3 = SugarElement.fromHtml('<span contenteditable="false">CCC</span>');
+  InsertAll.append(container2, [ child2_1, child2_2, child2_3 ]);
+  checkFirst('First of container2 should be first CEF', child2_1, container2);
+  checkLast('Last of container2 should be last CEF', child2_3, container2);
+
 });

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improved
 - Direct invalid child text nodes of list elements will be wrapped in list item elements. #TINY-4818
 
+### Changed
+- The formatting of `contenteditable="false"` elements are no longer cloned to new cells while creating new table rows. #TINY-9449
+
 ### Fixed
 - An element could be dropped onto the decendants of a noneditable element. #TINY-9364
 - Checkmark did not show in menu colorswatches. #TINY-9395

--- a/versions.txt
+++ b/versions.txt
@@ -1,2 +1,4 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
+
+sugar@9.2.0


### PR DESCRIPTION
Related Ticket: TINY-9449

Description of Changes:
* This issue is related to cloning the formatting during the creation of new table rows. Here we have the case when formatting of merge tag prefix unexpectedly cloned to the new cell.  The clone logic searches for the first cursor position in the original cell and collects ancestors' formatting nodes. It seems to me that the main root of the issue is that the search is continuing even within the `CEF` elements, instead of stopping before them. This [test](https://github.com/tinymce/tinymce/blob/develop/modules/snooker/src/test/ts/browser/CloneFormatsTest.ts) shows that cloning formatting nodes even if they are in the `CEF` container is the expected behavior. In this PR I am trying to revisit the approach and treat `CEF` elements the same way as `img` elements and prevent search propagation into the CEF elements.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


[TINY-9449]: https://ephocks.atlassian.net/browse/TINY-9449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ