### PR TITLE
TINY-9717: Media Dialog - Uncaught TypeError: Cannot read properties of undefined

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- The `urlinput` dialog component would not open the typeahead dropdown when the input value was reset to an empty string. #TINY-9717
+
 ## 6.4.1 - 2023-03-29
 
 ### Fixed

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
@@ -24,7 +24,7 @@ type UrlInputSpec = Omit<Dialog.UrlInput, 'type'>;
 
 const getItems = (fileType: 'image' | 'media' | 'file', input: AlloyComponent, urlBackstage: UiFactoryBackstageForUrlInput) => {
   const urlInputValue = Representing.getValue(input);
-  const term = urlInputValue.meta.text !== undefined ? urlInputValue.meta.text : urlInputValue.value;
+  const term = urlInputValue?.meta?.text !== undefined ? urlInputValue.meta.text : urlInputValue.value;
   const info = urlBackstage.getLinkInformation();
   return info.fold(
     () => [],

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
@@ -24,7 +24,7 @@ type UrlInputSpec = Omit<Dialog.UrlInput, 'type'>;
 
 const getItems = (fileType: 'image' | 'media' | 'file', input: AlloyComponent, urlBackstage: UiFactoryBackstageForUrlInput) => {
   const urlInputValue = Representing.getValue(input);
-  const term = urlInputValue?.meta?.text !== undefined ? urlInputValue.meta.text : urlInputValue.value;
+  const term = urlInputValue?.meta?.text ?? urlInputValue.value;
   const info = urlBackstage.getLinkInformation();
   return info.fold(
     () => [],

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
@@ -262,4 +262,11 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
       'Checking Rep.getValue'
     );
   });
+
+  it('TINY-9717: it should open dropdown after the input value was reset to an empty string', async () => {
+    const component = hook.component();
+    Representing.setValue(component, { value: '' });
+    await pOpenMenu();
+    closeMenu();
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-9717

Description of Changes:
* Fix a small issue at the `getItems` function in the `UrlInput` module
* 
Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
