### PR TITLE
TINY-9879: Preparation for TinyMCE 6.7.0 release

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ Tiny Technologies, Inc. supports the following community versions of TinyMCE:
 | Version | Supported                      |
 |---------| ------------------------------ |
 | 5.10.x  | &#10004;                       |
-| 6.6.x   | &#10004;                       |
+| 6.7.x   | &#10004;                       |
 | Other   | &#10006;                       |
 
 For supported enterprise versions of TinyMCE, refer to the enterprise [Supported TinyMCE versions documentation](https://www.tiny.cloud/docs/tinymce/6/support/#supportedversionsandplatforms).

--- a/modules/acid/package.json
+++ b/modules/acid/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ephox/acid",
   "description": "Color library including Alloy UI component for a color picker",
-  "version": "5.2.0-alpha.0",
+  "version": "5.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
     "directory": "modules/acid"
   },
   "dependencies": {
-    "@ephox/alloy": "13.1.0-alpha.0",
+    "@ephox/alloy": "^13.1.0",
     "@ephox/boulder": "^7.1.5",
     "@ephox/katamari": "^9.1.5",
     "@ephox/sugar": "^9.2.1"

--- a/modules/alloy/package.json
+++ b/modules/alloy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/alloy",
-  "version": "13.1.0-alpha.0",
+  "version": "13.1.0",
   "description": "Ui Framework",
   "dependencies": {
     "@ephox/agar": "^7.4.3",

--- a/modules/bridge/package.json
+++ b/modules/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/bridge",
-  "version": "4.6.0-alpha.0",
+  "version": "4.6.0",
   "description": "Ui API for TinyMCE 5",
   "repository": {
     "type": "git",

--- a/modules/darwin/package.json
+++ b/modules/darwin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/darwin",
   "description": "This project's purpose is to handle selection and cursor navigation.",
-  "version": "8.1.0-alpha.0",
+  "version": "8.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -20,10 +20,10 @@
   ],
   "dependencies": {
     "@ephox/katamari": "^9.1.5",
-    "@ephox/phoenix": "8.3.0-alpha.0",
-    "@ephox/robin": "10.3.0-alpha.0",
+    "@ephox/phoenix": "^8.3.0",
+    "@ephox/robin": "^10.3.0",
     "@ephox/sand": "^6.0.9",
-    "@ephox/snooker": "11.1.0-alpha.0",
+    "@ephox/snooker": "^11.1.0",
     "@ephox/sugar": "^9.2.1"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",

--- a/modules/oxide-icons-default/package.json
+++ b/modules/oxide-icons-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/oxide-icons-default",
-  "version": "2.6.0-alpha.0",
+  "version": "2.6.0",
   "description": "The default icon pack for TinyMCE",
   "repository": {
     "type": "git",

--- a/modules/oxide/package.json
+++ b/modules/oxide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/oxide",
-  "version": "2.7.0-alpha.0",
+  "version": "2.7.0",
   "description": "TinyMCE 5 Oxide skin",
   "repository": {
     "type": "git",

--- a/modules/phoenix/package.json
+++ b/modules/phoenix/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/phoenix",
   "description": "DOM node text gathering library, rose from the ashes of some other projects we can't remember the names of now (edit: seek, sherlock, gift)",
-  "version": "8.3.0-alpha.0",
+  "version": "8.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -21,7 +21,7 @@
   "dependencies": {
     "@ephox/boss": "^6.0.9",
     "@ephox/katamari": "^9.1.5",
-    "@ephox/polaris": "6.3.0-alpha.0",
+    "@ephox/polaris": "^6.3.0",
     "@ephox/sugar": "^9.2.1"
   },
   "devDependencies": {

--- a/modules/polaris/CHANGELOG.md
+++ b/modules/polaris/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 6.2.2 - 2023-08-30
+
 ### Fixed
 - `Search.findmany` now removes overlapped indices. #TINY-10062
 

--- a/modules/polaris/package.json
+++ b/modules/polaris/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/polaris",
   "description": "This project does data manipulation on arrays and strings.",
-  "version": "6.3.0-alpha.0",
+  "version": "6.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",

--- a/modules/robin/package.json
+++ b/modules/robin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/robin",
   "description": "This project is for grouping sibling DOM nodes together by boundary points, for example the list of elements and nodes representing a word.",
-  "version": "10.3.0-alpha.0",
+  "version": "10.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -21,8 +21,8 @@
   "dependencies": {
     "@ephox/boss": "^6.0.9",
     "@ephox/katamari": "^9.1.5",
-    "@ephox/phoenix": "8.3.0-alpha.0",
-    "@ephox/polaris": "6.3.0-alpha.0",
+    "@ephox/phoenix": "^8.3.0",
+    "@ephox/polaris": "^6.3.0",
     "@ephox/sugar": "^9.2.1"
   },
   "devDependencies": {

--- a/modules/snooker/package.json
+++ b/modules/snooker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/snooker",
   "description": "This project implements the table model.",
-  "version": "11.1.0-alpha.0",
+  "version": "11.1.0",
   "files": [
     "lib/main",
     "lib/demo",
@@ -22,7 +22,7 @@
     "@ephox/dragster": "^7.2.1",
     "@ephox/katamari": "^9.1.5",
     "@ephox/porkbun": "^7.0.9",
-    "@ephox/robin": "10.3.0-alpha.0",
+    "@ephox/robin": "^10.3.0",
     "@ephox/sugar": "^9.2.1"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 6.7.0 - 2023-08-30
+
 ### Added
 - New `help_accessibility` option displays the keyboard shortcut to open the in-application help in the status bar. #TINY-9379
 - Added a new `InsertNewBlockBefore` command which inserts an empty block before the block containing the current selection. #TINY-10022

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,3 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
 
-polaris@6.2.2


### PR DESCRIPTION
Related Ticket: TINY-9879

Description of Changes:
* Follow release preparation steps in https://internal-docs.tiny.work/internal-docs/1.1/engineering/releases/release-preparation.html

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
