### PR TITLE
TINY-10049: Implement optional border to dialog iframe component

### DIFF
--- a/modules/bridge/CHANGELOG.md
+++ b/modules/bridge/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added `streamContent` optional property to `IframeSpec` that defaults to `false`. #TINY-10032
+- Added `border` optional property to `IframeSpec` that defaults to `false`. #TINY-10049
 
 ### Changed
 - Made `buttons` an optional property of `DialogSpec` that defaults to an empty array. #TINY-9996

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Iframe.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Iframe.ts
@@ -5,6 +5,7 @@ import { FormComponentWithLabel, formComponentWithLabelFields, FormComponentWith
 
 export interface IframeSpec extends FormComponentWithLabelSpec {
   type: 'iframe';
+  border?: boolean;
   sandboxed?: boolean;
   streamContent?: boolean;
   transparent?: boolean;
@@ -12,12 +13,14 @@ export interface IframeSpec extends FormComponentWithLabelSpec {
 
 export interface Iframe extends FormComponentWithLabel {
   type: 'iframe';
+  border: boolean;
   sandboxed: boolean;
   streamContent: boolean;
   transparent: boolean;
 }
 
 const iframeFields = formComponentWithLabelFields.concat([
+  FieldSchema.defaultedBoolean('border', false),
   FieldSchema.defaultedBoolean('sandboxed', true),
   FieldSchema.defaultedBoolean('streamContent', false),
   FieldSchema.defaultedBoolean('transparent', true)

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -468,6 +468,10 @@
   .tox-dialog__iframe--bordered {
     border: @dialog-iframe-bordered-border-width solid @dialog-iframe-bordered-border-color;
     border-radius: @dialog-iframe-bordered-border-radius;
+
+    &:focus-within {
+      &:extend(.tox .tox-textfield:focus);
+    }
   }
 
   // Make popups in a dialog appear over other dialog (urlinput, colorinput etc)

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -458,19 +458,19 @@
     }
   }
 
-  // Allow iframes to have consistent BG with Editor iframe
   .tox-dialog__iframe {
+    // Allow iframes to have consistent BG with Editor iframe
     &.tox-dialog__iframe--opaque {
       background: @edit-area-iframe-background-color;
     }
-  }
 
-  .tox-dialog__iframe--bordered {
-    border: @dialog-iframe-bordered-border-width solid @dialog-iframe-bordered-border-color;
-    border-radius: @dialog-iframe-bordered-border-radius;
+    &.tox-dialog__iframe--bordered {
+      border: @dialog-iframe-bordered-border-width solid @dialog-iframe-bordered-border-color;
+      border-radius: @dialog-iframe-bordered-border-radius;
 
-    &:focus-within {
-      &:extend(.tox .tox-textfield:focus);
+      &:focus-within {
+        &:extend(.tox .tox-textfield:focus);
+      }
     }
   }
 

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -65,6 +65,10 @@
 @dialog-tab-max-width: 13em;
 @dialog-tab-column-max-width: 11em;
 
+@dialog-iframe-bordered-border-width: 1px;
+@dialog-iframe-bordered-border-color: @border-color;
+@dialog-iframe-bordered-border-radius: @panel-border-radius;
+
 // These get stacked on top of the global dialog z-index (1100)
 @z-index-dialogs-offset-wrap-background: 1;
 @z-index-dialogs-offset-dialog: 2;
@@ -459,6 +463,11 @@
     &.tox-dialog__iframe--opaque {
       background: @edit-area-iframe-background-color;
     }
+  }
+
+  .tox-dialog__iframe--bordered {
+    border: @dialog-iframe-bordered-border-width solid @dialog-iframe-bordered-border-color;
+    border-radius: @dialog-iframe-bordered-border-radius;
   }
 
   // Make popups in a dialog appear over other dialog (urlinput, colorinput etc)

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `ai`, `ai-prompt` and `send` icons. #TINY-9942
 - New `streamContent` property for the `iframe` dialog component which controls dialog `setData()` behavior. With the property set to `true`, frame content will update with `document.write()` to avoid reloading the frame, and end scroll positions will be maintained as new content streams in. #TINY-10032
 - Add `ai` buttons to the default toolbar and menubar. #TINY-9939
+- New `border` property for the `iframe` dialog component which controls the visibility of its border. #TINY-10049
 
 ### Improved
 - When defining a modal or inline dialog, if the `buttons` property is `undefined` or an empty array, the footer will now no longer be rendered. #TINY-9996

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -54,17 +54,14 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
 };
 
 const renderIFrame = (spec: IframeSpec, providersBackstage: UiFactoryBackstageProviders, initialData: Optional<string>): SketchSpec => {
-  const isBordered = spec.border;
-  const isSandbox = spec.sandboxed;
-  const isOpaque = !spec.transparent;
   const baseClass = 'tox-dialog__iframe';
-  const getModClassIf = (condition: boolean, mod: string): string [] =>
-    condition ? [ `${baseClass}--${mod}` ] : [];
+  const borderedClass = spec.border ? [ `${baseClass}--bordered` ] : [];
+  const opaqueClass = spec.transparent ? [] : [ `${baseClass}--opaque` ];
 
   const attributes = {
     ...spec.label.map<{ title?: string }>((title) => ({ title })).getOr({}),
     ...initialData.map((html) => ({ srcdoc: html })).getOr({}),
-    ...isSandbox ? { sandbox: 'allow-scripts allow-same-origin' } : { },
+    ...spec.sandboxed ? { sandbox: 'allow-scripts allow-same-origin' } : { },
   };
 
   const sourcing = getDynamicSource(initialData, spec.streamContent);
@@ -80,8 +77,8 @@ const renderIFrame = (spec: IframeSpec, providersBackstage: UiFactoryBackstagePr
         attributes,
         classes: [
           baseClass,
-          ...getModClassIf(isOpaque, 'opaque'),
-          ...getModClassIf(isBordered, 'bordered')
+          ...borderedClass,
+          ...opaqueClass
         ]
       },
       behaviours: Behaviour.derive([

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -54,9 +54,12 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
 };
 
 const renderIFrame = (spec: IframeSpec, providersBackstage: UiFactoryBackstageProviders, initialData: Optional<string>): SketchSpec => {
+  const isBordered = spec.border;
   const isSandbox = spec.sandboxed;
-  const isTransparent = spec.transparent;
+  const isOpaque = !spec.transparent;
   const baseClass = 'tox-dialog__iframe';
+  const getModClassIf = (condition: boolean, mod: string): string [] =>
+    condition ? [ `${baseClass}--${mod}` ] : [];
 
   const attributes = {
     ...spec.label.map<{ title?: string }>((title) => ({ title })).getOr({}),
@@ -75,7 +78,11 @@ const renderIFrame = (spec: IframeSpec, providersBackstage: UiFactoryBackstagePr
       dom: {
         tag: 'iframe',
         attributes,
-        classes: (isTransparent ? [ baseClass ] : [ baseClass, `${baseClass}--opaque` ])
+        classes: [
+          baseClass,
+          ...getModClassIf(isOpaque, 'opaque'),
+          ...getModClassIf(isBordered, 'bordered')
+        ]
       },
       behaviours: Behaviour.derive([
         Tabstopping.config({ }),

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
@@ -76,8 +76,8 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
           s.element('iframe', {
             classes: [
               arr.has('tox-dialog__iframe'),
-              transparent ? arr.not(`${baseClassPrefix}opaque`) : arr.has(`${baseClassPrefix}opaque`),
-              border ? arr.has(`${baseClassPrefix}bordered`) : arr.not(`${baseClassPrefix}bordered`)
+              (transparent ? arr.not : arr.has)(`${baseClassPrefix}opaque`),
+              (border ? arr.has : arr.not)(`${baseClassPrefix}bordered`)
             ],
             attrs: {
               // Should be no source.

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
@@ -18,6 +18,7 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
         renderIFrame({
           name: 'frame-a',
           label: Optional.some('iframe label'),
+          border: false,
           sandboxed: true,
           streamContent: false,
           transparent: true
@@ -25,6 +26,7 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
         renderIFrame({
           name: 'frame-b',
           label: Optional.some('iframe label'),
+          border: false,
           sandboxed: true,
           streamContent: false,
           transparent: false
@@ -32,10 +34,19 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
         renderIFrame({
           name: 'frame-c',
           label: Optional.some('iframe label'),
+          border: false,
           sandboxed: true,
           streamContent: true,
           transparent: true
-        }, TestProviders, Optional.none())
+        }, TestProviders, Optional.none()),
+        renderIFrame({
+          name: 'frame-d',
+          label: Optional.some('iframe label'),
+          border: true,
+          sandboxed: true,
+          streamContent: false,
+          transparent: true
+        }, TestProviders, Optional.none()),
       ]
     })
   ));
@@ -45,7 +56,7 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
     return Composing.getCurrent(frame).getOrDie('Could not find internal frame field');
   };
 
-  const assertInitialIframeStructure = (component: AlloyComponent, transparent: boolean) => Assertions.assertStructure(
+  const assertInitialIframeStructure = (component: AlloyComponent, transparent: boolean, border: boolean) => Assertions.assertStructure(
     'Checking initial structure',
     ApproxStructure.build((s, str, arr) => {
       const labelStructure = s.element('label', {
@@ -53,6 +64,7 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
         html: str.is('iframe label')
       });
 
+      const baseClassPrefix = 'tox-dialog__iframe--';
       const iframeStructure = s.element('div', {
         classes: [ arr.has('tox-navobj') ],
         children: [
@@ -64,7 +76,8 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
           s.element('iframe', {
             classes: [
               arr.has('tox-dialog__iframe'),
-              transparent ? arr.not('tox-dialog__iframe--opaque') : arr.has('tox-dialog__iframe--opaque')
+              transparent ? arr.not(`${baseClassPrefix}opaque`) : arr.has(`${baseClassPrefix}opaque`),
+              border ? arr.has(`${baseClassPrefix}bordered`) : arr.not(`${baseClassPrefix}bordered`)
             ],
             attrs: {
               // Should be no source.
@@ -88,10 +101,11 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
   );
 
   it('Check basic structure', () => {
-    const [ frame1, frame2, frame3 ] = hook.component().components();
-    assertInitialIframeStructure(frame1, true);
-    assertInitialIframeStructure(frame2, false);
-    assertInitialIframeStructure(frame3, true);
+    const [ frame1, frame2, frame3, frame4 ] = hook.component().components();
+    assertInitialIframeStructure(frame1, true, false);
+    assertInitialIframeStructure(frame2, false, false);
+    assertInitialIframeStructure(frame3, true, false);
+    assertInitialIframeStructure(frame4, true, true);
   });
 
   context('iframe content', () => {


### PR DESCRIPTION
Related Ticket: TINY-10049

Description of Changes:
* Implement optional border and place behind new `border` property in `IframeSpec`
* Use border styles from https://github.com/tinymce/tinymce/pull/8777/files
* Add focus styles for border

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
