### PR TITLE
TINY-9176: Focus Styles QA fixes

### DIFF
--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -14,7 +14,6 @@
 @collection-item-label-text-color: @text-color;
 @collection-item-label-text-transform: none;
 
-@collection-item-hover-background-color: @active-background-color;
 @collection-item-secondary-active-background-color: @menubar-select-active-background-color;
 
 @collection-item-label-disabled-text-color: fade(@collection-item-label-text-color, 50%);
@@ -24,6 +23,7 @@
 @collection-list-item-label-active-text-color: @active-text-color;
 @collection-list-item-enabled-background-color: @enabled-background-color;
 @collection-list-item-label-enabled-text-color: @enabled-text-color;
+@collection-list-item-table-background-color: contrast(@background-color, fade(@color-tint, 35), fade(@color-tint, 65));
 
 @collection-toolbar-item-active-background-color: @hover-background-color;
 @collection-toolbar-item-label-active-text-color: @active-text-color;
@@ -243,7 +243,7 @@
   }
 
   .tox-collection--list .tox-fancymenuitem.tox-collection__item--active:not(.tox-collection__item--state-disabled) {
-    background-color: @collection-list-item-enabled-background-color;
+    background-color: @collection-list-item-table-background-color;
   }
 
   // active menu item (when hovering)

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -118,6 +118,11 @@
     display: flex;
     -webkit-touch-callout: none;
     user-select: none;
+
+    // Preserve text color for code inline format against grey background color
+    code {
+      color: @collection-list-item-label-enabled-text-color;
+    }
   }
 
   .tox-collection--list .tox-collection__item {
@@ -250,11 +255,6 @@
   .tox-collection--list:not(.tox-background-menu) .tox-collection__item.tox-collection__item--active:not(.tox-collection__item--state-disabled):not(.tox-fancymenuitem) {
     background-color: @collection-list-item-active-background-color;
     color: @collection-list-item-label-active-text-color;
-
-    // Preserve text color for code inline format against grey background color
-    code {
-      color: @collection-list-item-label-enabled-text-color;
-    }
 
     svg {
       fill: @collection-list-item-label-active-text-color;

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -118,11 +118,6 @@
     display: flex;
     -webkit-touch-callout: none;
     user-select: none;
-
-    // Preserve text color for code inline format against grey background color
-    code {
-      color: @collection-list-item-label-enabled-text-color;
-    }
   }
 
   .tox-collection--list .tox-collection__item {
@@ -253,11 +248,15 @@
 
   // active menu item (when hovering)
   .tox-collection--list:not(.tox-background-menu) .tox-collection__item.tox-collection__item--active:not(.tox-collection__item--state-disabled):not(.tox-fancymenuitem) {
-    background-color: @collection-list-item-active-background-color;
     color: @collection-list-item-label-active-text-color;
 
     svg {
       fill: @collection-list-item-label-active-text-color;
+    }
+
+    // Preserve text color for code inline format against grey background color
+    .tox-collection__item-label > * {
+      background-color: @collection-list-item-active-background-color !important;
     }
   }
 
@@ -369,6 +368,7 @@
   }
 
   // Make a space between all elements within a list item
+  /* stylelint-disable-next-line no-descending-specificity */
   .tox-collection--list .tox-collection__item > *:not(:first-child) {
     margin-left: @pad-sm;
   }
@@ -395,6 +395,7 @@
   }
 
   // Make a space between all elements within a list item
+  /* stylelint-disable-next-line no-descending-specificity */
   .tox-collection--list .tox-collection__item > *:not(:first-child) {
     margin-right: @pad-sm;
   }

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -27,6 +27,7 @@
 
 @collection-item-disabled-label-text-color: fade(@collection-item-label-text-color, 50%);
 @collection-item-disabled-caret-color: fade(@collection-item-label-text-color, 50%);
+@collection-item-disabled-icon-color: @collection-item-disabled-label-text-color;
 
 @collection-item-table-background-color: #cce2fa;
 
@@ -56,49 +57,53 @@
     display: flex;
     -webkit-touch-callout: none;
     user-select: none;
-  }
 
-  .tox-collection__item-caret {
-    align-items: center;
-    display: flex;
-    min-height: @collection-item-list-icon-height;
+    &.tox-collection__item-caret {
+      align-items: center;
+      display: flex;
+      min-height: @collection-item-list-icon-height;
 
-    svg {
-      fill: @collection-item-icon-color;
+      svg {
+        fill: @collection-item-icon-color;
+      }
     }
-  }
 
-  .tox-collection__item-icon,
-  .tox-collection__item-checkmark {
-    align-items: center;
-    display: flex;
-    height: @collection-item-list-icon-height;
-    justify-content: center;
-    width: @collection-item-list-icon-width;
+    .tox-collection__item-icon,
+    .tox-collection__item-checkmark {
+      align-items: center;
+      display: flex;
+      height: @collection-item-list-icon-height;
+      justify-content: center;
+      width: @collection-item-list-icon-width;
 
-    svg {
-      fill: currentColor;
+      svg {
+        fill: currentColor;
+      }
     }
-  }
 
-  // Disabled item
-  .tox-collection__item--state-disabled {
-    background-color: transparent;
-    color: @collection-item-disabled-label-text-color;
-    cursor: not-allowed;
+    // Disabled item
+    &.tox-collection__item--state-disabled {
+      background-color: transparent;
+      color: @collection-item-disabled-label-text-color;
+      cursor: not-allowed;
 
-    .tox-collection__item-caret svg {
-      fill: @collection-item-disabled-caret-color;
+      .tox-collection__item-icon svg {
+        fill: @collection-item-disabled-icon-color;
+      }
+
+      .tox-collection__item-caret svg {
+        fill: @collection-item-disabled-caret-color;
+      }
     }
-  }
 
-  .tox-collection__item-accessory {
-    color: @text-color-muted;
-    display: inline-block;
-    font-size: @font-size-sm;
-    height: @collection-item-list-icon-height;
-    line-height: @collection-item-list-icon-height;
-    text-transform: none;
+    &.tox-collection__item-accessory {
+      color: @text-color-muted;
+      display: inline-block;
+      font-size: @font-size-sm;
+      height: @collection-item-list-icon-height;
+      line-height: @collection-item-list-icon-height;
+      text-transform: none;
+    }
   }
 
   .tox-collection__item-label {
@@ -135,8 +140,8 @@
     }
 
     .tox-collection__item {
-      height: @toolbar-button-height; // 28px
-      margin: (@toolbar-button-spacing-y + 1px) @toolbar-button-spacing-x @toolbar-button-spacing-y 0; // 4px 0 3px 0
+      height: @toolbar-button-height;
+      margin: (@toolbar-button-spacing-y + 1px) @toolbar-button-spacing-x @toolbar-button-spacing-y 0;
       padding: 0 4px;
     }
 

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -14,22 +14,27 @@
 @collection-item-label-text-color: @text-color;
 @collection-item-label-text-transform: none;
 
-@collection-item-icon-color: @collection-item-label-text-color;
-@collection-item-active-background-color: @active-background-color;
-@collection-item-active-label-text-color: @active-text-color;
-@collection-item-active-icon-color: @collection-item-active-label-text-color;
-@collection-item-enabled-background-color: @enabled-background-color;
-@collection-item-enabled-label-text-color: @enabled-text-color;
-@collection-item-enabled-icon-color: @collection-item-enabled-label-text-color;
-@collection-item-enabled-active-background-color: @enabled-active-background-color;
-@collection-item-hover-background-color: @hover-background-color;
+@collection-item-hover-background-color: @active-background-color;
 @collection-item-secondary-active-background-color: @menubar-select-active-background-color;
 
-@collection-item-disabled-label-text-color: fade(@collection-item-label-text-color, 50%);
-@collection-item-disabled-caret-color: fade(@collection-item-label-text-color, 50%);
-@collection-item-disabled-icon-color: @collection-item-disabled-label-text-color;
+@collection-item-label-disabled-text-color: fade(@collection-item-label-text-color, 50%);
+@collection-item-caret-disabled-text-color: fade(@collection-item-label-text-color, 50%);
 
-@collection-item-table-background-color: #cce2fa;
+@collection-list-item-active-background-color: @hover-background-color;
+@collection-list-item-label-active-text-color: @active-text-color;
+@collection-list-item-enabled-background-color: @enabled-background-color;
+@collection-list-item-label-enabled-text-color: @enabled-text-color;
+
+@collection-toolbar-item-active-background-color: @hover-background-color;
+@collection-toolbar-item-label-active-text-color: @active-text-color;
+@collection-toolbar-item-enabled-background-color: @enabled-background-color;
+@collection-toolbar-item-enabled-active-background-color: @enabled-active-background-color;
+@collection-toolbar-item-label-enabled-text-color: @enabled-text-color;
+
+@collection-grid-item-active-background-color: @hover-background-color;
+@collection-grid-item-label-active-text-color: @active-text-color;
+@collection-grid-item-enabled-background-color: @enabled-background-color;
+@collection-grid-item-label-enabled-text-color: @enabled-text-color;
 
 @collection-item-list-icon-height: 24px;
 @collection-item-list-icon-width: 24px;
@@ -50,6 +55,62 @@
     //
   }
 
+  .tox-collection--list {
+    //
+  }
+
+  .tox-collection--toolbar {
+    //
+  }
+
+  .tox-collection--grid {
+    //
+  }
+
+  .tox-collection--toolbar .tox-collection__group {
+    display: flex;
+    padding: 0;
+  }
+
+  .tox-collection--grid .tox-collection__group {
+    display: flex;
+    flex-wrap: wrap;
+    max-height: (32px * 6) + (32px / 2);
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding: 0;
+  }
+
+  .tox-collection--list .tox-collection__group {
+    border-bottom-width: 0;
+    border-color: @collection-item-separator-color;
+    border-left-width: 0;
+    border-right-width: 0;
+    border-style: solid;
+    border-top-width: 1px;
+    padding: @collection-item-separator-margin-y 0;
+
+    &:first-child {
+      border-top-width: 0;
+    }
+  }
+
+  // Group headings should only be used on collection lists.
+  .tox-collection__group-heading {
+    background-color: @collection-group-label-background-color;
+    color: @collection-group-label-text-color;
+    cursor: default;
+    font-size: @collection-group-label-font-size;
+    font-style: @collection-group-label-font-style;
+    font-weight: @collection-group-label-font-weight;
+    margin-bottom: @collection-item-separator-margin-y;
+    margin-top: -@collection-item-separator-margin-y;
+    padding: @collection-item-padding;
+    text-transform: @collection-group-label-text-transform;
+    -webkit-touch-callout: none;
+    user-select: none;
+  }
+
   .tox-collection__item {
     align-items: center;
     border-radius: @collection-item-radius;
@@ -57,53 +118,74 @@
     display: flex;
     -webkit-touch-callout: none;
     user-select: none;
+  }
 
-    &.tox-collection__item-caret {
-      align-items: center;
-      display: flex;
-      min-height: @collection-item-list-icon-height;
+  .tox-collection--list .tox-collection__item {
+    padding: @collection-item-padding;
+  }
 
-      svg {
-        fill: @collection-item-icon-color;
-      }
+  .tox-collection--toolbar .tox-collection__item {
+    border-radius: @toolbar-button-border-radius;
+    padding: @pad-xs;
+  }
+
+  .tox-collection--grid .tox-collection__item {
+    border-radius: @toolbar-button-border-radius;
+    padding: @pad-xs;
+  }
+
+  // Note: Ensure "enabled" is before "active", as active styles should have a higher precedence
+  .tox-collection--list .tox-collection__item--enabled {
+    color: @collection-list-item-label-enabled-text-color;
+  }
+
+  .tox-collection--list .tox-collection__item--active {
+    background-color: @collection-list-item-active-background-color;
+  }
+
+  .tox-collection--toolbar .tox-collection__item--enabled {
+    background-color: @collection-toolbar-item-enabled-background-color;
+    color: @collection-toolbar-item-label-enabled-text-color;
+
+    &.tox-collection__item--active {
+      background-color: @collection-toolbar-item-enabled-active-background-color;
     }
+  }
 
-    .tox-collection__item-icon,
-    .tox-collection__item-checkmark {
-      align-items: center;
-      display: flex;
-      height: @collection-item-list-icon-height;
-      justify-content: center;
-      width: @collection-item-list-icon-width;
+  .tox-collection--toolbar .tox-collection__item--active {
+    background-color: @collection-toolbar-item-active-background-color;
+  }
 
-      svg {
-        fill: currentColor;
-      }
+  .tox-collection--grid .tox-collection__item--enabled {
+    background-color: @collection-grid-item-enabled-background-color;
+    color: @collection-grid-item-label-enabled-text-color;
+  }
+
+  .tox-collection--grid .tox-collection__item--active:not(.tox-collection__item--state-disabled) {
+    background-color: @collection-grid-item-active-background-color;
+    color: @collection-grid-item-label-active-text-color;
+  }
+
+  .tox-collection--toolbar .tox-collection__item--active:not(.tox-collection__item--state-disabled) {
+    color: @collection-toolbar-item-label-active-text-color;
+  }
+
+  .tox-collection__item-icon,
+  .tox-collection__item-checkmark {
+    align-items: center;
+    display: flex;
+    height: @collection-item-list-icon-height;
+    justify-content: center;
+    width: @collection-item-list-icon-width;
+
+    svg {
+      fill: currentColor;
     }
+  }
 
-    // Disabled item
-    &.tox-collection__item--state-disabled {
-      background-color: transparent;
-      color: @collection-item-disabled-label-text-color;
-      cursor: not-allowed;
-
-      .tox-collection__item-icon svg {
-        fill: @collection-item-disabled-icon-color;
-      }
-
-      .tox-collection__item-caret svg {
-        fill: @collection-item-disabled-caret-color;
-      }
-    }
-
-    &.tox-collection__item-accessory {
-      color: @text-color-muted;
-      display: inline-block;
-      font-size: @font-size-sm;
-      height: @collection-item-list-icon-height;
-      line-height: @collection-item-list-icon-height;
-      text-transform: none;
-    }
+  .tox-collection--toolbar-lg .tox-collection__item-icon {
+    height: @collection-item-list-icon-height * 2;
+    width: @collection-item-list-icon-width * 2;
   }
 
   .tox-collection__item-label {
@@ -118,6 +200,72 @@
     word-break: break-all;
   }
 
+  .tox-collection__item-accessory {
+    color: @text-color-muted;
+    display: inline-block;
+    font-size: @font-size-sm;
+    height: @collection-item-list-icon-height;
+    line-height: @collection-item-list-icon-height;
+    text-transform: none;
+  }
+
+  .tox-collection__item-caret {
+    align-items: center;
+    display: flex;
+    min-height: @collection-item-list-icon-height;
+
+    // Workaround for the above not centering items in IE11. See https://github.com/philipwalton/flexbugs/issues/231#issuecomment-362790042
+    &::after {
+      content: '';
+      font-size: 0;
+      min-height: inherit;
+    }
+
+    svg {
+      fill: @collection-item-label-text-color;
+    }
+  }
+
+  // Disabled item
+  .tox-collection__item--state-disabled {
+    background-color: transparent;
+    color: @collection-item-label-disabled-text-color;
+    cursor: not-allowed;
+
+    .tox-collection__item-caret svg {
+      fill: @collection-item-caret-disabled-text-color;
+    }
+  }
+
+  // Tickable items that are not ticked hide the check mark SVG (not the entire icon so there is still a gap)
+  .tox-collection--list .tox-collection__item:not(.tox-collection__item--enabled) .tox-collection__item-checkmark svg {
+    display: none;
+  }
+
+  // Tickable items that are not ticked and have an adjacent shortcut hide the check mark completely (gap is removed)
+  .tox-collection--list .tox-collection__item:not(.tox-collection__item--enabled) .tox-collection__item-accessory + .tox-collection__item-checkmark {
+    display: none;
+  }
+
+  .tox-collection--list .tox-fancymenuitem.tox-collection__item--active:not(.tox-collection__item--state-disabled) {
+    background-color: @collection-list-item-enabled-background-color;
+  }
+
+  // active menu item (when hovering)
+  .tox-collection--list:not(.tox-background-menu) .tox-collection__item.tox-collection__item--active:not(.tox-collection__item--state-disabled):not(.tox-fancymenuitem) {
+    background-color: @collection-list-item-active-background-color;
+    color: @collection-list-item-label-active-text-color;
+
+    svg {
+      fill: @collection-list-item-label-active-text-color;
+    }
+  }
+
+  // parent menu item when focus/hover is shifted to its children menu
+  .tox-collection--list.tox-background-menu .tox-collection__item.tox-collection__item--active:not(.tox-collection__item--state-disabled):not(.tox-fancymenuitem) {
+    background-color: @collection-item-secondary-active-background-color;
+  }
+
   .tox-collection--horizontal {
     background-color: @menu-background-color;
     border: 1px solid @collection-item-separator-color;
@@ -130,203 +278,29 @@
     margin-bottom: 0;
     overflow-x: auto;
     padding: 0;
-
-    .tox-collection__group {
-      align-items: center;
-      display: flex;
-      flex-wrap: nowrap;
-      margin: 0;
-      padding: 0 @pad-xs;
-    }
-
-    .tox-collection__item {
-      height: @toolbar-button-height;
-      margin: (@toolbar-button-spacing-y + 1px) @toolbar-button-spacing-x @toolbar-button-spacing-y 0;
-      padding: 0 4px;
-    }
-
-    .tox-collection__item-label {
-      white-space: nowrap;
-    }
-
-    .tox-collection__item-caret {
-      margin-left: 4px;
-    }
   }
 
-  .tox-collection--grid {
-    .tox-collection__group {
-      display: flex;
-      flex-wrap: wrap;
-      max-height: (32px * 6) + (32px / 2);
-      overflow-x: hidden;
-      overflow-y: auto;
-      padding: 0;
-    }
-
-    .tox-collection__item {
-      border-radius: @toolbar-button-border-radius;
-      padding: @pad-xs;
-
-      &.tox-collection__item--enabled {
-        background-color: @collection-item-enabled-background-color;
-        color: @collection-item-enabled-label-text-color;
-      }
-
-      &.tox-collection__item--active:not(.tox-collection__item--state-disabled) {
-        background-color: @collection-item-active-background-color;
-        color: @collection-item-active-label-text-color;
-      }
-    }
+  /* stylelint-disable-next-line no-descending-specificity */
+  .tox-collection--horizontal .tox-collection__group {
+    align-items: center;
+    display: flex;
+    flex-wrap: nowrap;
+    margin: 0;
+    padding: 0 @pad-xs;
   }
 
-  .tox-collection--toolbar-lg .tox-collection__item-icon {
-    height: @collection-item-list-icon-height * 2;
-    width: @collection-item-list-icon-width * 2;
+  .tox-collection--horizontal .tox-collection__item {
+    height: @toolbar-button-height; // 28px
+    margin: (@toolbar-button-spacing-y + 1px) @toolbar-button-spacing-x @toolbar-button-spacing-y 0; // 4px 0 3px 0
+    padding: 0 4px;
   }
 
-  .tox-collection--toolbar {
-    .tox-collection__group {
-      display: flex;
-      padding: 0;
-    }
-
-    .tox-collection__item {
-      border-radius: @toolbar-button-border-radius;
-      padding: @pad-xs;
-
-      &:hover,
-      &:focus,
-      &:focus-visible {
-        background: @collection-item-active-background-color;
-        color: @collection-item-active-label-text-color;
-
-        svg {
-          fill: @collection-item-active-icon-color;
-        }
-      }
-
-      &.tox-collection__item--enabled {
-        &:not(.tox-collection__item--active) {
-          background-color: @collection-item-enabled-background-color;
-          color: @collection-item-enabled-label-text-color;
-
-          svg {
-            fill: @collection-item-enabled-icon-color;
-          }
-        }
-
-        &:hover,
-        &:focus,
-        &:focus-visible {
-          background-color: @collection-item-enabled-active-background-color;
-          color: @collection-item-active-label-text-color;
-
-          svg {
-            fill: @collection-item-active-icon-color;
-          }
-        }
-      }
-
-      &.tox-collection__item--active:not(.tox-collection__item--state-disabled):not(.tox-collection__item--enabled) {
-        background-color: @collection-item-hover-background-color;
-        color: @collection-item-active-label-text-color;
-
-        svg {
-          fill: @collection-item-active-icon-color;
-        }
-      }
-    }
+  .tox-collection--horizontal .tox-collection__item-label {
+    white-space: nowrap;
   }
 
-  .tox-collection--list {
-    .tox-collection__group {
-      border-bottom-width: 0;
-      border-color: @collection-item-separator-color;
-      border-left-width: 0;
-      border-right-width: 0;
-      border-style: solid;
-      border-top-width: 1px;
-      padding: @collection-item-separator-margin-y 0;
-
-      &:first-child {
-        border-top-width: 0;
-      }
-    }
-
-    // Group headings should only be used on collection lists.
-    .tox-collection__group-heading {
-      background-color: @collection-group-label-background-color;
-      color: @collection-group-label-text-color;
-      cursor: default;
-      font-size: @collection-group-label-font-size;
-      font-style: @collection-group-label-font-style;
-      font-weight: @collection-group-label-font-weight;
-      margin-bottom: @collection-item-separator-margin-y;
-      margin-top: -@collection-item-separator-margin-y;
-      padding: @collection-item-padding;
-      text-transform: @collection-group-label-text-transform;
-      -webkit-touch-callout: none;
-      user-select: none;
-    }
-
-    // disable descending specificity to allow grouping selectors under one parent
-    /* stylelint-disable no-descending-specificity */
-    .tox-collection__item {
-      padding: @collection-item-padding;
-
-      svg {
-        fill: @collection-item-icon-color;
-      }
-
-      &:not(.tox-collection__item--enabled) .tox-collection__item-checkmark svg {
-        display: none;
-      }
-
-      &.tox-collection__item--enabled .tox-collection__item-checkmark svg {
-        display: block;
-      }
-
-      &hover,
-      &focus,
-      &focus-visible {
-        background-color: @collection-item-hover-background-color;
-      }
-
-      &.tox-collection__item--active:not(.tox-collection__item--state-disabled) .tox-collection__item-accessory {
-        color: @collection-item-active-icon-color;
-      }
-    }
-    /* stylelint-enable no-descending-specificity */
-
-    // parent menu item when focus/hover is shifted to its children menu
-    &.tox-background-menu .tox-collection__item--active:not(.tox-collection__item--state-disabled) {
-      background-color: @collection-item-secondary-active-background-color;
-      color: @collection-item-label-text-color;
-
-      .tox-collection__item-accessory {
-        color: @collection-item-active-icon-color;
-      }
-
-      .tox-collection__item-caret svg {
-        fill: @collection-item-icon-color;
-      }
-    }
-
-    // active menu item (when hovering)
-    &:not(.tox-background-menu) .tox-collection__item--active:not(.tox-collection__item--state-disabled):not(.tox-fancymenuitem) {
-      background-color: @collection-item-active-background-color;
-      color: @collection-item-active-label-text-color;
-
-      svg {
-        fill: @collection-item-active-icon-color;
-      }
-    }
-
-    // Use the old background colour for the table creation (insert table)
-    .tox-fancymenuitem.tox-collection__item--active:not(.tox-collection__item--state-disabled) {
-      background-color: @collection-item-table-background-color;
-    }
+  .tox-collection--horizontal .tox-collection__item-caret {
+    margin-left: 4px;
   }
 
   .tox-collection__item-container {
@@ -404,7 +378,6 @@
     margin-left: @pad-xs;
   }
 
-  /* stylelint-disable-next-line no-descending-specificity */
   .tox-collection__item-accessory {
     margin-left: @pad-md;
     text-align: right;
@@ -431,7 +404,6 @@
     margin-right: @pad-xs;
   }
 
-  /* stylelint-disable-next-line no-descending-specificity */
   .tox-collection__item-accessory {
     margin-right: @pad-md;
     text-align: left;
@@ -445,4 +417,8 @@
   .tox-collection--horizontal .tox-collection__item-caret {
     margin-right: 4px;
   }
+}
+
+.tox-collection--list .tox-collection__item--active:not(.tox-collection__item--state-disabled) .tox-collection__item-accessory {
+  color: @collection-list-item-label-active-text-color;
 }

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -251,6 +251,11 @@
     background-color: @collection-list-item-active-background-color;
     color: @collection-list-item-label-active-text-color;
 
+    // Preserve text color for code inline format against grey background color
+    code {
+      color: @collection-list-item-label-enabled-text-color;
+    }
+
     svg {
       fill: @collection-list-item-label-active-text-color;
     }

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -134,11 +134,6 @@
     padding: @pad-xs;
   }
 
-  // Note: Ensure "enabled" is before "active", as active styles should have a higher precedence
-  .tox-collection--list .tox-collection__item--enabled {
-    color: @collection-list-item-label-enabled-text-color;
-  }
-
   .tox-collection--list .tox-collection__item--active {
     background-color: @collection-list-item-active-background-color;
   }

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
@@ -97,8 +97,6 @@
 
   .tox-tbtn--disabled,
   .tox-tbtn--disabled:hover,
-  .tox-tbtn--disabled:focus-visible,
-  .tox-tbtn--disabled:focus,
   .tox-tbtn:disabled,
   .tox-tbtn:disabled:hover {
     background: @toolbar-button-disabled-background-color;
@@ -114,7 +112,7 @@
     }
   }
 
-  .tox-tbtn:not(.tox-tbtn--disabled):not(.tox-tbtn--enabled) {
+  .tox-tbtn:not(.tox-tbtn--enabled) {
     &:active {
       background: @toolbar-button-active-background-color;
       border: @toolbar-button-active-border;
@@ -137,6 +135,15 @@
       svg {
         fill: @toolbar-button-hover-icon-color;
       }
+    }
+  }
+
+  .tox-tbtn.tox-tbtn--disabled:focus,
+  .tox-tbtn.tox-tbtn--disabled:focus-visible {
+    color: @toolbar-button-disabled-text-color;
+
+    svg { /* stylelint-disable-line no-descending-specificity */
+      fill: @toolbar-button-disabled-text-color;
     }
   }
 

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
@@ -2,7 +2,6 @@
 // Toolbar button
 // When making changes here, please review toolbar-button/toolbar-split-button.less, collection/collection.less, toolbar-button/toolbar-select-button.less and menubar/menubar-button.less
 //
-
 @toolbar-button-background-color: transparent;
 @toolbar-button-border-radius: 3px;
 @toolbar-button-border: 0;
@@ -47,7 +46,7 @@
 @toolbar-button-enabled-transform: none;
 @toolbar-button-enabled-active-background-color: @enabled-active-background-color;
 @toolbar-button-enabled-active-icon-color: @toolbar-button-enabled-active-text-color;
-@toolbar-button-enabled-active-text-color: @active-text-color;
+@toolbar-button-enabled-active-text-color: @toolbar-button-active-text-color;
 
 @toolbar-button-disabled-background-color: @toolbar-button-background-color;
 @toolbar-button-disabled-border: @toolbar-button-border;
@@ -112,7 +111,7 @@
     }
   }
 
-  .tox-tbtn:not(.tox-tbtn--enabled) {
+  .tox-tbtn:not(.tox-tbtn--disabled):not(.tox-tbtn--enabled) {
     &:active {
       background: @toolbar-button-active-background-color;
       border: @toolbar-button-active-border;
@@ -140,6 +139,7 @@
 
   .tox-tbtn.tox-tbtn--disabled:focus,
   .tox-tbtn.tox-tbtn--disabled:focus-visible {
+    background: @toolbar-button-hover-background-color;
     color: @toolbar-button-disabled-text-color;
 
     svg { /* stylelint-disable-line no-descending-specificity */

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-split-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-split-button.less
@@ -9,6 +9,8 @@
 @toolbar-split-button-hover-background-color: @hover-background-color;
 @toolbar-split-button-chevron-color: fade(@text-color, 50%);
 @toolbar-split-button-enabled-chevron-color: fade(@enabled-text-color, 50%);
+@toolbar-split-button-active-chevron-color: @toolbar-button-active-icon-color;
+@toolbar-split-button-enabled-active-chevron-color: @toolbar-button-enabled-active-icon-color;
 
 .tox {
   .tox-split-button {
@@ -21,62 +23,79 @@
 
     .tox-tbtn {
       margin: 0;
+    }
 
+    &:focus-visible {
+      background: @toolbar-split-button-hover-background-color;
+
+      .tox-tbtn svg {
+        fill: @toolbar-button-active-icon-color;
+      }
+    }
+
+    &:not(.tox-tbtn--disabled) .tox-tbtn.tox-split-button__chevron {
+      width: 18px;
+
+      svg {
+        fill: @toolbar-split-button-chevron-color;
+      }
+
+      &:active,
       &:hover,
       &:focus,
       &:focus-visible {
         background: @toolbar-split-button-hover-background-color;
-      }
 
-      &:active {
-        box-shadow: 0 0 0 2px @toolbar-split-button-hover-background-color inset;
+        svg {
+          fill: @toolbar-split-button-active-chevron-color;
+        }
       }
 
       &.tox-tbtn--enabled {
-        background: @toolbar-split-button-enabled-background-color;
+        svg {
+          fill: @toolbar-split-button-enabled-chevron-color;
+        }
 
         &:active,
         &:hover,
         &:focus,
         &:focus-visible {
           background: @toolbar-split-button-enabled-active-background-color;
-        }
-      }
 
-      &.tox-split-button__chevron {
-        width: 18px;
-
-        svg {
-          fill: @toolbar-split-button-chevron-color;
-        }
-
-        &.tox-tbtn--enabled {
           svg {
-            fill: @toolbar-split-button-enabled-chevron-color;
-          }
-
-          &:active,
-          &:hover,
-          &:focus,
-          &:focus-visible {
-            svg {
-              fill: @toolbar-button-enabled-active-icon-color;
-            }
+            fill: @toolbar-split-button-enabled-active-chevron-color;
           }
         }
       }
+    }
 
-      &.tox-tbtn--disabled {
-        &:hover,
-        &:focus,
-        .tox-tbtn:hover,
-        .tox-tbtn:focus,
-        .tox-tbtn:focus-visible {
-          background: @toolbar-button-disabled-background-color;
-          box-shadow: @toolbar-button-disabled-box-shadow;
-          color: @toolbar-button-disabled-text-color;
-        }
+    &.tox-tbtn--disabled {
+      background: @toolbar-button-disabled-background-color;
+      box-shadow: @toolbar-button-disabled-box-shadow;
+      color: @toolbar-button-disabled-text-color;
+    }
+
+    &:not(.tox-tbtn--disabled) .tox-tbtn--enabled {
+      background: @toolbar-split-button-enabled-background-color;
+
+      &:active,
+      &:hover,
+      &:focus,
+      &:focus-visible {
+        background: @toolbar-split-button-enabled-active-background-color;
       }
+    }
+
+    &:active,
+    &:hover,
+    &:focus,
+    &:focus-visible {
+      box-shadow: 0 0 0 2px @toolbar-split-button-hover-background-color inset;
+    }
+
+    /* stylelint-disable-next-line no-descending-specificity */
+    &:focus-visible .tox-tbtn.tox-split-button__chevron svg {
+      fill: @toolbar-button-active-icon-color;
     }
   }
 


### PR DESCRIPTION
Related Ticket: TINY-9176

Description of Changes:
* Fixed borders on split buttons when active, hovered, enabled
* Fixed missing focus on split buttons using keyboard navigation
* Fixed missing focus on disabled buttons using keyboard navigation
* Fixed icon color in disabled menu items
* Fixed table grid background color
* Reverted variable name changes causing issues in premium skins

Pre-checks:
* [x] ~Changelog entry added~ Existing TINY-9176
* [x] T~ests have been added (if applicable)~ Requires manual QA
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
