### PR TITLE
TINY-9461: Pressing enter in a block in a noneditable root causes invalid nesting

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inline boundary was rendered for noneditable inline boundary elements. #TINY-9471
 - Clicking on a disabled split button will no longer call the `onAction` callback. #TINY-9504
 - The "Edit Link" dialog incorrectly retrieved the URL value when opened immediately after the link insertion. #TINY-7993
+- Inserting newlines inside an editable element inside a noneditable root would sometimes try to split the editable element. #TINY-9461
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
@@ -670,4 +670,16 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
     TinyAssertions.assertContent(editor, '<p>a</p><p>c</p>');
     TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
   });
+
+  it('TINY-9461: Enter inside an editing host should not split the editing host', () => {
+    const editor = hook.editor();
+    const initialContent = '<p contenteditable="true">ab</p>';
+
+    editor.getBody().contentEditable = 'false';
+    editor.setContent(initialContent);
+    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    pressEnter(editor, true);
+    TinyAssertions.assertContent(editor, initialContent);
+    editor.getBody().contentEditable = 'false';
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -105,6 +105,27 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
       TinyAssertions.assertContent(editor, '<p><span contenteditable="false">a</span></p><p>&nbsp;</p>');
       TinyAssertions.assertCursor(editor, [ 1 ], 0);
     });
+
+    it('TINY-9461: should not split editing host in noneditable root', () => {
+      const editor = hook.editor();
+      const initialContent = '<p contenteditable="true">ab</p>';
+      editor.getBody().contentEditable = 'false';
+      editor.setContent(initialContent);
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      insertNewline(editor, { });
+      TinyAssertions.assertContent(editor, initialContent);
+      editor.getBody().contentEditable = 'true';
+    });
+
+    it('TINY-9461: should wrap div contents in paragraph and split inner paragraph in a div editing host inside a noneditable root', () => {
+      const editor = hook.editor();
+      editor.getBody().contentEditable = 'false';
+      editor.setContent('<div contenteditable="true">ab</div>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      insertNewline(editor, { });
+      TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>a</p><p>b</p></div>');
+      editor.getBody().contentEditable = 'true';
+    });
   });
 
   context('br_newline_selector', () => {

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -126,6 +126,25 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
       TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>a</p><p>b</p></div>');
       editor.getBody().contentEditable = 'true';
     });
+
+    it('TINY-9461: should not split editing host', () => {
+      const editor = hook.editor();
+      const initialContent = '<div contenteditable="false"><p contenteditable="true">ab</p></div>';
+      editor.setContent(initialContent);
+      TinySelections.setCursor(editor, [ 1, 0, 0 ], 1);
+      insertNewline(editor, { });
+      TinyAssertions.assertContent(editor, initialContent);
+    });
+
+    it('TINY-9461: should wrap div contents in paragraph and split inner paragraph in a div editing host', () => {
+      const editor = hook.editor();
+      editor.getBody().contentEditable = 'false';
+      editor.setContent('<div contenteditable="false"><div contenteditable="true">ab</div></div>');
+      TinySelections.setCursor(editor, [ 1, 0, 0 ], 1);
+      insertNewline(editor, { });
+      TinyAssertions.assertContent(editor, '<div contenteditable="false"><div contenteditable="true"><p>a</p><p>b</p></div></div>');
+      editor.getBody().contentEditable = 'true';
+    });
   });
 
   context('br_newline_selector', () => {

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -140,7 +140,7 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
       const editor = hook.editor();
       editor.getBody().contentEditable = 'false';
       editor.setContent('<div contenteditable="false"><div contenteditable="true">ab</div></div>');
-      TinySelections.setCursor(editor, [ 1, 0, 0 ], 1);
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
       insertNewline(editor, { });
       TinyAssertions.assertContent(editor, '<div contenteditable="false"><div contenteditable="true"><p>a</p><p>b</p></div></div>');
       editor.getBody().contentEditable = 'true';


### PR DESCRIPTION
Related Ticket: TINY-9461

Description of Changes:
* Prevents editing host elements like contentEditable true in a contentEditable false to be split.
* Prevents editing hosts elements inside a noneditable root to be split.
* Fixed issue with schema checking not being correct it would put P in P since it checked the wrong element parent.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
