### PR TITLE
TINY-9496: onSetup should run when defining a custom group toolbar button

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Direct invalid child text nodes of list elements will be wrapped in list item elements. #TINY-4818
 
 ### Fixed
+- onSetup function would not run when defining custom group toolbar button. #TINY-9496
 - An element could be dropped onto the decendants of a noneditable element. #TINY-9364
 - Checkmark did not show in menu colorswatches. #TINY-9395
 - Toolbar split buttons in advlist plugin to show the correct state when the cursor is in a checklist. #TINY-5167

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -132,6 +132,18 @@ const renderCommonStructure = (
 
 const renderFloatingToolbarButton = (spec: Toolbar.GroupToolbarButton, backstage: UiFactoryBackstage, identifyButtons: (toolbar: string | ToolbarGroupOption[]) => ToolbarGroup[], attributes: Record<string, string>): SketchSpec => {
   const sharedBackstage = backstage.shared;
+  const editorOffCell = Cell(Fun.noop);
+  const specialisation = {
+    toolbarButtonBehaviours: [],
+    getApi: getButtonApi,
+    onSetup: spec.onSetup
+  };
+  const behaviours: Behaviours = [
+    AddEventsBehaviour.config('toolbar-group-button-events', [
+      onControlAttached(specialisation, editorOffCell),
+      onControlDetached(specialisation, editorOffCell)
+    ])
+  ];
 
   return FloatingToolbarButton.sketch({
     lazySink: sharedBackstage.getSink,
@@ -142,7 +154,7 @@ const renderFloatingToolbarButton = (spec: Toolbar.GroupToolbarButton, backstage
       toggledClass: ToolbarButtonClasses.Ticked
     },
     parts: {
-      button: renderCommonStructure(spec.icon, spec.text, spec.tooltip, Optional.none(), Optional.none(), sharedBackstage.providers),
+      button: renderCommonStructure(spec.icon, spec.text, spec.tooltip, Optional.none(), Optional.some(behaviours), sharedBackstage.providers),
       toolbar: {
         dom: {
           tag: 'div',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
@@ -1,5 +1,6 @@
 import { ApproxStructure, Assertions, Mouse, StructAssert, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 import { McEditor } from '@ephox/wrap-mcagar';
 
@@ -121,4 +122,25 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
       return Promise.resolve();
     })
   );
+
+  it('TINY-9496: onSetup function should run when defining custom group toolbar button', () =>
+    pTestWithEditor({
+      ...defaultToolbarGroupOptions,
+      toolbar: 'test',
+      setup: (editor: Editor) => {
+        editor.ui.registry.addGroupToolbarButton('test', {
+          text: 'test',
+          items: 'alignleft aligncenter alignright',
+          onSetup: (api) => {
+            api.setEnabled(false);
+            return Fun.noop;
+          }
+        });
+      }
+    }, () => {
+      UiFinder.exists(SugarBody.body(), '.tox-toolbar__group button.tox-tbtn.tox-tbtn--select.tox-tbtn--disabled:has(.tox-tbtn__select-label:contains("test"))');
+      return Promise.resolve();
+    })
+  );
+
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
@@ -3,6 +3,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 import { McEditor } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
@@ -123,7 +124,8 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
     })
   );
 
-  it('TINY-9496: onSetup function should run when defining custom group toolbar button', () =>
+  it('TINY-9496: onSetup function should run when defining custom group toolbar button', () => {
+    let hasSetupBeenCalled = false;
     pTestWithEditor({
       ...defaultToolbarGroupOptions,
       toolbar: 'test',
@@ -131,16 +133,16 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
         editor.ui.registry.addGroupToolbarButton('test', {
           text: 'test',
           items: 'alignleft aligncenter alignright',
-          onSetup: (api) => {
-            api.setEnabled(false);
+          onSetup: () => {
+            hasSetupBeenCalled = true;
             return Fun.noop;
           }
         });
       }
     }, () => {
-      UiFinder.exists(SugarBody.body(), '.tox-toolbar__group button.tox-tbtn.tox-tbtn--select.tox-tbtn--disabled:has(.tox-tbtn__select-label:contains("test"))');
+      assert.isTrue(hasSetupBeenCalled);
       return Promise.resolve();
-    })
-  );
+    });
+  });
 
 });


### PR DESCRIPTION
Related Ticket: TINY-9496

Description of Changes:
* onSetup function was not running when defining custom group toolbar button

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
