### PR TITLE
TINY-10056: Make dialog 'x' close button clickable when dialog is busy

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- Added new `isBlocked` API to the `Blocking`.
+
 ### Changed
 - `ModalDialogApis.getFooter` now returns an `Optional<AlloyComponent>` instead of `AlloyComponent`. #TINY-9996
 

--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
-- Added new `isBlocked` API to the `Blocking`.
+- Added new `isBlocked` API to the `Blocking` behaviour.
 
 ### Changed
 - `ModalDialogApis.getFooter` now returns an `Optional<AlloyComponent>` instead of `AlloyComponent`. #TINY-9996

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/ModalDialog.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/ModalDialog.ts
@@ -1,4 +1,4 @@
-import { Id, Singleton } from '@ephox/katamari';
+import { Fun, Id, Singleton } from '@ephox/katamari';
 import { Traverse } from '@ephox/sugar';
 
 import * as AriaLabel from '../../aria/AriaLabel';
@@ -42,7 +42,7 @@ const factory: CompositeSketchFactory<ModalDialogDetail, ModalDialogSpec> = (det
         AddEventsBehaviour.config('dialog-blocker-events', [
           // Ensure we use runOnSource otherwise this would cause an infinite loop, as `focusIn` would fire a `focusin` which would then get responded to and so forth
           AlloyEvents.runOnSource(NativeEvents.focusin(), () => {
-            Keying.focusIn(dialog);
+            Blocking.isBlocked(dialog) ? Fun.noop() : Keying.focusIn(dialog);
           })
         ])
       ])

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/blocking/BlockingApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/blocking/BlockingApis.ts
@@ -5,8 +5,9 @@ import * as Behaviour from '../../api/behaviour/Behaviour';
 import { Focusing } from '../../api/behaviour/Focusing';
 import { Keying } from '../../api/behaviour/Keying';
 import { Replacing } from '../../api/behaviour/Replacing';
+import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as GuiFactory from '../../api/component/GuiFactory';
-import { BlockFn, UnblockFn } from './BlockingTypes';
+import { BlockFn, BlockingConfig, BlockingState, UnblockFn } from './BlockingTypes';
 
 // Mark this component as busy, or blocked.
 export const block: BlockFn = (
@@ -54,3 +55,6 @@ export const unblock: UnblockFn = (component, config, state) => {
   }
   state.clear();
 };
+
+export const isBlocked = (component: AlloyComponent, blockingConfig: BlockingConfig, blockingState: BlockingState): boolean =>
+  blockingState.isBlocked();

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/blocking/BlockingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/blocking/BlockingTypes.ts
@@ -39,4 +39,5 @@ export interface BlockingState extends BehaviourState {
 export interface BlockingBehaviour extends Behaviour.AlloyBehaviour<BlockingConfigSpec, BlockingConfig, BlockingState> {
   readonly block: WrappedApiFunc<BlockFn>;
   readonly unblock: WrappedApiFunc<UnblockFn>;
+  readonly isBlocked: (component: AlloyComponent) => boolean;
 }

--- a/modules/alloy/src/test/ts/browser/ui/dialog/ModalDialogTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dialog/ModalDialogTest.ts
@@ -314,10 +314,10 @@ describe('browser.alloy.ui.dialog.ModalDialogTest', () => {
     }));
 
     Mouse.clickOn(doc, '.test-dialog-blocker');
-    await FocusTools.pTryOnSelector('Focus should move to first focusable element when clicking the blocker', doc, '.test-busy-class');
+    await FocusTools.pTryOnSelector('Focus should move to blocker element when clicking the blocker', doc, '.test-busy-class');
 
     Mouse.clickOn(doc, '.test-dialog');
-    await FocusTools.pTryOnSelector('Focus should move to first focusable element when clicking the blocker', doc, '.test-busy-class');
+    await FocusTools.pTryOnSelector('Focus should move to blocker element when clicking the blocker', doc, '.test-busy-class');
 
     ModalDialog.setIdle(dialog);
   });

--- a/modules/alloy/src/test/ts/browser/ui/dialog/ModalDialogTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dialog/ModalDialogTest.ts
@@ -318,6 +318,8 @@ describe('browser.alloy.ui.dialog.ModalDialogTest', () => {
 
     Mouse.clickOn(doc, '.test-dialog');
     await FocusTools.pTryOnSelector('Focus should move to first focusable element when clicking the blocker', doc, '.test-busy-class');
+
+    ModalDialog.setIdle(dialog);
   });
 
   // it('TINY-10056: Close button still clickable when dialog is busy', () => {

--- a/modules/alloy/src/test/ts/browser/ui/dialog/ModalDialogTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dialog/ModalDialogTest.ts
@@ -322,24 +322,6 @@ describe('browser.alloy.ui.dialog.ModalDialogTest', () => {
     ModalDialog.setIdle(dialog);
   });
 
-  // it('TINY-10056: Close button still clickable when dialog is busy', () => {
-  //   debugger;
-  //   const dialog = hook.component();
-  //   const doc = SugarDocument.getDocument();
-
-  //   ModalDialog.setBusy(dialog, (_d, bs) => ({
-  //     dom: {
-  //       tag: 'div',
-  //       classes: [ 'test-busy-class' ],
-  //       innerHtml: 'Loading',
-  //     },
-  //     behaviours: bs
-  //   }));
-
-  //   Mouse.clickOn(doc, dialogSelectors.close);
-  //   UiFinder.notExists(SugarBody.body(), dialogSelectors.dialog);
-  // });
-
   it('TINY-9520: Dialog busy test', async () => {
     const dialog = hook.component();
     const doc = SugarDocument.getDocument();

--- a/modules/alloy/src/test/ts/browser/ui/dialog/ModalDialogTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/dialog/ModalDialogTest.ts
@@ -300,6 +300,44 @@ describe('browser.alloy.ui.dialog.ModalDialogTest', () => {
     await FocusTools.pTryOnSelector('Focus should move to first focusable element when clicking the blocker', doc, dialogSelectors.body);
   });
 
+  it('TINY-10056: Clicking on blocker shouldn\'t focus first focusable when dialog is blocked', async () => {
+    const dialog = hook.component();
+    const doc = SugarDocument.getDocument();
+
+    ModalDialog.setBusy(dialog, (_d, bs) => ({
+      dom: {
+        tag: 'div',
+        classes: [ 'test-busy-class' ],
+        innerHtml: 'Loading',
+      },
+      behaviours: bs
+    }));
+
+    Mouse.clickOn(doc, '.test-dialog-blocker');
+    await FocusTools.pTryOnSelector('Focus should move to first focusable element when clicking the blocker', doc, '.test-busy-class');
+
+    Mouse.clickOn(doc, '.test-dialog');
+    await FocusTools.pTryOnSelector('Focus should move to first focusable element when clicking the blocker', doc, '.test-busy-class');
+  });
+
+  // it('TINY-10056: Close button still clickable when dialog is busy', () => {
+  //   debugger;
+  //   const dialog = hook.component();
+  //   const doc = SugarDocument.getDocument();
+
+  //   ModalDialog.setBusy(dialog, (_d, bs) => ({
+  //     dom: {
+  //       tag: 'div',
+  //       classes: [ 'test-busy-class' ],
+  //       innerHtml: 'Loading',
+  //     },
+  //     behaviours: bs
+  //   }));
+
+  //   Mouse.clickOn(doc, dialogSelectors.close);
+  //   UiFinder.notExists(SugarBody.body(), dialogSelectors.dialog);
+  // });
+
   it('TINY-9520: Dialog busy test', async () => {
     const dialog = hook.component();
     const doc = SugarDocument.getDocument();

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed an issue that prevented setting the inline dialog `size` to 'medium' or 'normal'. #TINY-10015
-- Fixed an issue that prevented close button to be clicked when dialog is blocked. #TINY-10056
+- Fixed an issue that prevented the close button from being clicked when the dialog was blocked. #TINY-10056
 
 ### Added
 - Added new `bottom` to inline dialog type. This new inline dialog option allows the inline dialog to be positioned at the bottom of the editor. #TINY-9888

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed an issue that prevented setting the inline dialog `size` to 'medium' or 'normal'. #TINY-10015
+- Fixed an issue that prevented close button to be clicked when dialog is blocked. #TINY-10056
 
 ### Added
 - Added new `bottom` to inline dialog type. This new inline dialog option allows the inline dialog to be positioned at the bottom of the editor. #TINY-9888

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dialogs.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dialogs.ts
@@ -1,8 +1,8 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyParts, AlloySpec, Behaviour, Button, Container, DomFactory, Focusing, Keying, ModalDialog,
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyParts, AlloySpec, Behaviour, Blocking, Button, Container, DomFactory, Focusing, Keying, ModalDialog,
   NativeEvents, SketchSpec, SystemEvents, Tabstopping
 } from '@ephox/alloy';
-import { Optional, Result } from '@ephox/katamari';
+import { Fun, Optional, Result } from '@ephox/katamari';
 import { Class, SugarBody } from '@ephox/sugar';
 
 import Env from 'tinymce/core/api/Env';
@@ -174,7 +174,7 @@ const renderDialog = (spec: DialogSpec): SketchSpec => {
           // Note: `runOnSource` here will only listen to the event at the outer component level.
           // Using just `run` instead will cause an infinite loop as `focusIn` would fire a `focusin` which would then get responded to and so forth.
           AlloyEvents.runOnSource(NativeEvents.focusin(), (comp, _se) => {
-            Keying.focusIn(comp);
+            Blocking.isBlocked(comp) ? Fun.noop() : Keying.focusIn(comp);
           })
         ])),
         AddEventsBehaviour.config('scroll-lock', [

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
@@ -38,36 +38,32 @@ const getHeader = (title: string, dialogId: string, backstage: UiFactoryBackstag
   draggable: backstage.dialog.isDraggableModal()
 }, dialogId, backstage.shared.providers);
 
-const getBusySpec = (message: string, bs: Behaviour.AlloyBehaviourRecord, providers: UiFactoryBackstageProviders, headerHeight: Optional<number>): AlloySpec => {
-  return {
-    dom: {
-      tag: 'div',
-      classes: [ 'tox-dialog__busy-spinner' ],
-      attributes: {
-        'aria-label': providers.translate(message)
-      },
-      styles: {
-        left: '0px',
-        right: '0px',
-        bottom: '0px',
-        top: `${headerHeight.getOr('0')}px`,
-        position: 'absolute'
-      }
+const getBusySpec = (message: string, bs: Behaviour.AlloyBehaviourRecord, providers: UiFactoryBackstageProviders, headerHeight: Optional<number>): AlloySpec => ({
+  dom: {
+    tag: 'div',
+    classes: [ 'tox-dialog__busy-spinner' ],
+    attributes: {
+      'aria-label': providers.translate(message)
     },
-    behaviours: bs,
-    components: [{
-      dom: DomFactory.fromHtml('<div class="tox-spinner"><div></div><div></div><div></div></div>')
-    }]
-  };
-};
+    styles: {
+      left: '0px',
+      right: '0px',
+      bottom: '0px',
+      top: `${headerHeight.getOr(0)}px`,
+      position: 'absolute'
+    }
+  },
+  behaviours: bs,
+  components: [{
+    dom: DomFactory.fromHtml('<div class="tox-spinner"><div></div><div></div><div></div></div>')
+  }]
+});
 
 const getEventExtras = (lazyDialog: () => AlloyComponent, providers: UiFactoryBackstageProviders, extra: SharedWindowExtra): ExtraListeners => ({
   onClose: () => extra.closeWindow(),
   onBlock: (blockEvent: FormBlockEvent) => {
     const headerHeight = SelectorFind.descendant<HTMLElement>(lazyDialog().element, '.tox-dialog__header').map((header) => Height.get(header));
-    ModalDialog.setBusy(lazyDialog(), (_comp, bs) => {
-      return getBusySpec(blockEvent.message, bs, providers, headerHeight);
-    });
+    ModalDialog.setBusy(lazyDialog(), (_comp, bs) => getBusySpec(blockEvent.message, bs, providers, headerHeight));
   },
   onUnblock: () => {
     ModalDialog.setIdle(lazyDialog());

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
@@ -64,7 +64,7 @@ const getBusySpec = (message: string, bs: Behaviour.AlloyBehaviourRecord, provid
 const getEventExtras = (lazyDialog: () => AlloyComponent, providers: UiFactoryBackstageProviders, extra: SharedWindowExtra): ExtraListeners => ({
   onClose: () => extra.closeWindow(),
   onBlock: (blockEvent: FormBlockEvent) => {
-    const headerHeight = SelectorFind.descendant<HTMLElement>(lazyDialog().element, '.tox-dialog__header').map((header) => Height.get(header) + 2);
+    const headerHeight = SelectorFind.descendant<HTMLElement>(lazyDialog().element, '.tox-dialog__header').map((header) => Height.get(header));
     ModalDialog.setBusy(lazyDialog(), (_comp, bs) => {
       return getBusySpec(blockEvent.message, bs, providers, headerHeight);
     });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -73,7 +73,7 @@ const renderInlineDialog = <T extends Dialog.DialogData>(dialogInit: DialogManag
     {
       onBlock: (event) => {
         Blocking.block(dialog, (_comp, bs) => {
-          const headerHeight = memHeader.getOpt(dialog).map((dialog) => Height.get(dialog.element) + 2);
+          const headerHeight = memHeader.getOpt(dialog).map((dialog) => Height.get(dialog.element));
           return SilverDialogCommon.getBusySpec(event.message, bs, backstage.shared.providers, headerHeight);
         });
       },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -5,7 +5,7 @@ import {
 } from '@ephox/alloy';
 import { Dialog, DialogManager } from '@ephox/bridge';
 import { Fun, Id, Optional, Optionals } from '@ephox/katamari';
-import { Attribute, Classes, SugarElement, SugarNode } from '@ephox/sugar';
+import { Attribute, Classes, Height, SugarElement, SugarNode } from '@ephox/sugar';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
 import { RepresentingConfigs } from '../alien/RepresentingConfigs';
@@ -72,7 +72,10 @@ const renderInlineDialog = <T extends Dialog.DialogData>(dialogInit: DialogManag
     () => instanceApi,
     {
       onBlock: (event) => {
-        Blocking.block(dialog, (_comp, bs) => SilverDialogCommon.getBusySpec(event.message, bs, backstage.shared.providers));
+        Blocking.block(dialog, (_comp, bs) => {
+          const headerHeight = memHeader.getOpt(dialog).map((dialog) => Height.get(dialog.element) + 2);
+          return SilverDialogCommon.getBusySpec(event.message, bs, backstage.shared.providers, headerHeight);
+        });
       },
       onUnblock: () => {
         Blocking.unblock(dialog);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
@@ -47,8 +47,11 @@ describe('browser.tinymce.themes.silver.window.SilverDialogBlockTest', () => {
     onAction: store.adder('clicked')
   };
 
-  const pClick = async (editor: Editor) => {
-    const button = await TinyUiActions.pWaitForUi(editor, 'button:contains("Clickable?")') as SugarElement<HTMLButtonElement>;
+  const clickableButtonSelector = 'button:contains("Clickable?")';
+  const closeButtonSelector = '.tox-button[title="Close"]';
+
+  const pClick = async (editor: Editor, selector: string) => {
+    const button = await TinyUiActions.pWaitForUi(editor, selector) as SugarElement<HTMLButtonElement>;
     const coords = SugarLocation.absolute(button);
     const centerX = coords.left + 0.5 * Width.get(button);
     const centerY = coords.top + 0.5 * Height.get(button);
@@ -93,7 +96,7 @@ describe('browser.tinymce.themes.silver.window.SilverDialogBlockTest', () => {
       it('TINY-6487: Ensure the button clicks when unblocked', async () => {
         const editor = hook.editor();
         DialogUtils.open(editor, dialogSpec, test.params);
-        await pClick(editor);
+        await pClick(editor, clickableButtonSelector);
         store.assertEq(`Ensure that it clicks (${test.label})`, [ 'clicked' ]);
         DialogUtils.close(editor);
       });
@@ -102,7 +105,7 @@ describe('browser.tinymce.themes.silver.window.SilverDialogBlockTest', () => {
         const editor = hook.editor();
         const api = DialogUtils.open(editor, dialogSpec, test.params);
         api.block('Block message');
-        await pClick(editor);
+        await pClick(editor, clickableButtonSelector);
         store.cAssertEq(`Ensure that it has not clicked (${test.label})`, []);
         DialogUtils.close(editor);
       });
@@ -112,7 +115,7 @@ describe('browser.tinymce.themes.silver.window.SilverDialogBlockTest', () => {
         const api = DialogUtils.open(editor, dialogSpec, test.params);
         api.block('Block message');
         api.unblock();
-        await pClick(editor);
+        await pClick(editor, clickableButtonSelector);
         store.cAssertEq(`Ensure that it has not clicked (${test.label})`, [ 'clicked' ]);
         DialogUtils.close(editor);
       });
@@ -139,6 +142,14 @@ describe('browser.tinymce.themes.silver.window.SilverDialogBlockTest', () => {
         assertBusyStructure('Bild hochladen');
         DialogUtils.close(editor);
         I18n.setCode('en');
+      });
+
+      it('TINY-6487: Ensure close button is clickable ', async () => {
+        const editor = hook.editor();
+        const api = DialogUtils.open(editor, dialogSpec, test.params);
+        api.block('Block message');
+        await pClick(editor, closeButtonSelector);
+        store.cAssertEq(`Ensure that it has clicked (${test.label})`, [ 'clicked' ]);
       });
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
@@ -150,6 +150,7 @@ describe('browser.tinymce.themes.silver.window.SilverDialogBlockTest', () => {
         api.block('Block message');
         await pClick(editor, closeButtonSelector);
         store.cAssertEq(`Ensure that it has clicked (${test.label})`, [ 'clicked' ]);
+        UiFinder.notExists(SugarBody.body(), '[role="dialog"]');
       });
 
       it('TINY-10056: Asserting blocker offsetTop, should left dialog header unblocked', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
@@ -144,12 +144,25 @@ describe('browser.tinymce.themes.silver.window.SilverDialogBlockTest', () => {
         I18n.setCode('en');
       });
 
-      it('TINY-6487: Ensure close button is clickable ', async () => {
+      it('TINY-10056: Ensure close button is clickable when dialog is blocked', async () => {
         const editor = hook.editor();
         const api = DialogUtils.open(editor, dialogSpec, test.params);
         api.block('Block message');
         await pClick(editor, closeButtonSelector);
         store.cAssertEq(`Ensure that it has clicked (${test.label})`, [ 'clicked' ]);
+      });
+
+      it('TINY-10056: Asserting blocker offsetTop, should left dialog header unblocked', async () => {
+        const editor = hook.editor();
+        const api = DialogUtils.open(editor, dialogSpec, test.params);
+
+        const dialog = await TinyUiActions.pWaitForDialog(editor);
+        api.block('Block message');
+
+        const headerHeight = Height.get(UiFinder.findIn<HTMLElement>(dialog, '.tox-dialog__header').getOrDie());
+        const blocker = UiFinder.findIn<HTMLElement>(dialog, '.tox-dialog__busy-spinner').getOrDie();
+        assert.equal(blocker.dom.offsetTop, headerHeight, 'Ensure that the blocker is the same height as the header');
+        DialogUtils.close(editor);
       });
     });
   });


### PR DESCRIPTION
Related Ticket: TINY-10056

Description of Changes:
* Make dialog blocker only blocks the body and footer
* Clicking on the blocker/dialog header wouldn't focus on the first element in dialog (see ticket for more info)
* Added `isBlocked` API to the `Blocking`.;

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
