### PR TITLE
TINY-9680: context toolbar not showing the correct status for `advlist`

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Table toolbar was visible even if the table was within a noneditable host element. #TINY-9664
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460
 - Inline alert in the "Search and Replace" dialog persisted when it wasn't necessary. #TINY-9704
+- Context toolbars was not showning the correct status for the `advlist` buttons. #TINY-9680
 
 ## 6.4.0 - 2023-03-15
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Table toolbar was visible even if the table was within a noneditable host element. #TINY-9664
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460
 - Inline alert in the "Search and Replace" dialog persisted when it wasn't necessary. #TINY-9704
-- Context toolbars was not showning the correct status for the `advlist` buttons. #TINY-9680
+- Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680
 
 ## 6.4.0 - 2023-03-15
 

--- a/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
@@ -48,8 +48,8 @@ const setNodeChangeHandler = (editor: Editor, nodeChangeHandler: (e: NodeChangeE
 };
 
 export {
-  isTableCellNode,
-  isListNode,
+  isTableCellNode, // Exported for testing
+  isListNode, // Exported for testing
   inList,
   getSelectedStyleType,
   isWithinNonEditableList,

--- a/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
@@ -1,6 +1,7 @@
 import { Arr, Optional, Type } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
+import { NodeChangeEvent } from 'tinymce/core/api/EventTypes';
 
 const isCustomList = (list: HTMLElement): boolean =>
   /\btox\-/.test(list.className);
@@ -35,10 +36,23 @@ const isWithinNonEditableList = (editor: Editor, element: Element | null): boole
   return isWithinNonEditable(editor, parentList);
 };
 
+const setNodeChangeHandler = (editor: Editor, nodeChangeHandler: (e: NodeChangeEvent) => void): () => void => {
+  const initialNode = editor.selection.getNode();
+  // Set the initial state
+  nodeChangeHandler({
+    parents: editor.dom.getParents(initialNode),
+    element: initialNode
+  });
+  editor.on('NodeChange', nodeChangeHandler);
+  return () => editor.off('NodeChange', nodeChangeHandler);
+};
+
 export {
-  isTableCellNode, // Exported for testing
-  isListNode, // Exported for testing
+  isTableCellNode,
+  isListNode,
   inList,
   getSelectedStyleType,
-  isWithinNonEditableList
+  isWithinNonEditableList,
+  setNodeChangeHandler
 };
+

--- a/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
@@ -3,7 +3,6 @@ import { Type } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { NodeChangeEvent } from 'tinymce/core/api/EventTypes';
 import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import Tools from 'tinymce/core/api/util/Tools';
 
 import * as Options from '../api/Options';
@@ -26,13 +25,11 @@ const normalizeStyleValue = (styleValue: string | undefined): string =>
   Type.isNullable(styleValue) || styleValue === 'default' ? '' : styleValue;
 
 const makeSetupHandler = (editor: Editor, nodeName: ListType) => (api: Toolbar.ToolbarSplitButtonInstanceApi | Toolbar.ToolbarToggleButtonInstanceApi) => {
-  const nodeChangeHandler = (e: EditorEvent<NodeChangeEvent>) => {
+  const nodeChangeHandler = (e: NodeChangeEvent) => {
     api.setActive(ListUtils.inList(editor, e.parents, nodeName));
     api.setEnabled(!ListUtils.isWithinNonEditableList(editor, e.element));
   };
-  editor.on('NodeChange', nodeChangeHandler);
-
-  return () => editor.off('NodeChange', nodeChangeHandler);
+  return ListUtils.setNodeChangeHandler(editor, nodeChangeHandler);
 };
 
 const addSplitButton = (editor: Editor, id: string, tooltip: string, cmd: string, nodeName: ListType, styles: string[]): void => {

--- a/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
@@ -25,13 +25,12 @@ const normalizeStyleValue = (styleValue: string | undefined): string =>
   Type.isNullable(styleValue) || styleValue === 'default' ? '' : styleValue;
 
 const makeSetupHandler = (editor: Editor, nodeName: ListType) => (api: Toolbar.ToolbarSplitButtonInstanceApi | Toolbar.ToolbarToggleButtonInstanceApi) => {
-  const updateButtonState = (element: Element, parents: Node[]) => {
+  const updateButtonState = (editor: Editor, parents: Node[]) => {
+    const element = editor.selection.getStart(true);
     api.setActive(ListUtils.inList(editor, parents, nodeName));
     api.setEnabled(!ListUtils.isWithinNonEditableList(editor, element));
   };
-  const nodeChangeHandler = (e: NodeChangeEvent) => updateButtonState(e.element, e.parents);
-  const element = editor.selection.getStart(true);
-  updateButtonState(element, editor.dom.getParents(element));
+  const nodeChangeHandler = (e: NodeChangeEvent) => updateButtonState(editor, e.parents);
 
   return ListUtils.setNodeChangeHandler(editor, nodeChangeHandler);
 };

--- a/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
@@ -25,10 +25,14 @@ const normalizeStyleValue = (styleValue: string | undefined): string =>
   Type.isNullable(styleValue) || styleValue === 'default' ? '' : styleValue;
 
 const makeSetupHandler = (editor: Editor, nodeName: ListType) => (api: Toolbar.ToolbarSplitButtonInstanceApi | Toolbar.ToolbarToggleButtonInstanceApi) => {
-  const nodeChangeHandler = (e: NodeChangeEvent) => {
-    api.setActive(ListUtils.inList(editor, e.parents, nodeName));
-    api.setEnabled(!ListUtils.isWithinNonEditableList(editor, e.element));
+  const updateButtonState = (element: Element, parents: Node[]) => {
+    api.setActive(ListUtils.inList(editor, parents, nodeName));
+    api.setEnabled(!ListUtils.isWithinNonEditableList(editor, element));
   };
+  const nodeChangeHandler = (e: NodeChangeEvent) => updateButtonState(e.element, e.parents);
+  const element = editor.selection.getStart(true);
+  updateButtonState(element, editor.dom.getParents(element));
+
   return ListUtils.setNodeChangeHandler(editor, nodeChangeHandler);
 };
 

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistOptionsAndToolbarTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistOptionsAndToolbarTest.ts
@@ -85,59 +85,6 @@ describe('browser.tinymce.plugins.advlist.AdvlistOptionsAndToolbarTest', () => {
       })), button);
     });
 
-  context('Context Toolbar Split buttons active state', () => {
-    const hook = TinyHooks.bddSetup<Editor>({
-      ...baseOptions,
-      inline: true, // this is needed because otherwise `TinySelections.setSelection` does not trigger the context toolbar correctly
-      setup: (ed: Editor) => {
-        ed.ui.registry.addContextToolbar('textselection', {
-          predicate: (_node) => true,
-          items: 'numlist bullist',
-          position: 'selection',
-          scope: 'node'
-        });
-      }
-    }, [ AdvListPlugin, ListsPlugin ]);
-
-    const pAssertButtonToggledState = (name: string, state: boolean) =>
-      Waiter.pTryUntil('Wait for context toolbar button state', () => {
-        const button = UiFinder.findIn(SugarBody.body(), `.tox-pop__dialog .tox-split-button[aria-label="${name}"]`).getOrDie();
-        return Assertions.assertStructure('', ApproxStructure.build((s, _, __) => s.element('div', {
-          children: [
-            s.element('span', {
-              exactClasses: [ 'tox-tbtn', ...(state ? [ 'tox-tbtn--enabled' ] : [] ) ]
-            }),
-            s.theRest()
-          ]
-        })), button);
-      });
-
-    it('TINY-9680: context toolbar should have the correct enabled element', async () => {
-      const editor = hook.editor();
-      editor.setContent(`
-          <ol>
-            <li>1</li>
-            <li>2</li>
-          </ol>
-          <ul>
-            <li>1</li>
-            <li>2</li>
-          </ul>
-        `);
-      TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
-      await UiFinder.pWaitForVisible('Waiting for node toolbar to appear', SugarBody.body(), '.tox-tbtn');
-      await TinyUiActions.pWaitForPopup(editor, '.tox-pop__dialog .tox-toolbar');
-      await pAssertButtonToggledState('Bullet list', false);
-      await pAssertButtonToggledState('Numbered list', true);
-
-      TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 1, 0, 0 ], 1);
-      await UiFinder.pWaitForVisible('Waiting for node toolbar to appear', SugarBody.body(), '.tox-tbtn');
-      await TinyUiActions.pWaitForPopup(editor, '.tox-pop__dialog .tox-toolbar');
-      await pAssertButtonToggledState('Bullet list', true);
-      await pAssertButtonToggledState('Numbered list', false);
-    });
-  });
-
   context('AdvList options and toolbar test', () => {
     before(() => {
       AdvListPlugin();
@@ -351,6 +298,58 @@ describe('browser.tinymce.plugins.advlist.AdvlistOptionsAndToolbarTest', () => {
 
       TinySelections.setCursor(editor, [ 0, 0, 1, 0, 1, 0, 0 ], 1);
       await pAssertButtonToggledState('Bullet list', false);
+      await pAssertButtonToggledState('Numbered list', false);
+    });
+  });
+
+  context('Context Toolbar Split buttons active state', () => {
+    const hook = TinyHooks.bddSetup<Editor>({
+      ...baseOptions,
+      setup: (ed: Editor) => {
+        ed.ui.registry.addContextToolbar('textselection', {
+          predicate: (_node) => true,
+          items: 'numlist bullist',
+          position: 'selection',
+          scope: 'node'
+        });
+      }
+    }, [ AdvListPlugin, ListsPlugin ], true);
+
+    const pAssertButtonToggledState = (name: string, state: boolean) =>
+      Waiter.pTryUntil('Wait for context toolbar button state', () => {
+        const button = UiFinder.findIn(SugarBody.body(), `.tox-pop__dialog .tox-split-button[aria-label="${name}"]`).getOrDie();
+        return Assertions.assertStructure('', ApproxStructure.build((s, _, __) => s.element('div', {
+          children: [
+            s.element('span', {
+              exactClasses: [ 'tox-tbtn', ...(state ? [ 'tox-tbtn--enabled' ] : [] ) ]
+            }),
+            s.theRest()
+          ]
+        })), button);
+      });
+
+    it('TINY-9680: context toolbar should have the correct enabled element', async () => {
+      const editor = hook.editor();
+      editor.setContent(`
+          <ol>
+            <li>1</li>
+            <li>2</li>
+          </ol>
+          <ul>
+            <li>1</li>
+            <li>2</li>
+          </ul>
+        `);
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+      await UiFinder.pWaitForVisible('Waiting for node toolbar to appear', SugarBody.body(), '.tox-tbtn');
+      await TinyUiActions.pWaitForPopup(editor, '.tox-pop__dialog .tox-toolbar');
+      await pAssertButtonToggledState('Bullet list', false);
+      await pAssertButtonToggledState('Numbered list', true);
+
+      TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 1, 0, 0 ], 1);
+      await UiFinder.pWaitForVisible('Waiting for node toolbar to appear', SugarBody.body(), '.tox-tbtn');
+      await TinyUiActions.pWaitForPopup(editor, '.tox-pop__dialog .tox-toolbar');
+      await pAssertButtonToggledState('Bullet list', true);
       await pAssertButtonToggledState('Numbered list', false);
     });
   });

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistOptionsAndToolbarTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistOptionsAndToolbarTest.ts
@@ -1,5 +1,5 @@
 import { ApproxStructure, Assertions, UiFinder, Waiter } from '@ephox/agar';
-import { it, before, context, describe } from '@ephox/bedrock-client';
+import { before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 import { McEditor, TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
@@ -298,6 +298,59 @@ describe('browser.tinymce.plugins.advlist.AdvlistOptionsAndToolbarTest', () => {
 
       TinySelections.setCursor(editor, [ 0, 0, 1, 0, 1, 0, 0 ], 1);
       await pAssertButtonToggledState('Bullet list', false);
+      await pAssertButtonToggledState('Numbered list', false);
+    });
+  });
+
+  context('Context Toolbar Split buttons active state', () => {
+    const hook = TinyHooks.bddSetup<Editor>({
+      ...baseOptions,
+      inline: true,
+      setup: (ed: Editor) => {
+        ed.ui.registry.addContextToolbar('textselection', {
+          predicate: (_node) => true,
+          items: 'undo numlist bullist',
+          position: 'selection',
+          scope: 'node'
+        });
+      }
+    }, [ AdvListPlugin, ListsPlugin ]);
+
+    const pAssertButtonToggledState = (name: string, state: boolean) =>
+      Waiter.pTryUntil('Wait for context toolbar button state', () => {
+        const button = UiFinder.findIn(SugarBody.body(), `.tox-pop__dialog .tox-split-button[aria-label="${name}"]`).getOrDie();
+        return Assertions.assertStructure('', ApproxStructure.build((s, _, __) => s.element('div', {
+          children: [
+            s.element('span', {
+              exactClasses: [ 'tox-tbtn', ...(state ? [ 'tox-tbtn--enabled' ] : [] ) ]
+            }),
+            s.theRest()
+          ]
+        })), button);
+      });
+
+    it('TINY-9680: context toolbar should have the correct enabled element', async () => {
+      const editor = hook.editor();
+      editor.setContent(`
+        <ol>
+          <li>1</li>
+          <li>2</li>
+        </ol>
+        <ul>
+          <li>1</li>
+          <li>2</li>
+        </ul>
+      `);
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+      await UiFinder.pWaitForVisible('Waiting for node toolbar to appear', SugarBody.body(), '.tox-tbtn');
+      await TinyUiActions.pWaitForPopup(editor, '.tox-pop__dialog .tox-toolbar');
+      await pAssertButtonToggledState('Bullet list', false);
+      await pAssertButtonToggledState('Numbered list', true);
+
+      TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 1, 0, 0 ], 1);
+      await UiFinder.pWaitForVisible('Waiting for node toolbar to appear', SugarBody.body(), '.tox-tbtn');
+      await TinyUiActions.pWaitForPopup(editor, '.tox-pop__dialog .tox-toolbar');
+      await pAssertButtonToggledState('Bullet list', true);
       await pAssertButtonToggledState('Numbered list', false);
     });
   });

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistOptionsAndToolbarTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistOptionsAndToolbarTest.ts
@@ -85,6 +85,59 @@ describe('browser.tinymce.plugins.advlist.AdvlistOptionsAndToolbarTest', () => {
       })), button);
     });
 
+  context('Context Toolbar Split buttons active state', () => {
+    const hook = TinyHooks.bddSetup<Editor>({
+      ...baseOptions,
+      inline: true, // this is needed because otherwise `TinySelections.setSelection` does not trigger the context toolbar correctly
+      setup: (ed: Editor) => {
+        ed.ui.registry.addContextToolbar('textselection', {
+          predicate: (_node) => true,
+          items: 'numlist bullist',
+          position: 'selection',
+          scope: 'node'
+        });
+      }
+    }, [ AdvListPlugin, ListsPlugin ]);
+
+    const pAssertButtonToggledState = (name: string, state: boolean) =>
+      Waiter.pTryUntil('Wait for context toolbar button state', () => {
+        const button = UiFinder.findIn(SugarBody.body(), `.tox-pop__dialog .tox-split-button[aria-label="${name}"]`).getOrDie();
+        return Assertions.assertStructure('', ApproxStructure.build((s, _, __) => s.element('div', {
+          children: [
+            s.element('span', {
+              exactClasses: [ 'tox-tbtn', ...(state ? [ 'tox-tbtn--enabled' ] : [] ) ]
+            }),
+            s.theRest()
+          ]
+        })), button);
+      });
+
+    it('TINY-9680: context toolbar should have the correct enabled element', async () => {
+      const editor = hook.editor();
+      editor.setContent(`
+          <ol>
+            <li>1</li>
+            <li>2</li>
+          </ol>
+          <ul>
+            <li>1</li>
+            <li>2</li>
+          </ul>
+        `);
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+      await UiFinder.pWaitForVisible('Waiting for node toolbar to appear', SugarBody.body(), '.tox-tbtn');
+      await TinyUiActions.pWaitForPopup(editor, '.tox-pop__dialog .tox-toolbar');
+      await pAssertButtonToggledState('Bullet list', false);
+      await pAssertButtonToggledState('Numbered list', true);
+
+      TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 1, 0, 0 ], 1);
+      await UiFinder.pWaitForVisible('Waiting for node toolbar to appear', SugarBody.body(), '.tox-tbtn');
+      await TinyUiActions.pWaitForPopup(editor, '.tox-pop__dialog .tox-toolbar');
+      await pAssertButtonToggledState('Bullet list', true);
+      await pAssertButtonToggledState('Numbered list', false);
+    });
+  });
+
   context('AdvList options and toolbar test', () => {
     before(() => {
       AdvListPlugin();
@@ -298,59 +351,6 @@ describe('browser.tinymce.plugins.advlist.AdvlistOptionsAndToolbarTest', () => {
 
       TinySelections.setCursor(editor, [ 0, 0, 1, 0, 1, 0, 0 ], 1);
       await pAssertButtonToggledState('Bullet list', false);
-      await pAssertButtonToggledState('Numbered list', false);
-    });
-  });
-
-  context('Context Toolbar Split buttons active state', () => {
-    const hook = TinyHooks.bddSetup<Editor>({
-      ...baseOptions,
-      inline: true,
-      setup: (ed: Editor) => {
-        ed.ui.registry.addContextToolbar('textselection', {
-          predicate: (_node) => true,
-          items: 'undo numlist bullist',
-          position: 'selection',
-          scope: 'node'
-        });
-      }
-    }, [ AdvListPlugin, ListsPlugin ]);
-
-    const pAssertButtonToggledState = (name: string, state: boolean) =>
-      Waiter.pTryUntil('Wait for context toolbar button state', () => {
-        const button = UiFinder.findIn(SugarBody.body(), `.tox-pop__dialog .tox-split-button[aria-label="${name}"]`).getOrDie();
-        return Assertions.assertStructure('', ApproxStructure.build((s, _, __) => s.element('div', {
-          children: [
-            s.element('span', {
-              exactClasses: [ 'tox-tbtn', ...(state ? [ 'tox-tbtn--enabled' ] : [] ) ]
-            }),
-            s.theRest()
-          ]
-        })), button);
-      });
-
-    it('TINY-9680: context toolbar should have the correct enabled element', async () => {
-      const editor = hook.editor();
-      editor.setContent(`
-        <ol>
-          <li>1</li>
-          <li>2</li>
-        </ol>
-        <ul>
-          <li>1</li>
-          <li>2</li>
-        </ul>
-      `);
-      TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
-      await UiFinder.pWaitForVisible('Waiting for node toolbar to appear', SugarBody.body(), '.tox-tbtn');
-      await TinyUiActions.pWaitForPopup(editor, '.tox-pop__dialog .tox-toolbar');
-      await pAssertButtonToggledState('Bullet list', false);
-      await pAssertButtonToggledState('Numbered list', true);
-
-      TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 1, 0, 0 ], 1);
-      await UiFinder.pWaitForVisible('Waiting for node toolbar to appear', SugarBody.body(), '.tox-tbtn');
-      await TinyUiActions.pWaitForPopup(editor, '.tox-pop__dialog .tox-toolbar');
-      await pAssertButtonToggledState('Bullet list', true);
       await pAssertButtonToggledState('Numbered list', false);
     });
   });


### PR DESCRIPTION
Related Ticket: TINY-9680

Description of Changes:
the problem seems to was caused by the different way that we manage the `makeSetupHandler` in [advlist](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts) versus in the [lists](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/plugins/lists/main/ts/ui/Buttons.ts#L7-L13), so I simply aligned the two behaviors.

About the test, at the moment there is some strange thing that is going on with the test about the open of the `context toolbar`

- I had to put it as the first `context` because somehow the other test block the opening of the `context toolbar`
- I had to put `inline: true` otherwise it does not work
- I tried to use: `editor.dispatch('contexttoolbar-show', { toolbarKey });` but it won't reproduce the bug

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
