### PR TITLE
TINY-9936: Added accordion to help

### DIFF
--- a/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
@@ -19,6 +19,7 @@ export interface PluginUrl extends PartialPluginUrl {
 
 // These lists are automatically sorted when generating the dialog.
 const urls = Arr.map<PartialPluginUrl, PluginUrl>([
+  { key: 'accordion', name: 'Accordion' },
   { key: 'advlist', name: 'Advanced List' },
   { key: 'anchor', name: 'Anchor' },
   { key: 'autolink', name: 'Autolink' },


### PR DESCRIPTION
Related Ticket: TINY-9936

Description of Changes:
* Adds the accordion plugin to the help dialog.
* Not adding a changelog for this since plugin is a new documented plugin so it would just make sense that it is in the help dialog list.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
