### PR TITLE
TINY-9842: returning empty string in custom context menu update function would not fall back to native context menu

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `a` elements were allowed to have non-inline child elements when the editor schema was set to `html4`. #TINY-9805
 
 ### Fixed
+- Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842
 - Right clicking on a merge tag would result in different highlighting across browsers. #TINY-9848
 - Command + backspace would not add an undo level on Mac. #TINY-8910
 - Ctrl + backspace and Ctrl + delete would not restore correct caret position after redo. #TINY-8910

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/SilverContextMenu.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/SilverContextMenu.ts
@@ -81,9 +81,9 @@ const generateContextMenu = (contextMenus: Record<string, Menu.ContextMenuApi>, 
     // Either read and convert the list of items out of the plugin, or assume it's a standard menu item reference
     return Obj.get(contextMenus, name.toLowerCase()).map((menu) => {
       const items = menu.update(selectedElement);
-      if (Type.isString(items)) {
+      if (Type.isString(items) && Strings.isNotEmpty(Strings.trim(items))) {
         return addContextMenuGroup(acc, items.split(' '));
-      } else if (items.length > 0) {
+      } else if (Type.isArray(items) && items.length > 0) {
         // TODO: Should we add a StructureSchema check here?
         const allItems = Arr.map(items, makeContextItem);
         return addContextMenuGroup(acc, allItems);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/CustomContextMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/CustomContextMenuTest.ts
@@ -1,8 +1,8 @@
-import { Keyboard, Keys, UiFinder, Waiter } from '@ephox/agar';
+import { Keyboard, Keys, Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -109,6 +109,33 @@ describe('browser.tinymce.themes.silver.editor.contextmenu.CustomContextMenuTest
         UiFinder.exists(SugarBody.body(), 'div[title="customSubMenuItem"] div.tox-collection__item-accessory:contains("custom-shortcut")');
         UiFinder.exists(SugarBody.body(), 'div[title="customNestedMenuItem"] div.tox-collection__item-accessory:contains("custom-nested-shortcut")');
       });
+    });
+  });
+
+  context('Multiple empty context menus', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+    }, [], true);
+    before(() => {
+      const editor = hook.editor();
+      editor.ui.registry.addContextMenu('one', {
+        update: Fun.constant('')
+      });
+      editor.ui.registry.addContextMenu('two', {
+        update: Fun.constant('')
+      });
+      editor.ui.registry.addContextMenu('three', {
+        update: Fun.constant('')
+      });
+      editor.options.set('contextmenu', 'one two three');
+    });
+
+    it('TINY-9842: Multiple empty custom context menus should fallback to native context menu', () => {
+      const editor = hook.editor();
+      editor.setContent('abc');
+      TinySelections.setCursor(editor, [ 0, 0 ], 2);
+      Mouse.contextMenuOn(TinyDom.body(editor), 'p');
+      UiFinder.exists(SugarBody.body(), '.tox.tox-silver-sink.tox-tinymce-aux:empty');
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9842

Description of Changes:
* returning empty string in custom context menu update function would not fall back to native context menu

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
