### PR TITLE
TINY-9629: change the `more...` button tooltip

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dialog `tabpanel` tab labels are now allowed to word wrap for better readability with long labels. #TINY-9947
 - Added newlines before and after `details` elements in the output HTML. #TINY-9959
 - Added padding for empty `summary` elements so that they can be properly edited. #TINY-9959
+- Updated toolbar "More" button tooltip text from "More..." to "Reveal or hide additional toolbar items". #TINY-9629
 
 ### Changed
 - The `caption`, `address` and `dt` elements no longer incorrectly allow non-inline child elements when the editor schema is set to _HTML 4_. #TINY-9768

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815
 
+### Improved
+- Updated toolbar "More" button tooltip text from "More..." to "Reveal or hide additional toolbar items". #TINY-9629
+
 ## 6.5.1 - 2023-06-19
 
 ### Fixed
@@ -52,7 +55,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dialog `tabpanel` tab labels are now allowed to word wrap for better readability with long labels. #TINY-9947
 - Added newlines before and after `details` elements in the output HTML. #TINY-9959
 - Added padding for empty `summary` elements so that they can be properly edited. #TINY-9959
-- Updated toolbar "More" button tooltip text from "More..." to "Reveal or hide additional toolbar items". #TINY-9629
 
 ### Changed
 - The `caption`, `address` and `dt` elements no longer incorrectly allow non-inline child elements when the editor schema is set to _HTML 4_. #TINY-9768

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -112,7 +112,7 @@ const renderMoreToolbarCommon = (toolbarSpec: MoreDrawerToolbarSpec) => {
         name: 'more',
         icon: Optional.some('more-drawer'),
         enabled: true,
-        tooltip: Optional.some('More...'),
+        tooltip: Optional.some('Reveal or hide additional toolbar items'),
         primary: false,
         buttonType: Optional.none(),
         borderless: false

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -89,11 +89,11 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
         toolbar: Arr.range(10, Fun.constant('bold | italic ')).join('')
       },
       initial: [{
-        clickOn: 'button[title="More..."]',
+        clickOn: 'button[title="Reveal or hide additional toolbar items"]',
         waitFor: '.tox-toolbar__overflow'
       }],
       assertAbove: '.tox-toolbar__overflow',
-      assertBelow: 'button[title="More..."]'
+      assertBelow: 'button[title="Reveal or hide additional toolbar items"]'
     }));
 
     it('Menu button in overflow toolbar should open up', () => pTest({
@@ -104,7 +104,7 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
       },
       initial: [
         {
-          clickOn: 'button[title="More..."]',
+          clickOn: 'button[title="Reveal or hide additional toolbar items"]',
           waitFor: '.tox-toolbar__overflow'
         }, {
           clickOn: 'button[title="Align"]',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
@@ -42,7 +42,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.InlineToolbarDrawerFloati
     editor.setContent('<p>Line 1</p><p>Line 2</p><p>Line 3</p>');
     editor.focus();
     TinySelections.setCursor(editor, [ 2, 0 ], 'Line 3'.length);
-    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[title="More..."]');
+    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[title="Reveal or hide additional toolbar items"]');
     await pRunTests(editor);
     McEditor.remove(editor);
   };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/SplitFloatingToolbarKeyboardNavigationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/SplitFloatingToolbarKeyboardNavigationTest.ts
@@ -26,7 +26,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.SplitFloatingToolbarKeybo
 
   it('TINY-9723: Menu toolbar items should not be tabstoppable', async () => {
     const editor = hook.editor();
-    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[title="More..."]');
+    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[title="Reveal or hide additional toolbar items"]');
     const menubutton = await TinyUiActions.pWaitForPopup(editor, '.tox-tbtn[title="menubutton"]');
     assert.isFalse(Attribute.has(menubutton, 'data-alloy-tabstop'));
     // Focus is on the first toolbar__group on the fontsize button

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -104,7 +104,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest',
       });
 
       it(`TINY-9271: Emits 'ToggleToolbarDrawer' in ${toolbarMode} via user click`, async () => {
-        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[title="More..."]'));
+        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[title="Reveal or hide additional toolbar items"]'));
       });
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -416,18 +416,18 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       assert.equal(Html.get(editorContainer), expectedHtml);
     };
 
-    it('TINY-9419: "More..." button should not be removed if the toolbar is opened and view is opened and close', () => {
+    it('TINY-9419: "Reveal or hide additional toolbar items" button should not be removed if the toolbar is opened and view is opened and close', () => {
       const editor = hook.editor();
 
       editor.setContent('<p>ab</p>');
-      TinyUiActions.clickOnToolbar(editor, '[title="More..."]');
+      TinyUiActions.clickOnToolbar(editor, '[title="Reveal or hide additional toolbar items"]');
 
       editor.execCommand('ToggleView', false, 'myview1');
       assertViewHtml(0, '<button>myview1</button>');
       editor.execCommand('ToggleView', false, 'myview1');
       assertMainViewVisible();
-      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[title="More..."]');
-      assert.isTrue(moreButton.isValue(), 'More... button should be there');
+      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[title="Reveal or hide additional toolbar items"]');
+      assert.isTrue(moreButton.isValue(), 'Reveal or hide additional toolbar items button should be there');
     });
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
@@ -25,12 +25,12 @@ const pOpenMenuWithSelector = async (label: string, selector: string): Promise<v
 };
 
 const pOpenMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[title="More..."]');
+  Mouse.clickOn(SugarBody.body(), 'button[title="Reveal or hide additional toolbar items"]');
   await UiFinder.pWaitForVisible('Waiting for more drawer to open', SugarBody.body(), getToolbarSelector(type, true));
 };
 
 const pCloseMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[title="More..."]');
+  Mouse.clickOn(SugarBody.body(), 'button[title="Reveal or hide additional toolbar items"]');
   await Waiter.pTryUntil('Waiting for more drawer to close', () => UiFinder.notExists(SugarBody.body(), getToolbarSelector(type, false)));
 };
 


### PR DESCRIPTION
Related Ticket: 
[TINY-9629](https://ephocks.atlassian.net/browse/TINY-9629)

Description of Changes:
update `More...` button tooltip on toolbar to `Reveal or hide additional toolbar items`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-9629]: https://ephocks.atlassian.net/browse/TINY-9629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ