### PR TITLE
TINY-10128: For streamContent: true iframes, use numerical value for scrolling and only scroll after iframe load

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Right-clicking on an image in a non-editable context opened the Image context menu. #TINY-10016
 - The `color_cols` option was not respected when a custom `color_map` was defined. #TINY-10098
 - The `color_cols` options were were not rounded to the nearest number when set to a decimal number. #TINY-9737
+- An "Uncaught TypeError: Cannot read properties of null" error would sometimes be thrown when updating the content of a `streamContent: true` iframe dialog component. #TINY-10128
 
 ## 6.6.0 - 2023-07-12
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- An "Uncaught TypeError: Cannot read properties of null" error would sometimes be thrown when updating the content of a `streamContent: true` iframe dialog component. #TINY-10128
+
 ## 6.6.1 - 2023-08-02
 
 ### Added
@@ -27,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Right-clicking on an image in a non-editable context opened the Image context menu. #TINY-10016
 - The `color_cols` option was not respected when a custom `color_map` was defined. #TINY-10098
 - The `color_cols` options were were not rounded to the nearest number when set to a decimal number. #TINY-9737
-- An "Uncaught TypeError: Cannot read properties of null" error would sometimes be thrown when updating the content of a `streamContent: true` iframe dialog component. #TINY-10128
 
 ## 6.6.0 - 2023-07-12
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -1,6 +1,6 @@
 import { AlloyComponent, Behaviour, Focusing, FormField, Receiving, SketchSpec, Tabstopping } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Cell, Fun, Optional, Throttler, Type } from '@ephox/katamari';
+import { Cell, Fun, Optional, Optionals, Throttler, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Attribute, Class, Compare, SugarElement, Traverse } from '@ephox/sugar';
 
@@ -88,7 +88,7 @@ const writeValue = (iframeElement: SugarElement<HTMLIFrameElement>, html: string
 // the scroll jumping caused by the delay.
 // TINY-10097: On Safari, throttle to 500ms reduce flickering as the document.write() method still observes significant flickering.
 // Also improves scrolling, as scroll positions are maintained manually similar to Firefox.
-const throttleInterval = isSafariOrFirefox ? Optional.some(500) : Optional.none();
+const throttleInterval = Optionals.someIf(isSafariOrFirefox, 500);
 
 // TINY-10078: Use Throttler.adaptable to ensure that any content added during the waiting period is not lost.
 const writeValueThrottler = throttleInterval.map((interval) => Throttler.adaptable(writeValue, interval));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -31,7 +31,10 @@ const isElementScrollAtBottom = ({ scrollTop, scrollHeight, clientHeight }: HTML
   Math.ceil(scrollTop) + clientHeight >= scrollHeight;
 
 const scrollToY = (win: Window, y: number | 'bottom') =>
-  win.scrollTo(0, y === 'bottom' ? win.document.body.scrollHeight : y);
+  // TINY-10128: The iframe body is occasionally null when we attempt to scroll, so use a fallback value of 999999999. This is the
+  // maximum value Window.scrollTo would take on Safari, Number.MAX_SAFE_INTEGER does not work. We also do not want to wait for the
+  // body to load as doing so can cause a visual lag.
+  win.scrollTo(0, y === 'bottom' ? (win.document.body?.scrollHeight ?? 999999999) : y);
 
 const getScrollingElement = (doc: Document, html: string): Optional<HTMLElement> => {
   // TINY-10110: The scrolling element can change between body and documentElement depending on whether there

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -73,7 +73,7 @@ const writeValue = (iframeElement: SugarElement<HTMLIFrameElement>, html: string
         }
       };
 
-      // TINY-10128: Attempting to scroll before the iframe has finished loading will not work
+      // TINY-10128: Attempting to scroll before the iframe has finished loading will not work.
       iframe.addEventListener('load', scrollAfterWrite, { once: true });
 
       doc.open();
@@ -82,7 +82,7 @@ const writeValue = (iframeElement: SugarElement<HTMLIFrameElement>, html: string
     });
 };
 
-// TINY-10078: On Firefox, throttle to 500ms allow improve scrolling experience. Since we are manually maintaining previous scroll
+// TINY-10078, TINY-10128: On Firefox, throttle to 500ms allow improve scrolling experience. Since we are manually maintaining previous scroll
 // position on each update, when updating too rapidly, attempting to scroll around the iframe can feel stuck. Also, Firefox takes a
 // longer time to fire the iframe load event. Since we attach the scroll functionality to the load handler, throttling reduces
 // the scroll jumping caused by the delay.

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -31,10 +31,10 @@ const isElementScrollAtBottom = ({ scrollTop, scrollHeight, clientHeight }: HTML
   Math.ceil(scrollTop) + clientHeight >= scrollHeight;
 
 const scrollToY = (win: Window, y: number | 'bottom') =>
-  // TINY-10128: The iframe body is occasionally null when we attempt to scroll, so use a fallback value of 999999999. This is the
-  // maximum value Window.scrollTo would take on Safari, Number.MAX_SAFE_INTEGER does not work. We also do not want to wait for the
+  // TINY-10128: The iframe body is occasionally null when we attempt to scroll, so instead of using body.scrollHeight, use a
+  // fallback value. 2^31 - 1 is the maximum value Window.scrollTo would take on Safari. We also do not want to wait for the
   // body to load as doing so can cause a visual lag.
-  win.scrollTo(0, y === 'bottom' ? (win.document.body?.scrollHeight ?? 999999999) : y);
+  win.scrollTo(0, y === 'bottom' ? 2147483647 : y);
 
 const getScrollingElement = (doc: Document, html: string): Optional<HTMLElement> => {
   // TINY-10110: The scrolling element can change between body and documentElement depending on whether there

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
@@ -326,9 +326,8 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
         setValueInIntervals(frame, interval, maxNumIntervals, shouldContentHaveDoctype);
 
         await Waiter.pTryUntil('Wait for update intervals to finish', () => {
-          // TINY-10078: Artificial 200ms throttle on Firefox to improve scrolling.
-          // TINY-10097: Artificial 500ms throttle on Safari to reduce flickering and improve scrolling.
-          const expectedLoads = (isSafariOrFirefox ? interval * maxNumIntervals / (isSafari ? 500 : 200) : maxNumIntervals) + 1;
+          // TINY-10078, TINY-10097, TINY-10128: Artificial 500ms throttles on Safari and Firefox.
+          const expectedLoads = (isSafariOrFirefox ? interval * maxNumIntervals / 500 : maxNumIntervals) + 1;
           if (isFirefox) {
             assert.approximately(loadCount, expectedLoads, 1, `iframe should have approximately ${expectedLoads} loads`);
           } else {


### PR DESCRIPTION
Related Ticket: TINY-10128

Description of Changes:
* Use a numerical value for Window.scrollTo instead of body.scrollHeight (in case body is `null`)
* On all browsers, wait for `load` before attempting to scroll, as trying to scroll before iframe is loaded does not work

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~ - already have tests for interval updates, but this fix targets a rare edge case
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
