### PR TITLE
TINY-9861: Resurrect the pad_empty_with_br option

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- New `pad_empty_with_br` option that can be set to `true` to pad empty block elements with `<br>` tag instead of nbsp character. #TINY-9861
+
 ### Changed
 - The pattern replacement removes spaces if they were contained in a tag that only contains a space and the text to replace. #TINY-9744
 

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -323,6 +323,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   noneditable_class: string;
   noneditable_regexp: RegExp[];
   object_resizing: string;
+  pad_empty_with_br: boolean;
   paste_as_text: boolean;
   preview_styles: string;
   promotion: boolean;

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -168,6 +168,7 @@ interface BaseEditorOptions {
   noneditable_regexp?: RegExp | RegExp[];
   nowrap?: boolean;
   object_resizing?: boolean | string;
+  pad_empty_with_br?: boolean;
   paste_as_text?: boolean;
   paste_block_drop?: boolean;
   paste_data_images?: boolean;

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -568,6 +568,11 @@ const register = (editor: Editor): void => {
     default: true
   });
 
+  registerOption('pad_empty_with_br', {
+    processor: 'boolean',
+    default: false,
+  });
+
   registerOption('inline_styles', {
     processor: 'boolean',
     default: true,

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -62,6 +62,7 @@ export interface DomParserSettings {
   forced_root_block?: boolean | string;
   forced_root_block_attrs?: Record<string, string>;
   inline_styles?: boolean;
+  pad_empty_with_br?: boolean;
   preserve_cdata?: boolean;
   /**
    * @deprecated Remove trailing <br> tags functionality has been added to tinymce.dom.Serializer and option will be removed in the next major release */
@@ -216,7 +217,7 @@ const whitespaceCleaner = (root: AstNode, schema: Schema, settings: DomParserSet
         const isNodeEmpty = isEmpty(schema, nonEmptyElements, whitespaceElements, node);
 
         if (elementRule.paddInEmptyBlock && isNodeEmpty && isTextRootBlockEmpty(node)) {
-          paddEmptyNode(args, isBlock, node);
+          paddEmptyNode(settings, args, isBlock, node);
         } else if (elementRule.removeEmpty && isNodeEmpty) {
           if (isBlock(node)) {
             node.remove();
@@ -224,7 +225,7 @@ const whitespaceCleaner = (root: AstNode, schema: Schema, settings: DomParserSet
             node.unwrap();
           }
         } else if (elementRule.paddEmpty && (isNodeEmpty || isPaddedWithNbsp(node))) {
-          paddEmptyNode(args, isBlock, node);
+          paddEmptyNode(settings, args, isBlock, node);
         }
       }
     } else if (node.type === 3) {

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
@@ -195,7 +195,7 @@ const register = (htmlParser: DomParser, settings: DomSerializerSettings, dom: D
   // make it possible to place the caret inside empty blocks. This logic tries to remove
   // these elements and keep br elements that where intended to be there intact
   if (settings.remove_trailing_brs) {
-    RemoveTrailingBr.addNodeFilter(htmlParser, htmlParser.schema);
+    RemoveTrailingBr.addNodeFilter(settings, htmlParser, htmlParser.schema);
   }
 };
 

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerImpl.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerImpl.ts
@@ -92,6 +92,7 @@ const DomSerializerImpl = (settings: DomSerializerSettings, editor?: Editor): Do
   const defaultedSettings: DomSerializerSettings = {
     entity_encoding: 'named',
     remove_trailing_brs: true,
+    pad_empty_with_br: false,
     ...settings
   };
 

--- a/modules/tinymce/src/core/main/ts/dom/RemoveTrailingBr.ts
+++ b/modules/tinymce/src/core/main/ts/dom/RemoveTrailingBr.ts
@@ -24,7 +24,7 @@ export const addNodeFilter = (settings: DomSerializerSettings, htmlParser: DomPa
       let node: AstNode | null = nodes[i];
       let parent = node.parent;
 
-      if (parent && blockElements[parent.name] && node === parent.lastChild) {
+      if (parent && isBlock(parent) && node === parent.lastChild) {
         // Loop all nodes to the left of the current node and check for other BR elements
         // excluding bookmarks since they are invisible
         let prev = node.prev;

--- a/modules/tinymce/src/core/main/ts/dom/RemoveTrailingBr.ts
+++ b/modules/tinymce/src/core/main/ts/dom/RemoveTrailingBr.ts
@@ -6,8 +6,9 @@ import Schema from '../api/html/Schema';
 import Tools from '../api/util/Tools';
 import * as TransparentElements from '../content/TransparentElements';
 import { isEmpty, paddEmptyNode } from '../html/ParserUtils';
+import { DomSerializerSettings } from './DomSerializerImpl';
 
-export const addNodeFilter = (htmlParser: DomParser, schema: Schema): void => {
+export const addNodeFilter = (settings: DomSerializerSettings, htmlParser: DomParser, schema: Schema): void => {
   htmlParser.addNodeFilter('br', (nodes, _, args) => {
     const blockElements = Tools.extend({}, schema.getBlockElements());
     const nonEmptyElements = schema.getNonEmptyElements();
@@ -16,7 +17,7 @@ export const addNodeFilter = (htmlParser: DomParser, schema: Schema): void => {
     // Remove brs from body element as well
     blockElements.body = 1;
 
-    const isBlock = (node: AstNode) => node.name in blockElements && TransparentElements.isTransparentAstInline(schema, node);
+    const isBlock = (node: AstNode) => node.name in blockElements || TransparentElements.isTransparentAstInline(schema, node);
 
     // Must loop forwards since it will otherwise remove all brs in <p>a<br><br><br></p>
     for (let i = 0, l = nodes.length; i < l; i++) {
@@ -54,7 +55,7 @@ export const addNodeFilter = (htmlParser: DomParser, schema: Schema): void => {
               if (elementRule.removeEmpty) {
                 parent.remove();
               } else if (elementRule.paddEmpty) {
-                paddEmptyNode(args, isBlock, parent);
+                paddEmptyNode(settings, args, isBlock, parent);
               }
             }
           }

--- a/modules/tinymce/src/core/main/ts/dom/RemoveTrailingBr.ts
+++ b/modules/tinymce/src/core/main/ts/dom/RemoveTrailingBr.ts
@@ -17,7 +17,7 @@ export const addNodeFilter = (settings: DomSerializerSettings, htmlParser: DomPa
     // Remove brs from body element as well
     blockElements.body = 1;
 
-    const isBlock = (node: AstNode) => node.name in blockElements || TransparentElements.isTransparentAstInline(schema, node);
+    const isBlock = (node: AstNode) => node.name in blockElements || TransparentElements.isTransparentAstBlock(schema, node);
 
     // Must loop forwards since it will otherwise remove all brs in <p>a<br><br><br></p>
     for (let i = 0, l = nodes.length; i < l; i++) {

--- a/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
@@ -36,7 +36,7 @@ const register = (parser: DomParser, settings: DomParserSettings): void => {
   const schema = parser.schema;
 
   if (settings.remove_trailing_brs) {
-    RemoveTrailingBr.addNodeFilter(parser, schema);
+    RemoveTrailingBr.addNodeFilter(settings, parser, schema);
   }
 
   parser.addAttributeFilter('href', (nodes) => {

--- a/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
@@ -1,13 +1,13 @@
 import { Optional, Type, Unicode } from '@ephox/katamari';
 
-import { ParserArgs } from '../api/html/DomParser';
+import { DomParserSettings, ParserArgs } from '../api/html/DomParser';
 import AstNode from '../api/html/Node';
 import Schema, { SchemaMap } from '../api/html/Schema';
 
-const paddEmptyNode = (args: ParserArgs, isBlock: (node: AstNode) => boolean, node: AstNode): void => {
-  if (args.insert && isBlock(node)) {
+const paddEmptyNode = (settings: DomParserSettings, args: ParserArgs, isBlock: (node: AstNode) => boolean, node: AstNode): void => {
+  const brPreferred = settings.pad_empty_with_br || args.insert;
+  if (brPreferred && isBlock(node)) {
     const astNode = new AstNode('br', 1);
-    astNode.attr('data-mce-bogus', '1');
     node.empty().append(astNode);
   } else {
     node.empty().append(new AstNode('#text', 3)).value = Unicode.nbsp;

--- a/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
@@ -8,6 +8,9 @@ const paddEmptyNode = (settings: DomParserSettings, args: ParserArgs, isBlock: (
   const brPreferred = settings.pad_empty_with_br || args.insert;
   if (brPreferred && isBlock(node)) {
     const astNode = new AstNode('br', 1);
+    if (args.insert) {
+      astNode.attr('data-mce-bogus', '1');
+    }
     node.empty().append(astNode);
   } else {
     node.empty().append(new AstNode('#text', 3)).value = Unicode.nbsp;

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -112,6 +112,7 @@ const mkSerializerSettings = (editor: Editor): DomSerializerSettings => {
     ...removeUndefined<DomSerializerSettings>({
       // SerializerSettings
       remove_trailing_brs: getOption('remove_trailing_brs'),
+      pad_empty_with_br: getOption('pad_empty_with_br'),
       url_converter: getOption('url_converter'),
       url_converter_scope: getOption('url_converter_scope'),
 

--- a/modules/tinymce/src/core/test/ts/browser/PadEmptyWithBrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/PadEmptyWithBrTest.ts
@@ -4,7 +4,7 @@ import { TinyAssertions, TinySelections, TinyHooks } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
 
-describe('browser.tinymce.core.EditorPaddEmptyWithBrTest', () => {
+describe('browser.tinymce.core.EditorPadEmptyWithBrTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     add_unload_trigger: false,
     disable_nodechange: true,

--- a/modules/tinymce/src/core/test/ts/browser/PadEmptyWithBrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/PadEmptyWithBrTest.ts
@@ -1,33 +1,38 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { describe, context, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
 import { TinyAssertions, TinySelections, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Theme from 'tinymce/themes/silver/Theme';
 
 describe('browser.tinymce.core.EditorPadEmptyWithBrTest', () => {
-  const hook = TinyHooks.bddSetupLight<Editor>({
-    add_unload_trigger: false,
-    disable_nodechange: true,
-    custom_elements: 'custom1,~custom2',
-    extended_valid_elements: 'custom1,custom2,script[*]',
-    entities: 'raw',
-    indent: false,
-    base_url: '/project/tinymce/js/tinymce',
-    pad_empty_with_br: true,
-    remove_trailing_brs: false,
-  }, [ Theme ]);
+  Arr.each([ false, true ], (remove_trailing_brs: boolean) => {
+    context(`remove_trailing_brs: ${remove_trailing_brs}`, () => {
+      const hook = TinyHooks.bddSetupLight<Editor>({
+        add_unload_trigger: false,
+        disable_nodechange: true,
+        custom_elements: 'custom1,~custom2',
+        extended_valid_elements: 'custom1,custom2,script[*]',
+        entities: 'raw',
+        indent: false,
+        base_url: '/project/tinymce/js/tinymce',
+        pad_empty_with_br: true,
+        remove_trailing_brs,
+      }, [ Theme ]);
 
-  it('TINY-9861: Pad empty elements with br', () => {
-    const editor = hook.editor();
-    editor.setContent('<p>a</p><p></p>');
-    TinyAssertions.assertContent(editor, '<p>a</p><p><br></p>');
-  });
+      it('TINY-9861: Pad empty elements with br', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>a</p><p></p>');
+        TinyAssertions.assertContent(editor, '<p>a</p><p><br></p>');
+      });
 
-  it('TINY-9861: Pad empty elements with br on insert at caret', () => {
-    const editor = hook.editor();
-    editor.setContent('<p>a</p>');
-    TinySelections.setCursor(editor, [ 0, 0 ], 1);
-    editor.insertContent('<p>b</p><p></p>');
-    TinyAssertions.assertContent(editor, '<p>a</p><p>b</p><p><br></p>');
+      it('TINY-9861: Pad empty elements with br on insert at caret', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>a</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        editor.insertContent('<p>b</p><p></p>');
+        TinyAssertions.assertContent(editor, '<p>a</p><p>b</p><p><br></p>');
+      });
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/PadEmptyWithBrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/PadEmptyWithBrTest.ts
@@ -1,0 +1,33 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinySelections, TinyHooks } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Theme from 'tinymce/themes/silver/Theme';
+
+describe('browser.tinymce.core.EditorPaddEmptyWithBrTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    add_unload_trigger: false,
+    disable_nodechange: true,
+    custom_elements: 'custom1,~custom2',
+    extended_valid_elements: 'custom1,custom2,script[*]',
+    entities: 'raw',
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce',
+    pad_empty_with_br: true,
+    remove_trailing_brs: false,
+  }, [ Theme ]);
+
+  it('TINY-9861: Pad empty elements with br', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>a</p><p></p>');
+    TinyAssertions.assertContent(editor, '<p>a</p><p><br></p>');
+  });
+
+  it('TINY-9861: Pad empty elements with br on insert at caret', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>a</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    editor.insertContent('<p>b</p><p></p>');
+    TinyAssertions.assertContent(editor, '<p>a</p><p>b</p><p><br></p>');
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
@@ -308,6 +308,17 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     assert.equal(ser.serialize(getTestElement()), '<p>test</p><p>&nbsp;</p>');
   });
 
+  it('TINY-9861: Pad empty elements with BR', () => {
+    const ser = DomSerializer({ pad_empty_with_br: true });
+
+    ser.setRules('#p,table,tr,#td,br');
+
+    setTestHtml('<p>a</p><p></p>');
+    assert.equal(ser.serialize(getTestElement()), '<p>a</p><p><br></p>');
+    setTestHtml('<p>a</p><table><tr><td><br></td></tr></table>');
+    assert.equal(ser.serialize(getTestElement()), '<p>a</p><table><tr><td><br></td></tr></table>');
+  });
+
   it('Do not padd empty elements with padded children', () => {
     const ser = DomSerializer({ fix_list_elements: true });
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
@@ -317,6 +317,11 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
     assert.equal(ser.serialize(getTestElement()), '<p>a</p><p><br></p>');
     setTestHtml('<p>a</p><table><tr><td><br></td></tr></table>');
     assert.equal(ser.serialize(getTestElement()), '<p>a</p><table><tr><td><br></td></tr></table>');
+
+    // pad empty transparent <del> element with br
+    ser.setRules('-p,br,#del');
+    setTestHtml('<del><p></p><br></del>');
+    assert.equal(ser.serialize(getTestElement()), '<del><br></del>');
   });
 
   it('Do not padd empty elements with padded children', () => {

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -753,7 +753,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
         const parser = DomParser(scenario.settings, schema);
         const root = parser.parse('<ul><li></li><li> </li><li><br /></li><li>\u00a0</li><li>a</li></ul>', { insert: true });
-        assert.equal(serializer.serialize(root), '<ul><li><br></li><li><br></li><li><br></li><li><br></li><li>a</li></ul>');
+        assert.equal(serializer.serialize(root), '<ul><li><br data-mce-bogus="1"></li><li><br data-mce-bogus="1"></li><li><br></li><li><br data-mce-bogus="1"></li><li>a</li></ul>');
       });
 
       it('Preserve space in inline span', () => {

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -735,12 +735,25 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
         assert.equal(serializer.serialize(root), '<ul><li>\u00a0</li></ul><ul><li>\u00a0</li></ul>');
       });
 
+      it('TINY-9861: Pad empty with br', () => {
+        const schema = Schema();
+        const serializer = HtmlSerializer({ }, schema);
+
+        const parser1 = DomParser({ pad_empty_with_br: true }, schema);
+        const root1 = parser1.parse('<p>a</p><p></p>');
+        assert.equal(serializer.serialize(root1), '<p>a</p><p><br></p>');
+
+        const parser2 = DomParser({ pad_empty_with_br: false }, schema);
+        const root2 = parser2.parse('<p>a</p><p></p>');
+        assert.equal(serializer.serialize(root2), '<p>a</p><p>\u00A0</p>');
+      });
+
       it('Pad empty and prefer br on insert', () => {
         const schema = Schema();
 
         const parser = DomParser(scenario.settings, schema);
         const root = parser.parse('<ul><li></li><li> </li><li><br /></li><li>\u00a0</li><li>a</li></ul>', { insert: true });
-        assert.equal(serializer.serialize(root), '<ul><li><br data-mce-bogus="1"></li><li><br data-mce-bogus="1"></li><li><br></li><li><br data-mce-bogus="1"></li><li>a</li></ul>');
+        assert.equal(serializer.serialize(root), '<ul><li><br></li><li><br></li><li><br></li><li><br></li><li>a</li></ul>');
       });
 
       it('Preserve space in inline span', () => {


### PR DESCRIPTION
Related Ticket: TINY-9861

Description of Changes:
* The `pad_empty_with_br` option ported back from tinymce5

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
