### PR TITLE
TINY-9748: Do not add resizehandles if editor is not in focus.

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460
 - Inline alert in the "Search and Replace" dialog persisted when it wasn't necessary. #TINY-9704
 - Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680
+- Initiating the editor with a table at the start would display resize handles even when the editor is not in focus. #TINY-9748
 - On iOS Safari, Hangul (Korean) characters will no longer merge onto the previous line after inserting a newline by pressing Enter. #TINY-9746
 - Directionality commands was setting the `dir` attribute on noneditable elements within a noneditable root. #TINY-9662
 - The content of the dialog body could not be scrolled. #TINY-9668

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460
 - Inline alert in the "Search and Replace" dialog persisted when it wasn't necessary. #TINY-9704
 - Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680
-- Initiating the editor with a table at the start would display resize handles even when the editor is not in focus. #TINY-9748
+- Initiating the editor with a table at the start would display resize handles even when the editor wasn't focused. #TINY-9748
 - On iOS Safari, Hangul (Korean) characters will no longer merge onto the previous line after inserting a newline by pressing Enter. #TINY-9746
 - Directionality commands was setting the `dir` attribute on noneditable elements within a noneditable root. #TINY-9662
 - The content of the dialog body could not be scrolled. #TINY-9668

--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -429,7 +429,7 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
       img.removeAttribute(elementSelectionAttr);
     });
 
-    if (Type.isNonNullable(controlElm) && isChildOrEqual(controlElm, rootElement)) {
+    if (Type.isNonNullable(controlElm) && isChildOrEqual(controlElm, rootElement) && editor.hasFocus()) {
       disableGeckoResize();
       const startElm = selection.getStart(true);
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/UnmergeCellTableResizeTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/UnmergeCellTableResizeTest.ts
@@ -243,6 +243,7 @@ describe('browser.tinymce.models.dom.table.UnmergeCellTableResizeTest', () => {
   };
 
   const pUnmergeCellsMeasureTableWidth = async (editor: Editor, scenario: Scenario) => {
+    editor.focus();
     const table = insertTable(editor, scenario.html);
     await TableTestUtils.pDragHandle(editor, 'se', -100, 0);
     const widthBefore = TableTestUtils.getWidths(editor, table.dom);


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
The editor will now require to be in focus before it adds the resize handles

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
