### PR TITLE
TINY-9516: InlineFormatDelete element with multiple children selection test fails on latest Firefox v108.0.2

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/delete/InlineFormatDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/InlineFormatDeleteTest.ts
@@ -868,15 +868,7 @@ describe('browser.tinymce.core.delete.InlineFormatDelete', () => {
                         style: str.is('text-decoration: underline;')
                       },
                       children: [
-                        s.element('em', {
-                          children: [
-                            s.element('strong', {
-                              children: [
-                                s.element('br', {})
-                              ]
-                            })
-                          ]
-                        })
+                        s.element('br', {})
                       ]
                     })
                   ]
@@ -904,7 +896,8 @@ describe('browser.tinymce.core.delete.InlineFormatDelete', () => {
           });
         })
       );
-      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0 ], 0);
+      const selPath = browser.isFirefox() ? [ 0, 0 ] : [ 0, 0, 0, 0 ];
+      TinyAssertions.assertCursor(editor, selPath, 0);
     });
 
     it('Backspace partial selection from start to middle of text format element should do nothing', () => {


### PR DESCRIPTION
Related Ticket: TINY-9516

Description of Changes:
* Updated structure and selection assertion to match Firefox's updated `contenteditable` behaviour on v108.0.2

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
