### PR TITLE
TINY-9280: Screen readers announce the highlighted menu item in typeahead

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `firstTabstop` optional property to `ModalDialogDetail`, to specify the index of elements to focus on when dialog shows. #TINY-9520
 - Exposed `OffsetOrigin` module and `DockingType` type in api main entry point. #TINY-9414
 
+### Changed
+-  `aria-activedescendant` attribute for `Typeahead` input component is updated to the menu item that is highlighted. #TINY-9280
+
 ### Removed
 - Removed `positionWithin` from `Positioning` behaviour's APIs. #TINY-9226
 - Removed `showWithin` from `InlineView` sketcher's APIs. #TINY-9226

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/TypeaheadSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/TypeaheadSchema.ts
@@ -1,5 +1,6 @@
 import { FieldSchema } from '@ephox/boulder';
 import { Cell, Fun, Optional } from '@ephox/katamari';
+import { Attribute } from '@ephox/sugar';
 
 import { Coupling } from '../../api/behaviour/Coupling';
 import { Focusing } from '../../api/behaviour/Focusing';
@@ -82,6 +83,10 @@ const parts: () => PartType.PartTypeAdt[] = Fun.constant([
               if (detail.model.populateFromBrowse) {
                 setValueFromItem(detail.model, input, item);
               }
+
+              // Since the focus is still on the typeahead comp, aria-activedescendant must be set to
+              // make screen readers to announce the menu item being highligted
+              Attribute.getOpt(item.element, 'id').each((id) => Attribute.set(input.element, 'aria-activedescendant', id));
             });
           } else {
             // ASSUMPTION: Currently, any interaction with the menu via the keyboard or the mouse

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/TypeaheadSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/TypeaheadSchema.ts
@@ -84,8 +84,11 @@ const parts: () => PartType.PartTypeAdt[] = Fun.constant([
                 setValueFromItem(detail.model, input, item);
               }
 
-              // Since the focus is still on the typeahead comp, aria-activedescendant must be set to
-              // make screen readers to announce the menu item being highligted
+              // The focus is retained on the input element when the menu is shown (unlike the combobox in which the focus is passed onto the menu).
+              // This causes the screen readers not to be able to announce the menu or highlighted item
+              // The solution is to tell the screen readers which menu item is highligted using aria-activedescendant attribute
+              // TINY-9280: The aria attribute will be removed when the menu is closed. Since onDehighlight is called only when highlighting a new menu item
+              // this will be handled in https://github.com/tinymce/tinymce/blob/2d8c1c034e8aa484b868a0c44605489ee0ca9cd4/modules/alloy/src/main/ts/ephox/alloy/ui/composite/TypeaheadSpec.ts#L282
               Attribute.getOpt(item.element, 'id').each((id) => Attribute.set(input.element, 'aria-activedescendant', id));
             });
           } else {

--- a/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/typeahead/TypeaheadTest.ts
@@ -144,12 +144,16 @@ UnitTest.asynctest('Browser Test: .ui.typeahead.TypeaheadTest', (success, failur
       UiControls.sSetValue(typeahead.element, 'new-value'),
       Keyboard.sKeydown(doc, Keys.down(), {}),
 
+      steps.sAssertAriaActiveDescendant('aria-activedescendant is not set', ''),
+
       steps.sAssertFocusOnTypeahead('After pressing Down after Enter'),
       steps.sWaitForMenu('After pressing Down after Enter'),
       NavigationUtils.highlights(gui.element, Keys.down(), {}, [
         item('new-value2'),
         item('new-value1')
       ]),
+
+      steps.sAssertAriaActiveDescendant('aria-activedescendant is set when an item is highligted', 'new-value1'),
 
       Keyboard.sKeyup(doc, Keys.escape(), { }),
       steps.sAssertValue('After pressing ESC', 'New-value1'),
@@ -164,6 +168,8 @@ UnitTest.asynctest('Browser Test: .ui.typeahead.TypeaheadTest', (success, failur
         item('new-value12'),
         item('new-value11')
       ]),
+
+      steps.sAssertAriaActiveDescendant('aria-activedescendant is updated when a new item is highligted', 'new-value11'),
 
       Mouse.sClickOn(gui.element, '.item[data-value="new-value12"]'),
       steps.sWaitForNoMenu('After clicking on item'),
@@ -225,6 +231,8 @@ UnitTest.asynctest('Browser Test: .ui.typeahead.TypeaheadTest', (success, failur
         Focus.focus(component.element);
       }),
       steps.sWaitForNoMenu('Blurring should dismiss popup'),
+
+      steps.sAssertAriaActiveDescendant('aria-activedescendant is removed when the popup is closed', ''),
 
       Step.sync(() => {
         Representing.setValue(typeahead, {

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/dropdown/TestDropdownMenu.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/dropdown/TestDropdownMenu.ts
@@ -96,7 +96,8 @@ const renderItem = (spec: TestItem): ItemSpec => {
           attributes: {
             'data-value': spec.data.value,
             'data-test-id': 'item-' + spec.data.value,
-            'aria-disabled': spec.data.meta.disabled === true ? true : false
+            'aria-disabled': spec.data.meta.disabled === true ? true : false,
+            'id': spec.data.value
           },
           classes: [ ],
           innerHtml: spec.data.meta.text

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/dropdown/TestDropdownMenu.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/dropdown/TestDropdownMenu.ts
@@ -96,7 +96,7 @@ const renderItem = (spec: TestItem): ItemSpec => {
           attributes: {
             'data-value': spec.data.value,
             'data-test-id': 'item-' + spec.data.value,
-            'aria-disabled': spec.data.meta.disabled,
+            'aria-disabled': spec.data.meta.disabled === true ? true : false,
             'id': spec.data.value
           },
           classes: [ ],

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/dropdown/TestDropdownMenu.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/dropdown/TestDropdownMenu.ts
@@ -96,7 +96,7 @@ const renderItem = (spec: TestItem): ItemSpec => {
           attributes: {
             'data-value': spec.data.value,
             'data-test-id': 'item-' + spec.data.value,
-            'aria-disabled': spec.data.meta.disabled === true ? true : false,
+            'aria-disabled': spec.data.meta.disabled,
             'id': spec.data.value
           },
           classes: [ ],

--- a/modules/alloy/src/test/ts/module/ephox/alloy/test/typeahead/TestTypeaheadSteps.ts
+++ b/modules/alloy/src/test/ts/module/ephox/alloy/test/typeahead/TestTypeaheadSteps.ts
@@ -1,5 +1,5 @@
 import { Assertions, Chain, FocusTools, Logger, Step, UiFinder, Waiter } from '@ephox/agar';
-import { SugarElement, Value } from '@ephox/sugar';
+import { Attribute, SugarElement, Value } from '@ephox/sugar';
 
 import { AlloyComponent } from 'ephox/alloy/api/component/ComponentApi';
 import * as AlloyTriggers from 'ephox/alloy/api/events/AlloyTriggers';
@@ -13,6 +13,7 @@ interface TestTypeaheadSteps {
   readonly sAssertFocusOnTypeahead: <T>(label: string) => Step<T, T>;
   readonly sTriggerInputEvent: <T>(label: string) => Step<T, T>;
   readonly sAssertValue: <T>(label: string, expected: string) => Step<T, T>;
+  readonly sAssertAriaActiveDescendant: <T>(label: string, expected: string) => Step<T, T>;
 }
 
 export default (doc: SugarElement<HTMLDocument>, gui: GuiSystem, typeahead: AlloyComponent): TestTypeaheadSteps => {
@@ -69,12 +70,21 @@ export default (doc: SugarElement<HTMLDocument>, gui: GuiSystem, typeahead: Allo
     ])
   );
 
+  const sAssertAriaActiveDescendant = <T>(label: string, expected: string) => Logger.t<T, T>(
+    label + ' sAssertAriaActiveDescendant',
+    Chain.asStep(typeahead.element, [
+      Chain.mapper((input) => Attribute.getOpt(input, 'aria-activedescendant').getOr('')),
+      Assertions.cAssertEq('Checking aria-activedescendant of typeahead', expected)
+    ])
+  );
+
   return {
     sWaitForMenu,
     sWaitForNoMenu,
     sAssertTextSelection,
     sAssertFocusOnTypeahead,
     sTriggerInputEvent,
-    sAssertValue
+    sAssertValue,
+    sAssertAriaActiveDescendant
   };
 };

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - New optional `defaultExpandedIds` and `onToggleExpand` options to the `tree` component config. #TINY-9653
 
+### Improved
+- Screen readers are now able to announce the highlighted menu item of link comboboxes. #TINY-9280
+
 ### Fixed
 - Enabling or Disabling checkboxes would not set the correct classes and attributes. #TINY-4189
 - Table toolbar was visible even if the table was within a noneditable host element. #TINY-9664
@@ -47,7 +50,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pressing enter inside the `inputfontsize` input field now moves focus back into the editor content. #TINY-9598
 - Drag and drop events for elements with a `contenteditable="false"` attribute now includes target element details. #TINY-9599
 - Updated focus, active, and enabled colors of UI buttons for improved contrast against the UI color. #TINY-9176
-- Screen readers are now able to announce the highlighted menu item of link comboboxes. #TINY-9280
 
 ### Changed
 - The `link` plugins context menu items no longer appears for links that include elements with a `contenteditable="false"` attribute. #TINY-9491

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pressing enter inside the `inputfontsize` input field now moves focus back into the editor content. #TINY-9598
 - Drag and drop events for elements with a `contenteditable="false"` attribute now includes target element details. #TINY-9599
 - Updated focus, active, and enabled colors of UI buttons for improved contrast against the UI color. #TINY-9176
+- Screen readers are now able to announce the highlighted menu item of link comboboxes. #TINY-9280
 
 ### Changed
 - The `link` plugins context menu items no longer appears for links that include elements with a `contenteditable="false"` attribute. #TINY-9491

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -1,6 +1,6 @@
 import { AlloySpec, RawDomSchema } from '@ephox/alloy';
 import { Toolbar } from '@ephox/bridge';
-import { Fun, Obj, Optional, Type } from '@ephox/katamari';
+import { Fun, Id, Obj, Optional, Type } from '@ephox/katamari';
 
 import I18n from 'tinymce/core/api/util/I18n';
 
@@ -83,11 +83,13 @@ const renderColorStructure = (item: ItemStructureSpec, providerBackstage: UiFact
 };
 
 const renderItemDomStructure = (ariaLabel: Optional<string>): RawDomSchema => {
-  const domTitle = ariaLabel.map((label): { attributes?: { title: string }} => ({
+  const domTitle = ariaLabel.map((label): { attributes?: { title: string, id?: string }} => ({
     attributes: {
       // TODO: AP-213 change this temporary solution to use tooltips, ensure its aria readable still.
       // for icon only implementations we need either a title or aria label to satisfy aria requirements.
-      title: I18n.translate(label)
+      title: I18n.translate(label),
+      // TODO: No idea if this is good
+      id: Id.generate('menu_item')
     }
   })).getOr({});
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -83,7 +83,7 @@ const renderColorStructure = (item: ItemStructureSpec, providerBackstage: UiFact
 };
 
 const renderItemDomStructure = (ariaLabel: Optional<string>): RawDomSchema => {
-  const domTitle = ariaLabel.map((label): { attributes?: { title: string, id?: string }} => ({
+  const domTitle = ariaLabel.map((label): { attributes?: { title: string; id?: string }} => ({
     attributes: {
       // TODO: AP-213 change this temporary solution to use tooltips, ensure its aria readable still.
       // for icon only implementations we need either a title or aria label to satisfy aria requirements.

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -88,8 +88,7 @@ const renderItemDomStructure = (ariaLabel: Optional<string>): RawDomSchema => {
       // TODO: AP-213 change this temporary solution to use tooltips, ensure its aria readable still.
       // for icon only implementations we need either a title or aria label to satisfy aria requirements.
       title: I18n.translate(label),
-      // TODO: No idea if this is good
-      id: Id.generate('menu_item')
+      id: Id.generate('menu-item')
     }
   })).getOr({});
 


### PR DESCRIPTION
Related Ticket: TINY-9280

**Description of Changes**:
* Added `id` attribute to menu items
* `aria-activedescendant` of `Typeahead`/`urlinput` is updated to the menu item that is highlighted


Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

