### PR TITLE
TINY-9760: Disable inserting an accordion into noneditable elements

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Typing after deleting formatted content could remove a space at the start of the typing. TINY-9310
+- Typing after deleting formatted content could remove a space at the start of the typing. #TINY-9310
+- Disable inserting an accordion into noneditable elements. #TINY-9760
 
 ### Added
 - New optional `defaultExpandedIds` and `onToggleExpand` options to the `tree` component config. #TINY-9653

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Typing after deleting formatted content could remove a space at the start of the typing. #TINY-9310
-- Disable inserting an accordion into noneditable elements. #TINY-9760
 
 ### Added
 - New optional `defaultExpandedIds` and `onToggleExpand` options to the `tree` component config. #TINY-9653

--- a/modules/tinymce/src/plugins/accordion/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/accordion/main/ts/core/Actions.ts
@@ -6,7 +6,7 @@ import * as Events from '../api/Events';
 import * as Utils from './Utils';
 
 const insertAccordion = (editor: Editor): void => {
-  if (Utils.isInSummary(editor)) {
+  if (!Utils.isInsertAllowed(editor)) {
     return;
   }
 

--- a/modules/tinymce/src/plugins/accordion/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/accordion/main/ts/core/Utils.ts
@@ -17,6 +17,9 @@ export const isInSummary = (editor: Editor): boolean => {
   return isSummary(node) || Boolean(editor.dom.getParent(node, isSummary));
 };
 
+export const isInsertAllowed = (editor: Editor): boolean =>
+  !isInSummary(editor) && editor.dom.isEditable(editor.selection.getNode());
+
 export const getSelectedDetails = (editor: Editor): Optional<HTMLDetailsElement> =>
   Optional.from(editor.dom.getParent(editor.selection.getNode(), isDetails));
 

--- a/modules/tinymce/src/plugins/accordion/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/accordion/main/ts/ui/Buttons.ts
@@ -5,7 +5,7 @@ import Editor from 'tinymce/core/api/Editor';
 import * as Utils from '../core/Utils';
 
 const onSetup = (editor: Editor) => (buttonApi: Toolbar.ToolbarButtonInstanceApi | Menu.MenuItemInstanceApi) => {
-  const onNodeChange = () => buttonApi.setEnabled(!Utils.isInSummary(editor));
+  const onNodeChange = () => buttonApi.setEnabled(Utils.isInsertAllowed(editor));
   editor.on('NodeChange', onNodeChange);
   return () => editor.off('NodeChange', onNodeChange);
 };

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionPluginTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionPluginTest.ts
@@ -290,4 +290,12 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
     TinyAssertions.assertCursor(editor, [ 0, 1 ], 0);
   });
+
+  it('TINY-9760: Prevent inserting an accordion into noneditable elements', () => {
+    const editor = hook.editor();
+    editor.setContent('<div contenteditable="false"><p>noneditable</p></div>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 0);
+    editor.execCommand('InsertAccordion');
+    TinyAssertions.assertContentPresence(editor, { 'div[contenteditable="false"] > details': 0 });
+  });
 });


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Disabled inserting an accordion into noneditable elements.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
