### PR TITLE
TINY-9759: Fixed test flake

### DIFF
--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/ContentEditableTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/ContentEditableTest.ts
@@ -97,6 +97,8 @@ describe('browser.tinymce.plugins.quickbars.ContentEditableTest', () => {
         editor.setContent('<p contenteditable="true">abc</p>');
         TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
         await pAssertToolbarVisible();
+        TinySelections.setCursor(editor, [ 0, 0 ], 0, true);
+        await pAssertToolbarNotVisible();
       });
     });
 


### PR DESCRIPTION
Related Ticket: TINY-9759

Description of Changes:
* Fixefox on Windows started to flake due to a recent change this adds a fix that make sure that the toolbar is hidden before it continues the other tests for the noneditable state.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
