### PR TITLE
TINY-9593: Fix pasting links from quickbars

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Creating a list in a table cell when the caret is in front of an anchor element would not properly include the anchor in the list. #TINY-6853
 - Formatting could be applied or removed on noneditable list items inside a noneditable root. #TINY-9563
 - Annotation would not be removed if the annotation was immediately deleted after being created. #TINY-9399
+- Inserting a link for a selection from quickbars didn't preserve formatting. #TINY-9593
 
 ## 6.3.2 - 2023-02-22
 

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -1,4 +1,4 @@
-import { Fun, Optional } from '@ephox/katamari';
+import { Fun, Optional, Optionals } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import { InlineContent } from 'tinymce/core/api/ui/Ui';
@@ -90,7 +90,7 @@ const setupContextToolbars = (editor: Editor): void => {
     const onlyText = Utils.isOnlyTextSelected(editor);
     if (anchor.isNone() && onlyText) {
       const text = Utils.getAnchorText(editor.selection, anchor);
-      return text.length > 0 ? Optional.none() : Optional.some(value);
+      return Optionals.someIf(text.length === 0, value);
     } else {
       return Optional.none();
     }

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -79,16 +79,18 @@ const setupContextToolbars = (editor: Editor): void => {
     return Fun.noop;
   };
 
-  /*
+  /**
    * if we're editing a link, don't change the text.
    * if anything other than text is selected, don't change the text.
+   * TINY-9593: If there is a text selection return `Optional.none`
+   * because `mceInsertLink` command will handle the selection.
    */
   const getLinkText = (value: string) => {
     const anchor = Utils.getAnchorElement(editor);
     const onlyText = Utils.isOnlyTextSelected(editor);
     if (anchor.isNone() && onlyText) {
       const text = Utils.getAnchorText(editor.selection, anchor);
-      return Optional.some(text.length > 0 ? text : value);
+      return text.length > 0 ? Optional.none() : Optional.some(value);
     } else {
       return Optional.none();
     }

--- a/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
@@ -182,4 +182,14 @@ describe('browser.tinymce.plugins.link.QuickLinkTest', () => {
     TinyUiActions.keydown(editor, Keys.enter());
     UiFinder.notExists(SugarBody.body(), '.tox-pop__dialog');
   });
+
+  it('TINY-9593: Preserve formatting on text selection', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>Lorem <em><strong>ipsum</strong></em> dolor sit amet</p>');
+    TinySelections.setSelection(editor, [ 0, 1, 0, 0 ], ''.length, [ 0, 1, 0, 0 ], 'ipsum'.length);
+    await pOpenQuickLink(editor);
+    FocusTools.setActiveValue(doc, 'http://tiny.cloud/2');
+    TinyUiActions.keydown(editor, Keys.enter());
+    TinyAssertions.assertContent(editor, '<p>Lorem <a href="http://tiny.cloud/2"><em><strong>ipsum</strong></em></a> dolor sit amet</p>');
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-9593

Description of Changes:
* Formatting after pasting a link from quickbars is preserved now.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
