### PR TITLE
TINY-10123: Fix deleting in `summary` on Safari

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the inability to insert content next to the `details` element when it is the first or last content element. Now pressing the `Up` or `Down` arrow key will insert a block element before or after the `details` element. #TINY-9827
 - An empty `contenteditable="true"` element within a noneditable root was deleted upon pressing the Backspace key. #TINY-10011
 - The `color_cols` option was not respected when set to the value 5 with a custom `color_map` specified. #TINY-10126
+- On Safari, deleting backwards within a `summary` element would remove the entire `details` element if it had no other content. #TINY-10123
 
 ## 6.6.2 - 2023-08-09
 

--- a/modules/tinymce/src/core/main/ts/delete/DetailsDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/DetailsDelete.ts
@@ -223,7 +223,7 @@ const handleDeleteActionSafari = (editor: Editor, forward: boolean, granularity:
           });
         };
 
-        const container = editor.dom.create('span', { 'data-mce-bogus': 'all' });
+        const container = editor.dom.create('span', { 'data-mce-bogus': '1' });
         appendAllChildNodes(node, container);
         node.appendChild(container);
         applySelection();

--- a/modules/tinymce/src/core/test/ts/browser/delete/DetailsDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/DetailsDeleteTest.ts
@@ -56,7 +56,7 @@ describe('browser.tinymce.core.delete.DeleteDetailsTest', () => {
       expectedPrevented: true
     }));
 
-    it('Delete forward in middle of summary should not be prevented', () => testDeleteForward({
+    it('Delete forward in middle of summary should be prevented on Safari', () => testDeleteForward({
       html: '<details open=""><summary>s1</summary><div><p>&nbsp;</p></div></details>',
       selection: caret([ 0, 0, 0 ], 1),
       expectedSelection: caret([ 0, 0, 0 ], 1),
@@ -65,16 +65,13 @@ describe('browser.tinymce.core.delete.DeleteDetailsTest', () => {
       expectedHtml: `<details open=""><summary>s${isSafari ? '' : '1'}</summary><div><p>&nbsp;</p></div></details>`
     }));
 
-    it('Delete backward in middle of summary should not be prevented', function () {
-      // TODO - TINY-10123: On Safari, deleting backwards in summary in accordion with empty body deletes entire accordion
-      if (isSafari) {
-        this.skip();
-      }
+    it('TINY-10123: Delete backward in middle of summary should prevented on Safari', () => {
       testDeleteBackward({
         html: '<details open=""><summary>s1</summary><div><p>&nbsp;</p></div></details>',
         selection: caret([ 0, 0, 0 ], 1),
-        expectedSelection: caret([ 0, 0, 0 ], 1),
-        expectedPrevented: false
+        expectedSelection: caret([ 0, 0, 0 ], isSafari ? 0 : 1),
+        expectedPrevented: isSafari ? true : false,
+        expectedHtml: `<details open=""><summary>${isSafari ? '1' : 's1'}</summary><div><p>&nbsp;</p></div></details>`
       });
     });
 


### PR DESCRIPTION
Related Ticket: TINY-10123

Description of Changes:
* bogus workaround span affects the correct working of `dom.isEmpty` function

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
