### PR TITLE
TINY-9815: Skip fake tab stops from tab navigation flow

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Tab navigation did not forward focus over pseudo tab stops. #TINY-9815
+
 ## 12.2.0 - 2023-06-12
 
 ### Fixed

--- a/modules/alloy/package.json
+++ b/modules/alloy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/alloy",
-  "version": "12.2.1",
+  "version": "12.3.0-alpha.0",
   "description": "Ui Framework",
   "dependencies": {
     "@ephox/agar": "^7.4.3",

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/KeyingModeTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/KeyingModeTypes.ts
@@ -10,6 +10,7 @@ import { NativeSimulatedEvent, SimulatedEvent } from '../events/SimulatedEvent';
 export type KeyHandlerApi = (comp: AlloyComponent, se: NativeSimulatedEvent<KeyboardEvent>) => Optional<boolean>;
 
 export type KeyRuleHandler<C, S> = (comp: AlloyComponent, se: NativeSimulatedEvent<KeyboardEvent>, config: C, state: S) => Optional<boolean>;
+export type KeyRuleStatelessHandler<C> = (comp: AlloyComponent, se: NativeSimulatedEvent<KeyboardEvent>, config: C) => Optional<boolean>;
 
 export enum FocusInsideModes {
   OnFocusMode = 'onFocus',

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/TabbingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/TabbingTypes.ts
@@ -9,7 +9,7 @@ import { NativeSimulatedEvent } from '../events/SimulatedEvent';
 import * as ArrNavigation from '../navigation/ArrNavigation';
 import * as KeyMatch from '../navigation/KeyMatch';
 import * as KeyRules from '../navigation/KeyRules';
-import { KeyRuleHandler, TabbingConfig } from './KeyingModeTypes';
+import { KeyRuleStatelessHandler, TabbingConfig } from './KeyingModeTypes';
 import * as KeyingType from './KeyingType';
 
 const create = (cyclicField: FieldProcessor): KeyingType.KeyingType<TabbingConfig, Stateless> => {
@@ -93,29 +93,29 @@ const create = (cyclicField: FieldProcessor): KeyingType.KeyingType<TabbingConfi
     });
   };
 
-  const goBackwards: KeyRuleHandler<TabbingConfig, Stateless> = (component, simulatedEvent, tabbingConfig) => {
+  const goBackwards: KeyRuleStatelessHandler<TabbingConfig> = (component, simulatedEvent, tabbingConfig) => {
     const navigate = tabbingConfig.cyclic ? ArrNavigation.cyclePrev : ArrNavigation.tryPrev;
     return go(component, simulatedEvent, tabbingConfig, navigate);
   };
 
-  const goForwards: KeyRuleHandler<TabbingConfig, Stateless> = (component, simulatedEvent, tabbingConfig) => {
+  const goForwards: KeyRuleStatelessHandler<TabbingConfig> = (component, simulatedEvent, tabbingConfig) => {
     const navigate = tabbingConfig.cyclic ? ArrNavigation.cycleNext : ArrNavigation.tryNext;
     return go(component, simulatedEvent, tabbingConfig, navigate);
   };
 
   const isFirstChild = (node: Node): boolean => node.parentNode?.firstChild === node;
 
-  const goFromPseudoTabstop: KeyRuleHandler<TabbingConfig, Stateless> = (component, simulatedEvent, tabbingConfig, state) =>
+  const goFromPseudoTabstop: KeyRuleStatelessHandler<TabbingConfig> = (component, simulatedEvent, tabbingConfig) =>
     findCurrent(component, tabbingConfig).filter((elem) => !tabbingConfig.useTabstopAt(elem))
       .fold(
         () => Optional.none(),
-        (elem) => (isFirstChild(elem.dom) ? goBackwards : goForwards)(component, simulatedEvent, tabbingConfig, state)
+        (elem) => (isFirstChild(elem.dom) ? goBackwards : goForwards)(component, simulatedEvent, tabbingConfig)
       );
 
-  const execute: KeyRuleHandler<TabbingConfig, Stateless> = (component, simulatedEvent, tabbingConfig) =>
+  const execute: KeyRuleStatelessHandler<TabbingConfig> = (component, simulatedEvent, tabbingConfig) =>
     tabbingConfig.onEnter.bind((f) => f(component, simulatedEvent));
 
-  const exit: KeyRuleHandler<TabbingConfig, Stateless> = (component, simulatedEvent, tabbingConfig) =>
+  const exit: KeyRuleStatelessHandler<TabbingConfig> = (component, simulatedEvent, tabbingConfig) =>
     tabbingConfig.onEscape.bind((f) => f(component, simulatedEvent));
 
   const getKeydownRules = Fun.constant([
@@ -127,7 +127,6 @@ const create = (cyclicField: FieldProcessor): KeyingType.KeyingType<TabbingConfi
   const getKeyupRules = Fun.constant([
     KeyRules.rule(KeyMatch.inSet(Keys.ESCAPE), exit),
     KeyRules.rule(KeyMatch.inSet(Keys.TAB), goFromPseudoTabstop),
-
   ]);
 
   return KeyingType.typical(schema, NoState.init, getKeydownRules, getKeyupRules, () => Optional.some(focusIn));

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/TabbingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/TabbingTypes.ts
@@ -1,6 +1,6 @@
 import { FieldProcessor, FieldSchema } from '@ephox/boulder';
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Compare, Height, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
+import { Compare, Height, SelectorFilter, SelectorFind, SugarElement, Traverse } from '@ephox/sugar';
 
 import * as Keys from '../alien/Keys';
 import { AlloyComponent } from '../api/component/ComponentApi';
@@ -103,14 +103,12 @@ const create = (cyclicField: FieldProcessor): KeyingType.KeyingType<TabbingConfi
     return go(component, simulatedEvent, tabbingConfig, navigate);
   };
 
-  const isFirstChild = (node: Node): boolean => node.parentNode?.firstChild === node;
+  const isFirstChild = (elem: SugarElement<HTMLElement>): boolean =>
+    Traverse.parentNode(elem).bind(Traverse.firstChild).exists((child) => Compare.eq(child, elem));
 
   const goFromPseudoTabstop: KeyRuleStatelessHandler<TabbingConfig> = (component, simulatedEvent, tabbingConfig) =>
     findCurrent(component, tabbingConfig).filter((elem) => !tabbingConfig.useTabstopAt(elem))
-      .fold(
-        () => Optional.none(),
-        (elem) => (isFirstChild(elem.dom) ? goBackwards : goForwards)(component, simulatedEvent, tabbingConfig)
-      );
+      .bind((elem) => (isFirstChild(elem) ? goBackwards : goForwards)(component, simulatedEvent, tabbingConfig));
 
   const execute: KeyRuleStatelessHandler<TabbingConfig> = (component, simulatedEvent, tabbingConfig) =>
     tabbingConfig.onEnter.bind((f) => f(component, simulatedEvent));

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The pattern replacement removes spaces if they were contained in a tag that only contains a space and the text to replace. #TINY-9744
 
+### Fixed
+- Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815
+
 ## 6.5.0 - 2023-06-12
 
 ### Added

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
@@ -91,9 +91,6 @@ describe('webdriver.tinymce.themes.silver.dialogs.IFrameDialogTest', () => {
     await FocusTools.pTryOnSelector('focus should be on iframe', SugarDocument.getDocument(), 'iframe');
     await pPressTab('iframe => body', false);
 
-    await FocusTools.pTryOnSelector('focus should be on the "after" tabstop', SugarDocument.getDocument(), 'div[class*="alloy-fake-after-tabstop"]');
-    await pPressTab('div[class*="alloy-fake-after-tabstop"]', false);
-
     await FocusTools.pTryOnSelector('focus should be on button (cancel)', SugarDocument.getDocument(), 'button:contains("Close")');
     await pPressTab('button.tox-button--secondary', true);
 
@@ -106,9 +103,6 @@ describe('webdriver.tinymce.themes.silver.dialogs.IFrameDialogTest', () => {
       await FocusTools.pTryOnSelector('focus should be on the iframe', SugarDocument.getDocument(), 'iframe');
       await pPressTab('iframe', true);
     }
-
-    await FocusTools.pTryOnSelector('focus should be on the "before" tabstop', SugarDocument.getDocument(), 'div[class*="alloy-fake-before-tabstop"]');
-    await pPressTab('div[class*="alloy-fake-before-tabstop"]', true);
 
     await FocusTools.pTryOnSelector('focus should move back to input (iframe >> input)', SugarDocument.getDocument(), 'input');
   });

--- a/versions.txt
+++ b/versions.txt
@@ -1,2 +1,3 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
+alloy@12.3.0


### PR DESCRIPTION
Related Ticket: TINY-9815

Description of Changes:
* There are two fake tab stop divs wrapping the iframe element. When the focus is on the component before the iframe the Tab press successfully skips the first fake tab stop div and moves focus to the iframe. However next Tab press does not skip the second tab stop div because there is only keyup event fired on it, as such keydown Tab key rules do not work. The solution is to bind key rules to keyup event but check that focus is currently on tab stop div to avoid duplicated tab handling.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
