### PR TITLE
TINY-8297: Quickbar toolbar positioned in the middle of table cell selection if contains more than one table cell

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Select would in some situations when it was reused or otherwise reset not have an initial selected value when expected to. #TINY-9679
 
+### Improved
+- `Anchor` now returns the selected cells, if the selection contains more than one table cell. #TINY-8297
+- `SelectionAnchor` now uses the bounds of table cell selection, if the selection contains more than one table cell. #TINY-8297
+
 ## 12.1.0 - 2023-03-15
 
 ### Added

--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Select would in some situations when it was reused or otherwise reset not have an initial selected value when expected to. #TINY-9679
 
 ### Improved
-- `Anchor` now returns the first and the last of selected cells, if the selection contains more than one table cell. #TINY-8297
+- Improved `SelectionAnchorSpec.getSelection` to support the selection of both `SimRange` and `SelectionTableCellRange`.
 - `SelectionAnchor` now uses the bounds of table cell selection, if the selection contains more than one table cell. #TINY-8297
 
 ## 12.1.0 - 2023-03-15

--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Select would in some situations when it was reused or otherwise reset not have an initial selected value when expected to. #TINY-9679
 
 ### Improved
-- `Anchor` now returns the selected cells, if the selection contains more than one table cell. #TINY-8297
+- `Anchor` now returns the first and the last of selected cells, if the selection contains more than one table cell. #TINY-8297
 - `SelectionAnchor` now uses the bounds of table cell selection, if the selection contains more than one table cell. #TINY-8297
 
 ## 12.1.0 - 2023-03-15

--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Select would in some situations when it was reused or otherwise reset not have an initial selected value when expected to. #TINY-9679
 
 ### Improved
-- Improved `SelectionAnchorSpec.getSelection` to support the selection of both `SimRange` and `SelectionTableCellRange`.
 - `SelectionAnchor` now uses the bounds of table cell selection, if the selection contains more than one table cell. #TINY-8297
+
+### Changed
+- Changed `SelectionAnchorSpec.getSelection` to support the selection of both `SimRange` and `SelectionTableCellRange`.
 
 ## 12.1.0 - 2023-03-15
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/Anchoring.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/Anchoring.ts
@@ -60,7 +60,7 @@ export interface HasLayoutAnchorSpec {
 
 export interface SelectionAnchorSpec extends CommonAnchorSpec, HasLayoutAnchorSpec {
   type: 'selection';
-  getSelection?: () => Optional<SimRange>;
+  getSelection?: () => Optional<SimRange | SugarElement<HTMLTableCellElement>[]>;
   root: SugarElement<Node>;
   bubble?: Bubble;
   overrides?: AnchorOverrides;
@@ -68,7 +68,7 @@ export interface SelectionAnchorSpec extends CommonAnchorSpec, HasLayoutAnchorSp
 }
 
 export interface SelectionAnchor extends AnchorDetail<SelectionAnchor>, HasLayoutAnchor {
-  getSelection: Optional<() => Optional<SimRange>>;
+  getSelection: Optional<() => Optional<SimRange | SugarElement<HTMLTableCellElement>[]>>;
   root: SugarElement<Node>;
   bubble: Optional<Bubble>;
   overrides: AnchorOverrides;

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/Anchoring.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/Anchoring.ts
@@ -58,9 +58,14 @@ export interface HasLayoutAnchorSpec {
   layouts?: Layouts;
 }
 
+export interface SelectionTableCellRange {
+  firstCell: SugarElement<HTMLTableCellElement>;
+  lastCell: SugarElement<HTMLTableCellElement>;
+}
+
 export interface SelectionAnchorSpec extends CommonAnchorSpec, HasLayoutAnchorSpec {
   type: 'selection';
-  getSelection?: () => Optional<SimRange | SugarElement<HTMLTableCellElement>[]>;
+  getSelection?: () => Optional<SimRange | SelectionTableCellRange>;
   root: SugarElement<Node>;
   bubble?: Bubble;
   overrides?: AnchorOverrides;
@@ -68,7 +73,7 @@ export interface SelectionAnchorSpec extends CommonAnchorSpec, HasLayoutAnchorSp
 }
 
 export interface SelectionAnchor extends AnchorDetail<SelectionAnchor>, HasLayoutAnchor {
-  getSelection: Optional<() => Optional<SimRange | SugarElement<HTMLTableCellElement>[]>>;
+  getSelection: Optional<() => Optional<SimRange | SelectionTableCellRange>>;
   root: SugarElement<Node>;
   bubble: Optional<Bubble>;
   overrides: AnchorOverrides;

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
@@ -53,9 +53,9 @@ const placement = (component: AlloyComponent, anchorInfo: SelectionAnchor, origi
         return ContentAnchorCommon.getBox(rawRect.left, rawRect.top, rawRect.width, rawRect.height);
       });
     } else {
-      const menuRects = sel.map((x) => x.dom.getBoundingClientRect());
+      const selectionRects = sel.map((x) => x.dom.getBoundingClientRect());
 
-      const minMax = Arr.foldl(menuRects, (acc, rect) => {
+      const bounds = Arr.foldl(selectionRects, (acc, rect) => {
         return {
           left: Math.min(acc.left, rect.left),
           right: Math.max(acc.right, rect.right),
@@ -70,7 +70,7 @@ const placement = (component: AlloyComponent, anchorInfo: SelectionAnchor, origi
         bottom: Number.MIN_VALUE
       });
 
-      return ContentAnchorCommon.getBox(minMax.left, minMax.top, minMax.right - minMax.left, minMax.bottom - minMax.top);
+      return ContentAnchorCommon.getBox(bounds.left, bounds.top, bounds.right - bounds.left, bounds.bottom - bounds.top);
     }
   });
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
@@ -1,5 +1,5 @@
 import { FieldSchema } from '@ephox/boulder';
-import { Optional, Unicode } from '@ephox/katamari';
+import { Arr, Optional, Unicode } from '@ephox/katamari';
 import { Insert, Remove, SimRange, SimSelection, SugarElement, SugarNode, Traverse, WindowSelection } from '@ephox/sugar';
 
 import * as Descend from '../../alien/Descend';
@@ -15,14 +15,21 @@ import * as ContentAnchorCommon from './ContentAnchorCommon';
 const descendOnce = (element: SugarElement<Node>, offset: number): Descend.ElementAndOffset<Node> =>
   SugarNode.isText(element) ? Descend.point(element, offset) : Descend.descendOnce(element, offset);
 
-const getAnchorSelection = (win: Window, anchorInfo: SelectionAnchor): Optional<SimRange> => {
+const isSimRange = (detail: SimRange | SugarElement<Node>[]): detail is SimRange =>
+  (detail as SimRange).start !== undefined;
+
+const getAnchorSelection = (win: Window, anchorInfo: SelectionAnchor): Optional<SimRange | SugarElement<HTMLTableCellElement>[]> => {
   // FIX TEST Test both providing a getSelection and not providing a getSelection
   const getSelection = anchorInfo.getSelection.getOrThunk(() => () => WindowSelection.getExact(win));
 
   return getSelection().map((sel) => {
-    const modStart = descendOnce(sel.start, sel.soffset);
-    const modFinish = descendOnce(sel.finish, sel.foffset);
-    return SimSelection.range(modStart.element, modStart.offset, modFinish.element, modFinish.offset);
+    if (isSimRange(sel)) {
+      const modStart = descendOnce(sel.start, sel.soffset);
+      const modFinish = descendOnce(sel.finish, sel.foffset);
+      return SimSelection.range(modStart.element, modStart.offset, modFinish.element, modFinish.offset);
+    }
+
+    return sel;
   });
 };
 
@@ -32,20 +39,49 @@ const placement = (component: AlloyComponent, anchorInfo: SelectionAnchor, origi
 
   const selectionBox = getAnchorSelection(win, anchorInfo).bind((sel) => {
     // This represents the *visual* rectangle of the selection.
-    const optRect = WindowSelection.getBounds(win, SimSelection.exactFromRange(sel)).orThunk(() => {
-      const x = SugarElement.fromText(Unicode.zeroWidth);
-      Insert.before(sel.start, x);
-      // Certain things like <p><br/></p> with (p, 0) or <br>) as collapsed selection do not return a client rectangle
-      const rect = WindowSelection.getFirstRect(win, SimSelection.exact(x, 0, x, 1));
-      Remove.remove(x);
-      return rect;
-    });
+    if (isSimRange(sel)) {
+      const optRect = WindowSelection.getBounds(win, SimSelection.exactFromRange(sel)).orThunk(() => {
+        const x = SugarElement.fromText(Unicode.zeroWidth);
+        Insert.before(sel.start, x);
+        // Certain things like <p><br/></p> with (p, 0) or <br>) as collapsed selection do not return a client rectangle
+        const rect = WindowSelection.getFirstRect(win, SimSelection.exact(x, 0, x, 1));
+        Remove.remove(x);
+        return rect;
+      });
 
-    return optRect.bind((rawRect) => ContentAnchorCommon.getBox(rawRect.left, rawRect.top, rawRect.width, rawRect.height));
+      return optRect.bind((rawRect) => {
+        return ContentAnchorCommon.getBox(rawRect.left, rawRect.top, rawRect.width, rawRect.height);
+      });
+    } else {
+      const menuRects = sel.map((x) => x.dom.getBoundingClientRect());
+
+      const minMax = Arr.foldl(menuRects, (acc, rect) => {
+        return {
+          left: Math.min(acc.left, rect.left),
+          right: Math.max(acc.right, rect.right),
+          top: Math.min(acc.top, rect.top),
+          bottom: Math.max(acc.bottom, rect.bottom)
+        };
+      },
+      {
+        left: Number.MAX_VALUE,
+        right: Number.MIN_VALUE,
+        top: Number.MAX_VALUE,
+        bottom: Number.MIN_VALUE
+      });
+
+      return ContentAnchorCommon.getBox(minMax.left, minMax.top, minMax.right - minMax.left, minMax.bottom - minMax.top);
+    }
   });
 
   const targetElement = getAnchorSelection(win, anchorInfo)
-    .bind((sel) => SugarNode.isElement(sel.start) ? Optional.some(sel.start) : Traverse.parentElement(sel.start));
+    .bind((sel) => {
+      if (isSimRange(sel)) {
+        return SugarNode.isElement(sel.start) ? Optional.some(sel.start) : Traverse.parentElement(sel.start);
+      }
+
+      return Arr.head(sel);
+    });
   const elem = targetElement.getOr(component.element);
 
   return ContentAnchorCommon.calcNewAnchor(selectionBox, rootPoint, anchorInfo, origin, elem);

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
@@ -16,7 +16,7 @@ const descendOnce = (element: SugarElement<Node>, offset: number): Descend.Eleme
   SugarNode.isText(element) ? Descend.point(element, offset) : Descend.descendOnce(element, offset);
 
 const isSimRange = (detail: SimRange | SugarElement<Node>[]): detail is SimRange =>
-  (detail as SimRange).start !== undefined;
+  (detail as SimRange).foffset !== undefined;
 
 const getAnchorSelection = (win: Window, anchorInfo: SelectionAnchor): Optional<SimRange | SugarElement<HTMLTableCellElement>[]> => {
   // FIX TEST Test both providing a getSelection and not providing a getSelection
@@ -41,11 +41,11 @@ const placement = (component: AlloyComponent, anchorInfo: SelectionAnchor, origi
     // This represents the *visual* rectangle of the selection.
     if (isSimRange(sel)) {
       const optRect = WindowSelection.getBounds(win, SimSelection.exactFromRange(sel)).orThunk(() => {
-        const x = SugarElement.fromText(Unicode.zeroWidth);
-        Insert.before(sel.start, x);
+        const zeroWidth = SugarElement.fromText(Unicode.zeroWidth);
+        Insert.before(sel.start, zeroWidth);
         // Certain things like <p><br/></p> with (p, 0) or <br>) as collapsed selection do not return a client rectangle
-        const rect = WindowSelection.getFirstRect(win, SimSelection.exact(x, 0, x, 1));
-        Remove.remove(x);
+        const rect = WindowSelection.getFirstRect(win, SimSelection.exact(zeroWidth, 0, zeroWidth, 1));
+        Remove.remove(zeroWidth);
         return rect;
       });
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
@@ -27,9 +27,9 @@ const getAnchorSelection = (win: Window, anchorInfo: SelectionAnchor): Optional<
       const modStart = descendOnce(sel.start, sel.soffset);
       const modFinish = descendOnce(sel.finish, sel.foffset);
       return SimSelection.range(modStart.element, modStart.offset, modFinish.element, modFinish.offset);
+    } else {
+      return sel;
     }
-
-    return sel;
   });
 };
 
@@ -70,9 +70,9 @@ const placement = (component: AlloyComponent, anchorInfo: SelectionAnchor, origi
     .bind((sel) => {
       if (isSimRange(sel)) {
         return SugarNode.isElement(sel.start) ? Optional.some(sel.start) : Traverse.parentElement(sel.start);
+      } else {
+        return Optional.some(sel.firstCell);
       }
-
-      return Optional.some(sel.firstCell);
     });
   const elem = targetElement.getOr(component.element);
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Help text displayed at **Help > Help > Keyboard Navigation** re-written. #DOC-1936
 - These characters '$', '~', '+', '|', '№', '`' are now considered as punctuation marks. Therefore, they will not increase the word count. #TINY-8122
 - Updated the `codesample` plugin dialog and `template` plugin dialog to use the 'listbox' component to match other dialogs. #TINY-9630
+- Quickbar toolbars are now positioned in the middle of the selection horizontally, when it contains more than one table cell selected.
 
 ### Changed
 - The `caption`, `address` and `dt` elements were allowed to have non-inline children elements when the editor schema was set to `html4`. #TINY-9768

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Help text displayed at **Help > Help > Keyboard Navigation** re-written. #DOC-1936
 - These characters '$', '~', '+', '|', '№', '`' are now considered as punctuation marks. Therefore, they will not increase the word count. #TINY-8122
 - Updated the `codesample` plugin dialog and `template` plugin dialog to use the 'listbox' component to match other dialogs. #TINY-9630
-- Quickbar toolbars are now positioned in the middle of the selection horizontally, when it contains more than one table cell selected.
+- Quickbar toolbars are now positioned in the middle of the selection horizontally, if the selection contains more than one table cell. #TINY-8297
 
 ### Changed
 - The `caption`, `address` and `dt` elements were allowed to have non-inline children elements when the editor schema was set to `html4`. #TINY-9768

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -28,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Help text displayed at **Help > Help > Keyboard Navigation** re-written. #DOC-1936
 - These characters '$', '~', '+', '|', '№', '`' are now considered as punctuation marks. Therefore, they will not increase the word count. #TINY-8122
 - Updated the `codesample` plugin dialog and `template` plugin dialog to use the 'listbox' component to match other dialogs. #TINY-9630
-- `getCursorAnchor` of selection now returns the first and last selected cells, if the selection contains more than one table cell. #TINY-8297
 - Quickbar toolbars are now positioned in the middle of the selection horizontally, if the selection contains more than one table cell. #TINY-8297
 - Exposed `dataTransfer` property of drag and drop events for elements with a `contenteditable="false"` attribute. #TINY-9601
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Help text displayed at **Help > Help > Keyboard Navigation** re-written. #DOC-1936
 - These characters '$', '~', '+', '|', '№', '`' are now considered as punctuation marks. Therefore, they will not increase the word count. #TINY-8122
 - Updated the `codesample` plugin dialog and `template` plugin dialog to use the 'listbox' component to match other dialogs. #TINY-9630
+- `getCursorAnchor` of selection now returns the first and last selected cells, if the selection contains more than one table cell. #TINY-8297
 - Quickbar toolbars are now positioned in the middle of the selection horizontally, if the selection contains more than one table cell. #TINY-8297
 - Exposed `dataTransfer` property of drag and drop events for elements with a `contenteditable="false"` attribute. #TINY-9601
 

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/ToolbarPositionTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/ToolbarPositionTest.ts
@@ -10,7 +10,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/quickbars/Plugin';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
 
-import { pAssertToolbarVisible, pGetToolBar } from '../module/test/Utils';
+import { pAssertToolbarVisible } from '../module/test/Utils';
 
 type TableSizingMode = 'relative' | 'fixed';
 
@@ -173,11 +173,11 @@ describe('browser.tinymce.plugins.quickbars.ToolbarPositionTest', () => {
   };
 
   const getToolbarBounds = async (): Promise<DOMRect> => {
-    const toolbar = await pGetToolBar();
+    const toolbar = await UiFinder.pWaitFor('Wait for toolbar to exist', SugarBody.body(), '.tox-pop__dialog .tox-toolbar');
     return toolbar.dom.getBoundingClientRect();
   };
 
-  const removeToolbar = async (editor: Editor) => {
+  const pRemoveToolbar = async (editor: Editor) => {
     TinySelections.setCursor(editor, [ 1 ], 0);
     await pAssertToolbarNotVisible();
   };
@@ -216,7 +216,7 @@ describe('browser.tinymce.plugins.quickbars.ToolbarPositionTest', () => {
               const selectedCellBounds = getBoundsOfSelectedCells(selectedCells);
 
               await pAssertToolbarPosition(selectedCellBounds);
-              await removeToolbar(editor);
+              await pRemoveToolbar(editor);
 
               currentWindowEnd++;
             }
@@ -256,7 +256,7 @@ describe('browser.tinymce.plugins.quickbars.ToolbarPositionTest', () => {
               const selectedCellBounds = getBoundsOfSelectedCells(selectedCells);
 
               await pAssertToolbarPosition(selectedCellBounds);
-              await removeToolbar(editor);
+              await pRemoveToolbar(editor);
 
               currentWindowEnd += columnSize;
             }
@@ -296,7 +296,7 @@ describe('browser.tinymce.plugins.quickbars.ToolbarPositionTest', () => {
             const selectedCellBounds = getBoundsOfSelectedCells(selectedCells);
 
             await pAssertToolbarPosition(selectedCellBounds);
-            await removeToolbar(editor);
+            await pRemoveToolbar(editor);
 
             currentWindowEnd += columnsToMove;
           }
@@ -319,7 +319,7 @@ describe('browser.tinymce.plugins.quickbars.ToolbarPositionTest', () => {
         const tableBounds = Boxes.absolute(table);
         await pAssertToolbarPosition(tableBounds);
 
-        await removeToolbar(editor);
+        await pRemoveToolbar(editor);
       });
 
       // When selection starts from last cell of the table and expands to the last paragraph in the editor, the toolbar should be displayed in the center of the table
@@ -353,7 +353,7 @@ describe('browser.tinymce.plugins.quickbars.ToolbarPositionTest', () => {
           height: mergedBounds.bottom - mergedBounds.y,
         });
 
-        await removeToolbar(editor);
+        await pRemoveToolbar(editor);
       });
     });
   });

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/ToolbarPositionTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/ToolbarPositionTest.ts
@@ -111,9 +111,6 @@ describe('browser.tinymce.plugins.quickbars.ToolbarPositionTest', () => {
     const toolbarBounds = await getToolbarBounds();
     await pAssertToolbarVisible();
 
-    // const selectedCells = editor.model.table.getSelectedCells();
-    // const selectedCellBounds = getBoundsOfSelectedCells(selectedCells);
-
     const middleOfSelectedCellBounds = selectedCellBounds.width / 2;
     const middleOfToolbarBounds = toolbarBounds.width / 2;
 
@@ -155,7 +152,7 @@ describe('browser.tinymce.plugins.quickbars.ToolbarPositionTest', () => {
       const toolbarLocation = toolbarBounds.top < selectedCellBounds.y ? 'top' : 'bottom';
 
       // When there's sufficient space to show the toolbar in the middle of the selection, it should be in the middle of the selection horizontally
-      // When there's not insufficient space to show the toolbar in the middle of the selection, it should be from the start of the selection
+      // When there's insufficient space to show the toolbar in the middle of the selection, it should be from the start of the selection
       const toolbarStartPosition = middleOfToolbarBounds < selectedCellBounds.x + middleOfSelectedCellBounds ? 'center' : 'start';
 
       return {
@@ -332,8 +329,8 @@ describe('browser.tinymce.plugins.quickbars.ToolbarPositionTest', () => {
 
         const table = SelectorFind.descendant<HTMLTableElement>(TinyDom.body(editor), 'table').getOrDie('Could not find table');
         const cells = getCells(table);
-        const startTd = Arr.find(cells, (elm) => Html.get(elm) === '9').getOrDie('Could not find start TD');
-        const tableBounds = WindowSelection.getBounds(window, SimSelection.exact(startTd, 0, startTd, 1)).getOrDie('Could not get bounds of table cell');
+        const td = Arr.find(cells, (elm) => Html.get(elm) === '9').getOrDie('Could not find TD');
+        const tableBounds = WindowSelection.getBounds(window, SimSelection.exact(td, 0, td, 1)).getOrDie('Could not get bounds of table cell');
 
         const paragraph = SelectorFind.descendant<HTMLParagraphElement>(TinyDom.body(editor), 'p').getOrDie('Could not find paragraph');
         const selP = SimSelection.exact(paragraph, 0, paragraph, 1);

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/ToolbarPositionTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/ToolbarPositionTest.ts
@@ -2,6 +2,7 @@ import { Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { Boxes } from '@ephox/alloy';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
+import { PlatformDetection } from '@ephox/sand';
 import { Html, SelectorFilter, SelectorFind, SimSelection, SugarBody, SugarElement, WindowSelection } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
@@ -304,8 +305,11 @@ describe('browser.tinymce.plugins.quickbars.ToolbarPositionTest', () => {
     });
 
     context('Selection outside table', () => {
+      // Skipping safari, the quickbar toolbar is positioned differently in safari and chrome, see TINY-9851
+      const skipIfSafari = PlatformDetection.detect().browser.isSafari() ? it.skip : it;
+
       // When selection starts from outside the table and expands to the table, the toolbar should be displayed in the center of the table
-      it('TINY-8297: Selection starts from starting paragraph and expands to the first cell of the table in the editor', async () => {
+      skipIfSafari('TINY-8297: Selection starts from starting paragraph and expands to the first cell of the table in the editor', async () => {
         const editor = hook.editor();
         editor.setContent('<p>Some text</p>' + generateTable(tableLayout, 3, 3));
         editor.focus();

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/ToolbarPositionTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/ToolbarPositionTest.ts
@@ -1,0 +1,361 @@
+import { Mouse, UiFinder, Waiter } from '@ephox/agar';
+import { Boxes } from '@ephox/alloy';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { Html, SelectorFilter, SelectorFind, SimSelection, SugarBody, SugarElement, WindowSelection } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/quickbars/Plugin';
+import TablePlugin from 'tinymce/plugins/table/Plugin';
+
+import { pAssertToolbarVisible, pGetToolBar } from '../module/test/Utils';
+
+type TableSizingMode = 'relative' | 'fixed';
+
+describe('browser.tinymce.plugins.quickbars.ToolbarPositionTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'quickbars link',
+    base_url: '/project/tinymce/js/tinymce',
+    min_height: 500,
+  }, [ Plugin, TablePlugin ]);
+
+  const pAssertToolbarNotVisible = async () => {
+    // We can't wait for something to happen, as nothing will change. So instead, just wait some time for when the toolbar would have normally shown
+    await Waiter.pWait(50);
+    UiFinder.notExists(SugarBody.body(), '.tox-pop__dialog .tox-toolbar');
+  };
+
+  const selectWithMouse = (start: SugarElement<Node>, end: SugarElement<Node>): void => {
+    Mouse.mouseDown(start, { button: 0 });
+    Mouse.mouseOver(end, { button: 0 });
+    Mouse.mouseUp(end, { button: 0 });
+  };
+
+  const getCells = (table: SugarElement<HTMLTableElement>, selector: string = 'td,th'): SugarElement<HTMLTableCellElement>[] =>
+    SelectorFilter.descendants(table, selector);
+
+  const selectCellsWithMouse = (editor: Editor, selectCells: [ string, string ]) => {
+    const table = SelectorFind.descendant<HTMLTableElement>(TinyDom.body(editor), 'table').getOrDie('Could not find table');
+    const cells = getCells(table);
+    const startTd = Arr.find(cells, (elm) => Html.get(elm) === selectCells[0]).getOrDie('Could not find start TD');
+    const endTd = Arr.find(cells, (elm) => Html.get(elm) === selectCells[1]).getOrDie('Could not find end TD');
+
+    selectWithMouse(startTd, endTd);
+  };
+
+  const getUnit = (mode: TableSizingMode): 'px' | '%' | null => {
+    switch (mode) {
+      case 'fixed':
+        return 'px';
+      case 'relative':
+        return '%';
+    }
+  };
+
+  const generateWidth = (mode: TableSizingMode, cols: number) => `width: ${100 / cols}${getUnit(mode)}`;
+
+  const generateTable = (mode: TableSizingMode, rows: number, cols: number) => {
+    const tableWidth = generateWidth(mode, 1);
+    const cellWidth = generateWidth(mode, cols);
+
+    const getCellStyle = ` style="${cellWidth}"`;
+
+    const renderedRows = Arr.range(rows, (row) =>
+      '<tr>' + Arr.range(cols, (col) => {
+        const cellNum = (row * cols) + col + 1;
+        return `<td${getCellStyle}>${cellNum}</td>`;
+      }).join('') + '</tr>'
+    ).join('');
+
+    const renderedColumns = Arr.range(cols, () =>
+      `<col style="${cellWidth}"></col>`
+    ).join('');
+
+    const colgroups = '<colgroup>' + renderedColumns + '</colgroup>';
+
+    return `<table border="1" style="border-collapse: collapse;${tableWidth}">${colgroups}<tbody>${renderedRows}</tbody></table>`;
+  };
+
+  const getBoundsOfSelectedCells = (selectedCells: HTMLTableCellElement[]): Boxes.Bounds => {
+    // Using Boxes.absolute instead of getBoundingClient here, because getBoundingClient would return the values relative to the iframe
+    // But getBoundingClient on the toolbar would return the values relative to the page, as the sink is placed in the body
+    const menuRects = selectedCells.map((x) => Boxes.absolute(SugarElement.fromDom(x)));
+
+    const selectedCellBounds = Arr.foldl(menuRects, (acc, rect) => {
+      return {
+        x: Math.min(acc.x, rect.x),
+        right: Math.max(acc.right, rect.right),
+        y: Math.min(acc.y, rect.y),
+        bottom: Math.max(acc.bottom, rect.bottom)
+      };
+    }, {
+      x: Number.MAX_VALUE,
+      right: Number.MIN_VALUE,
+      y: Number.MAX_VALUE,
+      bottom: Number.MIN_VALUE
+    });
+
+    return {
+      width: selectedCellBounds.right - selectedCellBounds.x,
+      height: selectedCellBounds.bottom - selectedCellBounds.y,
+      ...selectedCellBounds
+    };
+  };
+
+  const marginOfError = 5;
+  const distanceBetweenToolbar = 13;
+
+  const pAssertToolbarPosition = async (selectedCellBounds: Boxes.Bounds) => {
+    const toolbarBounds = await getToolbarBounds();
+    await pAssertToolbarVisible();
+
+    // const selectedCells = editor.model.table.getSelectedCells();
+    // const selectedCellBounds = getBoundsOfSelectedCells(selectedCells);
+
+    const middleOfSelectedCellBounds = selectedCellBounds.width / 2;
+    const middleOfToolbarBounds = toolbarBounds.width / 2;
+
+    const getHorizontalCenteredBounds = () => {
+      return {
+        left: middleOfSelectedCellBounds - middleOfToolbarBounds + selectedCellBounds.x,
+        right: middleOfSelectedCellBounds + middleOfToolbarBounds + selectedCellBounds.x,
+      };
+    };
+
+    const getHorizontalStartBounds = () => {
+      return {
+        left: selectedCellBounds.x,
+        right: selectedCellBounds.x + toolbarBounds.width,
+      };
+    };
+
+    const dialogPadding = 4;
+    // Checks if the toolbar is shown at the top or bottom of the selection
+    const getToolbarTopBounds = () => {
+
+      return {
+        top: selectedCellBounds.y - toolbarBounds.height - distanceBetweenToolbar + dialogPadding,
+        bottom: selectedCellBounds.y - distanceBetweenToolbar + dialogPadding
+      };
+    };
+
+    // Not required to add the dialogPadding, as the top position can be calculated from bottom of the selection + distance between toolbar
+    // Bottom position would be the same as the top position + toolbar height
+    const getBottomToolbarBounds = () => {
+      return {
+        top: selectedCellBounds.bottom + distanceBetweenToolbar,
+        bottom: selectedCellBounds.bottom + distanceBetweenToolbar + toolbarBounds.height
+      };
+    };
+
+    const getExpectedBounds = () => {
+      // Checking the position of the toolbar, if the toolbar is shown at the top or bottom of the selection
+      const toolbarLocation = toolbarBounds.top < selectedCellBounds.y ? 'top' : 'bottom';
+
+      // When there's sufficient space to show the toolbar in the middle of the selection, it should be in the middle of the selection horizontally
+      // When there's not insufficient space to show the toolbar in the middle of the selection, it should be from the start of the selection
+      const toolbarStartPosition = middleOfToolbarBounds < selectedCellBounds.x + middleOfSelectedCellBounds ? 'center' : 'start';
+
+      return {
+        ...(toolbarLocation === 'top' ? getToolbarTopBounds() : getBottomToolbarBounds()),
+        ...(toolbarStartPosition === 'center' ? getHorizontalCenteredBounds() : getHorizontalStartBounds())
+      };
+    };
+
+    const expectedBounds = getExpectedBounds();
+
+    assert.closeTo(toolbarBounds.left, expectedBounds.left, marginOfError, 'Toolbar left is not positioned correctly');
+    assert.closeTo(toolbarBounds.top, expectedBounds.top, marginOfError, 'Toolbar top is not positioned correctly');
+    assert.closeTo(toolbarBounds.bottom, expectedBounds.bottom, marginOfError, 'Toolbar bottom is not positioned correctly');
+    assert.closeTo(toolbarBounds.right, expectedBounds.right, marginOfError, 'Toolbar right is not positioned correctly');
+  };
+
+  const getToolbarBounds = async (): Promise<DOMRect> => {
+    const toolbar = await pGetToolBar();
+    return toolbar.dom.getBoundingClientRect();
+  };
+
+  const removeToolbar = async (editor: Editor) => {
+    TinySelections.setCursor(editor, [ 1 ], 0);
+    await pAssertToolbarNotVisible();
+  };
+
+  // Test with different tableLayout, as the toolbar is positioned differently, when it has sufficient space to show the toolbar in the middle of the selection
+  Arr.each([ 'fixed', 'relative' ], (tableLayout: TableSizingMode) => {
+    context(`Table layout: ${tableLayout}`, () => {
+
+
+      // Traverse row to row, selects 2 cells initially, then it expands the selection to the right and once it has reaches the end, moves the starting position to the next column
+      // Once convered all cells in the row, it moves to the next row
+      // E.g.: selected cells for 3x3 table
+      // 1. 1, 2
+      // 2. 1, 2, 3
+      // 3. once it has reached the of the row, it moves the starting position to start with 2,3
+      // 4. 2, 3
+      // and moves to the next row....
+      it(`TINY-8297: Toolbar display in the center of horizontal selection`, async () => {
+        const editor = hook.editor();
+        const columnSize = 3;
+        const rowSize = 3;
+
+        editor.focus();
+        editor.setContent(generateTable(tableLayout, rowSize, columnSize));
+
+        for (let row = 1; row <= rowSize; row++ ) {
+          const currentRowMax = (row * columnSize) + 1;
+          let windowStart = ((row - 1) * columnSize) + 1;
+
+          for (let windowEnd = windowStart + 1; windowEnd < currentRowMax; windowEnd++) {
+            let currentWindowEnd = windowEnd;
+
+            while (currentWindowEnd < currentRowMax) {
+              selectCellsWithMouse(editor, [ windowStart.toString(), currentWindowEnd.toString() ]);
+
+              const selectedCells = editor.model.table.getSelectedCells();
+              const selectedCellBounds = getBoundsOfSelectedCells(selectedCells);
+
+              await pAssertToolbarPosition(selectedCellBounds);
+              await removeToolbar(editor);
+
+              currentWindowEnd++;
+            }
+
+            windowStart++;
+          }
+        }
+      });
+
+      // Traverse column to column, selects 2 cells vertically initially, then it expands the selection to the bottom and once it has reaches the bottom, moves the starting position to the next row
+      // Once convered all cells in the column, it moves to the next column
+      // E.g.: selected cells for 3x3 table
+      // 1. 1, 4
+      // 2. 1, 4, 7
+      // 3. once it has reached the of the column, it moves the starting position to start with 4, 7
+      // 4. 4, 7
+      // and moves to the next column....
+      it(`TINY-8297: Toolbar display in the center of vertical selection`, async () => {
+        const editor = hook.editor();
+        const columnSize = 3;
+        const rowSize = 3;
+
+        editor.focus();
+        editor.setContent(generateTable(tableLayout, rowSize, columnSize));
+
+        for (let column = 1; column <= columnSize; column++) {
+          const currentColumnMax = (rowSize - 1) * columnSize + column;
+          let windowStart = column;
+
+          for (let windowEnd = windowStart + columnSize; windowEnd <= currentColumnMax; windowEnd += columnSize) {
+            let currentWindowEnd = windowEnd;
+
+            while (currentWindowEnd <= currentColumnMax) {
+              selectCellsWithMouse(editor, [ windowStart.toString(), currentWindowEnd.toString() ]);
+
+              const selectedCells = editor.model.table.getSelectedCells();
+              const selectedCellBounds = getBoundsOfSelectedCells(selectedCells);
+
+              await pAssertToolbarPosition(selectedCellBounds);
+              await removeToolbar(editor);
+
+              currentWindowEnd += columnSize;
+            }
+
+            windowStart += columnSize;
+          }
+        }
+      });
+
+      // Traverse 2x2, then it expands the selection to 3x3, 4x4...
+      // Once convered all cells with the starting position, it moves the starting position
+      // E.g.: selected cells for 6x6 table
+      // 1. 1, 2, 7, 8
+      // 2. 1, 2, 3, 7, 8, 9, 13, 14, 15
+      // 3. once it has reached the end, it moves the starting position to start with 7, 8
+      // 4. 7, 8, 13, 14
+      // and ....
+      it(`TINY-8297: Toolbar display in the center of box selection`, async () => {
+        const editor = hook.editor();
+        const columnSize = 6;
+        const rowSize = 6;
+        const tableSize = columnSize * rowSize;
+
+        editor.setContent(generateTable(tableLayout, rowSize, columnSize));
+        editor.focus();
+
+        const columnsToMove = columnSize + 1;
+        let windowStart = 1;
+
+        for (let windowEnd = windowStart + columnsToMove; windowEnd <= tableSize; windowEnd += columnsToMove) {
+          let currentWindowEnd = windowEnd;
+
+          while (currentWindowEnd <= tableSize) {
+            selectCellsWithMouse(editor, [ windowStart.toString(), currentWindowEnd.toString() ]);
+
+            const selectedCells = editor.model.table.getSelectedCells();
+            const selectedCellBounds = getBoundsOfSelectedCells(selectedCells);
+
+            await pAssertToolbarPosition(selectedCellBounds);
+            await removeToolbar(editor);
+
+            currentWindowEnd += columnsToMove;
+          }
+
+          windowStart += columnsToMove;
+        }
+      });
+    });
+  });
+
+  context('Selection outside table', () => {
+    // When selection starts from outside the table and expands to the table, the toolbar should be displayed in the center of the table
+    it('TINY-8297: Selection starts from starting paragraph and expands to the first cell of the table in the editor', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p>Some text</p>' + generateTable('fixed', 3, 3));
+      editor.focus();
+
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 1, 1, 0, 0 ], 1);
+
+      const table = SelectorFind.descendant<HTMLTableElement>(TinyDom.body(editor), 'table').getOrDie('Could not find table');
+      const tableBounds = Boxes.absolute(table);
+      await pAssertToolbarPosition(tableBounds);
+
+      await removeToolbar(editor);
+    });
+
+    // When selection starts from last cell of the table and expands to the last paragraph in the editor, the toolbar should be displayed in the center of the table
+    it('TINY-8297: Selection starts from last cell of table and expands to the last paragraph in the editor', async () => {
+      const editor = hook.editor();
+      editor.setContent(generateTable('fixed', 3, 3) + '<p>Some Text</p>' );
+      editor.focus();
+
+      TinySelections.setSelection(editor, [ 0, 1, 2, 2 ], 0, [ 1, 0 ], 9);
+
+      const table = SelectorFind.descendant<HTMLTableElement>(TinyDom.body(editor), 'table').getOrDie('Could not find table');
+      const cells = getCells(table);
+      const startTd = Arr.find(cells, (elm) => Html.get(elm) === '9').getOrDie('Could not find start TD');
+      const tableBounds = Boxes.absolute(startTd);
+
+      const paragraph = SelectorFind.descendant<HTMLParagraphElement>(TinyDom.body(editor), 'p').getOrDie('Could not find paragraph');
+      const selP = SimSelection.exact(paragraph, 0, paragraph, 1);
+      const paragraphBounds = WindowSelection.getBounds(window, selP).getOrDie('Could not get bounds of paragraph');
+
+      // Padding within td cell, selection that extend from td to paragraph should be the bounds of the text
+      const mergedBounds = {
+        x: paragraphBounds.left,
+        right: Math.max(tableBounds.right, paragraphBounds.right),
+        bottom: paragraphBounds.bottom,
+        y: tableBounds.y + 6
+      };
+
+      await pAssertToolbarPosition({
+        ...mergedBounds,
+        width: mergedBounds.right - mergedBounds.x,
+        height: mergedBounds.bottom - mergedBounds.y,
+      });
+
+      await removeToolbar(editor);
+    });
+  });
+});

--- a/modules/tinymce/src/plugins/quickbars/test/ts/module/test/Utils.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/module/test/Utils.ts
@@ -1,5 +1,5 @@
 import { UiFinder, Waiter } from '@ephox/agar';
-import { SugarBody } from '@ephox/sugar';
+import { SugarBody, SugarElement } from '@ephox/sugar';
 
 const toolbarSelector = '.tox-pop__dialog .tox-toolbar';
 
@@ -9,7 +9,14 @@ const pAssertToolbarNotVisible = (): Promise<void> =>
 const pAssertToolbarVisible = (): Promise<void> =>
   Waiter.pTryUntil('toolbar should exist', () => UiFinder.exists(SugarBody.body(), toolbarSelector));
 
+const pGetToolBar = async (): Promise<SugarElement<Element>> => {
+  return Waiter.pTryUntil('get toolbar',
+    () => UiFinder.findIn(SugarBody.body(), toolbarSelector).getOrDie()
+  );
+};
+
 export {
   pAssertToolbarNotVisible,
-  pAssertToolbarVisible
+  pAssertToolbarVisible,
+  pGetToolBar
 };

--- a/modules/tinymce/src/plugins/quickbars/test/ts/module/test/Utils.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/module/test/Utils.ts
@@ -1,5 +1,5 @@
 import { UiFinder, Waiter } from '@ephox/agar';
-import { SugarBody, SugarElement } from '@ephox/sugar';
+import { SugarBody } from '@ephox/sugar';
 
 const toolbarSelector = '.tox-pop__dialog .tox-toolbar';
 
@@ -9,14 +9,7 @@ const pAssertToolbarNotVisible = (): Promise<void> =>
 const pAssertToolbarVisible = (): Promise<void> =>
   Waiter.pTryUntil('toolbar should exist', () => UiFinder.exists(SugarBody.body(), toolbarSelector));
 
-const pGetToolBar = async (): Promise<SugarElement<Element>> => {
-  return Waiter.pTryUntil('get toolbar',
-    () => UiFinder.findIn(SugarBody.body(), toolbarSelector).getOrDie()
-  );
-};
-
 export {
   pAssertToolbarNotVisible,
-  pAssertToolbarVisible,
-  pGetToolBar
+  pAssertToolbarVisible
 };

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Anchors.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Anchors.ts
@@ -1,5 +1,5 @@
 import { AlloyComponent, Bubble, HotspotAnchorSpec, Layout, LayoutInset, MaxHeight, NodeAnchorSpec, SelectionAnchorSpec } from '@ephox/alloy';
-import { Optional } from '@ephox/katamari';
+import { Arr, Optional } from '@ephox/katamari';
 import { SimSelection, SugarElement, SugarShadowDom } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -84,6 +84,13 @@ const getCursorAnchor = (editor: Editor, bodyElement: () => SugarElement<HTMLEle
   root: bodyElement(),
   getSelection: () => {
     const rng = editor.selection.getRng();
+
+    // Only return a range if there is a selection of more than one cell.
+    const selectedCells = editor.model.table.getSelectedCells();
+    if (selectedCells.length > 1) {
+      return Optional.some(Arr.map(selectedCells, SugarElement.fromDom));
+    }
+
     return Optional.some(
       SimSelection.range(SugarElement.fromDom(rng.startContainer), rng.startOffset, SugarElement.fromDom(rng.endContainer), rng.endOffset)
     );

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Anchors.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Anchors.ts
@@ -1,5 +1,5 @@
 import { AlloyComponent, Bubble, HotspotAnchorSpec, Layout, LayoutInset, MaxHeight, NodeAnchorSpec, SelectionAnchorSpec } from '@ephox/alloy';
-import { Arr, Optional } from '@ephox/katamari';
+import { Optional } from '@ephox/katamari';
 import { SimSelection, SugarElement, SugarShadowDom } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -88,7 +88,14 @@ const getCursorAnchor = (editor: Editor, bodyElement: () => SugarElement<HTMLEle
     // Only return a range if there is a selection of more than one cell.
     const selectedCells = editor.model.table.getSelectedCells();
     if (selectedCells.length > 1) {
-      return Optional.some(Arr.map(selectedCells, SugarElement.fromDom));
+      const firstCell = selectedCells[0];
+      const lastCell = selectedCells[selectedCells.length - 1];
+      const selectionTableCellRange = {
+        firstCell: SugarElement.fromDom(firstCell),
+        lastCell: SugarElement.fromDom(lastCell)
+      };
+
+      return Optional.some(selectionTableCellRange);
     }
 
     return Optional.some(

--- a/versions.txt
+++ b/versions.txt
@@ -1,5 +1,6 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
+alloy@12.2.0
 mcagar@8.4.0
 oxide@2.5.0
 polaris@6.2.0


### PR DESCRIPTION
Related Ticket: TINY-8297

Description of Changes:
* Quickbar toolbar positioned in the middle of table cell selection if contains more than one table cell selection

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
