### PR TITLE
TINY-6888: now delete `li` in particular situation doesn't cause error

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815
-- `backspaceDeleteIntoListCaret` try to use a pointer to a removed element. #TINY-6888
+- deleting `li` with only `br`s in it sometimes caused a crush. #TINY-6888
 
 ## 6.5.0 - 2023-06-12
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815
+- `backspaceDeleteIntoListCaret` try to use a pointer to a removed element. #TINY-6888
 
 ## 6.5.0 - 2023-06-12
 

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -225,7 +225,10 @@ const backspaceDeleteIntoListCaret = (editor: Editor, isForward: boolean): boole
 
       editor.undoManager.transact(() => {
         removeBlock(dom, block, root);
-        ToggleList.mergeWithAdjacentLists(dom, otherLi.parentNode as HTMLElement);
+        const parentNode = otherLi.parentNode as HTMLElement | null;
+        if (parentNode) {
+          ToggleList.mergeWithAdjacentLists(dom, parentNode);
+        }
         editor.selection.select(otherLi, true);
         editor.selection.collapse(isForward);
       });

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -224,11 +224,9 @@ const backspaceDeleteIntoListCaret = (editor: Editor, isForward: boolean): boole
       }
 
       editor.undoManager.transact(() => {
+        const parentNode = otherLi.parentNode as HTMLElement;
         removeBlock(dom, block, root);
-        const parentNode = otherLi.parentNode as HTMLElement | null;
-        if (parentNode) {
-          ToggleList.mergeWithAdjacentLists(dom, parentNode);
-        }
+        ToggleList.mergeWithAdjacentLists(dom, parentNode);
         editor.selection.select(otherLi, true);
         editor.selection.collapse(isForward);
       });

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteFromBlockIntoLiTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteFromBlockIntoLiTest.ts
@@ -126,4 +126,12 @@ describe('Browser Test: .RemoveTrailingBlockquoteTest', () => {
     TinyContentActions.keystroke(editor, Keys.backspace());
     TinyAssertions.assertContent(editor, '<ul><li>a</li></ul>');
   });
+
+  it('TINY-6888: delete a `li` with a `br` and a `br` with `data-mce-bogus', () => {
+    const editor = hook.editor();
+    editor.setContent('<ol><li>aaa</li><li><br><br data-mce-bogus="1"></li><li>ccc</li></ol>', { format: 'raw' });
+    TinySelections.setCursor(editor, [ 0, 1 ], 0);
+    TinyContentActions.keystroke(editor, Keys.delete());
+    TinyAssertions.assertContent(editor, '<ol><li>aaa</li><li>ccc</li></ol>');
+  });
 });

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteFromBlockIntoLiTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteFromBlockIntoLiTest.ts
@@ -133,5 +133,15 @@ describe('Browser Test: .RemoveTrailingBlockquoteTest', () => {
     TinySelections.setCursor(editor, [ 0, 1 ], 0);
     TinyContentActions.keystroke(editor, Keys.delete());
     TinyAssertions.assertContent(editor, '<ol><li>aaa</li><li>ccc</li></ol>');
+
+    editor.setContent('<ol><li>aaa</li><li>foo<br><br></li><li>ccc</li></ol>', { format: 'raw' });
+    TinySelections.setSelection(editor, [ 0, 1 ], 0, [ 0, 2 ], 0);
+    TinyContentActions.keystroke(editor, Keys.delete());
+    TinyAssertions.assertContent(editor, '<ol><li>aaa</li><li>ccc</li></ol>');
+
+    editor.setContent('<ol><li>aaa</li><li>foo<br><br><br></li><li>ccc</li></ol>', { format: 'raw' });
+    TinySelections.setSelection(editor, [ 0, 1 ], 0, [ 0, 2 ], 0);
+    TinyContentActions.keystroke(editor, Keys.delete());
+    TinyAssertions.assertContent(editor, '<ol><li>aaa</li><li>ccc</li></ol>');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-6888

Description of Changes:
The problem was that when we were in a `li` and the parent of the new caret container is the same `li` we remove the `li` and then we try to use `ToggleList.mergeWithAdjacentLists` we use it on `otherLi.parentNode`, but at that point we already removed `otherLi`.

To solve this now the `otherLi.parentNode` reference is stored in a `cost` before the remove

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
