### PR TITLE
TINY-9772: Move TINY-8872 changelog entry from 6.3.0 to 6.4.0

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -123,6 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - After closing a view, the `more...` toolbar button disappeared if the editor had `toolbar_mode: 'sliding'` and the toolbar was opened. #TINY-9419
 - Inline dialogs would open partially off screen when the toolbar had a small width. #TINY-9588
 - Word count was inaccurate for documents with specific characters. #TINY-8122
+- The `autoresize` plugin would cause infinite resizing when `content_css` was set to `document`. #TINY-8872
 
 ## 6.3.2 - 2023-02-22
 
@@ -177,7 +178,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A newline could not be inserted when the selection was restored from a bookmark after an inline element with a `contenteditable="false"` attribute. #TINY-9194
 - The global `tinymce.dom.styleSheetLoader` was not affected by the `content_css_cors` option. #TINY-6037
 - The caret was moved to the previous line when a text pattern executed a `mceInsertContent` command on Enter key when running on Firefox. #TINY-9193
-- The `autoresize` plugin used to cause infinite resize when `content_css` is set to `document`. #TINY-8872
 
 ## 6.2.0 - 2022-09-08
 


### PR DESCRIPTION
Related Ticket: TINY-9772

Description of Changes:
* Move TINY-8872 changelog entry from 6.3.0 to 6.4.0, as TINY-8872 was released as part of 6.4

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
