### PR TITLE
TINY-9823: Fix inserting lists with noneditable selection

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the constrained bounds calculation for dismissal of toolbar when using `toolbar_location: 'bottom'`. #TINY-9718
 - The floating toolbar did not occupy the entire available space when the page had a flexbox layout. #TINY-9847
 - Fixed backspace and delete keypresses within details elements. #TINY-9884
+- `InsertOrderedList` did not work if there was a `contenteditable=false` element with selection. #TINY-9823
 
 ## 6.4.2 - 2023-04-26
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -82,7 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the constrained bounds calculation for dismissal of toolbar when using `toolbar_location: 'bottom'`. #TINY-9718
 - The floating toolbar did not occupy the entire available space when the page had a flexbox layout. #TINY-9847
 - Fixed backspace and delete keypresses within details elements. #TINY-9884
-- `InsertOrderedList` did not work if there was a `contenteditable=false` element with selection. #TINY-9823
+- Applying lists did not work if the selection included a `contenteditable=false` block element. #TINY-9823
 
 ## 6.4.2 - 2023-04-26
 

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -209,10 +209,7 @@ const applyList = (editor: Editor, listName: string, detail: ListDetail): void =
 
   const bookmark = Bookmark.createBookmark(rng);
 
-  const selectedTextBlocks = Arr.filter(
-    getSelectedTextBlocks(editor, rng, root),
-    (element) => element.getAttribute('contenteditable') !== 'false'
-  );
+  const selectedTextBlocks = Arr.filter(getSelectedTextBlocks(editor, rng, root), editor.dom.isEditable);
 
   Tools.each(selectedTextBlocks, (block) => {
     let listBlock: HTMLElement;

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -11,7 +11,7 @@ import * as Bookmark from '../core/Bookmark';
 import { listToggleActionFromListName } from '../core/ListAction';
 import * as NodeType from '../core/NodeType';
 import * as Selection from '../core/Selection';
-import { isInNonEditableRoot, isCustomList, isWithinNonEditableList } from '../core/Util';
+import { isCustomList, isWithinNonEditableList } from '../core/Util';
 import { flattenListSelection } from './Indendation';
 
 interface ListDetail {
@@ -345,7 +345,7 @@ const toggleSingleList = (editor: Editor, parentList: HTMLElement | null, listNa
 
 const toggleList = (editor: Editor, listName: 'UL' | 'OL' | 'DL', _detail: ListDetail | null): void => {
   const parentList = Selection.getParentList(editor);
-  if (isWithinNonEditableList(editor, parentList) || isInNonEditableRoot(editor)) {
+  if (isWithinNonEditableList(editor, parentList) || !editor.hasEditableRoot()) {
     return;
   }
 

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -1,4 +1,4 @@
-import { Optional, Type, Unicode } from '@ephox/katamari';
+import { Arr, Optional, Type, Unicode } from '@ephox/katamari';
 
 import BookmarkManager from 'tinymce/core/api/dom/BookmarkManager';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
@@ -11,7 +11,7 @@ import * as Bookmark from '../core/Bookmark';
 import { listToggleActionFromListName } from '../core/ListAction';
 import * as NodeType from '../core/NodeType';
 import * as Selection from '../core/Selection';
-import { hasNonEditableBlocksSelected, isCustomList, isWithinNonEditableList } from '../core/Util';
+import { isInNonEditableRoot, isCustomList, isWithinNonEditableList } from '../core/Util';
 import { flattenListSelection } from './Indendation';
 
 interface ListDetail {
@@ -208,7 +208,11 @@ const applyList = (editor: Editor, listName: string, detail: ListDetail): void =
   }
 
   const bookmark = Bookmark.createBookmark(rng);
-  const selectedTextBlocks = getSelectedTextBlocks(editor, rng, root);
+
+  const selectedTextBlocks = Arr.filter(
+    getSelectedTextBlocks(editor, rng, root),
+    (element) => element.getAttribute('contenteditable') !== 'false'
+  );
 
   Tools.each(selectedTextBlocks, (block) => {
     let listBlock: HTMLElement;
@@ -344,7 +348,7 @@ const toggleSingleList = (editor: Editor, parentList: HTMLElement | null, listNa
 
 const toggleList = (editor: Editor, listName: 'UL' | 'OL' | 'DL', _detail: ListDetail | null): void => {
   const parentList = Selection.getParentList(editor);
-  if (isWithinNonEditableList(editor, parentList) || hasNonEditableBlocksSelected(editor)) {
+  if (isWithinNonEditableList(editor, parentList) || isInNonEditableRoot(editor)) {
     return;
   }
 

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Util.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Util.ts
@@ -27,9 +27,6 @@ const isWithinNonEditableList = (editor: Editor, element: Element | null): boole
   return isWithinNonEditable(editor, parentList);
 };
 
-const isInNonEditableRoot = (editor: Editor): boolean =>
-  editor.getBody().getAttribute('contenteditable') === 'false';
-
 const setNodeChangeHandler = (editor: Editor, nodeChangeHandler: (e: NodeChangeEvent) => void): () => void => {
   const initialNode = editor.selection.getNode();
   // Set the initial state
@@ -46,6 +43,5 @@ export {
   inList,
   selectionIsWithinNonEditableList,
   isWithinNonEditableList,
-  isInNonEditableRoot,
   setNodeChangeHandler
 };

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Util.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Util.ts
@@ -1,4 +1,4 @@
-import { Arr, Fun } from '@ephox/katamari';
+import { Arr } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import { NodeChangeEvent } from 'tinymce/core/api/EventTypes';
@@ -27,8 +27,8 @@ const isWithinNonEditableList = (editor: Editor, element: Element | null): boole
   return isWithinNonEditable(editor, parentList);
 };
 
-const hasNonEditableBlocksSelected = (editor: Editor): boolean =>
-  Arr.exists(editor.selection.getSelectedBlocks(), Fun.not(editor.dom.isEditable));
+const isInNonEditableRoot = (editor: Editor): boolean =>
+  editor.getBody().getAttribute('contenteditable') === 'false';
 
 const setNodeChangeHandler = (editor: Editor, nodeChangeHandler: (e: NodeChangeEvent) => void): () => void => {
   const initialNode = editor.selection.getNode();
@@ -46,6 +46,6 @@ export {
   inList,
   selectionIsWithinNonEditableList,
   isWithinNonEditableList,
-  hasNonEditableBlocksSelected,
+  isInNonEditableRoot,
   setNodeChangeHandler
 };

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ContentEditableFalseActionsTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ContentEditableFalseActionsTest.ts
@@ -127,13 +127,14 @@ ${listContent}
     })
   );
 
-  it('TINY-9458: InsertOrderedList command should noop if noneditable blocks are selected', () => {
+  it('TINY-9823: InsertOrderedList command should ignore noneditable blocks', () => {
     const editor = hook.editor();
     const initialContent = '<p>a</p>\n<p contenteditable="false">b</p>\n<p>c</p>';
+    const expectedContent = '<ol>\n<li>a</li>\n</ol>\n<p contenteditable="false">b</p>\n<ol>\n<li>c</li>\n</ol>';
 
     editor.setContent(initialContent);
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 2, 0 ], 1);
     editor.execCommand('InsertOrderedList');
-    TinyAssertions.assertContent(editor, initialContent);
+    TinyAssertions.assertContent(editor, expectedContent);
   });
 });

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ContentEditableFalseActionsTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ContentEditableFalseActionsTest.ts
@@ -142,7 +142,7 @@ ${listContent}
   it('TINY-9823: InsertOrderedList command should ignore noneditable blocks', () => {
     testNonEditableBlocksIgnore('InsertOrderedList');
   });
-  
+
   it('TINY-9823: InsertUnorderedList command should ignore noneditable blocks', () => {
     testNonEditableBlocksIgnore('InsertUnorderedList');
   });

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ContentEditableFalseActionsTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ContentEditableFalseActionsTest.ts
@@ -127,14 +127,23 @@ ${listContent}
     })
   );
 
-  it('TINY-9823: InsertOrderedList command should ignore noneditable blocks', () => {
+  const testNonEditableBlocksIgnore = (command: 'InsertOrderedList' | 'InsertUnorderedList'): void => {
     const editor = hook.editor();
     const initialContent = '<p>a</p>\n<p contenteditable="false">b</p>\n<p>c</p>';
-    const expectedContent = '<ol>\n<li>a</li>\n</ol>\n<p contenteditable="false">b</p>\n<ol>\n<li>c</li>\n</ol>';
+    const tag = command === 'InsertOrderedList' ? 'ol' : 'ul';
+    const expectedContent = `<${tag}>\n<li>a</li>\n</${tag}>\n<p contenteditable="false">b</p>\n<${tag}>\n<li>c</li>\n</${tag}>`;
 
     editor.setContent(initialContent);
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 2, 0 ], 1);
-    editor.execCommand('InsertOrderedList');
+    editor.execCommand(command);
     TinyAssertions.assertContent(editor, expectedContent);
+  };
+
+  it('TINY-9823: InsertOrderedList command should ignore noneditable blocks', () => {
+    testNonEditableBlocksIgnore('InsertOrderedList');
+  });
+  
+  it('TINY-9823: InsertUnorderedList command should ignore noneditable blocks', () => {
+    testNonEditableBlocksIgnore('InsertUnorderedList');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9823

Description of Changes:
* Fixes inserting lists if there are elements with `contenteditable=false` in selection. Overrides some of the features introduced in [TINY-9458](https://github.com/tinymce/tinymce/pull/8373) PR.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-9458]: https://ephocks.atlassian.net/browse/TINY-9458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ