### PR TITLE
TINY-9629: Improve 'more' menu button announcement for people using screen readers

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,9 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 - Screen readers are now able to announce the highlighted menu item of link comboboxes. #TINY-9280
-
-### Improved
 - Toolbar buttons and menu items were not disabled when they couldn't be used on noneditable content. #TINY-9669
+- Updated toolbar "More" button tooltip text from "More..." to "Reveal or hide more toolbar items". #TINY-9629
 
 ### Fixed
 - In the tree component, a selected item in a directory would not stay selected after collapsing the directory. #TINY-9715

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Screen readers are now able to announce the highlighted menu item of link comboboxes. #TINY-9280
 - Now `icon` field for dialog footer `togglebutton`s is not mandatory. #TINY-9757
 - Toolbar buttons and menu items were not disabled when they couldn't be used on noneditable content. #TINY-9669
-- Updated toolbar "More" button tooltip text from "More..." to "Reveal or hide more toolbar items". #TINY-9629
+- Updated toolbar "More" button tooltip text from "More..." to "Reveal or hide additional toolbar items". #TINY-9629
 
 ### Fixed
 - In the tree component, a selected item in a directory would not stay selected after collapsing the directory. #TINY-9715

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -112,7 +112,7 @@ const renderMoreToolbarCommon = (toolbarSpec: MoreDrawerToolbarSpec) => {
         name: 'more',
         icon: Optional.some('more-drawer'),
         enabled: true,
-        tooltip: Optional.some('More...'),
+        tooltip: Optional.some('Click to expand or collapse'),
         primary: false,
         buttonType: Optional.none(),
         borderless: false

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -112,7 +112,7 @@ const renderMoreToolbarCommon = (toolbarSpec: MoreDrawerToolbarSpec) => {
         name: 'more',
         icon: Optional.some('more-drawer'),
         enabled: true,
-        tooltip: Optional.some('Toggle additional toolbar buttons'),
+        tooltip: Optional.some('Reveal or hide more toolbar items'),
         primary: false,
         buttonType: Optional.none(),
         borderless: false

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -112,7 +112,7 @@ const renderMoreToolbarCommon = (toolbarSpec: MoreDrawerToolbarSpec) => {
         name: 'more',
         icon: Optional.some('more-drawer'),
         enabled: true,
-        tooltip: Optional.some('Click to expand or collapse'),
+        tooltip: Optional.some('Toggle additional toolbar buttons'),
         primary: false,
         buttonType: Optional.none(),
         borderless: false

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -112,7 +112,7 @@ const renderMoreToolbarCommon = (toolbarSpec: MoreDrawerToolbarSpec) => {
         name: 'more',
         icon: Optional.some('more-drawer'),
         enabled: true,
-        tooltip: Optional.some('Reveal or hide more toolbar items'),
+        tooltip: Optional.some('Reveal or hide additional toolbar items'),
         primary: false,
         buttonType: Optional.none(),
         borderless: false

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -89,11 +89,11 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
         toolbar: Arr.range(10, Fun.constant('bold | italic ')).join('')
       },
       initial: [{
-        clickOn: 'button[title="Toggle additional toolbar buttons"]',
+        clickOn: 'button[title="Reveal or hide more toolbar items"]',
         waitFor: '.tox-toolbar__overflow'
       }],
       assertAbove: '.tox-toolbar__overflow',
-      assertBelow: 'button[title="Toggle additional toolbar buttons"]'
+      assertBelow: 'button[title="Reveal or hide more toolbar items"]'
     }));
 
     it('Menu button in overflow toolbar should open up', () => pTest({
@@ -104,7 +104,7 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
       },
       initial: [
         {
-          clickOn: 'button[title="Toggle additional toolbar buttons"]',
+          clickOn: 'button[title="Reveal or hide more toolbar items"]',
           waitFor: '.tox-toolbar__overflow'
         }, {
           clickOn: 'button[title="Align"]',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -89,11 +89,11 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
         toolbar: Arr.range(10, Fun.constant('bold | italic ')).join('')
       },
       initial: [{
-        clickOn: 'button[title="Click to expand or collapse"]',
+        clickOn: 'button[title="Toggle additional toolbar buttons"]',
         waitFor: '.tox-toolbar__overflow'
       }],
       assertAbove: '.tox-toolbar__overflow',
-      assertBelow: 'button[title="Click to expand or collapse"]'
+      assertBelow: 'button[title="Toggle additional toolbar buttons"]'
     }));
 
     it('Menu button in overflow toolbar should open up', () => pTest({
@@ -104,7 +104,7 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
       },
       initial: [
         {
-          clickOn: 'button[title="Click to expand or collapse"]',
+          clickOn: 'button[title="Toggle additional toolbar buttons"]',
           waitFor: '.tox-toolbar__overflow'
         }, {
           clickOn: 'button[title="Align"]',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -89,11 +89,11 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
         toolbar: Arr.range(10, Fun.constant('bold | italic ')).join('')
       },
       initial: [{
-        clickOn: 'button[title="More..."]',
+        clickOn: 'button[title="Click to expand or collapse"]',
         waitFor: '.tox-toolbar__overflow'
       }],
       assertAbove: '.tox-toolbar__overflow',
-      assertBelow: 'button[title="More..."]'
+      assertBelow: 'button[title="Click to expand or collapse"]'
     }));
 
     it('Menu button in overflow toolbar should open up', () => pTest({
@@ -104,7 +104,7 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
       },
       initial: [
         {
-          clickOn: 'button[title="More..."]',
+          clickOn: 'button[title="Click to expand or collapse"]',
           waitFor: '.tox-toolbar__overflow'
         }, {
           clickOn: 'button[title="Align"]',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -89,11 +89,11 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
         toolbar: Arr.range(10, Fun.constant('bold | italic ')).join('')
       },
       initial: [{
-        clickOn: 'button[title="Reveal or hide more toolbar items"]',
+        clickOn: 'button[title="Reveal or hide additional toolbar items"]',
         waitFor: '.tox-toolbar__overflow'
       }],
       assertAbove: '.tox-toolbar__overflow',
-      assertBelow: 'button[title="Reveal or hide more toolbar items"]'
+      assertBelow: 'button[title="Reveal or hide additional toolbar items"]'
     }));
 
     it('Menu button in overflow toolbar should open up', () => pTest({
@@ -104,7 +104,7 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
       },
       initial: [
         {
-          clickOn: 'button[title="Reveal or hide more toolbar items"]',
+          clickOn: 'button[title="Reveal or hide additional toolbar items"]',
           waitFor: '.tox-toolbar__overflow'
         }, {
           clickOn: 'button[title="Align"]',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
@@ -42,7 +42,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.InlineToolbarDrawerFloati
     editor.setContent('<p>Line 1</p><p>Line 2</p><p>Line 3</p>');
     editor.focus();
     TinySelections.setCursor(editor, [ 2, 0 ], 'Line 3'.length);
-    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[title="Toggle additional toolbar buttons"]');
+    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[title="Reveal or hide more toolbar items"]');
     await pRunTests(editor);
     McEditor.remove(editor);
   };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
@@ -42,7 +42,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.InlineToolbarDrawerFloati
     editor.setContent('<p>Line 1</p><p>Line 2</p><p>Line 3</p>');
     editor.focus();
     TinySelections.setCursor(editor, [ 2, 0 ], 'Line 3'.length);
-    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[title="Click to expand or collapse"]');
+    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[title="Toggle additional toolbar buttons"]');
     await pRunTests(editor);
     McEditor.remove(editor);
   };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
@@ -42,7 +42,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.InlineToolbarDrawerFloati
     editor.setContent('<p>Line 1</p><p>Line 2</p><p>Line 3</p>');
     editor.focus();
     TinySelections.setCursor(editor, [ 2, 0 ], 'Line 3'.length);
-    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[title="More..."]');
+    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[title="Click to expand or collapse"]');
     await pRunTests(editor);
     McEditor.remove(editor);
   };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
@@ -42,7 +42,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.InlineToolbarDrawerFloati
     editor.setContent('<p>Line 1</p><p>Line 2</p><p>Line 3</p>');
     editor.focus();
     TinySelections.setCursor(editor, [ 2, 0 ], 'Line 3'.length);
-    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[title="Reveal or hide more toolbar items"]');
+    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[title="Reveal or hide additional toolbar items"]');
     await pRunTests(editor);
     McEditor.remove(editor);
   };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -104,7 +104,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest',
       });
 
       it(`TINY-9271: Emits 'ToggleToolbarDrawer' in ${toolbarMode} via user click`, async () => {
-        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[title="Reveal or hide more toolbar items"]'));
+        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[title="Reveal or hide additional toolbar items"]'));
       });
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -104,7 +104,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest',
       });
 
       it(`TINY-9271: Emits 'ToggleToolbarDrawer' in ${toolbarMode} via user click`, async () => {
-        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[title="More..."]'));
+        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[title="Click to expand or collapse"]'));
       });
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -104,7 +104,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest',
       });
 
       it(`TINY-9271: Emits 'ToggleToolbarDrawer' in ${toolbarMode} via user click`, async () => {
-        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[title="Click to expand or collapse"]'));
+        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[title="Toggle additional toolbar buttons"]'));
       });
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -104,7 +104,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest',
       });
 
       it(`TINY-9271: Emits 'ToggleToolbarDrawer' in ${toolbarMode} via user click`, async () => {
-        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[title="Toggle additional toolbar buttons"]'));
+        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[title="Reveal or hide more toolbar items"]'));
       });
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -420,13 +420,13 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       const editor = hook.editor();
 
       editor.setContent('<p>ab</p>');
-      TinyUiActions.clickOnToolbar(editor, '[title="Toggle additional toolbar buttons"]');
+      TinyUiActions.clickOnToolbar(editor, '[title="Reveal or hide more toolbar items"]');
 
       editor.execCommand('ToggleView', false, 'myview1');
       assertViewHtml(0, '<button>myview1</button>');
       editor.execCommand('ToggleView', false, 'myview1');
       assertMainViewVisible();
-      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[title="Toggle additional toolbar buttons"]');
+      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[title="Reveal or hide more toolbar items"]');
       assert.isTrue(moreButton.isValue(), '"Expand or collapse" button should be there');
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -420,13 +420,13 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       const editor = hook.editor();
 
       editor.setContent('<p>ab</p>');
-      TinyUiActions.clickOnToolbar(editor, '[title="Click to expand or collapse"]');
+      TinyUiActions.clickOnToolbar(editor, '[title="Toggle additional toolbar buttons"]');
 
       editor.execCommand('ToggleView', false, 'myview1');
       assertViewHtml(0, '<button>myview1</button>');
       editor.execCommand('ToggleView', false, 'myview1');
       assertMainViewVisible();
-      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[title="Click to expand or collapse"]');
+      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[title="Toggle additional toolbar buttons"]');
       assert.isTrue(moreButton.isValue(), '"Expand or collapse" button should be there');
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -420,13 +420,13 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       const editor = hook.editor();
 
       editor.setContent('<p>ab</p>');
-      TinyUiActions.clickOnToolbar(editor, '[title="Reveal or hide more toolbar items"]');
+      TinyUiActions.clickOnToolbar(editor, '[title="Reveal or hide additional toolbar items"]');
 
       editor.execCommand('ToggleView', false, 'myview1');
       assertViewHtml(0, '<button>myview1</button>');
       editor.execCommand('ToggleView', false, 'myview1');
       assertMainViewVisible();
-      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[title="Reveal or hide more toolbar items"]');
+      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[title="Reveal or hide additional toolbar items"]');
       assert.isTrue(moreButton.isValue(), '"Expand or collapse" button should be there');
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -420,13 +420,13 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       const editor = hook.editor();
 
       editor.setContent('<p>ab</p>');
-      TinyUiActions.clickOnToolbar(editor, '[title="Reveal or hide more toolbar items"]');
+      TinyUiActions.clickOnToolbar(editor, '[title="Reveal or hide additional toolbar items"]');
 
       editor.execCommand('ToggleView', false, 'myview1');
       assertViewHtml(0, '<button>myview1</button>');
       editor.execCommand('ToggleView', false, 'myview1');
       assertMainViewVisible();
-      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[title="Reveal or hide more toolbar items"]');
+      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[title="Reveal or hide additional toolbar items"]');
       assert.isTrue(moreButton.isValue(), '"Reveal or hide" button should be there');
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -416,18 +416,18 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       assert.equal(Html.get(editorContainer), expectedHtml);
     };
 
-    it('TINY-9419: "More..." button should not be removed if the toolbar is opened and view is opened and close', () => {
+    it('TINY-9419: "Expand or collapse" button should not be removed if the toolbar is opened and view is opened and close', () => {
       const editor = hook.editor();
 
       editor.setContent('<p>ab</p>');
-      TinyUiActions.clickOnToolbar(editor, '[title="More..."]');
+      TinyUiActions.clickOnToolbar(editor, '[title="Click to expand or collapse"]');
 
       editor.execCommand('ToggleView', false, 'myview1');
       assertViewHtml(0, '<button>myview1</button>');
       editor.execCommand('ToggleView', false, 'myview1');
       assertMainViewVisible();
-      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[title="More..."]');
-      assert.isTrue(moreButton.isValue(), 'More... button should be there');
+      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[title="Click to expand or collapse"]');
+      assert.isTrue(moreButton.isValue(), '"Expand or collapse" button should be there');
     });
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
@@ -25,12 +25,12 @@ const pOpenMenuWithSelector = async (label: string, selector: string): Promise<v
 };
 
 const pOpenMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[title="Toggle additional toolbar buttons"]');
+  Mouse.clickOn(SugarBody.body(), 'button[title="Reveal or hide more toolbar items"]');
   await UiFinder.pWaitForVisible('Waiting for more drawer to open', SugarBody.body(), getToolbarSelector(type, true));
 };
 
 const pCloseMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[title="Toggle additional toolbar buttons"]');
+  Mouse.clickOn(SugarBody.body(), 'button[title="Reveal or hide more toolbar items"]');
   await Waiter.pTryUntil('Waiting for more drawer to close', () => UiFinder.notExists(SugarBody.body(), getToolbarSelector(type, false)));
 };
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
@@ -25,12 +25,12 @@ const pOpenMenuWithSelector = async (label: string, selector: string): Promise<v
 };
 
 const pOpenMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[title="More..."]');
+  Mouse.clickOn(SugarBody.body(), 'button[title="Click to expand or collapse"]');
   await UiFinder.pWaitForVisible('Waiting for more drawer to open', SugarBody.body(), getToolbarSelector(type, true));
 };
 
 const pCloseMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[title="More..."]');
+  Mouse.clickOn(SugarBody.body(), 'button[title="Click to expand or collapse"]');
   await Waiter.pTryUntil('Waiting for more drawer to close', () => UiFinder.notExists(SugarBody.body(), getToolbarSelector(type, false)));
 };
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
@@ -25,12 +25,12 @@ const pOpenMenuWithSelector = async (label: string, selector: string): Promise<v
 };
 
 const pOpenMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[title="Click to expand or collapse"]');
+  Mouse.clickOn(SugarBody.body(), 'button[title="Toggle additional toolbar buttons"]');
   await UiFinder.pWaitForVisible('Waiting for more drawer to open', SugarBody.body(), getToolbarSelector(type, true));
 };
 
 const pCloseMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[title="Click to expand or collapse"]');
+  Mouse.clickOn(SugarBody.body(), 'button[title="Toggle additional toolbar buttons"]');
   await Waiter.pTryUntil('Waiting for more drawer to close', () => UiFinder.notExists(SugarBody.body(), getToolbarSelector(type, false)));
 };
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
@@ -25,12 +25,12 @@ const pOpenMenuWithSelector = async (label: string, selector: string): Promise<v
 };
 
 const pOpenMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[title="Reveal or hide more toolbar items"]');
+  Mouse.clickOn(SugarBody.body(), 'button[title="Reveal or hide additional toolbar items"]');
   await UiFinder.pWaitForVisible('Waiting for more drawer to open', SugarBody.body(), getToolbarSelector(type, true));
 };
 
 const pCloseMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[title="Reveal or hide more toolbar items"]');
+  Mouse.clickOn(SugarBody.body(), 'button[title="Reveal or hide additional toolbar items"]');
   await Waiter.pTryUntil('Waiting for more drawer to close', () => UiFinder.notExists(SugarBody.body(), getToolbarSelector(type, false)));
 };
 


### PR DESCRIPTION
Related Ticket: 
https://ephocks.atlassian.net/browse/TINY-9629

Description of Changes:
Rename the Toolbar "More..." button to "Toggle additional toolbar buttons."

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
