### PR TITLE
TINY-9754: now fontsizeinput revert to old value instead of setting a default value

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `urlinput` dialog component would not open the typeahead dropdown when the input value was reset to an empty string. #TINY-9717
 - Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items. #TINY-9692
 - Enabled variant of togglable `tox-button` and `tox-button--secondary` now supports `hover`/`active`/`focus`/`disabled` states. #TINY-9713
-- Setting an invalid unit in the `fontsizeinput` would not have any effect on the font size and revert it back to the original value. #TINY-9754
+- Setting an invalid unit in the `fontsizeinput` would change it do the default value instead of reverting it back to the previous valid value. #TINY-9754
 
 ## 6.4.1 - 2023-03-29
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,13 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Improved
-- Now triyng to set a font size with an invalid unit in `fontsizeinput` cause to get back to the original value. #TINY-9754
-
 ### Fixed
 - The `urlinput` dialog component would not open the typeahead dropdown when the input value was reset to an empty string. #TINY-9717
 - Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items. #TINY-9692
 - Enabled variant of togglable `tox-button` and `tox-button--secondary` now supports `hover`/`active`/`focus`/`disabled` states. #TINY-9713
+- Setting an invalid unit in the `fontsizeinput` would not have any effect on the font size and revert it back to the original value. #TINY-9754
 
 ## 6.4.1 - 2023-03-29
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Improved
+- Now triyng to set a font size with an invalid unit in `fontsizeinput` cause to get back to the original value. #TINY-9754
+
 ### Fixed
 - The `urlinput` dialog component would not open the typeahead dropdown when the input value was reset to an empty string. #TINY-9717
 - Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items. #TINY-9692

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -17,6 +17,8 @@ interface BespokeSelectApi {
   readonly getComponent: () => AlloyComponent;
 }
 
+const defautlValue = 16;
+
 const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage, spec: NumberInputSpec): AlloySpec => {
   let currentComp: Optional<AlloyComponent> = Optional.none();
   let oldValue: Optional<string> = Optional.none();
@@ -42,7 +44,7 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
     const parsedText = Dimension.parse(text, [ 'unsupportedLength', 'empty' ]).or(
       oldValue.bind((value) => Dimension.parse(value, [ 'unsupportedLength', 'empty' ]))
     );
-    const value = parsedText.map((res) => res.value).getOr(0);
+    const value = parsedText.map((res) => res.value).getOr(defautlValue);
     const defaultUnit = Options.getFontSizeInputDefaultUnit(editor);
     const unit = parsedText.map((res) => res.unit).filter((u) => u !== '').getOr(defaultUnit);
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -1,10 +1,9 @@
 import { Keys } from '@ephox/agar';
 import { AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Button, Focusing, FocusInsideModes, Input, Keying, Memento, NativeEvents, Representing } from '@ephox/alloy';
 import { Arr, Cell, Fun, Id, Optional } from '@ephox/katamari';
-import { Dimension, Focus, SugarElement, Traverse } from '@ephox/sugar';
+import { Focus, SugarElement, Traverse } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
-import * as Options from 'tinymce/themes/silver/api/Options';
 import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 
 import { renderIconFromPack } from '../../button/ButtonSlices';
@@ -17,11 +16,8 @@ interface BespokeSelectApi {
   readonly getComponent: () => AlloyComponent;
 }
 
-const defaultValue = 16;
-
 const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage, spec: NumberInputSpec): AlloySpec => {
   let currentComp: Optional<AlloyComponent> = Optional.none();
-  let oldValue: Optional<string> = Optional.none();
 
   const getValueFromCurrentComp = (comp: Optional<AlloyComponent>): string =>
     comp.map((alloyComp) => Representing.getValue(alloyComp)).getOr('');
@@ -37,27 +33,18 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
 
   const customEvents = Id.generate('custom-number-input-events');
 
-  const isValidValue = (value: number): boolean => value >= 0;
-
   const changeValue = (f: (v: number, step: number) => number, fromInput: boolean, focusBack: boolean): void => {
     const text = getValueFromCurrentComp(currentComp);
-    const parsedText = Dimension.parse(text, [ 'unsupportedLength', 'empty' ]).or(
-      oldValue.bind((value) => Dimension.parse(value, [ 'unsupportedLength', 'empty' ]))
-    );
-    const value = parsedText.map((res) => res.value).getOr(defaultValue);
-    const defaultUnit = Options.getFontSizeInputDefaultUnit(editor);
-    const unit = parsedText.map((res) => res.unit).filter((u) => u !== '').getOr(defaultUnit);
 
-    const newValue = f(value, spec.getConfigFromUnit(unit).step);
-    const newValueWithUnit = `${isValidValue(newValue) ? newValue : value}${unit}`;
+    const newValue = spec.getNewValue(text, f);
 
-    const lenghtDelta = `${value}${unit}`.length - `${newValueWithUnit}`.length;
+    const lenghtDelta = text.length - `${newValue}`.length;
     const oldStart = currentComp.map((comp) => comp.element.dom.selectionStart - lenghtDelta);
     const oldEnd = currentComp.map((comp) => comp.element.dom.selectionEnd - lenghtDelta);
 
-    spec.onAction(newValueWithUnit, focusBack);
+    spec.onAction(newValue, focusBack);
     currentComp.each((comp) => {
-      Representing.setValue(comp, newValueWithUnit);
+      Representing.setValue(comp, newValue);
       if (fromInput) {
         oldStart.each((oldStart) => comp.element.dom.selectionStart = oldStart);
         oldEnd.each((oldEnd) => comp.element.dom.selectionEnd = oldEnd);
@@ -137,7 +124,6 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
           ]),
           AddEventsBehaviour.config('input-update-display-text', [
             AlloyEvents.run<UpdateMenuTextEvent>(updateMenuText, (comp, se) => {
-              oldValue = Optional.some(se.event.text);
               Representing.setValue(comp, se.event.text);
             }),
             AlloyEvents.run(NativeEvents.focusout(), (comp) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -17,7 +17,7 @@ interface BespokeSelectApi {
   readonly getComponent: () => AlloyComponent;
 }
 
-const defautlValue = 16;
+const defaultValue = 16;
 
 const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage, spec: NumberInputSpec): AlloySpec => {
   let currentComp: Optional<AlloyComponent> = Optional.none();
@@ -44,7 +44,7 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
     const parsedText = Dimension.parse(text, [ 'unsupportedLength', 'empty' ]).or(
       oldValue.bind((value) => Dimension.parse(value, [ 'unsupportedLength', 'empty' ]))
     );
-    const value = parsedText.map((res) => res.value).getOr(defautlValue);
+    const value = parsedText.map((res) => res.value).getOr(defaultValue);
     const defaultUnit = Options.getFontSizeInputDefaultUnit(editor);
     const unit = parsedText.map((res) => res.unit).filter((u) => u !== '').getOr(defaultUnit);
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -19,6 +19,7 @@ interface BespokeSelectApi {
 
 const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage, spec: NumberInputSpec): AlloySpec => {
   let currentComp: Optional<AlloyComponent> = Optional.none();
+  let oldValue: Optional<string> = Optional.none();
 
   const getValueFromCurrentComp = (comp: Optional<AlloyComponent>): string =>
     comp.map((alloyComp) => Representing.getValue(alloyComp)).getOr('');
@@ -38,7 +39,9 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
 
   const changeValue = (f: (v: number, step: number) => number, fromInput: boolean, focusBack: boolean): void => {
     const text = getValueFromCurrentComp(currentComp);
-    const parsedText = Dimension.parse(text, [ 'unsupportedLength', 'empty' ]);
+    const parsedText = Dimension.parse(text, [ 'unsupportedLength', 'empty' ]).or(
+      oldValue.bind((value) => Dimension.parse(value, [ 'unsupportedLength', 'empty' ]))
+    );
     const value = parsedText.map((res) => res.value).getOr(0);
     const defaultUnit = Options.getFontSizeInputDefaultUnit(editor);
     const unit = parsedText.map((res) => res.unit).filter((u) => u !== '').getOr(defaultUnit);
@@ -132,6 +135,7 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
           ]),
           AddEventsBehaviour.config('input-update-display-text', [
             AlloyEvents.run<UpdateMenuTextEvent>(updateMenuText, (comp, se) => {
+              oldValue = Optional.some(se.event.text);
               Representing.setValue(comp, se.event.text);
             }),
             AlloyEvents.run(NativeEvents.focusout(), (comp) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -151,7 +151,6 @@ const getNumberInputSpec = (editor: Editor): NumberInputSpec => {
     updateInputValue,
     onAction: (format, focusBack) => editor.execCommand('FontSize', false, format, { skip_focus: !focusBack }),
     getNewValue: (text, updateFunction) => {
-
       Dimension.parse(text, [ 'unsupportedLength', 'empty' ]);
 
       const parsedText = Dimension.parse(text, [ 'unsupportedLength', 'empty' ]).or(

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -1,7 +1,9 @@
 import { AlloyComponent, AlloySpec, AlloyTriggers, SketchSpec } from '@ephox/alloy';
 import { Arr, Fun, Obj, Optional } from '@ephox/katamari';
+import { Dimension } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
+import * as Options from 'tinymce/themes/silver/api/Options';
 
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
@@ -17,7 +19,7 @@ interface Config {
 export interface NumberInputSpec {
   onAction: (format: string, focusBack?: boolean) => void;
   updateInputValue: (comp: AlloyComponent) => void;
-  getConfigFromUnit: (unit: string) => Config;
+  getNewValue: (text: string, updateFunction: (value: number, step: number) => number) => string;
 }
 
 // See https://websemantics.uk/articles/font-size-conversion/ for conversions
@@ -136,15 +138,32 @@ const getConfigFromUnit = (unit: string): Config => {
   return configs[unit] ?? baseConfig;
 };
 
+const defaultValue = 16;
+const isValidValue = (value: number): boolean => value >= 0;
+
 const getNumberInputSpec = (editor: Editor): NumberInputSpec => {
+  const getCurrentValue = () => editor.queryCommandValue('FontSize');
   const updateInputValue = (comp: AlloyComponent) => AlloyTriggers.emitWith(comp, updateMenuText, {
-    text: editor.queryCommandValue('FontSize')
+    text: getCurrentValue()
   });
 
   return {
     updateInputValue,
-    getConfigFromUnit,
-    onAction: (format, focusBack) => editor.execCommand('FontSize', false, format, { skip_focus: !focusBack })
+    onAction: (format, focusBack) => editor.execCommand('FontSize', false, format, { skip_focus: !focusBack }),
+    getNewValue: (text, updateFunction) => {
+
+      Dimension.parse(text, [ 'unsupportedLength', 'empty' ]);
+
+      const parsedText = Dimension.parse(text, [ 'unsupportedLength', 'empty' ]).or(
+        Dimension.parse(getCurrentValue(), [ 'unsupportedLength', 'empty' ])
+      );
+      const value = parsedText.map((res) => res.value).getOr(defaultValue);
+      const defaultUnit = Options.getFontSizeInputDefaultUnit(editor);
+      const unit = parsedText.map((res) => res.unit).filter((u) => u !== '').getOr(defaultUnit);
+
+      const newValue = updateFunction(value, getConfigFromUnit(unit).step);
+      return `${isValidValue(newValue) ? newValue : value}${unit}`;
+    }
   };
 };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/NumberInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/NumberInputTest.ts
@@ -319,4 +319,22 @@ describe('browser.tinymce.themes.silver.throbber.NumberInputTest', () => {
     TinyUiActions.keystroke(editor, Keys.enter());
     assert.isTrue(editor.hasFocus(), 'after enter editor should have focus');
   });
+
+  it('TINY-9754: changing unit to an invalid unit should not set the size to 0', async () => {
+    const editor = hook.editor();
+    const originalFontSize = '16px';
+    editor.setContent(`<p style="font-size: ${originalFontSize};">abc</p>`);
+    TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
+
+    TinyUiActions.clickOnToolbar(editor, '.tox-number-input input');
+
+    const input = TinyUiActions.clickOnToolbar<HTMLInputElement>(editor, '.tox-number-input input');
+    UiControls.setValue(input, '15invalid_unit');
+    const root = SugarShadowDom.getRootNode(TinyDom.targetElement(editor));
+    FocusTools.setFocus(root, '.tox-number-input input');
+    await FocusTools.pTryOnSelector('Focus should be on input', root, '.tox-number-input input');
+    TinyUiActions.keystroke(editor, Keys.enter());
+
+    TinyAssertions.assertContent(editor, `<p style="font-size: ${originalFontSize};">a<span style="font-size: ${originalFontSize};">b</span>c</p>`);
+  });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/NumberInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/NumberInputTest.ts
@@ -322,19 +322,22 @@ describe('browser.tinymce.themes.silver.throbber.NumberInputTest', () => {
 
   it('TINY-9754: changing unit to an invalid unit should not set the size to 0', async () => {
     const editor = hook.editor();
-    const originalFontSize = '16px';
+    const originalFontSize = '18px';
     editor.setContent(`<p style="font-size: ${originalFontSize};">abc</p>`);
     TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
 
     TinyUiActions.clickOnToolbar(editor, '.tox-number-input input');
 
     const input = TinyUiActions.clickOnToolbar<HTMLInputElement>(editor, '.tox-number-input input');
-    UiControls.setValue(input, '15invalid_unit');
+    const invalidValue = '15invalid_unit';
+    UiControls.setValue(input, invalidValue);
+    assert.equal(input.dom.value, invalidValue, 'the value in the input should be setted to the invalid value');
     const root = SugarShadowDom.getRootNode(TinyDom.targetElement(editor));
     FocusTools.setFocus(root, '.tox-number-input input');
     await FocusTools.pTryOnSelector('Focus should be on input', root, '.tox-number-input input');
     TinyUiActions.keystroke(editor, Keys.enter());
 
+    assert.equal(input.dom.value, originalFontSize, 'the value in the input should go back to the previous value');
     TinyAssertions.assertContent(editor, `<p style="font-size: ${originalFontSize};">a<span style="font-size: ${originalFontSize};">b</span>c</p>`);
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9754

Description of Changes:

possible solutions to avoid that inserting a value with an invalid unit the value will be set to `0pt` (or any other default unit)

1. a mechanism that reverses it to the previous value.
2. check what value the user is trying to insert and add the default unit

I implemented the first one because the second one has these 2 problems:
- value: `abc` -> no number so back to the previous default.
- from `16pt` to `1emm` -> probably here the intention of the user would have been to go to `1em` but we cannot know that so we would convert it to `1pt` which is far away from the user intention.

**Other Change:**

- put a `defautlValue` different from `0` to cover other possible edge cases with a default that makes "more sense"

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
