### PR TITLE
TINY-9805: Prohibit block links in html4 scheme

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The `caption`, `address` and `dt` elements were allowed to have non-inline children elements when the editor schema was set to `html4`. #TINY-9768
-- The `a` elements were allowed to have non-inline children elements when the editor schema was set to `html4`. #TINY-9805
+- The `a` elements were allowed to have non-inline child elements when the editor schema was set to `html4`. #TINY-9805
 
 ### Fixed
 - Command + backspace would not add an undo level on Mac. #TINY-8910

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The `caption`, `address` and `dt` elements were allowed to have non-inline children elements when the editor schema was set to `html4`. #TINY-9768
+- The `a` elements were allowed to have non-inline children elements when the editor schema was set to `html4`. #TINY-9805
 
 ### Fixed
 - Command + backspace would not add an undo level on Mac. #TINY-8910
@@ -261,6 +262,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Reverted the undo level fix in the `autolink` plugin as it caused duplicated content in some edge cases. #TINY-8936
+
 
 ## 6.1.1 - 2022-07-27
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -263,7 +263,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Reverted the undo level fix in the `autolink` plugin as it caused duplicated content in some edge cases. #TINY-8936
 
-
 ## 6.1.1 - 2022-07-27
 
 ### Fixed

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -271,7 +271,7 @@ const compileSchema = (type: SchemaType): SchemaLookupTable => {
   add('ul', '', 'li');
   add('li', 'value', flowContent);
   add('dl', '', 'dt dd');
-  add('a', 'href target rel media hreflang type', flowContent);
+  add('a', 'href target rel media hreflang type', type === 'html4' ? phrasingContent : flowContent);
   add('q', 'cite', phrasingContent);
   add('ins del', 'cite datetime', flowContent);
   add('img', 'src sizes srcset alt usemap ismap width height');

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -521,6 +521,13 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
     });
   });
 
+  it('TINY-9805: html4 schema should not allow block children elements for the link element ', () => {
+    const schemaHtml4 = Schema({ schema: 'html4' });
+    Obj.each(schemaHtml4.getTextBlockElements(), (_v, child) => {
+      assert.isFalse(schemaHtml4.isValidChild('a', child));
+    });
+  });
+
   context('custom elements', () => {
     it('TBA: custom elements are added as element rules and copy the span/div rules', () => {
       const schema = Schema({


### PR DESCRIPTION
Related Ticket: TINY-9805

Description of Changes:
* Updated HTML4 schema now treats block elements as invalid children for links

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
