### PR TITLE
TINY-9331: added overflow hidden to clip the textarea scrollbars

### DIFF
--- a/modules/oxide/src/less/theme/components/form/textarea.less
+++ b/modules/oxide/src/less/theme/components/form/textarea.less
@@ -11,6 +11,9 @@
     display: flex;
     flex: 1;
 
+    // This is needed to clip the scrollbars by the border-radius see #TINY-9331
+    overflow: hidden;
+
     &:focus-within {
       &:extend(.tox .tox-textfield:focus);
     }


### PR DESCRIPTION
Related Ticket: TINY-9331

Description of Changes:
* Followup on a previous PR since QA found some isuses
* Added overflow hidden that seem to properly clip the scrollbars to the border-radius on all browsers.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
