### PR TITLE
TINY-9829: Dispatch "insertFromPaste" `beforeinput` event with `dataTransfer` object on paste

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -60,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Popups were not constrained within the scrollable container when in a shadow root. #TINY-9743
 - Pressing arrow keys inside RTL elements would move the caret in an incorrect direction when moving over elements with the `contenteditable` attribute set to `false`. #TINY-9565
 - Inserting table consecutively without focus in the editor would result in the table being inserted at the wrong position. #TINY-3909
-- Pasting content into the editor would not fire an input event. #TINY-9829
+- Pasting content into the editor would not fire `beforeinput` and `input` events. #TINY-9829
 - In some cases, the exiting a `blockquote` element could fail when the cursor was positioned at the end of the `blockquote`. #TINY-9794
 - Templates containing an `<html>` tag were not parsed before being rendered for preview. #TINY-9867
 - Typing after deleting formatted content could remove a space at the start of the typing. #TINY-9310

--- a/modules/tinymce/src/core/main/ts/events/InputEvents.ts
+++ b/modules/tinymce/src/core/main/ts/events/InputEvents.ts
@@ -6,6 +6,7 @@ import { clone } from './EventUtils';
 
 interface SpecificsInput {
   data?: null | string;
+  dataTransfer?: null | DataTransfer;
 }
 
 const createAndFireInputEvent = (eventType: string) =>

--- a/modules/tinymce/src/core/main/ts/paste/Clipboard.ts
+++ b/modules/tinymce/src/core/main/ts/paste/Clipboard.ts
@@ -1,4 +1,4 @@
-import { DataTransfer } from '@ephox/dragster';
+import { DataTransfer, DataTransferContent } from '@ephox/dragster';
 import { Arr, Cell, Strings, Type } from '@ephox/katamari';
 
 import Editor from '../api/Editor';
@@ -36,7 +36,7 @@ const doPaste = (editor: Editor, content: string, internal: boolean, pasteAsText
     const content = args.content;
     SmartPaste.insertContent(editor, content, pasteAsText);
     const dataTransfer = DataTransfer.createDataTransfer();
-    dataTransfer.setData('text/html', content);
+    DataTransferContent.setHtmlData(dataTransfer, content);
     InputEvents.fireBeforeInputEvent(editor, 'insertFromPaste', { dataTransfer });
     InputEvents.fireInputEvent(editor, 'insertFromPaste');
   }

--- a/modules/tinymce/src/core/main/ts/paste/Clipboard.ts
+++ b/modules/tinymce/src/core/main/ts/paste/Clipboard.ts
@@ -1,3 +1,4 @@
+import { DataTransfer } from '@ephox/dragster';
 import { Arr, Cell, Strings, Type } from '@ephox/katamari';
 
 import Editor from '../api/Editor';
@@ -34,6 +35,9 @@ const doPaste = (editor: Editor, content: string, internal: boolean, pasteAsText
   if (!args.cancelled) {
     const content = args.content;
     SmartPaste.insertContent(editor, content, pasteAsText);
+    const dataTransfer = DataTransfer.createDataTransfer();
+    dataTransfer.setData('text/html', content);
+    InputEvents.fireBeforeInputEvent(editor, 'insertFromPaste', { dataTransfer });
     InputEvents.fireInputEvent(editor, 'insertFromPaste');
   }
 };

--- a/modules/tinymce/src/core/test/ts/browser/paste/ImagePasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/ImagePasteTest.ts
@@ -11,6 +11,7 @@ import * as Clipboard from 'tinymce/core/paste/Clipboard';
 import * as PasteEventUtils from '../../module/test/PasteEventUtils';
 
 describe('browser.tinymce.core.paste.ImagePasteTest', () => {
+  const lastBeforeInputEvent = Singleton.value<EditorEvent<InputEvent>>();
   const lastInputEvent = Singleton.value<EditorEvent<InputEvent>>();
 
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -22,9 +23,8 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     paste_data_images: true,
     base_url: '/project/tinymce/js/tinymce',
     init_instance_callback: (editor: Editor) => {
-      editor.on('input', (e) => {
-        lastInputEvent.set(e);
-      });
+      editor.on('beforeinput', (e) => lastBeforeInputEvent.set(e));
+      editor.on('input', (e) => lastInputEvent.set(e));
     }
   }, []);
 
@@ -85,7 +85,7 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     ]);
     Clipboard.pasteImageData(editor, event, editor.selection.getRng());
 
-    await PasteEventUtils.pWaitForAndAssertInputEvent(lastInputEvent);
+    await PasteEventUtils.pWaitForAndAssertInputEvents(lastBeforeInputEvent, lastInputEvent);
     await pWaitForSelector(editor, 'img');
     await Waiter.pTryUntilPredicate('Wait for image to be cached', () => hasCachedItem('mceclip0') && hasCachedItem('mceclip1'));
 
@@ -103,7 +103,7 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     ]);
     Clipboard.pasteImageData(editor, event, editor.selection.getRng());
 
-    await PasteEventUtils.pWaitForAndAssertInputEvent(lastInputEvent);
+    await PasteEventUtils.pWaitForAndAssertInputEvents(lastBeforeInputEvent, lastInputEvent);
     await pWaitForSelector(editor, 'img');
     TinyAssertions.assertContent(editor, '<p><img src=\"data:image/gif;base64,' + base64ImgSrc + '">a</p>');
     assert.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
@@ -131,7 +131,7 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     ]);
     Clipboard.pasteImageData(editor, event, editor.selection.getRng());
 
-    await PasteEventUtils.pWaitForAndAssertInputEvent(lastInputEvent);
+    await PasteEventUtils.pWaitForAndAssertInputEvents(lastBeforeInputEvent, lastInputEvent);
     await pWaitForSelector(editor, 'img');
     TinyAssertions.assertContent(editor, '<p><img src="data:image/jpeg;base64,' + base64ImgSrc + '">a</p>');
     assert.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
@@ -151,7 +151,7 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     ]);
     Clipboard.pasteImageData(editor, event, editor.selection.getRng());
 
-    await PasteEventUtils.pWaitForAndAssertInputEvent(lastInputEvent);
+    await PasteEventUtils.pWaitForAndAssertInputEvents(lastBeforeInputEvent, lastInputEvent);
     await pWaitForSelector(editor, 'img');
     TinyAssertions.assertContent(editor, '<p><img src=\"data:image/tiff;base64,' + base64ImgSrc + '">a</p>');
     assert.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
@@ -167,7 +167,7 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
       dataTransfer.items.add(base64ToBlob(base64ImgSrc, 'image/gif', 'image.gif'));
     });
 
-    await PasteEventUtils.pWaitForAndAssertInputEvent(lastInputEvent);
+    await PasteEventUtils.pWaitForAndAssertInputEvents(lastBeforeInputEvent, lastInputEvent);
     await pWaitForSelector(editor, 'img');
     TinyAssertions.assertContent(editor, '<p><img src=\"data:image/gif;base64,' + base64ImgSrc + '">a</p>');
   });

--- a/modules/tinymce/src/core/test/ts/browser/paste/InternalClipboardTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/InternalClipboardTest.ts
@@ -28,7 +28,7 @@ describe('browser.tinymce.core.paste.InternalClipboardTest', () => {
 
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'table',
-    init_instance_callback: (editor: Editor) => {
+    setup: (editor: Editor) => {
       editor.on('PastePreProcess', (e) => setEventSingletonAndAddType(lastPreProcessEvent, e));
       editor.on('PastePostProcess', (e) => setEventSingletonAndAddType(lastPostProcessEvent, e));
       editor.on('beforeinput input', (e) => {
@@ -38,6 +38,7 @@ describe('browser.tinymce.core.paste.InternalClipboardTest', () => {
           setEventSingletonAndAddType(e.type === 'beforeinput' ? lastBeforeInputEvent : lastInputEvent, e);
         }
       });
+      editor.on('paste', (e) => eventTypes.push(e.type));
       editor.on('copy cut paste', (e) => dataTransfer.set(e.clipboardData));
     },
     base_url: '/project/tinymce/js/tinymce'
@@ -202,7 +203,7 @@ describe('browser.tinymce.core.paste.InternalClipboardTest', () => {
     const pWaitForAndAssertEvents = async (processExpectedData: PasteEventUtils.ProcessEventExpectedData, beforeinputExpectedDataTransferHtml: string): Promise<void> => {
       await PasteEventUtils.pWaitForAndAssertProcessEvents(lastPreProcessEvent, lastPostProcessEvent, processExpectedData);
       await PasteEventUtils.pWaitForAndAssertInputEvents(lastBeforeInputEvent, lastInputEvent, beforeinputExpectedDataTransferHtml);
-      assert.deepEqual(eventTypes, [ 'pastepreprocess', 'pastepostprocess', 'beforeinput', 'input' ], 'Paste events should be fired in correct order');
+      assert.deepEqual(eventTypes, [ 'paste', 'pastepreprocess', 'pastepostprocess', 'beforeinput', 'input' ], 'Paste events should be fired in correct order');
     };
 
     const pWaitForAndAssertNoEvents = () => PasteEventUtils.pWaitForAndAssertEventsDoNotFire([ lastPreProcessEvent, lastPostProcessEvent, lastInputEvent ]);

--- a/modules/tinymce/src/core/test/ts/browser/paste/InternalClipboardTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/InternalClipboardTest.ts
@@ -20,11 +20,10 @@ describe('browser.tinymce.core.paste.InternalClipboardTest', () => {
   const lastBeforeInputEvent = Singleton.value<EditorEvent<InputEvent>>();
   const lastInputEvent = Singleton.value<EditorEvent<InputEvent>>();
   let eventTypes: string[] = [];
-  const setEventSingletonAndAddType = (singleton: Singleton.Value<EditorEvent<any>>, event: EditorEvent<any>) => {
+  const setEventSingletonAndAddType = <T>(singleton: Singleton.Value<EditorEvent<T>>, event: EditorEvent<T>): void => {
     singleton.set(event);
     eventTypes.push(event.type);
   };
-  const isInputEventInsertFromPaste = (inputEvent: EditorEvent<InputEvent>): boolean => inputEvent.inputType === 'insertFromPaste';
 
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'table',
@@ -34,7 +33,7 @@ describe('browser.tinymce.core.paste.InternalClipboardTest', () => {
       editor.on('beforeinput input', (e) => {
         // TINY-9829: Only care about input events related to paste. When pasted content replaces some
         // existing content in the editor, a `deleteContentBackward` input event is fired which is irrelevant
-        if (isInputEventInsertFromPaste(e)) {
+        if (e.inputType === 'insertFromPaste') {
           setEventSingletonAndAddType(e.type === 'beforeinput' ? lastBeforeInputEvent : lastInputEvent, e);
         }
       });

--- a/modules/tinymce/src/core/test/ts/browser/paste/InternalClipboardTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/InternalClipboardTest.ts
@@ -192,7 +192,7 @@ describe('browser.tinymce.core.paste.InternalClipboardTest', () => {
       await PasteEventUtils.pWaitForAndAssertInputEvents(lastBeforeInputEvent, lastInputEvent, beforeinputExpectedDataTransferHtml);
     };
 
-    const pWaitForAndAssertNoEvents = async () => await PasteEventUtils.pWaitForAndAssertEventsDoNotFire([ lastPreProcessEvent, lastPostProcessEvent, lastInputEvent ]);
+    const pWaitForAndAssertNoEvents = () => PasteEventUtils.pWaitForAndAssertEventsDoNotFire([ lastPreProcessEvent, lastPostProcessEvent, lastInputEvent ]);
 
     it('TBA: Paste external content', async () => {
       const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/paste/InternalClipboardTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/InternalClipboardTest.ts
@@ -17,26 +17,17 @@ describe('browser.tinymce.core.paste.InternalClipboardTest', () => {
   const dataTransfer = Singleton.value<DataTransfer>();
   const lastPreProcessEvent = Singleton.value<EditorEvent<PastePreProcessEvent>>();
   const lastPostProcessEvent = Singleton.value<EditorEvent<PastePostProcessEvent>>();
+  const lastBeforeInputEvent = Singleton.value<EditorEvent<InputEvent>>();
   const lastInputEvent = Singleton.value<EditorEvent<InputEvent>>();
 
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'table',
     init_instance_callback: (editor: Editor) => {
-      editor.on('PastePreProcess', (e) => {
-        lastPreProcessEvent.set(e);
-      });
-
-      editor.on('PastePostProcess', (e) => {
-        lastPostProcessEvent.set(e);
-      });
-
-      editor.on('input', (e) => {
-        lastInputEvent.set(e);
-      });
-
-      editor.on('copy cut paste', (e) => {
-        dataTransfer.set(e.clipboardData);
-      });
+      editor.on('PastePreProcess', (e) => lastPreProcessEvent.set(e));
+      editor.on('PastePostProcess', (e) => lastPostProcessEvent.set(e));
+      editor.on('beforeinput', (e) => lastBeforeInputEvent.set(e));
+      editor.on('input', (e) => lastInputEvent.set(e));
+      editor.on('copy cut paste', (e) => dataTransfer.set(e.clipboardData));
     },
     base_url: '/project/tinymce/js/tinymce'
   }, [ TablePlugin ]);
@@ -196,9 +187,9 @@ describe('browser.tinymce.core.paste.InternalClipboardTest', () => {
   });
 
   context('paste', () => {
-    const pWaitForAndAssertEvents = async (processExpected: PasteEventUtils.ProcessEventExpectedData): Promise<void> => {
-      await PasteEventUtils.pWaitForAndAssertProcessEvents(lastPreProcessEvent, lastPostProcessEvent, processExpected);
-      await PasteEventUtils.pWaitForAndAssertInputEvent(lastInputEvent);
+    const pWaitForAndAssertEvents = async (processExpectedData: PasteEventUtils.ProcessEventExpectedData, beforeinputExpectedDataTransferHtml: string): Promise<void> => {
+      await PasteEventUtils.pWaitForAndAssertProcessEvents(lastPreProcessEvent, lastPostProcessEvent, processExpectedData);
+      await PasteEventUtils.pWaitForAndAssertInputEvents(lastBeforeInputEvent, lastInputEvent, beforeinputExpectedDataTransferHtml);
     };
 
     const pWaitForAndAssertNoEvents = async () => await PasteEventUtils.pWaitForAndAssertEventsDoNotFire([ lastPreProcessEvent, lastPostProcessEvent, lastInputEvent ]);
@@ -206,19 +197,19 @@ describe('browser.tinymce.core.paste.InternalClipboardTest', () => {
     it('TBA: Paste external content', async () => {
       const editor = hook.editor();
       paste(editor, '<p>abc</p>', { 'text/plain': 'X', 'text/html': '<p>X</p>' }, [ 0, 0 ], 0, [ 0, 0 ], 3);
-      await pWaitForAndAssertEvents({ internal: false, content: 'X' });
+      await pWaitForAndAssertEvents({ internal: false, content: 'X' }, 'X');
     });
 
     it('TBA: Paste external content treated as plain text', async () => {
       const editor = hook.editor();
       paste(editor, '<p>abc</p>', { 'text/html': '<p>X</p>' }, [ 0, 0 ], 0, [ 0, 0 ], 3);
-      await pWaitForAndAssertEvents({ internal: false, content: 'X' });
+      await pWaitForAndAssertEvents({ internal: false, content: 'X' }, 'X');
     });
 
     it('TINY-9829: Paste external plain-text-only content', async () => {
       const editor = hook.editor();
       paste(editor, '<p>abc</p>', { 'text/plain': 'X' }, [ 0, 0 ], 0, [ 0, 0 ], 3);
-      await pWaitForAndAssertEvents({ internal: false, content: 'X' });
+      await pWaitForAndAssertEvents({ internal: false, content: 'X' }, 'X');
     });
 
     it('TINY-9829: Paste external non-extractable content', async () => {
@@ -230,19 +221,19 @@ describe('browser.tinymce.core.paste.InternalClipboardTest', () => {
     it('TBA: Paste internal content with mark', async () => {
       const editor = hook.editor();
       paste(editor, '<p>abc</p>', { 'text/plain': 'X', 'text/html': InternalHtml.mark('<p>X</p>') }, [ 0, 0 ], 0, [ 0, 0 ], 3);
-      await pWaitForAndAssertEvents({ internal: true, content: '<p>X</p>' });
+      await pWaitForAndAssertEvents({ internal: true, content: '<p>X</p>' }, '<p>X</p>');
     });
 
     it('TBA: Paste internal content with mime', async () => {
       const editor = hook.editor();
       paste(editor, '<p>abc</p>', { 'text/plain': 'X', 'text/html': '<p>X</p>', 'x-tinymce/html': '<p>X</p>' }, [ 0, 0 ], 0, [ 0, 0 ], 3);
-      await pWaitForAndAssertEvents({ internal: true, content: '<p>X</p>' });
+      await pWaitForAndAssertEvents({ internal: true, content: '<p>X</p>' }, '<p>X</p>');
     });
 
     it('TINY-9489: uri-list should not be pasted in as a link', async () => {
       const editor = hook.editor();
       paste(editor, '<p>X</p>', { 'text/plain': 'https://tiny.com', 'text/uri-list': 'https://tiny.com' }, [ 0, 0 ], 0, [ 0, 0 ], 1);
-      await pWaitForAndAssertEvents({ internal: false, content: 'https://tiny.com' });
+      await pWaitForAndAssertEvents({ internal: false, content: 'https://tiny.com' }, 'https://tiny.com');
       TinyAssertions.assertContent(editor, '<p><a href="https://tiny.com">X</a></p>');
     });
   });

--- a/modules/tinymce/src/core/test/ts/browser/paste/PasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/PasteTest.ts
@@ -489,11 +489,15 @@ describe('browser.tinymce.core.paste.PasteTest', () => {
 
     it('TINY-9829: Paste command dispatches input event', async () => {
       const editor = hook.editor();
+      const beforeinputEvent = Singleton.value<EditorEvent<InputEvent>>();
       const inputEvent = Singleton.value<EditorEvent<InputEvent>>();
 
+      editor.on('beforeinput', (e) => beforeinputEvent.set(e));
       editor.on('input', (e) => inputEvent.set(e));
-      editor.execCommand('mceInsertClipboardContent', false, { html: '<p>Test</p>' });
-      await PasteEventUtils.pWaitForAndAssertInputEvent(inputEvent);
+
+      const html = '<p>Test</p>';
+      editor.execCommand('mceInsertClipboardContent', false, { html });
+      await PasteEventUtils.pWaitForAndAssertInputEvents(beforeinputEvent, inputEvent, html);
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9829

Description of Changes:
* [Previous PR](https://github.com/tinymce/tinymce/pull/8733) dealt with dispatching "insertFromPaste" `input` event on paste
* This PR dispatches an "insertFromPaste" `beforeinput` event with a dataTransfer property (as per native behaviour on Chrome) before dispatching that `input` event
* Refactor PasteEventUtils module

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
