### PR TITLE
TINY-9314: Make Directionality plugin work with direction CSS property

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Formatter API `canApply` was not returning `false` when the selection was in a noneditable context. #TINY-9678
 - When dragging image elements and dropping the image in the editor the `dragend` event would sometimes not fire on firefox. #TINY-9694
 - It was possible to remove links in noneditable contents with the 'unlink' editor command. #TINY-9739
+- Direction was not visually changing when using the Directionality plugin on an element which has the `direction` CSS property set. #TINY-9314
 
 ## 6.4.2 - TBD
 

--- a/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
@@ -25,10 +25,10 @@ const setDirOnElements = (dom: DOMUtils, blocks: Element[], dir: Dir): void => {
     const normalizedBlockParent = getParentElement(normalizedBlock);
     normalizedBlockParent.each((parent) => {
       const parentDirection = Direction.getDirection(parent);
-      if (parentDirection !== dir) {
-        Attribute.set(normalizedBlock, 'dir', dir);
-      } else {
+      if (parentDirection === dir) {
         Attribute.remove(normalizedBlock, 'dir');
+      } else {
+        Attribute.set(normalizedBlock, 'dir', dir);
       }
 
       // TINY-9314: Set an inline direction style if computed css direction is still not as desired. This can

--- a/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
@@ -31,10 +31,12 @@ const setDirOnElements = (dom: DOMUtils, blocks: Element[], dir: Dir): void => {
         Attribute.remove(normalizedBlock, 'dir');
       }
 
-      // set direction inline style property if it already exists
-      Css.getRaw(normalizedBlock, 'direction').each((_) => {
+      // TINY-9314: Set an inline direction style if computed css direction is still not as desired. This can
+      // happen either when there already is an inline direction style property or a direction style is
+      // derived from the stylesheet.
+      if (Direction.getDirection(normalizedBlock) !== dir) {
         dom.setStyle(normalizedBlock.dom, 'direction', dir);
-      });
+      }
 
       // remove dir attr and direction style from list children
       if (isBlockElementListItem) {

--- a/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
@@ -27,12 +27,12 @@ const setDirOnElements = (dom: DOMUtils, blocks: Element[], dir: Dir): void => {
       const parentDirection = Direction.getDirection(parent);
       if (parentDirection !== dir) {
         Attribute.set(normalizedBlock, 'dir', dir);
-      } else if (Direction.getDirection(normalizedBlock) !== dir) {
+      } else {
         Attribute.remove(normalizedBlock, 'dir');
       }
 
       // TINY-9314: Set an inline direction style if computed css direction is still not as desired. This can
-      // happen either when there already is an inline direction style property or a direction style is
+      // happen either when there already is an inline direction style or a direction style is
       // derived from the stylesheet.
       if (Direction.getDirection(normalizedBlock) !== dir) {
         dom.setStyle(normalizedBlock.dom, 'direction', dir);
@@ -40,7 +40,7 @@ const setDirOnElements = (dom: DOMUtils, blocks: Element[], dir: Dir): void => {
 
       // remove dir attr and direction style from list children
       if (isBlockElementListItem) {
-        const listItems = SelectorFilter.children(normalizedBlock, 'li[dir][style]');
+        const listItems = SelectorFilter.children(normalizedBlock, 'li[dir],li[style]');
         Arr.each(listItems, (listItem) => {
           Attribute.remove(listItem, 'dir');
           Css.remove(listItem, 'direction');

--- a/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
@@ -24,6 +24,10 @@ const setDirOnElements = (dom: DOMUtils, blocks: Element[], dir: Dir): void => {
     const normalizedBlock = getNormalizedBlock(blockElement, isBlockElementListItem);
     const normalizedBlockParent = getParentElement(normalizedBlock);
     normalizedBlockParent.each((parent) => {
+      // TINY-9314: Remove any inline direction style to ensure that it is only set when necessary and that
+      // the dir attribute is favored
+      dom.setStyle(normalizedBlock.dom, 'direction', null);
+
       const parentDirection = Direction.getDirection(parent);
       if (parentDirection === dir) {
         Attribute.remove(normalizedBlock, 'dir');
@@ -32,13 +36,12 @@ const setDirOnElements = (dom: DOMUtils, blocks: Element[], dir: Dir): void => {
       }
 
       // TINY-9314: Set an inline direction style if computed css direction is still not as desired. This can
-      // happen either when there already is an inline direction style or a direction style is
-      // derived from the stylesheet.
+      // happen when a direction style is inherited from a parent or derived from a stylesheet.
       if (Direction.getDirection(normalizedBlock) !== dir) {
         dom.setStyle(normalizedBlock.dom, 'direction', dir);
       }
 
-      // remove dir attr and direction style from list children
+      // Remove dir attr and direction style from list children
       if (isBlockElementListItem) {
         const listItems = SelectorFilter.children(normalizedBlock, 'li[dir],li[style]');
         Arr.each(listItems, (listItem) => {

--- a/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
@@ -1,5 +1,5 @@
 import { Arr, Optional } from '@ephox/katamari';
-import { Traverse, Attribute, SugarElement, SugarNode, SelectorFind, Direction, SelectorFilter, Css } from '@ephox/sugar';
+import { Traverse, Attribute, SugarElement, SugarNode, SelectorFind, Direction, SelectorFilter } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
@@ -43,7 +43,7 @@ const setDirOnElements = (dom: DOMUtils, blocks: Element[], dir: Dir): void => {
         const listItems = SelectorFilter.children(normalizedBlock, 'li[dir],li[style]');
         Arr.each(listItems, (listItem) => {
           Attribute.remove(listItem, 'dir');
-          Css.remove(listItem, 'direction');
+          dom.setStyle(listItem.dom, 'direction', null);
         });
       }
     });

--- a/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
+++ b/modules/tinymce/src/plugins/directionality/main/ts/core/Direction.ts
@@ -36,7 +36,7 @@ const setDirOnElements = (dom: DOMUtils, blocks: Element[], dir: Dir): void => {
       }
 
       // TINY-9314: Set an inline direction style if computed css direction is still not as desired. This can
-      // happen when a direction style is inherited from a parent or derived from a stylesheet.
+      // happen when the direction style is derived from a stylesheet.
       if (Direction.getDirection(normalizedBlock) !== dir) {
         dom.setStyle(normalizedBlock.dom, 'direction', dir);
       }

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionStyleTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionStyleTest.ts
@@ -17,95 +17,97 @@ describe('browser.tinymce.plugins.directionality.DirectionStyleTest', () => {
     TinyAssertions.assertContent(editor, expected);
   };
 
+  const baseSettings = {
+    plugins: 'directionality',
+    toolbar: 'ltr rtl',
+    base_url: '/project/tinymce/js/tinymce'
+  };
+
   context('TINY-9314: Inline direction style', () => {
-    const hook = TinyHooks.bddSetup<Editor>({
-      plugins: 'directionality',
-      toolbar: 'ltr rtl',
-      base_url: '/project/tinymce/js/tinymce'
-    }, [ Plugin ]);
+    const hook = TinyHooks.bddSetup<Editor>(baseSettings, [ Plugin ]);
 
     it('Applying ltr with dir="rtl" and direction: rtl', () => testDirectionStyle(
       hook.editor(),
-      '<p dir="rtl" style="direction: rtl;">RTL Style</p>',
+      '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>',
       'ltr',
-      '<p style="direction: ltr;">RTL Style</p>'
+      '<p style="direction: ltr;">Lorem ipsum</p>'
     ));
 
     it('Applying rtl with dir="ltr" and direction: ltr', () => testDirectionStyle(
       hook.editor(),
-      '<p dir="ltr" style="direction: ltr;">LTR Style</p>',
+      '<p dir="ltr" style="direction: ltr;">Lorem ipsum</p>',
       'rtl',
-      '<p dir="rtl" style="direction: rtl;">LTR Style</p>'
+      '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
     ));
 
     it('Applying ltr with dir="ltr" and direction: ltr', () => testDirectionStyle(
       hook.editor(),
-      '<p dir="ltr" style="direction: ltr;">RTL Style</p>',
+      '<p dir="ltr" style="direction: ltr;">Lorem ipsum</p>',
       'ltr',
-      '<p style="direction: ltr;">RTL Style</p>'
+      '<p style="direction: ltr;">Lorem ipsum</p>'
     ));
 
     it('Applying rtl with dir="rtl" and direction: rtl', () => testDirectionStyle(
       hook.editor(),
-      '<p dir="rtl" style="direction: rtl;">LTR Style</p>',
+      '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>',
       'rtl',
-      '<p dir="rtl" style="direction: rtl;">LTR Style</p>'
+      '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
     ));
 
     it('Applying ltr with no dir attribute and direction: rtl', () => testDirectionStyle(
       hook.editor(),
-      '<p style="direction: rtl;">RTL Style</p>',
+      '<p style="direction: rtl;">Lorem ipsum</p>',
       'ltr',
-      '<p style="direction: ltr;">RTL Style</p>'
+      '<p style="direction: ltr;">Lorem ipsum</p>'
     ));
 
     it('Applying rtl with no dir attribute and direction: ltr', () => testDirectionStyle(
       hook.editor(),
-      '<p style="direction: ltr;">LTR Style</p>',
+      '<p style="direction: ltr;">Lorem ipsum</p>',
       'rtl',
-      '<p dir="rtl" style="direction: rtl;">LTR Style</p>'
+      '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
     ));
 
     it('Applying ltr with no dir attribute and direction: ltr', () => testDirectionStyle(
       hook.editor(),
-      '<p style="direction: ltr;">LTR Style</p>',
+      '<p style="direction: ltr;">Lorem ipsum</p>',
       'ltr',
-      '<p style="direction: ltr;">LTR Style</p>'
+      '<p style="direction: ltr;">Lorem ipsum</p>'
     ));
 
     it('Applying rtl with no dir attribute and direction: rtl', () => testDirectionStyle(
       hook.editor(),
-      '<p style="direction: rtl;">RTL Style</p>',
+      '<p style="direction: rtl;">Lorem ipsum</p>',
       'rtl',
-      '<p dir="rtl" style="direction: rtl;">RTL Style</p>'
+      '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
     ));
 
     it('Applying ltr with dir="rtl" and direction: ltr', () => testDirectionStyle(
       hook.editor(),
-      '<p dir="rtl" style="direction: ltr;">LTR Style</p>',
+      '<p dir="rtl" style="direction: ltr;">Lorem ipsum</p>',
       'ltr',
-      '<p style="direction: ltr;">LTR Style</p>'
+      '<p style="direction: ltr;">Lorem ipsum</p>'
     ));
 
     it('Applying rtl with dir="rtl" and direction: ltr', () => testDirectionStyle(
       hook.editor(),
-      '<p dir="rtl" style="direction: ltr;">LTR Style</p>',
+      '<p dir="rtl" style="direction: ltr;">Lorem ipsum</p>',
       'rtl',
-      '<p dir="rtl" style="direction: rtl;">LTR Style</p>'
+      '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
     ));
 
     it('Applying ltr with dir="ltr" and direction: rtl', () => testDirectionStyle(
       hook.editor(),
-      '<p dir="ltr" style="direction: rtl;">RTL Style</p>',
+      '<p dir="ltr" style="direction: rtl;">Lorem ipsum</p>',
       'ltr',
-      '<p style="direction: ltr;">RTL Style</p>'
+      '<p style="direction: ltr;">Lorem ipsum</p>'
     ));
 
     it('Applying rtl with dir="ltr" and direction: rtl', () => testDirectionStyle(
       hook.editor(),
-      '<p dir="ltr" style="direction: rtl;">RTL Style</p>',
+      '<p dir="ltr" style="direction: rtl;">Lorem ipsum</p>',
       'rtl',
-      '<p dir="rtl" style="direction: rtl;">RTL Style</p>'
+      '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
     ));
 
     it('Should remove dir and direction style from selected list item and children', () => testDirectionStyle(
@@ -126,6 +128,130 @@ describe('browser.tinymce.plugins.directionality.DirectionStyleTest', () => {
       'rtl',
       [
         '<ul dir="rtl">',
+        '<li>foo',
+        '<ul>',
+        '<li dir="ltr">a</li>',
+        '<li dir="rtl">b</li>',
+        '<li>c</li>',
+        '</ul>',
+        '</li>',
+        '<li>bar</li>',
+        '<li>bar1</li>',
+        '<li>bar2</li>',
+        '<li>bar3</li>',
+        '</ul>'
+      ].join('\n')
+    ));
+  });
+
+  context('TINY-9314: Direction style from stylesheet', () => {
+    const hook = TinyHooks.bddSetup<Editor>({
+      ...baseSettings,
+      content_style: '.rtl-content { direction: rtl }; .ltr-content { direction: ltr }',
+    }, [ Plugin ]);
+
+    it('Applying ltr with dir="rtl" and direction: rtl', () => testDirectionStyle(
+      hook.editor(),
+      '<p class="rtl-content" dir="rtl">Lorem ipsum</p>',
+      'ltr',
+      '<p class="rtl-content" style="direction: ltr;">Lorem ipsum</p>'
+    ));
+
+    it('Applying rtl with dir="ltr" and direction: ltr', () => testDirectionStyle(
+      hook.editor(),
+      '<p class="ltr-content" dir="ltr">Lorem ipsum</p>',
+      'rtl',
+      '<p class="ltr-content" dir="rtl">Lorem ipsum</p>'
+    ));
+
+    it('Applying ltr with dir="ltr" and direction: ltr', () => testDirectionStyle(
+      hook.editor(),
+      '<p class="ltr-content" dir="ltr">Lorem ipsum</p>',
+      'ltr',
+      '<p class="ltr-content">Lorem ipsum</p>'
+    ));
+
+    it('Applying rtl with dir="rtl" and direction: rtl', () => testDirectionStyle(
+      hook.editor(),
+      '<p class="rtl-content" dir="rtl">Lorem ipsum</p>',
+      'rtl',
+      '<p class="rtl-content" dir="rtl">Lorem ipsum</p>'
+    ));
+
+    it('Applying ltr with no dir attribute and direction: rtl', () => testDirectionStyle(
+      hook.editor(),
+      '<p class="rtl-content">Lorem ipsum</p>',
+      'ltr',
+      '<p class="rtl-content" style="direction: ltr;">Lorem ipsum</p>'
+    ));
+
+    it('Applying rtl with no dir attribute and direction: ltr', () => testDirectionStyle(
+      hook.editor(),
+      '<p class="ltr-content">Lorem ipsum</p>',
+      'rtl',
+      '<p class="ltr-content" dir="rtl">Lorem ipsum</p>'
+    ));
+
+    it('Applying ltr with no dir attribute and direction: ltr', () => testDirectionStyle(
+      hook.editor(),
+      '<p class="ltr-content">Lorem ipsum</p>',
+      'ltr',
+      '<p class="ltr-content">Lorem ipsum</p>'
+    ));
+
+    it('Applying rtl with no dir attribute and direction: rtl', () => testDirectionStyle(
+      hook.editor(),
+      '<p class="rtl-content">Lorem ipsum</p>',
+      'rtl',
+      '<p class="rtl-content" dir="rtl">Lorem ipsum</p>'
+    ));
+
+    it('Applying ltr with dir="rtl" and direction: ltr', () => testDirectionStyle(
+      hook.editor(),
+      '<p class="ltr-content" dir="rtl">Lorem ipsum</p>',
+      'ltr',
+      '<p class="ltr-content">Lorem ipsum</p>'
+    ));
+
+    it('Applying rtl with dir="rtl" and direction: ltr', () => testDirectionStyle(
+      hook.editor(),
+      '<p class="ltr-content" dir="rtl">Lorem ipsum</p>',
+      'rtl',
+      '<p class="ltr-content" dir="rtl">Lorem ipsum</p>'
+    ));
+
+    it('Applying ltr with dir="ltr" and direction: rtl', () => testDirectionStyle(
+      hook.editor(),
+      '<p class="rtl-content" dir="ltr">Lorem ipsum</p>',
+      'ltr',
+      '<p class="rtl-content" style="direction: ltr;">Lorem ipsum</p>'
+    ));
+
+    it('Applying rtl with dir="ltr" and direction: rtl', () => testDirectionStyle(
+      hook.editor(),
+      '<p class="rtl-content" dir="ltr">Lorem ipsum</p>',
+      'rtl',
+      '<p class="rtl-content" dir="rtl">Lorem ipsum</p>'
+    ));
+
+    it('Should remove dir and direction style from selected list item and children', () => testDirectionStyle(
+      hook.editor(),
+      '<ul class="rtl-content">' +
+        '<li dir="ltr" style="direction: ltr;">foo' +
+          '<ul>' +
+            '<li dir="ltr">a</li>' +
+            '<li dir="rtl">b</li>' +
+            '<li>c</li>' +
+          '</ul>' +
+        '</li>' +
+        '<li style="direction: ltr;">bar</li>' +
+        '<li dir="rtl" style="direction: ltr;">bar1</li>' +
+        '<li dir="ltr" style="direction: rtl;">bar2</li>' +
+        '<li dir="xyz">bar3</li>' +
+      '</ul>',
+      'ltr',
+      [
+        '<ul class="rtl-content" style="direction: ltr;">',
         '<li>foo',
         '<ul>',
         '<li dir="ltr">a</li>',

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionStyleTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionStyleTest.ts
@@ -10,9 +10,9 @@ describe('browser.tinymce.plugins.directionality.DirectionStyleTest', () => {
   const applyDir = (editor: Editor, dir: Dir) =>
     TinyUiActions.clickOnToolbar(editor, dir === 'ltr' ? 'button[title="Left to right"]' : 'button[title="Right to left"]');
 
-  const testDirectionStyle = (editor: Editor, content: string, dir: Dir, expected: string) => {
+  const testDirectionStyle = (editor: Editor, content: string, dir: Dir, expected: string, cursorPath: number[] = [ 0, 0 ]) => {
     editor.setContent(content);
-    TinySelections.setCursor(editor, [ 0, 0 ], 0);
+    TinySelections.setCursor(editor, cursorPath, 0);
     applyDir(editor, dir);
     TinyAssertions.assertContent(editor, expected);
   };
@@ -108,6 +108,30 @@ describe('browser.tinymce.plugins.directionality.DirectionStyleTest', () => {
       '<p dir="ltr" style="direction: rtl;">Lorem ipsum</p>',
       'rtl',
       '<p dir="rtl">Lorem ipsum</p>'
+    ));
+
+    it('TINY-9314: Applying ltr to element whose parent has direction: rtl', () => testDirectionStyle(
+      hook.editor(),
+      '<div style="direction: rtl;"><p>Lorem ipsum</p></div>',
+      'ltr',
+      [
+        '<div style="direction: rtl;">',
+        '<p dir="ltr">Lorem ipsum</p>',
+        '</div>'
+      ].join('\n'),
+      [ 0, 0, 0 ]
+    ));
+
+    it('TINY-9314: Applying rtl to element whose parent has direction: ltr', () => testDirectionStyle(
+      hook.editor(),
+      '<div style="direction: ltr;"><p>Lorem ipsum</p></div>',
+      'rtl',
+      [
+        '<div style="direction: ltr;">',
+        '<p dir="rtl">Lorem ipsum</p>',
+        '</div>'
+      ].join('\n'),
+      [ 0, 0, 0 ]
     ));
 
     it('TINY-9314: Should remove dir and direction style from selected list item and children', () => testDirectionStyle(
@@ -232,6 +256,30 @@ describe('browser.tinymce.plugins.directionality.DirectionStyleTest', () => {
       '<p class="rtl-content" dir="ltr">Lorem ipsum</p>',
       'rtl',
       '<p class="rtl-content" dir="rtl">Lorem ipsum</p>'
+    ));
+
+    it('TINY-9314: Applying ltr to element whose parent has direction: rtl', () => testDirectionStyle(
+      hook.editor(),
+      '<div class="rtl-content"><p>Lorem ipsum</p></div>',
+      'ltr',
+      [
+        '<div class="rtl-content">',
+        '<p dir="ltr">Lorem ipsum</p>',
+        '</div>'
+      ].join('\n'),
+      [ 0, 0, 0 ]
+    ));
+
+    it('TINY-9314: Applying rtl to element whose parent has direction: ltr', () => testDirectionStyle(
+      hook.editor(),
+      '<div class="ltr-content"><p>Lorem ipsum</p></div>',
+      'rtl',
+      [
+        '<div class="ltr-content">',
+        '<p dir="rtl">Lorem ipsum</p>',
+        '</div>'
+      ].join('\n'),
+      [ 0, 0, 0 ]
     ));
 
     it('TINY-9314: Should remove dir and direction style from selected list item and children', () => testDirectionStyle(

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionStyleTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionStyleTest.ts
@@ -1,0 +1,145 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/directionality/Plugin';
+
+type Dir = 'rtl' | 'ltr';
+
+describe('browser.tinymce.plugins.directionality.DirectionStyleTest', () => {
+  const applyDir = (editor: Editor, dir: Dir) =>
+    TinyUiActions.clickOnToolbar(editor, dir === 'ltr' ? 'button[title="Left to right"]' : 'button[title="Right to left"]');
+
+  const testDirectionStyle = (editor: Editor, content: string, dir: Dir, expected: string) => {
+    editor.setContent(content);
+    TinySelections.setCursor(editor, [ 0, 0 ], 0);
+    applyDir(editor, dir);
+    TinyAssertions.assertContent(editor, expected);
+  };
+
+  context('TINY-9314: Inline direction style', () => {
+    const hook = TinyHooks.bddSetup<Editor>({
+      plugins: 'directionality',
+      toolbar: 'ltr rtl',
+      base_url: '/project/tinymce/js/tinymce'
+    }, [ Plugin ]);
+
+    it('Applying ltr with dir="rtl" and direction: rtl', () => testDirectionStyle(
+      hook.editor(),
+      '<p dir="rtl" style="direction: rtl;">RTL Style</p>',
+      'ltr',
+      '<p style="direction: ltr;">RTL Style</p>'
+    ));
+
+    it('Applying rtl with dir="ltr" and direction: ltr', () => testDirectionStyle(
+      hook.editor(),
+      '<p dir="ltr" style="direction: ltr;">LTR Style</p>',
+      'rtl',
+      '<p dir="rtl" style="direction: rtl;">LTR Style</p>'
+    ));
+
+    it('Applying ltr with dir="ltr" and direction: ltr', () => testDirectionStyle(
+      hook.editor(),
+      '<p dir="ltr" style="direction: ltr;">RTL Style</p>',
+      'ltr',
+      '<p style="direction: ltr;">RTL Style</p>'
+    ));
+
+    it('Applying rtl with dir="rtl" and direction: rtl', () => testDirectionStyle(
+      hook.editor(),
+      '<p dir="rtl" style="direction: rtl;">LTR Style</p>',
+      'rtl',
+      '<p dir="rtl" style="direction: rtl;">LTR Style</p>'
+    ));
+
+    it('Applying ltr with no dir attribute and direction: rtl', () => testDirectionStyle(
+      hook.editor(),
+      '<p style="direction: rtl;">RTL Style</p>',
+      'ltr',
+      '<p style="direction: ltr;">RTL Style</p>'
+    ));
+
+    it('Applying rtl with no dir attribute and direction: ltr', () => testDirectionStyle(
+      hook.editor(),
+      '<p style="direction: ltr;">LTR Style</p>',
+      'rtl',
+      '<p dir="rtl" style="direction: rtl;">LTR Style</p>'
+    ));
+
+    it('Applying ltr with no dir attribute and direction: ltr', () => testDirectionStyle(
+      hook.editor(),
+      '<p style="direction: ltr;">LTR Style</p>',
+      'ltr',
+      '<p style="direction: ltr;">LTR Style</p>'
+    ));
+
+    it('Applying rtl with no dir attribute and direction: rtl', () => testDirectionStyle(
+      hook.editor(),
+      '<p style="direction: rtl;">RTL Style</p>',
+      'rtl',
+      '<p dir="rtl" style="direction: rtl;">RTL Style</p>'
+    ));
+
+    it('Applying ltr with dir="rtl" and direction: ltr', () => testDirectionStyle(
+      hook.editor(),
+      '<p dir="rtl" style="direction: ltr;">LTR Style</p>',
+      'ltr',
+      '<p style="direction: ltr;">LTR Style</p>'
+    ));
+
+    it('Applying rtl with dir="rtl" and direction: ltr', () => testDirectionStyle(
+      hook.editor(),
+      '<p dir="rtl" style="direction: ltr;">LTR Style</p>',
+      'rtl',
+      '<p dir="rtl" style="direction: rtl;">LTR Style</p>'
+    ));
+
+    it('Applying ltr with dir="ltr" and direction: rtl', () => testDirectionStyle(
+      hook.editor(),
+      '<p dir="ltr" style="direction: rtl;">RTL Style</p>',
+      'ltr',
+      '<p style="direction: ltr;">RTL Style</p>'
+    ));
+
+    it('Applying rtl with dir="ltr" and direction: rtl', () => testDirectionStyle(
+      hook.editor(),
+      '<p dir="ltr" style="direction: rtl;">RTL Style</p>',
+      'rtl',
+      '<p dir="rtl" style="direction: rtl;">RTL Style</p>'
+    ));
+
+    it('Should remove dir and direction style from selected list item and children', () => testDirectionStyle(
+      hook.editor(),
+      '<ul>' +
+        '<li dir="ltr" style="direction: ltr;">foo' +
+          '<ul>' +
+            '<li dir="ltr">a</li>' +
+            '<li dir="rtl">b</li>' +
+            '<li>c</li>' +
+          '</ul>' +
+        '</li>' +
+        '<li style="direction: ltr;">bar</li>' +
+        '<li dir="rtl" style="direction: ltr;">bar1</li>' +
+        '<li dir="ltr" style="direction: rtl;">bar2</li>' +
+        '<li dir="xyz">bar3</li>' +
+      '</ul>',
+      'rtl',
+      [
+        '<ul dir="rtl">',
+        '<li>foo',
+        '<ul>',
+        '<li dir="ltr">a</li>',
+        '<li dir="rtl">b</li>',
+        '<li>c</li>',
+        '</ul>',
+        '</li>',
+        '<li>bar</li>',
+        '<li>bar1</li>',
+        '<li>bar2</li>',
+        '<li>bar3</li>',
+        '</ul>'
+      ].join('\n')
+    ));
+  });
+});
+

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionStyleTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionStyleTest.ts
@@ -30,84 +30,84 @@ describe('browser.tinymce.plugins.directionality.DirectionStyleTest', () => {
       hook.editor(),
       '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>',
       'ltr',
-      '<p style="direction: ltr;">Lorem ipsum</p>'
+      '<p>Lorem ipsum</p>'
     ));
 
     it('TINY-9314: Applying rtl with dir="ltr" and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p dir="ltr" style="direction: ltr;">Lorem ipsum</p>',
       'rtl',
-      '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
+      '<p dir="rtl">Lorem ipsum</p>'
     ));
 
     it('TINY-9314: Applying ltr with dir="ltr" and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p dir="ltr" style="direction: ltr;">Lorem ipsum</p>',
       'ltr',
-      '<p style="direction: ltr;">Lorem ipsum</p>'
+      '<p>Lorem ipsum</p>'
     ));
 
     it('TINY-9314: Applying rtl with dir="rtl" and direction: rtl', () => testDirectionStyle(
       hook.editor(),
       '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>',
       'rtl',
-      '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
+      '<p dir="rtl">Lorem ipsum</p>'
     ));
 
     it('TINY-9314: Applying ltr with no dir attribute and direction: rtl', () => testDirectionStyle(
       hook.editor(),
       '<p style="direction: rtl;">Lorem ipsum</p>',
       'ltr',
-      '<p style="direction: ltr;">Lorem ipsum</p>'
+      '<p>Lorem ipsum</p>'
     ));
 
     it('TINY-9314: Applying rtl with no dir attribute and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p style="direction: ltr;">Lorem ipsum</p>',
       'rtl',
-      '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
+      '<p dir="rtl">Lorem ipsum</p>'
     ));
 
     it('TINY-9314: Applying ltr with no dir attribute and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p style="direction: ltr;">Lorem ipsum</p>',
       'ltr',
-      '<p style="direction: ltr;">Lorem ipsum</p>'
+      '<p>Lorem ipsum</p>'
     ));
 
     it('TINY-9314: Applying rtl with no dir attribute and direction: rtl', () => testDirectionStyle(
       hook.editor(),
       '<p style="direction: rtl;">Lorem ipsum</p>',
       'rtl',
-      '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
+      '<p dir="rtl">Lorem ipsum</p>'
     ));
 
     it('TINY-9314: Applying ltr with dir="rtl" and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p dir="rtl" style="direction: ltr;">Lorem ipsum</p>',
       'ltr',
-      '<p style="direction: ltr;">Lorem ipsum</p>'
+      '<p>Lorem ipsum</p>'
     ));
 
     it('TINY-9314: Applying rtl with dir="rtl" and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p dir="rtl" style="direction: ltr;">Lorem ipsum</p>',
       'rtl',
-      '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
+      '<p dir="rtl">Lorem ipsum</p>'
     ));
 
     it('TINY-9314: Applying ltr with dir="ltr" and direction: rtl', () => testDirectionStyle(
       hook.editor(),
       '<p dir="ltr" style="direction: rtl;">Lorem ipsum</p>',
       'ltr',
-      '<p style="direction: ltr;">Lorem ipsum</p>'
+      '<p>Lorem ipsum</p>'
     ));
 
     it('TINY-9314: Applying rtl with dir="ltr" and direction: rtl', () => testDirectionStyle(
       hook.editor(),
       '<p dir="ltr" style="direction: rtl;">Lorem ipsum</p>',
       'rtl',
-      '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
+      '<p dir="rtl">Lorem ipsum</p>'
     ));
 
     it('TINY-9314: Should remove dir and direction style from selected list item and children', () => testDirectionStyle(

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionStyleTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionStyleTest.ts
@@ -23,94 +23,94 @@ describe('browser.tinymce.plugins.directionality.DirectionStyleTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   };
 
-  context('TINY-9314: Inline direction style', () => {
+  context('Inline direction style', () => {
     const hook = TinyHooks.bddSetup<Editor>(baseSettings, [ Plugin ]);
 
-    it('Applying ltr with dir="rtl" and direction: rtl', () => testDirectionStyle(
+    it('TINY-9314: Applying ltr with dir="rtl" and direction: rtl', () => testDirectionStyle(
       hook.editor(),
       '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>',
       'ltr',
       '<p style="direction: ltr;">Lorem ipsum</p>'
     ));
 
-    it('Applying rtl with dir="ltr" and direction: ltr', () => testDirectionStyle(
+    it('TINY-9314: Applying rtl with dir="ltr" and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p dir="ltr" style="direction: ltr;">Lorem ipsum</p>',
       'rtl',
       '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
     ));
 
-    it('Applying ltr with dir="ltr" and direction: ltr', () => testDirectionStyle(
+    it('TINY-9314: Applying ltr with dir="ltr" and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p dir="ltr" style="direction: ltr;">Lorem ipsum</p>',
       'ltr',
       '<p style="direction: ltr;">Lorem ipsum</p>'
     ));
 
-    it('Applying rtl with dir="rtl" and direction: rtl', () => testDirectionStyle(
+    it('TINY-9314: Applying rtl with dir="rtl" and direction: rtl', () => testDirectionStyle(
       hook.editor(),
       '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>',
       'rtl',
       '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
     ));
 
-    it('Applying ltr with no dir attribute and direction: rtl', () => testDirectionStyle(
+    it('TINY-9314: Applying ltr with no dir attribute and direction: rtl', () => testDirectionStyle(
       hook.editor(),
       '<p style="direction: rtl;">Lorem ipsum</p>',
       'ltr',
       '<p style="direction: ltr;">Lorem ipsum</p>'
     ));
 
-    it('Applying rtl with no dir attribute and direction: ltr', () => testDirectionStyle(
+    it('TINY-9314: Applying rtl with no dir attribute and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p style="direction: ltr;">Lorem ipsum</p>',
       'rtl',
       '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
     ));
 
-    it('Applying ltr with no dir attribute and direction: ltr', () => testDirectionStyle(
+    it('TINY-9314: Applying ltr with no dir attribute and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p style="direction: ltr;">Lorem ipsum</p>',
       'ltr',
       '<p style="direction: ltr;">Lorem ipsum</p>'
     ));
 
-    it('Applying rtl with no dir attribute and direction: rtl', () => testDirectionStyle(
+    it('TINY-9314: Applying rtl with no dir attribute and direction: rtl', () => testDirectionStyle(
       hook.editor(),
       '<p style="direction: rtl;">Lorem ipsum</p>',
       'rtl',
       '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
     ));
 
-    it('Applying ltr with dir="rtl" and direction: ltr', () => testDirectionStyle(
+    it('TINY-9314: Applying ltr with dir="rtl" and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p dir="rtl" style="direction: ltr;">Lorem ipsum</p>',
       'ltr',
       '<p style="direction: ltr;">Lorem ipsum</p>'
     ));
 
-    it('Applying rtl with dir="rtl" and direction: ltr', () => testDirectionStyle(
+    it('TINY-9314: Applying rtl with dir="rtl" and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p dir="rtl" style="direction: ltr;">Lorem ipsum</p>',
       'rtl',
       '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
     ));
 
-    it('Applying ltr with dir="ltr" and direction: rtl', () => testDirectionStyle(
+    it('TINY-9314: Applying ltr with dir="ltr" and direction: rtl', () => testDirectionStyle(
       hook.editor(),
       '<p dir="ltr" style="direction: rtl;">Lorem ipsum</p>',
       'ltr',
       '<p style="direction: ltr;">Lorem ipsum</p>'
     ));
 
-    it('Applying rtl with dir="ltr" and direction: rtl', () => testDirectionStyle(
+    it('TINY-9314: Applying rtl with dir="ltr" and direction: rtl', () => testDirectionStyle(
       hook.editor(),
       '<p dir="ltr" style="direction: rtl;">Lorem ipsum</p>',
       'rtl',
       '<p dir="rtl" style="direction: rtl;">Lorem ipsum</p>'
     ));
 
-    it('Should remove dir and direction style from selected list item and children', () => testDirectionStyle(
+    it('TINY-9314: Should remove dir and direction style from selected list item and children', () => testDirectionStyle(
       hook.editor(),
       '<ul>' +
         '<li dir="ltr" style="direction: ltr;">foo' +
@@ -144,97 +144,97 @@ describe('browser.tinymce.plugins.directionality.DirectionStyleTest', () => {
     ));
   });
 
-  context('TINY-9314: Direction style from stylesheet', () => {
+  context('Direction style from stylesheet', () => {
     const hook = TinyHooks.bddSetup<Editor>({
       ...baseSettings,
       content_style: '.rtl-content { direction: rtl }; .ltr-content { direction: ltr }',
     }, [ Plugin ]);
 
-    it('Applying ltr with dir="rtl" and direction: rtl', () => testDirectionStyle(
+    it('TINY-9314: Applying ltr with dir="rtl" and direction: rtl', () => testDirectionStyle(
       hook.editor(),
       '<p class="rtl-content" dir="rtl">Lorem ipsum</p>',
       'ltr',
       '<p class="rtl-content" style="direction: ltr;">Lorem ipsum</p>'
     ));
 
-    it('Applying rtl with dir="ltr" and direction: ltr', () => testDirectionStyle(
+    it('TINY-9314: Applying rtl with dir="ltr" and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p class="ltr-content" dir="ltr">Lorem ipsum</p>',
       'rtl',
       '<p class="ltr-content" dir="rtl">Lorem ipsum</p>'
     ));
 
-    it('Applying ltr with dir="ltr" and direction: ltr', () => testDirectionStyle(
+    it('TINY-9314: Applying ltr with dir="ltr" and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p class="ltr-content" dir="ltr">Lorem ipsum</p>',
       'ltr',
       '<p class="ltr-content">Lorem ipsum</p>'
     ));
 
-    it('Applying rtl with dir="rtl" and direction: rtl', () => testDirectionStyle(
+    it('TINY-9314: Applying rtl with dir="rtl" and direction: rtl', () => testDirectionStyle(
       hook.editor(),
       '<p class="rtl-content" dir="rtl">Lorem ipsum</p>',
       'rtl',
       '<p class="rtl-content" dir="rtl">Lorem ipsum</p>'
     ));
 
-    it('Applying ltr with no dir attribute and direction: rtl', () => testDirectionStyle(
+    it('TINY-9314: Applying ltr with no dir attribute and direction: rtl', () => testDirectionStyle(
       hook.editor(),
       '<p class="rtl-content">Lorem ipsum</p>',
       'ltr',
       '<p class="rtl-content" style="direction: ltr;">Lorem ipsum</p>'
     ));
 
-    it('Applying rtl with no dir attribute and direction: ltr', () => testDirectionStyle(
+    it('TINY-9314: Applying rtl with no dir attribute and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p class="ltr-content">Lorem ipsum</p>',
       'rtl',
       '<p class="ltr-content" dir="rtl">Lorem ipsum</p>'
     ));
 
-    it('Applying ltr with no dir attribute and direction: ltr', () => testDirectionStyle(
+    it('TINY-9314: Applying ltr with no dir attribute and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p class="ltr-content">Lorem ipsum</p>',
       'ltr',
       '<p class="ltr-content">Lorem ipsum</p>'
     ));
 
-    it('Applying rtl with no dir attribute and direction: rtl', () => testDirectionStyle(
+    it('TINY-9314: Applying rtl with no dir attribute and direction: rtl', () => testDirectionStyle(
       hook.editor(),
       '<p class="rtl-content">Lorem ipsum</p>',
       'rtl',
       '<p class="rtl-content" dir="rtl">Lorem ipsum</p>'
     ));
 
-    it('Applying ltr with dir="rtl" and direction: ltr', () => testDirectionStyle(
+    it('TINY-9314: Applying ltr with dir="rtl" and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p class="ltr-content" dir="rtl">Lorem ipsum</p>',
       'ltr',
       '<p class="ltr-content">Lorem ipsum</p>'
     ));
 
-    it('Applying rtl with dir="rtl" and direction: ltr', () => testDirectionStyle(
+    it('TINY-9314: Applying rtl with dir="rtl" and direction: ltr', () => testDirectionStyle(
       hook.editor(),
       '<p class="ltr-content" dir="rtl">Lorem ipsum</p>',
       'rtl',
       '<p class="ltr-content" dir="rtl">Lorem ipsum</p>'
     ));
 
-    it('Applying ltr with dir="ltr" and direction: rtl', () => testDirectionStyle(
+    it('TINY-9314: Applying ltr with dir="ltr" and direction: rtl', () => testDirectionStyle(
       hook.editor(),
       '<p class="rtl-content" dir="ltr">Lorem ipsum</p>',
       'ltr',
       '<p class="rtl-content" style="direction: ltr;">Lorem ipsum</p>'
     ));
 
-    it('Applying rtl with dir="ltr" and direction: rtl', () => testDirectionStyle(
+    it('TINY-9314: Applying rtl with dir="ltr" and direction: rtl', () => testDirectionStyle(
       hook.editor(),
       '<p class="rtl-content" dir="ltr">Lorem ipsum</p>',
       'rtl',
       '<p class="rtl-content" dir="rtl">Lorem ipsum</p>'
     ));
 
-    it('Should remove dir and direction style from selected list item and children', () => testDirectionStyle(
+    it('TINY-9314: Should remove dir and direction style from selected list item and children', () => testDirectionStyle(
       hook.editor(),
       '<ul class="rtl-content">' +
         '<li dir="ltr" style="direction: ltr;">foo' +


### PR DESCRIPTION
Related Ticket: TINY-9314

Description of Changes:
* Directionality plugin adds an inline `direction` style if the `dir` attribute has been taken precedence by either an inline `direction` style, or a `direction` style from the stylesheet
* Clean up `dir` attribute removal logic

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
