### PR TITLE
TINY-9653: Add defaultExpandedIds and onToggleExpand options to Tree component

### DIFF
--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Tree.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Tree.ts
@@ -1,4 +1,4 @@
-import { FieldSchema, StructureSchema } from '@ephox/boulder';
+import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
 import { Optional, Result } from '@ephox/katamari';
 
 import { ToolbarMenuButtonSpec, ToolbarMenuButton } from '../../api/Toolbar';
@@ -11,12 +11,23 @@ export interface TreeSpec {
   type: 'tree';
   items: TreeItemSpec[];
   onLeafAction?: (id: Id) => void;
+  defaultExpandedKeys?: Id[];
+  onExpand?: (
+    expandedKeys: Id[],
+    { expanded, node }: { expanded: boolean; node: Id }
+  ) => void;
 }
 
 export interface Tree {
   type: 'tree';
   items: TreeItem[];
+  defaultExpandedKeys: Optional<Id[]>;
   onLeafAction: Optional<(id: Id) => void>;
+  onExpand: Optional<(
+    expandedKeys: Id[],
+    { expanded, node }: { expanded: boolean; node: Id }
+  ) => void
+  >;
 }
 
 interface BaseTreeItemSpec {
@@ -57,7 +68,7 @@ const baseTreeItemFields = [
   FieldSchema.requiredStringEnum('type', [ 'directory', 'leaf' ]),
   ComponentSchema.title,
   FieldSchema.requiredString('id'),
-  FieldSchema.optionOf('menu', MenuButtonSchema ),
+  FieldSchema.optionOf('menu', MenuButtonSchema),
 ];
 
 const treeItemLeafFields = baseTreeItemFields;
@@ -83,7 +94,9 @@ const treeItemSchema = StructureSchema.chooseProcessor('type', {
 const treeFields = [
   ComponentSchema.type,
   FieldSchema.requiredArrayOf('items', treeItemSchema),
-  FieldSchema.optionFunction('onLeafAction')
+  FieldSchema.optionFunction('onLeafAction'),
+  FieldSchema.optionFunction('onExpand'),
+  FieldSchema.optionArrayOf('defaultExpandedKeys', ValueType.string),
 ];
 
 export const treeSchema = StructureSchema.objOf(treeFields);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Tree.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Tree.ts
@@ -21,7 +21,7 @@ export interface TreeSpec {
 export interface Tree {
   type: 'tree';
   items: TreeItem[];
-  defaultExpandedIds: Optional<Id[]>;
+  defaultExpandedIds: Id[];
   onLeafAction: Optional<(id: Id) => void>;
   onExpand: Optional<(
     expandedIds: Id[],
@@ -96,7 +96,7 @@ const treeFields = [
   FieldSchema.requiredArrayOf('items', treeItemSchema),
   FieldSchema.optionFunction('onLeafAction'),
   FieldSchema.optionFunction('onExpand'),
-  FieldSchema.optionArrayOf('defaultExpandedIds', ValueType.string),
+  FieldSchema.defaultedArrayOf('defaultExpandedIds', [], ValueType.string),
 ];
 
 export const treeSchema = StructureSchema.objOf(treeFields);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Tree.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Tree.ts
@@ -13,7 +13,7 @@ export interface TreeSpec {
   onLeafAction?: (id: Id) => void;
   defaultExpandedIds?: Id[];
   onExpand?: (
-    expandedKeys: Id[],
+    expandedIds: Id[],
     { expanded, node }: { expanded: boolean; node: Id }
   ) => void;
 }
@@ -24,7 +24,7 @@ export interface Tree {
   defaultExpandedIds: Optional<Id[]>;
   onLeafAction: Optional<(id: Id) => void>;
   onExpand: Optional<(
-    expandedKeys: Id[],
+    expandedIds: Id[],
     { expanded, node }: { expanded: boolean; node: Id }
   ) => void
   >;

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Tree.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Tree.ts
@@ -12,7 +12,7 @@ export interface TreeSpec {
   items: TreeItemSpec[];
   onLeafAction?: (id: Id) => void;
   defaultExpandedIds?: Id[];
-  onExpand?: (
+  onToggleExpand?: (
     expandedIds: Id[],
     { expanded, node }: { expanded: boolean; node: Id }
   ) => void;
@@ -23,7 +23,7 @@ export interface Tree {
   items: TreeItem[];
   defaultExpandedIds: Id[];
   onLeafAction: Optional<(id: Id) => void>;
-  onExpand: Optional<(
+  onToggleExpand: Optional<(
     expandedIds: Id[],
     { expanded, node }: { expanded: boolean; node: Id }
   ) => void
@@ -95,7 +95,7 @@ const treeFields = [
   ComponentSchema.type,
   FieldSchema.requiredArrayOf('items', treeItemSchema),
   FieldSchema.optionFunction('onLeafAction'),
-  FieldSchema.optionFunction('onExpand'),
+  FieldSchema.optionFunction('onToggleExpand'),
   FieldSchema.defaultedArrayOf('defaultExpandedIds', [], ValueType.string),
 ];
 

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Tree.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Tree.ts
@@ -11,7 +11,7 @@ export interface TreeSpec {
   type: 'tree';
   items: TreeItemSpec[];
   onLeafAction?: (id: Id) => void;
-  defaultExpandedKeys?: Id[];
+  defaultExpandedIds?: Id[];
   onExpand?: (
     expandedKeys: Id[],
     { expanded, node }: { expanded: boolean; node: Id }
@@ -21,7 +21,7 @@ export interface TreeSpec {
 export interface Tree {
   type: 'tree';
   items: TreeItem[];
-  defaultExpandedKeys: Optional<Id[]>;
+  defaultExpandedIds: Optional<Id[]>;
   onLeafAction: Optional<(id: Id) => void>;
   onExpand: Optional<(
     expandedKeys: Id[],
@@ -96,7 +96,7 @@ const treeFields = [
   FieldSchema.requiredArrayOf('items', treeItemSchema),
   FieldSchema.optionFunction('onLeafAction'),
   FieldSchema.optionFunction('onExpand'),
-  FieldSchema.optionArrayOf('defaultExpandedKeys', ValueType.string),
+  FieldSchema.optionArrayOf('defaultExpandedIds', ValueType.string),
 ];
 
 export const treeSchema = StructureSchema.objOf(treeFields);

--- a/modules/oxide/src/less/theme/components/tree/tree-button.less
+++ b/modules/oxide/src/less/theme/components/tree/tree-button.less
@@ -190,12 +190,6 @@
     display: flex;
     flex-direction: column;
 
-    &.tox-tree--directory--expanded {
-      > .tox-tree--directory__label .tox-chevron {
-        transform: rotate(90deg);
-      }
-    }
-
     /* stylelint-disable no-descending-specificity */
     .tox-tree--directory__label {
       font-weight: bold;
@@ -231,11 +225,20 @@
 
       .tox-chevron {
         margin-right: 6px;
-        transition: transform .5s ease-in-out;
       }
 
-      &.tox-tree--directory__label--active .tox-chevron {
-        transform: rotate(90deg);
+      &:has(+ .tox-tree--directory__children--growing),
+      &:has(+ .tox-tree--directory__children--shrinking) {
+        .tox-chevron {
+          transition: transform .5s ease-in-out;
+        }
+      }
+
+      &:has(+ .tox-tree--directory__children--growing),
+      &:has(+ .tox-tree--directory__children--open) {
+        .tox-chevron {
+          transform: rotate(90deg);
+        }
       }
     }
   }

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- New optional `defaultExpandedKeys` and `onExpand` options to the `tree` component config. #TINY-9653
+
 ### Fixed
 - Table toolbar was visible even if the table was within a noneditable host element. #TINY-9664
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- New optional `defaultExpandedKeys` and `onExpand` options to the `tree` component config. #TINY-9653
+- New optional `defaultExpandedIds` and `onToggleExpand` options to the `tree` component config. #TINY-9653
 
 ### Fixed
 - Table toolbar was visible even if the table was within a noneditable host element. #TINY-9664

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
@@ -1,5 +1,4 @@
 import { Dialog } from '@ephox/bridge';
-import { Id } from '@ephox/katamari';
 
 import { TinyMCE } from 'tinymce/core/api/PublicApi';
 

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
@@ -165,7 +165,7 @@ export default (): void => {
               }
             });
           };
-          const initialData: Data = { search: '', expandedKeys: [] };
+          const initialData: Data = { search: '', expandedKeys: [ 'dir' ] };
           ed.windowManager.open(getDialogSpec(getTree(initialData.search), initialData));
         }
       });

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
@@ -6,7 +6,6 @@ declare let tinymce: TinyMCE;
 
 interface Data {
   search: string;
-  expandedKeys: string[];
 }
 
 export default (): void => {
@@ -118,13 +117,14 @@ export default (): void => {
               return fullTree;
             }
           };
-          const getDialogSpec = (tree: Dialog.TreeItemSpec[], initialData: Data ): Dialog.DialogSpec<Data> => {
-            let expandedKeys = initialData.expandedKeys;
+
+          const getDialogSpec = (tree: Dialog.TreeItemSpec[], initialData: Data, initialExpandedIds: string[] ): Dialog.DialogSpec<Data> => {
+            let expandedIds = initialExpandedIds;
             return ({
               size: 'large',
               initialData,
               onChange: (api) => {
-                api.redial(getDialogSpec(getTree(''), { search: api.getData().search, expandedKeys }));
+                api.redial(getDialogSpec(getTree(''), { search: api.getData().search }, expandedIds));
               },
               title: 'Tree',
               buttons: [
@@ -153,9 +153,9 @@ export default (): void => {
                             console.log('clicked on item with id', id);
                             },
                             onExpand: (newExpandedKeys) => {
-                              expandedKeys = newExpandedKeys;
+                              expandedIds = newExpandedKeys;
                             },
-                            defaultExpandedKeys: initialData.expandedKeys,
+                            defaultExpandedIds: expandedIds,
                             items: tree
                           }]
                       },
@@ -165,8 +165,8 @@ export default (): void => {
               }
             });
           };
-          const initialData: Data = { search: '', expandedKeys: [ 'dir' ] };
-          ed.windowManager.open(getDialogSpec(getTree(initialData.search), initialData));
+          const initialData: Data = { search: '' };
+          ed.windowManager.open(getDialogSpec(getTree(initialData.search), initialData, [ 'dir' ]));
         }
       });
     }

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
@@ -7,6 +7,7 @@ declare let tinymce: TinyMCE;
 
 interface Data {
   search: string;
+  expandedKeys: string[];
 }
 
 export default (): void => {
@@ -21,7 +22,7 @@ export default (): void => {
           const fullTree: Dialog.TreeItemSpec [] = [
             {
               type: 'directory',
-              id: Id.generate(''),
+              id: 'dirempty',
               title: 'Dir Empty',
               menu: {
                 type: 'menubutton',
@@ -41,7 +42,7 @@ export default (): void => {
             },
             {
               type: 'directory',
-              id: Id.generate(''),
+              id: 'dir',
               title: 'Dir',
               menu: {
                 type: 'menubutton',
@@ -60,30 +61,30 @@ export default (): void => {
               children: [
                 {
                   type: 'directory',
-                  id: Id.generate(''),
+                  id: 'subdir',
                   title: 'Sub dir',
                   children: [
                     {
                       type: 'leaf',
                       title: 'File 1',
-                      id: Id.generate(''),
+                      id: '1',
                     },
                     {
                       type: 'leaf',
                       title: 'File 2',
-                      id: Id.generate(''),
+                      id: '2',
                     },
                   ]
                 },
                 {
                   type: 'leaf',
                   title: 'File 3',
-                  id: Id.generate(''),
+                  id: '3',
                 },
                 {
                   type: 'leaf',
                   title: 'File 4',
-                  id: Id.generate(''),
+                  id: '4',
                   menu: {
                     type: 'menubutton',
                     icon: 'image-options',
@@ -104,12 +105,12 @@ export default (): void => {
             {
               type: 'leaf',
               title: 'File 5',
-              id: Id.generate(''),
+              id: '5',
             },
             {
               type: 'leaf',
               title: 'File 6',
-              id: Id.generate(''),
+              id: '6',
             }];
           const getTree = (search: string) => {
             if (search.length > 2) {
@@ -118,45 +119,54 @@ export default (): void => {
               return fullTree;
             }
           };
-          const getDialogSpec = (tree: Dialog.TreeItemSpec[], initialData: Data ): Dialog.DialogSpec<Data> => ({
-            size: 'large',
-            initialData,
-            onChange: (api) => {
-              const { search } = api.getData();
-              api.redial(getDialogSpec(getTree(search), api.getData()));
-            },
-            title: 'Tree',
-            buttons: [
-              {
-                type: 'cancel',
-                text: 'Cancel',
-              }
-            ],
-            body: {
-              type: 'panel',
-              items: [
+          const getDialogSpec = (tree: Dialog.TreeItemSpec[], initialData: Data ): Dialog.DialogSpec<Data> => {
+            let expandedKeys = initialData.expandedKeys;
+            return ({
+              size: 'large',
+              initialData,
+              onChange: (api) => {
+                api.redial(getDialogSpec(getTree(''), { search: api.getData().search, expandedKeys }));
+              },
+              title: 'Tree',
+              buttons: [
                 {
-                  type: 'bar',
-                  items: [
-                    {
-                      type: 'panel',
-                      items: [
-                        {
-                          type: 'tree',
-                          onLeafAction: (id) => {
+                  type: 'cancel',
+                  text: 'Cancel',
+                }
+              ],
+              body: {
+                type: 'panel',
+                items: [
+                  {
+                    type: 'input',
+                    name: 'search'
+                  },
+                  {
+                    type: 'bar',
+                    items: [
+                      {
+                        type: 'panel',
+                        items: [
+                          {
+                            type: 'tree',
+                            onLeafAction: (id) => {
                             // eslint-disable-next-line
                             console.log('clicked on item with id', id);
-                          },
-                          items: tree
-                        }]
-                    },
-                  ]
-                }
-
-              ]
-            }
-          });
-          const initialData = { search: '' };
+                            },
+                            onExpand: (newExpandedKeys) => {
+                              expandedKeys = newExpandedKeys;
+                            },
+                            defaultExpandedKeys: initialData.expandedKeys,
+                            items: tree
+                          }]
+                      },
+                    ]
+                  }
+                ]
+              }
+            });
+          };
+          const initialData: Data = { search: '', expandedKeys: [] };
           ed.windowManager.open(getDialogSpec(getTree(initialData.search), initialData));
         }
       });

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
@@ -152,7 +152,7 @@ export default (): void => {
                             // eslint-disable-next-line
                             console.log('clicked on item with id', id);
                             },
-                            onExpand: (newExpandedKeys) => {
+                            onToggleExpand: (newExpandedKeys) => {
                               expandedIds = newExpandedKeys;
                             },
                             defaultExpandedIds: expandedIds,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
@@ -32,14 +32,14 @@ interface RenderDirectoryProps extends RenderItemProps {
   labelTabstopping: boolean;
   treeId: string;
   onLeafAction: OnLeafAction;
-  expandedKeys: string[];
+  expandedIds: string[];
 }
 
 interface RenderDirectoryLabelProps extends RenderItemProps {
   directory: Dialog.Directory;
   visible: boolean;
   noChildren: boolean;
-  expandedKeys: string[];
+  expandedIds: string[];
 }
 
 interface RenderDirectoryChildrenProps extends RenderItemProps {
@@ -47,7 +47,7 @@ interface RenderDirectoryChildrenProps extends RenderItemProps {
   visible: boolean;
   treeId: string;
   onLeafAction: OnLeafAction;
-  expandedKeys: string[];
+  expandedIds: string[];
 }
 
 const renderLabel = (text: string ): SimpleSpec => ({
@@ -157,7 +157,7 @@ const renderDirectoryLabel = ({
   directory,
   visible,
   noChildren,
-  expandedKeys,
+  expandedIds: expandedIds,
   backstage
 }: RenderDirectoryLabelProps): SimpleSpec => {
   const internalMenuButton = directory.menu.map((btn) => renderMenuButton(btn, 'tox-mbtn', backstage, Optional.none()));
@@ -202,7 +202,7 @@ const renderDirectoryLabel = ({
       ...(visible ? [ Tabstopping.config({}) ] : []),
       AddEventsBehaviour.config(directoryLabelEventsId, [
         AlloyEvents.runOnAttached((button, _se) => {
-          const dirExpanded = expandedKeys.includes(directory.id);
+          const dirExpanded = expandedIds.includes(directory.id);
           if (dirExpanded) {
             expandChildren(button);
           }
@@ -241,7 +241,7 @@ const renderDirectoryChildren = ({
   onLeafAction,
   visible,
   treeId,
-  expandedKeys,
+  expandedIds: expandedIds,
   backstage
 }: RenderDirectoryChildrenProps): SimpleSpec => {
   return {
@@ -252,7 +252,7 @@ const renderDirectoryChildren = ({
     components: children.map((item) => {
       return item.type === 'leaf' ?
         renderLeafLabel({ leaf: item, onLeafAction, visible, treeId, backstage }) :
-        renderDirectory({ directory: item, expandedKeys, onLeafAction, labelTabstopping: visible, treeId, backstage });
+        renderDirectory({ directory: item, expandedIds, onLeafAction, labelTabstopping: visible, treeId, backstage });
     }),
     behaviours: Behaviour.derive([
       Sliding.config({
@@ -276,16 +276,16 @@ const renderDirectory = ({
   labelTabstopping,
   treeId,
   backstage,
-  expandedKeys,
+  expandedIds: expandedIds,
 }: RenderDirectoryProps): SimpleSpec => {
   const { children } = directory;
   const computedChildrenComponents = (visible: boolean) =>
     children.map((item) => {
       return item.type === 'leaf' ?
         renderLeafLabel({ leaf: item, onLeafAction, visible, treeId, backstage }) :
-        renderDirectory({ directory: item, expandedKeys, onLeafAction, labelTabstopping: visible, treeId, backstage });
+        renderDirectory({ directory: item, expandedIds, onLeafAction, labelTabstopping: visible, treeId, backstage });
     });
-  const childrenVisible = expandedKeys.includes(directory.id);
+  const childrenVisible = expandedIds.includes(directory.id);
   return ({
     dom: {
       tag: 'div',
@@ -295,8 +295,8 @@ const renderDirectory = ({
       }
     },
     components: [
-      renderDirectoryLabel({ directory, expandedKeys, visible: labelTabstopping, noChildren: directory.children.length === 0, backstage }),
-      renderDirectoryChildren({ children, expandedKeys, onLeafAction, visible: childrenVisible, treeId, backstage })
+      renderDirectoryLabel({ directory, expandedIds, visible: labelTabstopping, noChildren: directory.children.length === 0, backstage }),
+      renderDirectoryChildren({ children, expandedIds, onLeafAction, visible: childrenVisible, treeId, backstage })
     ],
     behaviours: Behaviour.derive([
       Toggling.config({
@@ -333,13 +333,13 @@ const renderTree = (
 ): SimpleSpec => {
   const onLeafAction = spec.onLeafAction.getOr(Fun.noop);
   const onExpand = spec.onExpand.getOr(Fun.noop);
-  const defaultExpandedKeys: string[] = spec.defaultExpandedKeys.getOr([]);
-  const expandedKeys = Cell(defaultExpandedKeys);
+  const defaultExpandedIds: string[] = spec.defaultExpandedIds.getOr([]);
+  const expandedIds = Cell(defaultExpandedIds);
   const treeId = Id.generate('tree-id');
   const children = spec.items.map((item) => {
     return item.type === 'leaf' ?
       renderLeafLabel({ leaf: item, onLeafAction, visible: true, treeId, backstage }) :
-      renderDirectory({ directory: item, onLeafAction, expandedKeys: defaultExpandedKeys, labelTabstopping: true, treeId, backstage });
+      renderDirectory({ directory: item, onLeafAction, expandedIds: defaultExpandedIds, labelTabstopping: true, treeId, backstage });
   });
   return {
     dom: {
@@ -359,11 +359,11 @@ const renderTree = (
       AddEventsBehaviour.config(treeEventsId, [
         AlloyEvents.run<ExpandTreeNodeEventArgs>('expand-tree-node', (_cmp, se) => {
           const { expanded, node } = se.event;
-          expandedKeys.set( expanded ?
-            [ ...expandedKeys.get(), node ] :
-            expandedKeys.get().filter((id) => id !== node)
+          expandedIds.set( expanded ?
+            [ ...expandedIds.get(), node ] :
+            expandedIds.get().filter((id) => id !== node)
           );
-          onExpand(expandedKeys.get(), { expanded, node });
+          onExpand(expandedIds.get(), { expanded, node });
         })
       ])
     ])

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
@@ -333,7 +333,7 @@ const renderTree = (
   backstage: UiFactoryBackstage
 ): SimpleSpec => {
   const onLeafAction = spec.onLeafAction.getOr(Fun.noop);
-  const onExpand = spec.onExpand.getOr(Fun.noop);
+  const onExpand = spec.onToggleExpand.getOr(Fun.noop);
   const defaultExpandedIds: string[] = spec.defaultExpandedIds;
   const expandedIds = Cell(defaultExpandedIds);
   const treeId = Id.generate('tree-id');

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
@@ -11,7 +11,8 @@ import * as Icons from '../icons/Icons';
 
 type TreeSpec = Omit<Dialog.Tree, 'type'>;
 type OnLeafAction = (id: string) => void;
-interface ExpandTreeNodeEventArgs extends EventFormat {
+
+interface ToggleExpandTreeNodeEventArgs extends EventFormat {
   expanded: boolean;
   node: string;
 }
@@ -357,7 +358,7 @@ const renderTree = (
         cycles: false,
       }),
       AddEventsBehaviour.config(treeEventsId, [
-        AlloyEvents.run<ExpandTreeNodeEventArgs>('expand-tree-node', (_cmp, se) => {
+        AlloyEvents.run<ToggleExpandTreeNodeEventArgs>('expand-tree-node', (_cmp, se) => {
           const { expanded, node } = se.event;
           expandedIds.set( expanded ?
             [ ...expandedIds.get(), node ] :

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
@@ -334,7 +334,7 @@ const renderTree = (
 ): SimpleSpec => {
   const onLeafAction = spec.onLeafAction.getOr(Fun.noop);
   const onExpand = spec.onExpand.getOr(Fun.noop);
-  const defaultExpandedIds: string[] = spec.defaultExpandedIds.getOr([]);
+  const defaultExpandedIds: string[] = spec.defaultExpandedIds;
   const expandedIds = Cell(defaultExpandedIds);
   const treeId = Id.generate('tree-id');
   const children = spec.items.map((item) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
@@ -1,6 +1,8 @@
-import { Behaviour, Button as AlloyButton, Tabstopping, GuiFactory, SimpleSpec, Toggling, Replacing, Keying, AddEventsBehaviour, AlloyEvents, NativeEvents, AlloyComponent, CustomEvent, Receiving, Focusing, Sliding } from '@ephox/alloy';
+import {
+  Behaviour, Button as AlloyButton, Tabstopping, GuiFactory, SimpleSpec, Toggling, Replacing, Keying, AddEventsBehaviour, AlloyEvents, NativeEvents, AlloyComponent, CustomEvent, Receiving, Focusing, Sliding, AlloyTriggers, EventFormat
+} from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Fun, Id, Optional } from '@ephox/katamari';
+import { Cell, Fun, Id, Optional } from '@ephox/katamari';
 import { EventArgs, SelectorFind } from '@ephox/sugar';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
@@ -9,6 +11,10 @@ import * as Icons from '../icons/Icons';
 
 type TreeSpec = Omit<Dialog.Tree, 'type'>;
 type OnLeafAction = (id: string) => void;
+interface ExpandTreeNodeEventArgs extends EventFormat {
+  expanded: boolean;
+  node: string;
+}
 
 interface RenderItemProps {
   backstage: UiFactoryBackstage;
@@ -26,12 +32,14 @@ interface RenderDirectoryProps extends RenderItemProps {
   labelTabstopping: boolean;
   treeId: string;
   onLeafAction: OnLeafAction;
+  expandedKeys: string[];
 }
 
 interface RenderDirectoryLabelProps extends RenderItemProps {
   directory: Dialog.Directory;
   visible: boolean;
   noChildren: boolean;
+  expandedKeys: string[];
 }
 
 interface RenderDirectoryChildrenProps extends RenderItemProps {
@@ -39,6 +47,7 @@ interface RenderDirectoryChildrenProps extends RenderItemProps {
   visible: boolean;
   treeId: string;
   onLeafAction: OnLeafAction;
+  expandedKeys: string[];
 }
 
 const renderLabel = (text: string ): SimpleSpec => ({
@@ -148,6 +157,7 @@ const renderDirectoryLabel = ({
   directory,
   visible,
   noChildren,
+  expandedKeys,
   backstage
 }: RenderDirectoryLabelProps): SimpleSpec => {
   const internalMenuButton = directory.menu.map((btn) => renderMenuButton(btn, 'tox-mbtn', backstage, Optional.none()));
@@ -168,7 +178,11 @@ const renderDirectoryLabel = ({
   });
   const expandChildren = (button: AlloyComponent) => {
     SelectorFind.ancestor(button.element, '.tox-tree--directory').each((directoryEle) => {
-      button.getSystem().getByDom(directoryEle).each((directoryComp) => Toggling.toggle(directoryComp));
+      button.getSystem().getByDom(directoryEle).each((directoryComp) => {
+        const willExpand = !Toggling.isOn(directoryComp);
+        Toggling.toggle(directoryComp);
+        AlloyTriggers.emitWith(button, 'expand-tree-node', { expanded: willExpand, node: directory.id });
+      });
     });
   };
   return AlloyButton.sketch({
@@ -187,6 +201,12 @@ const renderDirectoryLabel = ({
     buttonBehaviours: Behaviour.derive([
       ...(visible ? [ Tabstopping.config({}) ] : []),
       AddEventsBehaviour.config(directoryLabelEventsId, [
+        AlloyEvents.runOnAttached((button, _se) => {
+          const dirExpanded = expandedKeys.includes(directory.id);
+          if (dirExpanded) {
+            expandChildren(button);
+          }
+        }),
         AlloyEvents.run<EventArgs<KeyboardEvent>>(NativeEvents.keydown(), (comp, se) => {
           const isRightArrowKey = se.event.raw.code === 'ArrowRight';
           const isLeftArrowKey = se.event.raw.code === 'ArrowLeft';
@@ -221,6 +241,7 @@ const renderDirectoryChildren = ({
   onLeafAction,
   visible,
   treeId,
+  expandedKeys,
   backstage
 }: RenderDirectoryChildrenProps): SimpleSpec => {
   return {
@@ -231,7 +252,7 @@ const renderDirectoryChildren = ({
     components: children.map((item) => {
       return item.type === 'leaf' ?
         renderLeafLabel({ leaf: item, onLeafAction, visible, treeId, backstage }) :
-        renderDirectory({ directory: item, onLeafAction, labelTabstopping: visible, treeId, backstage });
+        renderDirectory({ directory: item, expandedKeys, onLeafAction, labelTabstopping: visible, treeId, backstage });
     }),
     behaviours: Behaviour.derive([
       Sliding.config({
@@ -242,6 +263,7 @@ const renderDirectoryChildren = ({
         openClass: 'tox-tree--directory__children--open',
         growingClass: 'tox-tree--directory__children--growing',
         shrinkingClass: 'tox-tree--directory__children--shrinking',
+        expanded: visible,
       }),
       Replacing.config({})
     ])
@@ -253,15 +275,17 @@ const renderDirectory = ({
   onLeafAction,
   labelTabstopping,
   treeId,
-  backstage
+  backstage,
+  expandedKeys,
 }: RenderDirectoryProps): SimpleSpec => {
   const { children } = directory;
   const computedChildrenComponents = (visible: boolean) =>
     children.map((item) => {
       return item.type === 'leaf' ?
         renderLeafLabel({ leaf: item, onLeafAction, visible, treeId, backstage }) :
-        renderDirectory({ directory: item, onLeafAction, labelTabstopping: visible, treeId, backstage });
+        renderDirectory({ directory: item, expandedKeys, onLeafAction, labelTabstopping: visible, treeId, backstage });
     });
+  const childrenVisible = expandedKeys.includes(directory.id);
   return ({
     dom: {
       tag: 'div',
@@ -271,27 +295,27 @@ const renderDirectory = ({
       }
     },
     components: [
-      renderDirectoryLabel({ directory, visible: labelTabstopping, noChildren: directory.children.length === 0, backstage }),
-      renderDirectoryChildren({ children, onLeafAction, visible: false, treeId, backstage })
+      renderDirectoryLabel({ directory, expandedKeys, visible: labelTabstopping, noChildren: directory.children.length === 0, backstage }),
+      renderDirectoryChildren({ children, expandedKeys, onLeafAction, visible: childrenVisible, treeId, backstage })
     ],
     behaviours: Behaviour.derive([
       Toggling.config({
         ...( directory.children.length > 0 ? {
           aria: {
             mode: 'expanded',
-          }
+          },
         } : {}),
         toggleClass: 'tox-tree--directory--expanded',
         onToggled: (comp, childrenVisible) => {
           const childrenComp = comp.components()[1];
           const newChildren = computedChildrenComponents(childrenVisible);
-          if (childrenVisible) {
+          if (childrenVisible && !Sliding.hasGrown(childrenComp)) {
             Sliding.grow(childrenComp);
-          } else {
+          } else if (!childrenVisible && !Sliding.hasShrunk(childrenComp)) {
             Sliding.shrink(childrenComp);
           }
           Replacing.set(childrenComp, newChildren);
-        }
+        },
       }),
     ])
   });
@@ -301,16 +325,21 @@ interface UpdateTreeSelectedItemEvent extends CustomEvent {
   readonly value: string;
 }
 
+const treeEventsId = Id.generate('tree-event-id');
+
 const renderTree = (
   spec: TreeSpec,
   backstage: UiFactoryBackstage
 ): SimpleSpec => {
   const onLeafAction = spec.onLeafAction.getOr(Fun.noop);
+  const onExpand = spec.onExpand.getOr(Fun.noop);
+  const defaultExpandedKeys: string[] = spec.defaultExpandedKeys.getOr([]);
+  const expandedKeys = Cell(defaultExpandedKeys);
   const treeId = Id.generate('tree-id');
   const children = spec.items.map((item) => {
     return item.type === 'leaf' ?
       renderLeafLabel({ leaf: item, onLeafAction, visible: true, treeId, backstage }) :
-      renderDirectory({ directory: item, onLeafAction, labelTabstopping: true, treeId, backstage });
+      renderDirectory({ directory: item, onLeafAction, expandedKeys: defaultExpandedKeys, labelTabstopping: true, treeId, backstage });
   });
   return {
     dom: {
@@ -327,6 +356,16 @@ const renderTree = (
         selector: '.tox-tree--leaf__label--visible, .tox-tree--directory__label--visible',
         cycles: false,
       }),
+      AddEventsBehaviour.config(treeEventsId, [
+        AlloyEvents.run<ExpandTreeNodeEventArgs>('expand-tree-node', (_cmp, se) => {
+          const { expanded, node } = se.event;
+          expandedKeys.set( expanded ?
+            [ ...expandedKeys.get(), node ] :
+            expandedKeys.get().filter((id) => id !== node)
+          );
+          onExpand(expandedKeys.get(), { expanded, node });
+        })
+      ])
     ])
   };
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
@@ -337,7 +337,7 @@ const renderTree = (
   backstage: UiFactoryBackstage
 ): SimpleSpec => {
   const onLeafAction = spec.onLeafAction.getOr(Fun.noop);
-  const onExpand = spec.onToggleExpand.getOr(Fun.noop);
+  const onToggleExpand = spec.onToggleExpand.getOr(Fun.noop);
   const defaultExpandedIds: string[] = spec.defaultExpandedIds;
   const expandedIds = Cell(defaultExpandedIds);
   const treeId = Id.generate('tree-id');
@@ -368,7 +368,7 @@ const renderTree = (
             [ ...expandedIds.get(), node ] :
             expandedIds.get().filter((id) => id !== node)
           );
-          onExpand(expandedIds.get(), { expanded, node });
+          onToggleExpand(expandedIds.get(), { expanded, node });
         })
       ])
     ])

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
@@ -205,7 +205,11 @@ const renderDirectoryLabel = ({
         AlloyEvents.runOnAttached((button, _se) => {
           const dirExpanded = expandedIds.includes(directory.id);
           if (dirExpanded) {
-            expandChildren(button);
+            SelectorFind.ancestor(button.element, '.tox-tree--directory').each((directoryEle) => {
+              button.getSystem().getByDom(directoryEle).each((directoryComp) => {
+                Toggling.toggle(directoryComp);
+              });
+            });
           }
         }),
         AlloyEvents.run<EventArgs<KeyboardEvent>>(NativeEvents.keydown(), (comp, se) => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
@@ -77,7 +77,7 @@ describe('headless.tinymce.themes.silver.tree.TreeTest', () => {
       type: 'tree',
       onLeafAction: store.add,
       items: fullTree,
-      onExpand: (_expandedKeys, { expanded, node }) => {
+      onToggleExpand: (_expandedKeys, { expanded, node }) => {
         store.add(node + (expanded ? '-expanded' : '-collapsed'));
       },
       defaultExpandedIds: [ 'dir' ]

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
@@ -107,7 +107,7 @@ describe('headless.tinymce.themes.silver.tree.TreeTest', () => {
 
   it('Check initial event state', () => {
     const store = hook.store();
-    store.assertEq('Store should have an entry for the expanded dir', [ 'dir-expanded' ]);
+    store.assertEq('Store should be empty', []);
   });
 
   it('TINY-9614: Basic tree interactions', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
@@ -80,7 +80,7 @@ describe('headless.tinymce.themes.silver.tree.TreeTest', () => {
       onExpand: (_expandedKeys, { expanded, node }) => {
         store.add(node + (expanded ? '-expanded' : '-collapsed'));
       },
-      defaultExpandedKeys: [ 'dir' ]
+      defaultExpandedIds: [ 'dir' ]
     }));
 
     const tree = renderTree(treeSpec, extrasHook.access().extras.backstages.dialog );


### PR DESCRIPTION
Related Ticket: TINY-9653

Description of Changes:
* Add defaultExpandedKeys and onToggleExpand options to Tree component

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] ~Branch prefixed with `feature/`, `hotfix/` or `spike/`~

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
