### PR TITLE
TINY-9504: Fix clicking on a disabled split button

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Color picker dialog would not update the preview color if the hex input value was prefixed with `#` symbol. #TINY-9457
 - It was possible to open links inside the editor if the editor root was noneditable. #TINY-9470
 - Inline boundary was rendered for noneditable inline boundary elements. #TINY-9471
+- Clicking on a disabled split button will not call `onAction` callback anymore. #TINY-9504
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Color picker dialog would not update the preview color if the hex input value was prefixed with `#` symbol. #TINY-9457
 - It was possible to open links inside the editor if the editor root was noneditable. #TINY-9470
 - Inline boundary was rendered for noneditable inline boundary elements. #TINY-9471
-- Clicking on a disabled split button will not call `onAction` callback anymore. #TINY-9504
+- Clicking on a disabled split button will no longer call the `onAction` callback. #TINY-9504
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -291,7 +291,10 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
     },
 
     onExecute: (button: AlloyComponent) => {
-      spec.onAction(getApi(button));
+      const api = getApi(button)
+      if (api.isEnabled()) {
+        spec.onAction(api);
+      }
     },
 
     onItemExecute: (_a, _b, _c) => { },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -291,7 +291,7 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
     },
 
     onExecute: (button: AlloyComponent) => {
-      const api = getApi(button)
+      const api = getApi(button);
       if (api.isEnabled()) {
         spec.onAction(api);
       }

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
@@ -334,6 +334,12 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
     store.clear();
     assertSplitButtonDisabledState('Disabled', true, button3);
     assertSplitButtonActiveState('Off still', false, button3);
+
+    // TINY-9504: The button is disabled now. Clicking on it should not call onAction callback.
+    Mouse.clickOn(component.element, '.button3-container .tox-split-button .tox-tbtn');
+    store.assertEq('Store should not have action3', [ ]);
+    assertSplitButtonDisabledState('Disabled', true, button3);
+    assertSplitButtonActiveState('Off still', false, button3);
   });
 
   it('Fourth button (button4): menu button', async () => {


### PR DESCRIPTION
Related Ticket: TINY-9504

Description of Changes:
* Clicking on a disabled split button won't call `onAction` callback anymore. Added the necessary check.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
