### PR TITLE
TINY-10017: menu items will no longer overflow the menu containing them.

### DIFF
--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -193,6 +193,7 @@
     font-style: @collection-item-label-font-style;
     font-weight: @collection-item-label-font-weight;
     line-height: @collection-item-list-icon-height;
+    max-width: 100%;
     text-transform: @collection-item-label-text-transform;
     word-break: break-all;
   }

--- a/modules/oxide/src/less/theme/components/menu/menu.less
+++ b/modules/oxide/src/less/theme/components/menu/menu.less
@@ -42,6 +42,10 @@
       overflow-wrap: break-word;
       word-break: normal;
     }
+
+    .tox-dialog__popups .tox-menu .tox-collection__item-label {
+      word-break: break-all;
+    }
   }
 
   // Reset all margins for block elements when used in menu labels

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Right-clicking on an image that was in a non-editable area would open the image context menu. #TINY-10016
 - When an editable area was nested inside a non-editable area, creating lists was not possible. #TINY-10000
 - Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842
+- Autocompletion of url for links would on sufficiently long links and wide screens leave out middle parts of the url from view. #TINY-10017
 - Creating a list from multiple div elements would only create a partial list. #TINY-9872
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815
 - It was possible to delete the sole empty block just before a details element if it was nested within another details element. #TINY-9965


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-10017

Description of Changes:
Menuitem content could before overflow outside of the menu, becoming hidden from view.
We prevent some text from wordbreaking ugly. Restricted this more, to prevent it from affecting the dialog autocompletion.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
