### PR TITLE
TINY-10078, TINY-10097, TINY-10109, TINY-10110: Maintain non-end scroll positions, reduce flickering, and fix inconsistent autoscrolling for streamContent: true iframe dialog components

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,11 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Improved
-- On the Safari browser, content updates for `streamContent: true` iframe dialog components were throttled to 500ms intervals to reduce the visual impact of flickering when rapidly updating iframe content. #TINY-10097
+- Content updates for `streamContent: true` iframe dialog components on Safari are now throttled to 500ms intervals to reduce the visual impact of flickering when rapidly updating iframe content. #TINY-10097
 
 ### Fixed
-- On Safari and Firefox browsers, non-end scroll positions were not maintained when updating the content of a `streamContent: true` iframe dialog component. #TINY-10078
-- On the Safari browser, end scroll positions were not consistently maintained when updating the content of a `streamContent: true` iframe dialog component. #TINY-10109
+- On Safari and Firefox browsers, scroll positions were not always maintained when updating the content of a `streamContent: true` iframe dialog component. #TINY-10078 #TINY-10109
 - Scrolling behavior was inconsistent when updating a `streamContent: true` iframe dialog component with content lacking an HTML document type declaration. #TINY-10110
 
 ## 6.6.0 - 2023-07-12

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Improved
+- On the Safari browser, content updates for iframe dialog components with the `streamContent` property set to `true` were throttled to 500ms intervals to reduce the visual impact of flickering when rapidly updating iframe content. #TINY-10097
+
+### Fixed
+- On Safari and Firefox browsers, non-end scroll positions were not maintained when updating the content of an iframe dialog component with the `streamContent` property set to `true`. #TINY-10078
+
 ## 6.6.0 - 2023-07-12
 
 ### Added

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Improved
-- On the Safari browser, content updates for iframe dialog components with the `streamContent` property set to `true` were throttled to 500ms intervals to reduce the visual impact of flickering when rapidly updating iframe content. #TINY-10097
+- On the Safari browser, content updates for `streamContent: true` iframe dialog components were throttled to 500ms intervals to reduce the visual impact of flickering when rapidly updating iframe content. #TINY-10097
 
 ### Fixed
-- On Safari and Firefox browsers, non-end scroll positions were not maintained when updating the content of an iframe dialog component with the `streamContent` property set to `true`. #TINY-10078
-- On the Safari browser, end scroll positions were not consistently maintained when updating the content of an iframe dialog component with the `streamContent` property set to `true`. #TINY-10109
+- On Safari and Firefox browsers, non-end scroll positions were not maintained when updating the content of a `streamContent: true` iframe dialog component. #TINY-10078
+- On the Safari browser, end scroll positions were not consistently maintained when updating the content of a `streamContent: true` iframe dialog component. #TINY-10109
+- Scrolling behavior was inconsistent when updating a `streamContent: true` iframe dialog component with content lacking an HTML document type declaration. #TINY-10110
 
 ## 6.6.0 - 2023-07-12
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - On Safari and Firefox browsers, non-end scroll positions were not maintained when updating the content of an iframe dialog component with the `streamContent` property set to `true`. #TINY-10078
+- On the Safari browser, end scroll positions were not consistently maintained when updating the content of an iframe dialog component with the `streamContent` property set to `true`. #TINY-10109
 
 ## 6.6.0 - 2023-07-12
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -26,6 +26,8 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
   const isElementScrollAtBottom = ({ scrollTop, scrollHeight, clientHeight }: HTMLElement) =>
     Math.ceil(scrollTop) + clientHeight >= scrollHeight;
 
+  const scrollToBottom = (win: Window, body: HTMLElement) => win.scrollTo(0, body.scrollHeight);
+
   const writeValue = (iframeElement: SugarElement<HTMLIFrameElement>, html: string, fallbackFn: () => void): void => {
     const iframe = iframeElement.dom;
     Optional.from(iframe.contentDocument).fold(
@@ -50,9 +52,9 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
             if (isSafari) {
               // TINY-10078: Safari needs a small delay after document.write() to ensure scroll does not reset to
               // near-top unexpectedly
-              setTimeout(() => win.scrollTo(0, body.scrollHeight), 4);
+              setTimeout(() => scrollToBottom(win, body), 4);
             } else {
-              win.scrollTo(0, body.scrollHeight);
+              scrollToBottom(win, body);
             }
           } else if (!isScrollAtBottom && (isSafari || isFirefox) && !Type.isUndefined(lastScrollTop)) {
             // TINY-10078: Safari and Firefox reset scroll to top on each document.write(), so we need to restore scroll manually

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -31,7 +31,7 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
     win.scrollTo(0, y === 'bottom' ? win.document.body.scrollHeight : y);
 
   const getScrollingElement = (doc: Document, html: string): Optional<HTMLElement> => {
-    // TINY-10078: The scrolling element can change between body and documentElement depending on whether there
+    // TINY-10110: The scrolling element can change between body and documentElement depending on whether there
     // is a doctype declaration. However, this behavior is inconsistent on Chrome and Safari so checking for
     // the scroll properties is the most reliable way to determine which element is the scrolling element, at
     // least for the purposes of determining whether scroll is at bottom.

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -26,8 +26,8 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
   const isElementScrollAtBottom = ({ scrollTop, scrollHeight, clientHeight }: HTMLElement) =>
     Math.ceil(scrollTop) + clientHeight >= scrollHeight;
 
-  const scrollToY = (win: Window, scrollY: number | 'bottom') => {
-    const scrollToYInternal = (body: HTMLElement) => win.scrollTo(0, scrollY === 'bottom' ? body.scrollHeight : scrollY);
+  const scrollToYAfterWrite = (win: Window, scrollY: number | 'bottom') => {
+    const scrollToY = (body: HTMLElement) => win.scrollTo(0, scrollY === 'bottom' ? body.scrollHeight : scrollY);
 
     if (isSafari) {
       // TINY-10078: On Safari, the body not immediately available after document.write(), meaning the iframe has not finished updating.
@@ -49,9 +49,9 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
         }
       });
 
-      waitForBody().then(scrollToYInternal);
+      waitForBody().then(scrollToY);
     } else {
-      scrollToYInternal(win.document.body);
+      scrollToY(win.document.body);
     }
   };
 
@@ -74,10 +74,10 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
         const win = iframe.contentWindow;
         if (Type.isNonNullable(win)) {
           if (isScrollAtBottom) {
-            scrollToY(win, 'bottom');
+            scrollToYAfterWrite(win, 'bottom');
           } else if (!isScrollAtBottom && (isSafari || isFirefox) && lastScrollTop !== 0) {
             // TINY-10078: Safari and Firefox reset scroll to top on each document.write(), so we need to restore scroll manually
-            scrollToY(win, lastScrollTop);
+            scrollToYAfterWrite(win, lastScrollTop);
           }
         }
       });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -32,7 +32,7 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
 
   const getScrollingElement = (doc: Document, html: string): Optional<HTMLElement> => {
     // TINY-10078: The scrolling element can change between body and documentElement depending on whether there
-    // is a doctype declaration. However, the doctype behavior is inconsistent on Chrome and Safari checking for
+    // is a doctype declaration. However, this behavior is inconsistent on Chrome and Safari so checking for
     // the scroll properties is the most reliable way to determine which element is the scrolling element, at
     // least for the purposes of determining whether scroll is at bottom.
     const body = doc.body;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -95,8 +95,6 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
       // Ideally we should fetch data from the iframe...innerHtml, this triggers Cors errors
       cachedValue.get(),
     setValue: (frameComponent: AlloyComponent, html: string) => {
-      // TINY-3769: We need to use srcdoc here, instead of src with a data URI, otherwise browsers won't retain the Origin.
-      // See https://bugs.chromium.org/p/chromium/issues/detail?id=58999#c11
       if (cachedValue.get() !== html) {
         const iframeElement = frameComponent.element as SugarElement<HTMLIFrameElement>;
         const setSrcdocValue = () => Attribute.set(iframeElement, 'srcdoc', html);
@@ -105,6 +103,8 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
           const args = [ iframeElement, html, setSrcdocValue ] as const;
           writeValueThrottler.fold(() => writeValue(...args), (throttler) => throttler.throttle(...args));
         } else {
+          // TINY-3769: We need to use srcdoc here, instead of src with a data URI, otherwise browsers won't retain the Origin.
+          // See https://bugs.chromium.org/p/chromium/issues/detail?id=58999#c11
           setSrcdocValue();
         }
       }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -61,10 +61,14 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
       fallbackFn,
       (doc) => {
         let lastScrollTop = 0;
-        // TINY-10032: If documentElement is null, we assume document is empty and so scroll is at bottom.
-        const isScrollAtBottom = Optional.from(doc.documentElement).map((docEl) => {
-          lastScrollTop = docEl.scrollTop;
-          return docEl;
+        // TINY-10032: If documentElement (or body) is nullable, we assume document is empty and so scroll is at bottom.
+        const isScrollAtBottom = Optional.from(
+          // TINY-10078: On Firefox, if the HTML does not begin with a document type declaration, the body holds the scroll position,
+          // not the documentElement.
+          isFirefox && !html.startsWith('<!DOCTYPE') ? doc.body : doc.documentElement
+        ).map((el) => {
+          lastScrollTop = el.scrollTop;
+          return el;
         }).forall(isElementScrollAtBottom);
 
         doc.open();

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -63,9 +63,9 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
         let lastScrollTop = 0;
         // TINY-10032: If documentElement (or body) is nullable, we assume document is empty and so scroll is at bottom.
         const isScrollAtBottom = Optional.from(
-          // TINY-10078: On Firefox, if the HTML does not begin with a document type declaration, the body holds the scroll position,
+          // TINY-10078: On Firefox, if the HTML does not begin with an HTML document type declaration, the body holds the scroll position,
           // not the documentElement.
-          isFirefox && !html.startsWith('<!DOCTYPE') ? doc.body : doc.documentElement
+          isFirefox && !/^<!DOCTYPE (html|HTML)/.test(html) ? doc.body : doc.documentElement
         ).map((el) => {
           lastScrollTop = el.scrollTop;
           return el;


### PR DESCRIPTION
Related Ticket: TINY-10078, TINY-10097, TINY-10109, TINY-10110

Description of Changes:

TINY-10078
* Manually maintain non-end scroll positions on Firefox and Safari

TINY-10097
* Throttle iframe content updates to 500ms intervals on Safari to reduce visual impact of flickering (document.write() flickers on Safari but not Chrome or Firefox)

TINY-10109
* Fix Safari not consistently scrolling to the bottom by waiting for iframe load

TINY-10110
* Dynamically determine the scrolling element of an iframe based on content doctype declaration and other factors

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
