### PR TITLE
TINY-10010: Empty.isEmpty should respect empty CET

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resize handles would not appear on editable images in a non-editable context. #TINY-10118
 - The dialog size was not updated when the `size` argument was changed when redialling a dialog. #TINY-10209
 - Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10213
-- An empty element with a `contenteditable="true"` attribute within a table cell and noneditable root was deleted when the Backspace key was pressed. #TINY-10010
+- An empty element with a `contenteditable="true"` attribute within a table cell would not be treated as content and get removed if backspace or delete was being pressed. #TINY-10010
 
 ### Improved
 - Colorpicker now includes the Brightness/Saturation selector and hue slider in the keyboard navigable items. #TINY-9287

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Setting the content with an attribute that contains a self-closing HTML tag did not preserve the tag. #TINY-10088
 - Resize handles would not appear on editable images in a non-editable context. #TINY-10118
 - The dialog size was not updated when the `size` argument was changed when redialling a dialog. #TINY-10209
+- An empty element with a `contenteditable="true"` attribute within a table cell and noneditable root was deleted when the Backspace key was pressed. #TINY-10010
 
 ### Improved
 - Colorpicker now includes the Brightness/Saturation selector and hue slider in the keyboard navigable items. #TINY-9287

--- a/modules/tinymce/src/core/main/ts/dom/Empty.ts
+++ b/modules/tinymce/src/core/main/ts/dom/Empty.ts
@@ -1,5 +1,5 @@
 import { Fun } from '@ephox/katamari';
-import { Compare, SelectorExists, SugarElement } from '@ephox/sugar';
+import { Attribute, Compare, ContentEditable, SelectorExists, SugarNode, SugarElement, Traverse } from '@ephox/sugar';
 
 import DomTreeWalker from '../api/dom/TreeWalker';
 import * as CaretCandidate from '../caret/CaretCandidate';
@@ -28,7 +28,7 @@ const isBookmark = NodeType.hasAttribute('data-mce-bookmark');
 const isBogus = NodeType.hasAttribute('data-mce-bogus');
 const isBogusAll = NodeType.hasAttributeValue('data-mce-bogus', 'all');
 
-const isEmptyNode = (targetNode: Node, skipBogus: boolean): boolean => {
+const isEmptyNode = (targetNode: Node, skipBogus: boolean, skipEmptyCET: boolean): boolean => {
   let brCount = 0;
 
   if (isContent(targetNode, targetNode)) {
@@ -52,6 +52,14 @@ const isEmptyNode = (targetNode: Node, skipBogus: boolean): boolean => {
           continue;
         }
       }
+      if (!skipEmptyCET) {
+        const elm = SugarElement.fromDom(node);
+        if (SugarNode.isElement(elm)
+          && Attribute.get(elm, 'contenteditable') === 'true'
+          && Traverse.parentElement(elm).exists((elm) => !ContentEditable.isEditable(elm))) {
+          return false;
+        }
+      }
 
       if (NodeType.isBr(node)) {
         brCount++;
@@ -70,8 +78,8 @@ const isEmptyNode = (targetNode: Node, skipBogus: boolean): boolean => {
   }
 };
 
-const isEmpty = (elm: SugarElement<Node>, skipBogus: boolean = true): boolean =>
-  isEmptyNode(elm.dom, skipBogus);
+const isEmpty = (elm: SugarElement<Node>, skipBogus: boolean = true, skipEmptyCET: boolean = false): boolean =>
+  isEmptyNode(elm.dom, skipBogus, skipEmptyCET);
 
 export {
   isEmpty,

--- a/modules/tinymce/src/core/main/ts/dom/Empty.ts
+++ b/modules/tinymce/src/core/main/ts/dom/Empty.ts
@@ -28,6 +28,9 @@ const isBookmark = NodeType.hasAttribute('data-mce-bookmark');
 const isBogus = NodeType.hasAttribute('data-mce-bogus');
 const isBogusAll = NodeType.hasAttributeValue('data-mce-bogus', 'all');
 
+const hasNonEditableParent = (node: Node) =>
+  Traverse.parentElement(SugarElement.fromDom(node)).exists((parent) => !ContentEditable.isEditable(parent));
+
 const isEmptyNode = (targetNode: Node, skipBogus: boolean): boolean => {
   let brCount = 0;
 
@@ -52,8 +55,7 @@ const isEmptyNode = (targetNode: Node, skipBogus: boolean): boolean => {
           continue;
         }
       }
-      if (NodeType.isContentEditableTrue(node)
-        && Traverse.parentElement(SugarElement.fromDom(node)).exists((parent) => !ContentEditable.isEditable(parent))) {
+      if (NodeType.isContentEditableTrue(node) && hasNonEditableParent(node)) {
         return false;
       }
 

--- a/modules/tinymce/src/core/main/ts/dom/Empty.ts
+++ b/modules/tinymce/src/core/main/ts/dom/Empty.ts
@@ -1,5 +1,5 @@
 import { Fun } from '@ephox/katamari';
-import { Attribute, Compare, ContentEditable, SelectorExists, SugarNode, SugarElement, Traverse } from '@ephox/sugar';
+import { Compare, ContentEditable, SelectorExists, SugarElement, Traverse } from '@ephox/sugar';
 
 import DomTreeWalker from '../api/dom/TreeWalker';
 import * as CaretCandidate from '../caret/CaretCandidate';
@@ -28,7 +28,7 @@ const isBookmark = NodeType.hasAttribute('data-mce-bookmark');
 const isBogus = NodeType.hasAttribute('data-mce-bogus');
 const isBogusAll = NodeType.hasAttributeValue('data-mce-bogus', 'all');
 
-const isEmptyNode = (targetNode: Node, skipBogus: boolean, skipEmptyCET: boolean): boolean => {
+const isEmptyNode = (targetNode: Node, skipBogus: boolean): boolean => {
   let brCount = 0;
 
   if (isContent(targetNode, targetNode)) {
@@ -52,13 +52,9 @@ const isEmptyNode = (targetNode: Node, skipBogus: boolean, skipEmptyCET: boolean
           continue;
         }
       }
-      if (!skipEmptyCET) {
-        const elm = SugarElement.fromDom(node);
-        if (SugarNode.isElement(elm)
-          && Attribute.get(elm, 'contenteditable') === 'true'
-          && Traverse.parentElement(elm).exists((elm) => !ContentEditable.isEditable(elm))) {
-          return false;
-        }
+      if (NodeType.isContentEditableTrue(node)
+        && Traverse.parentElement(SugarElement.fromDom(node)).exists((parent) => !ContentEditable.isEditable(parent))) {
+        return false;
       }
 
       if (NodeType.isBr(node)) {
@@ -78,8 +74,8 @@ const isEmptyNode = (targetNode: Node, skipBogus: boolean, skipEmptyCET: boolean
   }
 };
 
-const isEmpty = (elm: SugarElement<Node>, skipBogus: boolean = true, skipEmptyCET: boolean = false): boolean =>
-  isEmptyNode(elm.dom, skipBogus, skipEmptyCET);
+const isEmpty = (elm: SugarElement<Node>, skipBogus: boolean = true): boolean =>
+  isEmptyNode(elm.dom, skipBogus);
 
 export {
   isEmpty,

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -1,5 +1,5 @@
-import { Arr, Fun, Type } from '@ephox/katamari';
-import { ContentEditable, SelectorFilter, SugarElement, Traverse } from '@ephox/sugar';
+import { Fun, Type } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import Env from '../api/Env';
@@ -9,6 +9,7 @@ import { EditorEvent } from '../api/util/EventDispatcher';
 import Tools from '../api/util/Tools';
 import VK from '../api/util/VK';
 import * as CaretContainer from '../caret/CaretContainer';
+import * as Empty from '../dom/Empty';
 import * as Rtc from '../Rtc';
 
 /**
@@ -84,12 +85,6 @@ const Quirks = (editor: Editor): Quirks => {
       return selection === allSelection;
     };
 
-    const hasPreservedEmptyElements = (elm: HTMLElement) => {
-      const scope = SugarElement.fromDom(elm);
-      const isEditableHost = (elm: SugarElement<HTMLElement>) => Traverse.parentElement(elm).exists((elm) => !ContentEditable.isEditable(elm));
-      return Arr.exists(SelectorFilter.descendants<HTMLElement>(scope, '[contenteditable="true"]'), isEditableHost);
-    };
-
     editor.on('keydown', (e) => {
       const keyCode = e.keyCode;
 
@@ -99,8 +94,7 @@ const Quirks = (editor: Editor): Quirks => {
         const body = editor.getBody();
 
         // Selection is collapsed but the editor isn't empty
-        // TINY-10011: empty CET elements should be preserved
-        if (isCollapsed && (!dom.isEmpty(body) || hasPreservedEmptyElements(body))) {
+        if (isCollapsed && !Empty.isEmpty(SugarElement.fromDom(body))) {
           return;
         }
 

--- a/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/CefDeleteTest.ts
@@ -1,7 +1,7 @@
-import { ApproxStructure, Keys } from '@ephox/agar';
+import { ApproxStructure, Assertions, Keys } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinyDom, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -279,6 +279,32 @@ describe('browser.tinymce.core.delete.CefDeleteTest', () => {
           TinyContentActions.keystroke(editor, key());
           TinyAssertions.assertCursor(editor, [ 0 ], 0);
           TinyAssertions.assertContent(editor, initialContent);
+        });
+      });
+
+      it(`TINY-10010: should not delete empty CET in a table cell and noneditable root when ${label} is pressed`, () => {
+        TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+          const initialContent = `
+            <table style="border-collapse: collapse; width: 100%;" border="1">
+              <tbody>
+              <tr>
+                <td>
+                  <div contenteditable="true" style="border: 2px solid red"></div>
+                </td>
+                <td>&nbsp;</td>
+              </tr>
+              </tbody>
+            </table>`;
+          editor.setContent(initialContent);
+          TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+          TinyContentActions.keystroke(editor, key());
+          Assertions.assertPresence(
+            'empty CET should not be deleted from the table cell',
+            {
+              'td div[contenteditable="true"]': 1,
+            },
+            TinyDom.body(editor)
+          );
         });
       });
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/EmptyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/EmptyTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { SugarElement } from '@ephox/sugar';
+import { SugarElement, SelectorFind } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import * as Empty from 'tinymce/core/dom/Empty';
@@ -42,6 +42,22 @@ describe('browser.tinymce.core.dom.EmptyTest', () => {
     testEmpty('<p><i><b></b></i><b><i><img src="#"></i></b></p>', false);
     testEmpty('<span data-mce-bookmark="x"></span>', false);
     testEmpty('<span contenteditable="false"></span>', false);
+    testEmpty('<div contenteditable="false"><span contenteditable="true"></span></div>', false);
     testEmpty('<a id="anchor"></a>', false);
+  });
+
+  it('TINY-10010: table cell with empty CET should not be treated as empty', () => {
+    const html = `<table style="border-collapse: collapse; width: 100%;" border="1">
+        <tbody>
+        <tr>
+          <td>
+            <div contenteditable="true" style="border: 2px solid red"></div>
+          </td>
+        </tr>
+        </tbody>
+      </table>`;
+    const table = SugarElement.fromHtml(html);
+    const td = SelectorFind.descendant(table, 'td').getOrDie();
+    assert.isFalse(Empty.isEmpty(td));
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10010

Description of Changes:
* Replace in `Quirks.ts` `DomUtils.isEmpty` on `Empty.isEmtpy`
* add to `Empty.isEmpty` function the condition to treat empty CET as a non-empty content

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
