### PR TITLE
TINY-9860: Use non-bogus <br> to pad last table cell

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SVG icons for back and foreground colors now use `class` instead of `id` to identify SVG elements that should change color. #TINY-9844
 - Anchor tag elements — `<a>` — no longer incorrectly allow non-inline child elements when the editor schema is set to _HTML 4_. #TINY-9805
 - Help dialog was restored to `medium` width for better readability #TINY-9947
+- Updated DOM logic to exclude `data-mce-bogus` attribute in empty table cells #TINY-9860.
+
 
 ### Fixed
 - Right-clicking on a merge tag instance presented different highlighting depending on the host browser. #TINY-9848

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -40,7 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SVG icons for back and foreground colors now use `class` instead of `id` to identify SVG elements that should change color. #TINY-9844
 - Anchor tag elements — `<a>` — no longer incorrectly allow non-inline child elements when the editor schema is set to _HTML 4_. #TINY-9805
 - Help dialog was restored to `medium` width for better readability #TINY-9947
-- Stopped adding `data-mce-bogus` attribute to `br` in empty table cells #TINY-9860.
 
 ### Fixed
 - Right-clicking on a merge tag instance presented different highlighting depending on the host browser. #TINY-9848

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SVG icons for back and foreground colors now use `class` instead of `id` to identify SVG elements that should change color. #TINY-9844
 - Anchor tag elements — `<a>` — no longer incorrectly allow non-inline child elements when the editor schema is set to _HTML 4_. #TINY-9805
 - Help dialog was restored to `medium` width for better readability #TINY-9947
-- Updated DOM logic to exclude `data-mce-bogus` attribute in empty table cells #TINY-9860
+- Stopped adding `data-mce-bogus` attribute to `br` in empty table cells #TINY-9860.
 
 ### Fixed
 - Right-clicking on a merge tag instance presented different highlighting depending on the host browser. #TINY-9848

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `caption`, `address` and `dt` elements no longer incorrectly allow non-inline child elements when the editor schema is set to _HTML 4_. #TINY-9768
 - SVG icons for back and foreground colors now use `class` instead of `id` to identify SVG elements that should change color. #TINY-9844
 - Anchor tag elements — `<a>` — no longer incorrectly allow non-inline child elements when the editor schema is set to _HTML 4_. #TINY-9805
-- Help dialog was restored to `medium` width for better readability #TINY-9947
+- Help dialog was restored to `medium` width for better readability. #TINY-9947
 
 ### Fixed
 - Right-clicking on a merge tag instance presented different highlighting depending on the host browser. #TINY-9848

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -192,7 +192,7 @@ const moveSelectionToMarker = (editor: Editor, marker: HTMLElement | null): void
       rng = nextRng;
       dom.remove(parentBlock);
     } else {
-      // If parentBlock is a table cell, add a br without 'data-mce-bogus' attribute.
+      // TINY-9860: If parentBlock is a table cell, add a br without 'data-mce-bogus' attribute.
       dom.add(parentBlock, dom.create('br', isCell ? {} : { 'data-mce-bogus': '1' }));
     }
   }

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -181,17 +181,19 @@ const moveSelectionToMarker = (editor: Editor, marker: HTMLElement | null): void
   dom.remove(marker);
 
   if (parentBlock && dom.isEmpty(parentBlock)) {
+    const isCell = isTableCell(parentBlock);
+
     Remove.empty(SugarElement.fromDom(parentBlock));
 
     rng.setStart(parentBlock, 0);
     rng.setEnd(parentBlock, 0);
 
-    if (!isTableCell(parentBlock) && !isPartOfFragment(parentBlock) && (nextRng = findNextCaretRng(rng))) {
+    if (!isCell && !isPartOfFragment(parentBlock) && (nextRng = findNextCaretRng(rng))) {
       rng = nextRng;
       dom.remove(parentBlock);
     } else {
       // If parentBlock is a table cell, add a br without 'data-mce-bogus' attribute.
-      dom.add(parentBlock, dom.create('br', isTableCell(parentBlock) ? {} : { 'data-mce-bogus': '1' }));
+      dom.add(parentBlock, dom.create('br', isCell ? {} : { 'data-mce-bogus': '1' }));
     }
   }
 

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -191,11 +191,7 @@ const moveSelectionToMarker = (editor: Editor, marker: HTMLElement | null): void
       dom.remove(parentBlock);
     } else {
       // If parentBlock is a table cell, add a br without 'data-mce-bogus' attribute.
-      if (isTableCell(parentBlock)) {
-        dom.add(parentBlock, dom.create('br'));
-      } else {
-        dom.add(parentBlock, dom.create('br', { 'data-mce-bogus': '1' }));
-      }
+      dom.add(parentBlock, dom.create('br', isTableCell(parentBlock) ? {} : { 'data-mce-bogus': '1' }));
     }
   }
 

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -190,7 +190,12 @@ const moveSelectionToMarker = (editor: Editor, marker: HTMLElement | null): void
       rng = nextRng;
       dom.remove(parentBlock);
     } else {
-      dom.add(parentBlock, dom.create('br', { 'data-mce-bogus': '1' }));
+      // If parentBlock is a table cell, add a br without 'data-mce-bogus' attribute.
+      if (isTableCell(parentBlock)) {
+        dom.add(parentBlock, dom.create('br'));
+      } else {
+        dom.add(parentBlock, dom.create('br', { 'data-mce-bogus': '1' }));
+      }
     }
   }
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableRemoveTrailingBrTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableRemoveTrailingBrTest.ts
@@ -40,6 +40,21 @@ describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
       TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0, 0, 1, 0, 0 ], 0);
     });
+
+    it('TINY-9860: last table cell is br, not removing br', async () => {
+      const editor = hookWithoutTrailingBr.editor();
+      editor.setContent('');
+      await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
+      TinyAssertions.assertContentPresence(editor, { br: 4 });
+    });
+
+    it('TINY-9860: nested table, last table cell is br, not removing br', async () => {
+      const editor = hookWithoutTrailingBr.editor();
+      editor.setContent('');
+      await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
+      await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
+      TinyAssertions.assertContentPresence(editor, { br: 7 });
+    });
   });
 
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableRemoveTrailingBrTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableRemoveTrailingBrTest.ts
@@ -5,6 +5,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
 
 import * as TableTestUtils from '../module/test/TableTestUtils';
+
 describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
   const baseSettings = {
     plugins: 'table code',
@@ -27,18 +28,21 @@ describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
       '</tbody>',
       '</table>',
     ].join('\n');
+
     it('TBA: serialised content should have nbsp\'s in table cells', async () => {
       const editor = hook.editor();
       editor.setContent('');
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
       TinyAssertions.assertContent(editor, tableOutputHtmlStr);
     });
+
     it('TINY-3909: should have correct cursor position for single table', async () => {
       const editor = hook.editor();
       editor.setContent('');
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
       TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0 ], 0);
     });
+
     it('TINY-3909: should have correct cursor position for nested table, no brs', async () => {
       const editor = hook.editor();
       editor.setContent('');
@@ -46,6 +50,7 @@ describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
       TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0, 0, 1, 0, 0 ], 0);
     });
+
     it('TINY-9860: should have correct number of non-bogus brs for single table', async () => {
       const editor = hook.editor();
       editor.setContent('');
@@ -53,6 +58,7 @@ describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
       TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0 ], 0);
       TinyAssertions.assertContentPresence(editor, { 'br': 4, 'br:not([data-mce-bogus])': 4 });
     });
+
     it('TINY-9860: should have correct number of non-bogus brs for nested table', async () => {
       const editor = hook.editor();
       editor.setContent('');
@@ -62,6 +68,7 @@ describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
       TinyAssertions.assertContentPresence(editor, { 'br': 7, 'br:not([data-mce-bogus])': 7 });
     });
   });
+
   context('remove_trailing_brs: false', () => {
     const hook = TinyHooks.bddSetup<Editor>({ ...baseSettings, remove_trailing_brs: false }, [ Plugin ], true);
     const tableOutputHtmlStr = [
@@ -78,18 +85,21 @@ describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
       '</tbody>',
       '</table>',
     ].join('\n');
+
     it('TBA: serialised content should have br\'s in table cells', async () => {
       const editor = hook.editor();
       editor.setContent('');
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
       TinyAssertions.assertContent(editor, tableOutputHtmlStr);
     });
+
     it('TINY-3909: should have correct cursor position for single table', async () => {
       const editor = hook.editor();
       editor.setContent('');
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
       TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0 ], 0);
     });
+
     it('TINY-3909: should have correct cursor position for nested table', async () => {
       const editor = hook.editor();
       editor.setContent('');
@@ -97,6 +107,7 @@ describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
       TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0, 0, 1, 0, 0 ], 0);
     });
+
     it('TINY-9860: should have correct number of non-bogus brs for single table', async () => {
       const editor = hook.editor();
       editor.setContent('');
@@ -104,6 +115,7 @@ describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
       TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0 ], 0);
       TinyAssertions.assertContentPresence(editor, { 'br': 4, 'br:not([data-mce-bogus])': 4 });
     });
+
     it('TINY-9860: should have correct number of non-bogus brs for nested table', async () => {
       const editor = hook.editor();
       editor.setContent('');

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableRemoveTrailingBrTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableRemoveTrailingBrTest.ts
@@ -45,7 +45,7 @@ describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
       TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0, 0, 1, 0, 0 ], 0);
     });
-    it('TINY-9860: should have correct number of non-bogus brs for single table, no brs', async () => {
+    it('TINY-9860: should have correct number of non-bogus brs for single table', async () => {
       const editor = hook.editor();
       editor.setContent('');
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableRemoveTrailingBrTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableRemoveTrailingBrTest.ts
@@ -10,6 +10,7 @@ describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
     plugins: 'table code',
     base_url: '/project/tinymce/js/tinymce'
   };
+
   context('remove_trailing_brs: true', () => {
     const hook = TinyHooks.bddSetup<Editor>({ ...baseSettings, remove_trailing_brs: true }, [ Plugin ], true);
     const tableOutputHtmlStr = [

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableRemoveTrailingBrTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableRemoveTrailingBrTest.ts
@@ -5,56 +5,111 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
 
 import * as TableTestUtils from '../module/test/TableTestUtils';
-
 describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
-
   const baseSettings = {
     plugins: 'table code',
     base_url: '/project/tinymce/js/tinymce'
   };
-
-  context('remove_trailing_br with nested table', () => {
-    const hookWithTrailingBr = TinyHooks.bddSetup<Editor>({ ...baseSettings, remove_trailing_br: true }, [ Plugin ], true);
-    const hookWithoutTrailingBr = TinyHooks.bddSetup<Editor>({ ...baseSettings, remove_trailing_br: false }, [ Plugin ], true);
-
-    it('TINY-3909: single table, not removing br', async () => {
-      const editor = hookWithoutTrailingBr.editor();
+  context('remove_trailing_brs: true', () => {
+    const hook = TinyHooks.bddSetup<Editor>({ ...baseSettings, remove_trailing_brs: true }, [ Plugin ], true);
+    const tableOutputHtmlStr = [
+      '<table style="border-collapse: collapse; width: 100%;" border="1"><colgroup><col style="width: 50%;"><col style="width: 50%;"></colgroup>',
+      '<tbody>',
+      '<tr>',
+      '<td>&nbsp;</td>',
+      '<td>&nbsp;</td>',
+      '</tr>',
+      '<tr>',
+      '<td>&nbsp;</td>',
+      '<td>&nbsp;</td>',
+      '</tr>',
+      '</tbody>',
+      '</table>',
+    ].join('\n');
+    it('TBA: serialised content should have nbsp\'s in table cells', async () => {
+      const editor = hook.editor();
+      editor.setContent('');
+      await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
+      TinyAssertions.assertContent(editor, tableOutputHtmlStr);
+    });
+    it('TINY-3909: should have correct cursor position for single table', async () => {
+      const editor = hook.editor();
       editor.setContent('');
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
       TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0 ], 0);
-      TinyAssertions.assertContentPresence(editor, { br: 4 });
     });
-
-    it('TINY-3909: nested table, removing br', async () => {
-      const editor = hookWithTrailingBr.editor();
+    it('TINY-3909: should have correct cursor position for nested table, no brs', async () => {
+      const editor = hook.editor();
       editor.setContent('');
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
       TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0, 0, 1, 0, 0 ], 0);
     });
-
-    it('TINY-3909: nested table, not removing br', async () => {
-      const editor = hookWithoutTrailingBr.editor();
+    it('TINY-9860: should have correct number of non-bogus brs for single table, no brs', async () => {
+      const editor = hook.editor();
       editor.setContent('');
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
-      await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
-      TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0, 0, 1, 0, 0 ], 0);
+      TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0 ], 0);
+      TinyAssertions.assertContentPresence(editor, { 'br': 4, 'br:not([data-mce-bogus])': 4 });
     });
-
-    it('TINY-9860: last table cell is br, not removing br', async () => {
-      const editor = hookWithoutTrailingBr.editor();
-      editor.setContent('');
-      await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
-      TinyAssertions.assertContentPresence(editor, { br: 4 });
-    });
-
-    it('TINY-9860: nested table, last table cell is br, not removing br', async () => {
-      const editor = hookWithoutTrailingBr.editor();
+    it('TINY-9860: should have correct number of non-bogus brs for nested table', async () => {
+      const editor = hook.editor();
       editor.setContent('');
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
-      TinyAssertions.assertContentPresence(editor, { br: 7 });
+      // Three brs for the outer table and four brs for the inner table
+      TinyAssertions.assertContentPresence(editor, { 'br': 7, 'br:not([data-mce-bogus])': 7 });
     });
   });
-
+  context('remove_trailing_brs: false', () => {
+    const hook = TinyHooks.bddSetup<Editor>({ ...baseSettings, remove_trailing_brs: false }, [ Plugin ], true);
+    const tableOutputHtmlStr = [
+      '<table style="border-collapse: collapse; width: 100%;" border="1"><colgroup><col style="width: 50%;"><col style="width: 50%;"></colgroup>',
+      '<tbody>',
+      '<tr>',
+      '<td><br></td>',
+      '<td><br></td>',
+      '</tr>',
+      '<tr>',
+      '<td><br></td>',
+      '<td><br></td>',
+      '</tr>',
+      '</tbody>',
+      '</table>',
+    ].join('\n');
+    it('TBA: serialised content should have br\'s in table cells', async () => {
+      const editor = hook.editor();
+      editor.setContent('');
+      await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
+      TinyAssertions.assertContent(editor, tableOutputHtmlStr);
+    });
+    it('TINY-3909: should have correct cursor position for single table', async () => {
+      const editor = hook.editor();
+      editor.setContent('');
+      await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
+      TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0 ], 0);
+    });
+    it('TINY-3909: should have correct cursor position for nested table', async () => {
+      const editor = hook.editor();
+      editor.setContent('');
+      await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
+      await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
+      TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0, 0, 1, 0, 0 ], 0);
+    });
+    it('TINY-9860: should have correct number of non-bogus brs for single table', async () => {
+      const editor = hook.editor();
+      editor.setContent('');
+      await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
+      TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0 ], 0);
+      TinyAssertions.assertContentPresence(editor, { 'br': 4, 'br:not([data-mce-bogus])': 4 });
+    });
+    it('TINY-9860: should have correct number of non-bogus brs for nested table', async () => {
+      const editor = hook.editor();
+      editor.setContent('');
+      await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
+      await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
+      // Three brs for the outer table and four brs for the inner table
+      TinyAssertions.assertContentPresence(editor, { 'br': 7, 'br:not([data-mce-bogus])': 7 });
+    });
+  });
 });


### PR DESCRIPTION
Related Ticket: 
https://ephocks.atlassian.net/browse/TINY-9860

Description of Changes:
remove `data-mce-bogue`for last table cell

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] <s>Docs ticket created (if applicable)</s>

GitHub issues (if applicable):
