### PR TITLE
TINY-10071: improve help dialog keyboard navigation

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contents would not be removed from the drag start source if dragging and dropping internally into a transparent block element. #TINY-9960
 - In some cases pressing enter would scroll the entire page. #TINY-9828
 - The border styles of a table were incorrectly split into a longhand form after table dialog updates. #TINY-9843
+- Links in `help dialog` -> `plugins` and `version` were not navigable via keyboard. #TINY-10071
 
 ## 6.6.0 - 2023-07-12
 

--- a/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
@@ -25,17 +25,19 @@ const tab = (editor: Editor): Dialog.TabSpec & { name: string } => {
     );
 
     const premiumPluginList = Arr.map(sortedPremiumPlugins, (pluginName) => `<li>${pluginName}</li>`).join('');
-    return '<div data-mce-tabstop="1" tabindex="-1">' +
+    return '<div>' +
       '<p><b>' + I18n.translate('Premium plugins:') + '</b></p>' +
       '<ul>' +
       premiumPluginList +
-      '<li class="tox-help__more-link" "><a href="https://www.tiny.cloud/pricing/?utm_campaign=editor_referral&utm_medium=help_dialog&utm_source=tinymce" rel="noopener" target="_blank">' + I18n.translate('Learn more...') + '</a></li>' +
+      '<li class="tox-help__more-link" ">' +
+      '<a href="https://www.tiny.cloud/pricing/?utm_campaign=editor_referral&utm_medium=help_dialog&utm_source=tinymce" rel="noopener" target="_blank"' +
+      ' data-alloy-tabstop="true" tabindex="-1">' + I18n.translate('Learn more...') + '</a></li>' +
       '</ul>' +
       '</div>';
   };
 
   const makeLink = (p: { name: string; url: string }): string =>
-    `<a href="${p.url}" target="_blank" rel="noopener">${p.name}</a>`;
+    `<a data-alloy-tabstop="true" tabindex="-1" href="${p.url}" target="_blank" rel="noopener">${p.name}</a>`;
 
   const identifyUnknownPlugin = (editor: Editor, key: string): PluginData => {
     const getMetadata = editor.plugins[key].getMetadata;
@@ -90,7 +92,7 @@ const tab = (editor: Editor): Dialog.TabSpec & { name: string } => {
     if (editor == null) {
       return '';
     }
-    return '<div data-mce-tabstop="1" tabindex="-1">' +
+    return '<div>' +
       pluginLister(editor) +
       '</div>';
   };

--- a/modules/tinymce/src/plugins/help/main/ts/ui/VersionTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/VersionTab.ts
@@ -5,7 +5,7 @@ import I18n from 'tinymce/core/api/util/I18n';
 const tab = (): Dialog.TabSpec & { name: string } => {
   const getVersion = (major: string, minor: string) => major.indexOf('@') === 0 ? 'X.X.X' : major + '.' + minor;
   const version = getVersion(EditorManager.majorVersion, EditorManager.minorVersion);
-  const changeLogLink = '<a href="https://www.tiny.cloud/docs/tinymce/6/changelog/?utm_campaign=editor_referral&utm_medium=help_dialog&utm_source=tinymce" rel="noopener" target="_blank">TinyMCE ' + version + '</a>';
+  const changeLogLink = '<a data-alloy-tabstop="true" tabindex="-1" href="https://www.tiny.cloud/docs/tinymce/6/changelog/?utm_campaign=editor_referral&utm_medium=help_dialog&utm_source=tinymce" rel="noopener" target="_blank">TinyMCE ' + version + '</a>';
 
   const htmlPanel: Dialog.HtmlPanelSpec = {
     type: 'htmlpanel',

--- a/modules/tinymce/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
@@ -1,5 +1,6 @@
 import { FocusTools, Keys, Mouse } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
+import { Obj } from '@ephox/katamari';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
@@ -72,6 +73,13 @@ describe('browser.tinymce.plugins.help.DialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Installed Plugins', 'div[role="document"]');
     pressTabKey(editor);
+    const installedPlugins = Obj.mapToArray(editor.plugins, (v, k) => k);
+    for (const installedPlugin of installedPlugins) {
+      await pAssertFocusOnItem(`Installed Plugins link:${installedPlugin}`, `a[href*="${installedPlugin}"]`);
+      pressTabKey(editor);
+    }
+    await pAssertFocusOnItem('Premium Plugins link:Learn more...', `a[href*="/pricing"]`);
+    pressTabKey(editor);
     await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
     pressTabKey(editor);
     await pAssertFocusOnItem('"x" Close Button', '.tox-button[title="Close"]');
@@ -86,6 +94,8 @@ describe('browser.tinymce.plugins.help.DialogKeyboardNavTest', () => {
     await pAssertFocusOnItem('Version Tab', '.tox-dialog__body-nav-item:contains("Version")');
     pressTabKey(editor);
     await pAssertFocusOnItem('TinyMCE Version', 'div[role="document"]');
+    pressTabKey(editor);
+    await pAssertFocusOnItem('Installed Plugins', `a[href*="tinymce"]`);
     pressTabKey(editor);
     await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
     pressTabKey(editor);


### PR DESCRIPTION
Related Ticket: TINY-10071

Description of Changes:

- [x] make links in `help dialog`  -> `plugins` navigable
- [x] make link in `help dialog`  -> `version` navigable

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
