### PR TITLE
TINY-10155: Add 'Browse files' tooltip to Media dialog file picker button

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resize handles would not appear on editable images in a non-editable context. #TINY-10118
 
 ### Improved
-- Improved the tooltips of picker buttons for the urlinput components in the "Insert/Edit Image" and "Insert/Edit Link" dialogs. #TINY-10155
+- Improved the tooltips of picker buttons for the urlinput components in the "Insert/Edit Image", "Insert/Edit Link" and "Insert/Edit Media" dialogs. #TINY-10155
 
 ## 6.7.0 - 2023-08-30
 

--- a/modules/tinymce/src/plugins/media/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/ui/Dialog.ts
@@ -221,7 +221,8 @@ const showDialog = (editor: Editor): void => {
     name: 'source',
     type: 'urlinput',
     filetype: 'media',
-    label: 'Source'
+    label: 'Source',
+    picker_text: 'Browse files'
   }];
   const sizeInput: Dialog.SizeInputSpec[] = !Options.hasDimensions(editor) ? [] : [{
     type: 'sizeinput',


### PR DESCRIPTION
Related Ticket: TINY-10155

Description of Changes:
* Added tooltip to Media dialog file picker button, originally not included in the ticket https://ephocks.atlassian.net/browse/TINY-10155?focusedCommentId=131258

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable) DOC-2177

GitHub issues (if applicable):
