### PR TITLE
TINY-10273: Adjacent SVG block level elements adds extra paragraph

### DIFF
--- a/modules/tinymce/src/core/main/ts/ForceBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/ForceBlocks.ts
@@ -44,13 +44,7 @@ const shouldRemoveTextNode = (blockElements: SchemaMap, node: Node) => {
     if (node.data.length === 0) {
       return true;
     } else if (/^\s+$/.test(node.data)) {
-      if (!node.nextSibling) {
-        return true;
-      } else if (isBlockElement(blockElements, node.nextSibling)) {
-        return true;
-      } else if (Namespace.isNonHtmlElementRoot(node.nextSibling)) {
-        return true;
-      }
+      return !node.nextSibling || isBlockElement(blockElements, node.nextSibling) || Namespace.isNonHtmlElementRoot(node.nextSibling);
     }
   }
 

--- a/modules/tinymce/src/core/main/ts/ForceBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/ForceBlocks.ts
@@ -43,8 +43,14 @@ const shouldRemoveTextNode = (blockElements: SchemaMap, node: Node) => {
   if (NodeType.isText(node)) {
     if (node.data.length === 0) {
       return true;
-    } else if (/^\s+$/.test(node.data) && (!node.nextSibling || isBlockElement(blockElements, node.nextSibling))) {
-      return true;
+    } else if (/^\s+$/.test(node.data)) {
+      if (!node.nextSibling) {
+        return true;
+      } else if (isBlockElement(blockElements, node.nextSibling)) {
+        return true;
+      } else if (Namespace.isNonHtmlElementRoot(node.nextSibling)) {
+        return true;
+      }
     }
   }
 

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -185,7 +185,8 @@ const whitespaceCleaner = (root: AstNode, schema: Schema, settings: DomParserSet
     return false;
   };
 
-  const isBlock = (node: AstNode) => node.name in blockElements || TransparentElements.isTransparentAstBlock(schema, node);
+  const isBlock = (node: AstNode) =>
+    node.name in blockElements || TransparentElements.isTransparentAstBlock(schema, node) || (Namespace.isNonHtmlElementRootName(node.name) && node.parent === root);
 
   const isAtEdgeOfBlock = (node: AstNode, start: boolean): boolean => {
     const neighbour = start ? node.prev : node.next;

--- a/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
@@ -155,4 +155,13 @@ describe('browser.tinymce.core.ForceBlocksTest', () => {
     pressArrowKey(editor);
     TinyAssertions.assertRawContent(editor, '<svg></svg><p>foo</p>');
   });
+
+  it('TINY-10273: Should create empty paragraphs for whitespace around SVG elements', () => {
+    const editor = hook.editor();
+
+    editor.setContent(' <svg></svg> <svg></svg> ', { format: 'raw' });
+    TinySelections.setCursor(editor, [ 0 ], 0);
+    pressArrowKey(editor);
+    TinyAssertions.assertRawContent(editor, '<svg></svg><svg></svg>');
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
@@ -156,7 +156,7 @@ describe('browser.tinymce.core.ForceBlocksTest', () => {
     TinyAssertions.assertRawContent(editor, '<svg></svg><p>foo</p>');
   });
 
-  it('TINY-10273: Should create empty paragraphs for whitespace around SVG elements', () => {
+  it('TINY-10273: Should not create empty paragraphs for whitespace around SVG elements', () => {
     const editor = hook.editor();
 
     editor.setContent(' <svg></svg> <svg></svg> ', { format: 'raw' });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1613,5 +1613,21 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       const serializedHtml = HtmlSerializer({}, schema).serialize(DomParser({ forced_root_block: 'p', sanitize: false }, schema).parse(input));
       assert.equal(serializedHtml, '<svg><circle><desc>foo<script>alert(1)</script></desc></circle></svg><p>foo</p>');
     });
+
+    it('TINY-10273: Trim whitespace before/after but not inside SVG elements at root level', () => {
+      const schema = Schema();
+      schema.addValidElements('svg[*]');
+      const input = '  <svg> <circle> </circle> </svg>  <svg> <circle> </circle> </svg>  ';
+      const serializedHtml = HtmlSerializer({}, schema).serialize(DomParser({ forced_root_block: 'p' }, schema).parse(input));
+      assert.equal(serializedHtml, '<svg> <circle> </circle> </svg><svg> <circle> </circle> </svg>');
+    });
+
+    it('TINY-10273: Trim whitespace before/after but between or inside SVG elements when inside a block element', () => {
+      const schema = Schema();
+      schema.addValidElements('svg[*]');
+      const input = '<div>  <svg> <circle> </circle> </svg>  <svg> <circle> </circle> </svg>  </div>';
+      const serializedHtml = HtmlSerializer({}, schema).serialize(DomParser({ forced_root_block: 'p' }, schema).parse(input));
+      assert.equal(serializedHtml, '<div><svg> <circle> </circle> </svg> <svg> <circle> </circle> </svg></div>');
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1614,7 +1614,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       assert.equal(serializedHtml, '<svg><circle><desc>foo<script>alert(1)</script></desc></circle></svg><p>foo</p>');
     });
 
-    it('TINY-10273: Trim whitespace before/after but not inside SVG elements at root level', () => {
+    it('TINY-10273: Trim whitespace before or after but not inside SVG elements at root level', () => {
       const schema = Schema();
       schema.addValidElements('svg[*]');
       const input = '  <svg> <circle> </circle> </svg>  <svg> <circle> </circle> </svg>  ';
@@ -1622,7 +1622,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       assert.equal(serializedHtml, '<svg> <circle> </circle> </svg><svg> <circle> </circle> </svg>');
     });
 
-    it('TINY-10273: Trim whitespace before/after but between or inside SVG elements when inside a block element', () => {
+    it('TINY-10273: Trim whitespace before or after but not between or inside SVG elements when inside a block element', () => {
       const schema = Schema();
       schema.addValidElements('svg[*]');
       const input = '<div>  <svg> <circle> </circle> </svg>  <svg> <circle> </circle> </svg>  </div>';


### PR DESCRIPTION
Related Ticket: TINY-10273

Description of Changes:
* Removed empty paragraphs created between SVG root elements.
* Didn't add a changelog since we didn't have official SVG support before.

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
