### PR TITLE
TINY-9408: Fix sticky-toolbar transition in iframe mode

### DIFF
--- a/modules/oxide/src/less/theme/components/editor/editor.less
+++ b/modules/oxide/src/less/theme/components/editor/editor.less
@@ -34,7 +34,7 @@
     box-shadow: @editor-header-box-shadow;
     padding: @pad-xs 0;
 
-    :not(.tox-editor-dock-transition) {
+    &:not(.tox-editor-dock-transition) {
       transition: box-shadow .5s;
     }
   }

--- a/modules/oxide/src/less/theme/components/editor/editor.less
+++ b/modules/oxide/src/less/theme/components/editor/editor.less
@@ -33,7 +33,10 @@
     border-bottom: @editor-header-border;
     box-shadow: @editor-header-box-shadow;
     padding: @pad-xs 0;
-    transition: box-shadow .5s;
+
+    :not(.tox-editor-dock-transition) {
+      transition: box-shadow .5s;
+    }
   }
 
   &:not(.tox-tinymce-inline).tox-tinymce--toolbar-bottom .tox-editor-header {

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Annotation would not be removed if the annotation was immediately deleted after being created. #TINY-9399
 - Inserting a link for a selection from quickbars didn't preserve formatting. #TINY-9593
 - Inline dialog position was not correct when the editor wasn't inline and was contained in a `fixed` or `absolute` positioned element. #TINY-9554
+- Sticky toolbars would not have fade transition when undocking in classic iframe mode. #TINY-9408
 
 ## 6.3.2 - 2023-02-22
 


### PR DESCRIPTION
Related Ticket: TINY-9408

Description of Changes:
* Fix transition of sticky-toolbar in inline mode
* Toolbar would disappear immediately, when it is meant to fade out

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
