### PR TITLE
TINY-9757: now `icon` field for `togglebutton`s is not mandatory

### DIFF
--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/DialogFooterButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/DialogFooterButton.ts
@@ -64,10 +64,9 @@ export interface DialogFooterMenuButton extends BaseDialogFooterButton {
   items: DialogFooterToggleMenuItem[];
 }
 
-export interface DialogFooterToggleButton extends Omit<BaseDialogFooterButton, 'icon'> {
+export interface DialogFooterToggleButton extends BaseDialogFooterButton {
   type: 'togglebutton';
   tooltip: string;
-  icon: string;
   text: Optional<string>;
   active: boolean;
 }
@@ -108,7 +107,7 @@ const toggleButtonSpecFields = [
   ...baseFooterButtonFields,
   FieldSchema.requiredStringEnum('type', [ 'togglebutton' ]),
   FieldSchema.requiredString('tooltip'),
-  ComponentSchema.icon,
+  ComponentSchema.optionalIcon,
   ComponentSchema.optionalText,
   FieldSchema.defaultedBoolean('active', false)
 ];

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 - Screen readers are now able to announce the highlighted menu item of link comboboxes. #TINY-9280
-- Now `icon` field for `togglebutton`s is not mandatory. #TINY-9757
+- Now `icon` field for dialog footer `togglebutton`s is not mandatory. #TINY-9757
 
 ### Improved
 - Toolbar buttons and menu items were not disabled when they couldn't be used on noneditable content. #TINY-9669

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 - Screen readers are now able to announce the highlighted menu item of link comboboxes. #TINY-9280
+- Now `icon` field for `togglebutton`s is not mandatory. #TINY-9757
 
 ### Improved
 - Toolbar buttons and menu items were not disabled when they couldn't be used on noneditable content. #TINY-9669

--- a/modules/tinymce/src/plugins/code/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/code/main/ts/ui/Dialog.ts
@@ -24,23 +24,6 @@ const open = (editor: Editor): void => {
         text: 'Cancel'
       },
       {
-        type: 'togglebutton',
-        name: 'dark_theme_toggle',
-        text: 'Dark/light mode',
-        tooltip: 'Dark/light mode',
-        active: true,
-      },
-
-      {
-        type: 'togglebutton',
-        name: 'dark_theme_toggle',
-        // text: !status.dark ? 'Dark/light mode' : 'Dark mode enabled',
-        text: 'Dark/light mode 2',
-        tooltip: 'Dark/light mode 2',
-        icon: 'paste',
-        active: true,
-      },
-      {
         type: 'submit',
         name: 'save',
         text: 'Save',

--- a/modules/tinymce/src/plugins/code/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/code/main/ts/ui/Dialog.ts
@@ -24,6 +24,23 @@ const open = (editor: Editor): void => {
         text: 'Cancel'
       },
       {
+        type: 'togglebutton',
+        name: 'dark_theme_toggle',
+        text: 'Dark/light mode',
+        tooltip: 'Dark/light mode',
+        active: true,
+      },
+
+      {
+        type: 'togglebutton',
+        name: 'dark_theme_toggle',
+        // text: !status.dark ? 'Dark/light mode' : 'Dark mode enabled',
+        text: 'Dark/light mode 2',
+        tooltip: 'Dark/light mode 2',
+        icon: 'paste',
+        active: true,
+      },
+      {
         type: 'submit',
         name: 'save',
         text: 'Save',


### PR DESCRIPTION
Related Ticket: TINY-9757

Description of Changes:
now `icon` field for `togglebutton`s is not mandatory

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
