### PR TITLE
TINY-10058: Add align property to labels to control text alignment

### DIFF
--- a/modules/bridge/CHANGELOG.md
+++ b/modules/bridge/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added `streamContent` optional property to `IframeSpec` that defaults to `false`. #TINY-10032
+- Added `align` optional property to `LabelSpec` that defaults to `start`. #TINY-10058
 
 ### Changed
 - Made `buttons` an optional property of `DialogSpec` that defaults to an empty array. #TINY-9996

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
@@ -1,4 +1,4 @@
-import { FieldProcessor } from '@ephox/boulder';
+import { FieldProcessor, FieldSchema } from '@ephox/boulder';
 
 import * as ComponentSchema from '../../core/ComponentSchema';
 import { BodyComponent, BodyComponentSpec } from './BodyComponent';
@@ -7,16 +7,19 @@ export interface LabelSpec {
   type: 'label';
   label: string;
   items: BodyComponentSpec[];
+  align?: 'start' | 'end';
 }
 
 export interface Label {
   type: 'label';
   label: string;
   items: BodyComponent[];
+  align: 'start' | 'end';
 }
 
 export const createLabelFields = (itemsField: FieldProcessor): FieldProcessor[] => [
   ComponentSchema.type,
   ComponentSchema.label,
-  itemsField
+  itemsField,
+  FieldSchema.defaultedStringEnum('align', 'start', [ 'start', 'end' ])
 ];

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
@@ -3,23 +3,25 @@ import { FieldProcessor, FieldSchema } from '@ephox/boulder';
 import * as ComponentSchema from '../../core/ComponentSchema';
 import { BodyComponent, BodyComponentSpec } from './BodyComponent';
 
+type Alignment = 'start' | 'center' | 'end';
+
 export interface LabelSpec {
   type: 'label';
   label: string;
   items: BodyComponentSpec[];
-  align?: 'start' | 'end';
+  align?: Alignment;
 }
 
 export interface Label {
   type: 'label';
   label: string;
   items: BodyComponent[];
-  align: 'start' | 'end';
+  align: Alignment;
 }
 
 export const createLabelFields = (itemsField: FieldProcessor): FieldProcessor[] => [
   ComponentSchema.type,
   ComponentSchema.label,
   itemsField,
-  FieldSchema.defaultedStringEnum('align', 'start', [ 'start', 'end' ])
+  FieldSchema.defaultedStringEnum('align', 'start', [ 'start', 'center', 'end' ])
 ];

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -356,6 +356,12 @@
       margin-bottom: 0;
       margin-top: 0;
     }
+
+    .tox-form__group .tox-label {
+      &.tox-label--end {
+        text-align: end;
+      }
+    }
   }
 
   .tox-dialog--width-lg {

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -362,6 +362,10 @@
     }
 
     .tox-form__group .tox-label {
+      &.tox-label--center {
+        text-align: center;
+      }
+
       &.tox-label--end {
         text-align: end;
       }

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `ai`, `ai-prompt` and `send` icons. #TINY-9942
 - New `streamContent` property for the `iframe` dialog component which controls dialog `setData()` behavior. With the property set to `true`, frame content will update with `document.write()` to avoid reloading the frame, and end scroll positions will be maintained as new content streams in. #TINY-10032
 - Add `ai` buttons to the default toolbar and menubar. #TINY-9939
+- New `align` property for the label dialog component that controls text alignment. #TINY-10058
 
 ### Improved
 - When defining a modal or inline dialog, if the `buttons` property is `undefined` or an empty array, the footer will now no longer be rendered. #TINY-9996

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Label.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Label.ts
@@ -9,10 +9,11 @@ import { RepresentingConfigs } from '../alien/RepresentingConfigs';
 type LabelSpec = Omit<Dialog.Label, 'type'>;
 
 export const renderLabel = (spec: LabelSpec, backstageShared: UiFactoryBackstageShared): SimpleSpec => {
+  const endClass = spec.align === 'end' ? [ 'tox-label--end' ] : [];
   const label: AlloySpec = {
     dom: {
       tag: 'label',
-      classes: [ 'tox-label' ]
+      classes: [ 'tox-label', ...endClass ]
     },
     components: [
       GuiFactory.text(backstageShared.providers.translate(spec.label))

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Label.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Label.ts
@@ -9,16 +9,20 @@ import { RepresentingConfigs } from '../alien/RepresentingConfigs';
 type LabelSpec = Omit<Dialog.Label, 'type'>;
 
 export const renderLabel = (spec: LabelSpec, backstageShared: UiFactoryBackstageShared): SimpleSpec => {
-  const endClass = spec.align === 'end' ? [ 'tox-label--end' ] : [];
+  const baseClass = 'tox-label';
+  const centerClass = spec.align === 'center' ? [ `${baseClass}--center` ] : [];
+  const endClass = spec.align === 'end' ? [ `${baseClass}--end` ] : [];
+
   const label: AlloySpec = {
     dom: {
       tag: 'label',
-      classes: [ 'tox-label', ...endClass ]
+      classes: [ baseClass, ...centerClass, ...endClass ]
     },
     components: [
       GuiFactory.text(backstageShared.providers.translate(spec.label))
     ]
   };
+
   const comps = Arr.map(spec.items, backstageShared.interpreter);
   return {
     dom: {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/label/LabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/label/LabelTest.ts
@@ -35,6 +35,12 @@ describe('headless.tinymce.themes.silver.components.label.LabelTest', () => {
     align: 'start'
   }, sharedBackstage));
 
+  const memCenterLabel = Memento.record(renderLabel({
+    label: 'Group of Options',
+    items,
+    align: 'center'
+  }, sharedBackstage));
+
   const memEndLabel = Memento.record(renderLabel({
     label: 'Group of Options',
     items,
@@ -43,10 +49,10 @@ describe('headless.tinymce.themes.silver.components.label.LabelTest', () => {
 
   const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build({
     dom: { tag: 'div' },
-    components: [ memBasicLabel.asSpec(), memHtmlLabel.asSpec(), memEndLabel.asSpec() ]
+    components: [ memBasicLabel.asSpec(), memHtmlLabel.asSpec(), memCenterLabel.asSpec(), memEndLabel.asSpec() ]
   }));
 
-  const assertLabelStructure = (component: AlloyComponent, alignEnd: boolean) => Assertions.assertStructure(
+  const assertLabelStructure = (component: AlloyComponent, alignment: 'start' | 'center' | 'end') => Assertions.assertStructure(
     'Checking initial structure',
     ApproxStructure.build((s, str, arr) => {
       const baseClass = 'tox-label';
@@ -56,7 +62,8 @@ describe('headless.tinymce.themes.silver.components.label.LabelTest', () => {
           s.element('label', {
             classes: [
               arr.has(baseClass),
-              (alignEnd ? arr.has : arr.not)(`${baseClass}--end`)
+              (alignment === 'center' ? arr.has : arr.not)(`${baseClass}--center`),
+              (alignment === 'end' ? arr.has : arr.not)(`${baseClass}--end`)
             ],
             children: [
               s.text(str.is('Group of Options'))
@@ -73,7 +80,7 @@ describe('headless.tinymce.themes.silver.components.label.LabelTest', () => {
 
   it('Check basic structure', () => {
     const label = memBasicLabel.get(hook.component());
-    assertLabelStructure(label, false);
+    assertLabelStructure(label, 'start');
   });
 
   it('TINY-7524: HTML like content should be rendered as plain text', () => {
@@ -98,8 +105,13 @@ describe('headless.tinymce.themes.silver.components.label.LabelTest', () => {
     );
   });
 
+  it('TINY-10058: Check label with center alignment', () => {
+    const label = memCenterLabel.get(hook.component());
+    assertLabelStructure(label, 'center');
+  });
+
   it('TINY-10058: Check label with end alignment', () => {
     const label = memEndLabel.get(hook.component());
-    assertLabelStructure(label, true);
+    assertLabelStructure(label, 'end');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10058

Description of Changes:
* Add align property to labels to control text alignment

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
