### PR TITLE
TINY-10073: copy-edits to remove run-on clauses in API comments/documentation

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - On Safari and Firefox browsers, scroll positions were not always maintained when updating the content of a `streamContent: true` iframe dialog component. #TINY-10078 #TINY-10109
 - Scrolling behavior was inconsistent when updating a `streamContent: true` iframe dialog component with content lacking an HTML document type declaration. #TINY-10110
-- A typo correction plus run-on sentences in API comments/documentation corrected. #TINY-10073
+- API comments/documentation corrected: a typo correction and run-on sentences fixed. #TINY-10073
 
 ## 6.6.0 - 2023-07-12
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - On Safari and Firefox browsers, scroll positions were not always maintained when updating the content of a `streamContent: true` iframe dialog component. #TINY-10078 #TINY-10109
 - Scrolling behavior was inconsistent when updating a `streamContent: true` iframe dialog component with content lacking an HTML document type declaration. #TINY-10110
-- Run-on sentences in API comments/documentation corrected. #TINY-10073
+- A typo correction plus run-on sentences in API comments/documentation corrected. #TINY-10073
 
 ## 6.6.0 - 2023-07-12
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - On Safari and Firefox browsers, scroll positions were not always maintained when updating the content of a `streamContent: true` iframe dialog component. #TINY-10078 #TINY-10109
 - Scrolling behavior was inconsistent when updating a `streamContent: true` iframe dialog component with content lacking an HTML document type declaration. #TINY-10110
+- Run-on sentences in API comments/documentation corrected. #TINY-10073
 
 ## 6.6.0 - 2023-07-12
 

--- a/modules/tinymce/src/core/main/ts/api/WindowManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/WindowManager.ts
@@ -162,7 +162,7 @@ options</a>.
 
     /**
      * Creates an alert dialog. Please don't use the blocking behavior of this
-     * native version use the callback method instead then it can be extended.
+     * native version. Use the callback method instead; then it can be extended.
      *
      * @method alert
      * @param {String} message Text to display in the new alert dialog.
@@ -175,8 +175,8 @@ options</a>.
     alert,
 
     /**
-     * Creates a confirm dialog. Please don't use the blocking behavior of this
-     * native version use the callback method instead then it can be extended.
+     * Creates an alert dialog. Please don't use the blocking behavior of this
+     * native version. Use the callback method instead; then it can be extended.
      *
      * @method confirm
      * @param {String} message Text to display in the new confirm dialog.

--- a/modules/tinymce/src/core/main/ts/api/WindowManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/WindowManager.ts
@@ -18,10 +18,10 @@ import { Dialog } from './ui/Ui';
  *   height: 240
  * });
  *
- * // Displays an alert box using the active editors window manager instance
+ * // Displays an alert box using the active editor’s window manager instance
  * tinymce.activeEditor.windowManager.alert('Hello world!');
  *
- * // Displays a confirm box and an alert message will be displayed depending on what you choose in the confirm
+ * // Displays a confirm box. An alert message will display depending on what is chosen in the confirm box.
  * tinymce.activeEditor.windowManager.confirm('Do you want to do something?', (state) => {
  *   const message = state ? 'Ok' : 'Cancel';
  *   tinymce.activeEditor.windowManager.alert(message);
@@ -145,7 +145,6 @@ const WindowManager = (editor: Editor): WindowManager => {
      *
      * @method open
      * @param {Object} config For information on the available options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/dialog-configuration/#options">Dialog - Configuration options</a>.
-options</a>.
      * @param {Object} params (Optional) For information on the available options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/dialog-configuration/#configuration-parameters">Dialog - Configuration parameters</a>.
      * @returns {WindowManager.DialogInstanceApi} A new dialog instance.
      */
@@ -161,7 +160,7 @@ options</a>.
     openUrl,
 
     /**
-     * Creates an alert dialog. Please don't use the blocking behavior of this
+     * Creates an alert dialog. Do not use the blocking behavior of this
      * native version. Use the callback method instead; then it can be extended.
      *
      * @method alert
@@ -175,7 +174,7 @@ options</a>.
     alert,
 
     /**
-     * Creates an alert dialog. Please don't use the blocking behavior of this
+     * Creates an alert dialog. Do not use the blocking behavior of this
      * native version. Use the callback method instead; then it can be extended.
      *
      * @method confirm


### PR DESCRIPTION
Copy-edits to remove run-on clauses in API comments/documentation

Related Ticket: TINY-10073

Description of Changes:
* Two run-on sentences in the API documentation no longer run-on.

Pre-checks:
* [x] Changelog entry added
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`
