### PR TITLE
TINY-9471: Inline boundaries styling gets applied to noneditable elements

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed a workaround for ensuring stylesheets are loaded in an outdated version of webkit. #TINY-9433
 - Lists in a noneditable root were incorrectly editable using list API commands, toolbar buttons and menu items. #TINY-9458
 - Color picker dialog would not update the preview color if the hex input value was prefixed with `#` symbol. #TINY-9457
+- Inline boundary was rendered for noneditable inline boundary elements. #TINY-9471
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/src/core/main/ts/keyboard/InlineUtils.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/InlineUtils.ts
@@ -12,7 +12,9 @@ import * as NodeType from '../dom/NodeType';
 import * as Bidi from '../text/Bidi';
 
 const isInlineTarget = (editor: Editor, elm: Node): elm is Element =>
-  Selectors.is(SugarElement.fromDom(elm), Options.getInlineBoundarySelector(editor)) && !TransparentElements.isTransparentBlock(editor.schema, elm);
+  Selectors.is(SugarElement.fromDom(elm), Options.getInlineBoundarySelector(editor))
+  && !TransparentElements.isTransparentBlock(editor.schema, elm)
+  && editor.dom.isEditable(elm);
 
 const isRtl = (element: Element): boolean =>
   DOMUtils.DOM.getStyle(element, 'direction', true) === 'rtl' || Bidi.hasStrongRtl(element.textContent ?? '');

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/InlineUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/InlineUtilsTest.ts
@@ -1,5 +1,6 @@
 import { Assertions } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { Hierarchy, SugarElement, SugarNode } from '@ephox/sugar';
 import { assert } from 'chai';
 
@@ -40,6 +41,9 @@ describe('browser.tinymce.core.keyboard.InlineUtilsTest', () => {
     return {
       options: {
         get: (name: string) => options[name] ?? 'a[href],code,.mce-annotation'
+      },
+      dom: {
+        isEditable: Fun.always
       },
       schema: Schema()
     } as any;

--- a/modules/tinymce/src/core/test/ts/browser/selection/InlineBoundarySelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/InlineBoundarySelectionTest.ts
@@ -1,0 +1,43 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.selection.InlineBoundarySelectionTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, []);
+
+  const assertInlineBoundarySelectionCount = (expectedCount: number) => (editor: Editor) => {
+    TinyAssertions.assertContentPresence(editor, {
+      '[data-mce-selected="inline-boundary"]': expectedCount
+    });
+  };
+
+  const assertInlineBoundarySelection = assertInlineBoundarySelectionCount(1);
+  const assertNoInlineBoundarySelection = assertInlineBoundarySelectionCount(0);
+
+  it('Should have inline boundary when caret is inside an anchor', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="#">a</a></p>');
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+    assertInlineBoundarySelection(editor);
+  });
+
+  it('TINY-9471: Should not have a inline boundary when caret is inside an noneditable anchor', () => {
+    const editor = hook.editor();
+    editor.setContent('<p contenteditable="false"><a href="#">a</a></p>');
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+    assertNoInlineBoundarySelection(editor);
+  });
+
+  it('TINY-9471: Should not have a inline boundary when caret is inside an noneditable root', () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<p><a href="#">a</a></p>');
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+    assertNoInlineBoundarySelection(editor);
+    editor.getBody().contentEditable = 'true';
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-9471

Description of Changes:
* Added predicate check for inline boundaries rendering
* Added tests for selections of inline boundaries in general and then some special case for the noneditables

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
