### PR TITLE
TINY-9669: Disable core toolbars/menuitems based on selection editable state

### DIFF
--- a/modules/mcagar/CHANGELOG.md
+++ b/modules/mcagar/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- Added `TinyState` module that contains transational functions for editor states.
+
 ## 8.3.0 - 2023-03-15
 
 ### Added

--- a/modules/mcagar/CHANGELOG.md
+++ b/modules/mcagar/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
-- Added `TinyState` module that contains transational functions for editor states.
+- Added `TinyState` module that contains transactional functions for editor states.
 
 ## 8.3.0 - 2023-03-15
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/Main.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/Main.ts
@@ -2,6 +2,7 @@ import * as TinyAssertions from './bdd/TinyAssertions';
 import * as TinyContentActions from './bdd/TinyContentActions';
 import * as TinyHooks from './bdd/TinyHooks';
 import * as TinySelections from './bdd/TinySelections';
+import * as TinyState from './bdd/TinyState';
 import * as TinyUiActions from './bdd/TinyUiActions';
 import * as LegacyUnit from './legacy/LegacyUnit';
 import * as McEditor from './McEditor';
@@ -36,5 +37,6 @@ export {
   TinyHooks,
   TinySelections,
   TinyContentActions,
+  TinyState,
   TinyUiActions
 };

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyState.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyState.ts
@@ -1,0 +1,14 @@
+import { Editor as EditorType } from '../../alien/EditorTypes';
+
+export const withNoneditableRootEditor = <T extends EditorType = EditorType>(editor: T, f: (editor: T) => void): void => {
+  editor.getBody().contentEditable = 'false';
+  f(editor);
+  editor.getBody().contentEditable = 'true';
+};
+
+export const withNoneditableRootEditorAsync = async <T extends EditorType = EditorType>(editor: T, f: (editor: T) => Promise<void>): Promise<void> => {
+  editor.getBody().contentEditable = 'false';
+  await f(editor);
+  editor.getBody().contentEditable = 'true';
+};
+

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New optional `defaultExpandedIds` and `onToggleExpand` options to the `tree` component config. #TINY-9653
 
 ### Improved
-- Toolbar buttons and menu items that couldn't be applied to the current noneditable selection was not disabled. #TINY-9669
+- Toolbar buttons and menu items were not disabled when they couldn't be used on noneditable content. #TINY-9669
 
 ### Fixed
 - Enabling or Disabling checkboxes would not set the correct classes and attributes. #TINY-4189

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - New optional `defaultExpandedIds` and `onToggleExpand` options to the `tree` component config. #TINY-9653
 
+### Improved
+- Toolbar buttons and menu items that couldn't be applied to the current noneditable selection was not disabled. #TINY-9669
+
 ### Fixed
 - Enabling or Disabling checkboxes would not set the correct classes and attributes. #TINY-4189
 - Table toolbar was visible even if the table was within a noneditable host element. #TINY-9664

--- a/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
@@ -127,7 +127,7 @@ export default (): void => {
     // rtl_ui: true,
     add_unload_trigger: false,
     autosave_ask_before_unload: false,
-    toolbar: 'fontsizeinput undo redo sidebar1 | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | align lineheight fontsize fontfamily blocks styles insertfile | styles | ' +
+    toolbar: 'undo redo sidebar1 | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | align lineheight fontsize fontfamily blocks styles insertfile | styles | ' +
     'bullist numlist outdent indent | link image | print preview media | forecolor backcolor emoticons table codesample code language | ltr rtl',
     contextmenu: 'link linkchecker image table lists configurepermanentpen',
 

--- a/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/DragDropOverridesTest.ts
@@ -2,7 +2,7 @@ import { Assertions, DragnDrop, Keyboard, Keys, Mouse, UiFinder, Waiter } from '
 import { before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Type } from '@ephox/katamari';
 import { Html, SelectorFind, SugarBody, SugarElement, SugarLocation, Traverse } from '@ephox/sugar';
-import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyDom, TinyHooks, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -480,25 +480,23 @@ describe('browser.tinymce.core.DragDropOverridesTest', () => {
     });
 
     it('TINY-9558: Should not be possible to drag a noneditable CEF element to a noneditable target within a noneditable root', async () => {
-      const editor = hook.editor();
-      const initialContent = '<div class="toDrag" contenteditable="false">To drag element</div><div class="destination">drop target</div>';
+      await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+        const initialContent = '<div class="toDrag" contenteditable="false">To drag element</div><div class="destination">drop target</div>';
 
-      editor.setContent(initialContent);
-      editor.getBody().contentEditable = 'false';
-      await moveToDragElementToDestinationElement(editor, 0, 0);
-      TinyAssertions.assertContent(editor, initialContent);
-      editor.getBody().contentEditable = 'true';
+        editor.setContent(initialContent);
+        await moveToDragElementToDestinationElement(editor, 0, 0);
+        TinyAssertions.assertContent(editor, initialContent);
+      });
     });
 
     it('TINY-9558: Should not be possible to drag a noneditable CEF element to an editable target within a noneditable root', async () => {
-      const editor = hook.editor();
-      const initialContent = '<div class="toDrag" contenteditable="false">To drag element</div><div contenteditable="true"><div class="destination">drop target</div></div>';
+      await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+        const initialContent = '<div class="toDrag" contenteditable="false">To drag element</div><div contenteditable="true"><div class="destination">drop target</div></div>';
 
-      editor.setContent(initialContent);
-      editor.getBody().contentEditable = 'false';
-      await moveToDragElementToDestinationElement(editor, 0, 0);
-      TinyAssertions.assertContent(editor, initialContent);
-      editor.getBody().contentEditable = 'true';
+        editor.setContent(initialContent);
+        await moveToDragElementToDestinationElement(editor, 0, 0);
+        TinyAssertions.assertContent(editor, initialContent);
+      });
     });
 
     context('Drag/drop padding', () => {

--- a/modules/tinymce/src/core/test/ts/browser/caret/FirefoxFakeCaretBeforeTableTypeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/FirefoxFakeCaretBeforeTableTypeTest.ts
@@ -1,5 +1,5 @@
 import { before, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -44,12 +44,11 @@ describe('browser.tinymce.core.FirefoxFakeCaretBeforeTableTypeTest', () => {
   });
 
   it('TINY-9459: should not render a fake caret before tables inside a noneditable root', () => {
-    const editor = hook.editor();
-    editor.getBody().contentEditable = 'false';
-    editor.setContent('<table><tbody><tr><td></td></tr></tbody></table>');
-    TinySelections.setCursor(editor, [], 0);
-    editor.nodeChanged();
-    TinyAssertions.assertContentPresence(editor, { '.mce-visual-caret': 0 });
-    editor.getBody().contentEditable = 'true';
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<table><tbody><tr><td></td></tr></tbody></table>');
+      TinySelections.setCursor(editor, [], 0);
+      editor.nodeChanged();
+      TinyAssertions.assertContentPresence(editor, { '.mce-visual-caret': 0 });
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -1,5 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -753,26 +753,23 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     });
 
     it('TINY-9462: insertContent in normal element in noneditable root should be a noop', () => {
-      const editor = hook.editor();
-      const content = '<div>text</div>';
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        const content = '<div>text</div>';
 
-      editor.getBody().contentEditable = 'false';
-      editor.setContent(content);
-      TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
-      editor.insertContent('hello');
-      TinyAssertions.assertContent(editor, content);
-      editor.getBody().contentEditable = 'true';
+        editor.setContent(content);
+        TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
+        editor.insertContent('hello');
+        TinyAssertions.assertContent(editor, content);
+      });
     });
 
     it('TINY-9462: insertContent in editable element in noneditable root should insert content', () => {
-      const editor = hook.editor();
-
-      editor.getBody().contentEditable = 'false';
-      editor.setContent('<div contenteditable="true">text</div>');
-      TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
-      editor.insertContent('hello');
-      TinyAssertions.assertContent(editor, '<div contenteditable="true">thelloxt</div>');
-      editor.getBody().contentEditable = 'true';
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        editor.setContent('<div contenteditable="true">text</div>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
+        editor.insertContent('hello');
+        TinyAssertions.assertContent(editor, '<div contenteditable="true">thelloxt</div>');
+      });
     });
 
     it('TINY-9595: insert paragraphs in a paragraph editing host paragraph should unwrap the paragraphs and not split the div and em', () => {
@@ -798,15 +795,14 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
     });
 
     it('TINY-9595: insert paragraphs in a paragraph editing host in a noneditable root editor should unwrap the paragraphs', () => {
-      const editor = hook.editor();
-      const content = '<p contenteditable="true"><em>ad</em></p>';
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        const content = '<p contenteditable="true"><em>ad</em></p>';
 
-      editor.getBody().contentEditable = 'false';
-      editor.setContent(content);
-      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
-      editor.insertContent('<p>b</p><p>c</p>');
-      editor.getBody().contentEditable = 'true';
-      TinyAssertions.assertContent(editor, '<p contenteditable="true"><em>abcd</em></p>');
+        editor.setContent(content);
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+        editor.insertContent('<p>b</p><p>c</p>');
+        TinyAssertions.assertContent(editor, '<p contenteditable="true"><em>abcd</em></p>');
+      });
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Keys } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -261,15 +261,14 @@ describe('browser.tinymce.core.delete.CefDeleteTest', () => {
       });
 
       it(`TINY-9477: should not delete anything between editables in a noneditable root when ${label} is pressed`, () => {
-        const editor = hook.editor();
-        const initialContent = '<p>a</p><p>b</p>';
-        editor.getBody().contentEditable = 'false';
-        editor.setContent(initialContent);
-        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
-        TinyContentActions.keystroke(editor, key());
-        TinyAssertions.assertSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
-        TinyAssertions.assertContent(editor, initialContent);
-        editor.getBody().contentEditable = 'true';
+        TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+          const initialContent = '<p>a</p><p>b</p>';
+          editor.setContent(initialContent);
+          TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
+          TinyContentActions.keystroke(editor, key());
+          TinyAssertions.assertSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
+          TinyAssertions.assertContent(editor, initialContent);
+        });
       });
     });
   });

--- a/modules/tinymce/src/core/test/ts/browser/delete/DeleteCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/DeleteCommandsTest.ts
@@ -1,6 +1,6 @@
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import * as DeleteCommands from 'tinymce/core/delete/DeleteCommands';
@@ -52,27 +52,25 @@ describe('browser.tinymce.core.delete.DeleteCommandsTest', () => {
     });
 
     it('TINY-9477: Delete on blocks in noneditable root should not do anything', () => {
-      const editor = hook.editor();
-      const initialContent = '<p>a</p><p>b</p>';
-      editor.getBody().contentEditable = 'false';
-      editor.setContent(initialContent);
-      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
-      DeleteCommands.deleteCommand(editor, caret);
-      TinyAssertions.assertContent(editor, initialContent);
-      TinyAssertions.assertSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
-      editor.getBody().contentEditable = 'true';
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        const initialContent = '<p>a</p><p>b</p>';
+        editor.setContent(initialContent);
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
+        DeleteCommands.deleteCommand(editor, caret);
+        TinyAssertions.assertContent(editor, initialContent);
+        TinyAssertions.assertSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
+      });
     });
 
     it('TINY-9477: ForwardDelete on blocks in noneditable root should not do anything', () => {
-      const editor = hook.editor();
-      const initialContent = '<p>a</p><p>b</p>';
-      editor.getBody().contentEditable = 'false';
-      editor.setContent(initialContent);
-      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
-      DeleteCommands.forwardDeleteCommand(editor, caret);
-      TinyAssertions.assertContent(editor, initialContent);
-      TinyAssertions.assertSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
-      editor.getBody().contentEditable = 'true';
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        const initialContent = '<p>a</p><p>b</p>';
+        editor.setContent(initialContent);
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
+        DeleteCommands.forwardDeleteCommand(editor, caret);
+        TinyAssertions.assertContent(editor, initialContent);
+        TinyAssertions.assertSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
+      });
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/ListItemFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/ListItemFormatTest.ts
@@ -1,7 +1,7 @@
 import { Cursors } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Type } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { FormatVars } from 'tinymce/core/fmt/FormatTypes';
@@ -216,16 +216,14 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
       );
 
       it('TINY-9563: applying bold on LIs in a noneditable root should not get bold styles', () => {
-        const editor = hook.editor();
-
-        editor.getBody().contentEditable = 'false';
-        testApplyInlineListFormat({
-          format: 'bold',
-          rawInput: '<p>a</p><ul><li>b</li><li>c</li></ul><p>d</p>',
-          selection: { startPath: [ 0, 0 ], soffset: 0, finishPath: [ 2, 0 ], foffset: 1 },
-          expected: '<p>a</p><ul><li>b</li><li>c</li></ul><p>d</p>',
+        TinyState.withNoneditableRootEditor(hook.editor(), () => {
+          testApplyInlineListFormat({
+            format: 'bold',
+            rawInput: '<p>a</p><ul><li>b</li><li>c</li></ul><p>d</p>',
+            selection: { startPath: [ 0, 0 ], soffset: 0, finishPath: [ 2, 0 ], foffset: 1 },
+            expected: '<p>a</p><ul><li>b</li><li>c</li></ul><p>d</p>',
+          });
         });
-        editor.getBody().contentEditable = 'true';
       });
     });
   });
@@ -352,17 +350,16 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
       );
 
       it('TINY-9563: remove bold on LI elements in a noneditable root should not remove bold styles', () => {
-        const editor = hook.editor();
-        const initialContent = '<ul><li style="font-weight: bold;">b</li><li style="font-weight: bold;">c</li></ul>';
+        TinyState.withNoneditableRootEditor(hook.editor(), () => {
+          const initialContent = '<ul><li style="font-weight: bold;">b</li><li style="font-weight: bold;">c</li></ul>';
 
-        editor.getBody().contentEditable = 'false';
-        testRemoveInlineListFormat({
-          format: 'bold',
-          rawInput: initialContent,
-          selection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 1, 0 ], foffset: 1 },
-          expected: initialContent,
+          testRemoveInlineListFormat({
+            format: 'bold',
+            rawInput: initialContent,
+            selection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 1, 0 ], foffset: 1 },
+            expected: initialContent,
+          });
         });
-        editor.getBody().contentEditable = 'true';
       });
     });
 

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -672,14 +672,13 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
   });
 
   it('TINY-9461: Enter inside an editing host should not split the editing host', () => {
-    const editor = hook.editor();
-    const initialContent = '<p contenteditable="true">ab</p>';
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+      const initialContent = '<p contenteditable="true">ab</p>';
 
-    editor.getBody().contentEditable = 'false';
-    editor.setContent(initialContent);
-    TinySelections.setCursor(editor, [ 0, 0 ], 1);
-    pressEnter(editor, true);
-    TinyAssertions.assertContent(editor, initialContent);
-    editor.getBody().contentEditable = 'false';
+      editor.setContent(initialContent);
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      pressEnter(editor, true);
+      TinyAssertions.assertContent(editor, initialContent);
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure } from '@ephox/agar';
 import { after, before, context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
@@ -107,24 +107,22 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
     });
 
     it('TINY-9461: should not split editing host in noneditable root', () => {
-      const editor = hook.editor();
-      const initialContent = '<p contenteditable="true">ab</p>';
-      editor.getBody().contentEditable = 'false';
-      editor.setContent(initialContent);
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      insertNewline(editor, { });
-      TinyAssertions.assertContent(editor, initialContent);
-      editor.getBody().contentEditable = 'true';
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        const initialContent = '<p contenteditable="true">ab</p>';
+        editor.setContent(initialContent);
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, { });
+        TinyAssertions.assertContent(editor, initialContent);
+      });
     });
 
     it('TINY-9461: should wrap div contents in paragraph and split inner paragraph in a div editing host inside a noneditable root', () => {
-      const editor = hook.editor();
-      editor.getBody().contentEditable = 'false';
-      editor.setContent('<div contenteditable="true">ab</div>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      insertNewline(editor, { });
-      TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>a</p><p>b</p></div>');
-      editor.getBody().contentEditable = 'true';
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        editor.setContent('<div contenteditable="true">ab</div>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, { });
+        TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>a</p><p>b</p></div>');
+      });
     });
 
     it('TINY-9461: should not split editing host', () => {
@@ -137,13 +135,12 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
     });
 
     it('TINY-9461: should wrap div contents in paragraph and split inner paragraph in a div editing host', () => {
-      const editor = hook.editor();
-      editor.getBody().contentEditable = 'false';
-      editor.setContent('<div contenteditable="false"><div contenteditable="true">ab</div></div>');
-      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
-      insertNewline(editor, { });
-      TinyAssertions.assertContent(editor, '<div contenteditable="false"><div contenteditable="true"><p>a</p><p>b</p></div></div>');
-      editor.getBody().contentEditable = 'true';
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        editor.setContent('<div contenteditable="false"><div contenteditable="true">ab</div></div>');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+        insertNewline(editor, { });
+        TinyAssertions.assertContent(editor, '<div contenteditable="false"><div contenteditable="true"><p>a</p><p>b</p></div></div>');
+      });
     });
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/selection/InlineBoundarySelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/InlineBoundarySelectionTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -33,11 +33,10 @@ describe('browser.tinymce.selection.InlineBoundarySelectionTest', () => {
   });
 
   it('TINY-9471: Should not have a inline boundary when caret is inside an noneditable root', () => {
-    const editor = hook.editor();
-    editor.getBody().contentEditable = 'false';
-    editor.setContent('<p><a href="#">a</a></p>');
-    TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
-    assertNoInlineBoundarySelection(editor);
-    editor.getBody().contentEditable = 'true';
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<p><a href="#">a</a></p>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+      assertNoInlineBoundarySelection(editor);
+    });
   });
 });

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/FakeSelectionTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/FakeSelectionTest.ts
@@ -2,7 +2,7 @@ import { Assertions, Keys } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { Html, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
-import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -220,7 +220,7 @@ describe('browser.tinymce.models.dom.table.FakeSelectionTest', () => {
 
   context('Noneditable root', () => {
     it('TINY-9459: Should not select cells with mouse in a noneditable root', () =>
-      TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
         assertTableSelection(
           editor,
           simpleTable,
@@ -231,7 +231,7 @@ describe('browser.tinymce.models.dom.table.FakeSelectionTest', () => {
     );
 
     it('TINY-9459: Should not select cells with keyboard in a noneditable root', () =>
-      TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
         editor.setContent('<table><tbody><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table>');
         TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
         TinyContentActions.keystroke(editor, Keys.down(), { shiftKey: true });

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/ApplyCellStyleCommandTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/ApplyCellStyleCommandTest.ts
@@ -2,7 +2,7 @@ import { ApproxStructure } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
 import { SugarElement, SugarNode } from '@ephox/sugar';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -209,7 +209,7 @@ describe('browser.tinymce.models.dom.table.command.ApplyCellStyleCommandTest', (
   });
 
   it('TINY-9459: Should not apply command to table in noneditable root', () => {
-    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent(table);
       TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
       applyCellStyle(editor, { backgroundColor: 'red' });

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/InsertCommandsTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/InsertCommandsTest.ts
@@ -1,12 +1,10 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
-
-import * as TableTestUtils from '../../../module/table/TableTestUtils';
 
 describe('browser.tinymce.models.dom.table.command.InsertCommandsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -169,7 +167,7 @@ describe('browser.tinymce.models.dom.table.command.InsertCommandsTest', () => {
 
   context('Noneditable root', () => {
     const testNoopExecCommand = (cmd: string) => () => {
-      TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
         const initalContent = '<table><tbody><tr><td>cell</td></tr></tbody></table>';
         editor.setContent(initalContent);
         TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/MergeCellCommandTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/MergeCellCommandTest.ts
@@ -1,12 +1,10 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { Css, Dimension, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
-import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
+import { TinyDom, TinyHooks, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-
-import * as TableTestUtils from '../../../module/table/TableTestUtils';
 
 interface PartialTableModifiedEvent {
   readonly type: string;
@@ -179,7 +177,7 @@ describe('browser.tinymce.models.dom.table.command.MergeCellCommandTest', () => 
   });
 
   it('TINY-9459: Should not merge cells in table inside noneditable root', () => {
-    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       testMerge(editor, {
         before: (
           '<table>' +

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/ModifyClassesCommandsTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/ModifyClassesCommandsTest.ts
@@ -1,12 +1,10 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
-
-import * as TableTestUtils from '../../../module/table/TableTestUtils';
 
 describe('browser.tinymce.models.dom.table.command.ModifyClassesCommandsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -294,7 +292,7 @@ describe('browser.tinymce.models.dom.table.command.ModifyClassesCommandsTest', (
   });
 
   it('TINY-9459: Should not apply mceTableToggleClass command on table in noneditable root', () => {
-    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       const initalContent = '<table><tbody><tr><td>cell</td></tr></tbody></table>';
       editor.setContent(initalContent);
       TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteColumnTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteColumnTest.ts
@@ -1,13 +1,11 @@
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
-
-import * as TableTestUtils from '../../../module/table/TableTestUtils';
 
 describe('browser.tinymce.models.dom.table.command.TableDeleteColumnTest', () => {
   let events: Array<EditorEvent<TableModifiedEvent>> = [];
@@ -65,7 +63,7 @@ describe('browser.tinymce.models.dom.table.command.TableDeleteColumnTest', () =>
   });
 
   it('TINY-9459: Should not apply mceTableDeleteCol command on table in noneditable root', () => {
-    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       const initalContent = '<table><tbody><tr><td>cell</td></tr></tbody></table>';
       editor.setContent(initalContent);
       TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteCommandTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteCommandTest.ts
@@ -1,10 +1,8 @@
 
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-
-import * as TableTestUtils from '../../../module/table/TableTestUtils';
 
 describe('browser.tinymce.models.dom.table.command.TableDeleteCommandTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -30,7 +28,7 @@ describe('browser.tinymce.models.dom.table.command.TableDeleteCommandTest', () =
   });
 
   it('TINY-9459: Should not apply mceTableDelete command on table inside a noneditable root', () => {
-    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       const initalContent = '<table><tbody><tr><td>cell</td></tr></tbody></table>';
       editor.setContent(initalContent);
       TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteRowTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteRowTest.ts
@@ -1,13 +1,11 @@
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
-
-import * as TableTestUtils from '../../../module/table/TableTestUtils';
 
 describe('browser.tinymce.models.dom.table.command.TableDeleteRowTest', () => {
   let events: Array<EditorEvent<TableModifiedEvent>> = [];
@@ -65,7 +63,7 @@ describe('browser.tinymce.models.dom.table.command.TableDeleteRowTest', () => {
   });
 
   it('TINY-9459: Should not apply mceTableDeleteRow command on table in noneditable root', () => {
-    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       const initalContent = '<table><tbody><tr><td>cell</td></tr></tbody></table>';
       editor.setContent(initalContent);
       TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableSizingModeCommandTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableSizingModeCommandTest.ts
@@ -1,11 +1,10 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
 
 import { tableSizingModeScenarioTest } from '../../../module/table/TableSizingModeCommandUtil';
-import * as TableTestUtils from '../../../module/table/TableTestUtils';
 
 describe('browser.tinymce.models.dom.table.command.TableSizingModeCommandTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -108,14 +107,12 @@ describe('browser.tinymce.models.dom.table.command.TableSizingModeCommandTest', 
     });
 
     it('TINY-9459: Should not apply mceTableSizingMode command on table inside a noneditable root', () => {
-      TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
         const initalContent = '<table><tbody><tr><td>cell</td></tr></tbody></table>';
-        editor.getBody().contentEditable = 'false';
         editor.setContent(initalContent);
         TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
         editor.execCommand('mceTableSizingMode', false, 'fixed');
         TinyAssertions.assertContent(editor, initalContent);
-        editor.getBody().contentEditable = 'true';
       });
     });
   });

--- a/modules/tinymce/src/models/dom/test/ts/module/table/TableTestUtils.ts
+++ b/modules/tinymce/src/models/dom/test/ts/module/table/TableTestUtils.ts
@@ -259,12 +259,6 @@ const assertWidths = (widths: { widthBefore: WidthData; widthAfter: WidthData })
   }
 };
 
-const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void): void => {
-  editor.getBody().contentEditable = 'false';
-  f(editor);
-  editor.getBody().contentEditable = 'true';
-};
-
 export {
   getCellWidth,
   assertTableStructure,
@@ -287,6 +281,5 @@ export {
   deleteRow,
   insertTable,
   makeInsertTable,
-  assertWidths,
-  withNoneditableRootEditor
+  assertWidths
 };

--- a/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
@@ -33,7 +33,7 @@ const isWithinNonEditable = (editor: Editor, element: Element | null): boolean =
 
 const isWithinNonEditableList = (editor: Editor, element: Element | null): boolean => {
   const parentList = editor.dom.getParent(element, 'ol,ul,dl');
-  return isWithinNonEditable(editor, parentList);
+  return isWithinNonEditable(editor, parentList) && editor.selection.isEditable();
 };
 
 const setNodeChangeHandler = (editor: Editor, nodeChangeHandler: (e: NodeChangeEvent) => void): () => void => {

--- a/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
@@ -28,9 +28,10 @@ const normalizeStyleValue = (styleValue: string | undefined): string =>
 const makeSetupHandler = (editor: Editor, nodeName: ListType) => (api: Toolbar.ToolbarSplitButtonInstanceApi | Toolbar.ToolbarToggleButtonInstanceApi) => {
   const nodeChangeHandler = (e: EditorEvent<NodeChangeEvent>) => {
     api.setActive(ListUtils.inList(editor, e.parents, nodeName));
-    api.setEnabled(!ListUtils.isWithinNonEditableList(editor, e.element));
+    api.setEnabled(!ListUtils.isWithinNonEditableList(editor, e.element) && editor.selection.isEditable());
   };
   editor.on('NodeChange', nodeChangeHandler);
+  api.setEnabled(editor.selection.isEditable());
 
   return () => editor.off('NodeChange', nodeChangeHandler);
 };

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
@@ -15,12 +15,6 @@ describe('browser.tinymce.plugins.advlist.NoneditableRootTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
 
-  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
-    editor.getBody().contentEditable = 'false';
-    f(editor);
-    editor.getBody().contentEditable = 'true';
-  };
-
   context('List ui controls', () => {
     const initialListContent = '<ol><li>a</li></ol>';
     const setupEditor = (editor: Editor) => {
@@ -29,7 +23,7 @@ describe('browser.tinymce.plugins.advlist.NoneditableRootTest', () => {
     };
 
     it('TINY-9458: List buttons numlist/bullist should be disabled', () => {
-      withNoneditableRootEditor(hook.editor(), (editor) => {
+      TinyState.withNoneditableRootEditor<Editor>(hook.editor(), (editor) => {
         setupEditor(editor);
 
         UiFinder.exists(SugarBody.body(), 'div[title="Numbered list"][aria-disabled="true"]');
@@ -38,7 +32,7 @@ describe('browser.tinymce.plugins.advlist.NoneditableRootTest', () => {
     });
 
     it('TINY-9458: Outdent/indent buttons should be noop', () => {
-      withNoneditableRootEditor(hook.editor(), (editor) => {
+      TinyState.withNoneditableRootEditor<Editor>(hook.editor(), (editor) => {
         setupEditor(editor);
 
         TinyUiActions.clickOnToolbar(editor, 'button[title="Decrease indent"]');
@@ -50,14 +44,12 @@ describe('browser.tinymce.plugins.advlist.NoneditableRootTest', () => {
     });
 
     it('TINY-9458: Context menu list properties should be disabled', async () => {
-      const editor = hook.editor();
+      await TinyState.withNoneditableRootEditorAsync<Editor>(hook.editor(), async (editor) => {
+        setupEditor(editor);
 
-      setupEditor(editor);
-
-      editor.getBody().contentEditable = 'false';
-      await TinyUiActions.pTriggerContextMenu(editor, 'li', '.tox-silver-sink [role="menuitem"]:contains("List properties...")');
-      UiFinder.exists(SugarBody.body(), '[role="menuitem"][aria-disabled="true"]:contains("List properties...")');
-      editor.getBody().contentEditable = 'true';
+        await TinyUiActions.pTriggerContextMenu(editor, 'li', '.tox-silver-sink [role="menuitem"]:contains("List properties...")');
+        UiFinder.exists(SugarBody.body(), '[role="menuitem"][aria-disabled="true"]:contains("List properties...")');
+      });
     });
   });
 });

--- a/modules/tinymce/src/plugins/anchor/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/ui/Buttons.ts
@@ -1,4 +1,18 @@
 import Editor from 'tinymce/core/api/Editor';
+import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
+
+const onSetupEditable = (editor: Editor) => (api: Toolbar.ToolbarButtonInstanceApi | Menu.MenuItemInstanceApi): VoidFunction => {
+  const nodeChanged = () => {
+    api.setEnabled(editor.selection.isEditable());
+  };
+
+  editor.on('NodeChange', nodeChanged);
+  nodeChanged();
+
+  return () => {
+    editor.off('NodeChange', nodeChanged);
+  };
+};
 
 const register = (editor: Editor): void => {
   const onAction = () => editor.execCommand('mceAnchor');
@@ -7,13 +21,22 @@ const register = (editor: Editor): void => {
     icon: 'bookmark',
     tooltip: 'Anchor',
     onAction,
-    onSetup: (buttonApi) => editor.selection.selectorChangedWithUnbind('a:not([href])', buttonApi.setActive).unbind
+    onSetup: (buttonApi) => {
+      const unbindSelectorChanged = editor.selection.selectorChangedWithUnbind('a:not([href])', buttonApi.setActive).unbind;
+      const unbindEditableChanged = onSetupEditable(editor)(buttonApi);
+
+      return () => {
+        unbindSelectorChanged();
+        unbindEditableChanged();
+      };
+    }
   });
 
   editor.ui.registry.addMenuItem('anchor', {
     icon: 'bookmark',
     text: 'Anchor...',
-    onAction
+    onAction,
+    onSetup: onSetupEditable(editor)
   });
 };
 

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/NoneditableRootTest.ts
@@ -1,7 +1,7 @@
 import { Keys, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/anchor/Plugin';
@@ -13,14 +13,8 @@ describe('browser.tinymce.plugins.anchor.NoneditableRootTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
 
-  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
-    editor.getBody().contentEditable = 'false';
-    f(editor);
-    editor.getBody().contentEditable = 'true';
-  };
-
   it('TINY-9669: Disable anchor button on noneditable content', () => {
-    withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       UiFinder.exists(SugarBody.body(), '[aria-label="Anchor"][aria-disabled="true"]');
@@ -30,18 +24,17 @@ describe('browser.tinymce.plugins.anchor.NoneditableRootTest', () => {
   });
 
   it('TINY-9669: Disable anchor menuitem on noneditable content', async () => {
-    const editor = hook.editor();
-    editor.getBody().contentEditable = 'false';
-    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Anchor..."][aria-disabled="true"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Anchor..."][aria-disabled="false"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    editor.getBody().contentEditable = 'true';
+    await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Anchor..."][aria-disabled="true"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Anchor..."][aria-disabled="false"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+    });
   });
 });
 

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/NoneditableRootTest.ts
@@ -1,0 +1,47 @@
+import { Keys, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/anchor/Plugin';
+
+describe('browser.tinymce.plugins.anchor.NoneditableRootTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'anchor',
+    toolbar: 'anchor',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
+    editor.getBody().contentEditable = 'false';
+    f(editor);
+    editor.getBody().contentEditable = 'true';
+  };
+
+  it('TINY-9669: Disable anchor button on noneditable content', () => {
+    withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Anchor"][aria-disabled="true"]');
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Anchor"][aria-disabled="false"]');
+    });
+  });
+
+  it('TINY-9669: Disable anchor menuitem on noneditable content', async () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Anchor..."][aria-disabled="true"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Anchor..."][aria-disabled="false"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    editor.getBody().contentEditable = 'true';
+  });
+});
+

--- a/modules/tinymce/src/plugins/charmap/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/ui/Buttons.ts
@@ -1,4 +1,18 @@
 import Editor from 'tinymce/core/api/Editor';
+import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
+
+const onSetupEditable = (editor: Editor) => (api: Toolbar.ToolbarButtonInstanceApi | Menu.MenuItemInstanceApi): VoidFunction => {
+  const nodeChanged = () => {
+    api.setEnabled(editor.selection.isEditable());
+  };
+
+  editor.on('NodeChange', nodeChanged);
+  nodeChanged();
+
+  return () => {
+    editor.off('NodeChange', nodeChanged);
+  };
+};
 
 const register = (editor: Editor): void => {
   const onAction = () => editor.execCommand('mceShowCharmap');
@@ -6,13 +20,15 @@ const register = (editor: Editor): void => {
   editor.ui.registry.addButton('charmap', {
     icon: 'insert-character',
     tooltip: 'Special character',
-    onAction
+    onAction,
+    onSetup: onSetupEditable(editor)
   });
 
   editor.ui.registry.addMenuItem('charmap', {
     icon: 'insert-character',
     text: 'Special character...',
-    onAction
+    onAction,
+    onSetup: onSetupEditable(editor)
   });
 };
 

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/NoneditableRootTest.ts
@@ -1,0 +1,47 @@
+import { Keys, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/charmap/Plugin';
+
+describe('browser.tinymce.plugins.charmap.NoneditableRootTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'charmap',
+    toolbar: 'charmap',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
+    editor.getBody().contentEditable = 'false';
+    f(editor);
+    editor.getBody().contentEditable = 'true';
+  };
+
+  it('TINY-9669: Disable charmap button on noneditable content', () => {
+    withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Special character"][aria-disabled="true"]');
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Special character"][aria-disabled="false"]');
+    });
+  });
+
+  it('TINY-9669: Disable charmap menuitem on noneditable content', async () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Special character..."][aria-disabled="true"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Special character..."][aria-disabled="false"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    editor.getBody().contentEditable = 'true';
+  });
+});
+

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/NoneditableRootTest.ts
@@ -1,7 +1,7 @@
 import { Keys, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/charmap/Plugin';
@@ -13,14 +13,8 @@ describe('browser.tinymce.plugins.charmap.NoneditableRootTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
 
-  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
-    editor.getBody().contentEditable = 'false';
-    f(editor);
-    editor.getBody().contentEditable = 'true';
-  };
-
   it('TINY-9669: Disable charmap button on noneditable content', () => {
-    withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       UiFinder.exists(SugarBody.body(), '[aria-label="Special character"][aria-disabled="true"]');
@@ -30,18 +24,17 @@ describe('browser.tinymce.plugins.charmap.NoneditableRootTest', () => {
   });
 
   it('TINY-9669: Disable charmap menuitem on noneditable content', async () => {
-    const editor = hook.editor();
-    editor.getBody().contentEditable = 'false';
-    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Special character..."][aria-disabled="true"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Special character..."][aria-disabled="false"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    editor.getBody().contentEditable = 'true';
+    await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Special character..."][aria-disabled="true"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Special character..."][aria-disabled="false"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+    });
   });
 });
 

--- a/modules/tinymce/src/plugins/codesample/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/browser/NoneditableRootTest.ts
@@ -1,0 +1,47 @@
+import { Keys, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/codesample/Plugin';
+
+describe('browser.tinymce.plugins.codesample.NoneditableRootTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'codesample',
+    toolbar: 'codesample',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
+    editor.getBody().contentEditable = 'false';
+    f(editor);
+    editor.getBody().contentEditable = 'true';
+  };
+
+  it('TINY-9669: Disable codesample button on noneditable content', () => {
+    withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Insert/edit code sample"][aria-disabled="true"]');
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Insert/edit code sample"][aria-disabled="false"]');
+    });
+  });
+
+  it('TINY-9669: Disable codesample menuitem on noneditable content', async () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Code sample..."][aria-disabled="true"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Code sample..."][aria-disabled="false"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    editor.getBody().contentEditable = 'true';
+  });
+});
+

--- a/modules/tinymce/src/plugins/codesample/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/browser/NoneditableRootTest.ts
@@ -1,7 +1,7 @@
 import { Keys, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/codesample/Plugin';
@@ -13,14 +13,8 @@ describe('browser.tinymce.plugins.codesample.NoneditableRootTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
 
-  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
-    editor.getBody().contentEditable = 'false';
-    f(editor);
-    editor.getBody().contentEditable = 'true';
-  };
-
   it('TINY-9669: Disable codesample button on noneditable content', () => {
-    withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       UiFinder.exists(SugarBody.body(), '[aria-label="Insert/edit code sample"][aria-disabled="true"]');
@@ -30,18 +24,17 @@ describe('browser.tinymce.plugins.codesample.NoneditableRootTest', () => {
   });
 
   it('TINY-9669: Disable codesample menuitem on noneditable content', async () => {
-    const editor = hook.editor();
-    editor.getBody().contentEditable = 'false';
-    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Code sample..."][aria-disabled="true"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Code sample..."][aria-disabled="false"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    editor.getBody().contentEditable = 'true';
+    await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Code sample..."][aria-disabled="true"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Code sample..."][aria-disabled="false"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+    });
   });
 });
 

--- a/modules/tinymce/src/plugins/directionality/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/ui/Buttons.ts
@@ -9,8 +9,10 @@ const getNodeChangeHandler = (editor: Editor, dir: 'ltr' | 'rtl') => (api: Toolb
   const nodeChangeHandler = (e: EditorEvent<NodeChangeEvent>) => {
     const element = SugarElement.fromDom(e.element);
     api.setActive(Direction.getDirection(element) === dir);
+    api.setEnabled(editor.selection.isEditable());
   };
   editor.on('NodeChange', nodeChangeHandler);
+  api.setEnabled(editor.selection.isEditable());
 
   return () => editor.off('NodeChange', nodeChangeHandler);
 };

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/NoneditableRootTest.ts
@@ -1,0 +1,42 @@
+import { UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/directionality/Plugin';
+
+describe('browser.tinymce.plugins.directionality.NoneditableRootTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'directionality',
+    toolbar: 'ltr rtl',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
+    editor.getBody().contentEditable = 'false';
+    f(editor);
+    editor.getBody().contentEditable = 'true';
+  };
+
+  it('TINY-9669: Disable ltr button on noneditable content', () => {
+    withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Left to right"][aria-disabled="true"]');
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Left to right"][aria-disabled="false"]');
+    });
+  });
+
+  it('TINY-9669: Disable rtl button on noneditable content', () => {
+    withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Right to left"][aria-disabled="true"]');
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Right to left"][aria-disabled="false"]');
+    });
+  });
+});
+

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/NoneditableRootTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/directionality/Plugin';
@@ -13,14 +13,8 @@ describe('browser.tinymce.plugins.directionality.NoneditableRootTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
 
-  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
-    editor.getBody().contentEditable = 'false';
-    f(editor);
-    editor.getBody().contentEditable = 'true';
-  };
-
   it('TINY-9669: Disable ltr button on noneditable content', () => {
-    withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       UiFinder.exists(SugarBody.body(), '[aria-label="Left to right"][aria-disabled="true"]');
@@ -30,7 +24,7 @@ describe('browser.tinymce.plugins.directionality.NoneditableRootTest', () => {
   });
 
   it('TINY-9669: Disable rtl button on noneditable content', () => {
-    withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       UiFinder.exists(SugarBody.body(), '[aria-label="Right to left"][aria-disabled="true"]');

--- a/modules/tinymce/src/plugins/emoticons/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/ui/Buttons.ts
@@ -1,4 +1,18 @@
 import Editor from 'tinymce/core/api/Editor';
+import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
+
+const onSetupEditable = (editor: Editor) => (api: Toolbar.ToolbarButtonInstanceApi | Menu.MenuItemInstanceApi): VoidFunction => {
+  const nodeChanged = () => {
+    api.setEnabled(editor.selection.isEditable());
+  };
+
+  editor.on('NodeChange', nodeChanged);
+  nodeChanged();
+
+  return () => {
+    editor.off('NodeChange', nodeChanged);
+  };
+};
 
 const register = (editor: Editor): void => {
   const onAction = () => editor.execCommand('mceEmoticons');
@@ -6,13 +20,15 @@ const register = (editor: Editor): void => {
   editor.ui.registry.addButton('emoticons', {
     tooltip: 'Emojis',
     icon: 'emoji',
-    onAction
+    onAction,
+    onSetup: onSetupEditable(editor)
   });
 
   editor.ui.registry.addMenuItem('emoticons', {
     text: 'Emojis...',
     icon: 'emoji',
-    onAction
+    onAction,
+    onSetup: onSetupEditable(editor)
   });
 };
 

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/NoneditableRootTest.ts
@@ -1,7 +1,7 @@
 import { Keys, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/emoticons/Plugin';
@@ -13,14 +13,8 @@ describe('browser.tinymce.plugins.emoticons.NoneditableRootTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
 
-  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
-    editor.getBody().contentEditable = 'false';
-    f(editor);
-    editor.getBody().contentEditable = 'true';
-  };
-
   it('TINY-9669: Disable emoticons button on noneditable content', () => {
-    withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       UiFinder.exists(SugarBody.body(), '[aria-label="Emojis"][aria-disabled="true"]');
@@ -30,18 +24,17 @@ describe('browser.tinymce.plugins.emoticons.NoneditableRootTest', () => {
   });
 
   it('TINY-9669: Disable emoticons menuitem on noneditable content', async () => {
-    const editor = hook.editor();
-    editor.getBody().contentEditable = 'false';
-    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Emojis..."][aria-disabled="true"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Emojis..."][aria-disabled="false"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    editor.getBody().contentEditable = 'true';
+    await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Emojis..."][aria-disabled="true"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Emojis..."][aria-disabled="false"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+    });
   });
 });
 

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/NoneditableRootTest.ts
@@ -1,0 +1,47 @@
+import { Keys, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/emoticons/Plugin';
+
+describe('browser.tinymce.plugins.emoticons.NoneditableRootTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'emoticons',
+    toolbar: 'emoticons',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
+    editor.getBody().contentEditable = 'false';
+    f(editor);
+    editor.getBody().contentEditable = 'true';
+  };
+
+  it('TINY-9669: Disable emoticons button on noneditable content', () => {
+    withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Emojis"][aria-disabled="true"]');
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Emojis"][aria-disabled="false"]');
+    });
+  });
+
+  it('TINY-9669: Disable emoticons menuitem on noneditable content', async () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Emojis..."][aria-disabled="true"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Emojis..."][aria-disabled="false"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    editor.getBody().contentEditable = 'true';
+  });
+});
+

--- a/modules/tinymce/src/plugins/image/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/Buttons.ts
@@ -1,11 +1,25 @@
 import { Type } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
+import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
 
 import { isFigure, isImage } from '../core/ImageData';
 import * as ImageSelection from '../core/ImageSelection';
 import * as Utils from '../core/Utils';
 import { Dialog } from './Dialog';
+
+const onSetupEditable = (editor: Editor) => (api: Toolbar.ToolbarButtonInstanceApi | Menu.MenuItemInstanceApi): VoidFunction => {
+  const nodeChanged = () => {
+    api.setEnabled(editor.selection.isEditable());
+  };
+
+  editor.on('NodeChange', nodeChanged);
+  nodeChanged();
+
+  return () => {
+    editor.off('NodeChange', nodeChanged);
+  };
+};
 
 const register = (editor: Editor): void => {
   editor.ui.registry.addToggleButton('image', {
@@ -15,14 +29,20 @@ const register = (editor: Editor): void => {
     onSetup: (buttonApi) => {
       // Set the initial state and then bind to selection changes to update the state when the selection changes
       buttonApi.setActive(Type.isNonNullable(ImageSelection.getSelectedImage(editor)));
-      return editor.selection.selectorChangedWithUnbind('img:not([data-mce-object]):not([data-mce-placeholder]),figure.image', buttonApi.setActive).unbind;
+      const unbindSelectorChanged = editor.selection.selectorChangedWithUnbind('img:not([data-mce-object]):not([data-mce-placeholder]),figure.image', buttonApi.setActive).unbind;
+      const unbindEditable = onSetupEditable(editor)(buttonApi);
+      return () => {
+        unbindSelectorChanged();
+        unbindEditable();
+      };
     }
   });
 
   editor.ui.registry.addMenuItem('image', {
     icon: 'image',
     text: 'Image...',
-    onAction: Dialog(editor).open
+    onAction: Dialog(editor).open,
+    onSetup: onSetupEditable(editor)
   });
 
   editor.ui.registry.addContextMenu('image', {

--- a/modules/tinymce/src/plugins/image/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/NoneditableRootTest.ts
@@ -1,7 +1,7 @@
 import { Keys, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
@@ -13,14 +13,8 @@ describe('browser.tinymce.plugins.image.NoneditableRootTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
 
-  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
-    editor.getBody().contentEditable = 'false';
-    f(editor);
-    editor.getBody().contentEditable = 'true';
-  };
-
   it('TINY-9669: Disable image button on noneditable content', () => {
-    withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       UiFinder.exists(SugarBody.body(), '[aria-label="Insert/edit image"][aria-disabled="true"]');
@@ -30,18 +24,17 @@ describe('browser.tinymce.plugins.image.NoneditableRootTest', () => {
   });
 
   it('TINY-9669: Disable image menuitem on noneditable content', async () => {
-    const editor = hook.editor();
-    editor.getBody().contentEditable = 'false';
-    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Image..."][aria-disabled="true"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Image..."][aria-disabled="false"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    editor.getBody().contentEditable = 'true';
+    await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Image..."][aria-disabled="true"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Image..."][aria-disabled="false"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+    });
   });
 });
 

--- a/modules/tinymce/src/plugins/image/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/NoneditableRootTest.ts
@@ -1,0 +1,47 @@
+import { Keys, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/image/Plugin';
+
+describe('browser.tinymce.plugins.image.NoneditableRootTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'image',
+    toolbar: 'image',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
+    editor.getBody().contentEditable = 'false';
+    f(editor);
+    editor.getBody().contentEditable = 'true';
+  };
+
+  it('TINY-9669: Disable image button on noneditable content', () => {
+    withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Insert/edit image"][aria-disabled="true"]');
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Insert/edit image"][aria-disabled="false"]');
+    });
+  });
+
+  it('TINY-9669: Disable image menuitem on noneditable content', async () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Image..."][aria-disabled="true"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Image..."][aria-disabled="false"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    editor.getBody().contentEditable = 'true';
+  });
+});
+

--- a/modules/tinymce/src/plugins/insertdatetime/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/main/ts/ui/Buttons.ts
@@ -1,11 +1,24 @@
 import { Cell } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
-import { Menu } from 'tinymce/core/api/ui/Ui';
+import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
 import Tools from 'tinymce/core/api/util/Tools';
 
 import * as Options from '../api/Options';
 import * as Actions from '../core/Actions';
+
+const onSetupEditable = (editor: Editor) => (api: Toolbar.ToolbarButtonInstanceApi | Menu.MenuItemInstanceApi): VoidFunction => {
+  const nodeChanged = () => {
+    api.setEnabled(editor.selection.isEditable());
+  };
+
+  editor.on('NodeChange', nodeChanged);
+  nodeChanged();
+
+  return () => {
+    editor.off('NodeChange', nodeChanged);
+  };
+};
 
 const register = (editor: Editor): void => {
   const formats = Options.getFormats(editor);
@@ -28,7 +41,8 @@ const register = (editor: Editor): void => {
     onItemAction: (_api, value) => {
       defaultFormat.set(value);
       insertDateTime(value);
-    }
+    },
+    onSetup: onSetupEditable(editor)
   });
 
   const makeMenuItemHandler = (format: string) => (): void => {
@@ -43,7 +57,8 @@ const register = (editor: Editor): void => {
       type: 'menuitem',
       text: Actions.getDateTime(editor, format),
       onAction: makeMenuItemHandler(format)
-    }))
+    })),
+    onSetup: onSetupEditable(editor)
   });
 };
 

--- a/modules/tinymce/src/plugins/insertdatetime/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/test/ts/browser/NoneditableRootTest.ts
@@ -1,0 +1,47 @@
+import { Keys, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/insertdatetime/Plugin';
+
+describe('browser.tinymce.plugins.insertdatetime.NoneditableRootTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'insertdatetime',
+    toolbar: 'insertdatetime',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
+    editor.getBody().contentEditable = 'false';
+    f(editor);
+    editor.getBody().contentEditable = 'true';
+  };
+
+  it('TINY-9669: Disable insertdatetime button on noneditable content', () => {
+    withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Insert date/time"][aria-disabled="true"]');
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Insert date/time"][aria-disabled="false"]');
+    });
+  });
+
+  it('TINY-9669: Disable insertdatetime menuitem on noneditable content', async () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Date/time"][aria-disabled="true"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Date/time"][aria-disabled="false"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    editor.getBody().contentEditable = 'true';
+  });
+});
+

--- a/modules/tinymce/src/plugins/insertdatetime/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/test/ts/browser/NoneditableRootTest.ts
@@ -1,7 +1,7 @@
 import { Keys, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/insertdatetime/Plugin';
@@ -13,14 +13,8 @@ describe('browser.tinymce.plugins.insertdatetime.NoneditableRootTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
 
-  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
-    editor.getBody().contentEditable = 'false';
-    f(editor);
-    editor.getBody().contentEditable = 'true';
-  };
-
   it('TINY-9669: Disable insertdatetime button on noneditable content', () => {
-    withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       UiFinder.exists(SugarBody.body(), '[aria-label="Insert date/time"][aria-disabled="true"]');
@@ -30,18 +24,17 @@ describe('browser.tinymce.plugins.insertdatetime.NoneditableRootTest', () => {
   });
 
   it('TINY-9669: Disable insertdatetime menuitem on noneditable content', async () => {
-    const editor = hook.editor();
-    editor.getBody().contentEditable = 'false';
-    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Date/time"][aria-disabled="true"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Date/time"][aria-disabled="false"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    editor.getBody().contentEditable = 'true';
+    await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Date/time"][aria-disabled="true"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Date/time"][aria-disabled="false"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+    });
   });
 });
 

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -12,14 +12,14 @@ const setupButtons = (editor: Editor): void => {
     icon: 'link',
     tooltip: 'Insert/edit link',
     onAction: Actions.openDialog(editor),
-    onSetup: Actions.toggleActiveState(editor)
+    onSetup: Actions.toggleLinkState(editor)
   });
 
   editor.ui.registry.addButton('openlink', {
     icon: 'new-tab',
     tooltip: 'Open link',
     onAction: Actions.gotoSelectedLink(editor),
-    onSetup: Actions.toggleEnabledState(editor)
+    onSetup: Actions.toggleGotoLinkState(editor)
   });
 
   editor.ui.registry.addButton('unlink', {
@@ -35,13 +35,14 @@ const setupMenuItems = (editor: Editor): void => {
     text: 'Open link',
     icon: 'new-tab',
     onAction: Actions.gotoSelectedLink(editor),
-    onSetup: Actions.toggleEnabledState(editor)
+    onSetup: Actions.toggleGotoLinkState(editor)
   });
 
   editor.ui.registry.addMenuItem('link', {
     icon: 'link',
     text: 'Link...',
     shortcut: 'Meta+K',
+    onSetup: Actions.toggleLinkMenuState(editor),
     onAction: Actions.openDialog(editor)
   });
 
@@ -101,7 +102,7 @@ const setupContextToolbars = (editor: Editor): void => {
       type: 'contextformtogglebutton',
       icon: 'link',
       tooltip: 'Link',
-      onSetup: Actions.toggleActiveState(editor)
+      onSetup: Actions.toggleLinkState(editor)
     },
     label: 'Link',
     predicate: (node) => Options.hasContextToolbar(editor) && Utils.isInAnchor(editor, node),
@@ -119,7 +120,7 @@ const setupContextToolbars = (editor: Editor): void => {
           const node = editor.selection.getNode();
           // TODO: Make a test for this later.
           buttonApi.setActive(Utils.isInAnchor(editor, node));
-          return Actions.toggleActiveState(editor)(buttonApi);
+          return Actions.toggleLinkState(editor)(buttonApi);
         },
         onAction: (formApi) => {
           const value = formApi.getValue();

--- a/modules/tinymce/src/plugins/link/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/NoneditableRootTest.ts
@@ -1,7 +1,7 @@
 import { Keys, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
@@ -16,14 +16,8 @@ describe('browser.tinymce.plugins.link.NoneditableRootTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
 
-  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
-    editor.getBody().contentEditable = 'false';
-    f(editor);
-    editor.getBody().contentEditable = 'true';
-  };
-
   it('TINY-9669: Disable link button on noneditable content', () => {
-    withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       UiFinder.exists(SugarBody.body(), '[aria-label="Insert/edit link"][aria-disabled="true"]');
@@ -33,7 +27,7 @@ describe('browser.tinymce.plugins.link.NoneditableRootTest', () => {
   });
 
   it('TINY-9669: Disable unlink button on noneditable content', () => {
-    withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<div><a href="#">Noneditable content</a></div><div contenteditable="true"><a href="#">Editable content</a></div>');
       TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2);
       UiFinder.exists(SugarBody.body(), '[aria-label="Remove link"][aria-disabled="true"]');
@@ -43,33 +37,31 @@ describe('browser.tinymce.plugins.link.NoneditableRootTest', () => {
   });
 
   it('TINY-9669: Disable link menuitem on noneditable content', async () => {
-    const editor = hook.editor();
-    editor.getBody().contentEditable = 'false';
-    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Link..."][aria-disabled="true"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Link..."][aria-disabled="false"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    editor.getBody().contentEditable = 'true';
+    await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Link..."][aria-disabled="true"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Link..."][aria-disabled="false"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+    });
   });
 
   it('TINY-9669: Disable unlink menuitem on noneditable content', async () => {
-    const editor = hook.editor();
-    editor.getBody().contentEditable = 'false';
-    editor.setContent('<div><a href="#">Noneditable content</a></div><div contenteditable="true"><a href="#">Editable content</a></div>');
-    TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Remove link"][aria-disabled="true"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 1, 0, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Remove link"][aria-disabled="false"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    editor.getBody().contentEditable = 'true';
+    await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+      editor.setContent('<div><a href="#">Noneditable content</a></div><div contenteditable="true"><a href="#">Editable content</a></div>');
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Remove link"][aria-disabled="true"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+      TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 1, 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Remove link"][aria-disabled="false"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+    });
   });
 });
 

--- a/modules/tinymce/src/plugins/link/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/NoneditableRootTest.ts
@@ -1,0 +1,75 @@
+import { Keys, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/link/Plugin';
+
+describe('browser.tinymce.plugins.link.NoneditableRootTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'link',
+    toolbar: 'link unlink openlink',
+    menu: {
+      insert: { title: 'Insert', items: 'link unlink' }
+    },
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
+    editor.getBody().contentEditable = 'false';
+    f(editor);
+    editor.getBody().contentEditable = 'true';
+  };
+
+  it('TINY-9669: Disable link button on noneditable content', () => {
+    withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Insert/edit link"][aria-disabled="true"]');
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Insert/edit link"][aria-disabled="false"]');
+    });
+  });
+
+  it('TINY-9669: Disable unlink button on noneditable content', () => {
+    withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<div><a href="#">Noneditable content</a></div><div contenteditable="true"><a href="#">Editable content</a></div>');
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Remove link"][aria-disabled="true"]');
+      TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 1, 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Remove link"][aria-disabled="false"]');
+    });
+  });
+
+  it('TINY-9669: Disable link menuitem on noneditable content', async () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Link..."][aria-disabled="true"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Link..."][aria-disabled="false"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    editor.getBody().contentEditable = 'true';
+  });
+
+  it('TINY-9669: Disable unlink menuitem on noneditable content', async () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<div><a href="#">Noneditable content</a></div><div contenteditable="true"><a href="#">Editable content</a></div>');
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Remove link"][aria-disabled="true"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 1, 0, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Remove link"][aria-disabled="false"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    editor.getBody().contentEditable = 'true';
+  });
+});
+

--- a/modules/tinymce/src/plugins/lists/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/ui/Buttons.ts
@@ -7,8 +7,11 @@ import * as Util from '../core/Util';
 const setupToggleButtonHandler = (editor: Editor, listName: string) => (api: Toolbar.ToolbarToggleButtonInstanceApi): () => void => {
   const toggleButtonHandler = (e: NodeChangeEvent) => {
     api.setActive(Util.inList(e.parents, listName));
-    api.setEnabled(!Util.isWithinNonEditableList(editor, e.element));
+    api.setEnabled(!Util.isWithinNonEditableList(editor, e.element) && editor.selection.isEditable());
   };
+
+  api.setEnabled(editor.selection.isEditable());
+
   return Util.setNodeChangeHandler(editor, toggleButtonHandler);
 };
 

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/NoneditableRootTest.ts
@@ -193,5 +193,25 @@ describe('browser.tinymce.plugins.lists.NoneditableRootTest', () => {
       UiFinder.exists(SugarBody.body(), '[role="menuitem"][aria-disabled="true"]:contains("List properties...")');
       editor.getBody().contentEditable = 'true';
     });
+
+    it('TINY-9669: Disable numbered list button on noneditable content', () => {
+      withNoneditableRootEditor(hook.editor(), (editor) => {
+        editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), '[aria-label="Numbered list"][aria-disabled="true"]');
+        TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), '[aria-label="Numbered list"][aria-disabled="false"]');
+      });
+    });
+
+    it('TINY-9669: Disable bullet list button on noneditable content', () => {
+      withNoneditableRootEditor(hook.editor(), (editor) => {
+        editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), '[aria-label="Bullet list"][aria-disabled="true"]');
+        TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), '[aria-label="Bullet list"][aria-disabled="false"]');
+      });
+    });
   });
 });

--- a/modules/tinymce/src/plugins/media/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/ui/Buttons.ts
@@ -1,6 +1,20 @@
 import Editor from 'tinymce/core/api/Editor';
+import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
 
 import { isMediaElement } from '../core/Selection';
+
+const onSetupEditable = (editor: Editor) => (api: Toolbar.ToolbarButtonInstanceApi | Menu.MenuItemInstanceApi): VoidFunction => {
+  const nodeChanged = () => {
+    api.setEnabled(editor.selection.isEditable());
+  };
+
+  editor.on('NodeChange', nodeChanged);
+  nodeChanged();
+
+  return () => {
+    editor.off('NodeChange', nodeChanged);
+  };
+};
 
 const register = (editor: Editor): void => {
   const onAction = () => editor.execCommand('mceMedia');
@@ -12,14 +26,20 @@ const register = (editor: Editor): void => {
     onSetup: (buttonApi) => {
       const selection = editor.selection;
       buttonApi.setActive(isMediaElement(selection.getNode()));
-      return selection.selectorChangedWithUnbind('img[data-mce-object],span[data-mce-object],div[data-ephox-embed-iri]', buttonApi.setActive).unbind;
+      const unbindSelectorChanged = selection.selectorChangedWithUnbind('img[data-mce-object],span[data-mce-object],div[data-ephox-embed-iri]', buttonApi.setActive).unbind;
+      const unbindEditable = onSetupEditable(editor)(buttonApi);
+      return () => {
+        unbindSelectorChanged();
+        unbindEditable();
+      };
     }
   });
 
   editor.ui.registry.addMenuItem('media', {
     icon: 'embed',
     text: 'Media...',
-    onAction
+    onAction,
+    onSetup: onSetupEditable(editor)
   });
 };
 

--- a/modules/tinymce/src/plugins/media/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/NoneditableRootTest.ts
@@ -1,0 +1,47 @@
+import { Keys, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/media/Plugin';
+
+describe('browser.tinymce.plugins.media.NoneditableRootTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'media',
+    toolbar: 'media',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
+    editor.getBody().contentEditable = 'false';
+    f(editor);
+    editor.getBody().contentEditable = 'true';
+  };
+
+  it('TINY-9669: Disable media button on noneditable content', () => {
+    withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Insert/edit media"][aria-disabled="true"]');
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Insert/edit media"][aria-disabled="false"]');
+    });
+  });
+
+  it('TINY-9669: Disable media menuitem on noneditable content', async () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Media..."][aria-disabled="true"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Media..."][aria-disabled="false"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    editor.getBody().contentEditable = 'true';
+  });
+});
+

--- a/modules/tinymce/src/plugins/media/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/NoneditableRootTest.ts
@@ -1,7 +1,7 @@
 import { Keys, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/media/Plugin';
@@ -13,14 +13,8 @@ describe('browser.tinymce.plugins.media.NoneditableRootTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
 
-  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
-    editor.getBody().contentEditable = 'false';
-    f(editor);
-    editor.getBody().contentEditable = 'true';
-  };
-
   it('TINY-9669: Disable media button on noneditable content', () => {
-    withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       UiFinder.exists(SugarBody.body(), '[aria-label="Insert/edit media"][aria-disabled="true"]');
@@ -30,18 +24,17 @@ describe('browser.tinymce.plugins.media.NoneditableRootTest', () => {
   });
 
   it('TINY-9669: Disable media menuitem on noneditable content', async () => {
-    const editor = hook.editor();
-    editor.getBody().contentEditable = 'false';
-    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Media..."][aria-disabled="true"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Media..."][aria-disabled="false"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    editor.getBody().contentEditable = 'true';
+    await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Media..."][aria-disabled="true"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Media..."][aria-disabled="false"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+    });
   });
 });
 

--- a/modules/tinymce/src/plugins/nonbreaking/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/main/ts/ui/Buttons.ts
@@ -1,4 +1,18 @@
 import Editor from 'tinymce/core/api/Editor';
+import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
+
+const onSetupEditable = (editor: Editor) => (api: Toolbar.ToolbarButtonInstanceApi | Menu.MenuItemInstanceApi): VoidFunction => {
+  const nodeChanged = () => {
+    api.setEnabled(editor.selection.isEditable());
+  };
+
+  editor.on('NodeChange', nodeChanged);
+  nodeChanged();
+
+  return () => {
+    editor.off('NodeChange', nodeChanged);
+  };
+};
 
 const register = (editor: Editor): void => {
   const onAction = () => editor.execCommand('mceNonBreaking');
@@ -6,13 +20,15 @@ const register = (editor: Editor): void => {
   editor.ui.registry.addButton('nonbreaking', {
     icon: 'non-breaking',
     tooltip: 'Nonbreaking space',
-    onAction
+    onAction,
+    onSetup: onSetupEditable(editor)
   });
 
   editor.ui.registry.addMenuItem('nonbreaking', {
     icon: 'non-breaking',
     text: 'Nonbreaking space',
-    onAction
+    onAction,
+    onSetup: onSetupEditable(editor)
   });
 };
 

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NoneditableRootTest.ts
@@ -1,0 +1,47 @@
+import { Keys, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/nonbreaking/Plugin';
+
+describe('browser.tinymce.plugins.nonbreaking.NoneditableRootTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'nonbreaking',
+    toolbar: 'nonbreaking',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
+    editor.getBody().contentEditable = 'false';
+    f(editor);
+    editor.getBody().contentEditable = 'true';
+  };
+
+  it('TINY-9669: Disable nonbreaking on noneditable content', () => {
+    withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Nonbreaking space"][aria-disabled="true"]');
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Nonbreaking space"][aria-disabled="false"]');
+    });
+  });
+
+  it('TINY-9669: Disable nonbreaking menuitem on noneditable content', async () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Nonbreaking space"][aria-disabled="true"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Nonbreaking space"][aria-disabled="false"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    editor.getBody().contentEditable = 'true';
+  });
+});
+

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NoneditableRootTest.ts
@@ -1,7 +1,7 @@
 import { Keys, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/nonbreaking/Plugin';
@@ -13,14 +13,8 @@ describe('browser.tinymce.plugins.nonbreaking.NoneditableRootTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
 
-  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
-    editor.getBody().contentEditable = 'false';
-    f(editor);
-    editor.getBody().contentEditable = 'true';
-  };
-
   it('TINY-9669: Disable nonbreaking on noneditable content', () => {
-    withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       UiFinder.exists(SugarBody.body(), '[aria-label="Nonbreaking space"][aria-disabled="true"]');
@@ -30,18 +24,17 @@ describe('browser.tinymce.plugins.nonbreaking.NoneditableRootTest', () => {
   });
 
   it('TINY-9669: Disable nonbreaking menuitem on noneditable content', async () => {
-    const editor = hook.editor();
-    editor.getBody().contentEditable = 'false';
-    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Nonbreaking space"][aria-disabled="true"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Nonbreaking space"][aria-disabled="false"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    editor.getBody().contentEditable = 'true';
+    await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Nonbreaking space"][aria-disabled="true"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Nonbreaking space"][aria-disabled="false"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+    });
   });
 });
 

--- a/modules/tinymce/src/plugins/pagebreak/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/pagebreak/main/ts/ui/Buttons.ts
@@ -1,4 +1,18 @@
 import Editor from 'tinymce/core/api/Editor';
+import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
+
+const onSetupEditable = (editor: Editor) => (api: Toolbar.ToolbarButtonInstanceApi | Menu.MenuItemInstanceApi): VoidFunction => {
+  const nodeChanged = () => {
+    api.setEnabled(editor.selection.isEditable());
+  };
+
+  editor.on('NodeChange', nodeChanged);
+  nodeChanged();
+
+  return () => {
+    editor.off('NodeChange', nodeChanged);
+  };
+};
 
 const register = (editor: Editor): void => {
   const onAction = () => editor.execCommand('mcePageBreak');
@@ -6,13 +20,15 @@ const register = (editor: Editor): void => {
   editor.ui.registry.addButton('pagebreak', {
     icon: 'page-break',
     tooltip: 'Page break',
-    onAction
+    onAction,
+    onSetup: onSetupEditable(editor)
   });
 
   editor.ui.registry.addMenuItem('pagebreak', {
     text: 'Page break',
     icon: 'page-break',
-    onAction
+    onAction,
+    onSetup: onSetupEditable(editor)
   });
 };
 

--- a/modules/tinymce/src/plugins/pagebreak/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/pagebreak/test/ts/browser/NoneditableRootTest.ts
@@ -1,7 +1,7 @@
 import { Keys, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyUiActions, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/pagebreak/Plugin';
@@ -13,14 +13,8 @@ describe('browser.tinymce.plugins.pagebreak.NoneditableRootTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
 
-  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
-    editor.getBody().contentEditable = 'false';
-    f(editor);
-    editor.getBody().contentEditable = 'true';
-  };
-
   it('TINY-9669: Disable pagebreak button on noneditable content', () => {
-    withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       UiFinder.exists(SugarBody.body(), '[aria-label="Page break"][aria-disabled="true"]');
@@ -30,18 +24,17 @@ describe('browser.tinymce.plugins.pagebreak.NoneditableRootTest', () => {
   });
 
   it('TINY-9669: Disable pagebreak menuitem on noneditable content', async () => {
-    const editor = hook.editor();
-    editor.getBody().contentEditable = 'false';
-    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Page break"][aria-disabled="true"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Page break"][aria-disabled="false"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    editor.getBody().contentEditable = 'true';
+    await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Page break"][aria-disabled="true"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Page break"][aria-disabled="false"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+    });
   });
 });
 

--- a/modules/tinymce/src/plugins/pagebreak/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/pagebreak/test/ts/browser/NoneditableRootTest.ts
@@ -1,0 +1,47 @@
+import { Keys, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/pagebreak/Plugin';
+
+describe('browser.tinymce.plugins.pagebreak.NoneditableRootTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'pagebreak',
+    toolbar: 'pagebreak',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
+    editor.getBody().contentEditable = 'false';
+    f(editor);
+    editor.getBody().contentEditable = 'true';
+  };
+
+  it('TINY-9669: Disable pagebreak button on noneditable content', () => {
+    withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Page break"][aria-disabled="true"]');
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Page break"][aria-disabled="false"]');
+    });
+  });
+
+  it('TINY-9669: Disable pagebreak menuitem on noneditable content', async () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Page break"][aria-disabled="true"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Page break"][aria-disabled="false"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    editor.getBody().contentEditable = 'true';
+  });
+});
+

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/ContentEditableTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/ContentEditableTest.ts
@@ -1,6 +1,6 @@
 import { Mouse, UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/quickbars/Plugin';
@@ -85,39 +85,35 @@ describe('browser.tinymce.plugins.quickbars.ContentEditableTest', () => {
 
   context('Noneditable root', () => {
     it('TINY-9460: Text selection toolbar is not shown on text in noneditable root', async () => {
-      const editor = hook.editor();
-      editor.getBody().contentEditable = 'false';
-      editor.setContent('<p>abc</p>');
-      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
-      await pAssertToolbarNotVisible();
-      editor.getBody().contentEditable = 'true';
+      await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+        editor.setContent('<p>abc</p>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
+        await pAssertToolbarNotVisible();
+      });
     });
 
     it('TINY-9460: Text selection toolbar is shown on editable text in noneditable root', async () => {
-      const editor = hook.editor();
-      editor.getBody().contentEditable = 'false';
-      editor.setContent('<p contenteditable="true">abc</p>');
-      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
-      await pAssertToolbarVisible();
-      editor.getBody().contentEditable = 'true';
+      await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+        editor.setContent('<p contenteditable="true">abc</p>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
+        await pAssertToolbarVisible();
+      });
     });
 
     it('TINY-9460: Image selection toolbar is not shown images in noneditable root', async () => {
-      const editor = hook.editor();
-      editor.getBody().contentEditable = 'false';
-      editor.setContent('<p><img src="about:blank"></p>');
-      TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
-      await pAssertToolbarNotVisible();
-      editor.getBody().contentEditable = 'true';
+      await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+        editor.setContent('<p><img src="about:blank"></p>');
+        TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+        await pAssertToolbarNotVisible();
+      });
     });
 
     it('TINY-9460: Image selection toolbar is shown editable images in noneditable root', async () => {
-      const editor = hook.editor();
-      editor.getBody().contentEditable = 'false';
-      editor.setContent('<p contenteditable="true"><img src="about:blank"></p>');
-      TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
-      await pAssertToolbarVisible();
-      editor.getBody().contentEditable = 'true';
+      await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+        editor.setContent('<p contenteditable="true"><img src="about:blank"></p>');
+        TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+        await pAssertToolbarVisible();
+      });
     });
   });
 });

--- a/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
@@ -138,7 +138,7 @@ export const getSelectionTargets = (editor: Editor): SelectionTargets => {
         api.setEnabled(false);
         api.setActive(false);
       }, (targets) => {
-        api.setEnabled(!isDisabled(targets));
+        api.setEnabled(!isDisabled(targets) && editor.selection.isEditable());
         api.setActive(isActive(targets));
       })
     );

--- a/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/selection/SelectionTargets.ts
@@ -128,7 +128,7 @@ export const getSelectionTargets = (editor: Editor): SelectionTargets => {
       targets.get().fold(() => {
         api.setEnabled(false);
       }, (targets) => {
-        api.setEnabled(!isDisabled(targets));
+        api.setEnabled(!isDisabled(targets) && editor.selection.isEditable());
       })
     );
 

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Buttons.ts
@@ -17,10 +17,24 @@ interface AddButtonSpec<T> {
   readonly onAction?: (api: T) => void;
 }
 
+const onSetupEditable = (editor: Editor) => (api: Toolbar.ToolbarButtonInstanceApi): VoidFunction => {
+  const nodeChanged = () => {
+    api.setEnabled(editor.selection.isEditable());
+  };
+
+  editor.on('NodeChange', nodeChanged);
+  nodeChanged();
+
+  return () => {
+    editor.off('NodeChange', nodeChanged);
+  };
+};
+
 const addButtons = (editor: Editor, selectionTargets: SelectionTargets): void => {
   editor.ui.registry.addMenuButton('table', {
     tooltip: 'Table',
     icon: 'table',
+    onSetup: onSetupEditable(editor),
     fetch: (callback) => callback('inserttable | cell row column | advtablesort | tableprops deletetable')
   });
 

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Buttons.ts
@@ -203,7 +203,8 @@ const addButtons = (editor: Editor, selectionTargets: SelectionTargets): void =>
   addButtonIfRegistered('tableinsertdialog', {
     tooltip: 'Insert table',
     command: 'mceInsertTableDialog',
-    icon: 'table'
+    icon: 'table',
+    onSetup: onSetupEditable(editor)
   });
 
   const tableClassList = filterNoneItem(Options.getTableClassList(editor));

--- a/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
@@ -18,6 +18,19 @@ interface AddMenuSpec<T> {
   readonly onAction?: (api: T) => void;
 }
 
+const onSetupEditable = (editor: Editor) => (api: Menu.MenuItemInstanceApi): VoidFunction => {
+  const nodeChanged = () => {
+    api.setEnabled(editor.selection.isEditable());
+  };
+
+  editor.on('NodeChange', nodeChanged);
+  nodeChanged();
+
+  return () => {
+    editor.off('NodeChange', nodeChanged);
+  };
+};
+
 const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets): void => {
   const cmd = (command: string) => () => editor.execCommand(command);
 
@@ -174,13 +187,15 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets): void 
     editor.ui.registry.addMenuItem('inserttable', {
       text: 'Table',
       icon: 'table',
-      onAction: cmd('mceInsertTableDialog')
+      onAction: cmd('mceInsertTableDialog'),
+      onSetup: onSetupEditable(editor)
     });
   } else {
     editor.ui.registry.addNestedMenuItem('inserttable', {
       text: 'Table',
       icon: 'table',
-      getSubmenuItems: () => [{ type: 'fancymenuitem', fancytype: 'inserttable', onAction: insertTableAction }]
+      getSubmenuItems: () => [{ type: 'fancymenuitem', fancytype: 'inserttable', onAction: insertTableAction }],
+      onSetup: onSetupEditable(editor)
     });
   }
 
@@ -190,7 +205,8 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets): void 
   editor.ui.registry.addMenuItem('inserttabledialog', {
     text: 'Insert table',
     icon: 'table',
-    onAction: cmd('mceInsertTableDialog')
+    onAction: cmd('mceInsertTableDialog'),
+    onSetup: onSetupEditable(editor)
   });
 
   addMenuIfRegistered('tableprops', {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
@@ -1,7 +1,7 @@
 import { Clipboard } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
-import { Insert, SugarElement, SugarNode, TextContent, Traverse } from '@ephox/sugar';
+import { SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 import { LegacyUnit, TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -9,6 +9,8 @@ import Editor from 'tinymce/core/api/Editor';
 import { TableEventData } from 'tinymce/core/api/EventTypes';
 import * as FakeClipboard from 'tinymce/plugins/table/api/Clipboard';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
+
+import * as TableTestUtils from '../module/test/TableTestUtils';
 
 describe('browser.tinymce.plugins.table.ClipboardTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -40,17 +42,6 @@ describe('browser.tinymce.plugins.table.ClipboardTest', () => {
     editor.dispatch('mouseup', { target: endElm, button: 0 } as unknown as MouseEvent);
 
     LegacyUnit.setSelection(editor, endElm, 0);
-  };
-
-  const createRow = (cellContents: string[]): SugarElement<HTMLTableRowElement> => {
-    const tr = SugarElement.fromTag('tr');
-    Arr.each(cellContents, (content) => {
-      const td = SugarElement.fromTag('td');
-      TextContent.set(td, content);
-      Insert.append(tr, td);
-    });
-
-    return tr;
   };
 
   it('TBA: selection.getContent with format equal to text', () => {
@@ -417,8 +408,8 @@ describe('browser.tinymce.plugins.table.ClipboardTest', () => {
     assert.isTrue(SugarNode.isTag('tr')(clipboardRows[0]));
 
     FakeClipboard.setRows(Optional.some(clipboardRows.concat([
-      createRow([ 'a', 'b' ]),
-      createRow([ 'c', 'd' ])
+      TableTestUtils.createRow([ 'a', 'b' ]),
+      TableTestUtils.createRow([ 'c', 'd' ])
     ])));
 
     LegacyUnit.setSelection(editor, 'tr:nth-child(2) td', 0);
@@ -542,8 +533,8 @@ describe('browser.tinymce.plugins.table.ClipboardTest', () => {
     assert.isTrue(SugarNode.isTag('td')(cells[0]));
 
     FakeClipboard.setColumns(Optional.some([
-      createRow([ 'a', 'b' ]),
-      createRow([ 'c', 'd' ])
+      TableTestUtils.createRow([ 'a', 'b' ]),
+      TableTestUtils.createRow([ 'c', 'd' ])
     ]));
 
     LegacyUnit.setSelection(editor, 'tr td:nth-child(2)', 0);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/NoneditableRootTest.ts
@@ -26,9 +26,9 @@ describe('browser.tinymce.plugins.table.NoneditableRootTest', () => {
     withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), '[aria-label="Table"][disabled="disabled"]');
+      UiFinder.exists(SugarBody.body(), '[aria-label="Table"]:disabled');
       TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), '[aria-label="Table"]:not([disabled="disabled"])');
+      UiFinder.exists(SugarBody.body(), '[aria-label="Table"]:not(:disabled)');
     });
   });
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/NoneditableRootTest.ts
@@ -1,17 +1,71 @@
 import { Keys, UiFinder } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Obj, Optional } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
+import * as FakeClipboard from 'tinymce/plugins/table/api/Clipboard';
 import Plugin from 'tinymce/plugins/table/Plugin';
 
+import * as TableTestUtils from '../module/test/TableTestUtils';
+
 describe('browser.tinymce.plugins.table.NoneditableRootTest', () => {
+  const simpleTableContols = {
+    tableprops: 'Table properties',
+    tablecellprops: 'Cell properties',
+    tableinsertrowbefore: 'Insert row before',
+    tableinsertrowafter: 'Insert row after',
+    tabledeleterow: 'Delete row',
+    tablerowprops: 'Row properties',
+    tablecutrow: 'Cut row',
+    tablecopyrow: 'Copy row',
+  };
+  const specialTableButtons = {
+    table: 'Table',
+    tablemergecells: 'Merge cells',
+    tablesplitcells: 'Split cell',
+    tablepasterowbefore: 'Paste row before',
+    tablepasterowafter: 'Paste row after',
+    tablepastecolbefore: 'Paste column before',
+    tablepastecolafter: 'Paste column after',
+  };
+  const simpleTableButtons = {
+    ...simpleTableContols,
+    tabledelete: 'Delete table',
+    tabledeletecol: 'Delete column',
+    tablecutcol: 'Cut column',
+    tablecopycol: 'Copy column',
+    tableinsertcolbefore: 'Insert column before',
+    tableinsertcolafter: 'Insert column after',
+    tableinsertdialog: 'Insert table'
+  };
+  const simpleTableMenuItems = {
+    ...simpleTableContols,
+    deletetable: 'Delete table',
+    tabledeletecolumn: 'Delete column',
+    tablecutcolumn: 'Cut column',
+    tablecopycolumn: 'Copy column',
+    tableinsertcolumnbefore: 'Insert column before',
+    tableinsertcolumnafter: 'Insert column after',
+    inserttabledialog: 'Insert table'
+  };
+  const specialTableMenuItems = {
+    inserttable: 'Table',
+    tablemergecells: 'Merge cells',
+    tablesplitcells: 'Split cell',
+    tablepasterowbefore: 'Paste row before',
+    tablepasterowafter: 'Paste row after',
+    tablepastecolumnbefore: 'Paste column before',
+    tablepastecolumnafter: 'Paste column after',
+  };
+  const tableButtons = { ...simpleTableButtons, ...specialTableButtons };
+  const tableMenuItems = { ...simpleTableMenuItems, ...specialTableMenuItems };
   const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'table',
-    toolbar: 'table',
+    toolbar: Obj.keys(tableButtons).join(' '),
     menu: {
-      insert: { title: 'Insert', items: 'inserttable inserttabledialog' }
+      table: { title: 'Table', items: Obj.keys(tableMenuItems).join(' ') }
     },
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
@@ -22,44 +76,125 @@ describe('browser.tinymce.plugins.table.NoneditableRootTest', () => {
     editor.getBody().contentEditable = 'true';
   };
 
-  it('TINY-9669: Disable table button on noneditable content', () => {
-    withNoneditableRootEditor(hook.editor(), (editor) => {
-      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), '[aria-label="Table"]:disabled');
-      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), '[aria-label="Table"]:not(:disabled)');
+  context('Noneditable root buttons', () => {
+    const testDisableButtonOnNoneditable = (title: string) => () => {
+      const editor = hook.editor();
+      editor.getBody().contentEditable = 'false';
+      editor.setContent(
+        '<div><table><tbody><tr><td>Noneditable content</td></tr></tbody></table></div>' +
+        '<div contenteditable="true"><table><tbody><tr><td>Editable content</td></tr></tbody></table></div>'
+      );
+      TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="true"]`);
+      TinySelections.setSelection(editor, [ 1, 0, 0, 0, 0, 0 ], 0, [ 1, 0, 0, 0, 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="false"]`);
+      editor.getBody().contentEditable = 'true';
+    };
+
+    const testDisableColPasteButtonOnNoneditable = (title: string) => {
+      return () => {
+        FakeClipboard.setColumns(Optional.some([ TableTestUtils.createRow([ 'a' ]) ]));
+        testDisableButtonOnNoneditable(title)();
+      };
+    };
+
+    const testDisableRowPasteButtonOnNoneditable = (title: string) => {
+      return () => {
+        FakeClipboard.setRows(Optional.some([ TableTestUtils.createRow([ 'a' ]) ]));
+        testDisableButtonOnNoneditable(title)();
+      };
+    };
+
+    Obj.each(simpleTableButtons, (title, key) => {
+      it(`TINY-9669: Disable ${key} on noneditable content`, testDisableButtonOnNoneditable(title));
+    });
+
+    it('TINY-9669: Disable table button on noneditable content', () => {
+      withNoneditableRootEditor(hook.editor(), (editor) => {
+        editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), '[aria-label="Table"]:disabled');
+        TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), '[aria-label="Table"]:not(:disabled)');
+      });
+    });
+
+    it(`TINY-9669: Disable tablepastecolbefore on noneditable content`, testDisableColPasteButtonOnNoneditable('Paste column before'));
+    it(`TINY-9669: Disable tablepastecolafter on noneditable content`, testDisableColPasteButtonOnNoneditable('Paste column after'));
+    it(`TINY-9669: Disable tablepasterowbefore on noneditable content`, testDisableRowPasteButtonOnNoneditable('Paste row before'));
+    it(`TINY-9669: Disable tablepasterowafter on noneditable content`, testDisableRowPasteButtonOnNoneditable('Paste row after'));
+
+    it('TINY-9669: Disable tablesplitcells on noneditable content', () => {
+      const editor = hook.editor();
+      const title = 'Split cell';
+      editor.getBody().contentEditable = 'false';
+      const table = '<table><tbody><tr><td colspan="2">A</td></tr><tr><td>A</td><td>B</td></tr></tbody></table></div>';
+      editor.setContent(`<div>${table}</div><div contenteditable="true">${table}</div>`);
+      TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 1);
+      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="true"]`);
+      TinySelections.setSelection(editor, [ 1, 0, 0, 0, 0, 0 ], 0, [ 1, 0, 0, 0, 0, 0 ], 1);
+      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="false"]`);
+      editor.getBody().contentEditable = 'true';
     });
   });
 
-  it('TINY-9669: Disable inserttable menuitem on noneditable content', async () => {
-    const editor = hook.editor();
-    editor.getBody().contentEditable = 'false';
-    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Table"][aria-disabled="true"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Table"][aria-disabled="false"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    editor.getBody().contentEditable = 'true';
-  });
+  context('Noneditable root menuitems', () => {
+    const testDisableMenuitemOnNoneditable = (menuitem: string) => async () => {
+      const editor = hook.editor();
+      editor.getBody().contentEditable = 'false';
+      editor.setContent(
+        '<div><table><tbody><tr><td>Noneditable content</td></tr></tbody></table></div>' +
+        '<div contenteditable="true"><table><tbody><tr><td>Editable content</td></tr></tbody></table></div>'
+      );
+      TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Table")');
+      await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="true"]`);
+      TinyUiActions.keystroke(editor, Keys.escape());
+      TinySelections.setSelection(editor, [ 1, 0, 0, 0, 0, 0 ], 0, [ 1, 0, 0, 0, 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Table")');
+      await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="false"]`);
+      TinyUiActions.keystroke(editor, Keys.escape());
+      editor.getBody().contentEditable = 'true';
+    };
 
-  it('TINY-9669: Disable inserttabledialog menuitem on noneditable content', async () => {
-    const editor = hook.editor();
-    editor.getBody().contentEditable = 'false';
-    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Insert table"][aria-disabled="true"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Insert table"][aria-disabled="false"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    editor.getBody().contentEditable = 'true';
+    const testDisableColPasteMenuItemOnNoneditable = (title: string) => {
+      return () => {
+        FakeClipboard.setColumns(Optional.some([ TableTestUtils.createRow([ 'a' ]) ]));
+        testDisableMenuitemOnNoneditable(title)();
+      };
+    };
+
+    const testDisableRowPasteMenuItemOnNoneditable = (title: string) => {
+      return () => {
+        FakeClipboard.setRows(Optional.some([ TableTestUtils.createRow([ 'a' ]) ]));
+        testDisableMenuitemOnNoneditable(title)();
+      };
+    };
+
+    Obj.each(simpleTableMenuItems, (title, key) => {
+      it(`TINY-9669: Disable ${key} on noneditable content`, testDisableMenuitemOnNoneditable(title));
+    });
+
+    it(`TINY-9669: Disable tablepastecolumnbefore on noneditable content`, testDisableColPasteMenuItemOnNoneditable('Paste column before'));
+    it(`TINY-9669: Disable tablepastecolumnafter on noneditable content`, testDisableColPasteMenuItemOnNoneditable('Paste column after'));
+    it(`TINY-9669: Disable tablepasterowbefore on noneditable content`, testDisableRowPasteMenuItemOnNoneditable('Paste row before'));
+    it(`TINY-9669: Disable tablepasterowafter on noneditable content`, testDisableRowPasteMenuItemOnNoneditable('Paste row after'));
+
+    it('TINY-9669: Disable tablesplitcells on noneditable content', async () => {
+      const editor = hook.editor();
+      editor.getBody().contentEditable = 'false';
+      const table = '<table><tbody><tr><td colspan="2">A</td></tr><tr><td>A</td><td>B</td></tr></tbody></table></div>';
+      editor.setContent(`<div>${table}</div><div contenteditable="true">${table}</div>`);
+      TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 1);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Table")');
+      await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="Split cell"][aria-disabled="true"]`);
+      TinyUiActions.keystroke(editor, Keys.escape());
+      TinySelections.setSelection(editor, [ 1, 0, 0, 0, 0, 0 ], 0, [ 1, 0, 0, 0, 0, 0 ], 1);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Table")');
+      await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="Split cell"][aria-disabled="false"]`);
+      TinyUiActions.keystroke(editor, Keys.escape());
+      editor.getBody().contentEditable = 'true';
+    });
   });
 });
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/NoneditableRootTest.ts
@@ -1,0 +1,65 @@
+import { Keys, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/table/Plugin';
+
+describe('browser.tinymce.plugins.table.NoneditableRootTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'table',
+    toolbar: 'table',
+    menu: {
+      insert: { title: 'Insert', items: 'inserttable inserttabledialog' }
+    },
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
+    editor.getBody().contentEditable = 'false';
+    f(editor);
+    editor.getBody().contentEditable = 'true';
+  };
+
+  it('TINY-9669: Disable table button on noneditable content', () => {
+    withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Table"][disabled="disabled"]');
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Table"]:not([disabled="disabled"])');
+    });
+  });
+
+  it('TINY-9669: Disable inserttable menuitem on noneditable content', async () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Table"][aria-disabled="true"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Table"][aria-disabled="false"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    editor.getBody().contentEditable = 'true';
+  });
+
+  it('TINY-9669: Disable inserttabledialog menuitem on noneditable content', async () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Insert table"][aria-disabled="true"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Insert table"][aria-disabled="false"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    editor.getBody().contentEditable = 'true';
+  });
+});
+

--- a/modules/tinymce/src/plugins/table/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/NoneditableRootTest.ts
@@ -20,9 +20,19 @@ describe('browser.tinymce.plugins.table.NoneditableRootTest', () => {
     tablerowprops: 'Row properties',
     tablecutrow: 'Cut row',
     tablecopyrow: 'Copy row',
+    tablecaption: 'Table caption',
+    tablerowheader: 'Row header',
+    tablecolheader: 'Column header'
+  };
+  const menuButtonTableButtons = {
+    table: 'Table',
+    tablecellvalign: 'Vertical align',
+    tablecellborderwidth: 'Border width',
+    tablecellborderstyle: 'Border style',
+    tablecellbackgroundcolor: 'Background color',
+    tablecellbordercolor: 'Border color'
   };
   const specialTableButtons = {
-    table: 'Table',
     tablemergecells: 'Merge cells',
     tablesplitcells: 'Split cell',
     tablepasterowbefore: 'Paste row before',
@@ -48,7 +58,12 @@ describe('browser.tinymce.plugins.table.NoneditableRootTest', () => {
     tablecopycolumn: 'Copy column',
     tableinsertcolumnbefore: 'Insert column before',
     tableinsertcolumnafter: 'Insert column after',
-    inserttabledialog: 'Insert table'
+    inserttabledialog: 'Insert table',
+    tablecellvalign: 'Vertical align',
+    tablecellborderwidth: 'Border width',
+    tablecellborderstyle: 'Border style',
+    tablecellbackgroundcolor: 'Background color',
+    tablecellbordercolor: 'Border color'
   };
   const specialTableMenuItems = {
     inserttable: 'Table',
@@ -57,9 +72,9 @@ describe('browser.tinymce.plugins.table.NoneditableRootTest', () => {
     tablepasterowbefore: 'Paste row before',
     tablepasterowafter: 'Paste row after',
     tablepastecolumnbefore: 'Paste column before',
-    tablepastecolumnafter: 'Paste column after',
+    tablepastecolumnafter: 'Paste column after'
   };
-  const tableButtons = { ...simpleTableButtons, ...specialTableButtons };
+  const tableButtons = { ...simpleTableButtons, ...menuButtonTableButtons, ...specialTableButtons };
   const tableMenuItems = { ...simpleTableMenuItems, ...specialTableMenuItems };
   const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'table',
@@ -70,24 +85,20 @@ describe('browser.tinymce.plugins.table.NoneditableRootTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
 
-  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
-    editor.getBody().contentEditable = 'false';
-    f(editor);
-    editor.getBody().contentEditable = 'true';
-  };
-
   context('Noneditable root buttons', () => {
-    const testDisableButtonOnNoneditable = (title: string) => () => {
+    const testDisableButtonOnNoneditable = (title: string, ariaDisabled = true) => () => {
       const editor = hook.editor();
+      const disabledSelector = ariaDisabled ? '[aria-disabled="true"]' : ':disabled';
+      const enabledSelector = ariaDisabled ? '[aria-disabled="false"]' : ':not(:disabled)';
       editor.getBody().contentEditable = 'false';
       editor.setContent(
         '<div><table><tbody><tr><td>Noneditable content</td></tr></tbody></table></div>' +
         '<div contenteditable="true"><table><tbody><tr><td>Editable content</td></tr></tbody></table></div>'
       );
       TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="true"]`);
+      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"]${disabledSelector}`);
       TinySelections.setSelection(editor, [ 1, 0, 0, 0, 0, 0 ], 0, [ 1, 0, 0, 0, 0, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="false"]`);
+      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"]${enabledSelector}`);
       editor.getBody().contentEditable = 'true';
     };
 
@@ -109,14 +120,8 @@ describe('browser.tinymce.plugins.table.NoneditableRootTest', () => {
       it(`TINY-9669: Disable ${key} on noneditable content`, testDisableButtonOnNoneditable(title));
     });
 
-    it('TINY-9669: Disable table button on noneditable content', () => {
-      withNoneditableRootEditor(hook.editor(), (editor) => {
-        editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-        UiFinder.exists(SugarBody.body(), '[aria-label="Table"]:disabled');
-        TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-        UiFinder.exists(SugarBody.body(), '[aria-label="Table"]:not(:disabled)');
-      });
+    Obj.each(menuButtonTableButtons, (title, key) => {
+      it(`TINY-9669: Disable ${key} button on noneditable content`, () => testDisableButtonOnNoneditable(title, false));
     });
 
     it(`TINY-9669: Disable tablepastecolbefore on noneditable content`, testDisableColPasteButtonOnNoneditable('Paste column before'));
@@ -158,16 +163,16 @@ describe('browser.tinymce.plugins.table.NoneditableRootTest', () => {
     };
 
     const testDisableColPasteMenuItemOnNoneditable = (title: string) => {
-      return () => {
+      return async () => {
         FakeClipboard.setColumns(Optional.some([ TableTestUtils.createRow([ 'a' ]) ]));
-        testDisableMenuitemOnNoneditable(title)();
+        await testDisableMenuitemOnNoneditable(title)();
       };
     };
 
     const testDisableRowPasteMenuItemOnNoneditable = (title: string) => {
-      return () => {
+      return async () => {
         FakeClipboard.setRows(Optional.some([ TableTestUtils.createRow([ 'a' ]) ]));
-        testDisableMenuitemOnNoneditable(title)();
+        await testDisableMenuitemOnNoneditable(title)();
       };
     };
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/ContextToolbarTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/ContextToolbarTest.ts
@@ -2,7 +2,7 @@ import { Assertions, FocusTools, Keys, Mouse, UiFinder, Waiter } from '@ephox/ag
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { Html, Remove, Replication, SelectorFilter, SugarBody, SugarDocument } from '@ephox/sugar';
-import { TinyContentActions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyContentActions, TinyDom, TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
@@ -136,7 +136,6 @@ describe('browser.tinymce.plugins.table.ContextToolbarTest', () => {
 
   it('TINY-9664: toolbars should not render if table is in a noneditable host', async () => {
     const editor = hook.editor();
-
     const setupTableSelection = () => {
       editor.setContent('<table><tbody><tr><td>x</td></tr></tbody></table>');
       TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 1);
@@ -146,9 +145,9 @@ describe('browser.tinymce.plugins.table.ContextToolbarTest', () => {
     setupTableSelection();
     await TinyUiActions.pWaitForUi(editor, toolbarSelector);
 
-    editor.getBody().contentEditable = 'false';
-    setupTableSelection();
-    await Waiter.pTryUntil('Wait for the toolbar to disappear', () => UiFinder.notExists(SugarBody.body(), toolbarSelector));
-    editor.getBody().contentEditable = 'true';
+    await TinyState.withNoneditableRootEditorAsync(hook.editor(), async () => {
+      setupTableSelection();
+      await Waiter.pTryUntil('Wait for the toolbar to disappear', () => UiFinder.notExists(SugarBody.body(), toolbarSelector));
+    });
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCaptionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCaptionTest.ts
@@ -1,5 +1,5 @@
 import { afterEach, context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -8,7 +8,6 @@ import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import Plugin from 'tinymce/plugins/table/Plugin';
 
 import { assertStructureIsRestoredToDefault, clickOnButton, pClickOnMenuItem, setEditorContentTableAndSelection } from '../../module/test/TableModifiersTestUtils';
-import * as TableTestUtils from '../../module/test/TableTestUtils';
 
 describe('browser.tinymce.plugins.table.ui.TableCaptionTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -188,14 +187,12 @@ describe('browser.tinymce.plugins.table.ui.TableCaptionTest', () => {
     });
 
     it('TINY-9459: Should not apply mceToggleCaption command on table inside a noneditable root', () => {
-      TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
         const initalContent = '<table><tbody><tr><td>cell</td></tr></tbody></table>';
-        editor.getBody().contentEditable = 'false';
         editor.setContent(initalContent);
         TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
         editor.execCommand('mceTableToggleCaption');
         TinyAssertions.assertContent(editor, initalContent);
-        editor.getBody().contentEditable = 'true';
       });
     });
   });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { SugarBody, SugarElement, SugarNode } from '@ephox/sugar';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -536,7 +536,7 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
   });
 
   it('TINY-9459: Should not open table row properties dialog on noneditable root', () => {
-    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<table><tbody><tr><td>x</td></tr></tbody></table>');
       TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
       editor.execCommand('mceTableCellProps');

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
@@ -425,7 +425,7 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
   });
 
   it('TINY-9459: Should not open table properties dialog on noneditable root', () => {
-    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<table><tbody><tr><td>x</td></tr></tbody></table>');
       TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
       editor.execCommand('mceTableProps');
@@ -434,7 +434,7 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
   });
 
   it('TINY-9459: Should not open table insert dialog on noneditable root', () => {
-    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<table><tbody><tr><td>x</td></tr></tbody></table>');
       TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
       editor.execCommand('mceInsertTableDialog');

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
@@ -2,7 +2,7 @@ import { UiFinder } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarBody, SugarElement, SugarNode } from '@ephox/sugar';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -405,7 +405,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
   });
 
   it('TINY-9459: Should not open table row properties dialog on noneditable root', () => {
-    TableTestUtils.withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<table><tbody><tr><td>x</td></tr></tbody></table>');
       TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
       editor.execCommand('mceTableRowProps');

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
@@ -6,8 +6,8 @@
  */
 
 import { ApproxStructure, Assertions, Cursors, Mouse, StructAssert, UiFinder, Waiter } from '@ephox/agar';
-import { Obj } from '@ephox/katamari';
-import { Attribute, Checked, Class, SelectorFind, SugarBody, Value } from '@ephox/sugar';
+import { Arr, Obj } from '@ephox/katamari';
+import { Attribute, Checked, Class, Insert, SelectorFind, SugarBody, SugarElement, TextContent, Value } from '@ephox/sugar';
 import { TinyDom, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -234,6 +234,17 @@ const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void):
   editor.getBody().contentEditable = 'true';
 };
 
+const createRow = (cellContents: string[]): SugarElement<HTMLTableRowElement> => {
+  const tr = SugarElement.fromTag('tr');
+  Arr.each(cellContents, (content) => {
+    const td = SugarElement.fromTag('td');
+    TextContent.set(td, content);
+    Insert.append(tr, td);
+  });
+
+  return tr;
+};
+
 export {
   pAssertDialogPresence,
   pAssertListBoxValue,
@@ -249,5 +260,6 @@ export {
   pClickDialogButton,
   assertElementStructure,
   assertApproxElementStructure,
-  withNoneditableRootEditor
+  withNoneditableRootEditor,
+  createRow
 };

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
@@ -228,12 +228,6 @@ const createTableChildren = (s: ApproxStructure.StructApi, str: ApproxStructure.
   return withColGroups ? [ columns, tbody ] : [ tbody ];
 };
 
-const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void): void => {
-  editor.getBody().contentEditable = 'false';
-  f(editor);
-  editor.getBody().contentEditable = 'true';
-};
-
 const createRow = (cellContents: string[]): SugarElement<HTMLTableRowElement> => {
   const tr = SugarElement.fromTag('tr');
   Arr.each(cellContents, (content) => {
@@ -260,6 +254,5 @@ export {
   pClickDialogButton,
   assertElementStructure,
   assertApproxElementStructure,
-  withNoneditableRootEditor,
   createRow
 };

--- a/modules/tinymce/src/plugins/template/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/ui/Buttons.ts
@@ -1,4 +1,18 @@
 import Editor from 'tinymce/core/api/Editor';
+import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
+
+const onSetupEditable = (editor: Editor) => (api: Toolbar.ToolbarButtonInstanceApi | Menu.MenuItemInstanceApi): VoidFunction => {
+  const nodeChanged = () => {
+    api.setEnabled(editor.selection.isEditable());
+  };
+
+  editor.on('NodeChange', nodeChanged);
+  nodeChanged();
+
+  return () => {
+    editor.off('NodeChange', nodeChanged);
+  };
+};
 
 const register = (editor: Editor): void => {
   const onAction = () => editor.execCommand('mceTemplate');
@@ -6,12 +20,14 @@ const register = (editor: Editor): void => {
   editor.ui.registry.addButton('template', {
     icon: 'template',
     tooltip: 'Insert template',
+    onSetup: onSetupEditable(editor),
     onAction
   });
 
   editor.ui.registry.addMenuItem('template', {
     icon: 'template',
     text: 'Insert template...',
+    onSetup: onSetupEditable(editor),
     onAction
   });
 };

--- a/modules/tinymce/src/plugins/template/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/NoneditableRootTest.ts
@@ -1,7 +1,7 @@
 import { Keys, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/template/Plugin';
@@ -13,14 +13,8 @@ describe('browser.tinymce.plugins.template.NoneditableRootTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
 
-  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
-    editor.getBody().contentEditable = 'false';
-    f(editor);
-    editor.getBody().contentEditable = 'true';
-  };
-
   it('TINY-9669: Disable template button on noneditable content', () => {
-    withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       UiFinder.exists(SugarBody.body(), '[aria-label="Insert template"][aria-disabled="true"]');
@@ -30,18 +24,17 @@ describe('browser.tinymce.plugins.template.NoneditableRootTest', () => {
   });
 
   it('TINY-9669: Disable template menuitem on noneditable content', async () => {
-    const editor = hook.editor();
-    editor.getBody().contentEditable = 'false';
-    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Insert template..."][aria-disabled="true"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Insert template..."][aria-disabled="false"]');
-    TinyUiActions.keystroke(editor, Keys.escape());
-    editor.getBody().contentEditable = 'true';
+    await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Insert template..."][aria-disabled="true"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Insert template..."][aria-disabled="false"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+    });
   });
 });
 

--- a/modules/tinymce/src/plugins/template/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/NoneditableRootTest.ts
@@ -1,0 +1,47 @@
+import { Keys, UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/template/Plugin';
+
+describe('browser.tinymce.plugins.template.NoneditableRootTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'template',
+    toolbar: 'template',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
+    editor.getBody().contentEditable = 'false';
+    f(editor);
+    editor.getBody().contentEditable = 'true';
+  };
+
+  it('TINY-9669: Disable template button on noneditable content', () => {
+    withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Insert template"][aria-disabled="true"]');
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Insert template"][aria-disabled="false"]');
+    });
+  });
+
+  it('TINY-9669: Disable template menuitem on noneditable content', async () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Insert template..."][aria-disabled="true"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+    TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
+    await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Insert template..."][aria-disabled="false"]');
+    TinyUiActions.keystroke(editor, Keys.escape());
+    editor.getBody().contentEditable = 'true';
+  });
+});
+

--- a/modules/tinymce/src/plugins/visualchars/test/ts/browser/PluginTest.ts
+++ b/modules/tinymce/src/plugins/visualchars/test/ts/browser/PluginTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyHooks, TinyUiActions, TinySelections, TinyAssertions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinyUiActions, TinySelections, TinyAssertions, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -90,36 +90,32 @@ describe('browser.tinymce.plugins.visualchars.PluginTest', () => {
   });
 
   it('TINY-9474: should not process noneditable elements in a noneditable root', async () => {
-    const editor = hook.editor();
-
-    editor.getBody().contentEditable = 'false';
-    editor.setContent('<p>abc&nbsp;&nbsp;</p><p contenteditable="true">123&nbsp;&nbsp;</p>');
-    TinyUiActions.clickOnToolbar(editor, 'button');
-    await Waiter.pTryUntil('wait for visual chars to appear', () => {
-      TinyAssertions.assertContentPresence(editor, {
-        'span.mce-nbsp': 2
+    await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+      editor.setContent('<p>abc&nbsp;&nbsp;</p><p contenteditable="true">123&nbsp;&nbsp;</p>');
+      TinyUiActions.clickOnToolbar(editor, 'button');
+      await Waiter.pTryUntil('wait for visual chars to appear', () => {
+        TinyAssertions.assertContentPresence(editor, {
+          'span.mce-nbsp': 2
+        });
       });
+      TinyUiActions.clickOnToolbar(editor, 'button');
     });
-    editor.getBody().contentEditable = 'true';
-    TinyUiActions.clickOnToolbar(editor, 'button');
   });
 
   it('TINY-9685: should add "mce-nbsp" to "mce-nbsp-wrap" elements in editable context', async () => {
-    const editor = hook.editor();
-
-    editor.getBody().contentEditable = 'false';
-    editor.setContent(`
-      <p><span class="mce-nbsp-wrap" contenteditable="false">&nbsp;</span></p>
-      <p contenteditable="true"><span class="mce-nbsp-wrap" contenteditable="false">&nbsp;</span></p>
-    `);
-    TinyUiActions.clickOnToolbar(editor, 'button');
-    await Waiter.pTryUntil('wait for visual chars to appear', () => {
-      TinyAssertions.assertContentPresence(editor, {
-        'span.mce-nbsp': 1,
-        '[contenteditable="true"] span.mce-nbsp': 1
+    await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+      editor.setContent(`
+        <p><span class="mce-nbsp-wrap" contenteditable="false">&nbsp;</span></p>
+        <p contenteditable="true"><span class="mce-nbsp-wrap" contenteditable="false">&nbsp;</span></p>
+      `);
+      TinyUiActions.clickOnToolbar(editor, 'button');
+      await Waiter.pTryUntil('wait for visual chars to appear', () => {
+        TinyAssertions.assertContentPresence(editor, {
+          'span.mce-nbsp': 1,
+          '[contenteditable="true"] span.mce-nbsp': 1
+        });
       });
+      TinyUiActions.clickOnToolbar(editor, 'button');
     });
-    editor.getBody().contentEditable = 'true';
-    TinyUiActions.clickOnToolbar(editor, 'button');
   });
 });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/AlignmentButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/AlignmentButtons.ts
@@ -2,7 +2,7 @@ import { Arr } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 
-import { onActionExecCommand, onSetupFormatToggle } from './ControlUtils';
+import { onActionExecCommand, onSetupStateToggle } from './ControlUtils';
 
 const register = (editor: Editor): void => {
   const alignToolbarButtons = [
@@ -17,7 +17,7 @@ const register = (editor: Editor): void => {
       tooltip: item.text,
       icon: item.icon,
       onAction: onActionExecCommand(editor, item.cmd),
-      onSetup: onSetupFormatToggle(editor, item.name)
+      onSetup: onSetupStateToggle(editor, item.name)
     });
   });
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/AlignmentButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/AlignmentButtons.ts
@@ -2,7 +2,7 @@ import { Arr } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 
-import { onActionExecCommand, onSetupStateToggle } from './ControlUtils';
+import { onActionExecCommand, onSetupEditableToggle, onSetupStateToggle } from './ControlUtils';
 
 const register = (editor: Editor): void => {
   const alignToolbarButtons = [
@@ -24,6 +24,7 @@ const register = (editor: Editor): void => {
   editor.ui.registry.addButton('alignnone', {
     tooltip: 'No alignment',
     icon: 'align-none',
+    onSetup: onSetupEditableToggle(editor),
     onAction: onActionExecCommand(editor, 'JustifyNone')
   });
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/ControlUtils.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/ControlUtils.ts
@@ -1,11 +1,11 @@
 import { Singleton } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
-import { Toolbar } from 'tinymce/core/api/ui/Ui';
+import { Toolbar, Menu } from 'tinymce/core/api/ui/Ui';
 
 import { FormatterFormatItem } from './complex/BespokeSelect';
 
-const onSetupEditableToggle = (editor: Editor) => (api: Toolbar.ToolbarButtonInstanceApi): VoidFunction => {
+const onSetupEditableToggle = (editor: Editor) => (api: Toolbar.ToolbarButtonInstanceApi | Menu.MenuItemInstanceApi): VoidFunction => {
   const boundNodeChange = Singleton.value<() => void>();
 
   const init = () => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/IndentOutdent.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/IndentOutdent.ts
@@ -1,11 +1,11 @@
 import Editor from 'tinymce/core/api/Editor';
 import { Toolbar } from 'tinymce/core/api/ui/Ui';
 
-import { onActionExecCommand, onSetupEvent } from './ControlUtils';
+import { onActionExecCommand, onSetupEditableToggle, onSetupEvent } from './ControlUtils';
 
 const onSetupOutdentState = (editor: Editor) =>
   onSetupEvent(editor, 'NodeChange', (api: Toolbar.ToolbarButtonInstanceApi) => {
-    api.setEnabled(editor.queryCommandState('outdent'));
+    api.setEnabled(editor.queryCommandState('outdent') && editor.selection.isEditable());
   });
 
 const registerButtons = (editor: Editor): void => {
@@ -19,6 +19,7 @@ const registerButtons = (editor: Editor): void => {
   editor.ui.registry.addButton('indent', {
     tooltip: 'Increase indent',
     icon: 'indent',
+    onSetup: onSetupEditableToggle(editor),
     onAction: onActionExecCommand(editor, 'indent')
   });
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/PasteControls.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/PasteControls.ts
@@ -6,6 +6,7 @@ import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import * as Options from '../../api/Options';
+import { composeUnbinders, onSetupEditableToggle } from './ControlUtils';
 
 const makeSetupHandler = (editor: Editor, pasteAsText: Cell<boolean>) => (api: Toolbar.ToolbarToggleButtonInstanceApi | Menu.ToggleMenuItemInstanceApi) => {
   api.setActive(pasteAsText.get());
@@ -14,7 +15,11 @@ const makeSetupHandler = (editor: Editor, pasteAsText: Cell<boolean>) => (api: T
     api.setActive(e.state);
   };
   editor.on('PastePlainTextToggle', pastePlainTextToggleHandler);
-  return () => editor.off('PastePlainTextToggle', pastePlainTextToggleHandler);
+
+  return composeUnbinders(
+    () => editor.off('PastePlainTextToggle', pastePlainTextToggleHandler),
+    onSetupEditableToggle(editor)(api)
+  );
 };
 
 const register = (editor: Editor): void => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/SimpleControls.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/SimpleControls.ts
@@ -1,7 +1,7 @@
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 
-import { onActionExecCommand, onSetupStateToggle } from './ControlUtils';
+import { onActionExecCommand, onSetupEditableToggle, onSetupStateToggle } from './ControlUtils';
 
 const onActionToggleFormat = (editor: Editor, fmt: string) => (): void => {
   editor.execCommand('mceToggleFormat', false, fmt);
@@ -37,21 +37,31 @@ const registerFormatButtons = (editor: Editor): void => {
 
 const registerCommandButtons = (editor: Editor): void => {
   Tools.each([
-    { name: 'cut', text: 'Cut', action: 'Cut', icon: 'cut' },
     { name: 'copy', text: 'Copy', action: 'Copy', icon: 'copy' },
-    { name: 'paste', text: 'Paste', action: 'Paste', icon: 'paste' },
     { name: 'help', text: 'Help', action: 'mceHelp', icon: 'help' },
     { name: 'selectall', text: 'Select all', action: 'SelectAll', icon: 'select-all' },
-    // visualaid was here but also exists in VisualAid.ts?
     { name: 'newdocument', text: 'New document', action: 'mceNewDocument', icon: 'new-document' },
+    { name: 'print', text: 'Print', action: 'mcePrint', icon: 'print' },
+  ], (btn) => {
+    editor.ui.registry.addButton(btn.name, {
+      tooltip: btn.text,
+      icon: btn.icon,
+      onAction: onActionExecCommand(editor, btn.action)
+    });
+  });
+
+  Tools.each([
+    { name: 'cut', text: 'Cut', action: 'Cut', icon: 'cut' },
+    { name: 'paste', text: 'Paste', action: 'Paste', icon: 'paste' },
+    // visualaid was here but also exists in VisualAid.ts?
     { name: 'removeformat', text: 'Clear formatting', action: 'RemoveFormat', icon: 'remove-formatting' },
     { name: 'remove', text: 'Remove', action: 'Delete', icon: 'remove' },
-    { name: 'print', text: 'Print', action: 'mcePrint', icon: 'print' },
     { name: 'hr', text: 'Horizontal line', action: 'InsertHorizontalRule', icon: 'horizontal-rule' }
   ], (btn) => {
     editor.ui.registry.addButton(btn.name, {
       tooltip: btn.text,
       icon: btn.icon,
+      onSetup: onSetupEditableToggle(editor),
       onAction: onActionExecCommand(editor, btn.action)
     });
   });
@@ -78,20 +88,10 @@ const registerButtons = (editor: Editor): void => {
 
 const registerMenuItems = (editor: Editor): void => {
   Tools.each([
-    { name: 'bold', text: 'Bold', action: 'Bold', icon: 'bold', shortcut: 'Meta+B' },
-    { name: 'italic', text: 'Italic', action: 'Italic', icon: 'italic', shortcut: 'Meta+I' },
-    { name: 'underline', text: 'Underline', action: 'Underline', icon: 'underline', shortcut: 'Meta+U' },
-    { name: 'strikethrough', text: 'Strikethrough', action: 'Strikethrough', icon: 'strike-through' },
-    { name: 'subscript', text: 'Subscript', action: 'Subscript', icon: 'subscript' },
-    { name: 'superscript', text: 'Superscript', action: 'Superscript', icon: 'superscript' },
-    { name: 'removeformat', text: 'Clear formatting', action: 'RemoveFormat', icon: 'remove-formatting' },
     { name: 'newdocument', text: 'New document', action: 'mceNewDocument', icon: 'new-document' },
-    { name: 'cut', text: 'Cut', action: 'Cut', icon: 'cut', shortcut: 'Meta+X' },
     { name: 'copy', text: 'Copy', action: 'Copy', icon: 'copy', shortcut: 'Meta+C' },
-    { name: 'paste', text: 'Paste', action: 'Paste', icon: 'paste', shortcut: 'Meta+V' },
     { name: 'selectall', text: 'Select all', action: 'SelectAll', icon: 'select-all', shortcut: 'Meta+A' },
-    { name: 'print', text: 'Print...', action: 'mcePrint', icon: 'print', shortcut: 'Meta+P' },
-    { name: 'hr', text: 'Horizontal line', action: 'InsertHorizontalRule', icon: 'horizontal-rule' }
+    { name: 'print', text: 'Print...', action: 'mcePrint', icon: 'print', shortcut: 'Meta+P' }
   ], (menuitem) => {
     editor.ui.registry.addMenuItem(menuitem.name, {
       text: menuitem.text,
@@ -101,9 +101,31 @@ const registerMenuItems = (editor: Editor): void => {
     });
   });
 
+  Tools.each([
+    { name: 'bold', text: 'Bold', action: 'Bold', icon: 'bold', shortcut: 'Meta+B' },
+    { name: 'italic', text: 'Italic', action: 'Italic', icon: 'italic', shortcut: 'Meta+I' },
+    { name: 'underline', text: 'Underline', action: 'Underline', icon: 'underline', shortcut: 'Meta+U' },
+    { name: 'strikethrough', text: 'Strikethrough', action: 'Strikethrough', icon: 'strike-through' },
+    { name: 'subscript', text: 'Subscript', action: 'Subscript', icon: 'subscript' },
+    { name: 'superscript', text: 'Superscript', action: 'Superscript', icon: 'superscript' },
+    { name: 'removeformat', text: 'Clear formatting', action: 'RemoveFormat', icon: 'remove-formatting' },
+    { name: 'cut', text: 'Cut', action: 'Cut', icon: 'cut', shortcut: 'Meta+X' },
+    { name: 'paste', text: 'Paste', action: 'Paste', icon: 'paste', shortcut: 'Meta+V' },
+    { name: 'hr', text: 'Horizontal line', action: 'InsertHorizontalRule', icon: 'horizontal-rule' }
+  ], (menuitem) => {
+    editor.ui.registry.addMenuItem(menuitem.name, {
+      text: menuitem.text,
+      icon: menuitem.icon,
+      shortcut: menuitem.shortcut,
+      onSetup: onSetupEditableToggle(editor),
+      onAction: onActionExecCommand(editor, menuitem.action)
+    });
+  });
+
   editor.ui.registry.addMenuItem('codeformat', {
     text: 'Code',
     icon: 'sourcecode',
+    onSetup: onSetupEditableToggle(editor),
     onAction: onActionToggleFormat(editor, 'code')
   });
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/SimpleControls.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/SimpleControls.ts
@@ -1,7 +1,7 @@
 import Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 
-import { onActionExecCommand, onSetupFormatToggle } from './ControlUtils';
+import { onActionExecCommand, onSetupStateToggle } from './ControlUtils';
 
 const onActionToggleFormat = (editor: Editor, fmt: string) => (): void => {
   editor.execCommand('mceToggleFormat', false, fmt);
@@ -19,7 +19,7 @@ const registerFormatButtons = (editor: Editor): void => {
     editor.ui.registry.addToggleButton(btn.name, {
       tooltip: btn.text,
       icon: btn.icon,
-      onSetup: onSetupFormatToggle(editor, btn.name),
+      onSetup: onSetupStateToggle(editor, btn.name),
       onAction: onActionToggleFormat(editor, btn.name)
     });
   });
@@ -29,7 +29,7 @@ const registerFormatButtons = (editor: Editor): void => {
     editor.ui.registry.addToggleButton(name, {
       text: name.toUpperCase(),
       tooltip: 'Heading ' + i,
-      onSetup: onSetupFormatToggle(editor, name),
+      onSetup: onSetupStateToggle(editor, name),
       onAction: onActionToggleFormat(editor, name)
     });
   }
@@ -65,7 +65,7 @@ const registerCommandToggleButtons = (editor: Editor): void => {
       tooltip: btn.text,
       icon: btn.icon,
       onAction: onActionExecCommand(editor, btn.action),
-      onSetup: onSetupFormatToggle(editor, btn.name)
+      onSetup: onSetupStateToggle(editor, btn.name)
     });
   });
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -7,6 +7,7 @@ import { Dialog, Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import * as Events from '../../../api/Events';
+import { composeUnbinders, onSetupEditableToggle } from '../ControlUtils';
 import * as ColorCache from './ColorCache';
 import * as Options from './Options';
 
@@ -159,9 +160,12 @@ const registerTextColorButton = (editor: Editor, name: string, format: ColorForm
 
       editor.on('TextColorChange', handler);
 
-      return () => {
-        editor.off('TextColorChange', handler);
-      };
+      return composeUnbinders(
+        onSetupEditableToggle(editor)(splitButtonApi),
+        () => {
+          editor.off('TextColorChange', handler);
+        }
+      );
     }
   });
 };
@@ -172,7 +176,7 @@ const registerTextColorMenuItem = (editor: Editor, name: string, format: ColorFo
     icon: name === 'forecolor' ? 'text-color' : 'highlight-bg-color',
     onSetup: (api) => {
       setIconColor(api, name, lastColor.get());
-      return Fun.noop;
+      return onSetupEditableToggle(editor)(api);
     },
     getSubmenuItems: () => [
       {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
@@ -5,6 +5,7 @@ import Editor from 'tinymce/core/api/Editor';
 import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 
 import { updateMenuIcon } from '../../dropdown/CommonDropdown';
+import { onSetupEditableToggle } from '../ControlUtils';
 import { createMenuItems, createSelectButton, FormatterFormatItem, SelectedFormat, SelectSpec } from './BespokeSelect';
 import { buildBasicStaticDataset } from './SelectDatasets';
 
@@ -58,6 +59,7 @@ const createAlignMenu = (editor: Editor, backstage: UiFactoryBackstage): void =>
   const menuItems = createMenuItems(editor, backstage, getSpec(editor));
   editor.ui.registry.addNestedMenuItem('align', {
     text: backstage.shared.providers.translate('Align'),
+    onSetup: onSetupEditableToggle(editor),
     getSubmenuItems: () => menuItems.items.validateItems(menuItems.getStyleItems())
   });
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -1,5 +1,5 @@
 import { Keys } from '@ephox/agar';
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Button, Disabling, Focusing, FocusInsideModes, Input, Keying, Memento, NativeEvents, Representing, SystemEvents } from '@ephox/alloy';
+import { AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Button, Disabling, Focusing, FocusInsideModes, Input, Keying, Memento, NativeEvents, Representing } from '@ephox/alloy';
 import { Arr, Cell, Fun, Id, Optional } from '@ephox/katamari';
 import { Dimension, Focus, SugarElement, Traverse } from '@ephox/sugar';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -1,5 +1,5 @@
 import { Keys } from '@ephox/agar';
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Button, Focusing, FocusInsideModes, Input, Keying, Memento, NativeEvents, Representing } from '@ephox/alloy';
+import { AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Button, Disabling, Focusing, FocusInsideModes, Input, Keying, Memento, NativeEvents, Representing, SystemEvents } from '@ephox/alloy';
 import { Arr, Cell, Fun, Id, Optional } from '@ephox/katamari';
 import { Dimension, Focus, SugarElement, Traverse } from '@ephox/sugar';
 
@@ -27,6 +27,7 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
     const comp = api.getComponent();
     currentComp = Optional.some(comp);
     spec.updateInputValue(comp);
+    Disabling.set(comp, !editor.selection.isEditable());
   });
 
   const getApi = (comp: AlloyComponent): BespokeSelectApi => ({ getComponent: Fun.constant(comp) });
@@ -81,6 +82,10 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
   const makeStepperButton = (action: (focusBack: boolean) => void, title: string, tooltip: string, classes: string[]) => {
     const translatedTooltip = backstage.shared.providers.translate(tooltip);
     const altExecuting = Id.generate('altExecuting');
+    const onSetup = onSetupEvent(editor, 'NodeChange', (api: BespokeSelectApi) => {
+      Disabling.set(api.getComponent(), !editor.selection.isEditable());
+    });
+
     return Button.sketch({
       dom: {
         tag: 'button',
@@ -94,14 +99,21 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
         renderIconFromPack(title, backstage.shared.providers.icons)
       ],
       buttonBehaviours: Behaviour.derive([
+        Disabling.config({}),
         AddEventsBehaviour.config(altExecuting, [
-          AlloyEvents.run(NativeEvents.keydown(), (_comp, se) => {
+          onControlAttached({ onSetup, getApi }, editorOffCell),
+          onControlDetached({ getApi }, editorOffCell),
+          AlloyEvents.run(NativeEvents.keydown(), (comp, se) => {
             if (se.event.raw.keyCode === Keys.space() || se.event.raw.keyCode === Keys.enter()) {
-              action(false);
+              if (!Disabling.isDisabled(comp)) {
+                action(false);
+              }
             }
           }),
-          AlloyEvents.run(NativeEvents.click(), (_comp, _se) => {
-            action(true);
+          AlloyEvents.run(NativeEvents.click(), (comp, _se) => {
+            if (!Disabling.isDisabled(comp)) {
+              action(true);
+            }
           })
         ])
       ]),
@@ -123,6 +135,7 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
     components: [
       Input.sketch({
         inputBehaviours: Behaviour.derive([
+          Disabling.config({}),
           AddEventsBehaviour.config(customEvents, [
             onControlAttached({ onSetup, getApi }, editorOffCell),
             onControlDetached({ getApi }, editorOffCell)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -1,4 +1,4 @@
-import { AlloyComponent, SketchSpec, TieredData } from '@ephox/alloy';
+import { AlloyComponent, Disabling, SketchSpec, TieredData } from '@ephox/alloy';
 import { Arr, Fun, Optional } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -179,6 +179,7 @@ const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec:
   const onSetup = onSetupEvent(editor, 'NodeChange', (api: BespokeSelectApi) => {
     const comp = api.getComponent();
     spec.updateText(comp);
+    Disabling.set(api.getComponent(), !editor.selection.isEditable());
   });
 
   return renderCommonDropdown(

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
@@ -6,7 +6,7 @@ import { BlockFormat, InlineFormat } from 'tinymce/core/api/fmt/Format';
 
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
-import { onActionToggleFormat } from '../ControlUtils';
+import { onActionToggleFormat, onSetupEditableToggle } from '../ControlUtils';
 import { createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import { findNearest } from './utils/FormatDetection';
@@ -61,6 +61,7 @@ const createBlocksMenu = (editor: Editor, backstage: UiFactoryBackstage): void =
   const menuItems = createMenuItems(editor, backstage, getSpec(editor));
   editor.ui.registry.addNestedMenuItem('blocks', {
     text: 'Blocks',
+    onSetup: onSetupEditableToggle(editor),
     getSubmenuItems: () => menuItems.items.validateItems(menuItems.getStyleItems())
   });
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
@@ -5,6 +5,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
+import { onSetupEditableToggle } from '../ControlUtils';
 import { createMenuItems, createSelectButton, FormatterFormatItem, PreviewSpec, SelectedFormat, SelectSpec } from './BespokeSelect';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 
@@ -107,6 +108,7 @@ const createFontFamilyMenu = (editor: Editor, backstage: UiFactoryBackstage): vo
   const menuItems = createMenuItems(editor, backstage, getSpec(editor));
   editor.ui.registry.addNestedMenuItem('fontfamily', {
     text: backstage.shared.providers.translate('Fonts'),
+    onSetup: onSetupEditableToggle(editor),
     getSubmenuItems: () => menuItems.items.validateItems(menuItems.getStyleItems())
   });
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -5,6 +5,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
+import { onSetupEditableToggle } from '../ControlUtils';
 import { createBespokeNumberInput } from './BespokeNumberInput';
 import { createMenuItems, createSelectButton, FormatterFormatItem, SelectedFormat, SelectSpec } from './BespokeSelect';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
@@ -156,6 +157,7 @@ const createFontSizeMenu = (editor: Editor, backstage: UiFactoryBackstage): void
   const menuItems = createMenuItems(editor, backstage, getSpec(editor));
   editor.ui.registry.addNestedMenuItem('fontsize', {
     text: 'Font sizes',
+    onSetup: onSetupEditableToggle(editor),
     getSubmenuItems: () => menuItems.items.validateItems(menuItems.getStyleItems())
   });
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
@@ -7,7 +7,7 @@ import { BlockFormat, InlineFormat } from 'tinymce/core/api/fmt/Format';
 import * as Options from '../../../api/Options';
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
-import { onActionToggleFormat } from '../ControlUtils';
+import { onActionToggleFormat, onSetupEditableToggle } from '../ControlUtils';
 import { createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
 import { AdvancedSelectDataset, BasicSelectItem, SelectDataset } from './SelectDatasets';
 import { getStyleFormats, isFormatReference, isNestedFormat, StyleFormatType } from './StyleFormat';
@@ -69,6 +69,7 @@ const createStylesMenu = (editor: Editor, backstage: UiFactoryBackstage): void =
   const menuItems = createMenuItems(editor, backstage, getSpec(editor, dataset));
   editor.ui.registry.addNestedMenuItem('styles', {
     text: 'Formats',
+    onSetup: onSetupEditableToggle(editor),
     getSubmenuItems: () => menuItems.items.validateItems(menuItems.getStyleItems())
   });
 };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
@@ -2,7 +2,7 @@ import { ApproxStructure, Assertions, FocusTools, Keyboard, Keys, Mouse, UiFinde
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -323,14 +323,13 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
 
   context('Noneditable root', () => {
     const testDisableOnNoneditable = (title: string) => () => {
-      const editor = hook.editor();
-      editor.getBody().contentEditable = 'false';
-      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"]:disabled`);
-      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"]:not(:disabled)`);
-      editor.getBody().contentEditable = 'true';
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), `[aria-label="${title}"]:disabled`);
+        TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), `[aria-label="${title}"]:not(:disabled)`);
+      });
     };
 
     it('TINY-9669: Disable align on noneditable content', testDisableOnNoneditable('Align'));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
@@ -1,5 +1,5 @@
 import { ApproxStructure, Assertions, FocusTools, Keyboard, Keys, Mouse, UiFinder } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
@@ -319,5 +319,24 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
     TinyUiActions.keydown(editor, Keys.left());
     await pAssertFocusOnAlignToolbarButton(); // Alignment
     UiFinder.notExists(SugarBody.body(), '[role="menu"]');
+  });
+
+  context('Noneditable root', () => {
+    const testDisableOnNoneditable = (title: string) => () => {
+      const editor = hook.editor();
+      editor.getBody().contentEditable = 'false';
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"]:disabled`);
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"]:not(:disabled)`);
+      editor.getBody().contentEditable = 'true';
+    };
+
+    it('TINY-9669: Disable align on noneditable content', testDisableOnNoneditable('Align'));
+    it('TINY-9669: Disable fontfamily on noneditable content', testDisableOnNoneditable('Fonts'));
+    it('TINY-9669: Disable fontsize on noneditable content', testDisableOnNoneditable('Font sizes'));
+    it('TINY-9669: Disable blocks on noneditable content', testDisableOnNoneditable('Blocks'));
+    it('TINY-9669: Disable styles on noneditable content', testDisableOnNoneditable('Formats'));
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/NoneditableRootTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/NoneditableRootTest.ts
@@ -1,0 +1,50 @@
+import { Keys, UiFinder } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.color.NoneditableRootTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    menubar: 'format',
+    toolbar: 'forecolor backcolor',
+  }, []);
+
+  context('Noneditable root buttons', () => {
+    const testDisableButtonOnNoneditable = (title: string) => () => {
+      const editor = hook.editor();
+      editor.getBody().contentEditable = 'false';
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="true"]`);
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="false"]`);
+      editor.getBody().contentEditable = 'true';
+    };
+
+    it('TINY-9669: Disable forecolor on noneditable content', testDisableButtonOnNoneditable('Text color'));
+    it('TINY-9669: Disable backcolor on noneditable content', testDisableButtonOnNoneditable('Background color'));
+  });
+
+  context('Noneditable root menuitems', () => {
+    const testDisableMenuitemOnNoneditable = (menu: string, menuitem: string) => async () => {
+      const editor = hook.editor();
+      editor.getBody().contentEditable = 'false';
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, `button:contains("${menu}")`);
+      await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="true"]`);
+      TinyUiActions.keystroke(editor, Keys.escape());
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, `button:contains("${menu}")`);
+      await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="false"]`);
+      TinyUiActions.keystroke(editor, Keys.escape());
+      editor.getBody().contentEditable = 'true';
+    };
+
+    it('TINY-9669: Disable forecolor on noneditable content', testDisableMenuitemOnNoneditable('Format', 'Text color'));
+    it('TINY-9669: Disable backcolor on noneditable content', testDisableMenuitemOnNoneditable('Format', 'Background color'));
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/NoneditableRootTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/NoneditableRootTest.ts
@@ -1,7 +1,7 @@
 import { Keys, UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -14,14 +14,13 @@ describe('browser.tinymce.themes.silver.editor.color.NoneditableRootTest', () =>
 
   context('Noneditable root buttons', () => {
     const testDisableButtonOnNoneditable = (title: string) => () => {
-      const editor = hook.editor();
-      editor.getBody().contentEditable = 'false';
-      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="true"]`);
-      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="false"]`);
-      editor.getBody().contentEditable = 'true';
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="true"]`);
+        TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="false"]`);
+      });
     };
 
     it('TINY-9669: Disable forecolor on noneditable content', testDisableButtonOnNoneditable('Text color'));
@@ -30,18 +29,17 @@ describe('browser.tinymce.themes.silver.editor.color.NoneditableRootTest', () =>
 
   context('Noneditable root menuitems', () => {
     const testDisableMenuitemOnNoneditable = (menu: string, menuitem: string) => async () => {
-      const editor = hook.editor();
-      editor.getBody().contentEditable = 'false';
-      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-      TinyUiActions.clickOnMenu(editor, `button:contains("${menu}")`);
-      await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="true"]`);
-      TinyUiActions.keystroke(editor, Keys.escape());
-      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-      TinyUiActions.clickOnMenu(editor, `button:contains("${menu}")`);
-      await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="false"]`);
-      TinyUiActions.keystroke(editor, Keys.escape());
-      editor.getBody().contentEditable = 'true';
+      await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+        editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+        TinyUiActions.clickOnMenu(editor, `button:contains("${menu}")`);
+        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="true"]`);
+        TinyUiActions.keystroke(editor, Keys.escape());
+        TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+        TinyUiActions.clickOnMenu(editor, `button:contains("${menu}")`);
+        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="false"]`);
+        TinyUiActions.keystroke(editor, Keys.escape());
+      });
     };
 
     it('TINY-9669: Disable forecolor on noneditable content', testDisableMenuitemOnNoneditable('Format', 'Text color'));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/AlignmentButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/AlignmentButtonsTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -49,14 +49,13 @@ describe('browser.tinymce.themes.silver.editor.core.AlignmentButtonsTest', () =>
 
   context('Noneditable root', () => {
     const testDisableOnNoneditable = (title: string) => () => {
-      const editor = hook.editor();
-      editor.getBody().contentEditable = 'false';
-      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="true"]`);
-      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="false"]`);
-      editor.getBody().contentEditable = 'true';
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="true"]`);
+        TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="false"]`);
+      });
     };
 
     it('TINY-9669: Disable alignleft on noneditable content', testDisableOnNoneditable('Align left'));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/AlignmentButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/AlignmentButtonsTest.ts
@@ -1,14 +1,14 @@
-import { ApproxStructure, Assertions } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { ApproxStructure, Assertions, UiFinder } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
 import { extractOnlyOne } from '../../../module/UiUtils';
 
 describe('browser.tinymce.themes.silver.editor.core.AlignmentButtonsTest', () => {
-  TinyHooks.bddSetupLight<Editor>({
+  const hook = TinyHooks.bddSetupLight<Editor>({
     toolbar: 'alignleft aligncenter alignright alignjustify alignnone',
     toolbar_mode: 'wrap',
     base_url: '/project/tinymce/js/tinymce'
@@ -45,5 +45,24 @@ describe('browser.tinymce.themes.silver.editor.core.AlignmentButtonsTest', () =>
       })),
       toolbar
     );
+  });
+
+  context('Noneditable root', () => {
+    const testDisableOnNoneditable = (title: string) => () => {
+      const editor = hook.editor();
+      editor.getBody().contentEditable = 'false';
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="true"]`);
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="false"]`);
+      editor.getBody().contentEditable = 'true';
+    };
+
+    it('TINY-9669: Disable alignleft on noneditable content', testDisableOnNoneditable('Align left'));
+    it('TINY-9669: Disable aligncenter on noneditable content', testDisableOnNoneditable('Align center'));
+    it('TINY-9669: Disable alignright on noneditable content', testDisableOnNoneditable('Align right'));
+    it('TINY-9669: Disable alignjustify on noneditable content', testDisableOnNoneditable('Justify'));
+    it('TINY-9669: Disable alignnone on noneditable content', testDisableOnNoneditable('No alignment'));
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
@@ -1,8 +1,8 @@
-import { UiFinder, Waiter } from '@ephox/agar';
+import { Keys, UiFinder, Waiter } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { Attribute } from '@ephox/sugar';
+import { Attribute, SugarBody } from '@ephox/sugar';
 import { McEditor, TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -143,6 +143,32 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
 
         await pAssertOptions(editor, menuSpec.menuSelector, [ '1', '1.1', '1.2', '1.3', '1.4', '1.5', '2' ], Optional.some('1.4'));
         menuSpec.close(editor, 'Line height');
+      });
+
+      it('TINY-9669: Disable lineheight button on noneditable content', () => {
+        const editor = hook.editor();
+        editor.getBody().contentEditable = 'false';
+        editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), '[aria-label="Line height"]:disabled');
+        TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), '[aria-label="Line height"]:not(:disabled)');
+        editor.getBody().contentEditable = 'true';
+      });
+
+      it('TINY-9669: Disable lineheight menuitem on noneditable content', async () => {
+        const editor = hook.editor();
+        editor.getBody().contentEditable = 'false';
+        editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+        TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
+        await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Line height"][aria-disabled="true"]');
+        TinyUiActions.keystroke(editor, Keys.escape());
+        TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+        TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
+        await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Line height"][aria-disabled="false"]');
+        TinyUiActions.keystroke(editor, Keys.escape());
+        editor.getBody().contentEditable = 'true';
       });
     });
 
@@ -285,6 +311,34 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
 
         editor.formatter.apply('lang', { value: 'zh' });
         await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled');
+      });
+
+      context('Noneditable', () => {
+        it('TINY-9669: Disable language button on noneditable content', () => {
+          const editor = hook.editor();
+          editor.getBody().contentEditable = 'false';
+          editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+          TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+          UiFinder.exists(SugarBody.body(), '[aria-label="Language"]:disabled');
+          TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+          UiFinder.exists(SugarBody.body(), '[aria-label="Language"]:not(:disabled)');
+          editor.getBody().contentEditable = 'true';
+        });
+
+        it('TINY-9669: Disable language menuitem on noneditable content', async () => {
+          const editor = hook.editor();
+          editor.getBody().contentEditable = 'false';
+          editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+          TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+          TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
+          await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Language"][aria-disabled="true"]');
+          TinyUiActions.keystroke(editor, Keys.escape());
+          TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+          TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
+          await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Language"][aria-disabled="false"]');
+          TinyUiActions.keystroke(editor, Keys.escape());
+          editor.getBody().contentEditable = 'true';
+        });
       });
     });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
@@ -3,7 +3,7 @@ import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Attribute, SugarBody } from '@ephox/sugar';
-import { McEditor, TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { McEditor, TinyAssertions, TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -146,29 +146,27 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
       });
 
       it('TINY-9669: Disable lineheight button on noneditable content', () => {
-        const editor = hook.editor();
-        editor.getBody().contentEditable = 'false';
-        editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-        UiFinder.exists(SugarBody.body(), '[aria-label="Line height"]:disabled');
-        TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-        UiFinder.exists(SugarBody.body(), '[aria-label="Line height"]:not(:disabled)');
-        editor.getBody().contentEditable = 'true';
+        TinyState.withNoneditableRootEditor<Editor>(hook.editor(), (editor) => {
+          editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+          TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+          UiFinder.exists(SugarBody.body(), '[aria-label="Line height"]:disabled');
+          TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+          UiFinder.exists(SugarBody.body(), '[aria-label="Line height"]:not(:disabled)');
+        });
       });
 
       it('TINY-9669: Disable lineheight menuitem on noneditable content', async () => {
-        const editor = hook.editor();
-        editor.getBody().contentEditable = 'false';
-        editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-        TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
-        await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Line height"][aria-disabled="true"]');
-        TinyUiActions.keystroke(editor, Keys.escape());
-        TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-        TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
-        await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Line height"][aria-disabled="false"]');
-        TinyUiActions.keystroke(editor, Keys.escape());
-        editor.getBody().contentEditable = 'true';
+        await TinyState.withNoneditableRootEditorAsync<Editor>(hook.editor(), async (editor) => {
+          editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+          TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+          TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
+          await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Line height"][aria-disabled="true"]');
+          TinyUiActions.keystroke(editor, Keys.escape());
+          TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+          TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
+          await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Line height"][aria-disabled="false"]');
+          TinyUiActions.keystroke(editor, Keys.escape());
+        });
       });
     });
 
@@ -315,29 +313,27 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
 
       context('Noneditable', () => {
         it('TINY-9669: Disable language button on noneditable content', () => {
-          const editor = hook.editor();
-          editor.getBody().contentEditable = 'false';
-          editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-          TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-          UiFinder.exists(SugarBody.body(), '[aria-label="Language"]:disabled');
-          TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-          UiFinder.exists(SugarBody.body(), '[aria-label="Language"]:not(:disabled)');
-          editor.getBody().contentEditable = 'true';
+          TinyState.withNoneditableRootEditor<Editor>(hook.editor(), (editor) => {
+            editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+            TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+            UiFinder.exists(SugarBody.body(), '[aria-label="Language"]:disabled');
+            TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+            UiFinder.exists(SugarBody.body(), '[aria-label="Language"]:not(:disabled)');
+          });
         });
 
         it('TINY-9669: Disable language menuitem on noneditable content', async () => {
-          const editor = hook.editor();
-          editor.getBody().contentEditable = 'false';
-          editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-          TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-          TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
-          await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Language"][aria-disabled="true"]');
-          TinyUiActions.keystroke(editor, Keys.escape());
-          TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-          TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
-          await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Language"][aria-disabled="false"]');
-          TinyUiActions.keystroke(editor, Keys.escape());
-          editor.getBody().contentEditable = 'true';
+          await TinyState.withNoneditableRootEditorAsync<Editor>(hook.editor(), async (editor) => {
+            editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+            TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+            TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
+            await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Language"][aria-disabled="true"]');
+            TinyUiActions.keystroke(editor, Keys.escape());
+            TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+            TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
+            await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Language"][aria-disabled="false"]');
+            TinyUiActions.keystroke(editor, Keys.escape());
+          });
         });
       });
     });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/PasteControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/PasteControlsTest.ts
@@ -1,0 +1,43 @@
+import { Keys, UiFinder } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.core.PasteControlsTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    menubar: 'edit',
+    toolbar: 'pastetext',
+  }, []);
+
+  context('Noneditable root', () => {
+    it('TINY-9669: Disable pastetext button noneditable content', () => {
+      const editor = hook.editor();
+      editor.getBody().contentEditable = 'false';
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Paste as text"][aria-disabled="true"]');
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), '[aria-label="Paste as text"][aria-disabled="false"]');
+      editor.getBody().contentEditable = 'true';
+    });
+
+    it('TINY-9669: Disable pastetext menuitem noneditable content', async () => {
+      const editor = hook.editor();
+      editor.getBody().contentEditable = 'false';
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Paste as text"][aria-disabled="true"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
+      await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Paste as text"][aria-disabled="false"]');
+      TinyUiActions.keystroke(editor, Keys.escape());
+      editor.getBody().contentEditable = 'true';
+    });
+  });
+});
+

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/PasteControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/PasteControlsTest.ts
@@ -1,7 +1,7 @@
 import { Keys, UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -14,29 +14,27 @@ describe('browser.tinymce.themes.silver.editor.core.PasteControlsTest', () => {
 
   context('Noneditable root', () => {
     it('TINY-9669: Disable pastetext button noneditable content', () => {
-      const editor = hook.editor();
-      editor.getBody().contentEditable = 'false';
-      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), '[aria-label="Paste as text"][aria-disabled="true"]');
-      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), '[aria-label="Paste as text"][aria-disabled="false"]');
-      editor.getBody().contentEditable = 'true';
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), '[aria-label="Paste as text"][aria-disabled="true"]');
+        TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), '[aria-label="Paste as text"][aria-disabled="false"]');
+      });
     });
 
     it('TINY-9669: Disable pastetext menuitem noneditable content', async () => {
-      const editor = hook.editor();
-      editor.getBody().contentEditable = 'false';
-      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-      TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Paste as text"][aria-disabled="true"]');
-      TinyUiActions.keystroke(editor, Keys.escape());
-      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-      TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Paste as text"][aria-disabled="false"]');
-      TinyUiActions.keystroke(editor, Keys.escape());
-      editor.getBody().contentEditable = 'true';
+      await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+        editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+        TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
+        await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Paste as text"][aria-disabled="true"]');
+        TinyUiActions.keystroke(editor, Keys.escape());
+        TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+        TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
+        await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Paste as text"][aria-disabled="false"]');
+        TinyUiActions.keystroke(editor, Keys.escape());
+      });
     });
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Keys, UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -113,14 +113,13 @@ describe('browser.tinymce.themes.silver.editor.core.SimpleControlsTest', () => {
 
   context('Noneditable root buttons', () => {
     const testDisableButtonOnNoneditable = (title: string) => () => {
-      const editor = hook.editor();
-      editor.getBody().contentEditable = 'false';
-      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="true"]`);
-      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="false"]`);
-      editor.getBody().contentEditable = 'true';
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="true"]`);
+        TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="false"]`);
+      });
     };
 
     it('TINY-9669: Disable bold on noneditable content', testDisableButtonOnNoneditable('Bold'));
@@ -144,18 +143,17 @@ describe('browser.tinymce.themes.silver.editor.core.SimpleControlsTest', () => {
 
   context('Noneditable root menuitems', () => {
     const testDisableMenuitemOnNoneditable = (menu: string, menuitem: string) => async () => {
-      const editor = hook.editor();
-      editor.getBody().contentEditable = 'false';
-      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-      TinyUiActions.clickOnMenu(editor, `button:contains("${menu}")`);
-      await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="true"]`);
-      TinyUiActions.keystroke(editor, Keys.escape());
-      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-      TinyUiActions.clickOnMenu(editor, `button:contains("${menu}")`);
-      await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="false"]`);
-      TinyUiActions.keystroke(editor, Keys.escape());
-      editor.getBody().contentEditable = 'true';
+      await TinyState.withNoneditableRootEditorAsync(hook.editor(), async (editor) => {
+        editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+        TinyUiActions.clickOnMenu(editor, `button:contains("${menu}")`);
+        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="true"]`);
+        TinyUiActions.keystroke(editor, Keys.escape());
+        TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+        TinyUiActions.clickOnMenu(editor, `button:contains("${menu}")`);
+        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="false"]`);
+        TinyUiActions.keystroke(editor, Keys.escape());
+      });
     };
 
     it('TINY-9669: Disable bold on noneditable content', testDisableMenuitemOnNoneditable('Format', 'Bold'));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
@@ -1,5 +1,5 @@
-import { ApproxStructure, UiFinder } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { ApproxStructure, Keys, UiFinder } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
@@ -8,7 +8,8 @@ import Editor from 'tinymce/core/api/Editor';
 describe('browser.tinymce.themes.silver.editor.core.SimpleControlsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
-    toolbar: 'bold italic underline strikethrough print hr',
+    menubar: 'edit insert format',
+    toolbar: 'bold italic underline strikethrough superscript subscript h1 h2 h3 h4 h5 h6 cut paste removeformat remove print hr',
   }, []);
 
   const assertToolbarButtonPressed = (title: string) =>
@@ -108,5 +109,65 @@ describe('browser.tinymce.themes.silver.editor.core.SimpleControlsTest', () => {
         ]
       });
     }));
+  });
+
+  context('Noneditable root buttons', () => {
+    const testDisableButtonOnNoneditable = (title: string) => () => {
+      const editor = hook.editor();
+      editor.getBody().contentEditable = 'false';
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="true"]`);
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="false"]`);
+      editor.getBody().contentEditable = 'true';
+    };
+
+    it('TINY-9669: Disable bold on noneditable content', testDisableButtonOnNoneditable('Bold'));
+    it('TINY-9669: Disable italic on noneditable content', testDisableButtonOnNoneditable('Italic'));
+    it('TINY-9669: Disable underline on noneditable content', testDisableButtonOnNoneditable('Underline'));
+    it('TINY-9669: Disable strikethrough on noneditable content', testDisableButtonOnNoneditable('Strikethrough'));
+    it('TINY-9669: Disable superscript on noneditable content', testDisableButtonOnNoneditable('Superscript'));
+    it('TINY-9669: Disable subscript on noneditable content', testDisableButtonOnNoneditable('Subscript'));
+    it('TINY-9669: Disable h1 on noneditable content', testDisableButtonOnNoneditable('Heading 1'));
+    it('TINY-9669: Disable h2 on noneditable content', testDisableButtonOnNoneditable('Heading 2'));
+    it('TINY-9669: Disable h3 on noneditable content', testDisableButtonOnNoneditable('Heading 3'));
+    it('TINY-9669: Disable h4 on noneditable content', testDisableButtonOnNoneditable('Heading 4'));
+    it('TINY-9669: Disable h5 on noneditable content', testDisableButtonOnNoneditable('Heading 5'));
+    it('TINY-9669: Disable h6 on noneditable content', testDisableButtonOnNoneditable('Heading 6'));
+    it('TINY-9669: Disable cut on noneditable content', testDisableButtonOnNoneditable('Cut'));
+    it('TINY-9669: Disable paste on noneditable content', testDisableButtonOnNoneditable('Paste'));
+    it('TINY-9669: Disable removeformat on noneditable content', testDisableButtonOnNoneditable('Clear formatting'));
+    it('TINY-9669: Disable remove on noneditable content', testDisableButtonOnNoneditable('Remove'));
+    it('TINY-9669: Disable hr on noneditable content', testDisableButtonOnNoneditable('Horizontal line'));
+  });
+
+  context('Noneditable root menuitems', () => {
+    const testDisableMenuitemOnNoneditable = (menu: string, menuitem: string) => async () => {
+      const editor = hook.editor();
+      editor.getBody().contentEditable = 'false';
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, `button:contains("${menu}")`);
+      await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="true"]`);
+      TinyUiActions.keystroke(editor, Keys.escape());
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, `button:contains("${menu}")`);
+      await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="false"]`);
+      TinyUiActions.keystroke(editor, Keys.escape());
+      editor.getBody().contentEditable = 'true';
+    };
+
+    it('TINY-9669: Disable bold on noneditable content', testDisableMenuitemOnNoneditable('Format', 'Bold'));
+    it('TINY-9669: Disable italic on noneditable content', testDisableMenuitemOnNoneditable('Format', 'Italic'));
+    it('TINY-9669: Disable underline on noneditable content', testDisableMenuitemOnNoneditable('Format', 'Underline'));
+    it('TINY-9669: Disable strikethrough on noneditable content', testDisableMenuitemOnNoneditable('Format', 'Strikethrough'));
+    it('TINY-9669: Disable superscript on noneditable content', testDisableMenuitemOnNoneditable('Format', 'Superscript'));
+    it('TINY-9669: Disable subscript on noneditable content', testDisableMenuitemOnNoneditable('Format', 'Subscript'));
+    it('TINY-9669: Disable code on noneditable content', testDisableMenuitemOnNoneditable('Format', 'Code'));
+    it('TINY-9669: Disable removeformat on noneditable content', testDisableMenuitemOnNoneditable('Format', 'Clear formatting'));
+    it('TINY-9669: Disable cut on noneditable content', testDisableMenuitemOnNoneditable('Edit', 'Cut'));
+    it('TINY-9669: Disable paste on noneditable content', testDisableMenuitemOnNoneditable('Edit', 'Paste'));
+    it('TINY-9669: Disable hr on noneditable content', testDisableMenuitemOnNoneditable('Insert', 'Horizontal line'));
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/IndentOutdentTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/IndentOutdentTest.ts
@@ -1,0 +1,30 @@
+import { UiFinder } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.toolbar.IndentOutdentTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    toolbar: 'outdent indent',
+  }, []);
+
+  context('Noneditable root', () => {
+    const testDisableOnNoneditable = (title: string) => () => {
+      const editor = hook.editor();
+      editor.getBody().contentEditable = 'false';
+      editor.setContent('<div><p style="padding-left: 40px">Noneditable content</p></div><div contenteditable="true"><p style="padding-left: 40px">Editable content</p></div>');
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="true"]`);
+      TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 1, 0, 0 ], 2);
+      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="false"]`);
+      editor.getBody().contentEditable = 'true';
+    };
+
+    it('TINY-9669: Disable outdent on noneditable content', testDisableOnNoneditable('Increase indent'));
+    it('TINY-9669: Disable indent on noneditable content', testDisableOnNoneditable('Decrease indent'));
+  });
+});
+

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/IndentOutdentTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/IndentOutdentTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -13,14 +13,13 @@ describe('browser.tinymce.themes.silver.editor.toolbar.IndentOutdentTest', () =>
 
   context('Noneditable root', () => {
     const testDisableOnNoneditable = (title: string) => () => {
-      const editor = hook.editor();
-      editor.getBody().contentEditable = 'false';
-      editor.setContent('<div><p style="padding-left: 40px">Noneditable content</p></div><div contenteditable="true"><p style="padding-left: 40px">Editable content</p></div>');
-      TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="true"]`);
-      TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 1, 0, 0 ], 2);
-      UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="false"]`);
-      editor.getBody().contentEditable = 'true';
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        editor.setContent('<div><p style="padding-left: 40px">Noneditable content</p></div><div contenteditable="true"><p style="padding-left: 40px">Editable content</p></div>');
+        TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="true"]`);
+        TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 1, 0, 0 ], 2);
+        UiFinder.exists(SugarBody.body(), `[aria-label="${title}"][aria-disabled="false"]`);
+      });
     };
 
     it('TINY-9669: Disable outdent on noneditable content', testDisableOnNoneditable('Increase indent'));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/NumberInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/NumberInputTest.ts
@@ -2,7 +2,7 @@ import { FocusTools, Keys, Mouse, UiControls, UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
 import { SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -322,19 +322,18 @@ describe('browser.tinymce.themes.silver.throbber.NumberInputTest', () => {
 
   context('Noneditable root', () => {
     it('TINY-9669: Disable outdent on noneditable content', () => {
-      const editor = hook.editor();
-      const body = SugarBody.body();
-      editor.getBody().contentEditable = 'false';
-      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
-      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
-      UiFinder.exists(body, '[aria-label="Decrease font size"]:disabled');
-      UiFinder.exists(body, '.tox-number-input input[type="text"]:disabled');
-      UiFinder.exists(body, '[aria-label="Increase font size"]:disabled');
-      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
-      UiFinder.exists(body, '[aria-label="Decrease font size"]:not(:disabled)');
-      UiFinder.exists(body, '.tox-number-input input[type="text"]:not(:disabled)');
-      UiFinder.exists(body, '[aria-label="Increase font size"]:not(:disabled)');
-      editor.getBody().contentEditable = 'true';
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        const body = SugarBody.body();
+        editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+        UiFinder.exists(body, '[aria-label="Decrease font size"]:disabled');
+        UiFinder.exists(body, '.tox-number-input input[type="text"]:disabled');
+        UiFinder.exists(body, '[aria-label="Increase font size"]:disabled');
+        TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+        UiFinder.exists(body, '[aria-label="Decrease font size"]:not(:disabled)');
+        UiFinder.exists(body, '.tox-number-input input[type="text"]:not(:disabled)');
+        UiFinder.exists(body, '[aria-label="Increase font size"]:not(:disabled)');
+      });
     });
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/NumberInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/NumberInputTest.ts
@@ -1,7 +1,7 @@
-import { FocusTools, Keys, Mouse, UiControls } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { FocusTools, Keys, Mouse, UiControls, UiFinder } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
-import { SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -312,5 +312,23 @@ describe('browser.tinymce.themes.silver.throbber.NumberInputTest', () => {
     assert.isFalse(editor.hasFocus(), 'before enter editor should not have focus');
     TinyUiActions.keystroke(editor, Keys.enter());
     assert.isTrue(editor.hasFocus(), 'after enter editor should have focus');
+  });
+
+  context('Noneditable root', () => {
+    it('TINY-9669: Disable outdent on noneditable content', () => {
+      const editor = hook.editor();
+      const body = SugarBody.body();
+      editor.getBody().contentEditable = 'false';
+      editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      UiFinder.exists(body, '[aria-label="Decrease font size"]:disabled');
+      UiFinder.exists(body, '.tox-number-input input[type="text"]:disabled');
+      UiFinder.exists(body, '[aria-label="Increase font size"]:disabled');
+      TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
+      UiFinder.exists(body, '[aria-label="Decrease font size"]:not(:disabled)');
+      UiFinder.exists(body, '.tox-number-input input[type="text"]:not(:disabled)');
+      UiFinder.exists(body, '[aria-label="Increase font size"]:not(:disabled)');
+      editor.getBody().contentEditable = 'true';
+    });
   });
 });

--- a/versions.txt
+++ b/versions.txt
@@ -1,2 +1,4 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
+mcagar@8.4.0
+


### PR DESCRIPTION
Related Ticket: TINY-9669

Description of Changes:
* Adds disabling toggling behavior when selecting noneditable contents for a ton of UI controls.
* There will be a follow up ticket to fix CSS issues some controls doesn't render correctly when being disabled.

Sorry for the fat PR but should be possible to review commit by commit.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
