### PR TITLE
TINY-9528: implementation of `toggleFullscreen` function for dialog

### DIFF
--- a/modules/bridge/src/demo/ts/dialogs/DemoDialogHelpers.ts
+++ b/modules/bridge/src/demo/ts/dialogs/DemoDialogHelpers.ts
@@ -29,7 +29,8 @@ const createDemoApi = <T extends DialogData>(internalStructure: Dialog<T>, initi
     setEnabled: (_name: string, _state: boolean) => {},
     block: (_message: string) => {},
     unblock: Fun.noop,
-    close: Fun.noop
+    close: Fun.noop,
+    toggleFullscreen: Fun.noop
   };
 };
 

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Dialog.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Dialog.ts
@@ -17,6 +17,7 @@ export interface DialogInstanceApi<T extends DialogData> {
   redial: (nu: DialogSpec<T>) => void;
   block: (msg: string) => void;
   unblock: () => void;
+  toggleFullscreen: () => void;
   close: () => void;
 }
 

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -334,6 +334,15 @@
     max-width: 1200px;
   }
 
+  .tox-dialog--fullscreen {
+    height: 100%;
+    max-width: 100%;
+
+    .tox-dialog__body-content {
+      max-height: 100%;
+    }
+  }
+
   .tox-dialog--width-md {
     // TODO (verify width for size medium)
     max-width: 800px;

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `font_size_input_default_unit` option allow to use of numbers without a unit in `fontsizeinput` and have them parsed with the default unit, if it is not defined the default is `pt` #TINY-9585
 - New `group` and `togglebutton` in view. #TINY-9523
 - New `togglebutton` in dialog footer buttons. #TINY-9523
+- Added `toggleFullscreen` to dialog API. #TINY-9528
 
 ### Improved
 - Direct invalid child text nodes of list elements will be wrapped in list item elements. #TINY-4818

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
@@ -1,7 +1,7 @@
 import { AlloyComponent, Composing, ModalDialog } from '@ephox/alloy';
 import { Dialog, DialogManager } from '@ephox/bridge';
 import { Fun, Id, Optional } from '@ephox/katamari';
-import { Classes, SugarElement } from '@ephox/sugar';
+import { Class, Classes, SugarElement } from '@ephox/sugar';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
 import { renderModalBody } from './SilverDialogBody';
@@ -74,11 +74,11 @@ const renderDialog = <T extends Dialog.DialogData>(dialogInit: DialogManager.Dia
       const fullscreenClass = 'tox-dialog--fullscreen';
       const sugarBody = SugarElement.fromDom(dialog.element.dom);
 
-      if (!Classes.hasAll(sugarBody, [ fullscreenClass ])) {
+      if (!Class.has(sugarBody, fullscreenClass)) {
         Classes.remove(sugarBody, dialogSize);
-        Classes.add(sugarBody, [ fullscreenClass ]);
+        Class.add(sugarBody, fullscreenClass);
       } else {
-        Classes.remove(sugarBody, [ fullscreenClass ]);
+        Class.remove(sugarBody, fullscreenClass);
         Classes.add(sugarBody, dialogSize);
       }
     };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
@@ -1,6 +1,7 @@
 import { AlloyComponent, Composing, ModalDialog } from '@ephox/alloy';
 import { Dialog, DialogManager } from '@ephox/bridge';
 import { Fun, Id, Optional } from '@ephox/katamari';
+import { Classes, SugarElement } from '@ephox/sugar';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
 import { renderModalBody } from './SilverDialogBody';
@@ -69,12 +70,26 @@ const renderDialog = <T extends Dialog.DialogData>(dialogInit: DialogManager.Dia
       return Composing.getCurrent(outerForm).getOr(outerForm);
     };
 
+    const toggleFullscreen = (): void => {
+      const fullscreenClass = 'tox-dialog--fullscreen';
+      const sugarBody = SugarElement.fromDom(dialog.element.dom);
+
+      if (!Classes.hasAll(sugarBody, [ fullscreenClass ])) {
+        Classes.remove(sugarBody, dialogSize);
+        Classes.add(sugarBody, [ fullscreenClass ]);
+      } else {
+        Classes.remove(sugarBody, [ fullscreenClass ]);
+        Classes.add(sugarBody, dialogSize);
+      }
+    };
+
     return {
       getId: Fun.constant(dialogId),
       getRoot: Fun.constant(dialog),
       getBody: () => ModalDialog.getBody(dialog),
       getFooter: () => ModalDialog.getFooter(dialog),
-      getFormWrapper: getForm
+      getFormWrapper: getForm,
+      toggleFullscreen
     };
   })();
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogInstanceApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogInstanceApi.ts
@@ -37,6 +37,7 @@ export interface DialogAccess {
   getBody: () => AlloyComponent;
   getFooter: () => AlloyComponent;
   getFormWrapper: () => AlloyComponent;
+  toggleFullscreen: () => void;
 }
 
 const getDialogApi = <T extends Dialog.DialogData>(
@@ -150,7 +151,8 @@ const getDialogApi = <T extends Dialog.DialogData>(
     unblock,
     showTab,
     redial,
-    close
+    close,
+    toggleFullscreen: access.toggleFullscreen
   };
 
   return instanceApi;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -5,7 +5,7 @@ import {
 } from '@ephox/alloy';
 import { Dialog, DialogManager } from '@ephox/bridge';
 import { Fun, Id, Optional } from '@ephox/katamari';
-import { Attribute, SugarNode } from '@ephox/sugar';
+import { Attribute, Classes, SugarElement, SugarNode } from '@ephox/sugar';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
 import { RepresentingConfigs } from '../alien/RepresentingConfigs';
@@ -70,11 +70,13 @@ const renderInlineDialog = <T extends Dialog.DialogData>(dialogInit: DialogManag
     backstage.shared.getSink
   );
 
+  const inlineClass = 'tox-dialog-inline';
+
   // TODO: Disable while validating?
   const dialog = GuiFactory.build({
     dom: {
       tag: 'div',
-      classes: [ 'tox-dialog', 'tox-dialog-inline' ],
+      classes: [ 'tox-dialog', inlineClass ],
       attributes: {
         role: 'dialog',
         ['aria-labelledby']: dialogLabelId,
@@ -127,6 +129,18 @@ const renderInlineDialog = <T extends Dialog.DialogData>(dialogInit: DialogManag
     ]
   });
 
+  const toggleFullscreen = (): void => {
+    const fullscreenClass = 'tox-dialog--fullscreen';
+    const sugarBody = SugarElement.fromDom(dialog.element.dom);
+    if (!Classes.hasAll(sugarBody, [ fullscreenClass ])) {
+      Classes.remove(sugarBody, [ inlineClass ]);
+      Classes.add(sugarBody, [ fullscreenClass ]);
+    } else {
+      Classes.remove(sugarBody, [ fullscreenClass ]);
+      Classes.add(sugarBody, [ inlineClass ]);
+    }
+  };
+
   // TODO: Clean up the dupe between this (InlineDialog) and SilverDialog
   const instanceApi = getDialogApi<T>({
     getId: Fun.constant(dialogId),
@@ -137,7 +151,7 @@ const renderInlineDialog = <T extends Dialog.DialogData>(dialogInit: DialogManag
       const body = memBody.get(dialog);
       return Composing.getCurrent(body).getOr(body);
     },
-    toggleFullscreen: Fun.noop
+    toggleFullscreen
   }, extra.redial, objOfCells);
 
   return {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -136,7 +136,8 @@ const renderInlineDialog = <T extends Dialog.DialogData>(dialogInit: DialogManag
     getFormWrapper: () => {
       const body = memBody.get(dialog);
       return Composing.getCurrent(body).getOr(body);
-    }
+    },
+    toggleFullscreen: Fun.noop
   }, extra.redial, objOfCells);
 
   return {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogApiAccessTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogApiAccessTest.ts
@@ -18,7 +18,6 @@ describe('browser.tinymce.themes.silver.window.SilverDialogApiAccessTest', () =>
 
   const dialogSpec: Dialog.DialogSpec<{ fieldA: string }> = {
     title: 'Silver Test Access Dialog',
-    size: 'medium',
     body: {
       type: 'panel',
       items: [
@@ -105,25 +104,21 @@ describe('browser.tinymce.themes.silver.window.SilverDialogApiAccessTest', () =>
         ]));
       });
 
-      // TODO: fix this it seems not to work with inline dialog
-      it.skip('TINY-9528: fullscrenn toggle should apply the correct class', () => {
+      it('TINY-9528: fullscrenn toggle should apply the correct class', () => {
         const editor = hook.editor();
         DialogUtils.open(editor, dialogSpec, test.params);
 
         const dialog = UiFinder.findIn(TinyDom.fromDom(document), '.tox-dialog').getOrDie();
         const dialogHasClass = (className: string) => dialog.dom.classList.contains(className);
 
-        // assert.isTrue(dialogHasClass('tox-dialog--width-md'), 'before toggle dialog should have class tox-dialog--width-md');
         assert.isFalse(dialogHasClass('tox-dialog--fullscreen'), 'before toggle dialog should not have class tox-dialog--fullscreen');
 
         Mouse.clickOn(SugarBody.body(), 'button:contains("Toggle fullscreen")');
 
-        // assert.isFalse(dialogHasClass('tox-dialog--width-md'), 'after toggle dialog should not have class tox-dialog--width-md');
         assert.isTrue(dialogHasClass('tox-dialog--fullscreen'), 'after toggle dialog should have class tox-dialog--fullscreen');
 
         Mouse.clickOn(SugarBody.body(), 'button:contains("Toggle fullscreen")');
 
-        // assert.isTrue(dialogHasClass('tox-dialog--width-md'), 'after a second toggle dialog should have class tox-dialog--width-md');
         assert.isFalse(dialogHasClass('tox-dialog--fullscreen'), 'after a second toggle dialog should not have class tox-dialog--fullscreen');
 
         DialogUtils.close(editor);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogApiAccessTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogApiAccessTest.ts
@@ -2,7 +2,7 @@ import { Mouse, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
-import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -113,11 +113,11 @@ describe('browser.tinymce.themes.silver.window.SilverDialogApiAccessTest', () =>
 
         assert.isFalse(dialogHasClass('tox-dialog--fullscreen'), 'before toggle dialog should not have class tox-dialog--fullscreen');
 
-        Mouse.clickOn(SugarBody.body(), 'button:contains("Toggle fullscreen")');
+        TinyUiActions.clickOnUi(editor, 'button:contains("Toggle fullscreen")');
 
         assert.isTrue(dialogHasClass('tox-dialog--fullscreen'), 'after toggle dialog should have class tox-dialog--fullscreen');
 
-        Mouse.clickOn(SugarBody.body(), 'button:contains("Toggle fullscreen")');
+        TinyUiActions.clickOnUi(editor, 'button:contains("Toggle fullscreen")');
 
         assert.isFalse(dialogHasClass('tox-dialog--fullscreen'), 'after a second toggle dialog should not have class tox-dialog--fullscreen');
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogApiAccessTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogApiAccessTest.ts
@@ -1,8 +1,8 @@
-import { Mouse, Waiter, TestStore } from '@ephox/agar';
+import { Mouse, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks } from '@ephox/wrap-mcagar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -18,6 +18,7 @@ describe('browser.tinymce.themes.silver.window.SilverDialogApiAccessTest', () =>
 
   const dialogSpec: Dialog.DialogSpec<{ fieldA: string }> = {
     title: 'Silver Test Access Dialog',
+    size: 'medium',
     body: {
       type: 'panel',
       items: [
@@ -35,40 +36,50 @@ describe('browser.tinymce.themes.silver.window.SilverDialogApiAccessTest', () =>
         text: 'Call api.setData after two seconds',
         align: 'start',
         primary: true
+      },
+      {
+        type: 'custom',
+        name: 'fullscreen',
+        text: 'Toggle fullscreen'
       }
     ],
     initialData: {
       fieldA: 'Init Value'
     },
-    onAction: (api, _actionData) => {
-      setTimeout(() => {
-        const currentData = api.getData();
-        store.adder('currentData: ' + currentData.fieldA)();
-        // Currently, this will be ignored once the dialog is closed.
-        api.setData({
-          fieldA: 'New Value'
-        });
+    onAction: (api, actionData) => {
+      if (actionData.name === 'async.setData') {
+        setTimeout(() => {
+          const currentData = api.getData();
+          store.adder('currentData: ' + currentData.fieldA)();
+          // Currently, this will be ignored once the dialog is closed.
+          api.setData({
+            fieldA: 'New Value'
+          });
 
-        // Check all APIs do not throw errors
-        api.setEnabled('async.setData', false);
-        api.setEnabled('async.setData', true);
-        api.block('message');
-        api.unblock();
-        api.showTab('new tab');
-        // Currently, it is only going to validate it if the dialog is still open
-        const redialSpec: Dialog.DialogSpec<{ fieldA: string }> = {
-          title: 'temporary redial to check the API',
-          body: {
-            type: 'panel',
-            items: []
-          },
-          buttons: []
-        };
-        api.redial(redialSpec);
-        api.close();
+          // Check all APIs do not throw errors
+          api.setEnabled('async.setData', false);
+          api.setEnabled('async.setData', true);
+          api.block('message');
+          api.unblock();
+          api.showTab('new tab');
+          // Currently, it is only going to validate it if the dialog is still open
+          const redialSpec: Dialog.DialogSpec<{ fieldA: string }> = {
+            title: 'temporary redial to check the API',
+            body: {
+              type: 'panel',
+              items: []
+            },
+            buttons: []
+          };
+          api.redial(redialSpec);
+          api.close();
 
-        store.adder('newData: ' + currentData.fieldA)();
-      }, 180);
+          store.adder('newData: ' + currentData.fieldA)();
+        }, 180);
+      }
+      if (actionData.name === 'fullscreen') {
+        api.toggleFullscreen();
+      }
     }
   };
 
@@ -92,6 +103,30 @@ describe('browser.tinymce.themes.silver.window.SilverDialogApiAccessTest', () =>
           'currentData: Init Value',
           'newData: Init Value'
         ]));
+      });
+
+      // TODO: fix this it seems not to work with inline dialog
+      it.skip('TINY-9528: fullscrenn toggle should apply the correct class', () => {
+        const editor = hook.editor();
+        DialogUtils.open(editor, dialogSpec, test.params);
+
+        const dialog = UiFinder.findIn(TinyDom.fromDom(document), '.tox-dialog').getOrDie();
+        const dialogHasClass = (className: string) => dialog.dom.classList.contains(className);
+
+        // assert.isTrue(dialogHasClass('tox-dialog--width-md'), 'before toggle dialog should have class tox-dialog--width-md');
+        assert.isFalse(dialogHasClass('tox-dialog--fullscreen'), 'before toggle dialog should not have class tox-dialog--fullscreen');
+
+        Mouse.clickOn(SugarBody.body(), 'button:contains("Toggle fullscreen")');
+
+        // assert.isFalse(dialogHasClass('tox-dialog--width-md'), 'after toggle dialog should not have class tox-dialog--width-md');
+        assert.isTrue(dialogHasClass('tox-dialog--fullscreen'), 'after toggle dialog should have class tox-dialog--fullscreen');
+
+        Mouse.clickOn(SugarBody.body(), 'button:contains("Toggle fullscreen")');
+
+        // assert.isTrue(dialogHasClass('tox-dialog--width-md'), 'after a second toggle dialog should have class tox-dialog--width-md');
+        assert.isFalse(dialogHasClass('tox-dialog--fullscreen'), 'after a second toggle dialog should not have class tox-dialog--fullscreen');
+
+        DialogUtils.close(editor);
       });
     });
   });


### PR DESCRIPTION
Related Ticket: TINY-9528

Description of Changes:
This function simple remove the current size class of the dialog and put a full-screen class instead or vice versa

`toggleFullscreen` is in `SilverDialog` and not in `SilverDialogInstanceApi` the dialog sizes are managed in `SilverDialog` and not in `SilverDialogInstanceApi`

P.S. about the docs ticket I did not find doc for the single API, so I did not create a ticket, if I miss something let me know and I will create it

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
