### PR TITLE
DOC-1888: added docs for selection.isEditable/dom.isEditable

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1845,7 +1845,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      *
      * @method isEditable
      * @param {Node} node Node to check if it's editable.
-     * @return {Boolean} Will be true if the node is editable and false it it's not editable.
+     * @return {Boolean} Will be true if the node is editable and false if it's not editable.
      */
     isEditable,
 

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1840,6 +1840,13 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     getContentEditable,
     getContentEditableParent,
 
+    /**
+     * Checks if the specified node is editable within the given context of it's parents.
+     *
+     * @method isEditable
+     * @param {Node} node Node to check if it's editable.
+     * @return {Boolean} Will be true if the node is editable and false it it's not editable.
+     */
     isEditable,
 
     /**

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1841,7 +1841,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     getContentEditableParent,
 
     /**
-     * Checks if the specified node is editable within the given context of it's parents.
+     * Checks if the specified node is editable within the given context of its parents.
      *
      * @method isEditable
      * @param {Node} node Node to check if it's editable.

--- a/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
@@ -258,7 +258,7 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
   };
 
   /**
-   * Checks if the current selection start and end containers is editable within their parent contexts.
+   * Checks if the current selection start and end containers are editable within their parent contexts.
    *
    * @method isEditable
    * @return {Boolean} Will be true if the selection is editable and false if it's not.

--- a/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
@@ -257,6 +257,12 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
     return !sel || rng.collapsed;
   };
 
+  /**
+   * Checks if the current selection start and end containers is editable within their parent contexts.
+   *
+   * @method isEditable
+   * @return {Boolean} Will be true if the selection is editable and false if it's not.
+   */
   const isEditable = (): boolean => {
     const rng = getRng();
 

--- a/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
@@ -261,7 +261,7 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
    * Checks if the current selection’s start and end containers are editable within their parent’s contexts.
    *
    * @method isEditable
-   * @return {Boolean} Will be true if the selection is editable and false if it's not.
+   * @return {Boolean} Will be true if the selection is editable and false if it's not editable.
    */
   const isEditable = (): boolean => {
     const rng = getRng();

--- a/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
@@ -258,7 +258,7 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
   };
 
   /**
-   * Checks if the current selection start and end containers are editable within their parent contexts.
+   * Checks if the current selection’s start and end containers are editable within their parent’s contexts.
    *
    * @method isEditable
    * @return {Boolean} Will be true if the selection is editable and false if it's not.


### PR DESCRIPTION
Related Ticket: DOC-1888

Description of Changes:
* Adds api docs for the new isEditable apis.

I'm trying to be vague of it's implementation details but still hint that they are O(n) so could be expensive to use.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
