### PR TITLE
TINY-9671: add buttons navigation via keyboard to view mode

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/view/View.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/view/View.ts
@@ -78,8 +78,7 @@ const renderViewHeader = (spec: ViewHeaderSpec) => {
       Keying.config({
         mode: 'flow',
         selector: 'button, .tox-button',
-        focusInside: FocusInsideModes.OnEnterOrSpaceMode,
-        cycles: false,
+        focusInside: FocusInsideModes.OnEnterOrSpaceMode
       })
     ]),
     components: hasGroups ?

--- a/modules/tinymce/src/themes/silver/main/ts/ui/view/View.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/view/View.ts
@@ -1,6 +1,6 @@
 import {
   AlloyComponent, AlloySpec, Behaviour, Composite, Container, Focusing, FocusInsideModes, Keying, PartType, RawDomSchema, SimpleSpec,
-  Sketcher, Tabstopping, UiSketcher
+  Sketcher, UiSketcher
 } from '@ephox/alloy';
 import { FieldSchema } from '@ephox/boulder';
 import { View as BridgeView } from '@ephox/bridge';
@@ -45,10 +45,6 @@ const renderButtonsGroup = (spec: BridgeView.ViewButtonsGroup, providers: UiFact
       tag: 'div',
       classes: [ 'tox-view__toolbar__group' ],
     },
-    behaviours: Behaviour.derive([
-      Tabstopping.config({}),
-      Focusing.config({})
-    ]),
     components: Arr.map(spec.buttons, (button) => renderViewButton(button, providers))
   };
 };
@@ -78,7 +74,6 @@ const renderViewHeader = (spec: ViewHeaderSpec) => {
       ]
     },
     behaviours: Behaviour.derive([
-      Tabstopping.config({}),
       Focusing.config({}),
       Keying.config({
         mode: 'flow',

--- a/modules/tinymce/src/themes/silver/main/ts/ui/view/View.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/view/View.ts
@@ -1,6 +1,6 @@
 import {
-  AlloyComponent, AlloySpec, Composite, Container, PartType, RawDomSchema, SimpleSpec,
-  Sketcher, UiSketcher
+  AlloyComponent, AlloySpec, Behaviour, Composite, Container, Focusing, FocusInsideModes, Keying, PartType, RawDomSchema, SimpleSpec,
+  Sketcher, Tabstopping, UiSketcher
 } from '@ephox/alloy';
 import { FieldSchema } from '@ephox/boulder';
 import { View as BridgeView } from '@ephox/bridge';
@@ -45,6 +45,10 @@ const renderButtonsGroup = (spec: BridgeView.ViewButtonsGroup, providers: UiFact
       tag: 'div',
       classes: [ 'tox-view__toolbar__group' ],
     },
+    behaviours: Behaviour.derive([
+      Tabstopping.config({}),
+      Focusing.config({})
+    ]),
     components: Arr.map(spec.buttons, (button) => renderViewButton(button, providers))
   };
 };
@@ -73,6 +77,16 @@ const renderViewHeader = (spec: ViewHeaderSpec) => {
         ...(isPhone || isTablet ? [ 'tox-view--mobile', 'tox-view--scrolling' ] : [])
       ]
     },
+    behaviours: Behaviour.derive([
+      Tabstopping.config({}),
+      Focusing.config({}),
+      Keying.config({
+        mode: 'flow',
+        selector: 'button, .tox-button',
+        focusInside: FocusInsideModes.OnEnterOrSpaceMode,
+        cycles: false,
+      })
+    ]),
     components: hasGroups ?
       endButtons
       : [

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -333,13 +333,13 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       await FocusTools.pTryOnSelector('With right it should pass from Button 1 to Button 2', root, '.tox-view__header [title="Button 2"]');
 
       TinyUiActions.keystroke(editor, Keys.right());
-      await FocusTools.pTryOnSelector('Pressing right again it should stay on Button 2', root, '.tox-view__header [title="Button 2"]');
+      await FocusTools.pTryOnSelector('Pressing right again it should move to Button 1', root, '.tox-view__header [title="Button 1"]');
 
       TinyUiActions.keystroke(editor, Keys.left());
-      await FocusTools.pTryOnSelector('With left it should pass from Button 2 to Button 1', root, '.tox-view__header [title="Button 1"]');
+      await FocusTools.pTryOnSelector('With left it should pass from Button 1 to Button 2', root, '.tox-view__header [title="Button 2"]');
 
       TinyUiActions.keystroke(editor, Keys.left());
-      await FocusTools.pTryOnSelector('Pressing left again it should stay on Button 1', root, '.tox-view__header [title="Button 1"]');
+      await FocusTools.pTryOnSelector('Pressing left again it should move to Button 1', root, '.tox-view__header [title="Button 1"]');
       toggleView('myview1');
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -340,6 +340,7 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
 
       TinyUiActions.keystroke(editor, Keys.left());
       await FocusTools.pTryOnSelector('Pressing left again it should stay on Button 1', root, '.tox-view__header [title="Button 1"]');
+      toggleView('myview1');
     });
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -1,7 +1,7 @@
-import { ApproxStructure, Assertions, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
+import { ApproxStructure, Assertions, FocusTools, Keys, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
-import { Attribute, Css, Html, SugarBody } from '@ephox/sugar';
+import { Attribute, Css, Html, SugarBody, SugarShadowDom } from '@ephox/sugar';
 import { TinyApis, TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -317,6 +317,29 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
       toggleView('myview1');
       TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+    });
+
+    it('TINY-9671: should be possible to navigate the header via keyboard', async () => {
+      const editor = hook.editor();
+      const root = SugarShadowDom.getRootNode(TinyDom.targetElement(editor));
+      toggleView('myview1');
+      FocusTools.setFocus(root, '.tox-view__header');
+      await FocusTools.pTryOnSelector('Focus should be on the view header', root, '.tox-view__header');
+
+      TinyUiActions.keystroke(editor, Keys.enter());
+      await FocusTools.pTryOnSelector('Button 1 should be the first selection', root, '.tox-view__header [title="Button 1"]');
+
+      TinyUiActions.keystroke(editor, Keys.right());
+      await FocusTools.pTryOnSelector('With right it should pass from Button 1 to Button 2', root, '.tox-view__header [title="Button 2"]');
+
+      TinyUiActions.keystroke(editor, Keys.right());
+      await FocusTools.pTryOnSelector('Pressing right again it should stay on Button 2', root, '.tox-view__header [title="Button 2"]');
+
+      TinyUiActions.keystroke(editor, Keys.left());
+      await FocusTools.pTryOnSelector('With left it should pass from Button 2 to Button 1', root, '.tox-view__header [title="Button 1"]');
+
+      TinyUiActions.keystroke(editor, Keys.left());
+      await FocusTools.pTryOnSelector('Pressing left again it should stay on Button 1', root, '.tox-view__header [title="Button 1"]');
     });
   });
 


### PR DESCRIPTION
Related Ticket: TINY-9671

Description of Changes:
add buttons navigation via keyboard to view mode

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
