### PR TITLE
Issue 8616: Fixes keyboard navigation in sliding toolbar.

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/SplitSlidingToolbarSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/SplitSlidingToolbarSchema.ts
@@ -62,6 +62,7 @@ const parts: () => PartType.PartTypeAdt[] = Fun.constant([
           }),
           Keying.config({
             mode: 'acyclic',
+            selector: '.tox-toolbar__group',
             onEscape: (comp) => {
               AlloyParts.getPart(comp, detail, 'overflow-button').each(Focusing.focus);
               return Optional.some<boolean>(true);

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Improved
+- Tab navigation no longer incorrectly stops at menu buttons within toolbar groups
+
 ### Added
 - New optional `defaultExpandedIds` and `onToggleExpand` options to the `tree` component config. #TINY-9653
 - New optional `defaultSelectedId` option to the `tree` component config. #TINY-9715


### PR DESCRIPTION
GitHub issue: #8618

Description of Changes:

* Updated Keying config of SplitSlidingToolbar to behave like the main toolbar, which correct keyboard tab navigation in the overflow toolbar

Pre-checks:
* [x] Changelog entry added
* [ ] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)
