### PR TITLE
TINY-10059: Add minimum height to iframe dialog component

### DIFF
--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -469,6 +469,8 @@
   }
 
   .tox-dialog__iframe {
+    min-height: 200px;
+
     // Allow iframes to have consistent BG with Editor iframe
     &.tox-dialog__iframe--opaque {
       background: @edit-area-iframe-background-color;

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -21,11 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `border` property for the `iframe` dialog component which controls the visibility of its border. #TINY-10049
 - New `align` property for the label dialog component that controls text alignment. #TINY-10058
 
-### Changed
-- The icon in `alertbanner` dialog component is not clickable if `url` field is not specified. #TINY-10013
-
 ### Improved
 - When defining a modal or inline dialog, if the `buttons` property is `undefined` or an empty array, the footer will now no longer be rendered. #TINY-9996
+- The `iframe` dialog component now has a minimum height of 200px. #TINY-10059
+
+### Changed
+- The icon in `alertbanner` dialog component is not clickable if `url` field is not specified. #TINY-10013
 
 ## 6.5.1 - 2023-06-19
 


### PR DESCRIPTION
Related Ticket: TINY-10059

Description of Changes:
* Add minimum height to iframe dialog component so it displays larger on `medium` sized inline dialogs

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
