### PR TITLE
TINY-10146: Refactor statusbar changes in TINY-9379 to use classes in JS

### DIFF
--- a/modules/oxide/src/less/theme/components/statusbar/statusbar.less
+++ b/modules/oxide/src/less/theme/components/statusbar/statusbar.less
@@ -94,6 +94,10 @@
       & .tox-statusbar__help-text {
         display: none;
       }
+
+      & .tox-statusbar__help-text:only-child {
+        display: block;
+      }
     }
   }
 

--- a/modules/oxide/src/less/theme/components/statusbar/statusbar.less
+++ b/modules/oxide/src/less/theme/components/statusbar/statusbar.less
@@ -59,31 +59,23 @@
     overflow: hidden;
 
     @media @breakpoint-gt-sm {
-      &:has(.tox-statusbar__right-container:only-child) {
-        justify-content: flex-end;
+      &.tox-statusbar__text-container-3-cols > .tox-statusbar__help-text,
+      &.tox-statusbar__text-container-3-cols > .tox-statusbar__right-container,
+      &.tox-statusbar__text-container-3-cols > .tox-statusbar__path {
+        flex: 0 0 calc(100% / 3);
       }
+    }
 
-      &:has(.tox-statusbar__help-text:only-child) {
-        justify-content: space-around;
-      }
+    &.tox-statusbar__text-container--flex-end {
+      justify-content: flex-end;
+    }
 
-      &:has(.tox-statusbar__help-text) {
-        justify-content: flex-start;
+    &.tox-statusbar__text-container--flex-start {
+      justify-content: flex-start;
+    }
 
-        &:has(.tox-statusbar__right-container) {
-          justify-content: flex-end;
-        }
-
-        &:has(.tox-statusbar__path):has(.tox-statusbar__right-container) {
-          justify-content: space-between;
-        }
-
-        & .tox-statusbar__path,
-        & .tox-statusbar__help-text,
-        & .tox-statusbar__right-container {
-          flex: 0 0 calc(100% / 3);
-        }
-      }
+    &.tox-statusbar__text-container--space-around {
+      justify-content: space-around;
     }
   }
 
@@ -101,23 +93,6 @@
     .tox-statusbar__text-container {
       & .tox-statusbar__help-text {
         display: none;
-      }
-
-      & .tox-statusbar__right-container {
-        display: flex;
-        flex: 0 0 auto;
-      }
-
-      &:has(.tox-statusbar__right-container) {
-        justify-content: flex-end;
-      }
-
-      &:has(.tox-statusbar__help-text:only-child) {
-        justify-content: space-around;
-
-        & .tox-statusbar__help-text {
-          display: block;
-        }
       }
     }
   }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
@@ -75,16 +75,41 @@ const renderStatusbar = (editor: Editor, providersBackstage: UiFactoryBackstageP
 
   const getTextComponents = (): SimpleSpec[] => {
     const components: SimpleSpec[] = [];
+    const shouldRenderHelp = Options.useHelpAccessibility(editor);
+    const shouldRenderElementPath = Options.useElementPath(editor);
+    const shouldRenderRightContainer = Options.useBranding(editor) || editor.hasPlugin('wordcount');
 
-    if (Options.useElementPath(editor)) {
+    const getTextComponentClass = () => {
+      const flexStart = 'tox-statusbar__text-container--flex-start';
+      const flexEnd = 'tox-statusbar__text-container--flex-end';
+      const spaceAround = 'tox-statusbar__text-container--space-around';
+
+      if (shouldRenderHelp) {
+        const container3Columns = 'tox-statusbar__text-container-3-cols';
+
+        if (!shouldRenderRightContainer && !shouldRenderElementPath) {
+          return [ container3Columns, spaceAround ];
+        }
+
+        if (shouldRenderRightContainer && !shouldRenderElementPath) {
+          return [ container3Columns, flexEnd ];
+        }
+
+        return [ container3Columns, flexStart ];
+      }
+
+      return [ shouldRenderRightContainer && !shouldRenderElementPath ? flexEnd : flexStart ];
+    };
+
+    if (shouldRenderElementPath) {
       components.push(ElementPath.renderElementPath(editor, { }, providersBackstage));
     }
 
-    if (Options.useHelpAccessibility(editor)) {
+    if (shouldRenderHelp) {
       components.push(renderHelpAccessibility());
     }
 
-    if (Options.useBranding(editor) || editor.hasPlugin('wordcount')) {
+    if (shouldRenderRightContainer) {
       components.push(renderRightContainer());
     }
 
@@ -92,7 +117,7 @@ const renderStatusbar = (editor: Editor, providersBackstage: UiFactoryBackstageP
       return [{
         dom: {
           tag: 'div',
-          classes: [ 'tox-statusbar__text-container' ]
+          classes: [ 'tox-statusbar__text-container', ...getTextComponentClass() ]
         },
         components
       }];

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
@@ -79,7 +79,7 @@ const renderStatusbar = (editor: Editor, providersBackstage: UiFactoryBackstageP
     const shouldRenderElementPath = Options.useElementPath(editor);
     const shouldRenderRightContainer = Options.useBranding(editor) || editor.hasPlugin('wordcount');
 
-    const getTextComponentClass = () => {
+    const getTextComponentClasses = () => {
       const flexStart = 'tox-statusbar__text-container--flex-start';
       const flexEnd = 'tox-statusbar__text-container--flex-end';
       const spaceAround = 'tox-statusbar__text-container--space-around';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
@@ -117,7 +117,7 @@ const renderStatusbar = (editor: Editor, providersBackstage: UiFactoryBackstageP
       return [{
         dom: {
           tag: 'div',
-          classes: [ 'tox-statusbar__text-container', ...getTextComponentClass() ]
+          classes: [ 'tox-statusbar__text-container', ...getTextComponentClasses() ]
         },
         components
       }];


### PR DESCRIPTION
Related Ticket: TINY-10146

Description of Changes:
* `has()` pseudo-class require a browser config to be set, the changes here to change from CSS to having different classes based on the count of the element in the container
* See ticket for screenshots

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
