### PR TITLE
TINY-9680: context toolbar not showing the correct status for `advlist`

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,12 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - The editor would display a notification error when it fails to retirieve a blob image uri. #TINY-9604
-- Menu buttons would have the Tabstopping behaviour in toolbar. #TINY-9723 
+- Menu buttons would have the Tabstopping behaviour in toolbar. #TINY-9723
 - The `urlinput` dialog component would not open the typeahead dropdown when the input value was reset to an empty string. #TINY-9717
 - Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items. #TINY-9692
 - Enabled variant of togglable `tox-button` and `tox-button--secondary` now supports `hover`/`active`/`focus`/`disabled` states. #TINY-9713
 - Setting an invalid unit in the `fontsizeinput` would change it do the default value instead of reverting it back to the previous valid value. #TINY-9754
 - Selection was not correctly scrolled horizontally into view when using the `selection.scrollIntoView` API. #TINY-9747
+- Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680
 
 ## 6.4.1 - 2023-03-29
 

--- a/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/core/ListUtils.ts
@@ -1,6 +1,7 @@
 import { Arr, Optional, Type } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
+import { NodeChangeEvent } from 'tinymce/core/api/EventTypes';
 
 const isCustomList = (list: HTMLElement): boolean =>
   /\btox\-/.test(list.className);
@@ -35,10 +36,23 @@ const isWithinNonEditableList = (editor: Editor, element: Element | null): boole
   return isWithinNonEditable(editor, parentList);
 };
 
+const setNodeChangeHandler = (editor: Editor, nodeChangeHandler: (e: NodeChangeEvent) => void): () => void => {
+  const initialNode = editor.selection.getNode();
+  // Set the initial state
+  nodeChangeHandler({
+    parents: editor.dom.getParents(initialNode),
+    element: initialNode
+  });
+  editor.on('NodeChange', nodeChangeHandler);
+  return () => editor.off('NodeChange', nodeChangeHandler);
+};
+
 export {
   isTableCellNode, // Exported for testing
   isListNode, // Exported for testing
   inList,
   getSelectedStyleType,
-  isWithinNonEditableList
+  isWithinNonEditableList,
+  setNodeChangeHandler
 };
+

--- a/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
@@ -3,7 +3,6 @@ import { Type } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 import { NodeChangeEvent } from 'tinymce/core/api/EventTypes';
 import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import Tools from 'tinymce/core/api/util/Tools';
 
 import * as Options from '../api/Options';
@@ -26,13 +25,14 @@ const normalizeStyleValue = (styleValue: string | undefined): string =>
   Type.isNullable(styleValue) || styleValue === 'default' ? '' : styleValue;
 
 const makeSetupHandler = (editor: Editor, nodeName: ListType) => (api: Toolbar.ToolbarSplitButtonInstanceApi | Toolbar.ToolbarToggleButtonInstanceApi) => {
-  const nodeChangeHandler = (e: EditorEvent<NodeChangeEvent>) => {
-    api.setActive(ListUtils.inList(editor, e.parents, nodeName));
-    api.setEnabled(!ListUtils.isWithinNonEditableList(editor, e.element));
+  const updateButtonState = (editor: Editor, parents: Node[]) => {
+    const element = editor.selection.getStart(true);
+    api.setActive(ListUtils.inList(editor, parents, nodeName));
+    api.setEnabled(!ListUtils.isWithinNonEditableList(editor, element));
   };
-  editor.on('NodeChange', nodeChangeHandler);
+  const nodeChangeHandler = (e: NodeChangeEvent) => updateButtonState(editor, e.parents);
 
-  return () => editor.off('NodeChange', nodeChangeHandler);
+  return ListUtils.setNodeChangeHandler(editor, nodeChangeHandler);
 };
 
 const addSplitButton = (editor: Editor, id: string, tooltip: string, cmd: string, nodeName: ListType, styles: string[]): void => {


### PR DESCRIPTION
Related Ticket: TINY-9680

Description of Changes:
the problem seems to was caused by the different way that we manage the `makeSetupHandler` in [advlist](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts) versus in the [lists](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/plugins/lists/main/ts/ui/Buttons.ts#L7-L13), so I simply aligned the two behaviors.

About the test, at the moment there is some strange thing that is going on with the test about the open of the `context toolbar`

- I had to put it as the first `context` because somehow the other test block the opening of the `context toolbar`
- I had to put `inline: true` otherwise it does not work
- I tried to use: `editor.dispatch('contexttoolbar-show', { toolbarKey });` but it won't reproduce the bug

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
