### PR TITLE
TINY-9565: Caret cycle when moving caret with arrow keys in inline noneditable span

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - It was possible to remove links in noneditable contents with the 'unlink' editor command. #TINY-9739
 - Direction was not visually changing when using the Directionality plugin on an element which has the `direction` CSS property set. #TINY-9314
 - Whitespace between transparent elements would incorrectly be converted into empty paragraphs. #TINY-9761
+- Pressing arrow keys inside RTL elements would move the caret in an incorrect direction when moving over elements with the `contenteditable` attribute set to `false`. #TINY-9565
 
 ## 6.4.2 - 2023-04-26
 

--- a/modules/tinymce/src/core/main/ts/keyboard/CefNavigation.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/CefNavigation.ts
@@ -1,6 +1,7 @@
 import { Fun, Optional } from '@ephox/katamari';
 import { Insert, SugarElement } from '@ephox/sugar';
 
+import EditorSelection from '../api/dom/Selection';
 import Editor from '../api/Editor';
 import * as Options from '../api/Options';
 import CaretPosition from '../caret/CaretPosition';
@@ -10,6 +11,7 @@ import { CaretWalker, HDirection } from '../caret/CaretWalker';
 import * as LineWalker from '../caret/LineWalker';
 import * as NodeType from '../dom/NodeType';
 import { getEdgeCefPosition } from './CefUtils';
+import * as InlineUtils from './InlineUtils';
 import * as NavigationUtils from './NavigationUtils';
 
 const isContentEditableFalse = NodeType.isContentEditableFalse;
@@ -75,8 +77,13 @@ const getVerticalRange = (editor: Editor, down: boolean): Optional<Range> => {
   });
 };
 
+const flipDirection = (selection: EditorSelection, forward: boolean) => {
+  const elm = forward ? selection.getEnd(true) : selection.getStart(true);
+  return InlineUtils.isRtl(elm) ? !forward : forward;
+};
+
 const moveH = (editor: Editor, forward: boolean): boolean =>
-  getHorizontalRange(editor, forward).exists((newRange) => {
+  getHorizontalRange(editor, flipDirection(editor.selection, forward)).exists((newRange) => {
     NavigationUtils.moveToRange(editor, newRange);
     return true;
   });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysCefTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysCefTest.ts
@@ -183,4 +183,26 @@ describe('browser.tinymce.core.keyboard.ArrowKeysCefTest', () => {
     // Checking 2 events fired verifies the event handlers finished running, so an exception shouldn't have been raised
     assertKeydownCount(2);
   });
+
+  it('TINY-9565: Should navigate CEFs in reverse if the element has a dir attribute of rtl', () => {
+    const editor = hook.editor();
+    editor.setContent('<p dir="rtl">&#x5e2;&#x5b4;&#x5d1;<span contenteditable="false">CEF</span><span contenteditable="false">CEF</span>&#x5e2;&#x5b4;&#x5d1;</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 3);
+    TinyContentActions.keystroke(editor, Keys.left());
+    TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 2);
+    TinyContentActions.keystroke(editor, Keys.left());
+    TinyAssertions.assertCursor(editor, [ 0, 2 ], 0);
+    TinyContentActions.keystroke(editor, Keys.left());
+    TinyAssertions.assertSelection(editor, [ 0 ], 2, [ 0 ], 3);
+    TinyContentActions.keystroke(editor, Keys.left());
+    TinyAssertions.assertCursor(editor, [ 0, 3 ], 1);
+    TinyContentActions.keystroke(editor, Keys.right());
+    TinyAssertions.assertSelection(editor, [ 0 ], 2, [ 0 ], 3);
+    TinyContentActions.keystroke(editor, Keys.right());
+    TinyAssertions.assertCursor(editor, [ 0, 2 ], 0);
+    TinyContentActions.keystroke(editor, Keys.right());
+    TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 2);
+    TinyContentActions.keystroke(editor, Keys.right());
+    TinyAssertions.assertCursor(editor, [ 0, 1 ], 0);
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-9565

Description of Changes:
* Changed so that the arrow keys are reversed if the selection is in a RTL context.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
