### PR TITLE
TINY-10124: Improved the keyboard focus visibility for links inside dialogs

### DIFF
--- a/modules/oxide/src/less/skins/ui/dark/skin.less
+++ b/modules/oxide/src/less/skins/ui/dark/skin.less
@@ -18,6 +18,11 @@
 
 @insert-table-picker-border-color: @tinymce-separator-color;
 
+@dialog-body-link-color: lighten(@color-tint, 25%);
+@dialog-body-link-hover-color: lighten(@dialog-body-link-color, 20%);
+@dialog-body-link-active-color: lighten(@dialog-body-link-color, 30%);
+@dialog-body-link-focus-outline-color: @dialog-body-link-color;
+
 .tox.tox-tinymce-aux .tox-toolbar__overflow {
   box-shadow: 0 0 0 1px @tinymce-separator-color;
 }

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -41,11 +41,11 @@
 
 @dialog-body-link-color: @color-tint;
 @dialog-body-link-text-decoration: underline;
-@dialog-body-link-hover-color: darken(@color-tint, 20%);
+@dialog-body-link-hover-color: darken(@dialog-body-link-color, 20%);
 @dialog-body-link-hover-text-decoration: underline;
-@dialog-body-link-active-color: darken(@color-tint, 30%);
+@dialog-body-link-active-color: darken(@dialog-body-link-color, 30%);
 @dialog-body-link-active-text-decoration: underline;
-@dialog-body-link-focus-outline-color: @color-tint;
+@dialog-body-link-focus-outline-color: @dialog-body-link-color;
 @dialog-body-link-focus-outline-border-radius: 1px;
 
 @dialog-body-h1-font-size: @font-size-lg;
@@ -235,8 +235,8 @@
   }
 
   .tox-dialog__body-nav-item--active {
-    border-bottom: 2px solid @color-tint;
-    color: @color-tint;
+    border-bottom: 2px solid @dialog-body-link-color;
+    color: @dialog-body-link-color;
   }
 
   .tox-dialog__body-content {

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -40,11 +40,13 @@
 @dialog-body-text-transform: none;
 
 @dialog-body-link-color: @color-tint;
-@dialog-body-link-text-decoration: none;
-@dialog-body-link-hover-color: darken(@color-tint, 10%);
-@dialog-body-link-hover-text-decoration: none;
-@dialog-body-link-active-color: darken(@color-tint, 10%);
-@dialog-body-link-active-text-decoration: none;
+@dialog-body-link-text-decoration: underline;
+@dialog-body-link-hover-color: darken(@color-tint, 20%);
+@dialog-body-link-hover-text-decoration: underline;
+@dialog-body-link-active-color: darken(@color-tint, 30%);
+@dialog-body-link-active-text-decoration: underline;
+@dialog-body-link-focus-outline-color: @color-tint;
+@dialog-body-link-focus-outline-border-radius: 1px;
 
 @dialog-body-h1-font-size: @font-size-lg;
 @dialog-body-h1-font-style: normal;
@@ -274,6 +276,12 @@
       &:focus {
         color: @dialog-body-link-hover-color;
         text-decoration: @dialog-body-link-hover-text-decoration;
+      }
+
+      &:focus-visible {
+        border-radius: @dialog-body-link-focus-outline-border-radius;
+        outline: 2px solid @dialog-body-link-focus-outline-color;
+        outline-offset: 2px;
       }
 
       &:active {

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Menus will now have a slight margin at the top and bottom to more clearly separate them from the edge of frame. #TINY-9978
 - Updated toolbar "More" button tooltip text from "More..." to "Reveal or hide additional toolbar items". #TINY-9629
 - Improved screen reader announcements of currently selected columns and rows in insert table menu item grid. #TINY-10140
-- Improved the keyboard focus visibility for links inside dialogs. #TINY-10124
+- Improved the keyboard focus visibility for links inside dialogs, including the dark skin #TINY-10124
 
 ### Changed
 - Change UndoLevelType from enum to union type so that it can be easier to use. #TINY-9764

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Menus will now have a slight margin at the top and bottom to more clearly separate them from the edge of frame. #TINY-9978
 - Updated toolbar "More" button tooltip text from "More..." to "Reveal or hide additional toolbar items". #TINY-9629
 - Improved screen reader announcements of currently selected columns and rows in insert table menu item grid. #TINY-10140
+- Improved the keyboard focus visibility for links inside dialogs. #TINY-10124
 
 ### Changed
 - Change UndoLevelType from enum to union type so that it can be easier to use. #TINY-9764


### PR DESCRIPTION
Related Ticket: TINY-10124

Description of Changes:
* Improved the color contrast between normal, hover and active states
* Added a focus outline around links when using keyboard navigation
* Updated the link colors in the dark skin to be AA compliant.

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
