### PR TITLE
TINY-9715: Selected item in tree component under directory now remains selected after collapsing and re-expanding the directory

### DIFF
--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Tree.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Tree.ts
@@ -16,6 +16,7 @@ export interface TreeSpec {
     expandedIds: Id[],
     { expanded, node }: { expanded: boolean; node: Id }
   ) => void;
+  defaultSelectedId?: Id;
 }
 
 export interface Tree {
@@ -28,6 +29,7 @@ export interface Tree {
     { expanded, node }: { expanded: boolean; node: Id }
   ) => void
   >;
+  defaultSelectedId: Optional<Id>;
 }
 
 interface BaseTreeItemSpec {
@@ -97,6 +99,7 @@ const treeFields = [
   FieldSchema.optionFunction('onLeafAction'),
   FieldSchema.optionFunction('onToggleExpand'),
   FieldSchema.defaultedArrayOf('defaultExpandedIds', [], ValueType.string),
+  FieldSchema.optionString('defaultSelectedId'),
 ];
 
 export const treeSchema = StructureSchema.objOf(treeFields);

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New optional `defaultExpandedIds` and `onToggleExpand` options to the `tree` component config. #TINY-9653
+- New optional `defaultSelectedId` option to the `tree` component config. #TINY-9715
 
 ### Fixed
+- In the tre component, a selected item in a directory would not stay selected after collapsing the directory. #TINY-9715
 - Enabling or Disabling checkboxes would not set the correct classes and attributes. #TINY-4189
 - Table toolbar was visible even if the table was within a noneditable host element. #TINY-9664
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New optional `defaultSelectedId` option to the `tree` component config. #TINY-9715
 
 ### Fixed
-- In the tre component, a selected item in a directory would not stay selected after collapsing the directory. #TINY-9715
+- In the tree component, a selected item in a directory would not stay selected after collapsing the directory. #TINY-9715
 - Enabling or Disabling checkboxes would not set the correct classes and attributes. #TINY-4189
 - Table toolbar was visible even if the table was within a noneditable host element. #TINY-9664
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
@@ -156,7 +156,8 @@ export default (): void => {
                               expandedIds = newExpandedKeys;
                             },
                             defaultExpandedIds: expandedIds,
-                            items: tree
+                            items: tree,
+                            defaultSelectedId: '3'
                           }]
                       },
                     ]

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
@@ -123,7 +123,8 @@ const renderLeafLabel = ({
       AddEventsBehaviour.config(leafLabelEventsId, [
         AlloyEvents.runOnAttached((comp, _se) => {
           selectedId.each((id) => {
-            (id === leaf.id ? Toggling.on : Toggling.off)(comp);
+            const toggle = id === leaf.id ? Toggling.on : Toggling.off;
+            toggle(comp);
           });
         }),
         AlloyEvents.run<EventArgs<KeyboardEvent>>(NativeEvents.keydown(), (comp, se) => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
@@ -266,7 +266,7 @@ describe('headless.tinymce.themes.silver.tree.TreeTest', () => {
     const file3 = dirChildren.getSystem().getByDom(file3Element).getOrDie();
     const isFile3Selected = Class.has(file3Element, '.tox-trbtn--enabled');
     if (!isFile3Selected) {
-      // The reason we havt to start from the hook component is because if we start from anywhere inside the tree, the mouse would click on the first
+      // The reason we have to start from the hook component is because if we start from anywhere inside the tree, the mouse would click on the first
       // leaf it finds which is file 1. So by using this selector we force the mouse to skip the subdirectory and
       // go for the direct leaf child instead.
       Mouse.clickOn(hook.component().element, '.tox-tree >.tox-tree--directory > .tox-tree--directory__children > .tox-tree--leaf__label');


### PR DESCRIPTION
Related Ticket: TINY-9715

Description of Changes:
* Selected item in tree component under directory now remains selected after collapsing and re-expanding the directory

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
