### PR TITLE
TINY-9678: CEF <p> tag element inside CEF root, apply's formatting to CET <p> element

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680
 - Directionality commands was setting the `dir` attribute on noneditable elements within a noneditable root. #TINY-9662
 - The content of the dialog body could not be scrolled. #TINY-9668
+- Formats were incorrectly applied to the closest editable element if the selection was in a noneditable context. #TINY-9678
+- Formats were incorrectly removed to the closest editable element if the selection was in a noneditable context. #TINY-9678
+- Formatter API `canApply` was not returning `false` when the selection was in a noneditable context. #TINY-9678
 
 ## 6.4.1 - 2023-03-29
 

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -56,7 +56,7 @@ const applyStyles = (dom: DOMUtils, elm: Element, format: ApplyFormat, vars: For
   }
 };
 
-const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | RangeLikeObject | null): void => {
+const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: Node | RangeLikeObject | null): void => {
   const formatList = ed.formatter.get(name) as ApplyFormat[];
   const format = formatList[0];
   const isCollapsed = !node && ed.selection.isCollapsed();
@@ -370,6 +370,12 @@ const applyFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | 
   }
 
   Events.fireFormatApply(ed, name, node, vars);
+};
+
+const applyFormat = (editor: Editor, name: string, vars?: FormatVars, node?: Node | RangeLikeObject | null): void => {
+  if (editor.selection.isEditable()) {
+    applyFormatAction(editor, name, vars, node);
+  }
 };
 
 export {

--- a/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
@@ -194,7 +194,7 @@ const canApply = (editor: Editor, name: string): boolean => {
   const formatList = editor.formatter.get(name);
   const dom = editor.dom;
 
-  if (formatList) {
+  if (formatList && editor.selection.isEditable()) {
     const startNode = editor.selection.getStart();
     const parents = FormatUtils.getParents(dom, startNode);
 

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -349,18 +349,7 @@ const removeFormatInternal = (ed: Editor, format: Format, vars?: FormatVars, nod
   return removeResult.keep();
 };
 
-/**
- * Removes the specified format for the specified node. It will also remove the node if it doesn't have
- * any attributes if the format specifies it to do so.
- *
- * @private
- * @param {Object} format Format object with items to remove from node.
- * @param {Object} vars Name/value object with variables to apply to format.
- * @param {Node} node Node to remove the format styles on.
- * @param {Node} compareNode Optional compare node, if specified the styles will be compared to that node.
- * @return {Boolean} True/false if the node was removed or not.
- */
-const removeFormat = (ed: Editor, format: Format, vars: FormatVars | undefined, node: Node, compareNode?: Node | null): boolean =>
+const removeFormatAction = (ed: Editor, format: Format, vars: FormatVars | undefined, node: Node, compareNode?: Node | null): boolean =>
   removeFormatInternal(ed, format, vars, node, compareNode).fold(
     Fun.never,
     (newName) => {
@@ -663,6 +652,25 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
   removeListStyleFormats(ed, name, vars);
 
   Events.fireFormatRemove(ed, name, node, vars);
+};
+
+/**
+ * Removes the specified format for the specified node. It will also remove the node if it doesn't have
+ * any attributes if the format specifies it to do so.
+ *
+ * @private
+ * @param {Object} format Format object with items to remove from node.
+ * @param {Object} vars Name/value object with variables to apply to format.
+ * @param {Node} node Node to remove the format styles on.
+ * @param {Node} compareNode Optional compare node, if specified the styles will be compared to that node.
+ * @return {Boolean} True/false if the node was removed or not.
+ */
+const removeFormat = (editor: Editor, format: Format, vars: FormatVars | undefined, node: Node, compareNode?: Node | null): boolean => {
+  if (editor.selection.isEditable()) {
+    return removeFormatAction(editor, format, vars, node, compareNode);
+  } else {
+    return false;
+  }
 };
 
 export {

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -2510,7 +2510,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       const initialContent = '<p>test</p><p contenteditable="true">editable</p>';
       editor.setContent(initialContent);
-      TinySelections.setSelection(editor, [ 0, 0 ], 4, [ 0, 0 ], 4);
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 4);
       editor.formatter.apply('bold');
       TinyAssertions.assertContent(editor, initialContent);
     });

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -1,7 +1,7 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Obj } from '@ephox/katamari';
-import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -1748,17 +1748,6 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     assert.equal(editor.getContent(), '<p>abc</p><p contenteditable="false">def</p><p><b>ghi</b></p>', 'Text in last paragraph is bold');
   });
 
-  it('contentEditable: true on start and contentEditable: false on end', () => {
-    const editor = hook.editor();
-    editor.formatter.register('format', {
-      inline: 'b'
-    });
-    editor.setContent('<p>abc</p><p contenteditable="false">def</p>');
-    LegacyUnit.setSelection(editor, 'p:nth-child(1)', 0, 'p:nth-child(2)', 3);
-    editor.formatter.apply('format');
-    assert.equal(editor.getContent(), '<p><b>abc</b></p><p contenteditable="false">def</p>', 'Text in first paragraph is bold');
-  });
-
   it('contentEditable: true inside contentEditable: false', () => {
     const editor = hook.editor();
     editor.formatter.register('format', {
@@ -2515,5 +2504,15 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     TinySelections.setCursor(editor, [ 0, 0 ], 7);
     editor.formatter.apply('blockquote');
     TinyAssertions.assertContent(editor, '<blockquote><p>test test</p></blockquote>');
+  });
+
+  it('TINY-9678: Should be a noop if selection is not in an editable context', () => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+      const initialContent = '<p>test</p><p contenteditable="true">editable</p>';
+      editor.setContent(initialContent);
+      TinySelections.setSelection(editor, [ 0, 0 ], 4, [ 0, 0 ], 4);
+      editor.formatter.apply('bold');
+      TinyAssertions.assertContent(editor, initialContent);
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
@@ -1,5 +1,5 @@
 import { before, context, describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -228,6 +228,14 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     editor.setContent('<p>a</p>');
     LegacyUnit.setSelection(editor, 'p', 0, 'p', 1);
     assert.isTrue(editor.formatter.canApply('bold'));
+  });
+
+  it('canApply should return false for noneditable selections', () => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<p>a</p>');
+      LegacyUnit.setSelection(editor, 'p', 0, 'p', 1);
+      assert.isFalse(editor.formatter.canApply('bold'));
+    });
   });
 
   it('Custom onmatch handler', () => {

--- a/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterCheckTest.ts
@@ -230,10 +230,10 @@ describe('browser.tinymce.core.FormatterCheckTest', () => {
     assert.isTrue(editor.formatter.canApply('bold'));
   });
 
-  it('canApply should return false for noneditable selections', () => {
+  it('TINY-9678: canApply should return false for noneditable selections', () => {
     TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<p>a</p>');
-      LegacyUnit.setSelection(editor, 'p', 0, 'p', 1);
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
       assert.isFalse(editor.formatter.canApply('bold'));
     });
   });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
@@ -266,7 +266,7 @@ describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
     TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       const initialContent = '<p><strong>test</strong></p><p contenteditable="true"><strong>editable</strong></p>';
       editor.setContent(initialContent);
-      TinySelections.setSelection(editor, [ 0, 0, 0 ], 4, [ 0, 0, 0 ], 4);
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 4);
       editor.formatter.remove('bold');
       TinyAssertions.assertContent(editor, initialContent);
     });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
@@ -1,5 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Format } from 'tinymce/core/fmt/FormatTypes';
@@ -259,6 +259,16 @@ describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
 
       TinyAssertions.assertContent(editor, '<p style="text-align: right;">Test text<img src="link" width="40" height="40"></p>');
       TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 2);
+    });
+  });
+
+  it('TINY-9678: Should be a noop if selection is not in an editable context', () => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+      const initialContent = '<p><strong>test</strong></p><p contenteditable="true"><strong>editable</strong></p>';
+      editor.setContent(initialContent);
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 4, [ 0, 0, 0 ], 4);
+      editor.formatter.remove('bold');
+      TinyAssertions.assertContent(editor, initialContent);
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9678

Description of Changes:
* Prevents formatting api calls from being executed if the selection is noneditable
* Returns `false` if the formatting `canApply` is executed on noneditable selections.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
