### PR TITLE
TINY-9808: Add option that disables the table merge on paste override

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Typing after deleting formatted content could remove a space at the start of the typing. TINY-9310
 
 ### Added
+- New optional `table_merge_content_on_paste` option which disables the merging behaviour when pasting a table inside an existing tinymce table. #TINY-9808
 - New optional `defaultExpandedIds` and `onToggleExpand` options to the `tree` component config. #TINY-9653
 - New optional `defaultSelectedId` option to the `tree` component config. #TINY-9715
 - New `help_accessibility` option which displays the keyboard shortcut to access the help functionality in the statusbar. #TINY-9379

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Typing after deleting formatted content could remove a space at the start of the typing. TINY-9310
 
 ### Added
-- New optional `table_merge_content_on_paste` option which disables the merging behaviour when pasting a table inside an existing tinymce table. #TINY-9808
+- New optional `table_merge_content_on_paste` option which disables the merging behaviour when pasting a table inside an existing table. #TINY-9808
 - New optional `defaultExpandedIds` and `onToggleExpand` options to the `tree` component config. #TINY-9653
 - New optional `defaultSelectedId` option to the `tree` component config. #TINY-9715
 - New `help_accessibility` option which displays the keyboard shortcut to access the help functionality in the statusbar. #TINY-9379

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Typing after deleting formatted content could remove a space at the start of the typing. TINY-9310
 
 ### Added
-- New optional `table_merge_content_on_paste` option which disables the merging behaviour when pasting a table inside an existing table. #TINY-9808
+- New `table_merge_content_on_paste` option which disables the merging behaviour when pasting a table inside an existing table. #TINY-9808
 - New optional `defaultExpandedIds` and `onToggleExpand` options to the `tree` component config. #TINY-9653
 - New optional `defaultSelectedId` option to the `tree` component config. #TINY-9715
 - New `help_accessibility` option which displays the keyboard shortcut to access the help functionality in the statusbar. #TINY-9379

--- a/modules/tinymce/src/models/dom/main/ts/table/actions/Clipboard.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/actions/Clipboard.ts
@@ -4,6 +4,7 @@ import { SugarElement, SugarElements, SugarNode } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 
+import { shouldMergeContentOnPaste } from '../api/Options';
 import * as Utils from '../core/TableUtils';
 import * as TableTargets from '../queries/TableTargets';
 import * as Ephemera from '../selection/Ephemera';
@@ -55,7 +56,7 @@ const registerEvents = (editor: Editor, actions: TableActions): void => {
           });
 
           const isTable = SugarNode.isTag('table');
-          if (elements.length === 1 && isTable(elements[0])) {
+          if (shouldMergeContentOnPaste(editor) && elements.length === 1 && isTable(elements[0])) {
             e.preventDefault();
 
             const doc = SugarElement.fromDom(editor.getDoc());

--- a/modules/tinymce/src/models/dom/main/ts/table/actions/Clipboard.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/actions/Clipboard.ts
@@ -4,7 +4,7 @@ import { SugarElement, SugarElements, SugarNode } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 
-import { shouldMergeContentOnPaste } from '../api/Options';
+import * as Options from '../api/Options';
 import * as Utils from '../core/TableUtils';
 import * as TableTargets from '../queries/TableTargets';
 import * as Ephemera from '../selection/Ephemera';
@@ -56,7 +56,7 @@ const registerEvents = (editor: Editor, actions: TableActions): void => {
           });
 
           const isTable = SugarNode.isTag('table');
-          if (shouldMergeContentOnPaste(editor) && elements.length === 1 && isTable(elements[0])) {
+          if (Options.shouldMergeContentOnPaste(editor) && elements.length === 1 && isTable(elements[0])) {
             e.preventDefault();
 
             const doc = SugarElement.fromDom(editor.getDoc());

--- a/modules/tinymce/src/models/dom/main/ts/table/api/Options.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/Options.ts
@@ -102,6 +102,11 @@ const register = (editor: Editor): void => {
     processor: 'boolean',
     default: true
   });
+
+  registerOption('table_merge_content_on_paste', {
+    processor: 'boolean',
+    default: true
+  });
 };
 
 const getTableCloneElements = (editor: Editor): Optional<string[]> => {
@@ -138,6 +143,8 @@ const hasTableResizeBars = option<boolean>('table_resize_bars');
 
 const shouldStyleWithCss = option<boolean>('table_style_by_css');
 
+const shouldMergeContentOnPaste = option<boolean>('table_merge_content_on_paste');
+
 const getTableDefaultAttributes = (editor: Editor): Record<string, string> => {
   // Note: The we don't rely on the default here as we need to dynamically lookup the widths based on the current editor state
   const options = editor.options;
@@ -169,5 +176,6 @@ export {
   hasTableResizeBars,
   getTableDefaultAttributes,
   getTableDefaultStyles,
-  tableUseColumnGroup
+  tableUseColumnGroup,
+  shouldMergeContentOnPaste
 };

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/PasteTableTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/PasteTableTest.ts
@@ -1,0 +1,65 @@
+import { Clipboard } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
+import { SugarElement } from '@ephox/sugar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.models.dom.table.PasteTableTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    table_merge_content_on_paste: false,
+    base_url: '/project/tinymce/js/tinymce',
+  }, []);
+  const nestedTable = `<table style="border-collapse: collapse; width: 100.242%;" border="1"><colgroup> <col style="width: 49.9179%;"> <col style="width: 49.9179%;"> </colgroup>
+<tbody>
+<tr>
+<td>1</td>
+<td>2</td>
+</tr>
+<tr>
+<td>3</td>
+<td>4</td>
+</tr>
+</tbody>
+</table>`;
+
+  const getContent = (secondCellContent = '&nbsp;') =>
+    `<table style="border-collapse: collapse; width: 100%;" border="1"><colgroup> <col style="width: 33.2976%;"> <col style="width: 33.2976%;"> <col style="width: 33.2976%;"> </colgroup>
+<tbody>
+<tr>
+<td>
+${nestedTable}
+</td>
+<td>
+${secondCellContent}
+</td>
+<td>&nbsp;</td>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+</tr>
+</tbody>
+</table>`;
+
+  const initialContent = getContent();
+
+  it('TINY-9808: Paste table inside table should not merge the tables when table_merge_content_on_paste is set to false', () => {
+    const editor = hook.editor();
+    editor.setContent(initialContent);
+    TinySelections.setSelection(editor, [ 0, 1, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1);
+    const dataTransfer = Clipboard.copy(SugarElement.fromDom(editor.selection.getNode()));
+    TinySelections.setSelection(editor, [ 0, 1, 0, 1 ], 0, [ 0, 1, 0, 1 ], 1);
+    const html = dataTransfer.getData('text/html');
+    Clipboard.pasteItems(SugarElement.fromDom(editor.selection.getNode()), {
+      'text/html': html
+    });
+    TinyAssertions.assertContent(editor, getContent(nestedTable));
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-9808

Description of Changes:
* Add option that disables the table merge on paste override

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
