### PR TITLE
TINY-10272: Fixed bug with data-mce-block being added to anchors inside svg elements

### DIFF
--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -5,6 +5,7 @@ import AstNode from '../api/html/Node';
 import Schema, { SchemaMap } from '../api/html/Schema';
 import * as Empty from '../dom/Empty';
 import * as NodeType from '../dom/NodeType';
+import * as Namespace from '../html/Namespace';
 
 export const transparentBlockAttr = 'data-mce-block';
 
@@ -12,7 +13,11 @@ export const transparentBlockAttr = 'data-mce-block';
 // This method is to avoid having to specify all possible valid characters other than lowercase a-z such as '-' or ':' etc.
 export const elementNames = (map: SchemaMap): string[] => Arr.filter(Obj.keys(map), (key) => !/[A-Z]/.test(key));
 
-const makeSelectorFromSchemaMap = (map: SchemaMap) => elementNames(map).join(',');
+const makeSelectorFromSchemaMap = (map: SchemaMap) =>
+  Arr.map(elementNames(map), (name) => {
+    // Exclude namespace elements from processing
+    return `${name}:` + Arr.map(Namespace.namespaceElements, (ns) => `not(${ns} ${name})`).join(':');
+  }).join(',');
 
 const updateTransparent = (blocksSelector: string, transparent: Element) => {
   if (Type.isNonNullable(transparent.querySelector(blocksSelector))) {

--- a/modules/tinymce/src/core/main/ts/html/Namespace.ts
+++ b/modules/tinymce/src/core/main/ts/html/Namespace.ts
@@ -12,6 +12,8 @@ export const isNonHtmlElementRoot = (node: Node): boolean => isNonHtmlElementRoo
 
 export const toScopeType = (node: Node | undefined): NamespaceType => node?.nodeName === 'svg' ? 'svg' : 'html';
 
+export const namespaceElements = [ 'svg' ];
+
 export const createNamespaceTracker = (): NamespaceTracker => {
   let scopes: Node[] = [];
 

--- a/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
@@ -12,7 +12,7 @@ describe('browser.tinymce.core.content.TransparentElementsTest', () => {
   const transparentElements = TransparentElements.elementNames(schema.getTransparentElements());
   const textBlockElements = TransparentElements.elementNames(schema.getTextBlockElements());
 
-  it('TINY-9172: makeElementList', () => {
+  it('TINY-9172: elementNames', () => {
     assert.deepEqual(TransparentElements.elementNames({ a: {}, h1: {}, A: {}, H1: {}}), [ 'a', 'h1' ]);
   });
 
@@ -72,6 +72,11 @@ describe('browser.tinymce.core.content.TransparentElementsTest', () => {
       expected: '<div><a href="#" data-mce-block="true"><p>link</p></a></div>'
     }));
 
+    it('TINY-10272: Should not add data-mce-block attributes inside SVG elements', () => testUpdateChildren({
+      input: '<svg><a href="#"><circle><desc><p>link</p></desc></circle></a></svg>',
+      expected: '<svg><a href="#"><circle><desc><p>link</p></desc></circle></a></svg>'
+    }));
+
     it('TINY-9232: Should split the H1 at the P element and remove any empty nodes that gets produced', () => testUpdateChildren({
       input: '<h1><a href="#"><p>link</p></a></h1>',
       expected: '<p>link</p>'
@@ -109,6 +114,12 @@ describe('browser.tinymce.core.content.TransparentElementsTest', () => {
       input: '<div><h1><a href="#"><p>link</p></a></h1></div><h1><a href="#"><p>link</p></a></h1>',
       path: [ 0, 0, 0, 0 ],
       expected: '<div><p>link</p></div><h1><a href="#"><p>link</p></a></h1>'
+    }));
+
+    it('TINY-10272: Should not add data-mce-block to closest element', () => testUpdateCaret({
+      input: '<svg><a href="#"><circle><desc><p>link</p></desc></circle></a></svg>',
+      path: [ 0 ],
+      expected: '<svg><a href="#"><circle><desc><p>link</p></desc></circle></a></svg>'
     }));
   });
 


### PR DESCRIPTION
Related Ticket: TINY-10272

Description of Changes:
* This is a pre-release bug so no changelog is needed
* It excludes SVGs by changing the selector to be `a:not(svg a)` so that it doesn't match on `a` elements inside `svg` elements.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
