### PR TITLE
TINY-9560: Fix `color_cols` option not being respected

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Annotation would not be removed if the annotation was immediately deleted after being created. #TINY-9399
 - Inserting a link for a selection from quickbars didn't preserve formatting. #TINY-9593
 - Inline dialog position was not correct when the editor wasn't inline and was contained in a `fixed` or `absolute` positioned element. #TINY-9554
+- `color_cols` option was not respected in the `forecolor` or `backcolor` color swatches. #TINY-9560
 
 ## 6.3.2 - 2023-02-22
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
@@ -8,8 +8,13 @@ import { Menu } from 'tinymce/core/api/ui/Ui';
 const foregroundId = 'forecolor';
 const backgroundId = 'hilitecolor';
 
+const defaultCols = 5;
+
 const calcCols = (colors: number): number =>
-  Math.max(5, Math.ceil(Math.sqrt(colors)));
+  Math.max(defaultCols, Math.ceil(Math.sqrt(colors)));
+
+const calcColsOption = (calculatedCols: number, fallbackCols: number): number =>
+  defaultCols === calculatedCols ? fallbackCols : calculatedCols;
 
 const mapColors = (colorMap: string[]): Menu.ChoiceMenuItemSpec[] => {
   const colors: Menu.ChoiceMenuItemSpec[] = [];
@@ -92,12 +97,12 @@ const register = (editor: Editor): void => {
 
   registerOption('color_cols_foreground', {
     processor: 'number',
-    default: calcCols(getColors(editor, foregroundId).length)
+    default: calcColsOption(calcCols(getColors(editor, backgroundId).length), option('color_cols')(editor))
   });
 
   registerOption('color_cols_background', {
     processor: 'number',
-    default: calcCols(getColors(editor, backgroundId).length)
+    default: calcColsOption(calcCols(getColors(editor, foregroundId).length), option('color_cols')(editor))
   });
 
   registerOption('custom_colors', {
@@ -125,7 +130,9 @@ const getColorCols = (editor: Editor, id: string): number => {
     return option('color_cols')(editor);
   }
 };
+
 const hasCustomColors = option('custom_colors');
+
 const getColors = (editor: Editor, id: string): Menu.ChoiceMenuItemSpec[] => {
   if (id === foregroundId && editor.options.isSet('color_map_foreground')) {
     return option<Menu.ChoiceMenuItemSpec[]>('color_map_foreground')(editor);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
@@ -97,12 +97,12 @@ const register = (editor: Editor): void => {
 
   registerOption('color_cols_foreground', {
     processor: 'number',
-    default: calcColsOption(calcCols(getColors(editor, backgroundId).length), option('color_cols')(editor))
+    default: calcColsOption(calcCols(getColors(editor, foregroundId).length), option('color_cols')(editor))
   });
 
   registerOption('color_cols_background', {
     processor: 'number',
-    default: calcColsOption(calcCols(getColors(editor, foregroundId).length), option('color_cols')(editor))
+    default: calcColsOption(calcCols(getColors(editor, backgroundId).length), option('color_cols')(editor))
   });
 
   registerOption('custom_colors', {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
@@ -1,5 +1,6 @@
 import { ApproxStructure, UiControls, UiFinder, Waiter } from '@ephox/agar';
 import { Assert, beforeEach, context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
 import { SugarBody, SugarShadowDom } from '@ephox/sugar';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
@@ -288,6 +289,43 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
       assertUiElementDoesNotExist(editor, 'div[data-mce-color="#FF0000"]');
       TinyUiActions.clickOnUi(editor, 'div[data-mce-color="#0000FF"]');
       Assert.eq('Cols is the expected value', getColorCols(editor, 'hilitecolor'), 3);
+    });
+  });
+
+  context('Custom Color Map Columns Test', () => {
+    const colorMap = [
+      '#2DC26B', 'Green',
+      '#F1C40F', 'Yellow',
+      '#E03E2D', 'Red',
+      '#B96AD9', 'Purple',
+      '#3598DB', 'Blue',
+      '#E67E23', 'Orange'
+    ];
+    const thirtySixColors = Arr.flatten([ colorMap, colorMap, colorMap, colorMap, colorMap, colorMap ]);
+    const fourtyNineColors = Arr.flatten([ thirtySixColors, colorMap, colorMap, [ '#ffffff', 'White' ]]);
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      toolbar: 'forecolor backcolor fontsize',
+      base_url: '/project/tinymce/js/tinymce',
+      color_map_foreground: thirtySixColors,
+      color_map_background: fourtyNineColors
+    }, [], true);
+
+    it('TINY-9184: color_map_foreground works as expected', async () => {
+      const editor = hook.editor();
+      setupContent(editor);
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      // Background Color swatch should have Math.sqrt(36) = 6 columns
+      Assert.eq('Cols is the expected value', getColorCols(editor, 'forecolor'), 6);
+    });
+
+    it('TINY-9184: color_map_background works as expected', async () => {
+      const editor = hook.editor();
+      setupContent(editor);
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Background color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      // Background Color swatch should have Math.sqrt(49) = 7 columns
+      Assert.eq('Cols is the expected value', getColorCols(editor, 'hilitecolor'), 7);
     });
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
@@ -168,6 +168,30 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
     });
   });
 
+  context('Custom Color Map Default Color Cols Sanity Test', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      toolbar: 'forecolor backcolor fontsize',
+      base_url: '/project/tinymce/js/tinymce',
+      color_cols: 3,
+    }, [], true);
+
+    it('TINY-9560: color_map_foreground has correct number of columns', async () => {
+      const editor = hook.editor();
+      setupContent(editor);
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      Assert.eq('Cols is the expected value', getColorCols(editor, 'forecolor'), 3);
+    });
+
+    it('TINY-9560: color_map_background has correct number of columns', async () => {
+      const editor = hook.editor();
+      setupContent(editor);
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Background color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      Assert.eq('Cols is the expected value', getColorCols(editor, 'hilitecolor'), 3);
+    });
+  });
+
   context('Custom Color Map Background Color Sanity Test', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       toolbar: 'forecolor backcolor fontsize',
@@ -176,6 +200,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
         '#0000FF', 'BLUE',
       ],
       color_cols_background: 3,
+      color_cols: 4
     }, [], true);
 
     it('TINY-9184: color_map_foreground works as expected', async () => {
@@ -185,7 +210,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
       await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
       assertUiElementDoesNotExist(editor, 'div[data-mce-color="#0000FF"]');
       assertUiElementDoesNotExist(editor, 'div[data-mce-color="#FF0000"]');
-      Assert.eq('Cols is the expected value', getColorCols(editor, 'forecolor'), 5);
+      Assert.eq('Cols is the expected value', getColorCols(editor, 'forecolor'), 4);
     });
 
     it('TINY-9184: color_map_background works as expected', async () => {
@@ -207,6 +232,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
         '#FF0000', 'RED',
       ],
       color_cols_foreground: 2,
+      color_cols: 4
     }, [], true);
 
     it('TINY-9184: color_map_foreground works as expected', async () => {
@@ -226,7 +252,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
       await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
       assertUiElementDoesNotExist(editor, 'div[data-mce-color="#FF0000"]');
       assertUiElementDoesNotExist(editor, 'div[data-mce-color="#0000FF"]');
-      Assert.eq('Cols is the expected value', getColorCols(editor, 'hilitecolor'), 5);
+      Assert.eq('Cols is the expected value', getColorCols(editor, 'hilitecolor'), 4);
     });
   });
 


### PR DESCRIPTION
Related Ticket: TINY-9560

Description of Changes:
* `forecolor` and `backcolor` color swatches did not have the correct number of columns when `color_cols` option was set
* `color_cols` option is now used as a fallback before the default number of columns for the `forecolor` and `backcolor` color swatches

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
