### PR TITLE
TINY-9489: Prevent safari from modifying paste content.

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `onSetup` api function would not run when defining custom group toolbar button. #TINY-9496
 - An element could be dropped onto the decendants of a noneditable element. #TINY-9364
 - Checkmark did not show in menu colorswatches. #TINY-9395
+- Pasting links to text would sometimes not generate the correct undo stack on safari. #TINY-9489
 - Toolbar split buttons in advlist plugin to show the correct state when the cursor is in a checklist. #TINY-5167
 - Dragging transparent elements into transparent blocks elements could produce invalid nesting of transparents. #TINY-9231
 - The `editor.insertContent` API would insert contents inside noneditable elements if the selection was inside the element. #TINY-9462

--- a/modules/tinymce/src/core/main/ts/paste/Clipboard.ts
+++ b/modules/tinymce/src/core/main/ts/paste/Clipboard.ts
@@ -240,6 +240,14 @@ const registerEventHandlers = (editor: Editor, pasteBin: PasteBin, pasteFormat: 
     if (hasContentType(clipboardContent, 'text/html')) {
       e.preventDefault();
       insertClipboardContent(editor, clipboardContent, clipboardContent['text/html'], plainTextMode);
+    } else if (hasContentType(clipboardContent, 'text/plain') && hasContentType(clipboardContent, 'text/uri-list')) {
+      /*
+      Safari adds the uri-list attribute to links copied within it.
+      When pasting something with the url-list within safari using the default functionality it will convert it from www.example.com to <a href="www.example.com">www.example.com</a> when pasting into the pasteBin-div.
+      This causes issues. To solve this we bypass the default paste functionality for this situation.
+       */
+      e.preventDefault();
+      insertClipboardContent(editor, clipboardContent, clipboardContent['text/plain'], plainTextMode);
     } else {
       // We can't extract the HTML content from the clipboard so we need to allow the paste
       // to run via the pastebin and then extract from there


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
We now try to prevent to rely on safari's default paste behavior for links provided by safari, as it attempted to be helpful.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
