### PR TITLE
TINY-9819: Added force_hex_color option

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Added `force_hex_color` editor option. Option `'always'` converts all RGB & RGBA colours to hex, `'rgb_only'` will only convert RGB and *not* RGBA colours to hex, `'off'` won't convert any colours to hex. #TINY-9819
+
 ### Improved
 - Colorpicker now includes the Brightness/Saturation selector and hue slider in the keyboard navigable items. #TINY-9287
 - Improved the tooltips of picker buttons for the urlinput components in the "Insert/Edit Image" and "Insert/Edit Link" dialogs. #TINY-10155
@@ -30,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Search and replace plugin would incorrectly find matching text inside SVG elements. #TINY-10162
 - Removed use of `async` for editor rendering which caused visual blinking when reloading the editor in-place. #TINY-10249
 - List items containing a list element surrounded by non list nodes would cause some list operations to fail. #TINY-10268
+- Hex colors are no longer always converted to RGB. #TINY-9819
 
 ## 6.7.1 - 2023-10-19
 

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -44,6 +44,8 @@ export interface ToolbarGroup {
 export type ToolbarMode = 'floating' | 'sliding' | 'scrolling' | 'wrap';
 export type ToolbarLocation = 'top' | 'bottom' | 'auto';
 
+export type ForceHexColor = 'always' | 'rgb_only' | 'off';
+
 interface BaseEditorOptions {
   a11y_advanced_options?: boolean;
   add_form_submit_trigger?: boolean;
@@ -117,7 +119,7 @@ interface BaseEditorOptions {
   font_size_style_values?: string;
   font_size_formats?: string;
   font_size_input_default_unit?: string;
-  force_hex_color?: 'always' | 'rgb_only' | 'off';
+  force_hex_color?: ForceHexColor;
   forced_root_block?: string;
   forced_root_block_attrs?: Record<string, string>;
   formats?: Formats;
@@ -301,7 +303,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   font_size_style_values: string;
   forced_root_block: string;
   forced_root_block_attrs: Record<string, string>;
-  force_hex_color: 'always' | 'rgb_only' | 'off';
+  force_hex_color: ForceHexColor;
   format_noneditable_selector: string;
   height: number | string;
   highlight_on_focus: boolean;

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -117,6 +117,7 @@ interface BaseEditorOptions {
   font_size_style_values?: string;
   font_size_formats?: string;
   font_size_input_default_unit?: string;
+  force_hex_color?: 'always' | 'rgb_only' | 'off';
   forced_root_block?: string;
   forced_root_block_attrs?: Record<string, string>;
   formats?: Formats;
@@ -300,6 +301,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   font_size_style_values: string;
   forced_root_block: string;
   forced_root_block_attrs: Record<string, string>;
+  force_hex_color: 'always' | 'rgb_only' | 'off';
   format_noneditable_selector: string;
   height: number | string;
   highlight_on_focus: boolean;

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -5,7 +5,7 @@ import * as Pattern from '../textpatterns/core/Pattern';
 import * as PatternTypes from '../textpatterns/core/PatternTypes';
 import DOMUtils from './dom/DOMUtils';
 import Editor from './Editor';
-import { EditorOptions } from './OptionTypes';
+import { EditorOptions, ForceHexColor } from './OptionTypes';
 import I18n from './util/I18n';
 import Tools from './util/Tools';
 
@@ -829,8 +829,9 @@ const register = (editor: Editor): void => {
 
   registerOption('force_hex_color', {
     processor: (value) => {
-      const valid = Arr.contains([ 'always', 'rgb_only', 'off' ], value);
-      return valid ? { value, valid } : { valid: false, message: 'Must be one of: always, rgb_only, or off.' };
+      const options: ForceHexColor[] = [ 'always', 'rgb_only', 'off' ];
+      const valid = Arr.contains(options, value);
+      return valid ? { value, valid } : { valid: false, message: `Must be one of: ${options.join(', ')}.` };
     },
     default: 'off',
   });

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -827,6 +827,14 @@ const register = (editor: Editor): void => {
     default: ''
   });
 
+  registerOption('force_hex_color', {
+    processor: (value) => {
+      const valid = Arr.contains([ 'always', 'rgb_only', 'off' ], value);
+      return valid ? { value, valid } : { valid: false, message: 'Must be one of: always, rgb_only, or off.' };
+    },
+    default: 'off',
+  });
+
   // These options must be registered later in the init sequence due to their default values
   editor.on('ScriptsLoaded', () => {
     registerOption('directionality', {
@@ -956,6 +964,8 @@ const hasTableTabNavigation = option('table_tab_navigation');
 const getDetailsInitialState = option('details_initial_state');
 const getDetailsSerializedState = option('details_serialized_state');
 
+const shouldForceHexColor = option('force_hex_color');
+
 export {
   register,
 
@@ -1059,5 +1069,6 @@ export {
   shouldSanitizeXss,
   getDetailsInitialState,
   getDetailsSerializedState,
-  shouldUseDocumentWrite
+  shouldUseDocumentWrite,
+  shouldForceHexColor
 };

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -65,6 +65,7 @@ export interface DOMUtilsSettings {
   onSetAttrib: (event: SetAttribEvent) => void;
   contentCssCors: boolean;
   referrerPolicy: ReferrerPolicy;
+  force_hex_color: 'always' | 'rgb_only' | 'off';
 }
 
 export type Target = Node | Window;
@@ -338,7 +339,8 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
   const schema = settings.schema ? settings.schema : Schema({});
   const styles = Styles({
     url_converter: settings.url_converter,
-    url_converter_scope: settings.url_converter_scope
+    url_converter_scope: settings.url_converter_scope,
+    force_hex_color: settings.force_hex_color,
   }, settings.schema);
 
   const events = settings.ownEvents ? new EventUtils() : EventUtils.Event;

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -11,7 +11,7 @@ import { GeomRect } from '../geom/Rect';
 import Entities from '../html/Entities';
 import Schema from '../html/Schema';
 import Styles, { StyleMap } from '../html/Styles';
-import { URLConverter } from '../OptionTypes';
+import { ForceHexColor, URLConverter } from '../OptionTypes';
 import { MappedEvent } from '../util/EventDispatcher';
 import Tools from '../util/Tools';
 import EventUtils, { EventUtilsCallback } from './EventUtils';
@@ -65,7 +65,7 @@ export interface DOMUtilsSettings {
   onSetAttrib: (event: SetAttribEvent) => void;
   contentCssCors: boolean;
   referrerPolicy: ReferrerPolicy;
-  force_hex_color: 'always' | 'rgb_only' | 'off';
+  force_hex_color: ForceHexColor;
 }
 
 export type Target = Node | Window;

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -268,12 +268,8 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
             // Convert RGB/RGBA colors to HEX
             if (typeof settings.force_hex_color === 'string' && settings.force_hex_color !== 'off') {
               RgbaColour.fromString(value).each((rgba) => {
-                if (
-                  // Always convert,
-                  settings.force_hex_color === 'always' ||
-                  // or only convert if there will be no loss of information from the alpha channel:
-                  rgba.alpha === 1
-                ) {
+                //  Always convert or only convert if there will be no loss of information from the alpha channel
+                if (settings.force_hex_color === 'always' || rgba.alpha === 1) {
                   value = Transformations.rgbaToHexString(RgbaColour.toString(rgba));
                 }
               });

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -19,7 +19,7 @@
 import { RgbaColour, Transformations } from '@ephox/acid';
 import { Obj, Unicode } from '@ephox/katamari';
 
-import { URLConverter } from '../OptionTypes';
+import { ForceHexColor, URLConverter } from '../OptionTypes';
 import Schema, { SchemaMap } from './Schema';
 
 export type StyleMap = Record<string, string | number>;
@@ -29,7 +29,7 @@ export interface StylesSettings {
   allow_svg_data_urls?: boolean;
   url_converter?: URLConverter;
   url_converter_scope?: any;
-  force_hex_color?: 'always' | 'rgb_only' | 'off';
+  force_hex_color?: ForceHexColor;
 }
 
 interface Styles {

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -17,7 +17,7 @@
  */
 
 import { RgbaColour, Transformations } from '@ephox/acid';
-import { Obj, Unicode } from '@ephox/katamari';
+import { Obj, Type, Unicode } from '@ephox/katamari';
 
 import { ForceHexColor, URLConverter } from '../OptionTypes';
 import Schema, { SchemaMap } from './Schema';
@@ -266,7 +266,7 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
             }
 
             // Convert RGB/RGBA colors to HEX
-            if (typeof settings.force_hex_color === 'string' && settings.force_hex_color !== 'off') {
+            if (Type.isString(settings.force_hex_color) && settings.force_hex_color !== 'off') {
               RgbaColour.fromString(value).each((rgba) => {
                 //  Always convert or only convert if there will be no loss of information from the alpha channel
                 if (settings.force_hex_color === 'always' || rgba.alpha === 1) {

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -432,7 +432,8 @@ const contentBodyLoaded = (editor: Editor): void => {
     referrerPolicy: Options.getReferrerPolicy(editor),
     onSetAttrib: (e) => {
       editor.dispatch('SetAttrib', e);
-    }
+    },
+    force_hex_color: Options.shouldForceHexColor(editor),
   });
 
   editor.parser = createParser(editor);

--- a/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
@@ -1,9 +1,6 @@
-import { Transformations } from '@ephox/acid';
-import { context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { describe, it } from '@ephox/bedrock-client';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
 import Schema from 'tinymce/core/api/html/Schema';
 import Styles from 'tinymce/core/api/html/Styles';
 
@@ -238,123 +235,35 @@ describe('browser.tinymce.core.html.StylesTest', () => {
     assertStyles(styles, 'background:url(vbscript:alert(1)', `background: url('vbscript:alert(1');`);
   });
 
-  const applyAndAssertForeColor = (editor: Editor, appliedColor: string, expectedColor: string) => {
-    // Reset content
-    editor.setContent('<p>colour me</p>');
-
-    return {
-      /** Apply color using 'mceApplyTextcolor' command. */
-      usingCommand: () => {
-        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 'color me'.length);
-        editor.execCommand('mceApplyTextcolor', 'forecolor' as any, appliedColor);
-        TinyAssertions.assertContentPresence(editor, { [`span[data-mce-style="color: ${expectedColor};"]`]: 1 });
-      },
-      /** Apply color using the 'forecolor' part of the toolbar. */
-      usingToolbar: async () => {
-        TinyUiActions.clickOnToolbar(editor, '[aria-label^="Text color"] > .tox-tbtn + .tox-split-button__chevron');
-        await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-        TinyUiActions.clickOnUi(editor, `div[data-mce-color="${appliedColor}"]`);
-        TinyAssertions.assertContentPresence(editor, { [`span[data-mce-style="color: ${expectedColor};"]`]: 1 });
-      },
-    };
-  };
-
-  context('force_hex_color option set to default ("off")', () => {
-    const hook = TinyHooks.bddSetupLight<Editor>({
-      base_url: '/project/tinymce/js/tinymce',
-    }, []);
-
-    it('TINY-9819: data-mce-style colors are left as RGB', () => {
-      const editor = hook.editor();
-      assert.equal(editor.options.get('force_hex_color'), 'off', 'force_hex_color must be set to "off"');
-      applyAndAssertForeColor(editor, '#E03E2D', 'rgb(224, 62, 45)').usingCommand();
-      applyAndAssertForeColor(editor, '#FF0000', 'rgb(255, 0, 0)').usingCommand();
-      applyAndAssertForeColor(editor, '#00FF00', 'rgb(0, 255, 0)').usingCommand();
-      applyAndAssertForeColor(editor, 'rgb(40, 120, 200)', 'rgb(40, 120, 200)').usingCommand();
-    });
-
-    it('TINY-9819: alpha channel is unaffected', () => {
-      const editor = hook.editor();
-      applyAndAssertForeColor(editor, 'rgba(224, 62, 45, 0.5)', 'rgba(224, 62, 45, 0.5)').usingCommand();
-      applyAndAssertForeColor(editor, 'rgba(3, 2, 1, 0.01)', 'rgba(3, 2, 1, 0.01)').usingCommand();
-    });
+  it('TINY-9819: force_hex_color set to "off" (the default)', () => {
+    const styles = Styles();
+    for (const color of [
+      '#aabbcc',
+      'rgb(1, 2, 3)',
+      'rgba(1, 2, 3, 0.5)',
+      `rgba(200, 150, 100, 0.95)`
+    ]) {
+      // All colors are unchanged:
+      assertStyles(styles, `color: ${color};`, `color: ${color};`);
+    }
   });
 
-  context('force_hex_color option set to "rgb_only"', () => {
-    const color_map = [ '#E03E2D', 'Red', 'rgb(10, 200, 10)', 'Green' ];
-    const hook = TinyHooks.bddSetupLight<Editor>({
-      base_url: '/project/tinymce/js/tinymce',
-      force_hex_color: 'rgb_only',
-      toolbar: 'forecolor',
-      color_map,
-    }, []);
-
-    it('TINY-9819: will leave RGBA colors unaffected', () => {
-      const editor = hook.editor();
-      assert.equal(editor.options.get('force_hex_color'), 'rgb_only', 'force_hex_color must be set to "rgb_only"');
-      applyAndAssertForeColor(editor, 'rgba(50, 60, 70, 0.4)', 'rgba(50, 60, 70, 0.4)').usingCommand();
-    });
-
-    it('TINY-9819: will convert RGB to HEX', () => {
-      applyAndAssertForeColor(hook.editor(), 'rgb(50, 60, 70)', '#323C46').usingCommand();
-      applyAndAssertForeColor(hook.editor(), 'rgb(105, 72, 72)', '#694848').usingCommand();
-    });
-
-    it('TINY-9819: will convert RGB to HEX with toolbar & color_map', async () => {
-      const editor = hook.editor();
-      await applyAndAssertForeColor(editor, color_map[0], color_map[0]).usingToolbar();
-      const hex = Transformations.rgbaToHexString(color_map[2]);
-      await applyAndAssertForeColor(editor, hex, hex).usingToolbar();
-    });
+  it('TINY-9819: force_hex_color set to "always"', () => {
+    const styles = Styles({ force_hex_color: 'always' });
+    assertStyles(styles, 'color: #aabbcc;', 'color: #aabbcc;');
+    assertStyles(styles, 'color: rgb(1, 2, 3);', 'color: #010203;');
+    assertStyles(styles, 'color: rgba(1, 2, 3, 1);', 'color: #010203;');
+    assertStyles(styles, 'color: rgba(1, 2, 3, 0);', 'color: #010203;');
+    assertStyles(styles, 'color: rgba(1, 2, 3, 0.5);', 'color: #010203;');
   });
 
-  context('force_hex_color option set to "always"', () => {
-    const color_map = [ '#E03E2D', 'Red', 'rgb(10, 200, 10)', 'Green', 'rgba(10, 10, 200, 0.9)', 'Blue' ];
-    const hook = TinyHooks.bddSetupLight<Editor>({
-      base_url: '/project/tinymce/js/tinymce',
-      force_hex_color: 'always',
-      toolbar: 'forecolor',
-      color_map,
-    }, []);
-
-    it('TINY-9819: will convert RGB & RGBA to HEX', () => {
-      const editor = hook.editor();
-      assert.equal(editor.options.get('force_hex_color'), 'always', 'force_hex_color must be set to "always"');
-      applyAndAssertForeColor(editor, 'rgb(50, 60, 70)', '#323C46').usingCommand();
-      applyAndAssertForeColor(editor, 'rgba(50, 60, 70, 0.4)', '#323C46').usingCommand();
-    });
-
-    it('TINY-9819: will convert RGB & RGBA to HEX with toolbar & color_map', async () => {
-      const editor = hook.editor();
-      await applyAndAssertForeColor(editor, color_map[0], color_map[0]).usingToolbar();
-      let hex = Transformations.rgbaToHexString(color_map[2]);
-      await applyAndAssertForeColor(editor, hex, hex).usingToolbar();
-      hex = Transformations.rgbaToHexString(color_map[4]);
-      await applyAndAssertForeColor(editor, hex, hex).usingToolbar();
-    });
+  it('TINY-9819: force_hex_color set to "rgb_only"', () => {
+    const styles = Styles({ force_hex_color: 'rgb_only' });
+    assertStyles(styles, 'color: #aabbcc;', 'color: #aabbcc;');
+    assertStyles(styles, 'color: rgb(1, 2, 3);', 'color: #010203;');
+    assertStyles(styles, 'color: rgba(1, 2, 3, 1);', 'color: #010203;');
+    assertStyles(styles, 'color: rgba(1, 2, 3, 0);', 'color: rgba(1, 2, 3, 0);');
+    assertStyles(styles, 'color: rgba(1, 2, 3, 0.5);', 'color: rgba(1, 2, 3, 0.5);');
   });
 
-  context('force_hex_color option set to "always" and without color_map', () => {
-    const hook = TinyHooks.bddSetupLight<Editor>({
-      base_url: '/project/tinymce/js/tinymce',
-      force_hex_color: 'always',
-      toolbar: 'forecolor',
-    }, []);
-
-    it('TINY-9819: will convert RGB & RGBA to HEX', () => {
-      const editor = hook.editor();
-      assert.isFalse(editor.options.isSet('color_map'));
-
-      applyAndAssertForeColor(editor, '#00FF00', '#00FF00').usingCommand();
-      applyAndAssertForeColor(editor, 'rgb(10, 200, 10)', '#0AC80A').usingCommand();
-      applyAndAssertForeColor(editor, 'rgba(10, 10, 200, 0.9)', '#0A0AC8').usingCommand();
-    });
-
-    it('TINY-9819: will convert RGB & RGBA to HEX with toolbar & without color_map', async () => {
-      const editor = hook.editor();
-      await applyAndAssertForeColor(editor, '#BA372A', '#BA372A').usingToolbar();
-      await applyAndAssertForeColor(editor, '#3598DB', '#3598DB').usingToolbar();
-      await applyAndAssertForeColor(editor, '#B96AD9', '#B96AD9').usingToolbar();
-    });
-  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
@@ -1,6 +1,9 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { Transformations } from '@ephox/acid';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
+import Editor from 'tinymce/core/api/Editor';
 import Schema from 'tinymce/core/api/html/Schema';
 import Styles from 'tinymce/core/api/html/Styles';
 
@@ -233,5 +236,125 @@ describe('browser.tinymce.core.html.StylesTest', () => {
     assertStyles(styles, 'color:expression(alert(1))', 'color: expression(alert(1));');
     assertStyles(styles, 'background:url(javascript:alert(1)', `background: url('javascript:alert(1');`);
     assertStyles(styles, 'background:url(vbscript:alert(1)', `background: url('vbscript:alert(1');`);
+  });
+
+  const applyAndAssertForeColor = (editor: Editor, appliedColor: string, expectedColor: string) => {
+    // Reset content
+    editor.setContent('<p>colour me</p>');
+
+    return {
+      /** Apply color using 'mceApplyTextcolor' command. */
+      usingCommand: () => {
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 'color me'.length);
+        editor.execCommand('mceApplyTextcolor', 'forecolor' as any, appliedColor);
+        TinyAssertions.assertContentPresence(editor, { [`span[data-mce-style="color: ${expectedColor};"]`]: 1 });
+      },
+      /** Apply color using the 'forecolor' part of the toolbar. */
+      usingToolbar: async () => {
+        TinyUiActions.clickOnToolbar(editor, '[aria-label^="Text color"] > .tox-tbtn + .tox-split-button__chevron');
+        await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+        TinyUiActions.clickOnUi(editor, `div[data-mce-color="${appliedColor}"]`);
+        TinyAssertions.assertContentPresence(editor, { [`span[data-mce-style="color: ${expectedColor};"]`]: 1 });
+      },
+    };
+  };
+
+  context('force_hex_color option set to default ("off")', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+    }, []);
+
+    it('TINY-9819: data-mce-style colors are left as RGB', () => {
+      const editor = hook.editor();
+      assert.equal(editor.options.get('force_hex_color'), 'off', 'force_hex_color must be set to "off"');
+      applyAndAssertForeColor(editor, '#E03E2D', 'rgb(224, 62, 45)').usingCommand();
+      applyAndAssertForeColor(editor, '#FF0000', 'rgb(255, 0, 0)').usingCommand();
+      applyAndAssertForeColor(editor, '#00FF00', 'rgb(0, 255, 0)').usingCommand();
+      applyAndAssertForeColor(editor, 'rgb(40, 120, 200)', 'rgb(40, 120, 200)').usingCommand();
+    });
+
+    it('TINY-9819: alpha channel is unaffected', () => {
+      const editor = hook.editor();
+      applyAndAssertForeColor(editor, 'rgba(224, 62, 45, 0.5)', 'rgba(224, 62, 45, 0.5)').usingCommand();
+      applyAndAssertForeColor(editor, 'rgba(3, 2, 1, 0.01)', 'rgba(3, 2, 1, 0.01)').usingCommand();
+    });
+  });
+
+  context('force_hex_color option set to "rgb_only"', () => {
+    const color_map = [ '#E03E2D', 'Red', 'rgb(10, 200, 10)', 'Green' ];
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      force_hex_color: 'rgb_only',
+      toolbar: 'forecolor',
+      color_map,
+    }, []);
+
+    it('TINY-9819: will leave RGBA colors unaffected', () => {
+      const editor = hook.editor();
+      assert.equal(editor.options.get('force_hex_color'), 'rgb_only', 'force_hex_color must be set to "rgb_only"');
+      applyAndAssertForeColor(editor, 'rgba(50, 60, 70, 0.4)', 'rgba(50, 60, 70, 0.4)').usingCommand();
+    });
+
+    it('TINY-9819: will convert RGB to HEX', () => {
+      applyAndAssertForeColor(hook.editor(), 'rgb(50, 60, 70)', '#323C46').usingCommand();
+      applyAndAssertForeColor(hook.editor(), 'rgb(105, 72, 72)', '#694848').usingCommand();
+    });
+
+    it('TINY-9819: will convert RGB to HEX with toolbar & color_map', async () => {
+      const editor = hook.editor();
+      await applyAndAssertForeColor(editor, color_map[0], color_map[0]).usingToolbar();
+      const hex = Transformations.rgbaToHexString(color_map[2]);
+      await applyAndAssertForeColor(editor, hex, hex).usingToolbar();
+    });
+  });
+
+  context('force_hex_color option set to "always"', () => {
+    const color_map = [ '#E03E2D', 'Red', 'rgb(10, 200, 10)', 'Green', 'rgba(10, 10, 200, 0.9)', 'Blue' ];
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      force_hex_color: 'always',
+      toolbar: 'forecolor',
+      color_map,
+    }, []);
+
+    it('TINY-9819: will convert RGB & RGBA to HEX', () => {
+      const editor = hook.editor();
+      assert.equal(editor.options.get('force_hex_color'), 'always', 'force_hex_color must be set to "always"');
+      applyAndAssertForeColor(editor, 'rgb(50, 60, 70)', '#323C46').usingCommand();
+      applyAndAssertForeColor(editor, 'rgba(50, 60, 70, 0.4)', '#323C46').usingCommand();
+    });
+
+    it('TINY-9819: will convert RGB & RGBA to HEX with toolbar & color_map', async () => {
+      const editor = hook.editor();
+      await applyAndAssertForeColor(editor, color_map[0], color_map[0]).usingToolbar();
+      let hex = Transformations.rgbaToHexString(color_map[2]);
+      await applyAndAssertForeColor(editor, hex, hex).usingToolbar();
+      hex = Transformations.rgbaToHexString(color_map[4]);
+      await applyAndAssertForeColor(editor, hex, hex).usingToolbar();
+    });
+  });
+
+  context('force_hex_color option set to "always" and without color_map', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      force_hex_color: 'always',
+      toolbar: 'forecolor',
+    }, []);
+
+    it('TINY-9819: will convert RGB & RGBA to HEX', () => {
+      const editor = hook.editor();
+      assert.isFalse(editor.options.isSet('color_map'));
+
+      applyAndAssertForeColor(editor, '#00FF00', '#00FF00').usingCommand();
+      applyAndAssertForeColor(editor, 'rgb(10, 200, 10)', '#0AC80A').usingCommand();
+      applyAndAssertForeColor(editor, 'rgba(10, 10, 200, 0.9)', '#0A0AC8').usingCommand();
+    });
+
+    it('TINY-9819: will convert RGB & RGBA to HEX with toolbar & without color_map', async () => {
+      const editor = hook.editor();
+      await applyAndAssertForeColor(editor, '#BA372A', '#BA372A').usingToolbar();
+      await applyAndAssertForeColor(editor, '#3598DB', '#3598DB').usingToolbar();
+      await applyAndAssertForeColor(editor, '#B96AD9', '#B96AD9').usingToolbar();
+    });
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ForceHexColorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ForceHexColorTest.ts
@@ -1,0 +1,128 @@
+import { Transformations } from '@ephox/acid';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.ForceHexColorTest', () => {
+  const applyAndAssertForeColor = (editor: Editor, appliedColor: string, expectedColor: string) => {
+    // Reset content
+    editor.setContent('<p>colour me</p>');
+
+    return {
+      /** Apply color using 'mceApplyTextcolor' command. */
+      usingCommand: () => {
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 'color me'.length);
+        editor.execCommand('mceApplyTextcolor', 'forecolor' as any, appliedColor);
+        TinyAssertions.assertContentPresence(editor, { [`span[data-mce-style="color: ${expectedColor};"]`]: 1 });
+      },
+      /** Apply color using the 'forecolor' part of the toolbar. */
+      usingToolbar: async () => {
+        TinyUiActions.clickOnToolbar(editor, '[aria-label^="Text color"] > .tox-tbtn + .tox-split-button__chevron');
+        await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
+        TinyUiActions.clickOnUi(editor, `div[data-mce-color="${appliedColor}"]`);
+        TinyAssertions.assertContentPresence(editor, { [`span[data-mce-style="color: ${expectedColor};"]`]: 1 });
+      },
+    };
+  };
+
+  context('force_hex_color option set to default ("off")', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+    }, []);
+
+    it('TINY-9819: data-mce-style colors are left as RGB', () => {
+      const editor = hook.editor();
+      assert.equal(editor.options.get('force_hex_color'), 'off', 'force_hex_color must be set to "off"');
+      applyAndAssertForeColor(editor, '#E03E2D', 'rgb(224, 62, 45)').usingCommand();
+      applyAndAssertForeColor(editor, '#FF0000', 'rgb(255, 0, 0)').usingCommand();
+      applyAndAssertForeColor(editor, '#00FF00', 'rgb(0, 255, 0)').usingCommand();
+      applyAndAssertForeColor(editor, 'rgb(40, 120, 200)', 'rgb(40, 120, 200)').usingCommand();
+    });
+
+    it('TINY-9819: alpha channel is unaffected', () => {
+      const editor = hook.editor();
+      applyAndAssertForeColor(editor, 'rgba(224, 62, 45, 0.5)', 'rgba(224, 62, 45, 0.5)').usingCommand();
+      applyAndAssertForeColor(editor, 'rgba(3, 2, 1, 0.01)', 'rgba(3, 2, 1, 0.01)').usingCommand();
+    });
+  });
+
+  context('force_hex_color option set to "rgb_only"', () => {
+    const color_map = [ '#E03E2D', 'Red', 'rgb(10, 200, 10)', 'Green' ];
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      force_hex_color: 'rgb_only',
+      toolbar: 'forecolor',
+      color_map,
+    }, []);
+
+    it('TINY-9819: will leave RGBA colors unaffected', () => {
+      const editor = hook.editor();
+      assert.equal(editor.options.get('force_hex_color'), 'rgb_only', 'force_hex_color must be set to "rgb_only"');
+      applyAndAssertForeColor(editor, 'rgba(50, 60, 70, 0.4)', 'rgba(50, 60, 70, 0.4)').usingCommand();
+    });
+
+    it('TINY-9819: will convert RGB to HEX', () => {
+      applyAndAssertForeColor(hook.editor(), 'rgb(50, 60, 70)', '#323C46').usingCommand();
+      applyAndAssertForeColor(hook.editor(), 'rgb(105, 72, 72)', '#694848').usingCommand();
+    });
+
+    it('TINY-9819: will convert RGB to HEX with toolbar & color_map', async () => {
+      const editor = hook.editor();
+      await applyAndAssertForeColor(editor, color_map[0], color_map[0]).usingToolbar();
+      const hex = Transformations.rgbaToHexString(color_map[2]);
+      await applyAndAssertForeColor(editor, hex, hex).usingToolbar();
+    });
+  });
+
+  context('force_hex_color option set to "always"', () => {
+    const color_map = [ '#E03E2D', 'Red', 'rgb(10, 200, 10)', 'Green', 'rgba(10, 10, 200, 0.9)', 'Blue' ];
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      force_hex_color: 'always',
+      toolbar: 'forecolor',
+      color_map,
+    }, []);
+
+    it('TINY-9819: will convert RGB & RGBA to HEX', () => {
+      const editor = hook.editor();
+      assert.equal(editor.options.get('force_hex_color'), 'always', 'force_hex_color must be set to "always"');
+      applyAndAssertForeColor(editor, 'rgb(50, 60, 70)', '#323C46').usingCommand();
+      applyAndAssertForeColor(editor, 'rgba(50, 60, 70, 0.4)', '#323C46').usingCommand();
+    });
+
+    it('TINY-9819: will convert RGB & RGBA to HEX with toolbar & color_map', async () => {
+      const editor = hook.editor();
+      await applyAndAssertForeColor(editor, color_map[0], color_map[0]).usingToolbar();
+      let hex = Transformations.rgbaToHexString(color_map[2]);
+      await applyAndAssertForeColor(editor, hex, hex).usingToolbar();
+      hex = Transformations.rgbaToHexString(color_map[4]);
+      await applyAndAssertForeColor(editor, hex, hex).usingToolbar();
+    });
+  });
+
+  context('force_hex_color option set to "always" and without color_map', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      force_hex_color: 'always',
+      toolbar: 'forecolor',
+    }, []);
+
+    it('TINY-9819: will convert RGB & RGBA to HEX', () => {
+      const editor = hook.editor();
+      assert.isFalse(editor.options.isSet('color_map'));
+
+      applyAndAssertForeColor(editor, '#00FF00', '#00FF00').usingCommand();
+      applyAndAssertForeColor(editor, 'rgb(10, 200, 10)', '#0AC80A').usingCommand();
+      applyAndAssertForeColor(editor, 'rgba(10, 10, 200, 0.9)', '#0A0AC8').usingCommand();
+    });
+
+    it('TINY-9819: will convert RGB & RGBA to HEX with toolbar & without color_map', async () => {
+      const editor = hook.editor();
+      await applyAndAssertForeColor(editor, '#BA372A', '#BA372A').usingToolbar();
+      await applyAndAssertForeColor(editor, '#3598DB', '#3598DB').usingToolbar();
+      await applyAndAssertForeColor(editor, '#B96AD9', '#B96AD9').usingToolbar();
+    });
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ForceHexColorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ForceHexColorTest.ts
@@ -13,16 +13,19 @@ describe('browser.tinymce.themes.silver.editor.ForceHexColorTest', () => {
     return {
       /** Apply color using 'mceApplyTextcolor' command. */
       usingCommand: () => {
-        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 'color me'.length);
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 'color me'.length + 1);
         editor.execCommand('mceApplyTextcolor', 'forecolor' as any, appliedColor);
         TinyAssertions.assertContentPresence(editor, { [`span[data-mce-style="color: ${expectedColor};"]`]: 1 });
+        TinyAssertions.assertContent(editor, `<p><span style="color: ${expectedColor};">colour me</span></p>`);
       },
       /** Apply color using the 'forecolor' part of the toolbar. */
       usingToolbar: async () => {
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 'color me'.length + 1);
         TinyUiActions.clickOnToolbar(editor, '[aria-label^="Text color"] > .tox-tbtn + .tox-split-button__chevron');
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
         TinyUiActions.clickOnUi(editor, `div[data-mce-color="${appliedColor}"]`);
         TinyAssertions.assertContentPresence(editor, { [`span[data-mce-style="color: ${expectedColor};"]`]: 1 });
+        TinyAssertions.assertContent(editor, `<p><span style="color: ${expectedColor};">colour me</span></p>`);
       },
     };
   };


### PR DESCRIPTION
Related Ticket: [TINY-9819](https://ephocks.atlassian.net/browse/TINY-9819)

Description of Changes:
Added an editor option called force_hex_color. Defaults to "off".
Setting to "always" will cause applied colors on the "data-mce-style" attribute to be set as HEX values instead of the default RGB (as of a change in v6). This reflects the behavior of applying colors in v5, as every style color was forced to HEX then.
Setting to "rgb_only" will only convert RGB colors, and _not_ RGBA.

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable): N/A

Original [pull request](https://github.com/tinymce/tinymce/pull/9076) was closed because I didn't have contributor status yet.


[TINY-9819]: https://ephocks.atlassian.net/browse/TINY-9819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ