### PR TITLE
TINY-9952: fix range selection for multiple `tr`s selection

### DIFF
--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/KeySelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/KeySelection.ts
@@ -42,7 +42,7 @@ const detect = (
       if (boxes.length > 1) {
         selectRange(container, boxes, cellSel.start, cellSel.finish);
         return Optional.some(Response.create(
-          Optional.some(Util.makeSitus(start, 0, start, Awareness.getEnd(start))),
+          Optional.some(Util.makeSitus(start, 0, finish, Awareness.getEnd(finish))),
           true
         ));
       } else {

--- a/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
@@ -44,7 +44,7 @@ export const MouseSelection = (bridge: WindowBridge, container: SugarElement<Nod
             annotations.selectRange(container, boxes, cellSel.start, cellSel.finish);
 
             // stop the browser from creating a big text selection, select the cell where the cursor is
-            bridge.setRelativeSelection(Situ.on(start, 0), Situ.on(finish, Awareness.getEnd(finish))); // <--- THIS?
+            bridge.setRelativeSelection(Situ.on(start, 0), Situ.on(finish, Awareness.getEnd(finish)));
           }
         });
       });

--- a/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
@@ -1,5 +1,5 @@
 import { Optional, Optionals, Singleton } from '@ephox/katamari';
-import { Compare, ContentEditable, EventArgs, SelectorFind, SugarElement, Traverse } from '@ephox/sugar';
+import { Awareness, Compare, ContentEditable, EventArgs, SelectorFind, Situ, SugarElement, Traverse } from '@ephox/sugar';
 
 import { SelectionAnnotation } from '../api/SelectionAnnotation';
 import { WindowBridge } from '../api/WindowBridge';
@@ -44,7 +44,7 @@ export const MouseSelection = (bridge: WindowBridge, container: SugarElement<Nod
             annotations.selectRange(container, boxes, cellSel.start, cellSel.finish);
 
             // stop the browser from creating a big text selection, select the cell where the cursor is
-            bridge.selectContents(finish);
+            bridge.setRelativeSelection(Situ.on(start, 0), Situ.on(finish, Awareness.getEnd(finish))); // <--- THIS?
           }
         });
       });

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contents would not be removed from the drag start source if dragging and dropping internally into a transparent block element. #TINY-9960
 - In some cases pressing enter would scroll the entire page. #TINY-9828
 - The border styles of a table were incorrectly split into a longhand form after table dialog updates. #TINY-9843
+- The `selection.getRng()` returned an incorrect value by selecting multiple rows of the table both with the keyboard and with the mouse. #TINY-9952
 
 ## 6.6.0 - TBA
 

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysTableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysTableTest.ts
@@ -246,5 +246,21 @@ describe('browser.tinymce.core.keyboard.ArrowKeysTableTest', () => {
       TinyContentActions.keystroke(editor, Keys.up());
       TinyAssertions.assertSelection(editor, [ 0, 0, 1, 1, 1, 0 ], 0, [ 0, 0, 1, 1, 1, 0 ], 0);
     });
+
+    it('TINY-9952: selecting multiple tr via keyboard should preserve the correct range', () => {
+      const editor = hook.editor();
+      editor.setContent(`
+        <table>
+          <tbody>
+            <tr><td>1</td></tr>
+            <tr><td>2</td></tr>
+          </tbody>
+        </table>
+      `);
+
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0 ], 0);
+      TinyContentActions.keystroke(editor, Keys.down(), { shift: true });
+      TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 1, 0 ], 1);
+    });
   });
 });

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/TwoCellsSelectionTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/TwoCellsSelectionTest.ts
@@ -1,5 +1,6 @@
 import { Mouse, UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
+import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -113,6 +114,8 @@ describe('browser.tinymce.models.dom.table.TwoCellsSelectionTest', () => {
   });
 
   context('TINY-9952: 2 rows selection', () => {
+    const platform = PlatformDetection.detect();
+
     it('TINY-9952: selecting 2 rows via mouse should set the correct range', () => {
       const editor = hook.editor();
       editor.setContent(
@@ -123,7 +126,7 @@ describe('browser.tinymce.models.dom.table.TwoCellsSelectionTest', () => {
         '</tbody>' +
         '</table>'
       );
-      TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0 ], 0);
       const startCell = UiFinder.findIn(TinyDom.body(editor), 'td:contains(A1)').getOrDie();
       const endCell = UiFinder.findIn(TinyDom.body(editor), 'td:contains(A2)').getOrDie();
 
@@ -133,7 +136,12 @@ describe('browser.tinymce.models.dom.table.TwoCellsSelectionTest', () => {
       Mouse.mouseOver(endCell);
       Mouse.mouseUp(endCell);
 
-      TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 1, 0 ], 1);
+      // this is difference is caused because mouse selection on table is using the native setting for range
+      if (!platform.browser.isSafari()) {
+        TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 1, 0 ], 1);
+      } else {
+        TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 1, 0, 0 ], 'A2'.length);
+      }
     });
   });
 });

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/TwoCellsSelectionTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/TwoCellsSelectionTest.ts
@@ -1,5 +1,5 @@
 import { Mouse, UiFinder } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -110,5 +110,30 @@ describe('browser.tinymce.models.dom.table.TwoCellsSelectionTest', () => {
       '</tbody>' +
       '</table>'
     );
+  });
+
+  context('TINY-9952: 2 rows selection', () => {
+    it('TINY-9952: selecting 2 rows via mouse should set the correct range', () => {
+      const editor = hook.editor();
+      editor.setContent(
+        '<table>' +
+        '<tbody>' +
+        '<tr><td>A1</td></tr>' +
+        '<tr><td>A2</td></tr>' +
+        '</tbody>' +
+        '</table>'
+      );
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0 ], 0);
+      const startCell = UiFinder.findIn(TinyDom.body(editor), 'td:contains(A1)').getOrDie();
+      const endCell = UiFinder.findIn(TinyDom.body(editor), 'td:contains(A2)').getOrDie();
+
+      Mouse.mouseOver(startCell);
+      Mouse.mouseDown(startCell);
+      Mouse.mouseOver(startCell);
+      Mouse.mouseOver(endCell);
+      Mouse.mouseUp(endCell);
+
+      TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 1, 0 ], 1);
+    });
   });
 });

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/TwoCellsSelectionTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/TwoCellsSelectionTest.ts
@@ -123,7 +123,7 @@ describe('browser.tinymce.models.dom.table.TwoCellsSelectionTest', () => {
         '</tbody>' +
         '</table>'
       );
-      TinySelections.setCursor(editor, [ 0, 0, 0, 0 ], 0);
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
       const startCell = UiFinder.findIn(TinyDom.body(editor), 'td:contains(A1)').getOrDie();
       const endCell = UiFinder.findIn(TinyDom.body(editor), 'td:contains(A2)').getOrDie();
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/TwoCellsSelectionTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/TwoCellsSelectionTest.ts
@@ -136,7 +136,7 @@ describe('browser.tinymce.models.dom.table.TwoCellsSelectionTest', () => {
       Mouse.mouseOver(endCell);
       Mouse.mouseUp(endCell);
 
-      // this is difference is caused because mouse selection on table is using the native setting for range
+      // this difference is caused because mouse selection on tables using the native setting for ranges
       if (!platform.browser.isSafari()) {
         TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 1, 0 ], 1);
       } else {


### PR DESCRIPTION
Related Ticket: TINY-9952

Description of Changes:
The issue was that selecting multiple rows in a table (via keyboard or mouse), used to set a wrong range.
`keyboard`: the returned range had start and end container as what should would be the start container
`mouse`: the returned range had start and end container as what should would be the end container

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
