### PR TITLE
TINY-10213: manage li with a list and then other elements

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Setting the content with an attribute that contains a self-closing HTML tag did not preserve the tag. #TINY-10088
 - Resize handles would not appear on editable images in a non-editable context. #TINY-10118
 - The dialog size was not updated when the `size` argument was changed when redialling a dialog. #TINY-10209
+- Indent/Undent a list that contains a not `li` with a `ul`/`ol` as first element make disappear all others elements inside the `li`. #TINY-10213
 
 ### Improved
 - Improved the tooltips of picker buttons for the urlinput components in the "Insert/Edit Image" and "Insert/Edit Link" dialogs. #TINY-10155

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Setting the content with an attribute that contains a self-closing HTML tag did not preserve the tag. #TINY-10088
 - Resize handles would not appear on editable images in a non-editable context. #TINY-10118
 - The dialog size was not updated when the `size` argument was changed when redialling a dialog. #TINY-10209
-- Indent/Undent a list that contains a not `li` with a `ul`/`ol` as first element make disappear all others elements inside the `li`. #TINY-10213
+- Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10213
 
 ### Improved
 - Improved the tooltips of picker buttons for the urlinput components in the "Insert/Edit Image" and "Insert/Edit Link" dialogs. #TINY-10155

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/ComposeList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/ComposeList.ts
@@ -70,13 +70,25 @@ const appendItem = (segment: Segment, item: SugarElement): void => {
   segment.item = item;
 };
 
+const createInPreviousLiItem = (scope: Document, attr: Record<string, any>, content: SugarElement[], tag: string): SugarElement => {
+  const item = SugarElement.fromTag(tag, scope);
+  Attribute.setAll(item, attr);
+  InsertAll.append(item, content);
+  return item;
+};
+
 const writeShallow = (scope: Document, cast: Segment[], entry: Entry): Segment[] => {
   const newCast = cast.slice(0, entry.depth);
 
   Arr.last(newCast).each((segment) => {
-    const item = createItem(scope, entry.itemAttributes, entry.content);
-    appendItem(segment, item);
-    normalizeSegment(segment, entry);
+    if (entry.isInPreviousLi) {
+      const item = createInPreviousLiItem(scope, entry.itemAttributes, entry.content, entry.listType);
+      Insert.append(segment.item, item);
+    } else {
+      const item = createItem(scope, entry.itemAttributes, entry.content);
+      appendItem(segment, item);
+      normalizeSegment(segment, entry);
+    }
   });
 
   return newCast;

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/ComposeList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/ComposeList.ts
@@ -115,6 +115,7 @@ const composeList = (scope: Document, entries: Entry[]): Optional<SugarElement<H
     if (isEntryList(entry)) {
       return entry.depth > cast.length ? writeDeep(scope, cast, entry) : writeShallow(scope, cast, entry);
     } else {
+      // this is needed becuase if the first element of the list is a comment we would not have the data to create the new list
       if (i === 0 && isEntryComment(entry)) {
         firstCommentEntryOpt = Optional.some(entry);
         return cast;

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/Entry.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/Entry.ts
@@ -26,6 +26,7 @@ export interface Entry {
   listType: ListType;
   listAttributes: Record<string, any>;
   itemAttributes: Record<string, any>;
+  isInPreviousLi: boolean;
 }
 
 const isIndented = (entry: Entry): boolean => entry.depth > 0;
@@ -45,7 +46,8 @@ const createEntry = (li: SugarElement, depth: number, isSelected: boolean): Opti
   content: cloneItemContent(li),
   itemAttributes: Attribute.clone(li),
   listAttributes: Attribute.clone(list),
-  listType: SugarNode.name(list) as ListType
+  listType: SugarNode.name(list) as ListType,
+  isInPreviousLi: false
 }));
 
 export {

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/Entry.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/Entry.ts
@@ -18,7 +18,9 @@ General workflow: Parse lists to entries -> Manipulate entries -> Compose entrie
 0-------1---2--------->Depth
 */
 
-export interface Entry {
+export type Entry = EntryList | EntryNoList;
+
+export interface EntryList {
   depth: number;
   dirty: boolean;
   content: SugarElement<Node>[];
@@ -26,8 +28,19 @@ export interface Entry {
   listType: ListType;
   listAttributes: Record<string, any>;
   itemAttributes: Record<string, any>;
+}
+
+export interface EntryNoList {
+  depth: number;
+  dirty: boolean;
+  content: SugarElement<Node>[];
+  isSelected: boolean;
+  type: string;
+  attributes: Record<string, any>;
   isInPreviousLi: boolean;
 }
+
+const isEntryList = (entry: Entry): entry is EntryList => 'listAttributes' in entry;
 
 const isIndented = (entry: Entry): boolean => entry.depth > 0;
 
@@ -52,6 +65,7 @@ const createEntry = (li: SugarElement, depth: number, isSelected: boolean): Opti
 
 export {
   createEntry,
+  isEntryList,
   isIndented,
   isSelected
 };

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/Entry.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/Entry.ts
@@ -18,7 +18,7 @@ General workflow: Parse lists to entries -> Manipulate entries -> Compose entrie
 0-------1---2--------->Depth
 */
 
-export type Entry = EntryList | EntryNoList;
+export type Entry = EntryList | EntryNoList | EntryComment;
 
 export interface EntryList {
   depth: number;
@@ -40,7 +40,19 @@ export interface EntryNoList {
   isInPreviousLi: boolean;
 }
 
+export interface EntryComment {
+  depth: number;
+  content: string;
+  dirty: boolean;
+  isSelected: boolean;
+  isComment: true;
+}
+
 const isEntryList = (entry: Entry): entry is EntryList => 'listAttributes' in entry;
+
+const isEntryNoList = (entry: Entry): entry is EntryNoList => 'isInPreviousLi' in entry;
+
+const isEntryComment = (entry: Entry): entry is EntryComment => 'isComment' in entry;
 
 const isIndented = (entry: Entry): boolean => entry.depth > 0;
 
@@ -65,7 +77,9 @@ const createEntry = (li: SugarElement, depth: number, isSelected: boolean): Opti
 
 export {
   createEntry,
+  isEntryComment,
   isEntryList,
+  isEntryNoList,
   isIndented,
   isSelected
 };

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/ListsIndendation.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/ListsIndendation.ts
@@ -8,7 +8,7 @@ import { ListAction } from '../core/ListAction';
 import * as Selection from '../core/Selection';
 import { createTextBlock } from '../core/TextBlock';
 import { composeList } from './ComposeList';
-import { Entry, isIndented, isSelected } from './Entry';
+import { Entry, isEntryComment, isIndented, isSelected } from './Entry';
 import { Indentation, indentEntry } from './Indentation';
 import { normalizeEntries } from './NormalizeEntries';
 import { EntrySet, ItemSelection, parseLists } from './ParseLists';
@@ -17,7 +17,9 @@ import { hasFirstChildList } from './Util';
 const outdentedComposer = (editor: Editor, entries: Entry[]): SugarElement<DocumentFragment>[] => {
   const normalizedEntries = normalizeEntries(entries);
   return Arr.map(normalizedEntries, (entry) => {
-    const content = SugarFragment.fromElements(entry.content);
+    const content = !isEntryComment(entry)
+      ? SugarFragment.fromElements(entry.content)
+      : SugarFragment.fromElements([ SugarElement.fromHtml(`<!--${entry.content}-->`) ]);
     return SugarElement.fromDom(createTextBlock(editor, content.dom));
   });
 };

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/NormalizeEntries.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/NormalizeEntries.ts
@@ -1,13 +1,26 @@
 import { Arr, Obj, Optional } from '@ephox/katamari';
 
-import { Entry } from './Entry';
+import { Entry, EntryList, isEntryList } from './Entry';
 
 const cloneListProperties = (target: Entry, source: Entry): void => {
-  target.listType = source.listType;
-  target.listAttributes = { ...source.listAttributes };
+  if (isEntryList(target) && isEntryList(source)) {
+    target.listType = source.listType;
+    target.listAttributes = { ...source.listAttributes };
+  }
+  if (!isEntryList(target) && isEntryList(source)) {
+    target.type = source.listType;
+    target.attributes = { ...source.listAttributes };
+  }
+  if (!isEntryList(target) && !isEntryList(source)) {
+    target.type = source.type;
+    target.attributes = { ...source.attributes };
+  }
+  if (isEntryList(target) && !isEntryList(source)) {
+    target.listAttributes = { ...source.attributes };
+  }
 };
 
-const cleanListProperties = (entry: Entry): void => {
+const cleanListProperties = (entry: EntryList): void => {
   // Remove the start attribute if generating a new list
   entry.listAttributes = Obj.filter(entry.listAttributes, (_value, key) => key !== 'start');
 };
@@ -29,7 +42,7 @@ const normalizeEntries = (entries: Entry[]): Entry[] => {
   Arr.each(entries, (entry, i) => {
     closestSiblingEntry(entries, i).fold(
       () => {
-        if (entry.dirty) {
+        if (entry.dirty && isEntryList(entry)) {
           cleanListProperties(entry);
         }
       },

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/NormalizeEntries.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/NormalizeEntries.ts
@@ -7,17 +7,6 @@ const cloneListProperties = (target: Entry, source: Entry): void => {
     target.listType = source.listType;
     target.listAttributes = { ...source.listAttributes };
   }
-  if (!isEntryList(target) && isEntryList(source)) {
-    target.type = source.listType;
-    target.attributes = { ...source.listAttributes };
-  }
-  if (!isEntryList(target) && !isEntryList(source)) {
-    target.type = source.type;
-    target.attributes = { ...source.attributes };
-  }
-  if (isEntryList(target) && !isEntryList(source)) {
-    target.listAttributes = { ...source.attributes };
-  }
 };
 
 const cleanListProperties = (entry: EntryList): void => {

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/ParseLists.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/ParseLists.ts
@@ -1,4 +1,4 @@
-import { Arr, Cell, Fun, Optional } from '@ephox/katamari';
+import { Arr, Cell, Optional } from '@ephox/katamari';
 import { Compare, SugarElement, Traverse } from '@ephox/sugar';
 
 import { createEntry, Entry } from './Entry';
@@ -50,17 +50,20 @@ const parseItem: Parser = (depth: number, itemSelection: Optional<ItemSelection>
         return parseList(depth, itemSelection, selectionState, list);
       } else {
         const result = parseList(depth, itemSelection, selectionState, list);
-
-        return Traverse.child(item, 1).fold(
-          Fun.constant(result),
-          (s) => {
-            return result.concat(parseSingleItem(depth, itemSelection, selectionState, s).map((e) => ({
+        const parsedSiblings = Arr.foldl(Traverse.children(item), (acc: Entry[], s, i) => {
+          if (i === 0) {
+            return acc;
+          } else {
+            const parsedSibling = parseSingleItem(depth, itemSelection, selectionState, s).map((e) => ({
               ...e,
               isInPreviousLi: true,
               listType: (s.dom.nodeName.toLowerCase() as any)
-            })));
+            }));
+            return acc.concat(parsedSibling);
           }
-        );
+        }, []);
+
+        return result.concat(parsedSiblings);
       }
     });
 

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/ParseLists.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/ParseLists.ts
@@ -62,23 +62,18 @@ const parseItem: Parser = (depth: number, itemSelection: Optional<ItemSelection>
   Traverse.firstChild(item).filter(isList).fold(
     () => parseSingleItem(depth, itemSelection, selectionState, item),
     (list) => {
-      if (Traverse.childNodesCount(item) === 1) {
-        return parseList(depth, itemSelection, selectionState, list);
-      } else {
-        const result = parseList(depth, itemSelection, selectionState, list);
-        const parsedSiblings = Arr.foldl(Traverse.children(item), (acc: Entry[], s, i) => {
-          if (i === 0) {
-            return acc;
-          } else {
-            const parsedSibling = parseSingleItem(depth, itemSelection, selectionState, s)
-              .map((e) => entryToEntryNoList(e, s.dom.nodeName.toLowerCase(), true));
+      const parsedSiblings = Arr.foldl(Traverse.children(item), (acc: Entry[], s, i) => {
+        if (i === 0) {
+          return acc;
+        } else {
+          const parsedSibling = parseSingleItem(depth, itemSelection, selectionState, s)
+            .map((e) => entryToEntryNoList(e, s.dom.nodeName.toLowerCase(), true));
 
-            return acc.concat(parsedSibling);
-          }
-        }, []);
+          return acc.concat(parsedSibling);
+        }
+      }, []);
 
-        return result.concat(parsedSiblings);
-      }
+      return parseList(depth, itemSelection, selectionState, list).concat(parsedSiblings);
     });
 
 const parseList: Parser = (depth: number, itemSelection: Optional<ItemSelection>, selectionState: Cell<boolean>, list: SugarElement<HTMLElement>): Entry[] =>

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/ParseLists.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/ParseLists.ts
@@ -1,4 +1,4 @@
-import { Arr, Cell, Optional } from '@ephox/katamari';
+import { Arr, Cell, Fun, Optional } from '@ephox/katamari';
 import { Compare, SugarElement, Traverse } from '@ephox/sugar';
 
 import { createEntry, Entry } from './Entry';
@@ -16,32 +16,53 @@ export interface EntrySet {
   readonly sourceList: SugarElement<HTMLElement>;
 }
 
+const parseSingleItem: Parser = (depth: number, itemSelection: Optional<ItemSelection>, selectionState: Cell<boolean>, item: SugarElement<HTMLElement>): Entry[] => {
+
+  // Update selectionState (start)
+  itemSelection.each((selection) => {
+    if (Compare.eq(selection.start, item)) {
+      selectionState.set(true);
+    }
+  });
+
+  const currentItemEntry = createEntry(item, depth, selectionState.get());
+
+  // Update selectionState (end)
+  itemSelection.each((selection) => {
+    if (Compare.eq(selection.end, item)) {
+      selectionState.set(false);
+    }
+  });
+
+  const childListEntries: Entry[] = Traverse.lastChild(item)
+    .filter(isList)
+    .map((list) => parseList(depth, itemSelection, selectionState, list))
+    .getOr([]);
+
+  return currentItemEntry.toArray().concat(childListEntries);
+};
+
 const parseItem: Parser = (depth: number, itemSelection: Optional<ItemSelection>, selectionState: Cell<boolean>, item: SugarElement<HTMLElement>): Entry[] =>
-  Traverse.firstChild(item).filter(isList).fold(() => {
+  Traverse.firstChild(item).filter(isList).fold(
+    () => parseSingleItem(depth, itemSelection, selectionState, item),
+    (list) => {
+      if (Traverse.childNodesCount(item) === 1) {
+        return parseList(depth, itemSelection, selectionState, list);
+      } else {
+        const result = parseList(depth, itemSelection, selectionState, list);
 
-    // Update selectionState (start)
-    itemSelection.each((selection) => {
-      if (Compare.eq(selection.start, item)) {
-        selectionState.set(true);
+        return Traverse.child(item, 1).fold(
+          Fun.constant(result),
+          (s) => {
+            return result.concat(parseSingleItem(depth, itemSelection, selectionState, s).map((e) => ({
+              ...e,
+              isInPreviousLi: true,
+              listType: (s.dom.nodeName.toLowerCase() as any)
+            })));
+          }
+        );
       }
     });
-
-    const currentItemEntry = createEntry(item, depth, selectionState.get());
-
-    // Update selectionState (end)
-    itemSelection.each((selection) => {
-      if (Compare.eq(selection.end, item)) {
-        selectionState.set(false);
-      }
-    });
-
-    const childListEntries: Entry[] = Traverse.lastChild(item)
-      .filter(isList)
-      .map((list) => parseList(depth, itemSelection, selectionState, list))
-      .getOr([]);
-
-    return currentItemEntry.toArray().concat(childListEntries);
-  }, (list) => parseList(depth, itemSelection, selectionState, list));
 
 const parseList: Parser = (depth: number, itemSelection: Optional<ItemSelection>, selectionState: Cell<boolean>, list: SugarElement<HTMLElement>): Entry[] =>
   Arr.bind(Traverse.children(list), (element) => {

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -458,7 +458,8 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
       '<ol>' +
       '<li>b</li>' +
       '</ol>' +
-      '<p>p</p>' +
+      '<p>p1</p>' +
+      '<p>p2</p>' +
       '</li>' +
       '</ol>'
     );
@@ -473,7 +474,8 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
       '<ol>' +
       '<li>b</li>' +
       '</ol>' +
-      '<p>p</p>' +
+      '<p>p1</p>' +
+      '<p>p2</p>' +
       '</li>' +
       '</ol>'
     );
@@ -487,7 +489,8 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
       '<ol start="5">' +
       '<li>b</li>' +
       '</ol>' +
-      '<p>p</p>' +
+      '<p>p1</p>' +
+      '<p>p2</p>' +
       '</li>' +
       '</ol>'
     );
@@ -502,7 +505,8 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
       '<li>a</li>' +
       '<li>b</li>' +
       '</ol>' +
-      '<p>p</p>' +
+      '<p>p1</p>' +
+      '<p>p2</p>' +
       '</li>' +
       '</ol>'
     );

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -449,6 +449,67 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
     assert.equal(editor.selection.getNode().nodeName, 'LI');
   });
 
+  it('TINY-10213: Indent an LI with a list inside should not delete the rest of the content', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<ol>' +
+      '<li>a</li>' +
+      '<li>' +
+      '<ol>' +
+      '<li>b</li>' +
+      '</ol>' +
+      '<p>p</p>' +
+      '</li>' +
+      '</ol>'
+    );
+
+    LegacyUnit.setSelection(editor, 'li', 0);
+    editor.execCommand('Outdent');
+
+    TinyAssertions.assertContent(editor,
+      '<p>a</p>' +
+      '<ol>' +
+      '<li style="list-style-type: none;">' +
+      '<ol>' +
+      '<li>b</li>' +
+      '</ol>' +
+      '<p>p</p>' +
+      '</li>' +
+      '</ol>'
+    );
+
+    assert.equal(editor.selection.getNode().nodeName, 'P');
+
+    editor.setContent(
+      '<ol start="2">' +
+      '<li>a</li>' +
+      '<li>' +
+      '<ol start="5">' +
+      '<li>b</li>' +
+      '</ol>' +
+      '<p>p</p>' +
+      '</li>' +
+      '</ol>'
+    );
+
+    LegacyUnit.setSelection(editor, 'li', 0);
+    editor.execCommand('Indent');
+
+    TinyAssertions.assertContent(editor,
+      '<ol>' +
+      '<li style="list-style-type: none;">' +
+      '<ol start="5">' +
+      '<li>a</li>' +
+      '<li>b</li>' +
+      '</ol>' +
+      '<p>p</p>' +
+      '</li>' +
+      '</ol>'
+    );
+
+    assert.equal(editor.selection.getNode().nodeName, 'LI');
+  });
+
   context('Parent context', () => {
     const testCommandAtTextPath = (command: string) => (inputHtml: string, path: number[], expectedHtml: string) => () => {
       const editor = hook.editor();

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -454,13 +454,15 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
     editor.setContent(
       '<ol>' +
       '<li>a</li>' +
+      '<!-- c1 -->' +
       '<li>' +
       '<ol>' +
       '<li>b</li>' +
       '</ol>' +
-      '<p>p1</p>' +
-      '<p>p2</p>' +
+      '<p data-fake-attr="something">p1</p>' +
+      '<p data-fake-attr="something">p2</p>' +
       '</li>' +
+      '<!-- c2 -->' +
       '</ol>'
     );
 
@@ -470,13 +472,15 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
     TinyAssertions.assertContent(editor,
       '<p>a</p>' +
       '<ol>' +
+      '<!-- c1 -->' +
       '<li style="list-style-type: none;">' +
       '<ol>' +
       '<li>b</li>' +
       '</ol>' +
-      '<p>p1</p>' +
-      '<p>p2</p>' +
+      '<p data-fake-attr="something">p1</p>' +
+      '<p data-fake-attr="something">p2</p>' +
       '</li>' +
+      '<!-- c2 -->' +
       '</ol>'
     );
 
@@ -485,13 +489,15 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
     editor.setContent(
       '<ol start="2">' +
       '<li>a</li>' +
+      '<!-- c1 -->' +
       '<li>' +
       '<ol start="5">' +
       '<li>b</li>' +
       '</ol>' +
-      '<p>p1</p>' +
-      '<p>p2</p>' +
+      '<p data-fake-attr="something">p1</p>' +
+      '<p data-fake-attr="something">p2</p>' +
       '</li>' +
+      '<!-- c2 -->' +
       '</ol>'
     );
 
@@ -503,11 +509,13 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
       '<li style="list-style-type: none;">' +
       '<ol start="5">' +
       '<li>a</li>' +
+      '<!-- c1 -->' +
       '<li>b</li>' +
       '</ol>' +
-      '<p>p1</p>' +
-      '<p>p2</p>' +
+      '<p data-fake-attr="something">p1</p>' +
+      '<p data-fake-attr="something">p2</p>' +
       '</li>' +
+      '<!-- c2 -->' +
       '</ol>'
     );
 

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ListModelTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ListModelTest.ts
@@ -5,7 +5,7 @@ import { SugarElement } from '@ephox/sugar';
 import * as fc from 'fast-check';
 
 import { composeList } from 'tinymce/plugins/lists/listmodel/ComposeList';
-import { Entry } from 'tinymce/plugins/lists/listmodel/Entry';
+import { Entry, isEntryList } from 'tinymce/plugins/lists/listmodel/Entry';
 import { normalizeEntries } from 'tinymce/plugins/lists/listmodel/NormalizeEntries';
 import { parseLists } from 'tinymce/plugins/lists/listmodel/ParseLists';
 import { ListType } from 'tinymce/plugins/lists/listmodel/Util';
@@ -49,14 +49,14 @@ describe('browser.tinymce.plugins.lists.ListModelTest', () => {
 
     const stringifyEntries = (entries: Entry[]): string => Arr.map(entries, stringifyEntry).join(',');
 
-    const stringifyEntry = (entry: Entry): string => `\n  {
+    const stringifyEntry = (entry: Entry): string => isEntryList(entry) ? `\n  {
         depth: ${entry.depth}
         content: ${entry.content.length > 0 ? serializeElements(entry.content) : '[Empty]'}
         listType: ${entry.listType}
         isSelected: ${entry.isSelected}
         listAttributes: ${JSON.stringify(entry.listAttributes)}
         itemAttributes: ${JSON.stringify(entry.itemAttributes)}
-      }`;
+      }` : '';
 
     const serializeElements = (elms: SugarElement[]): string => Arr.map(elms, (el) => el.dom.outerHTML).join('');
 

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ListModelTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ListModelTest.ts
@@ -21,7 +21,8 @@ describe('browser.tinymce.plugins.lists.ListModelTest', () => {
       content: arbitraryContent,
       listType: fc.constantFrom(ListType.OL, ListType.UL),
       listAttributes: fc.constantFrom({}, { style: 'list-style-type: lower-alpha;' }),
-      itemAttributes: fc.constantFrom({}, { style: 'color: red;' })
+      itemAttributes: fc.constantFrom({}, { style: 'color: red;' }),
+      isInPreviousLi: fc.constant(false)
     });
 
     const arbitraryEntries = fc.array(arbitraryEntry);


### PR DESCRIPTION
Related Ticket: TINY-10213

Description of Changes:
the problem here was that in order to merge on Indent a `li` with the successive `li` if that has a list as the first element, we parse that list but ignore the other elements inside the `li`.

to solve this issue I added the siblings in the parsing of that list.

But since our `Entry`'s structure wasn't design only to have entries that are `li` or `lists` so I added a kind of `Entry` that is neither a `li` or a `list` to manage the issue.


Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
