### PR TITLE
TINY-9827: Move the cursor out of the accordion at the document edges

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In some cases pressing enter would scroll the entire page. #TINY-9828
 - The border styles of a table were incorrectly split into a longhand form after table dialog updates. #TINY-9843
 - Links in `help dialog` -> `plugins` and `version` were not navigable via keyboard. #TINY-10071
-- Fixed the inability to insert content before the `details` element, when it is the first element in the editor's content. Now possible by pressing the `Up` arrow key when the cursor is at the start of the `details` element content. #TINY-9827
+- Fixed the inability to insert content next to the `details` element when it is the first or last content element. Now pressing the `Up` or `Down` arrow key will insert a block element before or after the `details` element. #TINY-9827
 
 ## 6.6.2 - 2023-08-09
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In some cases pressing enter would scroll the entire page. #TINY-9828
 - The border styles of a table were incorrectly split into a longhand form after table dialog updates. #TINY-9843
 - Links in `help dialog` -> `plugins` and `version` were not navigable via keyboard. #TINY-10071
+- Fixed the inability to insert content before the `details` element, when it is the first element in the editor's content. Now possible by pressing the `Up` arrow key when the cursor is at the start of the `details` element content. #TINY-9827
 
 ## 6.6.2 - 2023-08-09
 

--- a/modules/tinymce/src/core/main/ts/keyboard/ArrowKeys.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/ArrowKeys.ts
@@ -6,6 +6,7 @@ import VK from '../api/util/VK';
 import * as BoundarySelection from './BoundarySelection';
 import * as CefNavigation from './CefNavigation';
 import * as ContentEndpointNavigation from './ContentEndpointNavigation';
+import * as DetailsNavigation from './DetailsNavigation';
 import * as MatchKeys from './MatchKeys';
 import * as MediaNavigation from './MediaNavigation';
 import * as TableNavigation from './TableNavigation';
@@ -26,6 +27,9 @@ const executeKeydownOverride = (editor: Editor, caret: Cell<Text | null>, evt: K
     { keyCode: VK.LEFT, action: MatchKeys.action(TableNavigation.moveH, editor, false) },
     { keyCode: VK.UP, action: MatchKeys.action(TableNavigation.moveV, editor, false) },
     { keyCode: VK.DOWN, action: MatchKeys.action(TableNavigation.moveV, editor, true) },
+    { keyCode: VK.UP, action: MatchKeys.action(TableNavigation.moveV, editor, false) },
+    { keyCode: VK.UP, action: MatchKeys.action(DetailsNavigation.moveV, editor, false) },
+    { keyCode: VK.DOWN, action: MatchKeys.action(DetailsNavigation.moveV, editor, true) },
     { keyCode: VK.RIGHT, action: MatchKeys.action(MediaNavigation.moveH, editor, true) },
     { keyCode: VK.LEFT, action: MatchKeys.action(MediaNavigation.moveH, editor, false) },
     { keyCode: VK.UP, action: MatchKeys.action(MediaNavigation.moveV, editor, false) },

--- a/modules/tinymce/src/core/main/ts/keyboard/DetailsNavigation.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/DetailsNavigation.ts
@@ -1,0 +1,50 @@
+import { Optional } from '@ephox/katamari';
+
+import Editor from '../api/Editor';
+import CaretPosition from '../caret/CaretPosition';
+import * as LineReader from '../caret/LineReader';
+
+const moveUp = (editor: Editor, details: HTMLDetailsElement, summary: HTMLElement): boolean => {
+  const rng = editor.selection.getRng();
+  const pos = CaretPosition.fromRangeStart(rng);
+  const root = editor.getBody();
+
+  if (root.firstChild === details && LineReader.isAtFirstLine(summary, pos)) {
+    editor.execCommand('InsertNewBlockBefore');
+    return true;
+  } else {
+    return false;
+  }
+};
+
+const moveDown = (editor: Editor, details: HTMLDetailsElement): boolean => {
+  const rng = editor.selection.getRng();
+  const pos = CaretPosition.fromRangeStart(rng);
+  const root = editor.getBody();
+
+  if (root.lastChild === details && LineReader.isAtLastLine(details, pos)) {
+    editor.execCommand('InsertNewBlockAfter');
+    return true;
+  } else {
+    return false;
+  }
+};
+
+const move = (editor: Editor, forward: boolean) => {
+  if (forward) {
+    return Optional.from(editor.dom.getParent<HTMLDetailsElement>(editor.selection.getNode(), 'details'))
+      .map((details) => moveDown(editor, details))
+      .getOr(false);
+  } else {
+    return Optional.from(editor.dom.getParent<HTMLElement>(editor.selection.getNode(), 'summary'))
+      .bind((summary) => Optional.from(editor.dom.getParent(summary, 'details'))
+        .map((details) => moveUp(editor, details, summary))
+      ).getOr(false);
+  }
+};
+
+const moveV = (editor: Editor, forward: boolean): boolean => move(editor, forward);
+
+export {
+  moveV
+};

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionNavigationTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionNavigationTest.ts
@@ -1,0 +1,37 @@
+import { Keys } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinySelections, TinyAssertions, TinyContentActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/accordion/Plugin';
+
+import * as AccordionUtils from '../module/AccordionUtils';
+
+describe('browser.tinymce.plugins.accordion.AccordionNavigationTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>(
+    {
+      plugins: 'accordion',
+      base_url: '/project/tinymce/js/tinymce',
+    },
+    [ Plugin ]
+  );
+
+  it('TINY-9827: should move cursor above the first child accordion on ArrowUp key pressing', () => {
+    const editor = hook.editor();
+    editor.resetContent();
+    editor.execCommand('InsertAccordion');
+    TinySelections.setCursor(editor, [ 0, 0 ], 0);
+    TinyContentActions.keystroke(editor, Keys.up());
+    TinyAssertions.assertContent(editor, `<p>&nbsp;</p>\n` + AccordionUtils.createAccordion());
+    TinyAssertions.assertCursor(editor, [ 0 ], 0);
+  });
+
+  it('TINY-9827: should move cursor below the last child accordion on ArrowDown key pressing', () => {
+    const editor = hook.editor();
+    editor.execCommand('InsertAccordion');
+    TinySelections.setCursor(editor, [ 0, 1, 0 ], 0);
+    TinyContentActions.keystroke(editor, Keys.down());
+    TinyAssertions.assertContent(editor, AccordionUtils.createAccordion() + `\n<p>&nbsp;</p>`);
+    TinyAssertions.assertCursor(editor, [ 1 ], 0);
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-9827

Description of Changes:
* Track the accordion edge position and execute "InsertNewBlockBefore" command on ArrowUp key pressing.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
