### PR TITLE
TINY-10070: Warning is displayed to the console after closing dialog contain an iframe with api.close()

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - On Safari and Firefox browsers, scroll positions were not always maintained when updating the content of a `streamContent: true` iframe dialog component. #TINY-10078 #TINY-10109
 - Scrolling behavior was inconsistent when updating a `streamContent: true` iframe dialog component with content lacking an HTML document type declaration. #TINY-10110
+- Console may display warning message when closing dialog with an iframe component. #TINY-10070
 
 ## 6.6.0 - 2023-07-12
 
@@ -73,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dialog `tabpanel` tab labels are now allowed to word wrap for better readability with long labels. #TINY-9947
 - Added newlines before and after `details` elements in the output HTML. #TINY-9959
 - Added padding for empty `summary` elements so that they can be properly edited. #TINY-9959
+- Improved detection of scrollable containers when the `ui_mode: 'split'` option is set. #TINY-9385
 
 ### Changed
 - The `caption`, `address` and `dt` elements no longer incorrectly allow non-inline child elements when the editor schema is set to _HTML 4_. #TINY-9768

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogEvents.ts
@@ -95,7 +95,7 @@ const initDialog = <T extends Dialog.DialogData>(getInstanceApi: () => Dialog.Di
     }),
 
     fireApiEvent<FormActionEvent>(formActionEvent, (api, spec, event, component) => {
-      const focusIn = () => Keying.focusIn(component);
+      const focusIn = () => component.getSystem().isConnected() ? Keying.focusIn(component) : Fun.noop();
       const isDisabled = (focused: SugarElement<HTMLElement>) => Attribute.has(focused, 'disabled') || Attribute.getOpt(focused, 'aria-disabled').exists((val) => val === 'true');
       const rootNode = SugarShadowDom.getRootNode(component.element);
       const current = Focus.active(rootNode);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogEvents.ts
@@ -95,7 +95,7 @@ const initDialog = <T extends Dialog.DialogData>(getInstanceApi: () => Dialog.Di
     }),
 
     fireApiEvent<FormActionEvent>(formActionEvent, (api, spec, event, component) => {
-      const focusIn = () => component.getSystem().isConnected() ? Keying.focusIn(component) : Fun.noop();
+      const focusIn = component.getSystem().isConnected() ? () => Keying.focusIn(component) : Fun.noop;
       const isDisabled = (focused: SugarElement<HTMLElement>) => Attribute.has(focused, 'disabled') || Attribute.getOpt(focused, 'aria-disabled').exists((val) => val === 'true');
       const rootNode = SugarShadowDom.getRootNode(component.element);
       const current = Focus.active(rootNode);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
@@ -249,7 +249,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogTest', () => {
     });
   });
 
-  // TINY-10070, precautionary test, making sure the focus is on the iframe after closing the dialog
+  // TINY-10070, precautionary test, making sure the focus is on the editor iframe after closing the dialog
   it('Editor focus should be on text area after closing dialog', async () => {
     const editor = hook.editor();
     openDialog(editor, { inline: 'toolbar' }, createDialogSpec('normal', true, true), true);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
@@ -255,7 +255,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogTest', () => {
   });
 
   // TINY-10070, precautionary test, making sure the focus is on the editor iframe after closing the dialog
-  it('Editor focus should be on text area after closing dialog', async () => {
+  it('TINY-10070: Editor focus should be on text area after closing dialog', async () => {
     const editor = hook.editor();
     openDialog(editor, { inline: 'toolbar' }, createDialogWithIframeSpec());
     await TinyUiActions.pWaitForDialog(editor);


### PR DESCRIPTION
Related Ticket: 
[TINY-10070](https://ephocks.atlassian.net/browse/TINY-10070)

Description of Changes:
- applied Luke's suggestion, check if dialog is in the dom with `focusIn` function
- added precautionary test

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-10070]: https://ephocks.atlassian.net/browse/TINY-10070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ