### PR TITLE
TINY-9606: Dragging single child CEF from block doesn't pad it

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Formatting could be applied or removed on noneditable list items inside a noneditable root. #TINY-9563
 - Annotation would not be removed if the annotation was immediately deleted after being created. #TINY-9399
 - Inserting a link for a selection from quickbars didn't preserve formatting. #TINY-9593
+- Drag and dropping the last noneditable element out of it's parent block would not properly pad the parent block element. #TINY-9606
 
 ## 6.3.2 - 2023-02-22
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -77,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Annotation would not be removed if the annotation was immediately deleted after being created. #TINY-9399
 - Inserting a link for a selection from quickbars didn't preserve formatting. #TINY-9593
 - Inline dialog position was not correct when the editor wasn't inline and was contained in a `fixed` or `absolute` positioned element. #TINY-9554
-- Drag and dropping the last noneditable element out of it's parent block would not properly pad the parent block element. #TINY-9606
+- Drag and dropping the last noneditable element out of its parent block would not properly pad the parent block element. #TINY-9606
 
 ## 6.3.2 - 2023-02-22
 

--- a/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
@@ -219,7 +219,7 @@ const removeElementWithPadding = (dom: DOMUtils, elm: HTMLElement) => {
   const parentBlock = dom.getParent(elm.parentNode, dom.isBlock);
 
   removeElement(elm);
-  if (parentBlock && dom.isEmpty(parentBlock)) {
+  if (parentBlock && parentBlock !== dom.getRoot() && dom.isEmpty(parentBlock)) {
     PaddingBr.fillWithPaddingBr(SugarElement.fromDom(parentBlock));
   }
 };

--- a/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/DragDropOverrides.ts
@@ -1,4 +1,5 @@
 import { Arr, Singleton, Throttler, Type } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
 
 import DOMUtils from './api/dom/DOMUtils';
 import { EventUtilsEvent } from './api/dom/EventUtils';
@@ -11,6 +12,7 @@ import VK from './api/util/VK';
 import * as ClosestCaretCandidate from './caret/ClosestCaretCandidate';
 import * as MousePosition from './dom/MousePosition';
 import * as NodeType from './dom/NodeType';
+import * as PaddingBr from './dom/PaddingBr';
 import * as ErrorReporter from './ErrorReporter';
 import { isUIElement } from './focus/FocusController';
 import * as Predicate from './util/Predicate';
@@ -213,6 +215,15 @@ const removeElement = (elm: HTMLElement) => {
   }
 };
 
+const removeElementWithPadding = (dom: DOMUtils, elm: HTMLElement) => {
+  const parentBlock = dom.getParent(elm.parentNode, dom.isBlock);
+
+  removeElement(elm);
+  if (parentBlock && dom.isEmpty(parentBlock)) {
+    PaddingBr.fillWithPaddingBr(SugarElement.fromDom(parentBlock));
+  }
+};
+
 const isLeftMouseButtonPressed = (e: EditorEvent<MouseEvent>) => e.button === 0;
 
 const applyRelPos = (state: State, position: MousePosition.PagePosition) => ({
@@ -315,7 +326,7 @@ const drop = (state: Singleton.Value<State>, editor: Editor) => (e: EditorEvent<
 
         if (!args.isDefaultPrevented()) {
           editor.undoManager.transact(() => {
-            removeElement(state.element);
+            removeElementWithPadding(editor.dom, state.element);
             editor.insertContent(editor.dom.getOuterHTML(targetClone));
             editor._selectionOverrides.hideFakeCaret();
           });


### PR DESCRIPTION
Related Ticket: TINY-9606

Description of Changes:
* Added padding if needed when dragging the last item out of a block.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
