### PR TITLE
TINY-10128: Scroll directly after write on Chrome and Firefox instead of waiting for iframe load

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -32,11 +32,12 @@ const isElementScrollAtBottom = ({ scrollTop, scrollHeight, clientHeight }: HTML
 
 const scrollToY = (win: Window, y: number | 'bottom') =>
   // TINY-10128: The iframe body is occasionally null when we attempt to scroll, so instead of using body.scrollHeight, use a
-  // fallback value of 2147483583 - the minimum of the maximum value Window.scrollTo would take on supported browsers:
+  // fallback value of 99999999. To minimise the potential impact of future browser changes, this fallback is significantly smaller
+  // than the minimum of the maximum value Window.scrollTo would take on supported browsers:
   // Chromium: > Number.MAX_SAFE_INTEGER
   // Safari: 2^31 - 1 = 2147483647
   // Firefox: 2147483583
-  win.scrollTo(0, y === 'bottom' ? 2147483583 : y);
+  win.scrollTo(0, y === 'bottom' ? 99999999 : y);
 
 const getScrollingElement = (doc: Document, html: string): Optional<HTMLElement> => {
   // TINY-10110: The scrolling element can change between body and documentElement depending on whether there
@@ -73,22 +74,28 @@ const writeValue = (iframeElement: SugarElement<HTMLIFrameElement>, html: string
         }
       };
 
-      // TINY-10128: Attempting to scroll before the iframe has finished loading will not work.
-      iframe.addEventListener('load', scrollAfterWrite, { once: true });
+      // TINY-10128: Attempting to scroll before the iframe has finished loading will not work. However, on Firefox, waiting for load
+      // event before scrolling will cause the scroll to jump around erratically, causing an unpleasant UX. Therefore we will not do
+      // this for Firefox, with the trade-off of potentially losing bottom scroll when updating at a very rapid rate.
+      if (!isFirefox) {
+        iframe.addEventListener('load', scrollAfterWrite, { once: true });
+      }
 
       doc.open();
       doc.write(html);
       doc.close();
+
+      if (isFirefox) {
+        scrollAfterWrite();
+      }
     });
 };
 
-// TINY-10078, TINY-10128: On Firefox, throttle to 500ms allow improve scrolling experience. Since we are manually maintaining previous scroll
-// position on each update, when updating too rapidly, attempting to scroll around the iframe can feel stuck. Also, Firefox takes a
-// longer time to fire the iframe load event. Since we attach the scroll functionality to the load handler, throttling reduces
-// the scroll jumping caused by the delay.
-// TINY-10097: On Safari, throttle to 500ms reduce flickering as the document.write() method still observes significant flickering.
+// TINY-10078, TINY-10128: On Firefox, throttle to 200ms to improve scrolling experience. Since we are manually maintaining previous scroll
+// position on each update, when updating rapidly without a throttle, attempting to scroll around the iframe can feel stuck.
+// TINY-10097: On Safari, throttle to 500ms to reduce flickering as the document.write() method still observes significant flickering.
 // Also improves scrolling, as scroll positions are maintained manually similar to Firefox.
-const throttleInterval = Optionals.someIf(isSafariOrFirefox, 500);
+const throttleInterval = Optionals.someIf(isSafariOrFirefox, isSafari ? 500 : 200);
 
 // TINY-10078: Use Throttler.adaptable to ensure that any content added during the waiting period is not lost.
 const writeValueThrottler = throttleInterval.map((interval) => Throttler.adaptable(writeValue, interval));

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
@@ -328,8 +328,8 @@ describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
         setValueInIntervals(frame, interval, maxNumIntervals, shouldContentHaveDoctype);
 
         await Waiter.pTryUntil('Wait for update intervals to finish', () => {
-          // TINY-10078, TINY-10097, TINY-10128: Artificial 500ms throttles on Safari and Firefox.
-          const expectedLoads = (isSafariOrFirefox ? interval * maxNumIntervals / 500 : maxNumIntervals) + 1;
+          // TINY-10078, TINY-10097, TINY-10128: Artificial 500ms throttle on Safari, 200ms throttle on Firefox.
+          const expectedLoads = (isSafariOrFirefox ? interval * maxNumIntervals / (isSafari ? 500 : 200) : maxNumIntervals) + 1;
           if (isFirefox) {
             assert.approximately(loadCount, expectedLoads, 1, `iframe should have approximately ${expectedLoads} loads`);
           } else {


### PR DESCRIPTION
Related Ticket: TINY-10128
Related Comment: https://ephocks.atlassian.net/browse/TINY-10128?focusedCommentId=130527

Description of Changes:
* Scroll directly after write on Chrome and Firefox instead of waiting for iframe load to prevent scroll jumping
* Revert Firefox throttle back to 200ms
* Reduce the fallback value to 99999999 to minimise the chance future browser changes impact scrolling functionality

Pre-checks:
* [x] ~Changelog entry added~ Added in https://github.com/tinymce/tinymce/pull/8958
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
