### PR TITLE
TINY-10237: Enable SVG support

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Colorpicker now includes the Brightness/Saturation selector and hue slider in the keyboard navigable items. #TINY-9287
 - Improved the tooltips of picker buttons for the urlinput components in the "Insert/Edit Image" and "Insert/Edit Link" dialogs. #TINY-10155
 - Inline dialog will now respect `size: 'large'` argument in the dialog spec. #TINY-10209
+- SVG elements and it's children is now retained if you configure in SVG elements as a valid element. #TINY-10237
 
 ## 6.7.0 - 2023-08-30
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Colorpicker now includes the Brightness/Saturation selector and hue slider in the keyboard navigable items. #TINY-9287
 - Improved the tooltips of picker buttons for the urlinput components in the "Insert/Edit Image" and "Insert/Edit Link" dialogs. #TINY-10155
 - Inline dialog will now respect `size: 'large'` argument in the dialog spec. #TINY-10209
-- SVG elements and it's children is now retained if you configure in SVG elements as a valid element. #TINY-10237
+- SVG elements and their children are now retained when configured as valid elements. #TINY-10237
 
 ## 6.7.0 - 2023-08-30
 

--- a/modules/tinymce/src/core/main/ts/ForceBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/ForceBlocks.ts
@@ -10,6 +10,7 @@ import * as NodeType from './dom/NodeType';
 import * as PaddingBr from './dom/PaddingBr';
 import * as Parents from './dom/Parents';
 import * as EditorFocus from './focus/EditorFocus';
+import * as Namespace from './html/Namespace';
 
 /**
  * Makes sure that everything gets wrapped in paragraphs.
@@ -25,7 +26,8 @@ const isValidTarget = (schema: Schema, node: Node) => {
   if (NodeType.isText(node)) {
     return true;
   } else if (NodeType.isElement(node)) {
-    return !isBlockElement(schema.getBlockElements(), node) && !Bookmarks.isBookmarkNode(node) && !TransparentElements.isTransparentBlock(schema, node);
+    return !isBlockElement(schema.getBlockElements(), node) && !Bookmarks.isBookmarkNode(node) &&
+      !TransparentElements.isTransparentBlock(schema, node) && !Namespace.isNonHtmlElementRoot(node);
   } else {
     return false;
   }

--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -126,7 +126,7 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
           setRange(range);
 
           // Set the focus after the range has been set to avoid potential issues where the body has no selection
-          if (NodeType.isElement(closestContentEditable)) {
+          if (NodeType.isHTMLElement(closestContentEditable)) {
             closestContentEditable.focus();
           } else {
             editor.getBody().focus();

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -408,7 +408,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
 
         if (originalValue !== val && settings.onSetAttrib) {
           settings.onSetAttrib({
-            attrElm: $elm.dom,
+            attrElm: $elm.dom as HTMLElement, // We lie here to not break backwards compatibility
             attrName: name,
             attrValue: val
           });
@@ -464,7 +464,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
   const getStyle = (elm: string | Element | null, name: string, computed?: boolean): string | undefined => {
     const $elm = get(elm);
 
-    if (Type.isNullable($elm) || !NodeType.isElement($elm)) {
+    if (Type.isNullable($elm) || (!NodeType.isHTMLElement($elm) && !NodeType.isSVGElement($elm))) {
       return undefined;
     }
 
@@ -1094,7 +1094,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
   const fire = (target: Target, name: string, evt?: {}) => events.dispatch(target, name, evt);
 
   const getContentEditable = (node: Node) => {
-    if (node && NodeType.isElement(node)) {
+    if (node && NodeType.isHTMLElement(node)) {
       // Check for fake content editable
       const contentEditable = node.getAttribute('data-mce-contenteditable');
       if (contentEditable && contentEditable !== 'inherit') {
@@ -1126,7 +1126,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
   const isEditable = (node: Node | null | undefined) => {
     if (Type.isNonNullable(node)) {
       const scope = NodeType.isElement(node) ? node : node.parentElement;
-      return Type.isNonNullable(scope) && ContentEditable.isEditable(SugarElement.fromDom(scope));
+      return Type.isNonNullable(scope) && NodeType.isHTMLElement(scope) && ContentEditable.isEditable(SugarElement.fromDom(scope));
     } else {
       return false;
     }

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -272,7 +272,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
   };
 
   const parser = new DOMParser();
-  const sanitize = getSanitizer(defaultedSettings, schema);
+  const sanitizer = getSanitizer(defaultedSettings, schema);
 
   const parseAndSanitizeWithContext = (html: string, rootName: string, format: string = 'html'): Element => {
     const mimeType = format === 'xhtml' ? 'application/xhtml+xml' : 'text/html';
@@ -283,7 +283,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
     // If parsing XHTML then the content must contain the xmlns declaration, see https://www.w3.org/TR/xhtml1/normative.html#strict
     const wrappedHtml = format === 'xhtml' ? `<html xmlns="http://www.w3.org/1999/xhtml"><head></head><body>${content}</body></html>` : `<body>${content}</body>`;
     const body = parser.parseFromString(wrappedHtml, mimeType).body;
-    sanitize(body, mimeType);
+    sanitizer.sanitizeHtmlElement(body, mimeType);
     return isSpecialRoot ? body.firstChild as Element : body;
   };
 

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -8,10 +8,10 @@ import * as InvalidNodes from '../../html/InvalidNodes';
 import * as LegacyFilter from '../../html/LegacyFilter';
 import * as ParserFilters from '../../html/ParserFilters';
 import { isEmpty, isLineBreakNode, isPaddedWithNbsp, paddEmptyNode } from '../../html/ParserUtils';
+import { getSanitizer, internalElementAttr } from '../../html/Sanitization';
 import { BlobCache } from '../file/BlobCache';
 import Tools from '../util/Tools';
 import AstNode from './Node';
-import { getSanitizer, internalElementAttr } from './Sanitization';
 import Schema, { getTextRootBlockElements, SchemaMap, SchemaRegExpMap } from './Schema';
 
 /**

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -144,7 +144,7 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
     'noshade nowrap readonly selected autoplay loop controls allowfullscreen');
 
   const nonEmptyOrMoveCaretBeforeOnEnter = 'td th iframe video audio object script code';
-  const nonEmptyElementsMap = createLookupTable('non_empty_elements', nonEmptyOrMoveCaretBeforeOnEnter + ' pre', voidElementsMap);
+  const nonEmptyElementsMap = createLookupTable('non_empty_elements', nonEmptyOrMoveCaretBeforeOnEnter + ' pre svg', voidElementsMap);
   const moveCaretBeforeOnEnterElementsMap = createLookupTable('move_caret_before_on_enter_elements', nonEmptyOrMoveCaretBeforeOnEnter + ' table', voidElementsMap);
 
   const textBlockElementsMap = createLookupTable('text_block_elements', 'h1 h2 h3 h4 h5 h6 p div address pre form ' +
@@ -336,6 +336,9 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
       children[name] = element.children;
     });
   }
+
+  // Opt in is done with options like `extended_valid_elements`
+  delete elements.svg;
 
   addCustomElements(settings.custom_elements);
   addValidChildren(settings.valid_children);

--- a/modules/tinymce/src/core/main/ts/api/html/Serializer.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Serializer.ts
@@ -1,4 +1,5 @@
 import { Type } from '@ephox/katamari';
+
 import * as Namespace from '../../html/Namespace';
 import AstNode, { Attributes } from './Node';
 import Schema from './Schema';
@@ -167,3 +168,4 @@ const HtmlSerializer = (settings: HtmlSerializerSettings = {}, schema: Schema = 
 };
 
 export default HtmlSerializer;
+

--- a/modules/tinymce/src/core/main/ts/api/html/Serializer.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Serializer.ts
@@ -1,3 +1,5 @@
+import { Type } from '@ephox/katamari';
+import * as Namespace from '../../html/Namespace';
 import AstNode, { Attributes } from './Node';
 import Schema from './Schema';
 import Writer, { WriterSettings } from './Writer';
@@ -117,22 +119,30 @@ const HtmlSerializer = (settings: HtmlSerializerSettings = {}, schema: Schema = 
 
         writer.start(name, attrs, isEmpty);
 
-        if (!isEmpty) {
-          let child = node.firstChild;
-          if (child) {
-            // Pre and textarea elements treat the first newline character as optional and will omit it. As such, if the content starts
-            // with a newline we need to add in an additional newline to prevent the current newline in the value being treated as optional
-            // See https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
-            if ((name === 'pre' || name === 'textarea') && child.type === 3 && child.value?.[0] === '\n') {
-              writer.text('\n', true);
-            }
-
-            do {
-              walk(child);
-            } while ((child = child.next));
+        if (Namespace.isNonHtmlElementRootName(name)) {
+          if (Type.isString(node.value)) {
+            writer.text(node.value, true);
           }
 
           writer.end(name);
+        } else {
+          if (!isEmpty) {
+            let child = node.firstChild;
+            if (child) {
+              // Pre and textarea elements treat the first newline character as optional and will omit it. As such, if the content starts
+              // with a newline we need to add in an additional newline to prevent the current newline in the value being treated as optional
+              // See https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
+              if ((name === 'pre' || name === 'textarea') && child.type === 3 && child.value?.[0] === '\n') {
+                writer.text('\n', true);
+              }
+
+              do {
+                walk(child);
+              } while ((child = child.next));
+            }
+
+            writer.end(name);
+          }
         }
       } else {
         handler(node);

--- a/modules/tinymce/src/core/main/ts/dom/NodeType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/NodeType.ts
@@ -1,4 +1,5 @@
 import { Arr, Type } from '@ephox/katamari';
+import { SugarElement, SugarNode } from '@ephox/sugar';
 
 type NullableNode = Node | null | undefined;
 
@@ -12,7 +13,9 @@ const isNodeType = <T extends Node>(type: number) => {
 // won't implement the Object prototype, so Object.getPrototypeOf() will return null or something similar.
 const isRestrictedNode = (node: NullableNode): boolean => !!node && !Object.getPrototypeOf(node);
 
-const isElement = isNodeType<HTMLElement>(1);
+const isElement = isNodeType<Element>(1);
+const isHTMLElement = (node: NullableNode): node is HTMLElement => isElement(node) && SugarNode.isHTMLElement(SugarElement.fromDom(node));
+const isSVGElement = (node: NullableNode): node is SVGElement => isElement(node) && node.namespaceURI === 'http://www.w3.org/2000/svg';
 
 const matchNodeName = <T extends Node>(name: string): (node: NullableNode) => node is T => {
   const lowerCasedName = name.toLowerCase();
@@ -55,12 +58,6 @@ const matchStyleValues = (name: string, values: string): (node: NullableNode) =>
   };
 };
 
-const hasPropValue = (propName: keyof HTMLElement, propValue: any) => {
-  return (node: NullableNode): boolean => {
-    return isElement(node) && node[propName] === propValue;
-  };
-};
-
 const hasAttribute = (attrName: string) => {
   return (node: NullableNode): boolean => {
     return isElement(node) && node.hasAttribute(attrName);
@@ -79,7 +76,7 @@ const isTable = (node: NullableNode): node is HTMLTableElement => isElement(node
 
 const hasContentEditableState = (value: string) => {
   return (node: NullableNode): node is HTMLElement => {
-    if (isElement(node)) {
+    if (isHTMLElement(node)) {
       if (node.contentEditable === value) {
         return true;
       }
@@ -116,6 +113,8 @@ const isSummary = matchNodeName<HTMLElement>('summary');
 export {
   isText,
   isElement,
+  isHTMLElement,
+  isSVGElement,
   isCData,
   isPi,
   isComment,
@@ -130,7 +129,6 @@ export {
   isTableCellOrCaption,
   isRestrictedNode,
   matchNodeNames,
-  hasPropValue,
   hasAttribute,
   hasAttributeValue,
   matchStyleValues,

--- a/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
@@ -36,9 +36,6 @@ const isElementDirectlySelected = (dom: DOMUtils, node: Node): boolean => {
   }
 };
 
-const isEditable = (elm: HTMLElement): boolean =>
-  elm.isContentEditable === true;
-
 // TODO: TINY-9130 Look at making SelectionUtils.preserve maintain the noneditable selection instead
 const preserveSelection = (editor: Editor, action: () => void, shouldMoveStart: (startNode: Node) => boolean): void => {
   const { selection, dom } = editor;
@@ -313,7 +310,6 @@ const shouldExpandToSelector = (format: Format): boolean =>
 export {
   isNode,
   isElementNode,
-  isEditable,
   preserveSelection,
   getNonWhiteSpaceSibling,
   isTextBlock,

--- a/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MergeFormats.ts
@@ -14,7 +14,7 @@ const each = Tools.each;
 
 const mergeTextDecorationsAndColor = (dom: DOMUtils, format: ApplyFormat, vars: FormatVars | undefined, node: Node): void => {
   const processTextDecorationsAndColor = (n: Node) => {
-    if (NodeType.isElement(n) && NodeType.isElement(n.parentNode) && FormatUtils.isEditable(n)) {
+    if (NodeType.isHTMLElement(n) && NodeType.isElement(n.parentNode) && dom.isEditable(n)) {
       const parentTextDecoration = FormatUtils.getTextDecoration(dom, n.parentNode);
       if (dom.getStyle(n, 'color') && parentTextDecoration) {
         dom.setStyle(n, 'text-decoration', parentTextDecoration);
@@ -36,7 +36,7 @@ const mergeBackgroundColorAndFontSize = (dom: DOMUtils, format: ApplyFormat, var
   if (format.styles && format.styles.backgroundColor) {
     const hasFontSize = hasStyle(dom, 'fontSize');
     processChildElements(node,
-      (elm) => hasFontSize(elm) && FormatUtils.isEditable(elm),
+      (elm) => hasFontSize(elm) && dom.isEditable(elm),
       applyStyle(dom, 'backgroundColor', FormatUtils.replaceVars(format.styles.backgroundColor, vars))
     );
   }
@@ -47,11 +47,11 @@ const mergeSubSup = (dom: DOMUtils, format: ApplyFormat, vars: FormatVars | unde
   if (FormatUtils.isInlineFormat(format) && (format.inline === 'sub' || format.inline === 'sup')) {
     const hasFontSize = hasStyle(dom, 'fontSize');
     processChildElements(node,
-      (elm) => hasFontSize(elm) && FormatUtils.isEditable(elm),
+      (elm) => hasFontSize(elm) && dom.isEditable(elm),
       applyStyle(dom, 'fontSize', '')
     );
 
-    const inverseTagDescendants = Arr.filter(dom.select(format.inline === 'sup' ? 'sub' : 'sup', node), FormatUtils.isEditable);
+    const inverseTagDescendants = Arr.filter(dom.select(format.inline === 'sup' ? 'sub' : 'sup', node), dom.isEditable);
     dom.remove(inverseTagDescendants, true);
   }
 };

--- a/modules/tinymce/src/core/main/ts/fmt/MergeUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MergeUtils.ts
@@ -31,8 +31,8 @@ const findElementSibling = (node: Node, siblingName: 'nextSibling' | 'previousSi
 
 const mergeSiblingsNodes = (editor: Editor, prev: Node | undefined, next: Node | undefined) => {
   const elementUtils = ElementUtils(editor);
-  const isPrevEditable = NodeType.isElement(prev) && FormatUtils.isEditable(prev);
-  const isNextEditable = NodeType.isElement(next) && FormatUtils.isEditable(next);
+  const isPrevEditable = NodeType.isHTMLElement(prev) && editor.dom.isEditable(prev);
+  const isNextEditable = NodeType.isHTMLElement(next) && editor.dom.isEditable(next);
 
   // Check if next/prev exists and that they are elements
   if (isPrevEditable && isNextEditable) {
@@ -77,7 +77,7 @@ const clearChildStyles = (dom: DOMUtils, format: ApplyFormat, node: Node): void 
   if (format.clear_child_styles) {
     const selector = format.links ? '*:not(a)' : '*';
     each(dom.select(selector, node), (childNode) => {
-      if (isElementNode(childNode) && FormatUtils.isEditable(childNode)) {
+      if (isElementNode(childNode) && dom.isEditable(childNode)) {
         each(format.styles, (_value, name: string) => {
           dom.setStyle(childNode, name, '');
         });

--- a/modules/tinymce/src/core/main/ts/html/Namespace.ts
+++ b/modules/tinymce/src/core/main/ts/html/Namespace.ts
@@ -1,0 +1,45 @@
+export type NamespaceType = 'html' | 'svg';
+
+export interface NamespaceTracker {
+  readonly track: (node: Node) => NamespaceType;
+  readonly current: () => NamespaceType;
+  readonly reset: () => void;
+}
+
+export const isNonHtmlElementRootName = (name: string): boolean => name.toLowerCase() === 'svg';
+
+export const isNonHtmlElementRoot = (node: Node): boolean => isNonHtmlElementRootName(node.nodeName);
+
+export const toScopeType = (node: Node | undefined): NamespaceType => node?.nodeName === 'svg' ? 'svg' : 'html';
+
+export const createNamespaceTracker = (): NamespaceTracker => {
+  let scopes: Node[] = [];
+
+  const peek = () => scopes[scopes.length - 1];
+
+  const track = (node: Node): NamespaceType => {
+    if (isNonHtmlElementRoot(node)) {
+      scopes.push(node);
+    }
+
+    let currentScope: Node | undefined = peek();
+    if (currentScope && !currentScope.contains(node)) {
+      scopes.pop();
+      currentScope = peek();
+    }
+
+    return toScopeType(currentScope);
+  };
+
+  const current = () => toScopeType(peek());
+
+  const reset = () => {
+    scopes = [];
+  };
+
+  return {
+    track,
+    current,
+    reset
+  };
+};

--- a/modules/tinymce/src/core/main/ts/html/Sanitization.ts
+++ b/modules/tinymce/src/core/main/ts/html/Sanitization.ts
@@ -2,13 +2,13 @@ import { Arr, Obj, Strings, Type } from '@ephox/katamari';
 import { Attribute, NodeTypes, Remove, Replication, SugarElement } from '@ephox/sugar';
 import createDompurify, { Config, DOMPurifyI, SanitizeAttributeHookEvent, SanitizeElementHookEvent } from 'dompurify';
 
-import * as NodeType from '../../dom/NodeType';
-import Tools from '../util/Tools';
-import * as URI from '../util/URI';
-import { DomParserSettings } from './DomParser';
-import Schema from './Schema';
+import { DomParserSettings } from '../api/html/DomParser';
+import Schema from '../api/html/Schema';
+import Tools from '../api/util/Tools';
+import * as URI from '../api/util/URI';
+import * as NodeType from '../dom/NodeType';
 
-type MimeType = 'text/html' | 'application/xhtml+xml';
+export type MimeType = 'text/html' | 'application/xhtml+xml';
 type Sanitizer = (body: HTMLElement, mimeType: MimeType) => void;
 
 // A list of attributes that should be filtered further based on the parser settings

--- a/modules/tinymce/src/core/main/ts/schema/SchemaElementSets.ts
+++ b/modules/tinymce/src/core/main/ts/schema/SchemaElementSets.ts
@@ -9,7 +9,7 @@ export interface ElementSets<T> {
 
 export const getElementSetsAsStrings = (type: SchemaType): ElementSets<string> => {
   let globalAttributes: string, blockContent: string;
-  let phrasingContent: string, flowContent: string | undefined;
+  let phrasingContent: string;
 
   // Attributes present on all elements
   globalAttributes = 'id accesskey class dir lang style tabindex title role';
@@ -31,7 +31,7 @@ export const getElementSetsAsStrings = (type: SchemaType): ElementSets<string> =
       'hidden spellcheck translate';
     blockContent += ' article aside details dialog figure main header footer hgroup section nav ' + transparentContent;
     phrasingContent += ' audio canvas command datalist mark meter output picture ' +
-      'progress time wbr video ruby bdi keygen';
+      'progress time wbr video ruby bdi keygen svg';
   }
 
   // Add HTML4 elements unless it's html5-strict
@@ -43,13 +43,10 @@ export const getElementSetsAsStrings = (type: SchemaType): ElementSets<string> =
 
     const html4BlockContent = 'center dir isindex noframes';
     blockContent = [ blockContent, html4BlockContent ].join(' ');
-
-    // Flow content elements from the HTML5 spec (block+inline)
-    flowContent = [ blockContent, phrasingContent ].join(' ');
   }
 
   // Flow content elements from the HTML5 spec (block+inline)
-  flowContent = flowContent || [ blockContent, phrasingContent ].join(' ');
+  const flowContent = [ blockContent, phrasingContent ].join(' ');
 
   return { globalAttributes, blockContent, phrasingContent, flowContent };
 };

--- a/modules/tinymce/src/core/main/ts/schema/SchemaLookupTable.ts
+++ b/modules/tinymce/src/core/main/ts/schema/SchemaLookupTable.ts
@@ -16,18 +16,21 @@ export const makeSchema = (type: SchemaType): SchemaLookupTable => {
   const { globalAttributes, phrasingContent, flowContent } = SchemaElementSets.getElementSetsAsStrings(type);
   const schema: SchemaLookupTable = {};
 
+  const addElement = (name: string, attributes: string[], children: string[]) => {
+    schema[name] = {
+      attributes: Arr.mapToObject(attributes, Fun.constant({})),
+      attributesOrder: attributes,
+      children: Arr.mapToObject(children, Fun.constant({}))
+    };
+  };
+
   const add = (name: string, attributes: string = '', children: string = '') => {
     const childNames = SchemaUtils.split(children);
     const names = SchemaUtils.split(name);
     let ni = names.length;
+    const allAttributes = SchemaUtils.split([ globalAttributes, attributes ].join(' '));
     while (ni--) {
-      const attributesOrder = SchemaUtils.split([ globalAttributes, attributes ].join(' '));
-
-      schema[names[ni]] = {
-        attributes: Arr.mapToObject(attributesOrder, Fun.constant({})),
-        attributesOrder,
-        children: Arr.mapToObject(childNames, Fun.constant({}))
-      };
+      addElement(names[ni], allAttributes.slice(), childNames);
     }
   };
 
@@ -137,6 +140,9 @@ export const makeSchema = (type: SchemaType): SchemaLookupTable => {
     add('meter', 'value min max low high optimum', phrasingContent);
     add('details', 'open', [ flowContent, 'summary' ].join(' '));
     add('keygen', 'autofocus challenge disabled form keytype name');
+
+    // SVGs only support a subset of the global attributes
+    addElement('svg', 'id tabindex lang xml:space class style x y width height viewBox preserveAspectRatio zoomAndPan transform'.split(' '), []);
   }
 
   // Extend with HTML4 attributes unless it's html5-strict

--- a/modules/tinymce/src/core/main/ts/selection/ElementSelection.ts
+++ b/modules/tinymce/src/core/main/ts/selection/ElementSelection.ts
@@ -88,7 +88,7 @@ const getNode = (root: HTMLElement, rng: Range | undefined): HTMLElement => {
   }
 
   const elm = NodeType.isText(node) ? node.parentNode : node;
-  return NodeType.isElement(elm) ? elm : root;
+  return NodeType.isHTMLElement(elm) ? elm : root;
 };
 
 const getSelectedBlocks = (dom: DOMUtils, rng: Range, startElm?: Element, endElm?: Element): Element[] => {

--- a/modules/tinymce/src/core/test/ts/atomic/schema/SchemaElementSetsTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/schema/SchemaElementSetsTest.ts
@@ -33,7 +33,7 @@ describe('atomic.tinymce.core.schema.SchemaElementSetsTest', () => {
         'input', 'ins', 'kbd', 'label', 'map', 'noscript', 'object', 'q', 's', 'samp', 'script', 'select', 'small',
         'span', 'strong', 'sub', 'sup', 'textarea', 'u', 'var', '#text', '#comment', 'audio', 'canvas', 'command',
         'datalist', 'mark', 'meter', 'output', 'picture', 'progress', 'time', 'wbr', 'video', 'ruby', 'bdi', 'keygen',
-        'acronym', 'applet', 'basefont', 'big', 'font', 'strike', 'tt'
+        'svg', 'acronym', 'applet', 'basefont', 'big', 'font', 'strike', 'tt'
       ],
       flowContent: [
         'address', 'blockquote', 'div', 'dl', 'fieldset', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'menu',
@@ -42,7 +42,7 @@ describe('atomic.tinymce.core.schema.SchemaElementSetsTest', () => {
         'abbr', 'b', 'bdo', 'br', 'button', 'cite', 'code', 'del', 'dfn', 'em', 'embed', 'i', 'iframe', 'img', 'input',
         'ins', 'kbd', 'label', 'map', 'noscript', 'object', 'q', 's', 'samp', 'script', 'select', 'small', 'span', 'strong',
         'sub', 'sup', 'textarea', 'u', 'var', '#text', '#comment', 'audio', 'canvas', 'command', 'datalist', 'mark',
-        'meter', 'output', 'picture', 'progress', 'time', 'wbr', 'video', 'ruby', 'bdi', 'keygen', 'acronym', 'applet',
+        'meter', 'output', 'picture', 'progress', 'time', 'wbr', 'video', 'ruby', 'bdi', 'keygen', 'svg', 'acronym', 'applet',
         'basefont', 'big', 'font', 'strike', 'tt'
       ]
     }
@@ -64,7 +64,7 @@ describe('atomic.tinymce.core.schema.SchemaElementSetsTest', () => {
         'a', 'abbr', 'b', 'bdo', 'br', 'button', 'cite', 'code', 'del', 'dfn', 'em', 'embed', 'i', 'iframe', 'img',
         'input', 'ins', 'kbd', 'label', 'map', 'noscript', 'object', 'q', 's', 'samp', 'script', 'select', 'small',
         'span', 'strong', 'sub', 'sup', 'textarea', 'u', 'var', '#text', '#comment', 'audio', 'canvas', 'command',
-        'datalist', 'mark', 'meter', 'output', 'picture', 'progress', 'time', 'wbr', 'video', 'ruby', 'bdi', 'keygen'
+        'datalist', 'mark', 'meter', 'output', 'picture', 'progress', 'time', 'wbr', 'video', 'ruby', 'bdi', 'keygen', 'svg'
       ],
       flowContent: [
         'address', 'blockquote', 'div', 'dl', 'fieldset', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'menu',
@@ -73,7 +73,7 @@ describe('atomic.tinymce.core.schema.SchemaElementSetsTest', () => {
         'code', 'del', 'dfn', 'em', 'embed', 'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'label', 'map', 'noscript',
         'object', 'q', 's', 'samp', 'script', 'select', 'small', 'span', 'strong', 'sub', 'sup', 'textarea', 'u',
         'var', '#text', '#comment', 'audio', 'canvas', 'command', 'datalist', 'mark', 'meter', 'output', 'picture',
-        'progress', 'time', 'wbr', 'video', 'ruby', 'bdi', 'keygen'
+        'progress', 'time', 'wbr', 'video', 'ruby', 'bdi', 'keygen', 'svg'
       ]
     }
   }));

--- a/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
@@ -146,4 +146,13 @@ describe('browser.tinymce.core.ForceBlocksTest', () => {
       assert.equal(HtmlUtils.cleanHtml(editor.getBody().innerHTML), expectedInnerHtml);
     });
   });
+
+  it('TINY-10237: Should not wrap SVG elements', () => {
+    const editor = hook.editor();
+
+    editor.setContent('<svg></svg>foo', { format: 'raw' });
+    TinySelections.setCursor(editor, [ 1 ], 0);
+    pressArrowKey(editor);
+    TinyAssertions.assertRawContent(editor, '<svg></svg><p>foo</p>');
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -429,7 +429,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
       base_url: '/project/tinymce/js/tinymce'
     }, []);
 
-    it('TINY-10237: SVGs is not enabled by default', () => {
+    it('TINY-10237: SVGs is not allowed by default', () => {
       const editor = hook.editor();
       editor.setContent('<svg width="100" height="100"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><script>alert(1)</script></circle></svg>');
       TinyAssertions.assertContent(editor, '');
@@ -442,10 +442,23 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
       extended_valid_elements: 'svg[width|height]'
     }, []);
 
-    it('TINY-10237: Retain SVG content is SVGs are allowed', () => {
+    it('TINY-10237: Retain SVG content if SVGs are allowed but sanitize them', () => {
       const editor = hook.editor();
-      editor.setContent('<svg width="100" height="100"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><script>alert(1)</script></circle></svg>');
+      editor.setContent('<svg width="100" height="100" onload="alert(1)"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><script>alert(1)</script></circle></svg>');
       TinyAssertions.assertContent(editor, '<svg width="100" height="100"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></circle></svg>');
+    });
+
+    it('TINY-10237: Retain SVG content white space', () => {
+      const editor = hook.editor();
+      const svgHtml = `
+        <svg width="100" height="100">
+          <circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red">
+            <desc>foo</desc>
+          </circle>
+        </svg>
+      `.trim();
+      editor.setContent(svgHtml);
+      TinyAssertions.assertContent(editor, svgHtml);
     });
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -423,4 +423,43 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
       });
     });
   });
+
+  context('SVG elements not enabled by default', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce'
+    }, []);
+
+    it('TINY-10237: SVGs is not enabled by default', () => {
+      const editor = hook.editor();
+      editor.setContent('<svg width="100" height="100"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><script>alert(1)</script></circle></svg>');
+      TinyAssertions.assertContent(editor, '');
+    });
+  });
+
+  context('SVG elements', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      extended_valid_elements: 'svg[width|height]'
+    }, []);
+
+    it('TINY-10237: Retain SVG content is SVGs are allowed', () => {
+      const editor = hook.editor();
+      editor.setContent('<svg width="100" height="100"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><script>alert(1)</script></circle></svg>');
+      TinyAssertions.assertContent(editor, '<svg width="100" height="100"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></circle></svg>');
+    });
+  });
+
+  context('SVG elements xss_sanitization: false', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      extended_valid_elements: 'svg[width|height]',
+      xss_sanitization: false
+    }, []);
+
+    it('TINY-10237: Retain SVG content and scripts if sanitization is disabled', () => {
+      const editor = hook.editor();
+      editor.setContent('<svg width="100" height="100"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><script>alert(1)</script></circle></svg>');
+      TinyAssertions.assertContent(editor, '<svg width="100" height="100"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><script>alert(1)</script></circle></svg>');
+    });
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -824,4 +824,20 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
       TinyAssertions.assertContent(editor, '<details><summary>hellowonderfulworld</summary><div>body</div></details>');
     });
   });
+
+  context('SVG elements', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      indent: false,
+      base_url: '/project/tinymce/js/tinymce',
+      extended_valid_elements: 'svg[width|height]'
+    }, [], true);
+
+    it('TINY-10237: Inserting SVG elements but filter out things like scripts', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>ab</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      editor.insertContent('<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><desc><script>alert(1)</script><p>hello</p></circle></a></svg>');
+      TinyAssertions.assertContent(editor, '<p>a<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><desc><p>hello</p></desc></circle></svg>b</p>');
+    });
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
@@ -15,6 +15,8 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
   const getTestElement = (id: string = 'test') =>
     DOM.get(id) as HTMLElement;
 
+  const createSvgElement = (name: string) => document.createElementNS('http://www.w3.org/2000/svg', name);
+
   it('parseStyle', () => {
     DOM.add(document.body, 'div', { id: 'test' });
 
@@ -261,12 +263,35 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
     assert.equal(DOM.getAttrib(nonElement, 'test', ''), '');
     assert.equal(DOM.getAttrib(nonElement, 'test', 'x'), 'x');
 
+    const svg = createSvgElement('svg');
+    DOM.setAttrib(svg, 'class', 'foo');
+    assert.equal(DOM.getAttrib(svg, 'class'), 'foo');
+
     DOM.remove('test');
   });
 
   it('setGetAttrib on null', () => {
     assert.equal(DOM.getAttrib(null, 'test'), '');
     DOM.setAttrib(null, 'test', null);
+  });
+
+  it('getContentEditable', () => {
+    const test = DOM.add(document.body, 'div', { id: 'test' });
+
+    test.innerHTML = `
+      <span contenteditable="false"></span>
+      <span contenteditable="true"></span>
+      <span></span>
+      <svg></svg>
+    `;
+    const elms = test.children;
+
+    assert.equal(DOM.getContentEditable(elms[0]), 'false');
+    assert.equal(DOM.getContentEditable(elms[1]), 'true');
+    assert.equal(DOM.getContentEditable(elms[2]), null, 'inherit counts as null');
+    assert.equal(DOM.getContentEditable(elms[3]), null, 'We can not get the contentEditable state from SVGElement since it does not have that property');
+
+    DOM.remove('test');
   });
 
   it('getAttribs', () => {
@@ -323,6 +348,12 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
     assert.isUndefined(DOM.getStyle(null, 'fontSize'));
 
     DOM.remove('test');
+  });
+
+  it('setStyle/getStyle on a SVG element', () => {
+    const svg = createSvgElement('svg');
+    DOM.setStyle(svg, 'color', 'red');
+    assert.equal(DOM.getStyle(svg, 'color'), 'red');
   });
 
   it('getPos', () => {
@@ -933,6 +964,12 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
       editableRoot: false,
       path: [ 0, 0 ],
       expected: true
+    }));
+
+    it('TINY-10237: isEditable on SVG element should always be considered non-editable', testIsEditable({
+      input: '<svg></svg>',
+      path: [ 0 ],
+      expected: false
     }));
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/NodeTypeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/NodeTypeTest.ts
@@ -5,21 +5,51 @@ import { assert } from 'chai';
 import * as NodeType from 'tinymce/core/dom/NodeType';
 
 describe('browser.tinymce.core.dom.NodeTypeTest', () => {
-  it('isText/isElement/isComment', () => {
+  const createSvgElement = (name: string) => document.createElementNS('http://www.w3.org/2000/svg', name);
+
+  it('isText', () => {
     assert.isTrue(NodeType.isText(document.createTextNode('x')));
     assert.isFalse(NodeType.isText(null));
     assert.isFalse(NodeType.isText(document.createElement('div')));
     assert.isFalse(NodeType.isText(document.createComment('x')));
+    assert.isFalse(NodeType.isText(createSvgElement('svg')));
+    assert.isFalse(NodeType.isText(createSvgElement('g')));
+  });
 
+  it('isElement', () => {
     assert.isTrue(NodeType.isElement(document.createElement('div')));
+    assert.isTrue(NodeType.isElement(createSvgElement('svg')));
+    assert.isTrue(NodeType.isElement(createSvgElement('g')));
     assert.isFalse(NodeType.isElement(null));
     assert.isFalse(NodeType.isElement(document.createTextNode('x')));
     assert.isFalse(NodeType.isElement(document.createComment('x')));
+  });
 
+  it('isHTMLElement', () => {
+    assert.isTrue(NodeType.isHTMLElement(document.createElement('div')));
+    assert.isFalse(NodeType.isHTMLElement(null));
+    assert.isFalse(NodeType.isHTMLElement(document.createTextNode('x')));
+    assert.isFalse(NodeType.isHTMLElement(document.createComment('x')));
+    assert.isFalse(NodeType.isHTMLElement(createSvgElement('svg')));
+    assert.isFalse(NodeType.isHTMLElement(createSvgElement('g')));
+  });
+
+  it('isComment', () => {
     assert.isTrue(NodeType.isComment(document.createComment('x')));
     assert.isFalse(NodeType.isComment(null));
     assert.isFalse(NodeType.isComment(document.createTextNode('x')));
     assert.isFalse(NodeType.isComment(document.createElement('div')));
+    assert.isFalse(NodeType.isComment(createSvgElement('svg')));
+    assert.isFalse(NodeType.isComment(createSvgElement('g')));
+  });
+
+  it('isSVGElement', () => {
+    assert.isFalse(NodeType.isSVGElement(document.createComment('x')));
+    assert.isFalse(NodeType.isSVGElement(null));
+    assert.isFalse(NodeType.isSVGElement(document.createTextNode('x')));
+    assert.isFalse(NodeType.isSVGElement(document.createElement('div')));
+    assert.isTrue(NodeType.isSVGElement(createSvgElement('svg')));
+    assert.isTrue(NodeType.isSVGElement(createSvgElement('g')));
   });
 
   it('isBr', () => {
@@ -61,15 +91,6 @@ describe('browser.tinymce.core.dom.NodeTypeTest', () => {
     assert.isTrue(matchNodeNames(document.createElement('a')));
     assert.isTrue(matchNodeNames(document.createElement('div')));
     assert.isFalse(matchNodeNames(document.createElement('b')));
-  });
-
-  it('hasPropValue', () => {
-    const hasTabIndex3 = NodeType.hasPropValue('tabIndex', 3);
-
-    assert.isFalse(hasTabIndex3(null));
-    assert.isTrue(hasTabIndex3(SugarElement.fromHtml('<div tabIndex="3"></div>').dom));
-    assert.isFalse(hasTabIndex3(document.createElement('div')));
-    assert.isFalse(hasTabIndex3(document.createElement('b')));
   });
 
   it('isBogus', () => {

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1588,4 +1588,30 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       ], { valid_elements: '*[*]' });
     });
   });
+
+  context('SVG elements', () => {
+    it('TINY-10237: Should not wrap SVGs', () => {
+      const schema = Schema();
+      schema.addValidElements('svg[*]');
+      const input = '<svg></svg>foo';
+      const serializedHtml = HtmlSerializer({}, schema).serialize(DomParser({ forced_root_block: 'p' }, schema).parse(input));
+      assert.equal(serializedHtml, '<svg></svg><p>foo</p>');
+    });
+
+    it('TINY-10237: Should retain SVG elements as is but filter out scripts', () => {
+      const schema = Schema();
+      schema.addValidElements('svg[*]');
+      const input = '<svg><circle><desc><b>foo</b><script>alert(1)</script></desc></circle></svg>foo';
+      const serializedHtml = HtmlSerializer({}, schema).serialize(DomParser({ forced_root_block: 'p' }, schema).parse(input));
+      assert.equal(serializedHtml, '<svg><circle><desc><b>foo</b></desc></circle></svg><p>foo</p>');
+    });
+
+    it('TINY-10237: Should retain SVG elements and keep scripts if sanitize is set to false', () => {
+      const schema = Schema();
+      schema.addValidElements('svg[*]');
+      const input = '<svg><circle><desc>foo<script>alert(1)</script></desc></circle></svg>foo';
+      const serializedHtml = HtmlSerializer({}, schema).serialize(DomParser({ forced_root_block: 'p', sanitize: false }, schema).parse(input));
+      assert.equal(serializedHtml, '<svg><circle><desc>foo<script>alert(1)</script></desc></circle></svg><p>foo</p>');
+    });
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/NamespaceTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/NamespaceTest.ts
@@ -1,0 +1,61 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
+
+import * as Namespace from 'tinymce/core/html/Namespace';
+
+describe('browser.tinymce.core.html.NamespaceTest', () => {
+  const createSvgElement = (name: string) => document.createElementNS('http://www.w3.org/2000/svg', name);
+
+  it('isNonHtmlElementRootName', () => {
+    assert.isTrue(Namespace.isNonHtmlElementRootName('svg'));
+    assert.isFalse(Namespace.isNonHtmlElementRootName('span'));
+  });
+
+  it('isNonHtmlElementRoot', () => {
+    assert.isTrue(Namespace.isNonHtmlElementRoot(createSvgElement('svg')));
+    assert.isFalse(Namespace.isNonHtmlElementRoot(document.createElement('span')));
+  });
+
+  it('toScopeType', () => {
+    assert.equal(Namespace.toScopeType(createSvgElement('svg')), 'svg');
+    assert.equal(Namespace.toScopeType(document.createElement('span')), 'html');
+  });
+
+  it('Namespace tracker', () => {
+    const tracker = Namespace.createNamespaceTracker();
+    const scope = SugarElement.fromHtml(`
+      <div>
+        <p>
+          <span>foo</span>
+        </p>
+        <svg>
+          <circle>
+            <desc>
+              <p>bar</p>
+            </desc>
+          </circle>
+        </svg>
+        <span>baz</span>
+      </div>
+    `.trim());
+
+    const walker = document.createTreeWalker(
+      scope.dom,
+      NodeFilter.SHOW_ELEMENT
+    );
+
+    const states: Array<[ string, Namespace.NamespaceType ]> = [];
+    while (walker.nextNode()) {
+      const type = tracker.track(walker.currentNode);
+      assert.equal(type, tracker.current(), 'Current tracker state should be the last executed track result');
+      states.push([ walker.currentNode.nodeName.toLowerCase(), type ]);
+    }
+    assert.deepEqual(states, [[ 'p', 'html' ], [ 'span', 'html' ], [ 'svg', 'svg' ], [ 'circle', 'svg' ], [ 'desc', 'svg' ], [ 'p', 'svg' ], [ 'span', 'html' ]]);
+
+    tracker.track(createSvgElement('svg'));
+    assert.equal(tracker.current(), 'svg');
+    tracker.reset();
+    assert.equal(tracker.current(), 'html');
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
@@ -1,23 +1,70 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { assert } from 'chai';
 
 import Schema from 'tinymce/core/api/html/Schema';
 import { getSanitizer, MimeType } from 'tinymce/core/html/Sanitization';
 
 describe('browser.tinymce.core.html.SanitizationTest', () => {
-  const testHtmlSanitizer = (testCase: { input: string; expected: string; mimeType: MimeType }) => {
-    const sanitizer = getSanitizer({}, Schema());
+  context('Sanitize html', () => {
+    const testHtmlSanitizer = (testCase: { input: string; expected: string; mimeType: MimeType; sanitize?: boolean }) => {
+      const sanitizer = getSanitizer({ sanitize: testCase.sanitize ?? true }, Schema());
 
-    const body = document.createElement('body');
-    body.innerHTML = testCase.input;
-    sanitizer(body, testCase.mimeType);
+      const body = document.createElement('body');
+      body.innerHTML = testCase.input;
+      sanitizer.sanitizeHtmlElement(body, testCase.mimeType);
 
-    assert.equal(body.innerHTML, testCase.expected);
-  };
+      assert.equal(body.innerHTML, testCase.expected);
+    };
 
-  it('Sanitize iframe url', () => testHtmlSanitizer({
-    input: '<iframe src="javascript:alert(1)"></iframe>',
-    expected: '<iframe></iframe>',
-    mimeType: 'text/html'
-  }));
+    it('Sanitize iframe HTML', () => testHtmlSanitizer({
+      input: '<iframe src="x"><script>alert(1)</script></iframe><iframe src="javascript:alert(1)"></iframe>',
+      expected: '<iframe></iframe>',
+      mimeType: 'text/html'
+    }));
+
+    it('Disabled sanitization of iframe HTML', () => testHtmlSanitizer({
+      input: '<iframe src="x"><script>alert(1)</script></iframe><iframe src="javascript:alert(1)"></iframe>',
+      expected: '<iframe src="x"><script>alert(1)</script></iframe><iframe></iframe>',
+      mimeType: 'text/html',
+      sanitize: false
+    }));
+  });
+
+  context('Santitize non-html', () => {
+    const testNamespaceSanitizer = (testCase: { input: string; expected: string; sanitize?: boolean }) => {
+      const sanitizer = getSanitizer({ sanitize: testCase.sanitize ?? true }, Schema());
+
+      const body = document.createElement('body');
+      body.innerHTML = testCase.input;
+      sanitizer.sanitizeNamespaceElement(body);
+
+      assert.equal(body.innerHTML, testCase.expected);
+    };
+
+    it('Sanitize SVG', () => testNamespaceSanitizer({
+      input: '<svg><script>alert(1)</script><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></svg>',
+      expected: '<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></circle></svg>'
+    }));
+
+    it('Sanitize SVG with xlink', () => testNamespaceSanitizer({
+      input: '<svg><script>alert(1)</script><a xlink:href="url"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></a></svg>',
+      expected: '<svg><a xlink:href="url"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></circle></a></svg>'
+    }));
+
+    it('Sanitize SVG with mixed HTML', () => testNamespaceSanitizer({
+      input: '<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><desc><script>alert(1)</script><p>hello</p></circle></a></svg>',
+      expected: '<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><desc><p>hello</p></desc></circle></svg>'
+    }));
+
+    it('Sanitize SVG with xlink with script url', () => testNamespaceSanitizer({
+      input: '<svg><script>alert(1)</script><a xlink:href="javascript:alert(1)"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></a></svg>',
+      expected: '<svg><a><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></circle></a></svg>'
+    }));
+
+    it('Disabled sanitization of SVG', () => testNamespaceSanitizer({
+      input: '<svg><script>alert(1)</script><a xlink:href="javascript:alert(1)"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></a></svg>',
+      expected: '<svg><script>alert(1)</script><a xlink:href="javascript:alert(1)"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></circle></a></svg>',
+      sanitize: false
+    }));
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
@@ -1,0 +1,23 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { assert } from 'chai';
+
+import Schema from 'tinymce/core/api/html/Schema';
+import { getSanitizer, MimeType } from 'tinymce/core/html/Sanitization';
+
+describe('browser.tinymce.core.html.SanitizationTest', () => {
+  const testHtmlSanitizer = (testCase: { input: string; expected: string; mimeType: MimeType }) => {
+    const sanitizer = getSanitizer({}, Schema());
+
+    const body = document.createElement('body');
+    body.innerHTML = testCase.input;
+    sanitizer(body, testCase.mimeType);
+
+    assert.equal(body.innerHTML, testCase.expected);
+  };
+
+  it('Sanitize iframe url', () => testHtmlSanitizer({
+    input: '<iframe src="javascript:alert(1)"></iframe>',
+    expected: '<iframe></iframe>',
+    mimeType: 'text/html'
+  }));
+});

--- a/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
@@ -1,4 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
+import { PlatformDetection } from '@ephox/sand';
 import { assert } from 'chai';
 
 import Schema from 'tinymce/core/api/html/Schema';
@@ -6,6 +7,8 @@ import { getSanitizer, MimeType } from 'tinymce/core/html/Sanitization';
 
 describe('browser.tinymce.core.html.SanitizationTest', () => {
   context('Sanitize html', () => {
+    const isSafari = PlatformDetection.detect().browser.isSafari();
+
     const testHtmlSanitizer = (testCase: { input: string; expected: string; mimeType: MimeType; sanitize?: boolean }) => {
       const sanitizer = getSanitizer({ sanitize: testCase.sanitize ?? true }, Schema());
 
@@ -18,13 +21,15 @@ describe('browser.tinymce.core.html.SanitizationTest', () => {
 
     it('Sanitize iframe HTML', () => testHtmlSanitizer({
       input: '<iframe src="x"><script>alert(1)</script></iframe><iframe src="javascript:alert(1)"></iframe>',
-      expected: '<iframe></iframe>',
+      // Safari seems to encode the contents of iframes
+      expected: isSafari ? '<iframe src="x">&lt;script&gt;alert(1)&lt;/script&gt;</iframe>' : '<iframe></iframe>',
       mimeType: 'text/html'
     }));
 
     it('Disabled sanitization of iframe HTML', () => testHtmlSanitizer({
       input: '<iframe src="x"><script>alert(1)</script></iframe><iframe src="javascript:alert(1)"></iframe>',
-      expected: '<iframe src="x"><script>alert(1)</script></iframe><iframe></iframe>',
+      // Safari seems to encode the contents of iframes
+      expected: isSafari ? '<iframe src="x">&lt;script&gt;alert(1)&lt;/script&gt;</iframe><iframe></iframe>' : '<iframe src="x"><script>alert(1)</script></iframe><iframe></iframe>',
       mimeType: 'text/html',
       sanitize: false
     }));

--- a/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
@@ -22,7 +22,7 @@ describe('browser.tinymce.core.html.SanitizationTest', () => {
     it('Sanitize iframe HTML', () => testHtmlSanitizer({
       input: '<iframe src="x"><script>alert(1)</script></iframe><iframe src="javascript:alert(1)"></iframe>',
       // Safari seems to encode the contents of iframes
-      expected: isSafari ? '<iframe src="x">&lt;script&gt;alert(1)&lt;/script&gt;</iframe>' : '<iframe></iframe>',
+      expected: isSafari ? '<iframe src="x">&lt;script&gt;alert(1)&lt;/script&gt;</iframe><iframe></iframe>' : '<iframe></iframe>',
       mimeType: 'text/html'
     }));
 

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -253,12 +253,12 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
       INPUT: {}, IMG: {}, HR: {}, FRAME: {}, COL: {}, BR: {},
       BASEFONT: {}, BASE: {}, AREA: {}, SOURCE: {},
       TD: {}, TH: {}, IFRAME: {}, VIDEO: {}, AUDIO: {}, OBJECT: {},
-      WBR: {}, TRACK: {}, SCRIPT: {}, PRE: {}, CODE: {},
+      WBR: {}, TRACK: {}, SCRIPT: {}, PRE: {}, CODE: {}, SVG: {},
       embed: {}, param: {}, meta: {}, link: {}, isindex: {},
       input: {}, img: {}, hr: {}, frame: {}, col: {}, br: {},
       basefont: {}, base: {}, area: {}, source: {},
       td: {}, th: {}, iframe: {}, video: {}, audio: {}, object: {},
-      wbr: {}, track: {}, script: {}, pre: {}, code: {}
+      wbr: {}, track: {}, script: {}, pre: {}, code: {}, svg: {}
     });
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SerializerTest.ts
@@ -2,6 +2,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { assert } from 'chai';
 
 import DomParser from 'tinymce/core/api/html/DomParser';
+import AstNode from 'tinymce/core/api/html/Node';
 import Schema from 'tinymce/core/api/html/Schema';
 import HtmlSerializer from 'tinymce/core/api/html/Serializer';
 
@@ -56,5 +57,14 @@ describe('browser.tinymce.core.html.SerializerTest', () => {
       serializer.serialize(DomParser({ validate: false }, schema).parse('<textarea>\n\ncontent</textarea>')),
       '<textarea>\n\ncontent</textarea>'
     );
+  });
+
+  it('TINY-10237: Serialize svg node', () => {
+    const schema = Schema({ valid_elements: 'textarea' });
+    const serializer = HtmlSerializer({}, schema);
+    const svgNode = AstNode.create('svg');
+    svgNode.value = '<circle>';
+
+    assert.equal(serializer.serialize(svgNode), '<svg><circle></svg>');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10237

This is a bit on the big side but you should be able to review it commit by commit.

Description of Changes:
* Adds opt-in support for SVG elements by just allowing SVG then all children of a SVG is also valid
* Adds support for XLINK in SVGs since that is how you do links in previous version of SVG
* Adds opt-out XSS filtering of SVG elements.
* SVG elements are purified as a separate step since it can have SVG, HTML mixed.
* Treats SVG elements as black boxes anything inside them is just retained as it but filtered though sanitation. 
* Changes a bunch of predicate checks to be isHTMLElement before we could cheat by treating all elements in the editor as HTMLElements after this it's no longer the case it can now contain SVGElement nodes.
* Right now it just supports SVGs but this is kind of opening for other sub specs like MathML.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
