### PR TITLE
TINY-9459: Editable tables in noneditable root

### DIFF
--- a/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
@@ -1,5 +1,5 @@
 import { Optional, Optionals, Singleton } from '@ephox/katamari';
-import { Compare, ContentEditable, EventArgs, SelectorFind, SugarElement } from '@ephox/sugar';
+import { Compare, ContentEditable, EventArgs, SelectorFind, SugarElement, Traverse } from '@ephox/sugar';
 
 import { SelectionAnnotation } from '../api/SelectionAnnotation';
 import { WindowBridge } from '../api/WindowBridge';
@@ -14,6 +14,9 @@ export interface MouseSelection {
 
 const findCell = (target: SugarElement<Node>, isRoot: (e: SugarElement<Node>) => boolean): Optional<SugarElement<HTMLTableCellElement>> =>
   SelectorFind.closest<HTMLTableCellElement>(target, 'td,th', isRoot);
+
+const isInEditableContext = (cell: SugarElement<HTMLTableCellElement>) =>
+  Traverse.parentElement(cell).exists(ContentEditable.isEditable);
 
 export const MouseSelection = (bridge: WindowBridge, container: SugarElement<Node>, isRoot: (e: SugarElement<Node>) => boolean, annotations: SelectionAnnotation): MouseSelection => {
   const cursor = Singleton.value<SugarElement<HTMLTableCellElement>>();
@@ -51,7 +54,7 @@ export const MouseSelection = (bridge: WindowBridge, container: SugarElement<Nod
   /* Keep this as lightweight as possible when we're not in a table selection, it runs constantly */
   const mousedown = (event: EventArgs<MouseEvent>) => {
     annotations.clear(container);
-    findCell(event.target, isRoot).each(cursor.set);
+    findCell(event.target, isRoot).filter(isInEditableContext).each(cursor.set);
   };
 
   /* Keep this as lightweight as possible when we're not in a table selection, it runs constantly */

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Color picker dialog would not update the preview color if the hex input value was prefixed with `#` symbol. #TINY-9457
 - Table cell selection was possible even if the element was noneditable in a noneditable root element. #TINY-9459
 - Table commands were modifying noneditable tables. #TINY-9459
+- Fake carets were rendered for noneditable element and tables if the root was noneditable. #TINY-9459
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lists in a noneditable root were incorrectly editable using list API commands, toolbar buttons and menu items. #TINY-9458
 - Color picker dialog would not update the preview color if the hex input value was prefixed with `#` symbol. #TINY-9457
 - Table cell selection was possible even if the element was noneditable in a noneditable root element. #TINY-9459
+- Table commands were modifying noneditable tables. #TINY-9459
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed a workaround for ensuring stylesheets are loaded in an outdated version of webkit. #TINY-9433
 - Lists in a noneditable root were incorrectly editable using list API commands, toolbar buttons and menu items. #TINY-9458
 - Color picker dialog would not update the preview color if the hex input value was prefixed with `#` symbol. #TINY-9457
+- Table cell selection was possible even if the element was noneditable in a noneditable root element. #TINY-9459
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -35,9 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed a workaround for ensuring stylesheets are loaded in an outdated version of webkit. #TINY-9433
 - Lists in a noneditable root were incorrectly editable using list API commands, toolbar buttons and menu items. #TINY-9458
 - Color picker dialog would not update the preview color if the hex input value was prefixed with `#` symbol. #TINY-9457
-- Table cell selection was possible even if the element was noneditable in a noneditable root element. #TINY-9459
-- Table commands were modifying noneditable tables. #TINY-9459
-- Fake carets were rendered for noneditable element and tables if the root was noneditable. #TINY-9459
+- Table cell selection was possible even if the element was in a noneditable root element. #TINY-9459
+- Table commands were modifying tables in a noneditable root element. #TINY-9459
+- Fake carets were rendered for noneditable elements and tables in a noneditable root element. #TINY-9459
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/src/core/main/ts/caret/FakeCaret.ts
+++ b/modules/tinymce/src/core/main/ts/caret/FakeCaret.ts
@@ -1,5 +1,5 @@
 import { Singleton } from '@ephox/katamari';
-import { SelectorFilter, SugarElement } from '@ephox/sugar';
+import { ContentEditable, SelectorFilter, SugarElement, Traverse } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import Env from '../api/Env';
@@ -223,5 +223,7 @@ export const isFakeCaretTableBrowser = (): boolean => Env.browser.isFirefox();
 export const isInlineFakeCaretTarget = (node: Node | undefined | null): node is HTMLElement =>
   isContentEditableFalse(node) || isMedia(node);
 
-export const isFakeCaretTarget = (node: Node | undefined | null): node is HTMLElement =>
-  isInlineFakeCaretTarget(node) || (NodeType.isTable(node) && isFakeCaretTableBrowser());
+export const isFakeCaretTarget = (node: Node | undefined | null): node is HTMLElement => {
+  const isTarget = isInlineFakeCaretTarget(node) || (NodeType.isTable(node) && isFakeCaretTableBrowser());
+  return isTarget && Traverse.parentElement(SugarElement.fromDom(node)).exists(ContentEditable.isEditable);
+};

--- a/modules/tinymce/src/core/test/ts/browser/caret/CaretUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/CaretUtilsTest.ts
@@ -20,6 +20,7 @@ describe('browser.tinymce.core.CaretUtilTest', () => {
   const getRoot = viewBlock.get;
 
   const setupHtml = (html: string) => {
+    viewBlock.get().contentEditable = 'true';
     viewBlock.update(html);
 
     // IE messes zwsp up on innerHTML so we need to first set markers then replace then using dom operations

--- a/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
@@ -1,7 +1,7 @@
 import { Cursors } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
-import { Css, Html, Insert, Remove, SugarBody, SugarElement, SugarLocation } from '@ephox/sugar';
+import { ContentEditable, Css, Html, Insert, Remove, SugarBody, SugarElement, SugarLocation } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import { FakeCaretPosition, closestCaretCandidateNodeRect, closestFakeCaretCandidate } from 'tinymce/core/caret/ClosestCaretCandidate';
@@ -42,6 +42,7 @@ describe('browser.tinymce.core.ClosestCaretCandidateTest', () => {
 
   const createContainer = (html: string) => {
     const container = SugarElement.fromTag('div');
+    ContentEditable.set(container, true);
     Html.set(container, html);
     Css.setAll(container, {
       outline: '1px solid black',

--- a/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretTest.ts
@@ -1,6 +1,6 @@
 import { after, before, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { Attribute, Html, SelectorFilter, SelectorFind, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
+import { Attribute, ContentEditable, Html, Insert, SelectorFilter, SelectorFind, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
@@ -25,6 +25,7 @@ describe('browser.tinymce.core.caret.FakeCaretTest', () => {
       dom: DOMUtils(document)
     };
     fakeCaret = FakeCaret(mockEditor, getRoot().dom, isBlock, Fun.always);
+    viewBlock.get().contentEditable = 'true';
   });
 
   after(() => {
@@ -108,8 +109,17 @@ describe('browser.tinymce.core.caret.FakeCaretTest', () => {
   });
 
   it('isFakeCaretTarget', () => {
-    assert.isFalse(isFakeCaretTarget(SugarElement.fromHtml('<p></p>').dom), 'Should not need a fake caret');
-    assert.isTrue(isFakeCaretTarget(SugarElement.fromHtml('<p contenteditable="false"></p>').dom), 'Should always need a fake caret');
-    assert.equal(isFakeCaretTarget(SugarElement.fromHtml('<table></table>').dom), isFakeCaretTableBrowser(), 'Should on some browsers need a fake caret');
+    const createElement = (html: string, contentEditable: boolean = true) => {
+      const parent = SugarElement.fromTag('div');
+      const inner = SugarElement.fromHtml(html);
+      Insert.append(parent, inner);
+      ContentEditable.set(parent, contentEditable);
+      return inner;
+    };
+
+    assert.isFalse(isFakeCaretTarget(createElement('<p></p>').dom), 'Should not need a fake caret');
+    assert.isTrue(isFakeCaretTarget(createElement('<p contenteditable="false"></p>').dom), 'Should always need a fake caret');
+    assert.isFalse(isFakeCaretTarget(createElement('<p contenteditable="false"></p>', false).dom), 'Should not have fake caret since context is noneditable');
+    assert.equal(isFakeCaretTarget(createElement('<table></table>').dom), isFakeCaretTableBrowser(), 'Should on some browsers need a fake caret');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/caret/FirefoxFakeCaretBeforeTableTypeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/FirefoxFakeCaretBeforeTableTypeTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -41,5 +41,15 @@ describe('browser.tinymce.core.FirefoxFakeCaretBeforeTableTypeTest', () => {
     assertUndoManagerDataLength(editor, 1);
     KeyUtils.type(editor, 'a');
     assertUndoManagerDataLength(editor, 3);
+  });
+
+  it('TINY-9459: should not render a fake caret before tables inside a noneditable root', () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<table><tbody><tr><td></td></tr></tbody></table>');
+    TinySelections.setCursor(editor, [], 0);
+    editor.nodeChanged();
+    TinyAssertions.assertContentPresence(editor, { '.mce-visual-caret': 0 });
+    editor.getBody().contentEditable = 'true';
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteActionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteActionTest.ts
@@ -1,5 +1,5 @@
 import { Assertions } from '@ephox/agar';
-import { context, describe, it } from '@ephox/bedrock-client';
+import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Fun, Optional } from '@ephox/katamari';
 import { Hierarchy, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
@@ -15,6 +15,10 @@ describe('browser.tinymce.core.delete.CefDeleteActionTest', () => {
   const viewBlock = ViewBlock.bddSetup();
 
   const setHtml = viewBlock.update;
+
+  beforeEach(() => {
+    viewBlock.get().contentEditable = 'true';
+  });
 
   const readAction = (forward: boolean, cursorPath: number[], cursorOffset: number) => {
     const container = Hierarchy.follow(SugarElement.fromDom(viewBlock.get()), cursorPath).getOrDie();

--- a/modules/tinymce/src/models/dom/main/ts/table/api/Commands.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/Commands.ts
@@ -25,7 +25,7 @@ const getSelectionStartCellOrCaption = (editor: Editor): Optional<SugarElement<H
   TableSelection.getSelectionCellOrCaption(Utils.getSelectionStart(editor), Utils.getIsRoot(editor));
 
 const getSelectionStartCell = (editor: Editor): Optional<SugarElement<HTMLTableCellElement>> =>
-  TableSelection.getSelectionCell(Utils.getSelectionStart(editor), Utils.getIsRoot(editor));
+  TableSelection.getSelectionCell(Utils.getSelectionStart(editor), Utils.getIsRoot(editor)).filter((el) => editor.dom.isEditable(el.dom));
 
 const registerCommands = (editor: Editor, actions: TableActions): void => {
   const isRoot = Utils.getIsRoot(editor);

--- a/modules/tinymce/src/models/dom/main/ts/table/api/Commands.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/Commands.ts
@@ -25,7 +25,7 @@ const getSelectionStartCellOrCaption = (editor: Editor): Optional<SugarElement<H
   TableSelection.getSelectionCellOrCaption(Utils.getSelectionStart(editor), Utils.getIsRoot(editor));
 
 const getSelectionStartCell = (editor: Editor): Optional<SugarElement<HTMLTableCellElement>> =>
-  TableSelection.getSelectionCell(Utils.getSelectionStart(editor), Utils.getIsRoot(editor)).filter((el) => editor.dom.isEditable(el.dom));
+  TableSelection.getSelectionCell(Utils.getSelectionStart(editor), Utils.getIsRoot(editor)).filter((el) => Utils.isInEditableContext(el));
 
 const registerCommands = (editor: Editor, actions: TableActions): void => {
   const isRoot = Utils.getIsRoot(editor);

--- a/modules/tinymce/src/models/dom/main/ts/table/core/TableUtils.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/core/TableUtils.ts
@@ -7,7 +7,7 @@
 
 import { Arr, Optional, Strings } from '@ephox/katamari';
 import { TableLookup } from '@ephox/snooker';
-import { Attribute, Compare, SugarElement } from '@ephox/sugar';
+import { Attribute, Compare, ContentEditable, PredicateFind, SugarElement, SugarNode } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -47,6 +47,9 @@ const getRawWidth = (editor: Editor, elm: HTMLElement): Optional<string> => {
 const isPercentage = (value: string): boolean => /^(\d+(\.\d+)?)%$/.test(value);
 const isPixel = (value: string): boolean => /^(\d+(\.\d+)?)px$/.test(value);
 
+const isInEditableContext = (cell: SugarElement<HTMLTableCellElement>): boolean =>
+  PredicateFind.closest(cell, SugarNode.isTag('table')).exists(ContentEditable.isEditable);
+
 export {
   getBody,
   getIsRoot,
@@ -57,5 +60,6 @@ export {
   isPixel,
   getPixelWidth,
   getPixelHeight,
-  getRawWidth
+  getRawWidth,
+  isInEditableContext
 };

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/FakeSelectionTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/FakeSelectionTest.ts
@@ -1,8 +1,8 @@
 import { Assertions, Keys } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { Html, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
-import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -216,5 +216,27 @@ describe('browser.tinymce.models.dom.table.FakeSelectionTest', () => {
       'td[contenteditable="false"][data-mce-first-selected="1"]': 0,
       'td[contenteditable="false"][data-mce-last-selected="1"]': 0
     });
+  });
+
+  context('Noneditable root', () => {
+    it('TINY-9459: Should not select cells with mouse in a noneditable root', () =>
+      TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+        assertTableSelection(
+          editor,
+          simpleTable,
+          [ '1', '2' ],
+          []
+        );
+      })
+    );
+
+    it('TINY-9459: Should not select cells with keyboard in a noneditable root', () =>
+      TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+        editor.setContent('<table><tbody><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table>');
+        TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+        TinyContentActions.keystroke(editor, Keys.down(), { shiftKey: true });
+        TableTestUtils.assertSelectedCells(editor, [], Html.get);
+      })
+    );
   });
 });

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/ApplyCellStyleCommandTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/ApplyCellStyleCommandTest.ts
@@ -207,5 +207,13 @@ describe('browser.tinymce.models.dom.table.command.ApplyCellStyleCommandTest', (
     ]);
   });
 
+  it('TINY-9459: Should not apply command to table in noneditable root', () => {
+    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent(table);
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+      applyCellStyle(editor, { backgroundColor: 'red' });
+      assertTableCellStructure(editor, { });
+    });
+  });
 });
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/InsertCommandsTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/InsertCommandsTest.ts
@@ -1,10 +1,12 @@
-import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+
+import * as TableTestUtils from '../../../module/table/TableTestUtils';
 
 describe('browser.tinymce.models.dom.table.command.InsertCommandsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -163,5 +165,22 @@ describe('browser.tinymce.models.dom.table.command.InsertCommandsTest', () => {
       '<table><tbody><tr><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td>&nbsp;</td><td>&nbsp;</td></tr>' +
       '<tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table>'
     );
+  });
+
+  context('Noneditable root', () => {
+    const testNoopExecCommand = (cmd: string) => () => {
+      TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+        const initalContent = '<table><tbody><tr><td>cell</td></tr></tbody></table>';
+        editor.setContent(initalContent);
+        TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+        editor.execCommand(cmd);
+        TinyAssertions.assertContent(editor, initalContent);
+      });
+    };
+
+    it('TINY-9459: Should not apply mceInsertColBefore command on table in noneditable root', testNoopExecCommand('mceInsertColBefore'));
+    it('TINY-9459: Should not apply mceInsertColAfter command on table in noneditable root', testNoopExecCommand('mceInsertColAfter'));
+    it('TINY-9459: Should not apply mceInsertRowBefore command on table in noneditable root', testNoopExecCommand('mceInsertRowBefore'));
+    it('TINY-9459: Should not apply mceInsertRowAfter command on table in noneditable root', testNoopExecCommand('mceInsertRowAfter'));
   });
 });

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/MergeCellCommandTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/MergeCellCommandTest.ts
@@ -6,6 +6,8 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 
+import * as TableTestUtils from '../../../module/table/TableTestUtils';
+
 interface PartialTableModifiedEvent {
   readonly type: string;
   readonly structure: boolean;
@@ -174,6 +176,30 @@ describe('browser.tinymce.models.dom.table.command.MergeCellCommandTest', () => 
     editor.execCommand('mceTableMergeCells');
     const colspan = SelectorFind.descendant(TinyDom.body(editor), 'td[colspan="2"]').getOrDie();
     assert.approximately(getWidth(colspan), totalColsWidth, 2, 'Check new cell is similar width the the two cells that were merged');
+  });
+
+  it('TINY-9459: Should not merge cells in table inside noneditable root', () => {
+    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+      testMerge(editor, {
+        before: (
+          '<table>' +
+            '<tbody>' +
+            '<tr><td data-mce-selected="1" data-mce-first-selected="1">a1</td><td data-mce-selected="1">b1</td></tr>' +
+            '<tr><td data-mce-selected="1">a2</td><td data-mce-selected="1" data-mce-last-selected="1">b2</td></tr>' +
+            '</tbody>' +
+            '</table>'
+        ),
+        after: (
+          '<table>' +
+            '<tbody>' +
+            '<tr><td>a1</td><td>b1</td></tr>' +
+            '<tr><td>a2</td><td>b2</td></tr>' +
+            '</tbody>' +
+            '</table>'
+        ),
+        expectedEvents: [ ]
+      });
+    });
   });
 
   /*

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/ModifyClassesCommandsTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/ModifyClassesCommandsTest.ts
@@ -6,6 +6,8 @@ import Editor from 'tinymce/core/api/Editor';
 import { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
+import * as TableTestUtils from '../../../module/table/TableTestUtils';
+
 describe('browser.tinymce.models.dom.table.command.ModifyClassesCommandsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
@@ -288,6 +290,16 @@ describe('browser.tinymce.models.dom.table.command.ModifyClassesCommandsTest', (
         execCmdAndAssertEvent(editor, 'mceTableToggleClass', 'a');
         TinyAssertions.assertContent(editor, contentWithoutClass);
       });
+    });
+  });
+
+  it('TINY-9459: Should not apply mceTableToggleClass command on table in noneditable root', () => {
+    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+      const initalContent = '<table><tbody><tr><td>cell</td></tr></tbody></table>';
+      editor.setContent(initalContent);
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+      editor.execCommand('mceTableToggleClass', false, 'a');
+      TinyAssertions.assertContent(editor, initalContent);
     });
   });
 });

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteColumnTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteColumnTest.ts
@@ -7,6 +7,8 @@ import Editor from 'tinymce/core/api/Editor';
 import { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
+import * as TableTestUtils from '../../../module/table/TableTestUtils';
+
 describe('browser.tinymce.models.dom.table.command.TableDeleteColumnTest', () => {
   let events: Array<EditorEvent<TableModifiedEvent>> = [];
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -60,5 +62,15 @@ describe('browser.tinymce.models.dom.table.command.TableDeleteColumnTest', () =>
     editor.execCommand('mceTableDeleteCol');
     TinyAssertions.assertContent(editor, '');
     assertEvents(2);
+  });
+
+  it('TINY-9459: Should not apply mceTableDeleteCol command on table in noneditable root', () => {
+    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+      const initalContent = '<table><tbody><tr><td>cell</td></tr></tbody></table>';
+      editor.setContent(initalContent);
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+      editor.execCommand('mceTableDeleteCol');
+      TinyAssertions.assertContent(editor, initalContent);
+    });
   });
 });

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteRowTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteRowTest.ts
@@ -9,7 +9,7 @@ import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import * as TableTestUtils from '../../../module/table/TableTestUtils';
 
-describe('browser.tinymce.models.dom.table.command.TableDeleteColumnTest', () => {
+describe('browser.tinymce.models.dom.table.command.TableDeleteRowTest', () => {
   let events: Array<EditorEvent<TableModifiedEvent>> = [];
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
@@ -36,50 +36,50 @@ describe('browser.tinymce.models.dom.table.command.TableDeleteColumnTest', () =>
     });
   };
 
-  it('TINY-7916: Delete all columns should delete the table', () => {
+  it('TINY-7916: Delete all rows should delete the table', () => {
     const editor = hook.editor();
-    editor.setContent('<table><tbody><tr><td>1</td><td>2</td><td>3</td></tr></tbody></table>');
-    TinySelections.setCursor(editor, [ 0, 0, 0, 2, 0 ], 1);
+    editor.setContent('<table><tbody><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr></tbody></table>');
+    TinySelections.setCursor(editor, [ 0, 0, 2, 0, 0 ], 1);
 
-    editor.execCommand('mceTableDeleteCol');
-    TinyAssertions.assertCursor(editor, [ 0, 0, 0, 1, 0 ], 1);
-    editor.execCommand('mceTableDeleteCol');
+    editor.execCommand('mceTableDeleteRow');
+    TinyAssertions.assertCursor(editor, [ 0, 0, 1, 0, 0 ], 1);
+    editor.execCommand('mceTableDeleteRow');
     TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0, 0 ], 1);
-    editor.execCommand('mceTableDeleteCol');
+    editor.execCommand('mceTableDeleteRow');
     TinyAssertions.assertContent(editor, '');
     assertEvents(2);
   });
 
-  it('TINY-7916: Delete all columns with a contenteditable=false column', () => {
+  it('TINY-7916: Delete all rows with a contenteditable=false cell', () => {
     const editor = hook.editor();
-    editor.setContent('<table><tbody><tr><td contenteditable="false">1</td><td>2</td><td>3</td></tr></tbody></table>');
-    TinySelections.setCursor(editor, [ 0, 0, 0, 2, 0 ], 1);
+    editor.setContent('<table><tbody><tr><td contenteditable="false">1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr></tbody></table>');
+    TinySelections.setCursor(editor, [ 0, 0, 2, 0, 0 ], 1);
 
-    editor.execCommand('mceTableDeleteCol');
-    TinyAssertions.assertCursor(editor, [ 0, 0, 0, 1, 0 ], 1);
-    editor.execCommand('mceTableDeleteCol');
+    editor.execCommand('mceTableDeleteRow');
+    TinyAssertions.assertCursor(editor, [ 0, 0, 1, 0, 0 ], 1);
+    editor.execCommand('mceTableDeleteRow');
     TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
-    editor.execCommand('mceTableDeleteCol');
+    editor.execCommand('mceTableDeleteRow');
     TinyAssertions.assertContent(editor, '');
     assertEvents(2);
   });
 
-  it('TINY-9459: Should not apply mceTableDeleteCol command on table in noneditable root', () => {
+  it('TINY-9459: Should not apply mceTableDeleteRow command on table in noneditable root', () => {
     TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
       const initalContent = '<table><tbody><tr><td>cell</td></tr></tbody></table>';
       editor.setContent(initalContent);
       TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
-      editor.execCommand('mceTableDeleteCol');
+      editor.execCommand('mceTableDeleteRow');
       TinyAssertions.assertContent(editor, initalContent);
     });
   });
 
-  it('TINY-9459: Should not apply mceTableDeleteCol command on table in noneditable table', () => {
+  it('TINY-9459: Should not apply mceTableDeleteRow command on table in noneditable table', () => {
     const editor = hook.editor();
     const initalContent = '<table contenteditable="false"><tbody><tr><td>cell</td></tr></tbody></table>';
     editor.setContent(initalContent);
     TinySelections.setCursor(editor, [ 1, 0, 0, 0, 0 ], 0); // Index off by one due to cef fake caret
-    editor.execCommand('mceTableDeleteCol');
+    editor.execCommand('mceTableDeleteRow');
     TinyAssertions.assertContent(editor, initalContent);
   });
 });

--- a/modules/tinymce/src/models/dom/test/ts/module/table/TableTestUtils.ts
+++ b/modules/tinymce/src/models/dom/test/ts/module/table/TableTestUtils.ts
@@ -259,6 +259,12 @@ const assertWidths = (widths: { widthBefore: WidthData; widthAfter: WidthData })
   }
 };
 
+const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void): void => {
+  editor.getBody().contentEditable = 'false';
+  f(editor);
+  editor.getBody().contentEditable = 'true';
+};
+
 export {
   getCellWidth,
   assertTableStructure,
@@ -281,5 +287,6 @@ export {
   deleteRow,
   insertTable,
   makeInsertTable,
-  assertWidths
+  assertWidths,
+  withNoneditableRootEditor
 };

--- a/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSanityTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSanityTest.ts
@@ -11,7 +11,7 @@ describe('browser.tinymce.plugins.codesample.CodeSampleSanityTest', () => {
     plugins: 'codesample',
     toolbar: 'codesample',
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin ]);
+  }, [ Plugin ], true);
 
   const markupContent = '<p>hello world</p>';
   const newContent = 'editor content should not change to this';

--- a/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Commands.ts
@@ -2,22 +2,26 @@ import { Fun, Obj } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 
+import * as Utils from '../core/Utils';
 import * as CellDialog from '../ui/CellDialog';
 import * as RowDialog from '../ui/RowDialog';
 import * as TableDialog from '../ui/TableDialog';
 
 const registerCommands = (editor: Editor): void => {
+  const runAction = (f: () => void) => {
+    if (Utils.isInEditableContext(Utils.getSelectionStart(editor))) {
+      f();
+    }
+  };
+
   // Register dialog commands
   Obj.each({
     // AP-101 TableDialog.open renders a slightly different dialog if isNew is true
     mceTableProps: Fun.curry(TableDialog.open, editor, false),
     mceTableRowProps: Fun.curry(RowDialog.open, editor),
-    mceTableCellProps: Fun.curry(CellDialog.open, editor)
-  }, (func, name) => editor.addCommand(name, () => func()));
-
-  editor.addCommand('mceInsertTableDialog', (_ui) => {
-    TableDialog.open(editor, true);
-  });
+    mceTableCellProps: Fun.curry(CellDialog.open, editor),
+    mceInsertTableDialog: Fun.curry(TableDialog.open, editor, true),
+  }, (func, name) => editor.addCommand(name, () => runAction(func)));
 };
 
 export { registerCommands };

--- a/modules/tinymce/src/plugins/table/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/core/Utils.ts
@@ -5,7 +5,7 @@
  Make sure that if making changes to this file, the other files are updated as well
  */
 
-import { Compare, SugarElement } from '@ephox/sugar';
+import { Compare, ContentEditable, PredicateFind, SugarElement, SugarNode } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -30,6 +30,9 @@ const getSelectionStart = (editor: Editor): SugarElement<Element> =>
 const getSelectionEnd = (editor: Editor): SugarElement<Element> =>
   SugarElement.fromDom(editor.selection.getEnd());
 
+const isInEditableContext = (cell: SugarElement<Node>): boolean =>
+  PredicateFind.closest(cell, SugarNode.isTag('table')).forall(ContentEditable.isEditable);
+
 export {
   getNodeName,
   getBody,
@@ -37,5 +40,6 @@ export {
   addPxSuffix,
   removePxSuffix,
   getSelectionStart,
-  getSelectionEnd
+  getSelectionEnd,
+  isInEditableContext
 };

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
@@ -1,5 +1,6 @@
+import { UiFinder } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
-import { SugarElement, SugarNode } from '@ephox/sugar';
+import { SugarBody, SugarElement, SugarNode } from '@ephox/sugar';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -524,5 +525,22 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
     TinyAssertions.assertContent(editor, expectedhtml);
     assertEventsOrder([ 'tablemodified' ]);
     assertTableModifiedEvent({ structure: false, style: false });
+  });
+
+  it('TINY-9459: Should not open table row properties dialog on noneditable table', () => {
+    const editor = hook.editor();
+    editor.setContent('<table contenteditable="false"><tbody><tr><td>x</td></tr></tbody></table>');
+    TinySelections.setCursor(editor, [ 1, 0, 0, 0, 0 ], 0); // Index offset off by one due to cef fake caret
+    editor.execCommand('mceTableCellProps');
+    UiFinder.notExists(SugarBody.body(), '.tox-dialog');
+  });
+
+  it('TINY-9459: Should not open table row properties dialog on noneditable root', () => {
+    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<table><tbody><tr><td>x</td></tr></tbody></table>');
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+      editor.execCommand('mceTableCellProps');
+      UiFinder.notExists(SugarBody.body(), '.tox-dialog');
+    });
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogTest.ts
@@ -1,5 +1,6 @@
-import { ApproxStructure } from '@ephox/agar';
+import { ApproxStructure, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -413,5 +414,31 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     await TableTestUtils.pOpenTableDialog(editor);
     TableTestUtils.assertDialogValues(getExpectedData(2, ''), false, generalSelectors);
     await TableTestUtils.pClickDialogButton(editor, false);
+  });
+
+  it('TINY-9459: Should not open table properties dialog on noneditable table', () => {
+    const editor = hook.editor();
+    editor.setContent('<table contenteditable="false"><tbody><tr><td>x</td></tr></tbody></table>');
+    TinySelections.setCursor(editor, [ 1, 0, 0, 0, 0 ], 0); // Index offset off by one due to cef fake caret
+    editor.execCommand('mceTableProps');
+    UiFinder.notExists(SugarBody.body(), '.tox-dialog');
+  });
+
+  it('TINY-9459: Should not open table properties dialog on noneditable root', () => {
+    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<table><tbody><tr><td>x</td></tr></tbody></table>');
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+      editor.execCommand('mceTableProps');
+      UiFinder.notExists(SugarBody.body(), '.tox-dialog');
+    });
+  });
+
+  it('TINY-9459: Should not open table insert dialog on noneditable root', () => {
+    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<table><tbody><tr><td>x</td></tr></tbody></table>');
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+      editor.execCommand('mceInsertTableDialog');
+      UiFinder.notExists(SugarBody.body(), '.tox-dialog');
+    });
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
@@ -1,6 +1,7 @@
+import { UiFinder } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { SugarElement, SugarNode } from '@ephox/sugar';
+import { SugarBody, SugarElement, SugarNode } from '@ephox/sugar';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -393,5 +394,22 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, expectedHtml);
     assertEvents([{ type: 'tablemodified', structure: true, style: false }]);
+  });
+
+  it('TINY-9459: Should not open table row properties dialog on noneditable table', () => {
+    const editor = hook.editor();
+    editor.setContent('<table contenteditable="false"><tbody><tr><td>x</td></tr></tbody></table>');
+    TinySelections.setCursor(editor, [ 1, 0, 0, 0, 0 ], 0); // Index offset off by one due to cef fake caret
+    editor.execCommand('mceTableRowProps');
+    UiFinder.notExists(SugarBody.body(), '.tox-dialog');
+  });
+
+  it('TINY-9459: Should not open table row properties dialog on noneditable root', () => {
+    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<table><tbody><tr><td>x</td></tr></tbody></table>');
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+      editor.execCommand('mceTableRowProps');
+      UiFinder.notExists(SugarBody.body(), '.tox-dialog');
+    });
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
@@ -228,6 +228,12 @@ const createTableChildren = (s: ApproxStructure.StructApi, str: ApproxStructure.
   return withColGroups ? [ columns, tbody ] : [ tbody ];
 };
 
+const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void): void => {
+  editor.getBody().contentEditable = 'false';
+  f(editor);
+  editor.getBody().contentEditable = 'true';
+};
+
 export {
   pAssertDialogPresence,
   pAssertListBoxValue,
@@ -242,5 +248,6 @@ export {
   setDialogValues,
   pClickDialogButton,
   assertElementStructure,
-  assertApproxElementStructure
+  assertApproxElementStructure,
+  withNoneditableRootEditor
 };


### PR DESCRIPTION
Related Ticket: TINY-9459

Description of Changes:
* Blocks table commands for being applied to noneditable tables
* Blocks table cell selection from happening though mouse and keyboard in noneditable tables
* Prevents fake carets to be rendered before or after tables in Firefox in noneditable contexts
* Prevents fake carets to be rendered before or after noneditable elements in noneditable contexts.
* Fixed a flaking test for code sample unrelated to this PR but needed to change to make it build.
* Some test needed updating to set the `contentEditable` true to the scratch element of the tests.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
