### PR TITLE
TINY-10101: Fix Safari/Firefox not showing border when focus on iframe

### DIFF
--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -475,15 +475,27 @@
     &.tox-dialog__iframe--opaque {
       background: @edit-area-iframe-background-color;
     }
+  }
 
-    &.tox-dialog__iframe--bordered {
+  .tox-navobj-bordered {
+    position: relative;
+
+    &::before {
       border: @dialog-iframe-bordered-border-width solid @dialog-iframe-bordered-border-color;
       border-radius: @dialog-iframe-bordered-border-radius;
-
-      &:focus-within {
-        &:extend(.tox .tox-textfield:focus);
-      }
+      content: '';
+      inset: 0;
+      opacity: 1;
+      pointer-events: none;
+      position: absolute;
+      z-index: 1;
     }
+  }
+
+  .tox-navobj-bordered-focus.tox-navobj-bordered::before {
+    border-color: @textfield-focus-border-color;
+    box-shadow: @textfield-focus-box-shadow;
+    outline: @textfield-focus-outline;
   }
 
   // Make popups in a dialog appear over other dialog (urlinput, colorinput etc)

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - On Safari and Firefox browsers, scroll positions were not always maintained when updating the content of a `streamContent: true` iframe dialog component. #TINY-10078 #TINY-10109
 - Scrolling behavior was inconsistent when updating a `streamContent: true` iframe dialog component with content lacking an HTML document type declaration. #TINY-10110
+- On Safari and Firefox browsers, the border around the `iframe` dialog component was not visible. #TINY-10101
 
 ## 6.6.0 - 2023-07-12
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - On Safari and Firefox browsers, scroll positions were not always maintained when updating the content of a `streamContent: true` iframe dialog component. #TINY-10078 #TINY-10109
 - Scrolling behavior was inconsistent when updating a `streamContent: true` iframe dialog component with content lacking an HTML document type declaration. #TINY-10110
-- On Safari and Firefox browsers, the border around the `iframe` dialog component was not visible. #TINY-10101
+- On Safari and Firefox browsers, the border around the `iframe` dialog component was not highlighted when focused. #TINY-10101
 
 ## 6.6.0 - 2023-07-12
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/alien/RepresentingConfigs.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/alien/RepresentingConfigs.ts
@@ -65,7 +65,7 @@ const memory = (initialValue: any): RepresentingBehaviour => Representing.config
   }
 });
 
-export const RepresentingConfigs = {
+export {
   memento,
   withElement,
   withComp,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/BodyPanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/BodyPanel.ts
@@ -4,7 +4,7 @@ import { Arr, Fun, Optional } from '@ephox/katamari';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
-import { RepresentingConfigs } from '../alien/RepresentingConfigs';
+import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import * as FormValues from '../general/FormValues';
 import * as NavigableObject from '../general/NavigableObject';
 import { interpretInForm } from '../general/UiFactory';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/BodyPanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/BodyPanel.ts
@@ -58,7 +58,7 @@ const renderBodyPanel = (spec: BodyPanelSpec, dialogData: Dialog.DialogData, bac
         )
       }),
       AddEventsBehaviour.config('dialog-body-panel', [
-        // TINY-10101: This is to cater the case where clicks are made into the dialog instead using keyboard navigaton, as FocusShifted would not be triggered in that case.
+        // TINY-10101: This is to cater for the case where clicks are made into the dialog instead using keyboard navigation, as FocusShifted would not be triggered in that case.
         AlloyEvents.run(NativeEvents.focusin(), (comp, se) => {
           comp.getSystem().broadcastOn([ dialogFocusShiftedChannel ], {
             newFocus: Optional.some(se.event.target)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
@@ -5,7 +5,7 @@ import { Arr, Optional, Strings } from '@ephox/katamari';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
-import { RepresentingConfigs } from '../alien/RepresentingConfigs';
+import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import { formActionEvent } from '../general/FormEvents';
 
 const english: Record<string, string> = {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
@@ -5,7 +5,7 @@ import { Obj, Optional, Singleton } from '@ephox/katamari';
 import Resource from 'tinymce/core/api/Resource';
 
 import { ComposingConfigs } from '../alien/ComposingConfigs';
-import { RepresentingConfigs } from '../alien/RepresentingConfigs';
+import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 
 type CustomEditorSpec = Dialog.CustomEditor;
 type CustomEditorInitFn = Dialog.CustomEditorInitFn;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dialogs.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dialogs.ts
@@ -7,10 +7,10 @@ import { Class, SugarBody } from '@ephox/sugar';
 
 import Env from 'tinymce/core/api/Env';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import * as Backstage from '../../backstage/Backstage';
 import * as HtmlSanitizer from '../core/HtmlSanitizer';
 import * as NavigableObject from '../general/NavigableObject';
-import { dialogFocusShiftedChannel } from '../window/DialogChannels';
+import * as DialogChannels from '../window/DialogChannels';
 
 const isTouch = Env.deviceType.isTouch();
 
@@ -37,7 +37,7 @@ const defaultHeader = (title: AlloyParts.ConfiguredPart, close: AlloyParts.Confi
   ]
 });
 
-const pClose = (onClose: () => void, providersBackstage: UiFactoryBackstageProviders): AlloyParts.ConfiguredPart => ModalDialog.parts.close(
+const pClose = (onClose: () => void, providersBackstage: Backstage.UiFactoryBackstageProviders): AlloyParts.ConfiguredPart => ModalDialog.parts.close(
   // Need to find a way to make it clear in the docs whether parts can be sketches
   Button.sketch({
     dom: {
@@ -66,7 +66,7 @@ const pUntitled = (): AlloyParts.ConfiguredPart => ModalDialog.parts.title({
   }
 });
 
-const pBodyMessage = (message: string, providersBackstage: UiFactoryBackstageProviders): AlloyParts.ConfiguredPart => ModalDialog.parts.body({
+const pBodyMessage = (message: string, providersBackstage: Backstage.UiFactoryBackstageProviders): AlloyParts.ConfiguredPart => ModalDialog.parts.body({
   dom: {
     tag: 'div',
     classes: [ 'tox-dialog__body' ]
@@ -178,7 +178,7 @@ const renderDialog = (spec: DialogSpec): SketchSpec => {
             Blocking.isBlocked(comp) ? Fun.noop() : Keying.focusIn(comp);
           }),
           AlloyEvents.run<SystemEvents.AlloyFocusShiftedEvent>(SystemEvents.focusShifted(), (comp, se) => {
-            comp.getSystem().broadcastOn([ dialogFocusShiftedChannel ], {
+            comp.getSystem().broadcastOn([ DialogChannels.dialogFocusShiftedChannel ], {
               newFocus: se.event.newFocus
             });
           })

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dialogs.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dialogs.ts
@@ -10,6 +10,7 @@ import Env from 'tinymce/core/api/Env';
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as HtmlSanitizer from '../core/HtmlSanitizer';
 import * as NavigableObject from '../general/NavigableObject';
+import { dialogFocusShiftedChannel } from '../window/DialogChannels';
 
 const isTouch = Env.deviceType.isTouch();
 
@@ -175,6 +176,11 @@ const renderDialog = (spec: DialogSpec): SketchSpec => {
           // Using just `run` instead will cause an infinite loop as `focusIn` would fire a `focusin` which would then get responded to and so forth.
           AlloyEvents.runOnSource(NativeEvents.focusin(), (comp, _se) => {
             Blocking.isBlocked(comp) ? Fun.noop() : Keying.focusIn(comp);
+          }),
+          AlloyEvents.run<SystemEvents.AlloyFocusShiftedEvent>(SystemEvents.focusShifted(), (comp, se) => {
+            comp.getSystem().broadcastOn([ dialogFocusShiftedChannel ], {
+              newFocus: se.event.newFocus
+            });
           })
         ])),
         AddEventsBehaviour.config('scroll-lock', [

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
@@ -14,7 +14,7 @@ import * as ReadOnly from '../../ReadOnly';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 import { DisablingConfigs } from '../alien/DisablingConfigs';
 import { renderFormFieldWith, renderLabel } from '../alien/FieldLabeller';
-import { RepresentingConfigs } from '../alien/RepresentingConfigs';
+import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import { formChangeEvent } from '../general/FormEvents';
 
 const filterByExtension = (files: FileList, providersBackstage: UiFactoryBackstageProviders) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -4,11 +4,11 @@ import { Cell, Fun, Optional, Throttler, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Attribute, Class, Compare, SugarElement, Traverse } from '@ephox/sugar';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
-import { renderFormFieldWith, renderLabel } from '../alien/FieldLabeller';
-import { RepresentingConfigs } from '../alien/RepresentingConfigs';
+import * as Backstage from '../../backstage/Backstage';
+import * as FieldLabeller from '../alien/FieldLabeller';
+import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import * as NavigableObject from '../general/NavigableObject';
-import { dialogFocusShiftedChannel } from '../window/DialogChannels';
+import * as DialogChannels from '../window/DialogChannels';
 
 interface IFrameSourcing {
   readonly getValue: (frame: AlloyComponent) => string;
@@ -114,7 +114,7 @@ const getDynamicSource = (initialData: Optional<string>, stream: boolean): IFram
   };
 };
 
-const renderIFrame = (spec: IframeSpec, providersBackstage: UiFactoryBackstageProviders, initialData: Optional<string>): SketchSpec => {
+const renderIFrame = (spec: IframeSpec, providersBackstage: Backstage.UiFactoryBackstageProviders, initialData: Optional<string>): SketchSpec => {
   const baseClass = 'tox-dialog__iframe';
   const opaqueClass = spec.transparent ? [] : [ `${baseClass}--opaque` ];
   const containerBorderedClass = spec.border ? [ `tox-navobj-bordered` ] : [];
@@ -127,7 +127,7 @@ const renderIFrame = (spec: IframeSpec, providersBackstage: UiFactoryBackstagePr
 
   const sourcing = getDynamicSource(initialData, spec.streamContent);
 
-  const pLabel = spec.label.map((label) => renderLabel(label, providersBackstage));
+  const pLabel = spec.label.map((label) => FieldLabeller.renderLabel(label, providersBackstage));
 
   const factory = (newSpec: { uid: string }) => NavigableObject.craft(
     Optional.from(containerBorderedClass),
@@ -148,7 +148,7 @@ const renderIFrame = (spec: IframeSpec, providersBackstage: UiFactoryBackstagePr
         RepresentingConfigs.withComp(initialData, sourcing.getValue, sourcing.setValue),
         Receiving.config({
           channels: {
-            [dialogFocusShiftedChannel]: {
+            [DialogChannels.dialogFocusShiftedChannel]: {
               onReceive: (comp, message: DialogFocusShiftedEvent) => {
                 message.newFocus.each((newFocus) => {
                   Traverse.parentElement(comp.element).each((parent) => {
@@ -169,7 +169,7 @@ const renderIFrame = (spec: IframeSpec, providersBackstage: UiFactoryBackstagePr
     factory: { sketch: factory }
   });
 
-  return renderFormFieldWith(pLabel, pField, [ 'tox-form__group--stretched' ], [ ]);
+  return FieldLabeller.renderFormFieldWith(pLabel, pField, [ 'tox-form__group--stretched' ], [ ]);
 };
 
 export {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ImagePreview.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ImagePreview.ts
@@ -4,7 +4,7 @@ import { Cell, Optional, Type } from '@ephox/katamari';
 import { Attribute, Class, Css, Height, Ready, SugarElement, Width } from '@ephox/sugar';
 
 import { ComposingConfigs } from '../alien/ComposingConfigs';
-import { RepresentingConfigs } from '../alien/RepresentingConfigs';
+import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 
 type ImagePreviewSpec = Omit<Dialog.ImagePreview, 'type'>;
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Label.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Label.ts
@@ -4,7 +4,7 @@ import { Arr, Optional } from '@ephox/katamari';
 
 import { UiFactoryBackstageShared } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
-import { RepresentingConfigs } from '../alien/RepresentingConfigs';
+import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 
 type LabelSpec = Omit<Dialog.Label, 'type'>;
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ListBox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ListBox.ts
@@ -8,7 +8,7 @@ import { Attribute } from '@ephox/sugar';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
 import { renderLabel } from '../alien/FieldLabeller';
-import { RepresentingConfigs } from '../alien/RepresentingConfigs';
+import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import { renderCommonDropdown, updateMenuText } from '../dropdown/CommonDropdown';
 import { formChangeEvent } from '../general/FormEvents';
 import ItemResponse from '../menus/item/ItemResponse';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TabPanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TabPanel.ts
@@ -11,7 +11,7 @@ import { interpretInForm } from 'tinymce/themes/silver/ui/general/UiFactory';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
 import * as DialogTabHeight from '../alien/DialogTabHeight';
-import { RepresentingConfigs } from '../alien/RepresentingConfigs';
+import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import { formTabChangeEvent } from '../general/FormEvents';
 import * as NavigableObject from '../general/NavigableObject';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -14,7 +14,7 @@ import * as ReadOnly from '../../ReadOnly';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 import { DisablingConfigs } from '../alien/DisablingConfigs';
 import { renderFormField } from '../alien/FieldLabeller';
-import { RepresentingConfigs } from '../alien/RepresentingConfigs';
+import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import { renderIconFromPack, renderReplaceableIconFromPack } from '../button/ButtonSlices';
 import { getFetch, renderMenuButton, StoredMenuButton } from '../button/MenuButton';
 import { componentRenderPipeline } from '../menus/item/build/CommonMenuItem';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
@@ -9,7 +9,7 @@ import { Checked, Class, Traverse } from '@ephox/sugar';
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as ReadOnly from '../../ReadOnly';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
-import { RepresentingConfigs } from '../alien/RepresentingConfigs';
+import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import * as Icons from '../icons/Icons';
 import { formChangeEvent } from './FormEvents';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/NavigableObject.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/NavigableObject.ts
@@ -1,5 +1,5 @@
 import { AlloyComponent, AlloySpec, AlloyTriggers, Behaviour, Focusing, NativeEvents, SimpleSpec, Tabstopping } from '@ephox/alloy';
-import { Fun, Id } from '@ephox/katamari';
+import { Fun, Id, Optional } from '@ephox/katamari';
 import { Class, SelectorExists, SugarElement } from '@ephox/sugar';
 
 import { ComposingConfigs } from '../alien/ComposingConfigs';
@@ -28,11 +28,11 @@ const craftWithClasses = (classes: string[]): SimpleSpec => {
   };
 };
 
-const craft = (spec: AlloySpec): SimpleSpec => {
+const craft = (containerClasses: Optional<string[]>, spec: AlloySpec): SimpleSpec => {
   return {
     dom: {
       tag: 'div',
-      classes: [ 'tox-navobj' ]
+      classes: [ 'tox-navobj', ...containerClasses.getOr([]) ]
     },
     components: [
       craftWithClasses([ beforeObject ]),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/DialogChannels.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/DialogChannels.ts
@@ -5,11 +5,13 @@ const titleChannel = Id.generate('update-title');
 const bodyChannel = Id.generate('update-body');
 const footerChannel = Id.generate('update-footer');
 const bodySendMessageChannel = Id.generate('body-send-message');
+const dialogFocusShiftedChannel = Id.generate('dialog-focus-shifted');
 
 export {
   dialogChannel,
   titleChannel,
   bodyChannel,
   bodySendMessageChannel,
-  footerChannel
+  footerChannel,
+  dialogFocusShiftedChannel
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
@@ -6,7 +6,7 @@ import { Class, Classes, SugarElement } from '@ephox/sugar';
 import { UiFactoryBackstage } from '../../backstage/Backstage';
 import { renderModalBody } from './SilverDialogBody';
 import * as SilverDialogCommon from './SilverDialogCommon';
-import { SilverDialogEvents } from './SilverDialogEvents';
+import * as SilverDialogEvents from './SilverDialogEvents';
 import { renderModalFooter } from './SilverDialogFooter';
 import { DialogAccess, getDialogApi } from './SilverDialogInstanceApi';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogBody.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogBody.ts
@@ -86,18 +86,20 @@ const renderIframeBody = (spec: Dialog.UrlDialog): AlloyParts.ConfiguredPart => 
           classes: [ 'tox-dialog__body-iframe' ]
         },
         components: [
-          NavigableObject.craft({
-            dom: {
-              tag: 'iframe',
-              attributes: {
-                src: spec.url
-              }
-            },
-            behaviours: Behaviour.derive([
-              Tabstopping.config({ }),
-              Focusing.config({ })
-            ])
-          })
+          NavigableObject.craft(
+            Optional.none(),
+            {
+              dom: {
+                tag: 'iframe',
+                attributes: {
+                  src: spec.url
+                }
+              },
+              behaviours: Behaviour.derive([
+                Tabstopping.config({ }),
+                Focusing.config({ })
+              ])
+            })
         ]
       }
     ],

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
@@ -7,7 +7,7 @@ import { Arr, Cell, Obj, Optional } from '@ephox/katamari';
 import { Height, SelectorFind } from '@ephox/sugar';
 
 import { UiFactoryBackstage, UiFactoryBackstageProviders } from '../../backstage/Backstage';
-import { RepresentingConfigs } from '../alien/RepresentingConfigs';
+import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import { StoredMenuButton, StoredMenuItem } from '../button/MenuButton';
 import * as Dialogs from '../dialog/Dialogs';
 import { FormBlockEvent, formCancelEvent } from '../general/FormEvents';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogEvents.ts
@@ -130,7 +130,7 @@ const initDialog = <T extends Dialog.DialogData>(getInstanceApi: () => Dialog.Di
   ];
 };
 
-export const SilverDialogEvents = {
+export {
   initUrlDialog,
   initDialog
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -11,7 +11,7 @@ import { UiFactoryBackstage } from '../../backstage/Backstage';
 import { RepresentingConfigs } from '../alien/RepresentingConfigs';
 import { formCloseEvent } from '../general/FormEvents';
 import * as NavigableObject from '../general/NavigableObject';
-import { dialogChannel } from './DialogChannels';
+import { dialogChannel, dialogFocusShiftedChannel } from './DialogChannels';
 import { renderInlineBody } from './SilverDialogBody';
 import * as SilverDialogCommon from './SilverDialogCommon';
 import { SilverDialogEvents } from './SilverDialogEvents';
@@ -129,6 +129,11 @@ const renderInlineDialog = <T extends Dialog.DialogData>(dialogInit: DialogManag
           // Using just `run` instead will cause an infinite loop as `focusIn` would fire a `focusin` which would then get responded to and so forth.
           AlloyEvents.runOnSource(NativeEvents.focusin(), (comp, _se) => {
             Keying.focusIn(comp);
+          }),
+          AlloyEvents.run<SystemEvents.AlloyFocusShiftedEvent>(SystemEvents.focusShifted(), (comp, se) => {
+            comp.getSystem().broadcastOn([ dialogFocusShiftedChannel ], {
+              newFocus: se.event.newFocus
+            });
           })
         ])
       ),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverUrlDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverUrlDialog.ts
@@ -10,7 +10,7 @@ import { UiFactoryBackstage } from '../../backstage/Backstage';
 import { bodySendMessageChannel } from './DialogChannels';
 import { renderIframeBody } from './SilverDialogBody';
 import { DialogSpec, getEventExtras, getHeader, renderModalDialog, SharedWindowExtra } from './SilverDialogCommon';
-import { SilverDialogEvents } from './SilverDialogEvents';
+import * as SilverDialogEvents from './SilverDialogEvents';
 import { renderModalFooter } from './SilverDialogFooter';
 import { getUrlDialogApi } from './SilverUrlDialogInstanceApi';
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
@@ -82,8 +82,7 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
           s.element('iframe', {
             classes: [
               arr.has('tox-dialog__iframe'),
-              (transparent ? arr.not : arr.has)(`${baseClassPrefix}opaque`),
-              (border ? arr.has : arr.not)(`${baseClassPrefix}bordered`)
+              (transparent ? arr.not : arr.has)(`${baseClassPrefix}opaque`)
             ],
             attrs: {
               // Should be no source.

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
@@ -72,7 +72,7 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
 
       const baseClassPrefix = 'tox-dialog__iframe--';
       const iframeStructure = s.element('div', {
-        classes: [ arr.has('tox-navobj') ],
+        classes: [ arr.has('tox-navobj'), (border ? arr.has : arr.not)('tox-navobj-bordered') ],
         children: [
           s.element('div', {
             attrs: {

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
@@ -1,9 +1,11 @@
-import { FocusTools, RealKeys, RealMouse, UiFinder } from '@ephox/agar';
+import { FocusTools, RealKeys, RealMouse, UiFinder, Waiter } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { Focus, SugarDocument } from '@ephox/sugar';
+import { Focus, SelectorFind, SugarDocument } from '@ephox/sugar';
+import { assert } from 'chai';
+import { Dialog } from 'tinymce/core/api/ui/Ui';
 
 import { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
 import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
@@ -35,47 +37,51 @@ describe('webdriver.tinymce.themes.silver.dialogs.IFrameDialogTest', () => {
     );
   };
 
-  it('Keyboard navigate dialog with iframe component', async () => {
-    windowManager.open({
-      title: 'Custom Dialog',
-      body: {
-        type: 'panel',
-        items: [
-          {
-            name: 'input1',
-            type: 'input'
-          },
-          {
-            name: 'frame1',
-            type: 'iframe'
-          }
-        ]
-      },
-      buttons: [
+  const pWaitUntilIframeLoaded = () => UiFinder.pWaitForState<HTMLIFrameElement>(
+    'check iframe is loaded',
+    SugarDocument.getDocument(),
+    '.tox-dialog .tox-dialog__body iframe',
+    (iframe) => iframe.dom.contentDocument?.readyState === 'complete'
+  );
+
+  const dialogSpec: Dialog.DialogSpec<{}> = {
+    title: 'Custom Dialog',
+    body: {
+      type: 'panel',
+      items: [
         {
-          type: 'cancel',
-          text: 'Close'
+          name: 'input1',
+          type: 'input'
+        },
+        {
+          name: 'frame1',
+          type: 'iframe',
+          border: true
         }
-      ],
-      initialData: {
-        input1: 'Dog',
-        // NOTE: Tried some postMessage stuff to broadcast the scroll. Couldn't get it to work.
-        // We can't just read the scroll value due to permissions
-        frame1: '<!doctype html><html><head>' +
+      ]
+    },
+    buttons: [
+      {
+        type: 'cancel',
+        text: 'Close'
+      }
+    ],
+    initialData: {
+      input1: 'Dog',
+      // NOTE: Tried some postMessage stuff to broadcast the scroll. Couldn't get it to work.
+      // We can't just read the scroll value due to permissions
+      frame1: '<!doctype html><html><head>' +
           '</head>' +
           '<body><h1>Heading</h1>' +
           Arr.map([ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ], (n) => '<p>This is paragraph: ' + n + '</p>').join('\n') +
           '</body>'
-      }
-    }, {}, Fun.noop);
+    }
+  };
 
-    await UiFinder.pWaitForState<HTMLIFrameElement>(
-      'check iframe is loaded',
-      SugarDocument.getDocument(),
-      '.tox-dialog .tox-dialog__body iframe',
-      (iframe) => iframe.dom.contentDocument?.readyState === 'complete'
-    );
+  it('Keyboard navigate dialog with iframe component', async () => {
+    const dialogInstance = windowManager.open(dialogSpec, {}, Fun.noop);
 
+    await pWaitUntilIframeLoaded();
     const input = await FocusTools.pTryOnSelector('focus should be on the input initially', SugarDocument.getDocument(), 'input');
 
     if (isFirefox) {
@@ -109,7 +115,65 @@ describe('webdriver.tinymce.themes.silver.dialogs.IFrameDialogTest', () => {
 
     await FocusTools.pTryOnSelector('focus should be on the "before" tabstop', SugarDocument.getDocument(), 'div[class*="alloy-fake-before-tabstop"]');
     await pPressTab('div[class*="alloy-fake-before-tabstop"]', true);
+    windowManager.close(dialogInstance);
+  });
 
-    await FocusTools.pTryOnSelector('focus should move back to input (iframe >> input)', SugarDocument.getDocument(), 'input');
+  it('TINY-10101: Asserting border classes when iframe in dialog has focus', async () => {
+    const dialogInstance = windowManager.open(dialogSpec, {}, Fun.noop);
+
+    await pWaitUntilIframeLoaded();
+    const assertContainerBorderFocus = (hasFocus: boolean) => {
+      // console.log(UiFinder.notExists(SugarDocument.getDocument(), '.tox-dialog .tox-dialog__body .tox-navobj-bordered-focus'));
+      // console.log(SelectorFind.descendant(SugarDocument.getDocument(), '.tox-dialog .tox-dialog__body .tox-navobj-bordered').getOrDie().dom.classList);
+      return Waiter.pTryUntil('Waiting for container with border focus class',
+        () => assert.equal((SelectorFind.descendant)(SugarDocument.getDocument(), '.tox-dialog .tox-dialog__body .tox-navobj-bordered-focus').isSome(), hasFocus));
+    };
+
+    const input = await FocusTools.pTryOnSelector('focus should be on the input initially', SugarDocument.getDocument(), 'input');
+
+    if (isFirefox) {
+      // Firefox doesn't allow escaping the iframe when using shift+tab if it's body hasn't been interacted with? Focusing alone didn't work
+      // TODO: TINY-2308 - Investigate how to fix this, as it means tabbing can get stuck in the iframe on Firefox
+      await RealMouse.pClickOn('iframe => body');
+      await FocusTools.pTryOnSelector('focus should be on iframe', SugarDocument.getDocument(), 'iframe');
+      Focus.focus(input);
+    }
+
+    await pPressTab('input', false);
+    await FocusTools.pTryOnSelector('focus should be on iframe', SugarDocument.getDocument(), 'iframe');
+    await assertContainerBorderFocus(true);
+
+    await pPressTab('iframe => body', false);
+    await FocusTools.pTryOnSelector('focus should be on the "after" tabstop', SugarDocument.getDocument(), 'div[class*="alloy-fake-after-tabstop"]');
+    await assertContainerBorderFocus(false);
+
+    await pPressTab('div[class*="alloy-fake-after-tabstop"]', false);
+    await FocusTools.pTryOnSelector('focus should be on button (cancel)', SugarDocument.getDocument(), 'button:contains("Close")');
+    await assertContainerBorderFocus(false);
+    await pPressTab('button.tox-button--secondary', true);
+    await FocusTools.pTryOnSelector('focus should move back to iframe (button >> iframe)', SugarDocument.getDocument(), 'iframe');
+    await assertContainerBorderFocus(true);
+    await pPressTab('iframe => body', true);
+    // Firefox when shift+tabbing it will cause the iframe to be focused twice
+    // so we need to do an extra shift+tab
+    if (isFirefox) {
+      await FocusTools.pTryOnSelector('focus should be on the iframe', SugarDocument.getDocument(), 'iframe');
+      await assertContainerBorderFocus(true);
+      await pPressTab('iframe', true);
+    }
+    await FocusTools.pTryOnSelector('focus should be on the "before" tabstop', SugarDocument.getDocument(), 'div[class*="alloy-fake-before-tabstop"]');
+    await assertContainerBorderFocus(false);
+
+    await pPressTab('input', false);
+    await FocusTools.pTryOnSelector('focus should be on iframe', SugarDocument.getDocument(), 'iframe');
+
+    // Clicking on header should focus on the first focussable element in the dialog and should remove the border
+    await RealMouse.pClickOn('.tox-dialog__header');
+    await assertContainerBorderFocus(false);
+
+    await RealMouse.pClickOn('input');
+    await assertContainerBorderFocus(false);
+
+    windowManager.close(dialogInstance);
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
@@ -5,8 +5,8 @@ import { Arr, Fun } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Focus, SelectorFind, SugarDocument } from '@ephox/sugar';
 import { assert } from 'chai';
-import { Dialog } from 'tinymce/core/api/ui/Ui';
 
+import { Dialog } from 'tinymce/core/api/ui/Ui';
 import { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
 import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 


### PR DESCRIPTION
Related Ticket: TINY-10101

Description of Changes:
* Borders around the div instead of the iframe, there are some issues on Safari and Firefox the border still shows while the focus has shifted
* Created a channel within the dialog and broadcast the new focus element on `dialogFocusShiftedChannel`, `iframe` in dialog has `Receiving.config` to compare if the iframe has focus to remove the focussed class

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
