### PR TITLE
TINY-9848: Normalize merge tag highlighting across browsers on right click

### DIFF
--- a/modules/oxide/src/less/theme/content/mergetags/mergetag.less
+++ b/modules/oxide/src/less/theme/content/mergetags/mergetag.less
@@ -3,6 +3,11 @@
 @mergetag-affix-background-color: @mergetag-hover-background-color;
 
 .mce-content-body {
+  .mce-mergetag {
+    cursor: default !important;
+    user-select: none;
+  }
+
   .mce-mergetag:hover {
     background-color: @mergetag-hover-background-color;
   }

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- Normalize merge tag highlighting across browsers on right click. #TINY-9848
 - Typing after deleting formatted content could remove a space at the start of the typing. #TINY-9310
 - Invalid markup in Notification and Dialog close buttons. #TINY-9849
 


### PR DESCRIPTION
Related Ticket: TINY-9848

Description of Changes:
* Normalize merge tag highlighting across browsers on right click

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
