### PR TITLE
TINY-9614: Fix navigation inside tree using keyboard 

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/Button.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/Button.ts
@@ -35,7 +35,7 @@ const factory: SingleSketchFactory<ButtonDetail, ButtonSpec> = (detail): SketchS
     } else {
       // We are not a button, so type is irrelevant (unless specified)
       // Default role to button
-      const role = lookupAttr('role').getOr('button');
+      const role = detail.role.getOr(lookupAttr('role').getOr('button'));
       return { role };
     }
   };

--- a/modules/oxide/src/less/theme/components/tree/tree-button.less
+++ b/modules/oxide/src/less/theme/components/tree/tree-button.less
@@ -201,10 +201,6 @@
     .tox-tree--directory__label {
       font-weight: bold;
 
-      .tox-tree--directory__title__wrapper {
-        padding-left: 6px;
-      }
-
       .tox-mbtn {
         margin-left: auto;
 
@@ -212,12 +208,14 @@
           fill: transparent;
         }
 
-        &.tox-mbtn--active svg {
+        &.tox-mbtn--active svg,
+        &:focus svg {
           fill: @tree-button-menu-icon-color;
         }
       }
 
-      &:hover .tox-mbtn {
+      &:hover .tox-mbtn,
+      &:focus .tox-mbtn {
         svg {
           fill: @tree-button-menu-icon-color;
         }
@@ -228,6 +226,7 @@
       }
 
       .tox-chevron {
+        margin-right: 6px;
         transition: transform .5s ease-in-out;
 
         svg {
@@ -251,7 +250,8 @@
         fill: transparent;
       }
 
-      &.tox-mbtn--active svg {
+      &.tox-mbtn--active svg,
+      &:focus svg {
         fill: @tree-button-menu-icon-color;
       }
     }

--- a/modules/oxide/src/less/theme/components/tree/tree-button.less
+++ b/modules/oxide/src/less/theme/components/tree/tree-button.less
@@ -73,6 +73,7 @@
     outline: none;
     overflow: hidden;
     padding: 0;
+    padding-left: 8px;
     text-transform: @tree-button-text-transform;
 
     .tox-tree__label {

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The sidebar element now has accessibility role `region` when visible and `presentation` when hidden. #TINY-9517
 
 ### Fixed
+- Add support for navigating inside the tree component using arrow keys and shift key. #TINY-9614
 - Sometimes the editor would finish initializing before the silver theme would have finished loading. #TINY-9556
 - The searchreplace modal would close incorrectly when clicking outside of the alert that pops up when no match is found. #TINY-9443
 - Color picker on toolbar would not update when changing forecolor or backcolor from menu. #TINY-9439

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
@@ -23,6 +23,20 @@ export default (): void => {
               type: 'directory',
               id: Id.generate(''),
               title: 'Dir',
+              menu: {
+                type: 'menubutton',
+                icon: 'image-options',
+                fetch: (success) => success([
+                  {
+                    type: 'menuitem',
+                    text: 'menuitem',
+                    onAction: () => {
+                      // eslint-disable-next-line
+                        console.log('clicked action');
+                    }
+                  }
+                ])
+              },
               children: [
                 {
                   type: 'directory',
@@ -85,6 +99,7 @@ export default (): void => {
             }
           };
           const getDialogSpec = (tree: Dialog.TreeItemSpec[], initialData: Data ): Dialog.DialogSpec<Data> => ({
+            size: 'large',
             initialData,
             onChange: (api) => {
               const { search } = api.getData();
@@ -101,18 +116,31 @@ export default (): void => {
               type: 'panel',
               items: [
                 {
-                  type: 'input',
-                  name: 'search',
-                  label: 'Search',
-                },
-                {
-                  type: 'tree',
-                  onLeafAction: (id) => {
-                  // eslint-disable-next-line
+                  type: 'bar',
+                  items: [
+                    {
+                      type: 'panel',
+                      items: [{
+                        type: 'input',
+                        name: 'search',
+                        label: 'Search',
+                      },
+                      {
+                        type: 'tree',
+                        onLeafAction: (id) => {
+                          // eslint-disable-next-line
                   console.log('clicked on item with id', id);
-                  },
-                  items: tree
+                        },
+                        items: tree
+                      }]
+                    },
+                    {
+                      type: 'htmlpanel',
+                      html: '<div style="width: 1000px; height: 166px; border: 1px solid black; border-radius: 5px"></div>'
+                    }
+                  ]
                 }
+
               ]
             }
           });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/button/MenuButton.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/button/MenuButton.ts
@@ -50,7 +50,7 @@ const getMenuButtonApi = (component: AlloyComponent): Toolbar.ToolbarMenuButtonI
   })
 });
 
-const renderMenuButton = (spec: MenuButtonSpec, prefix: string, backstage: UiFactoryBackstage, role: Optional<string>): SketchSpec => {
+const renderMenuButton = (spec: MenuButtonSpec, prefix: string, backstage: UiFactoryBackstage, role: Optional<string>, tabstopping = true): SketchSpec => {
   return renderCommonDropdown({
     text: spec.text,
     icon: spec.icon,
@@ -88,7 +88,7 @@ const renderMenuButton = (spec: MenuButtonSpec, prefix: string, backstage: UiFac
     presets: 'normal',
     classes: [],
     dropdownBehaviours: [
-      Tabstopping.config({ })
+      ...(tabstopping ? [ Tabstopping.config({ }) ] : [])
     ]
   },
   prefix,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
@@ -35,6 +35,7 @@ const renderLeafLabel = (leaf: Dialog.Leaf, onLeafAction: OnLeafAction, visible:
       classes: [ `tox-tree--leaf__label`, 'tox-trbtn' ].concat(visible ? [ 'tox-tree--leaf__label--visible' ] : []),
     },
     components,
+    role: 'treeitem',
     action: (_button) => {
       onLeafAction(leaf.id);
     },
@@ -63,7 +64,7 @@ const renderDirectoryLabel = (directory: Dialog.Directory, visible: boolean, bac
     {
       dom: {
         tag: 'div',
-        classes: [ 'tox-chevron' ]
+        classes: [ 'tox-chevron' ],
       },
       components: [
         renderIconFromPack('chevron-right', backstage.shared.providers.icons),
@@ -84,6 +85,9 @@ const renderDirectoryLabel = (directory: Dialog.Directory, visible: boolean, bac
     action: (button) => {
       SelectorFind.sibling(button.element, '.tox-tree--directory__children').each((childrenEle) => {
         button.getSystem().getByDom(childrenEle).each((childrenComp) => Toggling.toggle(childrenComp));
+      });
+      SelectorFind.ancestor(button.element, '.tox-tree--directory').each((directoryEle) => {
+        button.getSystem().getByDom(directoryEle).each((directoryComp) => Toggling.toggle(directoryComp));
       });
     },
     buttonBehaviours: Behaviour.derive([
@@ -126,11 +130,21 @@ const renderDirectory = (dir: Dialog.Directory, onLeafAction: OnLeafAction, labe
     dom: {
       tag: 'div',
       classes: [ `tox-tree--directory` ],
+      attributes: {
+        role: 'treeitem'
+      }
     },
     components: [
       renderDirectoryLabel(dir, labelTabstopping, backstage),
       children
     ],
+    behaviours: Behaviour.derive([
+      Toggling.config({
+        aria: {
+          mode: 'expanded',
+        },
+      })
+    ])
   });
 };
 
@@ -143,6 +157,9 @@ const renderTree = (
     dom: {
       tag: 'div',
       classes: [ 'tox-tree' ],
+      attributes: {
+        role: 'tree'
+      }
     },
     components: spec.items.map((item) => {
       return item.type === 'leaf' ?

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
@@ -169,7 +169,8 @@ const renderTree = (
     behaviours: Behaviour.derive([
       Keying.config({
         mode: 'flow',
-        selector: '.tox-tree--leaf__label--visible, .tox-tree--directory__label--visible'
+        selector: '.tox-tree--leaf__label--visible, .tox-tree--directory__label--visible',
+        cycles: false
       })
     ])
   };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogTreeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogTreeTest.ts
@@ -1,0 +1,113 @@
+import { FocusTools, Keys } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.DialogTreeTest', () => {
+
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    toolbar: 'tree',
+    base_url: '/project/tinymce/js/tinymce',
+    setup: (ed: Editor) => {
+      ed.ui.registry.addButton('tree', {
+        text: 'Tree',
+        onAction: () => {
+          ed.windowManager.open({
+            title: 'Tree',
+            buttons: [
+              {
+                type: 'cancel',
+                text: 'Cancel',
+              }
+            ],
+            body: {
+              type: 'panel',
+              items: [{
+                type: 'tree',
+                onLeafAction: (id) => {
+                  console.log('clicked on item with id', id);
+                },
+                items: [
+                  {
+                    type: 'directory',
+                    id: 'dir',
+                    title: 'Dir',
+                    menu: {
+                      icon: 'image-options',
+                      type: 'menubutton',
+                      fetch: (success) => success([
+                        {
+                          type: 'menuitem',
+                          text: 'menuitem',
+                          onAction: () => {
+                            console.log('dir menubutton');
+                          }
+                        }
+                      ])
+                    },
+                    children: [
+                      {
+                        type: 'leaf',
+                        title: 'File 3',
+                        id: '3',
+                      },
+                      {
+                        type: 'leaf',
+                        title: 'File 4',
+                        id: '4',
+                        menu: {
+                          icon: 'image-options',
+                          type: 'menubutton',
+                          fetch: (success) => success([
+                            {
+                              type: 'menuitem',
+                              text: 'menuitem',
+                              onAction: () => {
+                                console.log('File 4 menubutton');
+                              }
+                            }
+                          ])
+                        }
+                      },
+                    ]
+                  },
+                  {
+                    type: 'leaf',
+                    title: 'File 5',
+                    id: '5',
+                  },
+                  {
+                    type: 'leaf',
+                    title: 'File 6',
+                    id: '6',
+                  },
+
+                ]
+              }]
+            }
+          });
+        }
+      });
+    }
+  }, [], true);
+
+  it('TINY-9614: Trigger the urlinput and check that the dropdown appears in front of the dialog', () => {
+    const editor = hook.editor();
+    TinyUiActions.clickOnToolbar(editor, 'button:contains("Tree")');
+    const dirElement = FocusTools.isOnSelector('Dir', SugarDocument.getDocument(), '.tox-tree--directory__label:contains("Dir")');
+    TinyUiActions.keystroke(editor, Keys.down());
+    const file5Element = FocusTools.isOnSelector('File 5', SugarDocument.getDocument(), '.tox-tree--leaf__label:contains("File 5")');
+    TinyUiActions.keystroke(editor, Keys.up());
+    FocusTools.isOn('Dir', dirElement);
+    TinyUiActions.keystroke(editor, Keys.tab());
+    const dirMenuElement = FocusTools.isOnSelector('Dir menu', SugarDocument.getDocument(), '.tox-tree--directory__label:contains("Dir") > .tox-mbtn' );
+    TinyUiActions.keystroke(editor, Keys.tab());
+    FocusTools.isOn('File 5', file5Element);
+    TinyUiActions.keystroke(editor, Keys.tab(), { shiftKey: true });
+    FocusTools.isOn('Dir menu', dirMenuElement);
+    TinyUiActions.keystroke(editor, Keys.tab(), { shiftKey: true });
+    FocusTools.isOn('Dir', dirElement);
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogTreeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogTreeTest.ts
@@ -1,5 +1,6 @@
 import { FocusTools, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
@@ -26,9 +27,7 @@ describe('browser.tinymce.themes.silver.editor.DialogTreeTest', () => {
               type: 'panel',
               items: [{
                 type: 'tree',
-                onLeafAction: (id) => {
-                  console.log('clicked on item with id', id);
-                },
+                onLeafAction: Fun.noop,
                 items: [
                   {
                     type: 'directory',
@@ -41,9 +40,7 @@ describe('browser.tinymce.themes.silver.editor.DialogTreeTest', () => {
                         {
                           type: 'menuitem',
                           text: 'menuitem',
-                          onAction: () => {
-                            console.log('dir menubutton');
-                          }
+                          onAction: Fun.noop
                         }
                       ])
                     },
@@ -64,9 +61,7 @@ describe('browser.tinymce.themes.silver.editor.DialogTreeTest', () => {
                             {
                               type: 'menuitem',
                               text: 'menuitem',
-                              onAction: () => {
-                                console.log('File 4 menubutton');
-                              }
+                              onAction: Fun.noop
                             }
                           ])
                         }
@@ -83,7 +78,6 @@ describe('browser.tinymce.themes.silver.editor.DialogTreeTest', () => {
                     title: 'File 6',
                     id: '6',
                   },
-
                 ]
               }]
             }

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
@@ -1,9 +1,9 @@
-import { ApproxStructure, Assertions, Mouse, UiFinder } from '@ephox/agar';
+import { ApproxStructure, Assertions, Mouse, UiFinder, FocusTools, Keyboard, Keys } from '@ephox/agar';
 import { AlloyComponent, GuiFactory, TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { StructureSchema } from '@ephox/boulder';
 import { Dialog } from '@ephox/bridge';
-import { Class, SelectorFind, SugarBody } from '@ephox/sugar';
+import { Class, SelectorFind, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import { renderTree } from 'tinymce/themes/silver/ui/dialog/Tree';
@@ -101,6 +101,13 @@ describe('headless.tinymce.themes.silver.tree.TreeTest', () => {
     ).getOrDie();
   };
 
+  const pAssertFocusOnItem = (doc: SugarElement<Document>, type: 'leaf' | 'directory', text: string): Promise<SugarElement<HTMLElement>> =>
+    FocusTools.pTryOnSelector(
+      'Focus should be on: ' + text,
+      doc,
+      `.tox-trbtn.tox-tree--${type}__label:contains(${text})`
+    );
+
   it('Check initial event state', () => {
     const store = hook.store();
     store.assertEq('Store should empty', []);
@@ -132,6 +139,12 @@ describe('headless.tinymce.themes.silver.tree.TreeTest', () => {
     store.clear();
     Mouse.clickOn(getTreeItem('.tox-tree').element, '.tox-tree--leaf__label');
     store.assertEq('File 1', [ '1' ]);
+
+    const dirLabelButton = FocusTools.setFocus(dir.element, '.tox-trbtn.tox-tree--directory__label');
+    Keyboard.keystroke(Keys.tab(), {}, dirLabelButton);
+    const file5Label = await pAssertFocusOnItem(SugarDocument.getDocument(), 'leaf', 'File 5');
+    Keyboard.keystroke(Keys.tab(), { shiftKey: true }, file5Label);
+    await pAssertFocusOnItem(SugarDocument.getDocument(), 'directory', 'Dir');
 
     store.clear();
     Mouse.clickOn(dir.element, '.tox-mbtn');

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
@@ -1,9 +1,9 @@
-import { ApproxStructure, Assertions, Mouse, UiFinder, FocusTools, Keyboard, Keys } from '@ephox/agar';
+import { ApproxStructure, Assertions, Mouse, UiFinder } from '@ephox/agar';
 import { AlloyComponent, GuiFactory, TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { StructureSchema } from '@ephox/boulder';
 import { Dialog } from '@ephox/bridge';
-import { Class, SelectorFind, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
+import { Class, SelectorFind, SugarBody } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import { renderTree } from 'tinymce/themes/silver/ui/dialog/Tree';
@@ -101,13 +101,6 @@ describe('headless.tinymce.themes.silver.tree.TreeTest', () => {
     ).getOrDie();
   };
 
-  const pAssertFocusOnItem = (doc: SugarElement<Document>, type: 'leaf' | 'directory', text: string): Promise<SugarElement<HTMLElement>> =>
-    FocusTools.pTryOnSelector(
-      'Focus should be on: ' + text,
-      doc,
-      `.tox-trbtn.tox-tree--${type}__label:contains(${text})`
-    );
-
   it('Check initial event state', () => {
     const store = hook.store();
     store.assertEq('Store should empty', []);
@@ -139,12 +132,6 @@ describe('headless.tinymce.themes.silver.tree.TreeTest', () => {
     store.clear();
     Mouse.clickOn(getTreeItem('.tox-tree').element, '.tox-tree--leaf__label');
     store.assertEq('File 1', [ '1' ]);
-
-    const dirLabelButton = FocusTools.setFocus(dir.element, '.tox-trbtn.tox-tree--directory__label');
-    Keyboard.keystroke(Keys.tab(), {}, dirLabelButton);
-    const file5Label = await pAssertFocusOnItem(SugarDocument.getDocument(), 'leaf', 'File 5');
-    Keyboard.keystroke(Keys.tab(), { shiftKey: true }, file5Label);
-    await pAssertFocusOnItem(SugarDocument.getDocument(), 'directory', 'Dir');
 
     store.clear();
     Mouse.clickOn(dir.element, '.tox-mbtn');


### PR DESCRIPTION
Related Ticket: TINY-9614

Description of Changes:
* Enable navigation in the Tree component using Tab and shift+Tab keys
* Fix styling of focused components
* Add aria attributes to tree items

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
