### PR TITLE
TINY-10140: Improve description on label of insert table grid menu item

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adding a newline after a table would in some specific cases not work. #TINY-9863
 - Menus will now have a slight margin at the top and bottom to more clearly separate them from the edge of frame. #TINY-9978
 - Updated toolbar "More" button tooltip text from "More..." to "Reveal or hide additional toolbar items". #TINY-9629
-- Improved announcement of current selected columns and rows in insert table menu item grid. #TINY-10140
+- Improved screen reader announcements of currently selected columns and rows in insert table menu item grid. #TINY-10140
 
 ### Changed
 - Change UndoLevelType from enum to union type so that it can be easier to use. #TINY-9764

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adding a newline after a table would in some specific cases not work. #TINY-9863
 - Menus will now have a slight margin at the top and bottom to more clearly separate them from the edge of frame. #TINY-9978
 - Updated toolbar "More" button tooltip text from "More..." to "Reveal or hide additional toolbar items". #TINY-9629
-- Updated the insert table grid menu with a more descriptive label for the selected columns and rows. #TINY-10140
+- Improved announcement of current selected columns and rows in insert table menu item grid. #TINY-10140
 
 ### Changed
 - Change UndoLevelType from enum to union type so that it can be easier to use. #TINY-9764

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adding a newline after a table would in some specific cases not work. #TINY-9863
 - Menus will now have a slight margin at the top and bottom to more clearly separate them from the edge of frame. #TINY-9978
 - Updated toolbar "More" button tooltip text from "More..." to "Reveal or hide additional toolbar items". #TINY-9629
+- Updated the insert table grid menu with a more descriptive label for the selected columns and rows. #TINY-10140
 
 ### Changed
 - Change UndoLevelType from enum to union type so that it can be easier to use. #TINY-9764

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/InsertTableMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/InsertTableMenuItem.ts
@@ -77,8 +77,13 @@ export const renderInsertTableMenuItem = (spec: Menu.InsertTableMenuItem, backst
   const sizeLabelId = Id.generate('size-label');
   const cells = makeCells(sizeLabelId, numRows, numColumns);
 
-  const makeLabelText = (row: number, col: number): PremadeSpec =>
-    GuiFactory.text(backstage.shared.providers.translate(`${col} columns and ${row} rows`));
+  const makeLabelText = (row: number, col: number): PremadeSpec => {
+    // TINY-10141: Add each of these strings to be translated?
+    const columnsText = backstage.shared.providers.translate(col > 1 ? `columns and` : `column and`);
+    const rowsText = backstage.shared.providers.translate(row > 1 ? `rows` : `row`);
+    const labelText = `${col} ${columnsText} ${row} ${rowsText}`;
+    return GuiFactory.text(labelText);
+  };
 
   const emptyLabelText = makeLabelText(0, 0);
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/InsertTableMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/InsertTableMenuItem.ts
@@ -78,27 +78,23 @@ export const renderInsertTableMenuItem = (spec: Menu.InsertTableMenuItem, backst
   const cells = makeCells(sizeLabelId, numRows, numColumns);
 
   const makeLabelText = (row: number, col: number): PremadeSpec =>
-    GuiFactory.text(`${col}x${row}`);
+    GuiFactory.text(backstage.shared.providers.translate(`${col} columns and ${row} rows`));
 
-  const makeAnnouncementText = (row: number, col: number): string =>
-    backstage.shared.providers.translate(`${col} columns x ${row} rows`);
+  const emptyLabelText = makeLabelText(0, 0);
 
-  const makeLabel = (row: number, col: number) => Memento.record({
+  const memLabel = Memento.record({
     dom: {
       tag: 'span',
       classes: [ 'tox-insert-table-picker__label' ],
       attributes: {
-        id: sizeLabelId,
-        ['aria-label']: makeAnnouncementText(row, col)
+        id: sizeLabelId
       }
     },
-    components: [ makeLabelText(row, col) ],
+    components: [ emptyLabelText ],
     behaviours: Behaviour.derive([
       Replacing.config({})
     ])
   });
-
-  const memLabel = makeLabel(0, 0);
 
   return {
     type: 'widget',
@@ -118,12 +114,13 @@ export const renderInsertTableMenuItem = (spec: Menu.InsertTableMenuItem, backst
         AddEventsBehaviour.config('insert-table-picker', [
           AlloyEvents.runOnAttached((c) => {
             // Restore the empty label when opened, otherwise it may still be using an old label from last time it was opened
-            Replacing.set(memLabel.get(c), [ makeLabel(0, 0).asSpec() ]);
+            Replacing.set(memLabel.get(c), [ emptyLabelText ]);
           }),
           AlloyEvents.runWithTarget<CellEvent>(cellOverEvent, (c, t, e) => {
             const { row, col } = e.event;
             selectCells(cells, row, col, numRows, numColumns);
-            Replacing.set(memLabel.get(c), [ makeLabel(row + 1, col + 1).asSpec() ]);
+            const labelComp = memLabel.get(c);
+            Replacing.set(labelComp, [ makeLabelText(row + 1, col + 1) ]);
           }),
           AlloyEvents.runWithTarget<CellEvent>(cellExecuteEvent, (c, _, e) => {
             const { row, col } = e.event;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/InsertTableMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/InsertTableMenuItem.ts
@@ -5,7 +5,7 @@ import {
 import { Menu } from '@ephox/bridge';
 import { Arr, Id } from '@ephox/katamari';
 
-import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
+import { UiFactoryBackstage } from '../../../../backstage/Backstage';
 
 const cellOverEvent = Id.generate('cell-over');
 const cellExecuteEvent = Id.generate('cell-execute');

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/InsertTableMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/InsertTableMenuItem.ts
@@ -75,14 +75,14 @@ const selectCells = (cells: AlloyComponent[][], selectedRow: number, selectedCol
 const makeComponents = (cells: AlloyComponent[][]): AlloySpec[] =>
   Arr.bind(cells, (cellRow) => Arr.map(cellRow, GuiFactory.premade));
 
+const makeLabelText = (row: number, col: number): PremadeSpec =>
+  GuiFactory.text(`${col}x${row}`);
+
 export const renderInsertTableMenuItem = (spec: Menu.InsertTableMenuItem, backstage: UiFactoryBackstage): ItemTypes.WidgetItemSpec => {
   const numRows = 10;
   const numColumns = 10;
   const getCellLabel = makeAnnouncementText(backstage);
   const cells = makeCells(getCellLabel, numRows, numColumns);
-
-  const makeLabelText = (row: number, col: number): PremadeSpec =>
-    GuiFactory.text(`${col}x${row}`);
 
   const emptyLabelText = makeLabelText(0, 0);
 
@@ -120,8 +120,7 @@ export const renderInsertTableMenuItem = (spec: Menu.InsertTableMenuItem, backst
           AlloyEvents.runWithTarget<CellEvent>(cellOverEvent, (c, t, e) => {
             const { row, col } = e.event;
             selectCells(cells, row, col, numRows, numColumns);
-            const labelComp = memLabel.get(c);
-            Replacing.set(labelComp, [ makeLabelText(row + 1, col + 1) ]);
+            Replacing.set(memLabel.get(c), [ makeLabelText(row + 1, col + 1) ]);
           }),
           AlloyEvents.runWithTarget<CellEvent>(cellExecuteEvent, (c, _, e) => {
             const { row, col } = e.event;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/InsertTableMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/InsertTableMenuItem.ts
@@ -79,9 +79,7 @@ export const renderInsertTableMenuItem = (spec: Menu.InsertTableMenuItem, backst
 
   const makeLabelText = (row: number, col: number): PremadeSpec => {
     // TINY-10141: Add each of these strings to be translated?
-    const columnsText = backstage.shared.providers.translate(col > 1 ? `columns and` : `column and`);
-    const rowsText = backstage.shared.providers.translate(row > 1 ? `rows` : `row`);
-    const labelText = `${col} ${columnsText} ${row} ${rowsText}`;
+    const labelText = backstage.shared.providers.translate(`${col} ${col === 1 ? 'column' : 'columns'} and ${row} ${row === 1 ? 'row' : 'rows'}`);
     return GuiFactory.text(labelText);
   };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
@@ -22,6 +22,9 @@ const tableCellsApprox = (s: ApproxStructure.StructApi, str: ApproxStructure.Str
   return cells;
 };
 
+const expectedLabelText = (cols: number, rows: number) =>
+  `${cols} ${cols === 1 ? 'column' : 'columns'} and ${rows} ${rows === 1 ? 'row' : 'rows'}`;
+
 const insertTablePickerApprox = (s: ApproxStructure.StructApi, str: ApproxStructure.StringApi, arr: ApproxStructure.ArrayApi, selectedRows: number, selectedCols: number) =>
   s.element('div', {
     classes: [ arr.has('tox-menu'), arr.has('tox-collection'), arr.has('tox-collection--list') ],
@@ -36,7 +39,7 @@ const insertTablePickerApprox = (s: ApproxStructure.StructApi, str: ApproxStruct
                 classes: [ arr.has('tox-insert-table-picker') ],
                 children: tableCellsApprox(s, str, arr, selectedRows, selectedCols).concat(s.element('span', {
                   classes: [ arr.has('tox-insert-table-picker__label') ],
-                  html: str.is(`${selectedCols} columns and ${selectedRows} rows`)
+                  html: str.is(expectedLabelText(selectedCols, selectedRows))
                 }))
               })
             ]
@@ -116,7 +119,7 @@ describe('browser.tinymce.themes.silver.skin.OxideTablePickerMenuTest', () => {
 
     const secondPicker = await pOpenTablePicker();
     UiFinder.notExists(secondPicker, 'div.tox-insert-table-picker__selected');
-    UiFinder.exists(secondPicker, 'span.tox-insert-table-picker__label:contains("0x0")');
+    UiFinder.exists(secondPicker, 'span.tox-insert-table-picker__label:contains("0 columns and 0 rows")');
     TinyUiActions.keyup(editor, Keys.escape());
     TinyUiActions.keyup(editor, Keys.escape());
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
@@ -109,7 +109,7 @@ describe('browser.tinymce.themes.silver.skin.OxideTablePickerMenuTest', () => {
     const item = UiFinder.findIn(firstPicker, 'div[role="button"]').getOrDie();
     Mouse.mouseOver(item);
     UiFinder.exists(firstPicker, 'div.tox-insert-table-picker__selected');
-    UiFinder.exists(firstPicker, 'span.tox-insert-table-picker__label:contains("1x1")');
+    UiFinder.exists(firstPicker, 'span.tox-insert-table-picker__label:contains("1 column and 1 row")');
 
     TinyUiActions.keyup(editor, Keys.escape());
     await Waiter.pTryUntil('Wait for menu to be hidden', () => UiFinder.notExists(SugarBody.body(), 'div.tox-fancymenuitem'));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
@@ -13,7 +13,8 @@ const tableCellsApprox = (s: ApproxStructure.StructApi, str: ApproxStructure.Str
     for (let j = 1; j <= 10; j++) {
       cells.push(s.element('div', {
         attrs: {
-          role: str.is('button')
+          role: str.is('button'),
+          ['aria-label']: str.is(`${j} columns, ${i} rows`)
         },
         classes: i <= selectedRows && j <= selectedCols ? [ arr.has('tox-insert-table-picker__selected') ] : [ arr.not('tox-insert-table-picker__selected') ]
       }));
@@ -21,9 +22,6 @@ const tableCellsApprox = (s: ApproxStructure.StructApi, str: ApproxStructure.Str
   }
   return cells;
 };
-
-const expectedLabelText = (cols: number, rows: number) =>
-  `${cols} ${cols === 1 ? 'column' : 'columns'} and ${rows} ${rows === 1 ? 'row' : 'rows'}`;
 
 const insertTablePickerApprox = (s: ApproxStructure.StructApi, str: ApproxStructure.StringApi, arr: ApproxStructure.ArrayApi, selectedRows: number, selectedCols: number) =>
   s.element('div', {
@@ -39,7 +37,7 @@ const insertTablePickerApprox = (s: ApproxStructure.StructApi, str: ApproxStruct
                 classes: [ arr.has('tox-insert-table-picker') ],
                 children: tableCellsApprox(s, str, arr, selectedRows, selectedCols).concat(s.element('span', {
                   classes: [ arr.has('tox-insert-table-picker__label') ],
-                  html: str.is(expectedLabelText(selectedCols, selectedRows))
+                  html: str.is(`${selectedCols}x${selectedRows}`)
                 }))
               })
             ]
@@ -112,14 +110,14 @@ describe('browser.tinymce.themes.silver.skin.OxideTablePickerMenuTest', () => {
     const item = UiFinder.findIn(firstPicker, 'div[role="button"]').getOrDie();
     Mouse.mouseOver(item);
     UiFinder.exists(firstPicker, 'div.tox-insert-table-picker__selected');
-    UiFinder.exists(firstPicker, 'span.tox-insert-table-picker__label:contains("1 column and 1 row")');
+    UiFinder.exists(firstPicker, 'span.tox-insert-table-picker__label:contains("1x1")');
 
     TinyUiActions.keyup(editor, Keys.escape());
     await Waiter.pTryUntil('Wait for menu to be hidden', () => UiFinder.notExists(SugarBody.body(), 'div.tox-fancymenuitem'));
 
     const secondPicker = await pOpenTablePicker();
     UiFinder.notExists(secondPicker, 'div.tox-insert-table-picker__selected');
-    UiFinder.exists(secondPicker, 'span.tox-insert-table-picker__label:contains("0 columns and 0 rows")');
+    UiFinder.exists(secondPicker, 'span.tox-insert-table-picker__label:contains("0x0")');
     TinyUiActions.keyup(editor, Keys.escape());
     TinyUiActions.keyup(editor, Keys.escape());
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
@@ -36,7 +36,7 @@ const insertTablePickerApprox = (s: ApproxStructure.StructApi, str: ApproxStruct
                 classes: [ arr.has('tox-insert-table-picker') ],
                 children: tableCellsApprox(s, str, arr, selectedRows, selectedCols).concat(s.element('span', {
                   classes: [ arr.has('tox-insert-table-picker__label') ],
-                  html: str.is(`${selectedCols}x${selectedRows}`)
+                  html: str.is(`${selectedCols} columns and ${selectedRows} rows`)
                 }))
               })
             ]


### PR DESCRIPTION
Related Ticket: TINY-10140

Description of Changes:
* Updated the table grid menu item cells with individual aria-labels to announce selection with "columns" and "rows".

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been ~added~ modified (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
