### PR TITLE
TINY-9713: fix --enabled for tox-button and tox-button--secondary

### DIFF
--- a/modules/oxide/src/less/theme/components/button/button-secondary.less
+++ b/modules/oxide/src/less/theme/components/button/button-secondary.less
@@ -45,6 +45,31 @@
 @button-secondary-active-box-shadow: @button-secondary-box-shadow;
 @button-secondary-active-text-color: @button-secondary-text-color;
 
+// Enabled state
+@button-secondary-enabled-background-color: @enabled-background-color;
+@button-secondary-enabled-background-image: @button-secondary-background-image;
+@button-secondary-enabled-border-color: @button-secondary-enabled-background-color;
+@button-secondary-enabled-box-shadow: @button-secondary-box-shadow;
+@button-secondary-enabled-text-color: @button-secondary-text-color;
+
+@button-secondary-enabled-focus-background-color: @button-secondary-enabled-hover-background-color;
+@button-secondary-enabled-focus-background-image: @button-secondary-hover-background-image;
+@button-secondary-enabled-focus-border-color: @button-secondary-enabled-hover-background-color;
+@button-secondary-enabled-focus-box-shadow: @button-secondary-enabled-box-shadow;
+@button-secondary-enabled-focus-text-color: @button-secondary-enabled-text-color;
+
+@button-secondary-enabled-hover-background-color: darken(@button-secondary-enabled-background-color, 5%);
+@button-secondary-enabled-hover-background-image: @button-secondary-hover-background-image;
+@button-secondary-enabled-hover-border-color: @button-secondary-enabled-hover-background-color;
+@button-secondary-enabled-hover-box-shadow: @button-secondary-enabled-box-shadow;
+@button-secondary-enabled-hover-text-color: @button-secondary-enabled-text-color;
+
+@button-secondary-enabled-active-background-color: darken(@button-secondary-enabled-background-color, 10%);
+@button-secondary-enabled-active-background-image: @button-secondary-background-image;
+@button-secondary-enabled-active-border-color: @button-secondary-enabled-active-background-color;
+@button-secondary-enabled-active-box-shadow: @button-secondary-enabled-box-shadow;
+@button-secondary-enabled-active-text-color: @button-secondary-enabled-text-color;
+
 .tox {
   .tox-button--secondary {
     background-color: @button-secondary-background-color;
@@ -98,26 +123,44 @@
       color: @button-secondary-active-text-color;
     }
 
-    &.tox-button--enabled,
-    &.tox-button--enabled:active,
-    &.tox-button--enabled:focus,
-    &.tox-button--enabled:hover,
-    &.tox-button--enabled:active:not(:disabled),
-    &.tox-button--enabled:focus:not(:disabled),
-    &.tox-button--enabled:hover:not(:disabled) {
-      background: @toolbar-button-enabled-background-color;
-      border-width: @button-border-width;
-      box-shadow: @button-active-box-shadow;
-      color: @toolbar-button-enabled-text-color;
+    // Enabled state
+    &.tox-button--enabled {
+      background-color: @button-secondary-enabled-background-color;
+      background-image: @button-secondary-enabled-background-image;
+      border-color: @button-secondary-enabled-border-color;
+      box-shadow: @button-secondary-enabled-box-shadow;
+      color: @button-secondary-enabled-text-color;
 
-      > * {
-        transform: @toolbar-button-enabled-transform;
+      &[disabled] {
+        background-color: @button-secondary-enabled-background-color;
+        background-image: @button-secondary-enabled-background-image;
+        border-color: @button-secondary-enabled-border-color;
+        box-shadow: @button-secondary-enabled-box-shadow;
+        color: @button-secondary-disabled-text-color;
       }
 
-      // Disable stylelint below because we're mixing the :hover modifier with the "--enabled" class
-      // since they need to be kept the same/use the same rules
-      svg { /* stylelint-disable-line no-descending-specificity */
-        fill: @toolbar-button-enabled-icon-color;
+      &:focus:not(:disabled) {
+        background-color: @button-secondary-enabled-focus-background-color;
+        background-image: @button-secondary-enabled-focus-background-image;
+        border-color: @button-secondary-enabled-focus-border-color;
+        box-shadow: @button-secondary-enabled-focus-box-shadow;
+        color: @button-secondary-enabled-focus-text-color;
+      }
+
+      &:hover:not(:disabled) {
+        background-color: @button-secondary-enabled-hover-background-color;
+        background-image: @button-secondary-enabled-hover-background-image;
+        border-color: @button-secondary-enabled-hover-border-color;
+        box-shadow: @button-secondary-enabled-hover-box-shadow;
+        color: @button-secondary-enabled-hover-text-color;
+      }
+
+      &:active:not(:disabled) {
+        background-color: @button-secondary-enabled-active-background-color;
+        background-image: @button-secondary-enabled-active-background-image;
+        border-color: @button-secondary-enabled-active-border-color;
+        box-shadow: @button-secondary-enabled-active-box-shadow;
+        color: @button-secondary-enabled-active-text-color;
       }
     }
   }

--- a/modules/oxide/src/less/theme/components/button/button-secondary.less
+++ b/modules/oxide/src/less/theme/components/button/button-secondary.less
@@ -46,7 +46,7 @@
 @button-secondary-active-text-color: @button-secondary-text-color;
 
 // Enabled state
-@button-secondary-enabled-background-color: @enabled-background-color;
+@button-secondary-enabled-background-color: contrast(@background-color, mix(darken(@background-color, 6%), @color-tint, 70%), mix(lighten(@background-color, 15%), @color-tint, 70%));
 @button-secondary-enabled-background-image: @button-secondary-background-image;
 @button-secondary-enabled-border-color: @button-secondary-enabled-background-color;
 @button-secondary-enabled-box-shadow: @button-secondary-box-shadow;

--- a/modules/oxide/src/less/theme/components/button/button-secondary.less
+++ b/modules/oxide/src/less/theme/components/button/button-secondary.less
@@ -97,5 +97,28 @@
       box-shadow: @button-secondary-active-box-shadow;
       color: @button-secondary-active-text-color;
     }
+
+    &.tox-button--enabled,
+    &.tox-button--enabled:active,
+    &.tox-button--enabled:focus,
+    &.tox-button--enabled:hover,
+    &.tox-button--enabled:active:not(:disabled),
+    &.tox-button--enabled:focus:not(:disabled),
+    &.tox-button--enabled:hover:not(:disabled) {
+      background: @toolbar-button-enabled-background-color;
+      border-width: @button-border-width;
+      box-shadow: @button-active-box-shadow;
+      color: @toolbar-button-enabled-text-color;
+
+      > * {
+        transform: @toolbar-button-enabled-transform;
+      }
+
+      // Disable stylelint below because we're mixing the :hover modifier with the "--enabled" class
+      // since they need to be kept the same/use the same rules
+      svg { /* stylelint-disable-line no-descending-specificity */
+        fill: @toolbar-button-enabled-icon-color;
+      }
+    }
   }
 }

--- a/modules/oxide/src/less/theme/components/button/button.less
+++ b/modules/oxide/src/less/theme/components/button/button.less
@@ -132,8 +132,13 @@
     }
 
     &.tox-button--enabled,
-    &.tox-button--enabled:hover {
-      background: @toolbar-button-enabled-background-color;
+    &.tox-button--enabled:active,
+    &.tox-button--enabled:focus,
+    &.tox-button--enabled:hover,
+    &.tox-button--enabled:active:not(:disabled),
+    &.tox-button--enabled:focus:not(:disabled),
+    &.tox-button--enabled:hover:not(:disabled) {
+      background: darken(@button-background-color, 10%);
       border-width: @button-border-width;
       box-shadow: @button-active-box-shadow;
       color: @toolbar-button-enabled-text-color;

--- a/modules/oxide/src/less/theme/components/button/button.less
+++ b/modules/oxide/src/less/theme/components/button/button.less
@@ -49,6 +49,31 @@
 @button-active-box-shadow: @button-box-shadow;
 @button-active-text-color: @button-text-color;
 
+// Enabled state
+@button-enabled-background-color: darken(@button-background-color, 10%);
+@button-enabled-background-image: @button-background-image;
+@button-enabled-border-color: @button-enabled-background-color;
+@button-enabled-box-shadow: @button-box-shadow;
+@button-enabled-text-color: @button-text-color;
+
+@button-enabled-focus-background-color: @button-enabled-hover-background-color;
+@button-enabled-focus-background-image: @button-hover-background-image;
+@button-enabled-focus-border-color: @button-enabled-hover-background-color;
+@button-enabled-focus-box-shadow: @button-enabled-box-shadow;
+@button-enabled-focus-text-color: @button-enabled-text-color;
+
+@button-enabled-hover-background-color: darken(@button-enabled-background-color, 5%);
+@button-enabled-hover-background-image: @button-hover-background-image;
+@button-enabled-hover-border-color: @button-enabled-hover-background-color;
+@button-enabled-hover-box-shadow: @button-enabled-box-shadow;
+@button-enabled-hover-text-color: @button-enabled-text-color;
+
+@button-enabled-active-background-color: darken(@button-enabled-background-color, 10%);
+@button-enabled-active-background-image: @button-background-image;
+@button-enabled-active-border-color: @button-enabled-active-background-color;
+@button-enabled-active-box-shadow: @button-enabled-box-shadow;
+@button-enabled-active-text-color: @button-enabled-text-color;
+
 .tox {
   .tox-button {
     background-color: @button-background-color;
@@ -131,26 +156,45 @@
       color: @button-active-text-color;
     }
 
-    &.tox-button--enabled,
-    &.tox-button--enabled:active,
-    &.tox-button--enabled:focus,
-    &.tox-button--enabled:hover,
-    &.tox-button--enabled:active:not(:disabled),
-    &.tox-button--enabled:focus:not(:disabled),
-    &.tox-button--enabled:hover:not(:disabled) {
-      background: darken(@button-background-color, 10%);
-      border-width: @button-border-width;
-      box-shadow: @button-active-box-shadow;
-      color: @toolbar-button-enabled-text-color;
+    // Enabled state
+    &.tox-button--enabled {
+      background-color: @button-enabled-background-color;
+      background-image: @button-enabled-background-image;
+      border-color: @button-enabled-border-color;
+      box-shadow: @button-enabled-box-shadow;
+      color: @button-enabled-text-color;
 
-      > * {
-        transform: @toolbar-button-enabled-transform;
+      &[disabled] {
+        background-color: @button-enabled-background-color;
+        background-image: @button-enabled-background-image;
+        border-color: @button-enabled-border-color;
+        box-shadow: @button-enabled-box-shadow;
+        color: @button-disabled-text-color;
+        cursor: not-allowed;
       }
 
-      // Disable stylelint below because we're mixing the :hover modifier with the "--enabled" class
-      // since they need to be kept the same/use the same rules
-      svg { /* stylelint-disable-line no-descending-specificity */
-        fill: @toolbar-button-enabled-icon-color;
+      &:focus:not(:disabled) {
+        background-color: @button-enabled-focus-background-color;
+        background-image: @button-enabled-focus-background-image;
+        border-color: @button-enabled-focus-border-color;
+        box-shadow: @button-enabled-focus-box-shadow;
+        color: @button-enabled-focus-text-color;
+      }
+
+      &:hover:not(:disabled) {
+        background-color: @button-enabled-hover-background-color;
+        background-image: @button-enabled-hover-background-image;
+        border-color: @button-enabled-hover-border-color;
+        box-shadow: @button-enabled-hover-box-shadow;
+        color: @button-enabled-hover-text-color;
+      }
+
+      &:active:not(:disabled) {
+        background-color: @button-enabled-active-background-color;
+        background-image: @button-enabled-active-background-image;
+        border-color: @button-enabled-active-border-color;
+        box-shadow: @button-enabled-active-box-shadow;
+        color: @button-enabled-active-text-color;
       }
     }
   }

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items. #TINY-9692
+- Togglable `tox-button` and `tox-button--secondary` did manage `hover` when `active`. #TINY-9713
 
 ## 6.4.1 - 2023-03-29
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items. #TINY-9692
-- Togglable `tox-button` and `tox-button--secondary` did manage `hover` when `active`. #TINY-9713
+- Enabled variant of togglable `tox-button` and `tox-button--secondary` now supports `hover`/`active`/`focus`/`disabled` states. #TINY-9713
 
 ## 6.4.1 - 2023-03-29
 


### PR DESCRIPTION
Related Ticket: TINY-9713

**NOTE:** these changes was in this PR: https://github.com/tinymce/tinymce/pull/8585 , I had to change the name of the branch because this is an hotfix

Description of Changes:
This fix `--enabled` for `tox-button` and `tox-button--secondary`, I asked for help with CSS to @noxuhax to have a maintainable and well written CSS

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
