### PR TITLE
TINY-9996: Prevent modal and inline dialog footer from rendering if buttons is undefined or empty array

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/ModalDialog.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/ModalDialog.ts
@@ -63,7 +63,7 @@ const factory: CompositeSketchFactory<ModalDialogDetail, ModalDialogSpec> = (det
 
   const getDialogBody = (dialog: AlloyComponent) => AlloyParts.getPartOrDie(dialog, detail, 'body');
 
-  const getDialogFooter = (dialog: AlloyComponent) => AlloyParts.getPartOrDie(dialog, detail, 'footer');
+  const getDialogFooter = (dialog: AlloyComponent) => AlloyParts.getPart(dialog, detail, 'footer');
 
   const setBusy = (dialog: AlloyComponent, getBusySpec: GetBusySpec) => {
     Blocking.block(dialog, getBusySpec);

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/ModalDialogTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/ModalDialogTypes.ts
@@ -59,7 +59,7 @@ export interface ModalDialogApis {
   show: (dialog: AlloyComponent) => void;
   hide: (dialog: AlloyComponent) => void;
   getBody: (dialog: AlloyComponent) => AlloyComponent;
-  getFooter: (dialog: AlloyComponent) => AlloyComponent;
+  getFooter: (dialog: AlloyComponent) => Optional<AlloyComponent>;
   setBusy: (dialog: AlloyComponent, getBusySpec: GetBusySpec) => void;
   setIdle: (dialog: AlloyComponent) => void;
 }

--- a/modules/alloy/src/test/ts/browser/ui/dialog/ModalDialogTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dialog/ModalDialogTest.ts
@@ -254,7 +254,7 @@ describe('browser.alloy.ui.dialog.ModalDialogTest', () => {
     const footer = ModalDialog.getFooter(dialog);
     Assertions.assertStructure('Checking footer of dialog', ApproxStructure.build((s, _str, arr) => s.element('div', {
       classes: [ arr.has('test-dialog-footer') ]
-    })), footer.element);
+    })), footer.getOrDie().element);
   });
 
   it('TINY-9520: Checking aria attribute of dialog', () => {

--- a/modules/bridge/CHANGELOG.md
+++ b/modules/bridge/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- Make `buttons` an optional property of `DialogSpec` that defaults to an empty array. #TINY-9996
+
 ## 4.3.0 - 2023-03-15
 
 ### Added

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Dialog.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Dialog.ts
@@ -47,7 +47,7 @@ export interface DialogSpec<T extends DialogData> {
   title: string;
   size?: DialogSize;
   body: TabPanel.TabPanelSpec | Panel.PanelSpec;
-  buttons: FooterButton.DialogFooterButtonSpec[];
+  buttons?: FooterButton.DialogFooterButtonSpec[];
   initialData?: Partial<T>;
 
   // Gets fired when a component within the dialog has an action used by some components
@@ -93,7 +93,7 @@ export const dialogSchema = StructureSchema.objOf([
     tabpanel: TabPanel.tabPanelSchema
   })),
   FieldSchema.defaultedString('size', 'normal'),
-  FieldSchema.requiredArrayOf('buttons', dialogButtonSchema),
+  FieldSchema.defaultedArrayOf('buttons', [], dialogButtonSchema),
   FieldSchema.defaulted('initialData', {}),
   FieldSchema.defaultedFunction('onAction', Fun.noop),
   FieldSchema.defaultedFunction('onChange', Fun.noop),

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Improved
-- When defining a modal or inline dialog, if the `buttons` property is `undefined` or is an empty array, the footer will now no longer be rendered. #TINY-9996
+- When defining a modal or inline dialog, if the `buttons` property is `undefined` or an empty array, the footer will now no longer be rendered. #TINY-9996
 
 ### Added
 - Added new `bottom` to inline dialog type. This new inline dialog option allows the inline dialog to be positioned at the bottom of the editor. #TINY-9888

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Improved
-- When defining a dialog, if `buttons` is `undefined` or is an empty array, the footer will now no longer be rendered. #TINY-9996
+- When defining a modal or inline dialog, if the `buttons` property is `undefined` or is an empty array, the footer will now no longer be rendered. #TINY-9996
 
 ### Added
 - Added new `bottom` to inline dialog type. This new inline dialog option allows the inline dialog to be positioned at the bottom of the editor. #TINY-9888

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Improved
+- When defining a dialog, if `buttons` is `undefined` or is an empty array, the footer will now no longer be rendered. #TINY-9996
+
 ### Added
 - Added new `bottom` to inline dialog type. This new inline dialog option allows the inline dialog to be positioned at the bottom of the editor. #TINY-9888
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
@@ -1,6 +1,6 @@
 import { AlloyComponent, Composing, ModalDialog } from '@ephox/alloy';
 import { Dialog, DialogManager } from '@ephox/bridge';
-import { Fun, Id, Optional } from '@ephox/katamari';
+import { Fun, Id, Optionals } from '@ephox/katamari';
 import { Class, Classes, SugarElement } from '@ephox/sugar';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
@@ -40,9 +40,10 @@ const renderDialog = <T extends Dialog.DialogData>(dialogInit: DialogManager.Dia
 
   const objOfCells = SilverDialogCommon.extractCellsToObject(storedMenuButtons);
 
-  const footer = storedMenuButtons.length === 0
-    ? Optional.none()
-    : Optional.some(renderModalFooter({ buttons: storedMenuButtons }, dialogId, backstage));
+  const footer = Optionals.someIf(
+    storedMenuButtons.length !== 0,
+    renderModalFooter({ buttons: storedMenuButtons }, dialogId, backstage)
+  );
 
   const dialogEvents = SilverDialogEvents.initDialog<T>(
     () => instanceApi,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
@@ -40,9 +40,9 @@ const renderDialog = <T extends Dialog.DialogData>(dialogInit: DialogManager.Dia
 
   const objOfCells = SilverDialogCommon.extractCellsToObject(storedMenuButtons);
 
-  const footer = renderModalFooter({
-    buttons: storedMenuButtons
-  }, dialogId, backstage);
+  const footer = storedMenuButtons.length === 0
+    ? Optional.none()
+    : Optional.some(renderModalFooter({ buttons: storedMenuButtons }, dialogId, backstage));
 
   const dialogEvents = SilverDialogEvents.initDialog<T>(
     () => instanceApi,
@@ -56,7 +56,7 @@ const renderDialog = <T extends Dialog.DialogData>(dialogInit: DialogManager.Dia
     id: dialogId,
     header,
     body,
-    footer: Optional.some(footer),
+    footer,
     extraClasses: dialogSize,
     extraBehaviours: [],
     extraStyles: {}

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogInstanceApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogInstanceApi.ts
@@ -17,7 +17,7 @@ const getCompByName = (access: DialogAccess, name: string): Optional<AlloyCompon
     const form = Composing.getCurrent(access.getFormWrapper()).getOr(access.getFormWrapper());
     return Form.getField(form, name).orThunk(() => {
       const footer = access.getFooter();
-      const footerState: Optional<FooterState> = Reflecting.getState(footer).get();
+      const footerState: Optional<FooterState> = footer.bind((f) => Reflecting.getState(f).get());
       return footerState.bind((f) => f.lookupByName(name));
     });
   } else {
@@ -36,7 +36,7 @@ export interface DialogAccess {
   getId: () => string;
   getRoot: () => AlloyComponent;
   getBody: () => AlloyComponent;
-  getFooter: () => AlloyComponent;
+  getFooter: () => Optional<AlloyComponent>;
   getFormWrapper: () => AlloyComponent;
   toggleFullscreen: () => void;
 }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -50,11 +50,13 @@ const renderInlineDialog = <T extends Dialog.DialogData>(dialogInit: DialogManag
 
   const objOfCells = SilverDialogCommon.extractCellsToObject(storagedMenuButtons);
 
-  const memFooter = Memento.record(
-    renderInlineFooter({
-      buttons: storagedMenuButtons
-    }, dialogId, backstage)
-  );
+  const optMemFooter = storagedMenuButtons.length === 0
+    ? Optional.none()
+    : Optional.some(Memento.record(
+      renderInlineFooter({
+        buttons: storagedMenuButtons
+      }, dialogId, backstage)
+    ));
 
   const dialogEvents = SilverDialogEvents.initDialog(
     () => instanceApi,
@@ -125,7 +127,7 @@ const renderInlineDialog = <T extends Dialog.DialogData>(dialogInit: DialogManag
     components: [
       memHeader.asSpec(),
       memBody.asSpec(),
-      memFooter.asSpec()
+      ...optMemFooter.map((memFooter) => [ memFooter.asSpec() ]).getOr([])
     ]
   });
 
@@ -145,7 +147,7 @@ const renderInlineDialog = <T extends Dialog.DialogData>(dialogInit: DialogManag
   const instanceApi = getDialogApi<T>({
     getId: Fun.constant(dialogId),
     getRoot: Fun.constant(dialog),
-    getFooter: () => memFooter.get(dialog),
+    getFooter: () => optMemFooter.map((memFooter) => memFooter.get(dialog)),
     getBody: () => memBody.get(dialog),
     getFormWrapper: () => {
       const body = memBody.get(dialog);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -4,7 +4,7 @@ import {
   Receiving, Reflecting, Replacing, SystemEvents
 } from '@ephox/alloy';
 import { Dialog, DialogManager } from '@ephox/bridge';
-import { Fun, Id, Optional } from '@ephox/katamari';
+import { Fun, Id, Optional, Optionals } from '@ephox/katamari';
 import { Attribute, Classes, SugarElement, SugarNode } from '@ephox/sugar';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
@@ -50,9 +50,9 @@ const renderInlineDialog = <T extends Dialog.DialogData>(dialogInit: DialogManag
 
   const objOfCells = SilverDialogCommon.extractCellsToObject(storagedMenuButtons);
 
-  const optMemFooter = storagedMenuButtons.length === 0
-    ? Optional.none()
-    : Optional.some(Memento.record(
+  const optMemFooter = Optionals.someIf(
+    storagedMenuButtons.length !== 0,
+    Memento.record(
       renderInlineFooter({
         buttons: storagedMenuButtons
       }, dialogId, backstage)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -127,7 +127,7 @@ const renderInlineDialog = <T extends Dialog.DialogData>(dialogInit: DialogManag
     components: [
       memHeader.asSpec(),
       memBody.asSpec(),
-      ...optMemFooter.map((memFooter) => [ memFooter.asSpec() ]).getOr([])
+      ...optMemFooter.map((memFooter) => memFooter.asSpec()).toArray()
     ]
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideBlockedDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideBlockedDialogTest.ts
@@ -28,7 +28,14 @@ describe('browser.tinymce.themes.silver.skin.OxideBlockedDialogTest', () => {
                 }
               ]
             },
-            buttons: [ ],
+            // TINY-9996: buttons must be non-empty array for footer to be rendered
+            buttons: [
+              {
+                type: 'cancel',
+                name: 'cancel',
+                text: 'Cancel'
+              }
+            ],
             onAction: (dialogApi, actionData) => {
               if (actionData.name === 'busy-button') {
                 dialogApi.block('Dialog is blocked.');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogFooterTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogFooterTest.ts
@@ -1,5 +1,6 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { describe, context, it, afterEach, beforeEach } from '@ephox/bedrock-client';
+import { Singleton } from '@ephox/katamari';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -8,42 +9,43 @@ import { Dialog } from 'tinymce/core/api/ui/Ui';
 type ButtonName = 'buttons-undefined' | 'buttons-empty' | 'buttons-nonempty';
 
 describe('browser.tinymce.themes.silver.window.SilverDialogFooterTest', () => {
-  let testDialogApi: Dialog.DialogInstanceApi<{}>;
-  const addTestButton = (editor: Editor, name: ButtonName, buttons?: Dialog.DialogFooterButtonSpec[]): void =>
-    editor.ui.registry.addButton(name, {
-      type: 'button',
-      text: name,
-      tooltip: name,
-      onAction: () => {
-        testDialogApi = editor.windowManager.open({
-          title: 'Test',
-          body: {
-            type: 'panel',
-            items: []
-          },
-          buttons
-        });
-      }
-    });
+  const testDialogApi = Singleton.value<Dialog.DialogInstanceApi<{}>>();
+  const addTestButtons = (editor: Editor, inline: boolean): void => {
+    const addTestButton = (editor: Editor, inline: boolean, name: ButtonName, buttons?: Dialog.DialogFooterButtonSpec[]): void =>
+      editor.ui.registry.addButton(name, {
+        type: 'button',
+        text: name,
+        tooltip: name,
+        onAction: () => {
+          testDialogApi.set(editor.windowManager.open({
+            title: 'Test',
+            body: {
+              type: 'panel',
+              items: []
+            },
+            buttons
+          }, inline ? { inline: 'bottom' } : {}));
+        }
+      });
 
-  const hook = TinyHooks.bddSetupLight<Editor>({
+    addTestButton(editor, inline, 'buttons-undefined');
+    addTestButton(editor, inline, 'buttons-empty', []);
+    addTestButton(editor, inline, 'buttons-nonempty', [
+      {
+        type: 'cancel',
+        name: 'cancel',
+        text: 'Cancel'
+      }
+    ]);
+  };
+
+  const makeHook = (inline: boolean) => TinyHooks.bddSetupLight<Editor>({
     toolbar: 'buttons-undefined buttons-empty buttons-nonempty',
     base_url: '/project/tinymce/js/tinymce',
-    setup: (editor: Editor) => {
-      addTestButton(editor, 'buttons-undefined');
-      addTestButton(editor, 'buttons-empty', []);
-      addTestButton(editor, 'buttons-nonempty', [
-        {
-          type: 'cancel',
-          name: 'cancel',
-          text: 'Cancel'
-        }
-      ]);
-    }
+    setup: (editor: Editor) => addTestButtons(editor, inline)
   });
 
-  const testForFooterPresence = (buttonName: ButtonName, hasFooter: boolean) => async () => {
-    const editor = hook.editor();
+  const testFooterPresence = async (editor: Editor, buttonName: ButtonName, hasFooter: boolean): Promise<void> => {
     TinyUiActions.clickOnToolbar(editor, `button[aria-label="${buttonName}"]`);
     const dialog = await TinyUiActions.pWaitForDialog(editor);
     Assertions.assertStructure(
@@ -76,10 +78,22 @@ describe('browser.tinymce.themes.silver.window.SilverDialogFooterTest', () => {
         })),
       dialog
     );
-    testDialogApi.close();
   };
 
-  it('TINY-9996: Footer should not be rendered if buttons is undefined', testForFooterPresence('buttons-undefined', false));
-  it('TINY-9996: Footer should not be rendered if buttons is empty array', testForFooterPresence('buttons-empty', false));
-  it('TINY-9996: Footer should be rendered if buttons is non-empty array', testForFooterPresence('buttons-nonempty', true));
+  beforeEach(() => testDialogApi.clear());
+  afterEach(() => testDialogApi.on((api) => api.close()));
+
+  context('Modal dialogs', () => {
+    const hook = makeHook(false);
+    it('TINY-9996: Footer should not be rendered if buttons is undefined', () => testFooterPresence(hook.editor(), 'buttons-undefined', false));
+    it('TINY-9996: Footer should not be rendered if buttons is empty array', () => testFooterPresence(hook.editor(), 'buttons-empty', false));
+    it('TINY-9996: Footer should be rendered if buttons is non-empty array', () => testFooterPresence(hook.editor(), 'buttons-nonempty', true));
+  });
+
+  context('Inline dialogs', () => {
+    const hook = makeHook(true);
+    it('TINY-9996: Footer should not be rendered if buttons is undefined', () => testFooterPresence(hook.editor(), 'buttons-undefined', false));
+    it('TINY-9996: Footer should not be rendered if buttons is empty array', () => testFooterPresence(hook.editor(), 'buttons-empty', false));
+    it('TINY-9996: Footer should be rendered if buttons is non-empty array', () => testFooterPresence(hook.editor(), 'buttons-nonempty', true));
+  });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogFooterTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogFooterTest.ts
@@ -1,0 +1,85 @@
+import { ApproxStructure, Assertions } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import { Dialog } from 'tinymce/core/api/ui/Ui';
+
+type ButtonName = 'buttons-undefined' | 'buttons-empty' | 'buttons-nonempty';
+
+describe('browser.tinymce.themes.silver.window.SilverDialogFooterTest', () => {
+  let testDialogApi: Dialog.DialogInstanceApi<{}>;
+  const addTestButton = (editor: Editor, name: string, buttons?: Dialog.DialogFooterButtonSpec[]): void =>
+    editor.ui.registry.addButton(name, {
+      type: 'button',
+      text: name,
+      tooltip: name,
+      onAction: () => {
+        testDialogApi = editor.windowManager.open({
+          title: 'Test',
+          body: {
+            type: 'panel',
+            items: []
+          },
+          buttons
+        });
+      }
+    });
+
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    toolbar: 'buttons-undefined buttons-empty buttons-nonempty',
+    base_url: '/project/tinymce/js/tinymce',
+    setup: (editor: Editor) => {
+      addTestButton(editor, 'buttons-undefined');
+      addTestButton(editor, 'buttons-empty', []);
+      addTestButton(editor, 'buttons-nonempty', [
+        {
+          type: 'cancel',
+          name: 'cancel',
+          text: 'Cancel'
+        }
+      ]);
+    }
+  });
+
+  const testForFooterPresence = (buttonName: ButtonName, hasFooter: boolean) => async () => {
+    const editor = hook.editor();
+    TinyUiActions.clickOnToolbar(editor, `button[aria-label="${buttonName}"]`);
+    const dialog = await TinyUiActions.pWaitForDialog(editor);
+    Assertions.assertStructure(
+      'Checking dialog structure to see if footer is rendered',
+      hasFooter
+        ? ApproxStructure.build((s, _, arr) => s.element('div', {
+          classes: [ arr.has('tox-dialog') ],
+          children: [
+            s.element('div', {
+              classes: [ arr.has('tox-dialog__header') ]
+            }),
+            s.element('div', {
+              classes: [ arr.has('tox-dialog__content-js') ]
+            }),
+            s.element('div', {
+              classes: [ arr.has('tox-dialog__footer') ]
+            })
+          ]
+        }))
+        : ApproxStructure.build((s, _, arr) => s.element('div', {
+          classes: [ arr.has('tox-dialog') ],
+          children: [
+            s.element('div', {
+              classes: [ arr.has('tox-dialog__header') ]
+            }),
+            s.element('div', {
+              classes: [ arr.has('tox-dialog__content-js') ]
+            })
+          ]
+        })),
+      dialog
+    );
+    testDialogApi.close();
+  };
+
+  it('TINY-9996: Footer should not be rendered if buttons is undefined', testForFooterPresence('buttons-undefined', false));
+  it('TINY-9996: Footer should not be rendered if buttons is empty array', testForFooterPresence('buttons-empty', false));
+  it('TINY-9996: Footer should be rendered if buttons is non-empty array', testForFooterPresence('buttons-nonempty', true));
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogFooterTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogFooterTest.ts
@@ -50,32 +50,20 @@ describe('browser.tinymce.themes.silver.window.SilverDialogFooterTest', () => {
     const dialog = await TinyUiActions.pWaitForDialog(editor);
     Assertions.assertStructure(
       'Checking dialog structure to see if footer is rendered',
-      hasFooter
-        ? ApproxStructure.build((s, _, arr) => s.element('div', {
-          classes: [ arr.has('tox-dialog') ],
-          children: [
-            s.element('div', {
-              classes: [ arr.has('tox-dialog__header') ]
-            }),
-            s.element('div', {
-              classes: [ arr.has('tox-dialog__content-js') ]
-            }),
-            s.element('div', {
-              classes: [ arr.has('tox-dialog__footer') ]
-            })
-          ]
-        }))
-        : ApproxStructure.build((s, _, arr) => s.element('div', {
-          classes: [ arr.has('tox-dialog') ],
-          children: [
-            s.element('div', {
-              classes: [ arr.has('tox-dialog__header') ]
-            }),
-            s.element('div', {
-              classes: [ arr.has('tox-dialog__content-js') ]
-            })
-          ]
-        })),
+      ApproxStructure.build((s, _, arr) => s.element('div', {
+        classes: [ arr.has('tox-dialog') ],
+        children: [
+          s.element('div', {
+            classes: [ arr.has('tox-dialog__header') ]
+          }),
+          s.element('div', {
+            classes: [ arr.has('tox-dialog__content-js') ]
+          }),
+          ...hasFooter ? [ s.element('div', {
+            classes: [ arr.has('tox-dialog__footer') ]
+          }) ] : []
+        ]
+      })),
       dialog
     );
   };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogFooterTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogFooterTest.ts
@@ -9,7 +9,7 @@ type ButtonName = 'buttons-undefined' | 'buttons-empty' | 'buttons-nonempty';
 
 describe('browser.tinymce.themes.silver.window.SilverDialogFooterTest', () => {
   let testDialogApi: Dialog.DialogInstanceApi<{}>;
-  const addTestButton = (editor: Editor, name: string, buttons?: Dialog.DialogFooterButtonSpec[]): void =>
+  const addTestButton = (editor: Editor, name: ButtonName, buttons?: Dialog.DialogFooterButtonSpec[]): void =>
     editor.ui.registry.addButton(name, {
       type: 'button',
       text: name,

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerTest.ts
@@ -211,7 +211,14 @@ describe('headless.tinymce.themes.silver.window.WindowManagerTest', () => {
           type: 'panel',
           items: []
         },
-        buttons: []
+        // TINY-9996: buttons must be non-empty array for footer to be rendered
+        buttons: [
+          {
+            type: 'cancel',
+            name: 'cancel',
+            text: 'Cancel'
+          }
+        ]
       });
 
       const structHeaderWithDrag = ApproxStructure.build((s, str, arr) => {


### PR DESCRIPTION
Related Ticket: TINY-9996

Description of Changes:
* Prevent modal and inline dialog footer from rendering if buttons is undefined or empty array
* Result: https://ephocks.atlassian.net/browse/TINY-9996?focusedCommentId=129659

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
