### PR TITLE
TINY-9633: Add test for fallback when invalid language code is specified

### DIFF
--- a/modules/tinymce/src/plugins/help/test/ts/browser/KeyboardNavTabI18nTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/KeyboardNavTabI18nTest.ts
@@ -30,4 +30,6 @@ describe('browser.tinymce.plugins.help.KeyboardNavTabI18nTest', () => {
   it('TINY-9633: Can load English by default', () => testLanguage('Begin'));
 
   it('TINY-9633: Can load German translation', () => testLanguage('Grundlagen', 'de'));
+
+  it('TINY-9633: Loads English fallback when invalid language code is specified', () => testLanguage('Begin', 'invalid'));
 });


### PR DESCRIPTION
Related Ticket: TINY-9633

Description of Changes:
* Add test for fallback when invalid language code is specified

Pre-checks:
* [x] ~Changelog entry added~ (added in https://github.com/tinymce/tinymce/pull/8764)
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
