### PR TITLE
TINY-9477: Backspace/delete with selection across block elements in a noneditable root deletes the elements

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inline boundary was rendered for noneditable inline boundary elements. #TINY-9471
 - Clicking on a disabled split button will no longer call the `onAction` callback. #TINY-9504
 - The "Edit Link" dialog incorrectly retrieved the URL value when opened immediately after the link insertion. #TINY-7993
+- Editor commands `ForwardDelete` and `Delete` was deleting contents inside noneditable elements. #TINY-9477
+- Backspace or delete keys was deleting contents inside noneditable elements. #TINY-9477
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
@@ -1,4 +1,4 @@
-import { Type } from '@ephox/katamari';
+import { Arr, Type } from '@ephox/katamari';
 import { Compare, SugarElement } from '@ephox/sugar';
 
 import { Bookmark } from '../../bookmark/BookmarkTypes';
@@ -265,8 +265,11 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
    */
   const isEditable = (): boolean => {
     const rng = getRng();
+    const fakeSelectedElements = editor.getBody().querySelectorAll('[data-mce-selected="1"]');
 
-    if (rng.startContainer === rng.endContainer) {
+    if (fakeSelectedElements.length > 0) {
+      return Arr.forall(fakeSelectedElements, (el) => dom.isEditable(el.parentElement));
+    } else if (rng.startContainer === rng.endContainer) {
       return dom.isEditable(rng.startContainer);
     } else {
       return dom.isEditable(rng.startContainer) && dom.isEditable(rng.endContainer);

--- a/modules/tinymce/src/core/main/ts/delete/DeleteCommands.ts
+++ b/modules/tinymce/src/core/main/ts/delete/DeleteCommands.ts
@@ -25,7 +25,8 @@ const findAction = (editor: Editor, caret: Cell<Text | null>, forward: boolean) 
     MediaDelete.backspaceDelete,
     BlockRangeDelete.backspaceDelete,
     InlineFormatDelete.backspaceDelete,
-  ], (item) => item(editor, forward));
+  ], (item) => item(editor, forward))
+    .filter((_) => editor.selection.isEditable());
 
 const deleteCommand = (editor: Editor, caret: Cell<Text | null>): void => {
   const result = findAction(editor, caret, false);

--- a/modules/tinymce/src/core/main/ts/keyboard/DeleteBackspaceKeys.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/DeleteBackspaceKeys.ts
@@ -40,15 +40,17 @@ const executeKeydownOverride = (editor: Editor, caret: Cell<Text | null>, evt: K
     { keyCode: VK.DELETE, action: MatchKeys.action(BlockBoundaryDelete.backspaceDelete, editor, true) },
     { keyCode: VK.BACKSPACE, action: MatchKeys.action(InlineFormatDelete.backspaceDelete, editor, false) },
     { keyCode: VK.DELETE, action: MatchKeys.action(InlineFormatDelete.backspaceDelete, editor, true) }
-  ], evt).each((applyAction) => {
-    evt.preventDefault();
-    const beforeInput = fireFakeBeforeInputEvent(editor, inputType);
+  ], evt)
+    .filter((_) => editor.selection.isEditable())
+    .each((applyAction) => {
+      evt.preventDefault();
+      const beforeInput = fireFakeBeforeInputEvent(editor, inputType);
 
-    if (!beforeInput.isDefaultPrevented()) {
-      applyAction();
-      fireFakeInputEvent(editor, inputType);
-    }
-  });
+      if (!beforeInput.isDefaultPrevented()) {
+        applyAction();
+        fireFakeInputEvent(editor, inputType);
+      }
+    });
 };
 
 const executeKeyupOverride = (editor: Editor, evt: KeyboardEvent, isBackspaceKeydown: boolean) => {

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -87,7 +87,7 @@ const Quirks = (editor: Editor): Quirks => {
       const keyCode = e.keyCode;
 
       // Empty the editor if it's needed for example backspace at <p><b>|</b></p>
-      if (!isDefaultPrevented(e) && (keyCode === DELETE || keyCode === BACKSPACE)) {
+      if (!isDefaultPrevented(e) && (keyCode === DELETE || keyCode === BACKSPACE) && editor.selection.isEditable()) {
         const isCollapsed = editor.selection.isCollapsed();
         const body = editor.getBody();
 

--- a/modules/tinymce/src/core/test/ts/browser/delete/DeleteCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/DeleteCommandsTest.ts
@@ -1,4 +1,4 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
@@ -28,5 +28,51 @@ describe('browser.tinymce.core.delete.DeleteCommandsTest', () => {
     DeleteCommands.forwardDeleteCommand(editor, caret);
     TinyAssertions.assertContent(editor, '<p><span style="color: red;">a</span>b</p>');
     TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1);
+  });
+
+  context('noneditable', () => {
+    it('TINY-9477: Delete on noneditable blocks should not do anything', () => {
+      const editor = hook.editor();
+      const initialContent = '<div contenteditable="false"><p>a</p><p>b</p></div>';
+      editor.setContent(initialContent);
+      TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 1, 1, 0 ], 1);
+      DeleteCommands.deleteCommand(editor, caret);
+      TinyAssertions.assertContent(editor, initialContent);
+      TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 1, 0 ], 1);
+    });
+
+    it('TINY-9477: ForwardDelete on noneditable blocks should not do anything', () => {
+      const editor = hook.editor();
+      const initialContent = '<div contenteditable="false"><p>a</p><p>b</p></div>';
+      editor.setContent(initialContent);
+      TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 1, 1, 0 ], 1);
+      DeleteCommands.forwardDeleteCommand(editor, caret);
+      TinyAssertions.assertContent(editor, initialContent);
+      TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 1, 0 ], 1);
+    });
+
+    it('TINY-9477: Delete on blocks in noneditable root should not do anything', () => {
+      const editor = hook.editor();
+      const initialContent = '<p>a</p><p>b</p>';
+      editor.getBody().contentEditable = 'false';
+      editor.setContent(initialContent);
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
+      DeleteCommands.deleteCommand(editor, caret);
+      TinyAssertions.assertContent(editor, initialContent);
+      TinyAssertions.assertSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
+      editor.getBody().contentEditable = 'true';
+    });
+
+    it('TINY-9477: ForwardDelete on blocks in noneditable root should not do anything', () => {
+      const editor = hook.editor();
+      const initialContent = '<p>a</p><p>b</p>';
+      editor.getBody().contentEditable = 'false';
+      editor.setContent(initialContent);
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
+      DeleteCommands.forwardDeleteCommand(editor, caret);
+      TinyAssertions.assertContent(editor, initialContent);
+      TinyAssertions.assertSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
+      editor.getBody().contentEditable = 'true';
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
@@ -1367,5 +1367,14 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
       foffset: 1,
       expected: false
     }));
+
+    it('TINY-9477: isEditable on selected noneditable table cells should be true since parent is editable', testIsEditableSelection({
+      input: '<table><tbody><tr><td contenteditable="false" data-mce-selected="1">a</td><td contenteditable="false" data-mce-selected="1">b</td></tr></tbody></table>',
+      spath: [ 0, 0, 0, 0, 0 ],
+      soffset: 0,
+      fpath: [ 0, 0, 0, 1, 0 ],
+      foffset: 1,
+      expected: true
+    }));
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9477

Description of Changes:
* Blocking commands and keyboard delete/backspace from being applied to noneditable content
* Rewrote editor.selection.isEditable to handle fake selections and prioritize them first.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
