### PR TITLE
TINY-9439: Color picker on toolbar is not updated when changing forecolor or backcolor from menu

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Direct invalid child text nodes of list elements will be wrapped in list item elements. #TINY-4818
 
 ### Fixed
+- Color picker on toolbar would not update when changing forecolor or backcolor from menu. #TINY-9439
 - An element could be dropped onto the decendants of a noneditable element. #TINY-9364
 - Checkmark did not show in menu colorswatches. #TINY-9395
 - Toolbar split buttons in advlist plugin to show the correct state when the cursor is in a checklist. #TINY-5167

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -166,7 +166,7 @@ const registerTextColorButton = (editor: Editor, name: string, format: ColorForm
   });
 };
 
-const registerTextColorMenuItem = (editor: Editor, name: string, format: ColorFormat, text: string) => {
+const registerTextColorMenuItem = (editor: Editor, name: string, format: ColorFormat, text: string, lastColor: Cell<string>) => {
   editor.ui.registry.addNestedMenuItem(name, {
     text,
     icon: name === 'forecolor' ? 'text-color' : 'highlight-bg-color',
@@ -179,8 +179,15 @@ const registerTextColorMenuItem = (editor: Editor, name: string, format: ColorFo
           storageKey: format,
         },
         onAction: (data) => {
-          applyColor(editor, format, data.value, Fun.noop);
-        }
+          applyColor(editor, format, data.value, (newColor) => {
+            lastColor.set(newColor);
+
+            Events.fireTextColorChange(editor, {
+              name,
+              color: newColor
+            });
+          } );
+        },
       }
     ]
   });
@@ -255,8 +262,8 @@ const register = (editor: Editor): void => {
   registerTextColorButton(editor, 'forecolor', 'forecolor', 'Text color', lastForeColor);
   registerTextColorButton(editor, 'backcolor', 'hilitecolor', 'Background color', lastBackColor);
 
-  registerTextColorMenuItem(editor, 'forecolor', 'forecolor', 'Text color');
-  registerTextColorMenuItem(editor, 'backcolor', 'hilitecolor', 'Background color');
+  registerTextColorMenuItem(editor, 'forecolor', 'forecolor', 'Text color', lastForeColor);
+  registerTextColorMenuItem(editor, 'backcolor', 'hilitecolor', 'Background color', lastBackColor);
 };
 
 export {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
@@ -271,4 +271,17 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
     assertFocusIsOnColor('rgb(224, 62, 45)');
     closeBackcolorMenu();
   });
+
+  it('TINY-9439: selecting color from menubar is successfully marked', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>black</p><p style="color: rgb(224, 62, 45);">red</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2, true);
+    await pOpenAndGetMenuColorMenu(editor);
+    TinyUiActions.clickOnUi(editor, '[role="menuitemradio"][title="red"]');
+
+    await openAndGetBackcolorMenu();
+    assertFocusIsOnColor('rgb(224, 62, 45)');
+    closeBackcolorMenu();
+  });
+
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
@@ -56,9 +56,13 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
       color: {
         title: 'Color',
         items: 'backcolor'
+      },
+      forecolor: {
+        title: 'Forecolor',
+        items: 'forecolor'
       }
     },
-    menubar: 'color'
+    menubar: 'color forecolor'
   }, []);
 
   const structColor = (value: string): ApproxStructure.Builder<StructAssert> =>
@@ -111,6 +115,16 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
   };
   const closeMenuColorMenu = (editor: Editor) =>
     TinyUiActions.clickOnMenu(editor, 'button:contains("Color")');
+
+  const pOpenAndGetMenuForecolorMenu = async (editor: Editor) => {
+    const mainButton = 'button:contains("Forecolor")';
+    const submenuButton = '[role="menu"] div[title="Text color"]';
+    TinyUiActions.clickOnMenu(editor, mainButton);
+    await TinyUiActions.pWaitForUi(editor, submenuButton);
+    TinyUiActions.clickOnUi(editor, submenuButton);
+    return TinyUiActions.pWaitForUi(editor, '.tox-swatches-menu');
+  };
+
   const openAndGetBackcolorMenu = openAndGetMenu('Background color');
   const closeBackcolorMenu = closeMenu('Background color');
 
@@ -282,6 +296,10 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
     await openAndGetBackcolorMenu();
     assertFocusIsOnColor('rgb(224, 62, 45)');
     closeBackcolorMenu();
+    await pOpenAndGetMenuForecolorMenu(editor);
+    TinyUiActions.clickOnUi(editor, '[role="menuitemradio"][title="Light Gray"]');
+    await openAndGetForecolorMenu();
+    assertFocusIsOnColor('rgb(236, 240, 241)');
   });
 
 });


### PR DESCRIPTION
Related Ticket: TINY-9439

Description of Changes:
* Color picker on toolbar is not updated when changing forecolor or backcolor from menu

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


[TINY-9439]: https://ephocks.atlassian.net/browse/TINY-9439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ