### PR TITLE
TINY-9554: Inline Dialog mispositioned inside fixed or absolute content

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Formatting could be applied or removed on noneditable list items inside a noneditable root. #TINY-9563
 - Annotation would not be removed if the annotation was immediately deleted after being created. #TINY-9399
 - Inserting a link for a selection from quickbars didn't preserve formatting. #TINY-9593
-- Inline dialog position is now correct even if the editor is not inline and it is contained in a `fixed`/`absolute` positioned element. #TINY-9554
+- Inline dialog position was not correct when the editor wasn't inline and was contained in a `fixed` or `absolute` positioned element. #TINY-9554
 
 ## 6.3.2 - 2023-02-22
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Formatting could be applied or removed on noneditable list items inside a noneditable root. #TINY-9563
 - Annotation would not be removed if the annotation was immediately deleted after being created. #TINY-9399
 - Inserting a link for a selection from quickbars didn't preserve formatting. #TINY-9593
+- Inline dialog position is now correct even if the editor is not inline and it is contained in a `fixed`/`absolute` positioned element. #TINY-9554
 
 ## 6.3.2 - 2023-02-22
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
@@ -184,7 +184,9 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
         inlineDialogComp,
         GuiFactory.premade(dialogUi.dialog),
         { anchor },
-        Optional.some(SugarBody.body())
+        editor.inline
+          ? Optional.some(SugarBody.body())
+          : Optional.some(SugarElement.fromDom(editor.getContainer()))
       );
 
       // Refresh the docking position if not using a sticky toolbar

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
@@ -1,6 +1,6 @@
 import { Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { Css, Dimension, Height, Insert, Remove, Scroll, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
+import { Css, Height, Insert, Remove, Scroll, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -121,7 +121,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogPositionTest', 
 
   context('TINY-9554: dialog position with editor in fixed container', () => {
     const setupElement = () => {
-      const container = SugarElement.fromHtml('<div style="position: fixed; top: 150; left: 150;"></div>');
+      const container = SugarElement.fromHtml('<div style="position: fixed; top: 150px; left: 150px;"></div>');
       const element = SugarElement.fromTag('textarea');
 
       Insert.append(SugarBody.body(), container);
@@ -146,13 +146,8 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogPositionTest', 
     it('TINY-9554: test position', async () => {
       const editor = hook.editor();
       const dialog = openDialog(editor);
-      const editorHeader = UiFinder.findIn(TinyDom.container(editor), '.tox-editor-header').getOrDie();
-      const editorHeaderHeight = Dimension.parse(Css.get(
-        editorHeader,
-        'height'
-      ), [ 'unsupportedLength' ]).map((dim) => dim.value).getOr(0);
 
-      await pAssertPos(dialog, 'absolute', 158, editorHeaderHeight + 10);
+      await pAssertPos(dialog, 'absolute', 306, 0);
 
       DialogUtils.close(editor);
     });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
@@ -1,6 +1,6 @@
 import { Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { Css, Height, Remove, Scroll, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
+import { Css, Height, Insert, Remove, Scroll, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -114,6 +114,41 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogPositionTest', 
       // Scroll back to top and assert not docked
       Scroll.to(0, 0);
       await pAssertPos(dialog, 'absolute', 158, -1906);
+
+      DialogUtils.close(editor);
+    });
+  });
+
+  context('TINY-9554: dialog position with editor in fixed container', () => {
+    const setupElement = () => {
+      const container = SugarElement.fromHtml('<div style="position: fixed; top: 0; left: 0;"></div>');
+      const element = SugarElement.fromTag('textarea');
+
+      Insert.append(SugarBody.body(), container);
+      Insert.append(container, element);
+
+      return {
+        element,
+        teardown: () => {
+          Remove.remove(element);
+          Remove.remove(container);
+        }
+      };
+    };
+
+    const hook = TinyHooks.bddSetupFromElement<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      resize: 'both',
+      height: 400,
+      width: 650,
+      toolbar_sticky: false,
+      toolbar_mode: 'wrap'
+    }, setupElement, []);
+
+    it('TINY-9554: test position', async () => {
+      const editor = hook.editor();
+      const dialog = openDialog(editor);
+      await pAssertPos(dialog, 'absolute', 158, -109);
 
       DialogUtils.close(editor);
     });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
@@ -121,7 +121,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogPositionTest', 
 
   context('TINY-9554: dialog position with editor in fixed container', () => {
     const setupElement = () => {
-      const container = SugarElement.fromHtml('<div style="position: fixed; top: 150px; left: 150px;"></div>');
+      const container = SugarElement.fromHtml('<div class="container" style="position: fixed; top: 150px; left: 150px;"></div>');
       const element = SugarElement.fromTag('textarea');
 
       Insert.append(SugarBody.body(), container);
@@ -143,11 +143,12 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogPositionTest', 
       menubar: false
     }, setupElement, []);
 
-    it('TINY-9554: test that the position of the dialog is inside the content of the editor', async () => {
+    it('TINY-9554: the dialog should be below the toolbar of the editor', () => {
       const editor = hook.editor();
       const dialog = openDialog(editor);
+      const editorToolbar = UiFinder.findIn(TinyDom.container(editor), '.tox-editor-header').getOrDie();
 
-      await pAssertPos(dialog, 'absolute', 306, 0);
+      assert.isTrue(editorToolbar.dom.getBoundingClientRect().bottom < dialog.dom.getBoundingClientRect().top);
 
       DialogUtils.close(editor);
     });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
@@ -143,7 +143,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogPositionTest', 
       menubar: false
     }, setupElement, []);
 
-    it('TINY-9554: test position', async () => {
+    it('TINY-9554: test that the position of the dialog is inside the content of the editor', async () => {
       const editor = hook.editor();
       const dialog = openDialog(editor);
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
@@ -1,6 +1,6 @@
 import { Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { Css, Height, Insert, Remove, Scroll, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
+import { Css, Dimension, Height, Insert, Remove, Scroll, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -121,7 +121,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogPositionTest', 
 
   context('TINY-9554: dialog position with editor in fixed container', () => {
     const setupElement = () => {
-      const container = SugarElement.fromHtml('<div style="position: fixed; top: 0; left: 0;"></div>');
+      const container = SugarElement.fromHtml('<div style="position: fixed; top: 150; left: 150;"></div>');
       const element = SugarElement.fromTag('textarea');
 
       Insert.append(SugarBody.body(), container);
@@ -138,17 +138,21 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogPositionTest', 
 
     const hook = TinyHooks.bddSetupFromElement<Editor>({
       base_url: '/project/tinymce/js/tinymce',
-      resize: 'both',
       height: 400,
       width: 650,
-      toolbar_sticky: false,
-      toolbar_mode: 'wrap'
+      menubar: false
     }, setupElement, []);
 
     it('TINY-9554: test position', async () => {
       const editor = hook.editor();
       const dialog = openDialog(editor);
-      await pAssertPos(dialog, 'absolute', 158, -109);
+      const editorHeader = UiFinder.findIn(TinyDom.container(editor), '.tox-editor-header').getOrDie();
+      const editorHeaderHeight = Dimension.parse(Css.get(
+        editorHeader,
+        'height'
+      ), [ 'unsupportedLength' ]).map((dim) => dim.value).getOr(0);
+
+      await pAssertPos(dialog, 'absolute', 158, editorHeaderHeight + 10);
 
       DialogUtils.close(editor);
     });

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestExtras.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestExtras.ts
@@ -77,6 +77,7 @@ export const TestExtras = (): TestExtras => {
     off: editorOff,
     insertContent: (_content: string, _args?: any) => {},
     execCommand: (_cmd: string, _ui?: boolean, _value?: any) => {},
+    getContainer: () => SugarBody.body().dom,
     ui: {
       show: Fun.noop
     },


### PR DESCRIPTION
Related Ticket: TINY-9554

Description of Changes:
The problem was that for inline dialogs we use to refer to the body even if the editor was not an inline editor, this does not work if the container of the editor is in position `fixed` or `absolute`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
