### PR TITLE
TINY-9888: New `bottom` inline dialog type to position inline dialog at the bottom of the editor

### DIFF
--- a/modules/oxide/src/less/theme/components/anchorbar/anchorbar.less
+++ b/modules/oxide/src/less/theme/components/anchorbar/anchorbar.less
@@ -11,4 +11,9 @@
     display: flex;
     flex: 0 0 auto;
   }
+
+  .tox-bottom-anchorbar {
+    display: flex;
+    flex: 0 0 auto;
+  }
 }

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Added new `bottom` to inline dialog type. This new inline dialog option allows the inline dialog to be positioned at the bottom of the editor. #TINY-9888
+
 ## 6.5.1 - 2023-06-19
 
 ### Fixed

--- a/modules/tinymce/src/core/main/ts/api/WindowManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/WindowManager.ts
@@ -29,7 +29,7 @@ import { Dialog } from './ui/Ui';
  */
 
 export interface WindowParams {
-  readonly inline?: 'cursor' | 'toolbar';
+  readonly inline?: 'cursor' | 'toolbar' | 'bottom';
   readonly ariaAttrs?: boolean;
 }
 

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -100,6 +100,13 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
     }
   });
 
+  const memBottomAnchorBar = Memento.record({
+    dom: {
+      tag: 'div',
+      classes: [ 'tox-bottom-anchorbar' ]
+    }
+  });
+
   const lazyHeader = () => lazyUiRefs.mainUi.get()
     .map((ui) => ui.outerContainer)
     .bind(OuterContainer.getHeader);
@@ -117,6 +124,11 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
   const lazyAnchorBar = lazyUiRefs.lazyGetInOuterOrDie(
     'anchor bar',
     memAnchorBar.getOpt
+  );
+
+  const lazyBottomAnchorBar = lazyUiRefs.lazyGetInOuterOrDie(
+    'bottom anchor bar',
+    memBottomAnchorBar.getOpt
   );
 
   const lazyToolbar = lazyUiRefs.lazyGetInOuterOrDie(
@@ -137,7 +149,8 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
       dialog: lazyDialogSinkResult
     },
     editor,
-    lazyAnchorBar
+    lazyAnchorBar,
+    lazyBottomAnchorBar
   );
 
   const makeHeaderPart = (): AlloyParts.ConfiguredPart => {
@@ -375,7 +388,7 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
       components: Arr.flatten<AlloySpec>([
         editorComponents,
         // Inline mode does not have a status bar
-        isInline ? [ ] : statusbar.toArray()
+        isInline ? [ ] : [ memBottomAnchorBar.asSpec(), ...statusbar.toArray() ]
       ])
     });
 

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -46,7 +46,7 @@ export interface UiFactoryBackstagePair {
   readonly dialog: UiFactoryBackstage;
 }
 
-const init = (lazySinks: { popup: () => Result<AlloyComponent, string>; dialog: () => Result<AlloyComponent, string> }, editor: Editor, lazyAnchorbar: () => AlloyComponent): UiFactoryBackstagePair => {
+const init = (lazySinks: { popup: () => Result<AlloyComponent, string>; dialog: () => Result<AlloyComponent, string> }, editor: Editor, lazyAnchorbar: () => AlloyComponent, lazyBottomAnchorBar: () => AlloyComponent): UiFactoryBackstagePair => {
   const contextMenuState = Cell(false);
   const toolbar = HeaderBackstage(editor);
 
@@ -68,7 +68,7 @@ const init = (lazySinks: { popup: () => Result<AlloyComponent, string>; dialog: 
   const commonBackstage = {
     shared: {
       providers,
-      anchors: Anchors.getAnchors(editor, lazyAnchorbar, toolbar.isPositionedAtTop),
+      anchors: Anchors.getAnchors(editor, lazyAnchorbar, lazyBottomAnchorBar, toolbar.isPositionedAtTop),
       header: toolbar,
     },
     urlinput,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
@@ -87,6 +87,8 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
   const open = <T extends Dialog.DialogData>(config: Dialog.DialogSpec<T>, params: WindowParams | undefined, closeWindow: (dialogApi: Dialog.DialogInstanceApi<T>) => void): Dialog.DialogInstanceApi<T> => {
     if (params !== undefined && params.inline === 'toolbar') {
       return openInlineDialog(config, extras.backstages.popup.shared.anchors.inlineDialog(), closeWindow, params.ariaAttrs);
+    } else if (params !== undefined && params.inline === 'bottom') {
+      return openBottomInlineDialog(config, extras.backstages.popup.shared.anchors.inlineBottomDialog(), closeWindow, params.ariaAttrs);
     } else if (params !== undefined && params.inline === 'cursor') {
       return openInlineDialog(config, extras.backstages.popup.shared.anchors.cursor(), closeWindow, params.ariaAttrs);
     } else {
@@ -233,6 +235,134 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
         // 'ResizeWindow` as that's handled by docking already.
         editor.on('ResizeEditor', refreshDocking);
       }
+
+      // Set the initial data in the dialog and focus the first focusable item
+      dialogUi.instanceApi.setData(initialData);
+      Keying.focusIn(dialogUi.dialog);
+
+      return dialogUi.instanceApi;
+    };
+
+    return DialogManager.DialogManager.open<T>(factory, config);
+  };
+
+  const openBottomInlineDialog = <T extends Dialog.DialogData>(config: Dialog.DialogSpec<T>, anchor: InlineDialogAnchor, closeWindow: (dialogApi: Dialog.DialogInstanceApi<T>) => void, ariaAttrs: boolean = false): Dialog.DialogInstanceApi<T> => {
+    const factory = (contents: Dialog.Dialog<T>, internalInitialData: Partial<T>, dataValidator: StructureProcessor): Dialog.DialogInstanceApi<T> => {
+      const initialData = validateData<T>(internalInitialData, dataValidator);
+      const inlineDialog = Singleton.value<AlloyComponent>();
+      const isToolbarLocationTop = extras.backstages.popup.shared.header.isPositionedAtTop();
+
+      const dialogInit = {
+        dataValidator,
+        initialData,
+        internalDialog: contents
+      };
+
+      const refreshDocking = () => inlineDialog.on((dialog) => {
+        InlineView.reposition(dialog);
+        Docking.refresh(dialog);
+      });
+
+      const dialogUi = renderInlineDialog<T>(
+        dialogInit,
+        {
+          redial: DialogManager.DialogManager.redial,
+          closeWindow: () => {
+            inlineDialog.on(InlineView.hide);
+            editor.off('ResizeEditor ScrollWindow ElementScroll', refreshDocking);
+            inlineDialog.clear();
+            closeWindow(dialogUi.instanceApi);
+          }
+        },
+        extras.backstages.popup,
+        ariaAttrs
+      );
+
+      const inlineAdditionalBehaviours = (editor: Editor): Behaviour.NamedConfiguredBehaviour<any, any>[] => {
+        return [
+          Docking.config({
+            contextual: {
+              lazyContext: () => Optional.some(Boxes.box(SugarElement.fromDom(editor.getContentAreaContainer()))),
+              fadeInClass: 'tox-dialog-dock-fadein',
+              fadeOutClass: 'tox-dialog-dock-fadeout',
+              transitionClass: 'tox-dialog-dock-transition'
+            },
+            modes: [ 'top', 'bottom' ],
+            lazyViewport: (comp) => {
+              const optScrollingContext = ScrollingContext.detectWhenSplitUiMode(editor, comp.element);
+              return optScrollingContext
+                .map(
+                  (sc) => {
+                    const combinedBounds = ScrollingContext.getBoundsFrom(sc);
+                    return {
+                      bounds: combinedBounds,
+                      optScrollEnv: Optional.some({
+                        currentScrollTop: sc.element.dom.scrollTop,
+                        scrollElmTop: SugarLocation.absolute(sc.element).top
+                      })
+                    };
+                  }
+                ).getOrThunk(
+                  () => {
+                    return {
+                      bounds: Boxes.win(),
+                      optScrollEnv: Optional.none()
+                    };
+                  }
+                );
+            }
+          })
+        ];
+      };
+
+      const inlineDialogComp = GuiFactory.build(InlineView.sketch({
+        lazySink: extras.backstages.popup.shared.getSink,
+        dom: {
+          tag: 'div',
+          classes: [ ]
+        },
+        // Fires the default dismiss event.
+        fireDismissalEventInstead: { },
+        ...isToolbarLocationTop ? { } : { fireRepositionEventInstead: { }},
+        inlineBehaviours: Behaviour.derive([
+          AddEventsBehaviour.config('window-manager-inline-events', [
+            AlloyEvents.run(SystemEvents.dismissRequested(), (_comp, _se) => {
+              AlloyTriggers.emit(dialogUi.dialog, formCancelEvent);
+            })
+          ]),
+          ...inlineAdditionalBehaviours(editor)
+        ]),
+        // Treat alert or confirm dialogs as part of the inline dialog
+        isExtraPart: (_comp, target) => isAlertOrConfirmDialog(target)
+      }));
+      inlineDialog.set(inlineDialogComp);
+
+      const getInlineDialogBounds = (): Optional<Boxes.Bounds> => {
+        return extras.backstages.popup.shared.getSink().toOptional().bind((s) => {
+          const optScrollingContext = ScrollingContext.detectWhenSplitUiMode(editor, s.element);
+
+          // margin bottom of the screen/editor content area container
+          const margin = 15;
+
+          const bounds = optScrollingContext.map((sc) => ScrollingContext.getBoundsFrom(sc)).getOr(Boxes.win());
+          const contentAreaContainer = Boxes.box(SugarElement.fromDom(editor.getContentAreaContainer()));
+
+          const constrainedBounds = Boxes.constrain(contentAreaContainer, bounds);
+
+          return Optional.some(Boxes.bounds(constrainedBounds.x, constrainedBounds.y, constrainedBounds.width, constrainedBounds.height - margin));
+        });
+      };
+
+      // Position the inline dialog
+      InlineView.showWithinBounds(
+        inlineDialogComp,
+        GuiFactory.premade(dialogUi.dialog),
+        { anchor },
+        getInlineDialogBounds
+      );
+
+      Docking.refresh(inlineDialogComp);
+      editor.on('ResizeEditor ScrollWindow ElementScroll', refreshDocking);
 
       // Set the initial data in the dialog and focus the first focusable item
       dialogUi.instanceApi.setData(initialData);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
@@ -328,7 +328,7 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
         return extras.backstages.popup.shared.getSink().toOptional().bind((s) => {
           const optScrollingContext = ScrollingContext.detectWhenSplitUiMode(editor, s.element);
 
-          // margin bottom of the screen/editor content area container
+          // Margin between element and the bottom of the screen or the editor content area container
           const margin = 15;
 
           const bounds = optScrollingContext.map((sc) => ScrollingContext.getBoundsFrom(sc)).getOr(Boxes.win());

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
@@ -303,12 +303,10 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
                     };
                   }
                 ).getOrThunk(
-                  () => {
-                    return {
-                      bounds: Boxes.win(),
-                      optScrollEnv: Optional.none()
-                    };
-                  }
+                () => ({
+                    bounds: Boxes.win(),
+                    optScrollEnv: Optional.none()
+                })
                 );
             }
           })

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
@@ -278,41 +278,6 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
         ariaAttrs
       );
 
-      const inlineAdditionalBehaviours = (editor: Editor): Behaviour.NamedConfiguredBehaviour<any, any>[] => {
-        return [
-          Docking.config({
-            contextual: {
-              lazyContext: () => Optional.some(Boxes.box(SugarElement.fromDom(editor.getContentAreaContainer()))),
-              fadeInClass: 'tox-dialog-dock-fadein',
-              fadeOutClass: 'tox-dialog-dock-fadeout',
-              transitionClass: 'tox-dialog-dock-transition'
-            },
-            modes: [ 'top', 'bottom' ],
-            lazyViewport: (comp) => {
-              const optScrollingContext = ScrollingContext.detectWhenSplitUiMode(editor, comp.element);
-              return optScrollingContext
-                .map(
-                  (sc) => {
-                    const combinedBounds = ScrollingContext.getBoundsFrom(sc);
-                    return {
-                      bounds: combinedBounds,
-                      optScrollEnv: Optional.some({
-                        currentScrollTop: sc.element.dom.scrollTop,
-                        scrollElmTop: SugarLocation.absolute(sc.element).top
-                      })
-                    };
-                  }
-                ).getOrThunk(
-                () => ({
-                    bounds: Boxes.win(),
-                    optScrollEnv: Optional.none()
-                })
-                );
-            }
-          })
-        ];
-      };
-
       const inlineDialogComp = GuiFactory.build(InlineView.sketch({
         lazySink: extras.backstages.popup.shared.getSink,
         dom: {
@@ -328,7 +293,31 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
               AlloyTriggers.emit(dialogUi.dialog, formCancelEvent);
             })
           ]),
-          ...inlineAdditionalBehaviours(editor)
+          Docking.config({
+            contextual: {
+              lazyContext: () => Optional.some(Boxes.box(SugarElement.fromDom(editor.getContentAreaContainer()))),
+              fadeInClass: 'tox-dialog-dock-fadein',
+              fadeOutClass: 'tox-dialog-dock-fadeout',
+              transitionClass: 'tox-dialog-dock-transition'
+            },
+            modes: [ 'top', 'bottom' ],
+            lazyViewport: (comp) => {
+              const optScrollingContext = ScrollingContext.detectWhenSplitUiMode(editor, comp.element);
+              return optScrollingContext.map((sc) => {
+                const combinedBounds = ScrollingContext.getBoundsFrom(sc);
+                return {
+                  bounds: combinedBounds,
+                  optScrollEnv: Optional.some({
+                    currentScrollTop: sc.element.dom.scrollTop,
+                    scrollElmTop: SugarLocation.absolute(sc.element).top
+                  })
+                };
+              }).getOrThunk(() => ({
+                bounds: Boxes.win(),
+                optScrollEnv: Optional.none()
+              }));
+            }
+          })
         ]),
         // Treat alert or confirm dialogs as part of the inline dialog
         isExtraPart: (_comp, target) => isAlertOrConfirmDialog(target)

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
@@ -313,6 +313,9 @@ describe('browser.tinymce.themes.silver.editor.SilverEditorTest', () => {
                 ]
               }),
               s.element('div', {
+                classes: [ arr.has('tox-bottom-anchorbar') ]
+              }),
+              s.element('div', {
                 classes: [ arr.has('tox-statusbar') ]
               })
             ]

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageSinkTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageSinkTest.ts
@@ -104,6 +104,7 @@ describe('browser.tinymce.themes.silver.editor.backstage.BackstageSinkTest', () 
             dialog: () => Result.value(dialogSink)
           },
           editor,
+          Fun.die('No lazy bottom anchor bar in this test'),
           Fun.die('No lazy anchor bar in this test')
         );
       });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/HeaderLocationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/HeaderLocationTest.ts
@@ -36,6 +36,9 @@ describe('browser.tinymce.themes.silver.editor.header.HeaderLocationTest', () =>
               ]
             }),
             s.element('div', {
+              classes: [ arr.has('tox-bottom-anchorbar') ]
+            }),
+            s.element('div', {
               classes: [ arr.has('tox-statusbar') ]
             }),
           ]

--- a/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
@@ -87,6 +87,7 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
           children: [
             s.anything(),
             s.anything(),
+            s.anything(),
             s.element('div', {
               classes: [ arr.has('tox-statusbar') ],
               children: [
@@ -128,6 +129,7 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
           children: [
             s.anything(),
             s.anything(),
+            s.anything(),
             s.element('div', {
               classes: [ arr.has('tox-statusbar') ],
               children: fullStatusbarSpec(s, str, arr)
@@ -150,6 +152,7 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
           children: [
             s.anything(),
             s.anything(),
+            s.anything(),
             s.element('div', {
               classes: [ arr.has('tox-statusbar') ],
               children: statusbarWithoutWordcountSpec(s, str, arr)
@@ -170,6 +173,7 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
         s.element('div', {
           classes: [ arr.has('tox-editor-container') ],
           children: [
+            s.anything(),
             s.anything(),
             s.anything(),
             s.element('div', {
@@ -223,6 +227,7 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
             children: [
               s.anything(),
               s.anything(),
+              s.anything(),
               s.element('div', {
                 classes: [ arr.has('tox-statusbar') ],
                 children: [
@@ -259,6 +264,7 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
           s.element('div', {
             classes: [ arr.has('tox-editor-container') ],
             children: [
+              s.anything(),
               s.anything(),
               s.anything(),
               s.element('div', {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogPositioningTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogPositioningTest.ts
@@ -79,5 +79,9 @@ describe('browser.tinymce.themes.silver.window.SilverDialogPositioningTest', () 
     it('TINY-9588: Inline toolbar dialog positioning', async () =>
       await pTestOpenDialogAssertPosition({ inline: 'toolbar' })
     );
+
+    it('TINY-9888: Inline toolbar (bottom) dialog positioning', async () =>
+      await pTestOpenDialogAssertPosition({ inline: 'bottom' })
+    );
   }))));
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
@@ -288,7 +288,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogPositionTest', 
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
           resize: 'both',
-          height: 500,
+          height: 400,
           width: 650,
         }, []);
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderUtils.ts
@@ -21,6 +21,14 @@ const statusbar = (s: ApproxStructure.StructApi, arr: ApproxStructure.ArrayApi):
     })
   ];
 
+const bottomAnchorbar = (s: ApproxStructure.StructApi, arr: ApproxStructure.ArrayApi): StructAssert[] =>
+  // should not change
+  [
+    s.element('div', {
+      classes: [ arr.has('tox-bottom-anchorbar') ]
+    })
+  ];
+
 const staticPartsInner = (s: ApproxStructure.StructApi, arr: ApproxStructure.ArrayApi): StructAssert[] =>
   // should not change
   [
@@ -157,8 +165,8 @@ const pAssertEditorContainer = async (isToolbarTop: boolean, expectedPart: Appro
       ApproxStructure.build((s, str, arr) => s.element('div', {
         classes: [ arr.has('tox-editor-container') ],
         children: isToolbarTop ?
-          expectedPart(s, str, arr).concat(staticPartsOuter(s, arr)).concat(statusbar(s, arr)) :
-          staticPartsOuter(s, arr).concat(expectedPart(s, str, arr)).concat(statusbar(s, arr))
+          expectedPart(s, str, arr).concat(staticPartsOuter(s, arr)).concat(bottomAnchorbar(s, arr)).concat(statusbar(s, arr)) :
+          staticPartsOuter(s, arr).concat(expectedPart(s, str, arr)).concat(bottomAnchorbar(s, arr)).concat(statusbar(s, arr))
       })),
       container
     )
@@ -174,8 +182,8 @@ const pScrollAndAssertStructure = async (isToolbarTop: boolean, scrollYDelta: nu
       ApproxStructure.build((s, str, arr) => s.element('div', {
         classes: [ arr.has('tox-editor-container') ],
         children: isToolbarTop ?
-          expectedPart(s, str, arr).concat(staticPartsOuter(s, arr)).concat(statusbar(s, arr)) :
-          staticPartsOuter(s, arr).concat(expectedPart(s, str, arr)).concat(statusbar(s, arr))
+          expectedPart(s, str, arr).concat(staticPartsOuter(s, arr)).concat(bottomAnchorbar(s, arr)).concat(statusbar(s, arr)) :
+          staticPartsOuter(s, arr).concat(expectedPart(s, str, arr)).concat(bottomAnchorbar(s, arr)).concat(statusbar(s, arr))
       })),
       container
     )

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestBackstage.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestBackstage.ts
@@ -22,6 +22,7 @@ export default (sink?: AlloyComponent): UiFactoryBackstage => {
       interpreter: Fun.identity as any,
       anchors: {
         inlineDialog: hotspotAnchorFn,
+        inlineBottomDialog: hotspotAnchorFn,
         banner: hotspotAnchorFn,
         cursor: () => ({
           type: 'selection',


### PR DESCRIPTION
Related Ticket: TINY-9888

Description of Changes:
* Added new inline dialog type `bottom`, this new inline dialog option allows the inline dialog to be positioned at the bottom of the editor
* See ticket for demo video

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
