### PR TITLE
TINY-10139: now `ElementType.isWrapElement` also takes the schema

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resize handles would not appear on editable images in a non-editable context. #TINY-10118
 - The dialog size was not updated when the `size` argument was changed when redialling a dialog. #TINY-10209
 - Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10213
-- Custom block element wasn't considered block element in some case. #TINY-10139
+- Custom block element wasn't considered block element in some cases. #TINY-10139
 
 ### Improved
 - Colorpicker now includes the Brightness/Saturation selector and hue slider in the keyboard navigable items. #TINY-9287

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resize handles would not appear on editable images in a non-editable context. #TINY-10118
 - The dialog size was not updated when the `size` argument was changed when redialling a dialog. #TINY-10209
 - Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10213
+- Custom block element wasn't considered block element in some case. #TINY-10139
 
 ### Improved
 - Colorpicker now includes the Brightness/Saturation selector and hue slider in the keyboard navigable items. #TINY-9287

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1,6 +1,7 @@
 import { Arr, Fun, Obj, Optionals, Strings, Type } from '@ephox/katamari';
 import { Attribute, Class, ContentEditable, Css, Html, Insert, Remove, Selectors, SugarElement, SugarNode, Traverse, WindowVisualViewport } from '@ephox/sugar';
 
+import Schema from '../../api/html/Schema';
 import * as TransparentElements from '../../content/TransparentElements';
 import * as NodeType from '../../dom/NodeType';
 import * as Position from '../../dom/Position';
@@ -9,7 +10,6 @@ import * as TrimNode from '../../dom/TrimNode';
 import { isWhitespaceText, isZwsp } from '../../text/Whitespace';
 import { GeomRect } from '../geom/Rect';
 import Entities from '../html/Entities';
-import Schema from '../html/Schema';
 import Styles, { StyleMap } from '../html/Styles';
 import { URLConverter } from '../OptionTypes';
 import { MappedEvent } from '../util/EventDispatcher';
@@ -1004,7 +1004,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
 
   const createRng = () => doc.createRange();
 
-  const split = <T extends Node>(parentElm: Node, splitElm: T, replacementElm?: T): T | undefined => {
+  const split = (schema: Schema) => <T extends Node>(parentElm: Node, splitElm: T, replacementElm?: T): T | undefined => {
     let range = createRng();
     let beforeFragment: DocumentFragment;
     let afterFragment: DocumentFragment;
@@ -1023,7 +1023,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
       afterFragment = range.extractContents();
 
       // Insert before chunk
-      parentNode.insertBefore(TrimNode.trimNode(self, beforeFragment), parentElm);
+      parentNode.insertBefore(TrimNode.trimNode(self, beforeFragment, schema), parentElm);
 
       // Insert middle chunk
       if (replacementElm) {
@@ -1034,7 +1034,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
       }
 
       // Insert after chunk
-      parentNode.insertBefore(TrimNode.trimNode(self, afterFragment), parentElm);
+      parentNode.insertBefore(TrimNode.trimNode(self, afterFragment, schema), parentElm);
       remove(parentElm);
 
       return replacementElm || splitElm;
@@ -1783,7 +1783,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      * @param {Element} replacementElm Optional replacement element to replace the split element with.
      * @return {Element} Returns the split element or the replacement element if that is specified.
      */
-    split,
+    split: split(schema),
 
     /**
      * Adds an event handler to the specified object.

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -1,7 +1,6 @@
 import { Arr, Fun, Obj, Optionals, Strings, Type } from '@ephox/katamari';
 import { Attribute, Class, ContentEditable, Css, Html, Insert, Remove, Selectors, SugarElement, SugarNode, Traverse, WindowVisualViewport } from '@ephox/sugar';
 
-import Schema from '../../api/html/Schema';
 import * as TransparentElements from '../../content/TransparentElements';
 import * as NodeType from '../../dom/NodeType';
 import * as Position from '../../dom/Position';
@@ -10,6 +9,7 @@ import * as TrimNode from '../../dom/TrimNode';
 import { isWhitespaceText, isZwsp } from '../../text/Whitespace';
 import { GeomRect } from '../geom/Rect';
 import Entities from '../html/Entities';
+import Schema from '../html/Schema';
 import Styles, { StyleMap } from '../html/Styles';
 import { URLConverter } from '../OptionTypes';
 import { MappedEvent } from '../util/EventDispatcher';
@@ -1004,7 +1004,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
 
   const createRng = () => doc.createRange();
 
-  const split = (schema: Schema) => <T extends Node>(parentElm: Node, splitElm: T, replacementElm?: T): T | undefined => {
+  const split = <T extends Node>(parentElm: Node, splitElm: T, replacementElm?: T): T | undefined => {
     let range = createRng();
     let beforeFragment: DocumentFragment;
     let afterFragment: DocumentFragment;
@@ -1783,7 +1783,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
      * @param {Element} replacementElm Optional replacement element to replace the split element with.
      * @return {Element} Returns the split element or the replacement element if that is specified.
      */
-    split: split(schema),
+    split,
 
     /**
      * Adds an event handler to the specified object.

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -32,6 +32,7 @@ interface Schema {
   isValidChild: (name: string, child: string) => boolean;
   isValid: (name: string, attr?: string) => boolean;
   isBlock: (name: string) => boolean;
+  isInline: (name: string) => boolean;
   getCustomElements: () => SchemaMap;
   addValidElements: (validElements: string) => void;
   setValidElements: (validElements: string) => void;
@@ -561,6 +562,8 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
 
   const isBlock = (name: string): boolean => Obj.has(getBlockElements(), name);
 
+  const isInline = (name: string): boolean => Obj.has(getTextInlineElements(), name);
+
   /**
    * Returns true/false if the specified element is valid or not
    * according to the schema.
@@ -633,6 +636,7 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
     isValidChild,
     isValid,
     isBlock,
+    isInline,
     getCustomElements,
     addValidElements,
     setValidElements,

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -1,8 +1,8 @@
-import { Arr, Fun, Obj, Type, Optional } from '@ephox/katamari';
+import { Arr, Fun, Obj, Optional, Type } from '@ephox/katamari';
 
 import * as CustomElementsRuleParser from '../../schema/CustomElementsRuleParser';
 import * as SchemaLookupTable from '../../schema/SchemaLookupTable';
-import { SchemaType, ElementSettings, SchemaElement, SchemaMap, SchemaRegExpMap, SchemaSettings } from '../../schema/SchemaTypes';
+import { ElementSettings, SchemaElement, SchemaMap, SchemaRegExpMap, SchemaSettings, SchemaType } from '../../schema/SchemaTypes';
 import * as SchemaUtils from '../../schema/SchemaUtils';
 import * as ValidChildrenRuleParser from '../../schema/ValidChildrenRuleParser';
 import * as ValidElementsRuleParser from '../../schema/ValidElementsRuleParser';
@@ -31,6 +31,7 @@ interface Schema {
   getSpecialElements: () => SchemaRegExpMap;
   isValidChild: (name: string, child: string) => boolean;
   isValid: (name: string, attr?: string) => boolean;
+  isBlock: (name: string) => boolean;
   getCustomElements: () => SchemaMap;
   addValidElements: (validElements: string) => void;
   setValidElements: (validElements: string) => void;
@@ -151,7 +152,7 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
     'blockquote center dir fieldset header footer article section hgroup aside main nav figure');
   const blockElementsMap = createLookupTable('block_elements', 'hr table tbody thead tfoot ' +
     'th tr td li ol ul caption dl dt dd noscript menu isindex option ' +
-    'datalist select optgroup figcaption details summary', textBlockElementsMap);
+    'datalist select optgroup figcaption details summary html body multicol listing', textBlockElementsMap);
   const textInlineElementsMap = createLookupTable('text_inline_elements', 'span strong b em i font s strike u var cite ' +
     'dfn code mark q sup sub samp');
 
@@ -558,6 +559,8 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
     return false;
   };
 
+  const isBlock = (name: string): boolean => Obj.has(getBlockElements(), name);
+
   /**
    * Returns true/false if the specified element is valid or not
    * according to the schema.
@@ -629,6 +632,7 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
     getSpecialElements,
     isValidChild,
     isValid,
+    isBlock,
     getCustomElements,
     addValidElements,
     setValidElements,

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -33,6 +33,7 @@ interface Schema {
   isValid: (name: string, attr?: string) => boolean;
   isBlock: (name: string) => boolean;
   isInline: (name: string) => boolean;
+  isWrapElement: (name: string) => boolean;
   getCustomElements: () => SchemaMap;
   addValidElements: (validElements: string) => void;
   setValidElements: (validElements: string) => void;
@@ -149,7 +150,8 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
   const nonEmptyElementsMap = createLookupTable('non_empty_elements', nonEmptyOrMoveCaretBeforeOnEnter + ' pre', voidElementsMap);
   const moveCaretBeforeOnEnterElementsMap = createLookupTable('move_caret_before_on_enter_elements', nonEmptyOrMoveCaretBeforeOnEnter + ' table', voidElementsMap);
 
-  const textBlockElementsMap = createLookupTable('text_block_elements', 'h1 h2 h3 h4 h5 h6 p div address pre form ' +
+  const headings = 'h1 h2 h3 h4 h5 h6';
+  const textBlockElementsMap = createLookupTable('text_block_elements', headings + ' p div address pre form ' +
     'blockquote center dir fieldset header footer article section hgroup aside main nav figure');
   const blockElementsMap = createLookupTable('block_elements', 'hr table tbody thead tfoot ' +
     'th tr td li ol ul caption dl dt dd noscript menu isindex option ' +
@@ -158,6 +160,8 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
     'dfn code mark q sup sub samp');
 
   const transparentElementsMap = createLookupTable('transparent_elements', 'a ins del canvas map');
+
+  const wrapBlockElementsMap = createLookupTable('wrap_block_elements', 'pre ' + headings);
 
   // See https://html.spec.whatwg.org/multipage/parsing.html#parsing-html-fragments
   each(('script noscript iframe noframes noembed title style textarea xmp plaintext').split(' '), (name) => {
@@ -497,6 +501,8 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
    */
   const getTransparentElements = Fun.constant(transparentElementsMap);
 
+  const getWrapBlockElements = Fun.constant(wrapBlockElementsMap);
+
   /**
    * Returns a map with special elements. These are elements that needs to be parsed
    * in a special way such as script, style, textarea etc. The map object values
@@ -563,6 +569,8 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
   const isBlock = (name: string): boolean => Obj.has(getBlockElements(), name);
 
   const isInline = (name: string): boolean => Obj.has(getTextInlineElements(), name);
+
+  const isWrapElement = (name: string): boolean => Obj.has(getWrapBlockElements(), name) || isInline(name);
 
   /**
    * Returns true/false if the specified element is valid or not
@@ -637,6 +645,7 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
     isValid,
     isBlock,
     isInline,
+    isWrapElement,
     getCustomElements,
     addValidElements,
     setValidElements,

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -568,7 +568,7 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
 
   const isBlock = (name: string): boolean => Obj.has(getBlockElements(), name);
 
-  const isInline = (name: string): boolean => Obj.has(getTextInlineElements(), name);
+  const isInline = (name: string): boolean => isValid(name) && !isBlock(name);
 
   const isWrapElement = (name: string): boolean => Obj.has(getWrapBlockElements(), name) || isInline(name);
 

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -33,7 +33,7 @@ interface Schema {
   isValid: (name: string, attr?: string) => boolean;
   isBlock: (name: string) => boolean;
   isInline: (name: string) => boolean;
-  isWrapElement: (name: string) => boolean;
+  isWrapper: (name: string) => boolean;
   getCustomElements: () => SchemaMap;
   addValidElements: (validElements: string) => void;
   setValidElements: (validElements: string) => void;
@@ -570,7 +570,7 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
 
   const isInline = (name: string): boolean => isValid(name) && !isBlock(name);
 
-  const isWrapElement = (name: string): boolean => Obj.has(getWrapBlockElements(), name) || isInline(name);
+  const isWrapper = (name: string): boolean => Obj.has(getWrapBlockElements(), name) || isInline(name);
 
   /**
    * Returns true/false if the specified element is valid or not
@@ -645,7 +645,7 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
     isValid,
     isBlock,
     isInline,
-    isWrapElement,
+    isWrapper,
     getCustomElements,
     addValidElements,
     setValidElements,

--- a/modules/tinymce/src/core/main/ts/caret/BlockBoundary.ts
+++ b/modules/tinymce/src/core/main/ts/caret/BlockBoundary.ts
@@ -12,7 +12,7 @@ const navigateIgnoreEmptyTextNodes = (forward: boolean, root: Node, from: CaretP
   CaretFinder.navigateIgnore(forward, root, from, isEmptyText);
 
 const getClosestBlock = (root: SugarElement<Node>, pos: CaretPosition): Optional<SugarElement<Element>> =>
-  Arr.find(Parents.parentsAndSelf(SugarElement.fromDom(pos.container()), root), ElementType.isBlock);
+  Arr.find(Parents.parentsAndSelf(SugarElement.fromDom(pos.container()), root), ElementType.isBlock());
 
 const isAtBeforeAfterBlockBoundary = (forward: boolean, root: SugarElement<Node>, pos: CaretPosition) =>
   navigateIgnoreEmptyTextNodes(forward, root.dom, pos)

--- a/modules/tinymce/src/core/main/ts/caret/BlockBoundary.ts
+++ b/modules/tinymce/src/core/main/ts/caret/BlockBoundary.ts
@@ -1,6 +1,7 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
 import { Compare, SugarElement } from '@ephox/sugar';
 
+import Schema from '../api/html/Schema';
 import * as ElementType from '../dom/ElementType';
 import * as Parents from '../dom/Parents';
 import * as CaretFinder from './CaretFinder';
@@ -11,17 +12,19 @@ import { isInSameBlock } from './CaretUtils';
 const navigateIgnoreEmptyTextNodes = (forward: boolean, root: Node, from: CaretPosition): Optional<CaretPosition> =>
   CaretFinder.navigateIgnore(forward, root, from, isEmptyText);
 
-const getClosestBlock = (root: SugarElement<Node>, pos: CaretPosition): Optional<SugarElement<Element>> =>
-  Arr.find(Parents.parentsAndSelf(SugarElement.fromDom(pos.container()), root), ElementType.isBlock());
+const isBlock = (schema: Schema) => (el: SugarElement<Node>): el is SugarElement<Element> => ElementType.isBlock(el, schema);
 
-const isAtBeforeAfterBlockBoundary = (forward: boolean, root: SugarElement<Node>, pos: CaretPosition) =>
+const getClosestBlock = (root: SugarElement<Node>, pos: CaretPosition, schema: Schema): Optional<SugarElement<Element>> =>
+  Arr.find(Parents.parentsAndSelf(SugarElement.fromDom(pos.container()), root), isBlock(schema));
+
+const isAtBeforeAfterBlockBoundary = (forward: boolean, root: SugarElement<Node>, pos: CaretPosition, schema: Schema) =>
   navigateIgnoreEmptyTextNodes(forward, root.dom, pos)
-    .forall((newPos) => getClosestBlock(root, pos).fold(
+    .forall((newPos) => getClosestBlock(root, pos, schema).fold(
       () => !isInSameBlock(newPos, pos, root.dom),
       (fromBlock) => !isInSameBlock(newPos, pos, root.dom) && Compare.contains(fromBlock, SugarElement.fromDom(newPos.container()))
     ));
 
-const isAtBlockBoundary = (forward: boolean, root: SugarElement<Node>, pos: CaretPosition) => getClosestBlock(root, pos).fold(
+const isAtBlockBoundary = (forward: boolean, root: SugarElement<Node>, pos: CaretPosition, schema: Schema) => getClosestBlock(root, pos, schema).fold(
   () => navigateIgnoreEmptyTextNodes(forward, root.dom, pos).forall((newPos) => !isInSameBlock(newPos, pos, root.dom)),
   (parent) => navigateIgnoreEmptyTextNodes(forward, parent.dom, pos).isNone()
 );

--- a/modules/tinymce/src/core/main/ts/caret/BlockBoundary.ts
+++ b/modules/tinymce/src/core/main/ts/caret/BlockBoundary.ts
@@ -1,8 +1,7 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Compare, SugarElement } from '@ephox/sugar';
+import { Compare, SugarElement, SugarNode } from '@ephox/sugar';
 
 import Schema from '../api/html/Schema';
-import * as ElementType from '../dom/ElementType';
 import * as Parents from '../dom/Parents';
 import * as CaretFinder from './CaretFinder';
 import { CaretPosition } from './CaretPosition';
@@ -12,7 +11,7 @@ import { isInSameBlock } from './CaretUtils';
 const navigateIgnoreEmptyTextNodes = (forward: boolean, root: Node, from: CaretPosition): Optional<CaretPosition> =>
   CaretFinder.navigateIgnore(forward, root, from, isEmptyText);
 
-const isBlock = (schema: Schema) => (el: SugarElement<Node>): el is SugarElement<Element> => ElementType.isBlock(el, schema);
+const isBlock = (schema: Schema) => (el: SugarElement<Node>): el is SugarElement<Element> => schema.isBlock(SugarNode.name(el));
 
 const getClosestBlock = (root: SugarElement<Node>, pos: CaretPosition, schema: Schema): Optional<SugarElement<Element>> =>
   Arr.find(Parents.parentsAndSelf(SugarElement.fromDom(pos.container()), root), isBlock(schema));

--- a/modules/tinymce/src/core/main/ts/caret/CaretBr.ts
+++ b/modules/tinymce/src/core/main/ts/caret/CaretBr.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import { SugarElement, SugarNode } from '@ephox/sugar';
 
 import Schema from '../api/html/Schema';
 import * as ElementType from '../dom/ElementType';
@@ -12,7 +12,7 @@ const isBr = (pos: CaretPosition): boolean =>
   getElementFromPosition(pos).exists(ElementType.isBr);
 
 const findBr = (forward: boolean, root: SugarElement<Node>, pos: CaretPosition, schema: Schema): Optional<CaretPosition> => {
-  const parentBlocks = Arr.filter(Parents.parentsAndSelf(SugarElement.fromDom(pos.container()), root), (el) => ElementType.isBlock(el, schema));
+  const parentBlocks = Arr.filter(Parents.parentsAndSelf(SugarElement.fromDom(pos.container()), root), (el) => schema.isBlock(SugarNode.name(el)));
   const scope = Arr.head(parentBlocks).getOr(root);
   return CaretFinder.fromPosition(forward, scope.dom, pos).filter(isBr);
 };

--- a/modules/tinymce/src/core/main/ts/caret/CaretBr.ts
+++ b/modules/tinymce/src/core/main/ts/caret/CaretBr.ts
@@ -1,6 +1,7 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
+import Schema from '../api/html/Schema';
 import * as ElementType from '../dom/ElementType';
 import * as Parents from '../dom/Parents';
 import * as CaretFinder from './CaretFinder';
@@ -10,17 +11,17 @@ import { getElementFromPosition, getElementFromPrevPosition } from './CaretUtils
 const isBr = (pos: CaretPosition): boolean =>
   getElementFromPosition(pos).exists(ElementType.isBr);
 
-const findBr = (forward: boolean, root: SugarElement<Node>, pos: CaretPosition): Optional<CaretPosition> => {
-  const parentBlocks = Arr.filter(Parents.parentsAndSelf(SugarElement.fromDom(pos.container()), root), ElementType.isBlock());
+const findBr = (forward: boolean, root: SugarElement<Node>, pos: CaretPosition, schema: Schema): Optional<CaretPosition> => {
+  const parentBlocks = Arr.filter(Parents.parentsAndSelf(SugarElement.fromDom(pos.container()), root), (el) => ElementType.isBlock(el, schema));
   const scope = Arr.head(parentBlocks).getOr(root);
   return CaretFinder.fromPosition(forward, scope.dom, pos).filter(isBr);
 };
 
-const isBeforeBr = (root: SugarElement<Node>, pos: CaretPosition): boolean =>
-  getElementFromPosition(pos).exists(ElementType.isBr) || findBr(true, root, pos).isSome();
+const isBeforeBr = (root: SugarElement<Node>, pos: CaretPosition, schema: Schema): boolean =>
+  getElementFromPosition(pos).exists(ElementType.isBr) || findBr(true, root, pos, schema).isSome();
 
-const isAfterBr = (root: SugarElement<Node>, pos: CaretPosition): boolean =>
-  getElementFromPrevPosition(pos).exists(ElementType.isBr) || findBr(false, root, pos).isSome();
+const isAfterBr = (root: SugarElement<Node>, pos: CaretPosition, schema: Schema): boolean =>
+  getElementFromPrevPosition(pos).exists(ElementType.isBr) || findBr(false, root, pos, schema).isSome();
 
 const findPreviousBr = Fun.curry(findBr, false);
 const findNextBr = Fun.curry(findBr, true);

--- a/modules/tinymce/src/core/main/ts/caret/CaretBr.ts
+++ b/modules/tinymce/src/core/main/ts/caret/CaretBr.ts
@@ -11,7 +11,7 @@ const isBr = (pos: CaretPosition): boolean =>
   getElementFromPosition(pos).exists(ElementType.isBr);
 
 const findBr = (forward: boolean, root: SugarElement<Node>, pos: CaretPosition): Optional<CaretPosition> => {
-  const parentBlocks = Arr.filter(Parents.parentsAndSelf(SugarElement.fromDom(pos.container()), root), ElementType.isBlock);
+  const parentBlocks = Arr.filter(Parents.parentsAndSelf(SugarElement.fromDom(pos.container()), root), ElementType.isBlock());
   const scope = Arr.head(parentBlocks).getOr(root);
   return CaretFinder.fromPosition(forward, scope.dom, pos).filter(isBr);
 };

--- a/modules/tinymce/src/core/main/ts/content/InsertContent.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContent.ts
@@ -41,7 +41,7 @@ const trimOrPad = (editor: Editor, value: string): string => {
 
   // Check for whitespace before/after value
   if (/^ | $/.test(value)) {
-    return trimOrPadLeftRight(dom, selection.getRng(), value);
+    return trimOrPadLeftRight(dom, selection.getRng(), value, editor.schema);
   } else {
     return value;
   }

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -5,6 +5,7 @@ import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
 import { ParserArgs } from '../api/html/DomParser';
 import AstNode from '../api/html/Node';
+import Schema from '../api/html/Schema';
 import HtmlSerializer from '../api/html/Serializer';
 import * as StyleUtils from '../api/html/StyleUtils';
 import Tools from '../api/util/Tools';
@@ -73,8 +74,8 @@ const validInsertion = (editor: Editor, value: string, parentNode: Element): voi
   }
 };
 
-const trimBrsFromTableCell = (dom: DOMUtils, elm: Element): void => {
-  Optional.from(dom.getParent(elm, 'td,th')).map(SugarElement.fromDom).each(PaddingBr.trimBlockTrailingBr);
+const trimBrsFromTableCell = (dom: DOMUtils, elm: Element, schema: Schema): void => {
+  Optional.from(dom.getParent(elm, 'td,th')).map(SugarElement.fromDom).each((el) => PaddingBr.trimBlockTrailingBr(el, schema));
 };
 
 // Remove children nodes that are exactly the same as a parent node - name, attributes, styles
@@ -364,7 +365,7 @@ export const insertHtmlAtCaret = (editor: Editor, value: string, details: Insert
   reduceInlineTextElements(editor, merge);
   moveSelectionToMarker(editor, dom.get('mce_marker'));
   unmarkFragmentElements(editor.getBody());
-  trimBrsFromTableCell(dom, selection.getStart());
+  trimBrsFromTableCell(dom, selection.getStart(), editor.schema);
   TransparentElements.updateCaret(editor.schema, editor.getBody(), selection.getStart());
 
   return value;

--- a/modules/tinymce/src/core/main/ts/content/NbspTrim.ts
+++ b/modules/tinymce/src/core/main/ts/content/NbspTrim.ts
@@ -1,21 +1,22 @@
 import { SugarElement } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
+import Schema from '../api/html/Schema';
 import CaretPosition from '../caret/CaretPosition';
 import { needsToBeNbspLeft, needsToBeNbspRight } from '../keyboard/Nbsps';
 
-const trimOrPadLeftRight = (dom: DOMUtils, rng: Range, html: string): string => {
+const trimOrPadLeftRight = (dom: DOMUtils, rng: Range, html: string, schema: Schema): string => {
   const root = SugarElement.fromDom(dom.getRoot());
 
   // Adjust the start if it needs to be an nbsp
-  if (needsToBeNbspLeft(root, CaretPosition.fromRangeStart(rng))) {
+  if (needsToBeNbspLeft(root, CaretPosition.fromRangeStart(rng), schema)) {
     html = html.replace(/^ /, '&nbsp;');
   } else {
     html = html.replace(/^&nbsp;/, ' ');
   }
 
   // Adjust the end if it needs to be an nbsp
-  if (needsToBeNbspRight(root, CaretPosition.fromRangeEnd(rng))) {
+  if (needsToBeNbspRight(root, CaretPosition.fromRangeEnd(rng), schema)) {
     html = html.replace(/(&nbsp;| )(<br( \/)>)?$/, '&nbsp;');
   } else {
     html = html.replace(/&nbsp;(<br( \/)?>)?$/, ' ');

--- a/modules/tinymce/src/core/main/ts/delete/BlockBoundaryDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/BlockBoundaryDelete.ts
@@ -11,7 +11,7 @@ const backspaceDelete = (editor: Editor, forward: boolean): Optional<() => void>
   const position = BlockMergeBoundary.read(rootNode.dom, forward, editor.selection.getRng())
     .map((blockBoundary) =>
       () => {
-        MergeBlocks.mergeBlocks(rootNode, forward, blockBoundary.from.block, blockBoundary.to.block)
+        MergeBlocks.mergeBlocks(rootNode, forward, blockBoundary.from.block, blockBoundary.to.block, editor.schema)
           .each((pos) => {
             editor.selection.setRng(pos.toRange());
           });

--- a/modules/tinymce/src/core/main/ts/delete/BlockRangeDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/BlockRangeDelete.ts
@@ -3,13 +3,14 @@ import { Compare, PredicateFind, SugarElement } from '@ephox/sugar';
 
 import EditorSelection from '../api/dom/Selection';
 import Editor from '../api/Editor';
+import Schema from '../api/html/Schema';
 import * as CaretFinder from '../caret/CaretFinder';
 import CaretPosition from '../caret/CaretPosition';
 import * as ElementType from '../dom/ElementType';
 import * as DeleteUtils from './DeleteUtils';
 import * as MergeBlocks from './MergeBlocks';
 
-const deleteRangeMergeBlocks = (rootNode: SugarElement<Node>, selection: EditorSelection): Optional<() => void> => {
+const deleteRangeMergeBlocks = (rootNode: SugarElement<Node>, selection: EditorSelection, schema: Schema): Optional<() => void> => {
   const rng = selection.getRng();
 
   return Optionals.lift2(
@@ -20,7 +21,7 @@ const deleteRangeMergeBlocks = (rootNode: SugarElement<Node>, selection: EditorS
         return Optional.some(() => {
           rng.deleteContents();
 
-          MergeBlocks.mergeBlocks(rootNode, true, block1, block2).each((pos) => {
+          MergeBlocks.mergeBlocks(rootNode, true, block1, block2, schema).each((pos) => {
             selection.setRng(pos.toRange());
           });
 
@@ -56,7 +57,7 @@ const emptyEditor = (editor: Editor): Optional<() => void> => {
 const deleteRange = (editor: Editor): Optional<() => void> => {
   const rootNode = SugarElement.fromDom(editor.getBody());
   const rng = editor.selection.getRng();
-  return isEverythingSelected(rootNode, rng) ? emptyEditor(editor) : deleteRangeMergeBlocks(rootNode, editor.selection);
+  return isEverythingSelected(rootNode, rng) ? emptyEditor(editor) : deleteRangeMergeBlocks(rootNode, editor.selection, editor.schema);
 };
 
 const backspaceDelete = (editor: Editor, _forward: boolean): Optional<() => void> =>

--- a/modules/tinymce/src/core/main/ts/delete/CefDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/CefDelete.ts
@@ -41,7 +41,7 @@ const backspaceDeleteCaret = (editor: Editor, forward: boolean): Optional<() => 
   // 5. CEF ancestor -> return true
 
   return getAncestorCe(editor, selectedNode).filter(NodeType.isContentEditableFalse).fold(
-    () => CefDeleteAction.read(editor.getBody(), forward, editor.selection.getRng()).map((deleteAction) =>
+    () => CefDeleteAction.read(editor.getBody(), forward, editor.selection.getRng(), editor.schema).map((deleteAction) =>
       () =>
         deleteAction.fold(
           deleteElement(editor, forward),

--- a/modules/tinymce/src/core/main/ts/delete/CefDeleteAction.ts
+++ b/modules/tinymce/src/core/main/ts/delete/CefDeleteAction.ts
@@ -46,7 +46,7 @@ const isAtContentEditableBlockCaret = (forward: boolean, from: CaretPosition): b
 };
 
 const isDeleteFromCefDifferentBlocks = (root: Node, forward: boolean, from: CaretPosition, to: CaretPosition, schema: Schema): boolean => {
-  const inSameBlock = (elm: Element) => ElementType.isInline(SugarElement.fromDom(elm), schema) && !CaretUtils.isInSameBlock(from, to, root);
+  const inSameBlock = (elm: Element) => schema.isInline(elm.nodeName.toLowerCase()) && !CaretUtils.isInSameBlock(from, to, root);
 
   return CaretUtils.getRelativeCefElm(!forward, from).fold(
     () => CaretUtils.getRelativeCefElm(forward, to).fold(Fun.never, inSameBlock),

--- a/modules/tinymce/src/core/main/ts/delete/InlineFormatDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/InlineFormatDelete.ts
@@ -2,6 +2,7 @@ import { Arr, Fun, Optional, Type } from '@ephox/katamari';
 import { PredicateExists, SugarElement, Traverse } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
+import Schema from '../api/html/Schema';
 import CaretPosition from '../caret/CaretPosition';
 import * as ElementType from '../dom/ElementType';
 import * as NodeType from '../dom/NodeType';
@@ -28,10 +29,10 @@ const hasOnlyOneChild = (elm: SugarElement<Node>): boolean =>
   Traverse.childNodesCount(elm) === 1;
 
 const getParentInlinesUntilMultichildInline = (editor: Editor): SugarElement<Node>[] =>
-  getParentsUntil(editor, (elm) => ElementType.isBlock()(elm) || hasMultipleChildren(elm));
+  getParentsUntil(editor, (elm) => ElementType.isBlock(elm, editor.schema) || hasMultipleChildren(elm));
 
 const getParentInlines = (editor: Editor): SugarElement<Node>[] =>
-  getParentsUntil(editor, ElementType.isBlock());
+  getParentsUntil(editor, (el) => ElementType.isBlock(el, editor.schema));
 
 const getFormatNodes = (editor: Editor, parentInlines: SugarElement<Node>[]): Node[] => {
   const isFormatElement = Fun.curry(CaretFormat.isFormatElement, editor);
@@ -144,11 +145,11 @@ const deleteRange = (editor: Editor): Optional<() => void> => {
 const backspaceDelete = (editor: Editor, forward: boolean): Optional<() => void> =>
   editor.selection.isCollapsed() ? deleteCaret(editor, forward) : deleteRange(editor);
 
-const hasAncestorInlineCaret = (elm: SugarElement<Node>): boolean =>
-  PredicateExists.ancestor(elm, (node) => FormatContainer.isCaretNode(node.dom), ElementType.isBlock());
+const hasAncestorInlineCaret = (elm: SugarElement<Node>, schema: Schema): boolean =>
+  PredicateExists.ancestor(elm, (node) => FormatContainer.isCaretNode(node.dom), (el) => ElementType.isBlock(el, schema));
 
 const hasAncestorInlineCaretAtStart = (editor: Editor): boolean =>
-  hasAncestorInlineCaret(SugarElement.fromDom(editor.selection.getStart()));
+  hasAncestorInlineCaret(SugarElement.fromDom(editor.selection.getStart()), editor.schema);
 
 const requiresRefreshCaretOverride = (editor: Editor): boolean => {
   const rng = editor.selection.getRng();

--- a/modules/tinymce/src/core/main/ts/delete/InlineFormatDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/InlineFormatDelete.ts
@@ -1,10 +1,9 @@
 import { Arr, Fun, Optional, Type } from '@ephox/katamari';
-import { PredicateExists, SugarElement, Traverse } from '@ephox/sugar';
+import { PredicateExists, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import Schema from '../api/html/Schema';
 import CaretPosition from '../caret/CaretPosition';
-import * as ElementType from '../dom/ElementType';
 import * as NodeType from '../dom/NodeType';
 import * as Parents from '../dom/Parents';
 import * as CaretFormat from '../fmt/CaretFormat';
@@ -29,10 +28,10 @@ const hasOnlyOneChild = (elm: SugarElement<Node>): boolean =>
   Traverse.childNodesCount(elm) === 1;
 
 const getParentInlinesUntilMultichildInline = (editor: Editor): SugarElement<Node>[] =>
-  getParentsUntil(editor, (elm) => ElementType.isBlock(elm, editor.schema) || hasMultipleChildren(elm));
+  getParentsUntil(editor, (elm) => editor.schema.isBlock(SugarNode.name(elm)) || hasMultipleChildren(elm));
 
 const getParentInlines = (editor: Editor): SugarElement<Node>[] =>
-  getParentsUntil(editor, (el) => ElementType.isBlock(el, editor.schema));
+  getParentsUntil(editor, (el) => editor.schema.isBlock(SugarNode.name(el)));
 
 const getFormatNodes = (editor: Editor, parentInlines: SugarElement<Node>[]): Node[] => {
   const isFormatElement = Fun.curry(CaretFormat.isFormatElement, editor);
@@ -146,7 +145,7 @@ const backspaceDelete = (editor: Editor, forward: boolean): Optional<() => void>
   editor.selection.isCollapsed() ? deleteCaret(editor, forward) : deleteRange(editor);
 
 const hasAncestorInlineCaret = (elm: SugarElement<Node>, schema: Schema): boolean =>
-  PredicateExists.ancestor(elm, (node) => FormatContainer.isCaretNode(node.dom), (el) => ElementType.isBlock(el, schema));
+  PredicateExists.ancestor(elm, (node) => FormatContainer.isCaretNode(node.dom), (el) => schema.isBlock(SugarNode.name(el)));
 
 const hasAncestorInlineCaretAtStart = (editor: Editor): boolean =>
   hasAncestorInlineCaret(SugarElement.fromDom(editor.selection.getStart()), editor.schema);

--- a/modules/tinymce/src/core/main/ts/delete/InlineFormatDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/InlineFormatDelete.ts
@@ -28,10 +28,10 @@ const hasOnlyOneChild = (elm: SugarElement<Node>): boolean =>
   Traverse.childNodesCount(elm) === 1;
 
 const getParentInlinesUntilMultichildInline = (editor: Editor): SugarElement<Node>[] =>
-  getParentsUntil(editor, (elm) => ElementType.isBlock(elm) || hasMultipleChildren(elm));
+  getParentsUntil(editor, (elm) => ElementType.isBlock()(elm) || hasMultipleChildren(elm));
 
 const getParentInlines = (editor: Editor): SugarElement<Node>[] =>
-  getParentsUntil(editor, ElementType.isBlock);
+  getParentsUntil(editor, ElementType.isBlock());
 
 const getFormatNodes = (editor: Editor, parentInlines: SugarElement<Node>[]): Node[] => {
   const isFormatElement = Fun.curry(CaretFormat.isFormatElement, editor);
@@ -145,7 +145,7 @@ const backspaceDelete = (editor: Editor, forward: boolean): Optional<() => void>
   editor.selection.isCollapsed() ? deleteCaret(editor, forward) : deleteRange(editor);
 
 const hasAncestorInlineCaret = (elm: SugarElement<Node>): boolean =>
-  PredicateExists.ancestor(elm, (node) => FormatContainer.isCaretNode(node.dom), ElementType.isBlock);
+  PredicateExists.ancestor(elm, (node) => FormatContainer.isCaretNode(node.dom), ElementType.isBlock());
 
 const hasAncestorInlineCaretAtStart = (editor: Editor): boolean =>
   hasAncestorInlineCaret(SugarElement.fromDom(editor.selection.getStart()));

--- a/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Compare, Insert, Remove, Replication, SugarElement, Traverse } from '@ephox/sugar';
+import { Compare, Insert, Remove, Replication, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import Schema from '../api/html/Schema';
 import * as CaretFinder from '../caret/CaretFinder';
@@ -11,7 +11,7 @@ import * as Parents from '../dom/Parents';
 
 const getChildrenUntilBlockBoundary = (block: SugarElement<Element>, schema: Schema): SugarElement<Node>[] => {
   const children = Traverse.children(block);
-  return Arr.findIndex(children, (el) => ElementType.isBlock(el, schema)).fold(
+  return Arr.findIndex(children, (el) => schema.isBlock(SugarNode.name(el))).fold(
     Fun.constant(children),
     (index) => children.slice(0, index)
   );

--- a/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Compare, Insert, Replication, Remove, SugarElement, Traverse } from '@ephox/sugar';
+import { Compare, Insert, Remove, Replication, SugarElement, Traverse } from '@ephox/sugar';
 
 import * as CaretFinder from '../caret/CaretFinder';
 import CaretPosition from '../caret/CaretPosition';
@@ -10,7 +10,7 @@ import * as Parents from '../dom/Parents';
 
 const getChildrenUntilBlockBoundary = (block: SugarElement<Element>): SugarElement<Node>[] => {
   const children = Traverse.children(block);
-  return Arr.findIndex(children, ElementType.isBlock).fold(
+  return Arr.findIndex(children, ElementType.isBlock()).fold(
     Fun.constant(children),
     (index) => children.slice(0, index)
   );

--- a/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
@@ -1,6 +1,7 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
 import { Compare, Insert, Remove, Replication, SugarElement, Traverse } from '@ephox/sugar';
 
+import Schema from '../api/html/Schema';
 import * as CaretFinder from '../caret/CaretFinder';
 import CaretPosition from '../caret/CaretPosition';
 import * as ElementType from '../dom/ElementType';
@@ -8,16 +9,16 @@ import * as Empty from '../dom/Empty';
 import * as PaddingBr from '../dom/PaddingBr';
 import * as Parents from '../dom/Parents';
 
-const getChildrenUntilBlockBoundary = (block: SugarElement<Element>): SugarElement<Node>[] => {
+const getChildrenUntilBlockBoundary = (block: SugarElement<Element>, schema: Schema): SugarElement<Node>[] => {
   const children = Traverse.children(block);
-  return Arr.findIndex(children, ElementType.isBlock()).fold(
+  return Arr.findIndex(children, (el) => ElementType.isBlock(el, schema)).fold(
     Fun.constant(children),
     (index) => children.slice(0, index)
   );
 };
 
-const extractChildren = (block: SugarElement<Element>): SugarElement<Node>[] => {
-  const children = getChildrenUntilBlockBoundary(block);
+const extractChildren = (block: SugarElement<Element>, schema: Schema): SugarElement<Node>[] => {
+  const children = getChildrenUntilBlockBoundary(block, schema);
   Arr.each(children, Remove.remove);
   return children;
 };
@@ -34,6 +35,7 @@ const nestedBlockMerge = (
   rootNode: SugarElement<Node>,
   fromBlock: SugarElement<Element>,
   toBlock: SugarElement<Element>,
+  schema: Schema,
   insertionPoint: SugarElement<Node>
 ): Optional<CaretPosition> => {
   if (Empty.isEmpty(toBlock)) {
@@ -46,21 +48,21 @@ const nestedBlockMerge = (
   }
 
   const position = CaretFinder.prevPosition(toBlock.dom, CaretPosition.before(insertionPoint.dom));
-  Arr.each(extractChildren(fromBlock), (child) => {
+  Arr.each(extractChildren(fromBlock, schema), (child) => {
     Insert.before(insertionPoint, child);
   });
   removeEmptyRoot(rootNode, fromBlock);
   return position;
 };
 
-const sidelongBlockMerge = (rootNode: SugarElement<Node>, fromBlock: SugarElement<Element>, toBlock: SugarElement<Element>): Optional<CaretPosition> => {
+const sidelongBlockMerge = (rootNode: SugarElement<Node>, fromBlock: SugarElement<Element>, toBlock: SugarElement<Element>, schema: Schema): Optional<CaretPosition> => {
   if (Empty.isEmpty(toBlock)) {
     if (Empty.isEmpty(fromBlock)) {
       const getInlineToBlockDescendants = (el: SugarElement<Element>) => {
         const helper = (node: SugarElement<Element>, elements: SugarElement<Element>[]): SugarElement<Element>[] =>
           Traverse.firstChild(node).fold(
             () => elements,
-            (child) => ElementType.isInline(child) ? helper(child, elements.concat(Replication.shallow(child))) : elements
+            (child) => ElementType.isInline(child, schema) ? helper(child, elements.concat(Replication.shallow(child))) : elements
           );
         return helper(el, []);
       };
@@ -83,7 +85,7 @@ const sidelongBlockMerge = (rootNode: SugarElement<Node>, fromBlock: SugarElemen
   }
 
   const position = CaretFinder.lastPositionIn(toBlock.dom);
-  Arr.each(extractChildren(fromBlock), (child) => {
+  Arr.each(extractChildren(fromBlock, schema), (child) => {
     Insert.append(toBlock, child);
   });
   removeEmptyRoot(rootNode, fromBlock);
@@ -106,18 +108,18 @@ const trimBr = (first: boolean, block: SugarElement<Element>) => {
     .each(Remove.remove);
 };
 
-const mergeBlockInto = (rootNode: SugarElement<Node>, fromBlock: SugarElement<Element>, toBlock: SugarElement<Element>): Optional<CaretPosition> => {
+const mergeBlockInto = (rootNode: SugarElement<Node>, fromBlock: SugarElement<Element>, toBlock: SugarElement<Element>, schema: Schema): Optional<CaretPosition> => {
   trimBr(true, fromBlock);
   trimBr(false, toBlock);
 
   return getInsertionPoint(fromBlock, toBlock).fold(
-    Fun.curry(sidelongBlockMerge, rootNode, fromBlock, toBlock),
-    Fun.curry(nestedBlockMerge, rootNode, fromBlock, toBlock)
+    Fun.curry(sidelongBlockMerge, rootNode, fromBlock, toBlock, schema),
+    Fun.curry(nestedBlockMerge, rootNode, fromBlock, toBlock, schema)
   );
 };
 
-const mergeBlocks = (rootNode: SugarElement<Node>, forward: boolean, block1: SugarElement<Element>, block2: SugarElement<Element>): Optional<CaretPosition> =>
-  forward ? mergeBlockInto(rootNode, block2, block1) : mergeBlockInto(rootNode, block1, block2);
+const mergeBlocks = (rootNode: SugarElement<Node>, forward: boolean, block1: SugarElement<Element>, block2: SugarElement<Element>, schema: Schema): Optional<CaretPosition> =>
+  forward ? mergeBlockInto(rootNode, block2, block1, schema) : mergeBlockInto(rootNode, block1, block2, schema);
 
 export {
   mergeBlocks

--- a/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
@@ -55,6 +55,8 @@ const nestedBlockMerge = (
   return position;
 };
 
+const isInline = (schema: Schema) => (node: SugarElement<Node>): node is SugarElement<HTMLElement> => schema.isInline(SugarNode.name(node));
+
 const sidelongBlockMerge = (rootNode: SugarElement<Node>, fromBlock: SugarElement<Element>, toBlock: SugarElement<Element>, schema: Schema): Optional<CaretPosition> => {
   if (Empty.isEmpty(toBlock)) {
     if (Empty.isEmpty(fromBlock)) {
@@ -62,7 +64,7 @@ const sidelongBlockMerge = (rootNode: SugarElement<Node>, fromBlock: SugarElemen
         const helper = (node: SugarElement<Element>, elements: SugarElement<Element>[]): SugarElement<Element>[] =>
           Traverse.firstChild(node).fold(
             () => elements,
-            (child) => ElementType.isInline(child, schema) ? helper(child, elements.concat(Replication.shallow(child))) : elements
+            (child) => isInline(schema)(child) ? helper(child, elements.concat(Replication.shallow(child))) : elements
           );
         return helper(el, []);
       };

--- a/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
@@ -55,7 +55,7 @@ const nestedBlockMerge = (
   return position;
 };
 
-const isInline = (schema: Schema) => (node: SugarElement<Node>): node is SugarElement<HTMLElement> => schema.isInline(SugarNode.name(node));
+const isInline = (schema: Schema, node: SugarElement<Node>): node is SugarElement<HTMLElement> => schema.isInline(SugarNode.name(node));
 
 const sidelongBlockMerge = (rootNode: SugarElement<Node>, fromBlock: SugarElement<Element>, toBlock: SugarElement<Element>, schema: Schema): Optional<CaretPosition> => {
   if (Empty.isEmpty(toBlock)) {
@@ -64,7 +64,7 @@ const sidelongBlockMerge = (rootNode: SugarElement<Node>, fromBlock: SugarElemen
         const helper = (node: SugarElement<Element>, elements: SugarElement<Element>[]): SugarElement<Element>[] =>
           Traverse.firstChild(node).fold(
             () => elements,
-            (child) => isInline(schema)(child) ? helper(child, elements.concat(Replication.shallow(child))) : elements
+            (child) => isInline(schema, child) ? helper(child, elements.concat(Replication.shallow(child))) : elements
           );
         return helper(el, []);
       };

--- a/modules/tinymce/src/core/main/ts/delete/MergeText.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeText.ts
@@ -11,7 +11,7 @@ const normalize = (node: Text, offset: number, count: number): void => {
     return;
   }
   const elm = SugarElement.fromDom(node);
-  const root = PredicateFind.ancestor(elm, ElementType.isBlock).getOr(elm);
+  const root = PredicateFind.ancestor(elm, ElementType.isBlock()).getOr(elm);
 
   // Get the whitespace
   const whitespace = node.data.slice(offset, offset + count);

--- a/modules/tinymce/src/core/main/ts/delete/MergeText.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeText.ts
@@ -1,9 +1,8 @@
 import { Strings } from '@ephox/katamari';
-import { PredicateFind, Remove, SugarElement } from '@ephox/sugar';
+import { PredicateFind, Remove, SugarElement, SugarNode } from '@ephox/sugar';
 
 import Schema from '../api/html/Schema';
 import CaretPosition from '../caret/CaretPosition';
-import * as ElementType from '../dom/ElementType';
 import * as Nbsps from '../keyboard/Nbsps';
 import * as Whitespace from '../text/Whitespace';
 
@@ -12,7 +11,7 @@ const normalize = (node: Text, offset: number, count: number, schema: Schema): v
     return;
   }
   const elm = SugarElement.fromDom(node);
-  const root = PredicateFind.ancestor(elm, (el) => ElementType.isBlock(el, schema)).getOr(elm);
+  const root = PredicateFind.ancestor(elm, (el) => schema.isBlock(SugarNode.name(el))).getOr(elm);
 
   // Get the whitespace
   const whitespace = node.data.slice(offset, offset + count);

--- a/modules/tinymce/src/core/main/ts/delete/MergeText.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeText.ts
@@ -1,44 +1,45 @@
 import { Strings } from '@ephox/katamari';
 import { PredicateFind, Remove, SugarElement } from '@ephox/sugar';
 
+import Schema from '../api/html/Schema';
 import CaretPosition from '../caret/CaretPosition';
 import * as ElementType from '../dom/ElementType';
 import * as Nbsps from '../keyboard/Nbsps';
 import * as Whitespace from '../text/Whitespace';
 
-const normalize = (node: Text, offset: number, count: number): void => {
+const normalize = (node: Text, offset: number, count: number, schema: Schema): void => {
   if (count === 0) {
     return;
   }
   const elm = SugarElement.fromDom(node);
-  const root = PredicateFind.ancestor(elm, ElementType.isBlock()).getOr(elm);
+  const root = PredicateFind.ancestor(elm, (el) => ElementType.isBlock(el, schema)).getOr(elm);
 
   // Get the whitespace
   const whitespace = node.data.slice(offset, offset + count);
 
   // Determine if we're at the end or start of the content
-  const isEndOfContent = offset + count >= node.data.length && Nbsps.needsToBeNbspRight(root, CaretPosition(node, node.data.length));
-  const isStartOfContent = offset === 0 && Nbsps.needsToBeNbspLeft(root, CaretPosition(node, 0));
+  const isEndOfContent = offset + count >= node.data.length && Nbsps.needsToBeNbspRight(root, CaretPosition(node, node.data.length), schema);
+  const isStartOfContent = offset === 0 && Nbsps.needsToBeNbspLeft(root, CaretPosition(node, 0), schema);
 
   // Replace the original whitespace with the normalized whitespace content
   node.replaceData(offset, count, Whitespace.normalize(whitespace, 4, isStartOfContent, isEndOfContent));
 };
 
-const normalizeWhitespaceAfter = (node: Text, offset: number): void => {
+const normalizeWhitespaceAfter = (node: Text, offset: number, schema: Schema): void => {
   const content = node.data.slice(offset);
   const whitespaceCount = content.length - Strings.lTrim(content).length;
 
-  normalize(node, offset, whitespaceCount);
+  normalize(node, offset, whitespaceCount, schema);
 };
 
-const normalizeWhitespaceBefore = (node: Text, offset: number): void => {
+const normalizeWhitespaceBefore = (node: Text, offset: number, schema: Schema): void => {
   const content = node.data.slice(0, offset);
   const whitespaceCount = content.length - Strings.rTrim(content).length;
 
-  normalize(node, offset - whitespaceCount, whitespaceCount);
+  normalize(node, offset - whitespaceCount, whitespaceCount, schema);
 };
 
-const mergeTextNodes = (prevNode: Text, nextNode: Text, normalizeWhitespace?: boolean, mergeToPrev: boolean = true): Text => {
+const mergeTextNodes = (prevNode: Text, nextNode: Text, schema: Schema, normalizeWhitespace?: boolean, mergeToPrev: boolean = true): Text => {
   const whitespaceOffset = Strings.rTrim(prevNode.data).length;
   const newNode = mergeToPrev ? prevNode : nextNode;
   const removeNode = mergeToPrev ? nextNode : prevNode;
@@ -53,7 +54,7 @@ const mergeTextNodes = (prevNode: Text, nextNode: Text, normalizeWhitespace?: bo
 
   // Normalize the whitespace around the merged elements, to ensure it doesn't get lost
   if (normalizeWhitespace) {
-    normalizeWhitespaceAfter(newNode, whitespaceOffset);
+    normalizeWhitespaceAfter(newNode, whitespaceOffset, schema);
   }
 
   return newNode;

--- a/modules/tinymce/src/core/main/ts/delete/Outdent.ts
+++ b/modules/tinymce/src/core/main/ts/delete/Outdent.ts
@@ -12,7 +12,7 @@ const backspaceDelete = (editor: Editor): Optional<() => void> => {
     const rng = editor.selection.getRng();
     const pos = CaretPosition.fromRangeStart(rng);
     const block = dom.getParent(rng.startContainer, dom.isBlock);
-    if (block !== null && BlockBoundary.isAtStartOfBlock(SugarElement.fromDom(block), pos)) {
+    if (block !== null && BlockBoundary.isAtStartOfBlock(SugarElement.fromDom(block), pos, editor.schema)) {
       return Optional.some(() => IndentOutdent.outdent(editor));
     }
   }

--- a/modules/tinymce/src/core/main/ts/dom/ElementType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/ElementType.ts
@@ -44,7 +44,7 @@ const lazyLookup = <T extends Node = HTMLElement>(items: string[]) => {
 const getBlockElements = (schema?: Schema) => schema ? Obj.mapToArray(schema.getBlockElements(), (_v, k) => k) : [];
 
 const isHeading = lazyLookup<HTMLHeadingElement>(headings);
-const isBlock = (schema?: Schema): any => schema ? lazyLookup(blocks.concat(getBlockElements(schema))) : lazyLookup(blocks);
+const isBlock = (schema?: Schema): (node: SugarElement<Node>) => node is SugarElement<HTMLElement> => schema ? lazyLookup(blocks.concat(getBlockElements(schema))) : lazyLookup(blocks);
 const isTable = (node: SugarElement<Node>): node is SugarElement<HTMLTableElement> => SugarNode.name(node) === 'table';
 const isInline = (node: SugarElement<Node>, schema?: Schema): node is SugarElement<HTMLElement> => SugarNode.isElement(node) && !isBlock(schema)(node);
 const isBr = (node: SugarElement<Node>): node is SugarElement<HTMLBRElement> => SugarNode.isElement(node) && SugarNode.name(node) === 'br';

--- a/modules/tinymce/src/core/main/ts/dom/ElementType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/ElementType.ts
@@ -3,15 +3,6 @@ import { SugarElement, SugarNode } from '@ephox/sugar';
 
 import Schema from '../api/html/Schema';
 
-const blocks = [
-  'article', 'aside', 'details', 'div', 'dt', 'figcaption', 'footer',
-  'form', 'fieldset', 'header', 'hgroup', 'html', 'main', 'nav',
-  'section', 'summary', 'body', 'p', 'dl', 'multicol', 'dd', 'figure',
-  'address', 'center', 'blockquote', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-  'listing', 'xmp', 'pre', 'plaintext', 'menu', 'dir', 'ul', 'ol', 'li', 'hr',
-  'table', 'tbody', 'thead', 'tfoot', 'th', 'tr', 'td', 'caption'
-];
-
 const voids = [
   'area', 'base', 'basefont', 'br', 'col', 'frame', 'hr', 'img', 'input',
   'isindex', 'link', 'meta', 'param', 'embed', 'source', 'wbr', 'track'
@@ -41,12 +32,10 @@ const lazyLookup = <T extends Node = HTMLElement>(items: string[]) => {
   };
 };
 
-const getBlockElements = (schema?: Schema) => schema ? Obj.mapToArray(schema.getBlockElements(), (_v, k) => k) : [];
-
 const isHeading = lazyLookup<HTMLHeadingElement>(headings);
-const isBlock = (schema?: Schema): (node: SugarElement<Node>) => node is SugarElement<HTMLElement> => schema ? lazyLookup(blocks.concat(getBlockElements(schema))) : lazyLookup(blocks);
+const isBlock = (node: SugarElement<Node>, schema: Schema): node is SugarElement<Element> => schema.isBlock(SugarNode.name(node));
 const isTable = (node: SugarElement<Node>): node is SugarElement<HTMLTableElement> => SugarNode.name(node) === 'table';
-const isInline = (node: SugarElement<Node>, schema?: Schema): node is SugarElement<HTMLElement> => SugarNode.isElement(node) && !isBlock(schema)(node);
+const isInline = (node: SugarElement<Node>, schema: Schema): node is SugarElement<HTMLElement> => SugarNode.isElement(node) && !isBlock(node, schema);
 const isBr = (node: SugarElement<Node>): node is SugarElement<HTMLBRElement> => SugarNode.isElement(node) && SugarNode.name(node) === 'br';
 const isTextBlock = lazyLookup(textBlocks);
 const isList = lazyLookup(lists);
@@ -56,7 +45,7 @@ const isTableSection = lazyLookup(tableSections);
 const isTableCell = lazyLookup<HTMLTableCellElement>(tableCells);
 const isWsPreserveElement = lazyLookup(wsElements);
 const isWrapBlockElement = lazyLookup(wrapBlockElements);
-const isWrapElement = (node: SugarElement<Node>, schema?: Schema): boolean => isWrapBlockElement(node) || isInline(node, schema);
+const isWrapElement = (node: SugarElement<Node>, schema: Schema): boolean => isWrapBlockElement(node) || isInline(node, schema);
 
 export {
   isBlock,

--- a/modules/tinymce/src/core/main/ts/dom/ElementType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/ElementType.ts
@@ -1,6 +1,8 @@
 import { Arr, Fun, Obj } from '@ephox/katamari';
 import { SugarElement, SugarNode } from '@ephox/sugar';
 
+import Schema from '../api/html/Schema';
+
 const blocks = [
   'article', 'aside', 'details', 'div', 'dt', 'figcaption', 'footer',
   'form', 'fieldset', 'header', 'hgroup', 'html', 'main', 'nav',
@@ -39,10 +41,12 @@ const lazyLookup = <T extends Node = HTMLElement>(items: string[]) => {
   };
 };
 
+const getBlockElements = (schema?: Schema) => schema ? Obj.mapToArray(schema.getBlockElements(), (_v, k) => k) : [];
+
 const isHeading = lazyLookup<HTMLHeadingElement>(headings);
-const isBlock = lazyLookup(blocks);
+const isBlock = (schema?: Schema): any => schema ? lazyLookup(blocks.concat(getBlockElements(schema))) : lazyLookup(blocks);
 const isTable = (node: SugarElement<Node>): node is SugarElement<HTMLTableElement> => SugarNode.name(node) === 'table';
-const isInline = (node: SugarElement<Node>): node is SugarElement<HTMLElement> => SugarNode.isElement(node) && !isBlock(node);
+const isInline = (node: SugarElement<Node>, schema?: Schema): node is SugarElement<HTMLElement> => SugarNode.isElement(node) && !isBlock(schema)(node);
 const isBr = (node: SugarElement<Node>): node is SugarElement<HTMLBRElement> => SugarNode.isElement(node) && SugarNode.name(node) === 'br';
 const isTextBlock = lazyLookup(textBlocks);
 const isList = lazyLookup(lists);
@@ -52,7 +56,7 @@ const isTableSection = lazyLookup(tableSections);
 const isTableCell = lazyLookup<HTMLTableCellElement>(tableCells);
 const isWsPreserveElement = lazyLookup(wsElements);
 const isWrapBlockElement = lazyLookup(wrapBlockElements);
-const isWrapElement = (node: SugarElement<Node>): boolean => isWrapBlockElement(node) || isInline(node);
+const isWrapElement = (node: SugarElement<Node>, schema?: Schema): boolean => isWrapBlockElement(node) || isInline(node, schema);
 
 export {
   isBlock,

--- a/modules/tinymce/src/core/main/ts/dom/ElementType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/ElementType.ts
@@ -28,7 +28,6 @@ const lazyLookup = <T extends Node = HTMLElement>(items: string[]) => {
 };
 
 const isTable = (node: SugarElement<Node>): node is SugarElement<HTMLTableElement> => SugarNode.name(node) === 'table';
-const isInline = (node: SugarElement<Node>, schema: Schema): node is SugarElement<HTMLElement> => SugarNode.isElement(node) && !schema.isBlock(SugarNode.name(node));
 const isBr = (node: SugarElement<Node>): node is SugarElement<HTMLBRElement> => SugarNode.isElement(node) && SugarNode.name(node) === 'br';
 const isTextBlock = lazyLookup(textBlocks);
 const isList = lazyLookup(lists);
@@ -37,11 +36,10 @@ const isTableSection = lazyLookup(tableSections);
 const isTableCell = lazyLookup<HTMLTableCellElement>(tableCells);
 const isWsPreserveElement = lazyLookup(wsElements);
 const isWrapBlockElement = lazyLookup(wrapBlockElements);
-const isWrapElement = (node: SugarElement<Node>, schema: Schema): boolean => isWrapBlockElement(node) || isInline(node, schema);
+const isWrapElement = (node: SugarElement<Node>, schema: Schema): boolean => isWrapBlockElement(node) || schema.isInline(SugarNode.name(node));
 
 export {
   isTable,
-  isInline,
   isTextBlock,
   isList,
   isListItem,

--- a/modules/tinymce/src/core/main/ts/dom/ElementType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/ElementType.ts
@@ -3,11 +3,6 @@ import { SugarElement, SugarNode } from '@ephox/sugar';
 
 import Schema from '../api/html/Schema';
 
-const voids = [
-  'area', 'base', 'basefont', 'br', 'col', 'frame', 'hr', 'img', 'input',
-  'isindex', 'link', 'meta', 'param', 'embed', 'source', 'wbr', 'track'
-];
-
 const tableCells = [ 'td', 'th' ];
 const tableSections = [ 'thead', 'tbody', 'tfoot' ];
 
@@ -32,7 +27,6 @@ const lazyLookup = <T extends Node = HTMLElement>(items: string[]) => {
   };
 };
 
-const isHeading = lazyLookup<HTMLHeadingElement>(headings);
 const isBlock = (node: SugarElement<Node>, schema: Schema): node is SugarElement<Element> => schema.isBlock(SugarNode.name(node));
 const isTable = (node: SugarElement<Node>): node is SugarElement<HTMLTableElement> => SugarNode.name(node) === 'table';
 const isInline = (node: SugarElement<Node>, schema: Schema): node is SugarElement<HTMLElement> => SugarNode.isElement(node) && !isBlock(node, schema);
@@ -40,7 +34,6 @@ const isBr = (node: SugarElement<Node>): node is SugarElement<HTMLBRElement> => 
 const isTextBlock = lazyLookup(textBlocks);
 const isList = lazyLookup(lists);
 const isListItem = lazyLookup(listItems);
-const isVoid = lazyLookup(voids);
 const isTableSection = lazyLookup(tableSections);
 const isTableCell = lazyLookup<HTMLTableCellElement>(tableCells);
 const isWsPreserveElement = lazyLookup(wsElements);
@@ -51,11 +44,9 @@ export {
   isBlock,
   isTable,
   isInline,
-  isHeading,
   isTextBlock,
   isList,
   isListItem,
-  isVoid,
   isTableSection,
   isTableCell,
   isBr,

--- a/modules/tinymce/src/core/main/ts/dom/ElementType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/ElementType.ts
@@ -1,8 +1,6 @@
 import { Arr, Fun, Obj } from '@ephox/katamari';
 import { SugarElement, SugarNode } from '@ephox/sugar';
 
-import Schema from '../api/html/Schema';
-
 const tableCells = [ 'td', 'th' ];
 const tableSections = [ 'thead', 'tbody', 'tfoot' ];
 
@@ -12,12 +10,9 @@ const textBlocks = [
   'section', 'hgroup', 'aside', 'nav', 'figure'
 ];
 
-const headings = [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ];
 const listItems = [ 'li', 'dd', 'dt' ];
 const lists = [ 'ul', 'ol', 'dl' ];
 const wsElements = [ 'pre', 'script', 'textarea', 'style' ];
-
-const wrapBlockElements = [ 'pre' ].concat(headings);
 
 const lazyLookup = <T extends Node = HTMLElement>(items: string[]) => {
   let lookup: Record<string, boolean> | undefined;
@@ -35,8 +30,6 @@ const isListItem = lazyLookup(listItems);
 const isTableSection = lazyLookup(tableSections);
 const isTableCell = lazyLookup<HTMLTableCellElement>(tableCells);
 const isWsPreserveElement = lazyLookup(wsElements);
-const isWrapBlockElement = lazyLookup(wrapBlockElements);
-const isWrapElement = (node: SugarElement<Node>, schema: Schema): boolean => isWrapBlockElement(node) || schema.isInline(SugarNode.name(node));
 
 export {
   isTable,
@@ -46,6 +39,5 @@ export {
   isTableSection,
   isTableCell,
   isBr,
-  isWsPreserveElement,
-  isWrapElement
+  isWsPreserveElement
 };

--- a/modules/tinymce/src/core/main/ts/dom/ElementType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/ElementType.ts
@@ -27,9 +27,8 @@ const lazyLookup = <T extends Node = HTMLElement>(items: string[]) => {
   };
 };
 
-const isBlock = (node: SugarElement<Node>, schema: Schema): node is SugarElement<Element> => schema.isBlock(SugarNode.name(node));
 const isTable = (node: SugarElement<Node>): node is SugarElement<HTMLTableElement> => SugarNode.name(node) === 'table';
-const isInline = (node: SugarElement<Node>, schema: Schema): node is SugarElement<HTMLElement> => SugarNode.isElement(node) && !isBlock(node, schema);
+const isInline = (node: SugarElement<Node>, schema: Schema): node is SugarElement<HTMLElement> => SugarNode.isElement(node) && !schema.isBlock(SugarNode.name(node));
 const isBr = (node: SugarElement<Node>): node is SugarElement<HTMLBRElement> => SugarNode.isElement(node) && SugarNode.name(node) === 'br';
 const isTextBlock = lazyLookup(textBlocks);
 const isList = lazyLookup(lists);
@@ -41,7 +40,6 @@ const isWrapBlockElement = lazyLookup(wrapBlockElements);
 const isWrapElement = (node: SugarElement<Node>, schema: Schema): boolean => isWrapBlockElement(node) || isInline(node, schema);
 
 export {
-  isBlock,
   isTable,
   isInline,
   isTextBlock,

--- a/modules/tinymce/src/core/main/ts/dom/ElementType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/ElementType.ts
@@ -22,6 +22,7 @@ const lazyLookup = <T extends Node = HTMLElement>(items: string[]) => {
   };
 };
 
+// WARNING: don't add anything to this file, the intention is to move these checks into the Schema
 const isTable = (node: SugarElement<Node>): node is SugarElement<HTMLTableElement> => SugarNode.name(node) === 'table';
 const isBr = (node: SugarElement<Node>): node is SugarElement<HTMLBRElement> => SugarNode.isElement(node) && SugarNode.name(node) === 'br';
 const isTextBlock = lazyLookup(textBlocks);

--- a/modules/tinymce/src/core/main/ts/dom/PaddingBr.ts
+++ b/modules/tinymce/src/core/main/ts/dom/PaddingBr.ts
@@ -1,6 +1,7 @@
 import { Arr, Unicode } from '@ephox/katamari';
 import { Attribute, Insert, Remove, SelectorFilter, SugarElement, SugarNode, SugarText, Traverse } from '@ephox/sugar';
 
+import Schema from '../api/html/Schema';
 import * as ElementType from './ElementType';
 
 const getLastChildren = (elm: SugarElement<Node>): SugarElement<Node>[] => {
@@ -42,10 +43,10 @@ const isPaddedElement = (elm: SugarElement<Node>): boolean => {
   return Arr.filter(Traverse.children(elm), isPaddingContents).length === 1;
 };
 
-const trimBlockTrailingBr = (elm: SugarElement<Node>): void => {
+const trimBlockTrailingBr = (elm: SugarElement<Node>, schema: Schema): void => {
   Traverse.lastChild(elm).each((lastChild) => {
     Traverse.prevSibling(lastChild).each((lastChildPrevSibling) => {
-      if (ElementType.isBlock()(elm) && ElementType.isBr(lastChild) && ElementType.isBlock()(lastChildPrevSibling)) {
+      if (ElementType.isBlock(elm, schema) && ElementType.isBr(lastChild) && ElementType.isBlock(lastChildPrevSibling, schema)) {
         Remove.remove(lastChild);
       }
     });

--- a/modules/tinymce/src/core/main/ts/dom/PaddingBr.ts
+++ b/modules/tinymce/src/core/main/ts/dom/PaddingBr.ts
@@ -45,7 +45,7 @@ const isPaddedElement = (elm: SugarElement<Node>): boolean => {
 const trimBlockTrailingBr = (elm: SugarElement<Node>): void => {
   Traverse.lastChild(elm).each((lastChild) => {
     Traverse.prevSibling(lastChild).each((lastChildPrevSibling) => {
-      if (ElementType.isBlock(elm) && ElementType.isBr(lastChild) && ElementType.isBlock(lastChildPrevSibling)) {
+      if (ElementType.isBlock()(elm) && ElementType.isBr(lastChild) && ElementType.isBlock()(lastChildPrevSibling)) {
         Remove.remove(lastChild);
       }
     });

--- a/modules/tinymce/src/core/main/ts/dom/PaddingBr.ts
+++ b/modules/tinymce/src/core/main/ts/dom/PaddingBr.ts
@@ -46,7 +46,7 @@ const isPaddedElement = (elm: SugarElement<Node>): boolean => {
 const trimBlockTrailingBr = (elm: SugarElement<Node>, schema: Schema): void => {
   Traverse.lastChild(elm).each((lastChild) => {
     Traverse.prevSibling(lastChild).each((lastChildPrevSibling) => {
-      if (ElementType.isBlock(elm, schema) && ElementType.isBr(lastChild) && ElementType.isBlock(lastChildPrevSibling, schema)) {
+      if (schema.isBlock(SugarNode.name(elm)) && ElementType.isBr(lastChild) && schema.isBlock(SugarNode.name(lastChildPrevSibling))) {
         Remove.remove(lastChild);
       }
     });

--- a/modules/tinymce/src/core/main/ts/dom/TrimNode.ts
+++ b/modules/tinymce/src/core/main/ts/dom/TrimNode.ts
@@ -3,6 +3,7 @@ import { SugarElement } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import DomTreeWalker from '../api/dom/TreeWalker';
+import Schema from '../api/html/Schema';
 import * as ElementType from './ElementType';
 import { isContent } from './Empty';
 import * as NodeType from './NodeType';
@@ -10,15 +11,15 @@ import * as NodeType from './NodeType';
 const isSpan = (node: Node): node is HTMLSpanElement =>
   node.nodeName.toLowerCase() === 'span';
 
-const isInlineContent = (node: Node | null, root: Node): boolean =>
-  Type.isNonNullable(node) && (isContent(node, root) || ElementType.isInline(SugarElement.fromDom(node)));
+const isInlineContent = (node: Node | null, root: Node, schema: Schema): boolean =>
+  Type.isNonNullable(node) && (isContent(node, root) || ElementType.isInline(SugarElement.fromDom(node), schema));
 
-const surroundedByInlineContent = (node: Node, root: Node): boolean => {
+const surroundedByInlineContent = (node: Node, root: Node, schema: Schema): boolean => {
   const prev = new DomTreeWalker(node, root).prev(false);
   const next = new DomTreeWalker(node, root).next(false);
   // Check if the next/previous is either inline content or the start/end (eg is undefined)
-  const prevIsInline = Type.isUndefined(prev) || isInlineContent(prev, root);
-  const nextIsInline = Type.isUndefined(next) || isInlineContent(next, root);
+  const prevIsInline = Type.isUndefined(prev) || isInlineContent(prev, root, schema);
+  const nextIsInline = Type.isUndefined(next) || isInlineContent(next, root, schema);
   return prevIsInline && nextIsInline;
 };
 
@@ -27,8 +28,8 @@ const isBookmarkNode = (node: Node): boolean =>
 
 // Keep text nodes with only spaces if surrounded by spans.
 // eg. "<p><span>a</span> <span>b</span></p>" should keep space between a and b
-const isKeepTextNode = (node: Node, root: Node): boolean =>
-  NodeType.isText(node) && node.data.length > 0 && surroundedByInlineContent(node, root);
+const isKeepTextNode = (node: Node, root: Node, schema: Schema): boolean =>
+  NodeType.isText(node) && node.data.length > 0 && surroundedByInlineContent(node, root, schema);
 
 // Keep elements as long as they have any children
 const isKeepElement = (node: Node): boolean =>
@@ -45,7 +46,7 @@ const isDocument = (node: Node): boolean =>
 //   <p>text 1<span></span></p><b>CHOP</b><p><span></span>text 2</p>
 // this function will then trim off empty edges and produce:
 //   <p>text 1</p><b>CHOP</b><p>text 2</p>
-const trimNode = <T extends Node>(dom: DOMUtils, node: T, root?: Node): T => {
+const trimNode = <T extends Node>(dom: DOMUtils, node: T, schema: Schema, root?: Node): T => {
   const rootNode = root || node;
   if (NodeType.isElement(node) && isBookmarkNode(node)) {
     return node;
@@ -53,7 +54,7 @@ const trimNode = <T extends Node>(dom: DOMUtils, node: T, root?: Node): T => {
 
   const children = node.childNodes;
   for (let i = children.length - 1; i >= 0; i--) {
-    trimNode(dom, children[i], rootNode);
+    trimNode(dom, children[i], schema, rootNode);
   }
 
   // If the only child is a bookmark then move it up
@@ -65,7 +66,7 @@ const trimNode = <T extends Node>(dom: DOMUtils, node: T, root?: Node): T => {
   }
 
   // Remove any empty nodes
-  if (!isDocument(node) && !isContent(node, rootNode) && !isKeepElement(node) && !isKeepTextNode(node, rootNode)) {
+  if (!isDocument(node) && !isContent(node, rootNode) && !isKeepElement(node) && !isKeepTextNode(node, rootNode, schema)) {
     dom.remove(node);
   }
 

--- a/modules/tinymce/src/core/main/ts/dom/TrimNode.ts
+++ b/modules/tinymce/src/core/main/ts/dom/TrimNode.ts
@@ -1,10 +1,8 @@
 import { Type } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import DomTreeWalker from '../api/dom/TreeWalker';
 import Schema from '../api/html/Schema';
-import * as ElementType from './ElementType';
 import { isContent } from './Empty';
 import * as NodeType from './NodeType';
 
@@ -12,7 +10,7 @@ const isSpan = (node: Node): node is HTMLSpanElement =>
   node.nodeName.toLowerCase() === 'span';
 
 const isInlineContent = (node: Node | null, root: Node, schema: Schema): boolean =>
-  Type.isNonNullable(node) && (isContent(node, root) || ElementType.isInline(SugarElement.fromDom(node), schema));
+  Type.isNonNullable(node) && (isContent(node, root) || schema.isInline(node.nodeName.toLowerCase()));
 
 const surroundedByInlineContent = (node: Node, root: Node, schema: Schema): boolean => {
   const prev = new DomTreeWalker(node, root).prev(false);

--- a/modules/tinymce/src/core/main/ts/keyboard/ContentEndpointNavigation.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/ContentEndpointNavigation.ts
@@ -5,14 +5,13 @@ import Editor from '../api/Editor';
 import Schema from '../api/html/Schema';
 import CaretPosition from '../caret/CaretPosition';
 import { isAtFirstLine, isAtLastLine } from '../caret/LineReader';
-import * as ElementType from '../dom/ElementType';
 import * as ForceBlocks from '../ForceBlocks';
 
 const isTarget = (node: SugarElement<Node>) => Arr.contains([ 'figcaption' ], SugarNode.name(node));
 
 const getClosestTargetBlock = (pos: CaretPosition, root: SugarElement<HTMLElement>, schema: Schema) => {
   const isRoot = Fun.curry(Compare.eq, root);
-  return PredicateFind.closest(SugarElement.fromDom(pos.container()), (el) => ElementType.isBlock(el, schema), isRoot).filter(isTarget);
+  return PredicateFind.closest(SugarElement.fromDom(pos.container()), (el) => schema.isBlock(SugarNode.name(el)), isRoot).filter(isTarget);
 };
 
 const isAtFirstOrLastLine = (root: SugarElement<HTMLElement>, forward: boolean, pos: CaretPosition) =>

--- a/modules/tinymce/src/core/main/ts/keyboard/ContentEndpointNavigation.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/ContentEndpointNavigation.ts
@@ -11,7 +11,7 @@ const isTarget = (node: SugarElement<Node>) => Arr.contains([ 'figcaption' ], Su
 
 const getClosestTargetBlock = (pos: CaretPosition, root: SugarElement<HTMLElement>) => {
   const isRoot = Fun.curry(Compare.eq, root);
-  return PredicateFind.closest(SugarElement.fromDom(pos.container()), ElementType.isBlock, isRoot).filter(isTarget);
+  return PredicateFind.closest(SugarElement.fromDom(pos.container()), ElementType.isBlock(), isRoot).filter(isTarget);
 };
 
 const isAtFirstOrLastLine = (root: SugarElement<HTMLElement>, forward: boolean, pos: CaretPosition) =>

--- a/modules/tinymce/src/core/main/ts/keyboard/ContentEndpointNavigation.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/ContentEndpointNavigation.ts
@@ -2,6 +2,7 @@ import { Arr, Fun } from '@ephox/katamari';
 import { Compare, Insert, PredicateFind, SugarElement, SugarNode } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
+import Schema from '../api/html/Schema';
 import CaretPosition from '../caret/CaretPosition';
 import { isAtFirstLine, isAtLastLine } from '../caret/LineReader';
 import * as ElementType from '../dom/ElementType';
@@ -9,9 +10,9 @@ import * as ForceBlocks from '../ForceBlocks';
 
 const isTarget = (node: SugarElement<Node>) => Arr.contains([ 'figcaption' ], SugarNode.name(node));
 
-const getClosestTargetBlock = (pos: CaretPosition, root: SugarElement<HTMLElement>) => {
+const getClosestTargetBlock = (pos: CaretPosition, root: SugarElement<HTMLElement>, schema: Schema) => {
   const isRoot = Fun.curry(Compare.eq, root);
-  return PredicateFind.closest(SugarElement.fromDom(pos.container()), ElementType.isBlock(), isRoot).filter(isTarget);
+  return PredicateFind.closest(SugarElement.fromDom(pos.container()), (el) => ElementType.isBlock(el, schema), isRoot).filter(isTarget);
 };
 
 const isAtFirstOrLastLine = (root: SugarElement<HTMLElement>, forward: boolean, pos: CaretPosition) =>
@@ -21,7 +22,7 @@ const moveCaretToNewEmptyLine = (editor: Editor, forward: boolean) => {
   const root = SugarElement.fromDom(editor.getBody());
   const pos = CaretPosition.fromRangeStart(editor.selection.getRng());
 
-  return getClosestTargetBlock(pos, root).exists(() => {
+  return getClosestTargetBlock(pos, root, editor.schema).exists(() => {
     if (isAtFirstOrLastLine(root, forward, pos)) {
       const insertFn = forward ? Insert.append : Insert.prepend;
       const rng = ForceBlocks.insertEmptyLine(editor, root, insertFn);

--- a/modules/tinymce/src/core/main/ts/keyboard/Nbsps.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/Nbsps.ts
@@ -17,7 +17,7 @@ import { isContent, isNbsp, isWhiteSpace } from '../text/CharType';
 const isInMiddleOfText = (pos: CaretPosition) => CaretPosition.isTextPosition(pos) && !pos.isAtStart() && !pos.isAtEnd();
 
 const getClosestBlock = (root: SugarElement<Node>, pos: CaretPosition): SugarElement<Node> => {
-  const parentBlocks = Arr.filter(Parents.parentsAndSelf(SugarElement.fromDom(pos.container()), root), ElementType.isBlock);
+  const parentBlocks = Arr.filter(Parents.parentsAndSelf(SugarElement.fromDom(pos.container()), root), ElementType.isBlock());
   return Arr.head(parentBlocks).getOr(root);
 };
 

--- a/modules/tinymce/src/core/main/ts/keyboard/Nbsps.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/Nbsps.ts
@@ -3,6 +3,7 @@ import { Css, PredicateFind, SugarElement, SugarNode } from '@ephox/sugar';
 
 import DomTreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
+import Schema from '../api/html/Schema';
 import { isAfterBlock, isAtEndOfBlock, isAtStartOfBlock, isBeforeBlock } from '../caret/BlockBoundary';
 import { isAfterBr, isBeforeBr } from '../caret/CaretBr';
 import * as CaretFinder from '../caret/CaretFinder';
@@ -16,24 +17,24 @@ import { isContent, isNbsp, isWhiteSpace } from '../text/CharType';
 
 const isInMiddleOfText = (pos: CaretPosition) => CaretPosition.isTextPosition(pos) && !pos.isAtStart() && !pos.isAtEnd();
 
-const getClosestBlock = (root: SugarElement<Node>, pos: CaretPosition): SugarElement<Node> => {
-  const parentBlocks = Arr.filter(Parents.parentsAndSelf(SugarElement.fromDom(pos.container()), root), ElementType.isBlock());
+const getClosestBlock = (root: SugarElement<Node>, pos: CaretPosition, schema: Schema): SugarElement<Node> => {
+  const parentBlocks = Arr.filter(Parents.parentsAndSelf(SugarElement.fromDom(pos.container()), root), (el) => ElementType.isBlock(el, schema));
   return Arr.head(parentBlocks).getOr(root);
 };
 
-const hasSpaceBefore = (root: SugarElement<Node>, pos: CaretPosition): boolean => {
+const hasSpaceBefore = (root: SugarElement<Node>, pos: CaretPosition, schema: Schema): boolean => {
   if (isInMiddleOfText(pos)) {
     return isAfterSpace(pos);
   } else {
-    return isAfterSpace(pos) || CaretFinder.prevPosition(getClosestBlock(root, pos).dom, pos).exists(isAfterSpace);
+    return isAfterSpace(pos) || CaretFinder.prevPosition(getClosestBlock(root, pos, schema).dom, pos).exists(isAfterSpace);
   }
 };
 
-const hasSpaceAfter = (root: SugarElement<Node>, pos: CaretPosition): boolean => {
+const hasSpaceAfter = (root: SugarElement<Node>, pos: CaretPosition, schema: Schema): boolean => {
   if (isInMiddleOfText(pos)) {
     return isBeforeSpace(pos);
   } else {
-    return isBeforeSpace(pos) || CaretFinder.nextPosition(getClosestBlock(root, pos).dom, pos).exists(isBeforeSpace);
+    return isBeforeSpace(pos) || CaretFinder.nextPosition(getClosestBlock(root, pos, schema).dom, pos).exists(isBeforeSpace);
   }
 };
 
@@ -46,13 +47,13 @@ const isInPre = (pos: CaretPosition) => getElementFromPosition(pos)
 const isAtBeginningOfBody = (root: SugarElement<Node>, pos: CaretPosition) => CaretFinder.prevPosition(root.dom, pos).isNone();
 const isAtEndOfBody = (root: SugarElement<Node>, pos: CaretPosition) => CaretFinder.nextPosition(root.dom, pos).isNone();
 
-const isAtLineBoundary = (root: SugarElement<Node>, pos: CaretPosition): boolean => (
+const isAtLineBoundary = (root: SugarElement<Node>, pos: CaretPosition, schema: Schema): boolean => (
   isAtBeginningOfBody(root, pos) ||
     isAtEndOfBody(root, pos) ||
-    isAtStartOfBlock(root, pos) ||
-    isAtEndOfBlock(root, pos) ||
-    isAfterBr(root, pos) ||
-    isBeforeBr(root, pos)
+    isAtStartOfBlock(root, pos, schema) ||
+    isAtEndOfBlock(root, pos, schema) ||
+    isAfterBr(root, pos, schema) ||
+    isBeforeBr(root, pos, schema)
 );
 
 const isCefBlock = (node: Node | null | undefined): node is HTMLElement =>
@@ -76,19 +77,19 @@ const isAfterCefBlock = (root: SugarElement, pos: CaretPosition) => {
   return pos.isAtStart() && (isPrevCefBlock(pos.container()) || isPrevCefBlock(prevPos.container()));
 };
 
-const needsToHaveNbsp = (root: SugarElement<Node>, pos: CaretPosition): boolean => {
+const needsToHaveNbsp = (root: SugarElement<Node>, pos: CaretPosition, schema: Schema): boolean => {
   if (isInPre(pos)) {
     return false;
   } else {
-    return isAtLineBoundary(root, pos) || hasSpaceBefore(root, pos) || hasSpaceAfter(root, pos);
+    return isAtLineBoundary(root, pos, schema) || hasSpaceBefore(root, pos, schema) || hasSpaceAfter(root, pos, schema);
   }
 };
 
-const needsToBeNbspLeft = (root: SugarElement<Node>, pos: CaretPosition): boolean => {
+const needsToBeNbspLeft = (root: SugarElement<Node>, pos: CaretPosition, schema: Schema): boolean => {
   if (isInPre(pos)) {
     return false;
   } else {
-    return isAtStartOfBlock(root, pos) || isBeforeBlock(root, pos) || isAfterBr(root, pos) || hasSpaceBefore(root, pos) || isAfterCefBlock(root, pos);
+    return isAtStartOfBlock(root, pos, schema) || isBeforeBlock(root, pos, schema) || isAfterBr(root, pos, schema) || hasSpaceBefore(root, pos, schema) || isAfterCefBlock(root, pos);
   }
 };
 
@@ -103,16 +104,16 @@ const leanRight = (pos: CaretPosition): CaretPosition => {
   }
 };
 
-const needsToBeNbspRight = (root: SugarElement<Node>, pos: CaretPosition): boolean => {
+const needsToBeNbspRight = (root: SugarElement<Node>, pos: CaretPosition, schema: Schema): boolean => {
   if (isInPre(pos)) {
     return false;
   } else {
-    return isAtEndOfBlock(root, pos) || isAfterBlock(root, pos) || isBeforeBr(root, pos) || hasSpaceAfter(root, pos) || isBeforeCefBlock(root, pos);
+    return isAtEndOfBlock(root, pos, schema) || isAfterBlock(root, pos, schema) || isBeforeBr(root, pos, schema) || hasSpaceAfter(root, pos, schema) || isBeforeCefBlock(root, pos);
   }
 };
 
-const needsToBeNbsp = (root: SugarElement<Node>, pos: CaretPosition): boolean =>
-  needsToBeNbspLeft(root, pos) || needsToBeNbspRight(root, leanRight(pos));
+const needsToBeNbsp = (root: SugarElement<Node>, pos: CaretPosition, schema: Schema): boolean =>
+  needsToBeNbspLeft(root, pos, schema) || needsToBeNbspRight(root, leanRight(pos), schema);
 
 const isNbspAt = (text: string, offset: number): boolean =>
   isNbsp(text.charAt(offset));
@@ -136,14 +137,14 @@ const normalizeNbspMiddle = (text: string): string => {
   }).join('');
 };
 
-const normalizeNbspAtStart = (root: SugarElement<Node>, node: Text, makeNbsp: boolean): boolean => {
+const normalizeNbspAtStart = (root: SugarElement<Node>, node: Text, makeNbsp: boolean, schema: Schema): boolean => {
   const text = node.data;
   const firstPos = CaretPosition(node, 0);
 
-  if (!makeNbsp && isNbspAt(text, 0) && !needsToBeNbsp(root, firstPos)) {
+  if (!makeNbsp && isNbspAt(text, 0) && !needsToBeNbsp(root, firstPos, schema)) {
     node.data = ' ' + text.slice(1);
     return true;
-  } else if (makeNbsp && isWhiteSpaceAt(text, 0) && needsToBeNbspLeft(root, firstPos)) {
+  } else if (makeNbsp && isWhiteSpaceAt(text, 0) && needsToBeNbspLeft(root, firstPos, schema)) {
     node.data = Unicode.nbsp + text.slice(1);
     return true;
   } else {
@@ -162,13 +163,13 @@ const normalizeNbspInMiddleOfTextNode = (node: Text): boolean => {
   }
 };
 
-const normalizeNbspAtEnd = (root: SugarElement<Node>, node: Text, makeNbsp: boolean): boolean => {
+const normalizeNbspAtEnd = (root: SugarElement<Node>, node: Text, makeNbsp: boolean, schema: Schema): boolean => {
   const text = node.data;
   const lastPos = CaretPosition(node, text.length - 1);
-  if (!makeNbsp && isNbspAt(text, text.length - 1) && !needsToBeNbsp(root, lastPos)) {
+  if (!makeNbsp && isNbspAt(text, text.length - 1) && !needsToBeNbsp(root, lastPos, schema)) {
     node.data = text.slice(0, -1) + ' ';
     return true;
-  } else if (makeNbsp && isWhiteSpaceAt(text, text.length - 1) && needsToBeNbspRight(root, lastPos)) {
+  } else if (makeNbsp && isWhiteSpaceAt(text, text.length - 1) && needsToBeNbspRight(root, lastPos, schema)) {
     node.data = text.slice(0, -1) + Unicode.nbsp;
     return true;
   } else {
@@ -176,17 +177,17 @@ const normalizeNbspAtEnd = (root: SugarElement<Node>, node: Text, makeNbsp: bool
   }
 };
 
-const normalizeNbsps = (root: SugarElement<Node>, pos: CaretPosition): Optional<CaretPosition> => {
+const normalizeNbsps = (root: SugarElement<Node>, pos: CaretPosition, schema: Schema): Optional<CaretPosition> => {
   const container = pos.container();
   if (!NodeType.isText(container)) {
     return Optional.none();
   }
 
   if (hasNbsp(pos)) {
-    const normalized = normalizeNbspAtStart(root, container, false) || normalizeNbspInMiddleOfTextNode(container) || normalizeNbspAtEnd(root, container, false);
+    const normalized = normalizeNbspAtStart(root, container, false, schema) || normalizeNbspInMiddleOfTextNode(container) || normalizeNbspAtEnd(root, container, false, schema);
     return Optionals.someIf(normalized, pos);
-  } else if (needsToBeNbsp(root, pos)) {
-    const normalized = normalizeNbspAtStart(root, container, true) || normalizeNbspAtEnd(root, container, true);
+  } else if (needsToBeNbsp(root, pos, schema)) {
+    const normalized = normalizeNbspAtStart(root, container, true, schema) || normalizeNbspAtEnd(root, container, true, schema);
     return Optionals.someIf(normalized, pos);
   } else {
     return Optional.none();
@@ -197,7 +198,7 @@ const normalizeNbspsInEditor = (editor: Editor): void => {
   const root = SugarElement.fromDom(editor.getBody());
 
   if (editor.selection.isCollapsed()) {
-    normalizeNbsps(root, CaretPosition.fromRangeStart(editor.selection.getRng())).each((pos) => {
+    normalizeNbsps(root, CaretPosition.fromRangeStart(editor.selection.getRng()), editor.schema).each((pos) => {
       editor.selection.setRng(pos.toRange());
     });
   }

--- a/modules/tinymce/src/core/main/ts/keyboard/Nbsps.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/Nbsps.ts
@@ -10,7 +10,6 @@ import * as CaretFinder from '../caret/CaretFinder';
 import { CaretPosition } from '../caret/CaretPosition';
 import { isAfterSpace, isBeforeSpace } from '../caret/CaretPositionPredicates';
 import { getElementFromPosition, isBlockLike } from '../caret/CaretUtils';
-import * as ElementType from '../dom/ElementType';
 import * as NodeType from '../dom/NodeType';
 import * as Parents from '../dom/Parents';
 import { isContent, isNbsp, isWhiteSpace } from '../text/CharType';
@@ -18,7 +17,7 @@ import { isContent, isNbsp, isWhiteSpace } from '../text/CharType';
 const isInMiddleOfText = (pos: CaretPosition) => CaretPosition.isTextPosition(pos) && !pos.isAtStart() && !pos.isAtEnd();
 
 const getClosestBlock = (root: SugarElement<Node>, pos: CaretPosition, schema: Schema): SugarElement<Node> => {
-  const parentBlocks = Arr.filter(Parents.parentsAndSelf(SugarElement.fromDom(pos.container()), root), (el) => ElementType.isBlock(el, schema));
+  const parentBlocks = Arr.filter(Parents.parentsAndSelf(SugarElement.fromDom(pos.container()), root), (el) => schema.isBlock(SugarNode.name(el)));
   return Arr.head(parentBlocks).getOr(root);
 };
 

--- a/modules/tinymce/src/core/main/ts/schema/SchemaTypes.ts
+++ b/modules/tinymce/src/core/main/ts/schema/SchemaTypes.ts
@@ -11,6 +11,7 @@ export interface ElementSettings {
   void_elements?: string;
   whitespace_elements?: string;
   transparent_elements?: string;
+  wrap_block_elements?: string;
 }
 
 export interface SchemaSettings extends ElementSettings {

--- a/modules/tinymce/src/core/main/ts/selection/FragmentReader.ts
+++ b/modules/tinymce/src/core/main/ts/selection/FragmentReader.ts
@@ -1,6 +1,7 @@
 import { Arr, Fun, Obj, Optional, Strings } from '@ephox/katamari';
 import { Compare, Css, Insert, Replication, SelectorFind, SugarElement, SugarFragment, SugarNode, Traverse } from '@ephox/sugar';
 
+import Schema from '../api/html/Schema';
 import * as ElementType from '../dom/ElementType';
 import * as Parents from '../dom/Parents';
 import * as SelectionUtils from './SelectionUtils';
@@ -45,10 +46,10 @@ const directListWrappers = (commonAnchorContainer: SugarElement<Node>) => {
   }
 };
 
-const getWrapElements = (rootNode: SugarElement<Node>, rng: Range) => {
+const getWrapElements = (rootNode: SugarElement<Node>, rng: Range, schema: Schema) => {
   const commonAnchorContainer = SugarElement.fromDom(rng.commonAncestorContainer);
   const parents = Parents.parentsAndSelf(commonAnchorContainer, rootNode);
-  const wrapElements = Arr.filter(parents, ElementType.isWrapElement);
+  const wrapElements = Arr.filter(parents, (el) => ElementType.isWrapElement(el, schema));
   const listWrappers = getFullySelectedListWrappers(parents, rng);
   const allWrappers = wrapElements.concat(listWrappers.length ? listWrappers : directListWrappers(commonAnchorContainer));
   return Arr.map(allWrappers, Replication.shallow);
@@ -56,8 +57,8 @@ const getWrapElements = (rootNode: SugarElement<Node>, rng: Range) => {
 
 const emptyFragment = () => SugarFragment.fromElements([]);
 
-const getFragmentFromRange = (rootNode: SugarElement<Node>, rng: Range) =>
-  wrap(SugarElement.fromDom(rng.cloneContents()), getWrapElements(rootNode, rng));
+const getFragmentFromRange = (rootNode: SugarElement<Node>, rng: Range, schema: Schema) =>
+  wrap(SugarElement.fromDom(rng.cloneContents()), getWrapElements(rootNode, rng, schema));
 
 const getParentTable = (rootElm: SugarElement<Node>, cell: SugarElement<HTMLTableCellElement>): Optional<SugarElement<HTMLTableElement>> =>
   SelectorFind.ancestor(cell, 'table', Fun.curry(Compare.eq, rootElm));
@@ -73,12 +74,12 @@ const getTableFragment = (rootNode: SugarElement<Node>, selectedTableCells: Suga
     );
   }).getOrThunk(emptyFragment);
 
-const getSelectionFragment = (rootNode: SugarElement<Node>, ranges: Range[]) =>
-  ranges.length > 0 && ranges[0].collapsed ? emptyFragment() : getFragmentFromRange(rootNode, ranges[0]);
+const getSelectionFragment = (rootNode: SugarElement<Node>, ranges: Range[], schema: Schema) =>
+  ranges.length > 0 && ranges[0].collapsed ? emptyFragment() : getFragmentFromRange(rootNode, ranges[0], schema);
 
-const read = (rootNode: SugarElement<Element>, ranges: Range[]): SugarElement<Node> => {
+const read = (rootNode: SugarElement<Element>, ranges: Range[], schema: Schema): SugarElement<Node> => {
   const selectedCells = TableCellSelection.getCellsFromElementOrRanges(ranges, rootNode);
-  return selectedCells.length > 0 ? getTableFragment(rootNode, selectedCells) : getSelectionFragment(rootNode, ranges);
+  return selectedCells.length > 0 ? getTableFragment(rootNode, selectedCells) : getSelectionFragment(rootNode, ranges, schema);
 };
 
 export {

--- a/modules/tinymce/src/core/main/ts/selection/FragmentReader.ts
+++ b/modules/tinymce/src/core/main/ts/selection/FragmentReader.ts
@@ -49,7 +49,7 @@ const directListWrappers = (commonAnchorContainer: SugarElement<Node>) => {
 const getWrapElements = (rootNode: SugarElement<Node>, rng: Range, schema: Schema) => {
   const commonAnchorContainer = SugarElement.fromDom(rng.commonAncestorContainer);
   const parents = Parents.parentsAndSelf(commonAnchorContainer, rootNode);
-  const wrapElements = Arr.filter(parents, (el) => ElementType.isWrapElement(el, schema));
+  const wrapElements = Arr.filter(parents, (el) => schema.isWrapElement(SugarNode.name(el)));
   const listWrappers = getFullySelectedListWrappers(parents, rng);
   const allWrappers = wrapElements.concat(listWrappers.length ? listWrappers : directListWrappers(commonAnchorContainer));
   return Arr.map(allWrappers, Replication.shallow);

--- a/modules/tinymce/src/core/main/ts/selection/FragmentReader.ts
+++ b/modules/tinymce/src/core/main/ts/selection/FragmentReader.ts
@@ -49,7 +49,7 @@ const directListWrappers = (commonAnchorContainer: SugarElement<Node>) => {
 const getWrapElements = (rootNode: SugarElement<Node>, rng: Range, schema: Schema) => {
   const commonAnchorContainer = SugarElement.fromDom(rng.commonAncestorContainer);
   const parents = Parents.parentsAndSelf(commonAnchorContainer, rootNode);
-  const wrapElements = Arr.filter(parents, (el) => schema.isWrapElement(SugarNode.name(el)));
+  const wrapElements = Arr.filter(parents, (el) => schema.isWrapper(SugarNode.name(el)));
   const listWrappers = getFullySelectedListWrappers(parents, rng);
   const allWrappers = wrapElements.concat(listWrappers.length ? listWrappers : directListWrappers(commonAnchorContainer));
   return Arr.map(allWrappers, Replication.shallow);

--- a/modules/tinymce/src/core/main/ts/selection/GetSelectionContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/selection/GetSelectionContentImpl.ts
@@ -65,7 +65,7 @@ const getSerializedContent = (editor: Editor, args: GetSelectionContentArgs): Co
   const sel = editor.selection.getSel();
   const ranges = EventProcessRanges.processRanges(editor, MultiRange.getRanges(sel));
 
-  const fragment = args.contextual ? FragmentReader.read(SugarElement.fromDom(editor.getBody()), ranges).dom : rng.cloneContents();
+  const fragment = args.contextual ? FragmentReader.read(SugarElement.fromDom(editor.getBody()), ranges, editor.schema).dom : rng.cloneContents();
   if (fragment) {
     tmpElm.appendChild(fragment);
   }

--- a/modules/tinymce/src/core/main/ts/selection/MultiClickSelection.ts
+++ b/modules/tinymce/src/core/main/ts/selection/MultiClickSelection.ts
@@ -15,7 +15,7 @@ const isContentEditableTrue = (elm: SugarElement<Node>): boolean => NodeType.isC
 const isRoot = (rootNode: Node) => (elm: SugarElement<Node>): boolean => Compare.eq(SugarElement.fromDom(rootNode), elm);
 
 const getClosestScope = (node: Node, rootNode: Node): Node =>
-  PredicateFind.closest(SugarElement.fromDom(node), (elm) => isContentEditableTrue(elm) || isBlock(elm), isRoot(rootNode))
+  PredicateFind.closest(SugarElement.fromDom(node), (elm) => isContentEditableTrue(elm) || isBlock()(elm), isRoot(rootNode))
     .getOr(SugarElement.fromDom(rootNode)).dom;
 
 const getClosestCef = (node: Node, rootNode: Node) =>

--- a/modules/tinymce/src/core/main/ts/selection/MultiClickSelection.ts
+++ b/modules/tinymce/src/core/main/ts/selection/MultiClickSelection.ts
@@ -1,11 +1,10 @@
-import { Compare, PredicateFind, SugarElement } from '@ephox/sugar';
+import { Compare, PredicateFind, SugarElement, SugarNode } from '@ephox/sugar';
 
 import DomTreeWalker from '../api/dom/TreeWalker';
 import Editor from '../api/Editor';
 import Schema from '../api/html/Schema';
 import { isCaretCandidate } from '../caret/CaretCandidate';
 import { CaretPosition } from '../caret/CaretPosition';
-import { isBlock } from '../dom/ElementType';
 import * as NodeType from '../dom/NodeType';
 import * as RangeNormalizer from './RangeNormalizer';
 
@@ -16,7 +15,7 @@ const isContentEditableTrue = (elm: SugarElement<Node>): boolean => NodeType.isC
 const isRoot = (rootNode: Node) => (elm: SugarElement<Node>): boolean => Compare.eq(SugarElement.fromDom(rootNode), elm);
 
 const getClosestScope = (node: Node, rootNode: Node, schema: Schema): Node =>
-  PredicateFind.closest(SugarElement.fromDom(node), (elm) => isContentEditableTrue(elm) || isBlock(elm, schema), isRoot(rootNode))
+  PredicateFind.closest(SugarElement.fromDom(node), (elm) => isContentEditableTrue(elm) || schema.isBlock(SugarNode.name(elm)), isRoot(rootNode))
     .getOr(SugarElement.fromDom(rootNode)).dom;
 
 const getClosestCef = (node: Node, rootNode: Node) =>

--- a/modules/tinymce/src/core/main/ts/selection/SetSelectionContent.ts
+++ b/modules/tinymce/src/core/main/ts/selection/SetSelectionContent.ts
@@ -3,6 +3,7 @@ import { Remove, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import BookmarkManager from '../api/dom/BookmarkManager';
 import Editor from '../api/Editor';
+import Schema from '../api/html/Schema';
 import HtmlSerializer from '../api/html/Serializer';
 import CaretPosition from '../caret/CaretPosition';
 import { SetSelectionContentArgs } from '../content/ContentTypes';
@@ -24,46 +25,46 @@ const walkPastBookmark = (node: Optional<SugarElement<Node>>, start: boolean): O
   node.filter((elm) => BookmarkManager.isBookmarkNode(elm.dom))
     .bind(start ? Traverse.nextSibling : Traverse.prevSibling);
 
-const merge = (outer: SugarElement<Text>, inner: SugarElement<Text>, rng: Range, start: boolean) => {
+const merge = (outer: SugarElement<Text>, inner: SugarElement<Text>, rng: Range, start: boolean, schema: Schema) => {
   const outerElm = outer.dom;
   const innerElm = inner.dom;
   const oldLength = start ? outerElm.length : innerElm.length;
   if (start) {
-    MergeText.mergeTextNodes(outerElm, innerElm, false, !start);
+    MergeText.mergeTextNodes(outerElm, innerElm, schema, false, !start);
     rng.setStart(innerElm, oldLength);
   } else {
-    MergeText.mergeTextNodes(innerElm, outerElm, false, !start);
+    MergeText.mergeTextNodes(innerElm, outerElm, schema, false, !start);
     rng.setEnd(innerElm, oldLength);
   }
 };
 
-const normalizeTextIfRequired = (inner: SugarElement<Text>, start: boolean) => {
+const normalizeTextIfRequired = (inner: SugarElement<Text>, start: boolean, schema: Schema) => {
   Traverse.parent(inner).each((root) => {
     const text = inner.dom;
-    if (start && needsToBeNbspLeft(root, CaretPosition(text, 0))) {
-      MergeText.normalizeWhitespaceAfter(text, 0);
-    } else if (!start && needsToBeNbspRight(root, CaretPosition(text, text.length))) {
-      MergeText.normalizeWhitespaceBefore(text, text.length);
+    if (start && needsToBeNbspLeft(root, CaretPosition(text, 0), schema)) {
+      MergeText.normalizeWhitespaceAfter(text, 0, schema);
+    } else if (!start && needsToBeNbspRight(root, CaretPosition(text, text.length), schema)) {
+      MergeText.normalizeWhitespaceBefore(text, text.length, schema);
     }
   });
 };
 
-const mergeAndNormalizeText = (outerNode: Optional<SugarElement<Text>>, innerNode: Optional<SugarElement<Node>>, rng: Range, start: boolean) => {
+const mergeAndNormalizeText = (outerNode: Optional<SugarElement<Text>>, innerNode: Optional<SugarElement<Node>>, rng: Range, start: boolean, schema: Schema) => {
   outerNode.bind((outer) => {
     // Normalize the text outside the inserted content
     const normalizer = start ? MergeText.normalizeWhitespaceBefore : MergeText.normalizeWhitespaceAfter;
-    normalizer(outer.dom, start ? outer.dom.length : 0);
+    normalizer(outer.dom, start ? outer.dom.length : 0, schema);
 
     // Merge the inserted content with other text nodes
-    return innerNode.filter(SugarNode.isText).map((inner) => merge(outer, inner, rng, start));
+    return innerNode.filter(SugarNode.isText).map((inner) => merge(outer, inner, rng, start, schema));
   }).orThunk(() => {
     // Note: Attempt to leave the inserted/inner content as is and only adjust if absolutely required
     const innerTextNode = walkPastBookmark(innerNode, start).or(innerNode).filter(SugarNode.isText);
-    return innerTextNode.map((inner) => normalizeTextIfRequired(inner, start));
+    return innerTextNode.map((inner) => normalizeTextIfRequired(inner, start, schema));
   });
 };
 
-const rngSetContent = (rng: Range, fragment: DocumentFragment): void => {
+const rngSetContent = (rng: Range, fragment: DocumentFragment, schema: Schema): void => {
   const firstChild = Optional.from(fragment.firstChild).map(SugarElement.fromDom);
   const lastChild = Optional.from(fragment.lastChild).map(SugarElement.fromDom);
 
@@ -74,8 +75,8 @@ const rngSetContent = (rng: Range, fragment: DocumentFragment): void => {
   const nextText = lastChild.bind(Traverse.nextSibling).filter(SugarNode.isText).bind(removeEmpty);
 
   // Join and normalize text
-  mergeAndNormalizeText(prevText, firstChild, rng, true);
-  mergeAndNormalizeText(nextText, lastChild, rng, false);
+  mergeAndNormalizeText(prevText, firstChild, rng, true, schema);
+  mergeAndNormalizeText(nextText, lastChild, rng, false, schema);
 
   rng.collapse(false);
 };
@@ -109,7 +110,7 @@ const setContent = (editor: Editor, content: string, args: Partial<SetSelectionC
     const cleanedContent = cleanContent(editor, updatedArgs);
 
     const rng = editor.selection.getRng();
-    rngSetContent(rng, rng.createContextualFragment(cleanedContent));
+    rngSetContent(rng, rng.createContextualFragment(cleanedContent), editor.schema);
     editor.selection.setRng(rng);
 
     ScrollIntoView.scrollRangeIntoView(editor, rng);

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteActionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteActionTest.ts
@@ -4,6 +4,7 @@ import { Fun, Optional } from '@ephox/katamari';
 import { Hierarchy, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
+import Schema from 'tinymce/core/api/html/Schema';
 import CaretPosition from 'tinymce/core/caret/CaretPosition';
 import * as CefDeleteAction from 'tinymce/core/delete/CefDeleteAction';
 
@@ -16,6 +17,8 @@ describe('browser.tinymce.core.delete.CefDeleteActionTest', () => {
 
   const setHtml = viewBlock.update;
 
+  const baseSchema = Schema();
+
   beforeEach(() => {
     viewBlock.get().contentEditable = 'true';
   });
@@ -25,7 +28,7 @@ describe('browser.tinymce.core.delete.CefDeleteActionTest', () => {
     const rng = document.createRange();
     rng.setStart(container.dom, cursorOffset);
     rng.setEnd(container.dom, cursorOffset);
-    return CefDeleteAction.read(viewBlock.get(), forward, rng);
+    return CefDeleteAction.read(viewBlock.get(), forward, rng, baseSchema);
   };
 
   const assertRemoveElementAction = (actionOpt: Optional<DeleteActionAdt>, elementPath: number[]) => {

--- a/modules/tinymce/src/core/test/ts/browser/delete/MergeBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/MergeBlocksTest.ts
@@ -4,6 +4,7 @@ import { Optional } from '@ephox/katamari';
 import { Hierarchy, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
+import Schema from 'tinymce/core/api/html/Schema';
 import CaretPosition from 'tinymce/core/caret/CaretPosition';
 import * as MergeBlocks from 'tinymce/core/delete/MergeBlocks';
 
@@ -14,6 +15,8 @@ describe('browser.tinymce.core.delete.MergeBlocksTest', () => {
 
   const setHtml = viewBlock.update;
 
+  const baseSchema = Schema();
+
   const assertHtml = (expectedHtml: string) => {
     Assertions.assertHtml('Should equal html', expectedHtml, viewBlock.get().innerHTML);
   };
@@ -21,7 +24,7 @@ describe('browser.tinymce.core.delete.MergeBlocksTest', () => {
   const mergeBlocks = (forward: boolean, block1Path: number[], block2Path: number[]) => {
     const block1 = Hierarchy.follow(SugarElement.fromDom(viewBlock.get()), block1Path).getOrDie() as SugarElement<Element>;
     const block2 = Hierarchy.follow(SugarElement.fromDom(viewBlock.get()), block2Path).getOrDie() as SugarElement<Element>;
-    return MergeBlocks.mergeBlocks(SugarElement.fromDom(viewBlock.get()), forward, block1, block2);
+    return MergeBlocks.mergeBlocks(SugarElement.fromDom(viewBlock.get()), forward, block1, block2, baseSchema);
   };
 
   const assertPosition = (position: Optional<CaretPosition>, expectedPath: number[], expectedOffset: number) => {

--- a/modules/tinymce/src/core/test/ts/browser/dom/ElementTypeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ElementTypeTest.ts
@@ -40,27 +40,11 @@ describe('browser.tinymce.core.dom.ElementTypeTest', () => {
     checkText(ElementType.isTable);
   });
 
-  it('Check heading elements', () => {
-    checkElement('h1', ElementType.isHeading, true);
-    checkElement('h2', ElementType.isHeading, true);
-    checkElement('span', ElementType.isHeading, false);
-    checkElement('table', ElementType.isHeading, false);
-    checkText(ElementType.isHeading);
-  });
-
   it('Check text block elements', () => {
     checkElement('p', ElementType.isTextBlock, true);
     checkElement('h1', ElementType.isTextBlock, true);
     checkElement('table', ElementType.isTextBlock, false);
     checkText(ElementType.isTextBlock);
-  });
-
-  it('Check void elements', () => {
-    checkElement('img', ElementType.isVoid, true);
-    checkElement('hr', ElementType.isVoid, true);
-    checkElement('h1', ElementType.isVoid, false);
-    checkElement('span', ElementType.isVoid, false);
-    checkText(ElementType.isVoid);
   });
 
   it('Check table cell elements', () => {

--- a/modules/tinymce/src/core/test/ts/browser/dom/ElementTypeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ElementTypeTest.ts
@@ -2,6 +2,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
+import Schema from 'tinymce/core/api/html/Schema';
 import * as ElementType from 'tinymce/core/dom/ElementType';
 
 describe('browser.tinymce.core.dom.ElementTypeTest', () => {
@@ -9,25 +10,27 @@ describe('browser.tinymce.core.dom.ElementTypeTest', () => {
     assert.equal(predicate(SugarElement.fromTag(name)), expectedValue, 'Should be the expected value for specified element');
   };
 
+  const baseSchema = Schema();
+
   const checkText = (predicate: (elm: SugarElement<Node>) => boolean) => {
     assert.isFalse(predicate(SugarElement.fromText('text')), 'Should be false for non element');
   };
 
   it('Check block elements', () => {
-    checkElement('p', ElementType.isBlock(), true);
-    checkElement('h1', ElementType.isBlock(), true);
-    checkElement('table', ElementType.isBlock(), true);
-    checkElement('span', ElementType.isBlock(), false);
-    checkElement('b', ElementType.isBlock(), false);
-    checkText(ElementType.isBlock());
+    checkElement('p', (el) => ElementType.isBlock(el, baseSchema), true);
+    checkElement('h1', (el) => ElementType.isBlock(el, baseSchema), true);
+    checkElement('table', (el) => ElementType.isBlock(el, baseSchema), true);
+    checkElement('span', (el) => ElementType.isBlock(el, baseSchema), false);
+    checkElement('b', (el) => ElementType.isBlock(el, baseSchema), false);
+    checkText((el) => ElementType.isBlock(el, baseSchema));
   });
 
   it('Check inline elements', () => {
-    checkElement('b', ElementType.isInline, true);
-    checkElement('span', ElementType.isInline, true);
-    checkElement('p', ElementType.isInline, false);
-    checkElement('h1', ElementType.isInline, false);
-    checkText(ElementType.isInline);
+    checkElement('b', (el) => ElementType.isInline(el, baseSchema), true);
+    checkElement('span', (el) => ElementType.isInline(el, baseSchema), true);
+    checkElement('p', (el) => ElementType.isInline(el, baseSchema), false);
+    checkElement('h1', (el) => ElementType.isInline(el, baseSchema), false);
+    checkText((el) => ElementType.isInline(el, baseSchema));
   });
 
   it('Check tables', () => {

--- a/modules/tinymce/src/core/test/ts/browser/dom/ElementTypeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ElementTypeTest.ts
@@ -14,12 +14,12 @@ describe('browser.tinymce.core.dom.ElementTypeTest', () => {
   };
 
   it('Check block elements', () => {
-    checkElement('p', ElementType.isBlock, true);
-    checkElement('h1', ElementType.isBlock, true);
-    checkElement('table', ElementType.isBlock, true);
-    checkElement('span', ElementType.isBlock, false);
-    checkElement('b', ElementType.isBlock, false);
-    checkText(ElementType.isBlock);
+    checkElement('p', ElementType.isBlock(), true);
+    checkElement('h1', ElementType.isBlock(), true);
+    checkElement('table', ElementType.isBlock(), true);
+    checkElement('span', ElementType.isBlock(), false);
+    checkElement('b', ElementType.isBlock(), false);
+    checkText(ElementType.isBlock());
   });
 
   it('Check inline elements', () => {

--- a/modules/tinymce/src/core/test/ts/browser/dom/ElementTypeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ElementTypeTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { SugarElement } from '@ephox/sugar';
+import { SugarElement, SugarNode } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import Schema from 'tinymce/core/api/html/Schema';
@@ -17,12 +17,12 @@ describe('browser.tinymce.core.dom.ElementTypeTest', () => {
   };
 
   it('Check block elements', () => {
-    checkElement('p', (el) => ElementType.isBlock(el, baseSchema), true);
-    checkElement('h1', (el) => ElementType.isBlock(el, baseSchema), true);
-    checkElement('table', (el) => ElementType.isBlock(el, baseSchema), true);
-    checkElement('span', (el) => ElementType.isBlock(el, baseSchema), false);
-    checkElement('b', (el) => ElementType.isBlock(el, baseSchema), false);
-    checkText((el) => ElementType.isBlock(el, baseSchema));
+    checkElement('p', (el) => baseSchema.isBlock(SugarNode.name(el)), true);
+    checkElement('h1', (el) => baseSchema.isBlock(SugarNode.name(el)), true);
+    checkElement('table', (el) => baseSchema.isBlock(SugarNode.name(el)), true);
+    checkElement('span', (el) => baseSchema.isBlock(SugarNode.name(el)), false);
+    checkElement('b', (el) => baseSchema.isBlock(SugarNode.name(el)), false);
+    checkText((el) => baseSchema.isBlock(SugarNode.name(el)));
   });
 
   it('Check inline elements', () => {

--- a/modules/tinymce/src/core/test/ts/browser/dom/ElementTypeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ElementTypeTest.ts
@@ -26,11 +26,11 @@ describe('browser.tinymce.core.dom.ElementTypeTest', () => {
   });
 
   it('Check inline elements', () => {
-    checkElement('b', (el) => ElementType.isInline(el, baseSchema), true);
-    checkElement('span', (el) => ElementType.isInline(el, baseSchema), true);
-    checkElement('p', (el) => ElementType.isInline(el, baseSchema), false);
-    checkElement('h1', (el) => ElementType.isInline(el, baseSchema), false);
-    checkText((el) => ElementType.isInline(el, baseSchema));
+    checkElement('b', (el) => baseSchema.isInline(SugarNode.name(el)), true);
+    checkElement('span', (el) => baseSchema.isInline(SugarNode.name(el)), true);
+    checkElement('p', (el) => baseSchema.isInline(SugarNode.name(el)), false);
+    checkElement('h1', (el) => baseSchema.isInline(SugarNode.name(el)), false);
+    checkText((el) => baseSchema.isInline(SugarNode.name(el)));
   });
 
   it('Check tables', () => {

--- a/modules/tinymce/src/core/test/ts/browser/dom/ElementTypeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ElementTypeTest.ts
@@ -1,8 +1,7 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { SugarElement, SugarNode } from '@ephox/sugar';
+import { SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import Schema from 'tinymce/core/api/html/Schema';
 import * as ElementType from 'tinymce/core/dom/ElementType';
 
 describe('browser.tinymce.core.dom.ElementTypeTest', () => {
@@ -10,28 +9,9 @@ describe('browser.tinymce.core.dom.ElementTypeTest', () => {
     assert.equal(predicate(SugarElement.fromTag(name)), expectedValue, 'Should be the expected value for specified element');
   };
 
-  const baseSchema = Schema();
-
   const checkText = (predicate: (elm: SugarElement<Node>) => boolean) => {
     assert.isFalse(predicate(SugarElement.fromText('text')), 'Should be false for non element');
   };
-
-  it('Check block elements', () => {
-    checkElement('p', (el) => baseSchema.isBlock(SugarNode.name(el)), true);
-    checkElement('h1', (el) => baseSchema.isBlock(SugarNode.name(el)), true);
-    checkElement('table', (el) => baseSchema.isBlock(SugarNode.name(el)), true);
-    checkElement('span', (el) => baseSchema.isBlock(SugarNode.name(el)), false);
-    checkElement('b', (el) => baseSchema.isBlock(SugarNode.name(el)), false);
-    checkText((el) => baseSchema.isBlock(SugarNode.name(el)));
-  });
-
-  it('Check inline elements', () => {
-    checkElement('b', (el) => baseSchema.isInline(SugarNode.name(el)), true);
-    checkElement('span', (el) => baseSchema.isInline(SugarNode.name(el)), true);
-    checkElement('p', (el) => baseSchema.isInline(SugarNode.name(el)), false);
-    checkElement('h1', (el) => baseSchema.isInline(SugarNode.name(el)), false);
-    checkText((el) => baseSchema.isInline(SugarNode.name(el)));
-  });
 
   it('Check tables', () => {
     checkElement('b', ElementType.isTable, false);

--- a/modules/tinymce/src/core/test/ts/browser/dom/PaddingBrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/PaddingBrTest.ts
@@ -3,9 +3,11 @@ import { describe, it } from '@ephox/bedrock-client';
 import { Html, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
+import Schema from 'tinymce/core/api/html/Schema';
 import * as PaddingBr from 'tinymce/core/dom/PaddingBr';
 
 describe('browser.tinymce.core.dom.PaddingBrTest', () => {
+  const baseSchema = Schema();
 
   const testRemoveTrailingBr = (label: string, inputHtml: string, expectedHtml: string) => {
     const elm = SugarElement.fromHtml(inputHtml);
@@ -15,7 +17,7 @@ describe('browser.tinymce.core.dom.PaddingBrTest', () => {
 
   const testTrimBlockTrailingBr = (label: string, inputHtml: string, expectedHtml: string) => {
     const elm = SugarElement.fromHtml(inputHtml);
-    PaddingBr.trimBlockTrailingBr(elm);
+    PaddingBr.trimBlockTrailingBr(elm, baseSchema);
     Assertions.assertHtml(label, expectedHtml, Html.getOuter(elm));
   };
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/TrimNodeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/TrimNodeTest.ts
@@ -2,16 +2,18 @@ import { describe, it } from '@ephox/bedrock-client';
 import { assert } from 'chai';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
+import Schema from 'tinymce/core/api/html/Schema';
 import * as TrimNode from 'tinymce/core/dom/TrimNode';
 
 describe('browser.tinymce.core.dom.TrimNodeTest', () => {
   const dom = DOMUtils(document, {});
+  const baseSchema = Schema();
 
   const testTrim = (label: string, inputHtml: string, expectedTrimmedHtml: string) => {
     it(label, () => {
       const elm = document.createElement('div');
       elm.innerHTML = inputHtml;
-      TrimNode.trimNode(dom, elm.firstChild as Node);
+      TrimNode.trimNode(dom, elm.firstChild as Node, baseSchema);
 
       const actual = elm.innerHTML;
       assert.equal(actual, expectedTrimmedHtml, 'is correct trimmed html');
@@ -36,14 +38,14 @@ describe('browser.tinymce.core.dom.TrimNodeTest', () => {
     elm.insertBefore(emptyTextNode, elm.lastChild);
     elm.insertBefore(emptyTextNode.cloneNode(), elm.firstChild);
 
-    const actual = TrimNode.trimNode(dom, elm);
+    const actual = TrimNode.trimNode(dom, elm, baseSchema);
 
     assert.equal(actual.innerHTML, ' <strong>abc</strong> abc', 'Empty text node shouldn\'t be trimmed');
   });
 
   it('Document node', () => {
     const expected = document.implementation.createHTMLDocument('test');
-    const actual = TrimNode.trimNode(dom, expected);
+    const actual = TrimNode.trimNode(dom, expected, baseSchema);
 
     assert.strictEqual(actual, expected, 'Should return document as is');
   });

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -219,13 +219,14 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
   it('getBlockElements', () => {
     const schema = Schema();
     assert.deepEqual(schema.getBlockElements(), {
-      SUMMARY: {}, MAIN: {}, DETAILS: {}, ASIDE: {}, HGROUP: {}, SECTION: {}, ARTICLE: {}, FOOTER: {}, HEADER: {},
+      LISTING: {}, MULTICOL: {}, BODY: {}, HTML: {}, SUMMARY: {}, MAIN: {},
+      DETAILS: {}, ASIDE: {}, HGROUP: {}, SECTION: {}, ARTICLE: {}, FOOTER: {}, HEADER: {},
       ISINDEX: {}, MENU: {}, NOSCRIPT: {}, FIELDSET: {}, FIGCAPTION: {}, DIR: {}, DD: {}, DT: {},
       DL: {}, CENTER: {}, BLOCKQUOTE: {}, CAPTION: {}, UL: {}, OL: {}, LI: {},
       TD: {}, TR: {}, TH: {}, TFOOT: {}, THEAD: {}, TBODY: {}, TABLE: {}, FORM: {},
       PRE: {}, ADDRESS: {}, DIV: {}, P: {}, HR: {}, H6: {}, H5: {}, H4: {}, H3: {},
       H2: {}, H1: {}, NAV: {}, FIGURE: {}, DATALIST: {}, OPTGROUP: {}, OPTION: {}, SELECT: {},
-      details: {}, summary: {}, main: {}, aside: {}, hgroup: {}, section: {}, article: {}, footer: {}, header: {},
+      details: {}, listing: {}, multicol: {}, body: {}, html: {}, summary: {}, main: {}, aside: {}, hgroup: {}, section: {}, article: {}, footer: {}, header: {},
       isindex: {}, menu: {}, noscript: {}, fieldset: {}, dir: {}, dd: {}, dt: {}, dl: {}, center: {},
       blockquote: {}, caption: {}, ul: {}, ol: {}, li: {}, td: {}, tr: {}, th: {}, tfoot: {}, thead: {},
       tbody: {}, table: {}, form: {}, pre: {}, address: {}, div: {}, p: {}, hr: {}, h6: {},

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -543,14 +543,6 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
   });
 
   context('custom elements', () => {
-    const checkElement = (name: string, predicate: (elm: SugarElement<Node>) => boolean, expectedValue: boolean) => {
-      assert.equal(predicate(SugarElement.fromTag(name)), expectedValue, `Should be ${expectedValue} for ${name}`);
-    };
-
-    const checkText = (predicate: (elm: SugarElement<Node>) => boolean) => {
-      assert.isFalse(predicate(SugarElement.fromText('text')), 'Should be false for non element');
-    };
-
     it('TBA: custom elements are added as element rules and copy the span/div rules', () => {
       const schema = Schema({
         custom_elements: '~foo-bar,bar-foo'
@@ -576,8 +568,17 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
 
       assert.hasAnyKeys(schema.getNonEmptyElements(), [ 'foo-bar', 'FOO-BAR', 'bar-foo', 'BAR-FOO' ]);
     });
+  });
 
-    it('TINY-10139: Check block elements', () => {
+  context('TINY-10139: check elements', () => {
+    const checkElement = (name: string, predicate: (elm: SugarElement<Node>) => boolean, expectedValue: boolean) => {
+      assert.equal(predicate(SugarElement.fromTag(name)), expectedValue, `Should be ${expectedValue} for ${name}`);
+    };
+
+    const checkText = (predicate: (elm: SugarElement<Node>) => boolean) => {
+      assert.isFalse(predicate(SugarElement.fromText('text')), 'Should be false for non element');
+    };
+    it('TINY-10139: check block elements', () => {
       const schema = Schema({
         custom_elements: 'foo,bar'
       });
@@ -592,7 +593,7 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
       checkElement('bar', (el) => schema.isBlock(SugarNode.name(el)), true);
     });
 
-    it('TINY-10139: Check inline elements', () => {
+    it('TINY-10139: check inline elements', () => {
       const schema = Schema({
         custom_elements: '~foo,~bar'
       });

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -578,6 +578,7 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
     const checkText = (predicate: (elm: SugarElement<Node>) => boolean) => {
       assert.isFalse(predicate(SugarElement.fromText('text')), 'Should be false for non element');
     };
+
     it('TINY-10139: check block elements', () => {
       const schema = Schema({
         custom_elements: 'foo,bar'

--- a/modules/tinymce/src/core/test/ts/browser/selection/FragmentReaderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/FragmentReaderTest.ts
@@ -3,6 +3,7 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { Hierarchy, Html, Insert, SugarElement } from '@ephox/sugar';
 
+import Schema from 'tinymce/core/api/html/Schema';
 import * as FragmentReader from 'tinymce/core/selection/FragmentReader';
 
 import * as ViewBlock from '../../module/test/ViewBlock';
@@ -20,7 +21,7 @@ describe('browser.tinymce.core.selection.FragmentReaderTest', () => {
     rng.setStart(sc.dom, startOffset);
     rng.setEnd(ec.dom, endOffset);
 
-    return FragmentReader.read(SugarElement.fromDom(viewBlock.get()), [ rng ]);
+    return FragmentReader.read(SugarElement.fromDom(viewBlock.get()), [ rng ], Schema());
   };
 
   const readFragmentCells = (paths: number[][]) => {
@@ -31,7 +32,7 @@ describe('browser.tinymce.core.selection.FragmentReaderTest', () => {
       return rng;
     });
 
-    return FragmentReader.read(SugarElement.fromDom(viewBlock.get()), ranges);
+    return FragmentReader.read(SugarElement.fromDom(viewBlock.get()), ranges, Schema());
   };
 
   const getFragmentHtml = (fragment: SugarElement<Node>) => {

--- a/modules/tinymce/src/core/test/ts/browser/selection/MultiClickSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/MultiClickSelectionTest.ts
@@ -6,6 +6,7 @@ import { assert } from 'chai';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
+import Schema from 'tinymce/core/api/html/Schema';
 import { findClosestBlockRange } from 'tinymce/core/selection/MultiClickSelection';
 
 import * as ViewBlock from '../../module/test/ViewBlock';
@@ -16,6 +17,7 @@ describe('browser.tinymce.core.selection.MultiClickSelectionTest', () => {
     const viewBlock = ViewBlock.bddSetup();
     const getRoot = viewBlock.get;
     const setupHtml = viewBlock.update;
+    const baseSchema = Schema();
 
     const toDomRange = (path: Cursors.CursorPath): Range => {
       const root = SugarElement.fromDom(getRoot());
@@ -34,7 +36,7 @@ describe('browser.tinymce.core.selection.MultiClickSelectionTest', () => {
     };
 
     const testFindClosestBlockRange = (startRngPath: Cursors.CursorPath, expectedRngPath: Cursors.CursorPath) =>
-      assertRange(toDomRange(expectedRngPath), findClosestBlockRange(toDomRange(startRngPath), getRoot()));
+      assertRange(toDomRange(expectedRngPath), findClosestBlockRange(toDomRange(startRngPath), getRoot(), baseSchema));
 
     it('TINY-8215: Should return the range with the whole text content of the block', () => {
       setupHtml('<p>aaa bIb ccc</p>');


### PR DESCRIPTION
Related Ticket: TINY-10139

Description of Changes:
`ElementType.ts` wasn't considering the schema so the custom elements were not considered so when for example when we try to get the wrap elements it doesn't consider the custom block elements as a block.

To solve it, now in `ElementType.ts` `isWrapElement`, `isBlock` and `isInline` require the `Schema` so we have a single source of truth about what is a block/wrap/inline.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable) -> DOC-2196

GitHub issues (if applicable):
