### PR TITLE
TINY-9598: enter in `inputfontsize`'s input put focus back to the editor

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improved
 - Direct invalid child text nodes of list elements will be wrapped in list item elements. #TINY-4818
 - Pressing backspace in an empty line now preserves formatting in a previous empty line. #TINY-9454
+- Enter in `inputfontsize`'s input now put focus back to the editor. #TINY-9598
 
 ### Changed
 - The `link` plugins context menu items will no longer appear for noneditable links. #TINY-9491

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -141,7 +141,7 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
           Keying.config({
             mode: 'special',
             onEnter: (_comp) => {
-              changeValue(Fun.identity, true, false);
+              changeValue(Fun.identity, true, true);
               return Optional.some(true);
             },
             onEscape: goToParent,

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/NumberInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/NumberInputTest.ts
@@ -298,4 +298,19 @@ describe('browser.tinymce.themes.silver.throbber.NumberInputTest', () => {
 
     editor.options.unset('font_size_input_default_unit');
   });
+
+  it('TINY-9598: pressing enter in the input field should take the focus back to the editor to allow user to digit with the new size', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>a</p>\n<p>b</p>');
+    TinySelections.setCursor(editor, [ 1 ], 1);
+    TinyUiActions.clickOnToolbar(editor, '.tox-number-input input');
+
+    const input = TinyUiActions.clickOnToolbar<HTMLInputElement>(editor, '.tox-number-input input');
+    const root = SugarShadowDom.getRootNode(TinyDom.targetElement(editor));
+    FocusTools.setFocus(root, '.tox-number-input input');
+    UiControls.setValue(input, '20em');
+    assert.isFalse(editor.hasFocus(), 'before enter editor should not have focus');
+    TinyUiActions.keystroke(editor, Keys.enter());
+    assert.isTrue(editor.hasFocus(), 'after enter editor should have focus');
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-9598

Description of Changes:
this is needed to avoid that if the user put the caret at the end of a line and change the size, they have no way to digit a text with the new size

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
