### PR TITLE
TINY-10032: Account for nullable documentElement and body when iframe has not finished loading

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -35,7 +35,7 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
             (doc) => {
               const isElementScrollAtBottom = ({ scrollTop, scrollHeight, clientHeight }: HTMLElement) => scrollTop + clientHeight >= scrollHeight;
               // TINY-10032: If documentElement is null, we assume document is empty and so scroll is at bottom.
-              const isScrollAtBottom = Optional.from(doc.documentElement).fold(Fun.always, isElementScrollAtBottom);
+              const isScrollAtBottom = Optional.from(doc.documentElement).forall(isElementScrollAtBottom);
 
               doc.open();
               doc.write(html);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -1,6 +1,6 @@
 import { AlloyComponent, Behaviour, Focusing, FormField, SketchSpec, Tabstopping } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Cell, Fun, Optional, Type } from '@ephox/katamari';
+import { Cell, Optional, Type } from '@ephox/katamari';
 import { Attribute, SugarElement } from '@ephox/sugar';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -1,6 +1,6 @@
 import { AlloyComponent, Behaviour, Focusing, FormField, SketchSpec, Tabstopping } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Cell, Fun, Optional } from '@ephox/katamari';
+import { Cell, Fun, Optional, Type } from '@ephox/katamari';
 import { Attribute, SugarElement } from '@ephox/sugar';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
@@ -44,7 +44,7 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
               const win = iframe.contentWindow;
               const body = doc.body;
               // TINY-10032: Do not attempt to scroll if body has not been loaded yet
-              if (isScrollAtBottom && win && body) {
+              if (isScrollAtBottom && Type.isNonNullable(win) && Type.isNonNullable(body)) {
                 win.scrollTo(0, body.scrollHeight);
               }
             });


### PR DESCRIPTION
Related Ticket: TINY-10032
Related Comment: [TINY-10032](https://ephocks.atlassian.net/browse/TINY-10032?focusedCommentId=129839)

Description of Changes:
Follow-up to https://github.com/tinymce/tinymce/pull/8868:
* Account for nullable documentElement and body when iframe has not finished loading

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~ Scenario very difficult to test for
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


[TINY-10032]: https://ephocks.atlassian.net/browse/TINY-10032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ