### PR TITLE
TINY-9947: Improved help dialog readability in all languages

### DIFF
--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -62,7 +62,6 @@
 
 @dialog-table-border-color: darken(@border-color, 55%);
 @dialog-nav-focus-background-color: fade(@color-tint, 10%);
-@dialog-tab-width: 15em;
 
 // These get stacked on top of the global dialog z-index (1100)
 @z-index-dialogs-offset-wrap-background: 1;
@@ -194,8 +193,9 @@
     align-items: flex-start;
     display: flex;
     flex-direction: column;
+    flex-shrink: 0;
+    max-width: 11em;
     padding: @dialog-body-padding;
-    width: @dialog-tab-width;
 
     @media @breakpoint-sm {
       body:not(.tox-force-desktop) & {

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -62,6 +62,7 @@
 
 @dialog-table-border-color: darken(@border-color, 55%);
 @dialog-nav-focus-background-color: fade(@color-tint, 10%);
+@dialog-tab-width: 15em;
 
 // These get stacked on top of the global dialog z-index (1100)
 @z-index-dialogs-offset-wrap-background: 1;
@@ -194,6 +195,7 @@
     display: flex;
     flex-direction: column;
     padding: @dialog-body-padding;
+    width: @dialog-tab-width;
 
     @media @breakpoint-sm {
       body:not(.tox-force-desktop) & {
@@ -213,7 +215,6 @@
     line-height: @line-height-base;
     margin-bottom: @pad-sm;
     text-decoration: none;
-    white-space: nowrap;
 
     &:focus {
       background-color: @dialog-nav-focus-background-color;

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -62,6 +62,7 @@
 
 @dialog-table-border-color: darken(@border-color, 55%);
 @dialog-nav-focus-background-color: fade(@color-tint, 10%);
+@dialog-tab-max-width: 11em;
 
 // These get stacked on top of the global dialog z-index (1100)
 @z-index-dialogs-offset-wrap-background: 1;
@@ -194,7 +195,7 @@
     display: flex;
     flex-direction: column;
     flex-shrink: 0;
-    max-width: 11em;
+    max-width: @dialog-tab-max-width;
     padding: @dialog-body-padding;
 
     @media @breakpoint-sm {

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -33,11 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - If the selection contains more than one table cell, Quickbar toolbars are now positioned in the middle of the selection horizontally. #TINY-8297
 - Exposed `dataTransfer` property of drag and drop events for elements with a `contenteditable="false"` attribute. #TINY-9601
 - Screen readers now announce instructions for resizing the editor using arrow keys, when the resize handle is focused. #TINY-9793
+- Dialog `tabpanel` tab labels are now allowed to word wrap for better readability with long labels #TINY-9947
 
 ### Changed
 - The `caption`, `address` and `dt` elements no longer incorrectly allow non-inline child elements when the editor schema is set to _HTML 4_. #TINY-9768
 - SVG icons for back and foreground colors now use `class` instead of `id` to identify SVG elements that should change color. #TINY-9844
 - Anchor tag elements — `<a>` — no longer incorrectly allow non-inline child elements when the editor schema is set to _HTML 4_. #TINY-9805
+- Help dialog was restored to `medium` width for better readability #TINY-9947
 
 ### Fixed
 - Right-clicking on a merge tag instance presented different highlighting depending on the host browser. #TINY-9848

--- a/modules/tinymce/src/plugins/help/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/Dialog.ts
@@ -79,7 +79,7 @@ const init = (editor: Editor, customTabs: CustomTabSpecs, pluginUrl: string) => 
     editor.windowManager.open(
       {
         title: 'Help',
-        size: 'normal',
+        size: 'medium',
         body,
         buttons: [
           {


### PR DESCRIPTION
Related Ticket: TINY-9947

Description of Changes:
* Reverts the help dialog width change made in TinyMCE 6.4
* Enables word wrap in tab labels
* Disables `flex-shrink` to encourage text to expand
* Sets a `max-width` that approximates the intended width of the tab column

The new design restores readability necessary for the now-translated Keyboard Navigation section, while also preserving the tab width on smaller dialogs.

## Help dialog before and after, Ukrainian
![help (uk) before](https://github.com/tinymce/tinymce/assets/298292/8faad452-9952-4947-973c-dc73a1f3631d)
![help (uk) after](https://github.com/tinymce/tinymce/assets/298292/1075f0fc-2441-4aa1-9a22-bc6aaad57e9c)

## Help dialog before and after, English
![help (en) before](https://github.com/tinymce/tinymce/assets/298292/37693e19-6e67-4256-a63f-87df43101f17)
![help (en) after](https://github.com/tinymce/tinymce/assets/298292/8fc9198f-4c28-45f5-b8c0-152b602febbf)

And to confirm smaller dialogs did not change:
## Special characters before and after, Ukrainian
![special characters (uk) before](https://github.com/tinymce/tinymce/assets/298292/a44d3287-62fa-4ffa-863f-2ae87dd3b8d9)
![special characters (uk) after](https://github.com/tinymce/tinymce/assets/298292/ddcebdc1-9134-41c6-af6f-38ed6e71492a)

## Special characters before and after, English
![special character (en) before](https://github.com/tinymce/tinymce/assets/298292/8a3d3fed-9212-4d6c-af55-6acf40062ee9)
![special character (en) after](https://github.com/tinymce/tinymce/assets/298292/6fc3a9e7-7a23-4320-bb7a-c7a25f0e5bca)

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~
