### PR TITLE
TINY-9629: revert change to `more...` button

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -24,8 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improved
 - Screen readers are now able to announce the highlighted menu item of link comboboxes. #TINY-9280
 - Now `icon` field for dialog footer `togglebutton`s is not mandatory. #TINY-9757
+
+### Improved
 - Toolbar buttons and menu items were not disabled when they couldn't be used on noneditable content. #TINY-9669
-- Updated toolbar "More" button tooltip text from "More..." to "Reveal or hide additional toolbar items". #TINY-9629
 - Help text displayed at **Help > Help > Keyboard Navigation** re-written. #DOC-1936
 - These characters '$', '~', '+', '|', '№', '`' are now considered as punctuation marks. Therefore, they will not increase the word count. #TINY-8122
 - Updated the `codesample` plugin dialog and `template` plugin dialog to use the 'listbox' component to match other dialogs. #TINY-9630

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -24,8 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improved
 - Screen readers are now able to announce the highlighted menu item of link comboboxes. #TINY-9280
 - Now `icon` field for dialog footer `togglebutton`s is not mandatory. #TINY-9757
-
-### Improved
 - Toolbar buttons and menu items were not disabled when they couldn't be used on noneditable content. #TINY-9669
 - Help text displayed at **Help > Help > Keyboard Navigation** re-written. #DOC-1936
 - These characters '$', '~', '+', '|', '№', '`' are now considered as punctuation marks. Therefore, they will not increase the word count. #TINY-8122

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -112,7 +112,7 @@ const renderMoreToolbarCommon = (toolbarSpec: MoreDrawerToolbarSpec) => {
         name: 'more',
         icon: Optional.some('more-drawer'),
         enabled: true,
-        tooltip: Optional.some('Reveal or hide additional toolbar items'),
+        tooltip: Optional.some('More...'),
         primary: false,
         buttonType: Optional.none(),
         borderless: false

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -89,11 +89,11 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
         toolbar: Arr.range(10, Fun.constant('bold | italic ')).join('')
       },
       initial: [{
-        clickOn: 'button[title="Reveal or hide additional toolbar items"]',
+        clickOn: 'button[title="More..."]',
         waitFor: '.tox-toolbar__overflow'
       }],
       assertAbove: '.tox-toolbar__overflow',
-      assertBelow: 'button[title="Reveal or hide additional toolbar items"]'
+      assertBelow: 'button[title="More..."]'
     }));
 
     it('Menu button in overflow toolbar should open up', () => pTest({
@@ -104,7 +104,7 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
       },
       initial: [
         {
-          clickOn: 'button[title="Reveal or hide additional toolbar items"]',
+          clickOn: 'button[title="More..."]',
           waitFor: '.tox-toolbar__overflow'
         }, {
           clickOn: 'button[title="Align"]',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
@@ -42,7 +42,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.InlineToolbarDrawerFloati
     editor.setContent('<p>Line 1</p><p>Line 2</p><p>Line 3</p>');
     editor.focus();
     TinySelections.setCursor(editor, [ 2, 0 ], 'Line 3'.length);
-    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[title="Reveal or hide additional toolbar items"]');
+    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[title="More..."]');
     await pRunTests(editor);
     McEditor.remove(editor);
   };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/SplitFloatingToolbarKeyboardNavigationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/SplitFloatingToolbarKeyboardNavigationTest.ts
@@ -26,7 +26,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.SplitFloatingToolbarKeybo
 
   it('TINY-9723: Menu toolbar items should not be tabstoppable', async () => {
     const editor = hook.editor();
-    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[title="Reveal or hide additional toolbar items"]');
+    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[title="More..."]');
     const menubutton = await TinyUiActions.pWaitForPopup(editor, '.tox-tbtn[title="menubutton"]');
     assert.isFalse(Attribute.has(menubutton, 'data-alloy-tabstop'));
     // Focus is on the first toolbar__group on the fontsize button

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -104,7 +104,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest',
       });
 
       it(`TINY-9271: Emits 'ToggleToolbarDrawer' in ${toolbarMode} via user click`, async () => {
-        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[title="Reveal or hide additional toolbar items"]'));
+        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[title="More..."]'));
       });
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -416,18 +416,18 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       assert.equal(Html.get(editorContainer), expectedHtml);
     };
 
-    it('TINY-9419: "Expand or collapse" button should not be removed if the toolbar is opened and view is opened and close', async () => {
+    it('TINY-9419: "More..." button should not be removed if the toolbar is opened and view is opened and close', () => {
       const editor = hook.editor();
 
       editor.setContent('<p>ab</p>');
-      TinyUiActions.clickOnToolbar(editor, '[title="Reveal or hide additional toolbar items"]');
+      TinyUiActions.clickOnToolbar(editor, '[title="More..."]');
 
       editor.execCommand('ToggleView', false, 'myview1');
       assertViewHtml(0, '<button>myview1</button>');
       editor.execCommand('ToggleView', false, 'myview1');
       assertMainViewVisible();
-      const moreButton = await TinyUiActions.pWaitForUi(editor, '[title="Reveal or hide additional toolbar items"]');
-      assert.isDefined(moreButton, '"Reveal or hide" button should be there');
+      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[title="More..."]');
+      assert.isTrue(moreButton.isValue(), 'More... button should be there');
     });
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
@@ -25,12 +25,12 @@ const pOpenMenuWithSelector = async (label: string, selector: string): Promise<v
 };
 
 const pOpenMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[title="Reveal or hide additional toolbar items"]');
+  Mouse.clickOn(SugarBody.body(), 'button[title="More..."]');
   await UiFinder.pWaitForVisible('Waiting for more drawer to open', SugarBody.body(), getToolbarSelector(type, true));
 };
 
 const pCloseMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[title="Reveal or hide additional toolbar items"]');
+  Mouse.clickOn(SugarBody.body(), 'button[title="More..."]');
   await Waiter.pTryUntil('Waiting for more drawer to close', () => UiFinder.notExists(SugarBody.body(), getToolbarSelector(type, false)));
 };
 


### PR DESCRIPTION
Related Ticket: 
https://ephocks.atlassian.net/browse/TINY-9629

Description of Changes:
This revert the changes for https://github.com/tinymce/tinymce/commit/c6196d0f42a067152811fe89285e799eb02f0b28

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
