### PR TITLE
TINY-10263: We now keep getModifierState properly accessible. (#9087)

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/keyboard/FakeKeys.ts
+++ b/modules/agar/src/main/ts/ephox/agar/keyboard/FakeKeys.ts
@@ -1,3 +1,4 @@
+import { Fun } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { SugarElement } from '@ephox/sugar';
 
@@ -84,6 +85,7 @@ const safari = (type: string, doc: SugarElement<Document>, value: number, modifi
   (oEvent as any).ctrlKey = modifiers.ctrlKey === true;
   (oEvent as any).metaKey = modifiers.metaKey === true;
   (oEvent as any).altKey = modifiers.altKey === true;
+  (oEvent as any).getModifierState = Fun.never;
 
   dispatcher.dom.dispatchEvent(oEvent);
 };

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- The function `getModifierState` did not work on events passed through the editor as expected. #TINY-10263
 - Removed use of `async` for editor rendering which caused visual blinking when reloading the editor in-place. #TINY-10249
 - Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10213
 

--- a/modules/tinymce/src/core/main/ts/events/EventUtils.ts
+++ b/modules/tinymce/src/core/main/ts/events/EventUtils.ts
@@ -11,6 +11,7 @@ export interface PartialEvent {
   readonly isImmediatePropagationStopped?: () => boolean;
   readonly stopImmediatePropagation?: () => void;
   readonly composedPath?: () => EventTarget[];
+  readonly getModifierState?: (keyArg: string) => boolean;
   returnValue?: boolean;
   defaultPrevented?: boolean;
   cancelBubble?: boolean;
@@ -67,6 +68,12 @@ const clone = <T extends PartialEvent>(originalEvent: T, data?: T): T => {
   if (Type.isNonNullable(originalEvent.composedPath)) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     event.composedPath = () => originalEvent.composedPath!();
+  }
+
+  // The getModifierState won't work when cloned, so delegate instead
+  if (Type.isNonNullable(originalEvent.getModifierState)) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    event.getModifierState = (keyArg: string) => originalEvent.getModifierState!(keyArg);
   }
 
   return event as T;

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/KeyboardEventTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/KeyboardEventTest.ts
@@ -1,0 +1,26 @@
+import { Keys } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyContentActions, TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.keyboard.KeyboardEventTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, []);
+
+  it('TINY-10263: getModifierState exists and does not crash the editor', () => {
+    const editor = hook.editor();
+    let eventFired = 0;
+
+    editor.on('keydown', (e) => {
+      eventFired++;
+      e.getModifierState('Shift');
+    });
+
+    TinyContentActions.keystroke(editor, Keys.enter());
+    assert.equal(eventFired, 1);
+  });
+});


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-10263

Description of Changes:
Backport from develop

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* ~~[ ]~~ Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
