### PR TITLE
TINY-10062: Remove overlapped indices in `Search.findmany`

### DIFF
--- a/modules/phoenix/src/test/ts/atomic/search/MatchSplitterTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/search/MatchSplitterTest.ts
@@ -1,4 +1,4 @@
-import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, describe, it } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Arr, Optional } from '@ephox/katamari';
 import { PositionArray, PRange } from '@ephox/polaris';
@@ -8,23 +8,13 @@ import * as MatchSplitter from 'ephox/phoenix/search/MatchSplitter';
 import * as Finder from 'ephox/phoenix/test/Finder';
 import * as TestRenders from 'ephox/phoenix/test/TestRenders';
 
-UnitTest.test('MatchSplitterTest', () => {
-  const data = () => {
-    return Gene('root', 'root', [
-      TextGene('1', 'AB'),
-      TextGene('2', 'C'),
-      TextGene('3', 'DEFGHI'),
-      TextGene('4', 'JKL'),
-      TextGene('5', 'MNOP')
-    ]);
-  };
+interface CheckExpect {
+  readonly text: string[];
+  readonly exact: string;
+  readonly word: string;
+}
 
-  interface CheckExpect {
-    text: string[];
-    exact: string;
-    word: string;
-  }
-
+describe('atomic.phoenix.search.MatchSplitterTest', () => {
   const check = (all: string[], expected: CheckExpect[], ids: string[], matches: (PRange & { word: string })[], input: Gene) => {
     const universe = TestUniverse(input);
     const items = Finder.getAll(universe, ids);
@@ -34,8 +24,8 @@ UnitTest.test('MatchSplitterTest', () => {
     });
 
     const actual = MatchSplitter.separate(universe, list, matches);
-    Assert.eq('Wrong sizes for MatchSplitter', expected.length, actual.length);
-    Assert.eq('', expected, Arr.map(actual, (a) => {
+    Assert.eq('Asserting length of result', expected.length, actual.length);
+    Assert.eq(`Asserting result of MatchSplitter.separate for word: "${all.join('')}"`, expected, Arr.map(actual, (a) => {
       return {
         text: TestRenders.texts(a.elements),
         exact: a.exact,
@@ -43,7 +33,7 @@ UnitTest.test('MatchSplitterTest', () => {
       };
     }));
 
-    Assert.eq('', all, TestRenders.texts(universe.get().children));
+    Assert.eq(`Asserting result for word: "${all.join('')}"`, all, TestRenders.texts(universe.get().children));
 
   };
 
@@ -55,17 +45,110 @@ UnitTest.test('MatchSplitterTest', () => {
     };
   };
 
-  /*
-    This is obviously not an easy thing to test, so there are key attributes that this test is
-    targeting. Firstly, that the text nodes are broken up as specified by the match positions.
-    Secondly, that the matches created for each equivalent match have passed through the information
-    correctly. The output format is transformed significantly so this isn't testing the output value
-    as transparently as was desired.
-  */
-  check([ 'AB', 'C', 'D', 'E', 'FG', 'H', 'I', 'JK', 'L', 'MNO', 'P' ], [
-    { text: [ 'C', 'D' ], exact: 'CD', word: 'w1' },
-    { text: [ 'FG' ], exact: 'FG', word: 'w2' },
-    { text: [ 'I', 'JK' ], exact: 'IJK', word: 'w3' },
-    { text: [ 'L', 'MNO' ], exact: 'LMNO', word: 'w4' }
-  ], [ '1', '2', '3', '4', '5' ], [ match(2, 4, 'w1'), match(5, 7, 'w2'), match(8, 11, 'w3'), match(11, 15, 'w4') ], data());
+  it('TINY-10062: MatchSplitter Test', () => {
+    /*
+      This is obviously not an easy thing to test, so there are key attributes that this test is
+      targeting. Firstly, that the text nodes are broken up as specified by the match positions.
+      Secondly, that the matches created for each equivalent match have passed through the information
+      correctly. The output format is transformed significantly so this isn't testing the output value
+      as transparently as was desired.
+    */
+    check([ 'AB', 'C', 'D', 'E', 'FG', 'H', 'I', 'JK', 'L', 'MNO', 'P' ],
+      [
+        { text: [ 'C', 'D' ], exact: 'CD', word: 'w1' },
+        { text: [ 'FG' ], exact: 'FG', word: 'w2' },
+        { text: [ 'I', 'JK' ], exact: 'IJK', word: 'w3' },
+        { text: [ 'L', 'MNO' ], exact: 'LMNO', word: 'w4' }
+      ],
+      [ '1', '2', '3', '4', '5' ],
+      [ match(2, 4, 'w1'), match(5, 7, 'w2'), match(8, 11, 'w3'), match(11, 15, 'w4') ],
+      Gene('root', 'root', [
+        TextGene('1', 'AB'),
+        TextGene('2', 'C'),
+        TextGene('3', 'DEFGHI'),
+        TextGene('4', 'JKL'),
+        TextGene('5', 'MNOP')
+      ])
+    );
+
+    check([ '<p>', ' ', 'Hello', ' ', 'World<', '/', 'p>' ],
+      [
+        { text: [ '<p>' ], exact: '<p>', word: '<p>' },
+        { text: [ 'Hello' ], exact: 'Hello', word: 'Hello' },
+        { text: [ 'World<' ], exact: 'World<', word: 'World<' },
+        { text: [ 'p>' ], exact: 'p>', word: 'p>' },
+      ],
+      [ '1' ],
+      [ match(0, 3, '<p>'), match(4, 9, 'Hello'), match(10, 16, 'World<'), match(17, 19, 'p>') ],
+      Gene('root', 'root', [
+        TextGene('1', '<p> Hello World</p>'),
+      ])
+    );
+
+    check([ '<p>Hello', ' ', 'World<', '/', 'p>' ],
+      [
+        { text: [ '<p>Hello' ], exact: '<p>Hello', word: '<p>Hello' },
+        { text: [ 'World<' ], exact: 'World<', word: 'World<' },
+        { text: [ 'p>' ], exact: 'p>', word: 'p>' },
+      ],
+      [ '1' ],
+      [ match(0, 8, '<p>Hello'), match(9, 15, 'World<'), match(16, 18, 'p>') ],
+      Gene('root', 'root', [
+        TextGene('1', '<p>Hello World</p>'),
+      ])
+    );
+
+    check([ '<p>Hello', ' ', 'World', ' ', '<', '/', 'p>' ],
+      [
+        { text: [ '<p>Hello' ], exact: '<p>Hello', word: '<p>Hello' },
+        { text: [ 'World' ], exact: 'World', word: 'World' },
+        { text: [ '<' ], exact: '<', word: '<' },
+        { text: [ 'p>' ], exact: 'p>', word: 'p>' },
+      ],
+      [ '1' ],
+      [ match(0, 8, '<p>Hello'), match(9, 14, 'World'), match(15, 16, '<'), match(17, 19, 'p>') ],
+      Gene('root', 'root', [
+        TextGene('1', '<p>Hello World </p>'),
+      ])
+    );
+
+    check([ '<p>', ' ', 'Hello', ' ', 'World', ' ', '<', '/', 'p>' ],
+      [
+        { text: [ '<p>' ], exact: '<p>', word: '<p>' },
+        { text: [ 'Hello' ], exact: 'Hello', word: 'Hello' },
+        { text: [ 'World' ], exact: 'World', word: 'World' },
+        { text: [ '<' ], exact: '<', word: '<' },
+        { text: [ 'p>' ], exact: 'p>', word: 'p>' },
+      ],
+      [ '1' ],
+      [ match(0, 3, '<p>'), match(4, 9, 'Hello'), match(10, 15, 'World'), match(16, 17, '<'), match(18, 20, 'p>') ],
+      Gene('root', 'root', [
+        TextGene('1', '<p> Hello World </p>'),
+      ])
+    );
+
+    check([ 'Test. [', 'IF:INTEXT', ']Test2 [/', 'IF', ']' ],
+      [
+        { text: [ 'IF:INTEXT' ], exact: 'IF:INTEXT', word: 'IF:INTEXT' },
+        { text: [ 'IF' ], exact: 'IF', word: 'IF' },
+      ],
+      [ '1' ],
+      [ match(7, 16, 'IF:INTEXT'), match(25, 27, 'IF') ],
+      Gene('root', 'root', [
+        TextGene('1', 'Test. [IF:INTEXT]Test2 [/IF]'),
+      ])
+    );
+
+    check([ 'Test. [/', 'IF', ']Test2 [', 'IF:INTEXT', ']' ],
+      [
+        { text: [ 'IF' ], exact: 'IF', word: 'IF' },
+        { text: [ 'IF:INTEXT' ], exact: 'IF:INTEXT', word: 'IF:INTEXT' },
+      ],
+      [ '1' ],
+      [ match(8, 10, 'IF'), match(18, 27, 'IF:INTEXT') ],
+      Gene('root', 'root', [
+        TextGene('1', 'Test. [/IF]Test2 [IF:INTEXT]'),
+      ])
+    );
+  });
 });

--- a/modules/phoenix/src/test/ts/atomic/search/SearcherTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/search/SearcherTest.ts
@@ -1,4 +1,4 @@
-import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, describe, it } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Arr, Fun } from '@ephox/katamari';
 
@@ -6,56 +6,17 @@ import * as Searcher from 'ephox/phoenix/search/Searcher';
 import * as Finder from 'ephox/phoenix/test/Finder';
 import * as TestRenders from 'ephox/phoenix/test/TestRenders';
 
-UnitTest.test('SearcherTest', () => {
-  /*
-    An example of some <b>test</b> data. The word being looked for will be word and for.
+interface CheckItem {
+  readonly items: string[];
+  readonly word: string;
+  readonly exact: string;
+}
 
-    There will be a couple of paragraphs. Some ending with fo
-
-    r and more.
-
-    <p>An example of some <span>test</span>data. The words being looked for will be word and for and test.</p>
-    <p>There will be three paragraphs. This one ends with partial fo</p>
-    <p>r and more.</p>
-  */
-  const data = () => {
-    return Gene('root', 'root', [
-      Gene('p1', 'p', [
-        TextGene('p1-a', 'An example of some '),
-        Gene('span1', 'span', [
-          TextGene('span1-a', 'test')
-        ]),
-        TextGene('p1-b', ' data. The word being looked for will be w'),
-        Gene('span1b', 'span', [
-          Gene('span1ba', 'span', [
-            TextGene('p1-c', 'or')
-          ])
-        ]),
-        TextGene('p1-d', 'd and for.')
-      ]),
-      Gene('p2', 'p', [
-        TextGene('p2-a', 'There will be some tes'),
-        Gene('span2', 'span', [
-          TextGene('span2-a', 't')
-        ]),
-        TextGene('p2-b', ' paragraphs. This one ends with a partial fo')
-      ]),
-      Gene('p3', 'p', [
-        TextGene('p3-a', 'r and more.')
-      ])
-    ]);
-  };
-
-  interface CheckItem {
-    items: string[];
-    word: string;
-    exact: string;
-  }
-
+describe('atomic.polaris.search.SearcherTest', () => {
   const checkWords = (expected: CheckItem[], itemIds: string[], words: string[], input: Gene) => {
     const universe = TestUniverse(input);
     const items = Finder.getAll(universe, itemIds);
-    const actual = Searcher.safeWords(universe, items, words, Fun.never as (e: Gene) => boolean);
+    const actual = Searcher.safeWords(universe, items, words, Fun.never);
 
     const processed = Arr.map(actual, (match): CheckItem => {
       return {
@@ -64,18 +25,140 @@ UnitTest.test('SearcherTest', () => {
         exact: match.exact
       };
     });
-    Assert.eq('', expected, processed);
+    Assert.eq(`Asserting result for word "${items.flatMap(({ children }) => children.map((x) => x.text)).join('')}"`, expected, processed);
   };
 
-  // An example of some <test> data. The <word> being looked <for> will be <w_or_d> and <for>.|There will be some <tes_t>
-  // paragraphs. This one ends with a partial fo|r and more.
+  it('TINY-10062: Search for words in multiply text elements', () => {
+    /*
+      An example of some <b>test</b> data. The word being looked for will be word and for.
 
-  checkWords([
-    { items: [ 'test' ], word: 'test', exact: 'test' },
-    { items: [ 'word' ], word: 'word', exact: 'word' },
-    { items: [ 'for' ], word: 'for', exact: 'for' },
-    { items: [ 'w', 'or', 'd' ], word: 'word', exact: 'word' },
-    { items: [ 'for' ], word: 'for', exact: 'for' },
-    { items: [ 'tes', 't' ], word: 'test', exact: 'test' }
-  ], [ 'p1', 'p2', 'p3' ], [ 'for', 'test', 'word' ], data());
+      There will be a couple of paragraphs. Some ending with fo
+
+      r and more.
+
+      <p>An example of some <span>test</span>data. The words being looked for will be word and for and test.</p>
+      <p>There will be three paragraphs. This one ends with partial fo</p>
+      <p>r and more.</p>
+    */
+    const data = () => {
+      return Gene('root', 'root', [
+        Gene('p1', 'p', [
+          TextGene('p1-a', 'An example of some '),
+          Gene('span1', 'span', [
+            TextGene('span1-a', 'test')
+          ]),
+          TextGene('p1-b', ' data. The word being looked for will be w'),
+          Gene('span1b', 'span', [
+            Gene('span1ba', 'span', [
+              TextGene('p1-c', 'or')
+            ])
+          ]),
+          TextGene('p1-d', 'd and for.')
+        ]),
+        Gene('p2', 'p', [
+          TextGene('p2-a', 'There will be some tes'),
+          Gene('span2', 'span', [
+            TextGene('span2-a', 't')
+          ]),
+          TextGene('p2-b', ' paragraphs. This one ends with a partial fo')
+        ]),
+        Gene('p3', 'p', [
+          TextGene('p3-a', 'r and more.')
+        ])
+      ]);
+    };
+
+    // An example of some <test> data. The <word> being looked <for> will be <w_or_d> and <for>.|There will be some <tes_t>
+    // paragraphs. This one ends with a partial fo|r and more.
+    checkWords([
+      { items: [ 'test' ], word: 'test', exact: 'test' },
+      { items: [ 'word' ], word: 'word', exact: 'word' },
+      { items: [ 'for' ], word: 'for', exact: 'for' },
+      { items: [ 'w', 'or', 'd' ], word: 'word', exact: 'word' },
+      { items: [ 'for' ], word: 'for', exact: 'for' },
+      { items: [ 'tes', 't' ], word: 'test', exact: 'test' }
+    ], [ 'p1', 'p2', 'p3' ], [ 'for', 'test', 'word' ], data());
+  });
+
+  it('TINY-10062: Search for words in single text element', () => {
+    checkWords([
+      { items: [ '<p>' ], word: '<p>', exact: '<p>' },
+      { items: [ ' Hello' ], word: ' Hello', exact: ' Hello' },
+      { items: [ 'World<' ], word: 'World<', exact: 'World<' },
+      { items: [ 'p>' ], word: 'p>', exact: 'p>' },
+    ],
+    [ 'p1' ],
+    [ '<p>', ' Hello', 'World<', 'p>' ],
+    Gene('root', 'root', [
+      Gene('p1', 'p', [
+        TextGene('p1-a', '<p> Hello World</p>'),
+      ]),
+    ]));
+
+    checkWords([
+      { items: [ '<p>Hello' ], word: '<p>Hello', exact: '<p>Hello' },
+      { items: [ 'World<' ], word: 'World<', exact: 'World<' },
+      { items: [ 'p>' ], word: 'p>', exact: 'p>' },
+    ],
+    [ 'p1' ],
+    [ '<p>Hello', 'World<', 'p>' ],
+    Gene('root', 'root', [
+      Gene('p1', 'p', [
+        TextGene('p1-a', '<p>Hello World</p>'),
+      ]),
+    ]));
+
+    checkWords([
+      { items: [ '<p>Hello' ], word: '<p>Hello', exact: '<p>Hello' },
+      { items: [ 'World' ], word: 'World', exact: 'World' },
+      { items: [ '<' ], word: '<', exact: '<' },
+      { items: [ 'p>' ], word: 'p>', exact: 'p>' },
+    ],
+    [ 'p1' ],
+    [ '<p>Hello', 'World', '<', 'p>' ],
+    Gene('root', 'root', [
+      Gene('p1', 'p', [
+        TextGene('p1-a', '<p>Hello World </p>'),
+      ]),
+    ]));
+
+    checkWords([
+      { items: [ '<p>' ], word: '<p>', exact: '<p>' },
+      { items: [ 'Hello' ], word: 'Hello', exact: 'Hello' },
+      { items: [ 'World' ], word: 'World', exact: 'World' },
+      { items: [ '<' ], word: '<', exact: '<' },
+      { items: [ 'p>' ], word: 'p>', exact: 'p>' },
+    ],
+    [ 'p1' ],
+    [ '<p>', 'Hello', 'World', '<', 'p>' ],
+    Gene('root', 'root', [
+      Gene('p1', 'p', [
+        TextGene('p1-a', '<p> Hello World </p>'),
+      ]),
+    ]));
+
+    checkWords([
+      { items: [ 'IF:INTEXT' ], word: 'IF:INTEXT', exact: 'IF:INTEXT' },
+      { items: [ 'IF' ], word: 'IF', exact: 'IF' },
+    ],
+    [ 'p1' ],
+    [ 'IF:INTEXT', 'IF' ],
+    Gene('root', 'root', [
+      Gene('p1', 'p', [
+        TextGene('p1-a', 'Test. [IF:INTEXT]Test2 [/IF]'),
+      ]),
+    ]));
+
+    checkWords([
+      { items: [ 'IF' ], word: 'IF', exact: 'IF' },
+      { items: [ 'IF:INTEXT' ], word: 'IF:INTEXT', exact: 'IF:INTEXT' },
+    ],
+    [ 'p1' ],
+    [ 'IF', 'IF:INTEXT' ],
+    Gene('root', 'root', [
+      Gene('p1', 'p', [
+        TextGene('p1-a', 'Test. [/IF]Test2 [IF:INTEXT]'),
+      ]),
+    ]));
+  });
 });

--- a/modules/phoenix/src/test/ts/browser/DomSearchTest.ts
+++ b/modules/phoenix/src/test/ts/browser/DomSearchTest.ts
@@ -5,8 +5,8 @@ import { Attribute, Html, Insert, InsertAll, Remove, SugarElement } from '@ephox
 import * as DomSearch from 'ephox/phoenix/api/dom/DomSearch';
 import * as DomWrapping from 'ephox/phoenix/api/dom/DomWrapping';
 
-export interface EntitiesMap {
-  [name: string]: string;
+interface EntitiesMap {
+  readonly [name: string]: string;
 }
 
 describe('browser.phoenix.api.DomSearchTest', () => {

--- a/modules/phoenix/src/test/ts/browser/DomSearchTest.ts
+++ b/modules/phoenix/src/test/ts/browser/DomSearchTest.ts
@@ -1,19 +1,37 @@
-import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { after, Assert, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { Attribute, Html, Insert, InsertAll, Remove, SugarElement } from '@ephox/sugar';
 
 import * as DomSearch from 'ephox/phoenix/api/dom/DomSearch';
 import * as DomWrapping from 'ephox/phoenix/api/dom/DomWrapping';
 
-UnitTest.test('DomSearchTest', () => {
+export interface EntitiesMap {
+  [name: string]: string;
+}
+
+describe('browser.phoenix.api.DomSearchTest', () => {
   const body = SugarElement.fromDom(document.body);
   const container = SugarElement.fromTag('div');
   Insert.append(body, container);
 
+  // Taken from: modules/tinymce/src/core/main/ts/api/html/Entities.ts, makes tests easier to read
+  const decode = (html: string) => {
+    const entityRegExp = /&#([a-z0-9]+);?|&([a-z0-9]+);/gi;
+    const reverseEntities: EntitiesMap = {
+      '&lt;': '<',
+      '&gt;': '>',
+      '&amp;': '&',
+      '&quot;': '"',
+      '&apos;': `'`
+    };
+
+    return html.replace(entityRegExp, (all) => reverseEntities[all]);
+  };
+
+  after(() => Remove.remove(container));
+
   const check = (expected: string, rawTexts: string[], words: string[]) => {
-    const elements = Arr.map(rawTexts, (x) => {
-      return SugarElement.fromText(x);
-    });
+    const elements = Arr.map(rawTexts, (x) => SugarElement.fromText(x));
 
     Remove.empty(container);
     InsertAll.append(container, elements);
@@ -28,13 +46,74 @@ UnitTest.test('DomSearchTest', () => {
       });
     });
 
-    Assert.eq('', expected, Html.get(container));
+    Assert.eq(`Asserting result for word: ${rawTexts.join('')},`, expected, decode(Html.get(container)));
   };
 
-  check('<span data-word="Sed">Sed</span>', [ 'Sed' ], [ 'Sed' ]);
-  check('<span data-word="Sed">Sed</span> ut perspiciatis <span data-word="unde">u</span><span data-word="unde">nde</span>' +
-    ' omnis <span data-word="iste">iste</span> natus error <span data-word="sit">sit</span> voluptatem', [ 'Sed', ' ut per', 'spiciatis u', 'nde om', 'ni', 's iste', ' natus', ' error', ' sit voluptatem' ], [ 'Sed', 'iste', 'unde', 'sit' ]);
-  check('<span data-word="Sed">Sed</span> <span data-word="ut">ut</span> per', [ 'Sed', ' ut per' ], [ 'Sed', 'ut' ]);
+  it('TINY-10062: Search for text in DOM', () => {
+    check('<span data-word="Sed">Sed</span>', [ 'Sed' ], [ 'Sed' ]);
+    check('<span data-word="Sed">Sed</span> ut perspiciatis <span data-word="unde">u</span><span data-word="unde">nde</span>' +
+      ' omnis <span data-word="iste">iste</span> natus error <span data-word="sit">sit</span> voluptatem', [ 'Sed', ' ut per', 'spiciatis u', 'nde om', 'ni', 's iste', ' natus', ' error', ' sit voluptatem' ], [ 'Sed', 'iste', 'unde', 'sit' ]);
+    check('<span data-word="Sed">Sed</span> <span data-word="ut">ut</span> per', [ 'Sed', ' ut per' ], [ 'Sed', 'ut' ]);
 
-  Remove.remove(container);
+    check(
+      [
+        '<span data-word="<p>"><p></span>',
+        '<span data-word="Hello">Hello</span>',
+        '<span data-word="World<">World<</span>/<span data-word="p>">p></span>'
+      ].join(' '),
+      [ '<p> Hello World</p>' ],
+      [ '<p>', 'Hello', 'World<', 'p>' ]
+    );
+
+    // No word boundaries before the space between the text within the element, so we just pass <p>Hello
+    check(
+      [
+        '<span data-word="<p>Hello"><p>Hello</span>',
+        '<span data-word="World<">World<</span>/<span data-word="p>">p></span>'
+      ].join(' '),
+      [ '<p>Hello World</p>' ],
+      [ '<p>Hello', 'World<', 'p>' ]
+    );
+
+    check(
+      [
+        '<span data-word="<p>"><p></span>',
+        '<span data-word="Hello">Hello</span>',
+        '<span data-word="World">World</span>',
+        '<span data-word="<"><</span>/<span data-word="p>">p></span>'
+      ].join(' '),
+      [ '<p> Hello World </p>' ],
+      [ '<p>', 'Hello', 'World', '<', 'p>' ]
+    );
+
+    check(
+      [
+        '<span data-word="<p>Hello"><p>Hello</span>',
+        '<span data-word="World">World</span>',
+        '<span data-word="<"><</span>/<span data-word="p>">p></span>'
+      ].join(' '),
+      [ '<p>Hello World </p>' ],
+      [ '<p>Hello', 'World', '<', 'p>' ]
+    );
+
+    check(
+      [
+        'Test.',
+        '[<span data-word="IF:INTEXT">IF:INTEXT</span>]Test2',
+        '[/<span data-word="IF">IF</span>]'
+      ].join(' '),
+      [ 'Test. [IF:INTEXT]Test2 [/IF]' ],
+      [ 'IF:INTEXT', 'IF' ]
+    );
+
+    check(
+      [
+        'Test.',
+        '[/<span data-word="IF">IF</span>]Test2',
+        '[<span data-word="IF:INTEXT">IF:INTEXT</span>]'
+      ].join(' '),
+      [ 'Test. [/IF]Test2 [IF:INTEXT]' ],
+      [ 'IF', 'IF:INTEXT' ]
+    );
+  });
 });

--- a/modules/polaris/CHANGELOG.md
+++ b/modules/polaris/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- `Search.findmany` now removes overlapped indices. #TINY-10062
+
 ## 6.2.0 - 2023-06-12
 
 ### Added

--- a/modules/polaris/src/main/ts/ephox/polaris/search/Sleuth.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/search/Sleuth.ts
@@ -11,20 +11,21 @@ const removeOverlapped = <T extends PRange>(array: T[]): T[] => {
 
   return Arr.foldl(sorted, (acc, item) => {
     const overlaps = Arr.exists(acc, (a) => item.start >= a.start && item.finish <= a.finish);
-    const matchingStartIndex = Arr.findIndex(acc, (a) => item.start === a.start).getOr(-1);
+    const matchingStartIndex = Arr.findIndex(acc, (a) => item.start === a.start);
 
-    if (!overlaps && matchingStartIndex === -1) {
-      return [ ...acc, item ];
-    }
-
-    // We want to take the greater finish point in the acc if the start matches
-    if (matchingStartIndex !== -1 && item.finish > acc[matchingStartIndex].finish) {
-      const before = acc.slice(0, matchingStartIndex);
-      const after = acc.slice(matchingStartIndex + 1);
-      return [ ...before, item, ...after ];
-    }
-
-    return acc;
+    // If the start is not the same and it is not within the start and finish, then we skip, else we append the item
+    // If start is the same, but it's not within finish, so we take the greater finish
+    // No need to get the ending part of the array as it's sorted, so we replace the item at the index with the greater finish item
+    return matchingStartIndex.fold(() => {
+      return overlaps ? acc : [ ...acc, item ];
+    },
+    (index) => {
+      if (item.finish > acc[index].finish) {
+        const before = acc.slice(0, index);
+        return [ ...before, item ];
+      }
+      return acc;
+    });
   }, [] as T[]);
 };
 

--- a/modules/polaris/src/main/ts/ephox/polaris/search/Sleuth.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/search/Sleuth.ts
@@ -13,8 +13,8 @@ const removeOverlapped = <T extends PRange>(array: T[]): T[] => {
     const overlaps = Arr.exists(acc, (a) => item.start >= a.start && item.finish <= a.finish);
     const matchingStartIndex = Arr.findIndex(acc, (a) => item.start === a.start);
 
-    // If the start is not the same and it is not within the start and finish, then we skip, else we append the item
-    // If start is the same, but it's not within finish, so we take the greater finish
+    // If there's no item with matching start in acc and within the start and finish, then we append, else we skip the item
+    // If there's a matching item with the same start in the acc, but it's not within finish, so we take the greater finish
     // No need to get the ending part of the array as it's sorted, so we replace the item at the index with the greater finish item
     return matchingStartIndex.fold(() => {
       return overlaps ? acc : [ ...acc, item ];

--- a/modules/polaris/src/main/ts/ephox/polaris/search/Sleuth.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/search/Sleuth.ts
@@ -3,24 +3,35 @@ import { Arr } from '@ephox/katamari';
 import { PRange, PRegExp } from '../pattern/Types';
 import * as Find from './Find';
 
-const sort = <T extends PRange>(array: T[]): T[] => {
-  const r: T[] = Array.prototype.slice.call(array, 0);
-  r.sort((a, b) => {
-    if (a.start < b.start) {
-      return -1;
-    } else if (b.start < a.start) {
-      return 1;
-    } else {
-      return 0;
+const sort = <T extends PRange>(array: T[]): T[] => Arr.sort(array, (a, b) => a.start - b.start);
+
+// Array needs to be sorted first
+const removeOverlapped = <T extends PRange>(array: T[]): T[] => {
+  const sorted = sort(array);
+
+  return Arr.foldl(sorted, (acc, item) => {
+    const overlaps = Arr.exists(acc, (a) => item.start >= a.start && item.finish <= a.finish);
+    const matchingStartIndex = Arr.findIndex(acc, (a) => item.start === a.start).getOr(-1);
+
+    if (!overlaps && matchingStartIndex === -1) {
+      return [ ...acc, item ];
     }
-  });
-  return r;
+
+    // We want to take the greater finish point in the acc if the start matches
+    if (matchingStartIndex !== -1 && item.finish > acc[matchingStartIndex].finish) {
+      const before = acc.slice(0, matchingStartIndex);
+      const after = acc.slice(matchingStartIndex + 1);
+      return [ ...before, item, ...after ];
+    }
+
+    return acc;
+  }, [] as T[]);
 };
 
 /**
  * For each target (pattern, ....), find the matching text (if there is any) and record the start and end offsets.
  *
- * Then sort the result by start point.
+ * Then sort by start point and remove overlapping result.
  */
 const search = <T extends { pattern: PRegExp }>(text: string, targets: T[]): Array<T & PRange> => {
   const unsorted = Arr.bind(targets, (t) => {
@@ -32,8 +43,7 @@ const search = <T extends { pattern: PRegExp }>(text: string, targets: T[]): Arr
       };
     });
   });
-
-  return sort(unsorted);
+  return removeOverlapped(unsorted);
 };
 
 export {

--- a/modules/polaris/src/test/ts/atomic/api/SearchFindTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/SearchFindTest.ts
@@ -1,4 +1,4 @@
-import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, it, describe } from '@ephox/bedrock-client';
 import { Arr, Unicode } from '@ephox/katamari';
 
 import * as Pattern from 'ephox/polaris/api/Pattern';
@@ -6,15 +6,16 @@ import * as Search from 'ephox/polaris/api/Search';
 import * as Safe from 'ephox/polaris/pattern/Safe';
 import { PRegExp } from 'ephox/polaris/pattern/Types';
 
-UnitTest.test('api.Search.findall (using api.Pattern)', () => {
+describe('atomic.polaris.api.SearchFindTest', () => {
   const checkAll = (expected: [number, number][], input: string, pattern: PRegExp) => {
     const actual = Search.findall(input, pattern);
-    Assert.eq('', expected.length, actual.length);
+    Assert.eq(`Checking length of result for "${input}"`, expected.length, actual.length);
     Arr.each(expected, (exp, i) => {
-      Assert.eq('', exp[0], actual[i].start);
-      Assert.eq('', exp[1], actual[i].finish);
+      Assert.eq(`Checking result of start for "${exp}"`, exp[0], actual[i].start);
+      Assert.eq(`Checking result of finish for "${exp}"`, exp[1], actual[i].finish);
     });
   };
+
   const testData = (pattern: PRegExp, name: string) => ({
     pattern,
     name
@@ -22,54 +23,120 @@ UnitTest.test('api.Search.findall (using api.Pattern)', () => {
 
   const checkMany = (expected: [number, number, string][], text: string, targets: ReturnType<typeof testData>[]) => {
     const actual = Search.findmany(text, targets);
-    Assert.eq('', expected.length, actual.length);
+    Assert.eq(`Checking length of result for "${text}"`, expected.length, actual.length);
     Arr.each(expected, (exp, i) => {
-      Assert.eq('', exp[0], actual[i].start);
-      Assert.eq('', exp[1], actual[i].finish);
-      Assert.eq('', exp[2], actual[i].name);
+      Assert.eq(`Checking result of start for "${exp}"`, exp[0], actual[i].start);
+      Assert.eq(`Checking result of finish for "${exp}"`, exp[1], actual[i].finish);
+      Assert.eq(`Checking result of name for "${exp}"`, exp[2], actual[i].name);
     });
   };
 
-  checkAll([], 'eskimo', Pattern.unsafetoken('hi'));
-  checkAll([[ 1, 7 ]], ' cattle', Pattern.unsafetoken('cattle'));
-  checkAll([], 'acattle', Pattern.unsafeword('cattle'));
-  checkAll([[ 1, 7 ]], ' cattle', Pattern.unsafeword('cattle'));
-  checkAll([], Unicode.zeroWidth + 'dog ', Pattern.safeword('dog'));
+  it('TINY-10062: checkAll ', () => {
+    checkAll([], 'eskimo', Pattern.unsafetoken('hi'));
+    checkAll([[ 1, 7 ]], ' cattle', Pattern.unsafetoken('cattle'));
+    checkAll([], 'acattle', Pattern.unsafeword('cattle'));
+    checkAll([[ 1, 7 ]], ' cattle', Pattern.unsafeword('cattle'));
+    checkAll([], Unicode.zeroWidth + 'dog ', Pattern.safeword('dog'));
 
-  checkAll([[ 3, 7 ], [ 10, 14 ]], `no it's i it's done.`, Pattern.unsafetoken(`it's`));
-  checkAll([[ 0, 12 ]], `catastrophe'`, Pattern.unsafetoken(`catastrophe'`));
+    checkAll([[ 3, 7 ], [ 10, 14 ]], `no it's i it's done.`, Pattern.unsafetoken(`it's`));
+    checkAll([[ 0, 12 ]], `catastrophe'`, Pattern.unsafetoken(`catastrophe'`));
 
-  checkAll([[ 0, 3 ]], 'sre', Pattern.unsafeword('sre'));
-  checkAll([[ 0, 3 ]], 'sre ', Pattern.unsafeword('sre'));
-  checkAll([[ 1, 4 ]], ' sre', Pattern.unsafeword('sre'));
-  checkAll([[ 1, 4 ]], ' sre ', Pattern.unsafeword('sre'));
-  checkAll([[ 0, 3 ], [ 4, 7 ]], 'sre sre', Pattern.unsafeword('sre'));
-  checkAll([[ 1, 4 ], [ 5, 8 ]], ' sre sre', Pattern.unsafeword('sre'));
-  checkAll([[ 1, 4 ], [ 5, 8 ], [ 9, 12 ]], ' sre sre sre', Pattern.unsafeword('sre'));
-  checkAll([[ 0, 3 ], [ 4, 7 ], [ 8, 11 ]], 'sre sre sre ', Pattern.unsafeword('sre'));
-  checkAll([[ 1, 4 ], [ 5, 8 ], [ 9, 12 ]], ' sre sre sre ', Pattern.unsafeword('sre'));
+    checkAll([[ 0, 3 ]], 'sre', Pattern.unsafeword('sre'));
+    checkAll([[ 0, 3 ]], 'sre ', Pattern.unsafeword('sre'));
+    checkAll([[ 1, 4 ]], ' sre', Pattern.unsafeword('sre'));
+    checkAll([[ 1, 4 ]], ' sre ', Pattern.unsafeword('sre'));
+    checkAll([[ 0, 3 ], [ 4, 7 ]], 'sre sre', Pattern.unsafeword('sre'));
+    checkAll([[ 1, 4 ], [ 5, 8 ]], ' sre sre', Pattern.unsafeword('sre'));
+    checkAll([[ 1, 4 ], [ 5, 8 ], [ 9, 12 ]], ' sre sre sre', Pattern.unsafeword('sre'));
+    checkAll([[ 0, 3 ], [ 4, 7 ], [ 8, 11 ]], 'sre sre sre ', Pattern.unsafeword('sre'));
+    checkAll([[ 1, 4 ], [ 5, 8 ], [ 9, 12 ]], ' sre sre sre ', Pattern.unsafeword('sre'));
 
-  checkAll([[ 'this '.length, 'this e'.length + Unicode.zeroWidth.length + 'nds'.length ]], 'this e' + Unicode.zeroWidth + 'nds here', Pattern.unsafeword('e' + Unicode.zeroWidth + 'nds'));
+    checkAll([[ 'this '.length, 'this e'.length + Unicode.zeroWidth.length + 'nds'.length ]], 'this e' + Unicode.zeroWidth + 'nds here', Pattern.unsafeword('e' + Unicode.zeroWidth + 'nds'));
 
-  const prefix = Safe.sanitise('[');
-  const suffix = Safe.sanitise(']');
-  checkAll([[ 1, 5 ]], ' [wo] and more', Pattern.unsafetoken(prefix + '[^' + suffix + ']*' + suffix));
+    checkAll([[ 1, 5 ]], ' [wo] and more', Pattern.unsafetoken(Safe.sanitise('[') + '[^' + Safe.sanitise(']') + ']*' + Safe.sanitise(']')));
+  });
 
-  checkMany([], '', []);
-  checkMany([
-    [ 1, 3, 'alpha' ]
-  ], ' aa bb cc', [
-    testData(Pattern.safeword('aa'), 'alpha')
-  ]);
+  it('TINY-10062: checkMany ', () => {
+    checkMany([], '', []);
+    checkMany([
+      [ 1, 3, 'alpha' ]
+    ], ' aa bb cc', [
+      testData(Pattern.safeword('aa'), 'alpha')
+    ]);
 
-  checkMany([
-    [ 0, 2, 'alpha' ],
-    [ 3, 6, 'beta' ],
-    [ 8, 18, 'gamma' ]
-  ], 'aa bbb  abcdefghij', [
-    testData(Pattern.safeword('bbb'), 'beta'),
-    testData(Pattern.safeword('abcdefghij'), 'gamma'),
-    testData(Pattern.safeword('aa'), 'alpha'),
-    testData(Pattern.safeword('not-there'), 'delta')
-  ]);
+    checkMany([
+      [ 0, 3, 'alpha' ],
+      [ 4, 9, 'beta' ],
+      [ 10, 16, 'gamma' ],
+      [ 17, 19, 'delta' ],
+    ], '<p> Hello World</p>', [
+      testData(Pattern.safeword('<p>'), 'alpha'),
+      testData(Pattern.safeword('Hello'), 'beta'),
+      testData(Pattern.safeword('World<'), 'gamma'),
+      testData(Pattern.safeword('p>'), 'delta'),
+    ]);
+
+    checkMany([
+      [ 0, 8, 'alpha' ],
+      [ 9, 15, 'beta' ],
+      [ 16, 18, 'gamma' ],
+    ], '<p>Hello World</p>', [
+      testData(Pattern.safeword('<p>Hello'), 'alpha'),
+      testData(Pattern.safeword('World<'), 'beta'),
+      testData(Pattern.safeword('p>'), 'gamma'),
+    ]);
+
+    checkMany([
+      [ 0, 3, 'alpha' ],
+      [ 4, 9, 'beta' ],
+      [ 10, 15, 'gamma' ],
+      [ 16, 17, 'epsilon' ],
+      [ 18, 20, 'zeta' ],
+    ], '<p> Hello World </p>', [
+      testData(Pattern.safeword('<p>'), 'alpha'),
+      testData(Pattern.safeword('Hello'), 'beta'),
+      testData(Pattern.safeword('World'), 'gamma'),
+      testData(Pattern.safeword('<'), 'epsilon'),
+      testData(Pattern.safeword('p>'), 'zeta'),
+    ]);
+
+    checkMany([
+      [ 0, 8, 'alpha' ],
+      [ 9, 14, 'beta' ],
+      [ 15, 16, 'delta' ],
+      [ 17, 19, 'gamma' ],
+    ], '<p>Hello World </p>', [
+      testData(Pattern.safeword('<p>Hello'), 'alpha'),
+      testData(Pattern.safeword('World'), 'beta'),
+      testData(Pattern.safeword('<'), 'delta'),
+      testData(Pattern.safeword('p>'), 'gamma'),
+    ]);
+
+    checkMany([
+      [ 7, 16, 'alpha' ],
+      [ 25, 27, 'beta' ],
+    ], 'Test. [IF:INTEXT]Test2 [/IF]', [
+      testData(Pattern.safeword('IF:INTEXT'), 'alpha'),
+      testData(Pattern.safeword('IF'), 'beta'),
+    ]);
+
+    checkMany([
+      [ 8, 10, 'alpha' ],
+      [ 18, 27, 'beta' ],
+    ], 'Test. [/IF]Test2 [IF:INTEXT]', [
+      testData(Pattern.safeword('IF'), 'alpha'),
+      testData(Pattern.safeword('IF:INTEXT'), 'beta'),
+    ]);
+
+    checkMany([
+      [ 0, 2, 'alpha' ],
+      [ 3, 6, 'beta' ],
+      [ 8, 18, 'gamma' ]
+    ], 'aa bbb  abcdefghij', [
+      testData(Pattern.safeword('bbb'), 'beta'),
+      testData(Pattern.safeword('abcdefghij'), 'gamma'),
+      testData(Pattern.safeword('aa'), 'alpha'),
+      testData(Pattern.safeword('not-there'), 'delta')
+    ]);
+  });
 });

--- a/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
+++ b/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
@@ -1,20 +1,20 @@
-import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional, Optionals } from '@ephox/katamari';
 
 import { WordScope } from 'ephox/robin/data/WordScope';
 import * as Identify from 'ephox/robin/words/Identify';
 
-UnitTest.test('words :: Identify', () => {
+describe('atomic.robin.words.IdentifyTest', () => {
   const none = Optional.none<string>();
   const some = Optional.some;
 
   const check = (expected: WordScope[], input: string) => {
     const actual = Identify.words(input);
-    Assert.eq('', expected.length, actual.length);
-    Arr.map(expected, (x, i) => {
-      Assert.eq('', expected[i].word, actual[i].word);
-      Assert.eq('', true, Optionals.equals(expected[i].left, actual[i].left));
-      Assert.eq('', true, Optionals.equals(expected[i].right, actual[i].right));
+    Assert.eq(`Checking length of result for "${input}"`, expected.length, actual.length);
+    Arr.map(expected, (_, i) => {
+      Assert.eq(`Checking result of word for "${expected[i].word}"`, expected[i].word, actual[i].word);
+      Assert.eq(`Checking result of left for expected: "${expected[i].left.getOr('')}", actual: "${actual[i].left.getOr('')}"`, true, Optionals.equals(expected[i].left, actual[i].left));
+      Assert.eq(`Checking result of right for expected:"${expected[i].right.getOr('')}", actual: "${actual[i].right.getOr('')}"`, true, Optionals.equals(expected[i].right, actual[i].right));
     });
   };
 
@@ -25,55 +25,102 @@ UnitTest.test('words :: Identify', () => {
     }));
   };
 
-  check([], '');
-  check([], ' ');
-  check([ WordScope('one', none, none) ], 'one');
-  check([ WordScope('this', some('('), some(')')) ], '(this)');
-  check([ WordScope(`don't`, some(' '), some(' ')) ], ` don't `);
-  check([
-    WordScope('it', some('"'), some(' ')),
-    WordScope('is', some(' '), some(' ')),
-    WordScope('a', some(' '), some(' ')),
-    WordScope('good', some(' '), some(' ')),
-    WordScope('day', some(' '), some(' ')),
-    WordScope('to', some(' '), some(' ')),
-    WordScope('live', some(' '), some('"'))
-  ], '"it is a good day to live"');
-  check([
-    WordScope(`twas`, some(`'`), some(' ')),
-    WordScope('the', some(' '), some(' ')),
-    WordScope('night', some(' '), some(' ')),
-    WordScope('before', some(' '), none)
-  ], ` 'twas the night before`);
+  it('TINY-10062: Check word', () => {
+    check([], '');
+    check([], ' ');
+    check([ WordScope('one', none, none) ], 'one');
+    check([ WordScope('this', some('('), some(')')) ], '(this)');
+    check([ WordScope(`don't`, some(' '), some(' ')) ], ` don't `);
+    check([
+      WordScope('it', some('"'), some(' ')),
+      WordScope('is', some(' '), some(' ')),
+      WordScope('a', some(' '), some(' ')),
+      WordScope('good', some(' '), some(' ')),
+      WordScope('day', some(' '), some(' ')),
+      WordScope('to', some(' '), some(' ')),
+      WordScope('live', some(' '), some('"'))
+    ], '"it is a good day to live"');
+    check([
+      WordScope(`twas`, some(`'`), some(' ')),
+      WordScope('the', some(' '), some(' ')),
+      WordScope('night', some(' '), some(' ')),
+      WordScope('before', some(' '), none)
+    ], ` 'twas the night before`);
 
-  check([
-    WordScope('this', some(`'`), some(' ')),
-    WordScope('the', some(' '), some(' ')),
-    WordScope('night', some(' '), some(' ')),
-    WordScope('before', some(' '), none)
-  ], ` 'this the night before`);
+    check([
+      WordScope('this', some(`'`), some(' ')),
+      WordScope('the', some(' '), some(' ')),
+      WordScope('night', some(' '), some(' ')),
+      WordScope('before', some(' '), none)
+    ], ` 'this the night before`);
 
-  // Note, the smart quotes.
-  checkWords(
-    [ 'Tale', 'is', 'about', 'an', 'adorable', 'mouse', 'with', 'a', 'lute',
-      'fighting', 'giant', 'crabs', 'Really', 'I’d', 'hope', 'that', 'was',
-      'enough', 'for', 'you', 'but', 'I\u2019ll', 'throw' ],
-    'Tale is about an adorable mouse with a lute fighting giant crabs. ' +
-    'Really I’d hope that was enough for you, but I\u2019ll throw');
+    // TINY-9654: Identify words containing non-latin characters
+    check([ WordScope('привет', none, none) ], 'привет');
+    check([ WordScope('привет', some(' '), some(' ')) ], ' привет ');
+    check([
+      WordScope('привет', some('"'), some(' ')),
+      WordScope('world', some(' '), some('"'))
+    ], '"привет world"');
+    check([
+      WordScope('Here', none, some(' ')),
+      WordScope('is', some(' '), some(' ')),
+      WordScope('a', some(' '), some(' ')),
+      WordScope('mixed', some(' '), some(' ')),
+      WordScope('word', some(' '), some(' ')),
+      WordScope('Mixedприmixedве\u2019т123', some(' '), some(`'`))
+    ], `Here is a mixed word Mixedприmixedве\u2019т123'`);
 
-  // TINY-9654: Identify words containing non-latin characters
-  check([ WordScope('привет', none, none) ], 'привет');
-  check([ WordScope('привет', some(' '), some(' ')) ], ' привет ');
-  check([
-    WordScope('привет', some('"'), some(' ')),
-    WordScope('world', some(' '), some('"'))
-  ], '"привет world"');
-  check([
-    WordScope('Here', none, some(' ')),
-    WordScope('is', some(' '), some(' ')),
-    WordScope('a', some(' '), some(' ')),
-    WordScope('mixed', some(' '), some(' ')),
-    WordScope('word', some(' '), some(' ')),
-    WordScope('Mixedприmixedве\u2019т123', some(' '), some(`'`))
-  ], `Here is a mixed word Mixedприmixedве\u2019т123'`);
+    check([
+      WordScope('<p>', none, some(' ')),
+      WordScope('Hello', some(' '), some(' ')),
+      WordScope('World<', some(' '), some('/')),
+      WordScope('p>', some('/'), none),
+    ], '<p> Hello World</p>');
+
+    check([
+      WordScope('<p>', none, some(' ')),
+      WordScope('Hello', some(' '), some(' ')),
+      WordScope('World', some(' '), some(' ')),
+      WordScope('<', some(' '), some('/')),
+      WordScope('p>', some('/'), none),
+    ], '<p> Hello World </p>');
+
+    check([
+      WordScope('<p>Hello', none, some(' ')),
+      WordScope('World', some(' '), some(' ')),
+      WordScope('<', some(' '), some('/')),
+      WordScope('p>', some('/'), none),
+    ], '<p>Hello World </p>');
+
+    check([
+      WordScope('<p>Hello', none, some(' ')),
+      WordScope('World<', some(' '), some('/')),
+      WordScope('p>', some('/'), none),
+    ], '<p>Hello World</p>');
+
+    check([
+      WordScope('Test', none, some('.')),
+      WordScope('IF:INTEXT', some('['), some(']')),
+      WordScope('Test2', some(']'), some(' ')),
+      WordScope('IF', some('/'), some(']')),
+    ], 'Test. [IF:INTEXT]Test2 [/IF]');
+
+    check([
+      WordScope('Test', none, some('.')),
+      WordScope('IF', some('/'), some(']')),
+      WordScope('Test2', some(']'), some(' ')),
+      WordScope('IF:INTEXT', some('['), some(']')),
+    ], 'Test. [/IF]Test2 [IF:INTEXT]');
+  });
+
+  it('TINY-10062: Check words', () => {
+    // Note, the smart quotes.
+    checkWords(
+      [ 'Tale', 'is', 'about', 'an', 'adorable', 'mouse', 'with', 'a', 'lute',
+        'fighting', 'giant', 'crabs', 'Really', 'I’d', 'hope', 'that', 'was',
+        'enough', 'for', 'you', 'but', 'I\u2019ll', 'throw' ],
+      'Tale is about an adorable mouse with a lute fighting giant crabs. ' +
+      'Really I’d hope that was enough for you, but I\u2019ll throw');
+
+  });
 });

--- a/versions.txt
+++ b/versions.txt
@@ -1,2 +1,4 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
+
+polaris@6.2.2


### PR DESCRIPTION
Related Ticket: TINY-10062

Description of Changes:
* Changes are mainly in `Search.findmany` to remove the overlapped indices in the result 
* Other changes are adding some tests for the code change, porting them into the new TDD style and putting assertion messages

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
