### PR TITLE
TINY-9280: Screen readers announce the highlighted menu item in typeahead

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+-  `aria-activedescendant` attribute for `Typeahead` input component is updated to the menu item that is highlighted. #TINY-9280
+
 ## 12.0.0 - 2022-11-23
 
 ### Added

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/TypeaheadSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/TypeaheadSchema.ts
@@ -1,5 +1,6 @@
 import { FieldSchema } from '@ephox/boulder';
 import { Cell, Fun, Optional } from '@ephox/katamari';
+import { Attribute } from '@ephox/sugar';
 
 import { Coupling } from '../../api/behaviour/Coupling';
 import { Focusing } from '../../api/behaviour/Focusing';
@@ -82,6 +83,10 @@ const parts: () => PartType.PartTypeAdt[] = Fun.constant([
               if (detail.model.populateFromBrowse) {
                 setValueFromItem(detail.model, input, item);
               }
+
+              // Since the focus is still on the typeahead comp, aria-activedescendant must be set to
+              // make screen readers to announce the menu item being highligted
+              Attribute.getOpt(item.element, 'id').each((id) => Attribute.set(input.element, 'aria-activedescendant', id));
             });
           } else {
             // ASSUMPTION: Currently, any interaction with the menu via the keyboard or the mouse

--- a/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadTest.ts
@@ -144,12 +144,16 @@ UnitTest.asynctest('Browser Test: .ui.typeahead.TypeaheadTest', (success, failur
       UiControls.sSetValue(typeahead.element, 'new-value'),
       Keyboard.sKeydown(doc, Keys.down(), {}),
 
+      steps.sAssertAriaActiveDescendant('aria-activedescendant is not set', ''),
+
       steps.sAssertFocusOnTypeahead('After pressing Down after Enter'),
       steps.sWaitForMenu('After pressing Down after Enter'),
       NavigationUtils.highlights(gui.element, Keys.down(), {}, [
         item('new-value2'),
         item('new-value1')
       ]),
+
+      steps.sAssertAriaActiveDescendant('aria-activedescendant is set when an item is highligted', 'new-value1'),
 
       Keyboard.sKeyup(doc, Keys.escape(), { }),
       steps.sAssertValue('After pressing ESC', 'New-value1'),
@@ -164,6 +168,8 @@ UnitTest.asynctest('Browser Test: .ui.typeahead.TypeaheadTest', (success, failur
         item('new-value12'),
         item('new-value11')
       ]),
+
+      steps.sAssertAriaActiveDescendant('aria-activedescendant is updated when a new item is highligted', 'new-value11'),
 
       Mouse.sClickOn(gui.element, '.item[data-value="new-value12"]'),
       steps.sWaitForNoMenu('After clicking on item'),
@@ -225,6 +231,8 @@ UnitTest.asynctest('Browser Test: .ui.typeahead.TypeaheadTest', (success, failur
         Focus.focus(component.element);
       }),
       steps.sWaitForNoMenu('Blurring should dismiss popup'),
+
+      steps.sAssertAriaActiveDescendant('aria-activedescendant is removed when the popup is closed', ''),
 
       Step.sync(() => {
         Representing.setValue(typeahead, {

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/typeahead/TestTypeaheadSteps.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/typeahead/TestTypeaheadSteps.ts
@@ -1,5 +1,5 @@
 import { Assertions, Chain, FocusTools, Logger, Step, UiFinder, Waiter } from '@ephox/agar';
-import { SugarElement, Value } from '@ephox/sugar';
+import { Attribute, SugarElement, Value } from '@ephox/sugar';
 
 import { AlloyComponent } from 'ephox/alloy/api/component/ComponentApi';
 import * as AlloyTriggers from 'ephox/alloy/api/events/AlloyTriggers';
@@ -13,6 +13,7 @@ interface TestTypeaheadSteps {
   readonly sAssertFocusOnTypeahead: <T>(label: string) => Step<T, T>;
   readonly sTriggerInputEvent: <T>(label: string) => Step<T, T>;
   readonly sAssertValue: <T>(label: string, expected: string) => Step<T, T>;
+  readonly sAssertAriaActiveDescendant: <T>(label: string, expected: string) => Step<T, T>;
 }
 
 export default (doc: SugarElement<HTMLDocument>, gui: GuiSystem, typeahead: AlloyComponent): TestTypeaheadSteps => {
@@ -69,12 +70,21 @@ export default (doc: SugarElement<HTMLDocument>, gui: GuiSystem, typeahead: Allo
     ])
   );
 
+  const sAssertAriaActiveDescendant = <T>(label: string, expected: string) => Logger.t<T, T>(
+    label + ' sAssertAriaActiveDescendant',
+    Chain.asStep(typeahead.element, [
+      Chain.mapper((input) => Attribute.getOpt(input, 'aria-activedescendant').getOr('')),
+      Assertions.cAssertEq('Checking aria-activedescendant of typeahead', expected)
+    ])
+  );
+
   return {
     sWaitForMenu,
     sWaitForNoMenu,
     sAssertTextSelection,
     sAssertFocusOnTypeahead,
     sTriggerInputEvent,
-    sAssertValue
+    sAssertValue,
+    sAssertAriaActiveDescendant
   };
 };

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Templates will be parsed before preview and insertion to make preview consistent with inserted template content and prevent XSS. #TINY-9244
 - Pressing backspace in an empty line now preserves formatting in a previous empty line. #TINY-9454
 - Pressing enter inside the `inputfontsize` input would not move the focus back into the editor content. #TINY-9598
+- Screen readers are now able to announce the highlighted menu item of link comboboxes. #TINY-9280
 
 ### Changed
 - The `link` plugins context menu items will no longer appear for noneditable links. #TINY-9491

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -1,6 +1,6 @@
 import { AlloySpec, RawDomSchema } from '@ephox/alloy';
 import { Toolbar } from '@ephox/bridge';
-import { Fun, Obj, Optional, Type } from '@ephox/katamari';
+import { Fun, Id, Obj, Optional, Type } from '@ephox/katamari';
 
 import I18n from 'tinymce/core/api/util/I18n';
 
@@ -83,11 +83,13 @@ const renderColorStructure = (item: ItemStructureSpec, providerBackstage: UiFact
 };
 
 const renderItemDomStructure = (ariaLabel: Optional<string>): RawDomSchema => {
-  const domTitle = ariaLabel.map((label): { attributes?: { title: string }} => ({
+  const domTitle = ariaLabel.map((label): { attributes?: { title: string, id?: string }} => ({
     attributes: {
       // TODO: AP-213 change this temporary solution to use tooltips, ensure its aria readable still.
       // for icon only implementations we need either a title or aria label to satisfy aria requirements.
-      title: I18n.translate(label)
+      title: I18n.translate(label),
+      // TODO: No idea if this is good
+      id: Id.generate('menu_item')
     }
   })).getOr({});
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -83,7 +83,7 @@ const renderColorStructure = (item: ItemStructureSpec, providerBackstage: UiFact
 };
 
 const renderItemDomStructure = (ariaLabel: Optional<string>): RawDomSchema => {
-  const domTitle = ariaLabel.map((label): { attributes?: { title: string, id?: string }} => ({
+  const domTitle = ariaLabel.map((label): { attributes?: { title: string; id?: string }} => ({
     attributes: {
       // TODO: AP-213 change this temporary solution to use tooltips, ensure its aria readable still.
       // for icon only implementations we need either a title or aria label to satisfy aria requirements.

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -88,8 +88,7 @@ const renderItemDomStructure = (ariaLabel: Optional<string>): RawDomSchema => {
       // TODO: AP-213 change this temporary solution to use tooltips, ensure its aria readable still.
       // for icon only implementations we need either a title or aria label to satisfy aria requirements.
       title: I18n.translate(label),
-      // TODO: No idea if this is good
-      id: Id.generate('menu_item')
+      id: Id.generate('menu-item')
     }
   })).getOr({});
 


### PR DESCRIPTION
Related Ticket: TINY-9280

Description of Changes:
* Added `id` attribute to menu items
* On `Typeahead`/`urlinput`, pressing keydown/keyup with the menu opened, will set the `aria-activedescendant` of the input field to the highlighted menu item. This makes the screen readers to announce the highlighted menu item.

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
