### PR TITLE
TINY-9419: `More...` button disapear if it is triggered and view mode is switched

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drag and dropping the last noneditable element out of its parent block would not properly pad the parent block element. #TINY-9606
 - Applying heading formats from `text_patterns` produced an invisible space before a word. #TINY-9603
 - Opening color swatches would cause tab to crash when `color_cols` or other column option was set to 0. #TINY-9649
+- Closing a view, `More...` button disappeared if the editor had `toolbar_mode: 'sliding'` and the toolbar was opened. #TINY-9419
 
 ## 6.3.2 - 2023-02-22
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -196,6 +196,10 @@ const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, Out
       });
     },
     showMainView: (comp: AlloyComponent) => {
+      if (toolbarDrawerOpenState) {
+        apis.toggleToolbarDrawer(comp);
+      }
+
       Composite.parts.getPart(comp, detail, 'editorContainer').each((editorContainer) => {
         const element = editorContainer.element;
 
@@ -203,9 +207,7 @@ const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, Out
         Attribute.remove(element, 'aria-hidden');
       });
 
-      if (toolbarDrawerOpenState) {
-        apis.toggleToolbarDrawer(comp);
-      }
+      apis.refreshToolbar(comp);
     }
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -196,16 +196,16 @@ const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, Out
       });
     },
     showMainView: (comp: AlloyComponent) => {
-      if (toolbarDrawerOpenState) {
-        apis.toggleToolbarDrawer(comp);
-      }
-
       Composite.parts.getPart(comp, detail, 'editorContainer').each((editorContainer) => {
         const element = editorContainer.element;
 
         Css.remove(element, 'display');
         Attribute.remove(element, 'aria-hidden');
       });
+
+      if (toolbarDrawerOpenState) {
+        apis.toggleToolbarDrawer(comp);
+      }
     }
   };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -347,4 +347,63 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       assert.equal(editor.queryCommandValue('ToggleView'), '', 'Should still be empty since inline mode does not support views');
     });
   });
+
+  context('Sliding toolbar', () => {
+    const hook = TinyHooks.bddSetup<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      toolbar_mode: 'sliding',
+      toolbar: Arr.range(10, Fun.constant('bold | italic ')).join(''),
+      width: 500,
+      setup: (editor: Editor) => {
+        editor.ui.registry.addView('myview1', {
+          buttons: [
+            {
+              type: 'button',
+              text: 'Button 1',
+              onAction: Fun.noop
+            },
+            {
+              type: 'button',
+              text: 'Button 2',
+              onAction: Fun.noop,
+              buttonType: 'primary'
+            }
+          ],
+          onShow: (api) => {
+            api.getContainer().innerHTML = '<button>myview1</button>';
+          },
+          onHide: Fun.noop
+        });
+      }
+    }, []);
+
+    const assertMainViewVisible = () => {
+      const editor = hook.editor();
+      const editorContainer = UiFinder.findIn(TinyDom.container(editor), '.tox-editor-container').getOrDie();
+
+      assert.isFalse(Attribute.has(editorContainer, 'aria-hidden'), 'Should not have aria-hidden');
+      assert.isTrue(Css.getRaw(editorContainer, 'display').isNone(), 'Should not have display none');
+    };
+
+    const assertViewHtml = (viewIndex: number, expectedHtml: string) => {
+      const editor = hook.editor();
+      const editorContainer = UiFinder.findIn<HTMLElement>(TinyDom.container(editor), `.tox-view:nth-child(${viewIndex + 1}) .tox-view__pane`).getOrDie();
+
+      assert.equal(Html.get(editorContainer), expectedHtml);
+    };
+
+    it('TINY-9419: "More..." button should not be removed if the toolbar is opened and view is opened and close', () => {
+      const editor = hook.editor();
+
+      editor.setContent('<p>ab</p>');
+      TinyUiActions.clickOnToolbar(editor, '[title="More..."]');
+
+      editor.execCommand('ToggleView', false, 'myview1');
+      assertViewHtml(0, '<button>myview1</button>');
+      editor.execCommand('ToggleView', false, 'myview1');
+      assertMainViewVisible();
+      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[title="More..."]');
+      assert.isTrue(moreButton.isValue(), 'More... button should be there');
+    });
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-9419

Description of Changes:
The problem is that the [toggleToolbarDrawer](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts#L200) uses [this refresh function](https://github.com/tinymce/tinymce/blob/develop/modules/alloy/src/main/ts/ephox/alloy/toolbar/SplitToolbarUtils.ts#L22), but it needs the width of the toolbar to render the buttons.

An easy fix is to show the toolbar before `toggleToolbarDrawer`, but this cause the user will see the animation again

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
