### PR TITLE
TINY-9251: Use K8s for TinyMCE build process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,13 +129,15 @@ timestamps {
         // TODO: Determine if this should be run on a container instead
         node('headless-macos') {
           // Prepare the branch on the node
-          checkout(scm)
-          gitMerge(primaryBranch)
-          cleanAndInstall()
-          exec("yarn ci -s tinymce-rollup")
+          lock('headless tests') {
+            checkout(scm)
+            gitMerge(primaryBranch)
+            cleanAndInstall()
+            exec("yarn ci -s tinymce-rollup")
 
-          echo "Platform: chrome-headless tests on node: $NODE_NAME"
-          runHeadlessTests(runAllTests)
+            echo "Platform: chrome-headless tests on node: $NODE_NAME"
+            runHeadlessTests(runAllTests)
+          }
         }
       }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('waluigi@release/7') _
+@Library('waluigi@feature/TINY-9806') _
 
 standardProperties()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('waluigi@feature/TINY-9806') _
+@Library('waluigi@release/7') _
 
 standardProperties()
 
@@ -56,9 +56,9 @@ timestamps {
   // NOTE: Ensure not to go over 7.5 CPU/RAM due to EC2 node sizes and the jnlp container requirements
   tinyPods.node([
     resourceRequestCpu: '6',
-    resourceRequestMemory: '6Gi',
+    resourceRequestMemory: '4Gi',
     resourceLimitCpu: '7.5',
-    resourceLimitMemory: '6Gi'
+    resourceLimitMemory: '4Gi'
   ]) {
     def props = readProperties(file: 'build.properties')
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,13 +51,18 @@ def gitMerge(String primaryBranch) {
   }
 }
 
-node("headless-macos") {
-  timestamps {
-    checkout scm
+timestamps {
+  // TinyMCE builds need more CPU and RAM (especially eslint)
+  // NOTE: Ensure not to go over 7.5 CPU/RAM due to EC2 node sizes and the jnlp container requirements
+  tinyPods.node([
+    resourceRequestCpu: '6',
+    resourceRequestMemory: '4Gi',
+    resourceLimitCpu: '7.5',
+    resourceLimitMemory: '4Gi'
+  ]) {
+    def props = readProperties(file: 'build.properties')
 
-    def props = readProperties file: 'build.properties'
-
-    def primaryBranch = props.primaryBranch
+    String primaryBranch = props.primaryBranch
     assert primaryBranch != null && primaryBranch != ""
     def runAllTests = env.BRANCH_NAME == primaryBranch
 
@@ -121,11 +126,14 @@ node("headless-macos") {
 
     processes["headless-and-archive"] = {
       stage("headless tests") {
-        // Prevent multiple headless tests running at once
-        lock("headless tests") {
-          // chrome-headless tests run on the same node as the pipeline
-          // we are re-using the state prepared by `ci-all` below
-          // if we ever change these tests to run on a different node, rollup is required in addition to the normal CI command
+        // TODO: Determine if this should be run on a container instead
+        node('headless-macos') {
+          // Prepare the branch on the node
+          checkout(scm)
+          gitMerge(primaryBranch)
+          cleanAndInstall()
+          exec("yarn ci -s tinymce-rollup")
+
           echo "Platform: chrome-headless tests on node: $NODE_NAME"
           runHeadlessTests(runAllTests)
         }
@@ -139,11 +147,8 @@ node("headless-macos") {
       }
     }
 
-    // our linux nodes have multiple executors, sometimes yarn creates conflicts
-    lock("Don't run yarn simultaneously") {
-      stage("Install tools") {
-        cleanAndInstall()
-      }
+    stage("Install tools") {
+      cleanAndInstall()
     }
 
     stage("Type check") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,9 +56,9 @@ timestamps {
   // NOTE: Ensure not to go over 7.5 CPU/RAM due to EC2 node sizes and the jnlp container requirements
   tinyPods.node([
     resourceRequestCpu: '6',
-    resourceRequestMemory: '4Gi',
+    resourceRequestMemory: '6Gi',
     resourceLimitCpu: '7.5',
-    resourceLimitMemory: '4Gi'
+    resourceLimitMemory: '6Gi'
   ]) {
     def props = readProperties(file: 'build.properties')
 


### PR DESCRIPTION
Migrate TinyMCE build process to containers

Related Ticket: TINY-9251

Description of Changes:
* Use a node container for building. Keep headless-test on mac-headless (`headless-macos`)

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
