### PR TITLE
TINY-9595: Paste paragraphs in CET p in noneditable root

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -67,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Creating a list in a table cell when the caret is in front of an anchor element would not properly include the anchor in the list. #TINY-6853
 - Formatting could be applied or removed on noneditable list items inside a noneditable root. #TINY-9563
 - Annotation would not be removed if the annotation was immediately deleted after being created. #TINY-9399
-- Inserting element that were invalid in the closest editing host would incorectly split the editing host. #TINY-9595
+- Inserting elements that was not valid within the closest editing host would incorrectly split the editing host. #TINY-9595
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Creating a list in a table cell when the caret is in front of an anchor element would not properly include the anchor in the list. #TINY-6853
 - Formatting could be applied or removed on noneditable list items inside a noneditable root. #TINY-9563
 - Annotation would not be removed if the annotation was immediately deleted after being created. #TINY-9399
+- Inserting element that were invalid in the closest editing host would incorectly split the editing host. #TINY-9595
 
 ## 6.3.1 - 2022-12-06
 

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -610,10 +610,10 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
     if (validate && invalidChildren.length > 0) {
       if (args.context) {
         const { pass: topLevelChildren, fail: otherChildren } = Arr.partition(invalidChildren, (child) => child.parent === rootNode);
-        InvalidNodes.cleanInvalidNodes(otherChildren, schema, matchFinder);
+        InvalidNodes.cleanInvalidNodes(otherChildren, schema, rootNode, matchFinder);
         args.invalid = topLevelChildren.length > 0;
       } else {
-        InvalidNodes.cleanInvalidNodes(invalidChildren, schema, matchFinder);
+        InvalidNodes.cleanInvalidNodes(invalidChildren, schema, rootNode, matchFinder);
       }
     }
 

--- a/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
@@ -1,4 +1,4 @@
-import { Type, Unicode } from '@ephox/katamari';
+import { Optional, Type, Unicode } from '@ephox/katamari';
 
 import { ParserArgs } from '../api/html/DomParser';
 import AstNode from '../api/html/Node';
@@ -33,10 +33,27 @@ const isEmpty = (schema: Schema, nonEmptyElements: SchemaMap, whitespaceElements
 const isLineBreakNode = (node: AstNode | null | undefined, isBlock: (node: AstNode) => boolean): boolean =>
   Type.isNonNullable(node) && (isBlock(node) || node.name === 'br');
 
+const findClosestEditingHost = (scope: AstNode): Optional<AstNode> => {
+  let editableNode;
+
+  for (let node: AstNode | undefined | null = scope; node; node = node.parent) {
+    const contentEditable = node.attr('contenteditable');
+
+    if (contentEditable === 'false') {
+      break;
+    } else if (contentEditable === 'true') {
+      editableNode = node;
+    }
+  }
+
+  return Optional.from(editableNode);
+};
+
 export {
   paddEmptyNode,
   isPaddedWithNbsp,
   hasOnlyChild,
   isEmpty,
-  isLineBreakNode
+  isLineBreakNode,
+  findClosestEditingHost
 };

--- a/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
@@ -396,10 +396,10 @@ describe('browser.tinymce.core.DragDropOverridesTest', () => {
     it('TINY-9364: Should allow dropping an element onto a contenteditable=true element that is within a contenteditable=false element', async () => {
       const editor = hook.editor();
       const originalContent = '<div class="toDrag" style="margin: 40px; width: 1110px; height: 120px; background-color: blue;" contenteditable="false">To drag element</div>'
-      + '<div style="margin: 40px; width: 1110px; height: 120px; background-color: red;" contenteditable="false"><span class="destination" contenteditable="true">Destination element</span></div>';
+      + '<div style="margin: 40px; width: 1110px; height: 120px; background-color: red;" contenteditable="false"><div class="destination" contenteditable="true">Destination element</div></div>';
       const expectedContent = '<div style="margin: 40px; width: 1110px; height: 120px; background-color: red;" contenteditable="false">' +
-      '<div class="toDrag" style="margin: 40px; width: 1110px; height: 120px; background-color: blue;" contenteditable="false">To drag element</div>' +
-      '<span class="destination" contenteditable="true">Destination element</span>' +
+      '<div class="destination" contenteditable="true">' +
+      '<div class="toDrag" style="margin: 40px; width: 1110px; height: 120px; background-color: blue;" contenteditable="false">To drag element</div>Destination element</div>' +
     '</div>';
       editor.setContent(originalContent);
       await moveToDragElementToDestinationElement(editor, 0, 0);

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -775,7 +775,7 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
       editor.getBody().contentEditable = 'true';
     });
 
-    it('TINY-9595: insert paragraphs in a paragraph editing host paragraph should unwrap the paragraphs and not split the em', () => {
+    it('TINY-9595: insert paragraphs in a paragraph editing host paragraph should unwrap the paragraphs and not split the div and em', () => {
       const editor = hook.editor();
       const content = '<div contenteditable="false"><p contenteditable="true"><em>ad</em></p></div>';
 
@@ -786,7 +786,7 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
       TinyAssertions.assertContent(editor, '<div contenteditable="false"><p contenteditable="true"><em>abcd</em></p></div>');
     });
 
-    it('TINY-9595: insert div in a dvi editing host paragraph should not wrap the divs but split the em', () => {
+    it('TINY-9595: insert paragraphs in a div editing host with an em should split the em but not the div editing host', () => {
       const editor = hook.editor();
       const content = '<div contenteditable="false"><div contenteditable="true"><em>ad</em></div></div>';
 
@@ -795,6 +795,18 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
       TinySelections.setCursor(editor, [ 1, 0, 0, 0 ], 1);
       editor.insertContent('<p>b</p><p>c</p>');
       TinyAssertions.assertContent(editor, '<div contenteditable="false"><div contenteditable="true"><em>a</em><p>b</p><p>c</p><em>d</em></div></div>');
+    });
+
+    it('TINY-9595: insert paragraphs in a paragraph editing host in a noneditable root editor should unwrap the paragraphs', () => {
+      const editor = hook.editor();
+      const content = '<p contenteditable="true"><em>ad</em></p>';
+
+      editor.getBody().contentEditable = 'false';
+      editor.setContent(content);
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+      editor.insertContent('<p>b</p><p>c</p>');
+      editor.getBody().contentEditable = 'true';
+      TinyAssertions.assertContent(editor, '<p contenteditable="true"><em>abcd</em></p>');
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -774,5 +774,27 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
       TinyAssertions.assertContent(editor, '<div contenteditable="true">thelloxt</div>');
       editor.getBody().contentEditable = 'true';
     });
+
+    it('TINY-9595: insert paragraphs in a paragraph editing host paragraph should unwrap the paragraphs and not split the em', () => {
+      const editor = hook.editor();
+      const content = '<div contenteditable="false"><p contenteditable="true"><em>ad</em></p></div>';
+
+      editor.setContent(content);
+      // Shifted since fake caret is before div
+      TinySelections.setCursor(editor, [ 1, 0, 0, 0 ], 1);
+      editor.insertContent('<p>b</p><p>c</p>');
+      TinyAssertions.assertContent(editor, '<div contenteditable="false"><p contenteditable="true"><em>abcd</em></p></div>');
+    });
+
+    it('TINY-9595: insert div in a dvi editing host paragraph should not wrap the divs but split the em', () => {
+      const editor = hook.editor();
+      const content = '<div contenteditable="false"><div contenteditable="true"><em>ad</em></div></div>';
+
+      editor.setContent(content);
+      // Shifted since fake caret is before div
+      TinySelections.setCursor(editor, [ 1, 0, 0, 0 ], 1);
+      editor.insertContent('<p>b</p><p>c</p>');
+      TinyAssertions.assertContent(editor, '<div contenteditable="false"><div contenteditable="true"><em>a</em><p>b</p><p>c</p><em>d</em></div></div>');
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/ParserUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/ParserUtilsTest.ts
@@ -1,0 +1,66 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr, Optional } from '@ephox/katamari';
+import { assert } from 'chai';
+
+import AstNode from 'tinymce/core/api/html/Node';
+import { findClosestEditingHost } from 'tinymce/core/html/ParserUtils';
+
+type CeType = 'false' | 'true' | 'inherit' | 'none';
+type Branch = [AstNode, AstNode[]];
+
+describe('browser.tinymce.core.html.ParserUtilsTest', () => {
+  context('findClosestEditingHost', () => {
+    const generateContentEditableBranch = (states: CeType[]): Optional<Branch> => {
+      const generateNode = (type: CeType) => {
+        const node = AstNode.create('div');
+        if (type !== 'none') {
+          node.attr('contenteditable', type);
+        }
+        return node;
+      };
+
+      return Arr.head(states).map((first) => {
+        const firstNode = generateNode(first);
+        return Arr.foldl(states.slice(1), ([ node, nodes ], type) => {
+          const newNode = generateNode(type);
+          return [ node.append(newNode), nodes.concat([ newNode ]) ];
+        }, [ firstNode, [ firstNode ]]);
+      });
+    };
+
+    const testFindClosestEditingHost = (states: CeType[], expectedIndex: number) => {
+      const [ node, nodes ] = generateContentEditableBranch(states).getOrDie('Failed to generate branch');
+      const actualIndex = findClosestEditingHost(node).bind((host) => Arr.findIndex(nodes, (bnode) => bnode === host)).getOr(-1);
+      assert.equal(actualIndex, expectedIndex, 'Expect to find editing host at specified index in branch.');
+    };
+
+    it('Should not find a editing host on a node without a contentEditable attribute', () =>
+      testFindClosestEditingHost([ 'none' ], -1)
+    );
+
+    it('Should not find a editing host on a cef node', () =>
+      testFindClosestEditingHost([ 'false' ], -1)
+    );
+
+    it('Should find a editing host on a cet node', () =>
+      testFindClosestEditingHost([ 'true' ], 0)
+    );
+
+    it('Should not find a editing host on a only cef nodes', () =>
+      testFindClosestEditingHost([ 'false', 'false', 'false' ], -1)
+    );
+
+    it('Should find last cet if there are multiple one in a row', () =>
+      testFindClosestEditingHost([ 'true', 'true', 'true' ], 0)
+    );
+
+    it('Should find last cet just before a cef', () =>
+      testFindClosestEditingHost([ 'true', 'false', 'true', 'true' ], 2)
+    );
+
+    it('Should find last cet ignoring inherit', () =>
+      testFindClosestEditingHost([ 'true', 'inherit', 'inherit', 'true' ], 0)
+    );
+  });
+});
+

--- a/modules/tinymce/src/core/test/ts/browser/html/ParserUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/ParserUtilsTest.ts
@@ -3,7 +3,7 @@ import { Arr, Optional } from '@ephox/katamari';
 import { assert } from 'chai';
 
 import AstNode from 'tinymce/core/api/html/Node';
-import { findClosestEditingHost } from 'tinymce/core/html/ParserUtils';
+import * as ParserUtils from 'tinymce/core/html/ParserUtils';
 
 type CeType = 'false' | 'true' | 'inherit' | 'none';
 type Branch = [AstNode, AstNode[]];

--- a/modules/tinymce/src/core/test/ts/browser/html/ParserUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/ParserUtilsTest.ts
@@ -69,6 +69,10 @@ describe('browser.tinymce.core.html.ParserUtilsTest', () => {
     it('Should find last cet ignoring inherit', () =>
       testFindClosestEditingHost([ 'true', 'inherit', 'inherit', 'true' ], 0)
     );
+
+    it('Should find last cet ignoring none', () =>
+      testFindClosestEditingHost([ 'true', 'none', 'none', 'true' ], 0)
+    );
   });
 });
 

--- a/modules/tinymce/src/core/test/ts/browser/html/ParserUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/ParserUtilsTest.ts
@@ -30,7 +30,7 @@ describe('browser.tinymce.core.html.ParserUtilsTest', () => {
 
     const testFindClosestEditingHost = (states: CeType[], expectedIndex: number) => {
       const [ node, nodes ] = generateContentEditableBranch(states).getOrDie('Failed to generate branch');
-      const actualIndex = findClosestEditingHost(node).bind((host) => Arr.findIndex(nodes, (bnode) => bnode === host)).getOr(-1);
+      const actualIndex = ParserUtils.findClosestEditingHost(node).bind((host) => Arr.findIndex(nodes, (bnode) => bnode === host)).getOr(-1);
       assert.equal(actualIndex, expectedIndex, 'Expect to find editing host at specified index in branch.');
     };
 
@@ -40,6 +40,10 @@ describe('browser.tinymce.core.html.ParserUtilsTest', () => {
 
     it('Should not find a editing host on a cef node', () =>
       testFindClosestEditingHost([ 'false' ], -1)
+    );
+
+    it('Should not find a editing host on a inherit node', () =>
+      testFindClosestEditingHost([ 'inherit' ], -1)
     );
 
     it('Should find a editing host on a cet node', () =>
@@ -56,6 +60,10 @@ describe('browser.tinymce.core.html.ParserUtilsTest', () => {
 
     it('Should find last cet just before a cef', () =>
       testFindClosestEditingHost([ 'true', 'false', 'true', 'true' ], 2)
+    );
+
+    it('Should not find a editing host since the closest one is cef', () =>
+      testFindClosestEditingHost([ 'true', 'false' ], -1)
     );
 
     it('Should find last cet ignoring inherit', () =>


### PR DESCRIPTION
Related Ticket: TINY-9595

Description of Changes:
* Adds a fix for not splitting editing hosts
* Adds a way to find the closest editing host in ast nodes
* Fixed a test in drag drop that broke now that it does the correct thing

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
