### PR TITLE
TINY-9310: fix placing of caret after `disableCaretContainer`

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Deleting formatted content and then press space and then digit a test places the space at the end of the content. TINY-9310
+
 ### Added
 - New optional `defaultExpandedIds` and `onToggleExpand` options to the `tree` component config. #TINY-9653
 - New optional `defaultSelectedId` option to the `tree` component config. #TINY-9715

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Deleting formatted content and then press space and then digit a test places the space at the end of the content. TINY-9310
+- Typing after deleting formatted content could remove a space at the start of the typing. TINY-9310
 
 ### Added
 - New optional `defaultExpandedIds` and `onToggleExpand` options to the `tree` component config. #TINY-9653

--- a/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
@@ -1,5 +1,5 @@
-import { Arr, Fun, Obj, Optional, Strings } from '@ephox/katamari';
-import { Attribute, Insert, Remove, SugarElement, SugarNode, Truncate } from '@ephox/sugar';
+import { Arr, Fun, Obj, Optional, Strings, Unicode } from '@ephox/katamari';
+import { Attribute, Insert, Remove, SugarElement, SugarNode } from '@ephox/sugar';
 
 import DomTreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
@@ -341,10 +341,7 @@ const disableCaretContainer = (editor: Editor, keyCode: number, moveCaret: boole
   }
 };
 
-const endsWithNbsp = (element: Node) => {
-  const elHtml = Truncate.getHtml(SugarElement.fromDom(element));
-  return Strings.endsWith(elHtml, '&nbsp;');
-};
+const endsWithNbsp = (element: Node) => NodeType.isText(element) && Strings.endsWith(element.data, Unicode.nbsp);
 
 const setup = (editor: Editor): void => {
   editor.on('mouseup keydown', (e) => {

--- a/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Obj, Optional, Strings } from '@ephox/katamari';
-import { Attribute, Insert, Remove, SugarElement, SugarNode } from '@ephox/sugar';
+import { Attribute, Insert, Remove, SugarElement, SugarNode, Truncate } from '@ephox/sugar';
 
 import DomTreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
@@ -128,7 +128,7 @@ const removeCaretContainer = (editor: Editor, node: Node | null, moveCaret: bool
 
     if (!node) {
       while ((node = dom.get(CARET_ID))) {
-        removeCaretContainerNode(editor, node, false);
+        removeCaretContainerNode(editor, node, moveCaret);
       }
     }
   } else {
@@ -325,10 +325,10 @@ const removeCaretFormat = (editor: Editor, name: string, vars?: FormatVars, simi
   }
 };
 
-const disableCaretContainer = (editor: Editor, keyCode: number) => {
+const disableCaretContainer = (editor: Editor, keyCode: number, moveCaret: boolean) => {
   const selection = editor.selection, body = editor.getBody();
 
-  removeCaretContainer(editor, null, false);
+  removeCaretContainer(editor, null, moveCaret);
 
   // Remove caret container if it's empty
   if ((keyCode === 8 || keyCode === 46) && selection.isCollapsed() && selection.getStart().innerHTML === ZWSP) {
@@ -341,9 +341,16 @@ const disableCaretContainer = (editor: Editor, keyCode: number) => {
   }
 };
 
+const endsWithNbsp = (element: Node) => {
+  const elHtml = Truncate.getHtml(SugarElement.fromDom(element));
+  // eslint-disable-next-line no-console
+  console.log('elHtml: ', elHtml);
+  return Strings.endsWith(elHtml, '&nbsp;');
+};
+
 const setup = (editor: Editor): void => {
   editor.on('mouseup keydown', (e) => {
-    disableCaretContainer(editor, e.keyCode);
+    disableCaretContainer(editor, e.keyCode, endsWithNbsp(editor.selection.getRng().endContainer));
   });
 };
 

--- a/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
@@ -343,8 +343,6 @@ const disableCaretContainer = (editor: Editor, keyCode: number, moveCaret: boole
 
 const endsWithNbsp = (element: Node) => {
   const elHtml = Truncate.getHtml(SugarElement.fromDom(element));
-  // eslint-disable-next-line no-console
-  console.log('elHtml: ', elHtml);
   return Strings.endsWith(elHtml, '&nbsp;');
 };
 

--- a/modules/tinymce/src/core/test/ts/browser/fmt/CaretFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/CaretFormatTest.ts
@@ -1,4 +1,4 @@
-import { ApproxStructure, Assertions, Keys, Mouse, StructAssert } from '@ephox/agar';
+import { ApproxStructure, Assertions, Mouse, StructAssert } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarElement } from '@ephox/sugar';
 import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
@@ -564,43 +564,5 @@ describe('browser.tinymce.core.fmt.CaretFormatTest', () => {
       ]
     })));
     TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0 ], 2, [ 0, 0, 0, 0 ], 2);
-  });
-
-  it.skip('TINY-9310: ', () => {
-    const editor = hook.editor();
-    editor.setContent('<p>a</p>');
-    TinySelections.setCursor(editor, [ 0 ], 1);
-    applyCaretFormat(editor, 'bold', {});
-    TinyContentActions.type(editor, 'b');
-    TinyContentActions.keystroke(editor, Keys.backspace());
-
-    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
-      return s.element('body', {
-        children: [
-          s.element('p', {
-            children: [
-              s.text(str.is('a')),
-              s.element('span', {
-                attrs: {
-                  'id': str.is('_mce_caret'),
-                  'data-mce-bogus': str.is('1')
-                },
-                children: [
-                  s.element('strong', {
-                    children: [
-                      s.text(str.is(Zwsp.ZWSP))
-                    ]
-                  })
-                ]
-              })
-            ]
-          })
-        ]
-      });
-    }));
-
-    TinyContentActions.keystroke(editor, Keys.space()); // TOFIX: this is not working
-    TinyContentActions.type(editor, 'c');
-    TinyAssertions.assertContent(editor, '<p>a c</p>');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/CaretFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/CaretFormatTest.ts
@@ -1,4 +1,4 @@
-import { ApproxStructure, Assertions, Mouse, StructAssert } from '@ephox/agar';
+import { ApproxStructure, Assertions, Keys, Mouse, StructAssert } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarElement } from '@ephox/sugar';
 import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
@@ -564,5 +564,43 @@ describe('browser.tinymce.core.fmt.CaretFormatTest', () => {
       ]
     })));
     TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0 ], 2, [ 0, 0, 0, 0 ], 2);
+  });
+
+  it.skip('TINY-9310: ', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>a</p>');
+    TinySelections.setCursor(editor, [ 0 ], 1);
+    applyCaretFormat(editor, 'bold', {});
+    TinyContentActions.type(editor, 'b');
+    TinyContentActions.keystroke(editor, Keys.backspace());
+
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+      return s.element('body', {
+        children: [
+          s.element('p', {
+            children: [
+              s.text(str.is('a')),
+              s.element('span', {
+                attrs: {
+                  'id': str.is('_mce_caret'),
+                  'data-mce-bogus': str.is('1')
+                },
+                children: [
+                  s.element('strong', {
+                    children: [
+                      s.text(str.is(Zwsp.ZWSP))
+                    ]
+                  })
+                ]
+              })
+            ]
+          })
+        ]
+      });
+    }));
+
+    TinyContentActions.keystroke(editor, Keys.space()); // TOFIX: this is not working
+    TinyContentActions.type(editor, 'c');
+    TinyAssertions.assertContent(editor, '<p>a c</p>');
   });
 });

--- a/modules/tinymce/src/core/test/ts/webdriver/keyboard/SpaceKeyTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/keyboard/SpaceKeyTest.ts
@@ -129,7 +129,11 @@ describe('webdriver.tinymce.core.keyboard.SpaceKeyTest', () => {
 
       await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.text(' ') ]);
       await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.text('c') ]);
-      TinyAssertions.assertContent(editor, '<p>a c</p>');
+      if (isFirefox) {
+        TinyAssertions.assertContent(editor, '<p>a<strong> c</strong></p>');
+      } else {
+        TinyAssertions.assertContent(editor, '<p>a c</p>');
+      }
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/webdriver/keyboard/SpaceKeyTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/keyboard/SpaceKeyTest.ts
@@ -1,9 +1,11 @@
-import { RealKeys } from '@ephox/agar';
+import { ApproxStructure, RealKeys } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
+import { applyCaretFormat } from 'tinymce/core/fmt/CaretFormat';
+import * as Zwsp from 'tinymce/core/text/Zwsp';
 
 describe('webdriver.tinymce.core.keyboard.SpaceKeyTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -90,6 +92,44 @@ describe('webdriver.tinymce.core.keyboard.SpaceKeyTest', () => {
       TinySelections.setCursor(editor, [ 0, 1 ], 0);
       await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.text(' ') ]);
       TinyAssertions.assertContent(editor, '<p><strong><span style="display: block;" contenteditable="false">a</span></strong>&nbsp;s</p>');
+    });
+
+    it('TINY-9310: deleting a formatted part and then press space and then insert a char should insert the char in the correct place', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p>a</p>');
+      TinySelections.setCursor(editor, [ 0 ], 1);
+      applyCaretFormat(editor, 'bold', {});
+      await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.text('b') ]);
+      await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.backspace() ]);
+
+      TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+        return s.element('body', {
+          children: [
+            s.element('p', {
+              children: [
+                s.text(str.is('a')),
+                s.element('span', {
+                  attrs: {
+                    'id': str.is('_mce_caret'),
+                    'data-mce-bogus': str.is('1')
+                  },
+                  children: [
+                    s.element('strong', {
+                      children: [
+                        s.text(str.is(Zwsp.ZWSP))
+                      ]
+                    })
+                  ]
+                })
+              ]
+            })
+          ]
+        });
+      }));
+
+      await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.text(' ') ]);
+      await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.text('c') ]);
+      TinyAssertions.assertContent(editor, '<p>a c</p>');
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9310

Description of Changes:
The problem was that `disableCaretContainer` calls `removeCaretContainerNode` with `moveCaret: false`, and this cause this case:

status: `a |<empty_formatted_tag/>`
press: `b`
result: `ab `

P.S.
FireFox seems to not remove the formatted content

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
