### PR TITLE
TINY-9704: Fix the flaky SearchReplaceDialogTest

### DIFF
--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceDialogTest.ts
@@ -129,8 +129,8 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceDialogTest', () => 
   it('TINY-9704: Should reset the "Not Found" alert after updating the search preferences', async () => {
     const editor = hook.editor();
     editor.setContent('<p>tiny tiny tiny tiny</p>');
-    TinySelections.setSelection(editor, [ 0, 0 ], 5, [ 0, 0 ], 9);
     await Utils.pOpenDialog(editor);
+    await Utils.pSetFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'tiny');
     await Utils.pAssertFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'tiny');
     findAndAssertFound(editor, 4);
     await Utils.pSelectPreference(editor, 'Find in selection');


### PR DESCRIPTION
Related Ticket: TINY-9704

Description of Changes:
* Fix the flaky Search and Replace dialog test.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
