### PR TITLE
TINY-10078 & TINY-10097: Replace Throttler.first with Throttler.adaptable to ensure content completeness

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -18,7 +18,8 @@ type IframeSpec = Omit<Dialog.Iframe, 'type'>;
 
 const browser = PlatformDetection.detect().browser;
 const isSafari = browser.isSafari();
-const isSafariOrFirefox = isSafari || browser.isFirefox();
+const isFirefox = browser.isFirefox();
+const isSafariOrFirefox = isSafari || isFirefox;
 const isChromium = browser.isChromium();
 
 const isElementScrollAtBottom = ({ scrollTop, scrollHeight, clientHeight }: HTMLElement) =>
@@ -83,7 +84,10 @@ const writeValue = (iframeElement: SugarElement<HTMLIFrameElement>, html: string
 // TINY-10097: On Safari, throttle to 500ms reduce flickering as the document.write() method still observes significant flickering.
 // Also improves scrolling, as scroll positions are maintained manually similar to Firefox.
 const throttleInterval = isSafariOrFirefox ? Optional.some(isSafari ? 500 : 200) : Optional.none();
-const writeValueThrottler = throttleInterval.map((interval) => Throttler.first(writeValue, interval));
+
+// TINY-10078: Use Throttler.adaptable to ensure that any content added during the waiting period is not lost.
+// On Firefox, using Throttler.adaptable results in some scrolling issues, but Throttler.first is unexpectedly sufficient to ensure content completeness.
+const writeValueThrottler = throttleInterval.map((interval) => isFirefox ? Throttler.first(writeValue, interval) : Throttler.adaptable(writeValue, interval));
 
 const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFrameSourcing => {
   const cachedValue = Cell(initialData.getOr(''));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -86,8 +86,7 @@ const writeValue = (iframeElement: SugarElement<HTMLIFrameElement>, html: string
 const throttleInterval = isSafariOrFirefox ? Optional.some(isSafari ? 500 : 200) : Optional.none();
 
 // TINY-10078: Use Throttler.adaptable to ensure that any content added during the waiting period is not lost.
-// On Firefox, using Throttler.adaptable results in some scrolling issues, but Throttler.first is unexpectedly sufficient to ensure content completeness.
-const writeValueThrottler = throttleInterval.map((interval) => isFirefox ? Throttler.first(writeValue, interval) : Throttler.adaptable(writeValue, interval));
+const writeValueThrottler = throttleInterval.map((interval) => Throttler.adaptable(writeValue, interval));
 
 const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFrameSourcing => {
   const cachedValue = Cell(initialData.getOr(''));

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
@@ -262,17 +262,17 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
       it(`TINY-10032: Should keep scroll at top when streamContent: true, iframe is at top, and ${doctypeLabel}`,
         testStreamScroll(ScrollPosition.Top, shouldContentHaveDoctype));
 
-      it(`TINY-10078: Should keep scroll at middle when streamContent: true, iframe is at middle, and ${doctypeLabel}`,
+      it(`TINY-10032: Should keep scroll at middle when streamContent: true, iframe is at middle, and ${doctypeLabel}`,
         testStreamScroll(ScrollPosition.Middle, shouldContentHaveDoctype));
 
       it(`TINY-10032: Should scroll to bottom when streamContent: true, iframe is already scrolled to bottom, and ${doctypeLabel}}`,
         testStreamScroll(ScrollPosition.Bottom, shouldContentHaveDoctype));
 
-      it(`TINY-10078: Check that scroll is kept at bottom when changing content iteratively and ${doctypeLabel}`,
+      it(`TINY-10109: Check that scroll is kept at bottom when changing content iteratively and ${doctypeLabel}`,
         testIterativeContentChange(streamFrameNumber, shouldContentHaveDoctype, (iframe, it) =>
           assertIframeScrollAtBottom(iframe, shouldContentHaveDoctype, `iframe should be scrolled to bottom on iteration ${it}`)));
 
-      it(`TINY-10078: Should scroll to bottom when adding overflowing content in an empty iframe and ${doctypeLabel}`, async () => {
+      it(`TINY-10032: Should scroll to bottom when adding overflowing content in an empty iframe and ${doctypeLabel}`, async () => {
         const frame = getFrameFromFrameNumber(streamFrameNumber);
         const iframe = frame.element.dom as HTMLIFrameElement;
         await Waiter.pTryUntil('Waiting for iframe content to be set to empty initially', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
@@ -137,8 +137,7 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
 
   const getDoctypeLabel = (hasDoctype: boolean) => hasDoctype ? 'content has doctype' : 'content does not have doctype';
 
-  const maxIterations = 10;
-  const testIterativeContentChange = (frameNumber: number, assertFn: (iframe: HTMLIFrameElement, it: number) => void, shouldContentHaveDoctype: boolean) => async () => {
+  const testIterativeContentChange = (frameNumber: number, shouldContentHaveDoctype: boolean, assertFn: (iframe: HTMLIFrameElement, it: number) => void, maxIterations: number = 10) => async () => {
     const frame = getFrameFromFrameNumber(frameNumber);
 
     for (let i = 0, content = ''; i < maxIterations; ++i) {
@@ -269,10 +268,9 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
         testStreamScroll(ScrollPosition.Bottom, shouldContentHaveDoctype));
 
       it(`TINY-10078: Check that scroll is kept at bottom when changing content iteratively and ${doctypeLabel}`,
-        testIterativeContentChange(streamFrameNumber, (iframe, it) =>
+        testIterativeContentChange(streamFrameNumber, shouldContentHaveDoctype, (iframe, it) =>
           assertNullableScrollAtBottom((shouldContentHaveDoctype ? iframe.contentDocument?.documentElement : iframe.contentDocument?.body) as HTMLElement,
-            `iframe should be scrolled to bottom on iteration ${it}`),
-        shouldContentHaveDoctype));
+            `iframe should be scrolled to bottom on iteration ${it}`)));
 
       it(`TINY-10078: Should scroll to bottom when adding overflowing content in an empty iframe and ${doctypeLabel}`, async () => {
         const frame = getFrameFromFrameNumber(streamFrameNumber);
@@ -329,7 +327,7 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
         await Waiter.pTryUntil('Wait for update intervals to finish', () => {
           // TINY-10078: Artificial 200ms throttle on Firefox to improve scrolling.
           // TINY-10097: Artificial 500ms throttle on Safari to reduce flickering and improve scrolling.
-          const expectedLoads = (isSafariOrFirefox ? interval * maxIterations / (isSafari ? 500 : 200) : maxNumIntervals) + 1;
+          const expectedLoads = (isSafariOrFirefox ? interval * maxNumIntervals / (isSafari ? 500 : 200) : maxNumIntervals) + 1;
           if (isFirefox) {
             assert.approximately(loadCount, expectedLoads, 1, `iframe should have approximately ${expectedLoads} loads`);
           } else {


### PR DESCRIPTION
Related Ticket: TINY-10078, TINY-10097

Description of Changes:
* Using `Throttler.first` is flawed as any content updates made during the waiting period is ignored, resulting in content incompleteness towards the end of the stream. This is replaced with `Throttler.adaptable` to resolve the issue.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
