### PR TITLE
TINY-10133: Don't unwrap `details` inside `li`

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resize handles would not appear on editable images in a non-editable context. #TINY-10118
 - The dialog size was not updated when the `size` argument was changed when redialling a dialog. #TINY-10209
 - Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10213
+- Removing an LI element containing a `details` element would incorrectly merge its content. #TINY-10133
 
 ### Improved
 - Colorpicker now includes the Brightness/Saturation selector and hue slider in the keyboard navigable items. #TINY-9287

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -1,5 +1,5 @@
 import { Arr, Optionals } from '@ephox/katamari';
-import { Compare, PredicateFind, Remove, SugarElement, SugarNode } from '@ephox/sugar';
+import { Compare, ContentEditable, PredicateFind, Remove, SugarElement, SugarNode } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import RangeUtils from 'tinymce/core/api/dom/RangeUtils';
@@ -61,8 +61,12 @@ const hasOnlyOneBlockChild = (dom: DOMUtils, elm: Element): boolean => {
   return childNodes.length === 1 && !NodeType.isListNode(childNodes[0]) && dom.isBlock(childNodes[0]);
 };
 
+const isUnwrappable = (elm: HTMLElement): boolean =>
+  ContentEditable.isEditable(SugarElement.fromDom(elm))
+    && !Arr.contains([ 'DETAILS' ], elm.nodeName);
+
 const unwrapSingleBlockChild = (dom: DOMUtils, elm: Element): void => {
-  if (hasOnlyOneBlockChild(dom, elm)) {
+  if (hasOnlyOneBlockChild(dom, elm) && isUnwrappable(elm.firstChild as HTMLElement)) {
     dom.remove(elm.firstChild as HTMLElement, true);
   }
 };

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -1,4 +1,4 @@
-import { Arr, Optionals } from '@ephox/katamari';
+import { Arr, Optional, Optionals } from '@ephox/katamari';
 import { Compare, ContentEditable, PredicateFind, Remove, SugarElement, SugarNode } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
@@ -61,13 +61,15 @@ const hasOnlyOneBlockChild = (dom: DOMUtils, elm: Element): boolean => {
   return childNodes.length === 1 && !NodeType.isListNode(childNodes[0]) && dom.isBlock(childNodes[0]);
 };
 
-const isUnwrappable = (elm: HTMLElement): boolean =>
-  ContentEditable.isEditable(SugarElement.fromDom(elm))
-    && !Arr.contains([ 'DETAILS' ], elm.nodeName);
+const isUnwrappable = (node: Node | null): node is HTMLElement =>
+  Optional.from(node)
+    .map(SugarElement.fromDom)
+    .filter(SugarNode.isHTMLElement)
+    .exists((el) => ContentEditable.isEditable(el) && !Arr.contains([ 'details' ], SugarNode.name(el)));
 
 const unwrapSingleBlockChild = (dom: DOMUtils, elm: Element): void => {
-  if (hasOnlyOneBlockChild(dom, elm) && isUnwrappable(elm.firstChild as HTMLElement)) {
-    dom.remove(elm.firstChild as HTMLElement, true);
+  if (hasOnlyOneBlockChild(dom, elm) && isUnwrappable(elm.firstChild)) {
+    dom.remove(elm.firstChild, true);
   }
 };
 


### PR DESCRIPTION
Related Ticket: TINY-10133

Description of Changes:
* Add `isUnwrappable` predicate to prevent the `details` from unwrapping when merging the `li` content on Backspace pressing.
* Noticed the same issue for CEF `li` child, so prevent unwrapping CEF as well.
Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
