### PR TITLE
TINY-9457: Color Picker doesn't handle hex color prefixed with #

### DIFF
--- a/modules/acid/src/main/ts/ephox/acid/api/colour/HexColour.ts
+++ b/modules/acid/src/main/ts/ephox/acid/api/colour/HexColour.ts
@@ -3,7 +3,7 @@ import { Strings, Optional } from '@ephox/katamari';
 import { Hex, Rgba } from './ColourTypes';
 
 const hexColour = (value: string): Hex => ({
-  value
+  value: normalizeHex(value)
 });
 
 const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;

--- a/modules/acid/src/main/ts/ephox/acid/gui/components/RgbForm.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/RgbForm.ts
@@ -224,7 +224,7 @@ const rgbFormFactory = (
     const onValidHex = (form: AlloyComponent, value: string) => {
       onValidHexx(form);
       const hex = HexColour.hexColour(value);
-      set('hex', Optional.some(value));
+      set('hex', Optional.some(hex.value));
 
       const rgb = RgbaColour.fromHex(hex);
       copyRgbToForm(form, rgb);

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Closing a dialog would scroll down the document in Safari. #TINY-9148
 - Quick toolbars were incorrectly rendered during the dragging of `contenteditable="false"` elements. #TINY-9305
 - Removed a workaround for ensuring stylesheets are loaded in an outdated version of webkit. #TINY-9433
+- Color picker dialog would not update the preview color if the hex input value was prefixed with `#` symbol. #TINY-9457
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
@@ -1,7 +1,7 @@
 import { ColourPicker } from '@ephox/acid';
 import { AlloyComponent, AlloyTriggers, Behaviour, Composing, Form, Memento, NativeEvents, Representing, SimpleSpec } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Optional, Strings } from '@ephox/katamari';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
@@ -73,7 +73,7 @@ export const renderColorPicker = (_spec: ColorPickerSpec, providerBackstage: UiF
             const formValues = Representing.getValue(rgbForm);
             return formValues.hex as Optional<string>;
           });
-          return optHex.map((hex) => '#' + hex).getOr('');
+          return optHex.map((hex) => '#' + Strings.removeLeading(hex, '#')).getOr('');
         },
         (comp, newValue) => {
           const pattern = /^#([a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?)/;

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/colorpicker/ColorPickerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/colorpicker/ColorPickerTest.ts
@@ -61,6 +61,13 @@ describe('headless.tinymce.themes.silver.components.colorpicker.ColorPickerTest'
     });
   };
 
+  const pAssertPreviewBgColor = (component: AlloyComponent, expected: string) => {
+    return Waiter.pTryUntil('Assert preview background color matches expected', () => {
+      const preview = UiFinder.findIn<HTMLCanvasElement>(component.element, '.tox-rgba-preview').getOrDie();
+      assert.equal(preview.dom.style.backgroundColor, expected);
+    });
+  };
+
   it('Representing state', async () => {
     const component = hook.component();
     RepresentingUtils.setComposedValue(
@@ -128,5 +135,31 @@ describe('headless.tinymce.themes.silver.components.colorpicker.ColorPickerTest'
       component,
       '#00EEDD'
     );
+  });
+
+  it('TINY-9457: Updates preview when hex field value prefixed with #', async () => {
+    const component = hook.component();
+    RepresentingUtils.setComposedValue(
+      component,
+      '#000000'
+    );
+
+    await pAssertColour(component, '0', 'R');
+    await pAssertColour(component, '0', 'G');
+    await pAssertColour(component, '0', 'B');
+
+    setHexValue(component, '#00EEDD');
+
+    await pAssertColour(component, '0', 'R');
+    await pAssertColour(component, '238', 'G');
+    await pAssertColour(component, '221', 'B');
+    await pAssertPaletteHue(component, 176);
+    await pAssertPreviewBgColor(component, 'rgb(0, 238, 221)');
+
+    RepresentingUtils.assertComposedValue(
+      component,
+      '#00EEDD'
+    );
+
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9457 [GitHub-#8156](https://github.com/tinymce/tinymce/issues/8156)

Description of Changes:
* remove the `#` prefix before updating the hex value in the state of the color picker component
Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
https://github.com/tinymce/tinymce/issues/8156