### PR TITLE
TINY-9587: Increase help dialog horizontal rule contrast in dark mode

### DIFF
--- a/modules/oxide/gulpfile.js
+++ b/modules/oxide/gulpfile.js
@@ -108,7 +108,7 @@ gulp.task('monitor', function (done) {
     this.server.on('close', done);
   });
 
-  gulp.watch('./src/**/*').on('change', gulp.series('css', 'buildDemos', 'copyTinymce'));
+  gulp.watch('./src/**/*').on('change', gulp.series('css', 'buildDemos', 'buildSkinSwitcher', 'copyTinymce'));
 });
 
 //
@@ -130,4 +130,4 @@ gulp.task('build', gulp.series('clean', 'css'));
 gulp.task('default', gulp.series('build'));
 
 gulp.task('demo-build', gulp.series('css', 'less', 'minifyCss', 'buildDemos', 'buildSkinSwitcher'));
-gulp.task('watch', gulp.series('build', 'buildDemos', 'copyTinymce', 'buildSkinSwitcher', 'monitor'));
+gulp.task('watch', gulp.series('build', 'buildDemos', 'buildSkinSwitcher', 'copyTinymce', 'monitor'));

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -60,7 +60,7 @@
 @dialog-body-h2-text-color: @text-color;
 @dialog-body-h2-text-transform: none;
 
-@dialog-table-border-color: darken(@border-color, 55%);
+@dialog-table-border-color: @border-color;
 @dialog-nav-focus-background-color: fade(@color-tint, 10%);
 
 // These get stacked on top of the global dialog z-index (1100)

--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -24,7 +24,7 @@
 @content-ui-darkmode: false; // Change this to true to get white icons in the content such as bookmarks.
 
 // Colors
-@border-color: darken(@background-color, 6.5%);
+@border-color: contrast(@background-color, darken(@background-color, 30%), lighten(@background-color, 30%));
 @text-color: contrast(@background-color, @color-black, @color-white);
 @text-color-muted: contrast(@background-color, fade(@color-black, 70%), fade(@color-white, 50%));
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Templates will be parsed before preview and insertion to make preview consistent with inserted template content and prevent XSS. #TINY-9244
 - Pressing backspace in an empty line now preserves formatting in a previous empty line. #TINY-9454
 - Pressing enter inside the `inputfontsize` input would not move the focus back into the editor content. #TINY-9598
+- Improved contrast of border colors against the background color throughout the UI. #TINY-9587
 
 ### Changed
 - The `link` plugins context menu items will no longer appear for noneditable links. #TINY-9491


### PR DESCRIPTION
Related Ticket: TINY-9587

Description of Changes:

- update `@dialog-table-border-color`, `@border-color` to increase the contrast of the border colour in dialog in dark mode.
- update oxide `gulpfile` to fix button not working after hot reload

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
