### PR TITLE
TINY-10209: Added support for large inline dialogs and updating dialog size on redial

### DIFF
--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -385,6 +385,11 @@
     max-width: 1200px;
   }
 
+  .tox-dialog--width-lg--inline {
+    height: 100%; // The height property is required to flex the textarea within large dialogs to fit to parent
+    max-width: 1200px;
+  }
+
   .tox-dialog--fullscreen {
     height: 100%;
     max-width: 100%;

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -385,11 +385,6 @@
     max-width: 1200px;
   }
 
-  .tox-dialog--width-lg--inline {
-    height: 100%; // The height property is required to flex the textarea within large dialogs to fit to parent
-    max-width: 1200px;
-  }
-
   .tox-dialog--fullscreen {
     height: 100%;
     max-width: 100%;

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,8 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Inline dialog will now respect `size: 'large'` argument in the dialog spec. #TINY-10209
+
 ### Fixed
 - Setting the content with an attribute that contains a self-closing HTML tag did not preserve the tag. #TINY-10088
+- The dialog size was not updated when the `size` argument was changed when redialling a dialog. #TINY-10209
 
 ## 6.7.0 - 2023-08-30
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
@@ -355,7 +355,7 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
       );
 
       Docking.refresh(inlineDialogComp);
-      editor.on('ResizeEditor ScrollWindow ElementScroll', refreshDocking);
+      editor.on('ResizeEditor ScrollWindow ElementScroll ResizeWindow', refreshDocking);
 
       // Set the initial data in the dialog and focus the first focusable item
       dialogUi.instanceApi.setData(initialData);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
@@ -167,7 +167,9 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
 
       const refreshDocking = () => inlineDialog.on((dialog) => {
         InlineView.reposition(dialog);
-        Docking.refresh(dialog);
+        if (!isStickyToolbar || !isToolbarLocationTop) {
+          Docking.refresh(dialog);
+        }
       });
 
       const dialogUi = renderInlineDialog<T>(
@@ -321,7 +323,7 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
                 optScrollEnv: Optional.none()
               }));
             }
-          }),
+          })
         ]),
         // Treat alert or confirm dialogs as part of the inline dialog
         isExtraPart: (_comp, target) => isAlertOrConfirmDialog(target)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
@@ -165,14 +165,10 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
         internalDialog: contents
       };
 
-      const refresh = (comp: AlloyComponent) => {
-        InlineView.reposition(comp);
-        Docking.refresh(comp);
-      };
-
-      const refreshDocking = () => inlineDialog.on(refresh);
-
-      const refreshView = () => refresh(inlineDialogComp);
+      const refreshDocking = () => inlineDialog.on((dialog) => {
+        InlineView.reposition(dialog);
+        Docking.refresh(dialog);
+      });
 
       const dialogUi = renderInlineDialog<T>(
         dialogInit,
@@ -187,7 +183,7 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
         },
         extras.backstages.popup,
         windowParams.ariaAttrs,
-        refreshView
+        refreshDocking
       );
 
       const inlineDialogComp = GuiFactory.build(InlineView.sketch({
@@ -265,14 +261,10 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
         internalDialog: contents
       };
 
-      const refresh = (comp: AlloyComponent) => {
-        InlineView.reposition(comp);
-        Docking.refresh(comp);
-      };
-
-      const refreshDocking = () => inlineDialog.on(refresh);
-
-      const refreshView = () => refresh(inlineDialogComp);
+      const refreshDocking = () => inlineDialog.on((dialog) => {
+        InlineView.reposition(dialog);
+        Docking.refresh(dialog);
+      });
 
       const dialogUi = renderInlineDialog<T>(
         dialogInit,
@@ -287,7 +279,7 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
         },
         extras.backstages.popup,
         windowParams.ariaAttrs,
-        refreshView
+        refreshDocking
       );
 
       const inlineDialogComp = GuiFactory.build(InlineView.sketch({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
@@ -165,10 +165,14 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
         internalDialog: contents
       };
 
-      const refreshDocking = () => inlineDialog.on((dialog) => {
-        InlineView.reposition(dialog);
-        Docking.refresh(dialog);
-      });
+      const refresh = (comp: AlloyComponent) => {
+        InlineView.reposition(comp);
+        Docking.refresh(comp);
+      };
+
+      const refreshDocking = () => inlineDialog.on(refresh);
+
+      const refreshView = () => refresh(inlineDialogComp);
 
       const dialogUi = renderInlineDialog<T>(
         dialogInit,
@@ -182,7 +186,8 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
           }
         },
         extras.backstages.popup,
-        windowParams.ariaAttrs
+        windowParams.ariaAttrs,
+        refreshView
       );
 
       const inlineDialogComp = GuiFactory.build(InlineView.sketch({
@@ -260,10 +265,14 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
         internalDialog: contents
       };
 
-      const refreshDocking = () => inlineDialog.on((dialog) => {
-        InlineView.reposition(dialog);
-        Docking.refresh(dialog);
-      });
+      const refresh = (comp: AlloyComponent) => {
+        InlineView.reposition(comp);
+        Docking.refresh(comp);
+      };
+
+      const refreshDocking = () => inlineDialog.on(refresh);
+
+      const refreshView = () => refresh(inlineDialogComp);
 
       const dialogUi = renderInlineDialog<T>(
         dialogInit,
@@ -277,7 +286,8 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
           }
         },
         extras.backstages.popup,
-        windowParams.ariaAttrs
+        windowParams.ariaAttrs,
+        refreshView
       );
 
       const inlineDialogComp = GuiFactory.build(InlineView.sketch({
@@ -319,7 +329,7 @@ const setup = (extras: WindowManagerSetup): WindowManagerImpl => {
                 optScrollEnv: Optional.none()
               }));
             }
-          })
+          }),
         ]),
         // Treat alert or confirm dialogs as part of the inline dialog
         isExtraPart: (_comp, target) => isAlertOrConfirmDialog(target)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
@@ -57,9 +57,6 @@ const renderDialog = <T extends Dialog.DialogData>(dialogInit: DialogManager.Dia
     footer,
     extraClasses: dialogSizeClasses,
     extraBehaviours: [
-      // Because this doesn't define `renderComponents`, all this does is update the state.
-      // We use the state for the initialData. The other parts (body etc.) render the
-      // components based on what reflecting receives.
       Reflecting.config({
         channel: `${dialogChannel}-${dialogId}`,
         updateState,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
@@ -22,7 +22,7 @@ const renderDialog = <T extends Dialog.DialogData>(dialogInit: DialogManager.Dia
 
   const dialogSize = Cell<Dialog.DialogSize>(internalDialog.size);
 
-  const dialogSizeClasses = SilverDialogCommon.getDialogSizeClasses(dialogSize.get()).toArray();
+  const dialogSizeClasses = SilverDialogCommon.getDialogSizeClass(dialogSize.get()).toArray();
 
   const updateState = (comp: AlloyComponent, incoming: DialogManager.DialogInit<T>) => {
     dialogSize.set(incoming.internalDialog.size);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
@@ -73,7 +73,7 @@ const fullscreenClass = 'tox-dialog--fullscreen';
 const largeDialogClass = 'tox-dialog--width-lg';
 const mediumDialogClass = 'tox-dialog--width-md';
 
-const getDialogSizeClasses = (size: Dialog.DialogSize): Optional<string> => {
+const getDialogSizeClass = (size: Dialog.DialogSize): Optional<string> => {
   switch (size) {
     case 'large':
       return Optional.some(largeDialogClass);
@@ -90,14 +90,14 @@ const updateDialogSizeClass = (size: Dialog.DialogSize, component: AlloyComponen
   if (!Arr.contains(classes, fullscreenClass)) {
     const currentSizeClass = Arr.find(classes, (c) => c === largeDialogClass || c === mediumDialogClass);
     currentSizeClass.map((c) => Classes.remove(sugarBody, [ c ]));
-    getDialogSizeClasses(size).map((dialogSizeClass) => Classes.add(sugarBody, [ dialogSizeClass ]));
+    getDialogSizeClass(size).map((dialogSizeClass) => Classes.add(sugarBody, [ dialogSizeClass ]));
   }
 };
 
 const toggleFullscreen = (comp: AlloyComponent, currentSize: Dialog.DialogSize): void => {
   const sugarBody = SugarElement.fromDom(comp.element.dom);
   const classes = Classes.get(sugarBody);
-  const currentSizeClass = Arr.find(classes, (c) => c === largeDialogClass || c === mediumDialogClass).or(getDialogSizeClasses(currentSize));
+  const currentSizeClass = Arr.find(classes, (c) => c === largeDialogClass || c === mediumDialogClass).or(getDialogSizeClass(currentSize));
   Classes.toggle(sugarBody, [ fullscreenClass, ...currentSizeClass.toArray() ]);
 };
 
@@ -157,7 +157,7 @@ export {
   getHeader,
   getEventExtras,
   updateDialogSizeClass,
-  getDialogSizeClasses,
+  getDialogSizeClass,
   toggleFullscreen,
   renderModalDialog,
   mapMenuButtons,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
@@ -11,7 +11,6 @@ import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import { StoredMenuButton, StoredMenuItem } from '../button/MenuButton';
 import * as Dialogs from '../dialog/Dialogs';
 import { FormBlockEvent, formCancelEvent } from '../general/FormEvents';
-import { dialogChannel } from './DialogChannels';
 import { ExtraListeners } from './SilverDialogEvents';
 import { renderModalHeader } from './SilverDialogHeader';
 
@@ -70,36 +69,24 @@ const getEventExtras = (lazyDialog: () => AlloyComponent, providers: UiFactoryBa
   }
 });
 
-const renderModalDialog = <T>(spec: DialogSpec, initialData: T, dialogEvents: AlloyEvents.AlloyEventKeyAndHandler<any>[], backstage: UiFactoryBackstage): AlloyComponent => {
-  const updateState = (_comp: AlloyComponent, incoming: T) => Optional.some(incoming);
-
-  return GuiFactory.build(Dialogs.renderDialog({
-    ...spec,
-    firstTabstop: 1,
-    lazySink: backstage.shared.getSink,
-    extraBehaviours: [
-      // Because this doesn't define `renderComponents`, all this does is update the state.
-      // We use the state for the initialData. The other parts (body etc.) render the
-      // components based on what reflecting receives.
-      Reflecting.config({
-        channel: `${dialogChannel}-${spec.id}`,
-        updateState,
-        initialData
-      }),
-      RepresentingConfigs.memory({ }),
-      ...spec.extraBehaviours
-    ],
-    onEscape: (comp) => {
-      AlloyTriggers.emit(comp, formCancelEvent);
-    },
-    dialogEvents,
-    eventOrder: {
-      [SystemEvents.receive()]: [ Reflecting.name(), Receiving.name() ],
-      [SystemEvents.attachedToDom()]: [ 'scroll-lock', Reflecting.name(), 'messages', 'dialog-events', 'alloy.base.behaviour' ],
-      [SystemEvents.detachedFromDom()]: [ 'alloy.base.behaviour', 'dialog-events', 'messages', Reflecting.name(), 'scroll-lock' ]
-    }
-  }));
-};
+const renderModalDialog = (spec: DialogSpec, dialogEvents: AlloyEvents.AlloyEventKeyAndHandler<any>[], backstage: UiFactoryBackstage): AlloyComponent => GuiFactory.build(Dialogs.renderDialog({
+  ...spec,
+  firstTabstop: 1,
+  lazySink: backstage.shared.getSink,
+  extraBehaviours: [
+    RepresentingConfigs.memory({ }),
+    ...spec.extraBehaviours
+  ],
+  onEscape: (comp) => {
+    AlloyTriggers.emit(comp, formCancelEvent);
+  },
+  dialogEvents,
+  eventOrder: {
+    [SystemEvents.receive()]: [ Reflecting.name(), Receiving.name() ],
+    [SystemEvents.attachedToDom()]: [ 'scroll-lock', Reflecting.name(), 'messages', 'dialog-events', 'alloy.base.behaviour' ],
+    [SystemEvents.detachedFromDom()]: [ 'alloy.base.behaviour', 'dialog-events', 'messages', Reflecting.name(), 'scroll-lock' ]
+  }
+}));
 
 const mapMenuButtons = (buttons: Dialog.DialogFooterButton[], menuItemStates: Record<string, Cell<boolean>> = {}): (Dialog.DialogFooterButton | StoredMenuButton)[] => {
   const mapItems = (button: Dialog.DialogFooterMenuButton): StoredMenuButton => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
@@ -69,6 +69,7 @@ const getEventExtras = (lazyDialog: () => AlloyComponent, providers: UiFactoryBa
   }
 });
 
+const fullscreenClass = 'tox-dialog--fullscreen';
 const largeDialogClass = 'tox-dialog--width-lg';
 const mediumDialogClass = 'tox-dialog--width-md';
 
@@ -86,13 +87,14 @@ const getDialogSizeClasses = (size: Dialog.DialogSize): Optional<string> => {
 const updateDialogSizeClass = (size: Dialog.DialogSize, component: AlloyComponent): void => {
   const sugarBody = SugarElement.fromDom(component.element.dom);
   const classes = Classes.get(sugarBody);
-  const currentSizeClass = Arr.find(classes, (c) => c === largeDialogClass || c === mediumDialogClass);
-  currentSizeClass.map((c) => Classes.remove(sugarBody, [ c ]));
-  getDialogSizeClasses(size).map((dialogSizeClass) => Classes.add(sugarBody, [ dialogSizeClass ]));
+  if (!Arr.contains(classes, fullscreenClass)) {
+    const currentSizeClass = Arr.find(classes, (c) => c === largeDialogClass || c === mediumDialogClass);
+    currentSizeClass.map((c) => Classes.remove(sugarBody, [ c ]));
+    getDialogSizeClasses(size).map((dialogSizeClass) => Classes.add(sugarBody, [ dialogSizeClass ]));
+  }
 };
 
 const toggleFullscreen = (comp: AlloyComponent, currentSize: Dialog.DialogSize): void => {
-  const fullscreenClass = 'tox-dialog--fullscreen';
   const sugarBody = SugarElement.fromDom(comp.element.dom);
   const classes = Classes.get(sugarBody);
   const currentSizeClass = Arr.find(classes, (c) => c === largeDialogClass || c === mediumDialogClass).or(getDialogSizeClasses(currentSize));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
@@ -4,7 +4,7 @@ import {
 } from '@ephox/alloy';
 import { Dialog, DialogManager } from '@ephox/bridge';
 import { Arr, Cell, Obj, Optional } from '@ephox/katamari';
-import { Height, SelectorFind } from '@ephox/sugar';
+import { Classes, Height, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import { UiFactoryBackstage, UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as RepresentingConfigs from '../alien/RepresentingConfigs';
@@ -69,6 +69,36 @@ const getEventExtras = (lazyDialog: () => AlloyComponent, providers: UiFactoryBa
   }
 });
 
+const largeDialogClass = 'tox-dialog--width-lg';
+const mediumDialogClass = 'tox-dialog--width-md';
+
+const getDialogSizeClasses = (size: Dialog.DialogSize): Optional<string> => {
+  switch (size) {
+    case 'large':
+      return Optional.some(largeDialogClass);
+    case 'medium':
+      return Optional.some(mediumDialogClass);
+    default:
+      return Optional.none();
+  }
+};
+
+const updateDialogSizeClass = (size: Dialog.DialogSize, component: AlloyComponent): void => {
+  const sugarBody = SugarElement.fromDom(component.element.dom);
+  const classes = Classes.get(sugarBody);
+  const currentSizeClass = Arr.find(classes, (c) => c === largeDialogClass || c === mediumDialogClass);
+  currentSizeClass.map((c) => Classes.remove(sugarBody, [ c ]));
+  getDialogSizeClasses(size).map((dialogSizeClass) => Classes.add(sugarBody, [ dialogSizeClass ]));
+};
+
+const toggleFullscreen = (comp: AlloyComponent, currentSize: Dialog.DialogSize): void => {
+  const fullscreenClass = 'tox-dialog--fullscreen';
+  const sugarBody = SugarElement.fromDom(comp.element.dom);
+  const classes = Classes.get(sugarBody);
+  const currentSizeClass = Arr.find(classes, (c) => c === largeDialogClass || c === mediumDialogClass).or(getDialogSizeClasses(currentSize));
+  Classes.toggle(sugarBody, [ fullscreenClass, ...currentSizeClass.toArray() ]);
+};
+
 const renderModalDialog = (spec: DialogSpec, dialogEvents: AlloyEvents.AlloyEventKeyAndHandler<any>[], backstage: UiFactoryBackstage): AlloyComponent => GuiFactory.build(Dialogs.renderDialog({
   ...spec,
   firstTabstop: 1,
@@ -124,6 +154,9 @@ export {
   getBusySpec,
   getHeader,
   getEventExtras,
+  updateDialogSizeClass,
+  getDialogSizeClasses,
+  toggleFullscreen,
   renderModalDialog,
   mapMenuButtons,
   extractCellsToObject

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
@@ -4,7 +4,7 @@ import {
 } from '@ephox/alloy';
 import { Dialog, DialogManager } from '@ephox/bridge';
 import { Arr, Cell, Obj, Optional } from '@ephox/katamari';
-import { Classes, Height, SelectorFind, SugarElement } from '@ephox/sugar';
+import { Class, Classes, Height, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import { UiFactoryBackstage, UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as RepresentingConfigs from '../alien/RepresentingConfigs';
@@ -85,20 +85,18 @@ const getDialogSizeClass = (size: Dialog.DialogSize): Optional<string> => {
 };
 
 const updateDialogSizeClass = (size: Dialog.DialogSize, component: AlloyComponent): void => {
-  const sugarBody = SugarElement.fromDom(component.element.dom);
-  const classes = Classes.get(sugarBody);
-  if (!Arr.contains(classes, fullscreenClass)) {
-    const currentSizeClass = Arr.find(classes, (c) => c === largeDialogClass || c === mediumDialogClass);
-    currentSizeClass.map((c) => Classes.remove(sugarBody, [ c ]));
-    getDialogSizeClass(size).map((dialogSizeClass) => Classes.add(sugarBody, [ dialogSizeClass ]));
+  const dialogBody = SugarElement.fromDom(component.element.dom);
+  if (!Class.has(dialogBody, fullscreenClass)) {
+    Classes.remove(dialogBody, [ largeDialogClass, mediumDialogClass ]);
+    getDialogSizeClass(size).each((dialogSizeClass) => Class.add(dialogBody, dialogSizeClass));
   }
 };
 
 const toggleFullscreen = (comp: AlloyComponent, currentSize: Dialog.DialogSize): void => {
-  const sugarBody = SugarElement.fromDom(comp.element.dom);
-  const classes = Classes.get(sugarBody);
+  const dialogBody = SugarElement.fromDom(comp.element.dom);
+  const classes = Classes.get(dialogBody);
   const currentSizeClass = Arr.find(classes, (c) => c === largeDialogClass || c === mediumDialogClass).or(getDialogSizeClass(currentSize));
-  Classes.toggle(sugarBody, [ fullscreenClass, ...currentSizeClass.toArray() ]);
+  Classes.toggle(dialogBody, [ fullscreenClass, ...currentSizeClass.toArray() ]);
 };
 
 const renderModalDialog = (spec: DialogSpec, dialogEvents: AlloyEvents.AlloyEventKeyAndHandler<any>[], backstage: UiFactoryBackstage): AlloyComponent => GuiFactory.build(Dialogs.renderDialog({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -24,7 +24,13 @@ interface RenderedDialog<T extends Dialog.DialogData> {
   readonly instanceApi: Dialog.DialogInstanceApi<T>;
 }
 
-const renderInlineDialog = <T extends Dialog.DialogData>(dialogInit: DialogManager.DialogInit<T>, extra: SilverDialogCommon.WindowExtra<T>, backstage: Backstage.UiFactoryBackstage, ariaAttrs: boolean = false): RenderedDialog<T> => {
+const renderInlineDialog = <T extends Dialog.DialogData>(
+  dialogInit: DialogManager.DialogInit<T>,
+  extra: SilverDialogCommon.WindowExtra<T>,
+  backstage: Backstage.UiFactoryBackstage,
+  ariaAttrs: boolean = false,
+  refreshView: () => void
+): RenderedDialog<T> => {
   const dialogId = Id.generate('dialog');
   const dialogLabelId = Id.generate('dialog-label');
   const dialogContentId = Id.generate('dialog-content');
@@ -37,6 +43,7 @@ const renderInlineDialog = <T extends Dialog.DialogData>(dialogInit: DialogManag
   const updateState = (comp: AlloyComponent, incoming: DialogManager.DialogInit<T>) => {
     dialogSize.set(incoming.internalDialog.size);
     SilverDialogCommon.updateDialogSizeClass(incoming.internalDialog.size, comp);
+    refreshView();
     return Optional.some(incoming);
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -26,6 +26,8 @@ interface RenderedDialog<T extends Dialog.DialogData> {
 
 const getInlineDialogSizeClass = (size: Dialog.DialogSize): Optional<string> => {
   switch (size) {
+    case 'large':
+      return Optional.some('tox-dialog--width-lg--inline');
     case 'medium':
       return Optional.some('tox-dialog--width-md');
     default:

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -38,7 +38,7 @@ const renderInlineDialog = <T extends Dialog.DialogData>(
 
   const dialogSize = Cell<Dialog.DialogSize>(internalDialog.size);
 
-  const dialogSizeClasses = SilverDialogCommon.getDialogSizeClasses(dialogSize.get()).toArray();
+  const dialogSizeClass = SilverDialogCommon.getDialogSizeClass(dialogSize.get()).toArray();
 
   // Reflecting behaviour broadcasts on dialog channel only on redial.
   const updateState = (comp: AlloyComponent, incoming: DialogManager.DialogInit<T>) => {
@@ -98,7 +98,7 @@ const renderInlineDialog = <T extends Dialog.DialogData>(
   const dialog = GuiFactory.build({
     dom: {
       tag: 'div',
-      classes: [ 'tox-dialog', inlineClass, ...dialogSizeClasses ],
+      classes: [ 'tox-dialog', inlineClass, ...dialogSizeClass ],
       attributes: {
         role: 'dialog',
         ['aria-labelledby']: dialogLabelId

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -29,7 +29,7 @@ const renderInlineDialog = <T extends Dialog.DialogData>(
   extra: SilverDialogCommon.WindowExtra<T>,
   backstage: Backstage.UiFactoryBackstage,
   ariaAttrs: boolean = false,
-  refreshView: () => void
+  refreshDocking: () => void
 ): RenderedDialog<T> => {
   const dialogId = Id.generate('dialog');
   const dialogLabelId = Id.generate('dialog-label');
@@ -40,10 +40,12 @@ const renderInlineDialog = <T extends Dialog.DialogData>(
 
   const dialogSizeClasses = SilverDialogCommon.getDialogSizeClasses(dialogSize.get()).toArray();
 
+  // Reflecting behaviour broadcasts on dialog channel only on redial.
   const updateState = (comp: AlloyComponent, incoming: DialogManager.DialogInit<T>) => {
+    // Update dialog size and position upon redial.
     dialogSize.set(incoming.internalDialog.size);
     SilverDialogCommon.updateDialogSizeClass(incoming.internalDialog.size, comp);
-    refreshView();
+    refreshDocking();
     return Optional.some(incoming);
   };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogPositioningTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogPositioningTest.ts
@@ -31,57 +31,161 @@ describe('browser.tinymce.themes.silver.window.SilverDialogPositioningTest', () 
       menubar: false
     }, [], true);
 
-    const dialogSpec: Dialog.DialogSpec<{}> = {
-      title: 'inlinedialog',
-      body: {
-        type: 'panel',
-        items: [
+    context('Open dialog and assert position within viewport', () => {
+      const dialogSpec: Dialog.DialogSpec<{}> = {
+        title: 'inlinedialog',
+        body: {
+          type: 'panel',
+          items: [
+            {
+              type: 'panel',
+              items: [
+                {
+                  type: 'htmlpanel',
+                  html: '<h1>Heading</h1><p>paragraph</p>',
+                  presets: 'presentation'
+                }
+              ]
+            }
+          ]
+        },
+        buttons: [
           {
-            type: 'panel',
-            items: [
-              {
-                type: 'htmlpanel',
-                html: '<h1>Heading</h1><p>paragraph</p>',
-                presets: 'presentation'
-              }
-            ]
+            type: 'submit',
+            name: 'ok',
+            text: 'OK',
+            primary: true
           }
-        ]
-      },
-      buttons: [
-        {
-          type: 'submit',
-          name: 'ok',
-          text: 'OK',
-          primary: true
+        ],
+        onSubmit: (api) => api.close(),
+      };
+
+      const pTestOpenDialogAssertPosition = async (params: WindowParams) => {
+        const editor = hook.editor();
+        const api = DialogUtils.open(editor, dialogSpec, params);
+        await TinyUiActions.pWaitForDialog(editor);
+        const dialog = UiFinder.findIn(SugarBody.body(), '.tox-dialog').getOrDie() as SugarElement<HTMLElement>;
+        const { left, right, top, bottom } = dialog.dom.getBoundingClientRect();
+        if (left < 0 || right > window.innerWidth || top < 0 || bottom > window.innerHeight) {
+          assert.fail('Dialog is outside of the viewable area');
         }
-      ],
-      onSubmit: (api) => api.close(),
-    };
+        api.close();
+        await Waiter.pTryUntil('Wait for dialog to close', () => UiFinder.notExists(SugarBody.body(), '[role="dialog"]'));
+      };
 
-    const pTestOpenDialogAssertPosition = async (params: WindowParams) => {
-      const editor = hook.editor();
-      const api = DialogUtils.open(editor, dialogSpec, params);
-      await TinyUiActions.pWaitForDialog(editor);
-      const dialog = UiFinder.findIn(SugarBody.body(), '.tox-dialog').getOrDie() as SugarElement<HTMLElement>;
-      const { left, right, top, bottom } = dialog.dom.getBoundingClientRect();
-      if (left < 0 || right > window.innerWidth || top < 0 || bottom > window.innerHeight) {
-        assert.fail('Dialog is outside of the viewable area');
-      }
-      api.close();
-      await Waiter.pTryUntil('Wait for dialog to close', () => UiFinder.notExists(SugarBody.body(), '[role="dialog"]'));
-    };
+      it('TINY-9588: Modal dialog positioning', async () =>
+        await pTestOpenDialogAssertPosition({})
+      );
 
-    it('TINY-9588: Modal dialog positioning', async () =>
-      await pTestOpenDialogAssertPosition({})
-    );
+      it('TINY-9588: Inline toolbar dialog positioning', async () =>
+        await pTestOpenDialogAssertPosition({ inline: 'toolbar' })
+      );
 
-    it('TINY-9588: Inline toolbar dialog positioning', async () =>
-      await pTestOpenDialogAssertPosition({ inline: 'toolbar' })
-    );
+      it('TINY-9888: Inline toolbar (bottom) dialog positioning', async () =>
+        await pTestOpenDialogAssertPosition({ inline: 'bottom' })
+      );
+    });
 
-    it('TINY-9888: Inline toolbar (bottom) dialog positioning', async () =>
-      await pTestOpenDialogAssertPosition({ inline: 'bottom' })
-    );
+    context('Redial dialog with new size and assert position within viewport', () => {
+      const getDialogSizeSpec = (size: 'normal' | 'medium' | 'large' = 'normal'): Dialog.DialogSpec<any> => ({
+        title: size + ' size dialog',
+        body: {
+          type: 'panel',
+          items: [
+            {
+              type: 'label',
+              label: 'Choose size:',
+              items: [
+                {
+                  type: 'bar',
+                  items: [
+                    {
+                      type: 'button',
+                      name: 'normal',
+                      text: 'Small'
+                    },
+                    {
+                      type: 'button',
+                      name: 'medium',
+                      text: 'Medium'
+                    },
+                    {
+                      type: 'button',
+                      name: 'large',
+                      text: 'Large'
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              type: 'button',
+              name: 'fullscreen',
+              text: 'Toggle Dialog Fullscreen'
+            }
+          ]
+        },
+        size,
+        onAction: (api, details) => {
+          if (details.name === 'fullscreen') {
+            api.toggleFullscreen();
+          } else {
+            api.redial(getDialogSizeSpec(details.name as 'normal' | 'medium' | 'large'));
+          }
+        }
+      });
+
+      const assertWithinBounds = (dialog: SugarElement<HTMLElement>) => {
+        const { left, right, top, bottom } = dialog.dom.getBoundingClientRect();
+        if (left < 0 || right > window.innerWidth || top < 0 || bottom > window.innerHeight) {
+          assert.fail('Dialog is outside of the viewable area');
+        }
+      };
+
+      const assertLargeInlineWithinBounds = (dialog: SugarElement<HTMLElement>) => {
+        const { left, right, top, bottom } = dialog.dom.getBoundingClientRect();
+        if (left < 0 || right > window.innerWidth) {
+          if ((toolbarLocation.location === 'top' && top < 0) || (toolbarLocation.location === 'bottom' && bottom > window.innerHeight)) {
+            assert.fail('Dialog is outside of the viewable area');
+          }
+        }
+      };
+
+      const pTestResizingDialog = async (params: WindowParams) => {
+        const editor = hook.editor();
+        const normalSpec = getDialogSizeSpec('normal');
+        const mediumSpec = getDialogSizeSpec('medium');
+        const largeSpec = getDialogSizeSpec('large');
+        const api = DialogUtils.open(editor, normalSpec, params);
+        await TinyUiActions.pWaitForDialog(editor);
+        const dialog = UiFinder.findIn(SugarBody.body(), '.tox-dialog').getOrDie() as SugarElement<HTMLElement>;
+        assertWithinBounds(dialog);
+        api.redial(mediumSpec);
+        assertWithinBounds(dialog);
+        api.redial(largeSpec);
+        // Large inline dialog will be taller than the viewport, but should still fit the rest of the screen
+        if (params.inline) {
+          assertLargeInlineWithinBounds(dialog);
+        } else {
+          assertWithinBounds(dialog);
+        }
+        api.redial(normalSpec);
+        assertWithinBounds(dialog);
+        api.close();
+        await Waiter.pTryUntil('Wait for dialog to close', () => UiFinder.notExists(SugarBody.body(), '[role="dialog"]'));
+      };
+
+      it('TINY-10209: Modal dialog size is updated', async () =>
+        await pTestResizingDialog({})
+      );
+
+      it('TINY-10209: Inline toolbar dialog size and position are updated', async () =>
+        await pTestResizingDialog({ inline: 'toolbar' })
+      );
+
+      it('TINY-10209: Inline toolbar (bottom) dialog size and position is updated', async () =>
+        await pTestResizingDialog({ inline: 'bottom' })
+      );
+    });
   }))));
 });


### PR DESCRIPTION
Related Ticket: TINY-10209

Description of Changes:
* Added large dialog class to inline dialogs when large size is specified
* Redialling dialogs with a new size now updates the size class
* Repositioning and re-docking was also necessary after the size of inline dialogs are updated.
* Modal dialogs only need the class to be updated to display correctly
* URL dialogs still do not support updating the size on redial
* Dialog sizes are retained and restored when fullscreen is toggled (api.toggleFullscreen)
* Some cleanup with reused functionality across modal, url, and inline dialogs, now that all sizes are supported and updated
  * Fullscreen toggle functionality
  * Retrieving and updating the size class.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
