### PR TITLE
TINY-9959: Delete and enter fixes

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -260,13 +260,13 @@ const register = (editor: Editor): void => {
   registerOption('indent_before', {
     processor: 'string',
     default: 'p,h1,h2,h3,h4,h5,h6,blockquote,div,title,style,pre,script,td,th,ul,ol,li,dl,dt,dd,area,table,thead,' +
-      'tfoot,tbody,tr,section,summary,article,hgroup,aside,figure,figcaption,option,optgroup,datalist'
+      'tfoot,tbody,tr,section,details,summary,article,hgroup,aside,figure,figcaption,option,optgroup,datalist'
   });
 
   registerOption('indent_after', {
     processor: 'string',
     default: 'p,h1,h2,h3,h4,h5,h6,blockquote,div,title,style,pre,script,td,th,ul,ol,li,dl,dt,dd,area,table,thead,' +
-      'tfoot,tbody,tr,section,summary,article,hgroup,aside,figure,figcaption,option,optgroup,datalist'
+      'tfoot,tbody,tr,section,details,summary,article,hgroup,aside,figure,figcaption,option,optgroup,datalist'
   });
 
   registerOption('indent_use_margin', {

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -829,8 +829,10 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
     });
 
     // Padd these by default
-    each(split('p h1 h2 h3 h4 h5 h6 th td pre div address caption li'), (name) => {
-      elements[name].paddEmpty = true;
+    each(split('p h1 h2 h3 h4 h5 h6 th td pre div address caption li summary'), (name) => {
+      if (elements[name]) {
+        elements[name].paddEmpty = true;
+      }
     });
 
     // Remove these if they have no attributes

--- a/modules/tinymce/src/core/main/ts/dom/NodeType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/NodeType.ts
@@ -110,6 +110,8 @@ const isTableCell = matchNodeNames<HTMLTableCellElement>([ 'td', 'th' ]);
 const isTableCellOrCaption = matchNodeNames<HTMLTableCellElement>([ 'td', 'th', 'caption' ]);
 const isMedia = matchNodeNames<HTMLElement>([ 'video', 'audio', 'object', 'embed' ]);
 const isListItem = matchNodeName<HTMLLIElement>('li');
+const isDetails = matchNodeName<HTMLDetailsElement>('details');
+const isSummary = matchNodeName<HTMLElement>('summary');
 
 export {
   isText,
@@ -136,5 +138,7 @@ export {
   isBogusAll,
   isTable,
   isTextareaOrInput,
-  isListItem
+  isListItem,
+  isDetails,
+  isSummary
 };

--- a/modules/tinymce/src/core/main/ts/newline/InsertDetailsNewLine.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertDetailsNewLine.ts
@@ -1,19 +1,34 @@
+import { Obj, Type } from '@ephox/katamari';
+
 import Editor from '../api/Editor';
 import * as Options from '../api/Options';
+import * as NodeType from '../dom/NodeType';
 import * as NewLineUtils from './NewLineUtils';
 
-export const isDetails = (node?: Node | null): node is HTMLDetailsElement =>
-  node?.nodeName === 'DETAILS';
-
 export const getDetailsRoot = (editor: Editor, element: Element): HTMLDetailsElement | null =>
-  editor.dom.getParent(element, isDetails);
+  editor.dom.getParent(element, NodeType.isDetails);
+
+const isAtDetailsEdge = (root: HTMLElement, element: Element, isTextBlock: (el: HTMLElement) => boolean) => {
+  let node = element;
+
+  while (node && node !== root && Type.isNull(node.nextSibling)) {
+    const parent = node.parentElement;
+
+    if (!parent || !isTextBlock(parent)) {
+      return NodeType.isDetails(parent);
+    }
+
+    node = parent;
+  }
+
+  return false;
+};
 
 export const isLastEmptyBlockInDetails = (editor: Editor, shiftKey: boolean, element: Element): boolean =>
   !shiftKey &&
   element.nodeName.toLowerCase() === Options.getForcedRootBlock(editor) &&
-  element.parentNode?.lastChild === element &&
   editor.dom.isEmpty(element) &&
-  isDetails(element.parentNode);
+  isAtDetailsEdge(editor.getBody(), element, (el) => Obj.has(editor.schema.getTextBlockElements(), el.nodeName.toLowerCase()));
 
 export const insertNewLine = (editor: Editor, createNewBlock: (name: string) => Element, parentBlock: Element): void => {
   const newBlock = createNewBlock(Options.getForcedRootBlock(editor));
@@ -23,7 +38,9 @@ export const insertNewLine = (editor: Editor, createNewBlock: (name: string) => 
   }
   editor.dom.insertAfter(newBlock, root);
   NewLineUtils.moveToCaretPosition(editor, newBlock);
-  if (root.children.length > 2) {
+
+  // TODO: This now only works with our Accordions not details with multiple root level children should we support that
+  if ((parentBlock.parentElement?.childNodes?.length ?? 0) > 1) {
     editor.dom.remove(parentBlock);
   }
 };

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -1,14 +1,15 @@
-import { Arr, Type } from '@ephox/katamari';
+import { Arr, Fun, Optional, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { SugarElement } from '@ephox/sugar';
 
-import DomTreeWalker from '../api/dom/TreeWalker';
+import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
 import * as Options from '../api/Options';
 import VK from '../api/util/VK';
 import * as CaretFinder from '../caret/CaretFinder';
 import CaretPosition from '../caret/CaretPosition';
 import * as DeleteUtils from '../delete/DeleteUtils';
+import * as NodeType from '../dom/NodeType';
 import * as PaddingBr from '../dom/PaddingBr';
 import * as FormatUtils from '../fmt/FormatUtils';
 
@@ -44,25 +45,14 @@ const filterDetails = (editor: Editor): void => {
   });
 };
 
-const isCaretInTheBeginning = (rng: Range, element: HTMLElement): boolean =>
-  CaretFinder.firstPositionIn(element).exists((pos) => pos.isEqual(CaretPosition.fromRangeStart(rng)));
-
-const isCaretInTheEnding = (rng: Range, element: HTMLElement): boolean =>
-  CaretFinder.lastPositionIn(element).exists((pos) => pos.isEqual(CaretPosition.fromRangeStart(rng)));
-
-const removeNode = (editor: Editor, node: Node) => editor.dom.remove(node, false);
-
 const emptyNodeContents = (node: Node) => PaddingBr.fillWithPaddingBr(SugarElement.fromDom(node));
 
-const setCaretToPosition = (editor: Editor) => (position: CaretPosition): void => {
+const setCaretToPosition = (editor: Editor, position: CaretPosition): void => {
   const node = position.getNode();
   if (!Type.isUndefined(node)) {
     editor.selection.setCursorLocation(node, position.offset());
   }
 };
-
-const isSummary = (node: Node | null | undefined): boolean => node?.nodeName === 'SUMMARY';
-const isDetails = (node: Node | null | undefined): boolean => node?.nodeName === 'DETAILS';
 
 const isEntireNodeSelected = (rng: Range, node: Node): boolean =>
   rng.startOffset === 0 && rng.endOffset === node.textContent?.length;
@@ -70,107 +60,229 @@ const isEntireNodeSelected = (rng: Range, node: Node): boolean =>
 const platform = PlatformDetection.detect();
 const browser = platform.browser;
 const os = platform.os;
-const isFirefox = browser.isFirefox();
 const isSafari = browser.isSafari();
 const isMacOSOriOS = os.isMacOS() || os.isiOS();
+
+interface DetailsElements {
+  readonly startSummary: Optional<HTMLElement>;
+  readonly startDetails: Optional<HTMLDetailsElement>;
+  readonly endDetails: Optional<HTMLDetailsElement>;
+}
+
+const isCaretInTheBeginningOf = (caretPos: CaretPosition, element: HTMLElement): boolean =>
+  CaretFinder.firstPositionIn(element).exists((pos) => pos.isEqual(caretPos));
+
+const isCaretInTheEndOf = (caretPos: CaretPosition, element: HTMLElement): boolean => {
+  return CaretFinder.lastPositionIn(element).exists((pos) => {
+    // Summary may or may not have a trailing BR
+    if (NodeType.isBr(pos.getNode())) {
+      return CaretFinder.prevPosition(element, pos).exists((pos2) => pos2.isEqual(caretPos)) || pos.isEqual(caretPos);
+    } else {
+      return pos.isEqual(caretPos);
+    }
+  });
+};
+
+const getDetailsElements = (dom: DOMUtils, rng: Range): Optional<DetailsElements> => {
+  const startDetails = Optional.from(dom.getParent(rng.startContainer, 'details'));
+  const endDetails = Optional.from(dom.getParent(rng.endContainer, 'details'));
+
+  if (startDetails.isSome() || endDetails.isSome()) {
+    const startSummary = startDetails.bind((details) => Optional.from(dom.select('summary', details)[0]));
+    return Optional.some({ startSummary, startDetails, endDetails });
+  } else {
+    return Optional.none();
+  }
+};
+
+const isPartialDelete = (rng: Range, detailsElements: DetailsElements) => {
+  const containsStart = (element: HTMLElement) => element.contains(rng.startContainer);
+  const containsEnd = (element: HTMLElement) => element.contains(rng.endContainer);
+  const startInSummary = detailsElements.startSummary.exists(containsStart);
+  const endInSummary = detailsElements.startSummary.exists(containsEnd);
+  const isPartiallySelectedDetailsElements = detailsElements.startDetails.forall((startDetails) => detailsElements.endDetails.forall((endDetails) => startDetails !== endDetails));
+  const isInPartiallySelectedSummary = (startInSummary || endInSummary) && !(startInSummary && endInSummary);
+
+  return isInPartiallySelectedSummary || isPartiallySelectedDetailsElements;
+};
+
+const isCaretAtStartOfSummary = (caretPos: CaretPosition, detailsElements: DetailsElements) =>
+  detailsElements.startSummary.exists((summary) => isCaretInTheBeginningOf(caretPos, summary));
+
+const isCaretAtEndOfSummary = (caretPos: CaretPosition, detailsElements: DetailsElements) =>
+  detailsElements.startSummary.exists((summary) => isCaretInTheEndOf(caretPos, summary));
+
+const isCaretInFirstPositionInBody = (caretPos: CaretPosition, detailsElements: DetailsElements) =>
+  detailsElements.startDetails.exists((details) =>
+    CaretFinder.prevPosition(details, caretPos).forall((pos) =>
+      detailsElements.startSummary.exists((summary) => !summary.contains(caretPos.container()) && summary.contains(pos.container()))
+    )
+  );
+
+const isCaretInLastPositionInBody = (root: HTMLElement, caretPos: CaretPosition, detailsElements: DetailsElements) =>
+  detailsElements.startDetails.exists((details) =>
+    CaretFinder.nextPosition(root, caretPos).forall((pos) =>
+      !details.contains(pos.container())
+    )
+  );
+
+const isInDetailsElement = (dom: DOMUtils, pos: CaretPosition) =>
+  Type.isNonNullable(dom.getParent(pos.container(), 'details'));
+
+const moveCaretToDetailsPos = (editor: Editor, pos: CaretPosition) => {
+  const details = editor.dom.getParent(pos.container(), 'details');
+
+  if (details && !details.open) {
+    const summary = editor.dom.select('summary', details)[0];
+    if (summary) {
+      CaretFinder.lastPositionIn(summary).each((pos) => setCaretToPosition(editor, pos));
+    }
+  } else {
+    setCaretToPosition(editor, pos);
+  }
+};
+
+const preventDeleteIntoDetails = (editor: Editor, forward: boolean) => {
+  const { dom, selection } = editor;
+  const root = editor.getBody();
+
+  if (editor.selection.isCollapsed()) {
+    const caretPos = CaretPosition.fromRangeStart(selection.getRng());
+    const parentBlock = dom.getParent(caretPos.container(), dom.isBlock);
+
+    // Prevent backspace/delete if the paragraph is empty and the start or end of it's parent container
+    // TODO: Clean this up!
+    if (parentBlock && dom.isEmpty(parentBlock)) {
+      if (Type.isNull(parentBlock.nextSibling)) {
+        const pos = CaretFinder.prevPosition(root, caretPos).filter((pos) => isInDetailsElement(dom, pos));
+        if (pos.isSome()) {
+          pos.each((pos) => {
+            if (!forward) {
+              moveCaretToDetailsPos(editor, pos);
+            }
+          });
+          return true;
+        }
+      } else if (Type.isNull(parentBlock.previousSibling)) {
+        const pos = CaretFinder.nextPosition(root, caretPos).filter((pos) => isInDetailsElement(dom, pos));
+        if (pos) {
+          return true;
+        }
+      }
+    }
+
+    return CaretFinder.navigate(forward, root, caretPos).fold(
+      Fun.never,
+      (pos) => {
+        if (isInDetailsElement(dom, pos)) {
+          if (parentBlock && dom.isEmpty(parentBlock)) {
+            editor.dom.remove(parentBlock);
+          }
+
+          if (!forward) {
+            moveCaretToDetailsPos(editor, pos);
+          }
+          return true;
+        } else {
+          return false;
+        }
+      }
+    );
+  } else {
+    return false;
+  }
+};
+
+const preventDeleteSummaryAction = (editor: Editor, detailElements: DetailsElements, e: KeyboardEvent): boolean => {
+  const selection = editor.selection;
+  const node = selection.getNode();
+  const rng = selection.getRng();
+  const isBackspace = e.keyCode === VK.BACKSPACE;
+  const isDelete = e.keyCode === VK.DELETE;
+  const isCollapsed = editor.selection.isCollapsed();
+  const caretPos = CaretPosition.fromRangeStart(rng);
+  const root = editor.getBody();
+
+  if (!isCollapsed && isPartialDelete(rng, detailElements)) {
+    return true;
+  } else if (isCollapsed && isBackspace && isCaretAtStartOfSummary(caretPos, detailElements)) {
+    return true;
+  } else if (isCollapsed && isDelete && isCaretAtEndOfSummary(caretPos, detailElements)) {
+    return true;
+  } else if (isCollapsed && isBackspace && isCaretInFirstPositionInBody(caretPos, detailElements)) {
+    return true;
+  } else if (isCollapsed && isDelete && isCaretInLastPositionInBody(root, caretPos, detailElements)) {
+    return true;
+  } else if (isSafari && NodeType.isSummary(node)) {
+    // TINY-9951: Safari bug, deleting within the summary causes all content to be removed and no caret position to be left
+    // https://bugs.webkit.org/show_bug.cgi?id=257745
+    if (!isCollapsed && isEntireNodeSelected(rng, node) || DeleteUtils.willDeleteLastPositionInElement(isDelete, caretPos, node)) {
+      emptyNodeContents(node);
+    } else {
+      editor.undoManager.transact(() => {
+        // Wrap all summary children in a temporary container to execute Backspace/Delete there, then unwrap
+        const sel = selection.getSel();
+        let { anchorNode, anchorOffset, focusNode, focusOffset } = sel ?? {};
+        const applySelection = () => {
+          if (Type.isNonNullable(anchorNode) && Type.isNonNullable(anchorOffset) && Type.isNonNullable(focusNode) && Type.isNonNullable(focusOffset)) {
+            sel?.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
+          }
+        };
+        const updateSelection = () => {
+          anchorNode = sel?.anchorNode;
+          anchorOffset = sel?.anchorOffset;
+          focusNode = sel?.focusNode;
+          focusOffset = sel?.focusOffset;
+        };
+        const appendAllChildNodes = (from: Node, to: Node) => {
+          Arr.each(from.childNodes, (child) => {
+            if (FormatUtils.isNode(child)) {
+              to.appendChild(child);
+            }
+          });
+        };
+
+        const container = editor.dom.create('span', { 'data-mce-bogus': 'all' });
+        appendAllChildNodes(node, container);
+        node.appendChild(container);
+        applySelection();
+        // Manually perform ranged deletion by keyboard shortcuts
+        if (isCollapsed && (isMacOSOriOS && (e.altKey || isBackspace && e.metaKey) || !isMacOSOriOS && e.ctrlKey)) {
+          sel?.modify('extend', isBackspace ? 'left' : 'right', e.metaKey ? 'line' : 'word');
+        }
+        if (!selection.isCollapsed() && isEntireNodeSelected(selection.getRng(), container)) {
+          emptyNodeContents(node);
+        } else {
+          editor.execCommand(isBackspace ? 'Delete' : 'ForwardDelete');
+          updateSelection();
+          appendAllChildNodes(container, node);
+          applySelection();
+        }
+        editor.dom.remove(container);
+      });
+    }
+
+    return true;
+  }
+
+  return false;
+};
 
 const preventDeletingSummary = (editor: Editor): void => {
   editor.on('keydown', (e) => {
     if (e.keyCode === VK.BACKSPACE || e.keyCode === VK.DELETE) {
-      const selection = editor.selection;
-      const node = selection.getNode();
-      const body = editor.getBody();
-      const prevNode = new DomTreeWalker(node, body).prev2(true);
-      const nextNode = new DomTreeWalker(node, body).next(true);
-      const startElement = selection.getStart();
-      const endElement = selection.getEnd();
-      const rng = selection.getRng();
-      const isBackspace = e.keyCode === VK.BACKSPACE;
-      const isCaretAtStart = isCaretInTheBeginning(rng, node);
-      const isBackspaceAndCaretAtStart = isBackspace && isCaretAtStart;
-      const isDelete = e.keyCode === VK.DELETE;
-      const isDeleteAndCaretAtEnd = isDelete && isCaretInTheEnding(rng, node);
-      const isCollapsed = editor.selection.isCollapsed();
-      const isEmpty = editor.dom.isEmpty(node);
-      const hasPrevNode = Type.isNonNullable(prevNode);
-      const hasNextNode = Type.isNonNullable(nextNode);
-      const isNotInSummaryAndIsPrevNodeDetails = hasPrevNode && !isSummary(node) && isDetails(prevNode);
-      const isDeleteInEmptyNodeAfterAccordion = isDelete && isEmpty && isNotInSummaryAndIsPrevNodeDetails;
-      const isBackspaceInEmptyNodeBeforeAccordion = isBackspace && isEmpty && !isSummary(node) && !isDetails(node) && isDetails(nextNode);
-
-      if (
-        !isCollapsed && isSummary(startElement) && startElement !== endElement && !Type.isNull(editor.dom.getParent(endElement, 'details'))
-        || isCollapsed && (
-          (isBackspaceAndCaretAtStart || isDeleteAndCaretAtEnd || isEmpty) && isSummary(node)
-          || isBackspaceAndCaretAtStart && isSummary(prevNode)
-          || isDeleteAndCaretAtEnd && node === editor.dom.getParent(node, 'details')?.lastChild
-          || isDeleteAndCaretAtEnd && isDetails(nextNode) && !isEmpty
-          || isFirefox && isDeleteInEmptyNodeAfterAccordion && !hasNextNode
-          || isFirefox && isBackspaceInEmptyNodeBeforeAccordion && !hasPrevNode
-        )
-      ) {
-        e.preventDefault();
-      } else if (isCollapsed && isBackspaceAndCaretAtStart && isNotInSummaryAndIsPrevNodeDetails) {
-        e.preventDefault();
-        if (isEmpty) {
-          removeNode(editor, node);
+      getDetailsElements(editor.dom, editor.selection.getRng()).fold(
+        () => {
+          if (preventDeleteIntoDetails(editor, e.keyCode === VK.DELETE)) {
+            e.preventDefault();
+          }
+        },
+        (detailsElements) => {
+          if (preventDeleteSummaryAction(editor, detailsElements, e)) {
+            e.preventDefault();
+          }
         }
-        CaretFinder.lastPositionIn(prevNode).each(setCaretToPosition(editor));
-      } else if (isFirefox && isCollapsed && isDeleteInEmptyNodeAfterAccordion && hasNextNode) {
-        e.preventDefault();
-        removeNode(editor, node);
-        CaretFinder.firstPositionIn(nextNode).each(setCaretToPosition(editor));
-      } else if (isSafari && isSummary(node)) {
-        // TINY-9951: Safari bug, deleting within the summary causes all content to be removed and no caret position to be left
-        // https://bugs.webkit.org/show_bug.cgi?id=257745
-        e.preventDefault();
-
-        if (!isCollapsed && isEntireNodeSelected(rng, node) || DeleteUtils.willDeleteLastPositionInElement(isDelete, CaretPosition.fromRangeStart(rng), node)) {
-          emptyNodeContents(node);
-        } else {
-          editor.undoManager.transact(() => {
-            // Wrap all summary children in a temporary container to execute Backspace/Delete there, then unwrap
-            const sel = selection.getSel();
-            let { anchorNode, anchorOffset, focusNode, focusOffset } = sel ?? {};
-            const applySelection = () => {
-              if (Type.isNonNullable(anchorNode) && Type.isNonNullable(anchorOffset) && Type.isNonNullable(focusNode) && Type.isNonNullable(focusOffset)) {
-                sel?.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
-              }
-            };
-            const updateSelection = () => {
-              anchorNode = sel?.anchorNode;
-              anchorOffset = sel?.anchorOffset;
-              focusNode = sel?.focusNode;
-              focusOffset = sel?.focusOffset;
-            };
-            const appendAllChildNodes = (from: Node, to: Node) => {
-              Arr.each(from.childNodes, (child) => {
-                if (FormatUtils.isNode(child)) {
-                  to.appendChild(child);
-                }
-              });
-            };
-
-            const container = editor.dom.create('span', { 'data-mce-bogus': 'all' });
-            appendAllChildNodes(node, container);
-            node.appendChild(container);
-            applySelection();
-            // Manually perform ranged deletion by keyboard shortcuts
-            if (isCollapsed && (isMacOSOriOS && (e.altKey || isBackspace && e.metaKey) || !isMacOSOriOS && e.ctrlKey)) {
-              sel?.modify('extend', isBackspace ? 'left' : 'right', e.metaKey ? 'line' : 'word');
-            }
-            if (!selection.isCollapsed() && isEntireNodeSelected(selection.getRng(), container)) {
-              emptyNodeContents(node);
-            } else {
-              editor.execCommand(isBackspace ? 'Delete' : 'ForwardDelete');
-              updateSelection();
-              appendAllChildNodes(container, node);
-              applySelection();
-            }
-            editor.dom.remove(container);
-          });
-        }
-      }
+      );
     }
   });
 };

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionPluginTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionPluginTest.ts
@@ -67,7 +67,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<ol><li>tiny</li></ol>',
       initialCursor: [[ 0, 0, 0 ], 'tiny'.length ],
-      assertContent: `<ol>\n<li>tiny${AccordionUtils.createAccordion()}</li>\n</ol>`,
+      assertContent: `<ol>\n<li>tiny\n${AccordionUtils.createAccordion()}\n</li>\n</ol>`,
       assertCursor: [[ 0, 0, 1, 0, 0 ], 'Accordion summary...'.length ],
     });
   });
@@ -76,7 +76,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<dl><dt>tiny</dt></dl>',
       initialCursor: [[ 0, 0, 0 ], 'tiny'.length ],
-      assertContent: `<dl>\n<dt>tiny${AccordionUtils.createAccordion()}</dt>\n</dl>`,
+      assertContent: `<dl>\n<dt>tiny\n${AccordionUtils.createAccordion()}\n</dt>\n</dl>`,
       assertCursor: [[ 0, 0, 1, 0, 0 ], 'Accordion summary...'.length ],
     });
   });
@@ -85,7 +85,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<dl><dd>tiny</dd></dl>',
       initialCursor: [[ 0, 0, 0 ], 'tiny'.length ],
-      assertContent: `<dl>\n<dd>tiny${AccordionUtils.createAccordion()}</dd>\n</dl>`,
+      assertContent: `<dl>\n<dd>tiny\n${AccordionUtils.createAccordion()}\n</dd>\n</dl>`,
       assertCursor: [[ 0, 0, 1, 0, 0 ], 'Accordion summary...'.length ],
     });
   });
@@ -94,7 +94,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<table><colgroup><col></colgroup><tbody><tr><td>&nbsp;</td></tr></tbody></table>',
       initialCursor: [[ 0, 1, 0, 0, 0 ], 0 ],
-      assertContent: `<table><colgroup><col></colgroup>\n<tbody>\n<tr>\n<td>${AccordionUtils.createAccordion()}</td>\n</tr>\n</tbody>\n</table>`,
+      assertContent: `<table><colgroup><col></colgroup>\n<tbody>\n<tr>\n<td>\n${AccordionUtils.createAccordion()}\n</td>\n</tr>\n</tbody>\n</table>`,
       assertCursor: [[ 0, 1, 0, 0, 0, 0, 0 ], 'Accordion summary...'.length ],
     });
   });
@@ -103,7 +103,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' }),
       initialCursor: [[ 0, 1, 0, 0 ], 'body'.length ],
-      assertContent: AccordionUtils.createAccordion({ summary: 'summary', body: `<p>body</p>\n${AccordionUtils.createAccordion()}` }),
+      assertContent: AccordionUtils.createAccordion({ summary: 'summary', body: `<p>body</p>\n${AccordionUtils.createAccordion()}\n` }),
       assertCursor: [[ 0, 1, 1, 0, 0 ], 'Accordion summary...'.length ],
     });
   });

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionEnterTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionEnterTest.ts
@@ -37,11 +37,11 @@ describe('webdriver.tinymce.plugins.accordion.AccordionEnterTest', () => {
   it('TINY-9731: Leave accordion body with ENTER keypress within an empty paragraph', async () => {
     const editor = hook.editor();
     editor.setContent(AccordionUtils.createAccordion({ body: '<p>tiny</p>' }));
-    TinySelections.setCursor(editor, [ 0, 1, 0 ], 'tiny'.length);
+    TinySelections.setCursor(editor, [ 0, 1, 0, 0 ], 'tiny'.length);
     await pDoEnter();
-    TinyAssertions.assertContentPresence(editor, { 'details > p': 2 });
+    TinyAssertions.assertContentPresence(editor, { 'details > div > p': 2 });
     await pDoEnter();
-    TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
+    TinyAssertions.assertContentPresence(editor, { 'details > div > p': 1 });
     TinyAssertions.assertContentPresence(editor, { 'details + p': 1 });
     TinyAssertions.assertCursor(editor, [ 1 ], 0);
   });
@@ -49,9 +49,9 @@ describe('webdriver.tinymce.plugins.accordion.AccordionEnterTest', () => {
   it('TINY-9731: Do not remove the only empty paragraph when leaving accordion body with ENTER keypress', async () => {
     const editor = hook.editor();
     editor.setContent(AccordionUtils.createAccordion({ body: '<p></p>' }));
-    TinySelections.setCursor(editor, [ 0, 1 ], 0);
+    TinySelections.setCursor(editor, [ 0, 1, 0 ], 0);
     await pDoEnter();
-    TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
+    TinyAssertions.assertContentPresence(editor, { 'details > div > p': 1 });
     TinyAssertions.assertContentPresence(editor, { 'details + p': 1 });
     TinyAssertions.assertCursor(editor, [ 1 ], 0);
   });


### PR DESCRIPTION
Related Ticket: TINY-9959

Description of Changes:
* Changed so that details elements gets newlines before/after them like other blocks
* Changed so that summary elements gets padded
* Merged in develop since I ran into out of memory issues
* Fixed enter by checking if all parents are text blocks and they are the last one so div > div > div > p should now work.
* Rewrote backspace delete so that it handles more cases and hopefully easier to understand.
* Fixed tests to that they now all pass at least locally.
* Moved predicates to the NodeType module.
* Removed the `entities: 'raw'` and `extended_valid_elements` overrides for the backspace delete tests so they test the default setup.

Left do do:
* Adding more tests for the backspace/delete cases like for example partial selections like `<p>f[oo</p><details><summary>b]ar</summary></details>` etc.
* Adding more tests for the enter cases like for example for multiple nested structures.
* Add a better fix for checking if the element is the last one in the details on enter is not generic now but works for accordions.
* Figure out why one of the tests needed a different path on Firefox and Safari.
* Obviously a lot of cleanup but that can be done after release.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
