### PR TITLE
TINY-9945 & TINY-9946: Improve non-collapsed selection logic for Backspace/Delete override in Accordions and convert key-driven tests to webdriver

### DIFF
--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -47,7 +47,7 @@ const isCaretInTheEnding = (editor: Editor, element: HTMLElement): boolean =>
 
 const preventDeletingSummary = (editor: Editor): void => {
   editor.on('keydown', (e) => {
-    if ((e.keyCode === VK.BACKSPACE || e.keyCode === VK.DELETE) && editor.selection.isCollapsed()) {
+    if (e.keyCode === VK.BACKSPACE || e.keyCode === VK.DELETE) {
       const node = editor.selection.getNode();
       const prevNode = new DomTreeWalker(node, editor.getBody()).prev2(true);
       const startElement = editor.selection.getStart();
@@ -55,12 +55,14 @@ const preventDeletingSummary = (editor: Editor): void => {
       const isCaretAtStart = isCaretInTheBeginning(editor, node);
       const isBackspaceAndCaretAtStart = e.keyCode === VK.BACKSPACE && isCaretAtStart;
       const isDeleteAndCaretAtEnd = e.keyCode === VK.DELETE && isCaretInTheEnding(editor, node);
+      const isCollapsed = editor.selection.isCollapsed();
 
       if (
-        startElement.nodeName === 'SUMMARY' && startElement !== endElement && !Type.isNull(editor.dom.getParent(endElement, 'details'))
-        || (isBackspaceAndCaretAtStart || isDeleteAndCaretAtEnd) && node.nodeName === 'SUMMARY'
-        || isBackspaceAndCaretAtStart && prevNode?.nodeName === 'SUMMARY'
-        || isDeleteAndCaretAtEnd && node === editor.dom.getParent(node, 'details')?.lastChild
+        !isCollapsed && startElement.nodeName === 'SUMMARY' && startElement !== endElement && !Type.isNull(editor.dom.getParent(endElement, 'details'))
+        || isCollapsed &&
+          ((isBackspaceAndCaretAtStart || isDeleteAndCaretAtEnd) && node.nodeName === 'SUMMARY'
+          || isBackspaceAndCaretAtStart && prevNode?.nodeName === 'SUMMARY'
+          || isDeleteAndCaretAtEnd && node === editor.dom.getParent(node, 'details')?.lastChild)
       ) {
         e.preventDefault();
       } else if (node.nodeName !== 'SUMMARY' && prevNode?.nodeName === 'DETAILS' && (isBackspaceAndCaretAtStart || e.keyCode === VK.DELETE && isCaretAtStart && editor.dom.isEmpty(node))) {

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionPluginTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionPluginTest.ts
@@ -1,6 +1,5 @@
-import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections, TinyContentActions, TinyAssertions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinySelections, TinyAssertions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -232,50 +231,6 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
       assert.equal(event.elements[0].nodeName, 'DETAILS');
       assert.isFalse(event.state);
     }, false);
-  });
-
-  it('TINY-9731: Toggle summary with ENTER keypress', () => {
-    const editor = hook.editor();
-    editor.setContent(AccordionUtils.createAccordion({ summary: 'tiny' }));
-    TinySelections.setCursor(editor, [ 0, 0, 0 ], 'tiny'.length);
-    TinyContentActions.keystroke(editor, Keys.enter());
-    TinyAssertions.assertContentPresence(editor, { 'details:not([open="open"])': 1 });
-    TinyContentActions.keystroke(editor, Keys.enter());
-    TinyAssertions.assertContentPresence(editor, { 'details[open="open"]': 1 });
-  });
-
-  it('TINY-9731: Leave accordion body with ENTER keypress within an empty paragraph', () => {
-    const editor = hook.editor();
-    editor.setContent(AccordionUtils.createAccordion({ body: '<p>tiny</p>' }));
-    TinySelections.setCursor(editor, [ 0, 1, 0 ], 'tiny'.length);
-    TinyContentActions.keystroke(editor, Keys.enter());
-    TinyAssertions.assertContentPresence(editor, { 'details > p': 2 });
-    TinyContentActions.keystroke(editor, Keys.enter());
-    TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
-    TinyAssertions.assertContentPresence(editor, { 'details + p': 1 });
-    TinyAssertions.assertCursor(editor, [ 1 ], 0);
-  });
-
-  it('TINY-9731: Do not remove the only empty paragraph when leaving accordion body with ENTER keypress', () => {
-    const editor = hook.editor();
-    editor.setContent(AccordionUtils.createAccordion({ body: '<p></p>' }));
-    TinySelections.setCursor(editor, [ 0, 1 ], 0);
-    TinyContentActions.keystroke(editor, Keys.enter());
-    TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
-    TinyAssertions.assertContentPresence(editor, { 'details + p': 1 });
-    TinyAssertions.assertCursor(editor, [ 1 ], 0);
-  });
-
-  it('TINY-9731: Leave accordion body with ENTER keypress within an empty paragraph for deprecated details', () => {
-    const editor = hook.editor();
-    editor.setContent(`<details open="open"><summary>summary</summary><p>tiny</p></details>`);
-    TinySelections.setCursor(editor, [ 0, 1, 0 ], 'tiny'.length);
-    TinyContentActions.keystroke(editor, Keys.enter());
-    TinyAssertions.assertContentPresence(editor, { 'details > p': 2 });
-    TinyContentActions.keystroke(editor, Keys.enter());
-    TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
-    TinyAssertions.assertContentPresence(editor, { 'details + p': 1 });
-    TinyAssertions.assertCursor(editor, [ 1 ], 0);
   });
 
   it('TINY-9760: Prevent inserting an accordion into noneditable elements', () => {

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionPluginTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionPluginTest.ts
@@ -278,41 +278,6 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     TinyAssertions.assertCursor(editor, [ 1 ], 0);
   });
 
-  it('TINY-9731: Prevent BACKSPACE from removing accordion body if a cursor is after the accordion', () => {
-    const editor = hook.editor();
-    editor.setContent(AccordionUtils.createAccordion({ body: '<p><br/></p>' }) + '<p><br/></p>');
-    TinySelections.setCursor(editor, [ 1, 0 ], 0);
-    TinyContentActions.keystroke(editor, Keys.backspace());
-    TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
-    TinyAssertions.assertCursor(editor, [ 0, 1 ], 0);
-  });
-
-  it('TINY-9884: Prevent BACKSPACE from removing accordion body if a cursor is in the accordion body', () => {
-    const editor = hook.editor();
-    editor.setContent(AccordionUtils.createAccordion({ body: '<p><br/></p>' }));
-    TinySelections.setCursor(editor, [ 0, 1 ], 0);
-    TinyContentActions.keystroke(editor, Keys.backspace());
-    TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
-    TinyAssertions.assertCursor(editor, [ 0, 1 ], 0);
-  });
-
-  it('TINY-9884: Prevent BACKSPACE from removing summary', () => {
-    const editor = hook.editor();
-    editor.setContent(AccordionUtils.createAccordion({ summary: '' }));
-    TinySelections.setCursor(editor, [ 0, 0 ], 0);
-    TinyContentActions.keystroke(editor, Keys.backspace());
-    TinyAssertions.assertContentPresence(editor, { 'details > summary': 1 });
-    TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
-  });
-
-  it('TINY-9884: Prevent BACKSPACE from removing summary when summary and details content are selected', () => {
-    const editor = hook.editor();
-    editor.setContent(AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' }));
-    TinySelections.setSelection(editor, [ 0, 0, 0 ], 'sum'.length, [ 0, 1, 0 ], 'bo'.length);
-    TinyContentActions.keystroke(editor, Keys.backspace());
-    TinyAssertions.assertContentPresence(editor, { 'details > summary': 1, 'details > p': 1 });
-  });
-
   it('TINY-9760: Prevent inserting an accordion into noneditable elements', () => {
     const editor = hook.editor();
     editor.setContent('<div contenteditable="false"><p>noneditable</p></div>');

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
@@ -29,6 +29,43 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
   const pDoBackspace = () => pDoBackspaceDelete('Backspace');
   const pDoDelete = () => pDoBackspaceDelete('Delete');
 
+  context('Backspace should not remove accordion elements', () => {
+    it('TINY-9731: Prevent BACKSPACE from removing accordion body if a cursor is after the accordion', async () => {
+      const editor = hook.editor();
+      editor.setContent(AccordionUtils.createAccordion({ body: '<p><br/></p>' }) + '<p><br/></p>');
+      TinySelections.setCursor(editor, [ 1, 0 ], 0);
+      await pDoBackspace();
+      TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
+      TinyAssertions.assertCursor(editor, [ 0, 1 ], 0);
+    });
+
+    it('TINY-9884: Prevent BACKSPACE from removing accordion body if a cursor is in the accordion body', async () => {
+      const editor = hook.editor();
+      editor.setContent(AccordionUtils.createAccordion({ body: '<p><br/></p>' }));
+      TinySelections.setCursor(editor, [ 0, 1 ], 0);
+      await pDoBackspace();
+      TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
+      TinyAssertions.assertCursor(editor, [ 0, 1 ], 0);
+    });
+
+    it('TINY-9884: Prevent BACKSPACE from removing summary', async () => {
+      const editor = hook.editor();
+      editor.setContent(AccordionUtils.createAccordion({ summary: '' }));
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+      await pDoBackspace();
+      TinyAssertions.assertContentPresence(editor, { 'details > summary': 1 });
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
+    });
+
+    it('TINY-9884: Prevent BACKSPACE from removing summary when summary and details content are selected', async () => {
+      const editor = hook.editor();
+      editor.setContent(AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' }));
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 'sum'.length, [ 0, 1, 0 ], 'bo'.length);
+      await pDoBackspace();
+      TinyAssertions.assertContentPresence(editor, { 'details > summary': 1, 'details > p': 1 });
+    });
+  });
+
   context('Deleting content in summary or body', () => {
     const createAccordionAndSelectAll = (editor: Editor, location: ContentLocation) => {
       editor.setContent(AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' }));

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
@@ -1,5 +1,6 @@
 import { RealKeys } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
+import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -49,6 +50,11 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
     });
 
     it('TINY-9884: Prevent BACKSPACE from removing summary', async () => {
+      if (PlatformDetection.detect().browser.isFirefox()) {
+        // TODO - TINY-9949: Firefox performs an incorrect selection which causes the summary to be
+        // removed unexpectedly, even though it should not be possible.
+        return;
+      }
       const editor = hook.editor();
       editor.setContent(AccordionUtils.createAccordion({ summary: '' }));
       TinySelections.setCursor(editor, [ 0, 0 ], 0);

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
@@ -49,11 +49,11 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
       TinyAssertions.assertCursor(editor, [ 0, 1 ], 0);
     });
 
-    it('TINY-9884: Prevent BACKSPACE from removing summary', async () => {
+    it('TINY-9884: Prevent BACKSPACE from removing summary', async function () {
       if (PlatformDetection.detect().browser.isFirefox()) {
         // TODO - TINY-9949: Firefox performs an incorrect selection which causes the summary to be
         // removed unexpectedly, even though it should not be possible.
-        return;
+        this.skip();
       }
       const editor = hook.editor();
       editor.setContent(AccordionUtils.createAccordion({ summary: '' }));

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionEnterTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionEnterTest.ts
@@ -7,7 +7,7 @@ import Editor from 'tinymce/core/api/Editor';
 import AccordionPlugin from '../../../main/ts/Plugin';
 import * as AccordionUtils from '../module/AccordionUtils';
 
-describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () => {
+describe('webdriver.tinymce.plugins.accordion.AccordionEnterTest', () => {
   const hook = TinyHooks.bddSetup<Editor>(
     {
       plugins: 'accordion',

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionEnterTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionEnterTest.ts
@@ -1,0 +1,70 @@
+import { RealKeys } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+import AccordionPlugin from '../../../main/ts/Plugin';
+import * as AccordionUtils from '../module/AccordionUtils';
+
+describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>(
+    {
+      plugins: 'accordion',
+      indent: false,
+      entities: 'raw',
+      extended_valid_elements: 'details[class|open|data-mce-open],summary[class],div[class],p',
+      base_url: '/project/tinymce/js/tinymce',
+    },
+    [ AccordionPlugin ],
+    true
+  );
+
+  const pDoEnter = async (): Promise<void> => {
+    await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.text('Enter') ]);
+  };
+
+  it('TINY-9731: Toggle summary with ENTER keypress', async () => {
+    const editor = hook.editor();
+    editor.setContent(AccordionUtils.createAccordion({ summary: 'tiny' }));
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 'tiny'.length);
+    await pDoEnter();
+    TinyAssertions.assertContentPresence(editor, { 'details:not([open="open"])': 1 });
+    await pDoEnter();
+    TinyAssertions.assertContentPresence(editor, { 'details[open="open"]': 1 });
+  });
+
+  it('TINY-9731: Leave accordion body with ENTER keypress within an empty paragraph', async () => {
+    const editor = hook.editor();
+    editor.setContent(AccordionUtils.createAccordion({ body: '<p>tiny</p>' }));
+    TinySelections.setCursor(editor, [ 0, 1, 0 ], 'tiny'.length);
+    await pDoEnter();
+    TinyAssertions.assertContentPresence(editor, { 'details > p': 2 });
+    await pDoEnter();
+    TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
+    TinyAssertions.assertContentPresence(editor, { 'details + p': 1 });
+    TinyAssertions.assertCursor(editor, [ 1 ], 0);
+  });
+
+  it('TINY-9731: Do not remove the only empty paragraph when leaving accordion body with ENTER keypress', async () => {
+    const editor = hook.editor();
+    editor.setContent(AccordionUtils.createAccordion({ body: '<p></p>' }));
+    TinySelections.setCursor(editor, [ 0, 1 ], 0);
+    await pDoEnter();
+    TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
+    TinyAssertions.assertContentPresence(editor, { 'details + p': 1 });
+    TinyAssertions.assertCursor(editor, [ 1 ], 0);
+  });
+
+  it('TINY-9731: Leave accordion body with ENTER keypress within an empty paragraph for deprecated details', async () => {
+    const editor = hook.editor();
+    editor.setContent(`<details open="open"><summary>summary</summary><p>tiny</p></details>`);
+    TinySelections.setCursor(editor, [ 0, 1, 0 ], 'tiny'.length);
+    await pDoEnter();
+    TinyAssertions.assertContentPresence(editor, { 'details > p': 2 });
+    await pDoEnter();
+    TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
+    TinyAssertions.assertContentPresence(editor, { 'details + p': 1 });
+    TinyAssertions.assertCursor(editor, [ 1 ], 0);
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-9945, TINY-9946

Description of Changes:
* Improve non-collapsed selection logic for Backspace/Delete override in Accordions (TINY-9945). This was overlooked in previous PR https://github.com/tinymce/tinymce/pull/8791
* After the improvement above, all key-driven Accordion tests can be converted to webdriver successfully (TINY-9946)

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
