### PR TITLE
TINY-9676: Revert TINY-9587

### DIFF
--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -60,7 +60,7 @@
 @dialog-body-h2-text-color: @text-color;
 @dialog-body-h2-text-transform: none;
 
-@dialog-table-border-color: @border-color;
+@dialog-table-border-color: darken(@border-color, 55%);
 @dialog-nav-focus-background-color: fade(@color-tint, 10%);
 
 // These get stacked on top of the global dialog z-index (1100)

--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -24,7 +24,7 @@
 @content-ui-darkmode: false; // Change this to true to get white icons in the content such as bookmarks.
 
 // Colors
-@border-color: contrast(@background-color, darken(@background-color, 30%), lighten(@background-color, 30%));
+@border-color: darken(@background-color, 6.5%);
 @text-color: contrast(@background-color, @color-black, @color-white);
 @text-color-muted: contrast(@background-color, fade(@color-black, 70%), fade(@color-white, 50%));
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Templates will be parsed before preview and insertion to make preview consistent with inserted template content and prevent XSS. #TINY-9244
 - Pressing backspace in an empty line now preserves formatting in a previous empty line. #TINY-9454
 - Pressing enter inside the `inputfontsize` input would not move the focus back into the editor content. #TINY-9598
-- Improved contrast of border colors against the background color throughout the UI. #TINY-9587
 - Drag and drop events for noneditable elements did not include details like target element. #TINY-9599
 - Updated focus, active, and enabled colors of UI buttons for improved contrast against the UI color. #TINY-9176
 


### PR DESCRIPTION
Related Ticket: TINY-9676

Alternate PR: https://github.com/tinymce/tinymce/pull/8537

Description of Changes:
* Revert all changes to border colors
* Contrast issues in dark mode remain as they are in previous version

Pre-checks:
* [x] Changelog entry removed
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
