### PR TITLE
TINY-9725: manage tap for `fontinputsize`'s buttons

### DIFF
--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyUiActions.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyUiActions.ts
@@ -1,4 +1,4 @@
-import { Keyboard, Mouse, UiFinder } from '@ephox/agar';
+import { Keyboard, Mouse, Touch, UiFinder } from '@ephox/agar';
 import { Type } from '@ephox/katamari';
 import { SugarElement, SugarShadowDom } from '@ephox/sugar';
 
@@ -28,6 +28,14 @@ const clickOnToolbar = <T extends Element>(editor: Editor, selector: string): Su
   const container = getToolbarRoot(editor);
   const elem = UiFinder.findIn<T>(container, selector).getOrDie();
   Mouse.click(elem);
+  return elem;
+};
+
+const tapOnToolbar = <T extends Element>(editor: Editor, selector: string): SugarElement<T> => {
+  const container = getToolbarRoot(editor);
+  const elem = UiFinder.findIn<T>(container, selector).getOrDie();
+  Touch.touchStart(elem);
+  Touch.touchEnd(elem);
   return elem;
 };
 
@@ -97,6 +105,8 @@ export {
   clickOnToolbar,
   clickOnMenu,
   clickOnUi,
+
+  tapOnToolbar,
 
   submitDialog,
   cancelDialog,

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Inline headers would not work in some situations when the editor was moved too far right horizontally. #TINY-9646
-- Tap on `fontsizeinput`'s buttons were not managed. #TINY-9725
+- Tapping on `fontsizeinput` buttons was not working correctly. #TINY-9725
 
 ## 6.4.0 - 2023-03-15
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Inline headers would not work in some situations when the editor was moved too far right horizontally. #TINY-9646
+- Tap on `fontsizeinput`'s buttons were not managed. #TINY-9725
 
 ## 6.4.0 - 2023-03-15
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -81,6 +81,9 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
   const makeStepperButton = (action: (focusBack: boolean) => void, title: string, tooltip: string, classes: string[]) => {
     const translatedTooltip = backstage.shared.providers.translate(tooltip);
     const altExecuting = Id.generate('altExecuting');
+
+    const onClick = () => action(true);
+
     return Button.sketch({
       dom: {
         tag: 'button',
@@ -100,14 +103,14 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
               action(false);
             }
           }),
-          AlloyEvents.run(NativeEvents.click(), (_comp, _se) => {
-            action(true);
-          })
+          AlloyEvents.run(NativeEvents.click(), onClick),
+          AlloyEvents.run(NativeEvents.touchend(), onClick)
         ])
       ]),
       eventOrder: {
         [NativeEvents.keydown()]: [ altExecuting, 'keying' ],
-        [NativeEvents.click()]: [ altExecuting, 'alloy.base.behaviour' ]
+        [NativeEvents.click()]: [ altExecuting, 'alloy.base.behaviour' ],
+        [NativeEvents.touchend()]: [ altExecuting, 'alloy.base.behaviour' ]
       }
     });
   };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/NumberInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/NumberInputTest.ts
@@ -36,6 +36,12 @@ describe('browser.tinymce.themes.silver.throbber.NumberInputTest', () => {
 
     TinyUiActions.clickOnToolbar(editor, '.tox-number-input .minus');
     TinyAssertions.assertContent(editor, '<p style="font-size: 16px;">a<span style="font-size: 16px;">b</span>c</p>');
+
+    TinyUiActions.tapOnToolbar(editor, '.tox-number-input .plus');
+    TinyAssertions.assertContent(editor, '<p style="font-size: 16px;">a<span style="font-size: 17px;">b</span>c</p>');
+
+    TinyUiActions.tapOnToolbar(editor, '.tox-number-input .minus');
+    TinyAssertions.assertContent(editor, '<p style="font-size: 16px;">a<span style="font-size: 16px;">b</span>c</p>');
   });
 
   it('TINY-9429: should be possible to change the font size from the input', async () => {


### PR DESCRIPTION
Related Ticket: TINY-9725

Description of Changes:
tap on `fontinputsize`'s buttons were not managed

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
