### PR TITLE
TINY-9807: No longer delete images on the wrong side of the caret

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680
 - On iOS Safari, Korean characters were merging onto the previous line upon typing after inserting a newline by pressing Enter. #TINY-9746
 - Initiating the editor with a table at the start would display resize handles even when the editor wasn't focused. #TINY-9748
-- Backspace would in some sitations delete the image in front of it instead of the element behind it as expected. #TINY-9807
+- Backspace would in some situations delete the image after the cursor instead of before it as expected. #TINY-9807
 - Directionality commands was setting the `dir` attribute on noneditable elements within a noneditable root. #TINY-9662
 - The content of the dialog body could not be scrolled. #TINY-9668
 - Some toolbar items were not rendering the `not-allowed` mouse cursor. #TINY-9758

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Context toolbars displayed the incorrect status for the `advlist` plugin buttons. #TINY-9680
 - On iOS Safari, Korean characters were merging onto the previous line upon typing after inserting a newline by pressing Enter. #TINY-9746
 - Initiating the editor with a table at the start would display resize handles even when the editor wasn't focused. #TINY-9748
+- Backspace would in some sitations delete the image in front of it instead of the element behind it as expected. #TINY-9807
 - Directionality commands was setting the `dir` attribute on noneditable elements within a noneditable root. #TINY-9662
 - The content of the dialog body could not be scrolled. #TINY-9668
 - Some toolbar items were not rendering the `not-allowed` mouse cursor. #TINY-9758

--- a/modules/tinymce/src/core/main/ts/delete/InlineFormatDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/InlineFormatDelete.ts
@@ -23,6 +23,7 @@ const getParentsUntil = (editor: Editor, pred: (elm: SugarElement<Node>) => bool
     (index) => parents.slice(0, index)
   );
 };
+
 const hasOnlyOneChild = (elm: SugarElement<Node>): boolean =>
   Traverse.childNodesCount(elm) === 1;
 

--- a/modules/tinymce/src/core/main/ts/delete/InlineFormatDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/InlineFormatDelete.ts
@@ -23,6 +23,8 @@ const getParentsUntil = (editor: Editor, pred: (elm: SugarElement<Node>) => bool
     (index) => parents.slice(0, index)
   );
 };
+const hasOnlyOneChild = (elm: SugarElement<Node>): boolean =>
+  Traverse.childNodesCount(elm) === 1;
 
 const getParentInlinesUntilMultichildInline = (editor: Editor): SugarElement<Node>[] =>
   getParentsUntil(editor, (elm) => ElementType.isBlock(elm) || hasMultipleChildren(elm));
@@ -53,7 +55,7 @@ const deleteLastPosition = (forward: boolean, editor: Editor, target: SugarEleme
 
 const deleteCaret = (editor: Editor, forward: boolean): Optional<() => void> => {
   const parentInlines = getParentInlinesUntilMultichildInline(editor);
-  return Arr.last(parentInlines).bind((target) => {
+  return Arr.last(Arr.filter(parentInlines, hasOnlyOneChild)).bind((target) => {
     const fromPos = CaretPosition.fromRangeStart(editor.selection.getRng());
     if (DeleteUtils.willDeleteLastPositionInElement(forward, fromPos, target.dom) && !CaretFormat.isEmptyCaretFormatElement(target)) {
       return Optional.some(() => deleteLastPosition(forward, editor, target, parentInlines));

--- a/modules/tinymce/src/core/main/ts/delete/InlineFormatDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/InlineFormatDelete.ts
@@ -55,8 +55,8 @@ const deleteLastPosition = (forward: boolean, editor: Editor, target: SugarEleme
 };
 
 const deleteCaret = (editor: Editor, forward: boolean): Optional<() => void> => {
-  const parentInlines = getParentInlinesUntilMultichildInline(editor);
-  return Arr.last(Arr.filter(parentInlines, hasOnlyOneChild)).bind((target) => {
+  const parentInlines = Arr.filter(getParentInlinesUntilMultichildInline(editor), hasOnlyOneChild);
+  return Arr.last(parentInlines).bind((target) => {
     const fromPos = CaretPosition.fromRangeStart(editor.selection.getRng());
     if (DeleteUtils.willDeleteLastPositionInElement(forward, fromPos, target.dom) && !CaretFormat.isEmptyCaretFormatElement(target)) {
       return Optional.some(() => deleteLastPosition(forward, editor, target, parentInlines));

--- a/modules/tinymce/src/core/test/ts/browser/delete/DeleteCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/DeleteCommandsTest.ts
@@ -30,6 +30,15 @@ describe('browser.tinymce.core.delete.DeleteCommandsTest', () => {
     TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1);
   });
 
+  it('TINY-9807: If placed between two images the first image should be deleted, not the second one', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><img id="one" src="about:blank"><img id="two" src="about:blank"></p>');
+    TinySelections.setCursor(editor, [ 0 ], 1);
+    DeleteCommands.deleteCommand(editor, caret);
+    TinyAssertions.assertContent(editor, '<p><img id="two" src="about:blank"></p>');
+    TinyAssertions.assertCursor(editor, [ 0 ], 0);
+  });
+
   context('noneditable', () => {
     it('TINY-9477: Delete on noneditable blocks should not do anything', () => {
       const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/delete/InlineFormatDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/InlineFormatDeleteTest.ts
@@ -26,10 +26,10 @@ describe('browser.tinymce.core.delete.InlineFormatDelete', () => {
     assert.isFalse(returnVal.isSome(), 'Should return false since the operation is a noop');
   };
 
-  const doBackspace = (editor: Editor) => {
+  const doBackspace = (editor: Editor, shouldBeSome: boolean = true) => {
     const returnVal = InlineFormatDelete.backspaceDelete(editor, false);
     returnVal.each((apply) => apply());
-    assert.isTrue(returnVal.isSome(), 'Should return true since the operation should have done something');
+    assert.isTrue(shouldBeSome === returnVal.isSome(), 'Should return true since the operation should have done something');
   };
 
   const noopBackspace = (editor: Editor) => {
@@ -970,6 +970,17 @@ describe('browser.tinymce.core.delete.InlineFormatDelete', () => {
       noopBackspace(editor);
       TinyAssertions.assertContent(editor, '<p><span style="text-decoration: underline;"><img src="about:blank">a</span></p>');
       TinyAssertions.assertSelection(editor, [ 0, 0 ], 0, [ 0, 0, 1 ], 'a'.length);
+    });
+  });
+
+  context('Interactions with other elements', () => {
+    it('TINY-9807: If placed between two images the inline format should do nothing', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><img id="one" src="about:blank"><img id="two" src="about:blank"></p>');
+      TinySelections.setCursor(editor, [ 0 ], 1);
+      doBackspace(editor, false);
+      TinyAssertions.assertContent(editor, '<p><img id="one" src="about:blank"><img id="two" src="about:blank"></p>');
+      TinyAssertions.assertCursor(editor, [ 0 ], 1);
     });
   });
 });


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
Would sometimes delete images behind the caret, this shouldn't happen anymore.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
