### PR TITLE
TINY-10098: Fix color_cols not respected

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improved
 - When defining a modal or inline dialog, if the buttons property is an empty array, or is not defined at all, the footer will now no longer be rendered. #TINY-9996
 - The `iframe` dialog component now has a minimum height of 200px. #TINY-10059
+- Improved detection of scrollable containers when the `ui_mode: 'split'` option is set. #TINY-9385
 
 ### Changed
 - The icon in an `alertbanner` dialog component is no longer clickable if the _URL_ field is not specified. #TINY-10013
@@ -76,7 +77,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dialog `tabpanel` tab labels are now allowed to word wrap for better readability with long labels. #TINY-9947
 - Added newlines before and after `details` elements in the output HTML. #TINY-9959
 - Added padding for empty `summary` elements so that they can be properly edited. #TINY-9959
-- Improved detection of scrollable containers when the `ui_mode: 'split'` option is set. #TINY-9385
 
 ### Changed
 - The `caption`, `address` and `dt` elements no longer incorrectly allow non-inline child elements when the editor schema is set to _HTML 4_. #TINY-9768

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - On Safari and Firefox browsers, scroll positions were not always maintained when updating the content of a `streamContent: true` iframe dialog component. #TINY-10078 #TINY-10109
 - Scrolling behavior was inconsistent when updating a `streamContent: true` iframe dialog component with content lacking an HTML document type declaration. #TINY-10110
+- The `color_cols` option was not respected when a custom `color_map` is defined. #TINY-10098
+- The `color_cols` options were were not rounded to the nearest number when set to a decimal number. #TINY-9737
 
 ## 6.6.0 - 2023-07-12
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
@@ -16,7 +16,7 @@ const calcCols = (colors: number): number =>
 const calcColsOption = (editor: Editor, numColors: number): number => {
   const calculatedCols = calcCols(numColors);
   const fallbackCols = option('color_cols')(editor);
-  return defaultCols === calculatedCols ? fallbackCols : calculatedCols;
+  return defaultCols === calculatedCols || fallbackCols !== defaultCols ? fallbackCols : calculatedCols;
 };
 
 const mapColors = (colorMap: string[]): Menu.ChoiceMenuItemSpec[] => {
@@ -135,7 +135,7 @@ const colorColsOption = (editor: Editor, id: string): number => {
 };
 
 const getColorCols = (editor: Editor, id: string): number => {
-  const colorCols = colorColsOption(editor, id);
+  const colorCols = Math.round(colorColsOption(editor, id));
   return colorCols > 0 ? colorCols : defaultCols;
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
@@ -8,15 +8,15 @@ import { Menu } from 'tinymce/core/api/ui/Ui';
 const foregroundId = 'forecolor';
 const backgroundId = 'hilitecolor';
 
-const defaultCols = 5;
+const DEFAULT_COLS = 5;
 
 const calcCols = (colors: number): number =>
-  Math.max(defaultCols, Math.ceil(Math.sqrt(colors)));
+  Math.max(DEFAULT_COLS, Math.ceil(Math.sqrt(colors)));
 
 const calcColsOption = (editor: Editor, numColors: number): number => {
   const calculatedCols = calcCols(numColors);
   const fallbackCols = option('color_cols')(editor);
-  return defaultCols === calculatedCols || fallbackCols !== defaultCols ? fallbackCols : calculatedCols;
+  return fallbackCols !== DEFAULT_COLS ? fallbackCols : calculatedCols;
 };
 
 const mapColors = (colorMap: string[]): Menu.ChoiceMenuItemSpec[] => {
@@ -136,7 +136,7 @@ const colorColsOption = (editor: Editor, id: string): number => {
 
 const getColorCols = (editor: Editor, id: string): number => {
   const colorCols = Math.round(colorColsOption(editor, id));
-  return colorCols > 0 ? colorCols : defaultCols;
+  return colorCols > 0 ? colorCols : DEFAULT_COLS;
 };
 
 const hasCustomColors = option('custom_colors');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
@@ -292,7 +292,28 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
     });
   });
 
-  context('Custom Color Map Columns Test', () => {
+  context('Decimal color_cols', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      toolbar: 'forecolor backcolor fontsize',
+      color_cols_foreground: 8.6,
+      color_cols_background: 4.3
+    }, [], true);
+
+    it('TINY-9737: ', async () => {
+      const editor = hook.editor();
+      setupContent(editor);
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      // Background Color swatch should have Math.sqrt(36) = 6 columns
+      Assert.eq('Cols is the expected value', getColorCols(editor, 'forecolor'), 9);
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Background color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      // Background Color swatch should have Math.sqrt(49) = 7 columns
+      Assert.eq('Cols is the expected value', getColorCols(editor, 'hilitecolor'), 4);
+    });
+  });
+
+  context('Custom Color Map Default Columns Test', () => {
     const colorMap = [
       '#2DC26B', 'Green',
       '#F1C40F', 'Yellow',
@@ -326,6 +347,37 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
       await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
       // Background Color swatch should have Math.sqrt(49) = 7 columns
       Assert.eq('Cols is the expected value', getColorCols(editor, 'hilitecolor'), 7);
+    });
+  });
+
+  context('Custom Color Map Columns Test', () => {
+    const colorMap = [
+      '#2DC26B', 'Green',
+      '#F1C40F', 'Yellow',
+      '#E03E2D', 'Red',
+      '#B96AD9', 'Purple',
+      '#3598DB', 'Blue',
+      '#E67E23', 'Orange'
+    ];
+    const thirtySixColors = Arr.flatten([ colorMap, colorMap, colorMap, colorMap, colorMap, colorMap ]);
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      toolbar: 'forecolor backcolor fontsize',
+      base_url: '/project/tinymce/js/tinymce',
+      color_cols: 8,
+      color_map: thirtySixColors,
+    }, [], true);
+
+    it('TINY-10098: color_cols works as expected with custom color_map', async () => {
+      const editor = hook.editor();
+      setupContent(editor);
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      // Background Color swatch should have Math.sqrt(36) = 6 columns
+      Assert.eq('Cols is the expected value', getColorCols(editor, 'forecolor'), 8);
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Background color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      // Background Color swatch should have Math.sqrt(49) = 7 columns
+      Assert.eq('Cols is the expected value', getColorCols(editor, 'hilitecolor'), 8);
     });
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
@@ -299,7 +299,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
       color_cols_background: 4.3
     }, [], true);
 
-    it('TINY-9737: ', async () => {
+    it('TINY-9737: Color_cols is rounded to nearest number', async () => {
       const editor = hook.editor();
       setupContent(editor);
       TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
@@ -313,6 +313,40 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
     });
   });
 
+  context('Custom Color Map With Fewer Than Default Custom Color Cols Test', () => {
+    const colorMap = [
+      '#2DC26B', 'Green',
+      '#F1C40F', 'Yellow',
+      '#E03E2D', 'Red',
+      '#B96AD9', 'Purple',
+      '#3598DB', 'Blue',
+      '#E67E23', 'Orange'
+    ];
+    const thirtySixColors = Arr.flatten([ colorMap, colorMap, colorMap, colorMap, colorMap, colorMap ]);
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      toolbar: 'forecolor backcolor fontsize',
+      base_url: '/project/tinymce/js/tinymce',
+      color_cols: 3,
+      color_map: thirtySixColors
+    }, [], true);
+
+    it('TINY-10098: color_map_foreground works as expected', async () => {
+      const editor = hook.editor();
+      setupContent(editor);
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Text color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      Assert.eq('Cols is the expected value', getColorCols(editor, 'forecolor'), 3);
+    });
+
+    it('TINY-10098: color_map_background works as expected', async () => {
+      const editor = hook.editor();
+      setupContent(editor);
+      TinyUiActions.clickOnToolbar(editor, '[aria-label="Background color"] > .tox-tbtn + .tox-split-button__chevron');
+      await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+      Assert.eq('Cols is the expected value', getColorCols(editor, 'hilitecolor'), 3);
+    });
+  });
+
   context('Custom Color Map Default Columns Test', () => {
     const colorMap = [
       '#2DC26B', 'Green',


### PR DESCRIPTION
Related Ticket: TINY-10098, TINY-9737

Description of Changes:
* Fixed color_cols not being respected when color_map is defined
* Rounded any color_cols option to nearest integer.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
