### PR TITLE
TINY-10032: Allow iframes to update using document.write and autoscroll to bottom on each update

### DIFF
--- a/modules/bridge/CHANGELOG.md
+++ b/modules/bridge/CHANGELOG.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- Added `streamContent` optional property to `IframeSpec` that defaults to `false`. #TINY-10032
+
 ### Changed
-- Make `buttons` an optional property of `DialogSpec` that defaults to an empty array. #TINY-9996
+- Made `buttons` an optional property of `DialogSpec` that defaults to an empty array. #TINY-9996
 
 ## 4.3.0 - 2023-03-15
 

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Iframe.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Iframe.ts
@@ -6,18 +6,24 @@ import { FormComponentWithLabel, formComponentWithLabelFields, FormComponentWith
 export interface IframeSpec extends FormComponentWithLabelSpec {
   type: 'iframe';
   sandboxed?: boolean;
+  scrollToBottom?: boolean;
   transparent?: boolean;
+  useDocumentWrite?: boolean;
 }
 
 export interface Iframe extends FormComponentWithLabel {
   type: 'iframe';
   sandboxed: boolean;
+  scrollToBottom: boolean;
   transparent: boolean;
+  useDocumentWrite: boolean;
 }
 
 const iframeFields = formComponentWithLabelFields.concat([
+  FieldSchema.defaultedBoolean('scrollToBottom', false),
   FieldSchema.defaultedBoolean('sandboxed', true),
-  FieldSchema.defaultedBoolean('transparent', true)
+  FieldSchema.defaultedBoolean('transparent', true),
+  FieldSchema.defaultedBoolean('useDocumentWrite', false)
 ]);
 
 export const iframeSchema = StructureSchema.objOf(iframeFields);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Iframe.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Iframe.ts
@@ -6,24 +6,21 @@ import { FormComponentWithLabel, formComponentWithLabelFields, FormComponentWith
 export interface IframeSpec extends FormComponentWithLabelSpec {
   type: 'iframe';
   sandboxed?: boolean;
-  scrollToBottom?: boolean;
+  streamContent?: boolean;
   transparent?: boolean;
-  useDocumentWrite?: boolean;
 }
 
 export interface Iframe extends FormComponentWithLabel {
   type: 'iframe';
   sandboxed: boolean;
-  scrollToBottom: boolean;
+  streamContent: boolean;
   transparent: boolean;
-  useDocumentWrite: boolean;
 }
 
 const iframeFields = formComponentWithLabelFields.concat([
-  FieldSchema.defaultedBoolean('scrollToBottom', false),
   FieldSchema.defaultedBoolean('sandboxed', true),
+  FieldSchema.defaultedBoolean('streamContent', false),
   FieldSchema.defaultedBoolean('transparent', true),
-  FieldSchema.defaultedBoolean('useDocumentWrite', false)
 ]);
 
 export const iframeSchema = StructureSchema.objOf(iframeFields);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Iframe.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Iframe.ts
@@ -20,7 +20,7 @@ export interface Iframe extends FormComponentWithLabel {
 const iframeFields = formComponentWithLabelFields.concat([
   FieldSchema.defaultedBoolean('sandboxed', true),
   FieldSchema.defaultedBoolean('streamContent', false),
-  FieldSchema.defaultedBoolean('transparent', true),
+  FieldSchema.defaultedBoolean('transparent', true)
 ]);
 
 export const iframeSchema = StructureSchema.objOf(iframeFields);

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added new `bottom` to inline dialog type. This new inline dialog option allows the inline dialog to be positioned at the bottom of the editor. #TINY-9888
 - Added new `persistent` option to `WindowParams`. This new option allows the inline dialog to be persistent, meaning that it will not be closed when the user clicks outside of the dialog. #TINY-9991
-- New `streamContent` property for `iframe` dialog component. When set to `true`, content is updated using `document.write` instead of `srcdoc` to prevent flickering at short update intervals, and the iframe automatically scrolls to the bottom on each update if the scroll position was at the bottom before the update. #TINY-10032
+- New `streamContent` property for the `iframe` dialog component which controls dialog `setData()` behavior. With the property set to `true`, frame content will update with `document.write()` to avoid reloading the frame, and end scroll positions will be maintained as new content streams in. #TINY-10032
 
 ### Improved
 - When defining a modal or inline dialog, if the `buttons` property is `undefined` or an empty array, the footer will now no longer be rendered. #TINY-9996

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added new `bottom` to inline dialog type. This new inline dialog option allows the inline dialog to be positioned at the bottom of the editor. #TINY-9888
+- New `streamContent` property for `iframe` dialog component. When set to `true`, content is updated using `document.write` instead of `srcdoc` to prevent flickering at short update intervals, and the iframe automatically scrolls to the bottom on each update if the scroll position was at the bottom before the update. #TINY-10032
 
 ## 6.5.1 - 2023-06-19
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -1,7 +1,7 @@
 import { AlloyComponent, Behaviour, Focusing, FormField, SketchSpec, Tabstopping } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Cell, Optional } from '@ephox/katamari';
-import { Attribute } from '@ephox/sugar';
+import { Attribute, SugarElement } from '@ephox/sugar';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { renderFormFieldWith, renderLabel } from '../alien/FieldLabeller';
@@ -15,7 +15,7 @@ interface IFrameSourcing {
 
 type IframeSpec = Omit<Dialog.Iframe, 'type'>;
 
-const getDynamicSource = (initialData: Optional<string>): IFrameSourcing => {
+const getDynamicSource = (initialData: Optional<string>, scrollToBottom: boolean, useDocumentWrite: boolean): IFrameSourcing => {
   const cachedValue = Cell(initialData.getOr(''));
   return {
     getValue: (_frameComponent: AlloyComponent): string =>
@@ -25,7 +25,28 @@ const getDynamicSource = (initialData: Optional<string>): IFrameSourcing => {
       // TINY-3769: We need to use srcdoc here, instead of src with a data URI, otherwise browsers won't retain the Origin.
       // See https://bugs.chromium.org/p/chromium/issues/detail?id=58999#c11
       if (cachedValue.get() !== html) {
-        Attribute.set(frameComponent.element, 'srcdoc', html);
+        const iframeElement = frameComponent.element as SugarElement<HTMLIFrameElement>;
+        const iframe = iframeElement.dom;
+        const iframeDocument = Optional.from(iframe.contentDocument);
+        const iframeWindow = Optional.from(iframe.contentWindow);
+        const setSrcdocValue = () => Attribute.set(iframeElement, 'srcdoc', html);
+
+        if (useDocumentWrite) {
+          iframeDocument.fold(
+            setSrcdocValue,
+            (doc) => {
+              doc.open();
+              doc.write(html);
+              doc.close();
+            }
+          );
+        } else {
+          setSrcdocValue();
+        }
+
+        if (scrollToBottom) {
+          iframeDocument.map((doc) => doc.body).each((body) => iframeWindow.each((win) => win.scrollTo(0, body.scrollHeight)));
+        }
       }
       cachedValue.set(html);
     }
@@ -43,7 +64,7 @@ const renderIFrame = (spec: IframeSpec, providersBackstage: UiFactoryBackstagePr
     ...isSandbox ? { sandbox: 'allow-scripts allow-same-origin' } : { },
   };
 
-  const sourcing = getDynamicSource(initialData);
+  const sourcing = getDynamicSource(initialData, spec.scrollToBottom, spec.useDocumentWrite);
 
   const pLabel = spec.label.map((label) => renderLabel(label, providersBackstage));
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -27,6 +27,7 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
       if (cachedValue.get() !== html) {
         const iframeElement = frameComponent.element as SugarElement<HTMLIFrameElement>;
         const setSrcdocValue = () => Attribute.set(iframeElement, 'srcdoc', html);
+
         if (stream) {
           const iframe = iframeElement.dom;
           const iframeDoc = Optional.from(iframe.contentDocument);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -30,27 +30,20 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
 
         if (stream) {
           const iframe = iframeElement.dom;
-          const iframeDoc = Optional.from(iframe.contentDocument);
-          const iframeWindow = Optional.from(iframe.contentWindow);
-
-          const isScrollAtBottom = () => {
-            const isElementScrollAtBottom = ({ scrollTop, scrollHeight, clientHeight }: HTMLElement) => scrollTop + clientHeight >= scrollHeight;
-            return iframeDoc.map((doc) => doc.documentElement).map((docEl) => isElementScrollAtBottom(docEl)).getOr(false);
-          };
-          const isAtBottom = isScrollAtBottom();
-
-          iframeDoc.fold(
+          Optional.from(iframe.contentDocument).fold(
             setSrcdocValue,
             (doc) => {
+              const isElementScrollAtBottom = ({ scrollTop, scrollHeight, clientHeight }: HTMLElement) => scrollTop + clientHeight >= scrollHeight;
+              const isScrollAtBottom = isElementScrollAtBottom(doc.documentElement);
+
               doc.open();
               doc.write(html);
               doc.close();
-            }
-          );
 
-          if (isAtBottom) {
-            iframeDoc.map((doc) => doc.body).each((body) => iframeWindow.each((win) => win.scrollTo(0, body.scrollHeight)));
-          }
+              if (isScrollAtBottom) {
+                Optional.from(iframe.contentWindow).each((win) => win.scrollTo(0, doc.body.scrollHeight));
+              }
+            });
         } else {
           setSrcdocValue();
         }

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
@@ -131,14 +131,15 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
   });
 
   context('Autoscrolling to bottom', () => {
-    const longContent = '<p>1</p>'.repeat(100);
+    const initialLongContent = '<p>1</p>'.repeat(50);
+    const newLongContent = `${initialLongContent}${'<p>2</p>'.repeat(50)}`;
 
     const testStreamScrollToBottom = (initialScrollAtBottom: boolean, shouldScrollToBottom: boolean) => () => {
       const isScrollAtBottom = ({ scrollTop, scrollHeight, clientHeight }: HTMLElement) => scrollTop + clientHeight >= scrollHeight;
       const isScrollAtTop = ({ scrollTop }: HTMLElement) => scrollTop === 0;
 
       const frame = getFrameFromFrameNumber(2);
-      Representing.setValue(frame, longContent);
+      Representing.setValue(frame, initialLongContent);
 
       const iframe = frame.element.dom as HTMLIFrameElement;
       Optional.from(iframe.contentWindow).fold(
@@ -155,7 +156,7 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
                 assert.isTrue(isScrollAtTop(docEl), 'iframe should be scrolled to top initially');
               }
 
-              Representing.setValue(frame, longContent);
+              Representing.setValue(frame, newLongContent);
               if (shouldScrollToBottom) {
                 assert.isTrue(isScrollAtBottom(docEl), 'iframe should be scrolled to bottom after setting value');
               } else {
@@ -174,7 +175,7 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
 
     it('TINY-10032: Should not scroll to bottom when stream: false', () => {
       const frame = getFrameFromFrameNumber(0);
-      Representing.setValue(frame, longContent);
+      Representing.setValue(frame, newLongContent);
       Optional.from(frame.element.dom.contentWindow).fold(
         () => assert.fail('Could not find iframe document element'),
         (win) => assert.equal(win.scrollY, 0, 'iframe scroll should be at top')

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
@@ -18,13 +18,17 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
           name: 'frame-a',
           label: Optional.some('iframe label'),
           sandboxed: true,
-          transparent: true
+          scrollToBottom: false,
+          transparent: true,
+          useDocumentWrite: false
         }, TestProviders, Optional.none()),
         renderIFrame({
           name: 'frame-b',
           label: Optional.some('iframe label'),
           sandboxed: true,
-          transparent: false
+          scrollToBottom: false,
+          transparent: false,
+          useDocumentWrite: false
         }, TestProviders, Optional.none()),
       ]
     })

--- a/versions.txt
+++ b/versions.txt
@@ -1,2 +1,3 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
+bridge@4.5.0


### PR DESCRIPTION
Related Ticket: TINY-10032

Description of Changes:
New `streamContent` property to `IframeSpec` which when set to `true`:
* Updates content using `document.write` instead of `srcdoc` to prevent flickering at short update intervals
* Automatically scrolls iframe window to the bottom on each update if the scroll position is at the bottom before the update

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
