### PR TITLE
TINY-9567: Changed selector for color swatch checkmark, same behavior

### DIFF
--- a/modules/oxide/src/less/theme/components/color-swatch/color-swatch.less
+++ b/modules/oxide/src/less/theme/components/color-swatch/color-swatch.less
@@ -87,7 +87,7 @@
       }
     }
 
-    &[aria-checked="true"] svg {
+    &.tox-collection__item--enabled svg {
       display: block;
     }
   }


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
Different selector. No changelog or tests should be needed, as the same behavior remains, and it shouldn't really change anything aside from using the better css selector.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
