### PR TITLE
TINY-9458: Editable lists in noneditable root

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Quick toolbars were incorrectly rendered during the dragging of `contenteditable="false"` elements. #TINY-9305
 - Visual characters were rendered inside noneditable elements. #TINY-9474
 - Removed a workaround for ensuring stylesheets are loaded in an outdated version of webkit. #TINY-9433
-- Lists in a noneditable root was editable by editor commands and editor ui. #TINY-9458
+- Lists in a noneditable root were incorrectly editable using list API commands, toolbar buttons and menu items. #TINY-9458
 - Color picker dialog would not update the preview color if the hex input value was prefixed with `#` symbol. #TINY-9457
 
 ## 6.3.1 - 2022-12-06

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Closing a dialog would scroll down the document in Safari. #TINY-9148
 - Quick toolbars were incorrectly rendered during the dragging of `contenteditable="false"` elements. #TINY-9305
 - Removed a workaround for ensuring stylesheets are loaded in an outdated version of webkit. #TINY-9433
+- Lists in a noneditable root was editable by editor commands and editor ui. #TINY-9458
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -200,7 +200,7 @@ interface DOMUtils {
   dispatch: (target: Node | Window, name: string, evt?: {}) => EventUtils;
   getContentEditable: (node: Node) => string | null;
   getContentEditableParent: (node: Node) => string | null;
-  isEditable: (node: Node) => boolean;
+  isEditable: (node: Node | null | undefined) => boolean;
   destroy: () => void;
   isChildOf: (node: Node, parent: Node) => boolean;
   dumpRng: (r: Range) => string;
@@ -1123,7 +1123,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     return state;
   };
 
-  const isEditable = (node: Node) => {
+  const isEditable = (node: Node | null | undefined) => {
     if (Type.isNonNullable(node)) {
       const scope = NodeType.isElement(node) ? node : node.parentElement;
       const isRootEditable = getContentEditable(getRoot()) === 'true';

--- a/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
@@ -28,7 +28,7 @@ const getSelectedStyleType = (editor: Editor): Optional<string> => {
 
 // Lists/core/Util.ts - Duplicated in Lists plugin
 const isWithinNonEditable = (editor: Editor, element: Element | null): boolean =>
-  element !== null && editor.dom.getContentEditableParent(element) === 'false';
+  element !== null && !editor.dom.isEditable(element);
 
 const isWithinNonEditableList = (editor: Editor, element: Element | null): boolean => {
   const parentList = editor.dom.getParent(element, 'ol,ul,dl');

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
@@ -1,0 +1,64 @@
+import { UiFinder } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/lists/Plugin';
+
+describe('browser.tinymce.plugins.advlist.NoneditableRootTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'lists advlist',
+    toolbar: 'numlist bullist | outdent indent',
+    contextmenu: 'lists',
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
+    editor.getBody().contentEditable = 'false';
+    f(editor);
+    editor.getBody().contentEditable = 'true';
+  };
+
+  context('List ui controls', () => {
+    const initialListContent = '<ol><li>a</li></ol>';
+    const setupEditor = (editor: Editor) => {
+      editor.setContent(initialListContent);
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+    };
+
+    it('TINY-9458: List buttons numlist/bullist should be disabled', () => {
+      withNoneditableRootEditor(hook.editor(), (editor) => {
+        setupEditor(editor);
+
+        UiFinder.exists(SugarBody.body(), 'div[title="Numbered list"][aria-disabled="true"]');
+        UiFinder.exists(SugarBody.body(), 'div[title="Bullet list"][aria-disabled="true"]');
+      });
+    });
+
+    it('TINY-9458: Outdent/indent buttons should be noop', () => {
+      withNoneditableRootEditor(hook.editor(), (editor) => {
+        setupEditor(editor);
+
+        TinyUiActions.clickOnToolbar(editor, 'button[title="Decrease indent"]');
+        TinyAssertions.assertContent(editor, initialListContent);
+
+        TinyUiActions.clickOnToolbar(editor, 'button[title="Increase indent"]');
+        TinyAssertions.assertContent(editor, initialListContent);
+      });
+    });
+
+    it('TINY-9458: Context menu list properties should be disabled', async () => {
+      const editor = hook.editor();
+
+      setupEditor(editor);
+
+      editor.getBody().contentEditable = 'false';
+      await TinyUiActions.pTriggerContextMenu(editor, 'li', '.tox-silver-sink [role="menuitem"]:contains("List properties...")');
+      UiFinder.exists(SugarBody.body(), '[role="menuitem"][aria-disabled="true"]:contains("List properties...")');
+      editor.getBody().contentEditable = 'true';
+    });
+  });
+});
+

--- a/modules/tinymce/src/plugins/lists/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/lists/demo/ts/demo/Demo.ts
@@ -5,7 +5,7 @@ declare let tinymce: TinyMCE;
 tinymce.init({
   selector: 'textarea.tinymce',
   plugins: 'lists code',
-  toolbar: 'numlist bullist | code',
+  toolbar: 'numlist bullist | outdent indent | code',
   height: 600,
   contextmenu: 'lists'
 });

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -11,7 +11,7 @@ import * as Bookmark from '../core/Bookmark';
 import { listToggleActionFromListName } from '../core/ListAction';
 import * as NodeType from '../core/NodeType';
 import * as Selection from '../core/Selection';
-import { isCustomList, isWithinNonEditableList } from '../core/Util';
+import { hasNonEditableBlocksSelected, isCustomList, isWithinNonEditableList } from '../core/Util';
 import { flattenListSelection } from './Indendation';
 
 interface ListDetail {
@@ -344,7 +344,7 @@ const toggleSingleList = (editor: Editor, parentList: HTMLElement | null, listNa
 
 const toggleList = (editor: Editor, listName: 'UL' | 'OL' | 'DL', _detail: ListDetail | null): void => {
   const parentList = Selection.getParentList(editor);
-  if (isWithinNonEditableList(editor, parentList)) {
+  if (isWithinNonEditableList(editor, parentList) || hasNonEditableBlocksSelected(editor)) {
     return;
   }
 

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Util.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Util.ts
@@ -1,4 +1,4 @@
-import { Arr } from '@ephox/katamari';
+import { Arr, Fun } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import { NodeChangeEvent } from 'tinymce/core/api/EventTypes';
@@ -15,7 +15,7 @@ const inList = (parents: Node[], listName: string): boolean =>
 
 // Advlist/core/ListUtils.ts - Duplicated in Advlist plugin
 const isWithinNonEditable = (editor: Editor, element: Element | null): boolean =>
-  element !== null && editor.dom.getContentEditableParent(element) === 'false';
+  element !== null && !editor.dom.isEditable(element);
 
 const selectionIsWithinNonEditableList = (editor: Editor): boolean => {
   const parentList = Selection.getParentList(editor);
@@ -26,6 +26,9 @@ const isWithinNonEditableList = (editor: Editor, element: Element | null): boole
   const parentList = editor.dom.getParent(element, 'ol,ul,dl');
   return isWithinNonEditable(editor, parentList);
 };
+
+const hasNonEditableBlocksSelected = (editor: Editor): boolean =>
+  Arr.exists(editor.selection.getSelectedBlocks(), Fun.not(editor.dom.isEditable));
 
 const setNodeChangeHandler = (editor: Editor, nodeChangeHandler: (e: NodeChangeEvent) => void): () => void => {
   const initialNode = editor.selection.getNode();
@@ -43,5 +46,6 @@ export {
   inList,
   selectionIsWithinNonEditableList,
   isWithinNonEditableList,
+  hasNonEditableBlocksSelected,
   setNodeChangeHandler
 };

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ContentEditableFalseActionsTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ContentEditableFalseActionsTest.ts
@@ -126,4 +126,14 @@ ${listContent}
       );
     })
   );
+
+  it('TINY-9458: InsertOrderedList command should noop if noneditable blocks are selected', () => {
+    const editor = hook.editor();
+    const initialContent = '<p>a</p>\n<p contenteditable="false">b</p>\n<p>c</p>';
+
+    editor.setContent(initialContent);
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 2, 0 ], 1);
+    editor.execCommand('InsertOrderedList');
+    TinyAssertions.assertContent(editor, initialContent);
+  });
 });

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/NoneditableRootTest.ts
@@ -1,0 +1,197 @@
+import { UiFinder } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/lists/Plugin';
+
+interface CommandTestCase {
+  readonly input: string;
+  readonly path: number[];
+  readonly offset: 0;
+  readonly cmd: string;
+  readonly args?: Record<string, any>;
+}
+
+describe('browser.tinymce.plugins.lists.NoneditableRootTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'lists',
+    toolbar: 'numlist bullist | outdent indent',
+    contextmenu: 'lists',
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
+    editor.getBody().contentEditable = 'false';
+    f(editor);
+    editor.getBody().contentEditable = 'true';
+  };
+
+  context('Commands', () => {
+    const testNoopListCommand = (testCase: CommandTestCase) => () => {
+      withNoneditableRootEditor(hook.editor(), (editor) => {
+        editor.setContent(testCase.input);
+        TinySelections.setCursor(editor, testCase.path, testCase.offset);
+        editor.execCommand(testCase.cmd, false, testCase.args ?? null);
+        TinyAssertions.assertContent(editor, testCase.input);
+      });
+    };
+
+    context('Ordered list', () => {
+      it('TINY-9458: Ordered list should not be applied in noneditable root', testNoopListCommand({
+        input: '<p>a</p>',
+        path: [ 0 ],
+        offset: 0,
+        cmd: 'InsertOrderedList'
+      }));
+
+      it('TINY-9458: Toggle off ordered list should not be applied in noneditable root', testNoopListCommand({
+        input: '<ol><li>a</li></ol>',
+        path: [ 0, 0, 0 ],
+        offset: 0,
+        cmd: 'InsertOrderedList'
+      }));
+
+      it('TINY-9458: Switch to ordered ordered list should not be applied in noneditable root', testNoopListCommand({
+        input: '<ul><li>a</li></ul>',
+        path: [ 0, 0, 0 ],
+        offset: 0,
+        cmd: 'InsertOrderedList'
+      }));
+    });
+
+    context('Unordered list', () => {
+      it('TINY-9458: Unordered list should not be applied in noneditable root', testNoopListCommand({
+        input: '<p>a</p>',
+        path: [ 0 ],
+        offset: 0,
+        cmd: 'InsertUnorderedList'
+      }));
+
+      it('TINY-9458: Toggle off unordered list should not be applied in noneditable root', testNoopListCommand({
+        input: '<ol><li>a</li></ol>',
+        path: [ 0, 0, 0 ],
+        offset: 0,
+        cmd: 'InsertUnorderedList'
+      }));
+
+      it('TINY-9458: Switch to unordered ordered list should not be applied in noneditable root', testNoopListCommand({
+        input: '<ol><li>a</li></ol>',
+        path: [ 0, 0, 0 ],
+        offset: 0,
+        cmd: 'InsertUnorderedList'
+      }));
+    });
+
+    context('Definition list', () => {
+      it('TINY-9458: Definition list should not be applied in noneditable root', testNoopListCommand({
+        input: '<p>a</p>',
+        path: [ 0 ],
+        offset: 0,
+        cmd: 'InsertDefinitionList'
+      }));
+
+      it('TINY-9458: Toggle off definition list should not be applied in noneditable root', testNoopListCommand({
+        input: '<ol><li>a</li></ol>',
+        path: [ 0, 0, 0 ],
+        offset: 0,
+        cmd: 'InsertDefinitionList'
+      }));
+
+      it('TINY-9458: Switch to definition list should not be applied in noneditable root', testNoopListCommand({
+        input: '<ol><li>a</li></ol>',
+        path: [ 0, 0, 0 ],
+        offset: 0,
+        cmd: 'InsertDefinitionList'
+      }));
+    });
+
+    context('Remove list', () => {
+      it('TINY-9458: Remove list should not be applied in noneditable root', testNoopListCommand({
+        input: '<ol><li>a</li></ol>',
+        path: [ 0, 0, 0 ],
+        offset: 0,
+        cmd: 'RemoveList'
+      }));
+    });
+
+    context('Update list', () => {
+      it('TINY-9458: Update list should not be applied in noneditable root', testNoopListCommand({
+        input: '<ol><li>a</li></ol>',
+        path: [ 0, 0, 0 ],
+        offset: 0,
+        cmd: 'mceListUpdate',
+        args: {
+          attrs: { class: 'foo' }
+        }
+      }));
+    });
+
+    context('Indent/outdent list', () => {
+      it('TINY-9458: Indent list should not be applied in noneditable root', testNoopListCommand({
+        input: '<ol><li>a</li></ol>',
+        path: [ 0, 0, 0 ],
+        offset: 0,
+        cmd: 'indent'
+      }));
+
+      it('TINY-9458: Outdent list should not be applied in noneditable root', testNoopListCommand({
+        input: '<ol><li>a</li></ol>',
+        path: [ 0, 0, 0 ],
+        offset: 0,
+        cmd: 'outdent'
+      }));
+    });
+
+    context('List props', () => {
+      it('TINY-9458: mceListProps command should be a noop', () => {
+        withNoneditableRootEditor(hook.editor(), (editor) => {
+          editor.execCommand('mceListProps');
+          UiFinder.notExists(SugarBody.body(), '.tox-dialog');
+        });
+      });
+    });
+  });
+
+  context('List ui controls', () => {
+    const initialListContent = '<ol><li>a</li></ol>';
+    const setupEditor = (editor: Editor) => {
+      editor.setContent(initialListContent);
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+    };
+
+    it('TINY-9458: List buttons numlist/bullist should be disabled', () => {
+      withNoneditableRootEditor(hook.editor(), (editor) => {
+        setupEditor(editor);
+
+        UiFinder.exists(SugarBody.body(), 'button[title="Numbered list"][aria-disabled="true"]');
+        UiFinder.exists(SugarBody.body(), 'button[title="Bullet list"][aria-disabled="true"]');
+      });
+    });
+
+    it('TINY-9458: Outdent/indent buttons should be noop', () => {
+      withNoneditableRootEditor(hook.editor(), (editor) => {
+        setupEditor(editor);
+
+        TinyUiActions.clickOnToolbar(editor, 'button[title="Decrease indent"]');
+        TinyAssertions.assertContent(editor, initialListContent);
+
+        TinyUiActions.clickOnToolbar(editor, 'button[title="Increase indent"]');
+        TinyAssertions.assertContent(editor, initialListContent);
+      });
+    });
+
+    it('TINY-9458: Context menu list properties should be disabled', async () => {
+      const editor = hook.editor();
+
+      setupEditor(editor);
+
+      editor.getBody().contentEditable = 'false';
+      await TinyUiActions.pTriggerContextMenu(editor, 'li', '.tox-silver-sink [role="menuitem"]:contains("List properties...")');
+      UiFinder.exists(SugarBody.body(), '[role="menuitem"][aria-disabled="true"]:contains("List properties...")');
+      editor.getBody().contentEditable = 'true';
+    });
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-9458

Description of Changes:
* Blocks list operations on lists in a noneditable root
* Blocks adding lists when any noneditable block is selected

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
