### PR TITLE
TINY-10268: manage list inside an li surrounded by 2 not li elements

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The function `getModifierState` did not work on events passed through the editor as expected. #TINY-10263
 - Removed use of `async` for editor rendering which caused visual blinking when reloading the editor in-place. #TINY-10249
 - Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10213
+- List items containing a list element surrounded by non list nodes would cause some list operations to fail. #TINY-10268
 
 ## 6.7.1 - 2023-10-19
 

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
@@ -1,4 +1,5 @@
 import { Arr, Optional, Type } from '@ephox/katamari';
+import { SugarElement, Traverse } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Schema from 'tinymce/core/api/html/Schema';
@@ -67,6 +68,12 @@ const getClosestListHost = (editor: Editor, elm: Node): HTMLElement => {
   return parentBlock.getOr(editor.getBody());
 };
 
+const isListInsideAnLiWithFirstAndLastNotListElement = (list: SugarElement<Node>): boolean =>
+  Traverse.parent(list).exists((parent) => NodeType.isListItemNode(parent.dom)
+    && Traverse.firstChild(parent).exists((firstChild) => !NodeType.isListNode(firstChild.dom))
+    && Traverse.lastChild(parent).exists((lastChild) => !NodeType.isListNode(lastChild.dom))
+  );
+
 const findLastParentListNode = (editor: Editor, elm: Element): Optional<HTMLOListElement | HTMLUListElement> => {
   const parentLists = editor.dom.getParents<HTMLOListElement | HTMLUListElement>(elm, 'ol,ul', getClosestListHost(editor, elm));
   return Arr.last(parentLists);
@@ -79,9 +86,18 @@ const getSelectedLists = (editor: Editor): Array<HTMLOListElement | HTMLUListEle
   return firstList.toArray().concat(subsequentLists);
 };
 
+const getParentLists = (editor: Editor) => {
+  const elm = editor.selection.getStart();
+  return editor.dom.getParents<HTMLOListElement | HTMLUListElement>(elm, 'ol,ul', getClosestListHost(editor, elm));
+};
+
 const getSelectedListRoots = (editor: Editor): HTMLElement[] => {
   const selectedLists = getSelectedLists(editor);
-  return getUniqueListRoots(editor, selectedLists);
+  const parentLists = getParentLists(editor);
+  return Arr.find(parentLists, (p) => isListInsideAnLiWithFirstAndLastNotListElement(SugarElement.fromDom(p))).fold(
+    () => getUniqueListRoots(editor, selectedLists),
+    (l) => [ l ]
+  );
 };
 
 const getUniqueListRoots = (editor: Editor, lists: HTMLElement[]): HTMLElement[] => {

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -522,6 +522,102 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
     assert.equal(editor.selection.getNode().nodeName, 'LI');
   });
 
+  it('TINY-10268: a `list` inside a `li` surrounded by 2 not element should allow the user to indent/outdent its `li`', () => {
+    const editor = hook.editor();
+    editor.setContent(`<ul>
+      <li>
+        Dedent me
+        <ul>
+          <li>or try to dedent me 1</li>
+          <li>or try to dedent me 2</li>
+        </ul>
+        <span>abc</span>
+      </li>
+    </ul>`);
+
+    TinySelections.setCursor(editor, [ 0, 0, 1, 0 ], 0);
+    editor.execCommand('Indent');
+
+    TinyAssertions.assertContent(editor, '<ul>' +
+      '<li>' +
+        'Dedent me' +
+        '<ul>' +
+          '<li style="list-style-type: none;"><ul><li>or try to dedent me 1</li></ul></li>' +
+          '<li>or try to dedent me 2</li>' +
+        '</ul>' +
+        '<span>abc</span>' +
+      '</li>' +
+    '</ul>');
+
+    TinySelections.setCursor(editor, [ 0, 0, 1, 0, 0, 0 ], 0);
+    editor.execCommand('Outdent');
+
+    TinyAssertions.assertContent(editor, '<ul>' +
+      '<li>' +
+        'Dedent me' +
+        '<ul>' +
+          '<li>or try to dedent me 1</li>' +
+          '<li>or try to dedent me 2</li>' +
+        '</ul>' +
+        '<span>abc</span>' +
+      '</li>' +
+    '</ul>');
+  });
+
+  it('TINY-10268: in a `list` inside a `li` with another list as sibling and 2 not `list` elements as first and last element of the parent `li` indent/outdent should work as expected', () => {
+    const editor = hook.editor();
+    editor.setContent(`<ul>
+      <li>
+        Dedent me
+        <ul>
+          <li>or try to dedent me 1</li>
+          <li>or try to dedent me 2</li>
+        </ul>
+        <ul>
+          <li>or try to dedent me 1</li>
+          <li>or try to dedent me 2</li>
+        </ul>
+        <span>abc</span>
+      </li>
+    </ul>`);
+
+    TinySelections.setCursor(editor, [ 0, 0, 1, 0 ], 0);
+    editor.execCommand('Indent');
+
+    TinyAssertions.assertContent(editor, '<ul>' +
+      '<li>' +
+        'Dedent me' +
+        '<ul>' +
+          '<li style="list-style-type: none;"><ul><li>or try to dedent me 1</li></ul></li>' +
+          '<li>or try to dedent me 2</li>' +
+        '</ul>' +
+        '<ul>' +
+          '<li>or try to dedent me 1</li>' +
+          '<li>or try to dedent me 2</li>' +
+        '</ul>' +
+        '<span>abc</span>' +
+      '</li>' +
+    '</ul>');
+
+    TinySelections.setCursor(editor, [ 0, 0, 1, 0, 0, 0 ], 0);
+    editor.execCommand('Outdent');
+
+    TinyAssertions.assertContent(editor, '<ul>' +
+      '<li>' +
+        'Dedent me' +
+        '<ul>' +
+          '<li>or try to dedent me 1</li>' +
+          '<li>or try to dedent me 2</li>' +
+        '</ul>' +
+        '<ul>' +
+          '<li>or try to dedent me 1</li>' +
+          '<li>or try to dedent me 2</li>' +
+        '</ul>' +
+        '<span>abc</span>' +
+      '</li>' +
+    '</ul>');
+  });
+
   context('Parent context', () => {
     const testCommandAtTextPath = (command: string) => (inputHtml: string, path: number[], expectedHtml: string) => () => {
       const editor = hook.editor();


### PR DESCRIPTION
Related Ticket: TINY-10268

Description of Changes:
cherry-pick of: https://github.com/tinymce/tinymce/pull/9086

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
