### PR TITLE
TINY-9667: Set width for Templates dialog left side bar

### DIFF
--- a/modules/oxide/src/less/theme/components/advtemplate/advtemplate.less
+++ b/modules/oxide/src/less/theme/components/advtemplate/advtemplate.less
@@ -18,7 +18,6 @@
 
         @media @breakpoint-sm {
           body:not(.tox-force-desktop) & {
-            max-width: 100%;
             width: 100%;
           }
         }

--- a/modules/oxide/src/less/theme/components/advtemplate/advtemplate.less
+++ b/modules/oxide/src/less/theme/components/advtemplate/advtemplate.less
@@ -12,6 +12,17 @@
   .tox-advtemplate {
     .tox-form__grid {
       flex: 1;
+
+      > div:first-child {
+        width: 30%;
+
+        @media @breakpoint-sm {
+          body:not(.tox-force-desktop) & {
+            max-width: 100%;
+            width: 100%;
+          }
+        }
+      }
     }
 
     iframe {


### PR DESCRIPTION
Related Ticket: TINY-9667

Description of Changes:
* set 30% width for the left side of Templates dialog (with the tree component)
* set width to 100% when it is on mobile

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
