### PR TITLE
TINY-9277: Remove the editor focus highlight when not in focus

### DIFF
--- a/modules/tinymce/src/core/main/ts/focus/FocusController.ts
+++ b/modules/tinymce/src/core/main/ts/focus/FocusController.ts
@@ -59,11 +59,11 @@ const registerEvents = (editorManager: EditorManager, e: { editor: Editor }) => 
 
   SelectionRestore.register(editor);
 
-  const toggleContainerFocus = (editor: Editor) => {
+  const toggleContentAreaOnFocus = (editor: Editor, fn: (element: SugarElement<Element>, clazz: string) => void) => {
     // Inline editors have a different approach to highlight the content area on focus
     if (Options.shouldHighlightOnFocus(editor) && editor.inline !== true) {
       const contentArea = SugarElement.fromDom(editor.getContainer());
-      Class.toggle(contentArea, 'tox-edit-focus');
+      fn(contentArea, 'tox-edit-focus');
     }
   };
 
@@ -77,7 +77,7 @@ const registerEvents = (editorManager: EditorManager, e: { editor: Editor }) => 
 
       editorManager.setActive(editor);
       editorManager.focusedEditor = editor;
-      toggleContainerFocus(editor);
+      toggleContentAreaOnFocus(editor, Class.add);
       editor.dispatch('focus', { blurredEditor: focusedEditor });
       editor.focus(true);
     }
@@ -87,9 +87,14 @@ const registerEvents = (editorManager: EditorManager, e: { editor: Editor }) => 
     Delay.setEditorTimeout(editor, () => {
       const focusedEditor = editorManager.focusedEditor;
 
+      // Remove focus if no longer on the same editor
+      if (focusedEditor !== editor) {
+        toggleContentAreaOnFocus(editor, Class.remove);
+      }
+
       // Still the same editor the blur was outside any editor UI
       if (!isUIElement(editor, getActiveElement(editor)) && focusedEditor === editor) {
-        toggleContainerFocus(focusedEditor);
+        toggleContentAreaOnFocus(editor, Class.remove);
         editor.dispatch('blur', { focusedEditor: null });
         editorManager.focusedEditor = null;
       }

--- a/modules/tinymce/src/core/main/ts/focus/FocusController.ts
+++ b/modules/tinymce/src/core/main/ts/focus/FocusController.ts
@@ -87,7 +87,7 @@ const registerEvents = (editorManager: EditorManager, e: { editor: Editor }) => 
     Delay.setEditorTimeout(editor, () => {
       const focusedEditor = editorManager.focusedEditor;
 
-      // Remove focus if no longer on the same editor
+      // Remove focus higlight if no longer in focus
       if (focusedEditor !== editor) {
         toggleContentAreaOnFocus(editor, Class.remove);
       }

--- a/modules/tinymce/src/core/test/ts/browser/focus/HighlightOnFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/HighlightOnFocusTest.ts
@@ -1,5 +1,6 @@
-import { context, describe, it } from '@ephox/bedrock-client';
-import { Class } from '@ephox/sugar';
+import { Waiter } from '@ephox/agar';
+import { after, before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
+import { Attribute, Class, Focus, Insert, Remove, SelectorFind, SugarElement } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -8,6 +9,10 @@ import Editor from 'tinymce/core/api/Editor';
 describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
   const assertIsHighlighted = (editor: Editor) => assert.isTrue(Class.has(TinyDom.container(editor), 'tox-edit-focus'), 'Editor container should have tox-edit-focus class');
   const assertIsNotHighlighted = (editor: Editor) => assert.isFalse(Class.has(TinyDom.container(editor), 'tox-edit-focus'), 'Editor container should not have tox-edit-focus class');
+  const focusOutsideEditor = async () => {
+    SelectorFind.child(SugarElement.fromDom(document.body), '#button1').map((el: any) => Focus.focus(el));
+    await Waiter.pWait(200);
+  };
 
   context('with highlight_on_focus: true', () => {
     const hook = TinyHooks.bddSetup<Editor>({
@@ -15,11 +20,39 @@ describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
       highlight_on_focus: true
     });
 
+    before(() => {
+      const fakeButton = SugarElement.fromTag('button');
+      const body = SugarElement.fromDom(document.body);
+      Attribute.set(fakeButton, 'id', 'button1');
+      Insert.append(fakeButton, SugarElement.fromText('Button 1'));
+      Insert.append(body, fakeButton);
+    });
+
+    after(() => {
+      // clean up
+      SelectorFind.child(SugarElement.fromDom(document.body), '#button1').map(Remove.remove);
+    });
+
+    beforeEach(async () => {
+      await focusOutsideEditor();
+    });
+
     it('TINY-9277: Content area should be highlighted on focus', () => {
       const editor = hook.editor();
       assertIsNotHighlighted(editor);
       editor.focus();
       assertIsHighlighted(editor);
+    });
+
+    it('TINY-9277: Content area should be not highlighted if no longer in focus', async () => {
+      const editor = hook.editor();
+      assertIsNotHighlighted(editor);
+      editor.focus();
+      assertIsHighlighted(editor);
+
+      // focus on another element
+      await focusOutsideEditor();
+      assertIsNotHighlighted(editor);
     });
   });
 
@@ -35,5 +68,4 @@ describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
       assertIsNotHighlighted(editor);
     });
   });
-
 });

--- a/modules/tinymce/src/core/test/ts/webdriver/keyboard/IframeTabfocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/keyboard/IframeTabfocusTest.ts
@@ -69,15 +69,5 @@ describe('webdriver.tinymce.core.keyboard.IframeTabfocusTest', () => {
       await RealMouse.pClickOn('iframe => body');
       assertIsHighlighted(editor);
     });
-
-    it('TINY-9277: Remove highlight when not in focus', async () => {
-      const editor = hook.editor();
-      assertIsNotHighlighted(editor);
-      await RealMouse.pClickOn('iframe => body');
-      assertIsHighlighted(editor);
-      // tab to defocus
-      await RealKeys.pSendKeysOn('body', [ RealKeys.text('\t') ]);
-      assertIsNotHighlighted(editor);
-    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/webdriver/keyboard/IframeTabfocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/keyboard/IframeTabfocusTest.ts
@@ -59,7 +59,6 @@ describe('webdriver.tinymce.core.keyboard.IframeTabfocusTest', () => {
       const editor = hook.editor();
       assertIsNotHighlighted(editor);
       // Pressing tab to focus on the editor
-      // await Waiter.pWait(2000);
       await RealKeys.pSendKeysOn('body', [ RealKeys.text('\t') ]);
       assertIsHighlighted(editor);
     });
@@ -69,6 +68,16 @@ describe('webdriver.tinymce.core.keyboard.IframeTabfocusTest', () => {
       assertIsNotHighlighted(editor);
       await RealMouse.pClickOn('iframe => body');
       assertIsHighlighted(editor);
+    });
+
+    it('TINY-9277: Remove highlight when not in focus', async () => {
+      const editor = hook.editor();
+      assertIsNotHighlighted(editor);
+      await RealMouse.pClickOn('iframe => body');
+      assertIsHighlighted(editor);
+      // tab to defocus
+      await RealKeys.pSendKeysOn('body', [ RealKeys.text('\t') ]);
+      assertIsNotHighlighted(editor);
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9277

Description of Changes:
* Removed the editor focus highlight when not in focus

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
