### PR TITLE
TINY-9813: Newlines should be added when pressing enter after a table.

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Redial would in some situations cause select elements not to have an initial value selected when they should have. #TINY-9679
 - Table toolbar was visible even if the table was within a noneditable host element. #TINY-9664
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460
+- Adding a newline in Chrome when the cursor was placed behind a table could in some specific situations not generate the expected newline. #TINY-9813
 - Show the calculated height and width of media embed elements in the `media` plugin dialog. #TINY-8714
 - Removing an image that failed to upload from an empty paragraph would leave the paragraph without a padding br. #TINY-9696
 - Allow a media embed element to be correctly resized when using the `media` plugin dialog by converting the media embed to a standalone iframe. #TINY-8714

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Redial would in some situations cause select elements not to have an initial value selected when they should have. #TINY-9679
 - Table toolbar was visible even if the table was within a noneditable host element. #TINY-9664
 - Quickbar toolbars was shown for noneditable contents in a noneditable root. #TINY-9460
-- Adding a newline in Chrome when the cursor was placed behind a table could in some specific situations not generate the expected newline. #TINY-9813
+- Adding a newline in Chrome when the cursor was placed after a table could in some specific situations not generate the expected newline. #TINY-9813
 - Show the calculated height and width of media embed elements in the `media` plugin dialog. #TINY-8714
 - Removing an image that failed to upload from an empty paragraph would leave the paragraph without a padding br. #TINY-9696
 - Allow a media embed element to be correctly resized when using the `media` plugin dialog by converting the media embed to a standalone iframe. #TINY-8714

--- a/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
@@ -245,9 +245,9 @@ const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>): void => {
   const start = SugarElement.fromDom(rng.startContainer);
 
   const child = Traverse.child(start, rng.startOffset);
-  const isCefOpt = child.map((element) => SugarNode.isHTMLElement(element) && !ContentEditable.isEditable(element));
+  const isCef = child.exists((element) => SugarNode.isHTMLElement(element) && !ContentEditable.isEditable(element));
 
-  const inRootAndLastOrCef = isInRoot && isCefOpt.getOr(true);
+  const inRootAndLastOrCef = isInRoot && isCef;
 
   // Creates a new block element by cloning the current one or creating a new one if the name is specified
   // This function will also copy any text formatting from the parent block and add it to the new one

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -23,7 +23,7 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
     const sel = editor.selection.getSel();
 
     if (Type.isNullable(sel)) {
-      throw new Error();
+      throw new Error('Sel is unexpectedly missing.');
     }
 
     const range = editor.contentDocument.createRange();

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -19,6 +19,9 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
     InsertNewLine.insert(editor, args as EditorEvent<KeyboardEvent>);
   };
 
+  /*
+  This function is used as a replacement for the TinySelections.setCursor as some changes are performed to cursor position in this setup.
+  */
   const setSelectionToBody = (editor: Editor, offset: number) => {
     const sel = editor.selection.getSel();
 


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
Added newlines where they should be added.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
