### PR TITLE
TINY-9818: Add option to restore document.write behaviour

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `help_accessibility` option which displays the keyboard shortcut to access the help functionality in the statusbar. #TINY-9379
 - New `accordion` plugin with the `InsertAccordion` command. #TINY-9730
 - New `details_initial_state` and `details_serialized_state` options. #TINY-9732
+- New `document_write` option that initializes the editor iframe using `document.write` instead of `srcdoc`. #TINY-9818
 
 ### Improved
 - Screen readers are now able to announce the highlighted menu item of link comboboxes. #TINY-9280

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `help_accessibility` option which displays the keyboard shortcut to access the help functionality in the statusbar. #TINY-9379
 - New `accordion` plugin with the `InsertAccordion` command. #TINY-9730
 - New `details_initial_state` and `details_serialized_state` options. #TINY-9732
-- New `document_write` option that initializes the editor iframe using `document.write` instead of `srcdoc`. #TINY-9818
+- New `init_content_sync` option that initializes the editor iframe using `document.write` instead of `srcdoc`. #TINY-9818
 
 ### Improved
 - Screen readers are now able to announce the highlighted menu item of link comboboxes. #TINY-9280

--- a/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
@@ -83,7 +83,7 @@ export default (): void => {
       { title: 'Some class', value: 'class-name' }
     ],
     importcss_append: true,
-    // document_write: true,
+    // init_content_sync: true,
     height: 400,
     image_advtab: true,
     file_picker_callback: (callback, _value, meta) => {

--- a/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
@@ -83,7 +83,7 @@ export default (): void => {
       { title: 'Some class', value: 'class-name' }
     ],
     importcss_append: true,
-    document_write: true,
+    // document_write: true,
     height: 400,
     image_advtab: true,
     file_picker_callback: (callback, _value, meta) => {

--- a/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
@@ -83,6 +83,7 @@ export default (): void => {
       { title: 'Some class', value: 'class-name' }
     ],
     importcss_append: true,
+    document_write: true,
     height: 400,
     image_advtab: true,
     file_picker_callback: (callback, _value, meta) => {

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -284,7 +284,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   contextmenu: string[];
   custom_colors: boolean;
   document_base_url: string;
-  document_write: boolean;
+  init_content_sync: boolean;
   draggable_modal: boolean;
   editable_class: string;
   font_css: string[];

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -284,6 +284,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   contextmenu: string[];
   custom_colors: boolean;
   document_base_url: string;
+  document_write: boolean;
   draggable_modal: boolean;
   editable_class: string;
   font_css: string[];

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -807,7 +807,7 @@ const register = (editor: Editor): void => {
     default: 'inherited'
   });
 
-  registerOption('document_write', {
+  registerOption('init_content_sync', {
     processor: 'boolean',
     default: false
   });
@@ -917,7 +917,7 @@ const getNonEditableRegExps = option('noneditable_regexp');
 const shouldPreserveCData = option('preserve_cdata');
 const shouldHighlightOnFocus = option('highlight_on_focus');
 const shouldSanitizeXss = option('xss_sanitization');
-const shouldUseDocumentWrite = option('document_write');
+const shouldUseDocumentWrite = option('init_content_sync');
 
 const hasTextPatternsLookup = (editor: Editor): boolean =>
   editor.options.isSet('text_patterns_lookup');

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -807,6 +807,11 @@ const register = (editor: Editor): void => {
     default: 'inherited'
   });
 
+  registerOption('document_write', {
+    processor: 'boolean',
+    default: false
+  });
+
   // These options must be registered later in the init sequence due to their default values
   editor.on('ScriptsLoaded', () => {
     registerOption('directionality', {
@@ -912,6 +917,7 @@ const getNonEditableRegExps = option('noneditable_regexp');
 const shouldPreserveCData = option('preserve_cdata');
 const shouldHighlightOnFocus = option('highlight_on_focus');
 const shouldSanitizeXss = option('xss_sanitization');
+const shouldUseDocumentWrite = option('document_write');
 
 const hasTextPatternsLookup = (editor: Editor): boolean =>
   editor.options.isSet('text_patterns_lookup');
@@ -1033,5 +1039,6 @@ export {
   shouldHighlightOnFocus,
   shouldSanitizeXss,
   getDetailsInitialState,
-  getDetailsSerializedState
+  getDetailsSerializedState,
+  shouldUseDocumentWrite
 };

--- a/modules/tinymce/src/core/test/ts/browser/init/InitDocumentWriteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitDocumentWriteTest.ts
@@ -1,0 +1,21 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { SelectorFind } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.init.InitDocumentWriteTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    document_write: true
+  }, [], true);
+
+  it('TINY-9818: Should initialize the editor', () => {
+    const editor = hook.editor();
+    const ifr = SelectorFind.descendant<HTMLIFrameElement>(TinyDom.container(editor), 'iframe').getOrDie('Could not find iframe');
+    assert.isEmpty(ifr.dom.srcdoc, 'Should not have srcdoc');
+    SelectorFind.descendant<HTMLLinkElement>(TinyDom.documentElement(editor), 'link').getOrDie('Could not find link');
+  });
+});
+

--- a/modules/tinymce/src/core/test/ts/browser/init/InitDocumentWriteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitDocumentWriteTest.ts
@@ -1,5 +1,5 @@
+import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { SelectorFind } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -13,9 +13,9 @@ describe('browser.tinymce.core.init.InitDocumentWriteTest', () => {
 
   it('TINY-9818: Should initialize the editor', () => {
     const editor = hook.editor();
-    const ifr = SelectorFind.descendant<HTMLIFrameElement>(TinyDom.container(editor), 'iframe').getOrDie('Could not find iframe');
-    assert.isEmpty(ifr.dom.srcdoc, 'Should not have srcdoc');
-    SelectorFind.descendant<HTMLLinkElement>(TinyDom.documentElement(editor), 'link').getOrDie('Could not find link');
+    const ifr = UiFinder.findIn<HTMLIFrameElement>(TinyDom.container(editor), 'iframe').getOrDie();
+    assert.isEmpty(ifr.dom.srcdoc, 'Should not have srcdoc set to a non empty string');
+    UiFinder.exists(TinyDom.documentElement(editor), 'link');
   });
 });
 

--- a/modules/tinymce/src/core/test/ts/browser/init/InitDocumentWriteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitDocumentWriteTest.ts
@@ -8,7 +8,7 @@ import Editor from 'tinymce/core/api/Editor';
 describe('browser.tinymce.core.init.InitDocumentWriteTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     base_url: '/project/tinymce/js/tinymce',
-    document_write: true
+    init_content_sync: true
   }, [], true);
 
   it('TINY-9818: Should initialize the editor', () => {


### PR DESCRIPTION
Related Ticket: TINY-9818

Description of Changes:
* Adds a `init_content_sync` boolean option to use the sync document.write to fill the `iframe` instead of `srcdoc` that is async.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
