### PR TITLE
TINY-9310: fix changelog's entry position

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
-- Typing after deleting formatted content could remove a space at the start of the typing. #TINY-9310
-- Invalid markup in Notification and Dialog close buttons. #TINY-9849
-
 ### Added
 - New `table_merge_content_on_paste` option which disables the merging behaviour when pasting a table inside an existing table. #TINY-9808
 - New optional `defaultExpandedIds` and `onToggleExpand` options to the `tree` component config. #TINY-9653
@@ -65,6 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pressing arrow keys inside RTL elements would move the caret in an incorrect direction when moving over elements with the `contenteditable` attribute set to `false`. #TINY-9565
 - Inserting table consecutively without focus in the editor would result in the table being inserted at the wrong position. #TINY-3909
 - In some cases, the exiting a `blockquote` element could fail when the cursor was positioned at the end of the `blockquote`. #TINY-9794
+- Typing after deleting formatted content could remove a space at the start of the typing. #TINY-9310
+- Invalid markup in Notification and Dialog close buttons. #TINY-9849
 
 ## 6.4.2 - 2023-04-26
 


### PR DESCRIPTION
Related Ticket: TINY-9310

Description of Changes:
In the [previous PR](https://github.com/tinymce/tinymce/commit/632782ee32cb541f8220ac5070c5740a0394c006#diff-230a1d97cb8ef9885f06853bfe2485250430fb50d576b83537e4fb71abbdf4e4R10) I created the changelog's entry in the wrong place

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
