### PR TITLE
TINY-9454: Preserve formatting when backspacing from one empty block to another

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 - Direct invalid child text nodes of list elements will be wrapped in list item elements. #TINY-4818
+- Pressing backspace in an empty line now preserves formatting in a previous empty line. #TINY-9454
 
 ### Changed
 - The `link` plugins context menu items will no longer appear for noneditable links. #TINY-9491

--- a/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Compare, Insert, PredicateFilter, Remove, SugarElement, Traverse } from '@ephox/sugar';
+import { Compare, Insert, Replication, PredicateFind, Remove, SugarElement, Traverse } from '@ephox/sugar';
 
 import * as CaretFinder from '../caret/CaretFinder';
 import CaretPosition from '../caret/CaretPosition';
@@ -55,22 +55,23 @@ const nestedBlockMerge = (
 
 const sidelongBlockMerge = (rootNode: SugarElement<Node>, fromBlock: SugarElement<Element>, toBlock: SugarElement<Element>): Optional<CaretPosition> => {
   if (Empty.isEmpty(toBlock)) {
-    const inlineDescendants = Traverse.firstChild(toBlock).fold(
-      Fun.constant([]),
-      (child) => {
-        const descendants = PredicateFilter.descendants(child, ElementType.isInline);
-        return ElementType.isInline(child) ? [ child, ...descendants ] : descendants;
-      }
-    );
+    if (Empty.isEmpty(fromBlock)) {
+      const bogus = PaddingBr.createPaddingBr();
+      const child = Traverse.firstChild(toBlock).fold(
+        Fun.constant(bogus),
+        (firstChild) => {
+          const firstChildCopy = Replication.deep(firstChild);
+          PredicateFind
+            .descendant(firstChildCopy, (el) => !Traverse.hasChildNodes(el))
+            .each((deepestChild) => Insert.append(deepestChild, bogus));
+          return firstChildCopy;
+        }
+      );
+      Remove.empty(fromBlock);
+      Insert.append(fromBlock, child);
+    }
 
     Remove.remove(toBlock);
-    if (Empty.isEmpty(fromBlock)) {
-      const bogus = PaddingBr.fillWithPaddingBr(fromBlock);
-      Arr.foldr(inlineDescendants, (descendant: SugarElement<HTMLElement>, wrapper) => {
-        Insert.wrap(descendant, wrapper);
-        return wrapper;
-      }, bogus);
-    }
     return CaretFinder.firstPositionIn(fromBlock.dom);
   }
 

--- a/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
@@ -67,9 +67,9 @@ const sidelongBlockMerge = (rootNode: SugarElement<Node>, fromBlock: SugarElemen
 
       const newFromBlockDescendants = Arr.foldr(
         getInlineToBlockDescendants(toBlock),
-        (element: SugarElement<Element>, wrapper) => {
-          Insert.wrap(element, wrapper);
-          return wrapper;
+        (element: SugarElement<Element>, descendant) => {
+          Insert.wrap(element, descendant);
+          return descendant;
         },
         PaddingBr.createPaddingBr()
       );

--- a/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
@@ -59,8 +59,7 @@ const sidelongBlockMerge = (rootNode: SugarElement<Node>, fromBlock: SugarElemen
     Remove.remove(toBlock);
     if (Empty.isEmpty(fromBlock)) {
       PaddingBr.fillWithPaddingBr(fromBlock);
-      SelectorFind.child(fromBlock, '[data-mce-bogus]').fold(
-        Fun.noop,
+      SelectorFind.child(fromBlock, '[data-mce-bogus]').each(
         (bogus) => Arr.each(descendants, (descendant) => Insert.wrap(bogus, descendant))
       );
     }

--- a/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Compare, Insert, Replication, PredicateFind, Remove, SugarElement, Traverse } from '@ephox/sugar';
+import { Compare, Insert, PredicateFilter, Remove, SugarElement, Traverse } from '@ephox/sugar';
 
 import * as CaretFinder from '../caret/CaretFinder';
 import CaretPosition from '../caret/CaretPosition';
@@ -55,23 +55,22 @@ const nestedBlockMerge = (
 
 const sidelongBlockMerge = (rootNode: SugarElement<Node>, fromBlock: SugarElement<Element>, toBlock: SugarElement<Element>): Optional<CaretPosition> => {
   if (Empty.isEmpty(toBlock)) {
-    if (Empty.isEmpty(fromBlock)) {
-      const bogus = PaddingBr.createPaddingBr();
-      const child = Traverse.firstChild(toBlock).fold(
-        Fun.constant(bogus),
-        (firstChild) => {
-          const firstChildCopy = Replication.deep(firstChild);
-          PredicateFind
-            .descendant(firstChildCopy, (el) => !Traverse.hasChildNodes(el))
-            .each((deepestChild) => Insert.append(deepestChild, bogus));
-          return firstChildCopy;
-        }
-      );
-      Remove.empty(fromBlock);
-      Insert.append(fromBlock, child);
-    }
+    const inlineDescendants = Traverse.firstChild(toBlock).fold(
+      Fun.constant([]),
+      (child) => {
+        const descendants = PredicateFilter.descendants(child, ElementType.isInline);
+        return ElementType.isInline(child) ? [ child, ...descendants ] : descendants;
+      }
+    );
 
     Remove.remove(toBlock);
+    if (Empty.isEmpty(fromBlock)) {
+      const bogus = PaddingBr.fillWithPaddingBr(fromBlock);
+      Arr.foldr(inlineDescendants, (descendant: SugarElement<HTMLElement>, wrapper) => {
+        Insert.wrap(descendant, wrapper);
+        return wrapper;
+      }, bogus);
+    }
     return CaretFinder.firstPositionIn(fromBlock.dom);
   }
 

--- a/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Compare, Insert, PredicateFilter, Remove, SugarElement, Traverse } from '@ephox/sugar';
+import { Compare, Insert, PredicateFilter, Replication, Remove, SugarElement, Traverse } from '@ephox/sugar';
 
 import * as CaretFinder from '../caret/CaretFinder';
 import CaretPosition from '../caret/CaretPosition';
@@ -60,7 +60,7 @@ const sidelongBlockMerge = (rootNode: SugarElement<Node>, fromBlock: SugarElemen
         Fun.constant([]),
         (child) => {
           const descendants = PredicateFilter.descendants(child, ElementType.isInline);
-          return ElementType.isInline(child) ? [ child, ...descendants ] : descendants;
+          return Arr.map(ElementType.isInline(child) ? [ child, ...descendants ] : descendants, Replication.shallow);
         }
       );
 

--- a/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
@@ -55,22 +55,29 @@ const nestedBlockMerge = (
 
 const sidelongBlockMerge = (rootNode: SugarElement<Node>, fromBlock: SugarElement<Element>, toBlock: SugarElement<Element>): Optional<CaretPosition> => {
   if (Empty.isEmpty(toBlock)) {
-    const inlineDescendants = Traverse.firstChild(toBlock).fold(
-      Fun.constant([]),
-      (child) => {
-        const descendants = PredicateFilter.descendants(child, ElementType.isInline);
-        return ElementType.isInline(child) ? [ child, ...descendants ] : descendants;
-      }
-    );
+    if (Empty.isEmpty(fromBlock)) {
+      const inlineToBlockDescendants = Traverse.firstChild(toBlock).fold(
+        Fun.constant([]),
+        (child) => {
+          const descendants = PredicateFilter.descendants(child, ElementType.isInline);
+          return ElementType.isInline(child) ? [ child, ...descendants ] : descendants;
+        }
+      );
+
+      const newFromBlockDescendants = Arr.foldr(
+        inlineToBlockDescendants,
+        (element: SugarElement<HTMLElement>, wrapper) => {
+          Insert.wrap(element, wrapper);
+          return wrapper;
+        },
+        PaddingBr.createPaddingBr()
+      );
+
+      Remove.empty(fromBlock);
+      Insert.append(fromBlock, newFromBlockDescendants);
+    }
 
     Remove.remove(toBlock);
-    if (Empty.isEmpty(fromBlock)) {
-      const bogus = PaddingBr.fillWithPaddingBr(fromBlock);
-      Arr.foldr(inlineDescendants, (descendant: SugarElement<HTMLElement>, wrapper) => {
-        Insert.wrap(descendant, wrapper);
-        return wrapper;
-      }, bogus);
-    }
     return CaretFinder.firstPositionIn(fromBlock.dom);
   }
 

--- a/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Compare, Insert, Remove, SugarElement, Traverse } from '@ephox/sugar';
+import { SelectorFind, Compare, SelectorFilter, Insert, Remove, SugarElement, Traverse } from '@ephox/sugar';
 
 import * as CaretFinder from '../caret/CaretFinder';
 import CaretPosition from '../caret/CaretPosition';
@@ -55,9 +55,14 @@ const nestedBlockMerge = (
 
 const sidelongBlockMerge = (rootNode: SugarElement<Node>, fromBlock: SugarElement<Element>, toBlock: SugarElement<Element>): Optional<CaretPosition> => {
   if (Empty.isEmpty(toBlock)) {
+    const descendants = SelectorFilter.descendants(toBlock, '*');
     Remove.remove(toBlock);
     if (Empty.isEmpty(fromBlock)) {
       PaddingBr.fillWithPaddingBr(fromBlock);
+      SelectorFind.child(fromBlock, '[data-mce-bogus]').fold(
+        Fun.noop,
+        (bogus) => Arr.each(descendants, (descendant) => Insert.wrap(bogus, descendant))
+      );
     }
     return CaretFinder.firstPositionIn(fromBlock.dom);
   }

--- a/modules/tinymce/src/core/main/ts/dom/PaddingBr.ts
+++ b/modules/tinymce/src/core/main/ts/dom/PaddingBr.ts
@@ -29,9 +29,11 @@ const createPaddingBr = (): SugarElement<HTMLBRElement> => {
   return br;
 };
 
-const fillWithPaddingBr = (elm: SugarElement<Node>): void => {
+const fillWithPaddingBr = (elm: SugarElement<Node>): SugarElement<HTMLBRElement> => {
   Remove.empty(elm);
-  Insert.append(elm, createPaddingBr());
+  const br = createPaddingBr();
+  Insert.append(elm, br);
+  return br;
 };
 
 const isPaddingContents = (elm: SugarElement<Node>): boolean => {

--- a/modules/tinymce/src/core/main/ts/dom/PaddingBr.ts
+++ b/modules/tinymce/src/core/main/ts/dom/PaddingBr.ts
@@ -29,11 +29,9 @@ const createPaddingBr = (): SugarElement<HTMLBRElement> => {
   return br;
 };
 
-const fillWithPaddingBr = (elm: SugarElement<Node>): SugarElement<HTMLBRElement> => {
+const fillWithPaddingBr = (elm: SugarElement<Node>): void => {
   Remove.empty(elm);
-  const br = createPaddingBr();
-  Insert.append(elm, br);
-  return br;
+  Insert.append(elm, createPaddingBr());
 };
 
 const isPaddingContents = (elm: SugarElement<Node>): boolean => {

--- a/modules/tinymce/src/core/test/ts/browser/delete/BlockBoundaryDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/BlockBoundaryDeleteTest.ts
@@ -441,4 +441,54 @@ describe('browser.tinymce.core.delete.BlockBoundaryDeleteTest', () => {
       TinyAssertions.assertCursor(editor, [ 0, 0, 0 ], 1);
     });
   });
+
+  it('TINY-9454: Should preserve formatting when merging with backspace from an empty block to an empty block', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      `<p>1st</p>` +
+      `<p><span data-mce-style="font-family: symbol;" style="font-family: symbol;"><em><strong><br data-mce-bogus="1"></strong></em></span></p>` +
+      `<p><span data-mce-style="font-family: arial;" style="font-family: arial;"><strong><em><br data-mce-bogus="1"></em></strong></span></p>` +
+      `<p>4th</p>`,
+      { format: 'raw' }
+    );
+
+    TinySelections.setCursor(editor, [ 2, 0, 0, 0 ], 0);
+    doBackspace(editor);
+
+    TinyAssertions.assertContentStructure(editor,
+      ApproxStructure.build((s, str, _arr) => s.element('body', {
+        children: [
+          s.element('p', { children: [ s.text(str.is('1st')) ] }),
+          s.element('p', {
+            children: [
+              s.element('span', {
+                attrs: {
+                  'style': str.is('font-family: symbol;'),
+                  'data-mce-style': str.is('font-family: symbol;'),
+                },
+                children: [
+                  s.element('em', {
+                    children: [
+                      s.element('strong', { })
+                    ]
+                  }),
+                ],
+              }),
+            ]
+          }),
+          s.element('p', { children: [ s.text(str.is('4th')) ] }),
+        ]
+      }))
+    );
+
+    TinyAssertions.assertContent(
+      editor,
+      `<p>1st</p>` +
+      `<p><span data-mce-style="font-family: symbol;" style="font-family: symbol;"><em><strong><br data-mce-bogus="1"></strong></em></span></p>` +
+      `<p>4th</p>`,
+      { format: 'raw' }
+    );
+
+    TinyAssertions.assertCursor(editor, [ 1, 0, 0, 0 ], 0);
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/delete/BlockBoundaryDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/BlockBoundaryDeleteTest.ts
@@ -446,7 +446,7 @@ describe('browser.tinymce.core.delete.BlockBoundaryDeleteTest', () => {
     const editor = hook.editor();
     editor.setContent(
       `<p>1st</p>` +
-      `<p><span data-mce-style="font-family: symbol;" style="font-family: symbol;"><em><strong><br data-mce-bogus="1"></strong></em></span><strong><em></em></strong></p>` +
+      `<p><span data-mce-style="font-family: symbol;" style="font-family: symbol;"><em><strong><br data-mce-bogus="1"></strong><i></i></em></span><strong><em></em></strong></p>` +
       `<p><span data-mce-style="font-family: arial;" style="font-family: arial;"><strong><em><br data-mce-bogus="1"></em></strong></span></p>` +
       `<p>4th</p>`,
       { format: 'raw' }

--- a/modules/tinymce/src/core/test/ts/browser/delete/BlockBoundaryDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/BlockBoundaryDeleteTest.ts
@@ -446,7 +446,7 @@ describe('browser.tinymce.core.delete.BlockBoundaryDeleteTest', () => {
     const editor = hook.editor();
     editor.setContent(
       `<p>1st</p>` +
-      `<p><span data-mce-style="font-family: symbol;" style="font-family: symbol;"><em><strong><br data-mce-bogus="1"></strong></em></span></p>` +
+      `<p><span data-mce-style="font-family: symbol;" style="font-family: symbol;"><em><strong><br data-mce-bogus="1"></strong></em></span><strong><em></em></strong></p>` +
       `<p><span data-mce-style="font-family: arial;" style="font-family: arial;"><strong><em><br data-mce-bogus="1"></em></strong></span></p>` +
       `<p>4th</p>`,
       { format: 'raw' }


### PR DESCRIPTION
Related Ticket: TINY-9454

Description of Changes:
* Preserve formatting when backspacing from one empty block to another. Otherwise block's formatting is cleared by inserting `br[data-mce-bogus]`.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
