### PR TITLE
TINY-9692: Set the pointer to default arrow instead of text cursor for the Tree component node labels

### DIFF
--- a/modules/oxide/src/less/theme/components/tree/tree-button.less
+++ b/modules/oxide/src/less/theme/components/tree/tree-button.less
@@ -77,6 +77,7 @@
     text-transform: @tree-button-text-transform;
 
     .tox-tree__label {
+      cursor: default;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items. #TINY-9692
+
 ## 6.4.1 - 2023-03-29
 
 ### Fixed


### PR DESCRIPTION
Related Ticket: TINY-9692

Description of Changes:
* Added `cursor: default` rule to `.tox-tree__label` class

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`
* [x] Do not merge until 6.4.1 is released

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
