### PR TITLE
TINY-9605: Hotfix for the removal of the outdated webkit bug workaround

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 6.3.2 - 2023-02-22
 
 ### Fixed
 - Removed a workaround for ensuring stylesheets are loaded in an outdated version of webkit. #TINY-9433

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Removed a workaround for ensuring stylesheets are loaded in an outdated version of webkit. #TINY-9433
+
 ## 6.3.1 - 2022-12-06
 
 ### Fixed

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related Ticket: TINY-9605

Description of Changes:
* This just included the removal of the outdated webkit bug workaround

- [ ] Merge this when doing the 6.3.2 community release

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
