### PR TITLE
TINY-9744: pattern replacement text sometime causes removal of spaces

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -26,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `editor.hasEditableRoot` API that returns `true` or `false` depending on the editable state of the editor root element. #TINY-9839
 - New `EditableRootStateChange` event that gets dispatched when the state of the editable root is changed. #TINY-9839
 - Added Oxide styles for `dl`, `dt`, `dd`, `ol`, and `strong` elements in dialog body content. #TINY-9919
-- New `createTextNode` API in `DOMUtils`. #TINY-9744
 
 ### Improved
 - Screen readers can now announce highlighted items listed in the Link dialog’s link combobox. #TINY-9280

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- The pattern replacement removes spaces if they were contained in a tag that only contains a space and the text to replace. #TINY-9744
+
 ## 6.5.0 - 2023-06-12
 
 ### Added

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `editor.hasEditableRoot` API that returns `true` or `false` depending on the editable state of the editor root element. #TINY-9839
 - New `EditableRootStateChange` event that gets dispatched when the state of the editable root is changed. #TINY-9839
 - Added Oxide styles for `dl`, `dt`, `dd`, `ol`, and `strong` elements in dialog body content. #TINY-9919
+- New `createTextNode` API in `DOMUtils`. #TINY-9744
 
 ### Improved
 - Screen readers can now announce highlighted items listed in the Link dialog’s link combobox. #TINY-9280

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -128,7 +128,6 @@ interface DOMUtils {
     <K extends keyof HTMLElementTagNameMap>(name: K, attrs?: Record<string, string | boolean | number | null>, html?: string | Node | null): HTMLElementTagNameMap[K];
     (name: string, attrs?: Record<string, string | boolean | number | null>, html?: string | Node | null): HTMLElement;
   };
-  createTextNode: (data: string) => Text;
   createHTML: (name: string, attrs?: Record<string, string | null>, html?: string) => string;
   createFragment: (html?: string) => DocumentFragment;
   remove: {
@@ -685,8 +684,6 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
       return outHtml + '>' + html + '</' + name + '>';
     }
   };
-
-  const createTextNode = (data: string): Text => doc.createTextNode(data);
 
   const createFragment = (html?: string): DocumentFragment => {
     const container = doc.createElement('div');
@@ -1347,8 +1344,6 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      * tinymce.activeEditor.selection.setContent(tinymce.activeEditor.dom.createHTML('a', { href: 'test.html' }, 'some line'));
      */
     createHTML,
-
-    createTextNode,
 
     /**
      * Creates a document fragment out of the specified HTML string.

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -128,6 +128,7 @@ interface DOMUtils {
     <K extends keyof HTMLElementTagNameMap>(name: K, attrs?: Record<string, string | boolean | number | null>, html?: string | Node | null): HTMLElementTagNameMap[K];
     (name: string, attrs?: Record<string, string | boolean | number | null>, html?: string | Node | null): HTMLElement;
   };
+  createTextNode: (data: string) => Text;
   createHTML: (name: string, attrs?: Record<string, string | null>, html?: string) => string;
   createFragment: (html?: string) => DocumentFragment;
   remove: {
@@ -684,6 +685,8 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
       return outHtml + '>' + html + '</' + name + '>';
     }
   };
+
+  const createTextNode = (data: string): Text => doc.createTextNode(data);
 
   const createFragment = (html?: string): DocumentFragment => {
     const container = doc.createElement('div');
@@ -1344,6 +1347,8 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      * tinymce.activeEditor.selection.setContent(tinymce.activeEditor.dom.createHTML('a', { href: 'test.html' }, 'some line'));
      */
     createHTML,
+
+    createTextNode,
 
     /**
      * Creates a document fragment out of the specified HTML string.

--- a/modules/tinymce/src/core/main/ts/textpatterns/utils/Utils.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/utils/Utils.ts
@@ -12,11 +12,8 @@ const cleanEmptyNodes = (dom: DOMUtils, node: Node | null, isRoot: (e: Node) => 
   if (node && dom.isEmpty(node) && !isRoot(node)) {
     const parent = node.parentNode;
 
-    if (NodeType.isText(node.firstChild) && isWhitespaceText(node.firstChild.data)) {
-      dom.replace(dom.createTextNode(node.firstChild.data), node);
-    } else {
-      dom.remove(node);
-    }
+    dom.remove(node, NodeType.isText(node.firstChild) && isWhitespaceText(node.firstChild.data));
+
     cleanEmptyNodes(dom, parent, isRoot);
   }
 };

--- a/modules/tinymce/src/core/main/ts/textpatterns/utils/Utils.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/utils/Utils.ts
@@ -3,6 +3,7 @@ import { Optional } from '@ephox/katamari';
 import DOMUtils from '../../api/dom/DOMUtils';
 import Editor from '../../api/Editor';
 import * as NodeType from '../../dom/NodeType';
+import { isWhitespaceText } from '../../text/Whitespace';
 import { getBlockPatterns, getInlinePatterns } from '../core/Pattern';
 import { PatternSet } from '../core/PatternTypes';
 
@@ -10,7 +11,12 @@ const cleanEmptyNodes = (dom: DOMUtils, node: Node | null, isRoot: (e: Node) => 
   // Recursively walk up the tree while we have a parent and the node is empty. If the node is empty, then remove it.
   if (node && dom.isEmpty(node) && !isRoot(node)) {
     const parent = node.parentNode;
-    dom.remove(node);
+
+    if (NodeType.isText(node.firstChild) && isWhitespaceText(node.firstChild.data)) {
+      dom.replace(document.createTextNode(node.firstChild.data), node);
+    } else {
+      dom.remove(node);
+    }
     cleanEmptyNodes(dom, parent, isRoot);
   }
 };

--- a/modules/tinymce/src/core/main/ts/textpatterns/utils/Utils.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/utils/Utils.ts
@@ -13,7 +13,7 @@ const cleanEmptyNodes = (dom: DOMUtils, node: Node | null, isRoot: (e: Node) => 
     const parent = node.parentNode;
 
     if (NodeType.isText(node.firstChild) && isWhitespaceText(node.firstChild.data)) {
-      dom.replace(document.createTextNode(node.firstChild.data), node);
+      dom.replace(dom.createTextNode(node.firstChild.data), node);
     } else {
       dom.remove(node);
     }

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/ReplacementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/ReplacementTest.ts
@@ -15,7 +15,8 @@ describe('browser.tinymce.core.textpatterns.ReplacementTest', () => {
       { start: 'complex pattern', replacement: '<h1>Text</h1><p>More text</p>' },
       { start: '*', end: '*', format: 'italic' },
       { start: '#', format: 'h1' },
-      { start: 'text_pattern', replacement: 'wow' }
+      { start: 'text_pattern', replacement: 'wow' },
+      { start: 'world ', replacement: 'World ' }
     ],
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
@@ -128,6 +129,12 @@ describe('browser.tinymce.core.textpatterns.ReplacementTest', () => {
     const editor = hook.editor();
     Utils.setContentAndPressEnter(editor, '<span data-mce-spelling="invalid">#</span>*brb<span data-mce-spelling="invalid">*</span>', 3, [ 0 ]);
     assertContentAndCursor(editor, '<h1><em>be right back</em></h1><p>&nbsp;|</p>');
+  });
+
+  it('TINY-9744: replacing the content of a tag that has also a space before should remove the tag but preserve the space', () => {
+    const editor = hook.editor();
+    Utils.setContentAndPressSpace(editor, 'Hello.<strong> world</strong>&nbsp;', 1, [ 0, 2 ]);
+    TinyAssertions.assertContent(editor, '<p>Hello. World &nbsp;</p>');
   });
 
   context('Fragmented text nodes in a paragraph', () => {

--- a/modules/tinymce/src/core/test/ts/browser/util/UtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/UtilsTest.ts
@@ -1,0 +1,22 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { SelectorFind } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+import * as Utils from '../../../../main/ts/textpatterns/utils/Utils';
+
+describe('atomic.tinymce.core.util.UtilsTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce'
+  }, [], true);
+
+  it('Utils.cleanEmptyNodes', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>a<strong id="tagToClean"> </strong>b</p>');
+
+    const emptyTag = SelectorFind.descendant(TinyDom.body(editor), '#tagToClean').getOrDie().dom;
+    Utils.cleanEmptyNodes(editor.dom, emptyTag, (e: Node) => e === editor.dom.getRoot());
+    TinyAssertions.assertContent(editor, '<p>a b</p>');
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-9744

Description of Changes:
replace text sometime causes removal of spaces, for example in this case:

```
Hello.<strong> world</strong> &nbsp;
```

if we have a pattern that replace `world ` with `World ` after we remove the previous string and replace it we have:

```
Hello.<strong> </strong>World &nbsp;
```

so when we clean-up the `strong` tag will be removed, since it has only a space in it

this is because `applyMatches` uses [removeMarker](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/core/main/ts/textpatterns/core/InlinePattern.ts#L318-L319) that uses [cleanEmptyNodes](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/core/main/ts/textpatterns/utils/Utils.ts#L9).

To solve this I made `cleanEmptyNodes` replacing the node with its content if the content is just a white space.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
