### PR TITLE
TINY-9951: Implement Safari workaround for editing content in Accordion summary using Backspace/Delete

### DIFF
--- a/modules/tinymce/src/core/main/ts/delete/InlineFormatDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/InlineFormatDelete.ts
@@ -7,7 +7,7 @@ import * as ElementType from '../dom/ElementType';
 import * as NodeType from '../dom/NodeType';
 import * as Parents from '../dom/Parents';
 import * as CaretFormat from '../fmt/CaretFormat';
-import { isCaretNode } from '../fmt/FormatContainer';
+import * as FormatContainer from '../fmt/FormatContainer';
 import * as DeleteElement from './DeleteElement';
 import * as DeleteUtils from './DeleteUtils';
 
@@ -80,7 +80,7 @@ const createCaretFormatAtStart = (editor: Editor, formatNodes: Node[]): void => 
   // otherwise create new caret format at start
   const pos = isBrInEmptyElement(editor, startElm) || isEmptyCaret(startElm)
     ? CaretFormat.replaceWithCaretFormat(startElm, formatNodes)
-    : CaretFormat.createCaretFormatAtStart(editor, formatNodes);
+    : CaretFormat.createCaretFormatAtStart(editor.selection.getRng(), formatNodes);
   editor.selection.setRng(pos.toRange());
 };
 
@@ -145,7 +145,7 @@ const backspaceDelete = (editor: Editor, forward: boolean): Optional<() => void>
   editor.selection.isCollapsed() ? deleteCaret(editor, forward) : deleteRange(editor);
 
 const hasAncestorInlineCaret = (elm: SugarElement<Node>): boolean =>
-  PredicateExists.ancestor(elm, (node) => isCaretNode(node.dom), ElementType.isBlock);
+  PredicateExists.ancestor(elm, (node) => FormatContainer.isCaretNode(node.dom), ElementType.isBlock);
 
 const hasAncestorInlineCaretAtStart = (editor: Editor): boolean =>
   hasAncestorInlineCaret(SugarElement.fromDom(editor.selection.getStart()));

--- a/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
@@ -366,9 +366,9 @@ const replaceWithCaretFormat = (targetNode: Node, formatNodes: Node[]): CaretPos
   return caretPosition;
 };
 
-const createCaretFormatAtStart = (editor: Editor, formatNodes: Node[]): CaretPosition => {
+const createCaretFormatAtStart = (rng: Range, formatNodes: Node[]): CaretPosition => {
   const { caretContainer, caretPosition } = createCaretFormat(formatNodes);
-  editor.selection.getRng().insertNode(caretContainer.dom);
+  rng.insertNode(caretContainer.dom);
 
   return caretPosition;
 };

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -1,4 +1,4 @@
-import { Arr, Singleton, Type } from '@ephox/katamari';
+import { Arr, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { SugarElement } from '@ephox/sugar';
 
@@ -10,6 +10,7 @@ import * as CaretFinder from '../caret/CaretFinder';
 import CaretPosition from '../caret/CaretPosition';
 import * as DeleteUtils from '../delete/DeleteUtils';
 import * as PaddingBr from '../dom/PaddingBr';
+import * as FormatUtils from '../fmt/FormatUtils';
 
 const preventSummaryToggle = (editor: Editor): void => {
   editor.on('click', (e) => {
@@ -61,6 +62,9 @@ const setCaretToPosition = (editor: Editor) => (position: CaretPosition): void =
 const isSummary = (node: Node | null | undefined): boolean => node?.nodeName === 'SUMMARY';
 const isDetails = (node: Node | null | undefined): boolean => node?.nodeName === 'DETAILS';
 
+const isEntireNodeSelected = (rng: Range, node: Node): boolean =>
+  rng.startOffset === 0 && rng.endOffset === node.textContent?.length;
+
 // TINY-9950: Firefox has some situations where its native behavior does not match what we expect, so
 // we have to perform Firefox-specific overrides.
 const platform = PlatformDetection.detect();
@@ -70,17 +74,16 @@ const isSafari = browser.isSafari();
 const isMacOS = platform.os.isMacOS();
 
 const preventDeletingSummary = (editor: Editor): void => {
-  const summaryAfterShortcutRangedDeletion = Singleton.value<HTMLElement>();
-
   editor.on('keydown', (e) => {
     if (e.keyCode === VK.BACKSPACE || e.keyCode === VK.DELETE) {
-      const node = editor.selection.getNode();
+      const selection = editor.selection;
+      const node = selection.getNode();
       const body = editor.getBody();
       const prevNode = new DomTreeWalker(node, body).prev2(true);
       const nextNode = new DomTreeWalker(node, body).next(true);
-      const startElement = editor.selection.getStart();
-      const endElement = editor.selection.getEnd();
-      const rng = editor.selection.getRng();
+      const startElement = selection.getStart();
+      const endElement = selection.getEnd();
+      const rng = selection.getRng();
       const isBackspace = e.keyCode === VK.BACKSPACE;
       const isCaretAtStart = isCaretInTheBeginning(rng, node);
       const isBackspaceAndCaretAtStart = isBackspace && isCaretAtStart;
@@ -119,55 +122,54 @@ const preventDeletingSummary = (editor: Editor): void => {
       } else if (isSafari && isSummary(node)) {
         // TINY-9951: Safari has a bug where upon pressing Backspace/Delete when the caret is directly within the summary,
         // all content is removed and the caret is prevented from being placed back into the summary.
-        if (isMacOS && (e.altKey || e.metaKey) || e.ctrlKey) {
-          // Allow ranged deletion by keyboard shortcuts natively, pad summary and relocate caret on keyup if needed
-          summaryAfterShortcutRangedDeletion.set(node);
+        e.preventDefault();
+
+        if (!isCollapsed && isEntireNodeSelected(rng, node) || DeleteUtils.willDeleteLastPositionInElement(isDelete, CaretPosition.fromRangeStart(rng), node)) {
+          PaddingBr.fillWithPaddingBr(SugarElement.fromDom(node));
         } else {
-          e.preventDefault();
-          if (!isCollapsed && rng.startOffset === 0 && rng.endOffset === node.textContent?.length || DeleteUtils.willDeleteLastPositionInElement(isDelete, CaretPosition.fromRangeStart(rng), node)) {
+          // Wrap all summary children in a temporary container to execute Backspace/Delete there, then unwrap
+          const sel = selection.getSel();
+          let { anchorNode, anchorOffset, focusNode, focusOffset } = sel ?? {};
+          const applySelection = () => {
+            if (Type.isNonNullable(anchorNode) && Type.isNonNullable(anchorOffset) && Type.isNonNullable(focusNode) && Type.isNonNullable(focusOffset)) {
+              sel?.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
+            }
+          };
+          const updateSelection = () => {
+            anchorNode = sel?.anchorNode;
+            anchorOffset = sel?.anchorOffset;
+            focusNode = sel?.focusNode;
+            focusOffset = sel?.focusOffset;
+          };
+          const appendAllChildNodes = (from: Node, to: Node) => {
+            Arr.each(from.childNodes, (child) => {
+              if (FormatUtils.isNode(child)) {
+                to.appendChild(child);
+              }
+            });
+          };
+
+          const container = editor.dom.create('span');
+          appendAllChildNodes(node, container);
+          node.appendChild(container);
+          applySelection();
+          // Allow ranged deletion by keyboard shortcuts
+          if (isCollapsed && (isMacOS && (e.altKey || isBackspace && e.metaKey) || !isMacOS && e.ctrlKey)) {
+            sel?.modify('extend', isBackspace ? 'left' : 'right', e.metaKey ? 'line' : 'word');
+          }
+          if (!selection.isCollapsed() && isEntireNodeSelected(selection.getRng(), container)) {
             PaddingBr.fillWithPaddingBr(SugarElement.fromDom(node));
           } else {
-            // Wrap all summary children in a temporary container to execute Backspace/Delete there, then unwrap
-            const selection = editor.selection.getSel();
-            let { anchorNode, anchorOffset, focusNode, focusOffset } = selection ?? {};
-            const applySelection = () => {
-              if (Type.isNonNullable(anchorNode) && Type.isNonNullable(anchorOffset) && Type.isNonNullable(focusNode) && Type.isNonNullable(focusOffset)) {
-                selection?.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
-              }
-            };
-            const updateSelection = () => {
-              anchorNode = selection?.anchorNode;
-              anchorOffset = selection?.anchorOffset;
-              focusNode = selection?.focusNode;
-              focusOffset = selection?.focusOffset;
-            };
-
-            const container = editor.dom.create('span');
-            Arr.each(node.childNodes, (child) => container.appendChild(child));
-            node.appendChild(container);
-            applySelection();
             editor.execCommand(isBackspace ? 'Delete' : 'ForwardDelete');
             updateSelection();
-            Arr.each(container.childNodes, (child) => node.appendChild(child));
-            editor.dom.remove(container);
+            appendAllChildNodes(container, node);
             applySelection();
           }
+          editor.dom.remove(container);
         }
       }
     }
   });
-
-  if (isSafari) {
-    editor.on('keyup', (_) => {
-      summaryAfterShortcutRangedDeletion.on((summary) => {
-        if (!isSummary(editor.selection.getNode())) {
-          PaddingBr.fillWithPaddingBr(SugarElement.fromDom(summary));
-          editor.selection.setCursorLocation(summary, 0);
-        }
-      });
-      summaryAfterShortcutRangedDeletion.clear();
-    });
-  }
 };
 
 const setup = (editor: Editor): void => {

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -63,7 +63,8 @@ const isDetails = (node: Node | null | undefined): boolean => node?.nodeName ===
 
 // TINY-9950: Firefox has some situations where its native behavior does not match what we expect, so
 // we have to perform Firefox-specific overrides.
-const browser = PlatformDetection.detect().browser;
+const platform = PlatformDetection.detect();
+const browser = platform.browser;
 const isFirefox = browser.isFirefox();
 const isSafari = browser.isSafari();
 
@@ -78,7 +79,8 @@ const preventDeletingSummary = (editor: Editor): void => {
       const endElement = editor.selection.getEnd();
       const rng = editor.selection.getRng();
       const isBackspace = e.keyCode === VK.BACKSPACE;
-      const isBackspaceAndCaretAtStart = isBackspace && isCaretInTheBeginning(rng, node);
+      const isCaretAtStart = isCaretInTheBeginning(rng, node);
+      const isBackspaceAndCaretAtStart = isBackspace && isCaretAtStart;
       const isDelete = e.keyCode === VK.DELETE;
       const isDeleteAndCaretAtEnd = isDelete && isCaretInTheEnding(rng, node);
       const isCollapsed = editor.selection.isCollapsed();
@@ -111,30 +113,42 @@ const preventDeletingSummary = (editor: Editor): void => {
         e.preventDefault();
         removeNode(editor, node);
         CaretFinder.firstPositionIn(nextNode).each(setCaretToPosition(editor));
+      } else if (isSafari && isSummary(node)) {
+        // TINY-9951: Safari has a bug where upon pressing Backspace/Delete when the caret is directly within the summary,
+        // all content is removed and the caret is prevented from being placed back into the summary.
+        e.preventDefault();
+
+        if (!isCollapsed && rng.startOffset === 0 && rng.endOffset === node.textContent?.length || DeleteUtils.willDeleteLastPositionInElement(isDelete, CaretPosition.fromRangeStart(rng), node)) {
+          PaddingBr.fillWithPaddingBr(SugarElement.fromDom(node));
+        } else {
+          // Wrap all summary children in a temporary container to execute Backspace/Delete there, then unwrap
+          const selection = editor.selection.getSel();
+          let { anchorNode, anchorOffset, focusNode, focusOffset } = selection ?? {};
+          const applySelection = () => {
+            if (Type.isNonNullable(anchorNode) && Type.isNonNullable(anchorOffset) && Type.isNonNullable(focusNode) && Type.isNonNullable(focusOffset)) {
+              selection?.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
+            }
+          };
+          const updateSelection = () => {
+            anchorNode = selection?.anchorNode;
+            anchorOffset = selection?.anchorOffset;
+            focusNode = selection?.focusNode;
+            focusOffset = selection?.focusOffset;
+          };
+
+          const container = editor.dom.create('span');
+          Arr.each(node.childNodes, (child) => container.appendChild(child));
+          node.appendChild(container);
+          applySelection();
+          editor.execCommand(isBackspace ? 'Delete' : 'ForwardDelete');
+          updateSelection();
+          Arr.each(container.childNodes, (child) => node.appendChild(child));
+          editor.dom.remove(container);
+          applySelection();
+        }
       }
     }
   });
-
-  if (isSafari) {
-    // TINY-9951: Safari has a bug where upon pressing Backspace/Delete when the caret is directly within the summary,
-    // all content is removed and the caret is prevented from being placed back into the summary.
-    editor.on('keydown', (e) => {
-      const node = editor.selection.getNode();
-      const isDelete = e.keyCode === VK.DELETE;
-      if ((e.keyCode === VK.BACKSPACE || isDelete) && isSummary(node)) {
-        if (isDelete && isCaretInTheBeginning(editor.selection.getRng(), node)) {
-          e.preventDefault();
-        } else {
-          const fromPos = CaretPosition.fromRangeStart(editor.selection.getRng());
-          if (e.altKey || e.metaKey || DeleteUtils.willDeleteLastPositionInElement(isDelete, fromPos, node)) {
-            PaddingBr.fillWithPaddingBr(SugarElement.fromDom(node));
-          } else {
-            editor.selection.getBookmark();
-          }
-        }
-      }
-    });
-  }
 };
 
 const setup = (editor: Editor): void => {

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -69,9 +69,10 @@ const isEntireNodeSelected = (rng: Range, node: Node): boolean =>
 
 const platform = PlatformDetection.detect();
 const browser = platform.browser;
+const os = platform.os;
 const isFirefox = browser.isFirefox();
 const isSafari = browser.isSafari();
-const isMacOS = platform.os.isMacOS();
+const isMacOSOriOS = os.isMacOS() || os.isiOS();
 
 const preventDeletingSummary = (editor: Editor): void => {
   editor.on('keydown', (e) => {
@@ -154,7 +155,7 @@ const preventDeletingSummary = (editor: Editor): void => {
           node.appendChild(container);
           applySelection();
           // Manually perform ranged deletion by keyboard shortcuts
-          if (isCollapsed && (isMacOS && (e.altKey || isBackspace && e.metaKey) || !isMacOS && e.ctrlKey)) {
+          if (isCollapsed && (isMacOSOriOS && (e.altKey || isBackspace && e.metaKey) || !isMacOSOriOS && e.ctrlKey)) {
             sel?.modify('extend', isBackspace ? 'left' : 'right', e.metaKey ? 'line' : 'word');
           }
           if (!selection.isCollapsed() && isEntireNodeSelected(selection.getRng(), container)) {

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -120,8 +120,8 @@ const preventDeletingSummary = (editor: Editor): void => {
         removeNode(editor, node);
         CaretFinder.firstPositionIn(nextNode).each(setCaretToPosition(editor));
       } else if (isSafari && isSummary(node)) {
-        // TINY-9951: Safari has a bug where upon pressing Backspace/Delete when the caret is directly within the summary,
-        // all content is removed and the caret is prevented from being placed back into the summary.
+        // TINY-9951: Safari bug, deleting within the summary causes all content to be removed and no caret position to be left
+        // https://bugs.webkit.org/show_bug.cgi?id=257745
         e.preventDefault();
 
         if (!isCollapsed && isEntireNodeSelected(rng, node) || DeleteUtils.willDeleteLastPositionInElement(isDelete, CaretPosition.fromRangeStart(rng), node)) {

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
@@ -79,8 +79,7 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       await pDoBackspaceDelete(deletionKey);
       TinyAssertions.assertContentPresence(editor, { 'details > summary': 1 });
-      // TINY-9951: Safari override results in a different cursor position due to bookmark
-      TinyAssertions.assertCursor(editor, isSafari ? [ 0, 0, 0 ] : [ 0, 0 ], 0);
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
     };
 
     it('TINY-9884: Prevent BACKSPACE from removing summary', () => testPreventSummaryDeletion(hook.editor(), 'Backspace'));
@@ -324,8 +323,9 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
         TinySelections.setCursor(editor, [ 0, 0, 0 ], deletionKey === 'Backspace' ? 'summary'.length : 0);
         await pDoCtrlBackspaceDelete(deletionKey);
         assertAccordionContent(editor, { summary: '', body: '<p>body</p>' });
-        // TINY-9302: Extra format caret added when using keyboard shortcut ranged deletion
-        TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0 ], 0);
+        // TINY-9302: Extra format caret added when using keyboard shortcut ranged deletion, except on Safari
+        // due to TINY-9951 workaround
+        TinyAssertions.assertCursor(editor, isSafari ? [ 0, 0 ] : [ 0, 0, 0, 0 ], 0);
       };
 
       it('TINY-9951: Can delete summary using Ctrl+Backspace', () => testCtrlDeletionInSummary(hook.editor(), 'Backspace'));
@@ -336,8 +336,9 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
         TinySelections.setCursor(editor, [ 0, 1, 0 ], deletionKey === 'Backspace' ? 'body'.length : 0);
         await pDoCtrlBackspaceDelete(deletionKey);
         assertAccordionContent(editor, { summary: 'summary', body: '<p></p>' });
-        // TINY-9302: Extra format caret added when using keyboard shortcut ranged deletion
-        TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0 ], 0);
+        // TINY-9302: Extra format caret added when using keyboard shortcut ranged deletion, except on Safari
+        // due to TINY-9951 workaround
+        TinyAssertions.assertCursor(editor, isSafari ? [ 0, 1 ] : [ 0, 1, 0, 0 ], 0);
       };
 
       it('TINY-9951: Can delete body using Ctrl+Backspace', () => testCtrlDeletionInBody(hook.editor(), 'Backspace'));

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
@@ -36,8 +36,10 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
   );
 
   const platform = PlatformDetection.detect();
+  const os = platform.os;
   const isSafari = platform.browser.isSafari();
-  const isMacOS = platform.os.isMacOS();
+  const isMacOS = os.isMacOS();
+  const isWindows = os.isWindows();
 
   const pDoBackspaceDelete = async (key: DeletionKey, modifier?: BackspaceDeleteModifier): Promise<void> => {
     await RealKeys.pSendKeysOn('iframe => body', [ Type.isUndefined(modifier) ? RealKeys.text(key) : RealKeys.combo(modifier, key) ]);
@@ -325,7 +327,15 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
         createAccordion(editor, getSummarySpec(initialContent));
         TinySelections.setCursor(editor, isSummary ? [ 0, 0, 0 ] : [ 0, 1, 0 ], isBackspace ? 'word1 wo'.length : 'wo'.length);
         await pDoCtrlBackspaceDelete(deletionKey);
-        const assertionContent = isBackspace ? 'word1 rd2' : 'wo word2';
+        let assertionContent: string;
+        if (isBackspace) {
+          assertionContent = 'word1 rd2';
+        } else if (isWindows) {
+          // Difference in native behavior for Ctrl + Delete on Windows
+          assertionContent = 'woword2';
+        } else {
+          assertionContent = 'wo word2';
+        }
         assertAccordionContent(editor, getSummarySpec(assertionContent));
         // TINY-9302: Extra format caret added when using keyboard shortcut ranged deletion, except on Safari
         // due to TINY-9951 workaround

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
@@ -64,7 +64,8 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
       TinyAssertions.assertCursor(editor, [ 0, 1 ], 0);
     });
 
-    const testPreventBodyDeletion = async (editor: Editor, deletionKey: DeletionKey) => {
+    const testPreventBodyDeletion = (deletionKey: DeletionKey) => async () => {
+      const editor = hook.editor();
       createAccordion(editor, { body: '<p><br></p>' });
       TinySelections.setCursor(editor, [ 0, 1 ], 0);
       await pDoBackspaceDelete(deletionKey);
@@ -72,10 +73,11 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
       TinyAssertions.assertCursor(editor, [ 0, 1 ], 0);
     };
 
-    it('TINY-9884: Prevent BACKSPACE from removing accordion body if a cursor is in the accordion body', () => testPreventBodyDeletion(hook.editor(), 'Backspace'));
-    it('TINY-9951: Prevent DELETE from removing accordion body if a cursor is in the accordion body', () => testPreventBodyDeletion(hook.editor(), 'Delete'));
+    it('TINY-9884: Prevent BACKSPACE from removing accordion body if a cursor is in the accordion body', testPreventBodyDeletion('Backspace'));
+    it('TINY-9951: Prevent DELETE from removing accordion body if a cursor is in the accordion body', testPreventBodyDeletion('Delete'));
 
-    const testPreventSummaryDeletion = async (editor: Editor, deletionKey: DeletionKey) => {
+    const testPreventSummaryDeletion = (deletionKey: DeletionKey) => async () => {
+      const editor = hook.editor();
       createAccordion(editor, { summary: '' });
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       await pDoBackspaceDelete(deletionKey);
@@ -83,18 +85,19 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
       TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
     };
 
-    it('TINY-9884: Prevent BACKSPACE from removing summary', () => testPreventSummaryDeletion(hook.editor(), 'Backspace'));
-    it('TINY-9951: Prevent DELETE from removing summary', () => testPreventSummaryDeletion(hook.editor(), 'Delete'));
+    it('TINY-9884: Prevent BACKSPACE from removing summary', testPreventSummaryDeletion('Backspace'));
+    it('TINY-9951: Prevent DELETE from removing summary', testPreventSummaryDeletion('Delete'));
 
-    const testPreventSummaryBodyDeletion = async (editor: Editor, deletionKey: DeletionKey) => {
+    const testPreventSummaryBodyDeletion = (deletionKey: DeletionKey) => async () => {
+      const editor = hook.editor();
       createAccordion(editor);
       TinySelections.setSelection(editor, [ 0, 0, 0 ], 'sum'.length, [ 0, 1, 0 ], 'bo'.length);
       await pDoBackspaceDelete(deletionKey);
       TinyAssertions.assertContentPresence(editor, { 'details > summary': 1, 'details > p': 1 });
     };
 
-    it('TINY-9884: Prevent BACKSPACE from removing summary when summary and details content are selected', () => testPreventSummaryBodyDeletion(hook.editor(), 'Backspace'));
-    it('TINY-9951: Prevent DELETE from removing summary when summary and details content are selected', () => testPreventSummaryBodyDeletion(hook.editor(), 'Delete'));
+    it('TINY-9884: Prevent BACKSPACE from removing summary when summary and details content are selected', testPreventSummaryBodyDeletion('Backspace'));
+    it('TINY-9951: Prevent DELETE from removing summary when summary and details content are selected', testPreventSummaryBodyDeletion('Delete'));
   });
 
   context('Deleting content in summary or body', () => {
@@ -236,7 +239,8 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
         }
       };
 
-      const testDeleteAllContentInAccordion = async (editor: Editor, contentLocation: ContentLocation, deletionKey: DeletionKey) => {
+      const testDeleteAllContentInAccordion = (contentLocation: ContentLocation, deletionKey: DeletionKey) => async () => {
+        const editor = hook.editor();
         createAccordionAndSelectAll(editor, contentLocation);
         await pDoBackspaceDelete(deletionKey);
         const isLocationSummary = contentLocation === 'summary';
@@ -244,12 +248,13 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
         TinyAssertions.assertCursor(editor, isLocationSummary ? [ 0, 0 ] : [ 0, 1 ], 0);
       };
 
-      it('TINY-9945: Can select all content in summary and delete it using Backspace', () => testDeleteAllContentInAccordion(hook.editor(), 'summary', 'Backspace'));
-      it('TINY-9945: Can select all content in summary and delete it using Delete', () => testDeleteAllContentInAccordion(hook.editor(), 'summary', 'Delete'));
-      it('TINY-9945: Can select all content in body and delete it using Backspace', () => testDeleteAllContentInAccordion(hook.editor(), 'body', 'Backspace'));
-      it('TINY-9945: Can select all content in body and delete it using Delete', () => testDeleteAllContentInAccordion(hook.editor(), 'body', 'Delete'));
+      it('TINY-9945: Can select all content in summary and delete it using Backspace', testDeleteAllContentInAccordion('summary', 'Backspace'));
+      it('TINY-9945: Can select all content in summary and delete it using Delete', testDeleteAllContentInAccordion('summary', 'Delete'));
+      it('TINY-9945: Can select all content in body and delete it using Backspace', testDeleteAllContentInAccordion('body', 'Backspace'));
+      it('TINY-9945: Can select all content in body and delete it using Delete', testDeleteAllContentInAccordion('body', 'Delete'));
 
-      const testDeleteSelectionFromStartInSummary = async (editor: Editor, deletionKey: DeletionKey) => {
+      const testDeleteSelectionFromStartInSummary = (deletionKey: DeletionKey) => async () => {
+        const editor = hook.editor();
         createAccordion(editor);
         TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 'sum'.length);
         await pDoBackspaceDelete(deletionKey);
@@ -257,10 +262,11 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
         TinyAssertions.assertCursor(editor, [ 0, 0, 0 ], 0);
       };
 
-      it('TINY-9951: Can select content from start in summary and delete it using Backspace', () => testDeleteSelectionFromStartInSummary(hook.editor(), 'Backspace'));
-      it('TINY-9951: Can select content from start in summary and delete it using Delete', () => testDeleteSelectionFromStartInSummary(hook.editor(), 'Delete'));
+      it('TINY-9951: Can select content from start in summary and delete it using Backspace', testDeleteSelectionFromStartInSummary('Backspace'));
+      it('TINY-9951: Can select content from start in summary and delete it using Delete', testDeleteSelectionFromStartInSummary('Delete'));
 
-      const testDeleteSelectionInMiddleInSummary = async (editor: Editor, deletionKey: DeletionKey) => {
+      const testDeleteSelectionInMiddleInSummary = (deletionKey: DeletionKey) => async () => {
+        const editor = hook.editor();
         createAccordion(editor);
         TinySelections.setSelection(editor, [ 0, 0, 0 ], 'su'.length, [ 0, 0, 0 ], 'summ'.length);
         await pDoBackspaceDelete(deletionKey);
@@ -268,10 +274,11 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
         TinyAssertions.assertCursor(editor, [ 0, 0, 0 ], 'su'.length);
       };
 
-      it('TINY-9951: Can select content in middle in summary and delete it using Backspace', () => testDeleteSelectionInMiddleInSummary(hook.editor(), 'Backspace'));
-      it('TINY-9951: Can select content in middle in summary and delete it using Delete', () => testDeleteSelectionInMiddleInSummary(hook.editor(), 'Delete'));
+      it('TINY-9951: Can select content in middle in summary and delete it using Backspace', testDeleteSelectionInMiddleInSummary('Backspace'));
+      it('TINY-9951: Can select content in middle in summary and delete it using Delete', testDeleteSelectionInMiddleInSummary('Delete'));
 
-      const testDeleteSelectionFromEndInSummary = async (editor: Editor, deletionKey: DeletionKey) => {
+      const testDeleteSelectionFromEndInSummary = (deletionKey: DeletionKey) => async () => {
+        const editor = hook.editor();
         createAccordion(editor);
         TinySelections.setSelection(editor, [ 0, 0, 0 ], 'sum'.length, [ 0, 0, 0 ], 'summary'.length);
         await pDoBackspaceDelete(deletionKey);
@@ -279,10 +286,11 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
         TinyAssertions.assertCursor(editor, [ 0, 0, 0 ], 'sum'.length);
       };
 
-      it('TINY-9951: Can select content from end in summary and delete it using Backspace', () => testDeleteSelectionFromEndInSummary(hook.editor(), 'Backspace'));
-      it('TINY-9951: Can select content from end in summary and delete it using Delete', () => testDeleteSelectionFromEndInSummary(hook.editor(), 'Delete'));
+      it('TINY-9951: Can select content from end in summary and delete it using Backspace', testDeleteSelectionFromEndInSummary('Backspace'));
+      it('TINY-9951: Can select content from end in summary and delete it using Delete', testDeleteSelectionFromEndInSummary('Delete'));
 
-      const testDeleteSelectionFromStartInBody = async (editor: Editor, deletionKey: DeletionKey) => {
+      const testDeleteSelectionFromStartInBody = (deletionKey: DeletionKey) => async () => {
+        const editor = hook.editor();
         createAccordion(editor);
         TinySelections.setSelection(editor, [ 0, 1, 0 ], 0, [ 0, 1, 0 ], 'bo'.length);
         await pDoBackspaceDelete(deletionKey);
@@ -290,10 +298,11 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
         TinyAssertions.assertCursor(editor, [ 0, 1, 0 ], 0);
       };
 
-      it('TINY-9951: Can select content from start in body and delete it using Backspace', () => testDeleteSelectionFromStartInBody(hook.editor(), 'Backspace'));
-      it('TINY-9951: Can select content from start in body and delete it using Delete', () => testDeleteSelectionFromStartInBody(hook.editor(), 'Delete'));
+      it('TINY-9951: Can select content from start in body and delete it using Backspace', testDeleteSelectionFromStartInBody('Backspace'));
+      it('TINY-9951: Can select content from start in body and delete it using Delete', testDeleteSelectionFromStartInBody('Delete'));
 
-      const testDeleteSelectionInMiddleInBody = async (editor: Editor, deletionKey: DeletionKey) => {
+      const testDeleteSelectionInMiddleInBody = (deletionKey: DeletionKey) => async () => {
+        const editor = hook.editor();
         createAccordion(editor);
         TinySelections.setSelection(editor, [ 0, 1, 0 ], 'b'.length, [ 0, 1, 0 ], 'bod'.length);
         await pDoBackspaceDelete(deletionKey);
@@ -301,10 +310,11 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
         TinyAssertions.assertCursor(editor, [ 0, 1, 0 ], 'b'.length);
       };
 
-      it('TINY-9951: Can select content in middle in body and delete it using Backspace', () => testDeleteSelectionInMiddleInBody(hook.editor(), 'Backspace'));
-      it('TINY-9951: Can select content in middle in body and delete it using Delete', () => testDeleteSelectionInMiddleInBody(hook.editor(), 'Delete'));
+      it('TINY-9951: Can select content in middle in body and delete it using Backspace', testDeleteSelectionInMiddleInBody('Backspace'));
+      it('TINY-9951: Can select content in middle in body and delete it using Delete', testDeleteSelectionInMiddleInBody('Delete'));
 
-      const testDeleteSelectionFromEndInBody = async (editor: Editor, deletionKey: DeletionKey) => {
+      const testDeleteSelectionFromEndInBody = (deletionKey: DeletionKey) => async () => {
+        const editor = hook.editor();
         createAccordion(editor);
         TinySelections.setSelection(editor, [ 0, 1, 0 ], 'bo'.length, [ 0, 1, 0 ], 'body'.length);
         await pDoBackspaceDelete(deletionKey);
@@ -312,14 +322,15 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
         TinyAssertions.assertCursor(editor, [ 0, 1, 0 ], 'bo'.length);
       };
 
-      it('TINY-9951: Can select content from end in body and delete it using Backspace', () => testDeleteSelectionFromEndInBody(hook.editor(), 'Backspace'));
-      it('TINY-9951: Can select content from end in body and delete it using Delete', () => testDeleteSelectionFromEndInBody(hook.editor(), 'Delete'));
+      it('TINY-9951: Can select content from end in body and delete it using Backspace', testDeleteSelectionFromEndInBody('Backspace'));
+      it('TINY-9951: Can select content from end in body and delete it using Delete', testDeleteSelectionFromEndInBody('Delete'));
     });
 
     context('Using ranged deletion keyboard shortcuts', () => {
       const pDoCtrlBackspaceDelete = (deletionKey: DeletionKey) => pDoBackspaceDelete(deletionKey, isMacOS ? { altKey: true } : { ctrlKey: true });
 
-      const testCtrlDeletion = async (editor: Editor, deletionKey: DeletionKey, location: ContentLocation) => {
+      const testCtrlDeletion = (deletionKey: DeletionKey, location: ContentLocation) => async () => {
+        const editor = hook.editor();
         const isBackspace = deletionKey === 'Backspace';
         const isSummary = location === 'summary';
         const initialContent = 'word1 word2';
@@ -352,13 +363,13 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
         TinyAssertions.assertCursor(editor, expectedPath, expectedOffset);
       };
 
-      const testCtrlDeletionInSummary = (editor: Editor, deletionKey: DeletionKey) => testCtrlDeletion(editor, deletionKey, 'summary');
-      it('TINY-9951: Can delete summary using Ctrl+Backspace', () => testCtrlDeletionInSummary(hook.editor(), 'Backspace'));
-      it('TINY-9951: Can delete summary using Ctrl+Delete', () => testCtrlDeletionInSummary(hook.editor(), 'Delete'));
+      const testCtrlDeletionInSummary = (deletionKey: DeletionKey) => testCtrlDeletion(deletionKey, 'summary');
+      it('TINY-9951: Can delete summary using Ctrl+Backspace', testCtrlDeletionInSummary('Backspace'));
+      it('TINY-9951: Can delete summary using Ctrl+Delete', testCtrlDeletionInSummary('Delete'));
 
-      const testCtrlDeletionInBody = (editor: Editor, deletionKey: DeletionKey) => testCtrlDeletion(editor, deletionKey, 'body');
-      it('TINY-9951: Can delete body using Ctrl+Backspace', () => testCtrlDeletionInBody(hook.editor(), 'Backspace'));
-      it('TINY-9951: Can delete body using Ctrl+Delete', () => testCtrlDeletionInBody(hook.editor(), 'Delete'));
+      const testCtrlDeletionInBody = (deletionKey: DeletionKey) => testCtrlDeletion(deletionKey, 'body');
+      it('TINY-9951: Can delete body using Ctrl+Backspace', testCtrlDeletionInBody('Backspace'));
+      it('TINY-9951: Can delete body using Ctrl+Delete', testCtrlDeletionInBody('Delete'));
     });
   });
 

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
@@ -18,9 +18,8 @@ interface AccordionSpec {
 }
 
 interface BackspaceDeleteModifier {
-  ctrl?: boolean;
-  alt?: boolean;
-  meta?: boolean;
+  ctrlKey?: boolean;
+  altKey?: boolean;
 }
 
 describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () => {
@@ -316,7 +315,7 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
     });
 
     context('Using ranged deletion keyboard shortcuts', () => {
-      const pDoCtrlBackspaceDelete = (deletionKey: DeletionKey) => pDoBackspaceDelete(deletionKey, isMacOS ? { alt: true } : { ctrl: true });
+      const pDoCtrlBackspaceDelete = (deletionKey: DeletionKey) => pDoBackspaceDelete(deletionKey, isMacOS ? { altKey: true } : { ctrlKey: true });
 
       const testCtrlDeletionInSummary = async (editor: Editor, deletionKey: DeletionKey) => {
         createAccordion(editor);

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
@@ -108,6 +108,15 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
         TinyAssertions.assertCursor(editor, [ 0, 0, 0 ], 'summar'.length);
       });
 
+      it('TINY-9951: Deleting content in summary by pressing BACKSPACE should work as expected if caret at the end of summary content and content is a single character', async () => {
+        const editor = hook.editor();
+        createAccordion(editor, { summary: 's', body: '<p>body</p>' });
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 's'.length);
+        await pDoBackspace();
+        assertAccordionContent(editor, { summary: '', body: '<p>body</p>' });
+        TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
+      });
+
       it('TINY-9951: Deleting content in summary by pressing BACKSPACE should work as expected if caret in middle of summary content', async () => {
         const editor = hook.editor();
         createAccordion(editor);
@@ -133,6 +142,15 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
         await pDoDelete();
         assertAccordionContent(editor, { summary: 'ummary', body: '<p>body</p>' });
         TinyAssertions.assertCursor(editor, [ 0, 0, 0 ], 0);
+      });
+
+      it('TINY-9951: Deleting content in summary by pressing DELETE should work as expected if caret at the beginning of summary content and content is a single character', async () => {
+        const editor = hook.editor();
+        createAccordion(editor, { summary: 's', body: '<p>body</p>' });
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+        await pDoDelete();
+        assertAccordionContent(editor, { summary: '', body: '<p>body</p>' });
+        TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
       });
 
       it('TINY-9951: Deleting content in summary by pressing DELETE should work as expected if caret in middle of summary content', async () => {

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
@@ -52,10 +52,6 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
     editor.setContent(getAccordionContent(spec));
 
   context('Undo/redo backspace/delete', () => {
-    const doUndoRedo = (editor: Editor, action: 'undo' | 'redo') => action === 'undo' ? editor.undoManager.undo() : editor.undoManager.redo();
-    const doUndo = (editor: Editor) => doUndoRedo(editor, 'undo');
-    const doRedo = (editor: Editor) => doUndoRedo(editor, 'redo');
-
     const testUndoRedo = (deletionKey: DeletionKey, location: ContentLocation) => async () => {
       const isBackspace = deletionKey === 'Backspace';
       const isSummary = location === 'summary';
@@ -83,11 +79,11 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
       }
       TinyAssertions.assertCursor(editor, path, expectedOffset);
 
-      doUndo(editor);
+      editor.undoManager.undo();
       assertAccordionContent(editor);
       TinyAssertions.assertCursor(editor, path, initialOffset);
 
-      doRedo(editor);
+      editor.undoManager.redo();
       assertAccordionContent(editor, expectedAccordionSpec);
       TinyAssertions.assertCursor(editor, path, expectedOffset);
     };


### PR DESCRIPTION
Related Ticket: TINY-9951

Description of Changes:
* Implement Safari backspace/delete workaround when caret is in summary to override native behavior of deleting all content in summary including the `<br>` which prevents the summary from being re-focused
* Add tests to cover more cases of backspace/delete in summary and body content, including for collapsed, ranged, and ranged-by-keyboard-shortcut deletions

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
