### PR TITLE
TINY-9956: Ensure consistent widths for dialog tabs between wide and thin views

### DIFF
--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -62,7 +62,8 @@
 
 @dialog-table-border-color: darken(@border-color, 55%);
 @dialog-nav-focus-background-color: fade(@color-tint, 10%);
-@dialog-tab-max-width: 11em;
+@dialog-tab-max-width: 13em;
+@dialog-tab-column-max-width: 11em;
 
 // These get stacked on top of the global dialog z-index (1100)
 @z-index-dialogs-offset-wrap-background: 1;
@@ -195,8 +196,11 @@
     display: flex;
     flex-direction: column;
     flex-shrink: 0;
-    max-width: @dialog-tab-max-width;
     padding: @dialog-body-padding;
+
+    @media @breakpoint-gt-sm {
+      max-width: @dialog-tab-column-max-width;
+    }
 
     @media @breakpoint-sm {
       body:not(.tox-force-desktop) & {
@@ -212,9 +216,11 @@
     border-bottom: 2px solid transparent;
     color: @text-color-muted;
     display: inline-block;
+    flex-shrink: 0;
     font-size: @font-size-sm;
     line-height: @line-height-base;
     margin-bottom: @pad-sm;
+    max-width: @dialog-tab-max-width;
     text-decoration: none;
 
     &:focus {

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -33,13 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - If the selection contains more than one table cell, Quickbar toolbars are now positioned in the middle of the selection horizontally. #TINY-8297
 - Exposed `dataTransfer` property of drag and drop events for elements with a `contenteditable="false"` attribute. #TINY-9601
 - Screen readers now announce instructions for resizing the editor using arrow keys, when the resize handle is focused. #TINY-9793
-- Dialog `tabpanel` tab labels are now allowed to word wrap for better readability with long labels #TINY-9947
+- Dialog `tabpanel` tab labels are now allowed to word wrap for better readability with long labels. #TINY-9947
 
 ### Changed
 - The `caption`, `address` and `dt` elements no longer incorrectly allow non-inline child elements when the editor schema is set to _HTML 4_. #TINY-9768
 - SVG icons for back and foreground colors now use `class` instead of `id` to identify SVG elements that should change color. #TINY-9844
 - Anchor tag elements — `<a>` — no longer incorrectly allow non-inline child elements when the editor schema is set to _HTML 4_. #TINY-9805
-- Help dialog was restored to `medium` width for better readability #TINY-9947
+- Help dialog was restored to `medium` width for better readability. #TINY-9947
 
 ### Fixed
 - Right-clicking on a merge tag instance presented different highlighting depending on the host browser. #TINY-9848


### PR DESCRIPTION
Related Ticket: TINY-9956

Description of Changes:
* #8796 introduced a small regression in tab widths using the thin (mobile) layout.
* To fix, `flex-shrink` and `max-width` had to be added to the individual tab elements, and the `max-width` on the tab column no longer applies in the thin layout.

Pre-checks:
* [x] ~Changelog entry added~ (it's under the same changelog as the previous ticket, unless we push the fix out to a future release)
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
