### PR TITLE
TINY-9828: fix `scrollToMarker` logic

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - It was possible to remove the summary element from a details element by drag and dropping. #TINY-9960
 - It was possible to break summary elements if contents containing blocks was dropped inside them. #TINY-9960
 - Contents would not be removed from the drag start source if dragging and dropping internally into a transparent block element. #TINY-9960
+- In some cases `scrollToMarker` make the entire page scroll. #TINY-9828
 
 ## 6.5.1 - 2023-06-19
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - It was possible to remove the summary element from a details element by drag and dropping. #TINY-9960
 - It was possible to break summary elements if contents containing blocks was dropped inside them. #TINY-9960
 - Contents would not be removed from the drag start source if dragging and dropping internally into a transparent block element. #TINY-9960
-- In some cases `scrollToMarker` make the entire page scroll. #TINY-9828
+- In some cases pressing enter makes the entire page scroll. #TINY-9828
 
 ## 6.5.1 - 2023-06-19
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - It was possible to remove the summary element from a details element by drag and dropping. #TINY-9960
 - It was possible to break summary elements if contents containing blocks was dropped inside them. #TINY-9960
 - Contents would not be removed from the drag start source if dragging and dropping internally into a transparent block element. #TINY-9960
-- In some cases pressing enter makes the entire page scroll. #TINY-9828
+- In some cases pressing enter would scroll the entire page. #TINY-9828
 
 ## 6.5.1 - 2023-06-19
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
@@ -1,7 +1,7 @@
 import { Assertions, Cursors, Waiter } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Cell } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -9,6 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 import { ScrollIntoViewEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import * as ScrollIntoView from 'tinymce/core/dom/ScrollIntoView';
+import * as InsertNewLine from 'tinymce/core/newline/InsertNewLine';
 
 interface State {
   readonly elm: HTMLElement;
@@ -171,6 +172,22 @@ describe('browser.tinymce.core.dom.ScrollIntoViewTest', () => {
       */
       assertHorizontalScrollPosition(editor, 0);
     });
+
+    it('TINY-9776: when the selection is scrolled into view selection if there is an horizontal scroll it should preserve the correct left position', async () => {
+      const editor = hook.editor();
+      await pSetContent(editor, `<div class="container-with-horizontal-scroll" style="margin-left: 100px">
+        <div style="height: 1000px; width: 2000px">a</div>
+        <div style="height: 50px">b</div>
+        <div style="height: 600px">a</div>
+      </div>`);
+      const leftScroll = 100;
+      TinySelections.setCursor(editor, [ 0, 2, 0 ], 0);
+      editor.getDoc().documentElement.scrollBy({ left: leftScroll });
+
+      editor.selection.scrollIntoView();
+
+      assertHorizontalScrollPosition(editor, leftScroll);
+    });
   });
 
   context('Private ScrollElementIntoView', () => {
@@ -239,5 +256,50 @@ describe('browser.tinymce.core.dom.ScrollIntoViewTest', () => {
       assertScrollIntoViewEventInfo(editor, value, 'div:nth-child(2)', true);
       assertScrollPosition(editor, 0, 0);
     });
+  });
+});
+
+context('scrollToMarker should not scroll the container', () => {
+  const insertNewline = (editor: Editor, args: Partial<EditorEvent<KeyboardEvent>>) => {
+    InsertNewLine.insert(editor, args as EditorEvent<KeyboardEvent>);
+  };
+  const container: SugarElement<HTMLButtonElement> = SugarElement.fromHtml('<div id="ephox-ui" style="border: 2px solid red; margin-top: 4000px; margin-bottom: 4000px"></div>');
+
+  const setupElement = () => {
+    const element = SugarElement.fromTag('textarea');
+
+    Insert.append(SugarBody.body(), container);
+    Insert.append(container, element);
+    return {
+      element,
+      teardown: () => {
+        Remove.remove(element);
+        Remove.remove(container);
+      }
+    };
+  };
+
+  const hook = TinyHooks.bddSetupFromElement<Editor>({
+    add_unload_trigger: false,
+    height: 500,
+    width: 500,
+    toolbar: false,
+    menubar: false,
+    statusbar: false,
+    base_url: '/project/tinymce/js/tinymce',
+    content_style: 'body.mce-content-body  { margin: 0 }'
+  }, setupElement, []);
+
+  it('TINY-9776: scrollToMarker should not scroll the container', () => {
+    const editor = hook.editor();
+    TinySelections.setCursor(editor, [ 0 ], 0);
+    window.scrollTo(0, 4500);
+    editor.selection.scrollIntoView();
+
+    const initialTop = container.dom.getBoundingClientRect().top;
+    while (editor.getContainer().clientHeight > editor.getBody().clientHeight) {
+      insertNewline(editor, {});
+    }
+    assert.equal(initialTop, container.dom.getBoundingClientRect().top);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ScrollIntoViewTest.ts
@@ -263,7 +263,7 @@ context('scrollToMarker should not scroll the container', () => {
   const insertNewline = (editor: Editor, args: Partial<EditorEvent<KeyboardEvent>>) => {
     InsertNewLine.insert(editor, args as EditorEvent<KeyboardEvent>);
   };
-  const container: SugarElement<HTMLButtonElement> = SugarElement.fromHtml('<div id="ephox-ui" style="border: 2px solid red; margin-top: 4000px; margin-bottom: 4000px"></div>');
+  const container: SugarElement<HTMLElement> = SugarElement.fromHtml('<div id="ephox-ui" style="border: 2px solid red; margin-top: 4000px; margin-bottom: 4000px"></div>');
 
   const setupElement = () => {
     const element = SugarElement.fromTag('textarea');


### PR DESCRIPTION
Related Ticket: TINY-9828

Description of Changes:
To avoid the scroll of the whole content in some cases I revert the logic to the previous version and fix it to avoid the problem that we had with the horizontal scroll.

to fix it, now the left position is calculated as the negative of the left of the editor's body.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
