### PR TITLE
TINY-10271: Backspace/delete can be performed on selected SVG elements in Firefox

### DIFF
--- a/modules/tinymce/src/core/main/ts/keyboard/KeyboardOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/KeyboardOverrides.ts
@@ -11,6 +11,7 @@ import * as EnterKey from './EnterKey';
 import * as HomeEndKeys from './HomeEndKeys';
 import * as InputKeys from './InputKeys';
 import * as PageUpDownKeys from './PageUpDownKeys';
+import * as PreventNoneditableInput from './PreventNoneditableInput';
 import * as SpaceKey from './SpaceKey';
 import * as TabKey from './TabKey';
 
@@ -23,6 +24,7 @@ const setup = (editor: Editor): Cell<Text | null> => {
   } else {
     const caret = BoundarySelection.setupSelectedState(editor);
 
+    PreventNoneditableInput.setup(editor);
     CaretContainerInput.setup(editor);
     ArrowKeys.setup(editor, caret);
     DeleteBackspaceKeys.setup(editor, caret);

--- a/modules/tinymce/src/core/main/ts/keyboard/PreventNoneditableInput.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/PreventNoneditableInput.ts
@@ -1,0 +1,12 @@
+import Editor from '../api/Editor';
+
+export const setup = (editor: Editor): void => {
+  editor.on('BeforeInput', (e) => {
+    // Normally input is blocked on non-editable elements that have contenteditable="false" however we are also treating
+    // SVG elements as non-editable and Firefox lets you delete parts of the SVG if you manage to select a part. So this
+    // checks for that scenario and prevents the default behaviour.
+    if (!editor.selection.isEditable()) {
+      e.preventDefault();
+    }
+  });
+};

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/PreventNoneditableInputTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/PreventNoneditableInputTest.ts
@@ -1,4 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
+import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -7,13 +8,20 @@ import Editor from 'tinymce/core/api/Editor';
 import * as InputEventUtils from '../../module/test/InputEventUtils';
 
 describe('browser.tinymce.core.keyboard.PreventNoneditableInputTest', () => {
+  const isSafari = PlatformDetection.detect().browser.isSafari();
+
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
     extended_valid_elements: 'svg[*]'
   }, []);
 
-  it('TINY-10271: Prevent input events inside a SVG element', () => {
+  it('TINY-10271: Prevent input events inside a SVG element', function () {
+    // Safari normalizes the selection so that it is outside the SVG so we can't setup a test that fails
+    if (isSafari) {
+      this.skip();
+    }
+
     const inputEvents: Array<{ inputType: string; defaultPrevented: boolean }> = [];
     const editor = hook.editor();
     const collect = ({ inputType, defaultPrevented }: InputEvent) => {

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/PreventNoneditableInputTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/PreventNoneditableInputTest.ts
@@ -1,0 +1,41 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+import * as InputEventUtils from '../../module/test/InputEventUtils';
+
+describe('browser.tinymce.core.keyboard.PreventNoneditableInputTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce',
+    extended_valid_elements: 'svg[*]'
+  }, []);
+
+  it('TINY-10271: Prevent input events inside a SVG element', () => {
+    const inputEvents: Array<{ inputType: string; defaultPrevented: boolean }> = [];
+    const editor = hook.editor();
+    const collect = ({ inputType, defaultPrevented }: InputEvent) => {
+      inputEvents.push({ inputType, defaultPrevented });
+    };
+    const initialContent = '<svg><circle cx="50" cy="50" r="50"></circle></svg>';
+
+    editor.on('beforeinput', collect);
+    editor.setContent(initialContent);
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    editor.dispatch('beforeinput', InputEventUtils.makeInputEvent('beforeinput', { inputType: 'deleteContent' }));
+    editor.dispatch('beforeinput', InputEventUtils.makeInputEvent('beforeinput', { inputType: 'insertText', data: 'x' }));
+    editor.off('beforeinput', collect);
+
+    assert.deepEqual(
+      inputEvents,
+      [
+        { inputType: 'deleteContent', defaultPrevented: true },
+        { inputType: 'insertText', defaultPrevented: true }
+      ],
+      'Events should be prevented'
+    );
+    TinyAssertions.assertContent(editor, initialContent);
+  });
+});

--- a/modules/tinymce/src/core/test/ts/module/test/InputEventUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/InputEventUtils.ts
@@ -24,9 +24,14 @@ const clone = <T extends Event>(originalEvent: T): T => {
     event.composedPath = () => originalEvent.composedPath!();
   }
 
+  event.preventDefault = () => {
+    originalEvent.preventDefault();
+    event.defaultPrevented = true;
+  };
+
   return event as T;
 };
 
 export const makeInputEvent = <A extends InputEvent>(name: 'beforeinput' | 'input', overrides: { [K in keyof A]?: A[K] }): InputEvent => {
-  return { ...clone(new InputEvent(name)), ...overrides };
+  return { ...clone(new InputEvent(name, { cancelable: true })), ...overrides };
 };

--- a/modules/tinymce/src/core/test/ts/module/test/InputEventUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/InputEventUtils.ts
@@ -6,8 +6,12 @@ const deprecated = new Set([
   'keyIdentifier', 'mozPressure'
 ]);
 
-const clone = <T extends Event>(originalEvent: T): T => {
-  const event: Record<string, any> = {};
+type Mutable<T> = {
+  -readonly [K in keyof T]: T[K];
+};
+
+const cloneEvent = <T extends Event>(originalEvent: T): T => {
+  const event: Mutable<T> = {} as Mutable<T>;
 
   // Copy all properties from the original event
   for (const name in originalEvent) {
@@ -24,14 +28,15 @@ const clone = <T extends Event>(originalEvent: T): T => {
     event.composedPath = () => originalEvent.composedPath!();
   }
 
+  // The preventDefault can't be cloned, so delegate instead
   event.preventDefault = () => {
     originalEvent.preventDefault();
     event.defaultPrevented = true;
   };
 
-  return event as T;
+  return event;
 };
 
 export const makeInputEvent = <A extends InputEvent>(name: 'beforeinput' | 'input', overrides: { [K in keyof A]?: A[K] }): InputEvent => {
-  return { ...clone(new InputEvent(name, { cancelable: true })), ...overrides };
+  return { ...cloneEvent(new InputEvent(name, { cancelable: true })), ...overrides };
 };


### PR DESCRIPTION
Related Ticket: TINY-10271

Description of Changes:
* Fixed delete/backspace but also type over inside SVG elements on Firefox.
* Didn't add a changelog since this is part of the overall support for SVG elements.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
