### PR TITLE
TINY-9863: improved newline break detection in divs before a cef

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `pad_empty_with_br` option that can be set to `true` to pad empty block elements with `<br>` tag instead of nbsp character. #TINY-9861
 
 ### Improved
+- Adding a newline after a table would in some specific cases not work. #TINY-9863
 - Updated toolbar "More" button tooltip text from "More..." to "Reveal or hide additional toolbar items". #TINY-9629
 
 ### Changed

--- a/modules/tinymce/src/core/main/ts/newline/NewLineAction.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineAction.ts
@@ -78,13 +78,12 @@ const canInsertIntoEditableRoot = (editor: Editor) => {
 
 const isInRootWithEmptyOrCEF = (editor: Editor) => {
   const rng = editor.selection.getRng();
-  const isInRoot = rng.collapsed && rng.startContainer === editor.dom.getRoot();
   const start = SugarElement.fromDom(rng.startContainer);
 
   const child = Traverse.child(start, rng.startOffset);
   const isCefOpt = child.map((element) => SugarNode.isHTMLElement(element) && !ContentEditable.isEditable(element));
 
-  return isInRoot && isCefOpt.getOr(true);
+  return rng.collapsed && isCefOpt.getOr(true);
 };
 
 const match = (predicates: Array<(editor: Editor, shiftKey: boolean) => boolean>, action: NewLineActionAdt) => {

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -1,8 +1,8 @@
-import { ApproxStructure } from '@ephox/agar';
+import { ApproxStructure, Cursors } from '@ephox/agar';
 import { after, before, context, describe, it } from '@ephox/bedrock-client';
 import { Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
@@ -24,16 +24,25 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
   /*
   This function is used as a replacement for the TinySelections.setCursor as some changes are performed to cursor position in this setup.
   */
-  const setSelectionToBody = (editor: Editor, offset: number) => {
+  const setSelectionTo = (editor: Editor, path: number[], offset: number) => {
     const sel = editor.selection.getSel();
 
     if (Type.isNullable(sel)) {
       throw new Error('Sel is unexpectedly missing.');
     }
 
+    const cursorPath = Cursors.path({
+      startPath: path,
+      soffset: offset,
+      finishPath: path,
+      foffset: offset
+    });
+
+    const cursorRange = Cursors.calculate(TinyDom.body(editor), cursorPath);
+
     const range = editor.contentDocument.createRange();
-    range.setStart(editor.dom.getRoot(), offset);
-    range.setEnd(editor.dom.getRoot(), offset);
+    range.setStart(cursorRange.start.dom, cursorRange.soffset);
+    range.setEnd(cursorRange.finish.dom, cursorRange.foffset);
 
     if (PlatformDetection.detect().browser.isSafari()) {
       editor.selection.setRng(range);
@@ -171,7 +180,7 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
     it('TINY-9813: Placed a cursor is placed after a table, with a noneditable afterwards', () => {
       const editor = hook.editor();
       editor.setContent('<table><tbody><tr><td><br></td></tr></tbody></table><div contenteditable="false"></div>');
-      setSelectionToBody(editor, 1);
+      setSelectionTo(editor, [], 1);
       insertNewline(editor, { });
       TinyAssertions.assertContent(editor, '<table><tbody><tr><td>&nbsp;</td></tr></tbody></table><p>&nbsp;</p><div contenteditable="false">&nbsp;</div>');
       TinyAssertions.assertCursor(editor, [ 1 ], 0);
@@ -180,7 +189,7 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
     it('TINY-9813: Placed a cursor is placed after a table, with an editable afterwards', () => {
       const editor = hook.editor();
       editor.setContent('<table><tbody><tr><td><br></td></tr></tbody></table><div contenteditable="true">&nbsp;</div>');
-      setSelectionToBody(editor, 1);
+      setSelectionTo(editor, [], 1);
       insertNewline(editor, { });
       TinyAssertions.assertContent(editor, '<table><tbody><tr><td>&nbsp;</td></tr></tbody></table><div contenteditable="true">&nbsp;</div><div contenteditable="true">&nbsp;</div>');
       TinyAssertions.assertCursor(editor, [ 1 ], 0);
@@ -189,10 +198,19 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
     it('TINY-9813: Placed a cursor is placed after a table, with nothing', () => {
       const editor = hook.editor();
       editor.setContent('<table><tbody><tr><td><br></td></tr></tbody></table>');
-      setSelectionToBody(editor, 1);
+      setSelectionTo(editor, [], 1);
       insertNewline(editor, { });
       TinyAssertions.assertContent(editor, '<table><tbody><tr><td>&nbsp;</td></tr></tbody></table><p>&nbsp;</p>');
       TinyAssertions.assertCursor(editor, [ 1 ], 0);
+    });
+
+    it('TINY-9813: Placed a cursor is placed after a table, with a noneditable afterwards, wrapped in div', () => {
+      const editor = hook.editor();
+      editor.setContent('<div><table><tbody><tr><td><br></td></tr></tbody></table><div contenteditable="false"></div></div>');
+      setSelectionTo(editor, [ 0 ], 1);
+      insertNewline(editor, { });
+      TinyAssertions.assertContent(editor, '<div><table><tbody><tr><td>&nbsp;</td></tr></tbody></table><p>&nbsp;</p><div contenteditable="false">&nbsp;</div></div>');
+      TinyAssertions.assertCursor(editor, [ 0, 1 ], 0);
     });
   });
 


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
Let the newline code merge with the previously added work. I initially thought that since the code was very eager to split the parent div, that's what we should do ( and we didn't do it on the previous issue because the body shouldn't be split ). Discussion about it made us agree that even when in divs they should not be split, so we can use the same code.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
