### PR TITLE
TINY-10008: move enable `contentEditable` after editor initialization

### DIFF
--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -392,14 +392,6 @@ const contentBodyLoaded = (editor: Editor): void => {
   editor.readonly = Options.isReadOnly(editor);
   editor._editableRoot = Options.hasEditableRoot(editor);
 
-  if (!editor.readonly && editor.hasEditableRoot()) {
-    if (editor.inline && DOM.getStyle(body, 'position', true) === 'static') {
-      body.style.position = 'relative';
-    }
-
-    body.contentEditable = 'true';
-  }
-
   (body as any).disabled = false;
 
   editor.editorUpload = EditorUpload(editor);
@@ -466,6 +458,14 @@ const contentBodyLoaded = (editor: Editor): void => {
       });
     });
   });
+
+  if (!editor.readonly && editor.hasEditableRoot()) {
+    if (editor.inline && DOM.getStyle(body, 'position', true) === 'static') {
+      body.style.position = 'relative';
+    }
+
+    body.contentEditable = 'true';
+  }
 };
 
 export {


### PR DESCRIPTION
Related Ticket: TINY-10008

Description of Changes:
I moved the `body.contentEditable = 'true';` after this [load](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/core/main/ts/init/InitContentBody.ts#L457-L466) that [load the initial content](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/core/main/ts/init/InitContentBody.ts#L370) so slow connections doesn't have the problem that they could start typing and then get the text overwrite by the default content

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
