### PR TITLE
TINY-9021: Drag/drop a content on the borderline of the table cells makes it dissappear

### DIFF
--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableResize.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableResize.ts
@@ -42,6 +42,7 @@ export interface TableResize {
   readonly refreshBars: (table: SugarElement<HTMLTableElement>) => void;
   readonly hideBars: () => void;
   readonly showBars: () => void;
+  readonly setHoverRefresh: (state: boolean) => void;
   readonly destroy: () => void;
   readonly events: TableResizeEventRegistry;
 }
@@ -85,6 +86,7 @@ const create = (wire: ResizeWire, resizing: ResizeBehaviour, lazySizing: (elemen
     refreshBars: manager.refresh,
     hideBars: manager.hideBars,
     showBars: manager.showBars,
+    setHoverRefresh: manager.setHoverRefresh,
     destroy: manager.destroy,
     events: events.registry
   };

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/BarManager.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/BarManager.ts
@@ -41,6 +41,7 @@ export interface BarManager {
   readonly off: () => void;
   readonly hideBars: () => void;
   readonly showBars: () => void;
+  readonly setHoverRefresh: (state: boolean) => void;
   readonly events: DragAdjustEvents['registry'];
 }
 
@@ -49,6 +50,7 @@ const resizeBarDragging = Styles.resolve('resizer-bar-dragging');
 export const BarManager = (wire: ResizeWire): BarManager => {
   const mutation = BarMutation();
   const resizing = Dragger.transform(mutation, {});
+  let hoverRefresh = true;
 
   let hoverTable = Optional.none<SugarElement<HTMLTableElement>>();
 
@@ -73,6 +75,10 @@ export const BarManager = (wire: ResizeWire): BarManager => {
     const newX = CellUtils.getCssValue(target, dir);
     const oldX = CellUtils.getAttrValue(target, 'data-initial-' + dir, 0);
     return newX - oldX;
+  };
+
+  const setHoverRefresh = (state: boolean) => {
+    hoverRefresh = state;
   };
 
   /* Resize the column once the user releases the mouse */
@@ -138,8 +144,10 @@ export const BarManager = (wire: ResizeWire): BarManager => {
         }
       },
       (table) => {
-        hoverTable = Optional.some(table);
-        Bars.refresh(wire, table);
+        if (hoverRefresh) {
+          hoverTable = Optional.some(table);
+          Bars.refresh(wire, table);
+        }
       }
     );
   });
@@ -168,6 +176,7 @@ export const BarManager = (wire: ResizeWire): BarManager => {
     off: resizing.off,
     hideBars: Fun.curry(Bars.hide, wire),
     showBars: Fun.curry(Bars.show, wire),
+    setHoverRefresh,
     events: events.registry
   };
 };

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/BarManager.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/BarManager.ts
@@ -132,7 +132,6 @@ export const BarManager = (wire: ResizeWire): BarManager => {
 
   /* mouseover on table: When the mouse moves within the CONTENT AREA (NOT THE TABLE), refresh the bars. */
   const mouseover = DomEvent.bind(wire.view(), 'mouseover', (event) => {
-    console.log(event.target);
     findClosestEditableTable(event.target).fold(
       () => {
         /*

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/BarManager.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/BarManager.ts
@@ -132,6 +132,7 @@ export const BarManager = (wire: ResizeWire): BarManager => {
 
   /* mouseover on table: When the mouse moves within the CONTENT AREA (NOT THE TABLE), refresh the bars. */
   const mouseover = DomEvent.bind(wire.view(), 'mouseover', (event) => {
+    console.log(event.target);
     findClosestEditableTable(event.target).fold(
       () => {
         /*

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The "Edit Link" dialog incorrectly retrieved the URL value when opened immediately after the link insertion. #TINY-7993
 - Inserting newlines inside an editable element inside a noneditable root would sometimes try to split the editable element. #TINY-9461
 - Creating a list in a table cell when the caret is in front of an anchor element would not properly include the anchor in the list. #TINY-6853
+- Dragging and dropping noneditable elements on table borders would remove the element on drop. #TINY-9021
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/src/models/dom/main/ts/table/api/TableResizeHandler.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/TableResizeHandler.ts
@@ -184,6 +184,18 @@ export const TableResizeHandler = (editor: Editor): TableResizeHandler => {
     });
   });
 
+  editor.on('dragstart dragend', (e) => {
+    tableResize.on((resize) => {
+      if (e.type === 'dragstart') {
+        resize.hideBars();
+        resize.setHoverRefresh(false);
+      } else {
+        resize.setHoverRefresh(true);
+        resize.showBars();
+      }
+    });
+  });
+
   editor.on('remove', () => {
     destroy();
   });

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/DragEditorContentsOverTableTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/DragEditorContentsOverTableTest.ts
@@ -1,0 +1,25 @@
+import { Mouse } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SelectorExists, SelectorFind } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.models.dom.table.DragEditorContentsOverTableTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce'
+  }, [], true);
+
+  it('TINY-9021: Should not render resize bars while dragging', () => {
+    const editor = hook.editor();
+    editor.setContent('<table><tbody><tr><td>1</td><td>2</td></tr></tbody></table>');
+
+    editor.fire('dragstart');
+    const cell = SelectorFind.descendant(TinyDom.body(editor), 'td').getOrDie();
+    Mouse.mouseOver(cell, { dx: 0, dy: 0 });
+    assert.isFalse(SelectorExists.descendant(TinyDom.documentElement(editor), '.ephox-snooker-resizer-bar'), 'Should not exist any resize bars');
+    editor.fire('dragend');
+  });
+});
+


### PR DESCRIPTION
Related Ticket: TINY-9021

Description of Changes:
* Hide the snooker resize bars while dragging contents over the table this prevents drops on those bars.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
