### PR TITLE
TINY-9769: Regression: quickimage button no longer works

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Setting an invalid unit in the `fontsizeinput` would change it do the default value instead of reverting it back to the previous valid value. #TINY-9754
 - Selection was not correctly scrolled horizontally into view when using the `selection.scrollIntoView` API. #TINY-9747
 - Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680
+- The image would not be inserted when using the `quickimage` button on Chrome. #TINY-9769
 
 ## 6.4.1 - 2023-03-29
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -138,8 +138,7 @@ const renderCommonStructure = (
               Replacing.set(displayIcon, [ renderReplaceableIconFromPack(se.event.icon, providersBackstage.icons) ]);
             });
           }),
-          AlloyEvents.run<EventArgs<MouseEvent>>(NativeEvents.mousedown(), (button, se) => {
-            se.event.prevent();
+          AlloyEvents.run<EventArgs<MouseEvent>>(NativeEvents.mousedown(), (button) => {
             AlloyTriggers.emit(button, focusButtonEvent);
           })
         ])

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -138,7 +138,8 @@ const renderCommonStructure = (
               Replacing.set(displayIcon, [ renderReplaceableIconFromPack(se.event.icon, providersBackstage.icons) ]);
             });
           }),
-          AlloyEvents.run<EventArgs<MouseEvent>>(NativeEvents.mousedown(), (button) => {
+          AlloyEvents.run<EventArgs<MouseEvent>>(NativeEvents.mousedown(), (button, se) => {
+            se.event.prevent();
             AlloyTriggers.emit(button, focusButtonEvent);
           })
         ])


### PR DESCRIPTION
Related Ticket: TINY-9769

Description of Changes:
* on Chrome `focusin` event is fired before `change` fileinput event, so the `focusin` handler is scheduled 1 sec later
* requires manual testing

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
