### PR TITLE
TINY-9670: Move iframe init code sideways from InitContentBody to InitIframe

### DIFF
--- a/modules/tinymce/src/core/main/ts/init/Init.ts
+++ b/modules/tinymce/src/core/main/ts/init/Init.ts
@@ -180,9 +180,8 @@ const init = async (editor: Editor): Promise<void> => {
   editor.editorContainer = renderInfo.editorContainer as HTMLElement;
   appendContentCssFromSettings(editor);
 
-  // Content editable mode ends here
   if (editor.inline) {
-    InitContentBody.initContentBody(editor);
+    InitContentBody.contentBodyLoaded(editor);
   } else {
     InitIframe.init(editor, {
       editorContainer: renderInfo.editorContainer,

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -1,5 +1,5 @@
 import { Obj, Type } from '@ephox/katamari';
-import { Attribute, DomEvent, Insert, Remove, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { Attribute, Insert, Remove, SugarElement, SugarShadowDom } from '@ephox/sugar';
 
 import Annotator from '../api/Annotator';
 import DOMUtils from '../api/dom/DOMUtils';
@@ -8,7 +8,6 @@ import DomSerializer, { DomSerializerSettings } from '../api/dom/Serializer';
 import StyleSheetLoader from '../api/dom/StyleSheetLoader';
 import Editor from '../api/Editor';
 import EditorUpload from '../api/EditorUpload';
-import Env from '../api/Env';
 import * as Events from '../api/Events';
 import Formatter from '../api/Formatter';
 import DomParser, { DomParserSettings } from '../api/html/DomParser';
@@ -467,40 +466,6 @@ const contentBodyLoaded = (editor: Editor): void => {
   });
 };
 
-const initContentBody = (editor: Editor, skipWrite?: boolean): void => {
-  // Restore visibility on target element
-  if (!editor.inline) {
-    editor.getElement().style.visibility = editor.orgVisibility as string;
-  }
-
-  // Setup iframe body
-  if (!skipWrite && !editor.inline) {
-    const iframe = editor.iframeElement as HTMLIFrameElement;
-    const binder = DomEvent.bind(SugarElement.fromDom(iframe), 'load', () => {
-      binder.unbind();
-
-      // Reset the content document, since using srcdoc will change the document
-      editor.contentDocument = iframe.contentDocument as Document;
-
-      // Continue to init the editor
-      contentBodyLoaded(editor);
-    });
-
-    // TINY-8916: Firefox has a bug in its srcdoc implementation that prevents cookies being sent so unfortunately we need
-    // to fallback to legacy APIs to load the iframe content. See https://bugzilla.mozilla.org/show_bug.cgi?id=1741489
-    if (Env.browser.isFirefox()) {
-      const doc = editor.getDoc();
-      doc.open();
-      doc.write(editor.iframeHTML as string);
-      doc.close();
-    } else {
-      iframe.srcdoc = editor.iframeHTML as string;
-    }
-  } else {
-    contentBodyLoaded(editor);
-  }
-};
-
 export {
-  initContentBody
+  contentBodyLoaded
 };

--- a/modules/tinymce/src/core/main/ts/init/InitIframe.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitIframe.ts
@@ -78,26 +78,13 @@ const createIframe = (editor: Editor, boxInfo: BoxInfo) => {
   DOM.add(boxInfo.iframeContainer, ifr);
 };
 
-const init = (editor: Editor, boxInfo: BoxInfo): void => {
-  createIframe(editor, boxInfo);
-
-  if (boxInfo.editorContainer) {
-    boxInfo.editorContainer.style.display = editor.orgDisplay;
-    editor.hidden = DOM.isHidden(boxInfo.editorContainer);
-  }
-
-  editor.getElement().style.display = 'none';
-  DOM.setAttrib(editor.id, 'aria-hidden', 'true');
-
-  // Restore visibility on target element
-  editor.getElement().style.visibility = editor.orgVisibility as string;
-
+const setupIframeBody = (editor: Editor): void => {
   // Setup iframe body
   const iframe = editor.iframeElement as HTMLIFrameElement;
   const binder = DomEvent.bind(SugarElement.fromDom(iframe), 'load', () => {
     binder.unbind();
 
-    // Reset the content document, since using srcdoc will change the document
+    // Set the content document, now that it is available
     editor.contentDocument = iframe.contentDocument as Document;
 
     // Continue to init the editor
@@ -114,7 +101,22 @@ const init = (editor: Editor, boxInfo: BoxInfo): void => {
   } else {
     iframe.srcdoc = editor.iframeHTML as string;
   }
+};
 
+const init = (editor: Editor, boxInfo: BoxInfo): void => {
+  createIframe(editor, boxInfo);
+
+  if (boxInfo.editorContainer) {
+    boxInfo.editorContainer.style.display = editor.orgDisplay;
+    editor.hidden = DOM.isHidden(boxInfo.editorContainer);
+  }
+
+  editor.getElement().style.display = 'none';
+  DOM.setAttrib(editor.id, 'aria-hidden', 'true');
+  // Restore visibility on target element
+  editor.getElement().style.visibility = editor.orgVisibility as string;
+
+  setupIframeBody(editor);
 };
 
 export {


### PR DESCRIPTION
Related Ticket: TINY-9670

Description of Changes:
* While explaining the Init process to @kemister85, I realised that the iframe-specific things `InitContentBody` does no longer need to be there. The `skipWrite` parameter is never used.
* So I moved all the code to `InitIframe`, which simplifies the explanation considerably.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
