### PR TITLE
TINY-10304: Fixed broken noeditable root advlist test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,11 +73,11 @@ timestamps {
 
     def platforms = [
       [ os: "windows", browser: "chrome" ],
-      // [ os: "windows", browser: "firefox" ],
-      // [ os: "windows", browser: "MicrosoftEdge" ],
-      // [ os: "macos", browser: "safari" ],
-      // [ os: "macos", browser: "chrome" ],
-      // [ os: "macos", browser: "firefox" ]
+      [ os: "windows", browser: "firefox" ],
+      [ os: "windows", browser: "MicrosoftEdge" ],
+      [ os: "macos", browser: "safari" ],
+      [ os: "macos", browser: "chrome" ],
+      [ os: "macos", browser: "firefox" ]
     ]
 
     def cleanAndInstall = {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,11 +73,11 @@ timestamps {
 
     def platforms = [
       [ os: "windows", browser: "chrome" ],
-      [ os: "windows", browser: "firefox" ],
-      [ os: "windows", browser: "MicrosoftEdge" ],
-      [ os: "macos", browser: "safari" ],
-      [ os: "macos", browser: "chrome" ],
-      [ os: "macos", browser: "firefox" ]
+      // [ os: "windows", browser: "firefox" ],
+      // [ os: "windows", browser: "MicrosoftEdge" ],
+      // [ os: "macos", browser: "safari" ],
+      // [ os: "macos", browser: "chrome" ],
+      // [ os: "macos", browser: "firefox" ]
     ]
 
     def cleanAndInstall = {

--- a/modules/mcagar/src/main/ts/ephox/mcagar/alien/EditorTypes.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/alien/EditorTypes.ts
@@ -47,6 +47,7 @@ export interface Editor {
   setContent: (content: string) => void;
 
   execCommand: (command: string, ui?: boolean, value?: any, args?: any) => boolean;
+  setEditableRoot: (state: boolean) => void;
 
   nodeChanged: () => void;
   focus: () => void;

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyState.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyState.ts
@@ -1,14 +1,14 @@
 import { Editor as EditorType } from '../../alien/EditorTypes';
 
 export const withNoneditableRootEditor = <T extends EditorType = EditorType>(editor: T, f: (editor: T) => void): void => {
-  editor.getBody().contentEditable = 'false';
+  editor.setEditableRoot(false);
   f(editor);
-  editor.getBody().contentEditable = 'true';
+  editor.setEditableRoot(true);
 };
 
 export const withNoneditableRootEditorAsync = async <T extends EditorType = EditorType>(editor: T, f: (editor: T) => Promise<void>): Promise<void> => {
-  editor.getBody().contentEditable = 'false';
+  editor.setEditableRoot(false);
   await f(editor);
-  editor.getBody().contentEditable = 'true';
+  editor.setEditableRoot(true);
 };
 

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
@@ -19,15 +19,15 @@ describe('browser.tinymce.plugins.advlist.NoneditableRootTest', () => {
     const initialListContent = '<ol><li>a</li></ol>';
     const setupEditor = (editor: Editor) => {
       editor.setContent(initialListContent);
-      TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
     };
 
-    it('TINY-9458: List buttons numlist/bullist should be disabled', () => {
-      TinyState.withNoneditableRootEditor<Editor>(hook.editor(), (editor) => {
+    it('TINY-9458: List buttons numlist/bullist should be disabled', async () => {
+      await TinyState.withNoneditableRootEditorAsync<Editor>(hook.editor(), async (editor) => {
         setupEditor(editor);
 
-        UiFinder.exists(SugarBody.body(), 'div[title="Numbered list"][aria-disabled="true"]');
-        UiFinder.exists(SugarBody.body(), 'div[title="Bullet list"][aria-disabled="true"]');
+        await UiFinder.pWaitFor('Waited for number list to be disabled', SugarBody.body(), 'div[title="Numbered list"][aria-disabled="true"]');
+        await UiFinder.pWaitFor('Waited for bullet list to be disabled', SugarBody.body(), 'div[title="Bullet list"][aria-disabled="true"]');
       });
     });
 

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
@@ -27,7 +27,7 @@ describe('browser.tinymce.plugins.advlist.NoneditableRootTest', () => {
       await TinyState.withNoneditableRootEditorAsync<Editor>(hook.editor(), async (editor) => {
         setupEditor(editor);
 
-        await UiFinder.pWaitFor('Waited for number list to be disabled', TinyDom.container(editor), 'div[title="Numbered list"][aria-disabled="true"]');
+        await UiFinder.pWaitFor('Waited for number list to be disabled' + document.body.innerHTML, TinyDom.container(editor), 'div[title="Numbered list"][aria-disabled="true"]');
         await UiFinder.pWaitFor('Waited for bullet list to be disabled', TinyDom.container(editor), 'div[title="Bullet list"][aria-disabled="true"]');
       });
     });

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
@@ -23,13 +23,12 @@ describe('browser.tinymce.plugins.advlist.NoneditableRootTest', () => {
       TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
     };
 
-    // eslint-disable-next-line mocha/no-exclusive-tests
-    it.only('TINY-9458: List buttons numlist/bullist should be disabled', async () => {
-      await TinyState.withNoneditableRootEditorAsync<Editor>(hook.editor(), async (editor) => {
+    it('TINY-9458: List buttons numlist/bullist should be disabled', () => {
+      TinyState.withNoneditableRootEditor<Editor>(hook.editor(), (editor) => {
         setupEditor(editor);
 
-        await UiFinder.pWaitFor('Waited for number list to be disabled' + document.body.innerHTML, TinyDom.container(editor), 'div[title="Numbered list"][aria-disabled="true"]');
-        await UiFinder.pWaitFor('Waited for bullet list to be disabled', TinyDom.container(editor), 'div[title="Bullet list"][aria-disabled="true"]');
+        UiFinder.exists(TinyDom.container(editor), 'div[title="Numbered list"][aria-disabled="true"]');
+        UiFinder.exists(TinyDom.container(editor), 'div[title="Bullet list"][aria-disabled="true"]');
       });
     });
 

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
@@ -4,7 +4,8 @@ import { SugarBody } from '@ephox/sugar';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Plugin from 'tinymce/plugins/lists/Plugin';
+import AdvListPlugin from 'tinymce/plugins/advlist/Plugin';
+import ListPlugin from 'tinymce/plugins/lists/Plugin';
 
 describe('browser.tinymce.plugins.advlist.NoneditableRootTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
@@ -13,7 +14,7 @@ describe('browser.tinymce.plugins.advlist.NoneditableRootTest', () => {
     contextmenu: 'lists',
     indent: false,
     base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin ], true);
+  }, [ ListPlugin, AdvListPlugin ], true);
 
   context('List ui controls', () => {
     const initialListContent = '<ol><li>a</li></ol>';

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
-import { TinyAssertions, TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/lists/Plugin';
@@ -22,12 +22,13 @@ describe('browser.tinymce.plugins.advlist.NoneditableRootTest', () => {
       TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
     };
 
-    it('TINY-9458: List buttons numlist/bullist should be disabled', async () => {
+    // eslint-disable-next-line mocha/no-exclusive-tests
+    it.only('TINY-9458: List buttons numlist/bullist should be disabled', async () => {
       await TinyState.withNoneditableRootEditorAsync<Editor>(hook.editor(), async (editor) => {
         setupEditor(editor);
 
-        await UiFinder.pWaitFor('Waited for number list to be disabled', SugarBody.body(), 'div[title="Numbered list"][aria-disabled="true"]');
-        await UiFinder.pWaitFor('Waited for bullet list to be disabled', SugarBody.body(), 'div[title="Bullet list"][aria-disabled="true"]');
+        await UiFinder.pWaitFor('Waited for number list to be disabled', TinyDom.container(editor), 'div[title="Numbered list"][aria-disabled="true"]');
+        await UiFinder.pWaitFor('Waited for bullet list to be disabled', TinyDom.container(editor), 'div[title="Bullet list"][aria-disabled="true"]');
       });
     });
 


### PR DESCRIPTION
Related Ticket: TINY-10304

Description of Changes:
* The issue seems to have been that the test didn't import the advlist pluign module correctly so if the pivot point between chunks shifted then it wasn't included.
* I also changed so that it uses the editor.setEditableRoot instead of toggling the contentEditable state on/off directly on body something that should have been done when the new API was introduced.
* No changelog since this only affects tests.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
