### PR TITLE
TINY-9960: Various fixes for dragging and dropping into or out of summary elements

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815
 - deleting `li` with only `br`s in it sometimes caused a crush. #TINY-6888
 - It was possible to remove the summary element from a details element by drag and dropping. #TINY-9960
+- It was possible to break summary elements if contents containing blocks was dropped inside them. #TINY-9960
+- Contents would not be removed from the drag start source if dragging and dropping internally into a transparent block element. #TINY-9960
 
 ## 6.5.1 - 2023-06-19
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815
 - deleting `li` with only `br`s in it sometimes caused a crush. #TINY-6888
+- It was possible to remove the summary element from a details element by drag and dropping. #TINY-9960
 
 ## 6.5.1 - 2023-06-19
 

--- a/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
@@ -123,7 +123,7 @@ export default (): void => {
     plugins: [
       'autosave', 'advlist', 'autolink', 'link', 'image', 'lists', 'charmap', 'preview', 'anchor', 'pagebreak',
       'searchreplace', 'wordcount', 'visualblocks', 'visualchars', 'code', 'fullscreen', 'insertdatetime', 'media', 'nonbreaking',
-      'save', 'table', 'directionality', 'emoticons', 'template', 'importcss', 'codesample', 'help'
+      'save', 'table', 'directionality', 'emoticons', 'template', 'importcss', 'codesample', 'help', 'accordion'
     ],
     // rtl_ui: true,
     add_unload_trigger: false,

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -1,5 +1,5 @@
 import { Arr, Optional, Type } from '@ephox/katamari';
-import { Replication, Class, Remove, SugarElement } from '@ephox/sugar';
+import { Remove, SugarElement } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
@@ -226,19 +226,6 @@ const findMarkerNode = (scope: AstNode): Optional<AstNode> => {
   return Optional.none();
 };
 
-const preventSplittingSummary = (editor: Editor): void => {
-  Arr.each(Arr.from(editor.getBody().querySelectorAll('details')), (accordion) => {
-    const summaries = Arr.filter(Arr.from(accordion.children), (node) => node.nodeName === 'SUMMARY');
-    if (summaries.length > 1) {
-      Arr.each(summaries.slice(1), (summary) => {
-        const element = SugarElement.fromDom(summary);
-        Class.remove(element, 'mce-accordion-summary');
-        Replication.mutate(element, 'p');
-      });
-    }
-  });
-};
-
 export const insertHtmlAtCaret = (editor: Editor, value: string, details: InsertContentDetails): string => {
   const selection = editor.selection;
   const dom = editor.dom;
@@ -370,7 +357,6 @@ export const insertHtmlAtCaret = (editor: Editor, value: string, details: Insert
   moveSelectionToMarker(editor, dom.get('mce_marker'));
   unmarkFragmentElements(editor.getBody());
   trimBrsFromTableCell(dom, selection.getStart());
-  preventSplittingSummary(editor);
   TransparentElements.updateCaret(editor.schema, editor.getBody(), selection.getStart());
 
   return value;

--- a/modules/tinymce/src/core/main/ts/html/InvalidNodes.ts
+++ b/modules/tinymce/src/core/main/ts/html/InvalidNodes.ts
@@ -25,7 +25,7 @@ const cleanInvalidNodes = (nodes: AstNode[], schema: Schema, rootNode: AstNode, 
   const textBlockElements = schema.getTextBlockElements();
   const nonEmptyElements = schema.getNonEmptyElements();
   const whitespaceElements = schema.getWhitespaceElements();
-  const nonSplittableElements = Tools.makeMap('tr,td,th,tbody,thead,tfoot,table');
+  const nonSplittableElements = Tools.makeMap('tr,td,th,tbody,thead,tfoot,table,summary');
   const fixed = new Set<AstNode>();
   const isSplittableElement = (node: AstNode) => node !== rootNode && !nonSplittableElements[node.name];
 

--- a/modules/tinymce/src/core/main/ts/paste/DragDrop.ts
+++ b/modules/tinymce/src/core/main/ts/paste/DragDrop.ts
@@ -8,10 +8,10 @@ import * as Options from '../api/Options';
 import Delay from '../api/util/Delay';
 import * as TransparentElements from '../content/TransparentElements';
 import * as NodeType from '../dom/NodeType';
+import * as PaddingBr from '../dom/PaddingBr';
 import * as Clipboard from './Clipboard';
 import * as InternalHtml from './InternalHtml';
 import * as PasteUtils from './PasteUtils';
-import * as PaddingBr from '../dom/PaddingBr';
 
 const getCaretRangeFromEvent = (editor: Editor, e: MouseEvent): Range | undefined =>
   // TODO: TINY-7075 Remove the "?? 0" here when agar passes valid client coords

--- a/modules/tinymce/src/core/main/ts/paste/DragDrop.ts
+++ b/modules/tinymce/src/core/main/ts/paste/DragDrop.ts
@@ -105,8 +105,10 @@ const setup = (editor: Editor, draggingInternallyState: Cell<boolean>): void => 
 
     const internalContent = dropContent[InternalHtml.internalHtmlMime()];
     const content = internalContent || dropContent['text/html'] || dropContent['text/plain'];
+    const needsInternalDrop = needsCustomInternalDrop(editor.dom, editor.schema, rng.startContainer, dropContent);
+    const isInternalDrop = draggingInternallyState.get();
 
-    if (draggingInternallyState.get() && !needsCustomInternalDrop(editor.dom, editor.schema, rng.startContainer, dropContent)) {
+    if (isInternalDrop && !needsInternalDrop) {
       return;
     }
 
@@ -116,7 +118,7 @@ const setup = (editor: Editor, draggingInternallyState: Cell<boolean>): void => 
       // FF 45 doesn't paint a caret when dragging in text in due to focus call by execCommand
       Delay.setEditorTimeout(editor, () => {
         editor.undoManager.transact(() => {
-          if (internalContent) {
+          if (internalContent || (isInternalDrop && needsInternalDrop)) {
             editor.execCommand('Delete');
           }
 

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -805,4 +805,23 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
       });
     });
   });
+
+  context('Summary elements', () => {
+    it('TINY-9885: Should not be able to insert HR block into summary', () => {
+      const editor = hook.editor();
+      const initialContent = '<details><summary>helloworld</summary><div>body</div></details>';
+      editor.setContent(initialContent);
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 'hello'.length);
+      editor.execCommand('InsertHorizontalRule');
+      TinyAssertions.assertContent(editor, initialContent);
+    });
+
+    it('TINY-9885: Should unwrap H1 element when inserting into summary element', () => {
+      const editor = hook.editor();
+      editor.setContent('<details><summary>helloworld</summary><div>body</div></details>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 'hello'.length);
+      editor.insertContent('<h1>wonderful</h1>');
+      TinyAssertions.assertContent(editor, '<details><summary>hellowonderfulworld</summary><div>body</div></details>');
+    });
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/paste/DragDropSummaryTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/DragDropSummaryTest.ts
@@ -5,6 +5,7 @@ import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 
 import * as DragDropUtils from '../../module/test/DragDropUtils';
+import * as InputEventUtils from '../../module/test/InputEventUtils';
 
 describe('browser.tinymce.core.paste.DragDropSummaryTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -39,7 +40,7 @@ describe('browser.tinymce.core.paste.DragDropSummaryTest', () => {
 
     editor.setContent('<details><div>body</div></details>', { format: 'raw' });
     TinyAssertions.assertContentPresence(editor, { 'summary': 0, 'summary > br': 0 });
-    editor.dispatch('input', new InputEvent('input', { inputType: 'deleteByDrag' }));
+    editor.dispatch('input', InputEventUtils.makeInputEvent('input', { inputType: 'deleteByDrag' }));
     TinyAssertions.assertContentPresence(editor, { 'summary': 1, 'summary > br': 1 });
     TinyAssertions.assertContent(editor, '<details><summary>&nbsp;</summary><div>body</div></details>');
   });
@@ -49,7 +50,7 @@ describe('browser.tinymce.core.paste.DragDropSummaryTest', () => {
 
     editor.setContent('<details><br><div>body</div></details>', { format: 'raw' });
     TinyAssertions.assertContentPresence(editor, { 'summary': 0, 'details > br': 1, 'summary > br': 0 });
-    editor.dispatch('input', new InputEvent('input', { inputType: 'deleteByDrag' }));
+    editor.dispatch('input', InputEventUtils.makeInputEvent('input', { inputType: 'deleteByDrag' }));
     TinyAssertions.assertContentPresence(editor, { 'summary': 1, 'details > br': 0, 'summary > br': 1 });
     TinyAssertions.assertContent(editor, '<details><summary>&nbsp;</summary><div>body</div></details>');
   });

--- a/modules/tinymce/src/core/test/ts/browser/paste/DragDropSummaryTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/DragDropSummaryTest.ts
@@ -1,6 +1,6 @@
 import { Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -11,27 +11,29 @@ describe('browser.tinymce.core.paste.DragDropSummaryTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     indent: false
-  }, []);
+  }, [], true);
 
   it('TINY-9960: Dropping a H1 internally into a summary element should unwrap it', async () => {
     const editor = hook.editor();
 
-    editor.setContent('<details><summary>bc</summary><div>body</div></details>');
-    DragDropUtils.dragDropHtmlInternallyToPath(editor, '<h1>a</h1>', [ 0, 0 ]);
+    editor.setContent('<details><summary>cd</summary><div>body</div></details><h1>a</h1><p>b</p>');
+    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 2, 0 ], 1);
+    DragDropUtils.dragDropHtmlInternallyToPath(editor, '<h1>a</h1><p>b</p>', [ 0, 0 ]);
 
     await Waiter.pTryUntil('Waited for content to be inserted', () => {
-      TinyAssertions.assertContent(editor, '<details><summary>abc</summary><div>body</div></details>');
+      TinyAssertions.assertContent(editor, '<details><summary>abcd</summary><div>body</div></details><p>&nbsp;</p>');
     });
   });
 
   it('TINY-9960: Dropping a H1 externally into a summary element should unwrap it', async () => {
     const editor = hook.editor();
 
-    editor.setContent('<details><summary>bc</summary><div>body</div></details>');
+    editor.setContent('<details><summary>bc</summary><div>body</div></details><p>d</p>');
+    TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 1);
     DragDropUtils.dragDropHtmlExternallyToPath(editor, '<h1>a</h1>', [ 0, 0 ]);
 
     await Waiter.pTryUntil('Waited for content to be inserted', () => {
-      TinyAssertions.assertContent(editor, '<details><summary>abc</summary><div>body</div></details>');
+      TinyAssertions.assertContent(editor, '<details><summary>abc</summary><div>body</div></details><p>d</p>');
     });
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/paste/DragDropSummaryTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/DragDropSummaryTest.ts
@@ -1,0 +1,57 @@
+import { Waiter } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+import * as DragDropUtils from '../../module/test/DragDropUtils';
+
+describe('browser.tinymce.core.paste.DragDropSummaryTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    indent: false
+  }, []);
+
+  it('TINY-9960: Dropping a H1 internally into a summary element should unwrap it', async () => {
+    const editor = hook.editor();
+
+    editor.setContent('<details><summary>bc</summary><div>body</div></details>');
+    DragDropUtils.dragDropHtmlInternallyToPath(editor, '<h1>a</h1>', [ 0, 0 ]);
+
+    await Waiter.pTryUntil('Waited for content to be inserted', () => {
+      TinyAssertions.assertContent(editor, '<details><summary>abc</summary><div>body</div></details>');
+    });
+  });
+
+  it('TINY-9960: Dropping a H1 externally into a summary element should unwrap it', async () => {
+    const editor = hook.editor();
+
+    editor.setContent('<details><summary>bc</summary><div>body</div></details>');
+    DragDropUtils.dragDropHtmlExternallyToPath(editor, '<h1>a</h1>', [ 0, 0 ]);
+
+    await Waiter.pTryUntil('Waited for content to be inserted', () => {
+      TinyAssertions.assertContent(editor, '<details><summary>abc</summary><div>body</div></details>');
+    });
+  });
+
+  it('TINY-9960: Delete by drag should add back missing summary element', () => {
+    const editor = hook.editor();
+
+    editor.setContent('<details><div>body</div></details>', { format: 'raw' });
+    TinyAssertions.assertContentPresence(editor, { 'summary': 0, 'summary > br': 0 });
+    editor.dispatch('input', new InputEvent('input', { inputType: 'deleteByDrag' }));
+    TinyAssertions.assertContentPresence(editor, { 'summary': 1, 'summary > br': 1 });
+    TinyAssertions.assertContent(editor, '<details><summary>&nbsp;</summary><div>body</div></details>');
+  });
+
+  it('TINY-9960: Delete by drag should add back missing summary element and trim leading BR', () => {
+    const editor = hook.editor();
+
+    editor.setContent('<details><br><div>body</div></details>', { format: 'raw' });
+    TinyAssertions.assertContentPresence(editor, { 'summary': 0, 'details > br': 1, 'summary > br': 0 });
+    editor.dispatch('input', new InputEvent('input', { inputType: 'deleteByDrag' }));
+    TinyAssertions.assertContentPresence(editor, { 'summary': 1, 'details > br': 0, 'summary > br': 1 });
+    TinyAssertions.assertContent(editor, '<details><summary>&nbsp;</summary><div>body</div></details>');
+  });
+});
+

--- a/modules/tinymce/src/core/test/ts/browser/paste/DragDropTransparentsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/DragDropTransparentsTest.ts
@@ -5,17 +5,13 @@ import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-
 
 import Editor from 'tinymce/core/api/Editor';
 
+import * as DragDropUtils from '../../module/test/DragDropUtils';
+
 describe('browser.tinymce.core.paste.DragDropTransparentElementsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
   }, [], true);
-
-  const dragDropInternally = (editor: Editor, html: string, target: SugarElement<Element>) => {
-    editor.fire('dragstart');
-    DragnDrop.dropItems([{ data: html, type: 'text/html' }], target);
-    editor.fire('dragend');
-  };
 
   const pWaitForContent = (editor: Editor, expected: string) =>
     Waiter.pTryUntil('Should be expected content', () => TinyAssertions.assertContent(editor, expected));
@@ -33,11 +29,10 @@ describe('browser.tinymce.core.paste.DragDropTransparentElementsTest', () => {
   it('TINY-9231: should unwrap inline anchors if dropping in a block anchor (internal)', async () => {
     const editor = hook.editor();
 
-    editor.setContent('<a href="#"><p>block link</p></a>');
-    TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
-    const target = SugarElement.fromDom(editor.selection.getNode());
-    dragDropInternally(editor, '<a href="#">link</a>', target);
-    await pWaitForContent(editor, '<a href="#"><p>linkblock link</p></a>');
+    editor.setContent('<a href="#"><p>block link</p></a><p><a href="#">link</a></p>');
+    TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 1, 0, 0 ], 4);
+    DragDropUtils.dragDropHtmlInternallyToPath(editor, '<a href="#">link</a>', [ 0, 0 ]);
+    await pWaitForContent(editor, '<a href="#"><p>linkblock link</p></a><p>&nbsp;</p>');
   });
 
   it('TINY-9231: should unwrap inline anchors if dropping inline link next to block link', async () => {
@@ -56,7 +51,7 @@ describe('browser.tinymce.core.paste.DragDropTransparentElementsTest', () => {
     editor.setContent('<a href="#"><p>block link</p></a>');
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
     const target = TinyDom.documentElement(editor);
-    dragDropInternally(editor, '<a href="#">link</a>', target);
+    DragDropUtils.dragDropHtmlInternallyToElement(editor, '<a href="#">link</a>', target);
     await pWaitForContent(editor, '<a href="#"><p>linkblock link</p></a>');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/selection/DetailsElementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/DetailsElementTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks, TinySelections, TinyAssertions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinyAssertions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -64,14 +64,5 @@ describe('browser.tinymce.selection.DetailsElementTest', () => {
     editor.setContent([ createAccordion({ open: true }), createAccordion({ open: false }) ].join(''));
     TinyAssertions.assertContent(editor, [ createAccordion({ open: false }), createAccordion({ open: false }) ].join(''));
     editor.options.unset('details_serialized_state');
-  });
-
-  it('TINY-9885: Should prevent 2 summaries appearing in details elements', () => {
-    const editor = hook.editor();
-    const initialContent = createAccordion({ summary: 'helloworld', body: '<p>body</p>', open: true });
-    editor.setContent(initialContent);
-    TinySelections.setCursor(editor, [ 0, 0, 0 ], 'hello'.length);
-    editor.execCommand('InsertHorizontalRule');
-    TinyAssertions.assertContent(editor, initialContent);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/selection/DetailsElementTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/DetailsElementTest.ts
@@ -68,9 +68,10 @@ describe('browser.tinymce.selection.DetailsElementTest', () => {
 
   it('TINY-9885: Should prevent 2 summaries appearing in details elements', () => {
     const editor = hook.editor();
-    editor.setContent([ createAccordion({ summary: 'helloworld', body: '<p>body</p>', open: true }) ].join(''));
+    const initialContent = createAccordion({ summary: 'helloworld', body: '<p>body</p>', open: true });
+    editor.setContent(initialContent);
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 'hello'.length);
     editor.execCommand('InsertHorizontalRule');
-    TinyAssertions.assertContent(editor, createAccordion({ summary: 'hello', body: '<hr><p>world</p><p>body</p>', open: true }));
+    TinyAssertions.assertContent(editor, initialContent);
   });
 });

--- a/modules/tinymce/src/core/test/ts/module/test/DragDropUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/DragDropUtils.ts
@@ -1,0 +1,22 @@
+import { DragnDrop } from '@ephox/agar';
+import { TinyDom } from '@ephox/mcagar';
+import { Hierarchy, SugarElement, SugarNode } from '@ephox/sugar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+export const dragDropHtmlInternallyToElement = (editor: Editor, html: string, target: SugarElement<Element>): void => {
+  editor.fire('dragstart');
+  DragnDrop.dropItems([{ data: html, type: 'text/html' }], target);
+  editor.fire('dragend');
+};
+
+export const dragDropHtmlInternallyToPath = (editor: Editor, html: string, path: number[]): void => {
+  const target = Hierarchy.follow(TinyDom.body(editor), path).filter(SugarNode.isElement).getOrDie('Could not resolve path to drop target element');
+  dragDropHtmlInternallyToElement(editor, html, target);
+};
+
+export const dragDropHtmlExternallyToPath = (editor: Editor, html: string, path: number[]): void => {
+  const target = Hierarchy.follow(TinyDom.body(editor), path).filter(SugarNode.isElement).getOrDie('Could not resolve path to drop target element');
+  DragnDrop.dropItems([{ data: html, type: 'text/html' }], target);
+};
+

--- a/modules/tinymce/src/core/test/ts/module/test/DragDropUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/DragDropUtils.ts
@@ -5,9 +5,9 @@ import { Hierarchy, SugarElement, SugarNode } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 
 export const dragDropHtmlInternallyToElement = (editor: Editor, html: string, target: SugarElement<Element>): void => {
-  editor.fire('dragstart');
+  editor.dispatch('dragstart');
   DragnDrop.dropItems([{ data: html, type: 'text/html' }], target);
-  editor.fire('dragend');
+  editor.dispatch('dragend');
 };
 
 export const dragDropHtmlInternallyToPath = (editor: Editor, html: string, path: number[]): void => {

--- a/modules/tinymce/src/core/test/ts/module/test/InputEventUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/InputEventUtils.ts
@@ -1,0 +1,32 @@
+import { Type } from '@ephox/katamari';
+
+const deprecated = new Set([
+  'keyLocation', 'layerX', 'layerY', 'returnValue',
+  'webkitMovementX', 'webkitMovementY',
+  'keyIdentifier', 'mozPressure'
+]);
+
+const clone = <T extends Event>(originalEvent: T): T => {
+  const event: Record<string, any> = {};
+
+  // Copy all properties from the original event
+  for (const name in originalEvent) {
+    // Some properties are deprecated and produces a warning so don't include them
+    if (!deprecated.has(name)) {
+      event[name] = originalEvent[name];
+    }
+  }
+
+  // The composed path can't be cloned, so delegate instead
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  if (Type.isNonNullable(originalEvent.composedPath)) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    event.composedPath = () => originalEvent.composedPath!();
+  }
+
+  return event as T;
+};
+
+export const makeInputEvent = <A extends InputEvent>(name: 'beforeinput' | 'input', overrides: { [K in keyof A]?: A[K] }): InputEvent => {
+  return { ...clone(new InputEvent(name)), ...overrides };
+};


### PR DESCRIPTION
Related Ticket: TINY-9960

Description of Changes:
* Added the accordion plugin to full featured example
* Changed the prevent splitting of summary to use the way it's done for other elements by unwrapping until it fits.
* Added fixed so drag/drop that will inject back a empty summary if it's removed by drag/drop.
* Fixed issue with drag/drop internally wouldn't remove the dragstart selection for summary and transparent elements.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
