### PR TITLE
Clean up our dependency lists, make sure devDependencies are not listed as dependencies

### DIFF
--- a/modules/acid/package.json
+++ b/modules/acid/package.json
@@ -11,8 +11,7 @@
     "@ephox/alloy": "^12.0.1",
     "@ephox/boulder": "^7.1.3",
     "@ephox/katamari": "^9.1.3",
-    "@ephox/sugar": "^9.1.3",
-    "tslib": "^2.0.0"
+    "@ephox/sugar": "^9.1.3"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",

--- a/modules/agar/package.json
+++ b/modules/agar/package.json
@@ -31,8 +31,7 @@
     "@ephox/sugar": "^9.1.3",
     "@types/sizzle": "^2.3.3",
     "fast-check": "^2.0.0",
-    "sizzle": "^2.3.4",
-    "tslib": "^2.0.0"
+    "sizzle": "^2.3.4"
   },
   "devDependencies": {
     "@ephox/katamari-assertions": "^4.0.7"

--- a/modules/alloy/package.json
+++ b/modules/alloy/package.json
@@ -7,8 +7,7 @@
     "@ephox/boulder": "^7.1.3",
     "@ephox/katamari": "^9.1.3",
     "@ephox/sand": "^6.0.7",
-    "@ephox/sugar": "^9.1.3",
-    "tslib": "^2.0.0"
+    "@ephox/sugar": "^9.1.3"
   },
   "files": [
     "lib/main",

--- a/modules/boss/package.json
+++ b/modules/boss/package.json
@@ -20,8 +20,7 @@
   ],
   "dependencies": {
     "@ephox/katamari": "^9.1.3",
-    "@ephox/sugar": "^9.1.3",
-    "tslib": "^2.0.0"
+    "@ephox/sugar": "^9.1.3"
   },
   "devDependencies": {
     "@ephox/katamari-assertions": "^4.0.7"

--- a/modules/bridge/package.json
+++ b/modules/bridge/package.json
@@ -14,8 +14,7 @@
   },
   "dependencies": {
     "@ephox/boulder": "^7.1.3",
-    "@ephox/katamari": "^9.1.3",
-    "tslib": "^2.0.0"
+    "@ephox/katamari": "^9.1.3"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",

--- a/modules/darwin/package.json
+++ b/modules/darwin/package.json
@@ -24,8 +24,7 @@
     "@ephox/robin": "^10.0.7",
     "@ephox/sand": "^6.0.7",
     "@ephox/snooker": "^11.0.8",
-    "@ephox/sugar": "^9.1.3",
-    "tslib": "^2.0.0"
+    "@ephox/sugar": "^9.1.3"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",

--- a/modules/dragster/package.json
+++ b/modules/dragster/package.json
@@ -21,8 +21,7 @@
   "dependencies": {
     "@ephox/katamari": "^9.1.3",
     "@ephox/porkbun": "^7.0.7",
-    "@ephox/sugar": "^9.1.3",
-    "tslib": "^2.0.0"
+    "@ephox/sugar": "^9.1.3"
   },
   "scripts": {
     "test": "bedrock-auto -b chrome-headless -d src/test",

--- a/modules/jax/package.json
+++ b/modules/jax/package.json
@@ -22,8 +22,7 @@
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
-    "@ephox/katamari": "^9.1.3",
-    "tslib": "^2.0.0"
+    "@ephox/katamari": "^9.1.3"
   },
   "files": [
     "lib/main",

--- a/modules/katamari-assertions/package.json
+++ b/modules/katamari-assertions/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "@ephox/bedrock-client": "11 || 12 || 13",
     "@ephox/dispute": "^1.0.3",
-    "@ephox/katamari": "^9.1.3",
-    "tslib": "^2.0.0"
+    "@ephox/katamari": "^9.1.3"
   },
   "files": [
     "lib/main",

--- a/modules/katamari/package.json
+++ b/modules/katamari/package.json
@@ -16,8 +16,7 @@
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
-    "@ephox/dispute": "^1.0.3",
-    "tslib": "^2.0.0"
+    "@ephox/dispute": "^1.0.3"
   },
   "files": [
     "lib/main",

--- a/modules/mcagar/package.json
+++ b/modules/mcagar/package.json
@@ -29,7 +29,6 @@
     "@ephox/sand": "^6.0.7",
     "@ephox/sugar": "^9.1.3",
     "fast-check": "^2.0.0",
-    "tslib": "^2.0.0"
   },
   "peerDependencies": {
     "tinymce": ">=4.0.0"

--- a/modules/mcagar/package.json
+++ b/modules/mcagar/package.json
@@ -28,7 +28,7 @@
     "@ephox/katamari": "^9.1.3",
     "@ephox/sand": "^6.0.7",
     "@ephox/sugar": "^9.1.3",
-    "fast-check": "^2.0.0",
+    "fast-check": "^2.0.0"
   },
   "peerDependencies": {
     "tinymce": ">=4.0.0"

--- a/modules/oxide/package.json
+++ b/modules/oxide/package.json
@@ -32,7 +32,7 @@
     "README.md",
     "LICENSE.txt"
   ],
-  "dependencies": {
+  "devDependencies": {
     "prism-themes": "^1.9.0",
     "prismjs": "^1.27.0"
   }

--- a/modules/phoenix/package.json
+++ b/modules/phoenix/package.json
@@ -22,8 +22,7 @@
     "@ephox/boss": "^6.0.7",
     "@ephox/katamari": "^9.1.3",
     "@ephox/polaris": "^6.0.7",
-    "@ephox/sugar": "^9.1.3",
-    "tslib": "^2.0.0"
+    "@ephox/sugar": "^9.1.3"
   },
   "devDependencies": {
     "@ephox/katamari-assertions": "^4.0.7"

--- a/modules/polaris/package.json
+++ b/modules/polaris/package.json
@@ -19,8 +19,7 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/katamari": "^9.1.3",
-    "tslib": "^2.0.0"
+    "@ephox/katamari": "^9.1.3"
   },
   "devDependencies": {
     "@ephox/katamari-assertions": "^4.0.7"

--- a/modules/robin/package.json
+++ b/modules/robin/package.json
@@ -23,8 +23,7 @@
     "@ephox/katamari": "^9.1.3",
     "@ephox/phoenix": "^8.0.7",
     "@ephox/polaris": "^6.0.7",
-    "@ephox/sugar": "^9.1.3",
-    "tslib": "^2.0.0"
+    "@ephox/sugar": "^9.1.3"
   },
   "devDependencies": {
     "@ephox/katamari-assertions": "^4.0.7"

--- a/modules/sand/package.json
+++ b/modules/sand/package.json
@@ -30,8 +30,7 @@
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
-    "@ephox/katamari": "^9.1.3",
-    "tslib": "^2.0.0"
+    "@ephox/katamari": "^9.1.3"
   },
   "main": "./lib/main/ts/ephox/sand/api/Main.js",
   "module": "./lib/main/ts/ephox/sand/api/Main.js",

--- a/modules/snooker/package.json
+++ b/modules/snooker/package.json
@@ -23,8 +23,7 @@
     "@ephox/katamari": "^9.1.3",
     "@ephox/porkbun": "^7.0.7",
     "@ephox/robin": "^10.0.7",
-    "@ephox/sugar": "^9.1.3",
-    "tslib": "^2.0.0"
+    "@ephox/sugar": "^9.1.3"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",


### PR DESCRIPTION
Related Ticket: None

Description of Changes:
* In the end, the only major change is removing `tslib` from each package - we no longer need it as we require the latest browsers. It's still a devDependency at the top level as our `tsconfig.json` is set to import it if necessary.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
