### PR TITLE
TINY-9911: Changed gulp-file to generate javascript files instead of css.

### DIFF
--- a/modules/oxide/gulpfile.js
+++ b/modules/oxide/gulpfile.js
@@ -94,7 +94,7 @@ gulp.task('minifyCss', function() {
     .pipe(cleanCSS({ rebase: false }))
     .pipe(through2.obj(function(file, _, cb) {
       if (file.isBuffer()) {
-        const contents = `tinymce.resources.add('${file.relative}', '${file.contents.toString().replace(/'/g, "\\'")}')`;
+        const contents = `tinymce.resources.add('${file.relative}', '${JSON.stringify(file.contents.toString())}')`;
         file.contents = Buffer.from(contents)
       }
       cb(null, file);

--- a/modules/oxide/gulpfile.js
+++ b/modules/oxide/gulpfile.js
@@ -10,6 +10,8 @@ const rename = require('gulp-rename');
 const chalk = require('chalk');
 const fs = require('fs');
 const path = require('path');
+const through2 = require('through2');
+
 
 const autoprefix = new lessAutoprefix({
   browsers: ['last 2 Safari versions', 'iOS 14.0', 'last 2 Chrome versions', 'Firefox ESR'],
@@ -90,7 +92,14 @@ gulp.task('minifyCss', function() {
   return gulp.src(['./build/skins/**/*.css', '!**/*.min.css'])
     .pipe(sourcemaps.init())
     .pipe(cleanCSS({ rebase: false }))
-    .pipe(rename({ extname: '.min.css' }))
+    .pipe(through2.obj(function(file, _, cb) {
+      if (file.isBuffer()) {
+        const contents = `tinymce.resources.add('${file.relative}', '${file.contents.toString().replace(/'/g, "\\'")}')`;
+        file.contents = Buffer.from(contents)
+      }
+      cb(null, file);
+    }))
+    .pipe(rename({ extname: '.js' }))
     .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest('./build/skins'))
     .pipe(connect.reload());


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
Used for testing withing the epic. Not intended for production release at this time. Will not pass tests due to removing the css files.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
