### PR TITLE
TINY-9768: HTML4 schema incorrectly allows non-inline children in <caption>, <address>, and <dt> elements

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Formatter API `canApply` was not returning `false` when the selection was in a noneditable context. #TINY-9678
 - When dragging image elements and dropping the image in the editor the `dragend` event would sometimes not fire on firefox. #TINY-9694
 - It was possible to remove links in noneditable contents with the 'unlink' editor command. #TINY-9739
+- The `caption`, `address` and `dt` elements were allowed to have non-inline children elements when the editor schema was set to `html4`. #TINY-9768
 
 ## 6.4.2 - TBD
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toolbar buttons and menu items were not disabled when they couldn't be used on noneditable content. #TINY-9669
 - Updated toolbar "More" button tooltip text from "More..." to "Reveal or hide additional toolbar items". #TINY-9629
 
+### Changed
+- The `caption`, `address` and `dt` elements were allowed to have non-inline children elements when the editor schema was set to `html4`. #TINY-9768
+
 ### Fixed
 - Command + backspace would not add an undo level on Mac. #TINY-8910
 - Ctrl + backspace and Ctrl + delete would not restore correct caret position after redo. #TINY-8910
@@ -38,7 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Formatter API `canApply` was not returning `false` when the selection was in a noneditable context. #TINY-9678
 - When dragging image elements and dropping the image in the editor the `dragend` event would sometimes not fire on firefox. #TINY-9694
 - It was possible to remove links in noneditable contents with the 'unlink' editor command. #TINY-9739
-- The `caption`, `address` and `dt` elements were allowed to have non-inline children elements when the editor schema was set to `html4`. #TINY-9768
 
 ## 6.4.2 - TBD
 

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -263,7 +263,8 @@ const compileSchema = (type: SchemaType): SchemaLookupTable => {
   add('body', 'onafterprint onbeforeprint onbeforeunload onblur onerror onfocus ' +
     'onhashchange onload onmessage onoffline ononline onpagehide onpageshow ' +
     'onpopstate onresize onscroll onstorage onunload', flowContent);
-  add('address dt dd div caption', '', flowContent);
+  add('dd div', '', flowContent);
+  add('address dt caption', '', type === 'html4' ? phrasingContent : flowContent);
   add('h1 h2 h3 h4 h5 h6 pre p abbr code var samp kbd sub sup i b u bdo span legend em strong small s cite dfn', '', phrasingContent);
   add('blockquote', 'cite', flowContent);
   add('ol', 'reversed start type', 'li');

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -507,6 +507,20 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
     });
   });
 
+  it('TINY-9768: html4 schema should not allow non-inline children for caption, address and dt elements ', () => {
+    const schemaHtml4 = Schema({ schema: 'html4' });
+    const schemaHtml5 = Schema({ schema: 'html5' });
+    Arr.each([ 'caption', 'address', 'dt' ], (parent) => {
+      Obj.each(schemaHtml4.getTextBlockElements(), (_v, child) => {
+        assert.isFalse(schemaHtml4.isValidChild(parent, child));
+      });
+      Obj.each(schemaHtml5.getTextBlockElements(), (_v, child) => {
+        assert.isTrue(schemaHtml5.isValidChild(parent, child));
+      });
+
+    });
+  });
+
   context('custom elements', () => {
     it('TBA: custom elements are added as element rules and copy the span/div rules', () => {
       const schema = Schema({


### PR DESCRIPTION
Related Ticket: TINY-9768

Description of Changes:
* updated html4 schema for the mentioned elements to have only phrasing content as child elements

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
