### PR TITLE
TINY-9604: Do not show error notification when editor fails to retrieve blob url

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -2,7 +2,7 @@ import { Arr, Strings, Type } from '@ephox/katamari';
 import { Attribute, SugarElement } from '@ephox/sugar';
 
 import * as ErrorReporter from '../ErrorReporter';
-import { BlobInfoImagePair, ImageScanner } from '../file/ImageScanner';
+import { BlobInfoImagePair, BlobUriError, ImageScanner } from '../file/ImageScanner';
 import { Uploader } from '../file/Uploader';
 import { UploadStatus } from '../file/UploadStatus';
 import * as Rtc from '../Rtc';
@@ -247,6 +247,8 @@ const EditorUpload = (editor: Editor): EditorUpload => {
         // In such case resultItem will contain appropriate text error message, instead of image data.
         if (Type.isString(resultItem)) {
           ErrorReporter.displayError(editor, resultItem);
+          return false;
+        } else if ((resultItem as BlobUriError).uriType === 'blob') {
           return false;
         } else {
           return true;

--- a/modules/tinymce/src/core/main/ts/file/Conversions.ts
+++ b/modules/tinymce/src/core/main/ts/file/Conversions.ts
@@ -16,7 +16,10 @@ interface DataUriResult {
 const blobUriToBlob = (url: string): Promise<Blob> =>
   fetch(url)
     .then((res) => res.ok ? res.blob() : Promise.reject())
-    .catch(() => Promise.reject(`Cannot convert ${url} to Blob. Resource might not exist or is inaccessible.`));
+    .catch(() => Promise.reject({
+      message: `Cannot convert ${url} to Blob. Resource might not exist or is inaccessible.`,
+      uriType: 'blob'
+    }));
 
 const extractBase64Data = (data: string): string => {
   const matches = /([a-z0-9+\/=\s]+)/i.exec(data);

--- a/modules/tinymce/src/core/main/ts/file/ImageScanner.ts
+++ b/modules/tinymce/src/core/main/ts/file/ImageScanner.ts
@@ -10,8 +10,13 @@ export interface BlobInfoImagePair {
   blobInfo: BlobInfo;
 }
 
+export interface BlobUriError {
+  uriType: 'blob';
+  message: string;
+}
+
 export interface ImageScanner {
-  findAll: (elm: HTMLElement, predicate?: (img: HTMLImageElement) => boolean) => Promise<Array<BlobInfoImagePair | string>>;
+  findAll: (elm: HTMLElement, predicate?: (img: HTMLImageElement) => boolean) => Promise<Array<BlobInfoImagePair | string | BlobUriError>>;
 }
 
 /**


### PR DESCRIPTION
Related Ticket: TINY-9604

Description of Changes:
* Do not show error notification when editor fails to retrieve blob url

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
