### PR TITLE
TINY-9997: Restore behavior that converts image url to image tag on paste

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed a regression where pasting an image url would result in the url being inserted as plain text instead of the image being inserted. #TINY-9997
+
 ## 6.5.0 - 2023-06-12
 
 ### Added

--- a/modules/tinymce/src/core/main/ts/paste/Clipboard.ts
+++ b/modules/tinymce/src/core/main/ts/paste/Clipboard.ts
@@ -38,14 +38,19 @@ const createPasteDataTransfer = (html: string): DataTransfer => {
   return dataTransfer;
 };
 
-const doPaste = (editor: Editor, content: string, internal: boolean, pasteAsText: boolean): void => {
+const doPaste = (editor: Editor, content: string, internal: boolean, pasteAsText: boolean, shouldSimulateInputEvent: boolean): void => {
   const res = ProcessFilters.process(editor, content, internal);
   if (!res.cancelled) {
     const content = res.content;
-    const args = InputEvents.fireBeforeInputEvent(editor, 'insertFromPaste', { dataTransfer: createPasteDataTransfer(content) });
-    if (!args.isDefaultPrevented()) {
-      SmartPaste.insertContent(editor, content, pasteAsText);
-      InputEvents.fireInputEvent(editor, 'insertFromPaste');
+    const doPasteAction = () => SmartPaste.insertContent(editor, content, pasteAsText);
+    if (shouldSimulateInputEvent) {
+      const args = InputEvents.fireBeforeInputEvent(editor, 'insertFromPaste', { dataTransfer: createPasteDataTransfer(content) });
+      if (!args.isDefaultPrevented()) {
+        doPasteAction();
+        InputEvents.fireInputEvent(editor, 'insertFromPaste');
+      }
+    } else {
+      doPasteAction();
     }
   }
 };
@@ -55,20 +60,20 @@ const doPaste = (editor: Editor, content: string, internal: boolean, pasteAsText
  * inserted at the current selection in the editor. It will also fire paste events
  * for custom user filtering.
  */
-const pasteHtml = (editor: Editor, html: string, internalFlag: boolean): void => {
+const pasteHtml = (editor: Editor, html: string, internalFlag: boolean, shouldSimulateInputEvent: boolean): void => {
   const internal = internalFlag ? internalFlag : InternalHtml.isMarked(html);
-  doPaste(editor, InternalHtml.unmark(html), internal, false);
+  doPaste(editor, InternalHtml.unmark(html), internal, false, shouldSimulateInputEvent);
 };
 
 /*
  * Pastes the specified text. This means that the plain text is processed
  * and converted into BR and P elements. It will fire paste events for custom filtering.
  */
-const pasteText = (editor: Editor, text: string): void => {
+const pasteText = (editor: Editor, text: string, shouldSimulateInputEvent: boolean): void => {
   const encodedText = editor.dom.encode(text).replace(/\r\n/g, '\n');
   const normalizedText = Whitespace.normalize(encodedText, Options.getPasteTabSpaces(editor));
   const html = Newlines.toBlockElements(normalizedText, Options.getForcedRootBlock(editor), Options.getForcedRootBlockAttrs(editor));
-  doPaste(editor, html, false, true);
+  doPaste(editor, html, false, true, shouldSimulateInputEvent);
 };
 
 /*
@@ -123,7 +128,7 @@ const pasteImage = (editor: Editor, imageItem: FileResult): void => {
     const existingBlobInfo = blobCache.getByData(base64, type);
     const blobInfo = existingBlobInfo ?? createBlobInfo(editor, blobCache, file, base64);
 
-    pasteHtml(editor, `<img src="${blobInfo.blobUri()}">`, false);
+    pasteHtml(editor, `<img src="${blobInfo.blobUri()}">`, false, true);
   });
 };
 
@@ -188,7 +193,7 @@ const isBrokenAndroidClipboardEvent = (e: ClipboardEvent): boolean =>
 const isKeyboardPasteEvent = (e: KeyboardEvent): boolean =>
   (VK.metaKeyPressed(e) && e.keyCode === 86) || (e.shiftKey && e.keyCode === 45);
 
-const insertClipboardContent = (editor: Editor, clipboardContent: ClipboardContents, html: string, plainTextMode: boolean): void => {
+const insertClipboardContent = (editor: Editor, clipboardContent: ClipboardContents, html: string, plainTextMode: boolean, shouldSimulateInputEvent: boolean): void => {
   let content = PasteUtils.trimHtml(html);
 
   const isInternal = hasContentType(clipboardContent, InternalHtml.internalHtmlMime()) || InternalHtml.isMarked(html);
@@ -219,9 +224,9 @@ const insertClipboardContent = (editor: Editor, clipboardContent: ClipboardConte
   }
 
   if (plainTextMode) {
-    pasteText(editor, content);
+    pasteText(editor, content, shouldSimulateInputEvent);
   } else {
-    pasteHtml(editor, content, isInternal);
+    pasteHtml(editor, content, isInternal, shouldSimulateInputEvent);
   }
 };
 
@@ -250,18 +255,18 @@ const registerEventHandlers = (editor: Editor, pasteBin: PasteBin, pasteFormat: 
       return;
     }
 
-    e.preventDefault();
-
     // If the clipboard API has HTML then use that directly
     if (hasContentType(clipboardContent, 'text/html')) {
-      insertClipboardContent(editor, clipboardContent, clipboardContent['text/html'], plainTextMode);
+      e.preventDefault();
+      insertClipboardContent(editor, clipboardContent, clipboardContent['text/html'], plainTextMode, true);
     } else if (hasContentType(clipboardContent, 'text/plain') && hasContentType(clipboardContent, 'text/uri-list')) {
       /*
       Safari adds the uri-list attribute to links copied within it.
       When pasting something with the url-list within safari using the default functionality it will convert it from www.example.com to <a href="www.example.com">www.example.com</a> when pasting into the pasteBin-div.
       This causes issues. To solve this we bypass the default paste functionality for this situation.
        */
-      insertClipboardContent(editor, clipboardContent, clipboardContent['text/plain'], plainTextMode);
+      e.preventDefault();
+      insertClipboardContent(editor, clipboardContent, clipboardContent['text/plain'], plainTextMode, true);
     } else {
       // We can't extract the HTML content from the clipboard so we need to allow the paste
       // to run via the pastebin and then extract from there
@@ -270,7 +275,7 @@ const registerEventHandlers = (editor: Editor, pasteBin: PasteBin, pasteFormat: 
         // Get the pastebin content and then remove it so the selection is restored
         const html = pasteBin.getHtml();
         pasteBin.remove();
-        insertClipboardContent(editor, clipboardContent, html, plainTextMode);
+        insertClipboardContent(editor, clipboardContent, html, plainTextMode, false);
       }, 0);
     }
   });

--- a/modules/tinymce/src/core/main/ts/paste/Commands.ts
+++ b/modules/tinymce/src/core/main/ts/paste/Commands.ts
@@ -22,6 +22,8 @@ const register = (editor: Editor, pasteFormat: Cell<string>): void => {
 
   editor.addCommand('mceInsertClipboardContent', (ui, value) => {
     if (value.html) {
+      // TINY-9997: Input events are not simulated when using paste commands, similar to how the 'mceInsertContent'
+      // and 'Delete' commands work.
       Clipboard.pasteHtml(editor, value.html, value.internal, false);
     }
 

--- a/modules/tinymce/src/core/main/ts/paste/Commands.ts
+++ b/modules/tinymce/src/core/main/ts/paste/Commands.ts
@@ -22,11 +22,11 @@ const register = (editor: Editor, pasteFormat: Cell<string>): void => {
 
   editor.addCommand('mceInsertClipboardContent', (ui, value) => {
     if (value.html) {
-      Clipboard.pasteHtml(editor, value.html, value.internal);
+      Clipboard.pasteHtml(editor, value.html, value.internal, false);
     }
 
     if (value.text) {
-      Clipboard.pasteText(editor, value.text);
+      Clipboard.pasteText(editor, value.text, false);
     }
   });
 };

--- a/modules/tinymce/src/core/main/ts/paste/DragDrop.ts
+++ b/modules/tinymce/src/core/main/ts/paste/DragDrop.ts
@@ -100,9 +100,9 @@ const setup = (editor: Editor, draggingInternallyState: Cell<boolean>): void => 
           const trimmedContent = PasteUtils.trimHtml(content);
 
           if (dropContent['text/html']) {
-            Clipboard.pasteHtml(editor, trimmedContent, internal);
+            Clipboard.pasteHtml(editor, trimmedContent, internal, true);
           } else {
-            Clipboard.pasteText(editor, trimmedContent);
+            Clipboard.pasteText(editor, trimmedContent, true);
           }
         });
       });

--- a/modules/tinymce/src/core/test/ts/browser/paste/ImagePasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/ImagePasteTest.ts
@@ -188,5 +188,8 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     await pAssertInputEvents();
     await pWaitForSelector(editor, 'img');
     TinyAssertions.assertContent(editor, `<p><img src="${imageUrl}">a</p>`);
+
+    editor.undoManager.undo();
+    TinyAssertions.assertContent(editor, `<p>${imageUrl}a</p>`);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/paste/ImagePasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/ImagePasteTest.ts
@@ -75,6 +75,8 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
   const pWaitForSelector = (editor: Editor, selector: string) =>
     Waiter.pTryUntilPredicate(`Wait for ${selector} to exist`, () => editor.dom.select(selector).length > 0);
 
+  const pAssertInputEvents = () => PasteEventUtils.pWaitForAndAssertInputEvents(lastBeforeInputEvent, lastInputEvent);
+
   it('TBA: pasteImages should set unique id in blobcache', async () => {
     const editor = hook.editor();
 
@@ -86,7 +88,7 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     ]);
     Clipboard.pasteImageData(editor, event, editor.selection.getRng());
 
-    await PasteEventUtils.pWaitForAndAssertInputEvents(lastBeforeInputEvent, lastInputEvent);
+    await pAssertInputEvents();
     await pWaitForSelector(editor, 'img');
     await Waiter.pTryUntilPredicate('Wait for image to be cached', () => hasCachedItem('mceclip0') && hasCachedItem('mceclip1'));
 
@@ -104,7 +106,7 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     ]);
     Clipboard.pasteImageData(editor, event, editor.selection.getRng());
 
-    await PasteEventUtils.pWaitForAndAssertInputEvents(lastBeforeInputEvent, lastInputEvent);
+    await pAssertInputEvents();
     await pWaitForSelector(editor, 'img');
     TinyAssertions.assertContent(editor, '<p><img src=\"data:image/gif;base64,' + base64ImgSrc + '">a</p>');
     assert.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
@@ -132,7 +134,7 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     ]);
     Clipboard.pasteImageData(editor, event, editor.selection.getRng());
 
-    await PasteEventUtils.pWaitForAndAssertInputEvents(lastBeforeInputEvent, lastInputEvent);
+    await pAssertInputEvents();
     await pWaitForSelector(editor, 'img');
     TinyAssertions.assertContent(editor, '<p><img src="data:image/jpeg;base64,' + base64ImgSrc + '">a</p>');
     assert.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
@@ -152,7 +154,7 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     ]);
     Clipboard.pasteImageData(editor, event, editor.selection.getRng());
 
-    await PasteEventUtils.pWaitForAndAssertInputEvents(lastBeforeInputEvent, lastInputEvent);
+    await pAssertInputEvents();
     await pWaitForSelector(editor, 'img');
     TinyAssertions.assertContent(editor, '<p><img src=\"data:image/tiff;base64,' + base64ImgSrc + '">a</p>');
     assert.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
@@ -168,8 +170,23 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
       dataTransfer.items.add(base64ToBlob(base64ImgSrc, 'image/gif', 'image.gif'));
     });
 
-    await PasteEventUtils.pWaitForAndAssertInputEvents(lastBeforeInputEvent, lastInputEvent);
+    await pAssertInputEvents();
     await pWaitForSelector(editor, 'img');
     TinyAssertions.assertContent(editor, '<p><img src=\"data:image/gif;base64,' + base64ImgSrc + '">a</p>');
+  });
+
+  it('TINY-9997: Image urls should be pasted as images', async () => {
+    const editor = hook.editor();
+    // Have to manually add extra undo level since the setContent in beforeEach does not add one. Since pasting
+    // an image url executes the UndoManager.extra method, which involves rolling back the first mutation, not
+    // having an undo level here would cause the initial content to be unexpectedly removed during the rollback.
+    editor.undoManager.add();
+
+    const imageUrl = 'https://www.example.com/image.jpg';
+    AgarClipboard.pasteItems(TinyDom.body(editor), { 'text/plain': imageUrl, 'text/html': imageUrl });
+
+    await pAssertInputEvents();
+    await pWaitForSelector(editor, 'img');
+    TinyAssertions.assertContent(editor, `<p><img src="${imageUrl}">a</p>`);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/paste/ImagePasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/ImagePasteTest.ts
@@ -37,6 +37,7 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
   afterEach(() => {
     const editor = hook.editor();
     editor.editorUpload.destroy();
+    lastBeforeInputEvent.clear();
     lastInputEvent.clear();
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/paste/InternalClipboardTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/InternalClipboardTest.ts
@@ -244,25 +244,5 @@ describe('browser.tinymce.core.paste.InternalClipboardTest', () => {
       await pWaitForAndAssertEvents({ internal: false, content: 'https://tiny.com' }, 'https://tiny.com');
       TinyAssertions.assertContent(editor, '<p><a href="https://tiny.com">X</a></p>');
     });
-
-    it('TINY-9829: Paste can be cancelled by beforeinput event', async () => {
-      const editor = hook.editor();
-      const cancelInputEvent = (e: EditorEvent<InputEvent>) => {
-        e.preventDefault();
-      };
-      const inputEvent = Singleton.value<EditorEvent<InputEvent>>();
-      const setInputEvent = (e: EditorEvent<InputEvent>) => inputEvent.set(e);
-
-      editor.on('beforeinput', cancelInputEvent);
-      editor.on('input', setInputEvent);
-
-      const initialContent = '<p>abc</p>';
-      paste(editor, initialContent, { 'text/plain': 'X', 'text/html': '<p>X</p>' }, [ 0, 0 ], 0, [ 0, 0 ], 3);
-      await PasteEventUtils.pWaitForAndAssertEventsDoNotFire([ inputEvent ]);
-      TinyAssertions.assertContent(editor, initialContent);
-
-      editor.off('beforeinput', cancelInputEvent);
-      editor.off('input', setInputEvent);
-    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/paste/PasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/PasteTest.ts
@@ -151,7 +151,7 @@ describe('browser.tinymce.core.paste.PasteTest', () => {
     TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
 
     editor.execCommand('mceInsertClipboardContent', false, { text: ' a ' });
-    TinyAssertions.assertContent(editor, '<p>t a xt</p>');
+    TinyAssertions.assertContent(editor, '<p>t&nbsp;a&nbsp;xt</p>');
   });
 
   it('TBA: paste plain text with linefeeds', () => {
@@ -160,7 +160,7 @@ describe('browser.tinymce.core.paste.PasteTest', () => {
     TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
 
     editor.execCommand('mceInsertClipboardContent', false, { text: 'a\nb\nc ' });
-    TinyAssertions.assertContent(editor, '<p>ta<br>b<br>c xt</p>');
+    TinyAssertions.assertContent(editor, '<p>ta<br>b<br>c&nbsp;xt</p>');
   });
 
   it('TBA: paste plain text with double linefeeds', () => {
@@ -487,7 +487,7 @@ describe('browser.tinymce.core.paste.PasteTest', () => {
       TinyAssertions.assertContent(editor, '<p style="color: rgb(255, 0, 0);">abc</p>');
     });
 
-    it('TINY-9829: Paste command dispatches input event', async () => {
+    it('TINY-9997: Paste command does not dispatch input events', async () => {
       const editor = hook.editor();
       const beforeinputEvent = Singleton.value<EditorEvent<InputEvent>>();
       const inputEvent = Singleton.value<EditorEvent<InputEvent>>();
@@ -499,29 +499,10 @@ describe('browser.tinymce.core.paste.PasteTest', () => {
 
       const html = '<p>Test</p>';
       editor.execCommand('mceInsertClipboardContent', false, { html });
-      await PasteEventUtils.pWaitForAndAssertInputEvents(beforeinputEvent, inputEvent, html);
+      await PasteEventUtils.pWaitForAndAssertEventsDoNotFire([ beforeinputEvent, inputEvent ]);
       TinyAssertions.assertContent(editor, html);
 
       editor.off('beforeinput', setBeforeInputEvent);
-      editor.off('input', setInputEvent);
-    });
-
-    it('TINY-9829: Paste can be cancelled by beforeinput event', async () => {
-      const editor = hook.editor();
-      const cancelInputEvent = (e: EditorEvent<InputEvent>) => {
-        e.preventDefault();
-      };
-      const inputEvent = Singleton.value<EditorEvent<InputEvent>>();
-      const setInputEvent = (e: EditorEvent<InputEvent>) => inputEvent.set(e);
-
-      editor.on('beforeinput', cancelInputEvent);
-      editor.on('input', setInputEvent);
-
-      editor.execCommand('mceInsertClipboardContent', false, { html: '<p>Test</p>' });
-      await PasteEventUtils.pWaitForAndAssertEventsDoNotFire([ inputEvent ]);
-      TinyAssertions.assertContent(editor, '');
-
-      editor.off('beforeinput', cancelInputEvent);
       editor.off('input', setInputEvent);
     });
   });

--- a/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
@@ -41,7 +41,7 @@ const pWaitForAndAssertProcessEvents = async (preProcessEvent: SingletonEvent<Pa
   assertLastPostProcessEvent();
 };
 
-const pWaitForAndAssertInputEvents = async (beforeinputEvent: SingletonEvent<InputEvent>, inputEvent: SingletonEvent<InputEvent>, expectedBeforeinputDataTransferHtml?: string): Promise<void> => {
+const pWaitForAndAssertInputEvents = async (beforeinputEvent: SingletonEvent<InputEvent>, inputEvent: SingletonEvent<InputEvent>, expectedBeforeinputDataTransferHtml?: string, isNative: boolean = false): Promise<void> => {
   const checkDataTransferHtml = !Type.isUndefined(expectedBeforeinputDataTransferHtml);
   const pWaitForInputEvents = (): Promise<void> =>
     pWaitFor('Did not fire input events', () => {
@@ -55,7 +55,9 @@ const pWaitForAndAssertInputEvents = async (beforeinputEvent: SingletonEvent<Inp
       assert.isNull(e.data, 'beforeinput event data should be null');
       const dataTransfer = e.dataTransfer;
       assert.isNotNull(dataTransfer, 'beforeinput event dataTransfer should not be null');
-      assert.isTrue(!Type.isNull(dataTransfer) && DataTransferMode.isInReadOnlyMode(dataTransfer), 'beforeinput event dataTransfer should be in read-only mode');
+      if (!isNative) {
+        assert.isTrue(!Type.isNull(dataTransfer) && DataTransferMode.isInReadOnlyMode(dataTransfer), 'beforeinput event dataTransfer should be in read-only mode');
+      }
       if (checkDataTransferHtml) {
         assert.equal(dataTransfer?.getData('text/html'), expectedBeforeinputDataTransferHtml, 'beforeinput event dataTransfer should contain expected html data');
       }

--- a/modules/tinymce/src/core/test/ts/webdriver/paste/CopyAndPasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/paste/CopyAndPasteTest.ts
@@ -12,6 +12,10 @@ import CodePlugin from 'tinymce/plugins/code/Plugin';
 import * as PasteEventUtils from '../../module/test/PasteEventUtils';
 
 describe('webdriver.tinymce.core.paste.CopyAndPasteTest', () => {
+  const platform = PlatformDetection.detect();
+  const os = platform.os;
+  const browser = platform.browser;
+
   const lastBeforeInputEvent = Singleton.value<EditorEvent<InputEvent>>();
   const lastInputEvent = Singleton.value<EditorEvent<InputEvent>>();
   let inputEventTypes: string[] = [];
@@ -208,12 +212,12 @@ describe('webdriver.tinymce.core.paste.CopyAndPasteTest', () => {
     editor.execCommand('mceCodeEditor');
     await TinyUiActions.pWaitForDialog(editor);
     const textareaSelector = 'div[role="dialog"] textarea';
-    await RealKeys.pSendKeysOn(textareaSelector, [ RealKeys.combo(PlatformDetection.detect().os.isMacOS() ? { meta: true } : { ctrl: true }, 'A') ]);
+    await RealKeys.pSendKeysOn(textareaSelector, [ RealKeys.combo(os.isMacOS() ? { meta: true } : { ctrl: true }, 'A') ]);
     await RealClipboard.pCopy(textareaSelector);
     TinyUiActions.cancelDialog(editor);
 
     await RealClipboard.pPaste('iframe => body');
-    await pAssertInputEvents('', true);
+    await pAssertInputEvents(browser.isSafari() ? '&lt;p&gt;abc&lt;/p&gt;' : '', true);
     TinyAssertions.assertContent(editor, '<p>&lt;p&gt;abc&lt;/p&gt;abc</p>');
   });
 

--- a/modules/tinymce/src/core/test/ts/webdriver/paste/CopyAndPasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/paste/CopyAndPasteTest.ts
@@ -212,4 +212,30 @@ describe('webdriver.tinymce.core.paste.CopyAndPasteTest', () => {
     await pAssertInputEvents('', true);
     TinyAssertions.assertContent(editor, '<p>&lt;p&gt;abc&lt;/p&gt;abc</p>');
   });
+
+  it('TINY-9829: Paste can be cancelled by beforeinput event', async () => {
+    const editor = hook.editor();
+    const cancelInputEvent = (e: EditorEvent<InputEvent>) => {
+      e.preventDefault();
+    };
+    const inputEvent = Singleton.value<EditorEvent<InputEvent>>();
+    const setInputEvent = (e: EditorEvent<InputEvent>) => inputEvent.set(e);
+
+    editor.on('beforeinput', cancelInputEvent);
+    editor.on('input', setInputEvent);
+
+    const initialContent = '<p>abc</p>\n<p>def</p>';
+    editor.setContent(initialContent);
+
+    await pCopyAndPaste(
+      editor,
+      { startPath: [ 0, 0 ], soffset: 0, finishPath: [ 0, 0 ], foffset: 'abc'.length },
+      { startPath: [ 1, 0 ], soffset: 'd'.length, finishPath: [ 1, 0 ], foffset: 'def'.length }
+    );
+    await PasteEventUtils.pWaitForAndAssertEventsDoNotFire([ inputEvent ]);
+    TinyAssertions.assertContent(editor, initialContent);
+
+    editor.off('beforeinput', cancelInputEvent);
+    editor.off('input', setInputEvent);
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-9997

Description of Changes:
* Restore behavior that converts image url to image tag on paste while still allowing firing of simulated input events when default is prevented, as introduced in https://github.com/tinymce/tinymce/pull/8733

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
