### PR TITLE
TINY-9839: Adding editable root API

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `accordion` and `accordion-toggle` icons. #TINY-9789
 - New `details_initial_state` and `details_serialized_state` options. #TINY-9732
 - New `init_content_sync` option that initializes the editor iframe using `document.write` instead of `srcdoc`. #TINY-9818
+- New `newdocument_content` option that changes the content that will be set when using the `New document` button. #TINY-9839
+- New `editable_root` option that can be set to `false` to prevent editing of the editors root element. #TINY-9839
+- New `editor.setEditableRoot` API that sets the editable state of the editor root element. #TINY-9838
+- New `editor.hasEditableRoot` API that returns `true` or `false` depending on the editable state of the editor root element. #TINY-9838
+- New `EditableRootStateChange` event that gets dispatched when the state of the editable root is changed. #TINY-9838
 
 ### Improved
 - Screen readers are now able to announce the highlighted menu item of link comboboxes. #TINY-9280

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -19,9 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `init_content_sync` option that initializes the editor iframe using `document.write` instead of `srcdoc`. #TINY-9818
 - New `newdocument_content` option that changes the content that will be set when using the `New document` button. #TINY-9839
 - New `editable_root` option that can be set to `false` to prevent editing of the editors root element. #TINY-9839
-- New `editor.setEditableRoot` API that sets the editable state of the editor root element. #TINY-9838
-- New `editor.hasEditableRoot` API that returns `true` or `false` depending on the editable state of the editor root element. #TINY-9838
-- New `EditableRootStateChange` event that gets dispatched when the state of the editable root is changed. #TINY-9838
+- New `editor.setEditableRoot` API that sets the editable state of the editor root element. #TINY-9839
+- New `editor.hasEditableRoot` API that returns `true` or `false` depending on the editable state of the editor root element. #TINY-9839
+- New `EditableRootStateChange` event that gets dispatched when the state of the editable root is changed. #TINY-9839
 
 ### Improved
 - Screen readers are now able to announce the highlighted menu item of link comboboxes. #TINY-9280

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -7,6 +7,7 @@ import * as EditorRemove from '../EditorRemove';
 import { BlobInfoImagePair } from '../file/ImageScanner';
 import * as EditorFocus from '../focus/EditorFocus';
 import * as Render from '../init/Render';
+import * as EditableRoot from '../mode/EditableRoot';
 import { NodeChange } from '../NodeChange';
 import { normalizeOptions } from '../options/NormalizeOptions';
 import SelectionOverrides from '../SelectionOverrides';
@@ -239,6 +240,7 @@ class Editor implements EditorObservable {
   public _pendingNativeEvents: string[] = [];
   public _selectionOverrides!: SelectionOverrides;
   public _skinLoaded: boolean = false;
+  public _editableRoot: boolean = true;
 
   // EditorObservable patches
   public bindPendingEventDelegates!: EditorObservable['bindPendingEventDelegates'];
@@ -1076,6 +1078,26 @@ class Editor implements EditorObservable {
    */
   public addVisual(elm?: HTMLElement): void {
     VisualAids.addVisual(this, elm);
+  }
+
+  /**
+   * Changes the editable state of the editor root element.
+   *
+   * @method setEditableRoot
+   * @param {Boolean} state State to set true for editable and false for non-editable.
+   */
+  public setEditableRoot(state: boolean): void {
+    EditableRoot.setEditableRoot(this, state);
+  }
+
+  /**
+   * Returns the current editable state of the editor root element.
+   *
+   * @method hasEditableRoot
+   * @return {Boolean} True if the root element is editable, false if it's not editable.
+   */
+  public hasEditableRoot(): boolean {
+    return EditableRoot.hasEditableRoot(this);
   }
 
   /**

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -1080,22 +1080,10 @@ class Editor implements EditorObservable {
     VisualAids.addVisual(this, elm);
   }
 
-  /**
-   * Changes the editable state of the editor root element.
-   *
-   * @method setEditableRoot
-   * @param {Boolean} state State to set true for editable and false for non-editable.
-   */
   public setEditableRoot(state: boolean): void {
     EditableRoot.setEditableRoot(this, state);
   }
 
-  /**
-   * Returns the current editable state of the editor root element.
-   *
-   * @method hasEditableRoot
-   * @return {Boolean} True if the root element is editable, false if it's not editable.
-   */
   public hasEditableRoot(): boolean {
     return EditableRoot.hasEditableRoot(this);
   }

--- a/modules/tinymce/src/core/main/ts/api/EventTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/EventTypes.ts
@@ -144,6 +144,10 @@ export interface PastePostProcessEvent {
   readonly internal: boolean;
 }
 
+export interface EditableRootStateChangeEvent {
+  state: boolean;
+}
+
 export interface NewTableRowEvent {
   node: HTMLTableRowElement;
 }

--- a/modules/tinymce/src/core/main/ts/api/Events.ts
+++ b/modules/tinymce/src/core/main/ts/api/Events.ts
@@ -4,7 +4,7 @@ import { RangeLikeObject } from '../selection/RangeTypes';
 import Editor from './Editor';
 import {
   BeforeSetContentEvent, SetContentEvent, PastePlainTextToggleEvent, PastePostProcessEvent, PastePreProcessEvent, GetContentEvent, BeforeGetContentEvent,
-  PreProcessEvent, PostProcessEvent
+  PreProcessEvent, PostProcessEvent, EditableRootStateChangeEvent
 } from './EventTypes';
 import { ParserArgs } from './html/DomParser';
 import { EditorEvent } from './util/EventDispatcher';
@@ -96,6 +96,9 @@ const firePastePostProcess = (editor: Editor, node: HTMLElement, internal: boole
 const firePastePlainTextToggle = (editor: Editor, state: boolean): EditorEvent<PastePlainTextToggleEvent> =>
   editor.dispatch('PastePlainTextToggle', { state });
 
+const fireEditableRootStateChange = (editor: Editor, state: boolean): EditorEvent<EditableRootStateChangeEvent> =>
+  editor.dispatch('EditableRootStateChange', { state });
+
 export {
   firePreProcess,
   firePostProcess,
@@ -120,5 +123,6 @@ export {
   fireAutocompleterEnd,
   firePastePlainTextToggle,
   firePastePostProcess,
-  firePastePreProcess
+  firePastePreProcess,
+  fireEditableRootStateChange
 };

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -95,6 +95,7 @@ interface BaseEditorOptions {
   document_base_url?: string;
   draggable_modal?: boolean;
   editable_class?: string;
+  editable_root?: boolean;
   element_format?: 'xhtml' | 'html';
   elementpath?: boolean;
   encoding?: string;
@@ -161,6 +162,7 @@ interface BaseEditorOptions {
   min_width?: number;
   model?: string;
   model_url?: string;
+  newdocument_content?: string;
   newline_behavior?: 'block' | 'linebreak' | 'invert' | 'default';
   no_newline_selector?: string;
   noneditable_class?: string;
@@ -287,6 +289,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   init_content_sync: boolean;
   draggable_modal: boolean;
   editable_class: string;
+  editable_root: boolean;
   font_css: string[];
   font_family_formats: string;
   font_size_classes: string;
@@ -315,6 +318,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   menu: Record<string, { title: string; items: string }>;
   menubar: boolean | string;
   model: string;
+  newdocument_content: string;
   no_newline_selector: string;
   noneditable_class: string;
   noneditable_regexp: RegExp[];

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -442,6 +442,11 @@ const register = (editor: Editor): void => {
     default: false
   });
 
+  registerOption('editable_root', {
+    processor: 'boolean',
+    default: true
+  });
+
   registerOption('plugins', {
     processor: 'string[]',
     default: []
@@ -812,6 +817,11 @@ const register = (editor: Editor): void => {
     default: false
   });
 
+  registerOption('newdocument_content', {
+    processor: 'string',
+    default: ''
+  });
+
   // These options must be registered later in the init sequence due to their default values
   editor.on('ScriptsLoaded', () => {
     registerOption('directionality', {
@@ -884,6 +894,7 @@ const shouldAddUnloadTrigger = option('add_unload_trigger');
 const getCustomUndoRedoLevels = option('custom_undo_redo_levels');
 const shouldDisableNodeChange = option('disable_nodechange');
 const isReadOnly = option('readonly');
+const hasEditableRoot = option('editable_root');
 const hasContentCssCors = option('content_css_cors');
 const getPlugins = option('plugins');
 const getExternalPlugins = option('external_plugins');
@@ -902,6 +913,7 @@ const shouldPasteBlockDrop = option('paste_block_drop');
 const shouldPasteDataImages = option('paste_data_images');
 const getPastePreProcess = option('paste_preprocess');
 const getPastePostProcess = option('paste_postprocess');
+const getNewDocumentContent = option('newdocument_content');
 const getPasteWebkitStyles = option('paste_webkit_styles');
 const shouldPasteRemoveWebKitStyles = option('paste_remove_styles_if_webkit');
 const shouldPasteMergeFormats = option('paste_merge_formats');
@@ -1001,6 +1013,7 @@ export {
   getCustomUndoRedoLevels,
   shouldDisableNodeChange,
   isReadOnly,
+  hasEditableRoot,
   hasContentCssCors,
   getPlugins,
   getExternalPlugins,
@@ -1020,6 +1033,7 @@ export {
   shouldPasteDataImages,
   getPastePreProcess,
   getPastePostProcess,
+  getNewDocumentContent,
   getPasteWebkitStyles,
   shouldPasteRemoveWebKitStyles,
   shouldPasteMergeFormats,

--- a/modules/tinymce/src/core/main/ts/api/commands/ContentCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/commands/ContentCommands.ts
@@ -1,5 +1,6 @@
 import * as InsertContent from '../../content/InsertContent';
 import Editor from '../Editor';
+import * as Options from '../Options';
 
 export const registerCommands = (editor: Editor): void => {
   editor.editorCommands.addCommands({
@@ -38,7 +39,7 @@ export const registerCommands = (editor: Editor): void => {
     },
 
     mceNewDocument: () => {
-      editor.setContent('');
+      editor.setContent(Options.getNewDocumentContent(editor));
     }
   });
 };

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -389,8 +389,9 @@ const contentBodyLoaded = (editor: Editor): void => {
   // TODO: See if we actually need to disable/re-enable here
   (body as any).disabled = true;
   editor.readonly = Options.isReadOnly(editor);
+  editor._editableRoot = Options.hasEditableRoot(editor);
 
-  if (!editor.readonly) {
+  if (!editor.readonly && editor._editableRoot) {
     if (editor.inline && DOM.getStyle(body, 'position', true) === 'static') {
       body.style.position = 'relative';
     }

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -391,7 +391,7 @@ const contentBodyLoaded = (editor: Editor): void => {
   editor.readonly = Options.isReadOnly(editor);
   editor._editableRoot = Options.hasEditableRoot(editor);
 
-  if (!editor.readonly && editor._editableRoot) {
+  if (!editor.readonly && editor.hasEditableRoot()) {
     if (editor.inline && DOM.getStyle(body, 'position', true) === 'static') {
       body.style.position = 'relative';
     }

--- a/modules/tinymce/src/core/main/ts/mode/EditableRoot.ts
+++ b/modules/tinymce/src/core/main/ts/mode/EditableRoot.ts
@@ -1,0 +1,18 @@
+import Editor from '../api/Editor';
+import * as Events from '../api/Events';
+
+export const setEditableRoot = (editor: Editor, state: boolean): void => {
+  if (editor._editableRoot !== state) {
+    editor._editableRoot = state;
+
+    if (!editor.readonly) {
+      editor.getBody().contentEditable = String(editor.hasEditableRoot());
+      editor.nodeChanged();
+    }
+
+    Events.fireEditableRootStateChange(editor, state);
+  }
+};
+
+export const hasEditableRoot = (editor: Editor): boolean => editor._editableRoot;
+

--- a/modules/tinymce/src/core/main/ts/mode/Readonly.ts
+++ b/modules/tinymce/src/core/main/ts/mode/Readonly.ts
@@ -68,7 +68,9 @@ const toggleReadOnly = (editor: Editor, state: boolean): void => {
     switchOffContentEditableTrue(body);
   } else {
     editor.readonly = false;
-    setContentEditable(body, true);
+    if (editor.hasEditableRoot()) {
+      setContentEditable(body, true);
+    }
     switchOnContentEditableTrue(body);
     setEditorCommandState(editor, 'StyleWithCSS', false);
     setEditorCommandState(editor, 'enableInlineTableEditing', false);

--- a/modules/tinymce/src/core/test/ts/browser/EditableRootTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditableRootTest.ts
@@ -6,10 +6,10 @@ import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.EditableRootTest', () => {
   const assertContentEditableState = (editor: Editor, expectedState: boolean) => {
-    assert.equal(editor.getBody().contentEditable === 'true', expectedState);
+    assert.equal(editor.getBody().isContentEditable, expectedState);
   };
 
-  const assertEditableState = (editor: Editor, expectedState: boolean) => {
+  const assertRootEditableState = (editor: Editor, expectedState: boolean) => {
     assert.equal(editor.hasEditableRoot(), expectedState);
     assertContentEditableState(editor, expectedState);
   };
@@ -28,7 +28,7 @@ describe('browser.tinymce.core.EditableRootTest', () => {
     }, [], true);
 
     it('TINY-9839: Should not have an editable root state or editable body', () => {
-      assertEditableState(hook.editor(), false);
+      assertRootEditableState(hook.editor(), false);
       assert.equal(initialContentEditableState, 'inherit', 'Should not be editable early in the init process');
     });
   });
@@ -39,7 +39,7 @@ describe('browser.tinymce.core.EditableRootTest', () => {
     }, [], true);
 
     it('TINY-9839: Should have an editable root state and editable body', () => {
-      assertEditableState(hook.editor(), true);
+      assertRootEditableState(hook.editor(), true);
     });
 
     it('TINY-9839: Should be able to toggle editable root state and track the state', () => {
@@ -51,13 +51,13 @@ describe('browser.tinymce.core.EditableRootTest', () => {
       });
 
       editor.setEditableRoot(false);
-      assertEditableState(hook.editor(), false);
+      assertRootEditableState(hook.editor(), false);
 
       // Setting false when it's false should not dispatch an event
       editor.setEditableRoot(false);
 
       editor.setEditableRoot(true);
-      assertEditableState(hook.editor(), true);
+      assertRootEditableState(hook.editor(), true);
 
       // Setting true when it's true should not dispatch an event
       editor.setEditableRoot(true);

--- a/modules/tinymce/src/core/test/ts/browser/EditableRootTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditableRootTest.ts
@@ -42,7 +42,7 @@ describe('browser.tinymce.core.EditableRootTest', () => {
       assertEditableState(hook.editor(), true);
     });
 
-    it('TINY-9839: Should be able to toggle editable root state and track it state', () => {
+    it('TINY-9839: Should be able to toggle editable root state and track the state', () => {
       const editor = hook.editor();
       const states: boolean[] = [];
 

--- a/modules/tinymce/src/core/test/ts/browser/EditableRootTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditableRootTest.ts
@@ -1,0 +1,97 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.EditableRootTest', () => {
+  const assertContentEditableState = (editor: Editor, expectedState: boolean) => {
+    assert.equal(editor.getBody().contentEditable === 'true', expectedState);
+  };
+
+  const assertEditableState = (editor: Editor, expectedState: boolean) => {
+    assert.equal(editor.hasEditableRoot(), expectedState);
+    assertContentEditableState(editor, expectedState);
+  };
+
+  context('editable_root: false', () => {
+    let initialContentEditableState = '';
+
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      editable_root: false,
+      setup: (editor: Editor) => {
+        editor.on('PreInit', () => {
+          initialContentEditableState = editor.getBody().contentEditable;
+        });
+      }
+    }, [], true);
+
+    it('TINY-9839: Should not have an editable root state or editable body', () => {
+      assertEditableState(hook.editor(), false);
+      assert.equal(initialContentEditableState, 'inherit', 'Should not be editable early in the init process');
+    });
+  });
+
+  context('editable_root: default', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce'
+    }, [], true);
+
+    it('TINY-9839: Should have an editable root state and editable body', () => {
+      assertEditableState(hook.editor(), true);
+    });
+
+    it('TINY-9839: Should be able to toggle editable root state and track it state', () => {
+      const editor = hook.editor();
+      const states: boolean[] = [];
+
+      editor.on('EditableRootStateChange', (e) => {
+        states.push(e.state);
+      });
+
+      editor.setEditableRoot(false);
+      assertEditableState(hook.editor(), false);
+
+      // Setting false when it's false should not dispatch an event
+      editor.setEditableRoot(false);
+
+      editor.setEditableRoot(true);
+      assertEditableState(hook.editor(), true);
+
+      // Setting true when it's true should not dispatch an event
+      editor.setEditableRoot(true);
+
+      assert.deepEqual(states, [ false, true ]);
+    });
+
+    it('TINY-9839: Should be unaffected by readonly mode state changes', () => {
+      const editor = hook.editor();
+
+      editor.mode.set('readonly');
+      assert.isTrue(editor.hasEditableRoot());
+      assertContentEditableState(editor, false);
+
+      editor.mode.set('design');
+      assert.isTrue(editor.hasEditableRoot());
+      assertContentEditableState(editor, true);
+
+      editor.setEditableRoot(false);
+
+      editor.mode.set('readonly');
+      assert.isFalse(editor.hasEditableRoot());
+      assertContentEditableState(editor, false);
+
+      editor.mode.set('design');
+      assert.isFalse(editor.hasEditableRoot());
+      assertContentEditableState(editor, false);
+
+      editor.mode.set('readonly');
+      editor.setEditableRoot(true);
+
+      assert.isTrue(editor.hasEditableRoot());
+      assertContentEditableState(editor, false);
+    });
+  });
+});
+

--- a/modules/tinymce/src/core/test/ts/browser/api/commands/ContentCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/api/commands/ContentCommandsTest.ts
@@ -79,4 +79,13 @@ describe('browser.tinymce.core.api.commands.ContentCommandsTest', () => {
     editor.execCommand('mceNewDocument');
     TinyAssertions.assertContent(editor, '');
   });
+
+  it('TINY-9839: mceNewDocument command with newdocument_content option', () => {
+    const editor = hook.editor();
+    editor.options.set('newdocument_content', '<p>initial</p>');
+    editor.setContent('<p>a</p>');
+    editor.execCommand('mceNewDocument');
+    TinyAssertions.assertContent(editor, '<p>initial</p>');
+    editor.options.unset('newdocument_content');
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-9839

Description of Changes:
* Adds the new editable root API according to spec
* Adds the new newdocument_content so that you can set default content when the root is non-editable

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
