### PR TITLE
TINY-9662: Directionality applies to noneditable elements

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460
 - Inline alert in the "Search and Replace" dialog persisted when it wasn't necessary. #TINY-9704
 - Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680
-- Directionality commands no longer applies to contents in elements with a `contenteditable="false"` attribute. #TINY-9662
+- Directionality commands was setting the `dir` attribute on elements within a noneditable root. #TINY-9662
 
 ## 6.4.1 - 2023-03-29
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460
 - Inline alert in the "Search and Replace" dialog persisted when it wasn't necessary. #TINY-9704
 - Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680
+- Directionality commands no longer applies to contents in elements with a `contenteditable="false"` attribute. #TINY-9662
 
 ## 6.4.1 - 2023-03-29
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460
 - Inline alert in the "Search and Replace" dialog persisted when it wasn't necessary. #TINY-9704
 - Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680
-- Directionality commands was setting the `dir` attribute on elements within a noneditable root. #TINY-9662
+- Directionality commands was setting the `dir` attribute on noneditable elements within a noneditable root. #TINY-9662
 
 ## 6.4.1 - 2023-03-29
 

--- a/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
@@ -16,29 +16,32 @@ const getNormalizedBlock = (element: SugarElement<Element>, isListItem: boolean)
 
 const isListItem = SugarNode.isTag('li');
 
-const setDir = (editor: Editor, dir: Dir): void => {
-  const selectedBlocks = editor.selection.getSelectedBlocks();
-  if (selectedBlocks.length > 0) {
-    Arr.each(selectedBlocks, (block) => {
-      const blockElement = SugarElement.fromDom(block);
-      const isBlockElementListItem = isListItem(blockElement);
-      const normalizedBlock = getNormalizedBlock(blockElement, isBlockElementListItem);
-      const normalizedBlockParent = getParentElement(normalizedBlock);
-      normalizedBlockParent.each((parent) => {
-        const parentDirection = Direction.getDirection(parent);
-        if (parentDirection !== dir) {
-          Attribute.set(normalizedBlock, 'dir', dir);
-        } else if (Direction.getDirection(normalizedBlock) !== dir) {
-          Attribute.remove(normalizedBlock, 'dir');
-        }
+const setDirOnElements = (blocks: Element[], dir: Dir): void => {
+  Arr.each(blocks, (block) => {
+    const blockElement = SugarElement.fromDom(block);
+    const isBlockElementListItem = isListItem(blockElement);
+    const normalizedBlock = getNormalizedBlock(blockElement, isBlockElementListItem);
+    const normalizedBlockParent = getParentElement(normalizedBlock);
+    normalizedBlockParent.each((parent) => {
+      const parentDirection = Direction.getDirection(parent);
+      if (parentDirection !== dir) {
+        Attribute.set(normalizedBlock, 'dir', dir);
+      } else if (Direction.getDirection(normalizedBlock) !== dir) {
+        Attribute.remove(normalizedBlock, 'dir');
+      }
 
-        // remove dir attr from list children
-        if (isBlockElementListItem) {
-          const listItems = SelectorFilter.children(normalizedBlock, 'li[dir]');
-          Arr.each(listItems, (listItem) => Attribute.remove(listItem, 'dir'));
-        }
-      });
+      // remove dir attr from list children
+      if (isBlockElementListItem) {
+        const listItems = SelectorFilter.children(normalizedBlock, 'li[dir]');
+        Arr.each(listItems, (listItem) => Attribute.remove(listItem, 'dir'));
+      }
     });
+  });
+};
+
+const setDir = (editor: Editor, dir: Dir): void => {
+  if (editor.selection.isEditable()) {
+    setDirOnElements(editor.selection.getSelectedBlocks(), dir);
     editor.nodeChanged();
   }
 };

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/CommandsTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/CommandsTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/directionality/Plugin';
@@ -9,12 +9,6 @@ describe('browser.tinymce.plugins.directionality.CommandsTest', () => {
     plugins: 'directionality',
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
-
-  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
-    editor.getBody().contentEditable = 'false';
-    f(editor);
-    editor.getBody().contentEditable = 'true';
-  };
 
   it('TINY-9669: mceDirectionLTR on a RTL block in LTR mode should remove the dir property', () => {
     const editor = hook.editor();
@@ -35,7 +29,7 @@ describe('browser.tinymce.plugins.directionality.CommandsTest', () => {
   });
 
   it('TINY-9669: Command should not be applied to noneditable content', () => {
-    withNoneditableRootEditor(hook.editor(), (editor) => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       const initialContent = '<div>Noneditable content</div>';
       editor.setContent(initialContent);
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/CommandsTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/CommandsTest.ts
@@ -1,0 +1,49 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/directionality/Plugin';
+
+describe('browser.tinymce.plugins.directionality.CommandsTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'directionality',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const withNoneditableRootEditor = (editor: Editor, f: (editor: Editor) => void) => {
+    editor.getBody().contentEditable = 'false';
+    f(editor);
+    editor.getBody().contentEditable = 'true';
+  };
+
+  it('TINY-9669: mceDirectionLTR on a RTL block in LTR mode should remove the dir property', () => {
+    const editor = hook.editor();
+
+    editor.setContent('<div dir="rtl">Noneditable content</div>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+    editor.execCommand('mceDirectionLTR');
+    TinyAssertions.assertContent(editor, '<div>Noneditable content</div>');
+  });
+
+  it('TINY-9669: mceDirectionRTL on a LTR block in LTR mode should add RTL to the dir property', () => {
+    const editor = hook.editor();
+
+    editor.setContent('<div>Noneditable content</div>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+    editor.execCommand('mceDirectionRTL');
+    TinyAssertions.assertContent(editor, '<div dir="rtl">Noneditable content</div>');
+  });
+
+  it('TINY-9669: Command should not be applied to noneditable content', () => {
+    withNoneditableRootEditor(hook.editor(), (editor) => {
+      const initialContent = '<div>Noneditable content</div>';
+      editor.setContent(initialContent);
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
+      editor.execCommand('mceDirectionLTR');
+      TinyAssertions.assertContent(editor, initialContent);
+      editor.execCommand('mceDirectionRTL');
+      TinyAssertions.assertContent(editor, initialContent);
+    });
+  });
+});
+


### PR DESCRIPTION
Related Ticket: TINY-9662

Description of Changes:
* Prevents directionality to be applied to noneditable blocks
* Did a bit of refactoring while I was at it

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
