### PR TITLE
TINY-9830: Add support for `h` parameter for vimeo video url in the Media plugin

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- Support for `h` hash parameter in vimeo video url in the Media plugin. #TINY-9830
 - New `table_merge_content_on_paste` option which disables the merging behaviour when pasting a table inside an existing table. #TINY-9808
 - New optional `defaultExpandedIds` and `onToggleExpand` options to the `tree` component config. #TINY-9653
 - New optional `defaultSelectedId` option to the `tree` component config. #TINY-9715

--- a/modules/tinymce/src/plugins/media/main/ts/core/UrlPatterns.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/UrlPatterns.ts
@@ -99,7 +99,6 @@ const getUrl = (pattern: UrlPattern, url: string): string => {
 
 const matchPattern = (url: string): UrlPattern | null => {
   const patterns = urlPatterns.filter((pattern) => pattern.regex.test(url));
-  console.log(patterns);
 
   if (patterns.length > 0) {
     return Tools.extend({}, patterns[0], { url: getUrl(patterns[0], url) });

--- a/modules/tinymce/src/plugins/media/main/ts/core/UrlPatterns.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/UrlPatterns.ts
@@ -31,6 +31,18 @@ const urlPatterns: UrlPattern[] = [
     allowFullscreen: true
   },
   {
+    regex: /vimeo\.com\/([0-9]+)\?h=(\w+)/,
+    type: 'iframe', w: 425, h: 350,
+    url: 'player.vimeo.com/video/$1?h=$2&title=0&byline=0&portrait=0&color=8dc7dc',
+    allowFullscreen: true
+  },
+  {
+    regex: /vimeo\.com\/(.*)\/([0-9]+)\?h=(\w+)/,
+    type: 'iframe', w: 425, h: 350,
+    url: 'player.vimeo.com/video/$2?h=$3&title=0&amp;byline=0',
+    allowFullscreen: true
+  },
+  {
     regex: /vimeo\.com\/([0-9]+)/,
     type: 'iframe', w: 425, h: 350,
     url: 'player.vimeo.com/video/$1?title=0&byline=0&portrait=0&color=8dc7dc',
@@ -87,6 +99,7 @@ const getUrl = (pattern: UrlPattern, url: string): string => {
 
 const matchPattern = (url: string): UrlPattern | null => {
   const patterns = urlPatterns.filter((pattern) => pattern.regex.test(url));
+  console.log(patterns);
 
   if (patterns.length > 0) {
     return Tools.extend({}, patterns[0], { url: getUrl(patterns[0], url) });

--- a/modules/tinymce/src/plugins/media/test/ts/atomic/UrlPatternsTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/atomic/UrlPatternsTest.ts
@@ -39,9 +39,19 @@ describe('atomic.tinymce.plugins.media.core.UrlPatternsTest', () => {
     'https://player.vimeo.com/video/12345?title=0&byline=0&portrait=0&color=8dc7dc'
   ));
 
+  it('Matches vimeo ID with hash parameter URL', () => check(
+    'https://vimeo.com/12345?h=abcd',
+    'https://player.vimeo.com/video/12345?h=abcd&title=0&byline=0&portrait=0&color=8dc7dc'
+  ));
+
   it('Matches vimeo channel with ID URL', () => check(
     'https://vimeo.com/channels/staffpicks/12345',
     'https://player.vimeo.com/video/12345?title=0&amp;byline=0'
+  ));
+
+  it('Matches vimeo channel with ID and hash parameter URL', () => check(
+    'https://vimeo.com/channels/staffpicks/12345?h=abcd',
+    'https://player.vimeo.com/video/12345?h=abcd&title=0&amp;byline=0'
   ));
 
   it('Matches dailymotion URL', () => check(


### PR DESCRIPTION
Related Ticket: TINY-9830

Description of Changes:
* Add support for `h` parameter for vimeo video url in the Media plugin

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
