### PR TITLE
TINY-9867: Parse templates containing <html> tags before rendering for preview

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pressing arrow keys inside RTL elements would move the caret in an incorrect direction when moving over elements with the `contenteditable` attribute set to `false`. #TINY-9565
 - Inserting table consecutively without focus in the editor would result in the table being inserted at the wrong position. #TINY-3909
 - In some cases, the exiting a `blockquote` element could fail when the cursor was positioned at the end of the `blockquote`. #TINY-9794
+- Templates containing an `<html>` tag were not parsed before being rendered for preview. #TINY-9867
 
 ## 6.4.2 - 2023-04-26
 

--- a/modules/tinymce/src/plugins/template/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/ui/Dialog.ts
@@ -1,4 +1,4 @@
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Cell, Optional } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
@@ -13,6 +13,7 @@ import * as Utils from '../core/Utils';
 type UpdateDialogCallback = (dialogApi: Dialog.DialogInstanceApi<DialogData>, template: InternalTemplate, previewHtml: string) => void;
 
 const getPreviewContent = (editor: Editor, html: string): string => {
+  const previewHtml = Cell(Utils.parseAndSerialize(editor, html));
   if (html.indexOf('<html>') === -1) {
     let contentCssEntries = '';
     const contentStyle = Options.getContentStyle(editor) ?? '';
@@ -50,7 +51,7 @@ const getPreviewContent = (editor: Editor, html: string): string => {
     const directionality = editor.getBody().dir;
     const dirAttr = directionality ? ' dir="' + encode(directionality) + '"' : '';
 
-    html = (
+    previewHtml.set(
       '<!DOCTYPE html>' +
       '<html>' +
       '<head>' +
@@ -59,13 +60,13 @@ const getPreviewContent = (editor: Editor, html: string): string => {
       preventClicksOnLinksScript +
       '</head>' +
       '<body class="' + encode(bodyClass) + '"' + dirAttr + '>' +
-      Utils.parseAndSerialize(editor, html) +
+      previewHtml.get() +
       '</body>' +
       '</html>'
     );
   }
 
-  return Templates.replaceTemplateValues(html, Options.getPreviewReplaceValues(editor));
+  return Templates.replaceTemplateValues(previewHtml.get(), Options.getPreviewReplaceValues(editor));
 };
 
 const open = (editor: Editor, templateList: ExternalTemplate[]): void => {

--- a/modules/tinymce/src/plugins/template/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/template/main/ts/ui/Dialog.ts
@@ -1,4 +1,4 @@
-import { Arr, Cell, Optional } from '@ephox/katamari';
+import { Arr, Optional } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
@@ -13,7 +13,7 @@ import * as Utils from '../core/Utils';
 type UpdateDialogCallback = (dialogApi: Dialog.DialogInstanceApi<DialogData>, template: InternalTemplate, previewHtml: string) => void;
 
 const getPreviewContent = (editor: Editor, html: string): string => {
-  const previewHtml = Cell(Utils.parseAndSerialize(editor, html));
+  let previewHtml = Utils.parseAndSerialize(editor, html);
   if (html.indexOf('<html>') === -1) {
     let contentCssEntries = '';
     const contentStyle = Options.getContentStyle(editor) ?? '';
@@ -51,7 +51,7 @@ const getPreviewContent = (editor: Editor, html: string): string => {
     const directionality = editor.getBody().dir;
     const dirAttr = directionality ? ' dir="' + encode(directionality) + '"' : '';
 
-    previewHtml.set(
+    previewHtml = (
       '<!DOCTYPE html>' +
       '<html>' +
       '<head>' +
@@ -60,13 +60,13 @@ const getPreviewContent = (editor: Editor, html: string): string => {
       preventClicksOnLinksScript +
       '</head>' +
       '<body class="' + encode(bodyClass) + '"' + dirAttr + '>' +
-      previewHtml.get() +
+      previewHtml +
       '</body>' +
       '</html>'
     );
   }
 
-  return Templates.replaceTemplateValues(previewHtml.get(), Options.getPreviewReplaceValues(editor));
+  return Templates.replaceTemplateValues(previewHtml, Options.getPreviewReplaceValues(editor));
 };
 
 const open = (editor: Editor, templateList: ExternalTemplate[]): void => {

--- a/modules/tinymce/src/plugins/template/test/ts/browser/DialogGetPreviewContentTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/DialogGetPreviewContentTest.ts
@@ -112,7 +112,7 @@ describe('browser.tinymce.plugins.template.Dialog.getPreviewContent', () => {
       content_css_cors: true,
       content_style: 'This is the style inserted into the document'
     });
-    // TINY-9867: Preview content will be parsed to minimise visual discrepancy with inserted content
+    // TINY-9867: Preview content is parsed to minimise visual discrepancy with inserted content
     checkPreview('<p>Custom content here</p>', '<html>Custom content here');
   });
 });

--- a/modules/tinymce/src/plugins/template/test/ts/browser/DialogGetPreviewContentTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/DialogGetPreviewContentTest.ts
@@ -68,7 +68,7 @@ describe('browser.tinymce.plugins.template.Dialog.getPreviewContent', () => {
 
   const checkPreview = (expected: string, html: string = '') => {
     const editor = hook.editor();
-    assert.equal(expected, getPreviewContent(editor, html));
+    assert.equal(getPreviewContent(editor, html), expected);
   };
 
   const { addSettings, cleanupSettings } = Settings(hook);
@@ -112,6 +112,7 @@ describe('browser.tinymce.plugins.template.Dialog.getPreviewContent', () => {
       content_css_cors: true,
       content_style: 'This is the style inserted into the document'
     });
-    checkPreview('<html>Custom content here', '<html>Custom content here');
+    // TINY-9867: Preview content will be parsed to minimise visual discrepancy with inserted content
+    checkPreview('<p>Custom content here</p>', '<html>Custom content here');
   });
 });

--- a/modules/tinymce/src/plugins/template/test/ts/browser/TemplateSanityTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/TemplateSanityTest.ts
@@ -87,8 +87,7 @@ describe('browser.tinymce.plugins.template.TemplateSanityTest', () => {
         UiFinder.findIn<HTMLIFrameElement>(dialogEl, 'iframe').fold(
           () => assert.fail('Preview iframe not found'),
           (iframe) => {
-            // fallback for pre-IE 8 using contentWindow.document
-            const iframeDoc = iframe.dom.contentDocument || iframe.dom.contentWindow?.document;
+            const iframeDoc = iframe.dom.contentDocument;
             const iframeBody = SugarElement.fromDom(iframeDoc?.body as Node);
             UiFinder.exists(iframeBody, parsedPreviewHtmlSelector);
             UiFinder.notExists(iframeBody, unparsedPreviewHtmlSelector);

--- a/modules/tinymce/src/plugins/template/test/ts/browser/TemplateSanityTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/TemplateSanityTest.ts
@@ -120,9 +120,9 @@ describe('browser.tinymce.plugins.template.TemplateSanityTest', () => {
   });
 
   context('Inserting unparsed content', () => {
+    const unparsedHtml = '<img src="error" onerror="window.document.unparsedHtmlFn();">';
     const assertFnDoesNotReadUnParsedHtmlInDom = async (editor: Editor, fn: (unparsedHtml: string) => void | Promise<void>): Promise<void> => {
       const fnReadsUnparsedHtmlInDom = async () => {
-        const unparsedHtml = '<img src="error" onerror="window.document.unparsedHtmlFn();">';
         const isUnParsedHtmlRead = Cell(false);
         (editor.getDoc() as any).unparsedHtmlFn = () => {
           isUnParsedHtmlRead.set(true);
@@ -144,10 +144,7 @@ describe('browser.tinymce.plugins.template.TemplateSanityTest', () => {
 
     it('TINY-9244: Unparsed html should not be read when inserting template via dialog', async () => {
       const editor = hook.editor();
-      const unparsedHtml = '<img src="error" onerror="window.document.unparsedHtmlFn();">';
-      addSettings({
-        templates: [{ title: 'a', description: 'b', content: unparsedHtml }],
-      });
+      addSettings({ templates: [{ title: 'a', description: 'b', content: unparsedHtml }] });
       await assertFnDoesNotReadUnParsedHtmlInDom(editor, async () => {
         await pInsertTemplate(editor);
       });

--- a/modules/tinymce/src/plugins/template/test/ts/browser/TemplateSanityTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/TemplateSanityTest.ts
@@ -78,7 +78,7 @@ describe('browser.tinymce.plugins.template.TemplateSanityTest', () => {
   });
 
   context('Previewing unparsed content', () => {
-    const unparsedHtml = '<html><body><img src="error" onerror="throw new Error();"></body></html>';
+    const unparsedHtml = '<img src="error" onerror="throw new Error();">';
     const unparsedPreviewHtmlSelector = 'p > img[src="error"][onerror="throw new Error();"]';
     const parsedPreviewHtmlSelector = 'p > img[src="error"][data-mce-src="error"]';
 

--- a/modules/tinymce/src/plugins/template/test/ts/browser/TemplateSanityTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/TemplateSanityTest.ts
@@ -122,17 +122,15 @@ describe('browser.tinymce.plugins.template.TemplateSanityTest', () => {
   context('Inserting unparsed content', () => {
     const unparsedHtml = '<img src="error" onerror="window.document.unparsedHtmlFn();">';
     const assertFnDoesNotReadUnParsedHtmlInDom = async (editor: Editor, fn: (unparsedHtml: string) => void | Promise<void>): Promise<void> => {
-      const fnReadsUnparsedHtmlInDom = async () => {
-        const isUnParsedHtmlRead = Cell(false);
-        (editor.getDoc() as any).unparsedHtmlFn = () => {
-          isUnParsedHtmlRead.set(true);
-        };
-        await fn(unparsedHtml);
-        // wait for any unparsed html to be read and error to be thrown if it is
-        await Waiter.pWait(1);
-        return isUnParsedHtmlRead.get();
+      const isUnParsedHtmlRead = Cell(false);
+      (editor.getDoc() as any).unparsedHtmlFn = () => {
+        isUnParsedHtmlRead.set(true);
       };
-      assert.isFalse(await fnReadsUnparsedHtmlInDom(), 'Unparsed html read');
+      await fn(unparsedHtml);
+      // wait for any unparsed html to be read and error to be thrown if it is
+      await Waiter.pWait(1);
+      assert.isFalse(isUnParsedHtmlRead.get(), 'Unparsed html read');
+      (editor.getDoc() as any).unparsedHtmlFn = null;
     };
 
     it('TINY-9244: Unparsed html should not be read when inserting template via command', async () => {


### PR DESCRIPTION
Related Ticket: TINY-9867

Description of Changes:
* Ensure that template html strings containing `<html>` are also parsed before being rendered for preview
* Refactor some tests

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
