### PR TITLE
TINY-10016: Context menu no longer shows up when right-clicking on non-editable image

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The pattern replacement removes spaces if they were contained in a tag that only contains a space and the text to replace. #TINY-9744
 
 ### Fixed
+- Right-clicking on an image that was in a non-editable area would open the image context menu. #TINY-10016
+- When an editable area was nested inside a non-editable area, creating lists was not possible. #TINY-10000
 - Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842
 - Creating a list from multiple div elements would only create a partial list. #TINY-9872
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815

--- a/modules/tinymce/src/plugins/image/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/Buttons.ts
@@ -46,8 +46,9 @@ const register = (editor: Editor): void => {
   });
 
   editor.ui.registry.addContextMenu('image', {
-    update: (element): string[] => isFigure(element) || (isImage(element) && !Utils.isPlaceholderImage(element)) ? [ 'image' ] : []
-  });
+    update: (element): string[] => {
+      return editor.selection.isEditable() && (isFigure(element) || (isImage(element) && !Utils.isPlaceholderImage(element))) ? [ 'image' ] : [];
+    } });
 
 };
 

--- a/modules/tinymce/src/plugins/image/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/Buttons.ts
@@ -46,9 +46,8 @@ const register = (editor: Editor): void => {
   });
 
   editor.ui.registry.addContextMenu('image', {
-    update: (element): string[] => {
-      return editor.selection.isEditable() && (isFigure(element) || (isImage(element) && !Utils.isPlaceholderImage(element))) ? [ 'image' ] : [];
-    } });
+    update: (element): string[] => editor.selection.isEditable() && (isFigure(element) || (isImage(element) && !Utils.isPlaceholderImage(element))) ? [ 'image' ] : []
+  });
 
 };
 

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ContextMenuTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ContextMenuTest.ts
@@ -1,6 +1,7 @@
-import { Keys, Waiter } from '@ephox/agar';
+import { Keys, Mouse, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
@@ -66,4 +67,27 @@ describe('browser.tinymce.plugins.image.ContextMenuTest', () => {
     await pWaitForAndSubmitDialog(editor);
     TinyAssertions.assertSelection(editor, [ 0 ], 0, [ 0 ], 1);
   });
+
+  it('TINY-10016: Opening context menus on a selected image in non-editable context', () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<p><img src="image.png" /></p><p>Second paragraph</p>', { format: 'raw' });
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    Mouse.contextMenuOn(TinyDom.body(editor), 'img');
+    assert.isEmpty(document.querySelector('.tox-silver-sink')?.children);
+    TinyAssertions.assertSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    editor.getBody().contentEditable = 'true';
+  });
+
+  it('TINY-10016: Opening context menus on an unselected image in non-editable context', () => {
+    const editor = hook.editor();
+    editor.getBody().contentEditable = 'false';
+    editor.setContent('<p><img src="image.png" /></p><p>Second paragraph</p>', { format: 'raw' });
+    TinySelections.setSelection(editor, [ 1, 0 ], 1, [ 1, 0 ], 1);
+    Mouse.contextMenuOn(TinyDom.body(editor), 'img');
+    assert.isEmpty(document.querySelector('.tox-silver-sink')?.children);
+    TinyAssertions.assertSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    editor.getBody().contentEditable = 'true';
+  });
+
 });


### PR DESCRIPTION
Related Ticket: TINY-10016

Description of Changes:
* Context menu no longer shows up when right-clicking on non-editable image

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
