### PR TITLE
TINY-9616: add active flag to togglebutton

### DIFF
--- a/modules/bridge/src/main/ts/ephox/bridge/components/view/ViewButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/view/ViewButton.ts
@@ -28,6 +28,7 @@ export interface ViewNormalButtonSpec extends BaseButtonSpec<ViewButtonApi> {
 
 export interface ViewToggleButtonSpec extends BaseButtonSpec<ViewToggleButtonApi> {
   type: 'togglebutton';
+  active?: boolean;
   onAction: (api: ViewToggleButtonApi) => void;
 }
 
@@ -55,6 +56,7 @@ export interface ViewNormalButton extends Omit<BaseButton<ViewButtonApi>, 'text'
 
 export interface ViewToggleButton extends BaseButton<ViewToggleButtonApi> {
   type: 'togglebutton';
+  active: boolean;
   onAction: (api: ViewToggleButtonApi) => void;
 }
 export interface ViewButtonsGroup {
@@ -81,6 +83,7 @@ const normalButtonFields = [
 
 const toggleButtonFields = [
   ...baseButtonFields,
+  FieldSchema.defaultedBoolean('active', false),
   FieldSchema.requiredStringEnum('type', [ 'togglebutton' ])
 ];
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/view/ViewButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/view/ViewButtons.ts
@@ -78,7 +78,8 @@ export const renderButton = (spec: ViewButtonWithoutGroup, providers: UiFactoryB
     classes: buttonTypeClasses
       .concat(...spec.icon.isSome() && !hasIconAndText ? [ 'tox-button--icon' ] : [])
       .concat(...hasIconAndText ? [ 'tox-button--icon-and-text' ] : [])
-      .concat(...spec.borderless ? [ 'tox-button--naked' ] : []),
+      .concat(...spec.borderless ? [ 'tox-button--naked' ] : [])
+      .concat(...spec.type === 'togglebutton' && spec.active ? [ ViewButtonClasses.Ticked ] : []),
     attributes: tooltipAttributes
   };
   const extraBehaviours: Behaviours = [];

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewButtonsTest.ts
@@ -1,10 +1,12 @@
 import { UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
+import { Class } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import { ViewButtonClasses } from 'tinymce/themes/silver/ui/toolbar/button/ButtonClasses';
 
 describe('browser.tinymce.themes.silver.view.ViewButtonsTest', () => {
   context('Iframe mode', () => {
@@ -38,6 +40,34 @@ describe('browser.tinymce.themes.silver.view.ViewButtonsTest', () => {
               tooltip: 'button-without-toggle',
               icon: 'help',
               onAction: Fun.noop
+            },
+            {
+              type: 'group',
+              buttons: [
+                {
+                  type: 'togglebutton',
+                  text: 'button-active-true',
+                  active: true,
+                  tooltip: 'button-active-true',
+                  icon: 'help',
+                  onAction: Fun.noop
+                },
+                {
+                  type: 'togglebutton',
+                  text: 'button-active-false',
+                  active: false,
+                  tooltip: 'button-active-false',
+                  icon: 'help',
+                  onAction: Fun.noop
+                },
+                {
+                  type: 'togglebutton',
+                  text: 'button-no-active',
+                  tooltip: 'button-no-active',
+                  icon: 'help',
+                  onAction: Fun.noop
+                }
+              ]
             }
           ],
           onShow: (api: any) => {
@@ -63,6 +93,11 @@ describe('browser.tinymce.themes.silver.view.ViewButtonsTest', () => {
 
     const getSvg = (editor: Editor, name: string) => UiFinder.findIn<HTMLElement>(TinyDom.container(editor), `.tox-view button[title='${name}'] svg`).getOrDie().dom.innerHTML;
 
+    const getButtonByTitle = (title: string) => {
+      const editor = hook.editor();
+      return UiFinder.findIn<HTMLElement>(TinyDom.container(editor), `.tox-view button[title='${title}']`).getOrDie();
+    };
+
     it('TINY-9523: tooglable button can be toggled with the correct implementation', () => {
       const editor = hook.editor();
 
@@ -79,6 +114,21 @@ describe('browser.tinymce.themes.silver.view.ViewButtonsTest', () => {
       assert.equal(getSvg(editor, 'button-without-toggle'), initialbuttonWithoutToggleButtonSvg, 'click should not toggle icon');
       clickViewButton(editor, 'button-without-toggle');
       assert.equal(getSvg(editor, 'button-without-toggle'), initialbuttonWithoutToggleButtonSvg, 'click should not toggle icon');
+
+      toggleView('myview1');
+    });
+
+    it('TINY-9616: if is active is true the button should have ViewButtonClasses.Ticked', async () => {
+      const editor = hook.editor();
+      toggleView('myview2');
+      await UiFinder.pWaitFor('buttons should be showed', TinyDom.container(editor), '[title="button-active-true"]');
+
+      const buttonActiveTrue = getButtonByTitle('button-active-true');
+      assert.isTrue(Class.has(buttonActiveTrue, ViewButtonClasses.Ticked), 'button with active true should have ticked class');
+      const buttonActiveFalse = getButtonByTitle('button-active-false');
+      assert.isFalse(Class.has(buttonActiveFalse, ViewButtonClasses.Ticked), 'button with active false should not have ticked class');
+      const buttonNoActive = getButtonByTitle('button-no-active');
+      assert.isFalse(Class.has(buttonNoActive, ViewButtonClasses.Ticked), 'button without active flag should not have ticked class');
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9616

Description of Changes:
this add the active flag to  `togglebutton` to allow to have the correct active status when the view is open

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
