### PR TITLE
TINY-4189: Checkbox and containing label now both disabled/enabled

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Enabling or Disabling checkboxes would not set the correct classes and attributes. #TINY-4189
+
 ## 6.4.0 - 2023-03-15
 
 ### Added

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
@@ -4,7 +4,7 @@ import {
 } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Fun, Optional } from '@ephox/katamari';
-import { Checked, Traverse } from '@ephox/sugar';
+import { Checked, Class, Traverse } from '@ephox/sugar';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as ReadOnly from '../../ReadOnly';
@@ -21,7 +21,6 @@ export const renderCheckbox = (spec: CheckboxSpec, providerBackstage: UiFactoryB
     return Optional.some(true);
   };
 
-  let isEnabled = spec.enabled;
   const pField = AlloyFormField.parts.field({
     factory: { sketch: Fun.identity },
     dom: {
@@ -37,16 +36,10 @@ export const renderCheckbox = (spec: CheckboxSpec, providerBackstage: UiFactoryB
       Disabling.config({
         disabled: () => !spec.enabled || providerBackstage.isDisabled(),
         onDisabled: (component) => {
-          if (isEnabled) { // Prevent recursive loop
-            isEnabled = false;
-            Traverse.parent(component.element).each((element) => component.getSystem().getByDom(element).each(Disabling.disable));
-          }
+          Traverse.parentElement(component.element).each((element) => Class.add(element, 'tox-checkbox--disabled'));
         },
         onEnabled: (component) => {
-          if (!isEnabled) { // Prevent recursive loop
-            isEnabled = true;
-            Traverse.parent(component.element).each((element) => component.getSystem().getByDom(element).each(Disabling.enable));
-          }
+          Traverse.parentElement(component.element).each((element) => Class.remove(element, 'tox-checkbox--disabled'));
         }
       }),
       Tabstopping.config({}),
@@ -110,13 +103,6 @@ export const renderCheckbox = (spec: CheckboxSpec, providerBackstage: UiFactoryB
     fieldBehaviours: Behaviour.derive([
       Disabling.config({
         disabled: () => !spec.enabled || providerBackstage.isDisabled(),
-        disableClass: 'tox-checkbox--disabled',
-        onDisabled: (comp) => {
-          AlloyFormField.getField(comp).each(Disabling.disable);
-        },
-        onEnabled: (comp) => {
-          AlloyFormField.getField(comp).each(Disabling.enable);
-        }
       }),
       ReadOnly.receivingConfig()
     ])

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/BasicCheckboxTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/BasicCheckboxTest.ts
@@ -1,5 +1,5 @@
 import { ApproxStructure, Assertions, Keyboard, Keys, UiFinder } from '@ephox/agar';
-import { AlloyComponent, Disabling, GuiFactory, Representing, TestHelpers } from '@ephox/alloy';
+import { AlloyComponent, Disabling, Form, GuiFactory, Representing, TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
 import { assert } from 'chai';
@@ -41,7 +41,11 @@ describe('headless.tinymce.themes.silver.components.checkbox.Checkbox component 
     Keyboard.keydown(keyCode, modifiers, input);
   };
 
-  it('Check basic structure', () => {
+  const getCompByName = (access: AlloyComponent, name: string) => {
+    return Form.getField(access, name).getOrDie();
+  };
+
+  it('TBA: Check basic structure', () => {
     Assertions.assertStructure(
       'Checking initial structure',
       ApproxStructure.build((s, str, arr) => s.element('label', {
@@ -76,7 +80,7 @@ describe('headless.tinymce.themes.silver.components.checkbox.Checkbox component 
     );
   });
 
-  it('Representing state updates', () => {
+  it('TBA: Representing state updates', () => {
     const component = hook.component();
     assertCheckboxState('Initial checkbox state', component, false);
     assert.isFalse(Disabling.isDisabled(component), 'Initial disabled state');
@@ -88,7 +92,7 @@ describe('headless.tinymce.themes.silver.components.checkbox.Checkbox component 
     assertCheckboxState('unchecked > checked', component, true);
   });
 
-  it('Disabling state', () => {
+  it('TBA: Disabling state', () => {
     const component = hook.component();
     Disabling.set(component, true);
     assert.isTrue(Disabling.isDisabled(component), 'enabled > disabled');
@@ -96,7 +100,89 @@ describe('headless.tinymce.themes.silver.components.checkbox.Checkbox component 
     assert.isFalse(Disabling.isDisabled(component), 'disabled > enabled');
   });
 
-  it('Keyboard events', () => {
+  it('TINY-4189:Disabling state', () => {
+    const component = hook.component();
+    Disabling.set(getCompByName(component, 'test-check-box'), true);
+    Assertions.assertStructure(
+      'Checking initial structure',
+      ApproxStructure.build((s, str, arr) => s.element('label', {
+        classes: [
+          arr.has('tox-checkbox'),
+          arr.has('tox-checkbox--disabled')
+        ],
+        attrs: {
+          'aria-disabled': str.is('true')
+        },
+        children: [
+          s.element('input', {
+            classes: [ arr.has('tox-checkbox__input') ],
+            attrs: {
+              type: str.is('checkbox')
+            }
+          }),
+          s.element('div', {
+            classes: [ arr.has('tox-checkbox__icons') ],
+            children: [
+              s.element('span', {
+                classes: [ arr.has('tox-icon'), arr.has('tox-checkbox-icon__checked') ],
+                html: str.startsWith('<svg')
+              }),
+              s.element('span', {
+                classes: [ arr.has('tox-icon'), arr.has('tox-checkbox-icon__unchecked') ],
+                html: str.startsWith('<svg')
+              })
+            ]
+          }),
+          s.element('span', {
+            classes: [ arr.has('tox-checkbox__label') ],
+            html: str.is('TestCheckbox')
+          })
+        ]
+      })),
+      hook.component().element
+    );
+    Disabling.set(getCompByName(component, 'test-check-box'), false);
+    Assertions.assertStructure(
+      'Checking initial structure',
+      ApproxStructure.build((s, str, arr) => s.element('label', {
+        classes: [
+          arr.has('tox-checkbox'),
+          arr.not('tox-checkbox--disabled')
+        ],
+        attrs: {
+          'aria-disabled': str.is('false')
+        },
+        children: [
+          s.element('input', {
+            classes: [ arr.has('tox-checkbox__input') ],
+            attrs: {
+              type: str.is('checkbox')
+            }
+          }),
+          s.element('div', {
+            classes: [ arr.has('tox-checkbox__icons') ],
+            children: [
+              s.element('span', {
+                classes: [ arr.has('tox-icon'), arr.has('tox-checkbox-icon__checked') ],
+                html: str.startsWith('<svg')
+              }),
+              s.element('span', {
+                classes: [ arr.has('tox-icon'), arr.has('tox-checkbox-icon__unchecked') ],
+                html: str.startsWith('<svg')
+              })
+            ]
+          }),
+          s.element('span', {
+            classes: [ arr.has('tox-checkbox__label') ],
+            html: str.is('TestCheckbox')
+          })
+        ]
+      })),
+      hook.component().element
+    );
+  });
+
+  it('TBA: Keyboard events', () => {
     const component = hook.component();
     setCheckboxState(component, true);
     pressKeyOnCheckbox(component, Keys.space());

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/BasicCheckboxTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/BasicCheckboxTest.ts
@@ -110,14 +110,12 @@ describe('headless.tinymce.themes.silver.components.checkbox.Checkbox component 
           arr.has('tox-checkbox'),
           arr.has('tox-checkbox--disabled')
         ],
-        attrs: {
-          'aria-disabled': str.is('true')
-        },
         children: [
           s.element('input', {
             classes: [ arr.has('tox-checkbox__input') ],
             attrs: {
-              type: str.is('checkbox')
+              type: str.is('checkbox'),
+              disabled: str.is('disabled')
             }
           }),
           s.element('div', {
@@ -149,14 +147,12 @@ describe('headless.tinymce.themes.silver.components.checkbox.Checkbox component 
           arr.has('tox-checkbox'),
           arr.not('tox-checkbox--disabled')
         ],
-        attrs: {
-          'aria-disabled': str.is('false')
-        },
         children: [
           s.element('input', {
             classes: [ arr.has('tox-checkbox__input') ],
             attrs: {
-              type: str.is('checkbox')
+              type: str.is('checkbox'),
+              disabled: str.none()
             }
           }),
           s.element('div', {


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
The checkbox would not trigger disable on the label. The checkbox now calls it.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
