### PR TITLE
TINY-9399: Fix removing annotation immediately after creation

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inserting newlines inside an editable element inside a noneditable root would sometimes try to split the editable element. #TINY-9461
 - Creating a list in a table cell when the caret is in front of an anchor element would not properly include the anchor in the list. #TINY-6853
 - Formatting could be applied or removed on noneditable list items inside a noneditable root. #TINY-9563
+- Removing annotation is possible immediately after creation without any selection changes. #TINY-9399
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -66,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inserting newlines inside an editable element inside a noneditable root would sometimes try to split the editable element. #TINY-9461
 - Creating a list in a table cell when the caret is in front of an anchor element would not properly include the anchor in the list. #TINY-6853
 - Formatting could be applied or removed on noneditable list items inside a noneditable root. #TINY-9563
-- Removing annotation is possible immediately after creation without any selection changes. #TINY-9399
+- Annotation would not be removed if the annotation was immediately deleted after being created. #TINY-9399
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/src/core/main/ts/api/Annotator.ts
+++ b/modules/tinymce/src/core/main/ts/api/Annotator.ts
@@ -92,11 +92,16 @@ const Annotator = (editor: Editor): Annotator => {
      * @param {String} name the name of the annotation to remove
      */
     remove: (name: string): void => {
-      const bookmark = editor.selection.getBookmark();
       identify(editor, Optional.some(name)).each(({ elements }) => {
+        /**
+         * TINY-9399: It is important to keep the bookmarking in the callback
+         * because it adjusts selection in a way that `identify` function
+         * cannot retain the selected word.
+         */
+        const bookmark = editor.selection.getBookmark();
         removeAnnotations(elements);
+        editor.selection.moveToBookmark(bookmark);
       });
-      editor.selection.moveToBookmark(bookmark);
     },
 
     /**

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationRemovedTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationRemovedTest.ts
@@ -179,9 +179,9 @@ describe('browser.tinymce.core.annotate.AnnotationRemovedTest', () => {
 
   it('TINY-9399: remove annotation right after its creation', () => {
     const editor = hook.editor();
-    editor.annotator.removeAll('alpha');
+    editor.setContent('<p>This was the first paragraph</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], 'This '.length, [ 0, 0 ], 'This was'.length);
-    editor.annotator.annotate('alpha', { comment: 'test' });
+    annotate(editor, 'alpha', 'id-one', { anything: 'comment-1' });
     TinyAssertions.assertContentPresence(editor, { 'span[data-mce-annotation="alpha"]': 1 });
     editor.annotator.remove('alpha');
     TinyAssertions.assertContentPresence(editor, { 'span[data-mce-annotation="alpha"]': 0 });

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationRemovedTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationRemovedTest.ts
@@ -176,4 +176,14 @@ describe('browser.tinymce.core.annotate.AnnotationRemovedTest', () => {
     });
     TinyAssertions.assertCursor(editor, [ 0, 2 ], 2);
   });
+
+  it('TINY-9399: remove annotation right after its creation', () => {
+    const editor = hook.editor();
+    editor.annotator.removeAll('alpha');
+    TinySelections.setSelection(editor, [ 0, 0 ], 'This '.length, [ 0, 0 ], 'This was'.length);
+    editor.annotator.annotate('alpha', { comment: 'test' });
+    TinyAssertions.assertContentPresence(editor, { 'span[data-mce-annotation="alpha"]': 1 });
+    editor.annotator.remove('alpha');
+    TinyAssertions.assertContentPresence(editor, { 'span[data-mce-annotation="alpha"]': 0 });
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-9399

Description of Changes:
* It is possible to remove an annotation immediately after creation without any selection changes.

The bug was introduced in TINY-8195 and connected to [this](https://github.com/tinymce/tinymce/pull/7485/files#diff-3882b4c135273323573f94b4f8e6a895594701e68d80588eb3749f9567e5502cL89-L92) bookmark, which adjusts the selection in the way that it is impossible to retain the selected word. 

Everything works fine by using offset bookmark `getBookmark(2)`, but I do not really understand the differences between different bookmark types (and only the default one is used in Tiny's code). Other possible solution is in this PR.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
