### PR TITLE
TINY-10249: avoid flickering when remove and put the editor back

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom block element wasn't considered block element in some cases. #TINY-10139
 - Search and replace plugin would incorrectly find matching text inside non-editable root elements. #TINY-10162
 - Search and replace plugin would incorrectly find matching text inside SVG elements. #TINY-10162
-- Using `render` with `async` makes editor's refresh slow causing a blink when the editor is removed and put back. #TINY-10249
+- Removed use of `async` for editor rendering which caused visual blinking when reloading the editor in-place. #TINY-10249
 
 ### Improved
 - Colorpicker now includes the Brightness/Saturation selector and hue slider in the keyboard navigable items. #TINY-9287

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom block element wasn't considered block element in some cases. #TINY-10139
 - Search and replace plugin would incorrectly find matching text inside non-editable root elements. #TINY-10162
 - Search and replace plugin would incorrectly find matching text inside SVG elements. #TINY-10162
+- Using `render` with `async` makes editor's refresh slow causing a blink when the editor is removed and put back. #TINY-10249
 
 ### Improved
 - Colorpicker now includes the Brightness/Saturation selector and hue slider in the keyboard navigable items. #TINY-9287

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -48,7 +48,7 @@ export interface RenderInfo {
     readonly getMothership: () => Gui.GuiSystem;
     readonly backstage: Backstage.UiFactoryBackstage;
   };
-  readonly renderUI: () => ModeRenderInfo;
+  readonly renderUI: () => Promise<ModeRenderInfo>;
 }
 
 export type ToolbarConfig = Array<string | Options.ToolbarGroupOption> | string | boolean;
@@ -484,7 +484,7 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
     editor.addQueryStateHandler('ToggleToolbarDrawer', () => OuterContainer.isToolbarDrawerToggled(outerContainer));
   };
 
-  const renderUIWithRefs = (uiRefs: ReadyUiReferences): ModeRenderInfo => {
+  const renderUIWithRefs = (uiRefs: ReadyUiReferences): Promise<ModeRenderInfo> => {
     const { mainUi, popupUi, uiMotherships } = uiRefs;
     Obj.map(Options.getToolbarGroups(editor), (toolbarGroupButtonConfig, name) => {
       editor.ui.registry.addGroupToolbarButton(name, toolbarGroupButtonConfig);
@@ -530,7 +530,7 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
     return dialogUi;
   };
 
-  const renderUI = (): ModeRenderInfo => {
+  const renderUI = (): Promise<ModeRenderInfo> => {
     const mainUi = renderMainUi();
     const dialogUi = renderDialogUi();
     // If dialogUi and popupUi are the same, LazyUiReferences should handle deduplicating then

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -48,7 +48,7 @@ export interface RenderInfo {
     readonly getMothership: () => Gui.GuiSystem;
     readonly backstage: Backstage.UiFactoryBackstage;
   };
-  readonly renderUI: () => Promise<ModeRenderInfo>;
+  readonly renderUI: () => ModeRenderInfo;
 }
 
 export type ToolbarConfig = Array<string | Options.ToolbarGroupOption> | string | boolean;
@@ -484,7 +484,7 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
     editor.addQueryStateHandler('ToggleToolbarDrawer', () => OuterContainer.isToolbarDrawerToggled(outerContainer));
   };
 
-  const renderUIWithRefs = (uiRefs: ReadyUiReferences): Promise<ModeRenderInfo> => {
+  const renderUIWithRefs = (uiRefs: ReadyUiReferences): ModeRenderInfo => {
     const { mainUi, popupUi, uiMotherships } = uiRefs;
     Obj.map(Options.getToolbarGroups(editor), (toolbarGroupButtonConfig, name) => {
       editor.ui.registry.addGroupToolbarButton(name, toolbarGroupButtonConfig);
@@ -530,7 +530,7 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
     return dialogUi;
   };
 
-  const renderUI = (): Promise<ModeRenderInfo> => {
+  const renderUI = (): ModeRenderInfo => {
     const mainUi = renderMainUi();
     const dialogUi = renderDialogUi();
     // If dialogUi and popupUi are the same, LazyUiReferences should handle deduplicating then

--- a/modules/tinymce/src/themes/silver/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Theme.ts
@@ -40,8 +40,8 @@ export default (): void => {
 
     // We wrap the `renderModeUI` function being returned by Render so that we can update
     // the getPopupSinkBounds mutable variable if required.
-    const renderUI = (): RenderResult => {
-      const renderResult = renderModeUI();
+    const renderUI = async (): Promise<RenderResult> => {
+      const renderResult = await renderModeUI();
 
       const optScrollingContext = ScrollingContext.detectWhenSplitUiMode(
         editor,

--- a/modules/tinymce/src/themes/silver/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Theme.ts
@@ -40,6 +40,7 @@ export default (): void => {
 
     // We wrap the `renderModeUI` function being returned by Render so that we can update
     // the getPopupSinkBounds mutable variable if required.
+    // DON'T define this function as `async`, otherwise it slows down the render ad it causes flickering if the editor is removed and re-init repeatedly
     const renderUI = (): RenderResult => {
       const renderResult = renderModeUI();
 

--- a/modules/tinymce/src/themes/silver/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Theme.ts
@@ -40,7 +40,7 @@ export default (): void => {
 
     // We wrap the `renderModeUI` function being returned by Render so that we can update
     // the getPopupSinkBounds mutable variable if required.
-    // DON'T define this function as `async`, otherwise it slows down the render ad it causes flickering if the editor is removed and re-init repeatedly
+    // DON'T define this function as `async`; otherwise, it will slow down the rendering process and cause flickering if the editor is repeatedly removed and re-initialized.
     const renderUI = (): RenderResult => {
       const renderResult = renderModeUI();
 

--- a/modules/tinymce/src/themes/silver/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Theme.ts
@@ -40,8 +40,8 @@ export default (): void => {
 
     // We wrap the `renderModeUI` function being returned by Render so that we can update
     // the getPopupSinkBounds mutable variable if required.
-    const renderUI = async (): Promise<RenderResult> => {
-      const renderResult = await renderModeUI();
+    const renderUI = (): RenderResult => {
+      const renderResult = renderModeUI();
 
       const optScrollingContext = ScrollingContext.detectWhenSplitUiMode(
         editor,

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -94,12 +94,12 @@ const attachUiMotherships = (editor: Editor, uiRoot: SugarElement<HTMLElement | 
   Attachment.attachSystem(uiRoot, uiRefs.dialogUi.mothership);
 };
 
-const render = async (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): Promise<ModeRenderInfo> => {
+const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): ModeRenderInfo => {
   const { mainUi, uiMotherships } = uiRefs;
   const lastToolbarWidth = Cell(0);
   const outerContainer = mainUi.outerContainer;
 
-  await loadIframeSkin(editor);
+  loadIframeSkin(editor);
 
   const eTargetNode = SugarElement.fromDom(args.targetNode);
   const uiRoot = SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(eTargetNode));

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -99,6 +99,10 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
   const lastToolbarWidth = Cell(0);
   const outerContainer = mainUi.outerContainer;
 
+  editor.on('SkinLoaded', () => {
+    setToolbar(editor, uiRefs, rawUiConfig, backstage);
+  });
+
   loadIframeSkin(editor);
 
   const eTargetNode = SugarElement.fromDom(args.targetNode);
@@ -106,10 +110,6 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
 
   Attachment.attachSystemAfter(eTargetNode, mainUi.mothership);
   attachUiMotherships(editor, uiRoot, uiRefs);
-
-  editor.on('SkinLoaded', () => {
-    setToolbar(editor, uiRefs, rawUiConfig, backstage);
-  });
 
   editor.on('PostRender', () => {
     // Set the sidebar before the toolbar and menubar

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -94,12 +94,13 @@ const attachUiMotherships = (editor: Editor, uiRoot: SugarElement<HTMLElement | 
   Attachment.attachSystem(uiRoot, uiRefs.dialogUi.mothership);
 };
 
-const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): ModeRenderInfo => {
+const render = async (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): Promise<ModeRenderInfo> => {
   const { mainUi, uiMotherships } = uiRefs;
   const lastToolbarWidth = Cell(0);
   const outerContainer = mainUi.outerContainer;
 
   loadIframeSkin(editor);
+  await new Promise((r) => r('')); // TODO: remove is just for a test
 
   const eTargetNode = SugarElement.fromDom(args.targetNode);
   const uiRoot = SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(eTargetNode));

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -110,29 +110,27 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
   attachUiMotherships(editor, uiRoot, uiRefs);
 
   editor.on('PostRender', () => {
-    if (editor.getWin()) {
-      // Set the sidebar before the toolbar and menubar
-      // - each sidebar has an associated toggle toolbar button that needs to check the
-      //   sidebar that is set to determine its active state on setup
-      OuterContainer.setSidebar(
-        outerContainer,
-        rawUiConfig.sidebar,
-        Options.getSidebarShow(editor)
-      );
+    // Set the sidebar before the toolbar and menubar
+    // - each sidebar has an associated toggle toolbar button that needs to check the
+    //   sidebar that is set to determine its active state on setup
+    OuterContainer.setSidebar(
+      outerContainer,
+      rawUiConfig.sidebar,
+      Options.getSidebarShow(editor)
+    );
 
-      setToolbarThrottled.throttle(editor, uiRefs, rawUiConfig, backstage);
+    setToolbarThrottled.throttle(editor, uiRefs, rawUiConfig, backstage);
 
-      lastToolbarWidth.set(editor.getWin().innerWidth);
+    lastToolbarWidth.set(editor.getWin().innerWidth);
 
-      OuterContainer.setMenubar(
-        outerContainer,
-        identifyMenus(editor, rawUiConfig)
-      );
+    OuterContainer.setMenubar(
+      outerContainer,
+      identifyMenus(editor, rawUiConfig)
+    );
 
-      OuterContainer.setViews(outerContainer, rawUiConfig.views);
+    OuterContainer.setViews(outerContainer, rawUiConfig.views);
 
-      setupEvents(editor, uiRefs);
-    }
+    setupEvents(editor, uiRefs);
   });
 
   editor.on('SkinLoaded', () => setToolbarThrottled.throttle(editor, uiRefs, rawUiConfig, backstage));

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -107,6 +107,10 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
   Attachment.attachSystemAfter(eTargetNode, mainUi.mothership);
   attachUiMotherships(editor, uiRoot, uiRefs);
 
+  editor.on('SkinLoaded', () => {
+    setToolbar(editor, uiRefs, rawUiConfig, backstage);
+  });
+
   editor.on('PostRender', () => {
     // Set the sidebar before the toolbar and menubar
     // - each sidebar has an associated toggle toolbar button that needs to check the
@@ -117,9 +121,8 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
       Options.getSidebarShow(editor)
     );
 
-    editor.once('SkinLoaded', () => {
-      setToolbar(editor, uiRefs, rawUiConfig, backstage);
-    });
+    setToolbar(editor, uiRefs, rawUiConfig, backstage);
+
     lastToolbarWidth.set(editor.getWin().innerWidth);
 
     OuterContainer.setMenubar(

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -94,7 +94,7 @@ const attachUiMotherships = (editor: Editor, uiRoot: SugarElement<HTMLElement | 
   Attachment.attachSystem(uiRoot, uiRefs.dialogUi.mothership);
 };
 
-const render = async (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): Promise<ModeRenderInfo> => {
+const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): ModeRenderInfo => {
   const { mainUi, uiMotherships } = uiRefs;
   const lastToolbarWidth = Cell(0);
   const outerContainer = mainUi.outerContainer;
@@ -117,7 +117,9 @@ const render = async (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: Re
       Options.getSidebarShow(editor)
     );
 
-    setToolbar(editor, uiRefs, rawUiConfig, backstage);
+    editor.once('SkinLoaded', () => {
+      setToolbar(editor, uiRefs, rawUiConfig, backstage);
+    });
     lastToolbarWidth.set(editor.getWin().innerWidth);
 
     OuterContainer.setMenubar(
@@ -196,8 +198,6 @@ const render = async (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: Re
     },
     isEnabled: () => !Disabling.isDisabled(outerContainer)
   };
-
-  await new Promise((r) => r('')); // TODO: remove is just for a test
 
   return {
     iframeContainer: socket.element.dom,

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -100,7 +100,6 @@ const render = async (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: Re
   const outerContainer = mainUi.outerContainer;
 
   loadIframeSkin(editor);
-  await new Promise((r) => r('')); // TODO: remove is just for a test
 
   const eTargetNode = SugarElement.fromDom(args.targetNode);
   const uiRoot = SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(eTargetNode));
@@ -197,6 +196,8 @@ const render = async (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: Re
     },
     isEnabled: () => !Disabling.isDisabled(outerContainer)
   };
+
+  await new Promise((r) => r('')); // TODO: remove is just for a test
 
   return {
     iframeContainer: socket.element.dom,

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -94,8 +94,6 @@ const attachUiMotherships = (editor: Editor, uiRoot: SugarElement<HTMLElement | 
   Attachment.attachSystem(uiRoot, uiRefs.dialogUi.mothership);
 };
 
-const setToolbarThrottled = Throttler.last(setToolbar, 50);
-
 const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): ModeRenderInfo => {
   const { mainUi, uiMotherships } = uiRefs;
   const lastToolbarWidth = Cell(0);
@@ -109,6 +107,10 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
   Attachment.attachSystemAfter(eTargetNode, mainUi.mothership);
   attachUiMotherships(editor, uiRoot, uiRefs);
 
+  editor.on('SkinLoaded', () => {
+    setToolbar(editor, uiRefs, rawUiConfig, backstage);
+  });
+
   editor.on('PostRender', () => {
     // Set the sidebar before the toolbar and menubar
     // - each sidebar has an associated toggle toolbar button that needs to check the
@@ -119,7 +121,7 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
       Options.getSidebarShow(editor)
     );
 
-    setToolbarThrottled.throttle(editor, uiRefs, rawUiConfig, backstage);
+    setToolbar(editor, uiRefs, rawUiConfig, backstage);
 
     lastToolbarWidth.set(editor.getWin().innerWidth);
 
@@ -132,8 +134,6 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
 
     setupEvents(editor, uiRefs);
   });
-
-  editor.on('SkinLoaded', () => setToolbarThrottled.throttle(editor, uiRefs, rawUiConfig, backstage));
 
   const socket = OuterContainer.getSocket(outerContainer).getOrDie('Could not find expected socket element');
 

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -105,7 +105,7 @@ const setupEvents = (editor: Editor, targetElm: SugarElement, ui: InlineHeader, 
     elementLoad.clear();
   });
 };
-const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): ModeRenderInfo => {
+const render = async (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): Promise<ModeRenderInfo> => {
   const { mainUi } = uiRefs;
 
   // This is used to store the reference to the header part of OuterContainer, which is
@@ -118,7 +118,7 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
   const ui = InlineHeader(editor, targetElm, uiRefs, backstage, floatContainer);
   const toolbarPersist = Options.isToolbarPersist(editor);
 
-  loadInlineSkin(editor);
+  await loadInlineSkin(editor);
 
   const render = () => {
     // Because we set the floatContainer immediately afterwards, this is just telling us

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -105,7 +105,7 @@ const setupEvents = (editor: Editor, targetElm: SugarElement, ui: InlineHeader, 
     elementLoad.clear();
   });
 };
-const render = async (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): Promise<ModeRenderInfo> => {
+const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage, args: RenderArgs): ModeRenderInfo => {
   const { mainUi } = uiRefs;
 
   // This is used to store the reference to the header part of OuterContainer, which is
@@ -118,7 +118,7 @@ const render = async (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: Re
   const ui = InlineHeader(editor, targetElm, uiRefs, backstage, floatContainer);
   const toolbarPersist = Options.isToolbarPersist(editor);
 
-  await loadInlineSkin(editor);
+  loadInlineSkin(editor);
 
   const render = () => {
     // Because we set the floatContainer immediately afterwards, this is just telling us


### PR DESCRIPTION
Related Ticket: TINY-10249

Description of Changes:

To avoid using `render` with `await` and with it having a slow refresh, we also need a second `setToolbar` after `SkinLoaded` event, this is because setting the toolbar and then getting the skin can let the skin to overwrite some styles

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
