### PR TITLE
TINY-9719: Address premium skin deployment issues due to prismjs dependency being misplaced as a dev dependency

### DIFF
--- a/modules/oxide/package.json
+++ b/modules/oxide/package.json
@@ -32,7 +32,7 @@
     "README.md",
     "LICENSE.txt"
   ],
-  "devDependencies": {
+  "dependencies": {
     "prism-themes": "^1.9.0",
     "prismjs": "^1.27.0"
   }


### PR DESCRIPTION
Related Ticket: 
https://ephocks.atlassian.net/browse/TINY-9719

Description of Changes:
Update prism packages from devDependencies to `dependencies` in oxide

Pre-checks:
* [x] <s>Changelog entry added</s>
* [x] <s>Tests have been added (if applicable)</s>
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] <s>Docs ticket created (if applicable)</s>

GitHub issues (if applicable):
