### PR TITLE
TINY-9652: Hide toolbar when editor is out of view in a scrollable container

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/DockingApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/DockingApis.ts
@@ -82,17 +82,8 @@ const applyMorph = (
 const refreshInternal = (component: AlloyComponent, config: DockingConfig, state: DockingState): void => {
   // Absolute coordinates (considers scroll)
   const viewport: DockingViewport = config.lazyViewport(component);
-  // If docked then check if we need to hide/show the component
-  const isDocked = state.isDocked();
 
-  viewport.optScrollEnv.fold(() => {
-    if (isDocked) {
-      updateVisibility(component, config, state, viewport);
-    }
-  }, (_scrollEnv) => {
-    // If scrolling environment is set, we want to hide the toolbar if editor is out of the viewport
-    updateVisibility(component, config, state, viewport);
-  });
+  updateVisibility(component, config, state, viewport);
 
   Dockables.tryMorph(component, viewport, state).each((morph) => {
     applyMorph(component, config, state, viewport, morph);

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/DockingApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/DockingApis.ts
@@ -85,11 +85,14 @@ const refreshInternal = (component: AlloyComponent, config: DockingConfig, state
   // If docked then check if we need to hide/show the component
   const isDocked = state.isDocked();
 
-  // Checking isDocked works for only, toolbar_location: top mode, as you scroll, it would be undocked, docked then hidden
-  // But for toobar_location, it would be from docked, undocked then hidden
-  if (isDocked || (!isDocked && Arr.contains(state.getModes(), 'bottom'))) {
+  viewport.optScrollEnv.fold(() => {
+    if (isDocked) {
+      updateVisibility(component, config, state, viewport);
+    }
+  }, (_scrollEnv) => {
+    // If scrolling environment is set, we want to hide the toolbar if editor is out of the viewport
     updateVisibility(component, config, state, viewport);
-  }
+  });
 
   Dockables.tryMorph(component, viewport, state).each((morph) => {
     applyMorph(component, config, state, viewport, morph);

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -1,4 +1,4 @@
-import { AlloyComponent, Attachment, Boxes, Disabling } from '@ephox/alloy';
+import { AlloyComponent, Attachment, Boxes, Disabling, Docking } from '@ephox/alloy';
 import { Cell, Singleton, Throttler } from '@ephox/katamari';
 import { DomEvent, Scroll, SugarElement } from '@ephox/sugar';
 
@@ -44,7 +44,7 @@ const setupEvents = (editor: Editor, targetElm: SugarElement, ui: InlineHeader, 
       if (prevPos !== pos) {
         // The proposed toolbar location has moved, so we need to reposition the Ui. This might
         // include things like refreshing any Docking / stickiness for the toolbars
-        ui.update();
+        ui.update(Docking.reset);
       } else if (hasResized) {
         // The proposed toolbar location hasn't moved, but the dimensions of the editor have changed.
         // We use "updateMode" here instead of "update". The primary reason is that "updateMode"
@@ -69,7 +69,7 @@ const setupEvents = (editor: Editor, targetElm: SugarElement, ui: InlineHeader, 
 
   // For both the initial load (SkinLoaded) and any resizes (ResizeWindow), we want to
   // update the positions of the Ui elements (and reset Docking / stickiness)
-  editor.on('SkinLoaded ResizeWindow', ui.update);
+  editor.on('SkinLoaded ResizeWindow', () => ui.update(Docking.reset));
 
   editor.on('NodeChange keydown', (e) => {
     requestAnimationFrame(() => resizeContent(e));
@@ -78,7 +78,7 @@ const setupEvents = (editor: Editor, targetElm: SugarElement, ui: InlineHeader, 
   // When the page has been scrolled, we need to update any docking positions. We also
   // want to reposition all the Ui elements if required.
   let lastScrollX = 0;
-  const updateUi = Throttler.last(() => ui.update(), 33);
+  const updateUi = Throttler.last(() => ui.update(Docking.refresh), 33);
   editor.on('ScrollWindow', () => {
     const newScrollX = Scroll.get().left;
     if (newScrollX !== lastScrollX) {
@@ -92,7 +92,7 @@ const setupEvents = (editor: Editor, targetElm: SugarElement, ui: InlineHeader, 
   if (Options.isSplitUiMode(editor)) {
     editor.on('ElementScroll', (_args) => {
       // When the scroller containing the editor scrolls, update the Ui positions
-      ui.update();
+      ui.update(Docking.refresh);
     });
   }
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
@@ -17,7 +17,7 @@ export interface InlineHeader {
   readonly isPositionedAtTop: () => boolean;
   readonly show: () => void;
   readonly hide: () => void;
-  readonly update: () => void;
+  readonly update: (stickyAction: (c: AlloyComponent) => void) => void;
   readonly updateMode: () => void;
   readonly repositionPopups: () => void;
 }
@@ -243,7 +243,7 @@ export const InlineHeader = (
     }
   };
 
-  const updateChromeUi = (stickyAction: (c: AlloyComponent) => void) => {
+  const update = (stickyAction: (c: AlloyComponent) => void) => {
     // Skip updating the ui if it's hidden
     if (!isVisible()) {
       return;
@@ -325,14 +325,14 @@ export const InlineHeader = (
       // calling reset here, to reset the state.
       // Another case would be when the toolbar is shown initially (with location_bottom)
       // we don't want to dock the toolbar, calling Docking.refresh
-      updateChromeUi((elem) => Docking.isDocked(elem) ? Docking.reset(elem) : Docking.refresh(elem));
+      update((elem) => Docking.isDocked(elem) ? Docking.reset(elem) : Docking.refresh(elem));
     } else {
       // Even if we aren't updating the docking mode, we still want to reposition
       // the Ui. NOTE: We are using Docking.refresh here, rather than Docking.reset. This
       // means it should keep whatever its "previous" coordinates were, and will just
       // behave like the window was scrolled again, and Docking needs to work out if it
       // is going to dock / undock
-      updateChromeUi(Docking.refresh);
+      update(Docking.refresh);
     }
   };
 
@@ -345,20 +345,12 @@ export const InlineHeader = (
     });
   };
 
-  const update = () => {
-    // Because we use Docking.reset here instead of Docking.refresh. That means
-    // that it will revert back to its original position, clear any state, and then
-    // trigger a refresh. This should be called in situations where the DOM has
-    // changed significantly (resizing, scrolling etc.)
-    updateChromeUi(Docking.reset);
-  };
-
   const updateMode = () => {
     const changedMode = doUpdateMode();
     // If the docking mode has changed due to the update, we want to reset
     // docking. This will clear any prior stored positions
     if (changedMode) {
-      update();
+      update(Docking.reset);
     }
   };
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestExtras.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestExtras.ts
@@ -78,6 +78,7 @@ export const TestExtras = (): TestExtras => {
     insertContent: (_content: string, _args?: any) => {},
     execCommand: (_cmd: string, _ui?: boolean, _value?: any) => {},
     getContainer: () => SugarBody.body().dom,
+    getContentAreaContainer: () => SugarBody.body().dom,
     ui: {
       show: Fun.noop
     },


### PR DESCRIPTION
Related Ticket: TINY-9652

Description of Changes:
* Changed the logic of `updateVisibility` of the toolbar when `ui_mode: 'split'`
	* 	In a scrollable container, for toolbar_location: top and if the toolbar is shown and the scrollable container is scrolled to the top, the toolbar should be invisible (in this case, the toolbar isn't docked, so the code updating the visibility is not triggered)
	* 	In a scrollable container, for toolbar_location: bottom and if the toolbar is shown and the scrollable container is scrolled to the furthest down to the bottom, the toolbar should be invisible 


Pre-checks:
* [x] ~Changelog entry added~ found in TINY-9414
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
