### PR TITLE
TINY-9287: Added brightness/saturation 2D selector and hue slider to tabstop targets, added speed multiplier for pressing shift.

### DIFF
--- a/modules/acid/src/demo/ts/ephox/acid/demo/Demo.ts
+++ b/modules/acid/src/demo/ts/ephox/acid/demo/Demo.ts
@@ -1,7 +1,8 @@
 import { Channels, Debugging, Gui, GuiFactory } from '@ephox/alloy';
-import { Fun, Optional } from '@ephox/katamari';
+import { Fun, Optional, Type } from '@ephox/katamari';
 import { Class, DomEvent, Insert, SugarElement } from '@ephox/sugar';
 
+import { Untranslated } from 'ephox/acid/alien/I18n';
 import * as ColourPicker from 'ephox/acid/gui/ColourPicker';
 
 import { strings } from '../../../../i18n/en';
@@ -19,12 +20,17 @@ DomEvent.bind(SugarElement.fromDom(document), 'mouseup', (evt) => {
   }
 });
 
-const fakeTranslate = (key: string): string =>
-  Optional.from(strings[key]).getOrThunk(() => {
+const fakeTranslate = (key: Untranslated): string => {
+  if (Type.isString(key)) {
+    return Optional.from(strings[key]).getOrThunk(() => {
     // eslint-disable-next-line no-console
-    console.error('Missing translation for ' + key);
-    return key;
-  });
+      console.error('Missing translation for ' + key);
+      return key;
+    });
+  } else {
+    return 'Untranslated, complex string';
+  }
+};
 
 const colourPickerFactory = ColourPicker.makeFactory(fakeTranslate, Fun.identity);
 

--- a/modules/acid/src/main/ts/ephox/acid/alien/I18n.ts
+++ b/modules/acid/src/main/ts/ephox/acid/alien/I18n.ts
@@ -1,0 +1,9 @@
+export interface RawString {
+  raw: string;
+}
+
+type Primitive = string | number | boolean | Record<string | number, any> | Function;
+
+export type TokenisedString = [ string, ...Primitive[] ];
+
+export type Untranslated = Primitive | TokenisedString | RawString | null | undefined;

--- a/modules/acid/src/main/ts/ephox/acid/gui/ColourPicker.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/ColourPicker.ts
@@ -4,6 +4,7 @@ import {
 import { FieldSchema } from '@ephox/boulder';
 import { Arr, Cell, Fun } from '@ephox/katamari';
 
+import { Untranslated } from '../alien/I18n';
 import { Hex } from '../api/colour/ColourTypes';
 import * as HsvColour from '../api/colour/HsvColour';
 import * as RgbaColour from '../api/colour/RgbaColour';
@@ -29,7 +30,7 @@ export interface ColourPickerSketcher extends Sketcher.SingleSketch<ColourPicker
 }
 
 const makeFactory = (
-  translate: (key: string) => string,
+  translate: (key: Untranslated) => string,
   getClass: (key: string) => string
 ): ColourPickerSketcher => {
   const factory = (detail: ColourPickerDetail) => {

--- a/modules/acid/src/main/ts/ephox/acid/gui/components/HueSlider.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/HueSlider.ts
@@ -30,8 +30,7 @@ const sliderFactory = (translate: (key: string) => string, getClass: (key: strin
       tag: 'div',
       classes: [ getClass('hue-slider') ],
       attributes: {
-        'role': 'presentation',
-        'aria-role': 'slider',
+        'role': 'slider',
         'aria-valuemin': 0,
         'aria-valuemax': 360,
         'aria-valuenow': 120,

--- a/modules/acid/src/main/ts/ephox/acid/gui/components/HueSlider.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/HueSlider.ts
@@ -1,5 +1,6 @@
-import { AlloyComponent, AlloyTriggers, Behaviour, Focusing, SketchSpec, Slider } from '@ephox/alloy';
+import { AlloyComponent, AlloyTriggers, Behaviour, Focusing, SketchSpec, Slider, Tabstopping } from '@ephox/alloy';
 import { Fun } from '@ephox/katamari';
+import { Attribute } from '@ephox/sugar';
 
 import { sliderUpdate } from '../ColourEvents';
 
@@ -29,7 +30,11 @@ const sliderFactory = (translate: (key: string) => string, getClass: (key: strin
       tag: 'div',
       classes: [ getClass('hue-slider') ],
       attributes: {
-        role: 'presentation'
+        'role': 'presentation',
+        'aria-role': 'slider',
+        'aria-valuemin': 0,
+        'aria-valuemax': 360,
+        'aria-valuenow': 120,
       }
     },
     rounded: false,
@@ -42,10 +47,12 @@ const sliderFactory = (translate: (key: string) => string, getClass: (key: strin
       thumb
     ],
     sliderBehaviours: Behaviour.derive([
+      Tabstopping.config({ }),
       Focusing.config({ })
     ]),
 
     onChange: (slider: AlloyComponent, _thumb: any, value: any) => {
+      Attribute.set(slider.element, 'aria-valuenow', Math.floor(360 - (value * 3.6)));
       AlloyTriggers.emitWith(slider, sliderUpdate, {
         value
       });

--- a/modules/acid/src/main/ts/ephox/acid/gui/components/SaturationBrightnessPalette.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/SaturationBrightnessPalette.ts
@@ -1,5 +1,6 @@
 import { AlloyComponent, AlloyTriggers, Behaviour, Composing, Focusing, Sketcher, SketchSpec, Slider, SliderTypes, UiSketcher } from '@ephox/alloy';
-import { Fun, Optional } from '@ephox/katamari';
+import { Fun, Optional, Type } from '@ephox/katamari';
+import { Attribute } from '@ephox/sugar';
 
 import { Hex } from '../../api/colour/ColourTypes';
 import * as HsvColour from '../../api/colour/HsvColour';
@@ -74,6 +75,7 @@ const paletteFactory = (_translate: (key: string) => string, getClass: (key: str
   const setPaletteThumb = (slider: AlloyComponent, hex: Hex): void => {
     const hsv = HsvColour.fromRgb(RgbaColour.fromHex(hex));
     Slider.setValue(slider, { x: hsv.saturation, y: 100 - hsv.value });
+    Attribute.set(slider.element, 'aria-valuetext', `Saturation ${hsv.saturation}%, Brightness ${hsv.value}%`);
   };
 
   const factory: UiSketcher.SingleSketchFactory<SaturationBrightnessPaletteDetail, SaturationBrightnessPaletteSpec> = (_detail): SketchSpec => {
@@ -83,6 +85,9 @@ const paletteFactory = (_translate: (key: string) => string, getClass: (key: str
     });
 
     const onChange = (slider: AlloyComponent, _thumb: AlloyComponent, value: number | SliderTypes.SliderValue) => {
+      if (!Type.isNumber(value)) {
+        Attribute.set(slider.element, 'aria-valuetext', `Saturation ${Math.floor(value.x)}%, Brightness ${Math.floor(100 - value.y)}%`);
+      }
       AlloyTriggers.emitWith(slider, ColourEvents.paletteUpdate, {
         value
       });
@@ -104,7 +109,8 @@ const paletteFactory = (_translate: (key: string) => string, getClass: (key: str
       dom: {
         tag: 'div',
         attributes: {
-          role: 'presentation'
+          'role': 'presentation',
+          'aria-valuetext': 'Saturation 0%, Brightness 0%'
         },
         classes: [ getClass('sv-palette') ]
       },

--- a/modules/acid/src/main/ts/ephox/acid/gui/components/SaturationBrightnessPalette.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/SaturationBrightnessPalette.ts
@@ -88,7 +88,7 @@ const paletteFactory = (translate: (key: Untranslated) => string, getClass: (key
 
     const onChange = (slider: AlloyComponent, _thumb: AlloyComponent, value: number | SliderTypes.SliderValue) => {
       if (!Type.isNumber(value)) {
-        Attribute.set(slider.element, 'aria-valuetext', `Saturation ${Math.floor(value.x)}%, Brightness ${Math.floor(100 - value.y)}%`);
+        Attribute.set(slider.element, 'aria-valuetext', translate([ 'Saturation {0}%, Brightness {1}%', Math.floor(value.x), Math.floor(100 - value.y) ]));
       }
       AlloyTriggers.emitWith(slider, ColourEvents.paletteUpdate, {
         value
@@ -111,8 +111,8 @@ const paletteFactory = (translate: (key: Untranslated) => string, getClass: (key
       dom: {
         tag: 'div',
         attributes: {
-          'role': 'presentation',
-          'aria-valuetext': 'Saturation 0%, Brightness 0%'
+          'role': 'slider',
+          'aria-valuetext': translate([ 'Saturation {0}%, Brightness {1}%', 0, 0 ])
         },
         classes: [ getClass('sv-palette') ]
       },

--- a/modules/acid/src/main/ts/ephox/acid/gui/components/SaturationBrightnessPalette.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/SaturationBrightnessPalette.ts
@@ -20,7 +20,11 @@ export interface SaturationBrightnessPaletteSketcher extends Sketcher.SingleSket
   setThumb: (slider: AlloyComponent, hex: Hex) => void;
 }
 
-const paletteFactory = (_translate: (key: string) => string, getClass: (key: string) => string): SaturationBrightnessPaletteSketcher => {
+const paletteFactory = (translate: (key: string) => string, getClass: (key: string) => string): SaturationBrightnessPaletteSketcher => {
+  const translateReplace = (key: string, value1: number, value2: number): string => {
+    return translate(key).replace('{0}', value1 + '').replace('{1}', value2 + '');
+  };
+
   const spectrumPart = Slider.parts.spectrum({
     dom: {
       tag: 'canvas',
@@ -75,7 +79,7 @@ const paletteFactory = (_translate: (key: string) => string, getClass: (key: str
   const setPaletteThumb = (slider: AlloyComponent, hex: Hex): void => {
     const hsv = HsvColour.fromRgb(RgbaColour.fromHex(hex));
     Slider.setValue(slider, { x: hsv.saturation, y: 100 - hsv.value });
-    Attribute.set(slider.element, 'aria-valuetext', `Saturation ${hsv.saturation}%, Brightness ${hsv.value}%`);
+    Attribute.set(slider.element, 'aria-valuetext', translateReplace('Saturation {0}%, Brightness {1}%', hsv.saturation, hsv.value));
   };
 
   const factory: UiSketcher.SingleSketchFactory<SaturationBrightnessPaletteDetail, SaturationBrightnessPaletteSpec> = (_detail): SketchSpec => {

--- a/modules/acid/src/main/ts/ephox/acid/gui/components/SaturationBrightnessPalette.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/SaturationBrightnessPalette.ts
@@ -2,6 +2,7 @@ import { AlloyComponent, AlloyTriggers, Behaviour, Composing, Focusing, Sketcher
 import { Fun, Optional, Type } from '@ephox/katamari';
 import { Attribute } from '@ephox/sugar';
 
+import { Untranslated } from '../../alien/I18n';
 import { Hex } from '../../api/colour/ColourTypes';
 import * as HsvColour from '../../api/colour/HsvColour';
 import * as RgbaColour from '../../api/colour/RgbaColour';
@@ -20,10 +21,7 @@ export interface SaturationBrightnessPaletteSketcher extends Sketcher.SingleSket
   setThumb: (slider: AlloyComponent, hex: Hex) => void;
 }
 
-const paletteFactory = (translate: (key: string) => string, getClass: (key: string) => string): SaturationBrightnessPaletteSketcher => {
-  const translateReplace = (key: string, value1: number, value2: number): string => {
-    return translate(key).replace('{0}', value1 + '').replace('{1}', value2 + '');
-  };
+const paletteFactory = (translate: (key: Untranslated) => string, getClass: (key: string) => string): SaturationBrightnessPaletteSketcher => {
 
   const spectrumPart = Slider.parts.spectrum({
     dom: {
@@ -79,7 +77,7 @@ const paletteFactory = (translate: (key: string) => string, getClass: (key: stri
   const setPaletteThumb = (slider: AlloyComponent, hex: Hex): void => {
     const hsv = HsvColour.fromRgb(RgbaColour.fromHex(hex));
     Slider.setValue(slider, { x: hsv.saturation, y: 100 - hsv.value });
-    Attribute.set(slider.element, 'aria-valuetext', translateReplace('Saturation {0}%, Brightness {1}%', hsv.saturation, hsv.value));
+    Attribute.set(slider.element, 'aria-valuetext', translate([ 'Saturation {0}%, Brightness {1}%', hsv.saturation, hsv.value ]));
   };
 
   const factory: UiSketcher.SingleSketchFactory<SaturationBrightnessPaletteDetail, SaturationBrightnessPaletteSpec> = (_detail): SketchSpec => {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/HorizontalModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/HorizontalModel.ts
@@ -57,15 +57,15 @@ const setToMax = (spectrum: AlloyComponent, detail: HorizontalSliderDetail): voi
 };
 
 // move in a direction by step size. Fire change at the end
-const moveBy = (direction: number, spectrum: AlloyComponent, detail: HorizontalSliderDetail): Optional<number> => {
+const moveBy = (direction: number, spectrum: AlloyComponent, detail: HorizontalSliderDetail, useMultiplier?: boolean): Optional<number> => {
   const f = (direction > 0) ? SliderModel.increaseBy : SliderModel.reduceBy;
-  const xValue = f(currentValue(detail), minX(detail), maxX(detail), step(detail));
+  const xValue = f(currentValue(detail), minX(detail), maxX(detail), step(detail, useMultiplier));
   fireSliderChange(spectrum, xValue);
   return Optional.some(xValue);
 };
 
-const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail: HorizontalSliderDetail): Optional<boolean> =>
-  moveBy(direction, spectrum, detail).map<boolean>(Fun.always);
+const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail: HorizontalSliderDetail, useMultiplier?: boolean): Optional<boolean> =>
+  moveBy(direction, spectrum, detail, useMultiplier).map<boolean>(Fun.always);
 
 // get x offset from event
 const getValueFromEvent = (simulatedEvent: NativeSimulatedEvent<MouseEvent | TouchEvent>): Optional<number> => {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderParts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderParts.ts
@@ -11,6 +11,7 @@ import { OptionalDomSchema } from '../../api/component/SpecTypes';
 import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as NativeEvents from '../../api/events/NativeEvents';
 import { NativeSimulatedEvent } from '../../events/SimulatedEvent';
+import * as KeyMatch from '../../navigation/KeyMatch';
 import * as PartType from '../../parts/PartType';
 import { EdgeActions, SliderDetail } from '../types/SliderTypes';
 
@@ -91,7 +92,7 @@ const thumbPart = PartType.required<SliderDetail, { dom: OptionalDomSchema; even
   }
 });
 
-const isShift = (event: any) => event.raw ? event.raw.shiftKey : false;
+const isShift = (event: NativeSimulatedEvent<KeyboardEvent>) => KeyMatch.isShift(event.event);
 
 const spectrumPart = PartType.required({
   schema: [
@@ -111,10 +112,10 @@ const spectrumPart = PartType.required({
         Keying.config(
           {
             mode: 'special',
-            onLeft: (spectrum, event) => model.onLeft(spectrum, detail, isShift(event.event)),
-            onRight: (spectrum, event) => model.onRight(spectrum, detail, isShift(event.event)),
-            onUp: (spectrum, event) => model.onUp(spectrum, detail, isShift(event.event)),
-            onDown: (spectrum, event) => model.onDown(spectrum, detail, isShift(event.event))
+            onLeft: (spectrum, event) => model.onLeft(spectrum, detail, isShift(event)),
+            onRight: (spectrum, event) => model.onRight(spectrum, detail, isShift(event)),
+            onUp: (spectrum, event) => model.onUp(spectrum, detail, isShift(event)),
+            onDown: (spectrum, event) => model.onDown(spectrum, detail, isShift(event))
           }
         ),
         Tabstopping.config({ }),

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderParts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderParts.ts
@@ -5,6 +5,7 @@ import { EventArgs, SugarPosition } from '@ephox/sugar';
 import * as Behaviour from '../../api/behaviour/Behaviour';
 import { Focusing } from '../../api/behaviour/Focusing';
 import { Keying } from '../../api/behaviour/Keying';
+import { Tabstopping } from '../../api/behaviour/Tabstopping';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { OptionalDomSchema } from '../../api/component/SpecTypes';
 import * as AlloyEvents from '../../api/events/AlloyEvents';
@@ -90,6 +91,8 @@ const thumbPart = PartType.required<SliderDetail, { dom: OptionalDomSchema; even
   }
 });
 
+const isShift = (event: any) => event.raw ? event.raw.shiftKey : false;
+
 const spectrumPart = PartType.required({
   schema: [
     FieldSchema.customField('mouseIsDown', () => Cell(false))
@@ -108,12 +111,13 @@ const spectrumPart = PartType.required({
         Keying.config(
           {
             mode: 'special',
-            onLeft: (spectrum) => model.onLeft(spectrum, detail),
-            onRight: (spectrum) => model.onRight(spectrum, detail),
-            onUp: (spectrum) => model.onUp(spectrum, detail),
-            onDown: (spectrum) => model.onDown(spectrum, detail)
+            onLeft: (spectrum, event) => model.onLeft(spectrum, detail, isShift(event.event)),
+            onRight: (spectrum, event) => model.onRight(spectrum, detail, isShift(event.event)),
+            onUp: (spectrum, event) => model.onUp(spectrum, detail, isShift(event.event)),
+            onDown: (spectrum, event) => model.onDown(spectrum, detail, isShift(event.event))
           }
         ),
+        Tabstopping.config({ }),
         Focusing.config({})
       ]),
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderSchema.ts
@@ -18,6 +18,7 @@ interface SliderModelSpec {
 
 const SliderSchema: FieldProcessor[] = [
   FieldSchema.defaulted('stepSize', 1),
+  FieldSchema.defaulted('speedMultiplier', 10),
   FieldSchema.defaulted('onChange', Fun.noop),
   FieldSchema.defaulted('onChoose', Fun.noop),
   FieldSchema.defaulted('onInit', Fun.noop),

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderValues.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderValues.ts
@@ -30,7 +30,7 @@ const yRange = (detail: VerticalSliderDetail): number => range(detail, maxY, min
 const halfX = (detail: HorizontalSliderDetail): number => xRange(detail) / 2;
 const halfY = (detail: VerticalSliderDetail): number => yRange(detail) / 2;
 
-const step = (detail: SliderDetail): number => detail.stepSize;
+const step = (detail: SliderDetail, useMultiplier?: boolean): number => useMultiplier ? detail.stepSize * detail.speedMultiplier : detail.stepSize;
 const snap = (detail: SliderDetail): boolean => detail.snapToGrid;
 const snapStart = (detail: SliderDetail): Optional<number> => detail.snapStart;
 const rounded = (detail: SliderDetail): boolean => detail.rounded;

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/TwoDModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/TwoDModel.ts
@@ -33,19 +33,19 @@ const setValueFrom = (spectrum: AlloyComponent, detail: TwoDSliderDetail, value:
 };
 
 // move in a direction by step size. Fire change at the end
-const moveBy = (direction: number, isVerticalMovement: boolean, spectrum: AlloyComponent, detail: TwoDSliderDetail): Optional<number> => {
+const moveBy = (direction: number, isVerticalMovement: boolean, spectrum: AlloyComponent, detail: TwoDSliderDetail, useMultiplier?: boolean): Optional<number> => {
   const f = (direction > 0) ? SliderModel.increaseBy : SliderModel.reduceBy;
   const xValue = isVerticalMovement ? currentValue(detail).x :
-    f(currentValue(detail).x, minX(detail), maxX(detail), step(detail));
+    f(currentValue(detail).x, minX(detail), maxX(detail), step(detail, useMultiplier));
   const yValue = !isVerticalMovement ? currentValue(detail).y :
-    f(currentValue(detail).y, minY(detail), maxY(detail), step(detail));
+    f(currentValue(detail).y, minY(detail), maxY(detail), step(detail, useMultiplier));
 
   fireSliderChange(spectrum, sliderValue(xValue, yValue));
   return Optional.some(xValue);
 };
 
-const handleMovement = (direction: number, isVerticalMovement: boolean) => (spectrum: AlloyComponent, detail: TwoDSliderDetail): Optional<boolean> =>
-  moveBy(direction, isVerticalMovement, spectrum, detail).map<boolean>(Fun.always);
+const handleMovement = (direction: number, isVerticalMovement: boolean) => (spectrum: AlloyComponent, detail: TwoDSliderDetail, useMultiplier?: boolean): Optional<boolean> =>
+  moveBy(direction, isVerticalMovement, spectrum, detail, useMultiplier).map<boolean>(Fun.always);
 
 // fire a slider change event with the minimum value
 const setToMin = (spectrum: AlloyComponent, detail: TwoDSliderDetail): void => {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/VerticalModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/VerticalModel.ts
@@ -57,15 +57,15 @@ const setToMax = (spectrum: AlloyComponent, detail: VerticalSliderDetail): void 
 };
 
 // move in a direction by step size. Fire change at the end
-const moveBy = (direction: number, spectrum: AlloyComponent, detail: VerticalSliderDetail): Optional<number> => {
+const moveBy = (direction: number, spectrum: AlloyComponent, detail: VerticalSliderDetail, useMultiplier?: boolean): Optional<number> => {
   const f = (direction > 0) ? SliderModel.increaseBy : SliderModel.reduceBy;
-  const yValue = f(currentValue(detail), minY(detail), maxY(detail), step(detail));
+  const yValue = f(currentValue(detail), minY(detail), maxY(detail), step(detail, useMultiplier));
   fireSliderChange(spectrum, yValue);
   return Optional.some(yValue);
 };
 
-const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail: VerticalSliderDetail): Optional<boolean> =>
-  moveBy(direction, spectrum, detail).map<boolean>(Fun.always);
+const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail: VerticalSliderDetail, useMultiplier?: boolean): Optional<boolean> =>
+  moveBy(direction, spectrum, detail, useMultiplier).map<boolean>(Fun.always);
 
 // get y offset from event
 const getValueFromEvent = (simulatedEvent: NativeSimulatedEvent<MouseEvent | TouchEvent>): Optional<number> => {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/SliderTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/SliderTypes.ts
@@ -48,10 +48,10 @@ export interface Manager {
   setToMax: (spectrum: AlloyComponent, detail: SliderDetail) => void;
   getValueFromEvent: (simulatedEvent: NativeSimulatedEvent<MouseEvent | TouchEvent>) => Optional<number | SugarPosition>;
   setPositionFromValue: (slider: AlloyComponent, thumb: AlloyComponent, detail: SliderDetail, parts: SliderModelDetailParts) => void;
-  onLeft: (spectrum: AlloyComponent, detail: SliderDetail) => Optional<boolean>;
-  onRight: (spectrum: AlloyComponent, detail: SliderDetail) => Optional<boolean>;
-  onUp: (spectrum: AlloyComponent, detail: SliderDetail) => Optional<boolean>;
-  onDown: (spectrum: AlloyComponent, detail: SliderDetail) => Optional<boolean>;
+  onLeft: (spectrum: AlloyComponent, detail: SliderDetail, useMultiplier?: boolean) => Optional<boolean>;
+  onRight: (spectrum: AlloyComponent, detail: SliderDetail, useMultiplier?: boolean) => Optional<boolean>;
+  onUp: (spectrum: AlloyComponent, detail: SliderDetail, useMultiplier?: boolean) => Optional<boolean>;
+  onDown: (spectrum: AlloyComponent, detail: SliderDetail, useMultiplier?: boolean) => Optional<boolean>;
   edgeActions: EdgeActions;
 }
 
@@ -91,6 +91,7 @@ export interface SliderDetail extends CompositeSketchDetail {
   model: SliderModelDetail;
   rounded: boolean;
   stepSize: number;
+  speedMultiplier: number;
   snapToGrid: boolean;
   snapStart: Optional<number>;
 

--- a/modules/oxide/src/less/theme/components/color-picker/color-picker.less
+++ b/modules/oxide/src/less/theme/components/color-picker/color-picker.less
@@ -61,6 +61,11 @@
     width: 20px;
   }
 
+  .tox-hue-slider-spectrum:focus,
+  .tox-sv-palette-spectrum:focus {
+    outline: #08f solid;
+  }
+
   .tox-hue-slider-thumb {
     background: white;
     border: 1px solid black;

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Improved
+- Colorpicker now includes the Brightness/Saturation selector and hue slider in the keyboard navigable items. #TINY-9287
+
 ## 6.7.0 - 2023-08-30
 
 ### Added

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
@@ -1,7 +1,9 @@
 import { ColourPicker } from '@ephox/acid';
 import { AlloyComponent, AlloyTriggers, Behaviour, Composing, Form, Memento, NativeEvents, Representing, SimpleSpec } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Arr, Optional, Strings } from '@ephox/katamari';
+import { Arr, Optional, Strings, Type } from '@ephox/katamari';
+
+import { Untranslated } from 'tinymce/core/api/util/I18n';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
@@ -22,8 +24,12 @@ const english: Record<string, string> = {
   'aria.input.invalid': 'Invalid input'
 };
 
-const translate = (providerBackstage: UiFactoryBackstageProviders) => (key: string) => {
-  return providerBackstage.translate(english[key]);
+const translate = (providerBackstage: UiFactoryBackstageProviders) => (key: Untranslated) => {
+  if (Type.isString(key)) {
+    return providerBackstage.translate(english[key]);
+  } else {
+    return providerBackstage.translate(key);
+  }
 };
 
 type ColorPickerSpec = Omit<Dialog.ColorPicker, 'type'>;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -1,7 +1,7 @@
-import { UiFinder, Waiter } from '@ephox/agar';
+import { FocusTools, Keys, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
-import { SelectorFilter, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { Attribute, SelectorFilter, SugarDocument, SugarElement, SugarShadowDom } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -112,6 +112,13 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         await Waiter.pTryUntil('Dialog should close', () => UiFinder.notExists(getBody(editor), dialogSelector));
       };
 
+      const assertAriaValues = (editor: Editor, hue: number, saturation: number, brightness: number) => {
+        const palette = UiFinder.findIn(getBody(editor), '.tox-sv-palette').getOrDie();
+        const slider = UiFinder.findIn(getBody(editor), '.tox-hue-slider').getOrDie();
+        assert.equal(Attribute.get(palette, 'aria-valuetext'), `Saturation ${saturation}%, Brightness ${brightness}%`);
+        assert.equal(Attribute.get(slider, 'aria-valuenow'), '' + hue);
+      };
+
       it('TBA: Open dialog, click Save and assert color is white', async () => {
         const editor = hook.editor();
         await pOpenDialog(editor);
@@ -134,11 +141,13 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         // Change color to black
         await pOpenDialog(editor);
         await pSetHexBlack(editor);
+        assertAriaValues(editor, 120, 0, 0);
         TinyUiActions.submitDialog(editor);
         await pWaitForDialogClose(editor);
         // Change color in the dialog but cancel
         await pOpenDialog(editor);
         await pSetHexWhite(editor);
+        assertAriaValues(editor, 120, 0, 100);
         await pCancelDialog(editor);
         assertColorBlack();
       });
@@ -174,6 +183,19 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         await pSetHex('invalid')(editor);
         TinyUiActions.submitDialog(editor);
         await pAssertExpectedAlert(editor, 'Invalid hex color code: #invalid');
+      });
+
+      it('TINY-9287: Keyboard tab navigation works as expected, starting at the canvas', async () => {
+        const editor = hook.editor();
+        const elem = TinyDom.targetElement(editor);
+        const doc = SugarShadowDom.getShadowRoot(elem).getOrThunk(() => SugarDocument.getDocument());
+        await pOpenDialog(editor);
+        await FocusTools.pTryOnSelector('Should have selected the main view', doc, 'canvas');
+        TinyUiActions.keydown(editor, Keys.tab());
+        await FocusTools.pTryOnSelector('Should have selected the hue slider', doc, '.tox-hue-slider-spectrum');
+        TinyUiActions.keydown(editor, Keys.tab());
+        await FocusTools.pTryOnSelector('Should have selected the next input', doc, '.tox-textfield');
+        await pCancelDialog(editor);
       });
     });
   });


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-9287

Description of Changes:
Included the Brightness/Saturation selection area and the Hue slider in the tabbing rotation.
Also added a speed multiplier when pressing shift, as requested.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
