### PR TITLE
TINY-9277: Border should only be triggered when focused on content area and removed otherwise

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -120,6 +120,7 @@ interface BaseEditorOptions {
   format_noneditable_selector?: string;
   height?: number | string;
   hidden_input?: boolean;
+  highlight_on_focus?: boolean;
   icons?: string;
   icons_url?: string;
   id?: string;
@@ -290,6 +291,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   forced_root_block_attrs: Record<string, string>;
   format_noneditable_selector: string;
   height: number | string;
+  highlight_on_focus: boolean;
   iframe_attrs: Record<string, string>;
   images_file_types: string;
   images_upload_base_path: string;

--- a/modules/tinymce/src/core/main/ts/focus/FocusController.ts
+++ b/modules/tinymce/src/core/main/ts/focus/FocusController.ts
@@ -70,6 +70,10 @@ const registerEvents = (editorManager: EditorManager, e: { editor: Editor }) => 
   editor.on('focusin', () => {
     const focusedEditor = editorManager.focusedEditor;
 
+    if (isEditorContentAreaElement(getActiveElement(editor))) {
+      toggleContentAreaOnFocus(editor, Class.add);
+    }
+
     if (focusedEditor !== editor) {
       if (focusedEditor) {
         focusedEditor.dispatch('blur', { focusedEditor: editor });
@@ -77,7 +81,6 @@ const registerEvents = (editorManager: EditorManager, e: { editor: Editor }) => 
 
       editorManager.setActive(editor);
       editorManager.focusedEditor = editor;
-      toggleContentAreaOnFocus(editor, Class.add);
       editor.dispatch('focus', { blurredEditor: focusedEditor });
       editor.focus(true);
     }
@@ -87,14 +90,13 @@ const registerEvents = (editorManager: EditorManager, e: { editor: Editor }) => 
     Delay.setEditorTimeout(editor, () => {
       const focusedEditor = editorManager.focusedEditor;
 
-      // Remove focus higlight if no longer in focus
-      if (focusedEditor !== editor) {
+      // Remove focus higlight if editor or if the editor content area element no longer in focus
+      if (!isEditorContentAreaElement(getActiveElement(editor)) || focusedEditor !== editor) {
         toggleContentAreaOnFocus(editor, Class.remove);
       }
 
       // Still the same editor the blur was outside any editor UI
       if (!isUIElement(editor, getActiveElement(editor)) && focusedEditor === editor) {
-        toggleContentAreaOnFocus(editor, Class.remove);
         editor.dispatch('blur', { focusedEditor: null });
         editorManager.focusedEditor = null;
       }

--- a/modules/tinymce/src/core/main/ts/focus/FocusController.ts
+++ b/modules/tinymce/src/core/main/ts/focus/FocusController.ts
@@ -90,7 +90,7 @@ const registerEvents = (editorManager: EditorManager, e: { editor: Editor }) => 
     Delay.setEditorTimeout(editor, () => {
       const focusedEditor = editorManager.focusedEditor;
 
-      // Remove focus higlight if editor or if the editor content area element no longer in focus
+      // Remove focus highlight when the content area is no longer the active editor element, or if the highlighted editor is not the current focused editor
       if (!isEditorContentAreaElement(getActiveElement(editor)) || focusedEditor !== editor) {
         toggleContentAreaOnFocus(editor, Class.remove);
       }

--- a/modules/tinymce/src/core/test/ts/browser/focus/HighlightOnFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/HighlightOnFocusTest.ts
@@ -1,10 +1,11 @@
-import { Waiter } from '@ephox/agar';
+import { Keys, Waiter } from '@ephox/agar';
 import { after, before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Attribute, Class, Focus, Insert, Remove, SelectorFind, SugarElement } from '@ephox/sugar';
-import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import SearchReplacePlugin from 'tinymce/plugins/searchreplace/Plugin';
 
 describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
   const assertIsHighlighted = (editor: Editor) => assert.isTrue(Class.has(TinyDom.container(editor), 'tox-edit-focus'), 'Editor container should have tox-edit-focus class');
@@ -17,8 +18,10 @@ describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
   context('with highlight_on_focus: true', () => {
     const hook = TinyHooks.bddSetup<Editor>({
       base_url: '/project/tinymce/js/tinymce',
+      plugins: 'searchreplace',
+      toolbar: 'searchreplace forecolor',
       highlight_on_focus: true
-    });
+    }, [ SearchReplacePlugin ]);
 
     before(() => {
       const fakeButton = SugarElement.fromTag('button');
@@ -53,6 +56,58 @@ describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
       // focus on another element
       await focusOutsideEditor();
       assertIsNotHighlighted(editor);
+    });
+
+    it('TINY-9277: Content area should be highlighted on focus and removed when shifted to menubar', async () => {
+      const editor = hook.editor();
+      assertIsNotHighlighted(editor);
+      editor.focus();
+      assertIsHighlighted(editor);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
+      await TinyUiActions.pWaitForUi(editor, '*[role="menu"]');
+      await Waiter.pWait(0);
+      assertIsNotHighlighted(editor);
+      TinyUiActions.keyup(editor, Keys.escape());
+    });
+
+    it('TINY-9277: Content area should be highlighted on focus and removed when shifted to toolbar', async () => {
+      const editor = hook.editor();
+      assertIsNotHighlighted(editor);
+      editor.focus();
+      assertIsHighlighted(editor);
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      await Waiter.pWait(0);
+      assertIsNotHighlighted(editor);
+      TinyUiActions.keyup(editor, Keys.escape());
+    });
+
+    it('TINY-9277: Content area should be highlighted on focus and removed when shifted to inline dialog', async () => {
+      const editor = hook.editor();
+      assertIsNotHighlighted(editor);
+      editor.focus();
+      assertIsHighlighted(editor);
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Find and replace"]');
+      await TinyUiActions.pWaitForDialog(editor);
+      await Waiter.pWait(0);
+      assertIsNotHighlighted(editor);
+      TinyUiActions.closeDialog(editor);
+      assertIsHighlighted(editor);
+    });
+
+    it('TINY-9277: Content area should be highlighted on focus and removed when shifted to dialog', async () => {
+      const editor = hook.editor();
+      assertIsNotHighlighted(editor);
+      editor.focus();
+      assertIsHighlighted(editor);
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      TinyUiActions.clickOnUi(editor, 'button[title="Custom color"]');
+      await TinyUiActions.pWaitForDialog(editor);
+      await Waiter.pWait(0);
+      assertIsNotHighlighted(editor);
+      TinyUiActions.closeDialog(editor);
+      assertIsHighlighted(editor);
     });
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/focus/HighlightOnFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/HighlightOnFocusTest.ts
@@ -15,6 +15,9 @@ describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
     await Waiter.pWait(200);
   };
 
+  const pAssertIsNotHighlighted = (editor: Editor) =>
+    Waiter.pTryUntil('Waiting for focus to be shifted', () => assertIsNotHighlighted(editor));
+
   context('with highlight_on_focus: true', () => {
     const hook = TinyHooks.bddSetup<Editor>({
       base_url: '/project/tinymce/js/tinymce',
@@ -65,8 +68,7 @@ describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
       assertIsHighlighted(editor);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
       await TinyUiActions.pWaitForUi(editor, '*[role="menu"]');
-      await Waiter.pWait(0);
-      assertIsNotHighlighted(editor);
+      await pAssertIsNotHighlighted(editor);
       TinyUiActions.keyup(editor, Keys.escape());
     });
 
@@ -77,8 +79,7 @@ describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
       assertIsHighlighted(editor);
       TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
       await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-      await Waiter.pWait(0);
-      assertIsNotHighlighted(editor);
+      await pAssertIsNotHighlighted(editor);
       TinyUiActions.keyup(editor, Keys.escape());
     });
 
@@ -89,8 +90,7 @@ describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
       assertIsHighlighted(editor);
       TinyUiActions.clickOnToolbar(editor, '[aria-label="Find and replace"]');
       await TinyUiActions.pWaitForDialog(editor);
-      await Waiter.pWait(0);
-      assertIsNotHighlighted(editor);
+      await pAssertIsNotHighlighted(editor);
       TinyUiActions.closeDialog(editor);
       assertIsHighlighted(editor);
     });
@@ -104,8 +104,7 @@ describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
       await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
       TinyUiActions.clickOnUi(editor, 'button[title="Custom color"]');
       await TinyUiActions.pWaitForDialog(editor);
-      await Waiter.pWait(0);
-      assertIsNotHighlighted(editor);
+      await pAssertIsNotHighlighted(editor);
       TinyUiActions.closeDialog(editor);
       assertIsHighlighted(editor);
     });

--- a/modules/tinymce/src/core/test/ts/browser/focus/HighlightOnFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/HighlightOnFocusTest.ts
@@ -1,6 +1,5 @@
 import { Keys, Waiter } from '@ephox/agar';
 import { after, before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
-import { Dialog } from '@ephox/bridge';
 import { Attribute, Class, Focus, Insert, Remove, SelectorFind, SugarElement } from '@ephox/sugar';
 import { TinyContentActions, TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
@@ -31,25 +30,6 @@ describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
       toolbar: 'forecolor',
       highlight_on_focus: true
     }, []);
-
-    const dummyDialog: Dialog.DialogSpec<{}> = {
-      title: 'Dummy dialog',
-      body: {
-        type: 'panel',
-        items: [
-          {
-            type: 'htmlpanel',
-            html: 'Lorem ipsum'
-          }
-        ]
-      },
-      buttons: [
-        {
-          type: 'submit',
-          text: 'Ok'
-        }
-      ]
-    };
 
     before(() => {
       const fakeButton = SugarElement.fromTag('button');
@@ -102,7 +82,7 @@ describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
     it('TINY-9277: Content area should be highlighted on focus and removed when shifted to inline toolbar dialog', async () => {
       const editor = hook.editor();
       assertHighlightOnFocus(editor);
-      DialogUtils.open(editor, dummyDialog, { inline: 'toolbar' });
+      DialogUtils.open(editor, { inline: 'toolbar' });
       await TinyUiActions.pWaitForDialog(editor);
       await pAssertIsNotHighlighted(editor);
       TinyUiActions.closeDialog(editor);
@@ -112,7 +92,7 @@ describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
     it('TINY-9277: Content area should be highlighted on focus and removed when shifted to inline cursor dialog', async () => {
       const editor = hook.editor();
       assertHighlightOnFocus(editor);
-      DialogUtils.open(editor, dummyDialog, { inline: 'cursor' });
+      DialogUtils.open(editor, { inline: 'cursor' });
       await TinyUiActions.pWaitForDialog(editor);
       await pAssertIsNotHighlighted(editor);
       TinyUiActions.closeDialog(editor);
@@ -122,7 +102,7 @@ describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
     it('TINY-9277: Content area should be highlighted on focus and removed when shifted to dialog', async () => {
       const editor = hook.editor();
       assertHighlightOnFocus(editor);
-      DialogUtils.open(editor, dummyDialog, { inline: 'cursor' });
+      DialogUtils.open(editor);
       await TinyUiActions.pWaitForDialog(editor);
       await pAssertIsNotHighlighted(editor);
       TinyUiActions.closeDialog(editor);

--- a/modules/tinymce/src/core/test/ts/browser/focus/HighlightOnFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/HighlightOnFocusTest.ts
@@ -83,20 +83,20 @@ describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
 
     it('TINY-9277: Content area should be highlighted on focus and removed when shifted to menubar', async () => {
       const editor = hook.editor();
-      assertHighlightOnFocus(editor );
+      assertHighlightOnFocus(editor);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
       await TinyUiActions.pWaitForUi(editor, '*[role="menu"]');
       await pAssertIsNotHighlighted(editor);
-      TinyUiActions.keyup(editor, Keys.escape())
+      TinyUiActions.keyup(editor, Keys.escape());
     });
 
     it('TINY-9277: Content area should be highlighted on focus and removed when shifted to toolbar', async () => {
       const editor = hook.editor();
-      assertHighlightOnFocus(editor );
+      assertHighlightOnFocus(editor);
       TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
       await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
       await pAssertIsNotHighlighted(editor);
-      TinyUiActions.keyup(editor, Keys.escape())
+      TinyUiActions.keyup(editor, Keys.escape());
     });
 
     it('TINY-9277: Content area should be highlighted on focus and removed when shifted to inline toolbar dialog', async () => {

--- a/modules/tinymce/src/core/test/ts/module/test/DialogUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/DialogUtils.ts
@@ -1,0 +1,11 @@
+import { Dialog } from '@ephox/bridge';
+
+import Editor from 'tinymce/core/api/Editor';
+import { WindowParams } from 'tinymce/core/api/WindowManager';
+
+const open = <T extends Dialog.DialogData>(editor: Editor, spec: Dialog.DialogSpec<T>, params: WindowParams): Dialog.DialogInstanceApi<T> =>
+  editor.windowManager.open(spec, params);
+
+export {
+  open
+};

--- a/modules/tinymce/src/core/test/ts/module/test/DialogUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/DialogUtils.ts
@@ -3,8 +3,27 @@ import { Dialog } from '@ephox/bridge';
 import Editor from 'tinymce/core/api/Editor';
 import { WindowParams } from 'tinymce/core/api/WindowManager';
 
-const open = <T extends Dialog.DialogData>(editor: Editor, spec: Dialog.DialogSpec<T>, params: WindowParams): Dialog.DialogInstanceApi<T> =>
-  editor.windowManager.open(spec, params);
+const dummyDialog: Dialog.DialogSpec<{}> = {
+  title: 'Dummy dialog',
+  body: {
+    type: 'panel',
+    items: [
+      {
+        type: 'htmlpanel',
+        html: 'Lorem ipsum'
+      }
+    ]
+  },
+  buttons: [
+    {
+      type: 'submit',
+      text: 'Ok'
+    }
+  ]
+};
+
+const open = (editor: Editor, params?: WindowParams): Dialog.DialogInstanceApi<{}> =>
+  editor.windowManager.open(dummyDialog, params);
 
 export {
   open


### PR DESCRIPTION
Related Ticket:  TINY-9277

Description of Changes:
* Border should only show when content area is focused, instead of checking the editor (which includes menubar, toolbar, dialog, etc)
* Added test cases

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
