### PR TITLE
TINY-9814: fix toolbar refresh with `toolbar_sticky`

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -73,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Typing after deleting formatted content could remove a space at the start of the typing. #TINY-9310
 - Invalid markup in Notification and Dialog close buttons. #TINY-9849
 - In dialogs, an incorrect `aria-describedby` attribute caused the body of the dialog to be announced when using a screen reader. #TINY-9816
-- Switching from a `view` to an `editor` with a `toolbar_sticky` and `toolbar_sticky_offset` and is scrolled, only the more button is showed. #TINY-9814
+- The sticky toolbar would not be rendered correctly when transitioning from the custom editor view to the main view. #TINY-9814
 
 ## 6.4.2 - 2023-04-26
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Typing after deleting formatted content could remove a space at the start of the typing. #TINY-9310
 - Invalid markup in Notification and Dialog close buttons. #TINY-9849
 - In dialogs, an incorrect `aria-describedby` attribute caused the body of the dialog to be announced when using a screen reader. #TINY-9816
+- Switching from a `view` to an `editor` with a `toolbar_sticky` and `toolbar_sticky_offset` and is scrolled, only the more button is showed. #TINY-9814
 
 ## 6.4.2 - 2023-04-26
 

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -167,6 +167,7 @@ const render = async (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: Re
       if (Type.isNull(OuterContainer.whichView(outerContainer))) {
         editor.focus();
         editor.nodeChanged();
+        OuterContainer.refreshToolbar(outerContainer);
       }
     }
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -207,7 +207,9 @@ const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, Out
         Attribute.remove(element, 'aria-hidden');
       });
 
-      apis.refreshToolbar(comp);
+      setTimeout(() => {
+        apis.refreshToolbar(comp);
+      }, 0);
     }
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -206,10 +206,6 @@ const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, Out
         Css.remove(element, 'display');
         Attribute.remove(element, 'aria-hidden');
       });
-
-      setTimeout(() => {
-        apis.refreshToolbar(comp);
-      }, 0);
     }
   };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, FocusTools, Keys, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
-import { Attribute, Css, Html, Scroll, SugarBody, SugarElement, SugarLocation, SugarShadowDom } from '@ephox/sugar';
+import { Attribute, Css, Html, Scroll, SugarBody, SugarShadowDom } from '@ephox/sugar';
 import { TinyApis, TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -475,13 +475,10 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       assert.equal(Html.get(editorContainer), expectedHtml);
     };
 
-    const pAssertFloatingToolbarPosition = async (editor: Editor, getTop: () => number): Promise<void> => {
-      const toolbar = await TinyUiActions.pWaitForUi(editor, '.tox-editor-header') as SugarElement<HTMLElement>;
+    const pAssertFloatingToolbarPosition = async (editor: Editor, top: number): Promise<void> => {
       await Waiter.pTryUntil('Wait for toolbar position', () => {
-        const top = getTop();
         const diff = 10;
-        const toolbarTop = toolbar.dom.getBoundingClientRect().top;
-        const posTop = SugarLocation.absolute(toolbar).top - toolbarTop;
+        const posTop = window.pageYOffset;
         assert.approximately(posTop, top, diff, `Drawer top position ${posTop}px should be ~${top}px`);
       });
     };
@@ -489,14 +486,11 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
     it('TINY-9814: coming back from a view when the toolbar is scrolled, should preserve the buttons in `tox-toolbar__primary`', async () => {
       const editor = hook.editor();
       editor.setContent(`<p>${Arr.range(100, Fun.constant('some text')).join('<br>')}</p>`);
-      const initialContainerPos = SugarLocation.absolute(TinyDom.contentAreaContainer(editor));
-      const offsetTop = initialContainerPos.top;
+      Scroll.to(0, 0);
+      await pAssertFloatingToolbarPosition(editor, 0);
 
-      Scroll.to(0, offsetTop);
-      await pAssertFloatingToolbarPosition(editor, Fun.constant(offsetTop));
-
-      Scroll.to(0, offsetTop + 500);
-      await pAssertFloatingToolbarPosition(editor, () => offsetTop + 500);
+      Scroll.to(0, 500);
+      await pAssertFloatingToolbarPosition(editor, 500);
 
       editor.execCommand('ToggleView', true, 'myview1');
       assertViewHtml(0, '<button>myview1</button>');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -476,7 +476,7 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
     };
 
     const pAssertFloatingToolbarPosition = async (editor: Editor, getTop: () => number): Promise<void> => {
-      const toolbar = await TinyUiActions.pWaitForUi(editor, '.tox-toolbar__overflow') as SugarElement<HTMLElement>;
+      const toolbar = await TinyUiActions.pWaitForUi(editor, '.tox-editor-header') as SugarElement<HTMLElement>;
       await Waiter.pTryUntil('Wait for toolbar position', () => {
         const top = getTop();
         const diff = 10;
@@ -490,12 +490,13 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       const editor = hook.editor();
       editor.setContent(`<p>${Arr.range(100, Fun.constant('some text')).join('<br>')}</p>`);
       const initialContainerPos = SugarLocation.absolute(TinyDom.contentAreaContainer(editor));
+      const offsetTop = initialContainerPos.top;
 
-      Scroll.to(0, initialContainerPos.top);
-      await pAssertFloatingToolbarPosition(editor, () => initialContainerPos.top);
+      Scroll.to(0, offsetTop);
+      await pAssertFloatingToolbarPosition(editor, Fun.constant(offsetTop));
 
-      Scroll.to(0, initialContainerPos.top + 500);
-      await pAssertFloatingToolbarPosition(editor, () => initialContainerPos.top + 500);
+      Scroll.to(0, offsetTop + 500);
+      await pAssertFloatingToolbarPosition(editor, () => offsetTop + 500);
 
       editor.execCommand('ToggleView', true, 'myview1');
       assertViewHtml(0, '<button>myview1</button>');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -489,12 +489,13 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
     it('TINY-9814: coming back from a view when the toolbar is scrolled, should preserve the buttons in `tox-toolbar__primary`', async () => {
       const editor = hook.editor();
       editor.setContent(`<p>${Arr.range(100, Fun.constant('some text')).join('<br>')}</p>`);
+      const initialContainerPos = SugarLocation.absolute(TinyDom.contentAreaContainer(editor));
 
-      Scroll.to(0, 0);
-      await pAssertFloatingToolbarPosition(editor, Fun.constant(0));
+      Scroll.to(0, initialContainerPos.top);
+      await pAssertFloatingToolbarPosition(editor, () => initialContainerPos.top);
 
-      Scroll.to(0, 500);
-      await pAssertFloatingToolbarPosition(editor, Fun.constant(500));
+      Scroll.to(0, initialContainerPos.top + 500);
+      await pAssertFloatingToolbarPosition(editor, () => initialContainerPos.top + 500);
 
       editor.execCommand('ToggleView', true, 'myview1');
       assertViewHtml(0, '<button>myview1</button>');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -416,6 +416,7 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       assert.equal(Html.get(editorContainer), expectedHtml);
     };
 
+    // HERE
     it('TINY-9419: "Expand or collapse" button should not be removed if the toolbar is opened and view is opened and close', async () => {
       const editor = hook.editor();
 
@@ -490,8 +491,8 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       editor.setContent(`<p>${Arr.range(100, Fun.constant('some text')).join('<br>')}</p>`);
       const initialContainerPos = SugarLocation.absolute(TinyDom.container(editor));
 
-      Scroll.to(0, initialContainerPos.top);
-      await pAssertFloatingToolbarPosition(editor, () => initialContainerPos.top);
+      Scroll.to(0, 0);
+      await pAssertFloatingToolbarPosition(editor, Fun.constant(0));
 
       Scroll.to(0, initialContainerPos.top + 500);
       await pAssertFloatingToolbarPosition(editor, () => initialContainerPos.top + 500);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -486,9 +486,9 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       const elementToScrollTo = UiFinder.findIn(TinyDom.body(editor), '.element_to_scroll_to').getOrDie();
       const toolbar = await TinyUiActions.pWaitForUi(editor, '.tox-toolbar__overflow');
 
-      assert.isTrue(Scroll.get().top < toolbar.dom.getBoundingClientRect().top, 'before scroll the scroll top should be before the toolbar');
+      await Waiter.pTryUntil('Wait for scroll top to be before the toolbar', () => Scroll.get().top < toolbar.dom.getBoundingClientRect().top);
       elementToScrollTo.dom.scrollIntoView();
-      assert.isTrue(Scroll.get().top > toolbar.dom.getBoundingClientRect().top, 'after scroll the scroll top should be after the toolbar');
+      await Waiter.pTryUntil('Wait for scroll top to be after the toolbar', () => Scroll.get().top > toolbar.dom.getBoundingClientRect().top);
 
       editor.execCommand('ToggleView', true, 'myview1');
       assertViewHtml(0, '<button>myview1</button>');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -416,7 +416,6 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       assert.equal(Html.get(editorContainer), expectedHtml);
     };
 
-    // HERE
     it('TINY-9419: "Expand or collapse" button should not be removed if the toolbar is opened and view is opened and close', async () => {
       const editor = hook.editor();
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -489,13 +489,12 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
     it('TINY-9814: coming back from a view when the toolbar is scrolled, should preserve the buttons in `tox-toolbar__primary`', async () => {
       const editor = hook.editor();
       editor.setContent(`<p>${Arr.range(100, Fun.constant('some text')).join('<br>')}</p>`);
-      const initialContainerPos = SugarLocation.absolute(TinyDom.container(editor));
 
       Scroll.to(0, 0);
       await pAssertFloatingToolbarPosition(editor, Fun.constant(0));
 
-      Scroll.to(0, initialContainerPos.top + 500);
-      await pAssertFloatingToolbarPosition(editor, () => initialContainerPos.top + 500);
+      Scroll.to(0, 500);
+      await pAssertFloatingToolbarPosition(editor, Fun.constant(500));
 
       editor.execCommand('ToggleView', true, 'myview1');
       assertViewHtml(0, '<button>myview1</button>');


### PR DESCRIPTION
Related Ticket: TINY-9814

Description of Changes:
Having `toolbar_sticky` and `toolbar_sticky_offset` and `autoresize` (to have the editor scrolling), cause a render problem when you switch back from a view to the editor.

the cause is similar to the one in this [PR](https://github.com/tinymce/tinymce/pull/8543).

without the `toolbar_sticky_offset` when you switch back from a view the toolbar is not rendered so it works as intended, but with `toolbar_sticky_offset` the toolbar is rendered immediately so, since the action before refresh is to [show the editor](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts#L206-L207), trying to refresh it immediately doesn't take the correct width.

However I see that removing entirely make this case works, but it break the one for the other [PR](https://github.com/tinymce/tinymce/pull/8543)

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
