### PR TITLE
Make placeholder and alert dynamic

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -3043,6 +3043,8 @@ Npm version bump due to package not being fully updated.
 ## 4.1.0 - 2014-06-18
 
 ### Added
+- Add new 'anchor_name_placeholder' to change the placeholder of input in anchor plugin
+- Add new 'anchor_invalid_message' to change the alert on invalid anchor name in anchor plugin
 - Added new file_picker_callback option to replace the old file_browser_callback the latter will still work though.
 - Added new custom colors to textcolor plugin will be displayed if a color picker is provided also shows the latest colors.
 - Added new color_picker_callback option to enable you to add custom color pickers to the editor.

--- a/modules/tinymce/src/plugins/anchor/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/api/Options.ts
@@ -14,11 +14,25 @@ const register = (editor: Editor): void => {
     processor: 'boolean',
     default: false
   });
+
+  registerOption('anchor_name_placeholder', {
+    processor: 'string',
+    default: 'example'
+  });
+
+  registerOption('anchor_invalid_message', {
+    processor: 'string',
+    default: 'ID should start with a letter, followed only by letters, numbers, dashes, dots, colons or underscores.'
+  });
 };
 
 const allowHtmlInNamedAnchor = option<boolean>('allow_html_in_named_anchor');
+const anchorNamePlaceholder = option<string>('anchor_name_placeholder');
+const anchorInvalidMessage = option<string>('anchor_invalid_message');
 
 export {
   register,
-  allowHtmlInNamedAnchor
+  allowHtmlInNamedAnchor,
+  anchorNamePlaceholder,
+  anchorInvalidMessage
 };

--- a/modules/tinymce/src/plugins/anchor/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/ui/Dialog.ts
@@ -1,11 +1,12 @@
 import Editor from 'tinymce/core/api/Editor';
+import * as Options from '../api/Options';
 
 import * as Anchor from '../core/Anchor';
 
 const insertAnchor = (editor: Editor, newId: string): boolean => {
   if (!Anchor.isValidId(newId)) {
     editor.windowManager.alert(
-      'ID should start with a letter, followed only by letters, numbers, dashes, dots, colons or underscores.'
+      Options.anchorInvalidMessage(editor)
     );
     return false;
   } else {
@@ -27,7 +28,7 @@ const open = (editor: Editor): void => {
           name: 'id',
           type: 'input',
           label: 'ID',
-          placeholder: 'example'
+          placeholder: Options.anchorNamePlaceholder(editor),
         }
       ]
     },


### PR DESCRIPTION
Hi! we have been using tinymce for our project and it has been working great. We recently tried out the anchor plugin and wanted to change the default placeholder that is shown

<img width="763" alt="Screenshot 2022-12-27 at 6 21 06 PM" src="https://user-images.githubusercontent.com/49276301/209669290-b7bfd886-721c-4e94-b5ef-a7e2e66f6b77.png">

Also, we wanted to improve the default message shown on invalid anchor

<img width="761" alt="Screenshot 2022-12-27 at 6 22 49 PM" src="https://user-images.githubusercontent.com/49276301/209669497-6f9e4058-e467-42ec-ab3b-d2e4409f4c3e.png">

Therefore, I created this PR to allow ability to do that.

Related Ticket: 
Description of Changes:
Add two new options

1. `anchor_name_placeholder`: To change the placeholder text
2. `anchor_invalid_message`: To change the default alert message

Pre-checks:
* [x] Changelog entry added
* [ ] Tests have been added (if applicable) - Need help in deciding if this is to be covered.
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
