### PR TITLE
TINY-9696: Add padding when removing elements if required.

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Table toolbar was visible even if the table was within a noneditable host element. #TINY-9664
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460
 - Show the calculated height and width of media embed elements in the `media` plugin dialog. #TINY-8714
-- Removing an image that failed to upload from an empty paragraph will not leave the paragraph without the correct padding. #TINY-9696
+- Removing an image that failed to upload from an empty paragraph would leave the paragraph without the correct padding. #TINY-9696
 - Allow a media embed element to be correctly resized when using the `media` plugin dialog by converting the media embed to a standalone iframe. #TINY-8714
 - Inline alert in the "Search and Replace" dialog persisted when it wasn't necessary. #TINY-9704
 - Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Table toolbar was visible even if the table was within a noneditable host element. #TINY-9664
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460
 - Show the calculated height and width of media embed elements in the `media` plugin dialog. #TINY-8714
+- Removing an image that failed to upload from an empty paragraph will not leave the paragraph without the correct padding. #TINY-9696
 - Allow a media embed element to be correctly resized when using the `media` plugin dialog by converting the media embed to a standalone iframe. #TINY-8714
 - Inline alert in the "Search and Replace" dialog persisted when it wasn't necessary. #TINY-9704
 - Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Table toolbar was visible even if the table was within a noneditable host element. #TINY-9664
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460
 - Show the calculated height and width of media embed elements in the `media` plugin dialog. #TINY-8714
-- Removing an image that failed to upload from an empty paragraph would leave the paragraph without the correct padding. #TINY-9696
+- Removing an image that failed to upload from an empty paragraph would leave the paragraph without a padding br. #TINY-9696
 - Allow a media embed element to be correctly resized when using the `media` plugin dialog by converting the media embed to a standalone iframe. #TINY-8714
 - Inline alert in the "Search and Replace" dialog persisted when it wasn't necessary. #TINY-9704
 - Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -1,5 +1,5 @@
 import { Arr, Strings, Type } from '@ephox/katamari';
-import { Attribute, Insert, Remove, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
+import { Attribute, Insert, Remove, SugarElement, SugarElements, SugarNode, Traverse } from '@ephox/sugar';
 
 import * as ErrorReporter from '../ErrorReporter';
 import { BlobInfoImagePair, BlobUriError, ImageScanner } from '../file/ImageScanner';
@@ -98,14 +98,15 @@ interface EditorUpload {
   destroy: () => void;
 }
 
-const isEmptyForPadding = (element: SugarElement<any>) =>
-  !Traverse.hasChildNodes(element) && SugarNode.isTag('p')(element);
+const isEmptyForPadding = (editor: Editor, element: SugarElement<any>) =>
+  editor.dom.isEmpty(element.dom) && Type.isNonNullable(editor.schema.getTextBlockElements()[SugarNode.name(element)]);
 
-const addPaddingToEmpty = (element: SugarElement<any>) => {
-  if (isEmptyForPadding(element)) {
-    Insert.append(element, SugarElement.fromHtml('<br data-mce-bogus="1" />'));
-  }
-};
+const addPaddingToEmpty = (editor: Editor) =>
+  (element: SugarElement<any>) => {
+    if (isEmptyForPadding(editor, element)) {
+      Insert.append(element, SugarElement.fromHtml('<br data-mce-bogus="1" />'));
+    }
+  };
 
 const EditorUpload = (editor: Editor): EditorUpload => {
   const blobCache = BlobCache();
@@ -221,13 +222,12 @@ const EditorUpload = (editor: Editor): EditorUpload => {
 
         if (imagesToRemove.length > 0 && !Rtc.isRtc(editor)) {
           editor.undoManager.transact(() => {
-            Arr.each(imagesToRemove, (element) => {
-              const sugarElement = SugarElement.fromDom(element);
+            Arr.each(SugarElements.fromDom(imagesToRemove), (sugarElement) => {
               const parentOpt = Traverse.parent(sugarElement);
               Remove.remove(sugarElement);
               // This needs a more editor-wide fix, see issue TINY-9802. Short version: Removing the image resulted in empty <p> elements, which confused the editor.
-              parentOpt.each(addPaddingToEmpty);
-              blobCache.removeByUri(element.src);
+              parentOpt.each(addPaddingToEmpty(editor));
+              blobCache.removeByUri(sugarElement.dom.src);
             });
           });
         } else if (shouldDispatchChange) {

--- a/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorUpload.ts
@@ -1,5 +1,5 @@
 import { Arr, Strings, Type } from '@ephox/katamari';
-import { Attribute, SugarElement } from '@ephox/sugar';
+import { Attribute, Insert, Remove, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import * as ErrorReporter from '../ErrorReporter';
 import { BlobInfoImagePair, BlobUriError, ImageScanner } from '../file/ImageScanner';
@@ -97,6 +97,15 @@ interface EditorUpload {
    */
   destroy: () => void;
 }
+
+const isEmptyForPadding = (element: SugarElement<any>) =>
+  !Traverse.hasChildNodes(element) && SugarNode.isTag('p')(element);
+
+const addPaddingToEmpty = (element: SugarElement<any>) => {
+  if (isEmptyForPadding(element)) {
+    Insert.append(element, SugarElement.fromHtml('<br data-mce-bogus="1" />'));
+  }
+};
 
 const EditorUpload = (editor: Editor): EditorUpload => {
   const blobCache = BlobCache();
@@ -213,7 +222,11 @@ const EditorUpload = (editor: Editor): EditorUpload => {
         if (imagesToRemove.length > 0 && !Rtc.isRtc(editor)) {
           editor.undoManager.transact(() => {
             Arr.each(imagesToRemove, (element) => {
-              editor.dom.remove(element);
+              const sugarElement = SugarElement.fromDom(element);
+              const parentOpt = Traverse.parent(sugarElement);
+              Remove.remove(sugarElement);
+              // This needs a more editor-wide fix, see issue TINY-9802. Short version: Removing the image resulted in empty <p> elements, which confused the editor.
+              parentOpt.each(addPaddingToEmpty);
               blobCache.removeByUri(element.src);
             });
           });

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -429,6 +429,22 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     return editor.uploadImages().then(() => assertEventsLength(1));
   });
 
+  it('TINY-9696: Removing an image should not leave the containing block without bogus element.', async () => {
+    const editor = hook.editor();
+    setInitialContent(editor, `<p>A</p><p></p><p>${imageHtml(testBlobDataUri)}</p>`);
+
+    editor.options.set('images_upload_handler', () => {
+      return Promise.reject({ message: 'Error', remove: true });
+    });
+
+    assertEventsLength(0);
+    await editor.uploadImages().then(() => {
+      assertEventsLength(1);
+    });
+
+    TinyAssertions.assertRawContent(editor, '<p>A</p><p><br data-mce-bogus="1"></p><p><br data-mce-bogus="1"></p>');
+  });
+
   it('TINY-8641: multiple successful upload and multiple fail upload simultaneous should trigger 1 change', () => {
     const editor = hook.editor();
     let successfulUploadsCounter = 0;

--- a/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorUploadTest.ts
@@ -429,7 +429,7 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     return editor.uploadImages().then(() => assertEventsLength(1));
   });
 
-  it('TINY-9696: Removing an image should not leave the containing block without bogus element.', async () => {
+  it('TINY-9696: Removing an image should not leave the containing block without bogus element for p.', async () => {
     const editor = hook.editor();
     setInitialContent(editor, `<p>A</p><p></p><p>${imageHtml(testBlobDataUri)}</p>`);
 
@@ -443,6 +443,38 @@ describe('browser.tinymce.core.EditorUploadTest', () => {
     });
 
     TinyAssertions.assertRawContent(editor, '<p>A</p><p><br data-mce-bogus="1"></p><p><br data-mce-bogus="1"></p>');
+  });
+
+  it('TINY-9696: Removing an image should not leave the containing block without bogus element for div.', async () => {
+    const editor = hook.editor();
+    setInitialContent(editor, `<p>A</p><p></p><div>${imageHtml(testBlobDataUri)}</div>`);
+
+    editor.options.set('images_upload_handler', () => {
+      return Promise.reject({ message: 'Error', remove: true });
+    });
+
+    assertEventsLength(0);
+    await editor.uploadImages().then(() => {
+      assertEventsLength(1);
+    });
+
+    TinyAssertions.assertRawContent(editor, '<p>A</p><p><br data-mce-bogus="1"></p><div><br data-mce-bogus="1"></div>');
+  });
+
+  it('TINY-9696: Removing an image should not leave the containing block without bogus element for h1.', async () => {
+    const editor = hook.editor();
+    setInitialContent(editor, `<p>A</p><p></p><h1>${imageHtml(testBlobDataUri)}</h1>`);
+
+    editor.options.set('images_upload_handler', () => {
+      return Promise.reject({ message: 'Error', remove: true });
+    });
+
+    assertEventsLength(0);
+    await editor.uploadImages().then(() => {
+      assertEventsLength(1);
+    });
+
+    TinyAssertions.assertRawContent(editor, '<p>A</p><p><br data-mce-bogus="1"></p><h1><br data-mce-bogus="1"></h1>');
   });
 
   it('TINY-8641: multiple successful upload and multiple fail upload simultaneous should trigger 1 change', () => {


### PR DESCRIPTION
Related Ticket: TINY-9696

Description of Changes:
Avoid leaving p-blocks empty and add padding if needed.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
