### PR TITLE
TINY-9563: Noneditable multi-line selection is formattable

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The "Edit Link" dialog incorrectly retrieved the URL value when opened immediately after the link insertion. #TINY-7993
 - Inserting newlines inside an editable element inside a noneditable root would sometimes try to split the editable element. #TINY-9461
 - Creating a list in a table cell when the caret is in front of an anchor element would not properly include the anchor in the list. #TINY-6853
-- Formatting was applied to noneditable list items inside a noneditable root. #TINY-9563
+- Formatting was applied or removed on noneditable list items inside a noneditable root. #TINY-9563
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The "Edit Link" dialog incorrectly retrieved the URL value when opened immediately after the link insertion. #TINY-7993
 - Inserting newlines inside an editable element inside a noneditable root would sometimes try to split the editable element. #TINY-9461
 - Creating a list in a table cell when the caret is in front of an anchor element would not properly include the anchor in the list. #TINY-6853
+- Formatting was applied to noneditable list items inside a noneditable root. #TINY-9563
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The "Edit Link" dialog incorrectly retrieved the URL value when opened immediately after the link insertion. #TINY-7993
 - Inserting newlines inside an editable element inside a noneditable root would sometimes try to split the editable element. #TINY-9461
 - Creating a list in a table cell when the caret is in front of an anchor element would not properly include the anchor in the list. #TINY-6853
-- Formatting was applied or removed on noneditable list items inside a noneditable root. #TINY-9563
+- Formatting could be applied or removed on noneditable list items inside a noneditable root. #TINY-9563
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/src/core/main/ts/fmt/ListItemFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ListItemFormat.ts
@@ -29,7 +29,7 @@ const isRngEndAtEndOfElement = (rng: Range, elm: Element) => {
     .exists((pos) => !NodeType.isBr(pos.getNode()) || CaretFinder.nextPosition(elm, pos).isSome()) === false;
 };
 
-const isEditableListItem = (dom: DOMUtils) => (elm: Element) => NodeType.isListItem(elm) && dom.getContentEditableParent(elm) !== 'false';
+const isEditableListItem = (dom: DOMUtils) => (elm: Element) => NodeType.isListItem(elm) && dom.isEditable(elm);
 
 const getFullySelectedBlocks = (selection: EditorSelection) => {
   const blocks = selection.getSelectedBlocks();

--- a/modules/tinymce/src/core/test/ts/browser/fmt/ListItemFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/ListItemFormatTest.ts
@@ -1,4 +1,3 @@
-
 import { Cursors } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Type } from '@ephox/katamari';
@@ -215,6 +214,19 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
           expected: '<p><strong>a</strong></p><ul contenteditable="false"><li>b</li><li>c</li></ul><p><strong>d</strong></p>',
         })
       );
+
+      it('TINY-9563: applying bold on LIs in a noneditable root should not get bold styles', () => {
+        const editor = hook.editor();
+
+        editor.getBody().contentEditable = 'false';
+        testApplyInlineListFormat({
+          format: 'bold',
+          rawInput: '<p>a</p><ul><li>b</li><li>c</li></ul><p>d</p>',
+          selection: { startPath: [ 0, 0 ], soffset: 0, finishPath: [ 2, 0 ], foffset: 1 },
+          expected: '<p>a</p><ul><li>b</li><li>c</li></ul><p>d</p>',
+        });
+        editor.getBody().contentEditable = 'true';
+      });
     });
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/fmt/ListItemFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/ListItemFormatTest.ts
@@ -351,7 +351,7 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
         })
       );
 
-      it.only('TINY-9563: remove bold on LI elements in a noneditable root should not remove bold styles', () => {
+      it('TINY-9563: remove bold on LI elements in a noneditable root should not remove bold styles', () => {
         const editor = hook.editor();
         const initialContent = '<ul><li style="font-weight: bold;">b</li><li style="font-weight: bold;">c</li></ul>';
 

--- a/modules/tinymce/src/core/test/ts/browser/fmt/ListItemFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/ListItemFormatTest.ts
@@ -350,6 +350,20 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
           expected: '<p>a</p><ul contenteditable="false"><li style="font-weight: bold;">b</li><li style="font-weight: bold;">c</li></ul><p>d</p>',
         })
       );
+
+      it.only('TINY-9563: remove bold on LI elements in a noneditable root should not remove bold styles', () => {
+        const editor = hook.editor();
+        const initialContent = '<ul><li style="font-weight: bold;">b</li><li style="font-weight: bold;">c</li></ul>';
+
+        editor.getBody().contentEditable = 'false';
+        testRemoveInlineListFormat({
+          format: 'bold',
+          rawInput: initialContent,
+          selection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 1, 0 ], foffset: 1 },
+          expected: initialContent,
+        });
+        editor.getBody().contentEditable = 'true';
+      });
     });
 
     context('Remove all formats', () => {


### PR DESCRIPTION
Related Ticket: TINY-9563

Description of Changes:
* Disable list formatting if the list is in a noneditable root

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
