### PR TITLE
TINY-10000: It is now possible to create a list in an editable part within a non-editable root

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `mceInsertClipboardContent` command will now also accept a `files` property to insert images. #TINY-9776
 
 ### Fixed
+- Creating lists is possible when the selection is in an editable area inside a non-editable area. #TINY-10000
 - Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842
 - Creating a list from multiple div elements would only create a partial list. #TINY-9872
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `mceInsertClipboardContent` command will now also accept a `files` property to insert images. #TINY-9776
 
 ### Fixed
-- Creating lists is possible when the selection is in an editable area inside a non-editable area. #TINY-10000
+- When an editable area was nested inside a non-editable area, creating lists was not possible. #TINY-10000
 - Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842
 - Creating a list from multiple div elements would only create a partial list. #TINY-9872
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -362,7 +362,7 @@ const toggleSingleList = (editor: Editor, parentList: HTMLElement | null, listNa
 
 const toggleList = (editor: Editor, listName: 'UL' | 'OL' | 'DL', _detail: ListDetail | null): void => {
   const parentList = Selection.getParentList(editor);
-  if (isWithinNonEditableList(editor, parentList) || !editor.hasEditableRoot()) {
+  if (isWithinNonEditableList(editor, parentList)) {
     return;
   }
 

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ContentEditableFalseActionsTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ContentEditableFalseActionsTest.ts
@@ -146,4 +146,26 @@ ${listContent}
   it('TINY-9823: InsertUnorderedList command should ignore noneditable blocks', () => {
     testNonEditableBlocksIgnore('InsertUnorderedList');
   });
+
+  const testEditableBlockInsideNonEditableBlock = (command: 'InsertOrderedList' | 'InsertUnorderedList'): void => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    const initialContent = '<div contenteditable="true"><p>a</p></div>';
+    const tag = command === 'InsertOrderedList' ? 'ol' : 'ul';
+    const expectedContent = `<div contenteditable="true">\n<${tag}>\n<li>a</li>\n</${tag}>\n</div>`;
+
+    editor.setContent(initialContent);
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+    editor.execCommand(command);
+    TinyAssertions.assertContent(editor, expectedContent);
+    editor.getBody().contentEditable = 'true';
+  };
+
+  it('TINY-10000: InsertOrderedList command should create a list in an editable block inside a non-editable block', () => {
+    testEditableBlockInsideNonEditableBlock('InsertOrderedList');
+  });
+
+  it('TINY-10000: InsertUnorderedList command should create a list in an editable block inside a non-editable block', () => {
+    testEditableBlockInsideNonEditableBlock('InsertUnorderedList');
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-10000

Description of Changes:
* It is now possible to create a list in an editable part within a non-editable root

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
