### PR TITLE
TINY-9739: Unlink button/command should not work in noneditable contexts

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680
 - Directionality commands was setting the `dir` attribute on noneditable elements within a noneditable root. #TINY-9662
 - The content of the dialog body could not be scrolled. #TINY-9668
+- It was possible to remove links in noneditable contents with the 'unlink' editor command. #TINY-9739
 
 ## 6.4.1 - 2023-03-29
 

--- a/modules/tinymce/src/core/main/ts/api/commands/LinkCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/commands/LinkCommands.ts
@@ -25,16 +25,18 @@ export const registerCommands = (editor: Editor): void => {
 
   editor.editorCommands.addCommands({
     unlink: () => {
-      if (editor.selection.isCollapsed()) {
-        const elm = editor.dom.getParent(editor.selection.getStart(), 'a');
-        if (elm) {
-          editor.dom.remove(elm, true);
+      if (editor.selection.isEditable()) {
+        if (editor.selection.isCollapsed()) {
+          const elm = editor.dom.getParent(editor.selection.getStart(), 'a');
+          if (elm) {
+            editor.dom.remove(elm, true);
+          }
+
+          return;
         }
 
-        return;
+        editor.formatter.remove('link');
       }
-
-      editor.formatter.remove('link');
     },
 
     mceInsertLink: applyLinkToSelection,

--- a/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
@@ -1,5 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -437,6 +437,15 @@ describe('browser.tinymce.core.FormattingCommandsTest', () => {
     editor.execCommand('SelectAll');
     editor.execCommand('unlink');
     TinyAssertions.assertContent(editor, '<p>test</p><div><p>test</p></div>');
+  });
+
+  it('TINY-9739: Removing link should be a noop for noneditable selections', () => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<p><a href="#">tiny</a></p>');
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 3);
+      editor.execCommand('unlink');
+      TinyAssertions.assertContent(editor, '<p><a href="#">tiny</a></p>');
+    });
   });
 
   it('subscript/superscript', () => {


### PR DESCRIPTION
Related Ticket: TINY-9739

Description of Changes:
* Prevent the `unlink` command from being executed on noneditable selections.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
