### PR TITLE
TINY-9964: Fixed issue with pressing space inside summary on firefox

### DIFF
--- a/modules/alloy/src/test/ts/browser/behaviour/docking/DockingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/docking/DockingTest.ts
@@ -237,7 +237,7 @@ describe('browser.alloy.behaviour.docking.DockingTest', () => {
       assertInitialStructures('After Docking.refresh', { static: staticBox, absolute: absoluteBox });
     });
 
-    it('External Scroll event', () => {
+    it('External Scroll event', async () => {
       const store = hook.store();
       const component = hook.component();
 
@@ -264,10 +264,12 @@ describe('browser.alloy.behaviour.docking.DockingTest', () => {
       // Now, broadcast an external scroll event to the mothership, and check that it triggers
       // refresh and puts the box back where it should be.
       hook.gui().broadcastEvent(SystemEvents.externalElementScroll(), { } as any);
-      assertInitialStructures(
-        'After broadcasting external scroll event',
-        { static: staticBox, absolute: absoluteBox }
-      );
+      await Waiter.pTryUntil('Waited for initial structure', () => {
+        assertInitialStructures(
+          'After broadcasting external scroll event',
+          { static: staticBox, absolute: absoluteBox }
+        );
+      });
     });
   });
 });

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815
+- It was not possible to press space to insert a space character inside a summary element on Firefox. #TINY-9954
 
 ## 6.5.0 - 2023-06-12
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815
-- It was not possible to press space to insert a space character inside a summary element on Firefox. #TINY-9954
+- It was not possible to press space to insert a space character inside a summary element on Firefox. #TINY-9964
 
 ## 6.5.0 - 2023-06-12
 

--- a/modules/tinymce/src/core/main/ts/keyboard/InsertSpace.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/InsertSpace.ts
@@ -27,7 +27,6 @@ const insertInlineBoundarySpaceOrNbsp = (root: SugarElement<Node>, pos: CaretPos
 const setSelection = (editor: Editor) => (pos: CaretPosition) => {
   editor.selection.setRng(pos.toRange());
   editor.nodeChanged();
-  return true;
 };
 
 const isInsideSummary = (domUtils: DOMUtils, node: Node) => domUtils.isEditable(domUtils.getParent(node, 'summary'));
@@ -59,7 +58,7 @@ const insertSpaceInSummaryAtSelectionOnFirefox = (editor: Editor): Optional<() =
     }
 
     const pos = CaretPosition.fromRangeStart(editor.selection.getRng());
-    insertSpaceOrNbspAtPosition(root, pos).each((pos) => editor.selection.setRng(pos.toRange()));
+    insertSpaceOrNbspAtPosition(root, pos).each(setSelection(editor));
   };
 
   return Optionals.someIf(Env.browser.isFirefox() && editor.selection.isEditable() && isInsideSummary(editor.dom, editor.selection.getRng().startContainer), insertSpaceThunk);

--- a/modules/tinymce/src/core/main/ts/keyboard/SpaceKey.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/SpaceKey.ts
@@ -7,7 +7,8 @@ import * as MatchKeys from './MatchKeys';
 
 const executeKeydownOverride = (editor: Editor, evt: KeyboardEvent) => {
   MatchKeys.executeWithDelayedAction([
-    { keyCode: VK.SPACEBAR, action: MatchKeys.action(InsertSpace.insertSpaceOrNbspAtSelection, editor) }
+    { keyCode: VK.SPACEBAR, action: MatchKeys.action(InsertSpace.insertSpaceOrNbspAtSelection, editor) },
+    { keyCode: VK.SPACEBAR, action: MatchKeys.action(InsertSpace.insertSpaceInSummaryAtSelectionOnFirefox, editor) }
   ], evt).each((applyAction) => {
     evt.preventDefault();
     const event = InputEvents.fireBeforeInputEvent(editor, 'insertText', { data: ' ' });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/SpaceKeyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/SpaceKeyTest.ts
@@ -88,7 +88,7 @@ describe('browser.tinymce.core.keyboard.SpaceKeyTest', () => {
       TinyAssertions.assertContent(editor, '<p>a<a href="#">b &nbsp;</a>c</p>');
     });
 
-    it('TINY-9954: Pressing space inside a summary should insert a space character on Firefox', function () {
+    it('TINY-9964: Pressing space inside a summary should insert a space character on Firefox', function () {
       if (!isFirefox) {
         this.skip();
       }
@@ -100,7 +100,7 @@ describe('browser.tinymce.core.keyboard.SpaceKeyTest', () => {
       TinyAssertions.assertContent(editor, '<details><summary>a b</summary><div>content</div></details>');
     });
 
-    it('TINY-9954: Pressing space on selected contents inside a summary should insert a space character on Firefox', function () {
+    it('TINY-9964: Pressing space on selected contents inside a summary should insert a space character on Firefox', function () {
       if (!isFirefox) {
         this.skip();
       }
@@ -112,7 +112,7 @@ describe('browser.tinymce.core.keyboard.SpaceKeyTest', () => {
       TinyAssertions.assertContent(editor, '<details><summary>a c</summary><div>content</div></details>');
     });
 
-    it('TINY-9954: Pressing space on selected contents inside non-editable content inside a summary should not insert a space character on Firefox', function () {
+    it('TINY-9964: Pressing space on selected contents inside non-editable content inside a summary should not insert a space character on Firefox', function () {
       if (!isFirefox) {
         this.skip();
       }
@@ -125,7 +125,7 @@ describe('browser.tinymce.core.keyboard.SpaceKeyTest', () => {
       });
     });
 
-    it('TINY-9954: Pressing space two times inside a summary should insert a space character and produce a single undo level on Firefox', function () {
+    it('TINY-9964: Pressing space two times inside a summary should insert a space character and produce a single undo level on Firefox', function () {
       if (!isFirefox) {
         this.skip();
       }

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/SpaceKeyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/SpaceKeyTest.ts
@@ -1,6 +1,7 @@
 import { Keys } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -10,6 +11,8 @@ describe('browser.tinymce.core.keyboard.SpaceKeyTest', () => {
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
   }, []);
+
+  const isFirefox = PlatformDetection.detect().browser.isFirefox();
 
   beforeEach(() => {
     hook.editor().focus();
@@ -84,5 +87,58 @@ describe('browser.tinymce.core.keyboard.SpaceKeyTest', () => {
       TinyAssertions.assertSelection(editor, [ 0, 1, 0 ], 3, [ 0, 1, 0 ], 3);
       TinyAssertions.assertContent(editor, '<p>a<a href="#">b &nbsp;</a>c</p>');
     });
+
+    it('TINY-9954: Pressing space inside a summary should insert a space character on Firefox', function () {
+      if (!isFirefox) {
+        this.skip();
+      }
+
+      const editor = hook.editor();
+      editor.setContent('<details><summary>ab</summary><div>content</div></details>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+      TinyContentActions.keystroke(editor, Keys.space());
+      TinyAssertions.assertContent(editor, '<details><summary>a b</summary><div>content</div></details>');
+    });
+
+    it('TINY-9954: Pressing space on selected contents inside a summary should insert a space character on Firefox', function () {
+      if (!isFirefox) {
+        this.skip();
+      }
+
+      const editor = hook.editor();
+      editor.setContent('<details><summary>abc</summary><div>content</div></details>');
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 2);
+      TinyContentActions.keystroke(editor, Keys.space());
+      TinyAssertions.assertContent(editor, '<details><summary>a c</summary><div>content</div></details>');
+    });
+
+    it('TINY-9954: Pressing space on selected contents inside non-editable content inside a summary should not insert a space character on Firefox', function () {
+      if (!isFirefox) {
+        this.skip();
+      }
+
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        editor.setContent('<details><summary>abc</summary><div>content</div></details>');
+        TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 2);
+        TinyContentActions.keystroke(editor, Keys.space());
+        TinyAssertions.assertContent(editor, '<details><summary>abc</summary><div>content</div></details>');
+      });
+    });
+
+    it('TINY-9954: Pressing space two times inside a summary should insert a space character and produce a single undo level on Firefox', function () {
+      if (!isFirefox) {
+        this.skip();
+      }
+
+      const editor = hook.editor();
+      editor.setContent('<details><summary>ab</summary><div>content</div></details>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+      TinyContentActions.keystroke(editor, Keys.space());
+      TinyContentActions.keystroke(editor, Keys.space());
+      TinyAssertions.assertContent(editor, '<details><summary>a &nbsp;b</summary><div>content</div></details>');
+      editor.undoManager.undo();
+      TinyAssertions.assertContent(editor, '<details><summary>ab</summary><div>content</div></details>');
+    });
+
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9964

Description of Changes:
* Fixed issue with space key not working inside summary elements in Firefox

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
