### PR TITLE
TINY-8910: Command+Delete and Ctrl+Delete do not trigger undo level correctly

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toolbar buttons and menu items were not disabled when they couldn't be used on noneditable content. #TINY-9669
 
 ### Fixed
+- Command + backspace would not add an undo level. #TINY-8910
 - In the tree component, a selected item in a directory would not stay selected after collapsing the directory. #TINY-9715
 - Enabling or Disabling checkboxes would not set the correct classes and attributes. #TINY-4189
 - Redial would in some situations cause select elements not to have an initial value selected when they should have. #TINY-9679

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toolbar buttons and menu items were not disabled when they couldn't be used on noneditable content. #TINY-9669
 
 ### Fixed
-- Command + backspace would not add an undo level. #TINY-8910
+- Command + backspace would not add an undo level on Mac. #TINY-8910
+- Ctrl + backspace and Ctrl + delete would not restore correct caret position after redo. #TINY-8910
 - In the tree component, a selected item in a directory would not stay selected after collapsing the directory. #TINY-9715
 - Enabling or Disabling checkboxes would not set the correct classes and attributes. #TINY-4189
 - Redial would in some situations cause select elements not to have an initial value selected when they should have. #TINY-9679

--- a/modules/tinymce/src/core/main/ts/keyboard/DeleteBackspaceKeys.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/DeleteBackspaceKeys.ts
@@ -102,6 +102,20 @@ const setup = (editor: Editor, caret: Cell<Text | null>): void => {
 
     isBackspaceKeydown = false;
   });
+
+  let isMetaBackspace = false;
+  editor.on('keydown', (evt) => {
+    isMetaBackspace = evt.metaKey && evt.key === 'Backspace';
+    if (isMetaBackspace && !evt.isDefaultPrevented()) {
+      editor.undoManager.beforeChange();
+    }
+  });
+  editor.on('keyup', (evt) => {
+    if (isMetaBackspace && !evt.isDefaultPrevented()) {
+      editor.undoManager.add();
+      isMetaBackspace = false;
+    }
+  });
 };
 
 export {

--- a/modules/tinymce/src/core/main/ts/keyboard/DeleteBackspaceKeys.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/DeleteBackspaceKeys.ts
@@ -105,7 +105,7 @@ const setup = (editor: Editor, caret: Cell<Text | null>): void => {
 
   let isMetaBackspace = false;
   editor.on('keydown', (evt) => {
-    isMetaBackspace = evt.metaKey && evt.key === 'Backspace';
+    isMetaBackspace = VK.metaKeyPressed(evt) && evt.key === 'Backspace';
     if (isMetaBackspace && !evt.isDefaultPrevented()) {
       editor.undoManager.beforeChange();
     }

--- a/modules/tinymce/src/core/main/ts/keyboard/DeleteBackspaceKeys.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/DeleteBackspaceKeys.ts
@@ -102,20 +102,6 @@ const setup = (editor: Editor, caret: Cell<Text | null>): void => {
 
     isBackspaceKeydown = false;
   });
-
-  let isMetaBackspace = false;
-  editor.on('keydown', (evt) => {
-    isMetaBackspace = VK.metaKeyPressed(evt) && evt.key === 'Backspace';
-    if (isMetaBackspace && !evt.isDefaultPrevented()) {
-      editor.undoManager.beforeChange();
-    }
-  });
-  editor.on('keyup', (evt) => {
-    if (isMetaBackspace && !evt.isDefaultPrevented()) {
-      editor.undoManager.add();
-      isMetaBackspace = false;
-    }
-  });
 };
 
 export {

--- a/modules/tinymce/src/core/main/ts/undo/Setup.ts
+++ b/modules/tinymce/src/core/main/ts/undo/Setup.ts
@@ -1,6 +1,7 @@
 import { Cell } from '@ephox/katamari';
 
 import Editor from '../api/Editor';
+import Env from '../api/Env';
 import { EditorEvent } from '../api/util/EventDispatcher';
 import * as Levels from './Levels';
 import { endTyping, setTyping } from './TypingState';
@@ -67,7 +68,9 @@ export const registerEvents = (editor: Editor, undoManager: UndoManager, locks: 
       return;
     }
 
-    if ((keyCode >= 33 && keyCode <= 36) || (keyCode >= 37 && keyCode <= 40) || keyCode === 45 || e.ctrlKey) {
+    const isMeta = Env.os.isMacOS() && e.key === 'Meta';
+
+    if ((keyCode >= 33 && keyCode <= 36) || (keyCode >= 37 && keyCode <= 40) || keyCode === 45 || e.ctrlKey || isMeta) {
       addNonTypingUndoLevel();
       editor.nodeChanged();
     }
@@ -113,6 +116,11 @@ export const registerEvents = (editor: Editor, undoManager: UndoManager, locks: 
       setTyping(undoManager, true, locks);
       undoManager.add({} as UndoLevel, e);
       isFirstTypedCharacter.set(true);
+    }
+
+    const isMetaBackspace = Env.os.isMacOS() && e.metaKey && e.key === 'Backspace';
+    if (isMetaBackspace) {
+      undoManager.beforeChange();
     }
   });
 

--- a/modules/tinymce/src/core/main/ts/undo/Setup.ts
+++ b/modules/tinymce/src/core/main/ts/undo/Setup.ts
@@ -116,6 +116,7 @@ export const registerEvents = (editor: Editor, undoManager: UndoManager, locks: 
       setTyping(undoManager, true, locks);
       undoManager.add({} as UndoLevel, e);
       isFirstTypedCharacter.set(true);
+      return;
     }
 
     const hasOnlyMetaOrCtrlModifier = Env.os.isMacOS() ? e.metaKey : e.ctrlKey && !e.altKey;

--- a/modules/tinymce/src/core/main/ts/undo/Setup.ts
+++ b/modules/tinymce/src/core/main/ts/undo/Setup.ts
@@ -118,8 +118,8 @@ export const registerEvents = (editor: Editor, undoManager: UndoManager, locks: 
       isFirstTypedCharacter.set(true);
     }
 
-    const isMetaBackspace = Env.os.isMacOS() && e.metaKey && e.key === 'Backspace';
-    if (isMetaBackspace) {
+    const hasOnlyMetaOrCtrlModifier = Env.os.isMacOS() ? e.metaKey : e.ctrlKey && !e.altKey;
+    if (hasOnlyMetaOrCtrlModifier) {
       undoManager.beforeChange();
     }
   });


### PR DESCRIPTION
Related Ticket: TINY-8910

Description of Changes:
* Added undo level when pressing cmd+backspace on Mac
* Restore correct caret position after pressing ctrl+backspace/delete on Windows

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
   Automatic testing for this case is next to impossible so we need to rely on manual QA for this one.
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
