### PR TITLE
TINY-10282: Focus no longer stolen by the editor due to notification closure

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The dialog size was not updated when the `size` argument was changed when redialling a dialog. #TINY-10209
 - Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10213
 - Custom block element wasn't considered block element in some cases. #TINY-10139
+- The editor no longer forcefully takes focus when a notification closes while the focus is outside of the editor. #TINY-10282
 - An empty element with a `contenteditable="true"` attribute within a table cell would not be treated as content and get removed if backspace or delete was being pressed. #TINY-10010
 - Removing an LI element containing a `details` element would incorrectly merge its content. #TINY-10133
 - The function `getModifierState` did not work on events passed through the editor as expected. #TINY-10263

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -2,7 +2,7 @@ import { Arr, Fun, Optional } from '@ephox/katamari';
 import { Focus, SugarElement } from '@ephox/sugar';
 
 import * as EditorView from '../EditorView';
-import { hasEditorOrUiFocus } from '../focus/EditorFocus';
+import * as EditorFocus from '../focus/EditorFocus';
 import NotificationManagerImpl from '../ui/NotificationManagerImpl';
 import Editor from './Editor';
 import * as Options from './Options';
@@ -106,9 +106,8 @@ const NotificationManager = (editor: Editor): NotificationManager => {
       const notification = getImplementation().open(spec, () => {
         closeNotification(notification);
         reposition();
-        if (hasEditorOrUiFocus(editor)) { // Prevent focus to move to the editor if it is not in the editor.
-          // Move focus back to editor when the last notification is closed,
-          // otherwise focus the top notification
+        if (EditorFocus.hasEditorOrUiFocus(editor)) {
+          // If the editor has focus move focus to the the next notification or the content if there are no more
           getTopNotification().fold(
             () => editor.focus(),
             (top) => Focus.focus(SugarElement.fromDom(top.getEl()))

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -2,6 +2,7 @@ import { Arr, Fun, Optional } from '@ephox/katamari';
 import { Focus, SugarElement } from '@ephox/sugar';
 
 import * as EditorView from '../EditorView';
+import { hasEditorOrUiFocus } from '../focus/EditorFocus';
 import NotificationManagerImpl from '../ui/NotificationManagerImpl';
 import Editor from './Editor';
 import * as Options from './Options';
@@ -105,12 +106,14 @@ const NotificationManager = (editor: Editor): NotificationManager => {
       const notification = getImplementation().open(spec, () => {
         closeNotification(notification);
         reposition();
-        // Move focus back to editor when the last notification is closed,
-        // otherwise focus the top notification
-        getTopNotification().fold(
-          () => editor.focus(),
-          (top) => Focus.focus(SugarElement.fromDom(top.getEl()))
-        );
+        if (hasEditorOrUiFocus(editor)) { // Prevent focus to move to the editor if it is not in the editor.
+          // Move focus back to editor when the last notification is closed,
+          // otherwise focus the top notification
+          getTopNotification().fold(
+            () => editor.focus(),
+            (top) => Focus.focus(SugarElement.fromDom(top.getEl()))
+          );
+        }
       });
 
       addNotification(notification);

--- a/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
@@ -1,6 +1,6 @@
-import { afterEach, context, describe, it } from '@ephox/bedrock-client';
+import { afterEach, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { Focus, SugarElement } from '@ephox/sugar';
+import { Focus, Insert, Remove, SugarElement } from '@ephox/sugar';
 import { LegacyUnit, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -158,6 +158,46 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
 
         n1.close();
         assert.isTrue(editor.hasFocus(), 'Focus should be on the editor');
+      });
+
+      context('focus is placed outside of the editor', () => {
+        const page = SugarElement.fromHtml<HTMLDivElement>('<input class="test-input" />');
+
+        beforeEach(() => {
+          const body = SugarElement.fromDom(document.body);
+          Insert.append(body, page);
+        });
+
+        afterEach(() => {
+          Remove.remove(page);
+        });
+
+        it('TINY-10282: Should not move focus around if the focus is not in the editor', () => {
+          const editor = hook.editor();
+          resetNotifications();
+
+          const testMsg1: NotificationSpec = { type: 'warning', text: 'test message 1' };
+          const testMsg2: NotificationSpec = { type: 'error', text: 'test message 2' };
+          const notifications = editor.notificationManager.getNotifications();
+
+          const hasFocus = (node: SugarElement<Node>) =>
+            Focus.search(node).isSome();
+
+          const n1 = editor.notificationManager.open(testMsg1);
+          const n2 = editor.notificationManager.open(testMsg2);
+          assert.lengthOf(notifications, 2, 'Should have two messages added.');
+
+          Focus.focus(page);
+
+          assert.isTrue(hasFocus(page), 'Focus should remain on the input');
+
+          n2.close();
+          assert.isTrue(hasFocus(page), 'Focus should remain on the input');
+
+          n1.close();
+          assert.isTrue(hasFocus(page), 'Focus should remain on the input');
+          assert.isTrue(!editor.hasFocus(), 'Focus should not be on the editor');
+        });
       });
 
       it('TINY-6528: Notification manager should throw events for notification modification', () => {

--- a/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
@@ -161,15 +161,15 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
       });
 
       context('focus is placed outside of the editor', () => {
-        const page = SugarElement.fromHtml<HTMLDivElement>('<input class="test-input" />');
+        const input = SugarElement.fromHtml<HTMLInputElement>('<input class="test-input" />');
 
         beforeEach(() => {
           const body = SugarElement.fromDom(document.body);
-          Insert.append(body, page);
+          Insert.append(body, input);
         });
 
         afterEach(() => {
-          Remove.remove(page);
+          Remove.remove(input);
         });
 
         it('TINY-10282: Should not move focus around if the focus is not in the editor', () => {
@@ -187,15 +187,15 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
           const n2 = editor.notificationManager.open(testMsg2);
           assert.lengthOf(notifications, 2, 'Should have two messages added.');
 
-          Focus.focus(page);
+          Focus.focus(input);
 
-          assert.isTrue(hasFocus(page), 'Focus should remain on the input');
+          assert.isTrue(hasFocus(input), 'Focus should remain on the input');
 
           n2.close();
-          assert.isTrue(hasFocus(page), 'Focus should remain on the input');
+          assert.isTrue(hasFocus(input), 'Focus should remain on the input');
 
           n1.close();
-          assert.isTrue(hasFocus(page), 'Focus should remain on the input');
+          assert.isTrue(hasFocus(input), 'Focus should remain on the input');
           assert.isTrue(!editor.hasFocus(), 'Focus should not be on the editor');
         });
       });


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-10282

Description of Changes:
Notifications would always take focus to the editor even when not appropriate. We now only take focus if it's in the editor 'area' ( The intention was to move it from the ui to the content, not from anywhere to there )

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
