### PR TITLE
TINY-9897: edits and copy-edits to code comments in `TypeaheadSchema.ts`

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/TypeaheadSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/TypeaheadSchema.ts
@@ -84,11 +84,12 @@ const parts: () => PartType.PartTypeAdt[] = Fun.constant([
                 setValueFromItem(detail.model, input, item);
               }
 
-              // The focus is retained on the input element when the menu is shown (unlike the combobox in which the focus is passed onto the menu).
-              // This causes the screen readers not to be able to announce the menu or highlighted item
-              // The solution is to tell the screen readers which menu item is highligted using aria-activedescendant attribute
-              // TINY-9280: The aria attribute will be removed when the menu is closed. Since onDehighlight is called only when highlighting a new menu item
-              // this will be handled in https://github.com/tinymce/tinymce/blob/2d8c1c034e8aa484b868a0c44605489ee0ca9cd4/modules/alloy/src/main/ts/ephox/alloy/ui/composite/TypeaheadSpec.ts#L282
+              // The focus is retained on the input element when the menu is shown, unlike the combobox, in which the focus is passed to the menu.
+              // This results in screen readers not being able to announce the menu or highlighted item.
+              // The solution is to tell screen readers which menu item is highlighted using the `aria-activedescendant` attribute.
+              // TINY-9280: The aria attribute is removed when the menu is closed.
+              // Since `onDehighlight` is called only when highlighting a new menu item, this will be handled in
+              // https://github.com/tinymce/tinymce/blob/2d8c1c034e8aa484b868a0c44605489ee0ca9cd4/modules/alloy/src/main/ts/ephox/alloy/ui/composite/TypeaheadSpec.ts#L282
               Attribute.getOpt(item.element, 'id').each((id) => Attribute.set(input.element, 'aria-activedescendant', id));
             });
           } else {


### PR DESCRIPTION
Related Ticket: TINY-9897

Description of Changes:
* No code change
* edits and copy-edits to code comments in `TypeaheadSchema.ts`

Pre-checks:
* [x] Changelog entry added
~* [ ] Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
~* [ ] Milestone set~
~* [ ] Docs ticket created (if applicable)~

GitHub issues (if applicable):
