### PR TITLE
TINY-9603: Fix an invisible space after applying heading text_patterns

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inserting elements that was not valid within the closest editing host would incorrectly split the editing host. #TINY-9595
 - `color_cols` option was not respected in the `forecolor` or `backcolor` color swatches. #TINY-9560
 - Drag and dropping the last noneditable element out of its parent block would not properly pad the parent block element. #TINY-9606
+- Applying heading formats from `text_patterns` produced an invisible space before a word. #TINY-9603
 
 ## 6.3.2 - 2023-02-22
 

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/BlockPattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/BlockPattern.ts
@@ -1,4 +1,5 @@
 import { Arr, Obj, Optional, Type, Unicode } from '@ephox/katamari';
+import { SugarText, SugarElement } from '@ephox/sugar';
 
 import * as TextSearch from '../../alien/TextSearch';
 import DOMUtils from '../../api/dom/DOMUtils';
@@ -9,6 +10,8 @@ import Tools from '../../api/util/Tools';
 import { generatePathRange, resolvePathRange } from '../utils/PathRange';
 import * as Utils from '../utils/Utils';
 import { BlockPattern, BlockPatternMatch, Pattern, PatternSet } from './PatternTypes';
+
+const startsWithSingleSpace = (s: string): boolean => /^\s[^\s]/.test(s);
 
 const stripPattern = (dom: DOMUtils, block: Node, pattern: BlockPattern): void => {
   // The pattern could be across fragmented text nodes, so we need to find the end
@@ -23,6 +26,20 @@ const stripPattern = (dom: DOMUtils, block: Node, pattern: BlockPattern): void =
 
       Utils.deleteRng(dom, rng, (e: Node) => e === block);
     });
+
+    /**
+     * TINY-9603: If there is a single space between pattern.start and text (e.g. # 1)
+     * then it will be left in the text content and then can appear in certain circumstances.
+     * This is not an issue with multiple spaces because they are transformed to non-breaking ones.
+     *
+     * In this specific case we've decided to remove this single space whatsoever 
+     * as it feels to be the expected behavior.
+     */
+    const text = SugarElement.fromDom(node);
+    const textContent = SugarText.get(text);
+    if (startsWithSingleSpace(textContent)) {
+      SugarText.set(text, textContent.replace(/^\s/, ''));
+    }
   });
 };
 

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/BlockPattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/BlockPattern.ts
@@ -38,7 +38,7 @@ const stripPattern = (dom: DOMUtils, block: Node, pattern: BlockPattern): void =
     const text = SugarElement.fromDom(node);
     const textContent = SugarText.get(text);
     if (startsWithSingleSpace(textContent)) {
-      SugarText.set(text, textContent.replace(/^\s/, ''));
+      SugarText.set(text, textContent.slice(1));
     }
   });
 };

--- a/modules/tinymce/src/core/main/ts/textpatterns/core/BlockPattern.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/core/BlockPattern.ts
@@ -32,7 +32,7 @@ const stripPattern = (dom: DOMUtils, block: Node, pattern: BlockPattern): void =
      * then it will be left in the text content and then can appear in certain circumstances.
      * This is not an issue with multiple spaces because they are transformed to non-breaking ones.
      *
-     * In this specific case we've decided to remove this single space whatsoever 
+     * In this specific case we've decided to remove this single space whatsoever
      * as it feels to be the expected behavior.
      */
     const text = SugarElement.fromDom(node);

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
@@ -169,7 +169,7 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
     Utils.setContentAndPressEnter(editor, '##### a');
     TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h5', 'a'));
   });
-  
+
   it('H5 format on single word node with several spaces using enter', () => {
     const editor = hook.editor();
     Utils.setContentAndPressEnter(editor, '#   a'); // nbsp spaces here

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
@@ -119,37 +119,73 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
   it('H1 format on single word node using enter', () => {
     const editor = hook.editor();
     Utils.setContentAndPressEnter(editor, '# a');
-    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h1', ' a'));
+    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h1', 'a'));
+  });
+
+  it('H1 format on single word node with several spaces using enter', () => {
+    const editor = hook.editor();
+    Utils.setContentAndPressEnter(editor, '#   a'); // nbsp spaces here
+    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h1', '   a'));
   });
 
   it('H2 format on single word node using enter', () => {
     const editor = hook.editor();
     Utils.setContentAndPressEnter(editor, '## a');
-    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h2', ' a'));
+    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h2', 'a'));
+  });
+
+  it('H2 format on single word node with several spaces using enter', () => {
+    const editor = hook.editor();
+    Utils.setContentAndPressEnter(editor, '#   a'); // nbsp spaces here
+    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h2', '   a'));
   });
 
   it('H3 format on single word node using enter', () => {
     const editor = hook.editor();
     Utils.setContentAndPressEnter(editor, '### a');
-    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h3', ' a'));
+    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h3', 'a'));
+  });
+
+  it('H3 format on single word node with several spaces using enter', () => {
+    const editor = hook.editor();
+    Utils.setContentAndPressEnter(editor, '#   a'); // nbsp spaces here
+    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h3', '   a'));
   });
 
   it('H4 format on single word node using enter', () => {
     const editor = hook.editor();
     Utils.setContentAndPressEnter(editor, '#### a');
-    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h4', ' a'));
+    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h4', 'a'));
+  });
+
+  it('H4 format on single word node with several spaces using enter', () => {
+    const editor = hook.editor();
+    Utils.setContentAndPressEnter(editor, '#   a'); // nbsp spaces here
+    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h4', '   a'));
   });
 
   it('H5 format on single word node using enter', () => {
     const editor = hook.editor();
     Utils.setContentAndPressEnter(editor, '##### a');
-    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h5', ' a'));
+    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h5', 'a'));
+  });
+  
+  it('H5 format on single word node with several spaces using enter', () => {
+    const editor = hook.editor();
+    Utils.setContentAndPressEnter(editor, '#   a'); // nbsp spaces here
+    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h5', '   a'));
   });
 
   it('H6 format on single word node using enter', () => {
     const editor = hook.editor();
     Utils.setContentAndPressEnter(editor, '###### a');
-    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h6', ' a'));
+    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h6', 'a'));
+  });
+
+  it('H6 format on single word node with several spaces using enter', () => {
+    const editor = hook.editor();
+    Utils.setContentAndPressEnter(editor, '#   a'); // nbsp spaces here
+    TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h6', '   a'));
   });
 
   it('OL format on single word node using enter', () => {

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsTest.ts
@@ -136,7 +136,7 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
 
   it('H2 format on single word node with several spaces using enter', () => {
     const editor = hook.editor();
-    Utils.setContentAndPressEnter(editor, '#   a'); // nbsp spaces here
+    Utils.setContentAndPressEnter(editor, '##   a'); // nbsp spaces here
     TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h2', '   a'));
   });
 
@@ -148,7 +148,7 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
 
   it('H3 format on single word node with several spaces using enter', () => {
     const editor = hook.editor();
-    Utils.setContentAndPressEnter(editor, '#   a'); // nbsp spaces here
+    Utils.setContentAndPressEnter(editor, '###   a'); // nbsp spaces here
     TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h3', '   a'));
   });
 
@@ -160,7 +160,7 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
 
   it('H4 format on single word node with several spaces using enter', () => {
     const editor = hook.editor();
-    Utils.setContentAndPressEnter(editor, '#   a'); // nbsp spaces here
+    Utils.setContentAndPressEnter(editor, '####   a'); // nbsp spaces here
     TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h4', '   a'));
   });
 
@@ -172,7 +172,7 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
 
   it('H5 format on single word node with several spaces using enter', () => {
     const editor = hook.editor();
-    Utils.setContentAndPressEnter(editor, '#   a'); // nbsp spaces here
+    Utils.setContentAndPressEnter(editor, '#####   a'); // nbsp spaces here
     TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h5', '   a'));
   });
 
@@ -184,7 +184,7 @@ describe('browser.tinymce.core.textpatterns.TextPatternsTest', () => {
 
   it('H6 format on single word node with several spaces using enter', () => {
     const editor = hook.editor();
-    Utils.setContentAndPressEnter(editor, '#   a'); // nbsp spaces here
+    Utils.setContentAndPressEnter(editor, '######   a'); // nbsp spaces here
     TinyAssertions.assertContentStructure(editor, Utils.blockStructHelper('h6', '   a'));
   });
 


### PR DESCRIPTION
Related Ticket: TINY-9603

Description of Changes:
If there is a single space between pattern.start and text (e.g. `# 1`) then it will be left in the text content as an invisible one and then can be transformed to nbsp in certain circumstances. This is not an issue with multiple spaces because they are transformed to non-breaking ones straight away. I've decided to remove this single space whatsoever as it feels to be the expected behavior.

Other solution is to preserve this space by replacing it with `&nbsp;` so it will be visible to the user.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
