### PR TITLE
TINY-9517: Sidebar element accessibility fixes

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `link` plugins context menu items will no longer appear for noneditable links. #TINY-9491
 - The formatting of `contenteditable="false"` elements are no longer cloned to new cells while creating new table rows. #TINY-9449
 - Changed the color of `@dialog-table-border-color`, and added right padding to the first cell of dialog table. #TINY-9380
-- The sidebar element now have attribute `role="region"` when visible and attribute `role="presentation"` when hidden. #TINY-9517
+- The sidebar element now has accessibility role `region` when visible and `presentation` when hidden. #TINY-9517
 
 ### Fixed
 - Sometimes the editor would finish initializing before the silver theme would have finished loading. #TINY-9556

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `link` plugins context menu items will no longer appear for noneditable links. #TINY-9491
 - The formatting of `contenteditable="false"` elements are no longer cloned to new cells while creating new table rows. #TINY-9449
 - Changed the color of `@dialog-table-border-color`, and added right padding to the first cell of dialog table. #TINY-9380
+- The sidebar element now have attribute `role="region"` when visible and attribute `role="presentation"` when hidden. #TINY-9517
 
 ### Fixed
 - Sometimes the editor would finish initializing before the silver theme would have finished loading. #TINY-9556

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarRoleAttributeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarRoleAttributeTest.ts
@@ -1,0 +1,83 @@
+import { ApproxStructure, Assertions, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { McEditor, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+const enum SidebarStateRoleAttr {
+  Grown = 'region',
+  Shrunk = 'presentation'
+}
+
+describe('browser.tinymce.themes.silver.sidebar.SidebarRoleAttributeTest', () => {
+  const baseSettings = {
+    base_url: '/project/tinymce/js/tinymce',
+    toolbar: 'sidebarone sidebartwo',
+    setup: (ed: Editor) => {
+      ed.ui.registry.addSidebar('sidebarone', {
+        tooltip: 'side bar one',
+        icon: 'comment',
+      });
+      ed.ui.registry.addSidebar('SideBarTwo', {
+        tooltip: 'side bar two',
+        icon: 'comment',
+      });
+    }
+  };
+
+  const assertSidebarStructure = (sidebarState: SidebarStateRoleAttr) => {
+    const sidebar = UiFinder.findIn(SugarBody.body(), '.tox-sidebar').getOrDie();
+    Assertions.assertStructure(
+      `Checking role attribute of sidebar`,
+      ApproxStructure.build((s, str, _) => s.element('div', {
+        attrs: {
+          role: str.is(sidebarState)
+        },
+        children: [
+          s.theRest()
+        ]
+      })),
+      sidebar
+    );
+  };
+
+  it('TINY-9517: No sidebar shown role should be presentation', async () => {
+    const editor = await McEditor.pFromSettings<Editor>({
+      ...baseSettings
+    });
+    assertSidebarStructure(SidebarStateRoleAttr.Shrunk);
+    McEditor.remove(editor);
+  });
+
+  it('TINY-9517: Sidebar one is set to shown on initialization, role should be complementary', async () => {
+    const editor = await McEditor.pFromSettings<Editor>({
+      ...baseSettings,
+      sidebar_show: 'sidebarone'
+    });
+    assertSidebarStructure(SidebarStateRoleAttr.Grown);
+    McEditor.remove(editor);
+  });
+
+  it('TINY-9517: Non-existent sidebar is set to show on initialization, sidebar role should be presentation', async () => {
+    const editor = await McEditor.pFromSettings<Editor>({
+      ...baseSettings,
+      sidebar_show: 'noexistsidebar'
+    });
+    assertSidebarStructure(SidebarStateRoleAttr.Shrunk);
+    McEditor.remove(editor);
+  });
+
+  it('TINY-9571: Sidebar toggling should reflect correct role attribute', async () => {
+    const editor = await McEditor.pFromSettings<Editor>({
+      ...baseSettings
+    });
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="' + 'side bar one' + '"]');
+    assertSidebarStructure(SidebarStateRoleAttr.Grown);
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="' + 'side bar one' + '"]');
+    assertSidebarStructure(SidebarStateRoleAttr.Shrunk);
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="' + 'side bar two' + '"]');
+    assertSidebarStructure(SidebarStateRoleAttr.Grown);
+    McEditor.remove(editor);
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarRoleAttributeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarRoleAttributeTest.ts
@@ -42,7 +42,7 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarRoleAttributeTest', () =>
     );
   };
 
-  it('TINY-9517: No sidebar shown role should be presentation', async () => {
+  it('TINY-9517: No sidebar shown, role should be presentation', async () => {
     const editor = await McEditor.pFromSettings<Editor>({
       ...baseSettings
     });
@@ -50,7 +50,7 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarRoleAttributeTest', () =>
     McEditor.remove(editor);
   });
 
-  it('TINY-9517: Sidebar one is set to shown on initialization, role should be complementary', async () => {
+  it('TINY-9517: Sidebar one is set to be shown on initialization, role should be region', async () => {
     const editor = await McEditor.pFromSettings<Editor>({
       ...baseSettings,
       sidebar_show: 'sidebarone'
@@ -59,7 +59,7 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarRoleAttributeTest', () =>
     McEditor.remove(editor);
   });
 
-  it('TINY-9517: Non-existent sidebar is set to show on initialization, sidebar role should be presentation', async () => {
+  it('TINY-9517: Non-existent sidebar is set to be shown on initialization, sidebar role should be presentation', async () => {
     const editor = await McEditor.pFromSettings<Editor>({
       ...baseSettings,
       sidebar_show: 'noexistsidebar'


### PR DESCRIPTION
Related Ticket: TINY-9517

Description of Changes:
* Sidebar element role attribute defaults to `role="presentation"` (hidden)
* Sidebar element role attribute changes to `role="region"` (with `sidebar_show` option)
* Toggling the sidebar element would toggle attributes with `region` and `presentation`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
