### PR TITLE
TINY-10044: Update WindowManager API docs

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/WindowManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/WindowManager.ts
@@ -144,8 +144,9 @@ const WindowManager = (editor: Editor): WindowManager => {
      * Opens a new window.
      *
      * @method open
-     * @param {Object} config For information on the available options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/dialog-configuration/#configurationoptions">Dialog - Configuration options</a>.
-     * @param {Object} params (Optional) For information on the available options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/dialog-configuration/#configurationparameters">Dialog - Configuration parameters</a>.
+     * @param {Object} config For information on the available options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/dialog-configuration/#options">Dialog - Configuration options</a>.
+options</a>.
+     * @param {Object} params (Optional) For information on the available options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/dialog-configuration/#configuration-parameters">Dialog - Configuration parameters</a>.
      * @returns {WindowManager.DialogInstanceApi} A new dialog instance.
      */
     open,

--- a/modules/tinymce/src/core/main/ts/api/WindowManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/WindowManager.ts
@@ -144,7 +144,9 @@ const WindowManager = (editor: Editor): WindowManager => {
      * Opens a new window.
      *
      * @method open
-     * @param {Object} args For a list of options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/dialog-configuration/#configurationoptions">Dialog - Configuration options</a>.
+     * @param {Object} config For information on the available options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/dialog-configuration/#configurationoptions">Dialog - Configuration options</a>.
+     * @param {Object} params (Optional) For information on the available options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/dialog-configuration/#configurationparameters">Dialog - Configuration parameters</a>.
+     * @returns {WindowManager.DialogInstanceApi} A new dialog instance.
      */
     open,
 
@@ -152,7 +154,8 @@ const WindowManager = (editor: Editor): WindowManager => {
      * Opens a new window for the specified url.
      *
      * @method openUrl
-     * @param {Object} args For a list of options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/urldialog/#configuration">URL dialog configuration</a>.
+     * @param {Object} config For information on the available options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/urldialog/#configuration">URL dialog - Configuration</a>.
+     * @returns {WindowManager.UrlDialogInstanceApi} A new URL dialog instance.
      */
     openUrl,
 


### PR DESCRIPTION
Related Ticket: TINY-10044

Description of Changes:
*  Update WindowManager API docs to include missing `params` argument on the `open` method
* Other small adjustments

Pre-checks:
* ~~[X] Changelog entry added~~
* ~~[X] Tests have been added (if applicable)~~
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [X] Docs ticket created (if applicable)

GitHub issues (if applicable):
