### PR TITLE
TINY-9959: Wrap accordion body in div to prevent selection issues

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exposed `dataTransfer` property of drag and drop events for elements with a `contenteditable="false"` attribute. #TINY-9601
 - Screen readers now announce instructions for resizing the editor using arrow keys, when the resize handle is focused. #TINY-9793
 - Dialog `tabpanel` tab labels are now allowed to word wrap for better readability with long labels. #TINY-9947
+- Added newlines before and after `details` elements in the output HTML. #TINY-9959
+- Added padding for empty `summary` elements so that they can be properly edited. #TINY-9959
 
 ### Changed
 - The `caption`, `address` and `dt` elements no longer incorrectly allow non-inline child elements when the editor schema is set to _HTML 4_. #TINY-9768

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -260,13 +260,13 @@ const register = (editor: Editor): void => {
   registerOption('indent_before', {
     processor: 'string',
     default: 'p,h1,h2,h3,h4,h5,h6,blockquote,div,title,style,pre,script,td,th,ul,ol,li,dl,dt,dd,area,table,thead,' +
-      'tfoot,tbody,tr,section,summary,article,hgroup,aside,figure,figcaption,option,optgroup,datalist'
+      'tfoot,tbody,tr,section,details,summary,article,hgroup,aside,figure,figcaption,option,optgroup,datalist'
   });
 
   registerOption('indent_after', {
     processor: 'string',
     default: 'p,h1,h2,h3,h4,h5,h6,blockquote,div,title,style,pre,script,td,th,ul,ol,li,dl,dt,dd,area,table,thead,' +
-      'tfoot,tbody,tr,section,summary,article,hgroup,aside,figure,figcaption,option,optgroup,datalist'
+      'tfoot,tbody,tr,section,details,summary,article,hgroup,aside,figure,figcaption,option,optgroup,datalist'
   });
 
   registerOption('indent_use_margin', {

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -829,8 +829,10 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
     });
 
     // Padd these by default
-    each(split('p h1 h2 h3 h4 h5 h6 th td pre div address caption li'), (name) => {
-      elements[name].paddEmpty = true;
+    each(split('p h1 h2 h3 h4 h5 h6 th td pre div address caption li summary'), (name) => {
+      if (elements[name]) {
+        elements[name].paddEmpty = true;
+      }
     });
 
     // Remove these if they have no attributes

--- a/modules/tinymce/src/core/main/ts/dom/NodeType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/NodeType.ts
@@ -110,6 +110,8 @@ const isTableCell = matchNodeNames<HTMLTableCellElement>([ 'td', 'th' ]);
 const isTableCellOrCaption = matchNodeNames<HTMLTableCellElement>([ 'td', 'th', 'caption' ]);
 const isMedia = matchNodeNames<HTMLElement>([ 'video', 'audio', 'object', 'embed' ]);
 const isListItem = matchNodeName<HTMLLIElement>('li');
+const isDetails = matchNodeName<HTMLDetailsElement>('details');
+const isSummary = matchNodeName<HTMLElement>('summary');
 
 export {
   isText,
@@ -136,5 +138,7 @@ export {
   isBogusAll,
   isTable,
   isTextareaOrInput,
-  isListItem
+  isListItem,
+  isDetails,
+  isSummary
 };

--- a/modules/tinymce/src/core/main/ts/newline/InsertDetailsNewLine.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertDetailsNewLine.ts
@@ -1,19 +1,34 @@
+import { Obj, Type } from '@ephox/katamari';
+
 import Editor from '../api/Editor';
 import * as Options from '../api/Options';
+import * as NodeType from '../dom/NodeType';
 import * as NewLineUtils from './NewLineUtils';
 
-export const isDetails = (node?: Node | null): node is HTMLDetailsElement =>
-  node?.nodeName === 'DETAILS';
-
 export const getDetailsRoot = (editor: Editor, element: Element): HTMLDetailsElement | null =>
-  editor.dom.getParent(element, isDetails);
+  editor.dom.getParent(element, NodeType.isDetails);
+
+const isAtDetailsEdge = (root: HTMLElement, element: Element, isTextBlock: (el: HTMLElement) => boolean) => {
+  let node = element;
+
+  while (node && node !== root && Type.isNull(node.nextSibling)) {
+    const parent = node.parentElement;
+
+    if (!parent || !isTextBlock(parent)) {
+      return NodeType.isDetails(parent);
+    }
+
+    node = parent;
+  }
+
+  return false;
+};
 
 export const isLastEmptyBlockInDetails = (editor: Editor, shiftKey: boolean, element: Element): boolean =>
   !shiftKey &&
   element.nodeName.toLowerCase() === Options.getForcedRootBlock(editor) &&
-  element.parentNode?.lastChild === element &&
   editor.dom.isEmpty(element) &&
-  isDetails(element.parentNode);
+  isAtDetailsEdge(editor.getBody(), element, (el) => Obj.has(editor.schema.getTextBlockElements(), el.nodeName.toLowerCase()));
 
 export const insertNewLine = (editor: Editor, createNewBlock: (name: string) => Element, parentBlock: Element): void => {
   const newBlock = createNewBlock(Options.getForcedRootBlock(editor));
@@ -23,7 +38,9 @@ export const insertNewLine = (editor: Editor, createNewBlock: (name: string) => 
   }
   editor.dom.insertAfter(newBlock, root);
   NewLineUtils.moveToCaretPosition(editor, newBlock);
-  if (root.children.length > 2) {
+
+  // TODO: This now only works with our Accordions not details with multiple root level children should we support that
+  if ((parentBlock.parentElement?.childNodes?.length ?? 0) > 1) {
     editor.dom.remove(parentBlock);
   }
 };

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -1,14 +1,15 @@
-import { Arr, Type } from '@ephox/katamari';
+import { Arr, Fun, Optional, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { SugarElement } from '@ephox/sugar';
 
-import DomTreeWalker from '../api/dom/TreeWalker';
+import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
 import * as Options from '../api/Options';
 import VK from '../api/util/VK';
 import * as CaretFinder from '../caret/CaretFinder';
 import CaretPosition from '../caret/CaretPosition';
 import * as DeleteUtils from '../delete/DeleteUtils';
+import * as NodeType from '../dom/NodeType';
 import * as PaddingBr from '../dom/PaddingBr';
 import * as FormatUtils from '../fmt/FormatUtils';
 
@@ -44,25 +45,14 @@ const filterDetails = (editor: Editor): void => {
   });
 };
 
-const isCaretInTheBeginning = (rng: Range, element: HTMLElement): boolean =>
-  CaretFinder.firstPositionIn(element).exists((pos) => pos.isEqual(CaretPosition.fromRangeStart(rng)));
-
-const isCaretInTheEnding = (rng: Range, element: HTMLElement): boolean =>
-  CaretFinder.lastPositionIn(element).exists((pos) => pos.isEqual(CaretPosition.fromRangeStart(rng)));
-
-const removeNode = (editor: Editor, node: Node) => editor.dom.remove(node, false);
-
 const emptyNodeContents = (node: Node) => PaddingBr.fillWithPaddingBr(SugarElement.fromDom(node));
 
-const setCaretToPosition = (editor: Editor) => (position: CaretPosition): void => {
+const setCaretToPosition = (editor: Editor, position: CaretPosition): void => {
   const node = position.getNode();
   if (!Type.isUndefined(node)) {
     editor.selection.setCursorLocation(node, position.offset());
   }
 };
-
-const isSummary = (node: Node | null | undefined): boolean => node?.nodeName === 'SUMMARY';
-const isDetails = (node: Node | null | undefined): boolean => node?.nodeName === 'DETAILS';
 
 const isEntireNodeSelected = (rng: Range, node: Node): boolean =>
   rng.startOffset === 0 && rng.endOffset === node.textContent?.length;
@@ -70,107 +60,229 @@ const isEntireNodeSelected = (rng: Range, node: Node): boolean =>
 const platform = PlatformDetection.detect();
 const browser = platform.browser;
 const os = platform.os;
-const isFirefox = browser.isFirefox();
 const isSafari = browser.isSafari();
 const isMacOSOriOS = os.isMacOS() || os.isiOS();
+
+interface DetailsElements {
+  readonly startSummary: Optional<HTMLElement>;
+  readonly startDetails: Optional<HTMLDetailsElement>;
+  readonly endDetails: Optional<HTMLDetailsElement>;
+}
+
+const isCaretInTheBeginningOf = (caretPos: CaretPosition, element: HTMLElement): boolean =>
+  CaretFinder.firstPositionIn(element).exists((pos) => pos.isEqual(caretPos));
+
+const isCaretInTheEndOf = (caretPos: CaretPosition, element: HTMLElement): boolean => {
+  return CaretFinder.lastPositionIn(element).exists((pos) => {
+    // Summary may or may not have a trailing BR
+    if (NodeType.isBr(pos.getNode())) {
+      return CaretFinder.prevPosition(element, pos).exists((pos2) => pos2.isEqual(caretPos)) || pos.isEqual(caretPos);
+    } else {
+      return pos.isEqual(caretPos);
+    }
+  });
+};
+
+const getDetailsElements = (dom: DOMUtils, rng: Range): Optional<DetailsElements> => {
+  const startDetails = Optional.from(dom.getParent(rng.startContainer, 'details'));
+  const endDetails = Optional.from(dom.getParent(rng.endContainer, 'details'));
+
+  if (startDetails.isSome() || endDetails.isSome()) {
+    const startSummary = startDetails.bind((details) => Optional.from(dom.select('summary', details)[0]));
+    return Optional.some({ startSummary, startDetails, endDetails });
+  } else {
+    return Optional.none();
+  }
+};
+
+const isPartialDelete = (rng: Range, detailsElements: DetailsElements) => {
+  const containsStart = (element: HTMLElement) => element.contains(rng.startContainer);
+  const containsEnd = (element: HTMLElement) => element.contains(rng.endContainer);
+  const startInSummary = detailsElements.startSummary.exists(containsStart);
+  const endInSummary = detailsElements.startSummary.exists(containsEnd);
+  const isPartiallySelectedDetailsElements = detailsElements.startDetails.forall((startDetails) => detailsElements.endDetails.forall((endDetails) => startDetails !== endDetails));
+  const isInPartiallySelectedSummary = (startInSummary || endInSummary) && !(startInSummary && endInSummary);
+
+  return isInPartiallySelectedSummary || isPartiallySelectedDetailsElements;
+};
+
+const isCaretAtStartOfSummary = (caretPos: CaretPosition, detailsElements: DetailsElements) =>
+  detailsElements.startSummary.exists((summary) => isCaretInTheBeginningOf(caretPos, summary));
+
+const isCaretAtEndOfSummary = (caretPos: CaretPosition, detailsElements: DetailsElements) =>
+  detailsElements.startSummary.exists((summary) => isCaretInTheEndOf(caretPos, summary));
+
+const isCaretInFirstPositionInBody = (caretPos: CaretPosition, detailsElements: DetailsElements) =>
+  detailsElements.startDetails.exists((details) =>
+    CaretFinder.prevPosition(details, caretPos).forall((pos) =>
+      detailsElements.startSummary.exists((summary) => !summary.contains(caretPos.container()) && summary.contains(pos.container()))
+    )
+  );
+
+const isCaretInLastPositionInBody = (root: HTMLElement, caretPos: CaretPosition, detailsElements: DetailsElements) =>
+  detailsElements.startDetails.exists((details) =>
+    CaretFinder.nextPosition(root, caretPos).forall((pos) =>
+      !details.contains(pos.container())
+    )
+  );
+
+const isInDetailsElement = (dom: DOMUtils, pos: CaretPosition) =>
+  Type.isNonNullable(dom.getParent(pos.container(), 'details'));
+
+const moveCaretToDetailsPos = (editor: Editor, pos: CaretPosition) => {
+  const details = editor.dom.getParent(pos.container(), 'details');
+
+  if (details && !details.open) {
+    const summary = editor.dom.select('summary', details)[0];
+    if (summary) {
+      CaretFinder.lastPositionIn(summary).each((pos) => setCaretToPosition(editor, pos));
+    }
+  } else {
+    setCaretToPosition(editor, pos);
+  }
+};
+
+const preventDeleteIntoDetails = (editor: Editor, forward: boolean) => {
+  const { dom, selection } = editor;
+  const root = editor.getBody();
+
+  if (editor.selection.isCollapsed()) {
+    const caretPos = CaretPosition.fromRangeStart(selection.getRng());
+    const parentBlock = dom.getParent(caretPos.container(), dom.isBlock);
+
+    // Prevent backspace/delete if the paragraph is empty and the start or end of it's parent container
+    // TODO: Clean this up!
+    if (parentBlock && dom.isEmpty(parentBlock)) {
+      if (Type.isNull(parentBlock.nextSibling)) {
+        const pos = CaretFinder.prevPosition(root, caretPos).filter((pos) => isInDetailsElement(dom, pos));
+        if (pos.isSome()) {
+          pos.each((pos) => {
+            if (!forward) {
+              moveCaretToDetailsPos(editor, pos);
+            }
+          });
+          return true;
+        }
+      } else if (Type.isNull(parentBlock.previousSibling)) {
+        const pos = CaretFinder.nextPosition(root, caretPos).filter((pos) => isInDetailsElement(dom, pos));
+        if (pos) {
+          return true;
+        }
+      }
+    }
+
+    return CaretFinder.navigate(forward, root, caretPos).fold(
+      Fun.never,
+      (pos) => {
+        if (isInDetailsElement(dom, pos)) {
+          if (parentBlock && dom.isEmpty(parentBlock)) {
+            editor.dom.remove(parentBlock);
+          }
+
+          if (!forward) {
+            moveCaretToDetailsPos(editor, pos);
+          }
+          return true;
+        } else {
+          return false;
+        }
+      }
+    );
+  } else {
+    return false;
+  }
+};
+
+const preventDeleteSummaryAction = (editor: Editor, detailElements: DetailsElements, e: KeyboardEvent): boolean => {
+  const selection = editor.selection;
+  const node = selection.getNode();
+  const rng = selection.getRng();
+  const isBackspace = e.keyCode === VK.BACKSPACE;
+  const isDelete = e.keyCode === VK.DELETE;
+  const isCollapsed = editor.selection.isCollapsed();
+  const caretPos = CaretPosition.fromRangeStart(rng);
+  const root = editor.getBody();
+
+  if (!isCollapsed && isPartialDelete(rng, detailElements)) {
+    return true;
+  } else if (isCollapsed && isBackspace && isCaretAtStartOfSummary(caretPos, detailElements)) {
+    return true;
+  } else if (isCollapsed && isDelete && isCaretAtEndOfSummary(caretPos, detailElements)) {
+    return true;
+  } else if (isCollapsed && isBackspace && isCaretInFirstPositionInBody(caretPos, detailElements)) {
+    return true;
+  } else if (isCollapsed && isDelete && isCaretInLastPositionInBody(root, caretPos, detailElements)) {
+    return true;
+  } else if (isSafari && NodeType.isSummary(node)) {
+    // TINY-9951: Safari bug, deleting within the summary causes all content to be removed and no caret position to be left
+    // https://bugs.webkit.org/show_bug.cgi?id=257745
+    if (!isCollapsed && isEntireNodeSelected(rng, node) || DeleteUtils.willDeleteLastPositionInElement(isDelete, caretPos, node)) {
+      emptyNodeContents(node);
+    } else {
+      editor.undoManager.transact(() => {
+        // Wrap all summary children in a temporary container to execute Backspace/Delete there, then unwrap
+        const sel = selection.getSel();
+        let { anchorNode, anchorOffset, focusNode, focusOffset } = sel ?? {};
+        const applySelection = () => {
+          if (Type.isNonNullable(anchorNode) && Type.isNonNullable(anchorOffset) && Type.isNonNullable(focusNode) && Type.isNonNullable(focusOffset)) {
+            sel?.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
+          }
+        };
+        const updateSelection = () => {
+          anchorNode = sel?.anchorNode;
+          anchorOffset = sel?.anchorOffset;
+          focusNode = sel?.focusNode;
+          focusOffset = sel?.focusOffset;
+        };
+        const appendAllChildNodes = (from: Node, to: Node) => {
+          Arr.each(from.childNodes, (child) => {
+            if (FormatUtils.isNode(child)) {
+              to.appendChild(child);
+            }
+          });
+        };
+
+        const container = editor.dom.create('span', { 'data-mce-bogus': 'all' });
+        appendAllChildNodes(node, container);
+        node.appendChild(container);
+        applySelection();
+        // Manually perform ranged deletion by keyboard shortcuts
+        if (isCollapsed && (isMacOSOriOS && (e.altKey || isBackspace && e.metaKey) || !isMacOSOriOS && e.ctrlKey)) {
+          sel?.modify('extend', isBackspace ? 'left' : 'right', e.metaKey ? 'line' : 'word');
+        }
+        if (!selection.isCollapsed() && isEntireNodeSelected(selection.getRng(), container)) {
+          emptyNodeContents(node);
+        } else {
+          editor.execCommand(isBackspace ? 'Delete' : 'ForwardDelete');
+          updateSelection();
+          appendAllChildNodes(container, node);
+          applySelection();
+        }
+        editor.dom.remove(container);
+      });
+    }
+
+    return true;
+  }
+
+  return false;
+};
 
 const preventDeletingSummary = (editor: Editor): void => {
   editor.on('keydown', (e) => {
     if (e.keyCode === VK.BACKSPACE || e.keyCode === VK.DELETE) {
-      const selection = editor.selection;
-      const node = selection.getNode();
-      const body = editor.getBody();
-      const prevNode = new DomTreeWalker(node, body).prev2(true);
-      const nextNode = new DomTreeWalker(node, body).next(true);
-      const startElement = selection.getStart();
-      const endElement = selection.getEnd();
-      const rng = selection.getRng();
-      const isBackspace = e.keyCode === VK.BACKSPACE;
-      const isCaretAtStart = isCaretInTheBeginning(rng, node);
-      const isBackspaceAndCaretAtStart = isBackspace && isCaretAtStart;
-      const isDelete = e.keyCode === VK.DELETE;
-      const isDeleteAndCaretAtEnd = isDelete && isCaretInTheEnding(rng, node);
-      const isCollapsed = editor.selection.isCollapsed();
-      const isEmpty = editor.dom.isEmpty(node);
-      const hasPrevNode = Type.isNonNullable(prevNode);
-      const hasNextNode = Type.isNonNullable(nextNode);
-      const isNotInSummaryAndIsPrevNodeDetails = hasPrevNode && !isSummary(node) && isDetails(prevNode);
-      const isDeleteInEmptyNodeAfterAccordion = isDelete && isEmpty && isNotInSummaryAndIsPrevNodeDetails;
-      const isBackspaceInEmptyNodeBeforeAccordion = isBackspace && isEmpty && !isSummary(node) && !isDetails(node) && isDetails(nextNode);
-
-      if (
-        !isCollapsed && isSummary(startElement) && startElement !== endElement && !Type.isNull(editor.dom.getParent(endElement, 'details'))
-        || isCollapsed && (
-          (isBackspaceAndCaretAtStart || isDeleteAndCaretAtEnd || isEmpty) && isSummary(node)
-          || isBackspaceAndCaretAtStart && isSummary(prevNode)
-          || isDeleteAndCaretAtEnd && node === editor.dom.getParent(node, 'details')?.lastChild
-          || isDeleteAndCaretAtEnd && isDetails(nextNode) && !isEmpty
-          || isFirefox && isDeleteInEmptyNodeAfterAccordion && !hasNextNode
-          || isFirefox && isBackspaceInEmptyNodeBeforeAccordion && !hasPrevNode
-        )
-      ) {
-        e.preventDefault();
-      } else if (isCollapsed && isBackspaceAndCaretAtStart && isNotInSummaryAndIsPrevNodeDetails) {
-        e.preventDefault();
-        if (isEmpty) {
-          removeNode(editor, node);
+      getDetailsElements(editor.dom, editor.selection.getRng()).fold(
+        () => {
+          if (preventDeleteIntoDetails(editor, e.keyCode === VK.DELETE)) {
+            e.preventDefault();
+          }
+        },
+        (detailsElements) => {
+          if (preventDeleteSummaryAction(editor, detailsElements, e)) {
+            e.preventDefault();
+          }
         }
-        CaretFinder.lastPositionIn(prevNode).each(setCaretToPosition(editor));
-      } else if (isFirefox && isCollapsed && isDeleteInEmptyNodeAfterAccordion && hasNextNode) {
-        e.preventDefault();
-        removeNode(editor, node);
-        CaretFinder.firstPositionIn(nextNode).each(setCaretToPosition(editor));
-      } else if (isSafari && isSummary(node)) {
-        // TINY-9951: Safari bug, deleting within the summary causes all content to be removed and no caret position to be left
-        // https://bugs.webkit.org/show_bug.cgi?id=257745
-        e.preventDefault();
-
-        if (!isCollapsed && isEntireNodeSelected(rng, node) || DeleteUtils.willDeleteLastPositionInElement(isDelete, CaretPosition.fromRangeStart(rng), node)) {
-          emptyNodeContents(node);
-        } else {
-          editor.undoManager.transact(() => {
-            // Wrap all summary children in a temporary container to execute Backspace/Delete there, then unwrap
-            const sel = selection.getSel();
-            let { anchorNode, anchorOffset, focusNode, focusOffset } = sel ?? {};
-            const applySelection = () => {
-              if (Type.isNonNullable(anchorNode) && Type.isNonNullable(anchorOffset) && Type.isNonNullable(focusNode) && Type.isNonNullable(focusOffset)) {
-                sel?.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
-              }
-            };
-            const updateSelection = () => {
-              anchorNode = sel?.anchorNode;
-              anchorOffset = sel?.anchorOffset;
-              focusNode = sel?.focusNode;
-              focusOffset = sel?.focusOffset;
-            };
-            const appendAllChildNodes = (from: Node, to: Node) => {
-              Arr.each(from.childNodes, (child) => {
-                if (FormatUtils.isNode(child)) {
-                  to.appendChild(child);
-                }
-              });
-            };
-
-            const container = editor.dom.create('span', { 'data-mce-bogus': 'all' });
-            appendAllChildNodes(node, container);
-            node.appendChild(container);
-            applySelection();
-            // Manually perform ranged deletion by keyboard shortcuts
-            if (isCollapsed && (isMacOSOriOS && (e.altKey || isBackspace && e.metaKey) || !isMacOSOriOS && e.ctrlKey)) {
-              sel?.modify('extend', isBackspace ? 'left' : 'right', e.metaKey ? 'line' : 'word');
-            }
-            if (!selection.isCollapsed() && isEntireNodeSelected(selection.getRng(), container)) {
-              emptyNodeContents(node);
-            } else {
-              editor.execCommand(isBackspace ? 'Delete' : 'ForwardDelete');
-              updateSelection();
-              appendAllChildNodes(container, node);
-              applySelection();
-            }
-            editor.dom.remove(container);
-          });
-        }
-      }
+      );
     }
   });
 };

--- a/modules/tinymce/src/plugins/accordion/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/accordion/main/ts/Plugin.ts
@@ -1,6 +1,7 @@
 import PluginManager from 'tinymce/core/api/PluginManager';
 
 import * as Commands from './api/Commands';
+import * as FilterContent from './core/FilterContent';
 import * as Keyboard from './core/Keyboard';
 import * as Buttons from './ui/Buttons';
 
@@ -9,5 +10,6 @@ export default (): void => {
     Buttons.register(editor);
     Commands.register(editor);
     Keyboard.setup(editor);
+    FilterContent.setup(editor);
   });
 };

--- a/modules/tinymce/src/plugins/accordion/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/accordion/main/ts/core/Actions.ts
@@ -1,8 +1,11 @@
 import { Id, Arr } from '@ephox/katamari';
+import { DomDescent } from '@ephox/phoenix';
+import { Attribute, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 
 import * as Events from '../api/Events';
+import * as Identifiers from './Identifiers';
 import * as Utils from './Utils';
 
 const insertAccordion = (editor: Editor): void => {
@@ -10,23 +13,33 @@ const insertAccordion = (editor: Editor): void => {
     return;
   }
 
+  const editorBody = SugarElement.fromDom(editor.getBody());
   const uid = Id.generate('acc');
   const summaryText = editor.dom.encode(editor.selection.getRng().toString() || editor.translate('Accordion summary...'));
   const bodyText = editor.dom.encode(editor.translate('Accordion body...'));
 
+  const accordionSummaryHtml = `<summary class="${Identifiers.accordionSummaryClass}">${summaryText}</summary>`;
+  const accordionBodyHtml = `<${Identifiers.accordionBodyWrapperTag} class="${Identifiers.accordionBodyWrapperClass}"><p>${bodyText}</p></${Identifiers.accordionBodyWrapperTag}>`;
+
   editor.undoManager.transact(() => {
-    editor.insertContent(`<details data-mce-id="${uid}" class="mce-accordion" open="open"><summary class="mce-accordion-summary">${summaryText}</summary><p>${bodyText}</p></details>`);
+    editor.insertContent([
+      `<details data-mce-id="${uid}" class="${Identifiers.accordionDetailsClass}" open="open">`,
+      accordionSummaryHtml,
+      accordionBodyHtml,
+      `</details>`
+    ].join(''));
 
-    const details = editor.dom.select(`[data-mce-id="${uid}"]`)[0];
-    if (!details) {
-      return;
-    }
-    details.removeAttribute('data-mce-id');
-
-    const summary = editor.dom.select('summary', details)[0];
-    if (summary) {
-      editor.selection.setCursorLocation(summary, 1);
-    }
+    SelectorFind.descendant(editorBody, `[data-mce-id="${uid}"]`).each((detailsElm) => {
+      Attribute.remove(detailsElm, 'data-mce-id');
+      SelectorFind.descendant(detailsElm, `summary`).each((summaryElm) => {
+        // Set the cursor location to be at the end of the summary text
+        const rng = editor.dom.createRng();
+        const des = DomDescent.freefallRtl(summaryElm);
+        rng.setStart(des.element.dom as Node, des.offset);
+        rng.setEnd(des.element.dom as Node, des.offset);
+        editor.selection.setRng(rng);
+      });
+    });
   });
 };
 

--- a/modules/tinymce/src/plugins/accordion/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/accordion/main/ts/core/FilterContent.ts
@@ -1,0 +1,152 @@
+import { Arr, Type } from '@ephox/katamari';
+
+import Editor from 'tinymce/core/api/Editor';
+import AstNode from 'tinymce/core/api/html/Node';
+
+import * as Identifiers from './Identifiers';
+
+interface AccordionChildren {
+  summaryNode: AstNode | undefined;
+  wrapperNode: AstNode | undefined;
+  otherNodes: AstNode[];
+}
+
+const getClassList = (node: AstNode): string[] =>
+  node.attr('class')?.split(' ') ?? [];
+
+const addClasses = (node: AstNode, classes: string[]): void => {
+  const classListSet = new Set([ ...getClassList(node), ...classes ]);
+  const newClassList = Array.from(classListSet);
+
+  if (newClassList.length > 0) {
+    node.attr('class', newClassList.join(' '));
+  }
+};
+
+const removeClasses = (node: AstNode, classes: Set<string>): void => {
+  const newClassList = Arr.filter(getClassList(node), (clazz) => !classes.has(clazz));
+  node.attr('class', newClassList.length > 0 ? newClassList.join(' ') : null);
+};
+
+const isAccordionDetailsNode = (node: AstNode): boolean =>
+  node.name === Identifiers.accordionTag && Arr.contains(getClassList(node), Identifiers.accordionDetailsClass);
+
+const isAccordionBodyWrapperNode = (node: AstNode): boolean =>
+  node.name === Identifiers.accordionBodyWrapperTag && Arr.contains(getClassList(node), Identifiers.accordionBodyWrapperClass);
+
+const getAccordionChildren = (accordionNode: AstNode): AccordionChildren => {
+  const children = accordionNode.children();
+  let summaryNode: AstNode | undefined;
+  let wrapperNode: AstNode | undefined;
+  const otherNodes: AstNode[] = [];
+
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+    // Only want to get the first summary element
+    if (child.name === 'summary' && Type.isNullable(summaryNode)) {
+      summaryNode = child;
+    } else if (isAccordionBodyWrapperNode(child) && Type.isNullable(wrapperNode)) {
+      wrapperNode = child;
+    } else {
+      otherNodes.push(child);
+    }
+  }
+
+  return {
+    summaryNode,
+    wrapperNode,
+    otherNodes
+  };
+};
+
+const padInputNode = (node: AstNode): void => {
+  // Add br to node to ensure the cursor can be placed inside the node
+  // Mark as bogus so that it is converted to an nbsp on serialization
+  const br = new AstNode('br', 1);
+  br.attr('data-mce-bogus', '1');
+  node.empty();
+  node.append(br);
+};
+
+const setup = (editor: Editor): void => {
+  editor.on('PreInit', () => {
+    const { serializer, parser } = editor;
+
+    // Purpose:
+    // - add mce-accordion-summary class to summary node
+    // - wrap details body in div and add mce-accordion-body class (TINY-9959 assists with Chrome selection issue)
+    parser.addNodeFilter(Identifiers.accordionTag, (nodes) => {
+      // Using a traditional for loop here as we may have to iterate over many nodes and it is the most performant way of doing so
+      for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i];
+        if (isAccordionDetailsNode(node)) {
+          const accordionNode = node;
+          const { summaryNode, wrapperNode, otherNodes } = getAccordionChildren(accordionNode);
+
+          const hasSummaryNode = Type.isNonNullable(summaryNode);
+          const newSummaryNode = hasSummaryNode ? summaryNode : new AstNode('summary', 1);
+          // If there is nothing in the summary, pad it with a br
+          // so the cursor can be put inside the accordion summary
+          if (Type.isNullable(newSummaryNode.firstChild)) {
+            padInputNode(newSummaryNode);
+          }
+          addClasses(newSummaryNode, [ Identifiers.accordionSummaryClass ]);
+          if (!hasSummaryNode) {
+            if (Type.isNonNullable(accordionNode.firstChild)) {
+              accordionNode.insert(newSummaryNode, accordionNode.firstChild, true);
+            } else {
+              accordionNode.append(newSummaryNode);
+            }
+          }
+
+          const hasWrapperNode = Type.isNonNullable(wrapperNode);
+          const newWrapperNode = hasWrapperNode ? wrapperNode : new AstNode(Identifiers.accordionBodyWrapperTag, 1);
+          addClasses(newWrapperNode, [ Identifiers.accordionBodyWrapperClass ]);
+          if (otherNodes.length > 0) {
+            for (let j = 0; j < otherNodes.length; j++) {
+              const otherNode = otherNodes[j];
+              newWrapperNode.append(otherNode);
+            }
+          }
+          // If there is nothing in the wrapper, append a placeholder p tag
+          // so the cursor can be put inside the accordion body
+          if (Type.isNullable(newWrapperNode.firstChild)) {
+            const pNode = new AstNode('p', 1);
+            padInputNode(pNode);
+            newWrapperNode.append(pNode);
+          }
+          if (!hasWrapperNode) {
+            accordionNode.append(newWrapperNode);
+          }
+        }
+      }
+    });
+
+    // Purpose:
+    // - remove div wrapping details content as it is only required during editor (see TINY-9959 for details)
+    // - remove mce-accordion-summary class on the summary node
+    serializer.addNodeFilter(Identifiers.accordionTag, (nodes) => {
+      const summaryClassRemoveSet = new Set([ Identifiers.accordionSummaryClass ]);
+      // Using a traditional for loop here as we may have to iterate over many nodes and it is the most performant way of doing so
+      for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i];
+        if (isAccordionDetailsNode(node)) {
+          const accordionNode = node;
+          const { summaryNode, wrapperNode } = getAccordionChildren(accordionNode);
+
+          if (Type.isNonNullable(summaryNode)) {
+            removeClasses(summaryNode, summaryClassRemoveSet);
+          }
+
+          if (Type.isNonNullable(wrapperNode)) {
+            wrapperNode.unwrap();
+          }
+        }
+      }
+    });
+  });
+};
+
+export {
+  setup
+};

--- a/modules/tinymce/src/plugins/accordion/main/ts/core/Identifiers.ts
+++ b/modules/tinymce/src/plugins/accordion/main/ts/core/Identifiers.ts
@@ -1,0 +1,14 @@
+
+const accordionTag = 'details';
+const accordionDetailsClass = 'mce-accordion';
+const accordionSummaryClass = 'mce-accordion-summary';
+const accordionBodyWrapperClass = 'mce-accordion-body';
+const accordionBodyWrapperTag = 'div';
+
+export {
+  accordionTag,
+  accordionBodyWrapperTag,
+  accordionDetailsClass,
+  accordionSummaryClass,
+  accordionBodyWrapperClass
+};

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionPluginTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionPluginTest.ts
@@ -67,7 +67,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<ol><li>tiny</li></ol>',
       initialCursor: [[ 0, 0, 0 ], 'tiny'.length ],
-      assertContent: `<ol>\n<li>tiny${AccordionUtils.createAccordion()}</li>\n</ol>`,
+      assertContent: `<ol>\n<li>tiny\n${AccordionUtils.createAccordion()}\n</li>\n</ol>`,
       assertCursor: [[ 0, 0, 1, 0, 0 ], 'Accordion summary...'.length ],
     });
   });
@@ -76,7 +76,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<dl><dt>tiny</dt></dl>',
       initialCursor: [[ 0, 0, 0 ], 'tiny'.length ],
-      assertContent: `<dl>\n<dt>tiny${AccordionUtils.createAccordion()}</dt>\n</dl>`,
+      assertContent: `<dl>\n<dt>tiny\n${AccordionUtils.createAccordion()}\n</dt>\n</dl>`,
       assertCursor: [[ 0, 0, 1, 0, 0 ], 'Accordion summary...'.length ],
     });
   });
@@ -85,7 +85,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<dl><dd>tiny</dd></dl>',
       initialCursor: [[ 0, 0, 0 ], 'tiny'.length ],
-      assertContent: `<dl>\n<dd>tiny${AccordionUtils.createAccordion()}</dd>\n</dl>`,
+      assertContent: `<dl>\n<dd>tiny\n${AccordionUtils.createAccordion()}\n</dd>\n</dl>`,
       assertCursor: [[ 0, 0, 1, 0, 0 ], 'Accordion summary...'.length ],
     });
   });
@@ -94,7 +94,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<table><colgroup><col></colgroup><tbody><tr><td>&nbsp;</td></tr></tbody></table>',
       initialCursor: [[ 0, 1, 0, 0, 0 ], 0 ],
-      assertContent: `<table><colgroup><col></colgroup>\n<tbody>\n<tr>\n<td>${AccordionUtils.createAccordion()}</td>\n</tr>\n</tbody>\n</table>`,
+      assertContent: `<table><colgroup><col></colgroup>\n<tbody>\n<tr>\n<td>\n${AccordionUtils.createAccordion()}\n</td>\n</tr>\n</tbody>\n</table>`,
       assertCursor: [[ 0, 1, 0, 0, 0, 0, 0 ], 'Accordion summary...'.length ],
     });
   });
@@ -103,7 +103,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' }),
       initialCursor: [[ 0, 1, 0, 0 ], 'body'.length ],
-      assertContent: AccordionUtils.createAccordion({ summary: 'summary', body: `<p>body</p>\n${AccordionUtils.createAccordion()}` }),
+      assertContent: AccordionUtils.createAccordion({ summary: 'summary', body: `<p>body</p>\n${AccordionUtils.createAccordion()}\n` }),
       assertCursor: [[ 0, 1, 1, 0, 0 ], 'Accordion summary...'.length ],
     });
   });

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionPluginTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionPluginTest.ts
@@ -3,9 +3,9 @@ import { TinyHooks, TinySelections, TinyAssertions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/accordion/Plugin';
 
 import type { ToggledAccordionEvent, ToggledAllAccordionsEvent } from '../../../main/ts/api/Events';
-import AccordionPlugin from '../../../main/ts/Plugin';
 import * as AccordionUtils from '../module/AccordionUtils';
 
 interface InsertAccordionTest {
@@ -40,20 +40,17 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
   const hook = TinyHooks.bddSetup<Editor>(
     {
       plugins: 'accordion',
-      indent: false,
-      entities: 'raw',
-      extended_valid_elements: 'details[class|open|data-mce-open],summary[class],div[class],p',
       base_url: '/project/tinymce/js/tinymce',
     },
-    [ AccordionPlugin ]
+    [ Plugin ]
   );
 
   it('TINY-9730: Insert an accordion into a single paragraph', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<p>tiny</p>',
       initialCursor: [[ 0, 0 ], 'tiny'.length ],
-      assertContent: '<p>tiny</p>' + AccordionUtils.createAccordion(),
-      assertCursor: [[ 1, 0 ], 1 ],
+      assertContent: '<p>tiny</p>\n' + AccordionUtils.createAccordion(),
+      assertCursor: [[ 1, 0, 0 ], 'Accordion summary...'.length ],
     });
   });
 
@@ -62,7 +59,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
       initialContent: '<p><br></p>',
       initialCursor: [[ 0, 0 ], 0 ],
       assertContent: AccordionUtils.createAccordion(),
-      assertCursor: [[ 0, 0 ], 1 ],
+      assertCursor: [[ 0, 0, 0 ], 'Accordion summary...'.length ],
     });
   });
 
@@ -70,8 +67,8 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<ol><li>tiny</li></ol>',
       initialCursor: [[ 0, 0, 0 ], 'tiny'.length ],
-      assertContent: `<ol><li>tiny${AccordionUtils.createAccordion()}</li></ol>`,
-      assertCursor: [[ 0, 0, 1, 0 ], 1 ],
+      assertContent: `<ol>\n<li>tiny${AccordionUtils.createAccordion()}</li>\n</ol>`,
+      assertCursor: [[ 0, 0, 1, 0, 0 ], 'Accordion summary...'.length ],
     });
   });
 
@@ -79,8 +76,8 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<dl><dt>tiny</dt></dl>',
       initialCursor: [[ 0, 0, 0 ], 'tiny'.length ],
-      assertContent: `<dl><dt>tiny${AccordionUtils.createAccordion()}</dt></dl>`,
-      assertCursor: [[ 0, 0, 1, 0 ], 1 ],
+      assertContent: `<dl>\n<dt>tiny${AccordionUtils.createAccordion()}</dt>\n</dl>`,
+      assertCursor: [[ 0, 0, 1, 0, 0 ], 'Accordion summary...'.length ],
     });
   });
 
@@ -88,8 +85,8 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<dl><dd>tiny</dd></dl>',
       initialCursor: [[ 0, 0, 0 ], 'tiny'.length ],
-      assertContent: `<dl><dd>tiny${AccordionUtils.createAccordion()}</dd></dl>`,
-      assertCursor: [[ 0, 0, 1, 0 ], 1 ],
+      assertContent: `<dl>\n<dd>tiny${AccordionUtils.createAccordion()}</dd>\n</dl>`,
+      assertCursor: [[ 0, 0, 1, 0, 0 ], 'Accordion summary...'.length ],
     });
   });
 
@@ -97,17 +94,17 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: '<table><colgroup><col></colgroup><tbody><tr><td>&nbsp;</td></tr></tbody></table>',
       initialCursor: [[ 0, 1, 0, 0, 0 ], 0 ],
-      assertContent: `<table><colgroup><col></colgroup><tbody><tr><td>${AccordionUtils.createAccordion()}</td></tr></tbody></table>`,
-      assertCursor: [[ 0, 1, 0, 0, 0, 0 ], 1 ],
+      assertContent: `<table><colgroup><col></colgroup>\n<tbody>\n<tr>\n<td>${AccordionUtils.createAccordion()}</td>\n</tr>\n</tbody>\n</table>`,
+      assertCursor: [[ 0, 1, 0, 0, 0, 0, 0 ], 'Accordion summary...'.length ],
     });
   });
 
   it('TINY-9730: Insert an accordion into an accordion body', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: AccordionUtils.createAccordion({ summary: 'summary', body: '<p>body</p>' }),
-      initialCursor: [[ 0, 1, 0 ], 'body'.length ],
-      assertContent: AccordionUtils.createAccordion({ summary: 'summary', body: `<p>body</p>${AccordionUtils.createAccordion()}` }),
-      assertCursor: [[ 0, 2, 0 ], 1 ],
+      initialCursor: [[ 0, 1, 0, 0 ], 'body'.length ],
+      assertContent: AccordionUtils.createAccordion({ summary: 'summary', body: `<p>body</p>\n${AccordionUtils.createAccordion()}` }),
+      assertCursor: [[ 0, 1, 1, 0, 0 ], 'Accordion summary...'.length ],
     });
   });
 
@@ -115,7 +112,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     testInsertingAccordion(hook.editor(), {
       initialContent: AccordionUtils.createAccordion({ summary: 'title', body: '<p>body</p>' }),
       initialCursor: [[ 0, 0, 0 ], 'title'.length ],
-      assertContent: AccordionUtils.createAccordion({ summary: 'title', body: '<p>body</p>' }),
+      assertContent: AccordionUtils.createAccordion({ summary: 'title', body: '<p>body</p>\n' }),
       assertCursor: [[ 0, 0, 0 ], 'title'.length ],
     });
   });
@@ -127,7 +124,7 @@ describe('browser.tinymce.plugins.accordion.AccordionPluginTest', () => {
     editor.execCommand('InsertAccordion');
     TinyAssertions.assertContent(editor, AccordionUtils.createAccordion({ summary: 'tiny' }));
     assert.equal(editor.selection.getNode().nodeName, 'SUMMARY');
-    TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+    TinyAssertions.assertCursor(editor, [ 0, 0, 0 ], 'tiny'.length);
   });
 
   it('TINY-9731: Remove an accordion element under the cursor', () => {

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/FilterContentTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/FilterContentTest.ts
@@ -1,6 +1,7 @@
 import { ApproxStructure, StructAssert, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Type, Unicode } from '@ephox/katamari';
+import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -22,6 +23,7 @@ interface ContentStructure {
 }
 
 describe('browser.tinymce.plugins.accordion.FilterContentTest', () => {
+  const browser = PlatformDetection.detect().browser;
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'accordion',
     toolbar: 'accordion',
@@ -112,11 +114,11 @@ describe('browser.tinymce.plugins.accordion.FilterContentTest', () => {
       TinyAssertions.assertContentStructure(
         editor,
         buildContentStructure({
-          before: () => ApproxStructure.fromHtml(`<p>blah1${Unicode.nbsp}</p>`),
+          before: () => ApproxStructure.fromHtml(`<p>blah1${browser.isSafari() ? ' ' : Unicode.nbsp}</p>`),
           accordion: buildAccordionStructure({
             summary: 'Test'
           }),
-          after: () => ApproxStructure.fromHtml('<p> blah2</p>'),
+          after: () => ApproxStructure.fromHtml(`<p>${browser.isSafari() ? Unicode.nbsp : ' '}blah2</p>`),
         })
       );
     });

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/FilterContentTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/FilterContentTest.ts
@@ -1,0 +1,370 @@
+import { ApproxStructure, StructAssert, Waiter } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Type, Unicode } from '@ephox/katamari';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/accordion/Plugin';
+
+import * as AccordionUtils from '../module/AccordionUtils';
+
+interface AccordionDetails {
+  readonly open?: boolean;
+  readonly summary?: string;
+  readonly body?: string[];
+  readonly isSelected?: boolean;
+}
+
+interface ContentStructure {
+  readonly accordion: ApproxStructure.Builder<StructAssert>;
+  readonly before?: ApproxStructure.Builder<StructAssert>;
+  readonly after?: ApproxStructure.Builder<StructAssert>;
+}
+
+describe('browser.tinymce.plugins.accordion.FilterContentTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'accordion',
+    toolbar: 'accordion',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const buildAccordionStructure = (details: AccordionDetails): ApproxStructure.Builder<StructAssert> => (s, str, _arr) => {
+    const { open, summary, body, isSelected } = details;
+    return s.element('details', {
+      exactClasses: [ 'mce-accordion' ],
+      exactAttrs: {
+        ...Type.isNullable(open) || open === true ? { open: str.is('open') } : {},
+        ...Type.isNullable(isSelected) || isSelected === true ? { 'data-mce-selected': str.is('1') } : {}
+      },
+      children: [
+        s.element('summary', {
+          exactClasses: [ 'mce-accordion-summary' ],
+          children: [
+            ApproxStructure.fromHtml(summary || 'Accordion summary...')
+          ]
+        }),
+        s.element('div', {
+          exactClasses: [ 'mce-accordion-body' ],
+          children: (body ?? [ '<p>Accordion body...</p>' ]).map((html) => ApproxStructure.fromHtml(html))
+        })
+      ]
+    });
+  };
+
+  const buildContentStructure = (contentStructure: ContentStructure) => {
+    const { before, accordion, after } = contentStructure;
+    return ApproxStructure.build((s, str, arr) => {
+      const beforeStruct = Type.isNonNullable(before) ? [ before(s, str, arr) ] : [];
+      const accordionStruct = [ accordion(s, str, arr) ];
+      const afterStruct = Type.isNonNullable(after) ? [ after(s, str, arr) ] : [];
+      return s.element('body', {
+        children: [
+          ...beforeStruct,
+          ...accordionStruct,
+          ...afterStruct
+        ]
+      });
+    });
+  };
+
+  context('parsing', () => {
+    it('TINY-9959: should have correct structure when inserting with toolbar button', () => {
+      const editor = hook.editor();
+
+      editor.setContent('');
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+
+      TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Insert accordion"]');
+      TinyAssertions.assertContentStructure(
+        editor,
+        buildContentStructure({
+          accordion: buildAccordionStructure({})
+        })
+      );
+    });
+
+    it('TINY-9959: should have correct structure when inserting with command', async () => {
+      const editor = hook.editor();
+
+      editor.setContent('');
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+
+      editor.execCommand('InsertAccordion');
+      // Occasionally the data-mce-selected attribute is not on the details element immediately
+      // so wrapping the assertion in a Waiter
+      await Waiter.pTryUntil('Should have correct structure and accordion should be selected', () => {
+        TinyAssertions.assertContentStructure(
+          editor,
+          buildContentStructure({
+            accordion: buildAccordionStructure({})
+          })
+        );
+      });
+    });
+
+    it('TINY-9959: should have correct structure when selecting text and inserting accordion', () => {
+      const editor = hook.editor();
+
+      editor.setContent('<p>blah1 Test blah2</p>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 'blah1 '.length, [ 0, 0 ], 'blah1 Test'.length);
+
+      editor.execCommand('InsertAccordion');
+      TinyAssertions.assertContentStructure(
+        editor,
+        buildContentStructure({
+          before: () => ApproxStructure.fromHtml(`<p>blah1${Unicode.nbsp}</p>`),
+          accordion: buildAccordionStructure({
+            summary: 'Test'
+          }),
+          after: () => ApproxStructure.fromHtml('<p> blah2</p>'),
+        })
+      );
+    });
+
+    it('TINY-9959: should have correct structure when inserting basic accordion with setContent', () => {
+      const editor = hook.editor();
+
+      editor.setContent('<p>before</p>' + AccordionUtils.createAccordion({}));
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+
+      TinyAssertions.assertContentStructure(
+        editor,
+        buildContentStructure({
+          before: () => ApproxStructure.fromHtml('<p>before</p>'),
+          accordion: buildAccordionStructure({
+            isSelected: false
+          }),
+        })
+      );
+    });
+
+    it('TINY-9959: should have correct structure when inserting basic accordion that is not open', () => {
+      const editor = hook.editor();
+
+      editor.setContent('<p>before</p>' + AccordionUtils.createAccordion({ open: false }));
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+
+      TinyAssertions.assertContentStructure(
+        editor,
+        buildContentStructure({
+          before: () => ApproxStructure.fromHtml('<p>before</p>'),
+          accordion: buildAccordionStructure({
+            open: false,
+            isSelected: false
+          }),
+        })
+      );
+    });
+
+    it('TINY-9959: should have correct structure when inserting accordion with formatting and headings', () => {
+      const editor = hook.editor();
+
+      editor.setContent('<p>before</p>' + AccordionUtils.createAccordion({
+        body: '<p><strong>First</strong></p><h2>Second</h2>'
+      }));
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+
+      TinyAssertions.assertContentStructure(
+        editor,
+        buildContentStructure({
+          before: () => ApproxStructure.fromHtml('<p>before</p>'),
+          accordion: buildAccordionStructure({
+            isSelected: false,
+            body: [ '<p><strong>First</strong></p>', '<h2>Second</h2>' ]
+          }),
+        })
+      );
+    });
+
+    it('TINY-9959: should have correct structure when inserting accordion where summary has no content', () => {
+      const editor = hook.editor();
+
+      editor.setContent(
+        '<p>before</p>' +
+        `<details class="mce-accordion" open="open"><summary></summary><p>bar</p></details>`
+      );
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+
+      TinyAssertions.assertContentStructure(
+        editor,
+        buildContentStructure({
+          before: () => ApproxStructure.fromHtml('<p>before</p>'),
+          accordion: buildAccordionStructure({
+            summary: '<br data-mce-bogus="1">',
+            body: [ '<p>bar</p>' ],
+            isSelected: false,
+          }),
+        })
+      );
+    });
+
+    it('TINY-9959: should have correct structure when inserting accordion where summary is not the first child', () => {
+      const editor = hook.editor();
+
+      editor.setContent(
+        '<p>before</p>' +
+        `<details class="mce-accordion" open="open"><p>bar</p><summary>foo</summary></details>`
+      );
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+
+      TinyAssertions.assertContentStructure(
+        editor,
+        buildContentStructure({
+          before: () => ApproxStructure.fromHtml('<p>before</p>'),
+          accordion: buildAccordionStructure({
+            summary: 'foo',
+            body: [ '<p>bar</p>' ],
+            isSelected: false,
+          }),
+        })
+      );
+    });
+
+    it('TINY-9959: should have correct structure when inserting accordion with multiple summary elements', () => {
+      const editor = hook.editor();
+
+      editor.setContent(
+        '<p>before</p>' +
+        `<details class="mce-accordion" open="open"><summary>foo</summary><p>bar</p><summary>baz</summary></details>`
+      );
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+
+      TinyAssertions.assertContentStructure(
+        editor,
+        buildContentStructure({
+          before: () => ApproxStructure.fromHtml('<p>before</p>'),
+          accordion: buildAccordionStructure({
+            summary: 'foo',
+            body: [ '<p>bar</p>', '<summary>baz</summary>' ],
+            isSelected: false,
+          }),
+        })
+      );
+    });
+
+    it('TINY-9959: should have correct structure when inserting accordion with only a summary element', () => {
+      const editor = hook.editor();
+
+      editor.setContent(
+        '<p>before</p>' +
+        `<details class="mce-accordion" open="open"><summary>foo</summary></details>`
+      );
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+
+      TinyAssertions.assertContentStructure(
+        editor,
+        buildContentStructure({
+          before: () => ApproxStructure.fromHtml('<p>before</p>'),
+          accordion: buildAccordionStructure({
+            summary: 'foo',
+            body: [ '<p><br data-mce-bogus="1"></p>' ],
+            // body: [ '<br data-mce-bogus="1">' ],
+            isSelected: false,
+          }),
+        })
+      );
+    });
+
+    it('TINY-9959: should have correct structure when inserting accordion with no summary element', () => {
+      const editor = hook.editor();
+
+      editor.setContent(
+        '<p>before</p>' +
+        `<details class="mce-accordion" open="open"><p>foo</p></details>`
+      );
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+
+      TinyAssertions.assertContentStructure(
+        editor,
+        buildContentStructure({
+          before: () => ApproxStructure.fromHtml('<p>before</p>'),
+          accordion: buildAccordionStructure({
+            summary: '<br data-mce-bogus="1">',
+            body: [ '<p>foo</p>' ],
+            isSelected: false,
+          }),
+        })
+      );
+    });
+
+    it('TINY-9959: should have correct structure when inserting accordion with no children', () => {
+      const editor = hook.editor();
+
+      editor.setContent(
+        '<p>before</p>' +
+        `<details class="mce-accordion" open="open"></details>`
+      );
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+
+      TinyAssertions.assertContentStructure(
+        editor,
+        buildContentStructure({
+          before: () => ApproxStructure.fromHtml('<p>before</p>'),
+          accordion: buildAccordionStructure({
+            summary: '<br data-mce-bogus="1">',
+            body: [ '<p><br data-mce-bogus="1"></p>' ],
+            isSelected: false,
+          }),
+        })
+      );
+    });
+
+    it('TINY-9959: should have correct structure when inserting accordion with empty children', () => {
+      const editor = hook.editor();
+
+      editor.setContent(
+        '<p>before</p>' +
+        `<details class="mce-accordion" open="open"><summary></summary><h2></h2></details>`
+      );
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+
+      TinyAssertions.assertContentStructure(
+        editor,
+        buildContentStructure({
+          before: () => ApproxStructure.fromHtml('<p>before</p>'),
+          accordion: buildAccordionStructure({
+            summary: '<br data-mce-bogus="1">',
+            body: [ '<h2><br data-mce-bogus="1"></h2>' ],
+            isSelected: false,
+          }),
+        })
+      );
+    });
+  });
+
+  context('serialization', () => {
+    it('TINY-9959: should have correct structure when inserting with toolbar button', () => {
+      const editor = hook.editor();
+
+      editor.setContent('');
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+
+      TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Insert accordion"]');
+      TinyAssertions.assertContent(editor, AccordionUtils.createAccordion({}));
+    });
+
+    it('TINY-9959: should have correct structure when inserting with command', () => {
+      const editor = hook.editor();
+
+      editor.setContent('');
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+
+      editor.execCommand('InsertAccordion');
+      TinyAssertions.assertContent(editor, AccordionUtils.createAccordion({}));
+    });
+
+    it('TINY-9959: should have correct structure when summary has no content', () => {
+      const editor = hook.editor();
+
+      editor.setContent('');
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+
+      editor.execCommand('InsertAccordion');
+      TinyAssertions.assertCursor(editor, [ 0, 0, 0 ], 'Accordion summary...'.length);
+
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 'Accordion summary...'.length);
+      editor.execCommand('Delete');
+      TinyAssertions.assertContent(editor, AccordionUtils.createAccordion({ summary: '&nbsp;' }));
+    });
+  });
+});

--- a/modules/tinymce/src/plugins/accordion/test/ts/module/AccordionUtils.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/module/AccordionUtils.ts
@@ -1,7 +1,17 @@
-const createAccordion = (
-  { open = true, summary = 'Accordion summary...', body = '<p>Accordion body...</p>' }:
-  { open?: boolean; summary?: string; body?: string } = {}): string =>
-  `<details class="mce-accordion"${open ? ` open="open"` : ''}><summary class="mce-accordion-summary">${summary}</summary>${body}</details>`;
+interface AccordionDetails {
+  readonly open?: boolean;
+  readonly summary?: string;
+  readonly body?: string;
+}
+
+const createAccordion = (details: AccordionDetails = {}): string => {
+  const {
+    open = true,
+    summary = 'Accordion summary...',
+    body = '<p>Accordion body...</p>\n'
+  } = details;
+  return `<details class="mce-accordion"${open ? ` open="open"` : ''}>\n<summary>${summary}</summary>\n${body}</details>`;
+};
 
 export {
   createAccordion

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionEnterTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionEnterTest.ts
@@ -37,11 +37,11 @@ describe('webdriver.tinymce.plugins.accordion.AccordionEnterTest', () => {
   it('TINY-9731: Leave accordion body with ENTER keypress within an empty paragraph', async () => {
     const editor = hook.editor();
     editor.setContent(AccordionUtils.createAccordion({ body: '<p>tiny</p>' }));
-    TinySelections.setCursor(editor, [ 0, 1, 0 ], 'tiny'.length);
+    TinySelections.setCursor(editor, [ 0, 1, 0, 0 ], 'tiny'.length);
     await pDoEnter();
-    TinyAssertions.assertContentPresence(editor, { 'details > p': 2 });
+    TinyAssertions.assertContentPresence(editor, { 'details > div > p': 2 });
     await pDoEnter();
-    TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
+    TinyAssertions.assertContentPresence(editor, { 'details > div > p': 1 });
     TinyAssertions.assertContentPresence(editor, { 'details + p': 1 });
     TinyAssertions.assertCursor(editor, [ 1 ], 0);
   });
@@ -49,9 +49,9 @@ describe('webdriver.tinymce.plugins.accordion.AccordionEnterTest', () => {
   it('TINY-9731: Do not remove the only empty paragraph when leaving accordion body with ENTER keypress', async () => {
     const editor = hook.editor();
     editor.setContent(AccordionUtils.createAccordion({ body: '<p></p>' }));
-    TinySelections.setCursor(editor, [ 0, 1 ], 0);
+    TinySelections.setCursor(editor, [ 0, 1, 0 ], 0);
     await pDoEnter();
-    TinyAssertions.assertContentPresence(editor, { 'details > p': 1 });
+    TinyAssertions.assertContentPresence(editor, { 'details > div > p': 1 });
     TinyAssertions.assertContentPresence(editor, { 'details + p': 1 });
     TinyAssertions.assertCursor(editor, [ 1 ], 0);
   });


### PR DESCRIPTION
Related Ticket: TINY-9959:

Description of Changes:
* Wrap the accordion (details element) body in a div when editing to prevent selection issues on Chrome
* The second commit was merged from #8811. Thanks @spocke for that
* For the changed files that apply to the wrapping div work see the first commit: https://github.com/tinymce/tinymce/commit/f8f8c4e58356c59ef99785b621a09ddd270a3b59

Pre-checks:
* [X] ~~Changelog entry added~~
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [X] Docs ticket created (if applicable)

GitHub issues (if applicable):
