### PR TITLE
TINY-10022: insert new block commands

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New `help_accessibility` option which displays the keyboard shortcut to access the help functionality in the statusbar. #TINY-9379
-- Added a new `InsertNewBlockBefore` command, which inserts an empty block before the current one where the cursor is placed. #TINY-10022
-- Added a new `InsertNewBlockAfter` command, which inserts an empty block after the current one where selection is placed. #TINY-10022
+- Added a new `InsertNewBlockBefore` command, which inserts an empty block before the one containing the current selection. #TINY-10022
+- Added a new `InsertNewBlockAfter` command, which inserts an empty block after the one containing the current selection. #TINY-10022
 
 ### Improved
 - Adding a newline after a table would in some specific cases not work. #TINY-9863

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New `help_accessibility` option which displays the keyboard shortcut to access the help functionality in the statusbar. #TINY-9379
+- Added a new `InsertNewBlockBefore` command, which inserts an empty block before the current one where the cursor is placed. #TINY-10022
+- Added a new `InsertNewBlockAfter` command, which inserts an empty block after the current one where selection is placed. #TINY-10022
 
 ### Improved
 - Adding a newline after a table would in some specific cases not work. #TINY-9863

--- a/modules/tinymce/src/core/main/ts/api/commands/Commands.ts
+++ b/modules/tinymce/src/core/main/ts/api/commands/Commands.ts
@@ -8,6 +8,7 @@ import * as HistoryCommands from './HistoryCommands';
 import * as IndentCommands from './IndentCommands';
 import * as LinkCommands from './LinkCommands';
 import * as ListCommands from './ListCommands';
+import * as NewBlockCommands from './NewBlockCommands';
 import * as NewlineCommands from './NewlineCommands';
 import * as SelectionCommands from './SelectionCommands';
 
@@ -47,6 +48,7 @@ export const registerCommands = (editor: Editor): void => {
   ContentCommands.registerCommands(editor);
   LinkCommands.registerCommands(editor);
   IndentCommands.registerCommands(editor);
+  NewBlockCommands.registerCommands(editor);
   NewlineCommands.registerCommands(editor);
   ListCommands.registerCommands(editor);
   FormatCommands.registerCommands(editor);

--- a/modules/tinymce/src/core/main/ts/api/commands/NewBlockCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/commands/NewBlockCommands.ts
@@ -1,0 +1,14 @@
+import * as NewBlock from '../../newline/NewBlock';
+import Editor from '../Editor';
+
+export const registerCommands = (editor: Editor): void => {
+  editor.editorCommands.addCommands({
+    InsertNewBlockBefore: () => {
+      NewBlock.insertBefore(editor);
+    },
+    InsertNewBlockAfter: () => {
+      NewBlock.insertAfter(editor);
+    },
+  });
+};
+

--- a/modules/tinymce/src/core/main/ts/newline/NewBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewBlock.ts
@@ -9,8 +9,8 @@ import * as NewLineUtils from './NewLineUtils';
 const getTopParentBlock = (editor: Editor, node: Node, root: Element, container: Node): Optional<SugarElement<Node>> => {
   const dom = editor.dom;
   const selector = (node: Node) => dom.isBlock(node) && node.parentElement === root;
-  const parentBlock = selector(node) ? node : dom.getParent(container, selector, root);
-  return Optional.from(parentBlock).map(SugarElement.fromDom);
+  const topParentBlock = selector(node) ? node : dom.getParent(container, selector, root);
+  return Optional.from(topParentBlock).map(SugarElement.fromDom);
 };
 
 const insert = (editor: Editor, before: boolean): void => {

--- a/modules/tinymce/src/core/main/ts/newline/NewBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewBlock.ts
@@ -1,0 +1,48 @@
+import { Insert, SugarElement } from '@ephox/sugar';
+
+import Editor from '../api/Editor';
+import * as Options from '../api/Options';
+import * as NewLineUtils from './NewLineUtils';
+
+const getTopParentBlock = (node: Node, root: Element, container: Node): Node => {
+  let parentBlock = node;
+
+  if (node === root) {
+    parentBlock = container;
+  }
+
+  while (parentBlock.parentElement && parentBlock.parentElement !== root) {
+    parentBlock = parentBlock.parentElement;
+  }
+
+  return parentBlock;
+};
+
+const insert = (editor: Editor, before: boolean): void => {
+  const dom = editor.dom;
+  const rng = editor.selection.getRng();
+  const node = before ? editor.selection.getStart() : editor.selection.getEnd();
+  const container = before ? rng.startContainer : rng.endContainer;
+  const editableRoot = NewLineUtils.getEditableRoot(dom, container);
+  const root = editableRoot ?? dom.getRoot();
+
+  const parentBlock = getTopParentBlock(node, root, container);
+
+  const newBlockName = Options.getForcedRootBlock(editor);
+  const newBlock = dom.create(newBlockName);
+  newBlock.innerHTML = '<br data-mce-bogus="1">';
+  const insert = before ? Insert.before : Insert.after;
+  if (parentBlock) {
+    insert(SugarElement.fromDom(parentBlock), SugarElement.fromDom(newBlock));
+  }
+
+  NewLineUtils.moveToCaretPosition(editor, newBlock);
+};
+
+const insertBefore = (editor: Editor): void => insert(editor, true);
+const insertAfter = (editor: Editor): void => insert(editor, false);
+
+export {
+  insertBefore,
+  insertAfter
+};

--- a/modules/tinymce/src/core/main/ts/newline/NewBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewBlock.ts
@@ -3,6 +3,7 @@ import { Insert, SugarElement } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import * as Options from '../api/Options';
+import * as InputEvents from '../events/InputEvents';
 import * as NewLineUtils from './NewLineUtils';
 
 const getTopParentBlock = (node: Node, root: Element, container: Node): Optional<SugarElement<Node>> => {
@@ -32,12 +33,12 @@ const insert = (editor: Editor, before: boolean): void => {
   const newBlockName = Options.getForcedRootBlock(editor);
 
   getTopParentBlock(node, root, container).each((parentBlock) => {
-    const newBlock = SugarElement.fromTag(newBlockName);
-    Insert.append(newBlock, SugarElement.fromHtml('<br data-mce-bogus="1">'));
+    const newBlock = NewLineUtils.createNewBlock(editor, container, parentBlock.dom, root, false, newBlockName);
 
-    insertFn(parentBlock, newBlock);
-    editor.selection.setCursorLocation(newBlock.dom, 0);
-    editor.dispatch('NewBlock', { newBlock: newBlock.dom });
+    insertFn(parentBlock, SugarElement.fromDom(newBlock));
+    editor.selection.setCursorLocation(newBlock, 0);
+    editor.dispatch('NewBlock', { newBlock });
+    InputEvents.fireInputEvent(editor, 'insertParagraph');
   });
 };
 

--- a/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
@@ -1,12 +1,15 @@
-import { Fun, Optional, Unicode } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import { Arr, Fun, Obj, Optional, Optionals, Unicode } from '@ephox/katamari';
+import { Css, SugarElement } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import DomTreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
+import * as Options from '../api/Options';
+import * as Bookmarks from '../bookmark/Bookmarks';
 import * as ElementType from '../dom/ElementType';
 import * as NodeType from '../dom/NodeType';
 import * as ScrollIntoView from '../dom/ScrollIntoView';
+import { isCaretNode } from '../fmt/FormatContainer';
 
 const firstNonWhiteSpaceNodeSibling = (node: Node | null): Node | null => {
   while (node) {
@@ -121,10 +124,112 @@ const isListItemParentBlock = (editor: Editor): boolean => {
   }).isSome();
 };
 
+const emptyBlock = (elm: Element): void => {
+  elm.innerHTML = '<br data-mce-bogus="1">';
+};
+
+const applyAttributes = (editor: Editor, node: Element, forcedRootBlockAttrs: Record<string, string>) => {
+  const dom = editor.dom;
+
+  // Merge and apply style attribute
+  Optional.from(forcedRootBlockAttrs.style)
+    .map(dom.parseStyle)
+    .each((attrStyles) => {
+      const currentStyles = Css.getAllRaw(SugarElement.fromDom(node));
+      const newStyles = { ...currentStyles, ...attrStyles };
+      dom.setStyles(node, newStyles);
+    });
+
+  // Merge and apply class attribute
+  const attrClassesOpt = Optional.from(forcedRootBlockAttrs.class).map((attrClasses) => attrClasses.split(/\s+/));
+  const currentClassesOpt = Optional.from(node.className).map((currentClasses) => Arr.filter(currentClasses.split(/\s+/), (clazz) => clazz !== ''));
+  Optionals.lift2(attrClassesOpt, currentClassesOpt, (attrClasses, currentClasses) => {
+    const filteredClasses = Arr.filter(currentClasses, (clazz) => !Arr.contains(attrClasses, clazz));
+    const newClasses = [ ...attrClasses, ...filteredClasses ];
+    dom.setAttrib(node, 'class', newClasses.join(' '));
+  });
+
+  // Apply any remaining forced root block attributes
+  const appliedAttrs = [ 'style', 'class' ];
+  const remainingAttrs = Obj.filter(forcedRootBlockAttrs, (_, attrs) => !Arr.contains(appliedAttrs, attrs));
+  dom.setAttribs(node, remainingAttrs);
+};
+
+const setForcedBlockAttrs = (editor: Editor, node: Element): void => {
+  const forcedRootBlockName = Options.getForcedRootBlock(editor);
+
+  if (forcedRootBlockName.toLowerCase() === node.tagName.toLowerCase()) {
+    const forcedRootBlockAttrs = Options.getForcedRootBlockAttrs(editor);
+    applyAttributes(editor, node, forcedRootBlockAttrs);
+  }
+};
+
+// Creates a new block element by cloning the current one or creating a new one if the name is specified
+// This function will also copy any text formatting from the parent block and add it to the new one
+const createNewBlock = (
+  editor: Editor,
+  container: Node,
+  parentBlock: Node,
+  editableRoot: HTMLElement | undefined,
+  keepStyles: boolean = true,
+  name?: string
+): Element => {
+  const dom = editor.dom;
+  const schema = editor.schema;
+  const newBlockName = Options.getForcedRootBlock(editor);
+  const parentBlockName = parentBlock ? parentBlock.nodeName.toUpperCase() : ''; // IE < 9 & HTML5
+  let node: Node | null = container;
+  const textInlineElements = schema.getTextInlineElements();
+
+  let block: Element;
+  if (name || parentBlockName === 'TABLE' || parentBlockName === 'HR') {
+    block = dom.create(name || newBlockName);
+  } else {
+    block = parentBlock.cloneNode(false) as Element;
+  }
+
+  let caretNode = block;
+
+  if (!keepStyles) {
+    dom.setAttrib(block, 'style', null); // wipe out any styles that came over with the block
+    dom.setAttrib(block, 'class', null);
+  } else {
+    // Clone any parent styles
+    do {
+      if (textInlineElements[node.nodeName]) {
+        // Ignore caret or bookmark nodes when cloning
+        if (isCaretNode(node) || Bookmarks.isBookmarkNode(node)) {
+          continue;
+        }
+
+        const clonedNode = node.cloneNode(false) as Element;
+        dom.setAttrib(clonedNode, 'id', ''); // Remove ID since it needs to be document unique
+
+        if (block.hasChildNodes()) {
+          clonedNode.appendChild(block.firstChild as Node);
+          block.appendChild(clonedNode);
+        } else {
+          caretNode = clonedNode;
+          block.appendChild(clonedNode);
+        }
+      }
+    } while ((node = node.parentNode) && node !== editableRoot);
+  }
+
+  setForcedBlockAttrs(editor, block);
+
+  emptyBlock(caretNode);
+
+  return block;
+};
+
 export {
   moveToCaretPosition,
   getEditableRoot,
   getParentBlock,
   getParentBlockName,
-  isListItemParentBlock
+  isListItemParentBlock,
+  createNewBlock,
+  setForcedBlockAttrs,
+  emptyBlock
 };

--- a/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
@@ -93,6 +93,7 @@ const getEditableRoot = (dom: DOMUtils, node: Node): HTMLElement | undefined => 
   while (parent !== root && parent && dom.getContentEditable(parent) !== 'false') {
     if (dom.getContentEditable(parent) === 'true') {
       editableRoot = parent as HTMLElement;
+      break;
     }
 
     parent = parent.parentNode;

--- a/modules/tinymce/src/core/test/ts/browser/api/commands/NewBlockCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/api/commands/NewBlockCommandsTest.ts
@@ -1,0 +1,233 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.api.commands.NewBlockCommandsTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    indent: false
+  }, [], true);
+
+  context('InsertNewBlockBefore command', () => {
+
+    it('TINY-10022: empty editor', () => {
+      const editor = hook.editor();
+      editor.execCommand('InsertNewBlockBefore');
+      TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>&nbsp;</p>');
+      TinyAssertions.assertCursor(editor, [ 0 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<p>X</p><p>&nbsp;</p>');
+    });
+
+    it('TINY-10022: should insert empty block after paragrpaph with text', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>AAA</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 2);
+      editor.execCommand('InsertNewBlockBefore');
+      TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>AAA</p>');
+      TinyAssertions.assertCursor(editor, [ 0 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<p>X</p><p>AAA</p>');
+    });
+
+    it('TINY-10022: should insert empty block before paragraph with inline elements', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><em>AAA</em></p>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+      editor.execCommand('InsertNewBlockBefore');
+      TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p><em>AAA</em></p>');
+      TinyAssertions.assertCursor(editor, [ 0 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<p>X</p><p><em>AAA</em></p>');
+    });
+
+    it('TINY-10022: should insert empty block before blockquote', () => {
+      const editor = hook.editor();
+      editor.setContent('<blockquote><p>AAA</p></blockquote>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+      editor.execCommand('InsertNewBlockBefore');
+      TinyAssertions.assertContent(editor, '<p>&nbsp;</p><blockquote><p>AAA</p></blockquote>');
+      TinyAssertions.assertCursor(editor, [ 0 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<p>X</p><blockquote><p>AAA</p></blockquote>');
+    });
+
+    it('TINY-10022: should insert new empty block between two paragraphs', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>AAA</p><p>BBB</p>');
+      TinySelections.setCursor(editor, [ 1, 0 ], 2);
+      editor.execCommand('InsertNewBlockBefore');
+      TinyAssertions.assertContent(editor, '<p>AAA</p><p>&nbsp;</p><p>BBB</p>');
+      TinyAssertions.assertCursor(editor, [ 1 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<p>AAA</p><p>X</p><p>BBB</p>');
+    });
+
+    it('TINY-10022: should insert new empty block between two blockquotes', () => {
+      const editor = hook.editor();
+      editor.setContent('<blockquote><p>AAA</p></blockquote><blockquote><p>BBB</p></blockquote>');
+      TinySelections.setCursor(editor, [ 1, 0, 0 ], 2);
+      editor.execCommand('InsertNewBlockBefore');
+      TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>&nbsp;</p><blockquote><p>BBB</p></blockquote>');
+      TinyAssertions.assertCursor(editor, [ 1 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>X</p><blockquote><p>BBB</p></blockquote>');
+    });
+
+    it('TINY-10022: insert new empty block within CET root', () => {
+      const editor = hook.editor();
+      editor.setContent('<div contenteditable="true"><p>AAA</p><p>BBB</p></div>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+      editor.execCommand('InsertNewBlockBefore');
+      TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>&nbsp;</p><p>AAA</p><p>BBB</p></div>');
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>X</p><p>AAA</p><p>BBB</p></div>');
+    });
+
+    it('TINY-10022: insert new empty block before start container of ranged selection', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>AAA</p><p>BBB</p>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 1, 0 ], 2);
+      editor.execCommand('InsertNewBlockBefore');
+      TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>AAA</p><p>BBB</p>');
+      TinyAssertions.assertCursor(editor, [ 0 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<p>X</p><p>AAA</p><p>BBB</p>');
+    });
+
+    it('TINY-10022: insert new empty block before noneditable block', () => {
+      const editor = hook.editor();
+      editor.setContent('<p contenteditable="false">AAA</p><p>BBB</p>');
+      TinySelections.select(editor, '[contenteditable]', []);
+      editor.execCommand('InsertNewBlockBefore');
+      TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p contenteditable="false">AAA</p><p>BBB</p>');
+      TinyAssertions.assertCursor(editor, [ 0 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<p>X</p><p contenteditable="false">AAA</p><p>BBB</p>');
+    });
+
+    it('TINY-10022: insert new empty block before text in CET nested within CEF', () => {
+      const editor = hook.editor();
+      editor.setContent('<div contenteditable="false">AAA<div contenteditable="true">BBB</div></div>');
+      // actual content: <p><br data-mce-bogus="1"> </p><div contenteditable="false">AAA<div contenteditable="true">BBB</div></div>
+      TinySelections.setCursor(editor, [ 1, 1, 0 ], 2);
+      editor.execCommand('InsertNewBlockBefore');
+      TinyAssertions.assertContent(editor, '<div contenteditable="false">AAA<div contenteditable="true"><p>&nbsp;</p>BBB</div></div>');
+      TinyAssertions.assertCursor(editor, [ 0, 1, 0 ], 0);
+    });
+  });
+
+  context('InsertNewBlockAfter command', () => {
+
+    it('TINY-10022: empty editor', () => {
+      const editor = hook.editor();
+      editor.resetContent();
+      editor.execCommand('InsertNewBlockAfter');
+      TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>&nbsp;</p>');
+      TinyAssertions.assertCursor(editor, [ 1 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>X</p>');
+    });
+
+    it('TINY-10022: should insert empty block after paragrpaph with text', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>AAA</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 2);
+      editor.execCommand('InsertNewBlockAfter');
+      TinyAssertions.assertContent(editor, '<p>AAA</p><p>&nbsp;</p>');
+      TinyAssertions.assertCursor(editor, [ 1 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<p>AAA</p><p>X</p>');
+    });
+
+    it('TINY-10022: should insert empty block after paragraph with inline elements', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><em>AAA</em></p>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+      editor.execCommand('InsertNewBlockAfter');
+      TinyAssertions.assertContent(editor, '<p><em>AAA</em></p><p>&nbsp;</p>');
+      TinyAssertions.assertCursor(editor, [ 1 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<p><em>AAA</em></p><p>X</p>');
+    });
+
+    it('TINY-10022: should insert empty block after blockquote', () => {
+      const editor = hook.editor();
+      editor.setContent('<blockquote><p>AAA</p></blockquote>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+      editor.execCommand('InsertNewBlockAfter');
+      TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>&nbsp;</p>');
+      TinyAssertions.assertCursor(editor, [ 1 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>X</p>');
+    });
+
+    it('TINY-10022: should insert new empty block between two paragraphs', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>AAA</p><p>BBB</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 2);
+      editor.execCommand('InsertNewBlockAfter');
+      TinyAssertions.assertContent(editor, '<p>AAA</p><p>&nbsp;</p><p>BBB</p>');
+      TinyAssertions.assertCursor(editor, [ 1 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<p>AAA</p><p>X</p><p>BBB</p>');
+    });
+
+    it('TINY-10022: should insert new empty block between two blockquotes', () => {
+      const editor = hook.editor();
+      editor.setContent('<blockquote><p>AAA</p></blockquote><blockquote><p>BBB</p></blockquote>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+      editor.execCommand('InsertNewBlockAfter');
+      TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>&nbsp;</p><blockquote><p>BBB</p></blockquote>');
+      TinyAssertions.assertCursor(editor, [ 1 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>X</p><blockquote><p>BBB</p></blockquote>');
+    });
+
+    it('TINY-10022: insert new empty block within CET root', () => {
+      const editor = hook.editor();
+      editor.setContent('<div contenteditable="true"><p>AAA</p><p>BBB</p></div>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+      editor.execCommand('InsertNewBlockAfter');
+      TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>AAA</p><p>&nbsp;</p><p>BBB</p></div>');
+      TinyAssertions.assertCursor(editor, [ 0, 1 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>AAA</p><p>X</p><p>BBB</p></div>');
+    });
+
+    it('TINY-10022: insert new empty block after end container of ranged selection', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>AAA</p><p>BBB</p>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 1, 0 ], 2);
+      editor.execCommand('InsertNewBlockAfter');
+      TinyAssertions.assertContent(editor, '<p>AAA</p><p>BBB</p><p>&nbsp;</p>');
+      TinyAssertions.assertCursor(editor, [ 2 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<p>AAA</p><p>BBB</p><p>X</p>');
+    });
+
+    it('TINY-10022: insert new empty block after noneditable block', () => {
+      const editor = hook.editor();
+      editor.setContent('<p contenteditable="false">AAA</p><p>BBB</p>');
+      TinySelections.select(editor, '[contenteditable]', []);
+      editor.execCommand('InsertNewBlockAfter');
+      TinyAssertions.assertContent(editor, '<p contenteditable="false">AAA</p><p>&nbsp;</p><p>BBB</p>');
+      TinyAssertions.assertCursor(editor, [ 1 ], 0);
+      editor.insertContent('X');
+      TinyAssertions.assertContent(editor, '<p contenteditable="false">AAA</p><p>X</p><p>BBB</p>');
+    });
+
+    it('TINY-10022: insert new empty block after text in CET nested within CEF', () => {
+      const editor = hook.editor();
+      editor.setContent('<div contenteditable="false">AAA<div contenteditable="true">BBB</div></div>');
+      // actual content: <p><br data-mce-bogus="1"> </p><div contenteditable="false">AAA<div contenteditable="true">BBB</div></div>
+      TinySelections.setCursor(editor, [ 1, 1, 0 ], 2);
+      editor.execCommand('InsertNewBlockAfter');
+      TinyAssertions.assertContent(editor, '<div contenteditable="false">AAA<div contenteditable="true">BBB<p>&nbsp;</p></div></div>');
+      TinyAssertions.assertCursor(editor, [ 0, 1, 1 ], 0);
+    });
+  });
+});
+

--- a/modules/tinymce/src/core/test/ts/browser/api/commands/NewBlockCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/api/commands/NewBlockCommandsTest.ts
@@ -1,5 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -107,14 +107,24 @@ describe('browser.tinymce.core.api.commands.NewBlockCommandsTest', () => {
       TinyAssertions.assertContent(editor, '<p>X</p><p contenteditable="false">AAA</p><p>BBB</p>');
     });
 
-    it('TINY-10022: insert new empty block before text in CET nested within CEF', () => {
-      const editor = hook.editor();
-      editor.setContent('<div contenteditable="false">AAA<div contenteditable="true">BBB</div></div>');
-      // actual content: <p><br data-mce-bogus="1"> </p><div contenteditable="false">AAA<div contenteditable="true">BBB</div></div>
-      TinySelections.setCursor(editor, [ 1, 1, 0 ], 2);
-      editor.execCommand('InsertNewBlockBefore');
-      TinyAssertions.assertContent(editor, '<div contenteditable="false">AAA<div contenteditable="true"><p>&nbsp;</p>BBB</div></div>');
-      TinyAssertions.assertCursor(editor, [ 0, 1, 0 ], 0);
+    it('TINY-10022: should not split editing host in noneditable root', () => {
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        const initialContent = '<p contenteditable="true">ab</p>';
+        editor.setContent(initialContent);
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, initialContent);
+      });
+    });
+
+    it('TINY-10022: should not insert new block in in noneditable root', () => {
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        const initialContent = '<p>ab</p>';
+        editor.setContent(initialContent);
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, initialContent);
+      });
     });
   });
 
@@ -217,14 +227,24 @@ describe('browser.tinymce.core.api.commands.NewBlockCommandsTest', () => {
       TinyAssertions.assertContent(editor, '<p contenteditable="false">AAA</p><p>X</p><p>BBB</p>');
     });
 
-    it('TINY-10022: insert new empty block after text in CET nested within CEF', () => {
-      const editor = hook.editor();
-      editor.setContent('<div contenteditable="false">AAA<div contenteditable="true">BBB</div></div>');
-      // actual content: <p><br data-mce-bogus="1"> </p><div contenteditable="false">AAA<div contenteditable="true">BBB</div></div>
-      TinySelections.setCursor(editor, [ 1, 1, 0 ], 2);
-      editor.execCommand('InsertNewBlockAfter');
-      TinyAssertions.assertContent(editor, '<div contenteditable="false">AAA<div contenteditable="true">BBB<p>&nbsp;</p></div></div>');
-      TinyAssertions.assertCursor(editor, [ 0, 1, 1 ], 0);
+    it('TINY-10022: should not split editing host in noneditable root', () => {
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        const initialContent = '<p contenteditable="true">ab</p>';
+        editor.setContent(initialContent);
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, initialContent);
+      });
+    });
+
+    it('TINY-10022: should not insert new block in in noneditable root', () => {
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        const initialContent = '<p>ab</p>';
+        editor.setContent(initialContent);
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, initialContent);
+      });
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/api/commands/NewBlockCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/api/commands/NewBlockCommandsTest.ts
@@ -10,7 +10,6 @@ describe('browser.tinymce.core.api.commands.NewBlockCommandsTest', () => {
   }, [], true);
 
   context('InsertNewBlockBefore command', () => {
-
     it('TINY-10022: empty editor', () => {
       const editor = hook.editor();
       editor.execCommand('InsertNewBlockBefore');
@@ -120,7 +119,6 @@ describe('browser.tinymce.core.api.commands.NewBlockCommandsTest', () => {
   });
 
   context('InsertNewBlockAfter command', () => {
-
     it('TINY-10022: empty editor', () => {
       const editor = hook.editor();
       editor.resetContent();


### PR DESCRIPTION
Related Ticket: TINY-10022

Description of Changes:
* Added two new commands for inserting new empty block before / after current position.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
