### PR TITLE
TINY-9746: Add iOS Safari workaround to prevent Hangul (Korean) characters from merging onto previous line after pressing Enter to insert newline

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460
 - Inline alert in the "Search and Replace" dialog persisted when it wasn't necessary. #TINY-9704
 - Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680
+- On iOS Safari, Hangul (Korean) characters will no longer merge onto the previous line after inserting a newline by pressing Enter. #TINY-9746
 
 ## 6.4.1 - 2023-03-29
 

--- a/modules/tinymce/src/core/main/ts/keyboard/EnterKey.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/EnterKey.ts
@@ -1,8 +1,16 @@
+import { Fun, Optional } from '@ephox/katamari';
+import { PlatformDetection } from '@ephox/sand';
+
 import Editor from '../api/Editor';
 import { EditorEvent } from '../api/util/EventDispatcher';
 import VK from '../api/util/VK';
+import { Bookmark } from '../bookmark/BookmarkTypes';
+import * as NodeType from '../dom/NodeType';
 import * as InsertNewLine from '../newline/InsertNewLine';
 import { endTypingLevelIgnoreLocks } from '../undo/TypingState';
+
+const platform = PlatformDetection.detect();
+const isIOSSafari = platform.os.isiOS() && platform.browser.isSafari();
 
 const handleEnterKeyEvent = (editor: Editor, event: EditorEvent<KeyboardEvent>) => {
   if (event.isDefaultPrevented()) {
@@ -18,9 +26,39 @@ const handleEnterKeyEvent = (editor: Editor, event: EditorEvent<KeyboardEvent>) 
 };
 
 const setup = (editor: Editor): void => {
+  let bookmark: Optional<Bookmark> = Optional.none();
+  let shouldOverrideKeyup = false;
+
+  const iOSSafariKeydownOverride = (editor: Editor): void => {
+    const rng = editor.selection.getRng();
+    if (rng.collapsed && NodeType.isText(rng.commonAncestorContainer)) {
+      bookmark = Optional.some(editor.selection.getBookmark());
+      editor.undoManager.add();
+      shouldOverrideKeyup = true;
+    }
+  };
+
+  const iOSSafariKeyupOverride = (editor: Editor, event: EditorEvent<KeyboardEvent>): void => {
+    editor.undoManager.undo();
+    bookmark.fold(Fun.noop, (b) => editor.selection.moveToBookmark(b));
+    handleEnterKeyEvent(editor, event);
+    shouldOverrideKeyup = false;
+    bookmark = Optional.none();
+  };
+
   editor.on('keydown', (event: EditorEvent<KeyboardEvent>) => {
     if (event.keyCode === VK.ENTER) {
-      handleEnterKeyEvent(editor, event);
+      if (isIOSSafari) {
+        iOSSafariKeydownOverride(editor);
+      } else {
+        handleEnterKeyEvent(editor, event);
+      }
+    }
+  });
+
+  editor.on('keyup', (event: EditorEvent<KeyboardEvent>) => {
+    if (event.keyCode === VK.ENTER && shouldOverrideKeyup) {
+      iOSSafariKeyupOverride(editor, event);
     }
   });
 };

--- a/modules/tinymce/src/core/main/ts/keyboard/EnterKey.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/EnterKey.ts
@@ -61,6 +61,11 @@ const setup = (editor: Editor): void => {
   editor.on('keydown', (event: EditorEvent<KeyboardEvent>) => {
     if (event.keyCode === VK.ENTER) {
       if (isIOSSafari && isCursorAfterHangulCharacter(editor.selection.getRng())) {
+        // TINY-9746: iOS Safari composes Hangul (Korean) characters by deleting the previous partial character and inserting
+        // the composed character. If the native Enter keypress event is not fired, iOS Safari will continue to compose across
+        // our custom newline by deleting it and inserting the composed character on the previous line, causing a bug. The workaround
+        // is to save a bookmark and an undo level on keydown while not preventing default to allow the native Enter keypress.
+        // Then on keyup, the effects of the native Enter keypress is undone and our own Enter key handler is called.
         iOSSafariKeydownOverride(editor);
       } else {
         handleEnterKeyEvent(editor, event);
@@ -78,6 +83,6 @@ const setup = (editor: Editor): void => {
 export {
   setup,
 
-  // for testing purposes
+  // for testing
   isCursorAfterHangulCharacter
 };

--- a/modules/tinymce/src/core/main/ts/keyboard/EnterKey.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/EnterKey.ts
@@ -76,5 +76,8 @@ const setup = (editor: Editor): void => {
 };
 
 export {
-  setup
+  setup,
+
+  // for testing purposes
+  isCursorAfterHangulCharacter
 };

--- a/modules/tinymce/src/core/main/ts/keyboard/EnterKey.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/EnterKey.ts
@@ -1,4 +1,4 @@
-import { Fun, Optional, Type } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 
 import Editor from '../api/Editor';
@@ -29,14 +29,13 @@ const isCaretAfterHangulCharacter = (rng: Range): boolean => {
   if (!rng.collapsed) {
     return false;
   }
-
   const startContainer = rng.startContainer;
-  if (!NodeType.isText(startContainer)) {
-    return false;
-  } else {
-    const text = startContainer.textContent;
+  if (NodeType.isText(startContainer)) {
+    const text = startContainer.data;
     const index = rng.startOffset - 1;
-    return Type.isNonNullable(text) && index < text.length && text.charCodeAt(index) >= 0xAC00 && text.charCodeAt(index) <= 0xD7A3;
+    return index < text.length && text.charCodeAt(index) >= 0xAC00 && text.charCodeAt(index) <= 0xD7A3;
+  } else {
+    return false;
   }
 };
 

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/CaretAfterHangulTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/CaretAfterHangulTest.ts
@@ -7,11 +7,11 @@ import Editor from 'tinymce/core/api/Editor';
 import { isCaretAfterHangulCharacter } from 'tinymce/core/keyboard/EnterKey';
 
 interface Scenario {
-  label: string;
-  input: string;
-  cursorPath: number[];
-  offset: number;
-  result: boolean;
+  readonly label: string;
+  readonly input: string;
+  readonly cursorPath: number[];
+  readonly offset: number;
+  readonly result: boolean;
 }
 
 describe('browser.tinymce.core.keyboard.CursorAfterHangulTest', () => {

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/CaretAfterHangulTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/CaretAfterHangulTest.ts
@@ -1,5 +1,4 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { Arr } from '@ephox/katamari';
 import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -7,7 +6,6 @@ import Editor from 'tinymce/core/api/Editor';
 import { isCaretAfterHangulCharacter } from 'tinymce/core/keyboard/EnterKey';
 
 interface Scenario {
-  readonly label: string;
   readonly input: string;
   readonly cursorPath: number[];
   readonly offset: number;
@@ -19,83 +17,90 @@ describe('browser.tinymce.core.keyboard.CursorAfterHangulTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [], true);
 
-  const scenarios: Scenario[] = [
-    {
-      label: 'Should return true when cursor is after Hangul text',
-      input: '<p>안</p>',
-      cursorPath: [ 0, 0 ],
-      offset: 1,
-      result: true
-    }, {
-      label: 'Should return true when cursor is in middle of Hangul text',
-      input: '<p>안녕</p>',
-      cursorPath: [ 0, 0 ],
-      offset: 1,
-      result: true
-    }, {
-      label: 'Should return true when cursor is after Hangul text in mixed text',
-      input: '<p>안a</p>',
-      cursorPath: [ 0, 0 ],
-      offset: 1,
-      result: true
-    }, {
-      label: 'Should return false when cursor is before Hangul text',
-      input: '<p>안</p>',
-      cursorPath: [ 0, 0 ],
-      offset: 0,
-      result: false
-    }, {
-      label: 'Should return false when cursor is before non-Hangul text',
-      input: '<p>a</p>',
-      cursorPath: [ 0, 0 ],
-      offset: 0,
-      result: false
-    }, {
-      label: 'Should return false when cursor is after of non-Hangul text',
-      input: '<p>a</p>',
-      cursorPath: [ 0, 0 ],
-      offset: 1,
-      result: false
-    }, {
-      label: 'Should return false when cursor is after non-Hangul text in mixed text',
-      input: '<p>a안</p>',
-      cursorPath: [ 0, 0 ],
-      offset: 1,
-      result: false
-    }, {
-      label: 'Should return false when cursor is in empty block',
-      input: '<p></p>',
-      cursorPath: [ 0, 0 ],
-      offset: 0,
-      result: false
-    }, {
-      label: 'Should return false when cursor is after Hangul text block',
-      input: '<p>안</p>',
-      cursorPath: [ 0 ],
-      offset: 1,
-      result: false
-    }, {
-      label: 'Should return false when cursor is after cef block',
-      input: '<div contenteditable="false">a</div>',
-      cursorPath: [ 0 ],
-      offset: 1,
-      result: false
-    }, {
-      label: 'Should return false when cursor is after image',
-      input: '<img src="about:blank">',
-      cursorPath: [ 0 ],
-      offset: 1,
-      result: false
-    }];
-
-  Arr.each(scenarios, (scenario) => {
-    it(`TINY-9746: ${scenario.label}`, () => {
+  const testIsCursorAfterHangulCharacter = (scenario: Scenario): (() => void) =>
+    (() => {
       const editor = hook.editor();
       editor.setContent(scenario.input);
       TinySelections.setCursor(editor, scenario.cursorPath, scenario.offset);
       assert.equal(isCaretAfterHangulCharacter(editor.selection.getRng()), scenario.result);
     });
-  });
+
+  it('TINY-9746: Should return true when cursor is after Hangul text', testIsCursorAfterHangulCharacter({
+    input: '<p>안</p>',
+    cursorPath: [ 0, 0 ],
+    offset: 1,
+    result: true
+  }));
+
+  it('TINY-9746: Should return true when cursor is in middle of Hangul text', testIsCursorAfterHangulCharacter({
+    input: '<p>안녕</p>',
+    cursorPath: [ 0, 0 ],
+    offset: 1,
+    result: true
+  }));
+
+  it('TINY-9746: Should return true when cursor is after Hangul text in mixed text', testIsCursorAfterHangulCharacter({
+    input: '<p>안a</p>',
+    cursorPath: [ 0, 0 ],
+    offset: 1,
+    result: true
+  }));
+
+  it('TINY-9746: Should return false when cursor is before Hangul text', testIsCursorAfterHangulCharacter({
+    input: '<p>안</p>',
+    cursorPath: [ 0, 0 ],
+    offset: 0,
+    result: false
+  }));
+
+  it('TINY-9746: Should return false when cursor is after non-Hangul text in mixed text', testIsCursorAfterHangulCharacter({
+    input: '<p>a안</p>',
+    cursorPath: [ 0, 0 ],
+    offset: 1,
+    result: false
+  }));
+
+  it('TINY-9746: Should return false when cursor is before non-Hangul text', testIsCursorAfterHangulCharacter({
+    input: '<p>a</p>',
+    cursorPath: [ 0, 0 ],
+    offset: 0,
+    result: false
+  }));
+
+  it('TINY-9746: Should return false when cursor is after non-Hangul text', testIsCursorAfterHangulCharacter({
+    input: '<p>a</p>',
+    cursorPath: [ 0, 0 ],
+    offset: 1,
+    result: false
+  }));
+
+  it('TINY-9746: Should return false when cursor is in empty block', testIsCursorAfterHangulCharacter({
+    input: '<p></p>',
+    cursorPath: [ 0, 0 ],
+    offset: 0,
+    result: false
+  }));
+
+  it('TINY-9746: Should return false when cursor is after Hangul text block', testIsCursorAfterHangulCharacter({
+    input: '<p>안</p>',
+    cursorPath: [ 0 ],
+    offset: 1,
+    result: false
+  }));
+
+  it('TINY-9746: Should return false when cursor is after cef block', testIsCursorAfterHangulCharacter({
+    input: '<div contenteditable="false">a</div>',
+    cursorPath: [ 0 ],
+    offset: 1,
+    result: false
+  }));
+
+  it('TINY-9746: Should return false when cursor is after image', testIsCursorAfterHangulCharacter({
+    input: '<img src="about:blank">',
+    cursorPath: [ 0 ],
+    offset: 1,
+    result: false
+  }));
 
   it('TINY-9746: Should return false when selection is non-collapsed', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/CaretAfterHangulTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/CaretAfterHangulTest.ts
@@ -4,7 +4,7 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import { isCursorAfterHangulCharacter } from 'tinymce/core/keyboard/EnterKey';
+import { isCaretAfterHangulCharacter } from 'tinymce/core/keyboard/EnterKey';
 
 interface Scenario {
   label: string;
@@ -93,7 +93,7 @@ describe('browser.tinymce.core.keyboard.CursorAfterHangulTest', () => {
       const editor = hook.editor();
       editor.setContent(scenario.input);
       TinySelections.setCursor(editor, scenario.cursorPath, scenario.offset);
-      assert.equal(isCursorAfterHangulCharacter(editor.selection.getRng()), scenario.result);
+      assert.equal(isCaretAfterHangulCharacter(editor.selection.getRng()), scenario.result);
     });
   });
 
@@ -101,6 +101,6 @@ describe('browser.tinymce.core.keyboard.CursorAfterHangulTest', () => {
     const editor = hook.editor();
     editor.setContent('<p>안녕</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
-    assert.equal(isCursorAfterHangulCharacter(editor.selection.getRng()), false);
+    assert.equal(isCaretAfterHangulCharacter(editor.selection.getRng()), false);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/CursorAfterHangulTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/CursorAfterHangulTest.ts
@@ -33,6 +33,12 @@ describe('browser.tinymce.core.keyboard.CursorAfterHangulTest', () => {
       offset: 1,
       result: true
     }, {
+      label: 'Should return true when cursor is after Hangul text in mixed text',
+      input: '<p>안a</p>',
+      cursorPath: [ 0, 0 ],
+      offset: 1,
+      result: true
+    }, {
       label: 'Should return false when cursor is before Hangul text',
       input: '<p>안</p>',
       cursorPath: [ 0, 0 ],
@@ -47,6 +53,12 @@ describe('browser.tinymce.core.keyboard.CursorAfterHangulTest', () => {
     }, {
       label: 'Should return false when cursor is after of non-Hangul text',
       input: '<p>a</p>',
+      cursorPath: [ 0, 0 ],
+      offset: 1,
+      result: false
+    }, {
+      label: 'Should return false when cursor is after non-Hangul text in mixed text',
+      input: '<p>a안</p>',
       cursorPath: [ 0, 0 ],
       offset: 1,
       result: false

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/CursorAfterHangulTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/CursorAfterHangulTest.ts
@@ -1,0 +1,94 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import { isCursorAfterHangulCharacter } from 'tinymce/core/keyboard/EnterKey';
+
+interface Scenario {
+  label: string;
+  input: string;
+  cursorPath: number[];
+  offset: number;
+  result: boolean;
+}
+
+describe('browser.tinymce.core.keyboard.CursorAfterHangulTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce'
+  }, [], true);
+
+  const scenarios: Scenario[] = [
+    {
+      label: 'Should return true when cursor is after Hangul text',
+      input: '<p>안</p>',
+      cursorPath: [ 0, 0 ],
+      offset: 1,
+      result: true
+    }, {
+      label: 'Should return true when cursor is in middle of Hangul text',
+      input: '<p>안녕</p>',
+      cursorPath: [ 0, 0 ],
+      offset: 1,
+      result: true
+    }, {
+      label: 'Should return false when cursor is before Hangul text',
+      input: '<p>안</p>',
+      cursorPath: [ 0, 0 ],
+      offset: 0,
+      result: false
+    }, {
+      label: 'Should return false when cursor is before non-Hangul text',
+      input: '<p>a</p>',
+      cursorPath: [ 0, 0 ],
+      offset: 0,
+      result: false
+    }, {
+      label: 'Should return false when cursor is after of non-Hangul text',
+      input: '<p>a</p>',
+      cursorPath: [ 0, 0 ],
+      offset: 1,
+      result: false
+    }, {
+      label: 'Should return false when cursor is in empty block',
+      input: '<p></p>',
+      cursorPath: [ 0, 0 ],
+      offset: 0,
+      result: false
+    }, {
+      label: 'Should return false when cursor is after Hangul text block',
+      input: '<p>안</p>',
+      cursorPath: [ 0 ],
+      offset: 1,
+      result: false
+    }, {
+      label: 'Should return false when cursor is after cef block',
+      input: '<div contenteditable="false">a</div>',
+      cursorPath: [ 0 ],
+      offset: 1,
+      result: false
+    }, {
+      label: 'Should return false when cursor is after image',
+      input: '<img src="about:blank">',
+      cursorPath: [ 0 ],
+      offset: 1,
+      result: false
+    }];
+
+  Arr.each(scenarios, (scenario) => {
+    it(`TINY-9746: ${scenario.label}`, () => {
+      const editor = hook.editor();
+      editor.setContent(scenario.input);
+      TinySelections.setCursor(editor, scenario.cursorPath, scenario.offset);
+      assert.equal(isCursorAfterHangulCharacter(editor.selection.getRng()), scenario.result);
+    });
+  });
+
+  it('TINY-9746: Should return false when selection is non-collapsed', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>안녕</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
+    assert.equal(isCursorAfterHangulCharacter(editor.selection.getRng()), false);
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-9746

Description of Changes:
On iOS Safari, if the cursor is after a Hangul (Korean) character when the Enter key is pressed:
* On keydown, save a bookmark and add an undo level. Do not prevent default to allow native Enter keypress to fire.
* On keyup, undo the effects of the native Enter keypress and execute our own Enter key handler

This is because iOS Safari composes Hangul characters by deleting the previous partial character and inserting the composed character.
* Without the native Enter keypress event being fired, iOS Safari will attempt to compose across our custom newline by deleting it and inserting the composed character on the previous line

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable) - can only add tests for parts of the fix, as it targets iOS Safari with a Korean keyboard, which is not suited for our CI environment.
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
