### PR TITLE
TINY-9459: blocked some additional commands

### DIFF
--- a/modules/darwin/CHANGELOG.md
+++ b/modules/darwin/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Table cells that are in a noneditable context was incorrectly selectable with keyboard and mouse.
+
 ## 8.0.0 - 2022-03-03
 
 ### Changed

--- a/modules/tinymce/src/models/dom/main/ts/table/api/Commands.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/Commands.ts
@@ -22,10 +22,10 @@ interface InsertTableArgs {
 }
 
 const getSelectionStartCellOrCaption = (editor: Editor): Optional<SugarElement<HTMLTableCellElement | HTMLTableCaptionElement>> =>
-  TableSelection.getSelectionCellOrCaption(Utils.getSelectionStart(editor), Utils.getIsRoot(editor));
+  TableSelection.getSelectionCellOrCaption(Utils.getSelectionStart(editor), Utils.getIsRoot(editor)).filter(Utils.isInEditableContext);
 
 const getSelectionStartCell = (editor: Editor): Optional<SugarElement<HTMLTableCellElement>> =>
-  TableSelection.getSelectionCell(Utils.getSelectionStart(editor), Utils.getIsRoot(editor)).filter((el) => Utils.isInEditableContext(el));
+  TableSelection.getSelectionCell(Utils.getSelectionStart(editor), Utils.getIsRoot(editor)).filter(Utils.isInEditableContext);
 
 const registerCommands = (editor: Editor, actions: TableActions): void => {
   const isRoot = Utils.getIsRoot(editor);
@@ -214,7 +214,7 @@ const registerCommands = (editor: Editor, actions: TableActions): void => {
     if (!Type.isObject(args)) {
       return;
     }
-    const cells = TableSelection.getCellsFromSelection(editor);
+    const cells = Arr.filter(TableSelection.getCellsFromSelection(editor), Utils.isInEditableContext);
     if (cells.length === 0) {
       return;
     }

--- a/modules/tinymce/src/models/dom/main/ts/table/core/TableUtils.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/core/TableUtils.ts
@@ -47,7 +47,7 @@ const getRawWidth = (editor: Editor, elm: HTMLElement): Optional<string> => {
 const isPercentage = (value: string): boolean => /^(\d+(\.\d+)?)%$/.test(value);
 const isPixel = (value: string): boolean => /^(\d+(\.\d+)?)px$/.test(value);
 
-const isInEditableContext = (cell: SugarElement<HTMLTableCellElement>): boolean =>
+const isInEditableContext = (cell: SugarElement<HTMLTableCellElement | HTMLTableCaptionElement>): boolean =>
   PredicateFind.closest(cell, SugarNode.isTag('table')).exists(ContentEditable.isEditable);
 
 export {

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/ApplyCellStyleCommandTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/ApplyCellStyleCommandTest.ts
@@ -15,6 +15,7 @@ describe('browser.tinymce.models.dom.table.command.ApplyCellStyleCommandTest', (
   const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'table',
     base_url: '/project/tinymce/js/tinymce',
+    indent: false,
     setup: (editor: Editor) => {
       editor.on('TableModified', logEvent);
     }
@@ -44,8 +45,8 @@ describe('browser.tinymce.models.dom.table.command.ApplyCellStyleCommandTest', (
   const table = '<table style="border-collapse: collapse; width: 100%;" border="1">' +
     '<tbody>' +
     '<tr>' +
-    `<td style="width: 50%;" >a</td>` +
-    `<td style="width: 50%;" >b</td>` +
+    `<td style="width: 50%;">a</td>` +
+    `<td style="width: 50%;">b</td>` +
     '</tr>' +
     '</tbody>' +
     '</table>';
@@ -212,7 +213,7 @@ describe('browser.tinymce.models.dom.table.command.ApplyCellStyleCommandTest', (
       editor.setContent(table);
       TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
       applyCellStyle(editor, { backgroundColor: 'red' });
-      assertTableCellStructure(editor, { });
+      TinyAssertions.assertContent(editor, table);
     });
   });
 });

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteCommandTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteCommandTest.ts
@@ -1,0 +1,41 @@
+
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+import * as TableTestUtils from '../../../module/table/TableTestUtils';
+
+describe('browser.tinymce.models.dom.table.command.TableDeleteCommandTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [], true);
+
+  it('Should delete table', () => {
+    const editor = hook.editor();
+    editor.setContent('<div><table><tbody><tr><td>cell</td></tr></tbody></table></div>');
+    TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0, 0 ], 0);
+    editor.execCommand('mceTableDelete');
+    TinyAssertions.assertContent(editor, '');
+  });
+
+  it('TINY-9459: Should not apply mceTableDelete command on table inside a noneditable div', () => {
+    const editor = hook.editor();
+    const initalContent = '<div contenteditable="false"><table><tbody><tr><td>cell</td></tr></tbody></table></div>';
+    editor.setContent(initalContent);
+    TinySelections.setCursor(editor, [ 1, 0, 0, 0, 0, 0 ], 0); // Index off by one due to cef fake caret
+    editor.execCommand('mceTableDelete');
+    TinyAssertions.assertContent(editor, initalContent);
+  });
+
+  it('TINY-9459: Should not apply mceTableDelete command on table inside a noneditable root', () => {
+    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+      const initalContent = '<table><tbody><tr><td>cell</td></tr></tbody></table>';
+      editor.setContent(initalContent);
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+      editor.execCommand('mceTableDelete');
+      TinyAssertions.assertContent(editor, initalContent);
+    });
+  });
+});

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCaptionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCaptionTest.ts
@@ -8,6 +8,7 @@ import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import Plugin from 'tinymce/plugins/table/Plugin';
 
 import { assertStructureIsRestoredToDefault, clickOnButton, pClickOnMenuItem, setEditorContentTableAndSelection } from '../../module/test/TableModifiersTestUtils';
+import * as TableTestUtils from '../../module/test/TableTestUtils';
 
 describe('browser.tinymce.plugins.table.ui.TableCaptionTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -173,6 +174,29 @@ describe('browser.tinymce.plugins.table.ui.TableCaptionTest', () => {
 
       toggleCaption(editor);
       assertTableStructureIsCorrect(editor, nestedTableCaptionStructure);
+    });
+  });
+
+  context('noneditable', () => {
+    it('TINY-9459: Should not apply mceToggleCaption command on table inside a noneditable div', () => {
+      const editor = hook.editor();
+      const initalContent = '<div contenteditable="false"><table><tbody><tr><td>cell</td></tr></tbody></table></div>';
+      editor.setContent(initalContent);
+      TinySelections.setCursor(editor, [ 1, 0, 0, 0, 0, 0 ], 0); // Index off by one due to cef fake caret
+      editor.execCommand('mceTableToggleCaption');
+      TinyAssertions.assertContent(editor, initalContent);
+    });
+
+    it('TINY-9459: Should not apply mceToggleCaption command on table inside a noneditable root', () => {
+      TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+        const initalContent = '<table><tbody><tr><td>cell</td></tr></tbody></table>';
+        editor.getBody().contentEditable = 'false';
+        editor.setContent(initalContent);
+        TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+        editor.execCommand('mceTableToggleCaption');
+        TinyAssertions.assertContent(editor, initalContent);
+        editor.getBody().contentEditable = 'true';
+      });
     });
   });
 });

--- a/versions.txt
+++ b/versions.txt
@@ -1,5 +1,6 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
 
+darwin@8.0.1
 sugar@9.2.0
 oxide-icons-default@2.2.0


### PR DESCRIPTION
Related Ticket: TINY-9459

Description of Changes:
* Found some commands that where still working while setting up a fiddle for QA so this is second PR for the original ticket.
* Add basic test for the `mceTableDelete` command
* Also missed adding changelog and add darwin to versions something I also forgot to do

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
