### PR TITLE
TINY-9714: Fix tree component css to align with new high contrast skin

### DIFF
--- a/modules/oxide/src/less/theme/components/tree/tree-button.less
+++ b/modules/oxide/src/less/theme/components/tree/tree-button.less
@@ -1,55 +1,56 @@
-
 //
-// Tree button
+// Tree component
 //
-
 @tree-button-background-color: transparent;
-@tree-button-border-radius: 4px;
+@tree-button-border-radius: 3px;
 @tree-button-border: 0;
 @tree-button-box-shadow: none;
 @tree-button-chevron-color: fade(@tree-button-icon-color, 50%);
+@tree-button-chevron-width: @base-value;
 @tree-button-font-size: @font-size-sm;
 @tree-button-font-style: normal;
 @tree-button-font-weight: @font-weight-normal;
 @tree-button-height: 28px;
-@tree-button-icon-color: contrast(@background-color, @color-white, @color-black);
-@tree-button-menu-icon-color: contrast(@tree-button-hover-background-color, @color-white, @color-black);
+@tree-button-icon-color: @tree-button-text-color;
 @tree-button-spacing-x: 1px;
 @tree-button-spacing-y: 5px;
-@tree-button-text-color: contrast(@background-color, @color-white, @color-black);
+@tree-button-text-color: @text-color;
 @tree-button-text-transform: none;
 
-@tree-button-hover-background-color: @hover-background-color;
-@tree-button-hover-border: @tree-button-border;
-@tree-button-hover-box-shadow: @tree-button-box-shadow;
-@tree-button-hover-icon-color: @tree-button-hover-text-color;
-@tree-button-hover-text-color: @active-text-color;
-
-@tree-button-focus-background-color: @tree-button-hover-background-color;
-@tree-button-focus-border: @tree-button-hover-border;
-@tree-button-focus-box-shadow: @tree-button-hover-box-shadow;
-@tree-button-focus-icon-color: @tree-button-hover-icon-color;
-@tree-button-focus-text-color: @tree-button-hover-text-color;
-
-@tree-button-active-background-color: @tree-button-enabled-background-color;
-@tree-button-active-border: @tree-button-enabled-border;
+@tree-button-active-background-color: @active-background-color;
+@tree-button-active-border: @tree-button-active-background-color;
 @tree-button-active-box-shadow: @tree-button-box-shadow; // set to `0 1px 1px 0 rgba(0, 0, 0, .1) inset` for a small push in effect
-@tree-button-active-icon-color: @tree-button-enabled-icon-color;
-@tree-button-active-text-color: @tree-button-enabled-text-color;
+@tree-button-active-icon-color: @tree-button-active-text-color;
+@tree-button-active-text-color: @active-text-color;
 @tree-button-active-transform: none; // Set to `translateY(1px)` for a small push down effect
 
-@tree-button-enabled-background-color: multiply(white, contrast(@background-color, fade(@color-tint, 35), fade(@color-tint, 65)));
+@tree-button-hover-background-color: @hover-background-color;
+@tree-button-hover-border: @tree-button-hover-background-color;
+@tree-button-hover-box-shadow: @tree-button-box-shadow;
+@tree-button-hover-icon-color: @tree-button-active-icon-color;
+@tree-button-hover-text-color: @tree-button-active-text-color;
+
+@tree-button-focus-background-color: @hover-background-color;
+@tree-button-focus-border: @tree-button-hover-border;
+@tree-button-focus-box-shadow: @tree-button-box-shadow;
+@tree-button-focus-icon-color: @tree-button-active-icon-color;
+@tree-button-focus-text-color: @tree-button-active-text-color;
+
+@tree-button-enabled-background-color: @enabled-background-color;
 @tree-button-enabled-border: @tree-button-hover-border;
 @tree-button-enabled-box-shadow: @tree-button-box-shadow;
-@tree-button-enabled-icon-color: @tree-button-hover-icon-color;
-@tree-button-enabled-text-color: @tree-button-hover-text-color;
+@tree-button-enabled-icon-color: @tree-button-enabled-text-color;
+@tree-button-enabled-text-color: @enabled-text-color;
 @tree-button-enabled-transform: none;
+@tree-button-enabled-active-background-color: @enabled-active-background-color;
+@tree-button-enabled-active-icon-color: @tree-button-enabled-active-text-color;
+@tree-button-enabled-active-text-color: @tree-button-active-text-color;
 
-@tree-button-disabled-background-color:  @tree-button-background-color;
+@tree-button-disabled-background-color: @tree-button-background-color;
 @tree-button-disabled-border: @tree-button-border;
 @tree-button-disabled-box-shadow: @tree-button-box-shadow;
-@tree-button-disabled-icon-color: fade(@tree-button-icon-color, 50%);
-@tree-button-disabled-text-color: fade(@tree-button-text-color, 50%);
+@tree-button-disabled-icon-color: @text-color-muted;
+@tree-button-disabled-text-color: @text-color-muted;
 
 .tox .tox-tree {
   display: flex;
@@ -88,32 +89,16 @@
     }
   }
 
-  .tox-trbtn:focus {
-    background: @tree-button-focus-background-color;
-    border: @tree-button-focus-border;
-    box-shadow: @tree-button-focus-box-shadow;
+  // This class doesn't seem to be used anywhere.
+  // The ruleset can probably be removed.
+  .tox-trbtn.tox-trbtn-more {
+    padding-left: 5px;
+    padding-right: 5px;
+    width: inherit;
   }
 
-  .tox-trbtn:hover {
-    background: @tree-button-hover-background-color;
-    border: @tree-button-hover-border;
-    box-shadow: @tree-button-hover-box-shadow;
-    color: @tree-button-hover-text-color;
-
-    svg {
-      fill: @tree-button-hover-icon-color;
-    }
-  }
-
-  .tox-trbtn:active {
-    background: @tree-button-active-background-color;
-    border: @tree-button-active-border;
-    box-shadow: @tree-button-active-box-shadow;
-    color: @tree-button-active-text-color;
-
-    svg {
-      fill: @tree-button-active-icon-color;
-    }
+  .tox-trbtn:focus-visible svg {
+    fill: @tree-button-focus-text-color;
   }
 
   .tox-trbtn--disabled,
@@ -129,13 +114,48 @@
     // Disable stylelint below because we're mixing the :disabled modifier with the "--disabled" class
     // since they need to be kept the same/use the same rules
     svg { /* stylelint-disable-line no-descending-specificity */
-      fill: @tree-button-disabled-icon-color;
+      fill: @tree-button-disabled-text-color;
+    }
+  }
+
+  .tox-trbtn:not(.tox-trbtn--disabled):not(.tox-trbtn--enabled) {
+    &:active {
+      background: @tree-button-active-background-color;
+      border: @tree-button-active-border;
+      box-shadow: @tree-button-active-box-shadow;
+      color: @tree-button-active-text-color;
+
+      svg {
+        fill: @tree-button-active-icon-color;
+      }
+    }
+
+    &:hover,
+    &:focus,
+    &:focus-visible {
+      background: @tree-button-hover-background-color;
+      border: @tree-button-hover-border;
+      box-shadow: @tree-button-hover-box-shadow;
+      color: @tree-button-hover-text-color;
+
+      svg {
+        fill: @tree-button-hover-icon-color;
+      }
+    }
+  }
+
+  .tox-trbtn.tox-trbtn--disabled:focus,
+  .tox-trbtn.tox-trbtn--disabled:focus-visible {
+    background: @tree-button-hover-background-color;
+    color: @tree-button-disabled-text-color;
+
+    svg { /* stylelint-disable-line no-descending-specificity */
+      fill: @tree-button-disabled-text-color;
     }
   }
 
   // An toggle on/off button's on state.
-  .tox-trbtn--enabled,
-  .tox-trbtn--enabled:hover {
+  .tox-trbtn.tox-trbtn--enabled {
     background: @tree-button-enabled-background-color;
     border: @tree-button-enabled-border;
     box-shadow: @tree-button-enabled-box-shadow;
@@ -150,40 +170,22 @@
     svg { /* stylelint-disable-line no-descending-specificity */
       fill: @tree-button-enabled-icon-color;
     }
-  }
 
-  .tox-trbtn:focus:not(.tox-trbtn--disabled) {
-    color: @tree-button-focus-text-color;
+    &:active,
+    &:hover,
+    &:focus,
+    &:focus-visible {
+      background: @tree-button-enabled-active-background-color;
+      color: @tree-button-enabled-active-text-color;
 
-    svg {
-      fill: @tree-button-focus-icon-color;
+      svg {
+        fill: @tree-button-enabled-active-icon-color;
+      }
     }
   }
 
   .tox-trbtn:active > * {
     transform: @tree-button-active-transform;
-  }
-
-  .tox-trbtn--return {
-    align-self: stretch;
-    height: unset;
-    width: 16px;
-  }
-
-  // For buttons with text label before or after icon
-  .tox-trbtn--labeled {
-    padding: 0 4px;
-    width: unset;
-  }
-
-  // Vertical label
-  .tox-trbtn__vlabel {
-    display: block;
-    font-size: 10px;
-    font-weight: @font-weight-normal;
-    letter-spacing: -.025em;
-    margin-bottom: @pad-xs;
-    white-space: nowrap;
   }
 
   .tox-tree--directory {
@@ -209,14 +211,14 @@
 
         &.tox-mbtn--active svg,
         &:focus svg {
-          fill: @tree-button-menu-icon-color;
+          fill: @tree-button-active-icon-color;
         }
       }
 
       &:hover .tox-mbtn,
       &:focus .tox-mbtn {
         svg {
-          fill: @tree-button-menu-icon-color;
+          fill: @tree-button-active-icon-color;
         }
       }
 
@@ -252,13 +254,13 @@
 
       &.tox-mbtn--active svg,
       &:focus svg {
-        fill: @tree-button-menu-icon-color;
+        fill: @tree-button-active-icon-color;
       }
     }
 
     &:hover .tox-mbtn {
       svg {
-        fill: @tree-button-menu-icon-color;
+        fill: @tree-button-active-icon-color;
       }
     }
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- `tree` component did follow the new high contrast skin in some scenarios. #TINY-9714
+
+
 ## 6.4.0 - 2023-03-15
 
 ### Added


### PR DESCRIPTION
Related Ticket: TINY-9714

Description of Changes:
* Fix tree component css to align with new high contrast skin

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/`, `hotfix/` or `spike/`~

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
