### PR TITLE
TINY-9685: fixed filtering for mce-nbsp-wrap elements

### DIFF
--- a/modules/tinymce/src/plugins/visualchars/main/ts/core/VisualChars.ts
+++ b/modules/tinymce/src/plugins/visualchars/main/ts/core/VisualChars.ts
@@ -6,16 +6,13 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Data from './Data';
 import * as Nodes from './Nodes';
 
-const isWrappedNbsp = (node: Node): node is HTMLSpanElement =>
-  node.nodeName.toLowerCase() === 'span' && (node as HTMLSpanElement).classList.contains('mce-nbsp-wrap');
-
 const show = (editor: Editor, rootElm: Element): void => {
   const dom = editor.dom;
   const nodeList = Nodes.filterEditableDescendants(SugarElement.fromDom(rootElm), Nodes.isMatch, editor.dom.isEditable(rootElm));
 
   Arr.each(nodeList, (n) => {
     const parent = n.dom.parentNode as Node;
-    if (isWrappedNbsp(parent)) {
+    if (Nodes.isWrappedNbsp(parent)) {
       Class.add(SugarElement.fromDom(parent), Data.nbspClass);
     } else {
       const withSpans = Nodes.replaceWithSpans(dom.encode(SugarNode.value(n) ?? ''));
@@ -35,7 +32,7 @@ const hide = (editor: Editor, rootElm: Element): void => {
   const nodeList = editor.dom.select(Data.selector, rootElm);
 
   Arr.each(nodeList, (node) => {
-    if (isWrappedNbsp(node)) {
+    if (Nodes.isWrappedNbsp(node)) {
       Class.remove(SugarElement.fromDom(node), Data.nbspClass);
     } else {
       editor.dom.remove(node, true);

--- a/modules/tinymce/src/plugins/visualchars/test/ts/browser/NodesTest.ts
+++ b/modules/tinymce/src/plugins/visualchars/test/ts/browser/NodesTest.ts
@@ -6,7 +6,12 @@ import { assert } from 'chai';
 
 import * as Nodes from 'tinymce/plugins/visualchars/core/Nodes';
 
-describe('atomic.tinymce.plugins.visualchars.NodesTest', () => {
+describe('browser.tinymce.plugins.visualchars.NodesTest', () => {
+  it('isWrappedNbsp', () => {
+    assert.isTrue(Nodes.isWrappedNbsp(SugarElement.fromHtml('<span class="mce-nbsp-wrap"></span>').dom));
+    assert.isFalse(Nodes.isWrappedNbsp(SugarElement.fromTag('span').dom));
+  });
+
   context('replaceWithSpans', () => {
     it('replace with spans', () => {
       Assertions.assertHtml(
@@ -89,6 +94,27 @@ describe('atomic.tinymce.plugins.visualchars.NodesTest', () => {
         '<b>editable 1</b>',
         '<i>editable 2</i>',
         '<b>editable 3</b>'
+      ]);
+    });
+
+    it('TINY-9685: should include "mce-nbsp-wrap" elements in editable contexts even if they them selfs are noneditable', () => {
+      const innerHtml = `
+        <span class="mce-nbsp-wrap" contenteditable="false">nbsp1</span>
+        <span contenteditable="false">
+          <span class="mce-nbsp-wrap" contenteditable="false">nbsp2</span>
+          <span contenteditable="true">
+            <span class="mce-nbsp-wrap" contenteditable="false">nbsp3</span>
+          </span>
+          <span class="mce-nbsp-wrap" contenteditable="false">nbsp4</span>
+        </span>
+      `;
+
+      const div = SugarElement.fromHtml(`<div>${innerHtml}</div>`);
+      const getHtml = (node: SugarElement<Node>) => SugarNode.isHTMLElement(node) ? Html.get(node) : '';
+
+      assert.deepEqual(Arr.map(Nodes.filterEditableDescendants(div, SugarNode.isElement, true), getHtml), [
+        'nbsp1',
+        'nbsp3'
       ]);
     });
   });

--- a/modules/tinymce/src/plugins/visualchars/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/visualchars/test/ts/browser/PluginTest.ts
@@ -103,4 +103,23 @@ describe('browser.tinymce.plugins.visualchars.PluginTest', () => {
     editor.getBody().contentEditable = 'true';
     TinyUiActions.clickOnToolbar(editor, 'button');
   });
+
+  it('TINY-9685: should add "mce-nbsp" to "mce-nbsp-wrap" elements in editable context', async () => {
+    const editor = hook.editor();
+
+    editor.getBody().contentEditable = 'false';
+    editor.setContent(`
+      <p><span class="mce-nbsp-wrap" contenteditable="false">&nbsp;</span></p>
+      <p contenteditable="true"><span class="mce-nbsp-wrap" contenteditable="false">&nbsp;</span></p>
+    `);
+    TinyUiActions.clickOnToolbar(editor, 'button');
+    await Waiter.pTryUntil('wait for visual chars to appear', () => {
+      TinyAssertions.assertContentPresence(editor, {
+        'span.mce-nbsp': 1,
+        '[contenteditable="true"] span.mce-nbsp': 1
+      });
+    });
+    editor.getBody().contentEditable = 'true';
+    TinyUiActions.clickOnToolbar(editor, 'button');
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-9685

Description of Changes:
* It should always process `mce-nbsp-wrap` elements regardless if they are editable or not.
* Moved atomic test to browser since it does dom things it's no longer atomic.
* Moved the isNbspWrapper to the Nodes module where all the other predicates are.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
