### PR TITLE
TINY-9676: Revert editor border color only

### DIFF
--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -8,7 +8,7 @@
 @dialog-background-color: contrast(@background-color, @background-color, lighten(@background-color, 5%));
 @dialog-busy-backdrop-background-color: @dialog-backdrop-background-color;
 
-@dialog-border-color: @border-color;
+@dialog-border-color: @border-color-contrasted;
 @dialog-border-radius: 10px;
 @dialog-border-width: 0px;
 @dialog-box-shadow: 0 16px 16px -10px fade(@color-black, 15%), 0 0 40px 1px fade(@color-black, 15%);
@@ -60,7 +60,7 @@
 @dialog-body-h2-text-color: @text-color;
 @dialog-body-h2-text-transform: none;
 
-@dialog-table-border-color: @border-color;
+@dialog-table-border-color: @border-color-contrasted;
 @dialog-nav-focus-background-color: fade(@color-tint, 10%);
 
 // These get stacked on top of the global dialog z-index (1100)

--- a/modules/oxide/src/less/theme/components/dropzone/dropzone.less
+++ b/modules/oxide/src/less/theme/components/dropzone/dropzone.less
@@ -2,7 +2,7 @@
 // Dropzone
 //
 
-@dropzone-border: 2px dashed @border-color;
+@dropzone-border: 2px dashed @border-color-contrasted;
 
 .tox {
   .tox-dropzone-container {

--- a/modules/oxide/src/less/theme/components/form/textfield.less
+++ b/modules/oxide/src/less/theme/components/form/textfield.less
@@ -3,7 +3,7 @@
 //
 
 @textfield-background-color: contrast(@background-color, @background-color, lighten(@background-color, 5%));
-@textfield-border-color: @border-color;
+@textfield-border-color: @border-color-contrasted;
 @textfield-border-radius: @control-border-radius;
 @textfield-border-style: solid;
 @textfield-border-width: 1px;

--- a/modules/oxide/src/less/theme/components/statusbar/statusbar.less
+++ b/modules/oxide/src/less/theme/components/statusbar/statusbar.less
@@ -8,7 +8,7 @@
 @statusbar-font-weight: @font-weight-normal;
 @statusbar-height: 25px;
 @statusbar-padding-x: @pad-sm;
-@statusbar-separator-color: @tinymce-separator-color;
+@statusbar-separator-color: @tinymce-border-color;
 @statusbar-text-color: contrast(@statusbar-background-color, @text-color-muted, fade(@color-white, 75));
 @statusbar-text-transform: none;
 @statusbar-not-disabled-selector: ~'&:not(:disabled):not([aria-disabled=true])';

--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -24,7 +24,8 @@
 @content-ui-darkmode: false; // Change this to true to get white icons in the content such as bookmarks.
 
 // Colors
-@border-color: contrast(@background-color, darken(@background-color, 30%), lighten(@background-color, 30%));
+@border-color: contrast(@background-color, darken(@background-color, 6.5%), lighten(@background-color, 6.5%));
+@border-color-contrasted: contrast(@background-color, darken(@border-color, 20%), lighten(@background-color, 20%));
 @text-color: contrast(@background-color, @color-black, @color-white);
 @text-color-muted: contrast(@background-color, fade(@color-black, 70%), fade(@color-white, 50%));
 

--- a/modules/oxide/src/less/theme/globals/global.less
+++ b/modules/oxide/src/less/theme/globals/global.less
@@ -6,7 +6,7 @@
 @tinymce-border-radius: 10px;
 @tinymce-border-width: 2px;
 @tinymce-box-shadow: none;
-@tinymce-separator-color: contrast(@background-color, darken(@border-color, 4.5%), lighten(@border-color, 4.5%));
+@tinymce-separator-color: @border-color-contrasted;
 @editor-header-inline-background-color: @background-color;
 
 .tox-tinymce {


### PR DESCRIPTION
Related Ticket: TINY-9676

Alternate PR: https://github.com/tinymce/tinymce/pull/8536

This PR was created to preserve some of the contrast changes:
* Dialog input border colors
* Help dialog table row separators
* Menu item separators
These changes improve light and dark mode

Description of Changes:
* Reverted only the border color change from TINY-9587

Pre-checks:
* [x] ~Changelog entry added~ Existing TINY-9587
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
