### PR TITLE
TINY-10115: Add support for case sensitive translations

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adding a newline after a table would in some specific cases not work. #TINY-9863
 - Menus will now have a slight margin at the top and bottom to more clearly separate them from the edge of frame. #TINY-9978
 - Updated toolbar "More" button tooltip text from "More..." to "Reveal or hide additional toolbar items". #TINY-9629
+- Where multiple case sensitive variants of a translation key are provided, they will now all be preserved in the translation object instead of just the lowercase variant. #TINY-10115
 
 ### Changed
 - Change UndoLevelType from enum to union type so that it can be easier to use. #TINY-9764

--- a/modules/tinymce/src/core/main/ts/api/util/I18n.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/I18n.ts
@@ -118,7 +118,7 @@ const translate = (text: Untranslated): TranslatedString => {
     // make sure we work on a string and return a string
     const textStr = toString(text);
     return Obj.has(langData, textStr)
-      ? langData[textStr].toString()
+      ? toString(langData[textStr])
       : Obj.get(langData, textStr.toLowerCase()).map(toString).getOr(textStr);
   };
 

--- a/modules/tinymce/src/core/main/ts/api/util/I18n.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/I18n.ts
@@ -20,8 +20,8 @@ export type Untranslated = Primitive | TokenisedString | RawString | null | unde
 export type TranslatedString = string;
 
 const isDuplicated = (items: string[], item: string) => {
-  let count = 0;
-  return Arr.exists(items, (x) => (x === item ? ++count : count) > 1);
+  const firstIndex = items.indexOf(item);
+  return firstIndex !== -1 && items.indexOf(item, firstIndex + 1) > firstIndex;
 };
 
 const isRaw = (str: any): str is RawString => Type.isObject(str) && Obj.has(str, 'raw');

--- a/modules/tinymce/src/core/main/ts/api/util/I18n.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/I18n.ts
@@ -19,6 +19,11 @@ export type Untranslated = Primitive | TokenisedString | RawString | null | unde
 
 export type TranslatedString = string;
 
+const isDuplicated = (items: string[], item: string) => {
+  let count = 0;
+  return Arr.exists(items, (x) => (x === item ? ++count : count) > 1);
+};
+
 const isRaw = (str: any): str is RawString => Type.isObject(str) && Obj.has(str, 'raw');
 
 const isTokenised = (str: any): str is TokenisedString => Type.isArray(str) && str.length > 1;
@@ -68,8 +73,10 @@ const add = (code: string, items: Record<string, string>): void => {
   const lcNames = Arr.map(Obj.keys(items), (name) => name.toLowerCase());
   Obj.each(items, (translation, name) => {
     const lcName = name.toLowerCase();
-    let count = 0;
-    if (lcName !== name && Arr.exists(lcNames, (lc) => (lc === lcName ? ++count : count) > 1)) {
+    if (lcName !== name && isDuplicated(lcNames, lcName)) {
+      if (!Obj.has(items, lcName)) {
+        langData[lcName] = translation;
+      }
       langData[name] = translation;
     } else {
       langData[lcName] = translation;

--- a/modules/tinymce/src/core/main/ts/api/util/I18n.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/I18n.ts
@@ -117,7 +117,9 @@ const translate = (text: Untranslated): TranslatedString => {
   const getLangData = (text: Untranslated) => {
     // make sure we work on a string and return a string
     const textStr = toString(text);
-    return Obj.get(langData, Obj.has(langData, textStr) ? textStr : textStr.toLowerCase()).map(toString).getOr(textStr);
+    return Obj.has(langData, textStr)
+      ? langData[textStr].toString()
+      : Obj.get(langData, textStr.toLowerCase()).map(toString).getOr(textStr);
   };
 
   const removeContext = (str: string) => str.replace(/{context:\w+}$/, '');

--- a/modules/tinymce/src/core/main/ts/api/util/I18n.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/I18n.ts
@@ -1,4 +1,4 @@
-import { Cell, Obj, Type } from '@ephox/katamari';
+import { Arr, Cell, Obj, Type } from '@ephox/katamari';
 
 /**
  * I18n class that handles translation of TinyMCE UI.
@@ -65,8 +65,15 @@ const add = (code: string, items: Record<string, string>): void => {
     data[code] = langData = {};
   }
 
+  const lcNames = Arr.map(Obj.keys(items), (name) => name.toLowerCase());
   Obj.each(items, (translation, name) => {
-    langData[name.toLowerCase()] = translation;
+    const lcName = name.toLowerCase();
+    let count = 0;
+    if (lcName !== name && Arr.exists(lcNames, (lc) => (lc === lcName ? ++count : count) > 1)) {
+      langData[name] = translation;
+    } else {
+      langData[lcName] = translation;
+    }
   });
 };
 
@@ -103,7 +110,7 @@ const translate = (text: Untranslated): TranslatedString => {
   const getLangData = (text: Untranslated) => {
     // make sure we work on a string and return a string
     const textstr = toString(text);
-    return Obj.get(langData, textstr.toLowerCase()).map(toString).getOr(textstr);
+    return Obj.get(langData, textstr).or(Obj.get(langData, textstr.toLowerCase())).map(toString).getOr(textstr);
   };
 
   const removeContext = (str: string) => str.replace(/{context:\w+}$/, '');

--- a/modules/tinymce/src/core/main/ts/api/util/I18n.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/I18n.ts
@@ -116,8 +116,8 @@ const translate = (text: Untranslated): TranslatedString => {
 
   const getLangData = (text: Untranslated) => {
     // make sure we work on a string and return a string
-    const textstr = toString(text);
-    return Obj.get(langData, textstr).or(Obj.get(langData, textstr.toLowerCase())).map(toString).getOr(textstr);
+    const textStr = toString(text);
+    return Obj.get(langData, Obj.has(langData, textStr) ? textStr : textStr.toLowerCase()).map(toString).getOr(textStr);
   };
 
   const removeContext = (str: string) => str.replace(/{context:\w+}$/, '');

--- a/modules/tinymce/src/core/test/ts/browser/util/I18nTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/I18nTest.ts
@@ -1,4 +1,4 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { assert } from 'chai';
 
@@ -87,5 +87,38 @@ describe('browser.tinymce.core.util.I18nTest', () => {
     assert.equal(I18n.translate('text'), 'translation2', 'Should be get code2 translation');
 
     I18n.setCode('en');
+  });
+
+  context('Case sensitive translations', () => {
+    const addTranslationsAndSetCode = (code: string, translations: Record<string, string>) => {
+      I18n.add(code, translations);
+      I18n.setCode(code);
+    };
+
+    const assertTranslation = (key: string, expectedTranslation: string) =>
+      assert.equal(I18n.translate(key), expectedTranslation);
+
+    it('All case sensitive variants of duplicate keys should be preserved where a lowercase variant is already present', () => {
+      addTranslationsAndSetCode('code-ci1', {
+        test: 'test',
+        Test: 'Test',
+        TEST: 'TEST'
+      });
+
+      assertTranslation('test', 'test');
+      assertTranslation('Test', 'Test');
+      assertTranslation('TEST', 'TEST');
+    });
+
+    it('All case sensitive variants of duplicate keys should be preserved and a lowercase variant should be added where a lowercase variant is not present', () => {
+      addTranslationsAndSetCode('code-ci1', {
+        Test: 'Test',
+        TEST: 'TEST'
+      });
+
+      assert.oneOf(I18n.translate('test'), [ 'Test', 'TEST' ]);
+      assertTranslation('Test', 'Test');
+      assertTranslation('TEST', 'TEST');
+    });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10115

Description of Changes:
* Where there are multiple case sensitive variants of a translation key, they will now all be kept in the translation object instead of just the lowercase variant
* If there is no lowercase variant present, then we manually add one to ensure that case insensitive matching still works

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
