### PR TITLE
TINY-9945: Ensure elements after accordion can be edited by Backspace/Delete as expected and allow select all & delete content in summary/body

### DIFF
--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -63,7 +63,7 @@ const preventDeletingSummary = (editor: Editor): void => {
         e.preventDefault();
       } else if (e.keyCode === VK.DELETE && node === editor.dom.getParent(node, 'details')?.lastChild && isCaretInTheEnding(editor, node)) {
         e.preventDefault();
-      } else if (node.nodeName !== 'SUMMARY' && prevNode?.nodeName === 'DETAILS' && editor.selection.isCollapsed() && isCaretInTheBeginning(editor, node)) {
+      } else if (node.nodeName !== 'SUMMARY' && prevNode?.nodeName === 'DETAILS' && editor.selection.isCollapsed() && (e.keyCode === VK.BACKSPACE && isCaretInTheBeginning(editor, node) || e.keyCode === VK.DELETE && editor.dom.isEmpty(node))) {
         e.preventDefault();
         CaretFinder.lastPositionIn(prevNode).each((position) => {
           const node = position.getNode();

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -47,7 +47,7 @@ const isCaretInTheEnding = (editor: Editor, element: HTMLElement): boolean =>
 
 const preventDeletingSummary = (editor: Editor): void => {
   editor.on('keydown', (e) => {
-    if (e.keyCode === VK.BACKSPACE || e.keyCode === VK.DELETE) {
+    if ((e.keyCode === VK.BACKSPACE || e.keyCode === VK.DELETE) && editor.selection.isCollapsed()) {
       const node = editor.selection.getNode();
       const prevNode = new DomTreeWalker(node, editor.getBody()).prev2(true);
       const startElement = editor.selection.getStart();
@@ -62,7 +62,7 @@ const preventDeletingSummary = (editor: Editor): void => {
         || isDeleteAndCaretAtEnd && node === editor.dom.getParent(node, 'details')?.lastChild
       ) {
         e.preventDefault();
-      } else if (node.nodeName !== 'SUMMARY' && prevNode?.nodeName === 'DETAILS' && editor.selection.isCollapsed() && (isBackspaceAndCaretAtStart || e.keyCode === VK.DELETE && editor.dom.isEmpty(node))) {
+      } else if (node.nodeName !== 'SUMMARY' && prevNode?.nodeName === 'DETAILS' && (isBackspaceAndCaretAtStart || e.keyCode === VK.DELETE && editor.dom.isEmpty(node))) {
         e.preventDefault();
         CaretFinder.lastPositionIn(prevNode).each((position) => {
           const node = position.getNode();

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -63,7 +63,7 @@ const preventDeletingSummary = (editor: Editor): void => {
         e.preventDefault();
       } else if (e.keyCode === VK.DELETE && node === editor.dom.getParent(node, 'details')?.lastChild && isCaretInTheEnding(editor, node)) {
         e.preventDefault();
-      } else if (node?.nodeName !== 'SUMMARY' && prevNode?.nodeName === 'DETAILS') {
+      } else if (node.nodeName !== 'SUMMARY' && prevNode?.nodeName === 'DETAILS' && editor.selection.isCollapsed() && isCaretInTheBeginning(editor, node)) {
         e.preventDefault();
         CaretFinder.lastPositionIn(prevNode).each((position) => {
           const node = position.getNode();

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -52,7 +52,8 @@ const preventDeletingSummary = (editor: Editor): void => {
       const prevNode = new DomTreeWalker(node, editor.getBody()).prev2(true);
       const startElement = editor.selection.getStart();
       const endElement = editor.selection.getEnd();
-      const isBackspaceAndCaretAtStart = e.keyCode === VK.BACKSPACE && isCaretInTheBeginning(editor, node);
+      const isCaretAtStart = isCaretInTheBeginning(editor, node);
+      const isBackspaceAndCaretAtStart = e.keyCode === VK.BACKSPACE && isCaretAtStart;
       const isDeleteAndCaretAtEnd = e.keyCode === VK.DELETE && isCaretInTheEnding(editor, node);
 
       if (
@@ -62,7 +63,7 @@ const preventDeletingSummary = (editor: Editor): void => {
         || isDeleteAndCaretAtEnd && node === editor.dom.getParent(node, 'details')?.lastChild
       ) {
         e.preventDefault();
-      } else if (node.nodeName !== 'SUMMARY' && prevNode?.nodeName === 'DETAILS' && (isBackspaceAndCaretAtStart || e.keyCode === VK.DELETE && editor.dom.isEmpty(node))) {
+      } else if (node.nodeName !== 'SUMMARY' && prevNode?.nodeName === 'DETAILS' && (isBackspaceAndCaretAtStart || e.keyCode === VK.DELETE && isCaretAtStart && editor.dom.isEmpty(node))) {
         e.preventDefault();
         CaretFinder.lastPositionIn(prevNode).each((position) => {
           const node = position.getNode();

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionPluginTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionPluginTest.ts
@@ -7,11 +7,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import type { ToggledAccordionEvent, ToggledAllAccordionsEvent } from '../../../main/ts/api/Events';
 import AccordionPlugin from '../../../main/ts/Plugin';
-
-const createAccordion = (
-  { open = true, summary = 'Accordion summary...', body = '<p>Accordion body...</p>' }:
-  { open?: boolean; summary?: string; body?: string } = {}): string =>
-  `<details class="mce-accordion"${open ? ` open="open"` : ''}><summary class="mce-accordion-summary">${summary}</summary>${body}</details>`;
+import * as AccordionUtils from '../module/AccordionUtils';
 
 interface InsertAccordionTest {
   readonly initialContent: string;
@@ -57,7 +53,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<p>tiny</p>',
       initialCursor: [[ 0, 0 ], 'tiny'.length ],
-      assertContent: '<p>tiny</p>' + createAccordion(),
+      assertContent: '<p>tiny</p>' + AccordionUtils.createAccordion(),
       assertCursor: [[ 1, 0 ], 1 ],
     });
   });
@@ -66,7 +62,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<p><br></p>',
       initialCursor: [[ 0, 0 ], 0 ],
-      assertContent: createAccordion(),
+      assertContent: AccordionUtils.createAccordion(),
       assertCursor: [[ 0, 0 ], 1 ],
     });
   });
@@ -75,7 +71,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<ol><li>tiny</li></ol>',
       initialCursor: [[ 0, 0, 0 ], 'tiny'.length ],
-      assertContent: `<ol><li>tiny${createAccordion()}</li></ol>`,
+      assertContent: `<ol><li>tiny${AccordionUtils.createAccordion()}</li></ol>`,
       assertCursor: [[ 0, 0, 1, 0 ], 1 ],
     });
   });
@@ -84,7 +80,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<dl><dt>tiny</dt></dl>',
       initialCursor: [[ 0, 0, 0 ], 'tiny'.length ],
-      assertContent: `<dl><dt>tiny${createAccordion()}</dt></dl>`,
+      assertContent: `<dl><dt>tiny${AccordionUtils.createAccordion()}</dt></dl>`,
       assertCursor: [[ 0, 0, 1, 0 ], 1 ],
     });
   });
@@ -93,7 +89,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<dl><dd>tiny</dd></dl>',
       initialCursor: [[ 0, 0, 0 ], 'tiny'.length ],
-      assertContent: `<dl><dd>tiny${createAccordion()}</dd></dl>`,
+      assertContent: `<dl><dd>tiny${AccordionUtils.createAccordion()}</dd></dl>`,
       assertCursor: [[ 0, 0, 1, 0 ], 1 ],
     });
   });
@@ -102,25 +98,25 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<table><colgroup><col></colgroup><tbody><tr><td>&nbsp;</td></tr></tbody></table>',
       initialCursor: [[ 0, 1, 0, 0, 0 ], 0 ],
-      assertContent: `<table><colgroup><col></colgroup><tbody><tr><td>${createAccordion()}</td></tr></tbody></table>`,
+      assertContent: `<table><colgroup><col></colgroup><tbody><tr><td>${AccordionUtils.createAccordion()}</td></tr></tbody></table>`,
       assertCursor: [[ 0, 1, 0, 0, 0, 0 ], 1 ],
     });
   });
 
   it('TINY-9730: Insert an accordion into an accordion body', () => {
     testInsertingAccordion(hook.editor(), {
-      initialContent: createAccordion({ summary: 'summary', body: '<p>body</p>' }),
+      initialContent: AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' }),
       initialCursor: [[ 0, 1, 0 ], 'body'.length ],
-      assertContent: createAccordion({ summary: 'summary', body: `<p>body</p>${createAccordion()}` }),
+      assertContent: AccordionUtils.createAccordion({ summary: 'summary', body: `<p>body</p>${AccordionUtils.createAccordion()}` }),
       assertCursor: [[ 0, 2, 0 ], 1 ],
     });
   });
 
   it('TINY-9730: Do not insert an accordion inside another accordion if selection is in summary', () => {
     testInsertingAccordion(hook.editor(), {
-      initialContent: createAccordion({ summary: 'title', body: '<p>body</p>' }),
+      initialContent: AccordionUtils.createAccordion({ summary: 'title', body: '<p>body</p>' }),
       initialCursor: [[ 0, 0, 0 ], 'title'.length ],
-      assertContent: createAccordion({ summary: 'title', body: '<p>body</p>' }),
+      assertContent: AccordionUtils.createAccordion({ summary: 'title', body: '<p>body</p>' }),
       assertCursor: [[ 0, 0, 0 ], 'title'.length ],
     });
   });
@@ -130,14 +126,14 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     editor.setContent('<p>tiny</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 'tiny'.length);
     editor.execCommand('InsertAccordion');
-    TinyAssertions.assertContent(editor, createAccordion({ summary: 'tiny' }));
+    TinyAssertions.assertContent(editor, AccordionUtils.createAccordion({ summary: 'tiny' }));
     assert.equal(editor.selection.getNode().nodeName, 'SUMMARY');
     TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
   });
 
   it('TINY-9731: Remove an accordion element under the cursor', () => {
     const editor = hook.editor();
-    editor.setContent(`${createAccordion()}<p>tiny</p>`);
+    editor.setContent(`${AccordionUtils.createAccordion()}<p>tiny</p>`);
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 'tiny'.length);
     editor.execCommand('RemoveAccordion');
     TinyAssertions.assertContent(editor, '<p>tiny</p>');
@@ -146,7 +142,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
 
   it('TINY-9731: Toggle an accordion element under the cursor', () => {
     const editor = hook.editor();
-    editor.setContent(`${createAccordion({ open: true })}<p>tiny</p>`);
+    editor.setContent(`${AccordionUtils.createAccordion({ open: true })}<p>tiny</p>`);
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
     editor.execCommand('ToggleAccordion');
     TinyAssertions.assertContentPresence(editor, { 'details:not([open="open"])': 1 });
@@ -158,7 +154,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
 
   it('TINY-9731: Toggle an accordion element under the cursor with an argument', () => {
     const editor = hook.editor();
-    editor.setContent(`${createAccordion({ open: true })}<p>tiny</p>`);
+    editor.setContent(`${AccordionUtils.createAccordion({ open: true })}<p>tiny</p>`);
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
     editor.execCommand('ToggleAccordion', false, false);
     TinyAssertions.assertContentPresence(editor, { 'details:not([open="open"])': 1 });
@@ -173,7 +169,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
 
   it('TINY-9731: Toggle all accordion elements', () => {
     const editor = hook.editor();
-    editor.setContent([ createAccordion({ open: true }), createAccordion({ open: true }) ].join(''));
+    editor.setContent([ AccordionUtils.createAccordion({ open: true }), AccordionUtils.createAccordion({ open: true }) ].join(''));
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
     editor.execCommand('ToggleAllAccordions');
     TinyAssertions.assertContentPresence(editor, { 'details:not([open="open"])': 2 });
@@ -185,7 +181,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
 
   it('TINY-9731: Toggle all accordion elements with an argument', () => {
     const editor = hook.editor();
-    editor.setContent([ createAccordion({ open: true }), createAccordion({ open: true }) ].join(''));
+    editor.setContent([ AccordionUtils.createAccordion({ open: true }), AccordionUtils.createAccordion({ open: true }) ].join(''));
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
     editor.execCommand('ToggleAllAccordions', false, false);
     TinyAssertions.assertContentPresence(editor, { 'details:not([open="open"])': 2 });
@@ -200,7 +196,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
 
   it('TINY-9731: Emit the "ToggledAccordion" event', () => {
     const editor = hook.editor();
-    editor.setContent(createAccordion({ summary: 'tiny' }));
+    editor.setContent(AccordionUtils.createAccordion({ summary: 'tiny' }));
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 'tiny'.length);
     testEvent(editor, 'ToggledAccordion', 'ToggleAccordion', (event: ToggledAccordionEvent) => {
       assert.equal(event.element.nodeName, 'DETAILS');
@@ -214,7 +210,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
 
   it('TINY-9731: Emit the "ToggledAllAccordions" event', () => {
     const editor = hook.editor();
-    editor.setContent([ createAccordion({ open: true }), createAccordion({ open: false }) ].join(''));
+    editor.setContent([ AccordionUtils.createAccordion({ open: true }), AccordionUtils.createAccordion({ open: false }) ].join(''));
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 'tiny'.length);
     testEvent(editor, 'ToggledAllAccordions', 'ToggleAllAccordions', (event: ToggledAllAccordionsEvent) => {
       assert.equal(event.elements.length, 2);
@@ -240,7 +236,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
 
   it('TINY-9731: Toggle summary with ENTER keypress', () => {
     const editor = hook.editor();
-    editor.setContent(createAccordion({ summary: 'tiny' }));
+    editor.setContent(AccordionUtils.createAccordion({ summary: 'tiny' }));
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 'tiny'.length);
     TinyContentActions.keystroke(editor, Keys.enter());
     TinyAssertions.assertContentPresence(editor, { 'details:not([open="open"])': 1 });
@@ -250,7 +246,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
 
   it('TINY-9731: Leave accordion body with ENTER keypress within an empty paragraph', () => {
     const editor = hook.editor();
-    editor.setContent(createAccordion({ body: '<p>tiny</p>' }));
+    editor.setContent(AccordionUtils.createAccordion({ body: '<p>tiny</p>' }));
     TinySelections.setCursor(editor, [ 0, 1, 0 ], 'tiny'.length);
     TinyContentActions.keystroke(editor, Keys.enter());
     TinyAssertions.assertContentPresence(editor, { 'details > p': 2 });
@@ -262,7 +258,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
 
   it('TINY-9731: Do not remove the only empty paragraph when leaving accordion body with ENTER keypress', () => {
     const editor = hook.editor();
-    editor.setContent(createAccordion({ body: '<p></p>' }));
+    editor.setContent(AccordionUtils.createAccordion({ body: '<p></p>' }));
     TinySelections.setCursor(editor, [ 0, 1 ], 0);
     TinyContentActions.keystroke(editor, Keys.enter());
     TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
@@ -284,7 +280,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
 
   it('TINY-9731: Prevent BACKSPACE from removing accordion body if a cursor is after the accordion', () => {
     const editor = hook.editor();
-    editor.setContent(createAccordion({ body: '<p><br/></p>' }) + '<p><br/></p>');
+    editor.setContent(AccordionUtils.createAccordion({ body: '<p><br/></p>' }) + '<p><br/></p>');
     TinySelections.setCursor(editor, [ 1, 0 ], 0);
     TinyContentActions.keystroke(editor, Keys.backspace());
     TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
@@ -293,7 +289,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
 
   it('TINY-9884: Prevent BACKSPACE from removing accordion body if a cursor is in the accordion body', () => {
     const editor = hook.editor();
-    editor.setContent(createAccordion({ body: '<p><br/></p>' }));
+    editor.setContent(AccordionUtils.createAccordion({ body: '<p><br/></p>' }));
     TinySelections.setCursor(editor, [ 0, 1 ], 0);
     TinyContentActions.keystroke(editor, Keys.backspace());
     TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
@@ -302,7 +298,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
 
   it('TINY-9884: Prevent BACKSPACE from removing summary', () => {
     const editor = hook.editor();
-    editor.setContent(createAccordion({ summary: '' }));
+    editor.setContent(AccordionUtils.createAccordion({ summary: '' }));
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
     TinyContentActions.keystroke(editor, Keys.backspace());
     TinyAssertions.assertContentPresence(editor, { 'details > summary': 1 });
@@ -311,7 +307,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
 
   it('TINY-9884: Prevent BACKSPACE from removing summary when summary and details content are selected', () => {
     const editor = hook.editor();
-    editor.setContent(createAccordion({ summary: 'summary', body: '<p>body</p>' }));
+    editor.setContent(AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' }));
     TinySelections.setSelection(editor, [ 0, 0, 0 ], 'sum'.length, [ 0, 1, 0 ], 'bo'.length);
     TinyContentActions.keystroke(editor, Keys.backspace());
     TinyAssertions.assertContentPresence(editor, { 'details > summary': 1, 'details > p': 1 });

--- a/modules/tinymce/src/plugins/accordion/test/ts/module/AccordionUtils.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/module/AccordionUtils.ts
@@ -1,0 +1,8 @@
+const createAccordion = (
+  { open = true, summary = 'Accordion summary...', body = '<p>Accordion body...</p>' }:
+  { open?: boolean; summary?: string; body?: string } = {}): string =>
+  `<details class="mce-accordion"${open ? ` open="open"` : ''}><summary class="mce-accordion-summary">${summary}</summary>${body}</details>`;
+
+export {
+  createAccordion
+};

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
@@ -1,0 +1,52 @@
+import { RealKeys } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+import AccordionPlugin from '../../../main/ts/Plugin';
+import * as AccordionUtils from '../module/AccordionUtils';
+
+type DeletionKey = 'Backspace' | 'Delete';
+type ContentLocation = 'summary' | 'body';
+
+describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>(
+    {
+      plugins: 'accordion',
+      indent: false,
+      entities: 'raw',
+      extended_valid_elements: 'details[class|open|data-mce-open],summary[class],div[class],p',
+      base_url: '/project/tinymce/js/tinymce',
+    },
+    [ AccordionPlugin ],
+    true
+  );
+
+  const pDoBackspaceDelete = async (key: DeletionKey): Promise<void> => {
+    await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.text(key) ]);
+  };
+
+  context('Deleting content in summary or body', () => {
+    const createAccordionAndSelectAll = (editor: Editor, location: ContentLocation) => {
+      editor.setContent(AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' }));
+      if (location === 'summary') {
+        TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 'summary'.length);
+      } else {
+        TinySelections.setSelection(editor, [ 0, 1, 0 ], 0, [ 0, 1, 0 ], 'body'.length);
+      }
+    };
+
+    const testDeleteAllContentInAccordion = async (editor: Editor, contentLocation: ContentLocation, deletionKey: DeletionKey) => {
+      createAccordionAndSelectAll(editor, contentLocation);
+      await pDoBackspaceDelete(deletionKey);
+      TinyAssertions.assertContentPresence(editor, { 'details > summary': 1, 'details > p': 1 });
+      TinyAssertions.assertContent(editor, AccordionUtils.createAccordion(contentLocation === 'summary' ? { summary: '', body: '<p>body</p>' } : { summary: 'summary', body: '<p></p>' }));
+    };
+
+    it('TINY-9945: Can select all content in summary and delete it using Backspace', () => testDeleteAllContentInAccordion(hook.editor(), 'summary', 'Backspace'));
+    it('TINY-9945: Can select all content in summary and delete it using Delete', () => testDeleteAllContentInAccordion(hook.editor(), 'summary', 'Delete'));
+    it('TINY-9945: Can select all content in body and delete it using Backspace', () => testDeleteAllContentInAccordion(hook.editor(), 'body', 'Backspace'));
+    it('TINY-9945: Can select all content in body and delete it using Delete', () => testDeleteAllContentInAccordion(hook.editor(), 'body', 'Delete'));
+  });
+});

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
@@ -53,34 +53,43 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
   });
 
   context('Backspace/delete in element immediately after accordion', () => {
-    const createAccordionWithParagraphAfter = (editor: Editor) =>
-      editor.setContent(`${AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' })}<p>x</p>`);
+    const createAccordionWithParagraphAfter = (editor: Editor, content: string) =>
+      editor.setContent(`${AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' })}<p>${content}</p>`);
+    const createAccordionWithSingleCharacterParagraphAfter = (editor: Editor) => createAccordionWithParagraphAfter(editor, 'a');
+    const createAccordionWithThreeCharacterParagraphAfter = (editor: Editor) => createAccordionWithParagraphAfter(editor, 'abc');
+    const createAccordionWithEmptyParagraphAfter = (editor: Editor) => createAccordionWithParagraphAfter(editor, '');
 
-    const createAccordionWithEmptyParagraphAfter = (editor: Editor) =>
-      editor.setContent(`${AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' })}<p></p>`);
-
-    const assertAccordionWithParagraphAfter = (editor: Editor) =>
-      TinyAssertions.assertContent(editor, `${AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' })}<p>x</p>`);
-
-    const assertAccordionWithEmptyParagraphAfter = (editor: Editor) =>
-      TinyAssertions.assertContent(editor, `${AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' })}<p></p>`);
+    const assertAccordionWithParagraphAfter = (editor: Editor, content: string) =>
+      TinyAssertions.assertContent(editor, `${AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' })}<p>${content}</p>`);
+    const assertAccordionWithSingleCharacterParagraphAfter = (editor: Editor) => assertAccordionWithParagraphAfter(editor, 'a');
+    const assertAccordionWithEmptyParagraphAfter = (editor: Editor) => assertAccordionWithParagraphAfter(editor, '');
 
     const assertAccordionWithParagraphAfterStructure = (editor: Editor) =>
       TinyAssertions.assertContentPresence(editor, { 'details > summary': 1, 'details > p': 1, 'p': 2 });
 
     it('TINY-9945: Can delete content in non-empty element immediately after accordion using BACKSPACE if caret is at end', async () => {
       const editor = hook.editor();
-      createAccordionWithParagraphAfter(editor);
-      TinySelections.setCursor(editor, [ 1, 0 ], 'x'.length);
+      createAccordionWithSingleCharacterParagraphAfter(editor);
+      TinySelections.setCursor(editor, [ 1, 0 ], 'a'.length);
       await pDoBackspace();
       assertAccordionWithParagraphAfterStructure(editor);
       assertAccordionWithEmptyParagraphAfter(editor);
       TinyAssertions.assertCursor(editor, [ 1 ], 0);
     });
 
+    it('TINY-9945: Can delete content in non-empty element immediately after accordion using BACKSPACE if caret is in middle', async () => {
+      const editor = hook.editor();
+      createAccordionWithThreeCharacterParagraphAfter(editor);
+      TinySelections.setCursor(editor, [ 1, 0 ], 'a'.length);
+      await pDoBackspace();
+      assertAccordionWithParagraphAfterStructure(editor);
+      assertAccordionWithParagraphAfter(editor, 'bc');
+      TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
+    });
+
     it('TINY-9945: Can delete content in non-empty element immediately after accordion using DELETE if caret is at start', async () => {
       const editor = hook.editor();
-      createAccordionWithParagraphAfter(editor);
+      createAccordionWithSingleCharacterParagraphAfter(editor);
       TinySelections.setCursor(editor, [ 1, 0 ], 0);
       await pDoDelete();
       assertAccordionWithParagraphAfterStructure(editor);
@@ -88,14 +97,24 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
       TinyAssertions.assertCursor(editor, [ 1 ], 0);
     });
 
-    it('TINY-9945: Should do nothing on DELETE if cursor is at end of non-empty immediately after accordion', async () => {
+    it('TINY-9945: Can delete content in non-empty element immediately after accordion using DELETE if caret is in middle', async () => {
       const editor = hook.editor();
-      createAccordionWithParagraphAfter(editor);
-      TinySelections.setCursor(editor, [ 1, 0 ], 'x'.length);
+      createAccordionWithThreeCharacterParagraphAfter(editor);
+      TinySelections.setCursor(editor, [ 1, 0 ], 1);
       await pDoDelete();
       assertAccordionWithParagraphAfterStructure(editor);
-      assertAccordionWithParagraphAfter(editor);
-      TinyAssertions.assertCursor(editor, [ 1, 0 ], 'x'.length);
+      assertAccordionWithParagraphAfter(editor, 'ac');
+      TinyAssertions.assertCursor(editor, [ 1, 0 ], 1);
+    });
+
+    it('TINY-9945: Should do nothing on DELETE if cursor is at end of non-empty immediately after accordion', async () => {
+      const editor = hook.editor();
+      createAccordionWithSingleCharacterParagraphAfter(editor);
+      TinySelections.setCursor(editor, [ 1, 0 ], 'a'.length);
+      await pDoDelete();
+      assertAccordionWithParagraphAfterStructure(editor);
+      assertAccordionWithSingleCharacterParagraphAfter(editor);
+      TinyAssertions.assertCursor(editor, [ 1, 0 ], 'a'.length);
     });
 
     it('TINY-9945: Caret should move to end of details in accordion after pressing BACKSPACE in empty element immediately after accordion', async () => {
@@ -110,11 +129,11 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
 
     it('TINY-9945: Caret should move to end of details in accordion after pressing BACKSPACE in non-empty element immediately after accordion if caret is at start', async () => {
       const editor = hook.editor();
-      createAccordionWithParagraphAfter(editor);
+      createAccordionWithSingleCharacterParagraphAfter(editor);
       TinySelections.setCursor(editor, [ 1, 0 ], 0);
       await pDoBackspace();
       assertAccordionWithParagraphAfterStructure(editor);
-      assertAccordionWithParagraphAfter(editor);
+      assertAccordionWithSingleCharacterParagraphAfter(editor);
       TinyAssertions.assertCursor(editor, [ 0, 1, 0 ], 'body'.length);
     });
 

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
@@ -26,6 +26,8 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
   const pDoBackspaceDelete = async (key: DeletionKey): Promise<void> => {
     await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.text(key) ]);
   };
+  const pDoBackspace = () => pDoBackspaceDelete('Backspace');
+  const pDoDelete = () => pDoBackspaceDelete('Delete');
 
   context('Deleting content in summary or body', () => {
     const createAccordionAndSelectAll = (editor: Editor, location: ContentLocation) => {
@@ -48,5 +50,82 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
     it('TINY-9945: Can select all content in summary and delete it using Delete', () => testDeleteAllContentInAccordion(hook.editor(), 'summary', 'Delete'));
     it('TINY-9945: Can select all content in body and delete it using Backspace', () => testDeleteAllContentInAccordion(hook.editor(), 'body', 'Backspace'));
     it('TINY-9945: Can select all content in body and delete it using Delete', () => testDeleteAllContentInAccordion(hook.editor(), 'body', 'Delete'));
+  });
+
+  context('Backspace/delete in element immediately after accordion', () => {
+    const createAccordionWithParagraphAfter = (editor: Editor) =>
+      editor.setContent(`${AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' })}<p>x</p>`);
+
+    const createAccordionWithEmptyParagraphAfter = (editor: Editor) =>
+      editor.setContent(`${AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' })}<p></p>`);
+
+    const assertAccordionWithParagraphAfter = (editor: Editor) =>
+      TinyAssertions.assertContent(editor, `${AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' })}<p>x</p>`);
+
+    const assertAccordionWithEmptyParagraphAfter = (editor: Editor) =>
+      TinyAssertions.assertContent(editor, `${AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' })}<p></p>`);
+
+    const assertAccordionWithParagraphAfterStructure = (editor: Editor) =>
+      TinyAssertions.assertContentPresence(editor, { 'details > summary': 1, 'details > p': 1, 'p': 2 });
+
+    it('TINY-9945: Can delete content in non-empty element immediately after accordion using BACKSPACE if caret is at end', async () => {
+      const editor = hook.editor();
+      createAccordionWithParagraphAfter(editor);
+      TinySelections.setCursor(editor, [ 1, 0 ], 'x'.length);
+      await pDoBackspace();
+      assertAccordionWithParagraphAfterStructure(editor);
+      assertAccordionWithEmptyParagraphAfter(editor);
+      TinyAssertions.assertCursor(editor, [ 1 ], 0);
+    });
+
+    it('TINY-9945: Can delete content in non-empty element immediately after accordion using DELETE if caret is at start', async () => {
+      const editor = hook.editor();
+      createAccordionWithParagraphAfter(editor);
+      TinySelections.setCursor(editor, [ 1, 0 ], 0);
+      await pDoDelete();
+      assertAccordionWithParagraphAfterStructure(editor);
+      assertAccordionWithEmptyParagraphAfter(editor);
+      TinyAssertions.assertCursor(editor, [ 1 ], 0);
+    });
+
+    it('TINY-9945: Should do nothing on DELETE if cursor is at end of non-empty immediately after accordion', async () => {
+      const editor = hook.editor();
+      createAccordionWithParagraphAfter(editor);
+      TinySelections.setCursor(editor, [ 1, 0 ], 'x'.length);
+      await pDoDelete();
+      assertAccordionWithParagraphAfterStructure(editor);
+      assertAccordionWithParagraphAfter(editor);
+      TinyAssertions.assertCursor(editor, [ 1, 0 ], 'x'.length);
+    });
+
+    it('TINY-9945: Caret should move to end of details in accordion after pressing BACKSPACE in empty element immediately after accordion', async () => {
+      const editor = hook.editor();
+      createAccordionWithEmptyParagraphAfter(editor);
+      TinySelections.setCursor(editor, [ 1, 0 ], 0);
+      await pDoBackspace();
+      assertAccordionWithParagraphAfterStructure(editor);
+      assertAccordionWithEmptyParagraphAfter(editor);
+      TinyAssertions.assertCursor(editor, [ 0, 1, 0 ], 'body'.length);
+    });
+
+    it('TINY-9945: Caret should move to end of details in accordion after pressing BACKSPACE in non-empty element immediately after accordion if caret is at start', async () => {
+      const editor = hook.editor();
+      createAccordionWithParagraphAfter(editor);
+      TinySelections.setCursor(editor, [ 1, 0 ], 0);
+      await pDoBackspace();
+      assertAccordionWithParagraphAfterStructure(editor);
+      assertAccordionWithParagraphAfter(editor);
+      TinyAssertions.assertCursor(editor, [ 0, 1, 0 ], 'body'.length);
+    });
+
+    it('TINY-9945: Caret should move to end of details in accordion after pressing DELETE in empty element immediately after accordion', async () => {
+      const editor = hook.editor();
+      createAccordionWithEmptyParagraphAfter(editor);
+      TinySelections.setCursor(editor, [ 1, 0 ], 0);
+      await pDoDelete();
+      assertAccordionWithParagraphAfterStructure(editor);
+      assertAccordionWithEmptyParagraphAfter(editor);
+      TinyAssertions.assertCursor(editor, [ 0, 1, 0 ], 'body'.length);
+    });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9945

Description of Changes:
* Make sure elements immediately after accordion can be edited using BACKSPACE or DELETE keys as expected (resolve TINY-9884 QA failure/regression). Do not move caret back into accordion if:
  * Backspace key + caret is at not at start
  * Delete key + element is not empty
* Allow select & delete all content in summary or detail (resolve limitation)
* Refactor boolean condition in DetailsElement module

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
