### PR TITLE
TINY-10162: Find & replace replaced text inside a non-editable root and svgs

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The dialog size was not updated when the `size` argument was changed when redialling a dialog. #TINY-10209
 - Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10213
 - Custom block element wasn't considered block element in some cases. #TINY-10139
+- Search and replace plugin would incorrectly find matching text inside non-editable root elements. #TINY-10162
+- Search and replace plugin would incorrectly find matching text inside SVG elements. #TINY-10162
 
 ### Improved
 - Colorpicker now includes the Brightness/Saturation selector and hue slider in the keyboard navigable items. #TINY-9287

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/core/TextCollect.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/core/TextCollect.ts
@@ -21,11 +21,10 @@ interface CollectCallbacks {
 const isSimpleBoundary = (dom: DOMUtils, node: Node) =>
   dom.isBlock(node) || Obj.has(dom.schema.getVoidElements(), node.nodeName);
 
-const isContentEditableFalse = (dom: DOMUtils, node: Node) =>
-  dom.getContentEditable(node) === 'false';
+const isContentEditableFalse = (dom: DOMUtils, node: Node) => !dom.isEditable(node);
 
 const isContentEditableTrueInCef = (dom: DOMUtils, node: Node) =>
-  dom.getContentEditable(node) === 'true' && node.parentNode && dom.getContentEditableParent(node.parentNode) === 'false';
+  dom.getContentEditable(node) === 'true' && node.parentNode && !dom.isEditable(node.parentNode);
 
 const isHidden = (dom: DOMUtils, node: Node) =>
   !dom.isBlock(node) && Obj.has(dom.schema.getWhitespaceElements(), node.nodeName);


### PR DESCRIPTION
Related Ticket: TINY-10162

Description of Changes:
* Uses the new dom.isEditable API so that it will properly handle SVGs and non-editable root elements.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
