### PR TITLE
TINY-9849: Fix invalid markup in close buttons

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Typing after deleting formatted content could remove a space at the start of the typing. #TINY-9310
+- Invalid markup in Notification and Dialog close buttons. #TINY-9849
 
 ### Added
 - New optional `defaultExpandedIds` and `onToggleExpand` options to the `tree` component config. #TINY-9653

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Notification.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Notification.ts
@@ -149,7 +149,7 @@ const factory: UiSketcher.SingleSketchFactory<NotificationSketchDetail, Notifica
     },
     components: [
       Icons.render('close', {
-        tag: 'div',
+        tag: 'span',
         classes: [ 'tox-icon' ],
         attributes: {
           'aria-label': detail.translationProvider('Close')

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
@@ -30,7 +30,7 @@ const renderClose = (providersBackstage: UiFactoryBackstageProviders) => Button.
     Tabstopping.config({ })
   ]),
   components: [
-    Icons.render('close', { tag: 'div', classes: [ 'tox-icon' ] }, providersBackstage.icons)
+    Icons.render('close', { tag: 'span', classes: [ 'tox-icon' ] }, providersBackstage.icons)
   ],
   action: (comp) => {
     AlloyTriggers.emit(comp, formCancelEvent);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
@@ -88,7 +88,7 @@ describe('browser.tinymce.themes.silver.editor.NotificationManagerImplTest', () 
               arr.has('tox-button--icon')
             ],
             children: [
-              s.element('div', {
+              s.element('span', {
                 attrs: {
                   'aria-label': str.is('Close')
                 },


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Fixed invalid markup in Notification and Dialog close buttons.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
