### PR TITLE
DOC-2029: Added API docs for setEditableRoot/hasEditableRoot

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -1080,10 +1080,22 @@ class Editor implements EditorObservable {
     VisualAids.addVisual(this, elm);
   }
 
+  /**
+   * Changes the editable state of the editor root element.
+   *
+   * @method setEditableRoot
+   * @param {Boolean} state State to set true for editable and false for non-editable.
+   */
   public setEditableRoot(state: boolean): void {
     EditableRoot.setEditableRoot(this, state);
   }
 
+  /**
+   * Returns the current editable state of the editor root element.
+   *
+   * @method hasEditableRoot
+   * @return {Boolean} True if the root element is editable, false if it's not editable.
+   */
   public hasEditableRoot(): boolean {
     return EditableRoot.hasEditableRoot(this);
   }

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -1081,7 +1081,7 @@ class Editor implements EditorObservable {
   }
 
   /**
-   * Changes the editable state of the editor root element.
+   * Changes the editable state of the editor's root element.
    *
    * @method setEditableRoot
    * @param {Boolean} state State to set true for editable and false for non-editable.
@@ -1091,10 +1091,10 @@ class Editor implements EditorObservable {
   }
 
   /**
-   * Returns the current editable state of the editor root element.
+   * Returns the current editable state of the editor's root element.
    *
    * @method hasEditableRoot
-   * @return {Boolean} True if the root element is editable, false if it's not editable.
+   * @return {Boolean} True if the root element is editable, false if it is not editable.
    */
   public hasEditableRoot(): boolean {
     return EditableRoot.hasEditableRoot(this);


### PR DESCRIPTION
Related Ticket: DOC-2029

Description of Changes:
* Added API docs for the new `setEditableRoot` and `hasEditableRoot` functions

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
