### PR TITLE
TINY-9965: Deleting content within the <details> of a nested accordion, removes nested accordion <summary> content

### DIFF
--- a/modules/alloy/src/test/ts/browser/behaviour/docking/DockingTest.ts
+++ b/modules/alloy/src/test/ts/browser/behaviour/docking/DockingTest.ts
@@ -237,7 +237,7 @@ describe('browser.alloy.behaviour.docking.DockingTest', () => {
       assertInitialStructures('After Docking.refresh', { static: staticBox, absolute: absoluteBox });
     });
 
-    it('External Scroll event', async () => {
+    it('External Scroll event', () => {
       const store = hook.store();
       const component = hook.component();
 
@@ -247,6 +247,8 @@ describe('browser.alloy.behaviour.docking.DockingTest', () => {
       store.assertEq('Store should start empty', [ ]);
       // Firstly, check things are where we expect them to be to start the test
       assertInitialStructures('Before docking', { static: staticBox, absolute: absoluteBox });
+
+      window.scrollTo(0, 2000);
 
       // Now, dock to the bottom, and check that it worked.
       Docking.forceDockToBottom(absoluteBox);
@@ -264,12 +266,10 @@ describe('browser.alloy.behaviour.docking.DockingTest', () => {
       // Now, broadcast an external scroll event to the mothership, and check that it triggers
       // refresh and puts the box back where it should be.
       hook.gui().broadcastEvent(SystemEvents.externalElementScroll(), { } as any);
-      await Waiter.pTryUntil('Waited for initial structure', () => {
-        assertInitialStructures(
-          'After broadcasting external scroll event',
-          { static: staticBox, absolute: absoluteBox }
-        );
-      });
+      assertInitialStructures(
+        'After broadcasting external scroll event',
+        { static: staticBox, absolute: absoluteBox }
+      );
     });
   });
 });

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815
+- It was possible to delete the first or last empty block just before a details element if it was within a another details element. #TINY-9965
 
 ## 6.5.1 - 2023-06-19
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815
-- It was possible to delete the last empty block just before a details element if it was nested within another details element. #TINY-9965
+- It was possible to delete the sole empty block just before a details element if it was nested within another details element. #TINY-9965
 
 ## 6.5.1 - 2023-06-19
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815
-- It was possible to delete the first or last empty block just before a details element if it was within a another details element. #TINY-9965
+- It was possible to delete the last empty block just before a details element if it was nested within another details element. #TINY-9965
 
 ## 6.5.1 - 2023-06-19
 

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -152,10 +152,12 @@ const preventDeleteIntoDetails = (editor: Editor, forward: boolean) => {
     const parentBlock = dom.getParent(caretPos.container(), dom.isBlock);
     const parentDetailsAtCaret = getParentDetailsElementAtPos(dom, caretPos);
     const inEmptyParentBlock = parentBlock && dom.isEmpty(parentBlock);
+    const isFirstBlock = parentBlock && Type.isNull(parentBlock.previousSibling);
+    const isLastBlock = parentBlock && Type.isNull(parentBlock?.nextSibling);
 
     // Pressing backspace or delete in an first or last empty block before or after details
     if (inEmptyParentBlock) {
-      const firstOrLast = forward ? Type.isNull(parentBlock.nextSibling) : Type.isNull(parentBlock.previousSibling);
+      const firstOrLast = forward ? isLastBlock : isFirstBlock;
       if (firstOrLast) {
         const isBeforeAfterDetails = CaretFinder.navigate(!forward, root, caretPos).exists((pos) => {
           return isInDetailsElement(dom, pos) && !Optionals.equals(parentDetailsAtCaret, getParentDetailsElementAtPos(dom, pos));
@@ -178,9 +180,9 @@ const preventDeleteIntoDetails = (editor: Editor, forward: boolean) => {
           }
 
           if (parentBlock && inEmptyParentBlock) {
-            if (forward && Type.isNull(parentBlock.previousSibling)) {
+            if (forward && isFirstBlock) {
               return true;
-            } else if (!forward && Type.isNull(parentBlock.nextSibling)) {
+            } else if (!forward && isLastBlock) {
               return true;
             }
 

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -285,26 +285,25 @@ const preventDeleteSummaryAction = (editor: Editor, detailElements: DetailsEleme
   return false;
 };
 
-export const handleKeyboardEvent = (editor: Editor, e: KeyboardEvent): void => {
-  if (e.keyCode === VK.BACKSPACE || e.keyCode === VK.DELETE) {
-    const forward = e.keyCode === VK.DELETE;
-    getDetailsElements(editor.dom, editor.selection.getRng()).fold(
-      () => {
-        if (preventDeleteIntoDetails(editor, forward)) {
-          e.preventDefault();
-        }
-      },
-      (detailsElements) => {
-        if (preventDeleteSummaryAction(editor, detailsElements, forward) || safariDeleteInSummaryAction(editor, e) || preventDeleteIntoDetails(editor, forward)) {
-          e.preventDefault();
-        }
-      }
-    );
-  }
+export const deleteAction = (editor: Editor, forward: boolean): boolean => {
+  return getDetailsElements(editor.dom, editor.selection.getRng()).fold(
+    () => preventDeleteIntoDetails(editor, forward),
+    (detailsElements) => preventDeleteSummaryAction(editor, detailsElements, forward) || preventDeleteIntoDetails(editor, forward)
+  );
 };
 
 const preventDeletingSummary = (editor: Editor): void => {
-  editor.on('keydown', (e) => handleKeyboardEvent(editor, e));
+  editor.on('keydown', (e) => {
+    if (e.keyCode === VK.BACKSPACE || e.keyCode === VK.DELETE) {
+      if (deleteAction(editor, e.keyCode === VK.DELETE)) {
+        e.preventDefault();
+      }
+
+      if (safariDeleteInSummaryAction(editor, e)) {
+        e.preventDefault();
+      }
+    }
+  });
 };
 
 export const setup = (editor: Editor): void => {

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -153,8 +153,8 @@ const preventDeleteIntoDetails = (editor: Editor, forward: boolean) => {
     const parentBlock = dom.getParent(caretPos.container(), dom.isBlock);
     const parentDetailsAtCaret = getParentDetailsElementAtPos(dom, caretPos);
     const inEmptyParentBlock = parentBlock && dom.isEmpty(parentBlock);
-    const isFirstBlock = parentBlock && Type.isNull(parentBlock.previousSibling);
-    const isLastBlock = parentBlock && Type.isNull(parentBlock?.nextSibling);
+    const isFirstBlock = Type.isNull(parentBlock?.previousSibling);
+    const isLastBlock = Type.isNull(parentBlock?.nextSibling);
 
     // Pressing backspace or delete in an first or last empty block before or after details
     if (inEmptyParentBlock) {

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -274,19 +274,13 @@ const preventDeleteSummaryAction = (editor: Editor, detailElements: DetailsEleme
   const caretPos = CaretPosition.fromRangeStart(rng);
   const root = editor.getBody();
 
-  if (!isCollapsed && isPartialDelete(rng, detailElements)) {
-    return true;
-  } else if (isCollapsed && !forward && isCaretAtStartOfSummary(caretPos, detailElements)) {
-    return true;
-  } else if (isCollapsed && forward && isCaretAtEndOfSummary(caretPos, detailElements)) {
-    return true;
-  } else if (isCollapsed && !forward && isCaretInFirstPositionInBody(caretPos, detailElements)) {
-    return true;
-  } else if (isCollapsed && forward && isCaretInLastPositionInBody(root, caretPos, detailElements)) {
-    return true;
+  if (!isCollapsed) {
+    return isPartialDelete(rng, detailElements);
+  } else if (!forward) {
+    return isCaretAtStartOfSummary(caretPos, detailElements) || isCaretInFirstPositionInBody(caretPos, detailElements);
+  } else {
+    return isCaretAtEndOfSummary(caretPos, detailElements) || isCaretInLastPositionInBody(root, caretPos, detailElements);
   }
-
-  return false;
 };
 
 export const deleteAction = (editor: Editor, forward: boolean): boolean => {

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -130,13 +130,14 @@ const getParentDetailsElementAtPos = (dom: DOMUtils, pos: CaretPosition) => Opti
 
 const isInDetailsElement = (dom: DOMUtils, pos: CaretPosition) => getParentDetailsElementAtPos(dom, pos).isSome();
 
-const moveCaretToDetailsPos = (editor: Editor, pos: CaretPosition) => {
+const moveCaretToDetailsPos = (editor: Editor, pos: CaretPosition, forward: boolean) => {
   const details = editor.dom.getParent(pos.container(), 'details');
 
   if (details && !details.open) {
     const summary = editor.dom.select('summary', details)[0];
     if (summary) {
-      CaretFinder.lastPositionIn(summary).each((pos) => setCaretToPosition(editor, pos));
+      const newPos = forward ? CaretFinder.firstPositionIn(summary) : CaretFinder.lastPositionIn(summary);
+      newPos.each((pos) => setCaretToPosition(editor, pos));
     }
   } else {
     setCaretToPosition(editor, pos);
@@ -176,7 +177,7 @@ const preventDeleteIntoDetails = (editor: Editor, forward: boolean) => {
 
         if (isInDetailsElement(dom, pos) && !Optionals.equals(parentDetailsAtCaret, parentDetailsAtNewPos)) {
           if (!forward) {
-            moveCaretToDetailsPos(editor, pos);
+            moveCaretToDetailsPos(editor, pos, false);
           }
 
           if (parentBlock && inEmptyParentBlock) {
@@ -186,6 +187,7 @@ const preventDeleteIntoDetails = (editor: Editor, forward: boolean) => {
               return true;
             }
 
+            moveCaretToDetailsPos(editor, pos, forward);
             editor.dom.remove(parentBlock);
           }
 

--- a/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
+++ b/modules/tinymce/src/core/main/ts/selection/DetailsElement.ts
@@ -297,9 +297,7 @@ const preventDeletingSummary = (editor: Editor): void => {
     if (e.keyCode === VK.BACKSPACE || e.keyCode === VK.DELETE) {
       if (deleteAction(editor, e.keyCode === VK.DELETE)) {
         e.preventDefault();
-      }
-
-      if (safariDeleteInSummaryAction(editor, e)) {
+      } else if (safariDeleteInSummaryAction(editor, e)) {
         e.preventDefault();
       }
     }

--- a/modules/tinymce/src/core/test/ts/browser/delete/DetailsDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/DetailsDeleteTest.ts
@@ -11,6 +11,7 @@ interface TestCase {
   readonly selection: Cursors.CursorPath;
   readonly expectedSelection: Cursors.CursorPath;
   readonly expectedPrevented: boolean;
+  readonly expectedHtml?: string;
 }
 
 describe('browser.tinymce.core.delete.DeleteDetailsTest', () => {
@@ -23,11 +24,13 @@ describe('browser.tinymce.core.delete.DeleteDetailsTest', () => {
 
   const testDeleteDetails = (forward: boolean) => (testCase: TestCase) => {
     const editor = hook.editor();
+    const expectedHtml = testCase.expectedHtml ?? testCase.html;
 
     editor.setContent(testCase.html);
     TinySelections.setSelection(editor, testCase.selection.startPath, testCase.selection.soffset, testCase.selection.finishPath, testCase.selection.foffset);
     const prevented = DetailsElement.deleteAction(editor, forward);
     assert.equal(prevented, testCase.expectedPrevented);
+    TinyAssertions.assertContent(editor, expectedHtml);
     TinyAssertions.assertSelection(editor, testCase.expectedSelection.startPath, testCase.expectedSelection.soffset, testCase.expectedSelection.finishPath, testCase.expectedSelection.foffset);
   };
 
@@ -36,35 +39,35 @@ describe('browser.tinymce.core.delete.DeleteDetailsTest', () => {
 
   context('Summary', () => {
     it('Delete forward at the end of summary should do nothing', () => testDeleteForward({
-      html: '<details open><summary>s1</summary><div><p>&nbsp;</p></details>',
+      html: '<details open=""><summary>s1</summary><div><p>&nbsp;</p></div></details>',
       selection: caret([ 0, 0, 0 ], 2),
       expectedSelection: caret([ 0, 0, 0 ], 2),
       expectedPrevented: true
     }));
 
     it('Delete backward at the start of summary should do nothing', () => testDeleteBackward({
-      html: '<details open><summary>s1</summary><div><p>&nbsp;</p></details>',
+      html: '<details open=""><summary>s1</summary><div><p>&nbsp;</p></div></details>',
       selection: caret([ 0, 0, 0 ], 0),
       expectedSelection: caret([ 0, 0, 0 ], 0),
       expectedPrevented: true
     }));
 
     it('Delete forward in middle of summary should not be prevented', () => testDeleteForward({
-      html: '<details open><summary>s1</summary><div><p>&nbsp;</p></details>',
+      html: '<details open=""><summary>s1</summary><div><p>&nbsp;</p></div></details>',
       selection: caret([ 0, 0, 0 ], 1),
       expectedSelection: caret([ 0, 0, 0 ], 1),
       expectedPrevented: false
     }));
 
     it('Delete backward in middle of summary should not be prevented', () => testDeleteBackward({
-      html: '<details open><summary>s1</summary><div><p>&nbsp;</p></details>',
+      html: '<details open=""><summary>s1</summary><div><p>&nbsp;</p></div></details>',
       selection: caret([ 0, 0, 0 ], 1),
       expectedSelection: caret([ 0, 0, 0 ], 1),
       expectedPrevented: false
     }));
 
     it('Delete backward in details body should not delete into summary', () => testDeleteBackward({
-      html: '<details open><summary>s1</summary><div><p>&nbsp;</p></details>',
+      html: '<details open=""><summary>s1</summary><div><p>&nbsp;</p></div></details>',
       selection: caret([ 0, 1, 0 ], 0),
       expectedSelection: caret([ 0, 1, 0 ], 0),
       expectedPrevented: true
@@ -73,58 +76,74 @@ describe('browser.tinymce.core.delete.DeleteDetailsTest', () => {
 
   context('Into details', () => {
     it('Delete forward before details should do nothing', () => testDeleteForward({
-      html: '<p>&nbsp;</p><details open><summary>s1</summary><div><p>&nbsp;</p></details>',
+      html: '<p>&nbsp;</p><details open=""><summary>s1</summary><div><p>&nbsp;</p></div></details>',
       selection: caret([ 0 ], 0),
       expectedSelection: caret([ 0 ], 0),
       expectedPrevented: true
     }));
 
     it('Delete backward after details should move caret but not change the content', () => testDeleteBackward({
-      html: '<details open><summary>s1</summary><div><p>body</p></details><p>&nbsp;</p>',
+      html: '<details open=""><summary>s1</summary><div><p>body</p></div></details><p>&nbsp;</p>',
       selection: caret([ 1 ], 0),
       expectedSelection: caret([ 0, 1, 0, 0 ], 'body'.length),
       expectedPrevented: true
     }));
 
     it('Delete forward in last empty block after details should do nothing', () => testDeleteForward({
-      html: '<details open><summary>s1</summary><div><p>&nbsp;</p></details><p>&nbsp;</p>',
+      html: '<details open=""><summary>s1</summary><div><p>&nbsp;</p></div></details><p>&nbsp;</p>',
       selection: caret([ 1 ], 0),
       expectedSelection: caret([ 1 ], 0),
       expectedPrevented: true
     }));
 
     it('Delete backward in first empty block before details should do nothing', () => testDeleteBackward({
-      html: '<p>&nbsp;</p><details open><summary>s1</summary><div><p>&nbsp;</p></details>',
+      html: '<p>&nbsp;</p><details open=""><summary>s1</summary><div><p>&nbsp;</p></div></details>',
       selection: caret([ 0 ], 0),
       expectedSelection: caret([ 0 ], 0),
       expectedPrevented: true
     }));
 
     it('Delete forward in empty block after details should do normal delete', () => testDeleteForward({
-      html: '<details open><summary>s1</summary><div><p>&nbsp;</p></details><p>&nbsp;</p><p>abc</p>',
+      html: '<details open=""><summary>s1</summary><div><p>&nbsp;</p></div></details><p>&nbsp;</p><p>abc</p>',
       selection: caret([ 1 ], 0),
       expectedSelection: caret([ 1 ], 0),
       expectedPrevented: false
     }));
 
     it('Delete backward in empty block before details should do nothing', () => testDeleteBackward({
-      html: '<p>abc</p><p>&nbsp;</p><details open><summary>s1</summary><div><p>&nbsp;</p></details>',
+      html: '<p>abc</p><p>&nbsp;</p><details open=""><summary>s1</summary><div><p>&nbsp;</p></div></details>',
       selection: caret([ 1 ], 0),
       expectedSelection: caret([ 1 ], 0),
       expectedPrevented: false
+    }));
+
+    it('Delete forward in empty block before details that is not the first one should delete the empty block', () => testDeleteForward({
+      html: '<p>abc</p><p>&nbsp;</p><details open=""><summary>s1</summary><div><p>&nbsp;</p></div></details>',
+      selection: caret([ 1 ], 0),
+      expectedSelection: caret([ 1, 0, 0 ], 0),
+      expectedPrevented: true,
+      expectedHtml: '<p>abc</p><details open=""><summary>s1</summary><div><p>&nbsp;</p></div></details>'
+    }));
+
+    it('Delete backward in empty block after details that is not the last one should delete the empty block', () => testDeleteBackward({
+      html: '<details open=""><summary>s1</summary><div><p>&nbsp;</p></div></details><p>&nbsp;</p><p>abc</p>',
+      selection: caret([ 1 ], 0),
+      expectedSelection: caret([ 0, 1, 0 ], 0),
+      expectedPrevented: true,
+      expectedHtml: '<details open=""><summary>s1</summary><div><p>&nbsp;</p></div></details><p>abc</p>'
     }));
   });
 
   context('Nested details', () => {
     it('TINY-9965: Delete forward before in first block before nested details should do nothing', () => testDeleteForward({
-      html: '<details open><summary>s1</summary><div><p>&nbsp;</p><details open><summary>s2</summary><div>body</div></details></div></details>',
+      html: '<details open=""><summary>s1</summary><div><p>&nbsp;</p><details open=""><summary>s2</summary><div>body</div></details></div></details>',
       selection: caret([ 0, 1, 0 ], 0),
       expectedSelection: caret([ 0, 1, 0 ], 0),
       expectedPrevented: true
     }));
 
     it('TINY-9965: Delete backward in last block after nested details should just move caret', () => testDeleteBackward({
-      html: '<details open><summary>s1</summary><div><details open><summary>s2</summary><div>body</div></details><p>&nbsp;</p></div></details>',
+      html: '<details open=""><summary>s1</summary><div><details open=""><summary>s2</summary><div>body</div></details><p>&nbsp;</p></div></details>',
       selection: caret([ 0, 1, 1 ], 0),
       expectedSelection: caret([ 0, 1, 0, 1, 0 ], 'body'.length),
       expectedPrevented: true

--- a/modules/tinymce/src/core/test/ts/browser/delete/DetailsDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/DetailsDeleteTest.ts
@@ -1,0 +1,105 @@
+import { Cursors, Keys } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+interface TestCase {
+  readonly html: string;
+  readonly selection: Cursors.CursorPath;
+  readonly expectedSelection: Cursors.CursorPath;
+  readonly expectedPrevented: boolean;
+}
+
+describe('browser.tinymce.core.delete.DeleteDetailsTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [], true);
+
+  const caret = (path: number[], offset: number): Cursors.CursorPath => ({ startPath: path, soffset: offset, finishPath: path, foffset: offset });
+
+  const testDeleteDetails = (forward: boolean) => (testCase: TestCase) => {
+    const editor = hook.editor();
+
+    editor.setContent(testCase.html);
+    TinySelections.setSelection(editor, testCase.selection.startPath, testCase.selection.soffset, testCase.selection.finishPath, testCase.selection.foffset);
+    const evt = editor.dispatch('keydown', new KeyboardEvent('keydown', { keyCode: forward ? Keys.delete() : Keys.backspace() }));
+    assert.equal(evt.isDefaultPrevented(), testCase.expectedPrevented);
+    TinyAssertions.assertSelection(editor, testCase.expectedSelection.startPath, testCase.expectedSelection.soffset, testCase.expectedSelection.finishPath, testCase.expectedSelection.foffset);
+  };
+
+  const testDeleteForward = testDeleteDetails(true);
+  const testDeleteBackward = testDeleteDetails(false);
+
+  context('Summary', () => {
+    it('Delete forward at the end of summary should do nothing', () => testDeleteForward({
+      html: '<details open><summary>s1</summary><div><p>&nbsp;</p></details>',
+      selection: caret([ 0, 0, 0 ], 2),
+      expectedSelection: caret([ 0, 0, 0 ], 2),
+      expectedPrevented: true
+    }));
+
+    it('Delete backward at the start of summary should do nothing', () => testDeleteBackward({
+      html: '<details open><summary>s1</summary><div><p>&nbsp;</p></details>',
+      selection: caret([ 0, 0, 0 ], 0),
+      expectedSelection: caret([ 0, 0, 0 ], 0),
+      expectedPrevented: true
+    }));
+
+    it('Delete forward in middle of summary should not be prevented', () => testDeleteForward({
+      html: '<details open><summary>s1</summary><div><p>&nbsp;</p></details>',
+      selection: caret([ 0, 0, 0 ], 1),
+      expectedSelection: caret([ 0, 0, 0 ], 1),
+      expectedPrevented: false
+    }));
+
+    it('Delete backward in middle of summary should not be prevented', () => testDeleteBackward({
+      html: '<details open><summary>s1</summary><div><p>&nbsp;</p></details>',
+      selection: caret([ 0, 0, 0 ], 1),
+      expectedSelection: caret([ 0, 0, 0 ], 1),
+      expectedPrevented: false
+    }));
+
+    it('Delete backward in details body should not delete into summary', () => testDeleteBackward({
+      html: '<details open><summary>s1</summary><div><p>&nbsp;</p></details>',
+      selection: caret([ 0, 1, 0 ], 0),
+      expectedSelection: caret([ 0, 1, 0 ], 0),
+      expectedPrevented: true
+    }));
+  });
+
+  context('Into details', () => {
+    it('Delete forward before details should do nothing', () => testDeleteForward({
+      html: '<p>&nbsp;</p><details open><summary>s1</summary><div><p>&nbsp;</p></details>',
+      selection: caret([ 0 ], 0),
+      expectedSelection: caret([ 0 ], 0),
+      expectedPrevented: true
+    }));
+
+    it('Delete backward after details should move caret but not change the content', () => testDeleteBackward({
+      html: '<details open><summary>s1</summary><div><p>body</p></details><p>&nbsp;</p>',
+      selection: caret([ 1 ], 0),
+      expectedSelection: caret([ 0, 1, 0, 0 ], 'body'.length),
+      expectedPrevented: true
+    }));
+  });
+
+  context('Nested details', () => {
+    it('TINY-9965: Delete forward before in first block before nested details should do nothing', () => testDeleteForward({
+      html: '<details open><summary>s1</summary><div><p>&nbsp;</p><details open><summary>s2</summary><div>body</div></details></div></details>',
+      selection: caret([ 0, 1, 0 ], 0),
+      expectedSelection: caret([ 0, 1, 0 ], 0),
+      expectedPrevented: true
+    }));
+
+    it('TINY-9965: Delete backward in last block after nested details should just move caret', () => testDeleteBackward({
+      html: '<details open><summary>s1</summary><div><details open><summary>s2</summary><div>body</div></details><p>&nbsp;</p></div></details>',
+      selection: caret([ 0, 1, 1 ], 0),
+      expectedSelection: caret([ 0, 1, 0, 1, 0 ], 'body'.length),
+      expectedPrevented: true
+    }));
+  });
+});
+

--- a/modules/tinymce/src/core/test/ts/browser/delete/DetailsDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/DetailsDeleteTest.ts
@@ -1,4 +1,4 @@
-import { Cursors, Keys } from '@ephox/agar';
+import { Cursors } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
@@ -26,9 +26,8 @@ describe('browser.tinymce.core.delete.DeleteDetailsTest', () => {
 
     editor.setContent(testCase.html);
     TinySelections.setSelection(editor, testCase.selection.startPath, testCase.selection.soffset, testCase.selection.finishPath, testCase.selection.foffset);
-    const evt = new KeyboardEvent('keydown', { keyCode: forward ? Keys.delete() : Keys.backspace(), cancelable: true });
-    DetailsElement.handleKeyboardEvent(editor, evt);
-    assert.equal(evt.defaultPrevented, testCase.expectedPrevented);
+    const prevented = DetailsElement.deleteAction(editor, forward);
+    assert.equal(prevented, testCase.expectedPrevented);
     TinyAssertions.assertSelection(editor, testCase.expectedSelection.startPath, testCase.expectedSelection.soffset, testCase.expectedSelection.finishPath, testCase.expectedSelection.foffset);
   };
 

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
@@ -277,7 +277,7 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
         TinyAssertions.assertCursor(editor, [ 0, 1, 0 ], 0);
       });
 
-      it('TINY-9965: Backspace should only move the caret to the end of the details body if you backspace in last block after a details', async () => {
+      it('TINY-9965: Backspace should only move the caret to the end of the details body if you backspace in last block after a nested details', async () => {
         const editor = hook.editor();
         const initialContent = AccordionUtils.createAccordion({ summary: 's1', body: AccordionUtils.createAccordion({ summary: 's2', body: 'body' }) + '\n<div>&nbsp;</div>\n' });
         editor.setContent(initialContent);

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
@@ -266,6 +266,26 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
         assertAccordionContent(editor);
         TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0 ], 'body'.length);
       });
+
+      it('TINY-9965: Nothing should happend if you delete before nested details inside details', async () => {
+        const editor = hook.editor();
+        const initialContent = AccordionUtils.createAccordion({ summary: 's1', body: `<div>&nbsp;</div>\n${AccordionUtils.createAccordion({ summary: 's2', body: 'body' })}\n` });
+        editor.setContent(initialContent);
+        TinySelections.setCursor(editor, [ 0, 1, 0 ], 0);
+        await pDoDelete();
+        TinyAssertions.assertContent(editor, initialContent);
+        TinyAssertions.assertCursor(editor, [ 0, 1, 0 ], 0);
+      });
+
+      it('TINY-9965: Backspace should only move the caret to the end of the details body if you backspace in last block after a details', async () => {
+        const editor = hook.editor();
+        const initialContent = AccordionUtils.createAccordion({ summary: 's1', body: AccordionUtils.createAccordion({ summary: 's2', body: 'body' }) + '\n<div>&nbsp;</div>\n' });
+        editor.setContent(initialContent);
+        TinySelections.setCursor(editor, [ 0, 1, 1 ], 0);
+        await pDoBackspace();
+        TinyAssertions.assertContent(editor, initialContent);
+        TinyAssertions.assertCursor(editor, [ 0, 1, 0, 1, 0 ], 'body'.length);
+      });
     });
 
     context('With a ranged selection', () => {

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionBackspaceDeleteTest.ts
@@ -267,7 +267,7 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
         TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0 ], 'body'.length);
       });
 
-      it('TINY-9965: Nothing should happend if you delete before nested details inside details', async () => {
+      it('TINY-9965: Nothing should happen if you delete before nested details inside details', async () => {
         const editor = hook.editor();
         const initialContent = AccordionUtils.createAccordion({ summary: 's1', body: `<div>&nbsp;</div>\n${AccordionUtils.createAccordion({ summary: 's2', body: 'body' })}\n` });
         editor.setContent(initialContent);


### PR DESCRIPTION
Related Ticket: TINY-9965

Description of Changes:
* Fixed issue with deleting blocks before/after nested details elements.
* Added more low level tests for details delete code.
* Separated the Safari specific delete in summary code form the rest of the details delete code.
* Various code cleanup.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
