### PR TITLE
TINY-9928: Remove fallback string literal and use loading from English file as fallback

### DIFF
--- a/modules/tinymce/src/plugins/help/main/ts/ui/KeyboardNavTabI18n.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/KeyboardNavTabI18n.ts
@@ -1,97 +1,13 @@
-import { Fun } from '@ephox/katamari';
-
 import Editor from 'tinymce/core/api/Editor';
 import Resource from 'tinymce/core/api/Resource';
 import I18n from 'tinymce/core/api/util/I18n';
 
-const fallback = `<h1>Begin keyboard navigation</h1>
-<dl>
-  <dt>Focus the Menu bar</dt>
-  <dd>Windows or Linux: Alt+F9</dd>
-  <dd>macOS: &#x2325;F9</dd>
-  <dt>Focus the Toolbar</dt>
-  <dd>Windows or Linux: Alt+F10</dd>
-  <dd>macOS: &#x2325;F10</dd>
-  <dt>Focus the footer</dt>
-  <dd>Windows or Linux: Alt+F11</dd>
-  <dd>macOS: &#x2325;F11</dd>
-  <dt>Focus a contextual toolbar</dt>
-  <dd>Windows, Linux or macOS: Ctrl+F9
-</dl>
+const pLoadHtmlByLangCode = (baseUrl: string, langCode: string): Promise<string> =>
+  Resource.load(`tinymce.html-i18n.help-keynav.${langCode}`, `${baseUrl}/js/i18n/keynav/${langCode}.js`);
 
-<p>Navigation will start at the first UI item, which will be highlighted, or underlined in the case of the first item in the Footer element path.</p>
-
-
-<h1>Navigate between UI sections</h1>
-
-<p>To move from one UI section to the next, press <strong>Tab</strong>.</p>
-
-<p>To move from one UI section to the previous, press <strong>Shift+Tab</strong>.</p>
-
-<p>The <strong>Tab</strong> order of these UI sections is:
-
-<ol>
-<li>Menu bar</li>
-<li>Each toolbar group</li>
-<li>Sidebar</li>
-<li>Element path in the footer</li>
-<li>Word count toggle button in the footer</li>
-<li>Branding link in the footer</li>
-<li>Editor resize handle in the footer</li>
-</ol>
-
-<p>If a UI section is not present, it is skipped.</p>
-
-<p>If the footer has keyboard navigation focus, and there is no visible sidebar, pressing <strong>Shift+Tab</strong> moves focus to the first toolbar group, not the last.
-
-<h1>Navigate within UI sections</h1>
-
-<p>To move from one UI element to the next, press the appropriate <strong>Arrow</strong> key.</p>
-
-<p>The <strong>Left</strong> and <strong>Right</strong> arrow keys</p>
-
-<ul>
-<li>move between menus in the menu bar.</li>
-<li>open a sub-menu in a menu.</li>
-<li>move between buttons in a toolbar group.</li>
-<li>move between items in the footer’s element path.</li>
-</ul>
-
-<p>The <strong>Down</strong> and <strong>Up</strong> arrow keys
-
-<ul>
-<li>move between menu items in a menu.</li>
-<li>move between items in a toolbar pop-up menu.</li>
-</ul>
-
-<p><strong>Arrow</strong> keys cycle within the focused UI section.</p>
-
-<p>To close an open menu, an open sub-menu, or an open pop-up menu, press the <strong>Esc</strong> key.
-
-<p>If the current focus is at the ‘top’ of a particular UI section, pressing the <strong>Esc</strong> key also exits keyboard navigation entirely.</p>
-
-<h1>Execute a menu item or toolbar button</h1>
-
-<p>When the desired menu item or toolbar button is highlighted, press <strong>Return</strong>, <strong>Enter</strong>, or the <strong>Space bar</strong> to execute the item.
-
-<h1>Navigate non-tabbed dialogs</h1>
-
-<p>In non-tabbed dialogs, the first interactive component takes focus when the dialog opens.</p>
-
-<p>Navigate between interactive dialog components by pressing <strong>Tab</strong> or <strong>Shift+Tab</strong>.</p>
-
-<h1>Navigate tabbed dialogs</h1>
-
-<p>In tabbed dialogs, the first button in the tab menu takes focus when the dialog opens.</p>
-
-<p>Navigate between interactive components of this dialog tab by pressing <strong>Tab</strong> or <strong>Shift+Tab</strong>.</p>
-
-<p>Switch to another dialog tab by giving the tab menu focus and then pressing the appropriate <strong>Arrow</strong> key to cycle through the available tabs.</p>`;
-
-const pLoadI18nHtml = (baseUrl: string): Promise<string> => {
-  const langCode = I18n.getCode();
-  return Resource.load(`tinymce.html-i18n.help-keynav.${langCode}`, `${baseUrl}/js/i18n/keynav/${langCode}.js`).catch(Fun.constant(fallback));
-};
+const pLoadI18nHtml = (baseUrl: string): Promise<string> =>
+  // TINY-9928: Load language file for the current language, or English if the file is not available
+  pLoadHtmlByLangCode(baseUrl, I18n.getCode()).catch(() => pLoadHtmlByLangCode(baseUrl, 'en'));
 
 const initI18nLoad = (editor: Editor, baseUrl: string): void => {
   editor.on('init', () => {

--- a/modules/tinymce/src/plugins/help/test/ts/browser/KeyboardNavTabI18nTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/KeyboardNavTabI18nTest.ts
@@ -1,7 +1,8 @@
 import { Mouse, UiFinder } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
-import { SugarBody } from '@ephox/sugar';
+import { before, context, describe, it } from '@ephox/bedrock-client';
+import { SugarBody, SugarElement } from '@ephox/sugar';
 import { McEditor, TinyUiActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
@@ -18,18 +19,41 @@ describe('browser.tinymce.plugins.help.KeyboardNavTabI18nTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   };
 
-  const testLanguage = async (firstWord: string, language?: string): Promise<void> => {
-    const editor = await McEditor.pFromSettings<Editor>({ ...baseSettings, language });
+  const createEditorWithLanguage = (language?: string): Promise<Editor> => McEditor.pFromSettings<Editor>({ ...baseSettings, language });
+
+  const openHelpDialogKeyboardNavigationTab = async (editor: Editor): Promise<SugarElement<Element>> => {
     editor.execCommand('mceHelp');
     const dialogEl = await TinyUiActions.pWaitForDialog(editor);
     Mouse.trueClickOn(SugarBody.body(), `.tox-dialog__body-nav-item:nth-child(2)`);
-    UiFinder.exists(dialogEl, `h1:contains("${firstWord}")`);
-    McEditor.remove(editor);
+    return dialogEl;
   };
 
-  it('TINY-9633: Can load English by default', () => testLanguage('Begin'));
+  context('Test language load', () => {
+    const testLanguage = async (firstWord: string, language?: string): Promise<void> => {
+      const editor = await createEditorWithLanguage(language);
+      const dialogEl = await openHelpDialogKeyboardNavigationTab(editor);
+      UiFinder.exists(dialogEl, `h1:contains("${firstWord}")`);
+      McEditor.remove(editor);
+    };
 
-  it('TINY-9633: Can load German translation', () => testLanguage('Grundlagen', 'de'));
+    it('TINY-9633: Can load English by default', () => testLanguage('Begin'));
+    it('TINY-9633: Can load German translation', () => testLanguage('Grundlagen', 'de'));
+    it('TINY-9633: Loads English fallback when invalid language code is specified', () => testLanguage('Begin', 'invalid'));
+  });
 
-  it('TINY-9633: Loads English fallback when invalid language code is specified', () => testLanguage('Begin', 'invalid'));
+  it('TINY-9920: Fallback HTML is the same as the one loaded from English HTML file', async () => {
+    const getKeyboardNavHtml = async (language: string): Promise<string> => {
+      const editor = await createEditorWithLanguage(language);
+      const dialogEl = await openHelpDialogKeyboardNavigationTab(editor);
+      const keyboardNavContentEl = UiFinder.findIn(dialogEl, '.tox-dialog__body-content [role="document"]')
+        .getOrThunk(() => assert.fail('Could not find Keyboard Navigation content element'));
+      McEditor.remove(editor);
+      return keyboardNavContentEl.dom.innerHTML;
+    };
+
+    const fallbackHtml = await getKeyboardNavHtml('invalid');
+    const englishHtml = await getKeyboardNavHtml('en');
+
+    assert.equal(fallbackHtml, englishHtml, 'Fallback HTML should be the same as the one loaded from English HTML file');
+  });
 });

--- a/modules/tinymce/src/plugins/help/test/ts/browser/KeyboardNavTabI18nTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/KeyboardNavTabI18nTest.ts
@@ -37,11 +37,11 @@ describe('browser.tinymce.plugins.help.KeyboardNavTabI18nTest', () => {
     };
 
     it('TINY-9633: Can load English by default', () => testLanguage('Begin'));
-    it('TINY-9633: Can load German translation', () => testLanguage('Grundlagen', 'de'));
-    it('TINY-9633: Loads English fallback when invalid language code is specified', () => testLanguage('Begin', 'invalid'));
+    it('TINY-9633: Can load English', () => testLanguage('Begin', 'en'));
+    it('TINY-9633: Can load German', () => testLanguage('Grundlagen', 'de'));
   });
 
-  it('TINY-9920: Fallback HTML is the same as the one loaded from English HTML file', async () => {
+  it('TINY-9920: Fallback HTML is the same as the HTML loaded from English file', async () => {
     const getKeyboardNavHtml = async (language: string): Promise<string> => {
       const editor = await createEditorWithLanguage(language);
       const dialogEl = await openHelpDialogKeyboardNavigationTab(editor);


### PR DESCRIPTION
Related Ticket: TINY-9928

Description of Changes:
* Remove fallback string literal and use loading from English file as fallback
* Add test that fallback is the same as the html loaded from English file

Pre-checks:
* [x] ~Changelog entry added~ Added in https://github.com/tinymce/tinymce/pull/8764
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
