### PR TITLE
TINY-9649: Prevent zero color columns from crashing page

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inserting elements that was not valid within the closest editing host would incorrectly split the editing host. #TINY-9595
 - `color_cols` option was not respected in the `forecolor` or `backcolor` color swatches. #TINY-9560
 - Drag and dropping the last noneditable element out of its parent block would not properly pad the parent block element. #TINY-9606
+- Opening color swatches would cause tab to crash when `color_cols` or other column option is set to 0. #TINY-9649
 
 ## 6.3.2 - 2023-02-22
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -85,7 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `color_cols` option was not respected in the `forecolor` or `backcolor` color swatches. #TINY-9560
 - Drag and dropping the last noneditable element out of its parent block would not properly pad the parent block element. #TINY-9606
 - Applying heading formats from `text_patterns` produced an invisible space before a word. #TINY-9603
-- Opening color swatches would cause tab to crash when `color_cols` or other column option is set to 0. #TINY-9649
+- Opening color swatches would cause tab to crash when `color_cols` or other column option was set to 0. #TINY-9649
 
 ## 6.3.2 - 2023-02-22
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
@@ -9,9 +9,10 @@ const foregroundId = 'forecolor';
 const backgroundId = 'hilitecolor';
 
 const defaultCols = 5;
+const minColors = Math.pow(defaultCols, 2);
 
 const calcCols = (colors: number): number =>
-  Math.max(defaultCols, Math.ceil(Math.sqrt(colors)));
+  colors > minColors ? Math.ceil(Math.sqrt(colors)) : defaultCols;
 
 const calcColsOption = (calculatedCols: number, fallbackCols: number): number =>
   defaultCols === calculatedCols ? fallbackCols : calculatedCols;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
@@ -9,10 +9,9 @@ const foregroundId = 'forecolor';
 const backgroundId = 'hilitecolor';
 
 const defaultCols = 5;
-const minColors = Math.pow(defaultCols, 2);
 
 const calcCols = (colors: number): number =>
-  colors > minColors ? Math.ceil(Math.sqrt(colors)) : defaultCols;
+  Math.max(defaultCols, Math.ceil(Math.sqrt(colors)));
 
 const calcColsOption = (editor: Editor, numColors: number): number => {
   const calculatedCols = calcCols(numColors);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
@@ -17,11 +17,7 @@ const calcCols = (colors: number): number =>
 const calcColsOption = (editor: Editor, numColors: number): number => {
   const calculatedCols = calcCols(numColors);
   const fallbackCols = option('color_cols')(editor);
-  if (defaultCols === calculatedCols && fallbackCols >= defaultCols) {
-    return fallbackCols;
-  } else {
-    return calculatedCols;
-  }
+  return defaultCols === calculatedCols ? fallbackCols : calculatedCols;
 };
 
 const mapColors = (colorMap: string[]): Menu.ChoiceMenuItemSpec[] => {
@@ -141,7 +137,7 @@ const colorColsOption = (editor: Editor, id: string): number => {
 
 const getColorCols = (editor: Editor, id: string): number => {
   const colorCols = colorColsOption(editor, id);
-  return colorCols >= defaultCols ? colorCols : defaultCols;
+  return colorCols > 0 ? colorCols : defaultCols;
 };
 
 const hasCustomColors = option('custom_colors');

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
@@ -14,8 +14,15 @@ const minColors = Math.pow(defaultCols, 2);
 const calcCols = (colors: number): number =>
   colors > minColors ? Math.ceil(Math.sqrt(colors)) : defaultCols;
 
-const calcColsOption = (calculatedCols: number, fallbackCols: number): number =>
-  defaultCols === calculatedCols ? fallbackCols : calculatedCols;
+const calcColsOption = (editor: Editor, numColors: number): number => {
+  const calculatedCols = calcCols(numColors);
+  const fallbackCols = option('color_cols')(editor);
+  if (defaultCols === calculatedCols && fallbackCols >= defaultCols) {
+    return fallbackCols;
+  } else {
+    return calculatedCols;
+  }
+};
 
 const mapColors = (colorMap: string[]): Menu.ChoiceMenuItemSpec[] => {
   const colors: Menu.ChoiceMenuItemSpec[] = [];
@@ -98,12 +105,12 @@ const register = (editor: Editor): void => {
 
   registerOption('color_cols_foreground', {
     processor: 'number',
-    default: calcColsOption(calcCols(getColors(editor, foregroundId).length), option('color_cols')(editor))
+    default: calcColsOption(editor, getColors(editor, foregroundId).length)
   });
 
   registerOption('color_cols_background', {
     processor: 'number',
-    default: calcColsOption(calcCols(getColors(editor, backgroundId).length), option('color_cols')(editor))
+    default: calcColsOption(editor, getColors(editor, backgroundId).length)
   });
 
   registerOption('custom_colors', {
@@ -122,7 +129,7 @@ const register = (editor: Editor): void => {
   });
 };
 
-const getColorCols = (editor: Editor, id: string): number => {
+const colorColsOption = (editor: Editor, id: string): number => {
   if (id === foregroundId) {
     return option('color_cols_foreground')(editor);
   } else if (id === backgroundId) {
@@ -130,6 +137,11 @@ const getColorCols = (editor: Editor, id: string): number => {
   } else {
     return option('color_cols')(editor);
   }
+};
+
+const getColorCols = (editor: Editor, id: string): number => {
+  const colorCols = colorColsOption(editor, id);
+  return colorCols >= defaultCols ? colorCols : defaultCols;
 };
 
 const hasCustomColors = option('custom_colors');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
@@ -329,6 +329,33 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
     });
   });
 
+  context('Color Cols Default From Zero Test', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      toolbar: 'forecolor backcolor fontsize',
+      base_url: '/project/tinymce/js/tinymce',
+      color_cols: 0,
+      color_cols_foreground: 0
+    }, [], true);
+
+    it('TINY-9560: color_map_foreground has correct number of columns', async () => {
+      const editor = hook.editor();
+      setupContent(editor);
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      // Foreground color gets value from `color_cols_foreground` which should be replaced when set to 0
+      Assert.eq('Cols is the expected value', getColorCols(editor, 'forecolor'), 5);
+    });
+
+    it('TINY-9560: color_map_background has correct number of columns', async () => {
+      const editor = hook.editor();
+      setupContent(editor);
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Background color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      // Background color should get default value from `color_cols` which should be replaced when set to 0
+      Assert.eq('Cols is the expected value', getColorCols(editor, 'hilitecolor'), 5);
+    });
+  });
+
   context('Custom default background and foreground set', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       toolbar: 'forecolor backcolor fontsize',


### PR DESCRIPTION
Related Ticket: TINY-9649

Description of Changes:
* Opening a color swatch with `color_cols`, `color_cols_foreground`, or `color_cols_background` set to `0` would cause the page to crash.
* Validated the number returned within `getColorCols` to be greater than zero
* If the number is set to zero or less in the option, the default number of columns, five, will be returned

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
