### PR TITLE
TINY-9919: Update dialog styles to accommodate for new Keyboard Navigation html in Help dialog

### DIFF
--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -274,13 +274,27 @@
       fill: @dialog-body-text-color;
     }
 
+    strong {
+      font-weight: @font-weight-bold;
+    }
+
     ul {
-      display: block;
       list-style-type: disc;
+    }
+
+    ul,
+    ol,
+    dd {
+      padding-inline-start: 2.5rem;
+    }
+
+    ul,
+    ol,
+    dl {
+      display: block;
       margin-bottom: @pad-md;
       margin-inline-end: 0;
       margin-inline-start: 0;
-      padding-inline-start: 2.5rem;
     }
 
     .tox-form__group h1 {

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -291,8 +291,15 @@
     ul,
     ol,
     dl {
-      display: block;
       margin-bottom: @pad-md;
+    }
+
+    ul,
+    ol,
+    dl,
+    dd,
+    dt {
+      display: block;
       margin-inline-end: 0;
       margin-inline-start: 0;
     }


### PR DESCRIPTION
Related Ticket: TINY-9919

Description of Changes:
* Define styles for `dl`, `dt`, `dd`, `ol`, and `strong` elements in Oxide to accommodate for new Keyboard Navigation html in Help dialog added in https://github.com/tinymce/tinymce/pull/8665 as part of DOC-1936

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
