### PR TITLE
TINY-10011: Preserve empty CET from pruning

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In some cases pressing enter would scroll the entire page. #TINY-9828
 - The border styles of a table were incorrectly split into a longhand form after table dialog updates. #TINY-9843
 - Links in `help dialog` -> `plugins` and `version` were not navigable via keyboard. #TINY-10071
+- An empty `contenteditable="true"` element within a noneditable root was deleted upon pressing the Backspace key. #TINY-10011
 
 ## 6.6.2 - 2023-08-09
 

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -1,5 +1,5 @@
-import { Fun, Type } from '@ephox/katamari';
-import { SelectorExists, SugarElement } from '@ephox/sugar';
+import { Arr, Fun, Type } from '@ephox/katamari';
+import { ContentEditable, SelectorFilter, SugarElement, Traverse } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import Env from '../api/Env';
@@ -84,9 +84,10 @@ const Quirks = (editor: Editor): Quirks => {
       return selection === allSelection;
     };
 
-    const hasPreservedEmptyElements = (node: Node) => {
-      const scope = SugarElement.fromDom(node);
-      return SelectorExists.descendant(scope, '[contenteditable="true"]');
+    const hasPreservedEmptyElements = (elm: HTMLElement) => {
+      const scope = SugarElement.fromDom(elm);
+      const isEditableHost = (elm: SugarElement<HTMLElement>) => Traverse.parentElement(elm).exists((elm) => !ContentEditable.isEditable(elm));
+      return Arr.exists(SelectorFilter.descendants<HTMLElement>(scope, '[contenteditable="true"]'), isEditableHost);
     };
 
     editor.on('keydown', (e) => {

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -1,4 +1,5 @@
 import { Fun, Type } from '@ephox/katamari';
+import { SelectorExists, SugarElement } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import Env from '../api/Env';
@@ -83,6 +84,11 @@ const Quirks = (editor: Editor): Quirks => {
       return selection === allSelection;
     };
 
+    const hasPreservedEmptyElements = (node: Node) => {
+      const scope = SugarElement.fromDom(node);
+      return SelectorExists.descendant(scope, '[contenteditable="true"]');
+    };
+
     editor.on('keydown', (e) => {
       const keyCode = e.keyCode;
 
@@ -92,7 +98,8 @@ const Quirks = (editor: Editor): Quirks => {
         const body = editor.getBody();
 
         // Selection is collapsed but the editor isn't empty
-        if (isCollapsed && !dom.isEmpty(body)) {
+        // TINY-10011: empty CET elements should be preserved
+        if (isCollapsed && (!dom.isEmpty(body) || hasPreservedEmptyElements(body))) {
           return;
         }
 

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
@@ -281,6 +281,15 @@ describe('browser.tinymce.core.delete.CefDeleteTest', () => {
           TinyAssertions.assertContent(editor, initialContent);
         });
       });
+
+      it(`TINY-10011: should delete empty CET in a editable root when ${label} is pressed`, () => {
+        const editor = hook.editor();
+        editor.setContent('<div contenteditable="true">&nbsp;</div>');
+        TinySelections.setCursor(editor, [ 0 ], 0);
+        TinyContentActions.keystroke(editor, key());
+        TinyAssertions.assertCursor(editor, [ 0 ], 0);
+        TinyAssertions.assertContent(editor, '');
+      });
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
@@ -270,6 +270,17 @@ describe('browser.tinymce.core.delete.CefDeleteTest', () => {
           TinyAssertions.assertContent(editor, initialContent);
         });
       });
+
+      it(`TINY-10011: should not delete empty CET in a noneditable root when ${label} is pressed`, () => {
+        TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+          const initialContent = '<div contenteditable="true">&nbsp;</div>';
+          editor.setContent(initialContent);
+          TinySelections.setCursor(editor, [ 0 ], 0);
+          TinyContentActions.keystroke(editor, key());
+          TinyAssertions.assertCursor(editor, [ 0 ], 0);
+          TinyAssertions.assertContent(editor, initialContent);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10011

Description of Changes:
* The issue is that on `Backspace` key pressing the editor prunes redundant formatting elements without text. In doing so the call `dom.isEmpty(body)` returns true even if the body has an empty CET element. The solution is to provide an additional check for such en empty preserved elements. The attempt to upgrade the `dom.isEmpty` function to treat such CET element as a `nonEmptyElement` failed. In some places we need `dom.isEmpty(cetElm)` returns true for activating padding empty blocks.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
