### PR TITLE
TINY-9747: fix scroll when is possible to scroll horizontally

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items. #TINY-9692
 - Enabled variant of togglable `tox-button` and `tox-button--secondary` now supports `hover`/`active`/`focus`/`disabled` states. #TINY-9713
 - Setting an invalid unit in the `fontsizeinput` would change it do the default value instead of reverting it back to the previous valid value. #TINY-9754
-- `scrollIntoView` doesn't manage horizontal scroll correctly. #TINY-9747
+- Selection was not correctly scrolled horizontally into view when using the `selection.scrollIntoView` API. #TINY-9747
 
 ## 6.4.1 - 2023-03-29
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items. #TINY-9692
 - Enabled variant of togglable `tox-button` and `tox-button--secondary` now supports `hover`/`active`/`focus`/`disabled` states. #TINY-9713
 - Setting an invalid unit in the `fontsizeinput` would change it do the default value instead of reverting it back to the previous valid value. #TINY-9754
+- `scrollIntoView` doesn't manage horizontal scroll correctly. #TINY-9747
 
 ## 6.4.1 - 2023-03-29
 

--- a/modules/tinymce/src/core/main/ts/dom/ScrollIntoView.ts
+++ b/modules/tinymce/src/core/main/ts/dom/ScrollIntoView.ts
@@ -117,14 +117,8 @@ const preserveWith = (editor: Editor, f: (startElement: SugarElement<Node>, endE
   editor.selection.setRng(rng);
 };
 
-const scrollToMarker = (marker: MarkerInfo, viewHeight: number, alignToTop: boolean, doc?: SugarElement<Document>) => {
-  const pos = marker.pos;
-  if (alignToTop) {
-    Scroll.to(pos.left, pos.top, doc);
-  } else {
-    marker.element.dom.scrollIntoView({ block: 'end' });
-  }
-};
+const scrollToMarker = (marker: MarkerInfo, _viewHeight: number, alignToTop: boolean, _doc?: SugarElement<Document>) =>
+  marker.element.dom.scrollIntoView({ block: alignToTop ? 'start' : 'end' });
 
 const intoWindowIfNeeded = (doc: SugarElement<Document>, scrollTop: number, viewHeight: number, marker: MarkerInfo, alignToTop?: boolean) => {
   const viewportBottom = viewHeight + scrollTop;

--- a/modules/tinymce/src/core/main/ts/dom/ScrollIntoView.ts
+++ b/modules/tinymce/src/core/main/ts/dom/ScrollIntoView.ts
@@ -122,10 +122,7 @@ const scrollToMarker = (marker: MarkerInfo, viewHeight: number, alignToTop: bool
   if (alignToTop) {
     Scroll.to(pos.left, pos.top, doc);
   } else {
-    // The position we want to scroll to is the...
-    // (absolute position of the marker, minus the view height) plus (the height of the marker)
-    const y = (pos.top - viewHeight) + marker.height;
-    Scroll.to(pos.left, y, doc);
+    marker.element.dom.scrollIntoView({ block: 'end' });
   }
 };
 

--- a/modules/tinymce/src/core/main/ts/dom/ScrollIntoView.ts
+++ b/modules/tinymce/src/core/main/ts/dom/ScrollIntoView.ts
@@ -117,38 +117,38 @@ const preserveWith = (editor: Editor, f: (startElement: SugarElement<Node>, endE
   editor.selection.setRng(rng);
 };
 
-const scrollToMarker = (marker: MarkerInfo, _viewHeight: number, alignToTop: boolean, _doc?: SugarElement<Document>) =>
+const scrollToMarker = (marker: MarkerInfo, alignToTop: boolean) =>
   marker.element.dom.scrollIntoView({ block: alignToTop ? 'start' : 'end' });
 
-const intoWindowIfNeeded = (doc: SugarElement<Document>, scrollTop: number, viewHeight: number, marker: MarkerInfo, alignToTop?: boolean) => {
+const intoWindowIfNeeded = (scrollTop: number, viewHeight: number, marker: MarkerInfo, alignToTop?: boolean) => {
   const viewportBottom = viewHeight + scrollTop;
   const markerTop = marker.pos.top;
   const markerBottom = marker.bottom;
   const largerThanViewport = markerBottom - markerTop >= viewHeight;
   // above the screen, scroll to top by default
   if (markerTop < scrollTop) {
-    scrollToMarker(marker, viewHeight, alignToTop !== false, doc);
+    scrollToMarker(marker, alignToTop !== false);
   // completely below the screen. Default scroll to the top if element height is larger
   // than the viewport, otherwise default to scrolling to the bottom
   } else if (markerTop > viewportBottom) {
     const align = largerThanViewport ? alignToTop !== false : alignToTop === true;
-    scrollToMarker(marker, viewHeight, align, doc);
+    scrollToMarker(marker, align);
   // partially below the bottom, only scroll if element height is less than viewport
   } else if (markerBottom > viewportBottom && !largerThanViewport) {
-    scrollToMarker(marker, viewHeight, alignToTop === true, doc);
+    scrollToMarker(marker, alignToTop === true);
   }
 };
 
 const intoWindow = (doc: SugarElement<Document>, scrollTop: number, marker: MarkerInfo, alignToTop?: boolean) => {
   const viewHeight = Traverse.defaultView(doc).dom.innerHeight;
-  intoWindowIfNeeded(doc, scrollTop, viewHeight, marker, alignToTop);
+  intoWindowIfNeeded(scrollTop, viewHeight, marker, alignToTop);
 };
 
 const intoFrame = (doc: SugarElement<Document>, scrollTop: number, marker: MarkerInfo, alignToTop?: boolean) => {
   const frameViewHeight = Traverse.defaultView(doc).dom.innerHeight; // height of iframe container
 
   // If the position is outside the iframe viewport, scroll to it
-  intoWindowIfNeeded(doc, scrollTop, frameViewHeight, marker, alignToTop);
+  intoWindowIfNeeded(scrollTop, frameViewHeight, marker, alignToTop);
 
   // If the new position is outside the window viewport, scroll to it
   const op = OuterPosition.find(marker.element);

--- a/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
@@ -57,11 +57,19 @@ describe('browser.tinymce.core.dom.ScrollIntoViewTest', () => {
     ScrollIntoView.scrollRangeIntoView(editor, rng);
   };
 
-  const assertScrollPosition = (editor: Editor, x: number, y: number) => {
+  const assertHorizontalScrollPosition = (editor: Editor, x: number) => {
     const actualX = Math.round(editor.dom.getViewPort(editor.getWin()).x);
-    const actualY = Math.round(editor.dom.getViewPort(editor.getWin()).y);
     assert.approximately(actualX, x, 3, `Scroll position X should be expected value: ${x} got ${actualX}`);
+  };
+
+  const assertVerticalScrollPosition = (editor: Editor, y: number) => {
+    const actualY = Math.round(editor.dom.getViewPort(editor.getWin()).y);
     assert.approximately(actualY, y, 3, `Scroll position Y should be expected value: ${y} got ${actualY}`);
+  };
+
+  const assertScrollPosition = (editor: Editor, x: number, y: number) => {
+    assertHorizontalScrollPosition(editor, x);
+    assertVerticalScrollPosition(editor, y);
   };
 
   const assertApproxScrollPosition = (editor: Editor, x: number, y: number) => {
@@ -151,7 +159,8 @@ describe('browser.tinymce.core.dom.ScrollIntoViewTest', () => {
 
       TinySelections.setCursor(editor, [ 0, 2, 0 ], 0);
       editor.selection.scrollIntoView();
-      assertScrollPosition(editor, 0, 704);
+      // TINY-9747: here the assertion on vertical scroll has a different value on a different browser this is probably caused by the scrollbar
+      assertHorizontalScrollPosition(editor, 0);
     });
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
@@ -24,6 +24,7 @@ describe('browser.tinymce.core.dom.ScrollIntoViewTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     add_unload_trigger: false,
     height: 500,
+    with: 1000,
     base_url: '/project/tinymce/js/tinymce',
     content_style: 'body.mce-content-body  { margin: 0 }'
   }, [], true);
@@ -59,8 +60,8 @@ describe('browser.tinymce.core.dom.ScrollIntoViewTest', () => {
   const assertScrollPosition = (editor: Editor, x: number, y: number) => {
     const actualX = Math.round(editor.dom.getViewPort(editor.getWin()).x);
     const actualY = Math.round(editor.dom.getViewPort(editor.getWin()).y);
-    assert.equal(actualX, x, `Scroll position X should be expected value: ${x} got ${actualX}`);
-    assert.equal(actualY, y, `Scroll position Y should be expected value: ${y} got ${actualY}`);
+    assert.approximately(actualX, x, 3, `Scroll position X should be expected value: ${x} got ${actualX}`);
+    assert.approximately(actualY, y, 3, `Scroll position Y should be expected value: ${y} got ${actualY}`);
   };
 
   const assertApproxScrollPosition = (editor: Editor, x: number, y: number) => {
@@ -138,6 +139,19 @@ describe('browser.tinymce.core.dom.ScrollIntoViewTest', () => {
       TinySelections.setCursor(editor, [ 2, 0 ], 0);
       editor.selection.scrollIntoView();
       assertScrollPosition(editor, 0, 689);
+    });
+
+    it('TINY-9747: when the selection is scrolled into view selection if there is an horizontal scroll it should preserve the correct left position', async () => {
+      const editor = hook.editor();
+      await pSetContent(editor, `<div class="container-with-horizontal-scroll" style="margin-left: 100px">
+        <div style="height: 1000px; width: 2000px">a</div>
+        <div style="height: 50px">b</div>
+        <div style="height: 600px">a</div>
+      </div>`);
+
+      TinySelections.setCursor(editor, [ 0, 2, 0 ], 0);
+      editor.selection.scrollIntoView();
+      assertScrollPosition(editor, 0, 704);
     });
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
@@ -159,7 +159,16 @@ describe('browser.tinymce.core.dom.ScrollIntoViewTest', () => {
 
       TinySelections.setCursor(editor, [ 0, 2, 0 ], 0);
       editor.selection.scrollIntoView();
-      // TINY-9747: here the assertion on vertical scroll has a different value on a different browser this is probably caused by the scrollbar
+      /*
+        TINY-9747: here the assertion on vertical scroll has a different value on a different browser
+        because if the scrollbar is showed to have the element `a` inside the view the required scroll is different:
+
+        ----   ----
+        |      |
+        |      a
+        a      scrollbar
+        ----   ----
+      */
       assertHorizontalScrollPosition(editor, 0);
     });
   });

--- a/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
@@ -24,7 +24,7 @@ describe('browser.tinymce.core.dom.ScrollIntoViewTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     add_unload_trigger: false,
     height: 500,
-    with: 1000,
+    width: 1000,
     base_url: '/project/tinymce/js/tinymce',
     content_style: 'body.mce-content-body  { margin: 0 }'
   }, [], true);


### PR DESCRIPTION
Related Ticket: TINY-9747

Description of Changes:
now `scrollToMarker` use native `scrollIntoView` instead of calculating the new position

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
