### PR TITLE
TINY-9991: Implement `persistent` mode for inline dialogs

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added new `bottom` to inline dialog type. This new inline dialog option allows the inline dialog to be positioned at the bottom of the editor. #TINY-9888
-- Added new `persistent` option to `WindowParams`. This new option allows the inline dialog to be persistent, meaning that it will not be closed when the user clicks outside of the window. #TINY-9991
+- Added new `persistent` option to `WindowParams`. This new option allows the inline dialog to be persistent, meaning that it will not be closed when the user clicks outside of the dialog. #TINY-9991
 
 ## 6.5.1 - 2023-06-19
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added new `bottom` to inline dialog type. This new inline dialog option allows the inline dialog to be positioned at the bottom of the editor. #TINY-9888
+- Added new `persistent` option to `WindowParams`. This new option allows the inline dialog to be persistent, meaning that it will not be closed when the user clicks outside of the window. #TINY-9991
 
 ## 6.5.1 - 2023-06-19
 

--- a/modules/tinymce/src/core/main/ts/api/WindowManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/WindowManager.ts
@@ -31,6 +31,7 @@ import { Dialog } from './ui/Ui';
 export interface WindowParams {
   readonly inline?: 'cursor' | 'toolbar' | 'bottom';
   readonly ariaAttrs?: boolean;
+  readonly persistent?: boolean;
 }
 
 interface WindowManager {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
@@ -4,7 +4,7 @@ import {
 } from '@ephox/alloy';
 import { StructureProcessor, StructureSchema } from '@ephox/boulder';
 import { Dialog, DialogManager } from '@ephox/bridge';
-import { Fun, Optional, Singleton, Type } from '@ephox/katamari';
+import { Optional, Singleton, Type } from '@ephox/katamari';
 import { SelectorExists, SugarBody, SugarElement, SugarLocation } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -190,7 +190,7 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
           classes: [ ]
         },
         // Fires the default dismiss event.
-        fireDismissalEventInstead: { },
+        fireDismissalEventInstead: (windowParams.persistent ? { event: 'doNotDismissYet' } : { }),
         // TINY-9412: The docking behaviour for inline dialogs is inconsistent
         // for toolbar_location: bottom. We need to clarify exactly what the behaviour
         // should be. The intent here might have been that they shouldn't automatically
@@ -201,7 +201,7 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
         inlineBehaviours: Behaviour.derive([
           AddEventsBehaviour.config('window-manager-inline-events', [
             AlloyEvents.run(SystemEvents.dismissRequested(), (_comp, _se) => {
-              windowParams.persistent ? Fun.noop() : AlloyTriggers.emit(dialogUi.dialog, formCancelEvent);
+              AlloyTriggers.emit(dialogUi.dialog, formCancelEvent);
             })
           ]),
           ...inlineAdditionalBehaviours(editor, isStickyToolbar, isToolbarLocationTop)
@@ -285,12 +285,12 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
           classes: [ ]
         },
         // Fires the default dismiss event.
-        fireDismissalEventInstead: { },
+        fireDismissalEventInstead: (windowParams.persistent ? { event: 'doNotDismissYet' } : { }),
         ...isToolbarLocationTop ? { } : { fireRepositionEventInstead: { }},
         inlineBehaviours: Behaviour.derive([
           AddEventsBehaviour.config('window-manager-inline-events', [
             AlloyEvents.run(SystemEvents.dismissRequested(), (_comp, _se) => {
-              windowParams.persistent ? Fun.noop() : AlloyTriggers.emit(dialogUi.dialog, formCancelEvent);
+              AlloyTriggers.emit(dialogUi.dialog, formCancelEvent);
             })
           ]),
           Docking.config({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
@@ -85,15 +85,17 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
   const confirmDialog = ConfirmDialog.setup(extras.backstages.dialog);
 
   const open = <T extends Dialog.DialogData>(config: Dialog.DialogSpec<T>, params: WindowParams | undefined, closeWindow: (dialogApi: Dialog.DialogInstanceApi<T>) => void): Dialog.DialogInstanceApi<T> => {
-    if (!Type.isUndefined(params) && params.inline === 'toolbar') {
-      return openInlineDialog(config, extras.backstages.popup.shared.anchors.inlineDialog(), closeWindow, params);
-    } else if (!Type.isUndefined(params) && params.inline === 'bottom') {
-      return openBottomInlineDialog(config, extras.backstages.popup.shared.anchors.inlineBottomDialog(), closeWindow, params);
-    } else if (!Type.isUndefined(params) && params.inline === 'cursor') {
-      return openInlineDialog(config, extras.backstages.popup.shared.anchors.cursor(), closeWindow, params);
-    } else {
-      return openModalDialog(config, closeWindow);
+    if (!Type.isUndefined(params)) {
+      if (params.inline === 'toolbar') {
+        return openInlineDialog(config, extras.backstages.popup.shared.anchors.inlineDialog(), closeWindow, params);
+      } else if (params.inline === 'bottom') {
+        return openBottomInlineDialog(config, extras.backstages.popup.shared.anchors.inlineBottomDialog(), closeWindow, params);
+      } else if (params.inline === 'cursor') {
+        return openInlineDialog(config, extras.backstages.popup.shared.anchors.cursor(), closeWindow, params);
+      }
     }
+
+    return openModalDialog(config, closeWindow);
   };
 
   const openUrl = (config: Dialog.UrlDialogSpec, closeWindow: (dialogApi: Dialog.UrlDialogInstanceApi) => void) =>

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -24,7 +24,7 @@ interface RenderedDialog<T extends Dialog.DialogData> {
   readonly instanceApi: Dialog.DialogInstanceApi<T>;
 }
 
-const renderInlineDialog = <T extends Dialog.DialogData>(dialogInit: DialogManager.DialogInit<T>, extra: SilverDialogCommon.WindowExtra<T>, backstage: UiFactoryBackstage, ariaAttrs: boolean): RenderedDialog<T> => {
+const renderInlineDialog = <T extends Dialog.DialogData>(dialogInit: DialogManager.DialogInit<T>, extra: SilverDialogCommon.WindowExtra<T>, backstage: UiFactoryBackstage, ariaAttrs: boolean = false): RenderedDialog<T> => {
   const dialogId = Id.generate('dialog');
   const dialogLabelId = Id.generate('dialog-label');
   const dialogContentId = Id.generate('dialog-content');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPersistenceTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPersistenceTest.ts
@@ -150,7 +150,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogPersistenceTest
             api.close();
           });
 
-          it('TINY-9991: Inline toolbar dialog persistent - clicking on the editor contet to show context toolbar', async () => {
+          it('TINY-9991: Inline toolbar dialog persistent - clicking on the editor content to show context toolbar', async () => {
             const editor = hook.editor();
             const api = DialogUtils.open(editor, dialogSpec, { inline: dialogLocation.location, persistent: persistentMode.persistent });
             await TinyUiActions.pWaitForDialog(editor);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPersistenceTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPersistenceTest.ts
@@ -1,0 +1,173 @@
+import { Cursors, Keys, Mouse, UiFinder } from '@ephox/agar';
+import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { SugarBody } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import { Dialog } from 'tinymce/core/api/ui/Ui';
+
+import * as DialogUtils from '../../module/DialogUtils';
+
+interface TestSpec {
+  label: string;
+  location: 'toolbar' | 'bottom';
+}
+
+describe('browser.tinymce.themes.silver.window.SilverInlineDialogPersistenceTest', () => {
+  Arr.each([
+    { label: 'Inline Mode', inline: true },
+    { label: 'Iframe Mode', inline: false }
+  ], (editorMode) => {
+    Arr.each([
+      { label: 'Inline dialog (bottom)', location: 'bottom' },
+      { label: 'Inline dialog (toolbar)', location: 'toolbar' }
+    ], (dialogLocation: TestSpec) => {
+      Arr.each([
+        { label: 'Persistent mode: true', persistent: true },
+        { label: 'Persistent mode: false', persistent: false }
+      ], (persistentMode) => {
+        context(`${editorMode.label} ${dialogLocation.label} - ${persistentMode.label} `, () => {
+          const hook = TinyHooks.bddSetup<Editor>({
+            base_url: '/project/tinymce/js/tinymce',
+            inline: editorMode.inline,
+            toolbar: 'bold italic underline | forecolor backcolor outdent indent',
+            setup: (ed: Editor) => {
+              ed.ui.registry.addContextToolbar('test-context-toolbar', {
+                predicate: (_) => true,
+                items: 'bold',
+                position: 'selection',
+                scope: 'node'
+              });
+            }
+          }, [], true);
+
+          const dialogSpec: Dialog.DialogSpec<{}> = {
+            title: 'inlinedialog',
+            body: {
+              type: 'panel',
+              items: [
+                {
+                  type: 'panel',
+                  items: [
+                    {
+                      type: 'htmlpanel',
+                      html: '<h1>Heading</h1><p>paragraph</p>',
+                      presets: 'presentation'
+                    }
+                  ]
+                }
+              ]
+            },
+            buttons: [
+              {
+                type: 'submit',
+                name: 'save',
+                text: 'Save',
+                primary: true
+              },
+              {
+                type: 'cancel',
+                name: 'cancel',
+                text: 'Cancel',
+              }
+            ],
+            onSubmit: (api) => api.close(),
+          };
+
+          const assertDialogVisibility = (isVisible: boolean) => {
+            const existsFn = isVisible ? UiFinder.exists : UiFinder.notExists;
+            existsFn(SugarBody.body(), '.tox-dialog-inline');
+          };
+
+          const closeMenu = (editor: Editor): void => {
+            const uiRoot = TinyUiActions.getUiRoot(editor);
+            TinyUiActions.keystroke(editor, Keys.escape());
+            UiFinder.notExists(uiRoot, '[role=menu]');
+          };
+
+          beforeEach(() => {
+            const editor = hook.editor();
+            editor.setContent(Arr.range(50, (index) => index === 5 ? '<a href="google.com">Google</a>' : '<p>Some content...</p>').join('\n'));
+          });
+
+          it('TINY-9991: Inline toolbar dialog persistent - clicking on the editor container', async () => {
+            const editor = hook.editor();
+            const api = DialogUtils.open(editor, dialogSpec, { inline: dialogLocation.location, persistent: persistentMode.persistent });
+            await TinyUiActions.pWaitForDialog(editor);
+
+            // Clicking on the editor container
+            Mouse.trueClickOn(TinyDom.body(editor), 'p');
+            assertDialogVisibility(persistentMode.persistent);
+            api.close();
+          });
+
+          it('TINY-9991: Inline toolbar dialog persistent - clicking on dialogs buttons to close dialog', async () => {
+            const editor = hook.editor();
+            const api = DialogUtils.open(editor, dialogSpec, { inline: dialogLocation.location, persistent: persistentMode.persistent });
+            await TinyUiActions.pWaitForDialog(editor);
+            Mouse.trueClickOn(TinyDom.body(editor), 'p');
+            assertDialogVisibility(persistentMode.persistent);
+            api.close();
+
+            // Dialog should be closed when pressing escape
+            DialogUtils.open(editor, dialogSpec, { inline: dialogLocation.location, persistent: persistentMode.persistent });
+            TinyUiActions.keystroke(editor, Keys.escape());
+            assertDialogVisibility(false);
+
+            // Dialog should be closed when clicking on cancel button
+            DialogUtils.open(editor, dialogSpec, { inline: dialogLocation.location, persistent: persistentMode.persistent });
+            TinyUiActions.closeDialog(editor);
+            assertDialogVisibility(false);
+
+            // Dialog should be closed when submitting
+            DialogUtils.open(editor, dialogSpec, { inline: dialogLocation.location, persistent: persistentMode.persistent });
+            TinyUiActions.submitDialog(editor);
+            assertDialogVisibility(false);
+
+            // Dialog should be closed when cancelling
+            DialogUtils.open(editor, dialogSpec, { inline: dialogLocation.location, persistent: persistentMode.persistent });
+            TinyUiActions.cancelDialog(editor);
+            assertDialogVisibility(false);
+          });
+
+          it('TINY-9991: Inline toolbar dialog persistent - clicking on menu bar', async () => {
+            const editor = hook.editor();
+            const api = DialogUtils.open(editor, dialogSpec, { inline: dialogLocation.location, persistent: persistentMode.persistent });
+            await TinyUiActions.pWaitForDialog(editor);
+            Mouse.trueClickOn(TinyDom.container(editor), 'button:contains("File")');
+            assertDialogVisibility(persistentMode.persistent);
+            closeMenu(editor);
+            api.close();
+          });
+
+          it('TINY-9991: Inline toolbar dialog persistent - clicking on toolbar', async () => {
+            const editor = hook.editor();
+            const api = DialogUtils.open(editor, dialogSpec, { inline: dialogLocation.location, persistent: persistentMode.persistent });
+            await TinyUiActions.pWaitForDialog(editor);
+            Mouse.trueClickOn(TinyDom.container(editor), '.tox-tbtn[title="Bold"]');
+            assertDialogVisibility(persistentMode.persistent);
+            api.close();
+          });
+
+          it('TINY-9991: Inline toolbar dialog persistent - clicking on the editor contet to show context toolbar', async () => {
+            const editor = hook.editor();
+            const api = DialogUtils.open(editor, dialogSpec, { inline: dialogLocation.location, persistent: persistentMode.persistent });
+            await TinyUiActions.pWaitForDialog(editor);
+
+            // Clicking on the editor container
+            editor.focus();
+            const elem = UiFinder.findIn(TinyDom.body(editor), 'a').getOrDie();
+            const target = Cursors.follow(elem, [ 0 ]).getOrDie();
+            editor.selection.select(target.dom);
+            Mouse.click(target);
+
+            await TinyUiActions.pWaitForUi(editor, '.tox-toolbar button[aria-label="Bold"]');
+            assertDialogVisibility(persistentMode.persistent);
+            api.close();
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-9991

Description of Changes:
* Fire the `doNotDismissYet` event instead of the default `dimissRequested` when the persistent mode is set to true
* This prevents inline dialog from being closed when clicking away from the dialog

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
