### PR TITLE
TINY-9887: Fixed formatter API regressions

### DIFF
--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -159,7 +159,7 @@ const makePlainAdaptor = (editor: Editor): RtcAdaptor => ({
     canApply: (name) => MatchFormat.canApply(editor, name),
     closest: (names) => MatchFormat.closest(editor, names),
     apply: (name, vars?, node?) => ApplyFormat.applyFormat(editor, name, vars, node),
-    remove: (name, vars, node, similar?) => RemoveFormat.remove(editor, name, vars, node, similar),
+    remove: (name, vars, node, similar?) => RemoveFormat.removeFormat(editor, name, vars, node, similar),
     toggle: (name, vars, node) => ToggleFormat.toggle(editor, name, vars, node),
     formatChanged: (registeredFormatListeners, formats, callback, similar, vars) => formatChangedInternal(editor, registeredFormatListeners, formats, callback, similar, vars)
   },

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -373,7 +373,7 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
 };
 
 const applyFormat = (editor: Editor, name: string, vars?: FormatVars, node?: Node | RangeLikeObject | null): void => {
-  if (editor.selection.isEditable()) {
+  if (node || editor.selection.isEditable()) {
     applyFormatAction(editor, name, vars, node);
   }
 };

--- a/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
@@ -66,7 +66,7 @@ const mergeWithChildren = (editor: Editor, formatList: ApplyFormat[], vars: Form
     if (FormatUtils.isInlineFormat(format)) {
       each(editor.dom.select(format.inline, node), (child) => {
         if (isElementNode(child)) {
-          RemoveFormat.removeFormat(editor, format, vars, child, format.exact ? child : null);
+          RemoveFormat.removeNodeFormat(editor, format, vars, child, format.exact ? child : null);
         }
       });
     }
@@ -80,7 +80,7 @@ const mergeWithParents = (editor: Editor, format: ApplyFormat, name: string, var
   // Note: RemoveFormat.removeFormat will not remove formatting from noneditable nodes
   const parentNode = node.parentNode;
   if (MatchFormat.matchNode(editor, parentNode, name, vars)) {
-    if (RemoveFormat.removeFormat(editor, format, vars, node)) {
+    if (RemoveFormat.removeNodeFormat(editor, format, vars, node)) {
       return;
     }
   }
@@ -89,7 +89,7 @@ const mergeWithParents = (editor: Editor, format: ApplyFormat, name: string, var
   if (format.merge_with_parents && parentNode) {
     editor.dom.getParent(parentNode, (parent) => {
       if (MatchFormat.matchNode(editor, parent, name, vars)) {
-        RemoveFormat.removeFormat(editor, format, vars, node);
+        RemoveFormat.removeNodeFormat(editor, format, vars, node);
         return true;
       } else {
         return false;

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -233,7 +233,7 @@ const removeListStyleFormats = (editor: Editor, name: string, vars: FormatVars |
   }
 };
 
-const removeFormatInternal = (ed: Editor, format: Format, vars?: FormatVars, node?: Node, compareNode?: Node | null): RemoveFormatAdt => {
+const removeNodeFormatInternal = (ed: Editor, format: Format, vars?: FormatVars, node?: Node, compareNode?: Node | null): RemoveFormatAdt => {
   const dom = ed.dom;
   const elementUtils = ElementUtils(ed);
   const schema = ed.schema;
@@ -369,8 +369,8 @@ const findFormatRoot = (editor: Editor, container: Node, name: string, vars?: Fo
   return formatRoot;
 };
 
-const removeFormatFromClone = (editor: Editor, format: Format, vars: FormatVars | undefined, clone: Node) =>
-  removeFormatInternal(editor, format, vars, clone, clone).fold(
+const removeNodeFormatFromClone = (editor: Editor, format: Format, vars: FormatVars | undefined, clone: Node) =>
+  removeNodeFormatInternal(editor, format, vars, clone, clone).fold(
     Fun.constant(clone),
     (newName) => {
       // To rename a node, it needs to be a child of another node
@@ -404,7 +404,7 @@ const wrapAndSplit = (
       let clone: Node | null = dom.clone(parent, false);
 
       for (let i = 0; i < formatList.length; i++) {
-        clone = removeFormatFromClone(editor, formatList[i], vars, clone);
+        clone = removeNodeFormatFromClone(editor, formatList[i], vars, clone);
         if (clone === null) {
           break;
         }
@@ -662,7 +662,7 @@ const removeFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node |
  * @return {Boolean} True/false if the node was removed or not.
  */
 const removeNodeFormat = (editor: Editor, format: Format, vars: FormatVars | undefined, node: Node, compareNode?: Node | null): boolean => {
-  return removeFormatInternal(editor, format, vars, node, compareNode).fold(
+  return removeNodeFormatInternal(editor, format, vars, node, compareNode).fold(
     Fun.never,
     (newName) => {
       // If renaming we are guaranteed this is a Element, so cast

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -445,7 +445,7 @@ const wrapAndSplit = (
   return container;
 };
 
-const removeFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range, similar?: boolean): void => {
+const removeFormatInternal = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range, similar?: boolean): void => {
   const formatList = ed.formatter.get(name) as Format[];
   const format = formatList[0];
   const dom = ed.dom;
@@ -646,7 +646,7 @@ const removeFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: 
 
 const removeFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range, similar?: boolean): void => {
   if (node || ed.selection.isEditable()) {
-    removeFormatAction(ed, name, vars, node, similar);
+    removeFormatInternal(ed, name, vars, node, similar);
   }
 };
 

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -349,17 +349,6 @@ const removeFormatInternal = (ed: Editor, format: Format, vars?: FormatVars, nod
   return removeResult.keep();
 };
 
-const removeFormatAction = (ed: Editor, format: Format, vars: FormatVars | undefined, node: Node, compareNode?: Node | null): boolean =>
-  removeFormatInternal(ed, format, vars, node, compareNode).fold(
-    Fun.never,
-    (newName) => {
-      // If renaming we are guaranteed this is a Element, so cast
-      ed.dom.rename(node as Element, newName);
-      return true;
-    },
-    Fun.always
-  );
-
 const findFormatRoot = (editor: Editor, container: Node, name: string, vars?: FormatVars, similar?: boolean) => {
   let formatRoot: Node | undefined;
 
@@ -456,7 +445,7 @@ const wrapAndSplit = (
   return container;
 };
 
-const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range, similar?: boolean): void => {
+const removeFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range, similar?: boolean): void => {
   const formatList = ed.formatter.get(name) as Format[];
   const format = formatList[0];
   const dom = ed.dom;
@@ -472,8 +461,8 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
   const isRemoveBookmarkNode = (node: Node | null): node is Element =>
     Bookmarks.isBookmarkNode(node) && NodeType.isElement(node) && (node.id === '_start' || node.id === '_end');
 
-  const removeNodeFormat = (node: Node) =>
-    Arr.exists(formatList, (fmt) => removeFormat(ed, fmt, vars, node, node));
+  const removeFormatOnNode = (node: Node) =>
+    Arr.exists(formatList, (fmt) => removeNodeFormat(ed, fmt, vars, node, node));
 
   // Merges the styles for each node
   const process = (node: Node) => {
@@ -482,13 +471,13 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
     const children = Arr.from(node.childNodes);
 
     // Process current node
-    const removed = removeNodeFormat(node);
+    const removed = removeFormatOnNode(node);
 
     // TINY-6567/TINY-7393: Include the parent if using an expanded selector format and no match was found for the current node
     const currentNodeMatches = removed || Arr.exists(formatList, (f) => MatchFormat.matchName(dom, node, f));
     const parentNode = node.parentNode;
     if (!currentNodeMatches && Type.isNonNullable(parentNode) && FormatUtils.shouldExpandToSelector(format)) {
-      removeNodeFormat(parentNode);
+      removeFormatOnNode(parentNode);
     }
 
     // Process the children
@@ -507,7 +496,7 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
     Arr.each(textDecorations, (decoration) => {
       if (NodeType.isElement(node) && ed.dom.getStyle(node, 'text-decoration') === decoration &&
         node.parentNode && FormatUtils.getTextDecoration(dom, node.parentNode) === decoration) {
-        removeFormat(ed, {
+        removeNodeFormat(ed, {
           deep: false,
           exact: true,
           inline: 'span',
@@ -652,6 +641,13 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
   removeListStyleFormats(ed, name, vars);
 
   Events.fireFormatRemove(ed, name, node, vars);
+
+};
+
+const removeFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range, similar?: boolean): void => {
+  if (node || ed.selection.isEditable()) {
+    removeFormatAction(ed, name, vars, node, similar);
+  }
 };
 
 /**
@@ -665,15 +661,19 @@ const remove = (ed: Editor, name: string, vars?: FormatVars, node?: Node | Range
  * @param {Node} compareNode Optional compare node, if specified the styles will be compared to that node.
  * @return {Boolean} True/false if the node was removed or not.
  */
-const removeFormat = (editor: Editor, format: Format, vars: FormatVars | undefined, node: Node, compareNode?: Node | null): boolean => {
-  if (editor.selection.isEditable()) {
-    return removeFormatAction(editor, format, vars, node, compareNode);
-  } else {
-    return false;
-  }
+const removeNodeFormat = (editor: Editor, format: Format, vars: FormatVars | undefined, node: Node, compareNode?: Node | null): boolean => {
+  return removeFormatInternal(editor, format, vars, node, compareNode).fold(
+    Fun.never,
+    (newName) => {
+      // If renaming we are guaranteed this is a Element, so cast
+      editor.dom.rename(node as Element, newName);
+      return true;
+    },
+    Fun.always
+  );
 };
 
 export {
   removeFormat,
-  remove
+  removeNodeFormat
 };

--- a/modules/tinymce/src/core/main/ts/fmt/ToggleFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ToggleFormat.ts
@@ -8,7 +8,7 @@ const toggle = (editor: Editor, name: string, vars?: FormatVars, node?: Node): v
   const fmt = editor.formatter.get(name);
   if (fmt) {
     if (MatchFormat.match(editor, name, vars, node) && (!('toggle' in fmt[0]) || fmt[0].toggle)) {
-      RemoveFormat.remove(editor, name, vars, node);
+      RemoveFormat.removeFormat(editor, name, vars, node);
     } else {
       ApplyFormat.applyFormat(editor, name, vars, node);
     }

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -1,7 +1,8 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Obj } from '@ephox/katamari';
-import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
+import { Hierarchy } from '@ephox/sugar';
+import { LegacyUnit, TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -2513,6 +2514,15 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 4);
       editor.formatter.apply('bold');
       TinyAssertions.assertContent(editor, initialContent);
+    });
+  });
+
+  it('TINY-9887: Should be not be noop if selection is not in an editable context but a custom editable node is specified', () => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<p>test</p><p contenteditable="true">editable</p>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 4);
+      editor.formatter.apply('bold', {}, Hierarchy.follow(TinyDom.body(editor), [ 1 ]).getOrDie().dom);
+      TinyAssertions.assertContent(editor, '<p>test</p><p contenteditable="true"><strong>editable</strong></p>');
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -2517,7 +2517,7 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     });
   });
 
-  it('TINY-9887: Should be not be noop if selection is not in an editable context but a custom editable node is specified', () => {
+  it('TINY-9887: Should not be noop if selection is not in an editable context but a custom editable node is specified', () => {
     TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       editor.setContent('<p>test</p><p contenteditable="true">editable</p>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 4);

--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
@@ -354,23 +354,25 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
 
   it('contentEditable: false on start and contentEditable: true on end', () => {
     const editor = hook.editor();
+    const initialContent = '<p>abc</p><p contenteditable="false"><b>def</b></p><p><b>ghj</b></p>';
     editor.formatter.register('format', { inline: 'b' });
-    editor.setContent('<p>abc</p><p contenteditable="false"><b>def</b></p><p><b>ghj</b></p>');
+    editor.setContent(initialContent);
     const rng = editor.dom.createRng();
     rng.setStart(editor.dom.select('b')[0].firstChild as Text, 0);
     rng.setEnd(editor.dom.select('b')[1].firstChild as Text, 3);
     editor.selection.setRng(rng);
     editor.formatter.remove('format');
-    assert.equal(editor.getContent(), '<p>abc</p><p contenteditable="false"><b>def</b></p><p>ghj</p>', 'Text in last paragraph is not bold');
+    TinyAssertions.assertContent(editor, initialContent);
   });
 
   it('contentEditable: true on start and contentEditable: false on end', () => {
     const editor = hook.editor();
+    const initialContent = '<p>abc</p><p><b>def</b></p><p contenteditable="false"><b>ghj</b></p>';
     editor.formatter.register('format', { inline: 'b' });
-    editor.setContent('<p>abc</p><p><b>def</b></p><p contenteditable="false"><b>ghj</b></p>');
+    editor.setContent(initialContent);
     LegacyUnit.setSelection(editor, 'p:nth-child(2) b', 0, 'p:last-of-type b', 3);
     editor.formatter.remove('format');
-    assert.equal(editor.getContent(), '<p>abc</p><p>def</p><p contenteditable="false"><b>ghj</b></p>', 'Text in first paragraph is not bold');
+    TinyAssertions.assertContent(editor, initialContent);
   });
 
   it('contentEditable: true inside contentEditable: false', () => {

--- a/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
@@ -1,5 +1,6 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
+import { Hierarchy } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Format } from 'tinymce/core/fmt/FormatTypes';
@@ -25,7 +26,7 @@ describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
 
   const doRemoveFormat = (editor: Editor, format: Format[]) => {
     editor.formatter.register('format', format);
-    RemoveFormat.remove(editor, 'format');
+    RemoveFormat.removeFormat(editor, 'format');
     editor.formatter.unregister('format');
   };
 
@@ -157,7 +158,7 @@ describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
       );
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 1, 1, 1 ], 0);
 
-      RemoveFormat.remove(editor, 'aligncenter');
+      RemoveFormat.removeFormat(editor, 'aligncenter');
       TinyAssertions.assertContent(editor,
         '<ul>' +
           '<li>a</li>' +
@@ -192,7 +193,7 @@ describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
       );
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 1, 1, 1, 1, 1 ], 0);
 
-      RemoveFormat.remove(editor, 'aligncenter');
+      RemoveFormat.removeFormat(editor, 'aligncenter');
       TinyAssertions.assertContent(editor,
         '<ul>' +
           '<li>1</li>' +
@@ -244,7 +245,7 @@ describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
       editor.setContent('<p style="text-align: right;">Test text<img src="link" width="40" height="40"></p>');
       TinySelections.setSelection(editor, [ 0 ], 1, [ 0 ], 2);
 
-      RemoveFormat.remove(editor, 'alignright');
+      RemoveFormat.removeFormat(editor, 'alignright');
 
       TinyAssertions.assertContent(editor, '<p style="text-align: right;">Test text<img src="link" width="40" height="40"></p>');
       TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 2);
@@ -255,7 +256,7 @@ describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
       editor.setContent('<p style="text-align: right;">Test text<img src="link" width="40" height="40" style="float: right"></p>');
       TinySelections.setSelection(editor, [ 0 ], 1, [ 0 ], 2);
 
-      RemoveFormat.remove(editor, 'alignright');
+      RemoveFormat.removeFormat(editor, 'alignright');
 
       TinyAssertions.assertContent(editor, '<p style="text-align: right;">Test text<img src="link" width="40" height="40"></p>');
       TinyAssertions.assertSelection(editor, [ 0 ], 1, [ 0 ], 2);
@@ -269,6 +270,15 @@ describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
       TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 4);
       editor.formatter.remove('bold');
       TinyAssertions.assertContent(editor, initialContent);
+    });
+  });
+
+  it('TINY-9887: Should not be a noop if selection is not in an editable context but a custom editable node is specified', () => {
+    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+      editor.setContent('<p><strong>test</strong></p><p contenteditable="true"><strong>editable</strong></p>');
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 4);
+      editor.formatter.remove('bold', {}, Hierarchy.follow(TinyDom.body(editor), [ 1, 0 ]).getOrDie().dom);
+      TinyAssertions.assertContent(editor, '<p><strong>test</strong></p><p contenteditable="true">editable</p>');
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9887

Description of Changes:
This is a follow up to TINY-9678 added the `selection.isEditable` check to the wrong function since they were very confusingly named `applyFormat` in the `ApplyFormat` module but `remove` in the `RemoveFormat` module but the `RemoveFormat` had a function that was called `removeFormat` but was not the opposite of the `applyFormat` function. So a refactored it now so that it makes more sense and is the same internal API. But also fixed a few regressions.

* Fixed regression with remove format being a noop if custom node was specified but selection was non editable.
* Fixed regression with apply format being a noop if custom node was specified but selection was non editable.
* Fixed regression with remove format not working in the first or last child of a CET see bug report not covering this though since it's not the real bug.
* Renamed the `RemoveFormat.remove` to `RemoveFormat.removeFormat` so that it's similar to `ApplyFormat.applyFormat`.
* Renamed the `RemoveFormat.removeFormat` to `RemoveFormat.removeNodeFormat` since it's node specific.
* Renamed the internal `removeFormatInternal` to `removeNodeFormatInternal`
* Named the internal `removeFormat` the `removeFormatInternal`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
