### PR TITLE
TINY-9776: Revert

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Change UndoLevelType from enum to union type so that it can be easier to use. #TINY-9764
 - The pattern replacement removes spaces if they were contained in a tag that only contains a space and the text to replace. #TINY-9744
-- The `mceInsertClipboardContent` command will now also accept a `files` property to insert images. #TINY-9776
 
 ### Fixed
 - Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842

--- a/modules/tinymce/src/core/main/ts/paste/Commands.ts
+++ b/modules/tinymce/src/core/main/ts/paste/Commands.ts
@@ -30,10 +30,6 @@ const register = (editor: Editor, pasteFormat: Cell<string>): void => {
     if (value.text) {
       Clipboard.pasteText(editor, value.text, false);
     }
-
-    if (value.files) {
-      Clipboard.pasteImageFiles(editor, value.files, editor.selection.getRng());
-    }
   });
 };
 

--- a/modules/tinymce/src/core/test/ts/browser/paste/PasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/PasteTest.ts
@@ -1,8 +1,7 @@
-import { UiFinder } from '@ephox/agar';
 import { afterEach, before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Singleton } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -13,26 +12,6 @@ import * as PasteUtils from 'tinymce/core/paste/PasteUtils';
 import * as PasteEventUtils from '../../module/test/PasteEventUtils';
 
 describe('browser.tinymce.core.paste.PasteTest', () => {
-  const base64ToBlob = (base64: string, type: string, filename: string): File => {
-    const buff = atob(base64);
-    const bytes = new Uint8Array(buff.length);
-
-    for (let i = 0; i < bytes.length; i++) {
-      bytes[i] = buff.charCodeAt(i);
-    }
-
-    return new window.File([ bytes ], filename, { type });
-  };
-  const base64ImgSrc = [
-    'R0lGODdhZABkAHcAACH/C05FVFNDQVBFMi4wAwEAAAAh+QQECgAAACwAAAAAZABkAIEAAAD78jY/',
-    'P3SsMjIC/4SPqcvtD6OctNqLs968+w+G4kiW5ommR8C27gvHrxrK9g3TIM7f+tcL5n4doZFFLB6F',
-    'Sc6SCRFIp9SqVTp6BiPXbjer5XG95Ck47IuWy2e0bLz2tt3DR5w8p7vgd2tej6TW5ycCGMM3aFZo',
-    'OCOYqFjDuOf4KPAHiPh4qZeZuEnXOfjpFto3ilZ6dxqWGreq1br2+hTLtigZaFcJuYOb67DLC+Qb',
-    'UIt3i2sshyzZtEFc7JwBLT1NXI2drb3N3e39DR4uPk5ebn6Onq6+zu488A4fLz9P335Aj58fb2+g',
-    '71/P759AePwADBxY8KDAhAr9MWyY7yFEgPYmRgxokWK7jEYa2XGcJ/HjgJAfSXI0mRGlRZUTWUJ0',
-    '2RCmQpkHaSLEKPKdzYU4c+78VzCo0KFEixo9ijSp0qVMmzp9CjWq1KlUq1q9eqEAADs='
-  ].join('');
-
   const browser = PlatformDetection.detect().browser;
   const hook = TinyHooks.bddSetupLight<Editor>({
     add_unload_trigger: false,
@@ -362,25 +341,6 @@ describe('browser.tinymce.core.paste.PasteTest', () => {
     assert.equal(PasteUtils.trimHtml('<span class="Apple-converted-space">\u00a0<\/span>b'), ' b');
     assert.equal(PasteUtils.trimHtml('a<span class="Apple-converted-space">\u00a0<\/span>'), 'a ');
     assert.equal(PasteUtils.trimHtml('<span class="Apple-converted-space">\u00a0<\/span>'), ' ');
-  });
-
-  it('TINY-9776: it should be possible to paste an image via mceInsertClipboardContent', async () => {
-    const editor = hook.editor();
-    editor.setContent('<p>text</p>');
-    TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
-
-    TinyAssertions.assertContentPresence(editor, { img: 0 });
-
-    editor.execCommand('mceInsertClipboardContent', false, {
-      files: [
-        base64ToBlob(base64ImgSrc, 'image/gif', 'image.gif'),
-        base64ToBlob(base64ImgSrc, 'someKindOfFile/abc', 'foo.bar')
-      ]
-    });
-
-    await UiFinder.pWaitForVisible('the image should be pasted', TinyDom.body(editor), 'img');
-
-    TinyAssertions.assertContentPresence(editor, { img: 1 });
   });
 
   context('paste_webkit_styles', () => {


### PR DESCRIPTION
TINY-9776: add the possibility to paste images with `mceInsertClipboardContent`

This reverts commit d7cfa10f33a6286ca01e87d929ab7f7c507ee962.

Related Ticket: TINY-9776

Description of Changes:
* Placeholder text

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/`, `hotfix/` or `spike/`~

Review:
* [x] ~Milestone set~
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
