### PR TITLE
TINY-9843: Fix border styles being split into longhand form after table updates

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - It was possible to break summary elements if contents containing blocks was dropped inside them. #TINY-9960
 - Contents would not be removed from the drag start source if dragging and dropping internally into a transparent block element. #TINY-9960
 - In some cases pressing enter would scroll the entire page. #TINY-9828
-- It was not possible to press space to insert a space character inside a summary element on Firefox. #TINY-9964
+- The border styles of a table were incorrectly split into a longhand form after table dialog updates. #TINY-9843
 
 ## 6.5.1 - 2023-06-19
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815
-- The border style of table was splitted into a longhand form after table updates, resulting a difference when being emitted during `getContent()`. #TINY-9843
+- The border styles of a table were incorrectly split into a longhand form after table dialog updates. #TINY-9843
 - It was not possible to press space to insert a space character inside a summary element on Firefox. #TINY-9964
 
 ## 6.5.1 - TBA

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815
+- The border style of table was splitted into a longhand form after table updates, resulting a difference when being emitted during `getContent()`. #TINY-9843
 
 ## 6.5.0 - 2023-06-12
 

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -123,7 +123,8 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
           return;
         }
 
-        const values = value.split(' ');
+        // Make sure not to split values like 'rgb(100, 50, 100);
+        const values = value.indexOf(',') > -1 ? [ value ] : value.split(' ');
         let i = values.length;
         while (i--) {
           if (values[i] !== values[0]) {

--- a/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
@@ -5,22 +5,27 @@ import Schema from 'tinymce/core/api/html/Schema';
 import Styles from 'tinymce/core/api/html/Styles';
 
 describe('browser.tinymce.core.html.StylesTest', () => {
+
+  const assertStyles = (styles: Styles, input: string, expected: string) => {
+    assert.equal(styles.serialize(styles.parse(input)), expected);
+  };
+
   it('Basic parsing/serializing', () => {
     const styles = Styles();
 
-    assert.equal(styles.serialize(styles.parse('FONT-SIZE:10px')), 'font-size: 10px;');
-    assert.equal(styles.serialize(styles.parse('FONT-SIZE:10px;COLOR:red')), 'font-size: 10px; color: red;');
-    assert.equal(styles.serialize(styles.parse('   FONT-SIZE  :  10px  ;   COLOR  :  red   ')), 'font-size: 10px; color: red;');
-    assert.equal(styles.serialize(styles.parse('key:"value"')), `key: 'value';`);
-    assert.equal(styles.serialize(styles.parse(`key:"value1" 'value2'`)), `key: 'value1' 'value2';`);
-    assert.equal(styles.serialize(styles.parse(`key:"val\\"ue1" 'val\\'ue2'`)), `key: 'val"ue1' 'val\\'ue2';`);
-    assert.equal(styles.serialize(styles.parse('width:100%')), 'width: 100%;');
-    assert.equal(styles.serialize(styles.parse('value:_; value2:"_"')), `value: _; value2: '_';`);
-    assert.equal(styles.serialize(styles.parse('value: "&amp;"')), `value: '&amp;';`);
-    assert.equal(styles.serialize(styles.parse('value: "&"')), `value: '&';`);
-    assert.equal(styles.serialize(styles.parse('value: ')), '');
-    assert.equal(
-      styles.serialize(styles.parse(`background: url('http://www.site.com/(foo)');`)),
+    assertStyles(styles, 'FONT-SIZE:10px', 'font-size: 10px;');
+    assertStyles(styles, 'FONT-SIZE:10px;COLOR:red', 'font-size: 10px; color: red;');
+    assertStyles(styles, 'FONT-SIZE  :  10px  ;   COLOR  :  red   ', 'font-size: 10px; color: red;');
+    assertStyles(styles, 'key:"value"', `key: 'value';`);
+    assertStyles(styles, `key:"value1" 'value2'`, `key: 'value1' 'value2';`);
+    assertStyles(styles, `key:"val\\"ue1" 'val\\'ue2'`, `key: 'val"ue1' 'val\\'ue2';`);
+    assertStyles(styles, 'width:100%', 'width: 100%;');
+    assertStyles(styles, 'value:_; value2:"_"', `value: _; value2: '_';`);
+    assertStyles(styles, 'value: "&amp;"', `value: '&amp;';`);
+    assertStyles(styles, 'value: "&"', `value: '&';`);
+    assertStyles(styles, 'value: ', '');
+    assertStyles(styles,
+      `background: url('http://www.site.com/(foo)');`,
       `background: url('http://www.site.com/(foo)');`
     );
   });
@@ -28,15 +33,18 @@ describe('browser.tinymce.core.html.StylesTest', () => {
   it('Colors force hex and lowercase', () => {
     const styles = Styles();
 
-    assert.equal(styles.serialize(styles.parse('color: rgb(1,2,3)')), 'color: rgb(1,2,3);');
-    assert.equal(styles.serialize(styles.parse('color: RGB(1,2,3)')), 'color: rgb(1,2,3);');
-    assert.equal(styles.serialize(styles.parse('color: #FF0000')), 'color: #ff0000;');
-    assert.equal(styles.serialize(styles.parse('  color:   RGB  (  1  ,  2  ,  3  )  ')), 'color: rgb  (  1  ,  2  ,  3  );');
-    assert.equal(
-      styles.serialize(styles.parse('   FONT-SIZE  :  10px  ;   COLOR  :  RGB  (  1  ,  2  ,  3  )   ')),
+    assertStyles(styles, 'color: rgb(1,2,3)', 'color: rgb(1,2,3);');
+    assertStyles(styles, 'color: RGB(1,2,3)', 'color: rgb(1,2,3);');
+    assertStyles(styles, 'color: #FF0000', 'color: #ff0000;');
+    assertStyles(styles, '  color:   RGB  (  1  ,  2  ,  3  )  ', 'color: rgb  (  1  ,  2  ,  3  );');
+    assertStyles(styles,
+      '   FONT-SIZE  :  10px  ;   COLOR  :  RGB  (  1  ,  2  ,  3  )   ',
       'font-size: 10px; color: rgb  (  1  ,  2  ,  3  );'
     );
-    assert.equal(styles.serialize(styles.parse('   FONT-SIZE  :  10px  ;   COLOR  :  RED   ')), 'font-size: 10px; color: red;');
+    assertStyles(styles,
+      '   FONT-SIZE  :  10px  ;   COLOR  :  RED   ',
+      'font-size: 10px; color: red;'
+    );
   });
 
   it('Urls convert urls and force format', () => {
@@ -46,22 +54,22 @@ describe('browser.tinymce.core.html.StylesTest', () => {
       }
     });
 
-    assert.equal(styles.serialize(styles.parse('background: url(a)')), `background: url('|a|');`);
-    assert.equal(styles.serialize(styles.parse('background: url("a")')), `background: url('|a|');`);
-    assert.equal(styles.serialize(styles.parse(`background: url('a')`)), `background: url('|a|');`);
-    assert.equal(styles.serialize(styles.parse('background: url(   a   )')), `background: url('|a|');`);
-    assert.equal(styles.serialize(styles.parse('background: url(   "a"   )')), `background: url('|a|');`);
-    assert.equal(styles.serialize(styles.parse(`background: url(    'a'    )`)), `background: url('|a|');`);
-    assert.equal(
-      styles.serialize(styles.parse(`background1: url(a); background2: url("a"); background3: url('a')`)),
+    assertStyles(styles, 'background: url(a)', `background: url('|a|');`);
+    assertStyles(styles, 'background: url("a")', `background: url('|a|');`);
+    assertStyles(styles, `background: url('a')`, `background: url('|a|');`);
+    assertStyles(styles, 'background: url(   a   )', `background: url('|a|');`);
+    assertStyles(styles, 'background: url(   "a"   )', `background: url('|a|');`);
+    assertStyles(styles, `background: url(    'a'    )`, `background: url('|a|');`);
+    assertStyles(styles,
+      `background1: url(a); background2: url("a"); background3: url('a')`,
       `background1: url('|a|'); background2: url('|a|'); background3: url('|a|');`
     );
-    assert.equal(
-      styles.serialize(styles.parse(`background: url('http://www.site.com/a?a=b&c=d')`)),
+    assertStyles(styles,
+      `background: url('http://www.site.com/a?a=b&c=d')`,
       `background: url('|http://www.site.com/a?a=b&c=d|');`
     );
-    assert.equal(
-      styles.serialize(styles.parse(`background: url('http://www.site.com/a_190x144.jpg');`)),
+    assertStyles(styles,
+      `background: url('http://www.site.com/a_190x144.jpg');`,
       `background: url('|http://www.site.com/a_190x144.jpg|');`
     );
   });
@@ -69,95 +77,94 @@ describe('browser.tinymce.core.html.StylesTest', () => {
   it('Compress styles', () => {
     const styles = Styles();
 
-    assert.equal(
-      styles.serialize(
-        styles.parse('border-top: 1px solid red; border-left: 1px solid red; border-bottom: 1px solid red; border-right: 1px solid red;')
-      ),
+    assertStyles(
+      styles,
+      'border-top: 1px solid red; border-left: 1px solid red; border-bottom: 1px solid red; border-right: 1px solid red;',
       'border: 1px solid red;'
     );
 
-    assert.equal(
-      styles.serialize(
-        styles.parse('border-width: 1pt 1pt 1pt 1pt; border-style: none none none none; border-color: black black black black;')
-      ),
+    assertStyles(
+      styles,
+      'border-width: 1pt 1pt 1pt 1pt; border-style: none none none none; border-color: black black black black;',
       'border: 1pt none black;'
     );
 
-    assert.equal(
-      styles.serialize(
-        styles.parse('border-width: 1pt 4pt 2pt 3pt; border-style: solid dashed dotted none; border-color: black red green blue;')
-      ),
+    assertStyles(
+      styles,
+      'border-width: 1pt 4pt 2pt 3pt; border-style: solid dashed dotted none; border-color: black red green blue;',
       'border-width: 1pt 4pt 2pt 3pt; border-style: solid dashed dotted none; border-color: black red green blue;'
     );
 
-    assert.equal(
-      styles.serialize(
-        styles.parse('border-top: 1px solid red; border-left: 1px solid red; border-right: 1px solid red; border-bottom: 1px solid red')
-      ),
+    assertStyles(
+      styles,
+      'border-top: 1px solid red; border-left: 1px solid red; border-right: 1px solid red; border-bottom: 1px solid red',
       'border: 1px solid red;'
     );
 
-    assert.equal(
-      styles.serialize(
-        styles.parse('border-top: 1px solid red; border-right: 2px solid red; border-bottom: 3px solid red; border-left: 4px solid red')
-      ),
+    assertStyles(
+      styles,
+      'border-top: 1px solid red; border-right: 2px solid red; border-bottom: 3px solid red; border-left: 4px solid red',
       'border-top: 1px solid red; border-right: 2px solid red; border-bottom: 3px solid red; border-left: 4px solid red;'
     );
 
-    assert.equal(
-      styles.serialize(
-        styles.parse('padding-top: 1px; padding-right: 2px; padding-bottom: 3px; padding-left: 4px')
-      ),
+    assertStyles(
+      styles,
+      'padding-top: 1px; padding-right: 2px; padding-bottom: 3px; padding-left: 4px',
       'padding: 1px 2px 3px 4px;'
     );
 
-    assert.equal(
-      styles.serialize(styles.parse('margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px')),
+    assertStyles(
+      styles,
+      'margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px',
       'margin: 1px 2px 3px 4px;'
     );
 
-    assert.equal(
-      styles.serialize(styles.parse('margin-top: 1px; margin-right: 1px; margin-bottom: 1px; margin-left: 2px')),
+    assertStyles(
+      styles,
+      'margin-top: 1px; margin-right: 1px; margin-bottom: 1px; margin-left: 2px',
       'margin: 1px 1px 1px 2px;'
     );
 
-    assert.equal(
-      styles.serialize(styles.parse('margin-top: 2px; margin-right: 1px; margin-bottom: 1px; margin-left: 1px')),
+    assertStyles(
+      styles,
+      'margin-top: 2px; margin-right: 1px; margin-bottom: 1px; margin-left: 1px',
       'margin: 2px 1px 1px 1px;'
     );
 
-    assert.equal(
-      styles.serialize(
-        styles.parse('border-top-color: red; border-right-color: green; border-bottom-color: blue; border-left-color: yellow')
-      ),
+    assertStyles(
+      styles,
+      'border-top-color: red; border-right-color: green; border-bottom-color: blue; border-left-color: yellow',
       'border-color: red green blue yellow;'
     );
 
-    assert.equal(
-      styles.serialize(styles.parse('border-width: 1px; border-style: solid; border-color: red')),
+    assertStyles(
+      styles,
+      'border-width: 1px; border-style: solid; border-color: red',
       'border: 1px solid red;'
     );
 
-    assert.equal(
-      styles.serialize(styles.parse('border-width: 1px; border-color: red')),
+    assertStyles(
+      styles,
+      'border-width: 1px; border-color: red',
       'border-width: 1px; border-color: red;'
     );
 
-    assert.equal(
-      styles.serialize(styles.parse('border-width: 1px; border-color: rgb(1, 2, 3)')),
+    assertStyles(
+      styles,
+      'border-width: 1px; border-color: rgb(1, 2, 3)',
       'border-width: 1px; border-color: rgb(1, 2, 3);'
     );
 
-    assert.equal(
-      styles.serialize(styles.parse('border-width: 1px; border-color: rgb(1, 2, 3); border-style: dashed')),
+    assertStyles(
+      styles,
+      'border-width: 1px; border-color: rgb(1, 2, 3); border-style: dashed',
       'border: 1px dashed rgb(1, 2, 3);'
     );
   });
 
   it('Font weight', () => {
     const styles = Styles();
-
-    assert.equal(styles.serialize(styles.parse('font-weight: 700')), 'font-weight: bold;');
+    assertStyles(styles, 'font-weight: 700', 'font-weight: bold;');
   });
 
   it('Valid styles', () => {
@@ -186,45 +193,45 @@ describe('browser.tinymce.core.html.StylesTest', () => {
   it('Suspicious (XSS) property names', () => {
     const styles = Styles();
 
-    assert.equal(styles.serialize(styles.parse(`font-fa"on-load\\3dxss\\28\\29\\20mily:'arial'`)), '');
-    assert.equal(styles.serialize(styles.parse(`font-fa\\"on-load\\3dxss\\28\\29\\20mily:'arial'`)), '');
-    assert.equal(styles.serialize(styles.parse(`font-fa\\22on-load\\3dxss\\28\\29\\20mily:'arial'`)), '');
+    assertStyles(styles, `font-fa"on-load\\3dxss\\28\\29\\20mily:'arial'`, '');
+    assertStyles(styles, `font-fa\\"on-load\\3dxss\\28\\29\\20mily:'arial'`, '');
+    assertStyles(styles, `font-fa\\22on-load\\3dxss\\28\\29\\20mily:'arial'`, '');
   });
 
   it('Script urls denied', () => {
     const styles = Styles();
 
-    assert.equal(styles.serialize(styles.parse('behavior:url(test.htc)')), '');
-    assert.equal(styles.serialize(styles.parse('b\\65havior:url(test.htc)')), '');
-    assert.equal(styles.serialize(styles.parse('color:expression(alert(1))')), '');
-    assert.equal(styles.serialize(styles.parse('color:\\65xpression(alert(1))')), '');
-    assert.equal(styles.serialize(styles.parse('color:exp/**/ression(alert(1))')), '');
-    assert.equal(styles.serialize(styles.parse('color:/**/')), '');
-    assert.equal(styles.serialize(styles.parse('color:  expression  (  alert(1))')), '');
-    assert.equal(styles.serialize(styles.parse('background:url(jAvaScript:alert(1)')), '');
-    assert.equal(styles.serialize(styles.parse('background:url(javascript:alert(1)')), '');
-    assert.equal(styles.serialize(styles.parse('background:url(j\\61vascript:alert(1)')), '');
-    assert.equal(styles.serialize(styles.parse('background:url(\\6a\\61vascript:alert(1)')), '');
-    assert.equal(styles.serialize(styles.parse('background:url(\\6A\\61vascript:alert(1)')), '');
-    assert.equal(styles.serialize(styles.parse('background:url\\28\\6A\\61vascript:alert(1)')), '');
-    assert.equal(styles.serialize(styles.parse('background:\\75rl(j\\61vascript:alert(1)')), '');
-    assert.equal(styles.serialize(styles.parse('b\\61ckground:\\75rl(j\\61vascript:alert(1)')), '');
-    assert.equal(styles.serialize(styles.parse('background:url(vbscript:alert(1)')), '');
-    assert.equal(styles.serialize(styles.parse('background:url(j\navas\u0000cr\tipt:alert(1)')), '');
-    assert.equal(styles.serialize(styles.parse('background:url(data:image/svg+xml,%3Csvg/%3E)')), '');
-    assert.equal(styles.serialize(styles.parse('background:url( data:image/svg+xml,%3Csvg/%3E)')), '');
-    assert.equal(styles.serialize(styles.parse('background:url\\28 data:image/svg+xml,%3Csvg/%3E)')), '');
-    assert.equal(styles.serialize(styles.parse('background:url("data: image/svg+xml,%3Csvg/%3E")')), '');
-    assert.equal(styles.serialize(styles.parse('background:url("data: ima ge/svg+xml,%3Csvg/%3E")')), '');
-    assert.equal(styles.serialize(styles.parse('background:url("data: image /svg+xml,%3Csvg/%3E")')), '');
+    assertStyles(styles, 'behavior:url(test.htc)', '');
+    assertStyles(styles, 'b\\65havior:url(test.htc)', '');
+    assertStyles(styles, 'color:expression(alert(1))', '');
+    assertStyles(styles, 'color:\\65xpression(alert(1))', '');
+    assertStyles(styles, 'color:exp/**/ression(alert(1))', '');
+    assertStyles(styles, 'color:/**/', '');
+    assertStyles(styles, 'color:  expression  (  alert(1))', '');
+    assertStyles(styles, 'background:url(jAvaScript:alert(1)', '');
+    assertStyles(styles, 'background:url(javascript:alert(1)', '');
+    assertStyles(styles, 'background:url(j\\61vascript:alert(1)', '');
+    assertStyles(styles, 'background:url(\\6a\\61vascript:alert(1)', '');
+    assertStyles(styles, 'background:url(\\6A\\61vascript:alert(1)', '');
+    assertStyles(styles, 'background:url\\28\\6A\\61vascript:alert(1)', '');
+    assertStyles(styles, 'background:\\75rl(j\\61vascript:alert(1)', '');
+    assertStyles(styles, 'b\\61ckground:\\75rl(j\\61vascript:alert(1)', '');
+    assertStyles(styles, 'background:url(vbscript:alert(1)', '');
+    assertStyles(styles, 'background:url(j\navas\u0000cr\tipt:alert(1)', '');
+    assertStyles(styles, 'background:url(data:image/svg+xml,%3Csvg/%3E)', '');
+    assertStyles(styles, 'background:url( data:image/svg+xml,%3Csvg/%3E)', '');
+    assertStyles(styles, 'background:url\\28 data:image/svg+xml,%3Csvg/%3E)', '');
+    assertStyles(styles, 'background:url("data: image/svg+xml,%3Csvg/%3E")', '');
+    assertStyles(styles, 'background:url("data: ima ge/svg+xml,%3Csvg/%3E")', '');
+    assertStyles(styles, 'background:url("data: image /svg+xml,%3Csvg/%3E")', '');
   });
 
   it('Script urls allowed', () => {
     const styles = Styles({ allow_script_urls: true });
 
-    assert.equal(styles.serialize(styles.parse('behavior:url(test.htc)')), `behavior: url('test.htc');`);
-    assert.equal(styles.serialize(styles.parse('color:expression(alert(1))')), 'color: expression(alert(1));');
-    assert.equal(styles.serialize(styles.parse('background:url(javascript:alert(1)')), `background: url('javascript:alert(1');`);
-    assert.equal(styles.serialize(styles.parse('background:url(vbscript:alert(1)')), `background: url('vbscript:alert(1');`);
+    assertStyles(styles, 'behavior:url(test.htc)', `behavior: url('test.htc');`);
+    assertStyles(styles, 'color:expression(alert(1))', 'color: expression(alert(1));');
+    assertStyles(styles, 'background:url(javascript:alert(1)', `background: url('javascript:alert(1');`);
+    assertStyles(styles, 'background:url(vbscript:alert(1)', `background: url('vbscript:alert(1');`);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
@@ -142,6 +142,16 @@ describe('browser.tinymce.core.html.StylesTest', () => {
       styles.serialize(styles.parse('border-width: 1px; border-color: red')),
       'border-width: 1px; border-color: red;'
     );
+
+    assert.equal(
+      styles.serialize(styles.parse('border-width: 1px; border-color: rgb(1, 2, 3)')),
+      'border-width: 1px; border-color: rgb(1, 2, 3);'
+    );
+
+    assert.equal(
+      styles.serialize(styles.parse('border-width: 1px; border-color: rgb(1, 2, 3); border-style: dashed')),
+      'border: 1px dashed rgb(1, 2, 3);'
+    );
   });
 
   it('Font weight', () => {

--- a/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
@@ -96,7 +96,7 @@ const applyDataToElement = (editor: Editor, tableElm: HTMLTableElement, data: Ta
     styles['border-style'] = advData.borderstyle;
   }
 
-  attrs.style = dom.serializeStyle({ ...Options.getDefaultStyles(editor), ...styles });
+  dom.setStyles(tableElm, { ...Options.getDefaultStyles(editor), ...styles });
   dom.setAttribs(tableElm, { ...Options.getDefaultAttributes(editor), ...attrs });
 };
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogTest.ts
@@ -476,7 +476,7 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
       '<table style="width: 500px; height: 500px; border-width: 2px; border-collapse: collapse; border-style: dotted;" border="1"><colgroup><col style="width: 50%;"><col style="width: 50%;"></colgroup>',
       '<tbody>',
       '<tr>',
-      '<td style="border-color: rgb(224, 62, 45); border-width: 5px; border-style: double;">&nbsp;</td>',
+      '<td style="border: 5px double rgb(224, 62, 45);">&nbsp;</td>',
       '<td style="border-width: 2px;">&nbsp;</td>',
       '</tr>',
       '<tr>',
@@ -515,24 +515,7 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     };
 
     it('TINY-9837: Should not apply border, cellpadding or bordercolor data to cells if none of them has been modified',
-      () => {
-        const expectedHtml = [
-          '<table style="width: 500px; height: 500px; border-width: 2px; border-collapse: collapse; border-style: dotted;" border="1"><colgroup><col style="width: 50%;"><col style="width: 50%;"></colgroup>',
-          '<tbody>',
-          '<tr>',
-          '<td style="border: 5px double rgb(224, 62, 45);">&nbsp;</td>',
-          '<td style="border-width: 2px;">&nbsp;</td>',
-          '</tr>',
-          '<tr>',
-          '<td style="border-width: 2px;">&nbsp;</td>',
-          '<td style="border-width: 2px;">&nbsp;</td>',
-          '</tr>',
-          '</tbody>',
-          '</table>'
-        ].join('');
-
-        testApplyDataToCells({ caption: true }, expectedHtml);
-      });
+      () => testApplyDataToCells({ caption: true }, baseHtml));
 
     it('TINY-9837: Should apply border to cells if it has been modified',
       () => testApplyDataToCells({ border: '3px' }, [


### PR DESCRIPTION
Related Ticket: TINY-9843

Description of Changes:
* Fix border styles in 'data-mce-style` being split into the longhand form after table updates

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
