### PR TITLE
TINY-9668: fix dialog's components `max-height` in order to make the content scroll

### DIFF
--- a/modules/oxide/src/less/theme/alien/unknowns.less
+++ b/modules/oxide/src/less/theme/alien/unknowns.less
@@ -35,6 +35,7 @@
   .tox-dialog__content-js {
     display: flex;
     flex: 1;
+    max-height: 70vh;
   }
 
   // TODO: How is this used? This rule quite drastically changes

--- a/modules/oxide/src/less/theme/alien/unknowns.less
+++ b/modules/oxide/src/less/theme/alien/unknowns.less
@@ -35,7 +35,6 @@
   .tox-dialog__content-js {
     display: flex;
     flex: 1;
-    max-height: 70vh;
   }
 
   // TODO: How is this used? This rule quite drastically changes

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -135,7 +135,6 @@
     display: flex;
     font-size: @font-size-base;
     justify-content: space-between;
-    max-height: calc(15vh - @pad-sm);
     padding: @dialog-header-padding;
     position: relative;
   }
@@ -231,7 +230,7 @@
     display: flex;
     flex: 1;
     flex-direction: column;
-    max-height: 650px; // TODO (verify max-height for dialogs)
+    max-height: min(650px, calc(100vh - 110px)); // TODO (verify max-height for dialogs)
     overflow: auto; //overflow controls all scrolling in the dialogs
     -webkit-overflow-scrolling: touch;
     padding: @dialog-body-padding;
@@ -364,7 +363,6 @@
     border-top: @dialog-footer-separator-border;
     display: flex;
     justify-content: space-between;
-    max-height: calc(15vh - (@pad-sm * 2));
     padding: @dialog-footer-padding;
   }
 

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -230,7 +230,7 @@
     display: flex;
     flex: 1;
     flex-direction: column;
-    max-height: min(650px, calc(100vh - 110px)); // TODO (verify max-height for dialogs)
+    max-height: ~"min(650px, calc(100vh - 110px))"; // TODO (verify max-height for dialogs)
     overflow: auto; //overflow controls all scrolling in the dialogs
     -webkit-overflow-scrolling: touch;
     padding: @dialog-body-padding;

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -135,6 +135,7 @@
     display: flex;
     font-size: @font-size-base;
     justify-content: space-between;
+    max-height: calc(15vh - @pad-sm);
     padding: @dialog-header-padding;
     position: relative;
   }
@@ -363,6 +364,7 @@
     border-top: @dialog-footer-separator-border;
     display: flex;
     justify-content: space-between;
+    max-height: calc(15vh - (@pad-sm * 2));
     padding: @dialog-footer-padding;
   }
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460
 - Inline alert in the "Search and Replace" dialog persisted when it wasn't necessary. #TINY-9704
 - Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680
+- The dialog's conent doesn't scroll. #TINY-9668
 
 ## 6.4.0 - 2023-03-15
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460
 - Inline alert in the "Search and Replace" dialog persisted when it wasn't necessary. #TINY-9704
 - Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680
-- The dialog's conent doesn't scroll. #TINY-9668
+- The content of the dialog body could not be scrolled. #TINY-9668
 
 ## 6.4.0 - 2023-03-15
 


### PR DESCRIPTION
Related Ticket: TINY-9668

Description of Changes:
~to fix this I added a `max-height` as `vh` to each component of the `dialog`:~
~`tox-dialog__header` -> 15vh - its padding~
~`tox-dialog__content-js` -> 70vh~
~`tox-dialog__footer` -> 15vh - its padding~

~this seems to work, but I'm not sure that we still need this [other fix](https://github.com/tinymce/tinymce/blob/develop/modules/oxide/src/less/theme/components/dialog/dialog.less#L233) for `tox-dialog__body-content`~

to fix scroll problem, the `max-height` of `tox-dialog__body-content` as been changed into a `min` between `650px` (the current value) and `calc(100vh - 110px)`

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
