### PR TITLE
TINY-10054: Quick toolbar would be shown inappropriately

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Right-clicking on an image that was in a non-editable area would open the image context menu. #TINY-10016
 - When an editable area was nested inside a non-editable area, creating lists was not possible. #TINY-10000
 - Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842
+- Quick Toolbar plugin would show text alignment buttons on pagebreaks. #TINY-10054
 - Creating a list from multiple div elements would only create a partial list. #TINY-9872
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815
 - It was possible to delete the sole empty block just before a details element if it was nested within another details element. #TINY-9965

--- a/modules/tinymce/src/plugins/quickbars/main/ts/selection/Toolbars.ts
+++ b/modules/tinymce/src/plugins/quickbars/main/ts/selection/Toolbars.ts
@@ -1,3 +1,5 @@
+import { Class, SugarElement } from '@ephox/sugar';
+
 import Editor from 'tinymce/core/api/Editor';
 
 import * as Options from '../api/Options';
@@ -5,7 +7,12 @@ import * as Options from '../api/Options';
 const addToEditor = (editor: Editor): void => {
   const isEditable = (node: Element | null): boolean => editor.dom.isEditable(node);
   const isInEditableContext = (el: Element) => isEditable(el.parentElement);
-  const isImage = (node: Element): boolean => node.nodeName === 'IMG' || node.nodeName === 'FIGURE' && /image/i.test(node.className) && isInEditableContext(node);
+  const isImage = (node: Element): boolean => {
+    const isImageFigure = node.nodeName === 'FIGURE' && /image/i.test(node.className);
+    const isImage = node.nodeName === 'IMG' || isImageFigure;
+    const isPagebreak = Class.has(SugarElement.fromDom(node), 'mce-pagebreak');
+    return isImage && isInEditableContext(node) && !isPagebreak;
+  };
 
   const imageToolbarItems = Options.getImageToolbarItems(editor);
   if (imageToolbarItems.length > 0) {

--- a/modules/tinymce/src/plugins/quickbars/test/ts/browser/SelectionToolbarTest.ts
+++ b/modules/tinymce/src/plugins/quickbars/test/ts/browser/SelectionToolbarTest.ts
@@ -15,7 +15,7 @@ enum Alignment {
 
 describe('browser.tinymce.plugins.quickbars.SelectionToolbarTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
-    plugins: 'quickbars link',
+    plugins: 'quickbars link pagebreak',
     inline: true,
     toolbar: false,
     menubar: false,
@@ -90,5 +90,15 @@ describe('browser.tinymce.plugins.quickbars.SelectionToolbarTest', () => {
     await pSetImageAndAssertToolbarState(editor, true, Alignment.Left);
     await pSetImageAndAssertToolbarState(editor, true, Alignment.Center);
     await pSetImageAndAssertToolbarState(editor, true, Alignment.Right);
+  });
+
+  it('TINY-10054: Pagebreak should not toggle toolbar', async () => {
+    const editor = hook.editor();
+    editor.setContent('<!-- pagebreak -->');
+    TinySelections.select(editor, 'img', []);
+    await Waiter.pWait(50); // Give the toolbar a chance to appear. If not present this test will pass even when it shouldn't.
+    await Waiter.pTryUntil('Wait for toolbar button state', () => {
+      UiFinder.notExists(SugarBody.body(), `.tox-toolbar button[aria-label="Align left"]`);
+    });
   });
 });


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
Broke the original isImage function up to increase readability as it was getting rather long.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
