### PR TITLE
TINY-9600: Provide configuration to turn off XSS sanitization

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `toggleFullscreen` to dialog API. #TINY-9528
 - New text-size-increase and text-size-decrease icons. #TINY-9530
 - New `text-size-increase` and `text-size-decrease` icons. #TINY-9530
+- New `xss_sanitization` option to allow for XSS sanitization to be disabled. #TINY-9600
 
 ### Improved
 - Direct invalid child text nodes of list elements will be wrapped in list item elements. #TINY-4818

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -95,6 +95,7 @@ interface BaseEditorOptions {
   document_base_url?: string;
   draggable_modal?: boolean;
   editable_class?: string;
+  editor_security?: boolean;
   element_format?: 'xhtml' | 'html';
   elementpath?: boolean;
   encoding?: string;
@@ -283,6 +284,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   document_base_url: string;
   draggable_modal: boolean;
   editable_class: string;
+  editor_security: boolean;
   font_css: string[];
   font_family_formats: string;
   font_size_classes: string;

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -95,7 +95,6 @@ interface BaseEditorOptions {
   document_base_url?: string;
   draggable_modal?: boolean;
   editable_class?: string;
-  editor_security?: boolean;
   element_format?: 'xhtml' | 'html';
   elementpath?: boolean;
   encoding?: string;
@@ -237,6 +236,7 @@ interface BaseEditorOptions {
   visual_anchor_class?: string;
   visual_table_class?: string;
   width?: number | string;
+  xss_sanitization?: boolean;
 
   // Internal settings (used by cloud or tests)
   disable_nodechange?: boolean;
@@ -284,7 +284,6 @@ export interface EditorOptions extends NormalizedEditorOptions {
   document_base_url: string;
   draggable_modal: boolean;
   editable_class: string;
-  editor_security: boolean;
   font_css: string[];
   font_family_formats: string;
   font_size_classes: string;
@@ -335,4 +334,5 @@ export interface EditorOptions extends NormalizedEditorOptions {
   visual_anchor_class: string;
   visual_table_class: string;
   width: number | string;
+  xss_sanitization: boolean;
 }

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -894,7 +894,7 @@ const getEditableClass = option('editable_class');
 const getNonEditableRegExps = option('noneditable_regexp');
 const shouldPreserveCData = option('preserve_cdata');
 const shouldHighlightOnFocus = option('highlight_on_focus');
-const isEditorSecurityEnabled = option('editor_security');
+const shouldSanitizeContent = option('editor_security');
 
 const hasTextPatternsLookup = (editor: Editor): boolean =>
   editor.options.isSet('text_patterns_lookup');
@@ -1011,5 +1011,5 @@ export {
   hasTableTabNavigation,
   shouldPreserveCData,
   shouldHighlightOnFocus,
-  isEditorSecurityEnabled
+  shouldSanitizeContent
 };

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -894,7 +894,7 @@ const getEditableClass = option('editable_class');
 const getNonEditableRegExps = option('noneditable_regexp');
 const shouldPreserveCData = option('preserve_cdata');
 const shouldHighlightOnFocus = option('highlight_on_focus');
-const shouldSanitizeContent = option('xss_sanitization');
+const shouldSanitizeXss = option('xss_sanitization');
 
 const hasTextPatternsLookup = (editor: Editor): boolean =>
   editor.options.isSet('text_patterns_lookup');
@@ -1011,5 +1011,5 @@ export {
   hasTableTabNavigation,
   shouldPreserveCData,
   shouldHighlightOnFocus,
-  shouldSanitizeContent
+  shouldSanitizeXss
 };

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -785,6 +785,11 @@ const register = (editor: Editor): void => {
     default: false
   });
 
+  registerOption('editor_security', {
+    processor: 'boolean',
+    default: true
+  });
+
   // These options must be registered later in the init sequence due to their default values
   editor.on('ScriptsLoaded', () => {
     registerOption('directionality', {
@@ -889,6 +894,7 @@ const getEditableClass = option('editable_class');
 const getNonEditableRegExps = option('noneditable_regexp');
 const shouldPreserveCData = option('preserve_cdata');
 const shouldHighlightOnFocus = option('highlight_on_focus');
+const isEditorSecurityEnabled = option('editor_security');
 
 const hasTextPatternsLookup = (editor: Editor): boolean =>
   editor.options.isSet('text_patterns_lookup');
@@ -1004,5 +1010,6 @@ export {
   getEditableClass,
   hasTableTabNavigation,
   shouldPreserveCData,
-  shouldHighlightOnFocus
+  shouldHighlightOnFocus,
+  isEditorSecurityEnabled
 };

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -785,7 +785,7 @@ const register = (editor: Editor): void => {
     default: false
   });
 
-  registerOption('editor_security', {
+  registerOption('xss_sanitization', {
     processor: 'boolean',
     default: true
   });
@@ -894,7 +894,7 @@ const getEditableClass = option('editable_class');
 const getNonEditableRegExps = option('noneditable_regexp');
 const shouldPreserveCData = option('preserve_cdata');
 const shouldHighlightOnFocus = option('highlight_on_focus');
-const shouldSanitizeContent = option('editor_security');
+const shouldSanitizeContent = option('xss_sanitization');
 
 const hasTextPatternsLookup = (editor: Editor): boolean =>
   editor.options.isSet('text_patterns_lookup');

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -56,18 +56,19 @@ export interface DomParserSettings {
   allow_html_in_named_anchor?: boolean;
   allow_script_urls?: boolean;
   allow_unsafe_link_target?: boolean;
+  blob_cache?: BlobCache;
   convert_fonts_to_spans?: boolean;
+  document?: Document;
   fix_list_elements?: boolean;
   font_size_legacy_values?: string;
   forced_root_block?: boolean | string;
   forced_root_block_attrs?: Record<string, string>;
+  inline_styles?: boolean;
   preserve_cdata?: boolean;
   remove_trailing_brs?: boolean;
   root_name?: string;
+  sanitize?: boolean;
   validate?: boolean;
-  inline_styles?: boolean;
-  blob_cache?: BlobCache;
-  document?: Document;
 }
 
 interface DomParser {
@@ -408,11 +409,11 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
   const defaultedSettings = {
     validate: true,
     root_name: 'body',
+    sanitize: true,
     ...settings
   };
 
   const parser = new DOMParser();
-  const purify = setupPurify(defaultedSettings, schema);
 
   const parseAndSanitizeWithContext = (html: string, rootName: string, format: string = 'html'): Element => {
     const mimeType = format === 'xhtml' ? 'application/xhtml+xml' : 'text/html';
@@ -425,8 +426,11 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
     const body = parser.parseFromString(wrappedHtml, mimeType).body;
 
     // Sanitize the content
-    purify.sanitize(body, getPurifyConfig(defaultedSettings, mimeType));
-    purify.removed = [];
+    if (defaultedSettings.sanitize) {
+      const purify = setupPurify(defaultedSettings, schema);
+      purify.sanitize(body, getPurifyConfig(defaultedSettings, mimeType));
+      purify.removed = [];
+    }
 
     return isSpecialRoot ? body.firstChild as Element : body;
   };

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -414,6 +414,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
   };
 
   const parser = new DOMParser();
+  const purify = setupPurify(defaultedSettings, schema);
 
   const parseAndSanitizeWithContext = (html: string, rootName: string, format: string = 'html'): Element => {
     const mimeType = format === 'xhtml' ? 'application/xhtml+xml' : 'text/html';
@@ -427,7 +428,6 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
 
     // Sanitize the content
     if (defaultedSettings.sanitize) {
-      const purify = setupPurify(defaultedSettings, schema);
       purify.sanitize(body, getPurifyConfig(defaultedSettings, mimeType));
       purify.removed = [];
     }

--- a/modules/tinymce/src/core/main/ts/content/PrePostProcess.ts
+++ b/modules/tinymce/src/core/main/ts/content/PrePostProcess.ts
@@ -20,7 +20,7 @@ const withSerializedContent = <R extends EditorEvent<{ content: string }>>(edito
     // Restore the content type back to being an AstNode. If the content has changed we need to
     // re-parse the new content, otherwise we can return the input.
     if (eventArgs.content !== serializedContent) {
-      const rootNode = DomParser({ validate: false, forced_root_block: false, sanitize: Options.shouldSanitizeContent(editor) }).parse(eventArgs.content, { context: content.name });
+      const rootNode = DomParser({ validate: false, forced_root_block: false, sanitize: Options.shouldSanitizeXss(editor) }).parse(eventArgs.content, { context: content.name });
       return { ...eventArgs, content: rootNode };
     } else {
       return { ...eventArgs, content };

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -80,7 +80,7 @@ const mkParserSettings = (editor: Editor): DomParserSettings => {
     remove_trailing_brs: getOption('remove_trailing_brs'),
     inline_styles: getOption('inline_styles'),
     root_name: getRootName(editor),
-    sanitize: getOption('editor_security'),
+    sanitize: getOption('xss_sanitization'),
     validate: true,
     blob_cache: blobCache,
     document: editor.getDoc()

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -80,6 +80,7 @@ const mkParserSettings = (editor: Editor): DomParserSettings => {
     remove_trailing_brs: getOption('remove_trailing_brs'),
     inline_styles: getOption('inline_styles'),
     root_name: getRootName(editor),
+    sanitize: getOption('editor_security'),
     validate: true,
     blob_cache: blobCache,
     document: editor.getDoc()

--- a/modules/tinymce/src/core/main/ts/paste/ProcessFilters.ts
+++ b/modules/tinymce/src/core/main/ts/paste/ProcessFilters.ts
@@ -2,6 +2,7 @@ import Editor from '../api/Editor';
 import * as Events from '../api/Events';
 import DomParser from '../api/html/DomParser';
 import HtmlSerializer from '../api/html/Serializer';
+import * as Options from '../api/Options';
 import Tools from '../api/util/Tools';
 
 interface ProcessResult {
@@ -10,7 +11,7 @@ interface ProcessResult {
 }
 
 const preProcess = (editor: Editor, html: string): string => {
-  const parser = DomParser({ }, editor.schema);
+  const parser = DomParser({ sanitize: Options.shouldSanitizeContent(editor) }, editor.schema);
 
   // Strip meta elements
   parser.addNodeFilter('meta', (nodes) => {

--- a/modules/tinymce/src/core/main/ts/paste/ProcessFilters.ts
+++ b/modules/tinymce/src/core/main/ts/paste/ProcessFilters.ts
@@ -11,7 +11,7 @@ interface ProcessResult {
 }
 
 const preProcess = (editor: Editor, html: string): string => {
-  const parser = DomParser({ sanitize: Options.shouldSanitizeContent(editor) }, editor.schema);
+  const parser = DomParser({ sanitize: Options.shouldSanitizeXss(editor) }, editor.schema);
 
   // Strip meta elements
   parser.addNodeFilter('meta', (nodes) => {

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -1,5 +1,6 @@
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Type } from '@ephox/katamari';
+import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -339,7 +340,11 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         const editor = hook.editor();
         editor.setContent('<p><iframe><p>test</p></iframe></p>');
         const content = editor.getContent();
-        assert.equal(content, '<p><iframe><p>test</p></iframe></p>', 'getContent should not error when there is iframes with child nodes in content');
+        assert.equal(content,
+          PlatformDetection.detect().browser.isSafari()
+            ? '<p><iframe>&lt;p&gt;test&lt;/p&gt;</iframe></p>'
+            : '<p><iframe><p>test</p></iframe></p>',
+          'getContent should not error when there is iframes with child nodes in content');
       });
 
       it('getContent text with unsanitized content', () => {

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -22,6 +22,11 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
     return htmlSerializer.serialize(node);
   };
 
+  const assertContentTreeEqualToHtml = (editor: Editor, html: string, msg: string) => {
+    const tree = editor.getContent({ format: 'tree' });
+    assert.equal(toHtml(tree), html, msg);
+  };
+
   const getFontTree = (): AstNode => {
     const body = new AstNode('body', 11);
     const font = new AstNode('font', 1);
@@ -123,8 +128,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         it('TBA: getContent tree', () => {
           const editor = hook.editor();
           editor.setContent('<p>tree</p>');
-          const tree = editor.getContent({ format: 'tree' });
-          assert.equal(toHtml(tree), '<p>tree</p>', 'Should be expected tree html');
+          assertContentTreeEqualToHtml(editor, '<p>tree</p>', 'Should be expected tree html');
           assertEventsFiredInOrder();
           assertEventsContentType();
         });
@@ -132,9 +136,8 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         it('TINY-6281: getContent tree with empty editor', () => {
           const editor = hook.editor();
           editor.setContent('');
-          const tree = editor.getContent({ format: 'tree' });
           // bogus br that sits in an empty editor is replaced with a &nbsp; by the html parser, hence the space
-          assert.equal(toHtml(tree), '<p> </p>', 'Should be expected tree html');
+          assertContentTreeEqualToHtml(editor, '<p> </p>', 'Should be expected tree html');
           assertEventsFiredInOrder();
           assertEventsContentType();
         });
@@ -142,8 +145,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         it('TBA: getContent tree filtered', () => {
           const editor = hook.editor();
           editor.setContent('<p><font size="7">x</font></p>', { format: 'raw' });
-          const tree = editor.getContent({ format: 'tree' });
-          assert.equal(toHtml(tree), '<p><span style="font-size: 300%;">x</span></p>', 'Should be expected tree filtered html');
+          assertContentTreeEqualToHtml(editor, '<p><span style="font-size: 300%;">x</span></p>', 'Should be expected tree filtered html');
           assertEventsFiredInOrder();
           assertEventsContentType();
         });
@@ -274,8 +276,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
             assert.equal(e.content, '<p>tree</p>');
             e.content = '<p>replaced</p>';
           });
-          const tree = editor.getContent({ format: 'tree' });
-          assert.equal(toHtml(tree), '<p>replaced</p>', 'Should be replaced html');
+          assertContentTreeEqualToHtml(editor, '<p>replaced</p>', 'Should be replaced html');
         });
 
         const initialContent = '<p>initial</p>';
@@ -336,8 +337,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
       it('getContent tree with unsanitized content', () => {
         const editor = hook.editor();
         editor.setContent(unsanitizedHtml);
-        const tree = editor.getContent({ format: 'tree' });
-        assert.equal(toHtml(tree), unsanitizedHtml, 'Unsanitized html should not be altered');
+        assertContentTreeEqualToHtml(editor, unsanitizedHtml, 'Unsanitized html should not be altered');
       });
 
       it('setContent tree with content altered to unsanitized html in BeforeSetContent', () => {
@@ -358,8 +358,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
           assert.equal(e.content, '<p>tree</p>');
           e.content = unsanitizedHtml;
         });
-        const tree = editor.getContent({ format: 'tree' });
-        assert.equal(toHtml(tree), unsanitizedHtml, 'Replaced content should be unaltered unsanitized html');
+        assertContentTreeEqualToHtml(editor, unsanitizedHtml, 'Replaced content should be unaltered unsanitized html');
       });
     });
   });

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -74,7 +74,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         xss_sanitization: false
       }
     ], (options) => {
-      context('Test with inline: ' + options.inline + ' and xss_sanitization: ' + options.xss_sanitization, () => {
+      context(`Test with inline: ${options.inline} and xss_sanitization: ${options.xss_sanitization}`, () => {
         let events: EditorEvent<SetContentEvent | GetContentEvent | BeforeSetContentEvent | BeforeGetContentEvent>[] = [];
         const hook = TinyHooks.bddSetupLight<Editor>({
           base_url: '/project/tinymce/js/tinymce',
@@ -290,7 +290,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         const manipulatedContent = '<p>manipulated</p>';
         Arr.each([
           [ 'setContent', manipulatedContent ],
-          [ 'insertContent', manipulatedContent + '\n' + initialContent ]
+          [ 'insertContent', `${manipulatedContent}\n${initialContent}` ]
         ] as const, ([ action, result ]) => {
           it(`TINY-9143: Can manipulate content in "BeforeSetContent" callback when called from "${action}" function`, () => {
             const editor = hook.editor();
@@ -313,7 +313,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
   ], (options) => {
     const unsanitizedHtml = '<p><a href="javascript:alert(1)">XSS</a></p>';
 
-    context('TINY-9600: Test unsanitized content with inline: ' + options.inline + ' and xss_sanitization: true', () => {
+    context(`TINY-9600: Test unsanitized content with inline: ${options.inline} and xss_sanitization: true`, () => {
       const hook = TinyHooks.bddSetupLight<Editor>({
         base_url: '/project/tinymce/js/tinymce',
         xss_sanitization: true,
@@ -359,7 +359,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
       });
     });
 
-    context('TINY-9600: Test unsanitized content with inline: ' + options.inline + ' and xss_sanitization: false', () => {
+    context(`TINY-9600: Test unsanitized content with inline: ${options.inline} and xss_sanitization: false`, () => {
       const hook = TinyHooks.bddSetupLight<Editor>({
         base_url: '/project/tinymce/js/tinymce',
         xss_sanitization: false,

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -18,10 +18,7 @@ const defaultExpectedEvents = [
 ];
 
 describe('browser.tinymce.core.content.EditorContentTest', () => {
-  const toHtml = (node: AstNode): string => {
-    const htmlSerializer = HtmlSerializer({});
-    return htmlSerializer.serialize(node);
-  };
+  const toHtml = (node: AstNode): string => HtmlSerializer({}).serialize(node);
 
   const assertContentTreeEqualToHtml = (editor: Editor, html: string, msg: string) => {
     const tree = editor.getContent({ format: 'tree' });

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -384,6 +384,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         editor.setContent('<p><iframe><p>test</p></iframe></p>');
         const content = editor.getContent();
         assert.equal(content,
+          // TINY-9624: Investigate Safari-specific HTML output
           PlatformDetection.detect().browser.isSafari()
             ? '<p><iframe>&lt;p&gt;test&lt;/p&gt;</iframe></p>'
             : '<p><iframe><p>test</p></iframe></p>',

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -335,6 +335,13 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         assert.equal(content, unsanitizedHtml, 'Unsanitized html should not be altered');
       });
 
+      it('getContent html with iframe with child node', () => {
+        const editor = hook.editor();
+        editor.setContent('<p><iframe><p>test</p></iframe></p>');
+        const content = editor.getContent();
+        assert.equal(content, '<p><iframe><p>test</p></iframe></p>', 'getContent should not error when there is iframes with child nodes in content');
+      });
+
       it('getContent text with unsanitized content', () => {
         const editor = hook.editor();
         editor.setContent(unsanitizedHtml);

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -40,6 +40,25 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
     return body;
   };
 
+  const testSetContentTreeWithContentAlteredInBeforeSetContent = (editor: Editor, alteredContent: string, msg: string) => {
+    editor.setContent('<p>tree</p>');
+    editor.once('BeforeSetContent', (e) => {
+      assert.equal(e.content, '<font size="7">x</font>');
+      e.content = alteredContent;
+    });
+    editor.setContent(getFontTree());
+    assert.equal(editor.getContent(), alteredContent, msg);
+  };
+
+  const testGetContentTreeWithContentAlteredInGetContent = (editor: Editor, alteredContent: string, msg: string) => {
+    editor.setContent('<p>tree</p>');
+    editor.once('GetContent', (e) => {
+      assert.equal(e.content, '<p>tree</p>');
+      e.content = alteredContent;
+    });
+    assertContentTreeEqualToHtml(editor, alteredContent, msg);
+  };
+
   Arr.each(
     [
       {
@@ -260,23 +279,12 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
 
         it('TINY-7996: Set tree content with content altered in BeforeSetContent', () => {
           const editor = hook.editor();
-          editor.setContent('<p>tree</p>');
-          editor.once('BeforeSetContent', (e) => {
-            assert.equal(e.content, '<font size="7">x</font>');
-            e.content = '<p>replaced</p>';
-          });
-          editor.setContent(getFontTree());
-          assert.equal(editor.getContent(), '<p>replaced</p>', 'Should be replaced html');
+          testSetContentTreeWithContentAlteredInBeforeSetContent(editor, '<p>replaced</p>', 'Should be replaced html');
         });
 
         it('TINY-7996: Get tree content with content altered in GetContent', () => {
           const editor = hook.editor();
-          editor.setContent('<p>tree</p>');
-          editor.once('GetContent', (e) => {
-            assert.equal(e.content, '<p>tree</p>');
-            e.content = '<p>replaced</p>';
-          });
-          assertContentTreeEqualToHtml(editor, '<p>replaced</p>', 'Should be replaced html');
+          testGetContentTreeWithContentAlteredInGetContent(editor, '<p>replaced</p>', 'Should be replaced html');
         });
 
         const initialContent = '<p>initial</p>';
@@ -342,23 +350,12 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
 
       it('setContent tree with content altered to unsanitized html in BeforeSetContent', () => {
         const editor = hook.editor();
-        editor.setContent('<p>tree</p>');
-        editor.once('BeforeSetContent', (e) => {
-          assert.equal(e.content, '<font size="7">x</font>');
-          e.content = unsanitizedHtml;
-        });
-        editor.setContent(getFontTree());
-        assert.equal(editor.getContent(), unsanitizedHtml, 'Replaced content should be unaltered unsanitized html');
+        testSetContentTreeWithContentAlteredInBeforeSetContent(editor, unsanitizedHtml, 'Replaced content should be unaltered unsanitized html');
       });
 
       it('getContent tree with content altered to unsanitized html in GetContent', () => {
         const editor = hook.editor();
-        editor.setContent('<p>tree</p>');
-        editor.once('GetContent', (e) => {
-          assert.equal(e.content, '<p>tree</p>');
-          e.content = unsanitizedHtml;
-        });
-        assertContentTreeEqualToHtml(editor, unsanitizedHtml, 'Replaced content should be unaltered unsanitized html');
+        testGetContentTreeWithContentAlteredInGetContent(editor, unsanitizedHtml, 'Replaced content should be unaltered unsanitized html');
       });
     });
   });

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -1,5 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { McEditor, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -773,20 +773,6 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
       editor.insertContent('hello');
       TinyAssertions.assertContent(editor, '<div contenteditable="true">thelloxt</div>');
       editor.getBody().contentEditable = 'true';
-    });
-  });
-
-  context('TINY-9600: Inserting unsanitized html with xss_sanitization: false', () => {
-    const unsanitizedHtml = '<p><a href="javascript:alert(1)">XSS</a></p>';
-
-    it('insertContent should not alter inserted unsanitized html', async () => {
-      const editor = await McEditor.pFromSettings<Editor>({
-        xss_sanitization: false,
-      });
-      editor.setContent('<p>initial</p>');
-      editor.insertContent(unsanitizedHtml);
-      TinyAssertions.assertContent(editor, unsanitizedHtml + '\n<p>initial</p>');
-      McEditor.remove(editor);
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -1,5 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { McEditor, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -773,6 +773,20 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
       editor.insertContent('hello');
       TinyAssertions.assertContent(editor, '<div contenteditable="true">thelloxt</div>');
       editor.getBody().contentEditable = 'true';
+    });
+  });
+
+  context('TINY-9600: Inserting unsanitized html with xss_sanitization: false', () => {
+    const unsanitizedHtml = '<p><a href="javascript:alert(1)">XSS</a></p>';
+
+    it('insertContent should not alter inserted unsanitized html', async () => {
+      const editor = await McEditor.pFromSettings<Editor>({
+        xss_sanitization: false,
+      });
+      editor.setContent('<p>initial</p>');
+      editor.insertContent(unsanitizedHtml);
+      TinyAssertions.assertContent(editor, unsanitizedHtml + '\n<p>initial</p>');
+      McEditor.remove(editor);
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertUnsanitizedContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertUnsanitizedContentTest.ts
@@ -11,7 +11,7 @@ describe('browser.tinymce.core.content.InsertUnsanitizedContentTest', () => {
     editor.setContent(initialContent);
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
     editor.insertContent(content);
-    TinyAssertions.assertContent(editor, expected + '\n' + initialContent);
+    TinyAssertions.assertContent(editor, `${expected}\n${initialContent}`);
   };
 
   context('TINY-9600: Inserting unsanitized html with xss_sanitization: true', () => {

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertUnsanitizedContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertUnsanitizedContentTest.ts
@@ -1,0 +1,40 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.content.InsertUnsanitizedContentTest', () => {
+  const unsanitizedHtml = '<p><a href="javascript:alert(1)">XSS</a></p>';
+  const sanitizedHtml = '<p><a>XSS</a></p>';
+  const testInsertContent = (editor: Editor, content: string, expected: string) => {
+    const initialContent = '<p>initial</p>';
+    editor.setContent(initialContent);
+    TinySelections.setCursor(editor, [ 0, 0 ], 0);
+    editor.insertContent(content);
+    TinyAssertions.assertContent(editor, expected + '\n' + initialContent);
+  };
+
+  context('TINY-9600: Inserting unsanitized html with xss_sanitization: true', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      xss_sanitization: true
+    }, []);
+
+    it('insertContent should sanitize inserted html', () => {
+      const editor = hook.editor();
+      testInsertContent(editor, unsanitizedHtml, sanitizedHtml);
+    });
+  });
+
+  context('TINY-9600: Inserting unsanitized html with xss_sanitization: false', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      xss_sanitization: false
+    }, []);
+
+    it('insertContent should not alter inserted unsanitized html', () => {
+      const editor = hook.editor();
+      testInsertContent(editor, unsanitizedHtml, unsanitizedHtml);
+    });
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1487,4 +1487,34 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       }));
     });
   });
+
+  context('TINY-9600: sanitize: false', () => {
+    const testDisablingSanitization = (testCase: { name: string; input: string }) => {
+      it(testCase.name, () => {
+        const parser = DomParser({ sanitize: false }, schema);
+        const serializedHtml = serializer.serialize(parser.parse(testCase.input));
+
+        assert.equal(serializedHtml, testCase.input);
+      });
+    };
+
+    Arr.each([{
+      name: 'should not remove script tags',
+      input: '<script>alert(1)</script>'
+    }, {
+      name: 'should not remove iframe tags with child nodes',
+      input: '<iframe src="https://example.com"><p>Lorem ipsum</p></iframe>'
+    }, {
+      name: 'should not remove iframe tags with srcdoc',
+      input: '<iframe srcdoc="Lorem ipsum"></iframe>'
+    }, {
+      name: 'should not remove unsafe attributes',
+      input: '<p><a href="javascript:alert(1)">XSS</a></p>'
+    },
+    {
+      name: 'should not remove svg tags',
+      input: '<svg><circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow"></circle></svg>'
+    }
+    ], testDisablingSanitization);
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/init/InitUnsanitizedContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitUnsanitizedContentTest.ts
@@ -1,0 +1,28 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { McEditor, TinyAssertions } from '@ephox/mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.init.InitUnsanitizedContentTest', () => {
+  const initAndAssertContent = (label: string, xss_sanitization: boolean, initial: string, expected: string) => {
+    it(label, async () => {
+      const editor = await McEditor.pFromHtml<Editor>(`<textarea>${initial}</textarea>`, {
+        base_url: '/project/tinymce/js/tinymce',
+        xss_sanitization
+      });
+      TinyAssertions.assertContent(editor, expected);
+      McEditor.remove(editor);
+    });
+  };
+
+  const unsanitizedHtml = '<p><a href="javascript:alert(1)">XSS</a></p>';
+
+  context('TINY-9600: xss_sanitized: true', () => {
+    const sanitizedHtml = '<p><a>XSS</a></p>';
+    initAndAssertContent('should sanitize initial content', true, unsanitizedHtml, sanitizedHtml);
+  });
+
+  context('TINY-9600: xss_sanitized: false', () => {
+    initAndAssertContent('should not sanitize initial content', false, unsanitizedHtml, unsanitizedHtml);
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/paste/UnsanitizedPasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/UnsanitizedPasteTest.ts
@@ -1,0 +1,38 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.paste.UnsanitizedPasteTest', () => {
+  const unsanitizedHtml = '<p><a href="javascript:alert(1)">XSS</a></p>';
+  const sanitizedHtml = '<p><a>XSS</a></p>';
+  const testPaste = (editor: Editor, content: string, expected: string) => {
+    editor.setContent('');
+    editor.execCommand('mceInsertClipboardContent', false, { html: content });
+    TinyAssertions.assertContent(editor, expected);
+  };
+
+  context('TINY-9600: xss_sanitization: true', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      xss_sanitization: true
+    }, []);
+
+    it('should sanitize pasted content', () => {
+      const editor = hook.editor();
+      testPaste(editor, unsanitizedHtml, sanitizedHtml);
+    });
+  });
+
+  context('TINY-9600: xss_sanitization: false', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      xss_sanitization: false
+    }, []);
+
+    it('should not sanitize pasted content', () => {
+      const editor = hook.editor();
+      testPaste(editor, unsanitizedHtml, unsanitizedHtml);
+    });
+  });
+});

--- a/modules/tinymce/src/plugins/media/main/ts/core/Sanitize.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Sanitize.ts
@@ -5,8 +5,10 @@ import * as Options from '../api/Options';
 import { Parser } from './Parser';
 
 const parseAndSanitize = (editor: Editor, context: string, html: string): AstNode => {
+  const getEditorOption = editor.options.get;
+  const sanitize = getEditorOption('xss_sanitization');
   const validate = Options.shouldFilterHtml(editor);
-  return Parser(editor.schema, { validate }).parse(html, { context });
+  return Parser(editor.schema, { sanitize, validate }).parse(html, { context });
 };
 
 export {

--- a/modules/tinymce/src/plugins/template/main/ts/core/Templates.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/core/Templates.ts
@@ -6,7 +6,7 @@ import Tools from 'tinymce/core/api/util/Tools';
 import * as Options from '../api/Options';
 import * as DateTimeHelper from './DateTimeHelper';
 import { ExternalTemplate, TemplateValues } from './Types';
-import { hasAnyClasses, sanitize } from './Utils';
+import { hasAnyClasses, parseAndSerialize } from './Utils';
 
 const createTemplateList = (editor: Editor, callback: (templates: ExternalTemplate[]) => void) => {
   return (): void => {
@@ -61,7 +61,7 @@ const insertTemplate = (editor: Editor, _ui: boolean, html: string): void => {
   const sel = editor.selection.getContent();
 
   html = replaceTemplateValues(html, Options.getTemplateReplaceValues(editor));
-  let el = dom.create('div', {}, sanitize(editor, html));
+  let el = dom.create('div', {}, parseAndSerialize(editor, html));
 
   // Find template element within div
   const n = dom.select('.mceTmpl', el);

--- a/modules/tinymce/src/plugins/template/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/core/Utils.ts
@@ -18,7 +18,7 @@ const htmlEscape = (html: string): string =>
 const hasAnyClasses = (dom: DOMUtils, n: Element, classes: string): boolean =>
   Arr.exists(classes.split(/\s+/), (c) => dom.hasClass(n, c));
 
-const sanitize = (editor: Editor, html: string): string =>
+const parseAndSerialize = (editor: Editor, html: string): string =>
   HtmlSerializer({ validate: true }, editor.schema).serialize(
     editor.parser.parse(html, { insert: true })
   );
@@ -26,5 +26,5 @@ const sanitize = (editor: Editor, html: string): string =>
 export {
   hasAnyClasses,
   htmlEscape,
-  sanitize
+  parseAndSerialize
 };

--- a/modules/tinymce/src/plugins/template/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/ui/Dialog.ts
@@ -59,7 +59,7 @@ const getPreviewContent = (editor: Editor, html: string): string => {
       preventClicksOnLinksScript +
       '</head>' +
       '<body class="' + encode(bodyClass) + '"' + dirAttr + '>' +
-      Utils.sanitize(editor, html) +
+      Utils.parseAndSerialize(editor, html) +
       '</body>' +
       '</html>'
     );


### PR DESCRIPTION
Related Ticket: TINY-9600

Description of Changes:
* Add `xss_sanitization: boolean` option (default: `true`) to enable/disable XSS sanitization in the parser
* Make all content-related behaviour, including `setContent`, `getContent`, initialising content, and pasting content, respect `xss_sanitization` option

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
