### PR TITLE
TINY-9385: Identify if an element is scrollable

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exposed `dataTransfer` property of drag and drop events for elements with a `contenteditable="false"` attribute. #TINY-9601
 - Screen readers now announce instructions for resizing the editor using arrow keys, when the resize handle is focused. #TINY-9793
 - Dialog `tabpanel` tab labels are now allowed to word wrap for better readability with long labels #TINY-9947
+- Improved isScroller function to include elements with overflow-x or overflow-y set to scroll or auto as scrollable. #TINY-9385
 
 ### Changed
 - The `caption`, `address` and `dt` elements no longer incorrectly allow non-inline child elements when the editor schema is set to _HTML 4_. #TINY-9768

--- a/modules/tinymce/src/themes/silver/main/ts/modes/ScrollingContext.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/ScrollingContext.ts
@@ -19,7 +19,13 @@ const nonScrollingOverflows = [ 'visible', 'hidden' ];
 export const isScroller = (elem: SugarElement<Node> | any): boolean => {
   if (SugarNode.isHTMLElement(elem)) {
     const overflow = Css.get(elem, 'overflow');
-    return Strings.trim(overflow).length > 0 && !Arr.contains(nonScrollingOverflows, overflow);
+    const overflowX = Css.get(elem, 'overflow-x');
+    const overflowY = Css.get(elem, 'overflow-y');
+    const hasVisibleOverflow = Strings.trim(overflow).length > 0 && !Arr.contains(nonScrollingOverflows, overflow);
+    const hasVisibleOverflowX = Strings.trim(overflowX).length > 0 && !Arr.contains(nonScrollingOverflows, overflowX);
+    const hasVisibleOverflowY = Strings.trim(overflowY).length > 0 && !Arr.contains(nonScrollingOverflows, overflowY);
+
+    return hasVisibleOverflow || hasVisibleOverflowX || hasVisibleOverflowY;
   } else {
     return false;
   }

--- a/modules/tinymce/src/themes/silver/test/ts/headless/modes/ScrollingContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/modes/ScrollingContextTest.ts
@@ -34,6 +34,26 @@ describe('headless.modes.ScrollingContextTest', () => {
       const div = SugarElement.fromHtml('<div style="overflow: scroll;">A</div>');
       assert.isTrue(ScrollingContext.isScroller(div), 'Should be a scroller');
     });
+
+    it('TINY-9226: overflow-x: scroll - a scroller', () => {
+      const div = SugarElement.fromHtml('<div style="overflow-x: scroll;">A</div>');
+      assert.isTrue(ScrollingContext.isScroller(div), 'Should be a scroller');
+    });
+
+    it('TINY-9226: overflow-y: scroll - a scroller', () => {
+      const div = SugarElement.fromHtml('<div style="overflow-y: scroll;">A</div>');
+      assert.isTrue(ScrollingContext.isScroller(div), 'Should be a scroller');
+    });
+
+    it('TINY-9226: overflow-x: auto - a scroller', () => {
+      const div = SugarElement.fromHtml('<div style="overflow-x: auto;">A</div>');
+      assert.isTrue(ScrollingContext.isScroller(div), 'Should be a scroller');
+    });
+
+    it('TINY-9226: overflow-y: auto - a scroller', () => {
+      const div = SugarElement.fromHtml('<div style="overflow-y: auto;">A</div>');
+      assert.isTrue(ScrollingContext.isScroller(div), 'Should be a scroller');
+    });
   });
 
   context('detect', () => {


### PR DESCRIPTION
Related Ticket: 
https://ephocks.atlassian.net/browse/TINY-9385

Description of Changes:
- added scroller detection to cover all edge cases such as `overflow-x`, `overflow-y`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
