### PR TITLE
TINY-9998: Applying bullist to a custom unordered list would turn list into paragraphs instead of a bulleted list.

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When loading content CSS takes more than half a second, the editor will be set to the "in progress" state until the CSS is ready. #TINY-10008
 
 ### Fixed
+- Clicking in the bullist toolbar button on a selected checklist would turn the list into paragraphs instead of a bulleted list. #TINY-9975
 - Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842
 - Autocompletion of url for links would on sufficiently long links and wide screens leave out middle parts of the url from view. #TINY-10017
 - Toolbar number input would not properly disable upon changing mode. #TINY-10129

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When loading content CSS takes more than half a second, the editor will be set to the "in progress" state until the CSS is ready. #TINY-10008
 
 ### Fixed
-- Clicking in the bullist toolbar button on a selected checklist would turn the list into paragraphs instead of a bulleted list. #TINY-9975
+- Applying an ordered or unordered list to a selected checklist would incorrectly turn the list into paragraphs. #TINY-9975
 - Returning an empty string in custom context menu update function would result in a small white line appearing on right click and the native browser context menu would not show up. #TINY-9842
 - Autocompletion of url for links would on sufficiently long links and wide screens leave out middle parts of the url from view. #TINY-10017
 - Toolbar number input would not properly disable upon changing mode. #TINY-10129

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -1,4 +1,4 @@
-import { Arr, Optional, Strings, Type, Unicode } from '@ephox/katamari';
+import { Arr, Optional, Type, Unicode } from '@ephox/katamari';
 import { Has, SugarElement } from '@ephox/sugar';
 
 import BookmarkManager from 'tinymce/core/api/dom/BookmarkManager';
@@ -317,10 +317,11 @@ const updateList = (editor: Editor, list: Element, listName: 'UL' | 'OL' | 'DL',
 };
 
 const updateCustomList = (editor: Editor, list: Element, listName: 'UL' | 'OL' | 'DL', detail: ListDetail): void => {
-  list.className = list.className.split(' ').filter((cls) => !/\btox\-/.test(cls)).join(' ');
-  if (Strings.isEmpty(list.className.trim()) ) {
-    list.removeAttribute('class');
-  }
+  list.classList.forEach((cls, _, classList) => {
+    if (!/\btox\-/.test(cls)) {
+      classList.remove(cls);
+    }
+  });
   if (list.nodeName !== listName) {
     const newList = editor.dom.rename(list, listName);
     updateListWithDetails(editor.dom, newList, detail);
@@ -365,10 +366,11 @@ const toggleSingleList = (editor: Editor, parentList: HTMLElement | null, listNa
     } else {
       const bookmark = Bookmark.createBookmark(editor.selection.getRng());
       if (isCustomList(parentList)) {
-        parentList.className = parentList.className.split(' ').filter((cls) => !/\btox\-/.test(cls)).join(' ');
-        if (Strings.isEmpty(parentList.className.trim()) ) {
-          parentList.removeAttribute('class');
-        }
+        parentList.classList.forEach((cls, _, classList) => {
+          if (!/\btox\-/.test(cls)) {
+            classList.remove(cls);
+          }
+        });
       }
       updateListWithDetails(editor.dom, parentList, detail);
       const newList = editor.dom.rename(parentList, listName) as HTMLElement;

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -318,8 +318,11 @@ const updateList = (editor: Editor, list: Element, listName: 'UL' | 'OL' | 'DL',
 
 const updateCustomList = (editor: Editor, list: Element, listName: 'UL' | 'OL' | 'DL', detail: ListDetail): void => {
   list.classList.forEach((cls, _, classList) => {
-    if (!/\btox\-/.test(cls)) {
+    if (cls.startsWith('tox-')) {
       classList.remove(cls);
+      if (classList.length === 0) {
+        list.removeAttribute('class');
+      }
     }
   });
   if (list.nodeName !== listName) {
@@ -367,8 +370,11 @@ const toggleSingleList = (editor: Editor, parentList: HTMLElement | null, listNa
       const bookmark = Bookmark.createBookmark(editor.selection.getRng());
       if (isCustomList(parentList)) {
         parentList.classList.forEach((cls, _, classList) => {
-          if (!/\btox\-/.test(cls)) {
+          if (cls.startsWith('tox-')) {
             classList.remove(cls);
+            if (classList.length === 0) {
+              parentList.removeAttribute('class');
+            }
           }
         });
       }

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyListOnCustomList.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyListOnCustomList.ts
@@ -1,0 +1,42 @@
+import { describe, it } from '@ephox/bedrock-client';
+import {Strings} from '@ephox/katamari';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/lists/Plugin';
+
+describe('browser.tinymce.plugins.lists.ApplyListOnParagraphWithStylesTest', () => {
+
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    indent: false,
+    plugins: 'lists',
+    toolbar: 'numlist bullist',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ]);
+
+  it('TINY-9998: Apply list to custom list should keep the original list structure', () => {
+    const editor = hook.editor();
+    const multilistContent = ( className: string, listType: 'ul' | 'ol' = 'ul' ) =>
+      // eslint-disable-next-line max-len
+      `<${listType}${Strings.isEmpty(className) ? '' : ` class="${className}"`}><li>a<${listType}${Strings.isEmpty(className) ? '' : ` class="${className}"`}><li>a1</li><li>a2</li></${listType}></li><li>b<${listType}${Strings.isEmpty(className) ? '' : ` class="${className}"`}><li>b1</li><li>b2</li></${listType}></li></${listType}>`;
+    editor.setContent(multilistContent('tox-checklist'));
+    editor.execCommand('SelectAll');
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Bullet list"]');
+    TinyAssertions.assertContent(editor, multilistContent(''));
+    editor.setContent(multilistContent('tox-checklist'));
+    editor.execCommand('SelectAll');
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Numbered list"]');
+    TinyAssertions.assertContent(editor, multilistContent('', 'ol'));
+    const singleListContent = ( className: string, listType: 'ul' | 'ol' = 'ul' ) =>
+      `<${listType}${Strings.isEmpty(className) ? '' : ` class="${className}"`}><li>a</li><li>b</li></${listType}>`;
+    editor.setContent(singleListContent('tox-checklist'));
+    editor.execCommand('SelectAll');
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Bullet list"]');
+    TinyAssertions.assertContent(editor, singleListContent(''));
+    editor.setContent(singleListContent('tox-checklist'));
+    editor.execCommand('SelectAll');
+    TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Numbered list"]');
+    TinyAssertions.assertContent(editor, singleListContent('', 'ol'));
+  });
+
+});

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyListOnCustomList.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyListOnCustomList.ts
@@ -14,7 +14,7 @@ describe('browser.tinymce.plugins.lists.ApplyListOnParagraphWithStylesTest', () 
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ]);
 
-  it('TINY-9998: Apply list to custom list should keep the original list structure', () => {
+  it('TINY-9998: Apply list to nested custom list should keep the original list structure', () => {
     const editor = hook.editor();
     const multilistContent = ( className: string, listType: 'ul' | 'ol' = 'ul' ) =>
       // eslint-disable-next-line max-len
@@ -27,6 +27,10 @@ describe('browser.tinymce.plugins.lists.ApplyListOnParagraphWithStylesTest', () 
     editor.execCommand('SelectAll');
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Numbered list"]');
     TinyAssertions.assertContent(editor, multilistContent('', 'ol'));
+  });
+
+  it('TINY-9998: Apply list to flat custom list should keep the original list structure', () => {
+    const editor = hook.editor();
     const singleListContent = ( className: string, listType: 'ul' | 'ol' = 'ul' ) =>
       `<${listType}${Strings.isEmpty(className) ? '' : ` class="${className}"`}><li>a</li><li>b</li></${listType}>`;
     editor.setContent(singleListContent('tox-checklist'));

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyListOnCustomList.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ApplyListOnCustomList.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import {Strings} from '@ephox/katamari';
+import { Strings } from '@ephox/katamari';
 import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/mcagar';
 
 import Editor from 'tinymce/core/api/Editor';


### PR DESCRIPTION
Related Ticket: TINY-9998 

Description of Changes:
* Applying bullist to a custom unordered list would turn list into paragraphs instead of a bulleted list.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
