### PR TITLE
TINY-10136: Prevent list generation to go outside of expected child nodes.

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Autocompletion of url for links would on sufficiently long links and wide screens leave out middle parts of the url from view. #TINY-10017
 - Toolbar number input would not properly disable upon changing mode. #TINY-10129
 - Quick Toolbar plugin would show text alignment buttons on pagebreaks. #TINY-10054
-- Creating lists would in some situations include unexpected elements into the list. #TINY-10136
+- Creating lists in empty blocks would sometimes include adjacent blocks. #TINY-10136
 - Creating a list from multiple div elements would only create a partial list. #TINY-9872
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815
 - It was possible to delete the sole empty block just before a details element if it was nested within another details element. #TINY-9965

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Autocompletion of url for links would on sufficiently long links and wide screens leave out middle parts of the url from view. #TINY-10017
 - Toolbar number input would not properly disable upon changing mode. #TINY-10129
 - Quick Toolbar plugin would show text alignment buttons on pagebreaks. #TINY-10054
+- Creating lists would in some situations include unexpected elements into the list. #TINY-10136
 - Creating a list from multiple div elements would only create a partial list. #TINY-9872
 - Tab navigation incorrectly stopped around `iframe` dialog component. #TINY-9815
 - It was possible to delete the sole empty block just before a details element if it was nested within another details element. #TINY-9965

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -64,7 +64,7 @@ const getEndPointNode = (editor: Editor, rng: Range, start: Boolean, root: Node)
   }
 
   const findBlockAncestor = (node: Node) => {
-    while (!NodeType.isBlock(node, editor.schema.getBlockElements()) && node.parentNode && root !== node) {
+    while (!editor.dom.isBlock(node) && node.parentNode && root !== node) {
       node = node.parentNode;
     }
 
@@ -82,14 +82,11 @@ const getEndPointNode = (editor: Editor, rng: Range, start: Boolean, root: Node)
   // For more info look at #TINY-6853
 
   const findBetterContainer = (container: Node, forward: boolean): Optional<Node> => {
-    const walker = new DomTreeWalker(container, root);
+    const walker = new DomTreeWalker(container, findBlockAncestor(container));
     const dir = forward ? 'next' : 'prev';
-    const blockParent = SugarElement.fromDom(findBlockAncestor(container));
     let node;
     while ((node = walker[dir]())) {
-      const suitableType = !(NodeType.isVoid(editor, node) || Unicode.isZwsp(node.textContent as string) || node.textContent?.length === 0);
-      const isWithinParent = Has.ancestor(SugarElement.fromDom(node), blockParent);
-      if (suitableType && isWithinParent) {
+      if (!(NodeType.isVoid(editor, node) || Unicode.isZwsp(node.textContent as string) || node.textContent?.length === 0)) {
         return Optional.some(node);
       }
     }

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyTest.ts
@@ -900,7 +900,7 @@ describe('browser.tinymce.plugins.lists.ApplyTest', () => {
     TinyAssertions.assertRawContent(editor, expected);
   });
 
-  it('TINY-10136: Do not list-convert too many elements', () => {
+  it('TINY-10136: Ensure that the list does not expand its search past the nearest parent block to prevent it from converting unexpected elements into list elements', () => {
     const editor = hook.editor();
     editor.setContent('<p><strong>a</strong></p><p><strong></strong></p><p><strong>b</strong></p>');
 

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyTest.ts
@@ -900,6 +900,17 @@ describe('browser.tinymce.plugins.lists.ApplyTest', () => {
     TinyAssertions.assertRawContent(editor, expected);
   });
 
+  it('TINY-10136: Do not list-convert too many elements', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><strong>a</strong></p><p><strong></strong></p><p><strong>b</strong></p>');
+
+    TinySelections.setCursor(editor, [ 1, 0 ], 0);
+
+    editor.execCommand('bold');
+    editor.execCommand('InsertUnorderedList');
+    TinyAssertions.assertContent(editor, '<p><strong>a</strong></p><ul><li></li></ul><p><strong>b</strong></p>');
+  });
+
   context('Parent context', () => {
     const testApplyOLAtTextPath = (inputHtml: string, path: number[], expectedHtml: string) => () => {
       const editor = hook.editor();


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-10136

Description of Changes:
Restrict the DOMtreeWalker to the correct parent.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
