### PR TITLE
TINY-9231: fixed firefox case with drag/drop next to block

### DIFF
--- a/modules/tinymce/src/core/main/ts/paste/DragDrop.ts
+++ b/modules/tinymce/src/core/main/ts/paste/DragDrop.ts
@@ -30,7 +30,7 @@ const setFocusedRange = (editor: Editor, rng: Range | undefined): void => {
 const hasImage = (dataTransfer: DataTransfer): boolean =>
   Arr.exists(dataTransfer.files, (file) => /^image\//.test(file.type));
 
-const isTransparentBlockDrop = (dom: DOMUtils, schema: Schema, target: Element, dropContent: Clipboard.ClipboardContents) => {
+const isTransparentBlockDrop = (dom: DOMUtils, schema: Schema, target: Node, dropContent: Clipboard.ClipboardContents) => {
   const parentTransparent = dom.getParent(target, (node) => TransparentElements.isTransparentBlock(schema, node));
   if (parentTransparent && Obj.has(dropContent, 'text/html')) {
     const fragment = new DOMParser().parseFromString(dropContent['text/html'], 'text/html').body;
@@ -79,7 +79,7 @@ const setup = (editor: Editor, draggingInternallyState: Cell<boolean>): void => 
 
     const internalContent = dropContent[InternalHtml.internalHtmlMime()];
     const content = internalContent || dropContent['text/html'] || dropContent['text/plain'];
-    const transparentElementDrop = isTransparentBlockDrop(editor.dom, editor.schema, e.target, dropContent);
+    const transparentElementDrop = isTransparentBlockDrop(editor.dom, editor.schema, rng.startContainer, dropContent);
 
     if (draggingInternallyState.get() && !transparentElementDrop) {
       return;

--- a/modules/tinymce/src/core/test/ts/browser/paste/DragDropTransparentsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/DragDropTransparentsTest.ts
@@ -1,7 +1,7 @@
 import { DragnDrop, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarElement } from '@ephox/sugar';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -10,6 +10,12 @@ describe('browser.tinymce.core.paste.DragDropTransparentElementsTest', () => {
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
   }, [], true);
+
+  const dragDropInternally = (editor: Editor, html: string, target: SugarElement<Element>) => {
+    editor.fire('dragstart');
+    DragnDrop.dropItems([{ data: html, type: 'text/html' }], target);
+    editor.fire('dragend');
+  };
 
   const pWaitForContent = (editor: Editor, expected: string) =>
     Waiter.pTryUntil('Should be expected content', () => TinyAssertions.assertContent(editor, expected));
@@ -30,9 +36,27 @@ describe('browser.tinymce.core.paste.DragDropTransparentElementsTest', () => {
     editor.setContent('<a href="#"><p>block link</p></a>');
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
     const target = SugarElement.fromDom(editor.selection.getNode());
-    editor.fire('dragstart');
+    dragDropInternally(editor, '<a href="#">link</a>', target);
+    await pWaitForContent(editor, '<a href="#"><p>linkblock link</p></a>');
+  });
+
+  it('TINY-9231: should unwrap inline anchors if dropping inline link next to block link', async () => {
+    const editor = hook.editor();
+
+    editor.setContent('<a href="#"><p>block link</p></a>');
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+    const target = TinyDom.documentElement(editor);
     DragnDrop.dropItems([{ data: '<a href="#">link</a>', type: 'text/html' }], target);
-    editor.fire('dragend');
+    await pWaitForContent(editor, '<a href="#"><p>linkblock link</p></a>');
+  });
+
+  it('TINY-9231: should unwrap inline anchors if dropping inline link next to block link (internal)', async () => {
+    const editor = hook.editor();
+
+    editor.setContent('<a href="#"><p>block link</p></a>');
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+    const target = TinyDom.documentElement(editor);
+    dragDropInternally(editor, '<a href="#">link</a>', target);
     await pWaitForContent(editor, '<a href="#"><p>linkblock link</p></a>');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9231

Description of Changes:
* This is a follow up PR to the previous TINY-9231 PR a Firefox specific case was found during QA

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-9231]: https://ephocks.atlassian.net/browse/TINY-9231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TINY-9231]: https://ephocks.atlassian.net/browse/TINY-9231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ