### PR TITLE
TINY-9644: fix styles for `fontinputsize` component

### DIFF
--- a/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
@@ -114,6 +114,7 @@
   }
 
   .tox-tbtn,
+  .tox-number-input,
   .tox-tbtn--select,
   .tox-split-button {
     margin: @toolbar-button-spacing-y @toolbar-button-spacing-x (@toolbar-button-spacing-y + 1px) 0;

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-number-input.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-number-input.less
@@ -2,7 +2,6 @@
 // Toolbar number input
 //
 
-@toolbar-number-input-button-height: 28px;
 @toolbar-number-input-button-width: 24px;
 @toolbar-number-input-button-margin: 2px;
 @toolbar-number-input-button-icon-ratio: .67;
@@ -50,7 +49,7 @@
     button {
       background: @toolbar-button-bespoke-background-color;
       color: @toolbar-button-text-color;
-      height: @toolbar-number-input-button-height;
+      height: @toolbar-button-height;
       text-align: center;
       width: @toolbar-number-input-button-width;
 


### PR DESCRIPTION
Related Ticket: TINY-9644

Description of Changes:
the problem was that in some cases we got that `skin.less` file that overwrites the styles for some elements and also that overwriting the `@toolbar-button-height` was not enough since we had also `@toolbar-number-input-button-height` with the same value

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
