### PR TITLE
TINY-9885: Fix breaking summaries into 2 elements

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The floating toolbar did not occupy the entire available space when the page had a flexbox layout. #TINY-9847
 - Fixed backspace and delete keypresses within details elements. #TINY-9884
 - Applying lists did not work if the selection included a `contenteditable=false` block element. #TINY-9823
+- Inserting elements in the middle of the summary caused the appearance of 2 summaries within details elements. #TINY-9885
 
 ## 6.4.2 - 2023-04-26
 

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -1,5 +1,5 @@
 import { Arr, Optional, Type } from '@ephox/katamari';
-import { Remove, SugarElement } from '@ephox/sugar';
+import { Replication, Class, Remove, SugarElement } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
@@ -226,6 +226,19 @@ const findMarkerNode = (scope: AstNode): Optional<AstNode> => {
   return Optional.none();
 };
 
+const preventSplittingSummary = (editor: Editor): void => {
+  Arr.each(Arr.from(editor.getBody().querySelectorAll('details')), (accordion) => {
+    const summaries = Arr.filter(Arr.from(accordion.children), (node) => node.nodeName === 'SUMMARY');
+    if (summaries.length > 1) {
+      Arr.each(summaries.slice(1), (summary) => {
+        const element = SugarElement.fromDom(summary);
+        Class.remove(element, 'mce-accordion-summary');
+        Replication.mutate(element, 'p');
+      });
+    }
+  });
+};
+
 export const insertHtmlAtCaret = (editor: Editor, value: string, details: InsertContentDetails): string => {
   const selection = editor.selection;
   const dom = editor.dom;
@@ -357,6 +370,7 @@ export const insertHtmlAtCaret = (editor: Editor, value: string, details: Insert
   moveSelectionToMarker(editor, dom.get('mce_marker'));
   unmarkFragmentElements(editor.getBody());
   trimBrsFromTableCell(dom, selection.getStart());
+  preventSplittingSummary(editor);
   TransparentElements.updateCaret(editor.schema, editor.getBody(), selection.getStart());
 
   return value;

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -1,7 +1,11 @@
 import { Arr } from '@ephox/katamari';
 
+import DomTreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
 import * as Options from '../api/Options';
+import VK from '../api/util/VK';
+import * as CaretFinder from '../caret/CaretFinder';
+import CaretPosition from '../caret/CaretPosition';
 
 const preventSummaryToggle = (editor: Editor): void => {
   editor.on('click', (e) => {
@@ -35,9 +39,47 @@ const filterDetails = (editor: Editor): void => {
   });
 };
 
+const isCaretInTheBeginning = (editor: Editor, element: HTMLElement): boolean =>
+  CaretFinder.firstPositionIn(element).exists((pos) => pos.isEqual(CaretPosition.fromRangeStart(editor.selection.getRng())));
+
+const isCaretInTheEnding = (editor: Editor, element: HTMLElement): boolean =>
+  CaretFinder.lastPositionIn(element).exists((pos) => pos.isEqual(CaretPosition.fromRangeStart(editor.selection.getRng())));
+
+const preventDeletingSummary = (editor: Editor): void => {
+  editor.on('keydown', (e) => {
+    if (e.keyCode === VK.BACKSPACE || e.keyCode === VK.DELETE) {
+      const node = editor.selection.getNode();
+      const prevNode = new DomTreeWalker(node, editor.getBody()).prev2(true);
+      const startElement = editor.selection.getStart();
+      const endElement = editor.selection.getEnd();
+
+      if (startElement?.nodeName === 'SUMMARY' && startElement !== endElement && editor.dom.getParent(endElement, 'details')) {
+        e.preventDefault();
+      } else if (e.keyCode === VK.BACKSPACE && node?.nodeName === 'SUMMARY' && isCaretInTheBeginning(editor, node)) {
+        e.preventDefault();
+      } else if (e.keyCode === VK.DELETE && node?.nodeName === 'SUMMARY' && isCaretInTheEnding(editor, node)) {
+        e.preventDefault();
+      } else if (e.keyCode === VK.BACKSPACE && prevNode?.nodeName === 'SUMMARY' && isCaretInTheBeginning(editor, node)) {
+        e.preventDefault();
+      } else if (e.keyCode === VK.DELETE && node === editor.dom.getParent(node, 'details')?.lastChild && isCaretInTheEnding(editor, node)) {
+        e.preventDefault();
+      } else if (node?.nodeName !== 'SUMMARY' && prevNode?.nodeName === 'DETAILS') {
+        e.preventDefault();
+        CaretFinder.lastPositionIn(prevNode).each((position) => {
+          const node = position.getNode();
+          if (node) {
+            editor.selection.setCursorLocation(node, position.offset());
+          }
+        });
+      }
+    }
+  });
+};
+
 const setup = (editor: Editor): void => {
   preventSummaryToggle(editor);
   filterDetails(editor);
+  preventDeletingSummary(editor);
 };
 
 export {

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -1,4 +1,5 @@
 import { Arr } from '@ephox/katamari';
+import { Replication, Class, SugarElement } from '@ephox/sugar';
 
 import DomTreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
@@ -39,6 +40,7 @@ const filterDetails = (editor: Editor): void => {
   });
 };
 
+<<<<<<< HEAD
 const isCaretInTheBeginning = (editor: Editor, element: HTMLElement): boolean =>
   CaretFinder.firstPositionIn(element).exists((pos) => pos.isEqual(CaretPosition.fromRangeStart(editor.selection.getRng())));
 
@@ -76,10 +78,26 @@ const preventDeletingSummary = (editor: Editor): void => {
   });
 };
 
+const preventSplittingSummary = (editor: Editor): void => {
+  editor.on('NodeChange', () => {
+    Arr.each(Arr.from(editor.getBody().querySelectorAll('details')), (accordion) => {
+      const summaries = Arr.from(accordion.querySelectorAll('summary'));
+      if (summaries.length > 1) {
+        Arr.each(summaries.slice(1), (summary) => {
+          const element = SugarElement.fromDom(summary);
+          Class.remove(element, 'mce-accordion-summary');
+          Replication.mutate(element, 'p');
+        });
+      }
+    });
+  });
+};
+
 const setup = (editor: Editor): void => {
   preventSummaryToggle(editor);
   filterDetails(editor);
   preventDeletingSummary(editor);
+  preventSplittingSummary(editor);
 };
 
 export {

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -1,12 +1,7 @@
 import { Arr } from '@ephox/katamari';
-import { Replication, Class, SugarElement } from '@ephox/sugar';
 
-import DomTreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
 import * as Options from '../api/Options';
-import VK from '../api/util/VK';
-import * as CaretFinder from '../caret/CaretFinder';
-import CaretPosition from '../caret/CaretPosition';
 
 const preventSummaryToggle = (editor: Editor): void => {
   editor.on('click', (e) => {
@@ -40,64 +35,9 @@ const filterDetails = (editor: Editor): void => {
   });
 };
 
-<<<<<<< HEAD
-const isCaretInTheBeginning = (editor: Editor, element: HTMLElement): boolean =>
-  CaretFinder.firstPositionIn(element).exists((pos) => pos.isEqual(CaretPosition.fromRangeStart(editor.selection.getRng())));
-
-const isCaretInTheEnding = (editor: Editor, element: HTMLElement): boolean =>
-  CaretFinder.lastPositionIn(element).exists((pos) => pos.isEqual(CaretPosition.fromRangeStart(editor.selection.getRng())));
-
-const preventDeletingSummary = (editor: Editor): void => {
-  editor.on('keydown', (e) => {
-    if (e.keyCode === VK.BACKSPACE || e.keyCode === VK.DELETE) {
-      const node = editor.selection.getNode();
-      const prevNode = new DomTreeWalker(node, editor.getBody()).prev2(true);
-      const startElement = editor.selection.getStart();
-      const endElement = editor.selection.getEnd();
-
-      if (startElement?.nodeName === 'SUMMARY' && startElement !== endElement && editor.dom.getParent(endElement, 'details')) {
-        e.preventDefault();
-      } else if (e.keyCode === VK.BACKSPACE && node?.nodeName === 'SUMMARY' && isCaretInTheBeginning(editor, node)) {
-        e.preventDefault();
-      } else if (e.keyCode === VK.DELETE && node?.nodeName === 'SUMMARY' && isCaretInTheEnding(editor, node)) {
-        e.preventDefault();
-      } else if (e.keyCode === VK.BACKSPACE && prevNode?.nodeName === 'SUMMARY' && isCaretInTheBeginning(editor, node)) {
-        e.preventDefault();
-      } else if (e.keyCode === VK.DELETE && node === editor.dom.getParent(node, 'details')?.lastChild && isCaretInTheEnding(editor, node)) {
-        e.preventDefault();
-      } else if (node?.nodeName !== 'SUMMARY' && prevNode?.nodeName === 'DETAILS') {
-        e.preventDefault();
-        CaretFinder.lastPositionIn(prevNode).each((position) => {
-          const node = position.getNode();
-          if (node) {
-            editor.selection.setCursorLocation(node, position.offset());
-          }
-        });
-      }
-    }
-  });
-};
-
-const preventSplittingSummary = (editor: Editor): void => {
-  editor.on('NodeChange', () => {
-    Arr.each(Arr.from(editor.getBody().querySelectorAll('details')), (accordion) => {
-      const summaries = Arr.from(accordion.querySelectorAll('summary'));
-      if (summaries.length > 1) {
-        Arr.each(summaries.slice(1), (summary) => {
-          const element = SugarElement.fromDom(summary);
-          Class.remove(element, 'mce-accordion-summary');
-          Replication.mutate(element, 'p');
-        });
-      }
-    });
-  });
-};
-
 const setup = (editor: Editor): void => {
   preventSummaryToggle(editor);
   filterDetails(editor);
-  preventDeletingSummary(editor);
-  preventSplittingSummary(editor);
 };
 
 export {

--- a/modules/tinymce/src/core/test/ts/browser/selection/DetailsElementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/DetailsElementTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyAssertions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -64,5 +64,13 @@ describe('browser.tinymce.selection.DetailsElementTest', () => {
     editor.setContent([ createAccordion({ open: true }), createAccordion({ open: false }) ].join(''));
     TinyAssertions.assertContent(editor, [ createAccordion({ open: false }), createAccordion({ open: false }) ].join(''));
     editor.options.unset('details_serialized_state');
+  });
+
+  it('TINY-9885: Should prevent 2 summaries appearing in details elements', () => {
+    const editor = hook.editor();
+    editor.setContent([ createAccordion({ summary: 'helloworld', open: true }) ].join(''));
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 'hello'.length);
+    editor.execCommand('InsertHorizontalRule');
+    TinyAssertions.assertContentPresence(editor, { 'details > summary:first-child': 1 });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/selection/DetailsElementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/DetailsElementTest.ts
@@ -68,9 +68,9 @@ describe('browser.tinymce.selection.DetailsElementTest', () => {
 
   it('TINY-9885: Should prevent 2 summaries appearing in details elements', () => {
     const editor = hook.editor();
-    editor.setContent([ createAccordion({ summary: 'helloworld', open: true }) ].join(''));
+    editor.setContent([ createAccordion({ summary: 'helloworld', body: '<p>body</p>', open: true }) ].join(''));
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 'hello'.length);
     editor.execCommand('InsertHorizontalRule');
-    TinyAssertions.assertContentPresence(editor, { 'details > summary:first-child': 1 });
+    TinyAssertions.assertContent(editor, createAccordion({ summary: 'hello', body: '<hr><p>world</p><p>body</p>', open: true }));
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9885

Description of Changes:
* Fixed breaking summaries into 2 elements when inserting a table or a horizontal rule inside.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
