### PR TITLE
TINY-10155: Improve tooltips for urlinput picker button in Image and Link dialogs

### DIFF
--- a/modules/bridge/CHANGELOG.md
+++ b/modules/bridge/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- Added `picker_text` optional property to `UrlInputSpec`. #TINY-10155
+
 ## 4.5.0 - 2023-07-12
 
 ### Added

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/UrlInput.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/UrlInput.ts
@@ -1,5 +1,5 @@
 import { StructureSchema, FieldSchema } from '@ephox/boulder';
-import { Result } from '@ephox/katamari';
+import { Optional, Result } from '@ephox/katamari';
 
 import * as ComponentSchema from '../../core/ComponentSchema';
 import { FormComponentWithLabel, FormComponentWithLabelSpec, formComponentWithLabelFields } from './FormComponent';
@@ -8,12 +8,14 @@ export interface UrlInputSpec extends FormComponentWithLabelSpec {
   type: 'urlinput';
   filetype?: 'image' | 'media' | 'file';
   enabled?: boolean;
+  text?: string;
 }
 
 export interface UrlInput extends FormComponentWithLabel {
   type: 'urlinput';
   filetype: 'image' | 'media' | 'file';
   enabled: boolean;
+  text: Optional<string>;
 }
 
 export interface UrlInputData {
@@ -25,7 +27,8 @@ export interface UrlInputData {
 
 const urlInputFields = formComponentWithLabelFields.concat([
   FieldSchema.defaultedStringEnum('filetype', 'file', [ 'image', 'media', 'file' ]),
-  ComponentSchema.enabled
+  ComponentSchema.enabled,
+  ComponentSchema.optionalText
 ]);
 
 export const urlInputSchema = StructureSchema.objOf(urlInputFields);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/UrlInput.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/UrlInput.ts
@@ -8,14 +8,14 @@ export interface UrlInputSpec extends FormComponentWithLabelSpec {
   type: 'urlinput';
   filetype?: 'image' | 'media' | 'file';
   enabled?: boolean;
-  text?: string;
+  picker_text?: string;
 }
 
 export interface UrlInput extends FormComponentWithLabel {
   type: 'urlinput';
   filetype: 'image' | 'media' | 'file';
   enabled: boolean;
-  text: Optional<string>;
+  picker_text: Optional<string>;
 }
 
 export interface UrlInputData {
@@ -28,7 +28,7 @@ export interface UrlInputData {
 const urlInputFields = formComponentWithLabelFields.concat([
   FieldSchema.defaultedStringEnum('filetype', 'file', [ 'image', 'media', 'file' ]),
   ComponentSchema.enabled,
-  ComponentSchema.optionalText
+  FieldSchema.optionString('picker_text')
 ]);
 
 export const urlInputSchema = StructureSchema.objOf(urlInputFields);

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Menus will now have a slight margin at the top and bottom to more clearly separate them from the edge of frame. #TINY-9978
 - Updated toolbar "More" button tooltip text from "More..." to "Reveal or hide additional toolbar items". #TINY-9629
 - Improved screen reader announcements of currently selected columns and rows in insert table menu item grid. #TINY-10140
-- Improved the tooltips of picker buttons for the urlinput components in the “Insert/Edit Image” and “Insert/Edit Link” dialogs. #TINY-10155
+- Improved the tooltips of picker buttons for the urlinput components in the "Insert/Edit Image" and "Insert/Edit Link" dialogs. #TINY-10155
 
 ### Changed
 - Change UndoLevelType from enum to union type so that it can be easier to use. #TINY-9764

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Menus will now have a slight margin at the top and bottom to more clearly separate them from the edge of frame. #TINY-9978
 - Updated toolbar "More" button tooltip text from "More..." to "Reveal or hide additional toolbar items". #TINY-9629
 - Improved screen reader announcements of currently selected columns and rows in insert table menu item grid. #TINY-10140
+- Improved the tooltips of picker buttons for the urlinput components in the “Insert/Edit Image” and “Insert/Edit Link” dialogs. #TINY-10155
 
 ### Changed
 - Change UndoLevelType from enum to union type so that it can be easier to use. #TINY-9764

--- a/modules/tinymce/src/plugins/image/main/ts/ui/MainTab.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/MainTab.ts
@@ -9,7 +9,8 @@ const makeItems = (info: ImageDialogInfo): Dialog.BodyComponentSpec[] => {
     name: 'src',
     type: 'urlinput',
     filetype: 'image',
-    label: 'Source'
+    label: 'Source',
+    picker_text: 'Browse files'
   };
   const imageList = info.imageList.map((items) => ({
     name: 'images',

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -59,7 +59,7 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
     editor.execCommand('mceImage');
     await TinyUiActions.pWaitForDialog(editor);
-    Mouse.clickOn(SugarBody.body(), 'button[title="Source"]');
+    Mouse.clickOn(SugarBody.body(), 'button[title="Browse files"]');
     await Waiter.pTryUntil('Wait for width to be populated', () => assertInputValue(generalTabSelectors.width, '200'));
     TinyUiActions.submitDialog(editor);
     assertCleanHtml('Checking output', editor, '<p><img src="https://www.google.com/logos/google.jpg" alt="" width="200"></p>');

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Dialog.ts
@@ -81,7 +81,8 @@ const makeDialog = (settings: LinkDialogInfo, onSubmit: (api: Dialog.DialogInsta
       name: 'url',
       type: 'urlinput',
       filetype: 'file',
-      label: 'URL'
+      label: 'URL',
+      picker_text: 'Browse links'
     }
   ];
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
@@ -236,7 +236,7 @@ export const renderUrlInput = (
   const memUrlPickerButton = Memento.record(renderButton({
     name: spec.name,
     icon: Optional.some('browse'),
-    text: spec.label.getOr(''),
+    text: spec.text.getOr(''),
     enabled: spec.enabled,
     primary: false,
     buttonType: Optional.none(),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
@@ -236,7 +236,7 @@ export const renderUrlInput = (
   const memUrlPickerButton = Memento.record(renderButton({
     name: spec.name,
     icon: Optional.some('browse'),
-    text: spec.picker_text.getOr(spec.label.getOr('')),
+    text: spec.picker_text.or(spec.label).getOr(''),
     enabled: spec.enabled,
     primary: false,
     buttonType: Optional.none(),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
@@ -236,7 +236,7 @@ export const renderUrlInput = (
   const memUrlPickerButton = Memento.record(renderButton({
     name: spec.name,
     icon: Optional.some('browse'),
-    text: spec.picker_text.getOr(''),
+    text: spec.picker_text.getOr(spec.name),
     enabled: spec.enabled,
     primary: false,
     buttonType: Optional.none(),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
@@ -236,7 +236,7 @@ export const renderUrlInput = (
   const memUrlPickerButton = Memento.record(renderButton({
     name: spec.name,
     icon: Optional.some('browse'),
-    text: spec.picker_text.getOr(spec.name),
+    text: spec.picker_text.getOr(spec.label.getOr('')),
     enabled: spec.enabled,
     primary: false,
     buttonType: Optional.none(),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
@@ -236,7 +236,7 @@ export const renderUrlInput = (
   const memUrlPickerButton = Memento.record(renderButton({
     name: spec.name,
     icon: Optional.some('browse'),
-    text: spec.text.getOr(''),
+    text: spec.picker_text.getOr(''),
     enabled: spec.enabled,
     primary: false,
     buttonType: Optional.none(),

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
@@ -17,7 +17,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
   const hook = TestHelpers.GuiSetup.bddSetup((store, _doc, _body) => GuiFactory.build(
     renderUrlInput({
       label: Optional.some('UrlInput label'),
-      picker_text: Optional.some('UrlInput text'),
+      picker_text: Optional.some('UrlInput picker text'),
       name: 'col1',
       filetype: 'file',
       enabled: true

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
@@ -1,5 +1,5 @@
-import { ApproxStructure, Assertions, Keyboard, Keys, Mouse, UiControls, UiFinder, Waiter } from '@ephox/agar';
-import { Disabling, Focusing, GuiFactory, Representing, TestHelpers } from '@ephox/alloy';
+import { ApproxStructure, Assertions, Keyboard, Keys, Mouse, TestStore, UiControls, UiFinder, Waiter } from '@ephox/agar';
+import { Container, Disabling, Focusing, GuiFactory, Representing, TestHelpers } from '@ephox/alloy';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Future, Optional } from '@ephox/katamari';
 import { Attribute, SelectorFind, SugarDocument, Value } from '@ephox/sugar';
@@ -14,10 +14,10 @@ import * as TestExtras from '../../../module/TestExtras';
 describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () => {
   const extrasHook = TestExtras.bddSetup();
 
-  const hook = TestHelpers.GuiSetup.bddSetup((store, _doc, _body) => GuiFactory.build(
+  const renderUrlInputWithPickerText = (store: TestStore<string>, pickerText?: string) =>
     renderUrlInput({
       label: Optional.some('UrlInput label'),
-      picker_text: Optional.some('UrlInput picker text'),
+      picker_text: Optional.from(pickerText),
       name: 'col1',
       filetype: 'file',
       enabled: true
@@ -49,7 +49,18 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
         store.adder('urlpicker')();
         return Future.pure({ value: 'http://tiny.cloud', meta: { before: entry.value }, fieldname: 'test' });
       })
-    }, Optional.none())
+    }, Optional.none());
+
+  const hook = TestHelpers.GuiSetup.bddSetup((store, _doc, _body) => GuiFactory.build(
+    Container.sketch({
+      dom: {
+        tag: 'div'
+      },
+      components: [
+        renderUrlInputWithPickerText(store, 'UrlInput picker text'),
+        renderUrlInputWithPickerText(store)
+      ]
+    })
   ), () => extrasHook.access().getPopupMothership());
 
   TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [
@@ -57,15 +68,18 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
     '.tox-collection__item--active { background: #cadbee }'
   ]);
 
+  const getFirstComponent = () =>
+    hook.component().components()[0];
+
   const getInput = () => {
-    const component = hook.component();
+    const component = getFirstComponent();
     return component.getSystem().getByDom(
       SelectorFind.descendant(component.element, 'input').getOrDie('Could not find input')
     ).getOrDie();
   };
 
-  const getPicker = () => {
-    const component = hook.component();
+  const getPicker = (specificText: boolean) => {
+    const component = hook.component().components()[specificText ? 0 : 1];
     return component.getSystem().getByDom(
       SelectorFind.descendant(component.element, 'button').getOrDie('Could not find picker button')
     ).getOrDie();
@@ -95,7 +109,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
   });
 
   it('Disabling state', () => {
-    const component = hook.component();
+    const component = getFirstComponent();
     assert.isFalse(Disabling.isDisabled(component), 'Initial disabled state');
     Disabling.set(component, true);
     assert.isTrue(Disabling.isDisabled(component), 'enabled > disabled');
@@ -215,7 +229,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
   });
 
   it('Click urlpicker and assert input state is updated', async () => {
-    const component = hook.component();
+    const component = getFirstComponent();
     const store = hook.store();
     const input = getInput();
 
@@ -272,12 +286,15 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
   });
 
   it('TINY-9717: it should open dropdown after the input value was reset to an empty string', async () => {
-    const component = hook.component();
+    const component = getFirstComponent();
     Representing.setValue(component, { value: '' });
     await pOpenMenu();
     closeMenu();
   });
 
   it('TINY-10155: Title attribute of picker button should be specified by picker_text property', () =>
-    assert.equal(Attribute.get(getPicker().element, 'title'), 'UrlInput picker text'));
+    assert.equal(Attribute.get(getPicker(true).element, 'title'), 'UrlInput picker text'));
+
+  it('TINY-10155: Title attribute of picker button should fall back to label when picker_text property is not specified', () =>
+    assert.equal(Attribute.get(getPicker(false).element, 'title'), 'col1'));
 });

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
@@ -2,7 +2,7 @@ import { ApproxStructure, Assertions, Keyboard, Keys, Mouse, UiControls, UiFinde
 import { Disabling, Focusing, GuiFactory, Representing, TestHelpers } from '@ephox/alloy';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Future, Optional } from '@ephox/katamari';
-import { SelectorFind, SugarDocument, Value } from '@ephox/sugar';
+import { Attribute, SelectorFind, SugarDocument, Value } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import { ApiUrlData } from 'tinymce/themes/silver/backstage/UrlInputBackstage';
@@ -61,6 +61,13 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
     const component = hook.component();
     return component.getSystem().getByDom(
       SelectorFind.descendant(component.element, 'input').getOrDie('Could not find input')
+    ).getOrDie();
+  };
+
+  const getPicker = () => {
+    const component = hook.component();
+    return component.getSystem().getByDom(
+      SelectorFind.descendant(component.element, 'button').getOrDie('Could not find picker button')
     ).getOrDie();
   };
 
@@ -270,4 +277,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
     await pOpenMenu();
     closeMenu();
   });
+
+  it('TINY-10155: Title attribute of picker button should be specified by picker_text property', () =>
+    assert.equal(Attribute.get(getPicker().element, 'title'), 'UrlInput picker text'));
 });

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
@@ -17,7 +17,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
   const hook = TestHelpers.GuiSetup.bddSetup((store, _doc, _body) => GuiFactory.build(
     renderUrlInput({
       label: Optional.some('UrlInput label'),
-      text: Optional.some('UrlInput text'),
+      picker_text: Optional.some('UrlInput text'),
       name: 'col1',
       filetype: 'file',
       enabled: true

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
@@ -296,5 +296,5 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
     assert.equal(Attribute.get(getPicker(true).element, 'title'), 'UrlInput picker text'));
 
   it('TINY-10155: Title attribute of picker button should fall back to label when picker_text property is not specified', () =>
-    assert.equal(Attribute.get(getPicker(false).element, 'title'), 'col1'));
+    assert.equal(Attribute.get(getPicker(false).element, 'title'), 'UrlInput label'));
 });

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
@@ -17,6 +17,7 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
   const hook = TestHelpers.GuiSetup.bddSetup((store, _doc, _body) => GuiFactory.build(
     renderUrlInput({
       label: Optional.some('UrlInput label'),
+      text: Optional.some('UrlInput text'),
       name: 'col1',
       filetype: 'file',
       enabled: true

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/components/urlinput/UrlInputTest.ts
@@ -16,6 +16,7 @@ describe('webdriver.tinymce.themes.silver.components.urlinput.UrlInputTest', () 
   const hook = TestHelpers.GuiSetup.bddSetup((store, _doc, _body) => GuiFactory.build(
     renderUrlInput({
       label: Optional.some('UrlInput label'),
+      text: Optional.some('UrlInput text'),
       name: 'col1',
       filetype: 'file',
       enabled: true

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/components/urlinput/UrlInputTest.ts
@@ -16,7 +16,7 @@ describe('webdriver.tinymce.themes.silver.components.urlinput.UrlInputTest', () 
   const hook = TestHelpers.GuiSetup.bddSetup((store, _doc, _body) => GuiFactory.build(
     renderUrlInput({
       label: Optional.some('UrlInput label'),
-      text: Optional.some('UrlInput text'),
+      picker_text: Optional.some('UrlInput picker text'),
       name: 'col1',
       filetype: 'file',
       enabled: true

--- a/versions.txt
+++ b/versions.txt
@@ -2,3 +2,4 @@
 # Format: [package_name]@[new_version]
 
 polaris@6.2.2
+bridge@4.6.0


### PR DESCRIPTION
Related Ticket: TINY-10155

Description of Changes:
* Added optional `picker_text` property to `UrlInputSpec` to specify tooltip text of picker button
* Improved picker button tooltips for Image and Link dialogs as per ticket DoD

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
