### PR TITLE
TINY-9754: now `fontsizeinput` revert to old value instead of setting a default value 

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,9 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 - Screen readers are now able to announce the highlighted menu item of link comboboxes. #TINY-9280
-
-### Improved
 - Toolbar buttons and menu items were not disabled when they couldn't be used on noneditable content. #TINY-9669
+- Now triyng to set a font size with an invalid unit in `fontsizeinput` cause to get back to the original value. #TINY-9754
 
 ### Fixed
 - In the tree component, a selected item in a directory would not stay selected after collapsing the directory. #TINY-9715

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -17,6 +17,8 @@ interface BespokeSelectApi {
   readonly getComponent: () => AlloyComponent;
 }
 
+const defautlValue = 16;
+
 const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage, spec: NumberInputSpec): AlloySpec => {
   let currentComp: Optional<AlloyComponent> = Optional.none();
   let oldValue: Optional<string> = Optional.none();
@@ -43,7 +45,7 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
     const parsedText = Dimension.parse(text, [ 'unsupportedLength', 'empty' ]).or(
       oldValue.bind((value) => Dimension.parse(value, [ 'unsupportedLength', 'empty' ]))
     );
-    const value = parsedText.map((res) => res.value).getOr(0);
+    const value = parsedText.map((res) => res.value).getOr(defautlValue);
     const defaultUnit = Options.getFontSizeInputDefaultUnit(editor);
     const unit = parsedText.map((res) => res.unit).filter((u) => u !== '').getOr(defaultUnit);
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/NumberInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/NumberInputTest.ts
@@ -320,6 +320,24 @@ describe('browser.tinymce.themes.silver.throbber.NumberInputTest', () => {
     assert.isTrue(editor.hasFocus(), 'after enter editor should have focus');
   });
 
+  it('TINY-9754: changing unit to an invalid unit should not set the size to 0', async () => {
+    const editor = hook.editor();
+    const originalFontSize = '16px';
+    editor.setContent(`<p style="font-size: ${originalFontSize};">abc</p>`);
+    TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
+
+    TinyUiActions.clickOnToolbar(editor, '.tox-number-input input');
+
+    const input = TinyUiActions.clickOnToolbar<HTMLInputElement>(editor, '.tox-number-input input');
+    UiControls.setValue(input, '15invalid_unit');
+    const root = SugarShadowDom.getRootNode(TinyDom.targetElement(editor));
+    FocusTools.setFocus(root, '.tox-number-input input');
+    await FocusTools.pTryOnSelector('Focus should be on input', root, '.tox-number-input input');
+    TinyUiActions.keystroke(editor, Keys.enter());
+
+    TinyAssertions.assertContent(editor, `<p style="font-size: ${originalFontSize};">a<span style="font-size: ${originalFontSize};">b</span>c</p>`);
+  });
+
   context('Noneditable root', () => {
     it('TINY-9669: Disable outdent on noneditable content', () => {
       TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {


### PR DESCRIPTION
Related Ticket: TINY-9754

Description of Changes:

possible solutions to avoid that inserting a value with an invalid unit the value will be set to `0pt` (or any other default unit)

1. a mechanism that reverses it to the previous value.
2. check what value the user is trying to insert and add the default unit

I implemented the first one because the second one has these 2 problems:
- value: `abc` -> no number so back to the previous default.
- from `16pt` to `1emm` -> probably here the intention of the user would have been to go to `1em` but we cannot know that so we would convert it to `1pt` which is far away from the user intention.

**Other Changes:**

- remove duplication in the `CHANGELOG`
- put a `defautlValue` different from `0` to cover other possible edge cases with a default that makes "more sense"

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
