### PR TITLE
TINY-9673: fix border for modal square custom editor content

### DIFF
--- a/modules/oxide/src/less/theme/components/well/well.less
+++ b/modules/oxide/src/less/theme/components/well/well.less
@@ -33,6 +33,11 @@
     border-radius: @well-border-radius;
     display: flex;
     flex: 1;
+    overflow: hidden;
     position: relative;
+
+    &:focus-within {
+      &:extend(.tox .tox-textfield:focus);
+    }
   }
 }

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The formatting of `contenteditable="false"` elements are no longer cloned to new cells while creating new table rows. #TINY-9449
 - Changed the color of `@dialog-table-border-color`, and added right padding to the first cell of dialog table. #TINY-9380
 - The sidebar element now has accessibility role `region` when visible and `presentation` when hidden. #TINY-9517
+- The class `tox-custom-editor` now has a border highlight when it is selected. #TINY-9673
 
 ### Fixed
 - Add support for navigating inside the tree component using arrow keys and shift key. #TINY-9614


### PR DESCRIPTION
Related Ticket: TINY-9673

Description of Changes:
fix border for modal square custom editor content

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/`, `hotfix/` or `spike/`~

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
