### PR TITLE
TINY-9704: Fix hiding the inline alert in Search and Replace dialog

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enabling or Disabling checkboxes would not set the correct classes and attributes. #TINY-4189
 - Table toolbar was visible even if the table was within a noneditable host element. #TINY-9664
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460
+- Inline alert in the "Search and Replace" dialog persisted when it wasn't necessary. #TINY-9704
 
 ## 6.4.0 - 2023-03-15
 

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Dialog.ts
@@ -44,8 +44,8 @@ const open = (editor: Editor, currentSearchState: Cell<Actions.SearchState>): vo
     Arr.each(buttons, toggle);
   };
 
-  const notFoundAlert = (api: Dialog.DialogInstanceApi<DialogData>): void => {
-    api.redial(getDialogSpec(true, api.getData()));
+  const toggleNotFoundAlert = (isVisible: boolean, api: Dialog.DialogInstanceApi<DialogData>): void => {
+    api.redial(getDialogSpec(isVisible, api.getData()));
   };
 
   // Temporarily workaround for iOS/iPadOS dialog placement to hide the keyboard
@@ -81,7 +81,7 @@ const open = (editor: Editor, currentSearchState: Cell<Actions.SearchState>): vo
       // Find new matches
       const count = Actions.find(editor, currentSearchState, data.findtext, data.matchcase, data.wholewords, data.inselection);
       if (count <= 0) {
-        notFoundAlert(api);
+        toggleNotFoundAlert(true, api);
       }
       disableAll(api, count === 0);
     }
@@ -208,6 +208,7 @@ const open = (editor: Editor, currentSearchState: Cell<Actions.SearchState>): vo
     },
     onAction: (api, details) => {
       const data = api.getData();
+      toggleNotFoundAlert(false, api);
       switch (details.name) {
         case 'find':
           doFind(api);

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Dialog.ts
@@ -200,7 +200,7 @@ const open = (editor: Editor, currentSearchState: Cell<Actions.SearchState>): vo
     initialData,
     onChange: (api, details) => {
       if (showNoMatchesAlertBanner) {
-        api.redial(getDialogSpec(false, api.getData()));
+        toggleNotFoundAlert(false, api);
       }
       if (details.name === 'findtext' && currentSearchState.get().count > 0) {
         reset(api);
@@ -208,7 +208,6 @@ const open = (editor: Editor, currentSearchState: Cell<Actions.SearchState>): vo
     },
     onAction: (api, details) => {
       const data = api.getData();
-      toggleNotFoundAlert(false, api);
       switch (details.name) {
         case 'find':
           doFind(api);
@@ -235,6 +234,7 @@ const open = (editor: Editor, currentSearchState: Cell<Actions.SearchState>): vo
         case 'matchcase':
         case 'wholewords':
         case 'inselection':
+          toggleNotFoundAlert(false, api);
           updateSearchState(api);
           reset(api);
           break;

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogTest.ts
@@ -125,4 +125,21 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceDialogTest', () => 
     TinyUiActions.closeDialog(editor);
     assert.equal(initialScroll.top, Scroll.get(doc).top);
   });
+
+  it('TINY-9704: Should reset the "Not Found" alert after updating the search preferences', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>tiny tiny tiny tiny</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 5, [ 0, 0 ], 9);
+    await Utils.pOpenDialog(editor);
+    await Utils.pAssertFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'tiny');
+    findAndAssertFound(editor, 4);
+    await Utils.pSelectPreference(editor, 'Find in selection');
+    assertFound(editor, 0);
+    findAndAssertFound(editor, 0);
+    assert.isTrue(await Utils.pAssertAlertInDialog(editor));
+    await Utils.pSelectPreference(editor, 'Find in selection');
+    findAndAssertFound(editor, 4);
+    assert.isFalse(await Utils.pAssertAlertInDialog(editor));
+    TinyUiActions.closeDialog(editor);
+  });
 });

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/module/test/Utils.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/module/test/Utils.ts
@@ -1,4 +1,5 @@
 import { UiControls, UiFinder, Waiter } from '@ephox/agar';
+import { Fun } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { SugarElement } from '@ephox/sugar';
 import { TinyContentActions, TinyUiActions } from '@ephox/wrap-mcagar';
@@ -17,6 +18,11 @@ const fakeEvent = (elm: SugarElement<HTMLElement>, name: string): void => {
 const pFindInDialog = async <T extends HTMLElement>(editor: Editor, selector: string): Promise<SugarElement<T>> => {
   const dialog = await TinyUiActions.pWaitForDialog(editor);
   return UiFinder.findIn<T>(dialog, selector).getOrDie();
+};
+
+const pAssertAlertInDialog = async (editor: Editor): Promise<boolean> => {
+  const dialog = await TinyUiActions.pWaitForDialog(editor);
+  return UiFinder.findIn(dialog, '.tox-notification--error').fold(Fun.never, Fun.always);
 };
 
 const pAssertFieldValue = async (editor: Editor, selector: string, value: string): Promise<void> => {
@@ -65,6 +71,7 @@ export {
   pOpenDialog,
   pOpenDialogWithKeyboard,
   pAssertFieldValue,
+  pAssertAlertInDialog,
   pSelectPreference,
   pSetFieldValue
 };


### PR DESCRIPTION
Related Ticket: TINY-9704

Description of Changes:
* Fix hiding the inline alert in the "Search and Replace" dialog when the search preferences are changed.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
