### PR TITLE
TINY-9769: Regression: quickimage button no longer works

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -138,7 +138,7 @@ const renderCommonStructure = (
               Replacing.set(displayIcon, [ renderReplaceableIconFromPack(se.event.icon, providersBackstage.icons) ]);
             });
           }),
-          AlloyEvents.run<EventArgs<MouseEvent>>(NativeEvents.mousedown(), (button, se) => {
+          AlloyEvents.run<EventArgs<MouseEvent>>(NativeEvents.mousedown(), (button) => {
             AlloyTriggers.emit(button, focusButtonEvent);
           })
         ])

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -139,7 +139,6 @@ const renderCommonStructure = (
             });
           }),
           AlloyEvents.run<EventArgs<MouseEvent>>(NativeEvents.mousedown(), (button, se) => {
-            se.event.prevent();
             AlloyTriggers.emit(button, focusButtonEvent);
           })
         ])


### PR DESCRIPTION
Related Ticket: TINY-9769

Description of Changes:
* Placeholder text

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
