### PR TITLE
TINY-10003: add refresh for `Toolbar`

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Going back from a view to the editor in mobile caused an error. #TINY-10003
+
 ## 13.0.0 - 2023-07-12
 
 ### Added

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/Toolbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/Toolbar.ts
@@ -26,6 +26,13 @@ const factory: CompositeSketchFactory<ToolbarDetail, ToolbarSpec> = (detail, com
 
   const getGroupContainer = (component: AlloyComponent) => detail.shell ? Optional.some(component) : AlloyParts.getPart(component, detail, 'groups');
 
+  const refresh = (toolbar: AlloyComponent) => {
+    const toolbarApi: ToolbarApis = toolbar.getApis();
+    if (toolbarApi.refresh) {
+      toolbarApi.refresh();
+    }
+  };
+
   // In shell mode, the group overrides need to be added to the main container, and there can be no children
   const extra: {
     behaviours: Array<NamedConfiguredBehaviour<any, any>>;
@@ -42,7 +49,8 @@ const factory: CompositeSketchFactory<ToolbarDetail, ToolbarSpec> = (detail, com
       extra.behaviours
     ),
     apis: {
-      setGroups
+      setGroups,
+      refresh
     },
     domModification: {
       attributes: {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/ToolbarTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/ToolbarTypes.ts
@@ -23,6 +23,7 @@ export interface ToolbarSpec extends CompositeSketchSpec {
 
 export interface ToolbarApis {
   setGroups: (toolbar: AlloyComponent, groups: AlloySpec []) => void;
+  refresh?: () => void;
 }
 
 export interface ToolbarSketcher extends CompositeSketch<ToolbarSpec>, ToolbarApis { }


### PR DESCRIPTION
Related Ticket: TINY-10003

Description of Changes:
Here the problem was that switching from a view to the editor calls [this refresh](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts#L132) , but in this case we were using [alloy/api/ui/Toolbar](https://github.com/tinymce/tinymce/blob/develop/modules/alloy/src/main/ts/ephox/alloy/api/ui/Toolbar.ts#L45) that didn't have the `refresh` API, and this cause the error.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
