### PR TITLE
TINY-9647: Two duplicated lines in the TinyMCE Changelog

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `group` and `togglebutton` in view. #TINY-9523
 - New `togglebutton` in dialog footer buttons. #TINY-9523
 - Added `toggleFullscreen` to dialog API. #TINY-9528
-- New text-size-increase and text-size-decrease icons. #TINY-9530
 - New `text-size-increase` and `text-size-decrease` icons. #TINY-9530
 - New `xss_sanitization` option to allow for XSS sanitization to be disabled. #TINY-9600
 - Added top right close 'x' button of the modal dialogs to keyboard navigation. #TINY-9520

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `highlight_on_focus` option which enables highlighting the content area on focus. #TINY-9277
 - New `fontsizeinput` toolbar item which allows the user to set the size via input and also increase and decrease it with `+` and `-` buttons. #TINY-9429
 - Added `skipFocus` option to the `ToggleToolbarDrawer` command to preserve focus. #TINY-9337
-- Added `common/space/delBetweenExclamationMarks` to remove spaces between exclamation marks. #TINY-9398
 - New `font_size_input_default_unit` option allow to use of numbers without a unit in `fontsizeinput` and have them parsed with the default unit, if it is not defined the default is `pt`. #TINY-9585
 - New `group` and `togglebutton` in view. #TINY-9523
 - New `togglebutton` in dialog footer buttons. #TINY-9523


### PR DESCRIPTION
Related Ticket: TINY-9647

Description of Changes:
* Removed near-duplicate line from changlog.
* Removed entry duplicated from entry in the Advanced Typography plugin changelog.

Pre-checks:
~* [ ] Changelog entry added~
~* [ ] Tests have been added (if applicable)~
~* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`~

Review:
~* [ ] Milestone set~
~* [ ] Docs ticket created (if applicable)~

GitHub issues (if applicable):
