### PR TITLE
TINY-10078: Throttle Firefox update interval to 200ms to improve freescrolling

### DIFF
--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
@@ -54,6 +54,8 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
 
   const browser = PlatformDetection.detect().browser;
   const isSafari = browser.isSafari();
+  const isFirefox = browser.isFirefox();
+  const isSafariOrFirefox = isSafari || isFirefox;
 
   const getFrameFromFrameNumber = (frameNumber: number) => {
     const frame = hook.component().components()[frameNumber];
@@ -318,10 +320,15 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
           }
         }, interval);
 
-        await Waiter.pTryUntil('Wait for iframe to finish loading', () => {
-          // TINY-10097: Artificial 500ms throttle on Safari to reduce flickering.
-          const expectedLoads = (isSafari ? interval * maxIterations / 500 : maxIterations) + 1;
-          assert.strictEqual(loadCount, expectedLoads, `iframe should have exactly ${expectedLoads} loads`);
+        await Waiter.pTryUntil('Wait for update intervals to finish', () => {
+          // TINY-10078: Artificial 200ms throttle on Firefox to improve scrolling.
+          // TINY-10097: Artificial 500ms throttle on Safari to reduce flickering and improve scrolling.
+          const expectedLoads = (isSafariOrFirefox ? interval * maxIterations / (isSafari ? 500 : 200) : maxIterations) + 1;
+          if (isFirefox) {
+            assert.approximately(loadCount, expectedLoads, 1, `iframe should have approximately ${expectedLoads} loads`);
+          } else {
+            assert.strictEqual(loadCount, expectedLoads, `iframe should have exactly ${expectedLoads} loads`);
+          }
           assert.equal(iframe.contentDocument?.body.innerHTML, content, 'iframe content should match');
           assertNullableScrollAtBottomOverflow((shouldContentHaveDoctype ? iframe.contentDocument?.documentElement : iframe.contentDocument?.body) as HTMLElement, 'iframe should be scrolled to bottom');
         });

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
@@ -282,8 +282,10 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
           assert.equal(iframe.contentDocument?.body.innerHTML, '', 'iframe should be empty initially');
         });
         await setContentAndWaitForLoad(frame, initialLongContent, shouldContentHaveDoctype);
-        assertNullableScrollAtBottomOverflow((shouldContentHaveDoctype ? iframe.contentDocument?.documentElement : iframe.contentDocument?.body) as HTMLElement,
-          'iframe should be scrolled to bottom after setting value');
+        await Waiter.pTryUntil('Waiting for iframe to be scrolled to bottom', () => {
+          assertNullableScrollAtBottomOverflow((shouldContentHaveDoctype ? iframe.contentDocument?.documentElement : iframe.contentDocument?.body) as HTMLElement,
+            'iframe should be scrolled to bottom after setting value');
+        });
       });
     });
 


### PR DESCRIPTION
Related Ticket: TINY-10078

Description of Changes:
* Follow-up to https://github.com/tinymce/tinymce/pull/8926
* Since we manually maintain non-end scroll positions on Firefox and Safari on each update, having rapid updates would cause freescrolling to feel stuck. Safari is already throttled to 500ms as part of TINY-10097, so here we throttle Firefox to 200ms to improve freescrolling.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
