### PR TITLE
TINY-10268: manage `list` inside an `li` surrounded by 2 not `li` elements

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Search and replace plugin would incorrectly find matching text inside non-editable root elements. #TINY-10162
 - Search and replace plugin would incorrectly find matching text inside SVG elements. #TINY-10162
 - Removed use of `async` for editor rendering which caused visual blinking when reloading the editor in-place. #TINY-10249
+- A `list` inside a `li` surrounded by 2 not `li` elements was just considered a `content` of that `li`. #TINY-10268
 
 ## 6.7.1 - 2023-10-19
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Search and replace plugin would incorrectly find matching text inside non-editable root elements. #TINY-10162
 - Search and replace plugin would incorrectly find matching text inside SVG elements. #TINY-10162
 - Removed use of `async` for editor rendering which caused visual blinking when reloading the editor in-place. #TINY-10249
-- A `list` inside a `li` surrounded by 2 not `li` elements was just considered a `content` of that `li`. #TINY-10268
+- List items containing the first and the last element as text and a nested list caused some list operations to fail. #TINY-10268
 
 ## 6.7.1 - 2023-10-19
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Search and replace plugin would incorrectly find matching text inside non-editable root elements. #TINY-10162
 - Search and replace plugin would incorrectly find matching text inside SVG elements. #TINY-10162
 - Removed use of `async` for editor rendering which caused visual blinking when reloading the editor in-place. #TINY-10249
-- List items containing the first and the last element as text and a nested list caused some list operations to fail. #TINY-10268
+- List items containing a list element surrounded by non list nodes would cause some list operations to fail. #TINY-10268
 
 ## 6.7.1 - 2023-10-19
 

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
@@ -69,9 +69,9 @@ const getClosestListHost = (editor: Editor, elm: Node): HTMLElement => {
 };
 
 const isListInsideLiWithSiblings = (list: SugarElement<Node>): boolean =>
-  Traverse.prevSibling(list).filter((sibling) => !NodeType.isListItemNode(sibling.dom)).isSome() &&
-  Traverse.nextSibling(list).filter((sibling) => !NodeType.isListItemNode(sibling.dom)).isSome() &&
-  Traverse.parent(list).filter((parent) => NodeType.isListItemNode(parent.dom)).isSome();
+  Traverse.prevSibling(list).exists((sibling) => !NodeType.isListItemNode(sibling.dom))
+  && Traverse.nextSibling(list).exists((sibling) => !NodeType.isListItemNode(sibling.dom))
+  && Traverse.parent(list).exists((parent) => NodeType.isListItemNode(parent.dom));
 
 const findLastParentListNode = (editor: Editor, elm: Element): Optional<HTMLOListElement | HTMLUListElement> => {
   const parentLists = editor.dom.getParents<HTMLOListElement | HTMLUListElement>(elm, 'ol,ul', getClosestListHost(editor, elm));

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
@@ -68,10 +68,11 @@ const getClosestListHost = (editor: Editor, elm: Node): HTMLElement => {
   return parentBlock.getOr(editor.getBody());
 };
 
-const isListInsideLiWithSiblings = (list: SugarElement<Node>): boolean =>
-  Traverse.prevSibling(list).exists((sibling) => !NodeType.isListItemNode(sibling.dom))
-  && Traverse.nextSibling(list).exists((sibling) => !NodeType.isListItemNode(sibling.dom))
-  && Traverse.parent(list).exists((parent) => NodeType.isListItemNode(parent.dom));
+const isListInsideAnLiWithFirstAndLastNotListElement = (list: SugarElement<Node>): boolean =>
+  Traverse.parent(list).exists((parent) => NodeType.isListItemNode(parent.dom)
+    && Traverse.firstChild(parent).exists((firstChild) => !NodeType.isListNode(firstChild.dom))
+    && Traverse.lastChild(parent).exists((lastChild) => !NodeType.isListNode(lastChild.dom))
+  );
 
 const findLastParentListNode = (editor: Editor, elm: Element): Optional<HTMLOListElement | HTMLUListElement> => {
   const parentLists = editor.dom.getParents<HTMLOListElement | HTMLUListElement>(elm, 'ol,ul', getClosestListHost(editor, elm));
@@ -93,7 +94,7 @@ const getParentLists = (editor: Editor) => {
 const getSelectedListRoots = (editor: Editor): HTMLElement[] => {
   const selectedLists = getSelectedLists(editor);
   const parentLists = getParentLists(editor);
-  return Arr.find(parentLists, (p) => isListInsideLiWithSiblings(SugarElement.fromDom(p))).fold(
+  return Arr.find(parentLists, (p) => isListInsideAnLiWithFirstAndLastNotListElement(SugarElement.fromDom(p))).fold(
     () => getUniqueListRoots(editor, selectedLists),
     (l) => [ l ]
   );

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -522,7 +522,7 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
     assert.equal(editor.selection.getNode().nodeName, 'LI');
   });
 
-  it('TINY-10268: a `list` inside a `li` surrounded by 2 not element should allow the user to intend/outdent its `li`', () => {
+  it('TINY-10268: a `list` inside a `li` surrounded by 2 not element should allow the user to indent/outdent its `li`', () => {
     const editor = hook.editor();
     editor.setContent(`<ul>
       <li>

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -535,7 +535,7 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
       </li>
     </ul>`);
 
-    LegacyUnit.setSelection(editor, '.to-indent', 0);
+    TinySelections.setCursor(editor, [ 0, 0, 1, 0 ], 0);
     editor.execCommand('Indent');
 
     TinyAssertions.assertContent(editor, '<ul>' +
@@ -549,7 +549,7 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
       '</li>' +
     '</ul>');
 
-    LegacyUnit.setSelection(editor, '.to-indent', 0);
+    TinySelections.setCursor(editor, [ 0, 0, 1, 0, 0, 0 ], 0);
     editor.execCommand('Outdent');
 
     TinyAssertions.assertContent(editor, '<ul>' +

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -528,7 +528,7 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
       <li>
         Dedent me
         <ul>
-          <li class="to-indent">or try to dedent me 1</li>
+          <li>or try to dedent me 1</li>
           <li>or try to dedent me 2</li>
         </ul>
         <span>abc</span>
@@ -542,7 +542,7 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
       '<li>' +
         'Dedent me' +
         '<ul>' +
-          '<li style="list-style-type: none;"><ul><li class="to-indent">or try to dedent me 1</li></ul></li>' +
+          '<li style="list-style-type: none;"><ul><li>or try to dedent me 1</li></ul></li>' +
           '<li>or try to dedent me 2</li>' +
         '</ul>' +
         '<span>abc</span>' +
@@ -556,7 +556,61 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
       '<li>' +
         'Dedent me' +
         '<ul>' +
-          '<li class="to-indent">or try to dedent me 1</li>' +
+          '<li>or try to dedent me 1</li>' +
+          '<li>or try to dedent me 2</li>' +
+        '</ul>' +
+        '<span>abc</span>' +
+      '</li>' +
+    '</ul>');
+  });
+
+  it('TINY-10268: in a `list` inside a `li` with another list as sibling and 2 not `list` elements as first and last element of the parent `li` indent/outdent should work as expected', () => {
+    const editor = hook.editor();
+    editor.setContent(`<ul>
+      <li>
+        Dedent me
+        <ul>
+          <li>or try to dedent me 1</li>
+          <li>or try to dedent me 2</li>
+        </ul>
+        <ul>
+          <li>or try to dedent me 1</li>
+          <li>or try to dedent me 2</li>
+        </ul>
+        <span>abc</span>
+      </li>
+    </ul>`);
+
+    TinySelections.setCursor(editor, [ 0, 0, 1, 0 ], 0);
+    editor.execCommand('Indent');
+
+    TinyAssertions.assertContent(editor, '<ul>' +
+      '<li>' +
+        'Dedent me' +
+        '<ul>' +
+          '<li style="list-style-type: none;"><ul><li>or try to dedent me 1</li></ul></li>' +
+          '<li>or try to dedent me 2</li>' +
+        '</ul>' +
+        '<ul>' +
+          '<li>or try to dedent me 1</li>' +
+          '<li>or try to dedent me 2</li>' +
+        '</ul>' +
+        '<span>abc</span>' +
+      '</li>' +
+    '</ul>');
+
+    TinySelections.setCursor(editor, [ 0, 0, 1, 0, 0, 0 ], 0);
+    editor.execCommand('Outdent');
+
+    TinyAssertions.assertContent(editor, '<ul>' +
+      '<li>' +
+        'Dedent me' +
+        '<ul>' +
+          '<li>or try to dedent me 1</li>' +
+          '<li>or try to dedent me 2</li>' +
+        '</ul>' +
+        '<ul>' +
+          '<li>or try to dedent me 1</li>' +
           '<li>or try to dedent me 2</li>' +
         '</ul>' +
         '<span>abc</span>' +

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -522,6 +522,48 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
     assert.equal(editor.selection.getNode().nodeName, 'LI');
   });
 
+  it('TINY-10268: a `list` inside a `li` surrounded by 2 not element should allow the user to intend/outdent its `li`', () => {
+    const editor = hook.editor();
+    editor.setContent(`<ul>
+      <li>
+        Dedent me
+        <ul>
+          <li class="to-indent">or try to dedent me 1</li>
+          <li>or try to dedent me 2</li>
+        </ul>
+        <span>abc</span>
+      </li>
+    </ul>`);
+
+    LegacyUnit.setSelection(editor, '.to-indent', 0);
+    editor.execCommand('Indent');
+
+    TinyAssertions.assertContent(editor, '<ul>' +
+      '<li>' +
+        'Dedent me' +
+        '<ul>' +
+          '<li style="list-style-type: none;"><ul><li class="to-indent">or try to dedent me 1</li></ul></li>' +
+          '<li>or try to dedent me 2</li>' +
+        '</ul>' +
+        '<span>abc</span>' +
+      '</li>' +
+    '</ul>');
+
+    LegacyUnit.setSelection(editor, '.to-indent', 0);
+    editor.execCommand('Outdent');
+
+    TinyAssertions.assertContent(editor, '<ul>' +
+      '<li>' +
+        'Dedent me' +
+        '<ul>' +
+          '<li class="to-indent">or try to dedent me 1</li>' +
+          '<li>or try to dedent me 2</li>' +
+        '</ul>' +
+        '<span>abc</span>' +
+      '</li>' +
+    '</ul>');
+  });
+
   context('Parent context', () => {
     const testCommandAtTextPath = (command: string) => (inputHtml: string, path: number[], expectedHtml: string) => () => {
       const editor = hook.editor();


### PR DESCRIPTION
Related Ticket: TINY-10268

Description of Changes:
Since our current model for table doesn't allow us to represent this situation:
```
<li>
  <something>
  <list>
  <something-else>
</li>
```
except managing it as a single `li` with some content ignoring the fact that there is a list in it.

to allow us to manage this case we have to change how the `selectedListRoots` is working no more returning the whole tree of lists until the end but stopping at the first list which is in that particular state

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
