### PR TITLE
TINY-9635: Use NodeIterator to perform node and attribute validation when sanitization is disabled

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -458,9 +458,10 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
       let uid = 0;
       let node;
       while ((node = nodeIterator.nextNode())) {
-        uid = processNode(node, defaultedSettings, schema, uid);
+        // disable schema validation to allow all elements and attributes including those not in the schema spec
+        uid = processNode(node, { ...defaultedSettings, validate: false }, schema, uid);
         if (NodeType.isElement(node)) {
-          filterAttributes(node, defaultedSettings.validate, schema);
+          filterAttributes(node, false, schema);
         }
       }
     }

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -456,7 +456,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
     const wrappedHtml = format === 'xhtml' ? `<html xmlns="http://www.w3.org/1999/xhtml"><head></head><body>${content}</body></html>` : `<body>${content}</body>`;
     const body = parser.parseFromString(wrappedHtml, mimeType).body;
 
-    if (false) {
+    if (defaultedSettings.sanitize) {
       // Sanitize the content
       purify.sanitize(body, getPurifyConfig(defaultedSettings, mimeType));
       purify.removed = [];

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -197,14 +197,17 @@ const processNode = (node: Node, settings: DomParserSettings, schema: Schema, ui
   return uid;
 };
 
-const shouldKeepAttribute = (validate: boolean | undefined, schema: Schema, tagName: string, attrName: string): boolean =>
-  !validate || schema.isValid(tagName, attrName) || Strings.startsWith(attrName, 'data-') || Strings.startsWith(attrName, 'aria-');
+const shouldKeepAttribute = (settings: DomParserSettings, schema: Schema, tagName: string, attrName: string, attrValue: string): boolean =>
+  !(attrName in filteredUrlAttrs && URI.isInvalidUri(settings, attrValue, tagName)) &&
+  (!settings.validate || schema.isValid(tagName, attrName) || Strings.startsWith(attrName, 'data-') || Strings.startsWith(attrName, 'aria-'));
 
-const filterAttributes = (ele: Element, validate: boolean, schema: Schema): void => {
+const filterAttributes = (ele: Element, settings: DomParserSettings, schema: Schema): void => {
   const { attributes } = ele;
   for (let i = attributes.length - 1; i >= 0; i--) {
-    const attrName = attributes[i].name;
-    if (!shouldKeepAttribute(validate, schema, ele.tagName.toLowerCase(), attrName)) {
+    const attr = attributes[i];
+    const attrName = attr.name;
+    const attrValue = attr.value;
+    if (!shouldKeepAttribute(settings, schema, ele.tagName.toLowerCase(), attrName, attrValue)) {
       ele.removeAttribute(attrName);
     }
   }
@@ -224,10 +227,7 @@ const setupPurify = (settings: DomParserSettings, schema: Schema): DOMPurifyI =>
     const tagName = ele.tagName.toLowerCase();
     const { attrName, attrValue } = evt;
 
-    evt.keepAttr = shouldKeepAttribute(settings.validate, schema, tagName, attrName);
-    if (attrName in filteredUrlAttrs && URI.isInvalidUri(settings, attrValue, tagName)) {
-      evt.keepAttr = false;
-    }
+    evt.keepAttr = shouldKeepAttribute(settings, schema, tagName, attrName, attrValue);
 
     if (evt.keepAttr) {
       evt.allowedAttributes[attrName] = true;
@@ -460,7 +460,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
       while ((node = nodeIterator.nextNode())) {
         uid = processNode(node, defaultedSettings, schema, uid);
         if (NodeType.isElement(node)) {
-          filterAttributes(node, defaultedSettings.validate, schema);
+          filterAttributes(node, defaultedSettings, schema);
         }
       }
     }

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -458,10 +458,9 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
       let uid = 0;
       let node;
       while ((node = nodeIterator.nextNode())) {
-        // disable schema validation to allow all elements and attributes including those not in the schema spec
-        uid = processNode(node, { ...defaultedSettings, validate: false }, schema, uid);
+        uid = processNode(node, defaultedSettings, schema, uid);
         if (NodeType.isElement(node)) {
-          filterAttributes(node, false, schema);
+          filterAttributes(node, defaultedSettings.validate, schema);
         }
       }
     }

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -456,7 +456,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
     const wrappedHtml = format === 'xhtml' ? `<html xmlns="http://www.w3.org/1999/xhtml"><head></head><body>${content}</body></html>` : `<body>${content}</body>`;
     const body = parser.parseFromString(wrappedHtml, mimeType).body;
 
-    if (defaultedSettings.sanitize) {
+    if (false) {
       // Sanitize the content
       purify.sanitize(body, getPurifyConfig(defaultedSettings, mimeType));
       purify.removed = [];

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -460,7 +460,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
       while ((node = nodeIterator.nextNode())) {
         uid = processNode(node, defaultedSettings, schema, uid);
         if (NodeType.isElement(node)) {
-          filterAttributes(node, settings, schema);
+          filterAttributes(node, defaultedSettings, schema);
         }
       }
     }

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -197,14 +197,14 @@ const processNode = (node: Node, settings: DomParserSettings, schema: Schema, ui
   return uid;
 };
 
-const shouldKeepAttribute = (settings: DomParserSettings, schema: Schema, tagName: string, attrName: string): boolean =>
-  !settings.validate || schema.isValid(tagName, attrName) || Strings.startsWith(attrName, 'data-') || Strings.startsWith(attrName, 'aria-');
+const shouldKeepAttribute = (validate: boolean | undefined, schema: Schema, tagName: string, attrName: string): boolean =>
+  !validate || schema.isValid(tagName, attrName) || Strings.startsWith(attrName, 'data-') || Strings.startsWith(attrName, 'aria-');
 
-const filterAttributes = (ele: Element, settings: DomParserSettings, schema: Schema): void => {
+const filterAttributes = (ele: Element, validate: boolean, schema: Schema): void => {
   const { attributes } = ele;
   for (let i = attributes.length - 1; i >= 0; i--) {
     const attrName = attributes[i].name;
-    if (!shouldKeepAttribute(settings, schema, ele.tagName.toLowerCase(), attrName)) {
+    if (!shouldKeepAttribute(validate, schema, ele.tagName.toLowerCase(), attrName)) {
       ele.removeAttribute(attrName);
     }
   }
@@ -224,7 +224,7 @@ const setupPurify = (settings: DomParserSettings, schema: Schema): DOMPurifyI =>
     const tagName = ele.tagName.toLowerCase();
     const { attrName, attrValue } = evt;
 
-    evt.keepAttr = shouldKeepAttribute(settings, schema, tagName, attrName);
+    evt.keepAttr = shouldKeepAttribute(settings.validate, schema, tagName, attrName);
     if (attrName in filteredUrlAttrs && URI.isInvalidUri(settings, attrValue, tagName)) {
       evt.keepAttr = false;
     }
@@ -460,7 +460,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
       while ((node = nodeIterator.nextNode())) {
         uid = processNode(node, defaultedSettings, schema, uid);
         if (NodeType.isElement(node)) {
-          filterAttributes(node, defaultedSettings, schema);
+          filterAttributes(node, defaultedSettings.validate, schema);
         }
       }
     }

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -202,12 +202,8 @@ const shouldKeepAttribute = (settings: DomParserSettings, schema: Schema, tagNam
 
 const filterAttributes = (ele: Element, settings: DomParserSettings, schema: Schema) => {
   const { attributes } = ele;
-  if (!attributes) {
-    return;
-  }
   for (let i = attributes.length - 1; i >= 0; i--) {
     const attrName = attributes[i].name;
-
     if (!shouldKeepAttribute(settings, schema, ele.tagName.toLowerCase(), attrName)) {
       ele.removeAttribute(attrName);
     }

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -200,7 +200,7 @@ const processNode = (node: Node, settings: DomParserSettings, schema: Schema, ui
 const shouldKeepAttribute = (settings: DomParserSettings, schema: Schema, tagName: string, attrName: string): boolean =>
   !settings.validate || schema.isValid(tagName, attrName) || Strings.startsWith(attrName, 'data-') || Strings.startsWith(attrName, 'aria-');
 
-const filterAttributes = (ele: Element, settings: DomParserSettings, schema: Schema) => {
+const filterAttributes = (ele: Element, settings: DomParserSettings, schema: Schema): void => {
   const { attributes } = ele;
   for (let i = attributes.length - 1; i >= 0; i--) {
     const attrName = attributes[i].name;

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -11,7 +11,7 @@ import { isEmpty, isLineBreakNode, isPaddedWithNbsp, paddEmptyNode } from '../..
 import { BlobCache } from '../file/BlobCache';
 import Tools from '../util/Tools';
 import AstNode from './Node';
-import { getSanitizer } from './Sanitization';
+import { getSanitizer, internalElementAttr } from './Sanitization';
 import Schema, { getTextRootBlockElements, SchemaMap, SchemaRegExpMap } from './Schema';
 
 /**
@@ -357,7 +357,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
   };
 
   const isWrappableNode = (blockElements: SchemaMap, node: AstNode) => {
-    const isInternalElement = Type.isString(node.attr('data-mce-type'));
+    const isInternalElement = Type.isString(node.attr(internalElementAttr));
     const isInlineElement = node.type === 1 && (!Obj.has(blockElements, node.name) && !TransparentElements.isTransparentAstBlock(schema, node));
 
     return node.type === 3 || (isInlineElement && !isInternalElement);

--- a/modules/tinymce/src/core/main/ts/api/html/Sanitization.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Sanitization.ts
@@ -1,0 +1,212 @@
+import { Arr, Obj, Strings, Type } from '@ephox/katamari';
+import { Attribute, NodeTypes, Remove, Replication, SugarElement } from '@ephox/sugar';
+import createDompurify, { Config, DOMPurifyI } from 'dompurify';
+
+import * as NodeType from '../../dom/NodeType';
+import Tools from '../util/Tools';
+import * as URI from '../util/URI';
+import { DomParserSettings } from './DomParser';
+import Schema from './Schema';
+
+type MimeType = 'text/html' | 'application/xhtml+xml';
+type SanitizeFn = (body: HTMLElement, mimeType: MimeType) => void;
+
+// A list of attributes that should be filtered further based on the parser settings
+const filteredUrlAttrs = Tools.makeMap('src,href,data,background,action,formaction,poster,xlink:href');
+const internalElementAttr = 'data-mce-type';
+
+const processNode = (node: Node, settings: DomParserSettings, schema: Schema, uid: number, evt?: createDompurify.SanitizeElementHookEvent): number => {
+  const validate = settings.validate;
+  const specialElements = schema.getSpecialElements();
+
+  // Pad conditional comments if they aren't allowed
+  if (node.nodeType === NodeTypes.COMMENT && !settings.allow_conditional_comments && /^\[if/i.test(node.nodeValue ?? '')) {
+    node.nodeValue = ' ' + node.nodeValue;
+  }
+
+  const lcTagName = evt?.tagName ?? node.nodeName.toLowerCase();
+
+  // Just leave non-elements such as text and comments up to dompurify
+  if (node.nodeType !== NodeTypes.ELEMENT || lcTagName === 'body') {
+    return uid;
+  }
+
+  // Construct the sugar element wrapper
+  const element = SugarElement.fromDom(node) as SugarElement<Element>;
+
+  // Determine if we're dealing with an internal attribute
+  const isInternalElement = Attribute.has(element, internalElementAttr);
+
+  // Cleanup bogus elements
+  const bogus = Attribute.get(element, 'data-mce-bogus');
+  if (!isInternalElement && Type.isString(bogus)) {
+    if (bogus === 'all') {
+      Remove.remove(element);
+    } else {
+      Remove.unwrap(element);
+    }
+    return uid;
+  }
+
+  // Determine if the schema allows the element and either add it or remove it
+  const rule = schema.getElementRule(lcTagName);
+  if (validate && !rule) {
+    // If a special element is invalid, then remove the entire element instead of unwrapping
+    if (Obj.has(specialElements, lcTagName)) {
+      Remove.remove(element);
+    } else {
+      Remove.unwrap(element);
+    }
+    return uid;
+  } else {
+    if (Type.isNonNullable(evt)) {
+      evt.allowedTags[lcTagName] = true;
+    }
+  }
+
+  // Validate the element using the attribute rules
+  if (validate && rule && !isInternalElement) {
+    // Fix the attributes for the element, unwrapping it if we have to
+    Arr.each(rule.attributesForced ?? [], (attr) => {
+      Attribute.set(element, attr.name, attr.value === '{$uid}' ? `mce_${uid++}` : attr.value);
+    });
+    Arr.each(rule.attributesDefault ?? [], (attr) => {
+      if (!Attribute.has(element, attr.name)) {
+        Attribute.set(element, attr.name, attr.value === '{$uid}' ? `mce_${uid++}` : attr.value);
+      }
+    });
+
+    // If none of the required attributes were found then remove
+    if (rule.attributesRequired && !Arr.exists(rule.attributesRequired, (attr) => Attribute.has(element, attr))) {
+      Remove.unwrap(element);
+      return uid;
+    }
+
+    // If there are no attributes then remove
+    if (rule.removeEmptyAttrs && Attribute.hasNone(element)) {
+      Remove.unwrap(element);
+      return uid;
+    }
+
+    // Change the node name if the schema says to
+    if (rule.outputName && rule.outputName !== lcTagName) {
+      Replication.mutate(element, rule.outputName as keyof HTMLElementTagNameMap);
+    }
+  }
+
+  return uid;
+};
+
+const shouldKeepAttribute = (settings: DomParserSettings, schema: Schema, tagName: string, attrName: string, attrValue: string): boolean =>
+  !(attrName in filteredUrlAttrs && URI.isInvalidUri(settings, attrValue, tagName)) &&
+  (!settings.validate || schema.isValid(tagName, attrName) || Strings.startsWith(attrName, 'data-') || Strings.startsWith(attrName, 'aria-'));
+
+const isRequiredAttributeOfInternalElement = (ele: Element, attrName: string): boolean =>
+  ele.hasAttribute(internalElementAttr) && (attrName === 'id' || attrName === 'class' || attrName === 'style');
+
+const isBooleanAttribute = (attrName: string, schema: Schema): boolean =>
+  attrName in schema.getBoolAttrs();
+
+const filterAttributes = (ele: Element, settings: DomParserSettings, schema: Schema): void => {
+  const { attributes } = ele;
+  for (let i = attributes.length - 1; i >= 0; i--) {
+    const attr = attributes[i];
+    const attrName = attr.name;
+    const attrValue = attr.value;
+    if (!shouldKeepAttribute(settings, schema, ele.tagName.toLowerCase(), attrName, attrValue) && !isRequiredAttributeOfInternalElement(ele, attrName)) {
+      ele.removeAttribute(attrName);
+    } else if (isBooleanAttribute(attrName, schema)) {
+      ele.setAttribute(attrName, attrName);
+    }
+  }
+};
+
+const setupPurify = (settings: DomParserSettings, schema: Schema): DOMPurifyI => {
+  const purify = createDompurify();
+  let uid = 0;
+
+  // We use this to add new tags to the allow-list as we parse, if we notice that a tag has been banned but it's still in the schema
+  purify.addHook('uponSanitizeElement', (ele, evt) => {
+    uid = processNode(ele, settings, schema, uid, evt);
+  });
+
+  // Let's do the same thing for attributes
+  purify.addHook('uponSanitizeAttribute', (ele, evt) => {
+    const tagName = ele.tagName.toLowerCase();
+    const { attrName, attrValue } = evt;
+
+    evt.keepAttr = shouldKeepAttribute(settings, schema, tagName, attrName, attrValue);
+
+    if (evt.keepAttr) {
+      evt.allowedAttributes[attrName] = true;
+
+      if (isBooleanAttribute(attrName, schema)) {
+        evt.attrValue = attrName;
+      }
+
+      // We need to tell DOMPurify to forcibly keep the attribute if it's an SVG data URI and svg data URIs are allowed
+      if (settings.allow_svg_data_urls && Strings.startsWith(attrValue, 'data:image/svg+xml')) {
+        evt.forceKeepAttr = true;
+      }
+    // For internal elements always keep the attribute if the attribute name is id, class or style
+    } else if (isRequiredAttributeOfInternalElement(ele, attrName)) {
+      evt.forceKeepAttr = true;
+    }
+  });
+
+  return purify;
+};
+
+const basePurifyConfig: Config = {
+  IN_PLACE: true,
+  ALLOW_UNKNOWN_PROTOCOLS: true,
+  // Deliberately ban all tags and attributes by default, and then un-ban them on demand in hooks
+  // #comment and #cdata-section are always allowed as they aren't controlled via the schema
+  // body is also allowed due to the DOMPurify checking the root node before sanitizing
+  ALLOWED_TAGS: [ '#comment', '#cdata-section', 'body' ],
+  ALLOWED_ATTR: []
+};
+
+const getPurifyConfig = (settings: DomParserSettings, mimeType: string): Config => {
+  const config = { ...basePurifyConfig };
+
+  // Set the relevant parser mimetype
+  config.PARSER_MEDIA_TYPE = mimeType;
+
+  // Allow any URI when allowing script urls
+  if (settings.allow_script_urls) {
+    config.ALLOWED_URI_REGEXP = /.*/;
+  // Allow anything except javascript (or similar) URIs if all html data urls are allowed
+  } else if (settings.allow_html_data_urls) {
+    config.ALLOWED_URI_REGEXP = /^(?!(\w+script|mhtml):)/i;
+  }
+
+  return config;
+};
+
+const getSanitizer = (settings: DomParserSettings, schema: Schema): SanitizeFn => {
+  if (settings.sanitize) {
+    const purify = setupPurify(settings, schema);
+    return (body, mimeType) => {
+      purify.sanitize(body, getPurifyConfig(settings, mimeType));
+      purify.removed = [];
+    };
+  } else {
+    let uid = 0;
+    return (body, _) => {
+      // eslint-disable-next-line no-bitwise
+      const nodeIterator = document.createNodeIterator(body, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT | NodeFilter.SHOW_TEXT);
+      let node;
+      while ((node = nodeIterator.nextNode())) {
+        uid = processNode(node, settings, schema, uid);
+        if (NodeType.isElement(node)) {
+          filterAttributes(node, settings, schema);
+        }
+      }
+    };
+  }
+};
+
+export {
+  getSanitizer
+};

--- a/modules/tinymce/src/core/main/ts/api/html/Sanitization.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Sanitization.ts
@@ -204,5 +204,6 @@ const getSanitizer = (settings: DomParserSettings, schema: Schema): Sanitizer =>
 };
 
 export {
-  getSanitizer
+  getSanitizer,
+  internalElementAttr
 };

--- a/modules/tinymce/src/core/main/ts/api/html/Sanitization.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Sanitization.ts
@@ -1,6 +1,6 @@
 import { Arr, Obj, Strings, Type } from '@ephox/katamari';
 import { Attribute, NodeTypes, Remove, Replication, SugarElement } from '@ephox/sugar';
-import createDompurify, { Config, DOMPurifyI } from 'dompurify';
+import createDompurify, { Config, DOMPurifyI, SanitizeElementHookEvent } from 'dompurify';
 
 import * as NodeType from '../../dom/NodeType';
 import Tools from '../util/Tools';
@@ -16,7 +16,7 @@ const filteredUrlAttrs = Tools.makeMap('src,href,data,background,action,formacti
 const internalElementAttr = 'data-mce-type';
 
 let uid = 0;
-const processNode = (node: Node, settings: DomParserSettings, schema: Schema, evt?: createDompurify.SanitizeElementHookEvent): void => {
+const processNode = (node: Node, settings: DomParserSettings, schema: Schema, evt?: SanitizeElementHookEvent): void => {
   const validate = settings.validate;
   const specialElements = schema.getSpecialElements();
 

--- a/modules/tinymce/src/core/main/ts/api/util/URI.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/URI.ts
@@ -61,7 +61,8 @@ const decodeUri = (encodedUri: string) => {
 };
 
 export const isInvalidUri = (settings: SafeUriOptions, uri: string, tagName?: string): boolean => {
-  const decodedUri = decodeUri(uri);
+  // remove all whitespaces from decoded uri to prevent impact on regex matching
+  const decodedUri = decodeUri(uri).replace(/\s/g, '');
 
   if (settings.allow_script_urls) {
     return false;

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -311,7 +311,8 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
     { inline: true },
     { inline: false }
   ], (options) => {
-    const unsanitizedHtml = '<p><a href="javascript:alert(1)">XSS</a></p>';
+    const unsanitizedHtml = '<p id="action">XSS</p>';
+    const htmlText = 'XSS';
 
     context(`TINY-9600: Test unsanitized content with inline: ${options.inline} and xss_sanitization: true`, () => {
       const hook = TinyHooks.bddSetupLight<Editor>({
@@ -320,7 +321,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         ...options
       }, []);
 
-      const sanitizedHtml = '<p><a>XSS</a></p>';
+      const sanitizedHtml = '<p>XSS</p>';
 
       it('setContent with unsanitized content should set sanitized html', () => {
         const editor = hook.editor();
@@ -339,7 +340,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         const editor = hook.editor();
         editor.setContent(unsanitizedHtml);
         const text = editor.getContent({ format: 'text' });
-        assert.equal(text, 'XSS', 'Text should be retrieved from sanitized html');
+        assert.equal(text, htmlText, 'Text should be retrieved from sanitized html');
       });
 
       it('getContent tree with unsanitized content should get sanitized tree', () => {
@@ -395,7 +396,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         const editor = hook.editor();
         editor.setContent(unsanitizedHtml);
         const text = editor.getContent({ format: 'text' });
-        assert.equal(text, 'XSS', 'Text content from unsanitized html should not be altered');
+        assert.equal(text, htmlText, 'Text content from unsanitized html should not be altered');
       });
 
       it('getContent tree with unsanitized content should get unsanitized tree', () => {

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertUnsanitizedContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertUnsanitizedContentTest.ts
@@ -4,8 +4,8 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.content.InsertUnsanitizedContentTest', () => {
-  const unsanitizedHtml = '<p><a href="javascript:alert(1)">XSS</a></p>';
-  const sanitizedHtml = '<p><a>XSS</a></p>';
+  const unsanitizedHtml = '<p id="action">XSS</p>';
+  const sanitizedHtml = '<p>XSS</p>';
   const testInsertContent = (editor: Editor, content: string, expected: string) => {
     const initialContent = '<p>initial</p>';
     editor.setContent(initialContent);

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -37,1454 +37,1479 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
   schema.addValidChildren('+body[style]');
 
-  it('Parse element', () => {
-    const parser = DomParser({}, schema);
-    const root = parser.parse('<B title="title" class="class">test</B>');
-    assert.equal(serializer.serialize(root), '<b class="class" title="title">test</b>', 'Inline element');
-    assert.equal(root.firstChild?.type, 1, 'Element type');
-    assert.equal(root.firstChild?.name, 'b', 'Element name');
-    assert.deepEqual(
-      root.firstChild?.attributes, [
-        { name: 'title', value: 'title' },
-        { name: 'class', value: 'class' },
-      ] as unknown as Attributes,
-      'Element attributes'
-    );
-    assert.deepEqual(countNodes(root), { 'body': 1, 'b': 1, '#text': 1 }, 'Element attributes (count)');
-  });
-
-  it('Retains code inside a script', () => {
-    const parser = DomParser({}, schema);
-    const root = parser.parse('  \t\r\n  <SCRIPT>  \t\r\n   a < b > \t\r\n   </S' + 'CRIPT>   \t\r\n  ');
-    assert.equal(serializer.serialize(root), '<script>  \t\n   a < b > \t\n   </s' + 'cript>', 'Retain code inside SCRIPT');
-    assert.deepEqual(countNodes(root), { 'body': 1, 'script': 1, '#text': 1 }, 'Retain code inside SCRIPT (count)');
-  });
-
-  it('Whitespace', () => {
-    let parser = DomParser({}, schema);
-    let root = parser.parse('  \t\r\n  <B>  \t\r\n   test  \t\r\n   </B>   \t\r\n  ');
-    assert.equal(serializer.serialize(root), ' <b> test </b> ', 'Redundant whitespace (inline element)');
-    assert.deepEqual(countNodes(root), { 'body': 1, 'b': 1, '#text': 3 }, 'Redundant whitespace (inline element) (count)');
-
-    parser = DomParser({}, schema);
-    root = parser.parse('  \t\r\n  <P>  \t\r\n   test  \t\r\n   </P>   \t\r\n  ');
-    assert.equal(serializer.serialize(root), '<p>test</p>', 'Redundant whitespace (block element)');
-    assert.deepEqual(countNodes(root), { 'body': 1, 'p': 1, '#text': 1 }, 'Redundant whitespace (block element) (count)');
-
-    parser = DomParser({}, schema);
-    root = parser.parse('  \t\r\n  <SCRIPT>  \t\r\n   test  \t\r\n   </S' + 'CRIPT>   \t\r\n  ');
-    assert.equal(
-      serializer.serialize(root),
-      '<script>  \t\n   test  \t\n   </s' + 'cript>',
-      'Whitespace around and inside SCRIPT'
-    );
-    assert.deepEqual(countNodes(root), { 'body': 1, 'script': 1, '#text': 1 }, 'Whitespace around and inside SCRIPT (count)');
-
-    parser = DomParser({}, schema);
-    root = parser.parse('  \t\r\n  <STYLE>  \t\r\n   test  \t\r\n   </STYLE>   \t\r\n  ');
-    assert.equal(serializer.serialize(root), '<style>  \t\n   test  \t\n   </style>', 'Whitespace around and inside STYLE');
-    assert.deepEqual(countNodes(root), { 'body': 1, 'style': 1, '#text': 1 }, 'Whitespace around and inside STYLE (count)');
-
-    parser = DomParser({}, schema);
-    root = parser.parse('<ul>\n<li>Item 1\n<ul>\n<li>\n \t Indented \t \n</li>\n</ul>\n</li>\n</ul>\n');
-    assert.equal(
-      serializer.serialize(root),
-      '<ul><li>Item 1<ul><li>Indented</li></ul></li></ul>',
-      'Whitespace around and inside blocks (ul/li)'
-    );
-    assert.deepEqual(countNodes(root), { 'body': 1, 'li': 2, 'ul': 2, '#text': 2 }, 'Whitespace around and inside blocks (ul/li) (count)');
-
-    parser = DomParser({}, Schema({ invalid_elements: 'hr,br' }));
-    root = parser.parse(
-      '\n<hr />\n<br />\n<div>\n<hr />\n<br />\n<img src="file.gif" data-mce-src="file.gif" />\n<hr />\n<br />\n</div>\n<hr />\n<br />\n'
-    );
-    assert.equal(
-      serializer.serialize(root),
-      '<div><img src="file.gif" data-mce-src="file.gif"></div>',
-      'Whitespace where the parser will produce multiple whitespace nodes'
-    );
-    assert.deepEqual(
-      countNodes(root),
-      { body: 1, div: 1, img: 1 },
-      'Whitespace where the parser will produce multiple whitespace nodes (count)'
-    );
-  });
-
-  it('Whitespace before/after invalid element with text in block', () => {
-    const parser = DomParser({}, Schema({ invalid_elements: 'em' }));
-    const root = parser.parse('<p>a <em>b</em> c</p>');
-    assert.equal(serializer.serialize(root), '<p>a b c</p>');
-  });
-
-  it('Whitespace before/after invalid element whitespace element in block', () => {
-    const parser = DomParser({}, Schema({ invalid_elements: 'span' }));
-    const root = parser.parse('<p> <span></span> </p>');
-    assert.equal(serializer.serialize(root), '<p>\u00a0</p>');
-  });
-
-  it('Whitespace preserved in PRE', () => {
-    let parser = DomParser({}, schema);
-    let root = parser.parse('  \t\r\n  <PRE>  \t\r\n   test  \t\r\n   </PRE>   \t\r\n  ');
-    assert.equal(serializer.serialize(root), '<pre>  \t\n   test  \t\n   </pre>', 'Whitespace around and inside PRE');
-    assert.deepEqual(countNodes(root), { 'body': 1, 'pre': 1, '#text': 1 }, 'Whitespace around and inside PRE (count)');
-
-    parser = DomParser({}, schema);
-    root = parser.parse('<PRE>  </PRE>');
-    assert.equal(serializer.serialize(root), '<pre>  </pre>', 'Whitespace around and inside PRE');
-    assert.deepEqual(countNodes(root), { 'body': 1, 'pre': 1, '#text': 1 }, 'Whitespace around and inside PRE (count)');
-  });
-
-  it('Whitespace preserved in SPAN inside PRE', () => {
-    const parser = DomParser({}, schema);
-    const root = parser.parse('  \t\r\n  <PRE>  \t\r\n  <span>    test    </span> \t\r\n   </PRE>   \t\r\n  ');
-    assert.equal(
-      serializer.serialize(root),
-      '<pre>  \t\n  <span>    test    </span> \t\n   </pre>',
-      'Whitespace around and inside PRE'
-    );
-    assert.deepEqual(countNodes(root), { 'body': 1, 'pre': 1, 'span': 1, '#text': 3 }, 'Whitespace around and inside PRE (count)');
-  });
-
-  it('Whitespace preserved in code', () => {
-    let parser = DomParser({}, schema);
-    let root = parser.parse('<code>  a  </code>');
-    assert.equal(serializer.serialize(root), '<code>  a  </code>', 'Whitespace inside code');
-    assert.deepEqual(countNodes(root), { 'body': 1, 'code': 1, '#text': 1 }, 'Whitespace inside code (count)');
-
-    parser = DomParser({}, schema);
-    root = parser.parse('<code>  </code>');
-    assert.equal(serializer.serialize(root), '<code>  </code>', 'Whitespace inside code');
-    assert.deepEqual(countNodes(root), { 'body': 1, 'code': 1, '#text': 1 }, 'Whitespace inside code (count)');
-  });
-
-  it('Parse invalid contents', () => {
-    let parser = DomParser({}, schema);
-    let root = parser.parse('<p class="a"><p class="b">123</p></p>');
-    assert.equal(serializer.serialize(root), '<p class="a"></p><p class="b">123</p><p></p>', 'P in P, splits outer P');
-    assert.deepEqual(countNodes(root), { 'body': 1, 'p': 3, '#text': 1 }, 'P in P, splits outer P (count)');
-
-    parser = DomParser({}, schema);
-    root = parser.parse('<p class="a">a<p class="b">b</p><p class="c">c</p>d</p>');
-    assert.equal(
-      serializer.serialize(root),
-      '<p class="a">a</p><p class="b">b</p><p class="c">c</p>d<p></p>',
-      'Two P in P, splits outer P'
-    );
-    assert.deepEqual(countNodes(root), { 'body': 1, 'p': 4, '#text': 4 }, 'Two P in P, splits outer P (count)');
-
-    parser = DomParser({}, schema);
-    root = parser.parse('<p class="a">abc<p class="b">def</p></p>');
-    assert.equal(serializer.serialize(root), '<p class="a">abc</p><p class="b">def</p><p></p>', 'P in P with nodes before');
-    assert.deepEqual(countNodes(root), { 'body': 1, 'p': 3, '#text': 2 }, 'P in P with nodes before (count)');
-
-    parser = DomParser({}, schema);
-    root = parser.parse('<p class="a"><p class="b">abc</p>def</p>');
-    assert.equal(serializer.serialize(root), '<p class="a"></p><p class="b">abc</p>def<p></p>', 'P in P with nodes after');
-    assert.deepEqual(countNodes(root), { 'body': 1, 'p': 3, '#text': 2 }, 'P in P with nodes after (count)');
-
-    parser = DomParser({}, schema);
-    root = parser.parse('<p class="a"><p class="b">abc</p><br></p>');
-    assert.equal(serializer.serialize(root), '<p class="a"></p><p class="b">abc</p><br><p></p>', 'P in P with BR after');
-    assert.deepEqual(countNodes(root), { 'body': 1, 'p': 3, 'br': 1, '#text': 1 }, 'P in P with BR after (count)');
-
-    parser = DomParser({}, schema);
-    root = parser.parse('<p class="a">a<strong>b<span>c<em>d<p class="b">e</p>f</em>g</span>h</strong>i</p>');
-    assert.equal(
-      serializer.serialize(root),
-      '<p class="a">a<strong>b<span>c<em>d</em></span></strong></p>' +
-      '<p class="b"><strong><em>e</em></strong></p>' +
-      '<strong><em>f</em>gh</strong>i<p></p>',
-      'P in P wrapped in inline elements'
-    );
-    assert.deepEqual(
-      countNodes(root),
-      { 'body': 1, 'p': 3, '#text': 8, 'strong': 3, 'span': 1, 'em': 3 },
-      'P in P wrapped in inline elements (count)'
-    );
-
-    parser = DomParser({}, schema);
-    root = parser.parse('<p class="a">a<p class="b">b<p class="c">c</p>d</p>e</p>');
-    assert.equal(
-      serializer.serialize(root),
-      '<p class="a">a</p><p class="b">b</p><p class="c">c</p>d<p></p>e<p></p>',
-      'P in P in P with text before/after'
-    );
-    assert.deepEqual(countNodes(root), { 'body': 1, 'p': 5, '#text': 5 }, 'P in P in P with text before/after (count)');
-
-    parser = DomParser({}, schema);
-    root = parser.parse('<p>a<ul><li>b</li><li>c</li></ul>d</p>');
-    assert.equal(serializer.serialize(root), '<p>a</p><ul><li>b</li><li>c</li></ul>d<p></p>', 'UL inside P');
-    assert.deepEqual(countNodes(root), { 'body': 1, 'p': 2, 'ul': 1, 'li': 2, '#text': 4 }, 'UL inside P (count)');
-
-    parser = DomParser({}, schema);
-    root = parser.parse('<table><tr><td><tr>a</tr></td></tr></table>');
-    assert.equal(serializer.serialize(root), 'a<table><tbody><tr><td></td></tr><tr></tr></tbody></table>', 'TR inside TD');
-    assert.deepEqual(countNodes(root), { 'body': 1, 'table': 1, 'tbody': 1, 'tr': 2, 'td': 1, '#text': 1 }, 'TR inside TD (count)');
-
-    parser = DomParser({}, Schema({ valid_elements: 'p,section,div' }));
-    root = parser.parse('<div><section><p>a</p></section></div>');
-    assert.equal(serializer.serialize(root), '<div><section><p>a</p></section></div>', 'P inside SECTION');
-    assert.deepEqual(countNodes(root), { 'body': 1, 'div': 1, 'section': 1, 'p': 1, '#text': 1 }, 'P inside SECTION (count)');
-  });
-
-  it('Remove empty nodes', () => {
-    const parser = DomParser({}, Schema({ valid_elements: '-p,-span[id|style],-strong' }));
-    let root = parser.parse(
-      '<p>a<span></span><span> </span><span id="x">b</span><span id="y"></span></p><p></p><p><span></span></p><p> </p>'
-    );
-    assert.equal(serializer.serialize(root), '<p>a <span id="x">b</span><span id="y"></span></p>');
-
-    root = parser.parse('<p>a&nbsp;<span style="text-decoration: underline"> </span>&nbsp;b</p>');
-    assert.equal(serializer.serialize(root), '<p>a\u00a0<span style="text-decoration: underline"> </span>\u00a0b</p>');
-
-    root = parser.parse('<p>a&nbsp;<strong> </strong>&nbsp;b</p>');
-    assert.equal(serializer.serialize(root), '<p>a\u00a0<strong> </strong>\u00a0b</p>');
-
-    root = parser.parse('<p>a&nbsp;<span style="text-decoration: underline"></span>&nbsp;b</p>');
-    assert.equal(serializer.serialize(root), '<p>a\u00a0\u00a0b</p>');
-
-    root = parser.parse('<p>a&nbsp;<span> </span>&nbsp;b</p>');
-    assert.equal(serializer.serialize(root), '<p>a\u00a0 \u00a0b</p>');
-  });
-
-  it('Parse invalid contents with node filters', () => {
-    const parser = DomParser({}, schema);
-    parser.addNodeFilter('p', (nodes) => {
-      Arr.each(nodes, (node) => {
-        node.attr('class', 'x');
+  Arr.each([{
+    name: 'sanitization enabled (default)',
+    isSanitizeEnabled: true,
+    settings: { }
+  },
+  {
+    name: 'TINY-9635: sanitization disabled',
+    isSanitizeEnabled: false,
+    settings: { sanitize: false }
+  }], (scenario) => {
+    context(scenario.name, () => {
+      it('Parse element', () => {
+        const parser = DomParser(scenario.settings, schema);
+        const root = parser.parse('<B title="title" class="class">test</B>');
+        assert.equal(serializer.serialize(root), '<b class="class" title="title">test</b>', 'Inline element');
+        assert.equal(root.firstChild?.type, 1, 'Element type');
+        assert.equal(root.firstChild?.name, 'b', 'Element name');
+        assert.deepEqual(
+          root.firstChild?.attributes, [
+            { name: 'title', value: 'title' },
+            { name: 'class', value: 'class' },
+          ] as unknown as Attributes,
+          'Element attributes'
+        );
+        assert.deepEqual(countNodes(root), { 'body': 1, 'b': 1, '#text': 1 }, 'Element attributes (count)');
       });
-    });
-    const root = parser.parse('<p>a<p>123</p>b</p>');
-    assert.equal(serializer.serialize(root), '<p class="x">a</p><p class="x">123</p>b<p class="x"></p>', 'P should have class x');
-  });
 
-  it('Parse invalid contents with attribute filters', () => {
-    const parser = DomParser({}, schema);
-    parser.addAttributeFilter('class', (nodes) => {
-      Arr.each(nodes, (node) => {
-        node.attr('class', 'x');
+      it('Retains code inside a script', () => {
+        const parser = DomParser(scenario.settings, schema);
+        const root = parser.parse('  \t\r\n  <SCRIPT>  \t\r\n   a < b > \t\r\n   </S' + 'CRIPT>   \t\r\n  ');
+        assert.equal(serializer.serialize(root), '<script>  \t\n   a < b > \t\n   </s' + 'cript>', 'Retain code inside SCRIPT');
+        assert.deepEqual(countNodes(root), { 'body': 1, 'script': 1, '#text': 1 }, 'Retain code inside SCRIPT (count)');
       });
-    });
-    const root = parser.parse('<p class="y">a<p class="y">123</p>b</p>');
-    assert.equal(serializer.serialize(root), '<p class="x">a</p><p class="x">123</p>b<p></p>', 'P should have class x');
-  });
-
-  it('addNodeFilter', () => {
-    let result: ParseTestResult | undefined;
-
-    const parser = DomParser({}, schema);
-    parser.addNodeFilter('#comment', (nodes, name, args) => {
-      result = { nodes, name, args };
-    });
-    parser.parse('text<!--text1-->text<!--text2-->');
-
-    assert.deepEqual(result?.args, {}, 'Parser args');
-    assert.equal(result?.name, '#comment', 'Parser filter result name');
-    assert.equal(result?.nodes.length, 2, 'Parser filter result node');
-    assert.equal(result?.nodes[0].name, '#comment', 'Parser filter result node(0) name');
-    assert.equal(result?.nodes[0].value, 'text1', 'Parser filter result node(0) value');
-    assert.equal(result?.nodes[1].name, '#comment', 'Parser filter result node(1) name');
-    assert.equal(result?.nodes[1].value, 'text2', 'Parser filter result node(1) value');
-  });
-
-  it('addNodeFilter multiple names', () => {
-    const results: Record<string, ParseTestResult> = {};
-
-    const parser = DomParser({}, schema);
-    parser.addNodeFilter('#comment,#text', (nodes, name, args) => {
-      results[name] = { nodes, name, args };
-    });
-    parser.parse('text1<!--text1-->text2<!--text2-->');
-
-    assert.deepEqual(results['#comment'].args, {}, 'Parser args');
-    assert.equal(results['#comment'].name, '#comment', 'Parser filter result name');
-    assert.equal(results['#comment'].nodes.length, 2, 'Parser filter result node');
-    assert.equal(results['#comment'].nodes[0].name, '#comment', 'Parser filter result node(0) name');
-    assert.equal(results['#comment'].nodes[0].value, 'text1', 'Parser filter result node(0) value');
-    assert.equal(results['#comment'].nodes[1].name, '#comment', 'Parser filter result node(1) name');
-    assert.equal(results['#comment'].nodes[1].value, 'text2', 'Parser filter result node(1) value');
-    assert.deepEqual(results['#text'].args, {}, 'Parser args');
-    assert.equal(results['#text'].name, '#text', 'Parser filter result name');
-    assert.equal(results['#text'].nodes.length, 2, 'Parser filter result node');
-    assert.equal(results['#text'].nodes[0].name, '#text', 'Parser filter result node(0) name');
-    assert.equal(results['#text'].nodes[0].value, 'text1', 'Parser filter result node(0) value');
-    assert.equal(results['#text'].nodes[1].name, '#text', 'Parser filter result node(1) name');
-    assert.equal(results['#text'].nodes[1].value, 'text2', 'Parser filter result node(1) value');
-  });
-
-  it('addNodeFilter with parser args', () => {
-    let result: ParseTestResult | undefined;
-
-    const parser = DomParser({}, schema);
-    parser.addNodeFilter('#comment', (nodes, name, args) => {
-      result = { nodes, name, args };
-    });
-    parser.parse('text<!--text1-->text<!--text2-->', { value: 1 });
-
-    assert.deepEqual(result?.args, { value: 1 }, 'Parser args');
-  });
-
-  it('TINY-7847: removeNodeFilter', () => {
-    const parser = DomParser({});
-    const numFilters = parser.getNodeFilters().length;
-    let called = false;
-
-    const filter = (_nodes: AstNode[]) => {
-      called = true;
-    };
-    parser.addNodeFilter('th,td', filter);
-    parser.addNodeFilter('th,td', Fun.noop);
-
-    assert.lengthOf(parser.getNodeFilters(), numFilters + 2, 'Before removing filters');
-    parser.removeNodeFilter('th', filter);
-    assert.lengthOf(parser.getNodeFilters(), numFilters + 2, 'After removing the first th node filter');
-    assert.lengthOf(parser.getNodeFilters()[numFilters].callbacks, 1, 'th node callbacks');
-    parser.removeNodeFilter('th', Fun.noop);
-    assert.lengthOf(parser.getNodeFilters(), numFilters + 1, 'After removing the second th node filter');
-    parser.removeNodeFilter('th,td');
-    assert.lengthOf(parser.getNodeFilters(), numFilters, 'After removing all th and td node filters');
-
-    // Ensure that after being removed the filters aren't called
-    parser.parse('<table><tr><th></th><td></td></tr></table>');
-    assert.isFalse(called);
-  });
-
-  it('addAttributeFilter', () => {
-    let result: ParseTestResult | undefined;
-
-    const parser = DomParser({});
-    parser.addAttributeFilter('src', (nodes, name, args) => {
-      result = { nodes, name, args };
-    });
-    parser.parse('<b>a<img src="1.gif" />b<img src="1.gif" />c</b>');
-
-    assert.deepEqual(result?.args, {}, 'Parser args');
-    assert.equal(result?.name, 'src', 'Parser filter result name');
-    assert.equal(result?.nodes.length, 2, 'Parser filter result node');
-    assert.equal(result?.nodes[0].name, 'img', 'Parser filter result node(0) name');
-    assert.equal(result?.nodes[0].attr('src'), '1.gif', 'Parser filter result node(0) attr');
-    assert.equal(result?.nodes[1].name, 'img', 'Parser filter result node(1) name');
-    assert.equal(result?.nodes[1].attr('src'), '1.gif', 'Parser filter result node(1) attr');
-  });
-
-  it('addAttributeFilter multiple', () => {
-    const results: any = {};
-
-    const parser = DomParser({});
-    parser.addAttributeFilter('src,href', (nodes, name, args) => {
-      results[name] = { nodes, name, args };
-    });
-    parser.parse('<b><a href="1.gif">a</a><img src="1.gif" />b<img src="1.gif" /><a href="2.gif">c</a></b>');
-
-    assert.deepEqual(results.src.args, {}, 'Parser args');
-    assert.equal(results.src.name, 'src', 'Parser filter result name');
-    assert.equal(results.src.nodes.length, 2, 'Parser filter result node');
-    assert.equal(results.src.nodes[0].name, 'img', 'Parser filter result node(0) name');
-    assert.equal(results.src.nodes[0].attr('src'), '1.gif', 'Parser filter result node(0) attr');
-    assert.equal(results.src.nodes[1].name, 'img', 'Parser filter result node(1) name');
-    assert.equal(results.src.nodes[1].attr('src'), '1.gif', 'Parser filter result node(1) attr');
-    assert.deepEqual(results.href.args, {}, 'Parser args');
-    assert.equal(results.href.name, 'href', 'Parser filter result name');
-    assert.equal(results.href.nodes.length, 2, 'Parser filter result node');
-    assert.equal(results.href.nodes[0].name, 'a', 'Parser filter result node(0) name');
-    assert.equal(results.href.nodes[0].attr('href'), '1.gif', 'Parser filter result node(0) attr');
-    assert.equal(results.href.nodes[1].name, 'a', 'Parser filter result node(1) name');
-    assert.equal(results.href.nodes[1].attr('href'), '2.gif', 'Parser filter result node(1) attr');
-  });
-
-  it('TINY-8888: mutating addNodeFilter -> addAttributeFilter', () => {
-    const parser = DomParser({});
-    parser.addNodeFilter('img', (nodes) => {
-      Arr.each(nodes, (node) => node.attr('src', null));
-    });
-    parser.addAttributeFilter('src', () => {
-      assert.fail('second src filter should not run, because src was removed');
-    });
-    parser.parse('<b>a<img src="1.gif" />b</b>');
-  });
-
-  it('TINY-8888: mutating addNodeFilter -> addNodeFilter', () => {
-    const parser = DomParser({});
-    parser.addNodeFilter('img', (nodes) => {
-      Arr.each(nodes, (node) => node.remove());
-    });
-    parser.addNodeFilter('img', () => {
-      assert.fail('second img filter should not run, because img was removed');
-    });
-    parser.parse('<b>a<img src="1.gif" />b</b>');
-  });
-
-  it('TINY-8888: mutating addAttributeFilter -> addAttributeFilter', () => {
-    const parser = DomParser({});
-    parser.addAttributeFilter('src', (nodes) => {
-      Arr.each(nodes, (node) => node.attr('src', null));
-    });
-    parser.addAttributeFilter('src', () => {
-      assert.fail('second src filter should not run, because src was removed');
-    });
-    parser.parse('<b>a<img src="1.gif" />b</b>');
-  });
-
-  it('TINY-8888: mutating addAttributeFilter only removes matching nodes', () => {
-    const parser = DomParser({});
-    parser.addAttributeFilter('src', (nodes) => {
-      nodes[0].attr('src', null);
-    });
-    let ranIdFilter = false;
-    parser.addAttributeFilter('src', (nodes) => {
-      ranIdFilter = true;
-      assert.lengthOf(nodes, 1);
-      assert.equal(nodes[0].attr('src'), '2.gif');
-    });
-    parser.parse('<b>a<img src="1.gif" />b<img src="2.gif" />c</b>');
-    assert.isTrue(ranIdFilter, 'second filter should run, because only one src attribute was removed');
-  });
-
-  it('TINY-7847: removeAttributeFilter', () => {
-    const parser = DomParser({});
-    const numFilters = parser.getAttributeFilters().length;
-    let called = false;
-
-    const filter = (_nodes: AstNode[]) => {
-      called = true;
-    };
-    parser.addAttributeFilter('controls,poster', filter);
-    parser.addAttributeFilter('controls,poster', Fun.noop);
-
-    assert.lengthOf(parser.getAttributeFilters(), numFilters + 2, 'Before removing filters');
-    parser.removeAttributeFilter('controls', filter);
-    assert.lengthOf(parser.getAttributeFilters(), numFilters + 2, 'After removing the first controls attribute filter');
-    assert.lengthOf(parser.getAttributeFilters()[numFilters].callbacks, 1, 'controls attribute node callbacks');
-    parser.removeAttributeFilter('controls', Fun.noop);
-    assert.lengthOf(parser.getAttributeFilters(), numFilters + 1, 'After removing the second controls attribute filter');
-    parser.removeAttributeFilter('controls,poster');
-    assert.lengthOf(parser.getAttributeFilters(), numFilters, 'After removing all controls and poster attribute filter');
-
-    // Ensure that after being removed the filters aren't called
-    parser.parse('<video controls poster="about:blank"></video>');
-    assert.isFalse(called);
-  });
-
-  it('Fix orphan LI elements', () => {
-    let parser = DomParser({}, schema);
-    let root = parser.parse('<ul><li>a</li></ul><li>b</li>');
-    assert.equal(serializer.serialize(root), '<ul><li>a</li><li>b</li></ul>', 'LI moved to previous sibling UL');
-
-    parser = DomParser({}, schema);
-    root = parser.parse('<li>a</li><ul><li>b</li></ul>');
-    assert.equal(serializer.serialize(root), '<ul><li>a</li><li>b</li></ul>', 'LI moved to next sibling UL');
-
-    parser = DomParser({}, schema);
-    root = parser.parse('<ol><li>a</li></ol><li>b</li>');
-    assert.equal(serializer.serialize(root), '<ol><li>a</li><li>b</li></ol>', 'LI moved to previous sibling OL');
-
-    parser = DomParser({}, schema);
-    root = parser.parse('<li>a</li><ol><li>b</li></ol>');
-    assert.equal(serializer.serialize(root), '<ol><li>a</li><li>b</li></ol>', 'LI moved to next sibling OL');
-
-    parser = DomParser({}, schema);
-    root = parser.parse('<li>a</li>');
-    assert.equal(serializer.serialize(root), '<ul><li>a</li></ul>', 'LI wrapped in new UL');
-  });
-
-  it('Remove empty elements', () => {
-    const schema = Schema({ valid_elements: 'span,-a,img' });
-
-    let parser = DomParser({}, schema);
-    let root = parser.parse('<span></span><a href="#"></a>');
-    assert.equal(serializer.serialize(root), '<span></span>', 'Remove empty a element');
-
-    parser = DomParser({}, Schema({ valid_elements: 'span,a[name],img' }));
-    root = parser.parse('<span></span><a name="anchor"></a>');
-    assert.equal(serializer.serialize(root), '<span></span><a name="anchor"></a>', 'Leave a with name attribute');
-
-    parser = DomParser({}, Schema({ valid_elements: 'span,a[href],img[src]' }));
-    root = parser.parse('<span></span><a href="#"><img src="about:blank" /></a>');
-    assert.equal(
-      serializer.serialize(root),
-      '<span></span><a href="#"><img src="about:blank"></a>',
-      'Leave elements with img in it'
-    );
-  });
-
-  it('Self closing list elements', () => {
-    const schema = Schema();
-
-    const parser = DomParser({}, schema);
-    const root = parser.parse('<ul><li>1<li><b>2</b><li><em><b>3</b></em></ul>');
-    assert.equal(
-      serializer.serialize(root),
-      '<ul><li>1</li><li><strong>2</strong></li><li><em><strong>3</strong></em></li></ul>',
-      'Split out LI elements in LI elements.'
-    );
-  });
-
-  it('Remove redundant br elements', () => {
-    const schema = Schema();
-
-    const parser = DomParser({ remove_trailing_brs: true }, schema);
-    const root = parser.parse(
-      '<p>a<br></p>' +
-      '<p>a<br>b<br></p>' +
-      '<p>a<br><br></p><p>a<br><span data-mce-type="bookmark"></span><br></p>' +
-      '<p>a<span data-mce-type="bookmark"></span><br></p>'
-    );
-    assert.equal(
-      serializer.serialize(root),
-      '<p>a</p><p>a<br>b</p><p>a<br><br></p><p>a<br><br></p><p>a</p>',
-      'Remove traling br elements.'
-    );
-  });
-
-  it('Replace br with nbsp when wrapped in two inline elements and one block', () => {
-    const schema = Schema();
-
-    const parser = DomParser({ remove_trailing_brs: true }, schema);
-    const root = parser.parse('<p><strong><em><br /></em></strong></p>');
-    assert.equal(serializer.serialize(root), '<p><strong><em>\u00a0</em></strong></p>');
-  });
-
-  it('Replace br with nbsp when wrapped in an inline element and placed in the root', () => {
-    const schema = Schema();
-
-    const parser = DomParser({ remove_trailing_brs: true }, schema);
-    const root = parser.parse('<strong><br /></strong>');
-    assert.equal(serializer.serialize(root), '<strong>\u00a0</strong>');
-  });
-
-  it(`Don't replace br inside root element when there is multiple brs`, () => {
-    const schema = Schema();
-
-    const parser = DomParser({ remove_trailing_brs: true }, schema);
-    const root = parser.parse('<strong><br /><br /></strong>');
-    assert.equal(serializer.serialize(root), '<strong><br><br></strong>');
-  });
-
-  it(`Don't replace br inside root element when there is siblings`, () => {
-    const schema = Schema();
-
-    const parser = DomParser({ remove_trailing_brs: true }, schema);
-    const root = parser.parse('<strong><br /></strong><em>x</em>');
-    assert.equal(serializer.serialize(root), '<strong><br></strong><em>x</em>');
-  });
-
-  it('Remove br in invalid parent bug', () => {
-    const schema = Schema({ valid_elements: 'br' });
-
-    const parser = DomParser({ remove_trailing_brs: true }, schema);
-    const root = parser.parse('<br>');
-    assert.equal(serializer.serialize(root), '', 'Remove traling br elements.');
-  });
-
-  it('Forced root blocks', () => {
-    const schema = Schema();
-
-    const parser = DomParser({ forced_root_block: 'p' }, schema);
-    const root = parser.parse(
-      '<!-- a -->' +
-      'b' +
-      '<b>c</b>' +
-      '<p>d</p>' +
-      '<p>e</p>' +
-      'f' +
-      '<b>g</b>' +
-      'h'
-    );
-    assert.equal(
-      serializer.serialize(root),
-      '<!-- a --><p>b<strong>c</strong></p><p>d</p><p>e</p><p>f<strong>g</strong>h</p>',
-      'Mixed text nodes, inline elements and blocks.'
-    );
-  });
-
-  it('Forced root blocks attrs', () => {
-    const schema = Schema();
-
-    const parser = DomParser({ forced_root_block: 'p', forced_root_block_attrs: { class: 'class1' }}, schema);
-    const root = parser.parse(
-      '<!-- a -->' +
-      'b' +
-      '<b>c</b>' +
-      '<p>d</p>' +
-      '<p>e</p>' +
-      'f' +
-      '<b>g</b>' +
-      'h'
-    );
-    assert.equal(serializer.serialize(root), '<!-- a -->' +
-      '<p class="class1">b<strong>c</strong></p>' +
-      '<p>d</p>' +
-      '<p>e</p>' +
-      '<p class="class1">f<strong>g</strong>h</p>',
-    'Mixed text nodes, inline elements and blocks.');
-  });
-
-  it('Parse html4 lists into html5 lists', () => {
-    const schema = Schema();
-
-    const parser = DomParser({ fix_list_elements: true }, schema);
-    const root = parser.parse('<ul><ul><li>a</li></ul></ul><ul><li>a</li><ul><li>b</li></ul></ul>');
-    assert.equal(
-      serializer.serialize(root),
-      '<ul><li style="list-style-type: none"><ul><li>a</li></ul></li></ul><ul><li>a<ul><li>b</li></ul></li></ul>'
-    );
-  });
-
-  it('Parse contents with html4 anchors and allow_html_in_named_anchor: false', () => {
-    const schema = Schema();
-
-    const parser = DomParser({ allow_html_in_named_anchor: false }, schema);
-    const root = parser.parse('<a name="x">a</a><a href="x">x</a>');
-    assert.equal(serializer.serialize(root), '<a name="x"></a>a<a href="x">x</a>');
-  });
-
-  it('Parse contents with html5 anchors and allow_html_in_named_anchor: false', () => {
-    const schema = Schema({ schema: 'html5' });
-
-    const parser = DomParser({ allow_html_in_named_anchor: false }, schema);
-    const root = parser.parse('<a id="x">a</a><a href="x">x</a>');
-    assert.equal(serializer.serialize(root), '<a id="x"></a>a<a href="x">x</a>');
-  });
-
-  it('Parse contents with html4 anchors and allow_html_in_named_anchor: true', () => {
-    const schema = Schema();
-
-    const parser = DomParser({ allow_html_in_named_anchor: true }, schema);
-    const root = parser.parse('<a name="x">a</a><a href="x">x</a>');
-    assert.equal(serializer.serialize(root), '<a name="x">a</a><a href="x">x</a>');
-  });
-
-  it('Parse contents with html5 anchors and allow_html_in_named_anchor: true', () => {
-    const schema = Schema({ schema: 'html5' });
-
-    const parser = DomParser({ allow_html_in_named_anchor: true }, schema);
-    const root = parser.parse('<a id="x">a</a><a href="x">x</a>');
-    assert.equal(serializer.serialize(root), '<a id="x">a</a><a href="x">x</a>');
-  });
-
-  it('Parse contents with html5 self closing datalist options', () => {
-    const schema = Schema({ schema: 'html5' });
-
-    const parser = DomParser({}, schema);
-    const root = parser.parse(
-      '<datalist><option label="a1" value="b1"><option label="a2" value="b2"><option label="a3" value="b3"></datalist>'
-    );
-    assert.equal(
-      serializer.serialize(root),
-      '<datalist><option label="a1" value="b1"></option><option label="a2" value="b2"></option>' +
-      '<option label="a3" value="b3"></option></datalist>'
-    );
-  });
-
-  it('Parse inline contents before block bug #5424', () => {
-    const schema = Schema({ schema: 'html5' });
-
-    const parser = DomParser({}, schema);
-    const root = parser.parse('<strong>1</strong> 2<p>3</p>');
-    assert.equal(serializer.serialize(root), '<strong>1</strong> 2<p>3</p>');
-  });
-
-  it('Invalid text blocks within a li', () => {
-    const schema = Schema({ schema: 'html5', valid_children: '-li[p]' });
-
-    const parser = DomParser({}, schema);
-    const root = parser.parse('<ul><li>1<p>2</p></li><li>a<p>b</p><p>c</p></li></ul>');
-    assert.equal(serializer.serialize(root), '<ul><li>12</li><li>ab</li><li>c</li></ul>');
-  });
-
-  it('Invalid inline element with space before', () => {
-    const schema = Schema();
-
-    const parser = DomParser({}, schema);
-    const root = parser.parse('<p><span>1</span> <strong>2</strong></p>');
-    assert.equal(serializer.serialize(root), '<p>1 <strong>2</strong></p>');
-  });
-
-  it('Valid classes', () => {
-    const schema = Schema({ valid_classes: 'classA classB' });
-
-    const parser = DomParser({}, schema);
-    const root = parser.parse('<p class="classA classB classC">a</p>');
-    assert.equal(serializer.serialize(root), '<p class="classA classB">a</p>');
-  });
-
-  it('Valid classes multiple elements', () => {
-    const schema = Schema({ valid_classes: { '*': 'classA classB', 'strong': 'classC' }});
-
-    const parser = DomParser({}, schema);
-    const root = parser.parse('<p class="classA classB classC"><strong class="classA classB classC classD">a</strong></p>');
-    assert.equal(serializer.serialize(root), '<p class="classA classB"><strong class="classA classB classC">a</strong></p>');
-  });
-
-  it('Pad empty list blocks', () => {
-    const schema = Schema();
-
-    const parser = DomParser({}, schema);
-    const root = parser.parse('<ul><li></li></ul><ul><li> </li></ul>');
-    assert.equal(serializer.serialize(root), '<ul><li>\u00a0</li></ul><ul><li>\u00a0</li></ul>');
-  });
-
-  it('Pad empty and prefer br on insert', () => {
-    const schema = Schema();
-
-    const parser = DomParser({}, schema);
-    const root = parser.parse('<ul><li></li><li> </li><li><br /></li><li>\u00a0</li><li>a</li></ul>', { insert: true });
-    assert.equal(serializer.serialize(root), '<ul><li><br data-mce-bogus="1"></li><li><br data-mce-bogus="1"></li><li><br></li><li><br data-mce-bogus="1"></li><li>a</li></ul>');
-  });
-
-  it('Preserve space in inline span', () => {
-    const schema = Schema();
-
-    const parser = DomParser({}, schema);
-    const root = parser.parse('a<span> </span>b');
-    assert.equal(serializer.serialize(root), 'a b');
-  });
-
-  it('Bug #7543 removes whitespace between bogus elements before a block', () => {
-    const serializer = HtmlSerializer();
-
-    assert.equal(
-      serializer.serialize(DomParser().parse(
-        '<div><b data-mce-bogus="1">a</b> <b data-mce-bogus="1">b</b><p>c</p></div>')
-      ),
-      '<div>a b<p>c</p></div>'
-    );
-  });
-
-  it('Bug #7582 removes whitespace between bogus elements before a block', () => {
-    const serializer = HtmlSerializer();
-
-    assert.equal(
-      serializer.serialize(DomParser().parse(
-        '<div>1 <span data-mce-bogus="1">2</span><div>3</div></div>')
-      ),
-      '<div>1 2<div>3</div></div>'
-    );
-  });
-
-  it('do not replace starting linebreak with space', () => {
-    const serializer = HtmlSerializer();
-
-    assert.equal(
-      serializer.serialize(DomParser().parse('<p>a<br />\nb</p>')),
-      '<p>a<br>b</p>'
-    );
-  });
-
-  it('Preserve internal elements', () => {
-    const html = '<span id="id" class="class"><b>text</b></span><span id="test" data-mce-type="something"></span>';
-
-    const parser1 = DomParser({}, Schema({ valid_elements: 'b' }));
-    const serializerHtml1 = serializer.serialize(parser1.parse(html));
-    assert.equal(
-      serializerHtml1,
-      '<b>text</b><span id="test" data-mce-type="something"></span>',
-      'Preserve internal span element without any span schema rule.'
-    );
-
-    const parser2 = DomParser({}, Schema({ valid_elements: 'b,span[class]' }));
-    const serializerHtml2 = serializer.serialize(parser2.parse(html));
-    assert.equal(
-      serializerHtml2,
-      '<span class="class"><b>text</b></span><span id="test" data-mce-type="something"></span>',
-      'Preserve internal span element with a span schema rule.'
-    );
-
-    const serializedHtml3 = serializer.serialize(parser1.parse('<b data-mce-type="test" id="x" style="color: red" src="1" data="2" onclick="3"></b>'));
-    assert.equal(
-      serializedHtml3,
-      '<b data-mce-type="test" id="x" style="color: red"></b>',
-      'Removes disallowed elements'
-    );
-  });
-
-  // TODO: TINY-4627/TINY-8363 - the iframe innerHTML on safari is `&lt;textarea&gt;` whereas on other browsers
-  //       is `<textarea>`. This causes the mXSS cleaner in DOMPurify to run and causes the different assertions below
-  it('parse iframe XSS', () => {
-    const serializer = HtmlSerializer();
-
-    assert.equal(
-      serializer.serialize(DomParser().parse('<iframe><textarea></iframe><img src="a" onerror="alert(document.domain)" />')),
-      browser.isSafari() ? '<iframe><textarea></iframe><img src="a">' : '<img src="a">'
-    );
-  });
-
-  it('Conditional comments (allowed)', () => {
-    const parser = DomParser({ allow_conditional_comments: true, validate: false }, schema);
-    const html = '<!--[if gte IE 4]>alert(1)<![endif]-->';
-    const serializedHtml = serializer.serialize(parser.parse(html));
-    assert.equal(serializedHtml, '<!--[if gte IE 4]>alert(1)<![endif]-->');
-  });
-
-  it('Conditional comments (denied)', () => {
-    const parser = DomParser({ allow_conditional_comments: false, validate: false }, schema);
-
-    let serializedHtml = serializer.serialize(parser.parse('<!--[if gte IE 4]>alert(1)<![endif]-->'));
-    assert.equal(serializedHtml, '<!-- [if gte IE 4]>alert(1)<![endif]-->');
-
-    serializedHtml = serializer.serialize(parser.parse('<!--[if !IE]>alert(1)<![endif]-->'));
-    assert.equal(serializedHtml, '<!-- [if !IE]>alert(1)<![endif]-->');
-
-    serializedHtml = serializer.serialize(parser.parse('<!--[iF !IE]>alert(1)<![endif]-->'));
-    assert.equal(serializedHtml, '<!-- [iF !IE]>alert(1)<![endif]-->');
-  });
-
-  it('allow_script_urls should allow any URIs', () => {
-    const parser = DomParser({ allow_script_urls: true });
-    const html = '<a href="javascript:alert(1)">1</a>' +
-      '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">3</a>';
-    const serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml,
-      '<a href="javascript:alert(1)">1</a>' +
-      '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">3</a>'
-    );
-  });
-
-  it('allow_html_data_urls should allow any data URIs, but not script URIs', () => {
-    const parser = DomParser({ allow_html_data_urls: true });
-    const html = '<a href="javascript:alert(1)">1</a>' +
-      '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">2</a>' +
-      '<a href="data:image/svg+xml;base64,x">3</a>';
-    const serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml,
-      '<a>1</a>' +
-      '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">2</a>' +
-      '<a href="data:image/svg+xml;base64,x">3</a>'
-    );
-  });
-
-  it('Parse script urls (disallow svg data image uris)', () => {
-    const parser = DomParser({ allow_svg_data_urls: false, allow_html_data_urls: false, validate: false }, schema);
-    const html = '<a href="data:image/svg+xml;base64,x">1</a>' +
-      '<img src="data:image/svg+xml;base64,x">';
-    const serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(
-      serializedHtml,
-      '<a>1</a>' +
-      '<img>'
-    );
-  });
-
-  it('Parse script urls (denied)', () => {
-    const parser = DomParser({ allow_script_urls: false, validate: false }, schema);
-    const html = '<a href="jAvaScript:alert(1)">1</a>' +
-      '<a href="vbscript:alert(2)">2</a>' +
-      '<a href="javascript:alert(3)">3</a>' +
-      '<a href="\njavascript:alert(4)">4</a>' +
-      '<a href="java\nscript:alert(5)">5</a>' +
-      '<a href="java\tscript:alert(6)">6</a>' +
-      '<a href="%6aavascript:alert(7)">7</a>' +
-      '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">8</a>' +
-      '<a href=" dAt%61: tExt/html  ; bAse64 , PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">9</a>' +
-      '<object data="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">10</object>' +
-      '<button formaction="javascript:alert(11)">11</button>' +
-      '<form action="javascript:alert(12)">12</form>' +
-      '<table background="javascript:alert(13)"><tbody><tr><td>13</td></tr></tbody></table>' +
-      '<a href="mhtml:14">14</a>' +
-      '<a xlink:href="jAvaScript:alert(15)">15</a>' +
-      '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">' +
-      '<a href="%E3%82%AA%E3%83%BC%E3%83">Invalid url</a>';
-    const serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(
-      serializedHtml,
-      '<a>1</a>' +
-      '<a>2</a>' +
-      '<a>3</a>' +
-      '<a>4</a>' +
-      '<a>5</a>' +
-      '<a>6</a>' +
-      '<a>7</a>' +
-      '<a>8</a>' +
-      '<a>9</a>' +
-      '<object>10</object>' +
-      '<button>11</button>' +
-      '<form>12</form>' +
-      '<table><tbody><tr><td>13</td></tr></tbody></table>' +
-      '<a>14</a>' +
-      '<a>15</a>' +
-      '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">' +
-      '<a href="%E3%82%AA%E3%83%BC%E3%83">Invalid url</a>'
-    );
-  });
-
-  it('Parse svg urls (default)', () => {
-    const parser = DomParser();
-    const serializedHtml = serializer.serialize(parser.parse(
-      '<iframe src="data:image/svg+xml;base64,x"></iframe>' +
-      '<a href="data:image/svg+xml;base64,x">1</a>' +
-      '<object data="data:image/svg+xml;base64,x"></object>' +
-      '<img src="data:image/svg+xml;base64,x">' +
-      '<video poster="data:image/svg+xml;base64,x"></video>'
-    ));
-    assert.equal(serializedHtml,
-      '<iframe></iframe>' +
-      '<a>1</a>' +
-      '<object></object>' +
-      '<img src="data:image/svg+xml;base64,x">' +
-      '<video></video>'
-    );
-  });
-
-  it('Parse svg urls (allowed)', () => {
-    const parser = DomParser({ allow_svg_data_urls: true });
-    const serializedHtml = serializer.serialize(parser.parse(
-      '<iframe src="data:image/svg+xml;base64,x"></iframe>' +
-      '<a href="data:image/svg+xml;base64,x">1</a>' +
-      '<object data="data:image/svg+xml;base64,x"></object>' +
-      '<img src="data:image/svg+xml;base64,x">' +
-      '<video poster="data:image/svg+xml;base64,x"></video>'
-    ));
-    assert.equal(serializedHtml,
-      '<iframe src="data:image/svg+xml;base64,x"></iframe>' +
-      '<a href="data:image/svg+xml;base64,x">1</a>' +
-      '<object data="data:image/svg+xml;base64,x"></object>' +
-      '<img src="data:image/svg+xml;base64,x">' +
-      '<video poster="data:image/svg+xml;base64,x"></video>'
-    );
-  });
-
-  it('Parse svg urls (denied)', () => {
-    const parser = DomParser({ allow_svg_data_urls: false });
-    const serializedHtml = serializer.serialize(parser.parse(
-      '<iframe src="data:image/svg+xml;base64,x"></iframe>' +
-      '<a href="data:image/svg+xml;base64,x">1</a>' +
-      '<object data="data:image/svg+xml;base64,x"></object>' +
-      '<img src="data:image/svg+xml;base64,x">' +
-      '<video poster="data:image/svg+xml;base64,x"></video>'
-    ));
-    assert.equal(serializedHtml,
-      '<iframe></iframe>' +
-      '<a>1</a>' +
-      '<object></object>' +
-      '<img>' +
-      '<video></video>'
-    );
-  });
-
-  it('getAttributeFilters/getNodeFilters', () => {
-    const parser = DomParser();
-    const cb1: ParserFilterCallback = (_nodes, _name, _args) => {};
-    const cb2: ParserFilterCallback = (_nodes, _name, _args) => {};
-
-    parser.addAttributeFilter('attr', cb1);
-    parser.addNodeFilter('node', cb2);
-
-    const attrFilters = parser.getAttributeFilters();
-    const nodeFilters = parser.getNodeFilters();
-
-    assert.deepEqual(attrFilters[attrFilters.length - 1], { name: 'attr', callbacks: [ cb1 ] }, 'Should be expected filter');
-    assert.deepEqual(nodeFilters[nodeFilters.length - 1], { name: 'node', callbacks: [ cb2 ] }, 'Should be expected filter');
-  });
-
-  it('extract base64 uris to blobcache if blob cache is provided', () => {
-    const blobCache = BlobCache();
-    const parser = DomParser({ blob_cache: blobCache });
-    const base64 = 'R0lGODdhDAAMAIABAMzMzP///ywAAAAADAAMAAACFoQfqYeabNyDMkBQb81Uat85nxguUAEAOw==';
-    const base64Uri = `data:image/gif;base64,${base64}`;
-    const serializedHtml = serializer.serialize(parser.parse(`<p><img src="${base64Uri}" /></p>`));
-    const blobInfo = blobCache.findFirst((bi) => bi.base64() === base64) as BlobInfo;
-    const blobUri = blobInfo.blobUri();
-
-    assert.equal(
-      serializedHtml,
-      `<p><img src="${blobUri}"></p>`,
-      'Should be html with blob uri'
-    );
-
-    blobCache.destroy();
-  });
-
-  it('duplicate base64 uris added only once to blobcache if blob cache is provided', () => {
-    const blobCache = BlobCache();
-    const parser = DomParser({ blob_cache: blobCache });
-    const base64 = 'R0lGODdhDAAMAIABAMzMzP///ywAAAAADAAMAAACFoQfqYeabNyDMkBQb81Uat85nxguUAEAOw==';
-    const gifBase64Uri = `data:image/gif;base64,${base64}`;
-    const pngBase64Uri = `data:image/png;base64,${base64}`;
-    const images = `<img src="${gifBase64Uri}" /><img src="${pngBase64Uri}" />`;
-    const serializedHtml = serializer.serialize(parser.parse(`<p>${images}</p><p>${images}</p>`));
-    let count = 0;
-    blobCache.findFirst((bi) => {
-      if (bi.base64() === base64) {
-        count++;
-      }
-      return false;
-    });
-
-    assert.equal(count, 2, 'Only one image per mime type should be in the blob cache');
-    assert.notInclude(serializedHtml, base64, 'HTML shouldn\'t include a base64 data URI');
-    blobCache.destroy();
-  });
-
-  it('do not extract base64 uris for transparent or placeholder images used by for example the page break plugin', () => {
-    const blobCache = BlobCache();
-    const placeholderImg = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mNk+P//PwMRgHFUIX0VAgAE3B3t0SaZ0AAAAABJRU5ErkJggg==';
-    const parser = DomParser({ blob_cache: blobCache });
-    const html = `<p><img src="${Env.transparentSrc}" /><img src="${placeholderImg}" data-mce-placeholder="1"></p>`;
-    const root = parser.parse(html);
-
-    assert.equal(
-      root.getAll('img')[0].attr('src'),
-      Env.transparentSrc,
-      'Should be the unchanged transparent image source'
-    );
-    assert.equal(
-      root.getAll('img')[1].attr('src'),
-      placeholderImg,
-      'Should be the unchanged placeholder image source'
-    );
-
-    blobCache.destroy();
-  });
-
-  it('do not extract base64 uris if blob cache is not provided', () => {
-    const parser = DomParser();
-    const html = '<p><img src="data:image/gif;base64,R0lGODdhDAAMAIABAMzMzP///ywAAAAADAAMAAACFoQfqYeabNyDMkBQb81Uat85nxguUAEAOw=="></p>';
-    const serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml, html, 'Should be html with base64 uri retained');
-  });
-
-  it('Parse away bogus elements', () => {
-    const testBogusParsing = (inputHtml: string, outputHtml: string) => {
-      const parser = DomParser({}, schema);
-      const serializedHtml = serializer.serialize(parser.parse(inputHtml));
-      assert.equal(serializedHtml, outputHtml);
-    };
-
-    testBogusParsing('a<b data-mce-bogus="1">b</b>c', 'abc');
-    testBogusParsing('a<b data-mce-bogus="true">b</b>c', 'abc');
-    testBogusParsing('a<b data-mce-bogus="1"></b>c', 'ac');
-    testBogusParsing('a<b data-mce-bogus="all">b</b>c', 'ac');
-    testBogusParsing('a<b data-mce-bogus="all"><!-- x --><?xml?></b>c', 'ac');
-    testBogusParsing('a<b data-mce-bogus="all"><b>b</b></b>c', 'ac');
-    testBogusParsing('a<b data-mce-bogus="all"><br>b</b><b>c</b>', 'a<b>c</b>');
-    testBogusParsing('a<b data-mce-bogus="all"><img>b</b><b>c</b>', 'a<b>c</b>');
-    testBogusParsing('a<b data-mce-bogus="all"><b attr="x">b</b></b>c', 'ac');
-    testBogusParsing('a<b data-mce-bogus="all"></b>c', 'ac');
-    testBogusParsing('a<b data-mce-bogus="all"></b><b>c</b>', 'a<b>c</b>');
-  });
-
-  it('remove bogus elements even if not part of valid_elements', () => {
-    const parser = DomParser({}, Schema({ valid_elements: 'p,span,' }));
-    const html = '<p>a <span data-mce-bogus="all">&nbsp;<span contenteditable="false">X</span>&nbsp;</span>b</p>';
-    const serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml, '<p>a b</p>');
-  });
-
-  it('Parse cdata with comments', () => {
-    const parser = DomParser({}, schema);
-
-    const serializedHtml = serializer.serialize(parser.parse('<div><![CDATA[<!--x--><!--y--!>-->]]></div>', { format: 'html' }));
-    assert.equal(serializedHtml, '<div><!--[CDATA[<!--x----><!--y-->--&gt;]]&gt;</div>');
-
-    const serializedXHtml = serializer.serialize(parser.parse('<div><![CDATA[<!--x--><!--y-->--><!--]]></div>', { format: 'xhtml' }));
-    assert.equal(serializedXHtml, '<div><![CDATA[<!--x--><!--y-->--><!--]]></div>');
-  });
-
-  it('TINY-7756: Parsing invalid nested children', () => {
-    const schema = Schema({ valid_children: '-td[button|a|div]' });
-    const parser = DomParser({}, schema);
-    const html = '<table><tr><td><button><a><meta /></a></button></td></tr></table>';
-    const serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml, '<table><tbody><tr><td></td></tr></tbody></table>', 'Should remove all invalid children but keep empty table');
-  });
-
-  it('TINY-7756: Parsing invalid nested children with a valid child between', () => {
-    const parser = DomParser();
-    const html =
-      '<table>' +
-        '<tbody>' +
-          '<tr>' +
-            '<td>' +
-              '<meta>' +
-                '<button>' +
-                  '<img />' +
+
+      it('Whitespace', () => {
+        let parser = DomParser(scenario.settings, schema);
+        let root = parser.parse('  \t\r\n  <B>  \t\r\n   test  \t\r\n   </B>   \t\r\n  ');
+        assert.equal(serializer.serialize(root), ' <b> test </b> ', 'Redundant whitespace (inline element)');
+        assert.deepEqual(countNodes(root), { 'body': 1, 'b': 1, '#text': 3 }, 'Redundant whitespace (inline element) (count)');
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('  \t\r\n  <P>  \t\r\n   test  \t\r\n   </P>   \t\r\n  ');
+        assert.equal(serializer.serialize(root), '<p>test</p>', 'Redundant whitespace (block element)');
+        assert.deepEqual(countNodes(root), { 'body': 1, 'p': 1, '#text': 1 }, 'Redundant whitespace (block element) (count)');
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('  \t\r\n  <SCRIPT>  \t\r\n   test  \t\r\n   </S' + 'CRIPT>   \t\r\n  ');
+        assert.equal(
+          serializer.serialize(root),
+          '<script>  \t\n   test  \t\n   </s' + 'cript>',
+          'Whitespace around and inside SCRIPT'
+        );
+        assert.deepEqual(countNodes(root), { 'body': 1, 'script': 1, '#text': 1 }, 'Whitespace around and inside SCRIPT (count)');
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('  \t\r\n  <STYLE>  \t\r\n   test  \t\r\n   </STYLE>   \t\r\n  ');
+        assert.equal(serializer.serialize(root), '<style>  \t\n   test  \t\n   </style>', 'Whitespace around and inside STYLE');
+        assert.deepEqual(countNodes(root), { 'body': 1, 'style': 1, '#text': 1 }, 'Whitespace around and inside STYLE (count)');
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('<ul>\n<li>Item 1\n<ul>\n<li>\n \t Indented \t \n</li>\n</ul>\n</li>\n</ul>\n');
+        assert.equal(
+          serializer.serialize(root),
+          '<ul><li>Item 1<ul><li>Indented</li></ul></li></ul>',
+          'Whitespace around and inside blocks (ul/li)'
+        );
+        assert.deepEqual(countNodes(root), { 'body': 1, 'li': 2, 'ul': 2, '#text': 2 }, 'Whitespace around and inside blocks (ul/li) (count)');
+
+        parser = DomParser(scenario.settings, Schema({ invalid_elements: 'hr,br' }));
+        root = parser.parse(
+          '\n<hr />\n<br />\n<div>\n<hr />\n<br />\n<img src="file.gif" data-mce-src="file.gif" />\n<hr />\n<br />\n</div>\n<hr />\n<br />\n'
+        );
+        assert.equal(
+          serializer.serialize(root),
+          '<div><img src="file.gif" data-mce-src="file.gif"></div>',
+          'Whitespace where the parser will produce multiple whitespace nodes'
+        );
+        assert.deepEqual(
+          countNodes(root),
+          { body: 1, div: 1, img: 1 },
+          'Whitespace where the parser will produce multiple whitespace nodes (count)'
+        );
+      });
+
+      it('Whitespace before/after invalid element with text in block', () => {
+        const parser = DomParser(scenario.settings, Schema({ invalid_elements: 'em' }));
+        const root = parser.parse('<p>a <em>b</em> c</p>');
+        assert.equal(serializer.serialize(root), '<p>a b c</p>');
+      });
+
+      it('Whitespace before/after invalid element whitespace element in block', () => {
+        const parser = DomParser(scenario.settings, Schema({ invalid_elements: 'span' }));
+        const root = parser.parse('<p> <span></span> </p>');
+        assert.equal(serializer.serialize(root), '<p>\u00a0</p>');
+      });
+
+      it('Whitespace preserved in PRE', () => {
+        let parser = DomParser(scenario.settings, schema);
+        let root = parser.parse('  \t\r\n  <PRE>  \t\r\n   test  \t\r\n   </PRE>   \t\r\n  ');
+        assert.equal(serializer.serialize(root), '<pre>  \t\n   test  \t\n   </pre>', 'Whitespace around and inside PRE');
+        assert.deepEqual(countNodes(root), { 'body': 1, 'pre': 1, '#text': 1 }, 'Whitespace around and inside PRE (count)');
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('<PRE>  </PRE>');
+        assert.equal(serializer.serialize(root), '<pre>  </pre>', 'Whitespace around and inside PRE');
+        assert.deepEqual(countNodes(root), { 'body': 1, 'pre': 1, '#text': 1 }, 'Whitespace around and inside PRE (count)');
+      });
+
+      it('Whitespace preserved in SPAN inside PRE', () => {
+        const parser = DomParser(scenario.settings, schema);
+        const root = parser.parse('  \t\r\n  <PRE>  \t\r\n  <span>    test    </span> \t\r\n   </PRE>   \t\r\n  ');
+        assert.equal(
+          serializer.serialize(root),
+          '<pre>  \t\n  <span>    test    </span> \t\n   </pre>',
+          'Whitespace around and inside PRE'
+        );
+        assert.deepEqual(countNodes(root), { 'body': 1, 'pre': 1, 'span': 1, '#text': 3 }, 'Whitespace around and inside PRE (count)');
+      });
+
+      it('Whitespace preserved in code', () => {
+        let parser = DomParser(scenario.settings, schema);
+        let root = parser.parse('<code>  a  </code>');
+        assert.equal(serializer.serialize(root), '<code>  a  </code>', 'Whitespace inside code');
+        assert.deepEqual(countNodes(root), { 'body': 1, 'code': 1, '#text': 1 }, 'Whitespace inside code (count)');
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('<code>  </code>');
+        assert.equal(serializer.serialize(root), '<code>  </code>', 'Whitespace inside code');
+        assert.deepEqual(countNodes(root), { 'body': 1, 'code': 1, '#text': 1 }, 'Whitespace inside code (count)');
+      });
+
+      it('Parse invalid contents', () => {
+        let parser = DomParser(scenario.settings, schema);
+        let root = parser.parse('<p class="a"><p class="b">123</p></p>');
+        assert.equal(serializer.serialize(root), '<p class="a"></p><p class="b">123</p><p></p>', 'P in P, splits outer P');
+        assert.deepEqual(countNodes(root), { 'body': 1, 'p': 3, '#text': 1 }, 'P in P, splits outer P (count)');
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('<p class="a">a<p class="b">b</p><p class="c">c</p>d</p>');
+        assert.equal(
+          serializer.serialize(root),
+          '<p class="a">a</p><p class="b">b</p><p class="c">c</p>d<p></p>',
+          'Two P in P, splits outer P'
+        );
+        assert.deepEqual(countNodes(root), { 'body': 1, 'p': 4, '#text': 4 }, 'Two P in P, splits outer P (count)');
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('<p class="a">abc<p class="b">def</p></p>');
+        assert.equal(serializer.serialize(root), '<p class="a">abc</p><p class="b">def</p><p></p>', 'P in P with nodes before');
+        assert.deepEqual(countNodes(root), { 'body': 1, 'p': 3, '#text': 2 }, 'P in P with nodes before (count)');
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('<p class="a"><p class="b">abc</p>def</p>');
+        assert.equal(serializer.serialize(root), '<p class="a"></p><p class="b">abc</p>def<p></p>', 'P in P with nodes after');
+        assert.deepEqual(countNodes(root), { 'body': 1, 'p': 3, '#text': 2 }, 'P in P with nodes after (count)');
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('<p class="a"><p class="b">abc</p><br></p>');
+        assert.equal(serializer.serialize(root), '<p class="a"></p><p class="b">abc</p><br><p></p>', 'P in P with BR after');
+        assert.deepEqual(countNodes(root), { 'body': 1, 'p': 3, 'br': 1, '#text': 1 }, 'P in P with BR after (count)');
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('<p class="a">a<strong>b<span>c<em>d<p class="b">e</p>f</em>g</span>h</strong>i</p>');
+        assert.equal(
+          serializer.serialize(root),
+          '<p class="a">a<strong>b<span>c<em>d</em></span></strong></p>' +
+          '<p class="b"><strong><em>e</em></strong></p>' +
+          '<strong><em>f</em>gh</strong>i<p></p>',
+          'P in P wrapped in inline elements'
+        );
+        assert.deepEqual(
+          countNodes(root),
+          { 'body': 1, 'p': 3, '#text': 8, 'strong': 3, 'span': 1, 'em': 3 },
+          'P in P wrapped in inline elements (count)'
+        );
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('<p class="a">a<p class="b">b<p class="c">c</p>d</p>e</p>');
+        assert.equal(
+          serializer.serialize(root),
+          '<p class="a">a</p><p class="b">b</p><p class="c">c</p>d<p></p>e<p></p>',
+          'P in P in P with text before/after'
+        );
+        assert.deepEqual(countNodes(root), { 'body': 1, 'p': 5, '#text': 5 }, 'P in P in P with text before/after (count)');
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('<p>a<ul><li>b</li><li>c</li></ul>d</p>');
+        assert.equal(serializer.serialize(root), '<p>a</p><ul><li>b</li><li>c</li></ul>d<p></p>', 'UL inside P');
+        assert.deepEqual(countNodes(root), { 'body': 1, 'p': 2, 'ul': 1, 'li': 2, '#text': 4 }, 'UL inside P (count)');
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('<table><tr><td><tr>a</tr></td></tr></table>');
+        assert.equal(serializer.serialize(root), 'a<table><tbody><tr><td></td></tr><tr></tr></tbody></table>', 'TR inside TD');
+        assert.deepEqual(countNodes(root), { 'body': 1, 'table': 1, 'tbody': 1, 'tr': 2, 'td': 1, '#text': 1 }, 'TR inside TD (count)');
+
+        parser = DomParser(scenario.settings, Schema({ valid_elements: 'p,section,div' }));
+        root = parser.parse('<div><section><p>a</p></section></div>');
+        assert.equal(serializer.serialize(root), '<div><section><p>a</p></section></div>', 'P inside SECTION');
+        assert.deepEqual(countNodes(root), { 'body': 1, 'div': 1, 'section': 1, 'p': 1, '#text': 1 }, 'P inside SECTION (count)');
+      });
+
+      it('Remove empty nodes', () => {
+        const parser = DomParser(scenario.settings, Schema({ valid_elements: '-p,-span[id|style],-strong' }));
+        let root = parser.parse(
+          '<p>a<span></span><span> </span><span id="x">b</span><span id="y"></span></p><p></p><p><span></span></p><p> </p>'
+        );
+        assert.equal(serializer.serialize(root), '<p>a <span id="x">b</span><span id="y"></span></p>');
+
+        root = parser.parse('<p>a&nbsp;<span style="text-decoration: underline"> </span>&nbsp;b</p>');
+        assert.equal(serializer.serialize(root), '<p>a\u00a0<span style="text-decoration: underline"> </span>\u00a0b</p>');
+
+        root = parser.parse('<p>a&nbsp;<strong> </strong>&nbsp;b</p>');
+        assert.equal(serializer.serialize(root), '<p>a\u00a0<strong> </strong>\u00a0b</p>');
+
+        root = parser.parse('<p>a&nbsp;<span style="text-decoration: underline"></span>&nbsp;b</p>');
+        assert.equal(serializer.serialize(root), '<p>a\u00a0\u00a0b</p>');
+
+        root = parser.parse('<p>a&nbsp;<span> </span>&nbsp;b</p>');
+        assert.equal(serializer.serialize(root), '<p>a\u00a0 \u00a0b</p>');
+      });
+
+      it('Parse invalid contents with node filters', () => {
+        const parser = DomParser(scenario.settings, schema);
+        parser.addNodeFilter('p', (nodes) => {
+          Arr.each(nodes, (node) => {
+            node.attr('class', 'x');
+          });
+        });
+        const root = parser.parse('<p>a<p>123</p>b</p>');
+        assert.equal(serializer.serialize(root), '<p class="x">a</p><p class="x">123</p>b<p class="x"></p>', 'P should have class x');
+      });
+
+      it('Parse invalid contents with attribute filters', () => {
+        const parser = DomParser(scenario.settings, schema);
+        parser.addAttributeFilter('class', (nodes) => {
+          Arr.each(nodes, (node) => {
+            node.attr('class', 'x');
+          });
+        });
+        const root = parser.parse('<p class="y">a<p class="y">123</p>b</p>');
+        assert.equal(serializer.serialize(root), '<p class="x">a</p><p class="x">123</p>b<p></p>', 'P should have class x');
+      });
+
+      it('addNodeFilter', () => {
+        let result: ParseTestResult | undefined;
+
+        const parser = DomParser(scenario.settings, schema);
+        parser.addNodeFilter('#comment', (nodes, name, args) => {
+          result = { nodes, name, args };
+        });
+        parser.parse('text<!--text1-->text<!--text2-->');
+
+        assert.deepEqual(result?.args, {}, 'Parser args');
+        assert.equal(result?.name, '#comment', 'Parser filter result name');
+        assert.equal(result?.nodes.length, 2, 'Parser filter result node');
+        assert.equal(result?.nodes[0].name, '#comment', 'Parser filter result node(0) name');
+        assert.equal(result?.nodes[0].value, 'text1', 'Parser filter result node(0) value');
+        assert.equal(result?.nodes[1].name, '#comment', 'Parser filter result node(1) name');
+        assert.equal(result?.nodes[1].value, 'text2', 'Parser filter result node(1) value');
+      });
+
+      it('addNodeFilter multiple names', () => {
+        const results: Record<string, ParseTestResult> = {};
+
+        const parser = DomParser(scenario.settings, schema);
+        parser.addNodeFilter('#comment,#text', (nodes, name, args) => {
+          results[name] = { nodes, name, args };
+        });
+        parser.parse('text1<!--text1-->text2<!--text2-->');
+
+        assert.deepEqual(results['#comment'].args, {}, 'Parser args');
+        assert.equal(results['#comment'].name, '#comment', 'Parser filter result name');
+        assert.equal(results['#comment'].nodes.length, 2, 'Parser filter result node');
+        assert.equal(results['#comment'].nodes[0].name, '#comment', 'Parser filter result node(0) name');
+        assert.equal(results['#comment'].nodes[0].value, 'text1', 'Parser filter result node(0) value');
+        assert.equal(results['#comment'].nodes[1].name, '#comment', 'Parser filter result node(1) name');
+        assert.equal(results['#comment'].nodes[1].value, 'text2', 'Parser filter result node(1) value');
+        assert.deepEqual(results['#text'].args, {}, 'Parser args');
+        assert.equal(results['#text'].name, '#text', 'Parser filter result name');
+        assert.equal(results['#text'].nodes.length, 2, 'Parser filter result node');
+        assert.equal(results['#text'].nodes[0].name, '#text', 'Parser filter result node(0) name');
+        assert.equal(results['#text'].nodes[0].value, 'text1', 'Parser filter result node(0) value');
+        assert.equal(results['#text'].nodes[1].name, '#text', 'Parser filter result node(1) name');
+        assert.equal(results['#text'].nodes[1].value, 'text2', 'Parser filter result node(1) value');
+      });
+
+      it('addNodeFilter with parser args', () => {
+        let result: ParseTestResult | undefined;
+
+        const parser = DomParser(scenario.settings, schema);
+        parser.addNodeFilter('#comment', (nodes, name, args) => {
+          result = { nodes, name, args };
+        });
+        parser.parse('text<!--text1-->text<!--text2-->', { value: 1 });
+
+        assert.deepEqual(result?.args, { value: 1 }, 'Parser args');
+      });
+
+      it('TINY-7847: removeNodeFilter', () => {
+        const parser = DomParser(scenario.settings);
+        const numFilters = parser.getNodeFilters().length;
+        let called = false;
+
+        const filter = (_nodes: AstNode[]) => {
+          called = true;
+        };
+        parser.addNodeFilter('th,td', filter);
+        parser.addNodeFilter('th,td', Fun.noop);
+
+        assert.lengthOf(parser.getNodeFilters(), numFilters + 2, 'Before removing filters');
+        parser.removeNodeFilter('th', filter);
+        assert.lengthOf(parser.getNodeFilters(), numFilters + 2, 'After removing the first th node filter');
+        assert.lengthOf(parser.getNodeFilters()[numFilters].callbacks, 1, 'th node callbacks');
+        parser.removeNodeFilter('th', Fun.noop);
+        assert.lengthOf(parser.getNodeFilters(), numFilters + 1, 'After removing the second th node filter');
+        parser.removeNodeFilter('th,td');
+        assert.lengthOf(parser.getNodeFilters(), numFilters, 'After removing all th and td node filters');
+
+        // Ensure that after being removed the filters aren't called
+        parser.parse('<table><tr><th></th><td></td></tr></table>');
+        assert.isFalse(called);
+      });
+
+      it('addAttributeFilter', () => {
+        let result: ParseTestResult | undefined;
+
+        const parser = DomParser(scenario.settings);
+        parser.addAttributeFilter('src', (nodes, name, args) => {
+          result = { nodes, name, args };
+        });
+        parser.parse('<b>a<img src="1.gif" />b<img src="1.gif" />c</b>');
+
+        assert.deepEqual(result?.args, {}, 'Parser args');
+        assert.equal(result?.name, 'src', 'Parser filter result name');
+        assert.equal(result?.nodes.length, 2, 'Parser filter result node');
+        assert.equal(result?.nodes[0].name, 'img', 'Parser filter result node(0) name');
+        assert.equal(result?.nodes[0].attr('src'), '1.gif', 'Parser filter result node(0) attr');
+        assert.equal(result?.nodes[1].name, 'img', 'Parser filter result node(1) name');
+        assert.equal(result?.nodes[1].attr('src'), '1.gif', 'Parser filter result node(1) attr');
+      });
+
+      it('addAttributeFilter multiple', () => {
+        const results: any = {};
+
+        const parser = DomParser(scenario.settings);
+        parser.addAttributeFilter('src,href', (nodes, name, args) => {
+          results[name] = { nodes, name, args };
+        });
+        parser.parse('<b><a href="1.gif">a</a><img src="1.gif" />b<img src="1.gif" /><a href="2.gif">c</a></b>');
+
+        assert.deepEqual(results.src.args, {}, 'Parser args');
+        assert.equal(results.src.name, 'src', 'Parser filter result name');
+        assert.equal(results.src.nodes.length, 2, 'Parser filter result node');
+        assert.equal(results.src.nodes[0].name, 'img', 'Parser filter result node(0) name');
+        assert.equal(results.src.nodes[0].attr('src'), '1.gif', 'Parser filter result node(0) attr');
+        assert.equal(results.src.nodes[1].name, 'img', 'Parser filter result node(1) name');
+        assert.equal(results.src.nodes[1].attr('src'), '1.gif', 'Parser filter result node(1) attr');
+        assert.deepEqual(results.href.args, {}, 'Parser args');
+        assert.equal(results.href.name, 'href', 'Parser filter result name');
+        assert.equal(results.href.nodes.length, 2, 'Parser filter result node');
+        assert.equal(results.href.nodes[0].name, 'a', 'Parser filter result node(0) name');
+        assert.equal(results.href.nodes[0].attr('href'), '1.gif', 'Parser filter result node(0) attr');
+        assert.equal(results.href.nodes[1].name, 'a', 'Parser filter result node(1) name');
+        assert.equal(results.href.nodes[1].attr('href'), '2.gif', 'Parser filter result node(1) attr');
+      });
+
+      it('TINY-8888: mutating addNodeFilter -> addAttributeFilter', () => {
+        const parser = DomParser(scenario.settings);
+        parser.addNodeFilter('img', (nodes) => {
+          Arr.each(nodes, (node) => node.attr('src', null));
+        });
+        parser.addAttributeFilter('src', () => {
+          assert.fail('second src filter should not run, because src was removed');
+        });
+        parser.parse('<b>a<img src="1.gif" />b</b>');
+      });
+
+      it('TINY-8888: mutating addNodeFilter -> addNodeFilter', () => {
+        const parser = DomParser(scenario.settings);
+        parser.addNodeFilter('img', (nodes) => {
+          Arr.each(nodes, (node) => node.remove());
+        });
+        parser.addNodeFilter('img', () => {
+          assert.fail('second img filter should not run, because img was removed');
+        });
+        parser.parse('<b>a<img src="1.gif" />b</b>');
+      });
+
+      it('TINY-8888: mutating addAttributeFilter -> addAttributeFilter', () => {
+        const parser = DomParser(scenario.settings);
+        parser.addAttributeFilter('src', (nodes) => {
+          Arr.each(nodes, (node) => node.attr('src', null));
+        });
+        parser.addAttributeFilter('src', () => {
+          assert.fail('second src filter should not run, because src was removed');
+        });
+        parser.parse('<b>a<img src="1.gif" />b</b>');
+      });
+
+      it('TINY-8888: mutating addAttributeFilter only removes matching nodes', () => {
+        const parser = DomParser(scenario.settings);
+        parser.addAttributeFilter('src', (nodes) => {
+          nodes[0].attr('src', null);
+        });
+        let ranIdFilter = false;
+        parser.addAttributeFilter('src', (nodes) => {
+          ranIdFilter = true;
+          assert.lengthOf(nodes, 1);
+          assert.equal(nodes[0].attr('src'), '2.gif');
+        });
+        parser.parse('<b>a<img src="1.gif" />b<img src="2.gif" />c</b>');
+        assert.isTrue(ranIdFilter, 'second filter should run, because only one src attribute was removed');
+      });
+
+      it('TINY-7847: removeAttributeFilter', () => {
+        const parser = DomParser(scenario.settings);
+        const numFilters = parser.getAttributeFilters().length;
+        let called = false;
+
+        const filter = (_nodes: AstNode[]) => {
+          called = true;
+        };
+        parser.addAttributeFilter('controls,poster', filter);
+        parser.addAttributeFilter('controls,poster', Fun.noop);
+
+        assert.lengthOf(parser.getAttributeFilters(), numFilters + 2, 'Before removing filters');
+        parser.removeAttributeFilter('controls', filter);
+        assert.lengthOf(parser.getAttributeFilters(), numFilters + 2, 'After removing the first controls attribute filter');
+        assert.lengthOf(parser.getAttributeFilters()[numFilters].callbacks, 1, 'controls attribute node callbacks');
+        parser.removeAttributeFilter('controls', Fun.noop);
+        assert.lengthOf(parser.getAttributeFilters(), numFilters + 1, 'After removing the second controls attribute filter');
+        parser.removeAttributeFilter('controls,poster');
+        assert.lengthOf(parser.getAttributeFilters(), numFilters, 'After removing all controls and poster attribute filter');
+
+        // Ensure that after being removed the filters aren't called
+        parser.parse('<video controls poster="about:blank"></video>');
+        assert.isFalse(called);
+      });
+
+      it('Fix orphan LI elements', () => {
+        let parser = DomParser(scenario.settings, schema);
+        let root = parser.parse('<ul><li>a</li></ul><li>b</li>');
+        assert.equal(serializer.serialize(root), '<ul><li>a</li><li>b</li></ul>', 'LI moved to previous sibling UL');
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('<li>a</li><ul><li>b</li></ul>');
+        assert.equal(serializer.serialize(root), '<ul><li>a</li><li>b</li></ul>', 'LI moved to next sibling UL');
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('<ol><li>a</li></ol><li>b</li>');
+        assert.equal(serializer.serialize(root), '<ol><li>a</li><li>b</li></ol>', 'LI moved to previous sibling OL');
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('<li>a</li><ol><li>b</li></ol>');
+        assert.equal(serializer.serialize(root), '<ol><li>a</li><li>b</li></ol>', 'LI moved to next sibling OL');
+
+        parser = DomParser(scenario.settings, schema);
+        root = parser.parse('<li>a</li>');
+        assert.equal(serializer.serialize(root), '<ul><li>a</li></ul>', 'LI wrapped in new UL');
+      });
+
+      it('Remove empty elements', () => {
+        const schema = Schema({ valid_elements: 'span,-a,img' });
+
+        let parser = DomParser(scenario.settings, schema);
+        let root = parser.parse('<span></span><a href="#"></a>');
+        assert.equal(serializer.serialize(root), '<span></span>', 'Remove empty a element');
+
+        parser = DomParser(scenario.settings, Schema({ valid_elements: 'span,a[name],img' }));
+        root = parser.parse('<span></span><a name="anchor"></a>');
+        assert.equal(serializer.serialize(root), '<span></span><a name="anchor"></a>', 'Leave a with name attribute');
+
+        parser = DomParser(scenario.settings, Schema({ valid_elements: 'span,a[href],img[src]' }));
+        root = parser.parse('<span></span><a href="#"><img src="about:blank" /></a>');
+        assert.equal(
+          serializer.serialize(root),
+          '<span></span><a href="#"><img src="about:blank"></a>',
+          'Leave elements with img in it'
+        );
+      });
+
+      it('Self closing list elements', () => {
+        const schema = Schema();
+
+        const parser = DomParser(scenario.settings, schema);
+        const root = parser.parse('<ul><li>1<li><b>2</b><li><em><b>3</b></em></ul>');
+        assert.equal(
+          serializer.serialize(root),
+          '<ul><li>1</li><li><strong>2</strong></li><li><em><strong>3</strong></em></li></ul>',
+          'Split out LI elements in LI elements.'
+        );
+      });
+
+      it('Remove redundant br elements', () => {
+        const schema = Schema();
+
+        const parser = DomParser({ remove_trailing_brs: true, ...scenario.settings }, schema);
+        const root = parser.parse(
+          '<p>a<br></p>' +
+          '<p>a<br>b<br></p>' +
+          '<p>a<br><br></p><p>a<br><span data-mce-type="bookmark"></span><br></p>' +
+          '<p>a<span data-mce-type="bookmark"></span><br></p>'
+        );
+        assert.equal(
+          serializer.serialize(root),
+          '<p>a</p><p>a<br>b</p><p>a<br><br></p><p>a<br><br></p><p>a</p>',
+          'Remove traling br elements.'
+        );
+      });
+
+      it('Replace br with nbsp when wrapped in two inline elements and one block', () => {
+        const schema = Schema();
+
+        const parser = DomParser({ remove_trailing_brs: true, ...scenario.settings }, schema);
+        const root = parser.parse('<p><strong><em><br /></em></strong></p>');
+        assert.equal(serializer.serialize(root), '<p><strong><em>\u00a0</em></strong></p>');
+      });
+
+      it('Replace br with nbsp when wrapped in an inline element and placed in the root', () => {
+        const schema = Schema();
+
+        const parser = DomParser({ remove_trailing_brs: true, ...scenario.settings }, schema);
+        const root = parser.parse('<strong><br /></strong>');
+        assert.equal(serializer.serialize(root), '<strong>\u00a0</strong>');
+      });
+
+      it(`Don't replace br inside root element when there is multiple brs`, () => {
+        const schema = Schema();
+
+        const parser = DomParser({ remove_trailing_brs: true, ...scenario.settings }, schema);
+        const root = parser.parse('<strong><br /><br /></strong>');
+        assert.equal(serializer.serialize(root), '<strong><br><br></strong>');
+      });
+
+      it(`Don't replace br inside root element when there is siblings`, () => {
+        const schema = Schema();
+
+        const parser = DomParser({ remove_trailing_brs: true, ...scenario.settings }, schema);
+        const root = parser.parse('<strong><br /></strong><em>x</em>');
+        assert.equal(serializer.serialize(root), '<strong><br></strong><em>x</em>');
+      });
+
+      it('Remove br in invalid parent bug', () => {
+        const schema = Schema({ valid_elements: 'br' });
+
+        const parser = DomParser({ remove_trailing_brs: true, ...scenario.settings }, schema);
+        const root = parser.parse('<br>');
+        assert.equal(serializer.serialize(root), '', 'Remove traling br elements.');
+      });
+
+      it('Forced root blocks', () => {
+        const schema = Schema();
+
+        const parser = DomParser({ forced_root_block: 'p', ...scenario.settings }, schema);
+        const root = parser.parse(
+          '<!-- a -->' +
+          'b' +
+          '<b>c</b>' +
+          '<p>d</p>' +
+          '<p>e</p>' +
+          'f' +
+          '<b>g</b>' +
+          'h'
+        );
+        assert.equal(
+          serializer.serialize(root),
+          '<!-- a --><p>b<strong>c</strong></p><p>d</p><p>e</p><p>f<strong>g</strong>h</p>',
+          'Mixed text nodes, inline elements and blocks.'
+        );
+      });
+
+      it('Forced root blocks attrs', () => {
+        const schema = Schema();
+
+        const parser = DomParser({ forced_root_block: 'p', forced_root_block_attrs: { class: 'class1' }, ...scenario.settings }, schema);
+        const root = parser.parse(
+          '<!-- a -->' +
+          'b' +
+          '<b>c</b>' +
+          '<p>d</p>' +
+          '<p>e</p>' +
+          'f' +
+          '<b>g</b>' +
+          'h'
+        );
+        assert.equal(serializer.serialize(root), '<!-- a -->' +
+          '<p class="class1">b<strong>c</strong></p>' +
+          '<p>d</p>' +
+          '<p>e</p>' +
+          '<p class="class1">f<strong>g</strong>h</p>',
+        'Mixed text nodes, inline elements and blocks.');
+      });
+
+      it('Parse html4 lists into html5 lists', () => {
+        const schema = Schema();
+
+        const parser = DomParser({ fix_list_elements: true, ...scenario.settings }, schema);
+        const root = parser.parse('<ul><ul><li>a</li></ul></ul><ul><li>a</li><ul><li>b</li></ul></ul>');
+        assert.equal(
+          serializer.serialize(root),
+          '<ul><li style="list-style-type: none"><ul><li>a</li></ul></li></ul><ul><li>a<ul><li>b</li></ul></li></ul>'
+        );
+      });
+
+      it('Parse contents with html4 anchors and allow_html_in_named_anchor: false', () => {
+        const schema = Schema();
+
+        const parser = DomParser({ allow_html_in_named_anchor: false, ...scenario.settings }, schema);
+        const root = parser.parse('<a name="x">a</a><a href="x">x</a>');
+        assert.equal(serializer.serialize(root), '<a name="x"></a>a<a href="x">x</a>');
+      });
+
+      it('Parse contents with html5 anchors and allow_html_in_named_anchor: false', () => {
+        const schema = Schema({ schema: 'html5' });
+
+        const parser = DomParser({ allow_html_in_named_anchor: false, ...scenario.settings }, schema);
+        const root = parser.parse('<a id="x">a</a><a href="x">x</a>');
+        assert.equal(serializer.serialize(root), '<a id="x"></a>a<a href="x">x</a>');
+      });
+
+      it('Parse contents with html4 anchors and allow_html_in_named_anchor: true', () => {
+        const schema = Schema();
+
+        const parser = DomParser({ allow_html_in_named_anchor: true, ...scenario.settings }, schema);
+        const root = parser.parse('<a name="x">a</a><a href="x">x</a>');
+        assert.equal(serializer.serialize(root), '<a name="x">a</a><a href="x">x</a>');
+      });
+
+      it('Parse contents with html5 anchors and allow_html_in_named_anchor: true', () => {
+        const schema = Schema({ schema: 'html5' });
+
+        const parser = DomParser({ allow_html_in_named_anchor: true, ...scenario.settings }, schema);
+        const root = parser.parse('<a id="x">a</a><a href="x">x</a>');
+        assert.equal(serializer.serialize(root), '<a id="x">a</a><a href="x">x</a>');
+      });
+
+      it('Parse contents with html5 self closing datalist options', () => {
+        const schema = Schema({ schema: 'html5' });
+
+        const parser = DomParser(scenario.settings, schema);
+        const root = parser.parse(
+          '<datalist><option label="a1" value="b1"><option label="a2" value="b2"><option label="a3" value="b3"></datalist>'
+        );
+        assert.equal(
+          serializer.serialize(root),
+          '<datalist><option label="a1" value="b1"></option><option label="a2" value="b2"></option>' +
+          '<option label="a3" value="b3"></option></datalist>'
+        );
+      });
+
+      it('Parse inline contents before block bug #5424', () => {
+        const schema = Schema({ schema: 'html5' });
+
+        const parser = DomParser(scenario.settings, schema);
+        const root = parser.parse('<strong>1</strong> 2<p>3</p>');
+        assert.equal(serializer.serialize(root), '<strong>1</strong> 2<p>3</p>');
+      });
+
+      it('Invalid text blocks within a li', () => {
+        const schema = Schema({ schema: 'html5', valid_children: '-li[p]' });
+
+        const parser = DomParser(scenario.settings, schema);
+        const root = parser.parse('<ul><li>1<p>2</p></li><li>a<p>b</p><p>c</p></li></ul>');
+        assert.equal(serializer.serialize(root), '<ul><li>12</li><li>ab</li><li>c</li></ul>');
+      });
+
+      it('Invalid inline element with space before', () => {
+        const schema = Schema();
+
+        const parser = DomParser(scenario.settings, schema);
+        const root = parser.parse('<p><span>1</span> <strong>2</strong></p>');
+        assert.equal(serializer.serialize(root), '<p>1 <strong>2</strong></p>');
+      });
+
+      it('Valid classes', () => {
+        const schema = Schema({ valid_classes: 'classA classB' });
+
+        const parser = DomParser(scenario.settings, schema);
+        const root = parser.parse('<p class="classA classB classC">a</p>');
+        assert.equal(serializer.serialize(root), '<p class="classA classB">a</p>');
+      });
+
+      it('Valid classes multiple elements', () => {
+        const schema = Schema({ valid_classes: { '*': 'classA classB', 'strong': 'classC' }});
+
+        const parser = DomParser(scenario.settings, schema);
+        const root = parser.parse('<p class="classA classB classC"><strong class="classA classB classC classD">a</strong></p>');
+        assert.equal(serializer.serialize(root), '<p class="classA classB"><strong class="classA classB classC">a</strong></p>');
+      });
+
+      it('Pad empty list blocks', () => {
+        const schema = Schema();
+
+        const parser = DomParser(scenario.settings, schema);
+        const root = parser.parse('<ul><li></li></ul><ul><li> </li></ul>');
+        assert.equal(serializer.serialize(root), '<ul><li>\u00a0</li></ul><ul><li>\u00a0</li></ul>');
+      });
+
+      it('Pad empty and prefer br on insert', () => {
+        const schema = Schema();
+
+        const parser = DomParser(scenario.settings, schema);
+        const root = parser.parse('<ul><li></li><li> </li><li><br /></li><li>\u00a0</li><li>a</li></ul>', { insert: true });
+        assert.equal(serializer.serialize(root), '<ul><li><br data-mce-bogus="1"></li><li><br data-mce-bogus="1"></li><li><br></li><li><br data-mce-bogus="1"></li><li>a</li></ul>');
+      });
+
+      it('Preserve space in inline span', () => {
+        const schema = Schema();
+
+        const parser = DomParser(scenario.settings, schema);
+        const root = parser.parse('a<span> </span>b');
+        assert.equal(serializer.serialize(root), 'a b');
+      });
+
+      it('Bug #7543 removes whitespace between bogus elements before a block', () => {
+        const serializer = HtmlSerializer();
+
+        assert.equal(
+          serializer.serialize(DomParser(scenario.settings).parse(
+            '<div><b data-mce-bogus="1">a</b> <b data-mce-bogus="1">b</b><p>c</p></div>')
+          ),
+          '<div>a b<p>c</p></div>'
+        );
+      });
+
+      it('Bug #7582 removes whitespace between bogus elements before a block', () => {
+        const serializer = HtmlSerializer();
+
+        assert.equal(
+          serializer.serialize(DomParser(scenario.settings).parse(
+            '<div>1 <span data-mce-bogus="1">2</span><div>3</div></div>')
+          ),
+          '<div>1 2<div>3</div></div>'
+        );
+      });
+
+      it('do not replace starting linebreak with space', () => {
+        const serializer = HtmlSerializer();
+
+        assert.equal(
+          serializer.serialize(DomParser(scenario.settings).parse('<p>a<br />\nb</p>')),
+          '<p>a<br>b</p>'
+        );
+      });
+
+      it('Preserve internal elements', () => {
+        const html = '<span id="id" class="class"><b>text</b></span><span id="test" data-mce-type="something"></span>';
+
+        const parser1 = DomParser(scenario.settings, Schema({ valid_elements: 'b' }));
+        const serializerHtml1 = serializer.serialize(parser1.parse(html));
+        assert.equal(
+          serializerHtml1,
+          '<b>text</b><span id="test" data-mce-type="something"></span>',
+          'Preserve internal span element without any span schema rule.'
+        );
+
+        const parser2 = DomParser(scenario.settings, Schema({ valid_elements: 'b,span[class]' }));
+        const serializerHtml2 = serializer.serialize(parser2.parse(html));
+        assert.equal(
+          serializerHtml2,
+          '<span class="class"><b>text</b></span><span id="test" data-mce-type="something"></span>',
+          'Preserve internal span element with a span schema rule.'
+        );
+
+        const serializedHtml3 = serializer.serialize(parser1.parse('<b data-mce-type="test" id="x" style="color: red" src="1" data="2" onclick="3"></b>'));
+        assert.equal(
+          serializedHtml3,
+          '<b data-mce-type="test" id="x" style="color: red"></b>',
+          'Removes disallowed elements'
+        );
+      });
+
+      // TODO: TINY-4627/TINY-8363 - the iframe innerHTML on safari is `&lt;textarea&gt;` whereas on other browsers
+      //       is `<textarea>`. This causes the mXSS cleaner in DOMPurify to run and causes the different assertions below
+      it('parse iframe XSS', () => {
+        const serializer = HtmlSerializer();
+
+        assert.equal(
+          serializer.serialize(DomParser(scenario.settings).parse('<iframe><textarea></iframe><img src="a" onerror="alert(document.domain)" />')),
+          browser.isSafari() || !scenario.isSanitizeEnabled ? '<iframe><textarea></iframe><img src="a">' : '<img src="a">'
+        );
+      });
+
+      it('Conditional comments (allowed)', () => {
+        const parser = DomParser({ allow_conditional_comments: true, validate: false, ...scenario.settings }, schema);
+        const html = '<!--[if gte IE 4]>alert(1)<![endif]-->';
+        const serializedHtml = serializer.serialize(parser.parse(html));
+        assert.equal(serializedHtml, '<!--[if gte IE 4]>alert(1)<![endif]-->');
+      });
+
+      it('Conditional comments (denied)', () => {
+        const parser = DomParser({ allow_conditional_comments: false, validate: false, ...scenario.settings }, schema);
+
+        let serializedHtml = serializer.serialize(parser.parse('<!--[if gte IE 4]>alert(1)<![endif]-->'));
+        assert.equal(serializedHtml, '<!-- [if gte IE 4]>alert(1)<![endif]-->');
+
+        serializedHtml = serializer.serialize(parser.parse('<!--[if !IE]>alert(1)<![endif]-->'));
+        assert.equal(serializedHtml, '<!-- [if !IE]>alert(1)<![endif]-->');
+
+        serializedHtml = serializer.serialize(parser.parse('<!--[iF !IE]>alert(1)<![endif]-->'));
+        assert.equal(serializedHtml, '<!-- [iF !IE]>alert(1)<![endif]-->');
+      });
+
+      it('allow_script_urls should allow any URIs', () => {
+        const parser = DomParser({ allow_script_urls: true, ...scenario.settings });
+        const html = '<a href="javascript:alert(1)">1</a>' +
+          '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">3</a>';
+        const serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(serializedHtml,
+          '<a href="javascript:alert(1)">1</a>' +
+          '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">3</a>'
+        );
+      });
+
+      it('allow_html_data_urls should allow any data URIs, but not script URIs', () => {
+        const parser = DomParser({ allow_html_data_urls: true, ...scenario.settings });
+        const html = '<a href="javascript:alert(1)">1</a>' +
+          '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">2</a>' +
+          '<a href="data:image/svg+xml;base64,x">3</a>';
+        const serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(serializedHtml,
+          '<a>1</a>' +
+          '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">2</a>' +
+          '<a href="data:image/svg+xml;base64,x">3</a>'
+        );
+      });
+
+      it('Parse script urls (disallow svg data image uris)', () => {
+        const parser = DomParser({ allow_svg_data_urls: false, allow_html_data_urls: false, validate: false, ...scenario.settings }, schema);
+        const html = '<a href="data:image/svg+xml;base64,x">1</a>' +
+          '<img src="data:image/svg+xml;base64,x">';
+        const serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(
+          serializedHtml,
+          '<a>1</a>' +
+          '<img>'
+        );
+      });
+
+      it('Parse script urls (denied)', () => {
+        const parser = DomParser({ allow_script_urls: false, validate: false, ...scenario.settings }, schema);
+        const html = '<a href="jAvaScript:alert(1)">1</a>' +
+          '<a href="vbscript:alert(2)">2</a>' +
+          '<a href="javascript:alert(3)">3</a>' +
+          '<a href="\njavascript:alert(4)">4</a>' +
+          '<a href="java\nscript:alert(5)">5</a>' +
+          '<a href="java\tscript:alert(6)">6</a>' +
+          '<a href="%6aavascript:alert(7)">7</a>' +
+          '<a href="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">8</a>' +
+          '<a href=" dAt%61: tExt/html  ; bAse64 , PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">9</a>' +
+          '<object data="data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+">10</object>' +
+          '<button formaction="javascript:alert(11)">11</button>' +
+          '<form action="javascript:alert(12)">12</form>' +
+          '<table background="javascript:alert(13)"><tbody><tr><td>13</td></tr></tbody></table>' +
+          '<a href="mhtml:14">14</a>' +
+          '<a xlink:href="jAvaScript:alert(15)">15</a>' +
+          '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">' +
+          '<a href="%E3%82%AA%E3%83%BC%E3%83">Invalid url</a>';
+        const serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(
+          serializedHtml,
+          '<a>1</a>' +
+          '<a>2</a>' +
+          '<a>3</a>' +
+          '<a>4</a>' +
+          '<a>5</a>' +
+          '<a>6</a>' +
+          '<a>7</a>' +
+          '<a>8</a>' +
+          '<a>9</a>' +
+          '<object>10</object>' +
+          '<button>11</button>' +
+          '<form>12</form>' +
+          '<table><tbody><tr><td>13</td></tr></tbody></table>' +
+          '<a>14</a>' +
+          '<a>15</a>' +
+          '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">' +
+          '<a href="%E3%82%AA%E3%83%BC%E3%83">Invalid url</a>'
+        );
+      });
+
+      it('Parse svg urls (default)', () => {
+        const parser = DomParser(scenario.settings);
+        const serializedHtml = serializer.serialize(parser.parse(
+          '<iframe src="data:image/svg+xml;base64,x"></iframe>' +
+          '<a href="data:image/svg+xml;base64,x">1</a>' +
+          '<object data="data:image/svg+xml;base64,x"></object>' +
+          '<img src="data:image/svg+xml;base64,x">' +
+          '<video poster="data:image/svg+xml;base64,x"></video>'
+        ));
+        assert.equal(serializedHtml,
+          '<iframe></iframe>' +
+          '<a>1</a>' +
+          '<object></object>' +
+          '<img src="data:image/svg+xml;base64,x">' +
+          // parser allows svg data urls in <img> and <video> by default but DOMPurify sanitization removes it for <video>
+          (scenario.isSanitizeEnabled ? '<video></video>' : '<video poster="data:image/svg+xml;base64,x"></video>')
+        );
+      });
+
+      it('Parse svg urls (allowed)', () => {
+        const parser = DomParser({ allow_svg_data_urls: true, ...scenario.settings });
+        const serializedHtml = serializer.serialize(parser.parse(
+          '<iframe src="data:image/svg+xml;base64,x"></iframe>' +
+          '<a href="data:image/svg+xml;base64,x">1</a>' +
+          '<object data="data:image/svg+xml;base64,x"></object>' +
+          '<img src="data:image/svg+xml;base64,x">' +
+          '<video poster="data:image/svg+xml;base64,x"></video>'
+        ));
+        assert.equal(serializedHtml,
+          '<iframe src="data:image/svg+xml;base64,x"></iframe>' +
+          '<a href="data:image/svg+xml;base64,x">1</a>' +
+          '<object data="data:image/svg+xml;base64,x"></object>' +
+          '<img src="data:image/svg+xml;base64,x">' +
+          '<video poster="data:image/svg+xml;base64,x"></video>'
+        );
+      });
+
+      it('Parse svg urls (denied)', () => {
+        const parser = DomParser({ allow_svg_data_urls: false, ...scenario.settings });
+        const serializedHtml = serializer.serialize(parser.parse(
+          '<iframe src="data:image/svg+xml;base64,x"></iframe>' +
+          '<a href="data:image/svg+xml;base64,x">1</a>' +
+          '<object data="data:image/svg+xml;base64,x"></object>' +
+          '<img src="data:image/svg+xml;base64,x">' +
+          '<video poster="data:image/svg+xml;base64,x"></video>'
+        ));
+        assert.equal(serializedHtml,
+          '<iframe></iframe>' +
+          '<a>1</a>' +
+          '<object></object>' +
+          '<img>' +
+          '<video></video>'
+        );
+      });
+
+      it('getAttributeFilters/getNodeFilters', () => {
+        const parser = DomParser(scenario.settings);
+        const cb1: ParserFilterCallback = (_nodes, _name, _args) => {};
+        const cb2: ParserFilterCallback = (_nodes, _name, _args) => {};
+
+        parser.addAttributeFilter('attr', cb1);
+        parser.addNodeFilter('node', cb2);
+
+        const attrFilters = parser.getAttributeFilters();
+        const nodeFilters = parser.getNodeFilters();
+
+        assert.deepEqual(attrFilters[attrFilters.length - 1], { name: 'attr', callbacks: [ cb1 ] }, 'Should be expected filter');
+        assert.deepEqual(nodeFilters[nodeFilters.length - 1], { name: 'node', callbacks: [ cb2 ] }, 'Should be expected filter');
+      });
+
+      it('extract base64 uris to blobcache if blob cache is provided', () => {
+        const blobCache = BlobCache();
+        const parser = DomParser({ blob_cache: blobCache, ...scenario.settings });
+        const base64 = 'R0lGODdhDAAMAIABAMzMzP///ywAAAAADAAMAAACFoQfqYeabNyDMkBQb81Uat85nxguUAEAOw==';
+        const base64Uri = `data:image/gif;base64,${base64}`;
+        const serializedHtml = serializer.serialize(parser.parse(`<p><img src="${base64Uri}" /></p>`));
+        const blobInfo = blobCache.findFirst((bi) => bi.base64() === base64) as BlobInfo;
+        const blobUri = blobInfo.blobUri();
+
+        assert.equal(
+          serializedHtml,
+          `<p><img src="${blobUri}"></p>`,
+          'Should be html with blob uri'
+        );
+
+        blobCache.destroy();
+      });
+
+      it('duplicate base64 uris added only once to blobcache if blob cache is provided', () => {
+        const blobCache = BlobCache();
+        const parser = DomParser({ blob_cache: blobCache, ...scenario.settings });
+        const base64 = 'R0lGODdhDAAMAIABAMzMzP///ywAAAAADAAMAAACFoQfqYeabNyDMkBQb81Uat85nxguUAEAOw==';
+        const gifBase64Uri = `data:image/gif;base64,${base64}`;
+        const pngBase64Uri = `data:image/png;base64,${base64}`;
+        const images = `<img src="${gifBase64Uri}" /><img src="${pngBase64Uri}" />`;
+        const serializedHtml = serializer.serialize(parser.parse(`<p>${images}</p><p>${images}</p>`));
+        let count = 0;
+        blobCache.findFirst((bi) => {
+          if (bi.base64() === base64) {
+            count++;
+          }
+          return false;
+        });
+
+        assert.equal(count, 2, 'Only one image per mime type should be in the blob cache');
+        assert.notInclude(serializedHtml, base64, 'HTML shouldn\'t include a base64 data URI');
+        blobCache.destroy();
+      });
+
+      it('do not extract base64 uris for transparent or placeholder images used by for example the page break plugin', () => {
+        const blobCache = BlobCache();
+        const placeholderImg = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mNk+P//PwMRgHFUIX0VAgAE3B3t0SaZ0AAAAABJRU5ErkJggg==';
+        const parser = DomParser({ blob_cache: blobCache, ...scenario.settings });
+        const html = `<p><img src="${Env.transparentSrc}" /><img src="${placeholderImg}" data-mce-placeholder="1"></p>`;
+        const root = parser.parse(html);
+
+        assert.equal(
+          root.getAll('img')[0].attr('src'),
+          Env.transparentSrc,
+          'Should be the unchanged transparent image source'
+        );
+        assert.equal(
+          root.getAll('img')[1].attr('src'),
+          placeholderImg,
+          'Should be the unchanged placeholder image source'
+        );
+
+        blobCache.destroy();
+      });
+
+      it('do not extract base64 uris if blob cache is not provided', () => {
+        const parser = DomParser(scenario.settings);
+        const html = '<p><img src="data:image/gif;base64,R0lGODdhDAAMAIABAMzMzP///ywAAAAADAAMAAACFoQfqYeabNyDMkBQb81Uat85nxguUAEAOw=="></p>';
+        const serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(serializedHtml, html, 'Should be html with base64 uri retained');
+      });
+
+      it('Parse away bogus elements', () => {
+        const testBogusParsing = (inputHtml: string, outputHtml: string) => {
+          const parser = DomParser(scenario.settings, schema);
+          const serializedHtml = serializer.serialize(parser.parse(inputHtml));
+          assert.equal(serializedHtml, outputHtml);
+        };
+
+        testBogusParsing('a<b data-mce-bogus="1">b</b>c', 'abc');
+        testBogusParsing('a<b data-mce-bogus="true">b</b>c', 'abc');
+        testBogusParsing('a<b data-mce-bogus="1"></b>c', 'ac');
+        testBogusParsing('a<b data-mce-bogus="all">b</b>c', 'ac');
+        testBogusParsing('a<b data-mce-bogus="all"><!-- x --><?xml?></b>c', 'ac');
+        testBogusParsing('a<b data-mce-bogus="all"><b>b</b></b>c', 'ac');
+        testBogusParsing('a<b data-mce-bogus="all"><br>b</b><b>c</b>', 'a<b>c</b>');
+        testBogusParsing('a<b data-mce-bogus="all"><img>b</b><b>c</b>', 'a<b>c</b>');
+        testBogusParsing('a<b data-mce-bogus="all"><b attr="x">b</b></b>c', 'ac');
+        testBogusParsing('a<b data-mce-bogus="all"></b>c', 'ac');
+        testBogusParsing('a<b data-mce-bogus="all"></b><b>c</b>', 'a<b>c</b>');
+      });
+
+      it('remove bogus elements even if not part of valid_elements', () => {
+        const parser = DomParser(scenario.settings, Schema({ valid_elements: 'p,span,' }));
+        const html = '<p>a <span data-mce-bogus="all">&nbsp;<span contenteditable="false">X</span>&nbsp;</span>b</p>';
+        const serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(serializedHtml, '<p>a b</p>');
+      });
+
+      it('Parse cdata with comments', () => {
+        const parser = DomParser(scenario.settings, schema);
+
+        const serializedHtml = serializer.serialize(parser.parse('<div><![CDATA[<!--x--><!--y--!>-->]]></div>', { format: 'html' }));
+        assert.equal(serializedHtml, '<div><!--[CDATA[<!--x----><!--y-->--&gt;]]&gt;</div>');
+
+        const serializedXHtml = serializer.serialize(parser.parse('<div><![CDATA[<!--x--><!--y-->--><!--]]></div>', { format: 'xhtml' }));
+        assert.equal(serializedXHtml, '<div><![CDATA[<!--x--><!--y-->--><!--]]></div>');
+      });
+
+      it('TINY-7756: Parsing invalid nested children', () => {
+        const schema = Schema({ valid_children: '-td[button|a|div]' });
+        const parser = DomParser(scenario.settings, schema);
+        const html = '<table><tr><td><button><a><meta /></a></button></td></tr></table>';
+        const serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(serializedHtml, '<table><tbody><tr><td></td></tr></tbody></table>', 'Should remove all invalid children but keep empty table');
+      });
+
+      it('TINY-7756: Parsing invalid nested children with a valid child between', () => {
+        const parser = DomParser(scenario.settings);
+        const html =
+          '<table>' +
+            '<tbody>' +
+              '<tr>' +
+                '<td>' +
+                  '<meta>' +
+                    '<button>' +
+                      '<img />' +
+                      '<button>' +
+                        '<a>' +
+                          '<meta />' +
+                        '</a>' +
+                      '</button>' +
+                      '<img />' +
+                    '</button>' +
+                  '</meta>' +
+                '</td>' +
+              '</tr>' +
+            '</tbody>' +
+          '</table>';
+        const serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(
+          serializedHtml,
+          '<table>' +
+            '<tbody>' +
+              '<tr>' +
+                '<td>' +
                   '<button>' +
-                    '<a>' +
-                      '<meta />' +
-                    '</a>' +
+                    '<img>' +
                   '</button>' +
-                  '<img />' +
-                '</button>' +
-              '</meta>' +
-            '</td>' +
-          '</tr>' +
-        '</tbody>' +
-      '</table>';
-    const serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(
-      serializedHtml,
-      '<table>' +
-        '<tbody>' +
-          '<tr>' +
-            '<td>' +
-              '<button>' +
-                '<img>' +
-              '</button>' +
-              '<button>' +
-                '<a></a>' +
-              '</button>' +
-              '<img>' +
-            '</td>' +
-          '</tr>' +
-        '</tbody>' +
-      '</table>'
-    );
-  });
-
-  it('TINY-8205: Fixes up invalid children even when top-level element does not fit the context', () => {
-    const parser = DomParser();
-    const html = '<p>Hello world! <button>This is a button with a meta tag in it<meta /></button></p>';
-    const serializedHtml = serializer.serialize(parser.parse(html, { context: 'p' }));
-
-    assert.equal(serializedHtml, '<p>Hello world! <button>This is a button with a meta tag in it</button></p>');
-  });
-
-  it('TINY-7756: should prevent dom clobbering overriding document/form properties', () => {
-    const parser = DomParser({}, Schema({ valid_elements: '*[id|src|name|class]' }));
-    const html = '<img src="x" name="getElementById" />' +
-      '<input id="attributes" />' +
-      '<output id="style"></output>' +
-      '<button name="action"></button>' +
-      '<select name="getElementsByName"></select>' +
-      '<fieldset name="method"></fieldset>' +
-      '<textarea name="click"></textarea>';
-    const serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml,
-      '<img src="x">' +
-      '<input>' +
-      '<output></output>' +
-      '<button></button>' +
-      '<select></select>' +
-      '<fieldset></fieldset>' +
-      '<textarea></textarea>'
-    );
-  });
-
-  it('TINY-8639: handling empty text inline elements when root block is empty', () => {
-    const html = '<p><strong></strong></p>' +
-    '<p><s></s></p>' +
-    '<p><span class="test"></span></p>' +
-    '<p><span style="color: red;"></span></p>' +
-    '<p><span></span></p>';
-
-    // Assert default behaviour when padd_empty_block_inline_children is not specified (should be equivalent to false)
-    let parser = DomParser({}, Schema({}));
-    let serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml,
-      '<p>\u00a0</p>' +
-      '<p>\u00a0</p>' +
-      '<p>\u00a0</p>' +
-      '<p>\u00a0</p>' +
-      '<p>\u00a0</p>'
-    );
-
-    parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
-    serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml,
-      '<p>\u00a0</p>' +
-      '<p>\u00a0</p>' +
-      '<p>\u00a0</p>' +
-      '<p>\u00a0</p>' +
-      '<p>\u00a0</p>'
-    );
-
-    parser = DomParser({}, Schema({ padd_empty_block_inline_children: true }));
-    serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml,
-      '<p><strong>\u00a0</strong></p>' +
-      '<p><s>\u00a0</s></p>' +
-      '<p><span class="test">\u00a0</span></p>' +
-      '<p><span style="color: red;">\u00a0</span></p>' +
-      '<p>\u00a0</p>'
-    );
-  });
-
-  it('TINY-8639: handling single space text inline elements when root block is otherwise empty', () => {
-    const html = '<p><strong> </strong></p>' +
-    '<p><s> </s></p>' +
-    '<p><span class="test"> </span></p>' +
-    '<p><span style="color: red;"> </span></p>' +
-    '<p><span> </span></p>';
-
-    // Assert default behaviour when padd_empty_block_inline_children is not specified (should be equivalent to false)
-    let parser = DomParser({}, Schema({}));
-    let serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml,
-      '<p><strong> </strong></p>' +
-      '<p><s> </s></p>' +
-      // isEmpty node logic considers a span with no style attribute and a single space to be empty (Node.ts -> isEmpty -> isEmptyTextNode)
-      '<p> </p>' +
-      '<p><span style="color: red;"> </span></p>' +
-      '<p>\u00a0</p>'
-    );
-
-    parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
-    serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml,
-      '<p><strong> </strong></p>' +
-      '<p><s> </s></p>' +
-      // isEmpty node logic considers a span with no style attribute and a single space to be empty (Node.ts -> isEmpty -> isEmptyTextNode)
-      '<p> </p>' +
-      '<p><span style="color: red;"> </span></p>' +
-      '<p>\u00a0</p>'
-    );
-
-    parser = DomParser({}, Schema({ padd_empty_block_inline_children: true }));
-    serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml,
-      '<p><strong> </strong></p>' +
-      '<p><s> </s></p>' +
-      '<p><span class="test">\u00a0</span></p>' +
-      '<p><span style="color: red;"> </span></p>' +
-      '<p>\u00a0</p>'
-    );
-  });
-
-  it('TINY-8639: handling single nbsp text inline elements when root block is otherwise empty', () => {
-    const html = '<p><strong>&nbsp;</strong></p>' +
-    '<p><s>&nbsp;</s></p>' +
-    '<p><span class="test">&nbsp;</span></p>' +
-    '<p><span style="color: red;">&nbsp;</span></p>' +
-    '<p><span>&nbsp;</span></p>';
-
-    // Assert default behaviour when padd_empty_block_inline_children is not specified (should be equivalent to false)
-    let parser = DomParser({}, Schema({}));
-    let serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml,
-      '<p><strong>\u00a0</strong></p>' +
-      '<p><s>\u00a0</s></p>' +
-      '<p><span class="test">\u00a0</span></p>' +
-      '<p><span style="color: red;">\u00a0</span></p>' +
-      '<p>\u00a0</p>'
-    );
-
-    parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
-    serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml,
-      '<p><strong>\u00a0</strong></p>' +
-      '<p><s>\u00a0</s></p>' +
-      '<p><span class="test">\u00a0</span></p>' +
-      '<p><span style="color: red;">\u00a0</span></p>' +
-      '<p>\u00a0</p>'
-    );
-
-    parser = DomParser({}, Schema({ padd_empty_block_inline_children: true }));
-    serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml,
-      '<p><strong>\u00a0</strong></p>' +
-      '<p><s>\u00a0</s></p>' +
-      '<p><span class="test">\u00a0</span></p>' +
-      '<p><span style="color: red;">\u00a0</span></p>' +
-      '<p>\u00a0</p>'
-    );
-  });
-
-  it('TINY-8639: should always remove empty inline element if it is not in an empty block', () => {
-    const html = '<p>ab<strong></strong>cd</p>' +
-    '<p>ab<s></s>cd</p>' +
-    '<p>ab<span class="test"></span>cd</p>' +
-    '<p>ab<span style="color: red;"></span>cd</p>' +
-    '<p>ab<span></span>cd</p>';
-
-    // Assert default behaviour when padd_empty_block_inline_children is not specified (should be equivalent to false)
-    let parser = DomParser({}, Schema({}));
-    let serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml,
-      '<p>abcd</p>' +
-      '<p>abcd</p>' +
-      '<p>abcd</p>' +
-      '<p>abcd</p>' +
-      '<p>abcd</p>'
-    );
-
-    parser = DomParser({}, Schema({ padd_empty_block_inline_children: false }));
-    serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml,
-      '<p>abcd</p>' +
-      '<p>abcd</p>' +
-      '<p>abcd</p>' +
-      '<p>abcd</p>' +
-      '<p>abcd</p>'
-    );
-
-    parser = DomParser({}, Schema({ padd_empty_block_inline_children: true }));
-    serializedHtml = serializer.serialize(parser.parse(html));
-
-    assert.equal(serializedHtml,
-      '<p>abcd</p>' +
-      '<p>abcd</p>' +
-      '<p>abcd</p>' +
-      '<p>abcd</p>' +
-      '<p>abcd</p>'
-    );
-  });
-
-  it('TINY-8780: Invalid special elements are removed entirely instead of being unwrapped', () => {
-    const parser = DomParser({ forced_root_block: 'p' }, Schema({ invalid_elements: 'script,style,iframe,textarea,div' }));
-    const html = '<script>var x = 1;</script>' +
-      '<style>.red-text { color: red; }</style>' +
-      '<iframe src="about:blank">content</iframe>' +
-      '<textarea>content</textarea>' +
-      '<p>paragraph</p>' +
-      '<div>div</div>';
-
-    const serializedHtml = serializer.serialize(parser.parse(html));
-    assert.equal(serializedHtml, '<p>paragraph</p><p>div</p>');
-  });
-
-  context('validate: false', () => {
-    it('invalid elements and attributes should not be removed', () => {
-      const parser = DomParser({ validate: false }, Schema({ valid_elements: 'span[id]' }));
-      const html = '<p>Hello world! <strong>This is bold</strong> and <span style="text-decoration: underline">this is underlined content</span>.</p>';
-      const serializedHtml = serializer.serialize(parser.parse(html));
-
-      assert.equal(serializedHtml, html);
-    });
-
-    it('empty elements should not be removed', () => {
-      const customSchema = Schema({ valid_elements: 'span[style],strong' });
-      (customSchema.getElementRule('span') as SchemaElement).removeEmptyAttrs = true;
-      (customSchema.getElementRule('strong') as SchemaElement).removeEmpty = true;
-      const parser = DomParser({ validate: false }, customSchema);
-      const html = '<p>Hello world! This should keep empty <strong></strong>elements <span></span>.</p>';
-      const serializedHtml = serializer.serialize(parser.parse(html));
-
-      assert.equal(serializedHtml, html);
-    });
-
-    it('empty elements should not be padded', () => {
-      const customSchema = Schema({ valid_elements: 'span' });
-      (customSchema.getElementRule('span') as SchemaElement).paddEmpty = true;
-      const parser = DomParser({ validate: false }, customSchema);
-      const html = '<p>Hello world! <span></span></p>';
-      const serializedHtml = serializer.serialize(parser.parse(html));
-
-      assert.equal(serializedHtml, html);
-    });
-
-    it('bogus elements should be removed', () => {
-      const parser = DomParser({ validate: false }, schema);
-      const html = '<p>Hello world! <span data-mce-bogus="1">This is inside a bogus element.</span></p><div data-mce-bogus="all"><strong>This is bogus content</strong></div>';
-      const serializedHtml = serializer.serialize(parser.parse(html));
-
-      assert.equal(serializedHtml, '<p>Hello world! This is inside a bogus element.</p>');
-    });
-
-    it('redundant whitespace should still be removed', () => {
-      const parser = DomParser({ validate: false }, schema);
-      let root = parser.parse('  \t\r\n  <P>  \t\r\n   test  \t\r\n   </P>   \t\r\n  ');
-      assert.equal(serializer.serialize(root), '<p>test</p>', 'Redundant whitespace (block element)');
-      assert.deepEqual(countNodes(root), { 'body': 1, 'p': 1, '#text': 1 }, 'Redundant whitespace (block element) (count)');
-
-      root = parser.parse('  \t\r\n  <PRE>  \t\r\n   test  \t\r\n   </PRE>   \t\r\n  ');
-      assert.equal(serializer.serialize(root), '<pre>  \t\n   test  \t\n   </pre>', 'Whitespace around and inside PRE');
-      assert.deepEqual(countNodes(root), { 'body': 1, 'pre': 1, '#text': 1 }, 'Whitespace around and inside PRE (count)');
-    });
-
-    it('unsafe content should still be removed', () => {
-      const parser = DomParser({ validate: false }, schema);
-      const html = '<p>Hello world!<a href="javascript:alert(1)">XSS</a></p>';
-      const serializedHtml = serializer.serialize(parser.parse(html));
-
-      assert.equal(serializedHtml, '<p>Hello world!<a>XSS</a></p>');
-    });
-
-    it('data and aria attributes should always be retained', () => {
-      const parser = DomParser();
-      const html = '<p><a href="http://www.google.com/fake1" data-custom="custom" aria-invalid="true">Hello world!</a></p>';
-      const serializedHtml = serializer.serialize(parser.parse(html));
-
-      assert.equal(serializedHtml, html);
-    });
-
-    context('Transparent elements', () => {
-      const getTransparentElements = (schema: Schema) => Arr.unique(Arr.map(Obj.keys(schema.getTransparentElements()), (s) => s.toLowerCase()));
-
-      const testSplitInvalidBlocksOut = (testCase: { input: string; expected: string }) => {
-        const parser = DomParser();
-        const serializedHtml = serializer.serialize(parser.parse(testCase.input));
-
-        assert.equal(serializedHtml, testCase.expected);
-      };
-
-      it('TINY-9172: inline transparents should not get data-mce-block attribute', () => {
-        const parser = DomParser();
-        const innerHtml = Arr.map(getTransparentElements(parser.schema), (name) => `<${name}>text</${name}>`).join('');
-        const html = `<p>${innerHtml}</p>`;
-        const serializedHtml = serializer.serialize(parser.parse(html));
-
-        assert.equal(serializedHtml, html);
+                  '<button>' +
+                    '<a></a>' +
+                  '</button>' +
+                  '<img>' +
+                '</td>' +
+              '</tr>' +
+            '</tbody>' +
+          '</table>'
+        );
       });
 
-      it('TINY-9172: root level transparents should not get data-mce-block attribute', () => {
-        const parser = DomParser();
-        const html = Arr.map(getTransparentElements(parser.schema), (name) => `<${name}>text</${name}>`).join('');
-        const expectedHtml = Arr.map(getTransparentElements(parser.schema), (name) => `<${name}>text</${name}>`).join('');
-        const serializedHtml = serializer.serialize(parser.parse(html));
+      it('TINY-8205: Fixes up invalid children even when top-level element does not fit the context', () => {
+        const parser = DomParser(scenario.settings);
+        const html = '<p>Hello world! <button>This is a button with a meta tag in it<meta /></button></p>';
+        const serializedHtml = serializer.serialize(parser.parse(html, { context: 'p' }));
 
-        assert.equal(serializedHtml, expectedHtml);
+        assert.equal(serializedHtml, '<p>Hello world! <button>This is a button with a meta tag in it</button></p>');
       });
 
-      it('TINY-9172: transparents wrapping blocks should get data-mce-block attribute', () => {
-        const parser = DomParser();
-        const innerHtml = Arr.map(getTransparentElements(parser.schema), (name) => `<${name}><p>text</p></${name}>`).join('');
-        const html = `<div>${innerHtml}</div>`;
-        const expectedInnerHtml = Arr.map(getTransparentElements(parser.schema), (name) => `<${name} data-mce-block="true"><p>text</p></${name}>`).join('');
-        const expectedHtml = `<div>${expectedInnerHtml}</div>`;
+      it('TINY-7756: should prevent dom clobbering overriding document/form properties', () => {
+        const parser = DomParser(scenario.settings, Schema({ valid_elements: '*[id|src|name|class]' }));
+        const html = '<img src="x" name="getElementById" />' +
+          '<input id="attributes" />' +
+          '<output id="style"></output>' +
+          '<button name="action"></button>' +
+          '<select name="getElementsByName"></select>' +
+          '<fieldset name="method"></fieldset>' +
+          '<textarea name="click"></textarea>';
         const serializedHtml = serializer.serialize(parser.parse(html));
 
-        assert.equal(serializedHtml, expectedHtml);
+        assert.equal(serializedHtml,
+          // dom clobbering prevention handled by DOMPurify sanitization
+          scenario.isSanitizeEnabled
+            ?
+            ('<img src="x">' +
+            '<input>' +
+            '<output></output>' +
+            '<button></button>' +
+            '<select></select>' +
+            '<fieldset></fieldset>' +
+            '<textarea></textarea>')
+            :
+            ('<img src="x" name="getElementById">' +
+            '<input id="attributes">' +
+            '<output id="style"></output>' +
+            '<button name="action"></button>' +
+            '<select name="getElementsByName"></select>' +
+            '<fieldset name="method"></fieldset>' +
+            '<textarea name="click"></textarea>')
+        );
       });
 
-      it('TINY-9232: H1 in H1 should unwrap to single H1', () => testSplitInvalidBlocksOut({
-        input: '<h1><a href="#"><h1>foo</h1></a></h1>',
-        expected: '<h1>foo</h1>'
-      }));
+      it('TINY-8639: handling empty text inline elements when root block is empty', () => {
+        const html = '<p><strong></strong></p>' +
+        '<p><s></s></p>' +
+        '<p><span class="test"></span></p>' +
+        '<p><span style="color: red;"></span></p>' +
+        '<p><span></span></p>';
 
-      it('TINY-9232: H1 and H2 in H1 should unwrap', () => testSplitInvalidBlocksOut({
-        input: '<h1><a href="#"><h1>a</h1><h2>b</h2></a></h1>',
-        expected: '<h1>a</h1><h2>b</h2>'
-      }));
+        // Assert default behaviour when padd_empty_block_inline_children is not specified (should be equivalent to false)
+        let parser = DomParser(scenario.settings, Schema({}));
+        let serializedHtml = serializer.serialize(parser.parse(html));
 
-      it('TINY-9232: H1 and H2 in H1 should unwrap but text should remain links', () => testSplitInvalidBlocksOut({
-        input: '<h1><a href="#">a<h1>b</h1>c<h2>d</h2>e</a></h1>',
-        expected: '<h1><a href="#">a</a></h1><h1>b</h1><h1><a href="#">c</a></h1><h2>d</h2><h1><a href="#">e</a></h1>'
-      }));
+        assert.equal(serializedHtml,
+          '<p>\u00a0</p>' +
+          '<p>\u00a0</p>' +
+          '<p>\u00a0</p>' +
+          '<p>\u00a0</p>' +
+          '<p>\u00a0</p>'
+        );
 
-      it('TINY-9232: H1 in H1 in DIV should unwrap down to DIV', () => testSplitInvalidBlocksOut({
-        input: '<div>a<h1><a href="#"><h1>b</h1></a></h1>c</div>',
-        expected: '<div>a<h1>b</h1>c</div>'
-      }));
+        parser = DomParser(scenario.settings, Schema({ padd_empty_block_inline_children: false }));
+        serializedHtml = serializer.serialize(parser.parse(html));
 
-      it('TINY-9232: Nested anchors wrapped in H1 and H2 should all unwrap', () => testSplitInvalidBlocksOut({
-        input: '<h1><a href="#1"><h2><a href="#2"><h3>foo</h3></a></h2></a></h1>',
-        expected: '<h3>foo</h3>'
-      }));
+        assert.equal(serializedHtml,
+          '<p>\u00a0</p>' +
+          '<p>\u00a0</p>' +
+          '<p>\u00a0</p>' +
+          '<p>\u00a0</p>' +
+          '<p>\u00a0</p>'
+        );
 
-      it('TINY-9232: H1 with content before and after anchor should be retained but the anchor should be unwrapped', () => testSplitInvalidBlocksOut({
-        input: '<h1>a<a href="#"><h1>foo</h1></a>b</h1>',
-        expected: '<h1>a</h1><h1>foo</h1><h1>b</h1>'
-      }));
+        parser = DomParser(scenario.settings, Schema({ padd_empty_block_inline_children: true }));
+        serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(serializedHtml,
+          '<p><strong>\u00a0</strong></p>' +
+          '<p><s>\u00a0</s></p>' +
+          '<p><span class="test">\u00a0</span></p>' +
+          '<p><span style="color: red;">\u00a0</span></p>' +
+          '<p>\u00a0</p>'
+        );
+      });
+
+      it('TINY-8639: handling single space text inline elements when root block is otherwise empty', () => {
+        const html = '<p><strong> </strong></p>' +
+        '<p><s> </s></p>' +
+        '<p><span class="test"> </span></p>' +
+        '<p><span style="color: red;"> </span></p>' +
+        '<p><span> </span></p>';
+
+        // Assert default behaviour when padd_empty_block_inline_children is not specified (should be equivalent to false)
+        let parser = DomParser(scenario.settings, Schema({}));
+        let serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(serializedHtml,
+          '<p><strong> </strong></p>' +
+          '<p><s> </s></p>' +
+          // isEmpty node logic considers a span with no style attribute and a single space to be empty (Node.ts -> isEmpty -> isEmptyTextNode)
+          '<p> </p>' +
+          '<p><span style="color: red;"> </span></p>' +
+          '<p>\u00a0</p>'
+        );
+
+        parser = DomParser(scenario.settings, Schema({ padd_empty_block_inline_children: false }));
+        serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(serializedHtml,
+          '<p><strong> </strong></p>' +
+          '<p><s> </s></p>' +
+          // isEmpty node logic considers a span with no style attribute and a single space to be empty (Node.ts -> isEmpty -> isEmptyTextNode)
+          '<p> </p>' +
+          '<p><span style="color: red;"> </span></p>' +
+          '<p>\u00a0</p>'
+        );
+
+        parser = DomParser(scenario.settings, Schema({ padd_empty_block_inline_children: true }));
+        serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(serializedHtml,
+          '<p><strong> </strong></p>' +
+          '<p><s> </s></p>' +
+          '<p><span class="test">\u00a0</span></p>' +
+          '<p><span style="color: red;"> </span></p>' +
+          '<p>\u00a0</p>'
+        );
+      });
+
+      it('TINY-8639: handling single nbsp text inline elements when root block is otherwise empty', () => {
+        const html = '<p><strong>&nbsp;</strong></p>' +
+        '<p><s>&nbsp;</s></p>' +
+        '<p><span class="test">&nbsp;</span></p>' +
+        '<p><span style="color: red;">&nbsp;</span></p>' +
+        '<p><span>&nbsp;</span></p>';
+
+        // Assert default behaviour when padd_empty_block_inline_children is not specified (should be equivalent to false)
+        let parser = DomParser(scenario.settings, Schema({}));
+        let serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(serializedHtml,
+          '<p><strong>\u00a0</strong></p>' +
+          '<p><s>\u00a0</s></p>' +
+          '<p><span class="test">\u00a0</span></p>' +
+          '<p><span style="color: red;">\u00a0</span></p>' +
+          '<p>\u00a0</p>'
+        );
+
+        parser = DomParser(scenario.settings, Schema({ padd_empty_block_inline_children: false }));
+        serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(serializedHtml,
+          '<p><strong>\u00a0</strong></p>' +
+          '<p><s>\u00a0</s></p>' +
+          '<p><span class="test">\u00a0</span></p>' +
+          '<p><span style="color: red;">\u00a0</span></p>' +
+          '<p>\u00a0</p>'
+        );
+
+        parser = DomParser(scenario.settings, Schema({ padd_empty_block_inline_children: true }));
+        serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(serializedHtml,
+          '<p><strong>\u00a0</strong></p>' +
+          '<p><s>\u00a0</s></p>' +
+          '<p><span class="test">\u00a0</span></p>' +
+          '<p><span style="color: red;">\u00a0</span></p>' +
+          '<p>\u00a0</p>'
+        );
+      });
+
+      it('TINY-8639: should always remove empty inline element if it is not in an empty block', () => {
+        const html = '<p>ab<strong></strong>cd</p>' +
+        '<p>ab<s></s>cd</p>' +
+        '<p>ab<span class="test"></span>cd</p>' +
+        '<p>ab<span style="color: red;"></span>cd</p>' +
+        '<p>ab<span></span>cd</p>';
+
+        // Assert default behaviour when padd_empty_block_inline_children is not specified (should be equivalent to false)
+        let parser = DomParser(scenario.settings, Schema({}));
+        let serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(serializedHtml,
+          '<p>abcd</p>' +
+          '<p>abcd</p>' +
+          '<p>abcd</p>' +
+          '<p>abcd</p>' +
+          '<p>abcd</p>'
+        );
+
+        parser = DomParser(scenario.settings, Schema({ padd_empty_block_inline_children: false }));
+        serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(serializedHtml,
+          '<p>abcd</p>' +
+          '<p>abcd</p>' +
+          '<p>abcd</p>' +
+          '<p>abcd</p>' +
+          '<p>abcd</p>'
+        );
+
+        parser = DomParser(scenario.settings, Schema({ padd_empty_block_inline_children: true }));
+        serializedHtml = serializer.serialize(parser.parse(html));
+
+        assert.equal(serializedHtml,
+          '<p>abcd</p>' +
+          '<p>abcd</p>' +
+          '<p>abcd</p>' +
+          '<p>abcd</p>' +
+          '<p>abcd</p>'
+        );
+      });
+
+      it('TINY-8780: Invalid special elements are removed entirely instead of being unwrapped', () => {
+        const parser = DomParser({ forced_root_block: 'p', ...scenario.settings }, Schema({ invalid_elements: 'script,style,iframe,textarea,div' }));
+        const html = '<script>var x = 1;</script>' +
+          '<style>.red-text { color: red; }</style>' +
+          '<iframe src="about:blank">content</iframe>' +
+          '<textarea>content</textarea>' +
+          '<p>paragraph</p>' +
+          '<div>div</div>';
+
+        const serializedHtml = serializer.serialize(parser.parse(html));
+        assert.equal(serializedHtml, '<p>paragraph</p><p>div</p>');
+      });
+
+      context('validate: false', () => {
+        it('invalid elements and attributes should not be removed', () => {
+          const parser = DomParser({ validate: false, ...scenario.settings }, Schema({ valid_elements: 'span[id]' }));
+          const html = '<p>Hello world! <strong>This is bold</strong> and <span style="text-decoration: underline">this is underlined content</span>.</p>';
+          const serializedHtml = serializer.serialize(parser.parse(html));
+
+          assert.equal(serializedHtml, html);
+        });
+
+        it('empty elements should not be removed', () => {
+          const customSchema = Schema({ valid_elements: 'span[style],strong' });
+          (customSchema.getElementRule('span') as SchemaElement).removeEmptyAttrs = true;
+          (customSchema.getElementRule('strong') as SchemaElement).removeEmpty = true;
+          const parser = DomParser({ validate: false, ...scenario.settings }, customSchema);
+          const html = '<p>Hello world! This should keep empty <strong></strong>elements <span></span>.</p>';
+          const serializedHtml = serializer.serialize(parser.parse(html));
+
+          assert.equal(serializedHtml, html);
+        });
+
+        it('empty elements should not be padded', () => {
+          const customSchema = Schema({ valid_elements: 'span' });
+          (customSchema.getElementRule('span') as SchemaElement).paddEmpty = true;
+          const parser = DomParser({ validate: false, ...scenario.settings }, customSchema);
+          const html = '<p>Hello world! <span></span></p>';
+          const serializedHtml = serializer.serialize(parser.parse(html));
+
+          assert.equal(serializedHtml, html);
+        });
+
+        it('bogus elements should be removed', () => {
+          const parser = DomParser({ validate: false, ...scenario.settings }, schema);
+          const html = '<p>Hello world! <span data-mce-bogus="1">This is inside a bogus element.</span></p><div data-mce-bogus="all"><strong>This is bogus content</strong></div>';
+          const serializedHtml = serializer.serialize(parser.parse(html));
+
+          assert.equal(serializedHtml, '<p>Hello world! This is inside a bogus element.</p>');
+        });
+
+        it('redundant whitespace should still be removed', () => {
+          const parser = DomParser({ validate: false, ...scenario.settings }, schema);
+          let root = parser.parse('  \t\r\n  <P>  \t\r\n   test  \t\r\n   </P>   \t\r\n  ');
+          assert.equal(serializer.serialize(root), '<p>test</p>', 'Redundant whitespace (block element)');
+          assert.deepEqual(countNodes(root), { 'body': 1, 'p': 1, '#text': 1 }, 'Redundant whitespace (block element) (count)');
+
+          root = parser.parse('  \t\r\n  <PRE>  \t\r\n   test  \t\r\n   </PRE>   \t\r\n  ');
+          assert.equal(serializer.serialize(root), '<pre>  \t\n   test  \t\n   </pre>', 'Whitespace around and inside PRE');
+          assert.deepEqual(countNodes(root), { 'body': 1, 'pre': 1, '#text': 1 }, 'Whitespace around and inside PRE (count)');
+        });
+
+        it('unsafe content should still be removed', () => {
+          const parser = DomParser({ validate: false, ...scenario.settings }, schema);
+          const html = '<p>Hello world!<a href="javascript:alert(1)">XSS</a></p>';
+          const serializedHtml = serializer.serialize(parser.parse(html));
+
+          assert.equal(serializedHtml, '<p>Hello world!<a>XSS</a></p>');
+        });
+
+        it('data and aria attributes should always be retained', () => {
+          const parser = DomParser(scenario.settings);
+          const html = '<p><a href="http://www.google.com/fake1" data-custom="custom" aria-invalid="true">Hello world!</a></p>';
+          const serializedHtml = serializer.serialize(parser.parse(html));
+
+          assert.equal(serializedHtml, html);
+        });
+
+        context('Transparent elements', () => {
+          const getTransparentElements = (schema: Schema) => Arr.unique(Arr.map(Obj.keys(schema.getTransparentElements()), (s) => s.toLowerCase()));
+
+          const testSplitInvalidBlocksOut = (testCase: { input: string; expected: string }) => {
+            const parser = DomParser(scenario.settings);
+            const serializedHtml = serializer.serialize(parser.parse(testCase.input));
+
+            assert.equal(serializedHtml, testCase.expected);
+          };
+
+          it('TINY-9172: inline transparents should not get data-mce-block attribute', () => {
+            const parser = DomParser(scenario.settings);
+            const innerHtml = Arr.map(getTransparentElements(parser.schema), (name) => `<${name}>text</${name}>`).join('');
+            const html = `<p>${innerHtml}</p>`;
+            const serializedHtml = serializer.serialize(parser.parse(html));
+
+            assert.equal(serializedHtml, html);
+          });
+
+          it('TINY-9172: root level transparents should not get data-mce-block attribute', () => {
+            const parser = DomParser(scenario.settings);
+            const html = Arr.map(getTransparentElements(parser.schema), (name) => `<${name}>text</${name}>`).join('');
+            const expectedHtml = Arr.map(getTransparentElements(parser.schema), (name) => `<${name}>text</${name}>`).join('');
+            const serializedHtml = serializer.serialize(parser.parse(html));
+
+            assert.equal(serializedHtml, expectedHtml);
+          });
+
+          it('TINY-9172: transparents wrapping blocks should get data-mce-block attribute', () => {
+            const parser = DomParser(scenario.settings);
+            const innerHtml = Arr.map(getTransparentElements(parser.schema), (name) => `<${name}><p>text</p></${name}>`).join('');
+            const html = `<div>${innerHtml}</div>`;
+            const expectedInnerHtml = Arr.map(getTransparentElements(parser.schema), (name) => `<${name} data-mce-block="true"><p>text</p></${name}>`).join('');
+            const expectedHtml = `<div>${expectedInnerHtml}</div>`;
+            const serializedHtml = serializer.serialize(parser.parse(html));
+
+            assert.equal(serializedHtml, expectedHtml);
+          });
+
+          it('TINY-9232: H1 in H1 should unwrap to single H1', () => testSplitInvalidBlocksOut({
+            input: '<h1><a href="#"><h1>foo</h1></a></h1>',
+            expected: '<h1>foo</h1>'
+          }));
+
+          it('TINY-9232: H1 and H2 in H1 should unwrap', () => testSplitInvalidBlocksOut({
+            input: '<h1><a href="#"><h1>a</h1><h2>b</h2></a></h1>',
+            expected: '<h1>a</h1><h2>b</h2>'
+          }));
+
+          it('TINY-9232: H1 and H2 in H1 should unwrap but text should remain links', () => testSplitInvalidBlocksOut({
+            input: '<h1><a href="#">a<h1>b</h1>c<h2>d</h2>e</a></h1>',
+            expected: '<h1><a href="#">a</a></h1><h1>b</h1><h1><a href="#">c</a></h1><h2>d</h2><h1><a href="#">e</a></h1>'
+          }));
+
+          it('TINY-9232: H1 in H1 in DIV should unwrap down to DIV', () => testSplitInvalidBlocksOut({
+            input: '<div>a<h1><a href="#"><h1>b</h1></a></h1>c</div>',
+            expected: '<div>a<h1>b</h1>c</div>'
+          }));
+
+          it('TINY-9232: Nested anchors wrapped in H1 and H2 should all unwrap', () => testSplitInvalidBlocksOut({
+            input: '<h1><a href="#1"><h2><a href="#2"><h3>foo</h3></a></h2></a></h1>',
+            expected: '<h3>foo</h3>'
+          }));
+
+          it('TINY-9232: H1 with content before and after anchor should be retained but the anchor should be unwrapped', () => testSplitInvalidBlocksOut({
+            input: '<h1>a<a href="#"><h1>foo</h1></a>b</h1>',
+            expected: '<h1>a</h1><h1>foo</h1><h1>b</h1>'
+          }));
+        });
+      });
     });
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1491,30 +1491,32 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
   context('TINY-9600: sanitize: false', () => {
     const testDisablingSanitization = (testCase: { name: string; input: string }) => {
       it(testCase.name, () => {
-        const parser = DomParser({ sanitize: false }, schema);
-        const serializedHtml = serializer.serialize(parser.parse(testCase.input));
-
+        const schema = Schema();
+        const serializedHtml = HtmlSerializer({}, schema).serialize(
+          DomParser({ sanitize: false }, schema).parse(testCase.input)
+        );
         assert.equal(serializedHtml, testCase.input);
       });
     };
 
-    Arr.each([{
-      name: 'should not remove script tags',
-      input: '<script>alert(1)</script>'
-    }, {
-      name: 'should not remove iframe tags with child nodes',
-      input: '<iframe src="https://example.com"><p>Lorem ipsum</p></iframe>'
-    }, {
-      name: 'should not remove iframe tags with srcdoc',
-      input: '<iframe srcdoc="Lorem ipsum"></iframe>'
-    }, {
-      name: 'should not remove unsafe attributes',
-      input: '<p><a href="javascript:alert(1)">XSS</a></p>'
-    },
-    {
-      name: 'should not remove svg tags',
-      input: '<svg><circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow"></circle></svg>'
-    }
+    Arr.each([
+      {
+        name: 'should not remove script tags',
+        input: '<script>alert(1)</script>'
+      }, {
+        name: 'should not remove iframe tags with child nodes',
+        input: '<iframe src="https://example.com"><p>Lorem ipsum</p></iframe>'
+      }, {
+        name: 'should not remove iframe tags with srcdoc',
+        input: '<iframe srcdoc="Lorem ipsum"></iframe>'
+      }, {
+        name: 'should not remove unsafe attributes',
+        input: '<p><a href="javascript:alert(1)">XSS</a></p>'
+      },
+      {
+        name: 'should not remove svg tags',
+        input: '<svg><circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow"></circle></svg>'
+      }
     ], testDisablingSanitization);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1488,60 +1488,58 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     });
   });
 
-  context('TINY-9600: sanitize: false', () => {
+  context('TINY-9600: sanitize: false with unsafe input', () => {
     const getNoSanitizeParser = (settings: DomParserSettings, schema: Schema): DomParser =>
       DomParser({ ...settings, sanitize: false }, schema);
 
-    context('Test unsafe input', () => {
-      const testDisablingSanitization = (outputs: string[], schemaSettings: SchemaSettings) => {
-        Arr.each([
-          {
-            name: 'script tags',
-            input: '<script>alert(1)</script>'
-          }, {
-            name: 'iframe tags with child nodes',
-            input: '<iframe src="https://example.com"><p>Lorem ipsum</p></iframe>'
-          }, {
-            name: 'iframe tags with srcdoc attribute',
-            input: '<iframe srcdoc="Lorem ipsum"></iframe>'
-          }, {
-            name: 'unsafe href attributes',
-            input: '<p><a href="javascript:alert(1)">XSS</a></p>'
-          },
-          {
-            name: 'svg tags',
-            input: '<svg><circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow"></circle></svg>'
-          }
-        ], (testCase, i) => {
-          it(testCase.name, () => {
-            const schema = Schema(schemaSettings);
-            const serializedHtml = HtmlSerializer({}, schema).serialize(
-              getNoSanitizeParser({}, schema).parse(testCase.input)
-            );
-            assert.equal(serializedHtml, outputs[i]);
-          });
+    const testDisablingSanitization = (outputs: string[], schemaSettings: SchemaSettings) => {
+      Arr.each([
+        {
+          name: 'script tags',
+          input: '<script>alert(1)</script>'
+        }, {
+          name: 'iframe tags with child nodes',
+          input: '<iframe src="https://example.com"><p>Lorem ipsum</p></iframe>'
+        }, {
+          name: 'iframe tags with srcdoc attribute',
+          input: '<iframe srcdoc="Lorem ipsum"></iframe>'
+        }, {
+          name: 'unsafe href attributes',
+          input: '<p><a href="javascript:alert(1)">XSS</a></p>'
+        },
+        {
+          name: 'svg tags',
+          input: '<svg><circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow"></circle></svg>'
+        }
+      ], (testCase, i) => {
+        it(testCase.name, () => {
+          const schema = Schema(schemaSettings);
+          const serializedHtml = HtmlSerializer({}, schema).serialize(
+            getNoSanitizeParser({}, schema).parse(testCase.input)
+          );
+          assert.equal(serializedHtml, outputs[i]);
         });
-      };
-
-      context('with default schema', () => {
-        testDisablingSanitization([
-          '',
-          '<iframe src="https://example.com"><p>Lorem ipsum</p></iframe>',
-          '<iframe></iframe>',
-          '<p><a>XSS</a></p>',
-          ''
-        ], {});
       });
+    };
 
-      context('with valid_elements: \'*[*]\' schema', () => {
-        testDisablingSanitization([
-          '<script>alert(1)</script>',
-          '<iframe src="https://example.com"><p>Lorem ipsum</p></iframe>',
-          '<iframe srcdoc="Lorem ipsum"></iframe>',
-          '<p><a>XSS</a></p>',
-          '<svg><circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow"></circle></svg>'
-        ], { valid_elements: '*[*]' });
-      });
+    context('with default schema', () => {
+      testDisablingSanitization([
+        '',
+        '<iframe src="https://example.com"><p>Lorem ipsum</p></iframe>',
+        '<iframe></iframe>',
+        '<p><a>XSS</a></p>',
+        ''
+      ], {});
+    });
+
+    context('with valid_elements: \'*[*]\' schema', () => {
+      testDisablingSanitization([
+        '<script>alert(1)</script>',
+        '<iframe src="https://example.com"><p>Lorem ipsum</p></iframe>',
+        '<iframe srcdoc="Lorem ipsum"></iframe>',
+        '<p><a>XSS</a></p>',
+        '<svg><circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow"></circle></svg>'
+      ], { valid_elements: '*[*]' });
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1489,34 +1489,46 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
   });
 
   context('TINY-9600: sanitize: false', () => {
-    const testDisablingSanitization = (testCase: { name: string; input: string }) => {
-      it(testCase.name, () => {
-        const schema = Schema();
-        const serializedHtml = HtmlSerializer({}, schema).serialize(
-          DomParser({ sanitize: false }, schema).parse(testCase.input)
-        );
-        assert.equal(serializedHtml, testCase.input);
-      });
-    };
-
-    Arr.each([
+    const testCases = [
       {
-        name: 'should not remove script tags',
+        name: 'script tags',
         input: '<script>alert(1)</script>'
       }, {
-        name: 'should not remove iframe tags with child nodes',
+        name: 'iframe tags with child nodes',
         input: '<iframe src="https://example.com"><p>Lorem ipsum</p></iframe>'
       }, {
-        name: 'should not remove iframe tags with srcdoc',
+        name: 'iframe tags with srcdoc attribute',
         input: '<iframe srcdoc="Lorem ipsum"></iframe>'
       }, {
-        name: 'should not remove unsafe attributes',
+        name: 'unsafe href attributes',
         input: '<p><a href="javascript:alert(1)">XSS</a></p>'
       },
       {
-        name: 'should not remove svg tags',
+        name: 'svg tags',
         input: '<svg><circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow"></circle></svg>'
       }
-    ], testDisablingSanitization);
+    ];
+
+    const testDisablingSanitization = (outputs: string[]) => {
+      Arr.each(testCases, (testCase, i) => {
+        it(testCase.name, () => {
+          const schema = Schema();
+          const serializedHtml = HtmlSerializer({}, schema).serialize(
+            DomParser({ sanitize: false }, schema).parse(testCase.input)
+          );
+          assert.equal(serializedHtml, outputs[i]);
+        });
+      });
+    };
+
+    context('with default schema', () => {
+      testDisablingSanitization([
+        '',
+        '<iframe src="https://example.com"><p>Lorem ipsum</p></iframe>',
+        '<iframe></iframe>',
+        '<p><a>XSS</a></p>',
+        '',
+      ]);
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/init/InitUnsanitizedContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitUnsanitizedContentTest.ts
@@ -15,14 +15,14 @@ describe('browser.tinymce.core.init.InitUnsanitizedContentTest', () => {
     });
   };
 
-  const unsanitizedHtml = '<p><a href="javascript:alert(1)">XSS</a></p>';
+  const unsanitizedHtml = '<p id="action">XSS</p>';
 
-  context('TINY-9600: xss_sanitized: true', () => {
-    const sanitizedHtml = '<p><a>XSS</a></p>';
+  context('TINY-9600: xss_sanitization: true', () => {
+    const sanitizedHtml = '<p>XSS</p>';
     initAndAssertContent('should sanitize initial content', true, unsanitizedHtml, sanitizedHtml);
   });
 
-  context('TINY-9600: xss_sanitized: false', () => {
+  context('TINY-9600: xss_sanitization: false', () => {
     initAndAssertContent('should not sanitize initial content', false, unsanitizedHtml, unsanitizedHtml);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/paste/UnsanitizedPasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/UnsanitizedPasteTest.ts
@@ -4,8 +4,8 @@ import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.paste.UnsanitizedPasteTest', () => {
-  const unsanitizedHtml = '<p><a href="javascript:alert(1)">XSS</a></p>';
-  const sanitizedHtml = '<p><a>XSS</a></p>';
+  const unsanitizedHtml = '<p id="action">XSS</p>';
+  const sanitizedHtml = '<p>XSS</p>';
   const testPaste = (editor: Editor, content: string, expected: string) => {
     editor.setContent('');
     editor.execCommand('mceInsertClipboardContent', false, { html: content });


### PR DESCRIPTION
Related Ticket: TINY-9635

Description of Changes:
Previously node and attribute validation code (incl. bogus element removal, schema validation, etc.) is attached to DOMPurify hooks
* With the new option `xss_sanitization` introduced in TINY-9600, this code is no longer run when DOMPurify sanitization is disabled with `xss_sanitization: false`

This PR reintroduces the functionality by using NodeIterator to iterate through the body to validate nodes and attributes when DOMPurify is disabled (`xss_sanitization: false`)
* We reuse the same logic as what was previously defined in the DOMPurify hooks where possible (attribute validation had to be slightly adapted)
* Sanitization code is also refactored into a new `Sanitization` module separate from `DomParser`
* Address bug in `isInvalidUri` where whitespaces in URIs prevented script/data regex from matching properly 

Pre-checks:
* [x] ~Changelog entry added~ - a follow-up to TINY-9600
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
