### PR TITLE
TINY-9610: added css workaround for unwrapped textareas

### DIFF
--- a/modules/oxide/src/less/theme/components/form/textarea.less
+++ b/modules/oxide/src/less/theme/components/form/textarea.less
@@ -25,14 +25,27 @@
     // restore appearance for scrollbars
     appearance: textarea;
 
-    // Remove border that gets imported from tox-textfield since that is applied by to the wrapper element
-    border: none;
-
     // This is required to allow white-spaces and new lines within textareas in Firefox
     white-space: pre-wrap;
+
+    &:focus {
+      &:extend(.tox .tox-textfield:focus);
+    }
   }
 
   .tox-textarea[disabled] {
     &:extend(.tox .tox-textfield[disabled]);
+  }
+
+  // Remove border and focus styling when textarea is wrapped since that is applied to the wrapper
+  // Comments uses unwrapped textareas see: TINY-9610
+  .tox-textarea-wrap .tox-textarea {
+    border: none;
+
+    &:focus {
+      &:extend(.tox .tox-textfield);
+
+      border: none;
+    }
   }
 }


### PR DESCRIPTION
Related Ticket: TINY-9610

Description of Changes:
* Moves the CSS border reset to a wrapper specific selector making the wrapper change backwards compatible

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
