### PR TITLE
TINY-9663: now view header scrolls on mobile

### DIFF
--- a/modules/oxide/src/less/theme/components/view/view.less
+++ b/modules/oxide/src/less/theme/components/view/view.less
@@ -1,4 +1,5 @@
 @view-header-padding: @pad-sm @pad-sm 0 @pad-sm;
+@view-header-padding-mobile: @pad-sm;
 @view-pane-padding: @pad-sm;
 
 @view-toolbar-button-spacing-x: 8px;
@@ -15,8 +16,9 @@
 
   .tox-view {
     display: flex;
-    flex: 1;
+    flex: 1 1 auto;
     flex-direction: column;
+    overflow: hidden;
   }
 
   .tox-view__header {
@@ -26,6 +28,16 @@
     justify-content: space-between;
     padding: @view-header-padding;
     position: relative;
+  }
+
+  .tox-view--mobile.tox-view__header,
+  .tox-view--mobile.tox-view__toolbar {
+    padding: @view-header-padding-mobile;
+  }
+
+  .tox-view--scrolling {
+    flex-wrap: nowrap;
+    overflow-x: auto;
   }
 
   .tox-view__toolbar {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/view/View.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/view/View.ts
@@ -5,6 +5,7 @@ import {
 import { FieldSchema } from '@ephox/boulder';
 import { View as BridgeView } from '@ephox/bridge';
 import { Arr, Optional } from '@ephox/katamari';
+import { PlatformDetection } from '@ephox/sand';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { renderButton } from './ViewButtons';
@@ -48,6 +49,10 @@ const renderButtonsGroup = (spec: BridgeView.ViewButtonsGroup, providers: UiFact
   };
 };
 
+const deviceDetection = PlatformDetection.detect().deviceType;
+const isPhone = deviceDetection.isPhone();
+const isTablet = deviceDetection.isTablet();
+
 const renderViewHeader = (spec: ViewHeaderSpec) => {
   let hasGroups = false;
   const endButtons = Arr.map(spec.buttons, (btnspec) => {
@@ -63,7 +68,10 @@ const renderViewHeader = (spec: ViewHeaderSpec) => {
     uid: spec.uid,
     dom: {
       tag: 'div',
-      classes: [ !hasGroups ? 'tox-view__header' : 'tox-view__toolbar' ]
+      classes: [
+        !hasGroups ? 'tox-view__header' : 'tox-view__toolbar',
+        ...(isPhone || isTablet ? [ 'tox-view--mobile', 'tox-view--scrolling' ] : [])
+      ]
     },
     components: hasGroups ?
       endButtons


### PR DESCRIPTION
Related Ticket: TINY-9663

Description of Changes:
Added class `tox-view--scrolling` similar to `tox-toolbar--scrolling` also added `tox-view--mobile` that overview the padding in mobile

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
