### PR TITLE
Temporary extra logging of fullscreen test

### DIFF
--- a/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
@@ -47,7 +47,19 @@ describe('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', () => {
 
   const assertHtmlAndBodyState = (editor: Editor, shouldExist: boolean) => {
     const existsFn = shouldExist ? UiFinder.exists : UiFinder.notExists;
-    existsFn(SugarBody.body(), 'root:.tox-fullscreen');
+
+    try {
+      existsFn(SugarBody.body(), 'root:.tox-fullscreen');
+    } catch (e) {
+      // TODO: Remove this once we figure out why this flakes this adds some extra logging
+      if (e instanceof Error) {
+        const hasToxFullscreen = Type.isNonNullable(document.querySelector('.tox-fullscreen'));
+        throw new Error(`${e.message} body-class: "${document.body.className}" html-class: "${document.documentElement.className}" hasToxFullscreen: ${hasToxFullscreen}`);
+      } else {
+        throw e;
+      }
+    }
+
     existsFn(Traverse.documentElement(SugarDocument.getDocument()), 'root:.tox-fullscreen');
   };
 


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* This adds some logging to the area of where we are seeing some flakes.
* It makes us able to see if the issue with with Sizzle that is used in the query matching.
* It checks if the command did anything or if it's just the body class that doesn't have the expected `.tox-fullscreen` class
* The plan is to remove this once we figure out why this is happening.

Pre-checks:

Review:
* [x] Milestone set

GitHub issues (if applicable):
