### PR TITLE
TINY-10230: corrections and copy-edits in the `addIcon` API documentation

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Setting the content with an attribute that contains a self-closing HTML tag did not preserve the tag. #TINY-10088
 - Resize handles would not appear on editable images in a non-editable context. #TINY-10118
+- Corrections and copy-edits to the `addIcon` API documentation. #TINY-10230
 
 ### Improved
 - Improved the tooltips of picker buttons for the urlinput components in the "Insert/Edit Image", "Insert/Edit Link" and "Insert/Edit Media" dialogs. #TINY-10155

--- a/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
+++ b/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
@@ -86,8 +86,8 @@ const registry = (): Registry.Registry => {
     addContextToolbar: bridge.addContextToolbar,
 
     /**
-     * Registers a new SVG icon, the icon name reference can be configured by any
-     * TinyMCE 5 Ui components that can display an icon. The icon is only available
+     * Registers a new SVG icon. The icon name reference can be configured by any
+     * TinyMCE UI components that can display an icon. The icon is only available
      * to the editor instance it was configured for.
      *
      * @method addIcon


### PR DESCRIPTION

Related Ticket: TINY-10230

Description of Changes:
* Removed reference to TinyMCE version 5.
* Plus some copy-edits.


Pre-checks:
* [x] Changelog entry added
~* [ ] Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
~* [ ] Milestone set~
~* [ ] Docs ticket created (if applicable)~

GitHub issues (if applicable):
