### PR TITLE
TINY-9606: fixed test labels ticket ids

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
@@ -440,19 +440,19 @@ describe('browser.tinymce.core.DragDropOverridesTest', () => {
         TinyAssertions.assertContent(editor, testCase.expectedHtml);
       };
 
-      it('TINY-9558: Should insert padding br into empty blocks when dragging the last block child out', async () => testDragDropPadding({
+      it('TINY-9606: Should insert padding br into empty blocks when dragging the last block child out', async () => testDragDropPadding({
         html: '<div><p class="toDrag" contenteditable="false">CEF</p></div><div class="destination">drop target</div>',
         expectedHtml: '<div>&nbsp;</div><div class="destination"><p class="toDrag" contenteditable="false">CEF</p>drop target</div>',
         expectedDragFromParentHtml: '<br data-mce-bogus="1">'
       }));
 
-      it('TINY-9558: Should insert padding br into empty blocks when dragging the last inline child out', async () => testDragDropPadding({
+      it('TINY-9606: Should insert padding br into empty blocks when dragging the last inline child out', async () => testDragDropPadding({
         html: '<p><span class="toDrag" contenteditable="false">CEF</span></p><div class="destination">drop target</div>',
         expectedHtml: '<p>&nbsp;</p><div class="destination"><span class="toDrag" contenteditable="false">CEF</span>drop target</div>',
         expectedDragFromParentHtml: '<br data-mce-bogus="1">'
       }));
 
-      it('TINY-9558: Should not insert padding br into blocks when not dragging the last child out', async () => testDragDropPadding({
+      it('TINY-9606: Should not insert padding br into blocks when not dragging the last child out', async () => testDragDropPadding({
         html: '<p>x<span class="toDrag" contenteditable="false">CEF</span></p><div class="destination">drop target</div>',
         expectedHtml: '<p>x</p><div class="destination"><span class="toDrag" contenteditable="false">CEF</span>drop target</div>',
         expectedDragFromParentHtml: 'x'


### PR DESCRIPTION
Related Ticket: TINY-9606

Description of Changes:
* Follow up PR to TINY-9606 noticed that I used the wrong ticket IDs in the test labels. So pretty minor. To many parallel PRs got them mixed up.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
