### PR TITLE
TINY-10254: manage the case when the selection is in multiple table inside a table

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10213
 - List items containing a list element surrounded by non list nodes would cause some list operations to fail. #TINY-10268
 - The `accordion` toggling with the Enter key press would behave incorrectly on Safari. #TINY-10177
+- Deleting a range that includes a part of a `table` and a `text`, both inside a `td` removed the entire content of the `td`. #TINY-10254
 
 ## 6.7.1 - 2023-10-19
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10213
 - List items containing a list element surrounded by non list nodes would cause some list operations to fail. #TINY-10268
 - The `accordion` toggling with the Enter key press would behave incorrectly on Safari. #TINY-10177
-- Deleting a range that includes a part of a `table` and a `text`, both inside a `td` removed the entire content of the `td`. #TINY-10254
+- Deleting a range that included both text of a cell and a nested table in that cell removed the entire content of the cell. #TINY-10254
 
 ## 6.7.1 - 2023-10-19
 

--- a/modules/tinymce/src/core/main/ts/delete/TableDeleteAction.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDeleteAction.ts
@@ -119,15 +119,9 @@ const getTableSelections = (cellRng: Optional<TableCellRng>, selectionDetails: S
       end: sameTableSelection
     });
   } else {
-    const isClosestTableIsNotTheCommonAncestor = (currentTable: Optional<SugarElement<HTMLTableElement>>) => {
-      const isTableDifferentFromTheAncestor =
-        !Optionals.lift2(selectionDetails.commonAncestorContainerTable, currentTable, Compare.eq).getOr(false);
-
-      return !selectionDetails.isSameTable && isTableDifferentFromTheAncestor;
-    };
     // Covers partial table selection (either start or end will have a tableSelection) and multitable selection (both start and end will have a tableSelection)
-    const startCell = getClosestCell(rng.startContainer, isRoot).filter(() => isClosestTableIsNotTheCommonAncestor(selectionDetails.startTable));
-    const endCell = getClosestCell(rng.endContainer, isRoot).filter(() => isClosestTableIsNotTheCommonAncestor(selectionDetails.endTable));
+    const startCell = getClosestCell(rng.startContainer, isRoot);
+    const endCell = getClosestCell(rng.endContainer, isRoot);
     const startTableSelection = startCell
       .bind(getCellRangeFromStartTable(isRoot))
       .bind(getTableSelectionFromCellRng(isRoot));

--- a/modules/tinymce/src/core/main/ts/delete/TableDeleteAction.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDeleteAction.ts
@@ -119,9 +119,15 @@ const getTableSelections = (cellRng: Optional<TableCellRng>, selectionDetails: S
       end: sameTableSelection
     });
   } else {
+    const isClosestTableIsNotTheCommonAncestor = (currentTable: Optional<SugarElement<HTMLTableElement>>) => {
+      const isTableDifferentFromTheAncestor =
+        !Optionals.lift2(selectionDetails.commonAncestorContainerTable, currentTable, Compare.eq).getOr(false);
+
+      return !selectionDetails.isSameTable && isTableDifferentFromTheAncestor;
+    };
     // Covers partial table selection (either start or end will have a tableSelection) and multitable selection (both start and end will have a tableSelection)
-    const startCell = getClosestCell(rng.startContainer, isRoot);
-    const endCell = getClosestCell(rng.endContainer, isRoot);
+    const startCell = getClosestCell(rng.startContainer, isRoot).filter(() => isClosestTableIsNotTheCommonAncestor(selectionDetails.startTable));
+    const endCell = getClosestCell(rng.endContainer, isRoot).filter(() => isClosestTableIsNotTheCommonAncestor(selectionDetails.endTable));
     const startTableSelection = startCell
       .bind(getCellRangeFromStartTable(isRoot))
       .bind(getTableSelectionFromCellRng(isRoot));

--- a/modules/tinymce/src/core/main/ts/delete/TableDeleteUtils.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDeleteUtils.ts
@@ -8,6 +8,7 @@ export type IsRootFn = (e: SugarElement<Node>) => boolean;
 export interface TableSelectionDetails {
   readonly startTable: Optional<SugarElement<HTMLTableElement>>;
   readonly endTable: Optional<SugarElement<HTMLTableElement>>;
+  readonly commonAncestorContainerTable: Optional<SugarElement<HTMLTableElement>>;
   readonly isStartInTable: boolean;
   readonly isEndInTable: boolean;
   readonly isSameTable: boolean;
@@ -22,6 +23,7 @@ const getTableCells = (table: SugarElement<HTMLTableElement>): SugarElement<HTML
 
 const getTableDetailsFromRange = (rng: Range, isRoot: IsRootFn): TableSelectionDetails => {
   const getTable = (node: Node) => TableCellSelection.getClosestTable(SugarElement.fromDom(node), isRoot);
+  const commonAncestorContainerTable = getTable(rng.commonAncestorContainer);
   const startTable = getTable(rng.startContainer);
   const endTable = getTable(rng.endContainer);
   const isStartInTable = startTable.isSome();
@@ -33,6 +35,7 @@ const getTableDetailsFromRange = (rng: Range, isRoot: IsRootFn): TableSelectionD
   return {
     startTable,
     endTable,
+    commonAncestorContainerTable,
     isStartInTable,
     isEndInTable,
     isSameTable,

--- a/modules/tinymce/src/core/main/ts/delete/TableDeleteUtils.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDeleteUtils.ts
@@ -8,7 +8,6 @@ export type IsRootFn = (e: SugarElement<Node>) => boolean;
 export interface TableSelectionDetails {
   readonly startTable: Optional<SugarElement<HTMLTableElement>>;
   readonly endTable: Optional<SugarElement<HTMLTableElement>>;
-  readonly commonAncestorContainerTable: Optional<SugarElement<HTMLTableElement>>;
   readonly isStartInTable: boolean;
   readonly isEndInTable: boolean;
   readonly isSameTable: boolean;
@@ -38,16 +37,16 @@ const getTableDetailsFromRange = (rng: Range, isRoot: IsRootFn): TableSelectionD
   const isEndTableSameAsCommonAncestorTable = areSameTable(endTable, commonAncestorContainerTable) && !isSameTableAtTheStart;
   endTable = endTable.filter(Fun.constant(!isEndTableSameAsCommonAncestorTable));
 
-  const noTableSameAsCommonAncestorTable = !isStartTableSameAsCommonAncestorTable && !isEndTableSameAsCommonAncestorTable;
-  const isSameTable = areSameTable(startTable, endTable) && noTableSameAsCommonAncestorTable;
   const isStartInTable = startTable.isSome();
   const isEndInTable = endTable.isSome();
+  const noTableSameAsCommonAncestorTable = !isStartTableSameAsCommonAncestorTable && !isEndTableSameAsCommonAncestorTable;
+
+  const isSameTable = areSameTable(startTable, endTable) && noTableSameAsCommonAncestorTable;
   const isMultiTable = !isSameTable && isStartInTable && isEndInTable && noTableSameAsCommonAncestorTable;
 
   return {
     startTable,
     endTable,
-    commonAncestorContainerTable,
     isStartInTable,
     isEndInTable,
     isSameTable,

--- a/modules/tinymce/src/core/main/ts/delete/TableDeleteUtils.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDeleteUtils.ts
@@ -1,4 +1,4 @@
-import { Optional, Optionals } from '@ephox/katamari';
+import { Fun, Optional, Optionals } from '@ephox/katamari';
 import { Compare, SelectorFilter, SugarElement } from '@ephox/sugar';
 
 import * as TableCellSelection from '../selection/TableCellSelection';
@@ -21,16 +21,28 @@ const isRootFromElement = (root: SugarElement<Node>): IsRootFn =>
 const getTableCells = (table: SugarElement<HTMLTableElement>): SugarElement<HTMLTableCellElement>[] =>
   SelectorFilter.descendants<HTMLTableCellElement>(table, 'td,th');
 
+const areSameTable = (table1: Optional<SugarElement<HTMLTableElement>>, table2: Optional<SugarElement<HTMLTableElement>>): boolean =>
+  Optionals.lift2(table1, table2, Compare.eq).getOr(false);
+
 const getTableDetailsFromRange = (rng: Range, isRoot: IsRootFn): TableSelectionDetails => {
   const getTable = (node: Node) => TableCellSelection.getClosestTable(SugarElement.fromDom(node), isRoot);
   const commonAncestorContainerTable = getTable(rng.commonAncestorContainer);
-  const startTable = getTable(rng.startContainer);
-  const endTable = getTable(rng.endContainer);
+  let startTable = getTable(rng.startContainer);
+  let endTable = getTable(rng.endContainer);
+
+  const isSameTableAtTheStart = areSameTable(startTable, endTable);
+
+  const isStartTableSameAsCommonAncestorTable = areSameTable(startTable, commonAncestorContainerTable) && !isSameTableAtTheStart;
+  startTable = startTable.filter(Fun.constant(!isStartTableSameAsCommonAncestorTable));
+
+  const isEndTableSameAsCommonAncestorTable = areSameTable(endTable, commonAncestorContainerTable) && !isSameTableAtTheStart;
+  endTable = endTable.filter(Fun.constant(!isEndTableSameAsCommonAncestorTable));
+
+  const noTableSameAsCommonAncestorTable = !isStartTableSameAsCommonAncestorTable && !isEndTableSameAsCommonAncestorTable;
+  const isSameTable = areSameTable(startTable, endTable) && noTableSameAsCommonAncestorTable;
   const isStartInTable = startTable.isSome();
   const isEndInTable = endTable.isSome();
-  // Partial selection - selection is not within the same table
-  const isSameTable = Optionals.lift2(startTable, endTable, Compare.eq).getOr(false);
-  const isMultiTable = !isSameTable && isStartInTable && isEndInTable;
+  const isMultiTable = !isSameTable && isStartInTable && isEndInTable && noTableSameAsCommonAncestorTable;
 
   return {
     startTable,

--- a/modules/tinymce/src/core/main/ts/delete/TableDeleteUtils.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDeleteUtils.ts
@@ -55,9 +55,8 @@ const adjustQuirksInDetails = (details: TableSelectionDetails, rng: Range, isRoo
 };
 
 const getTableDetailsFromRange = (rng: Range, isRoot: IsRootFn): TableSelectionDetails => {
-  const getTable = (node: Node) => TableCellSelection.getClosestTable(SugarElement.fromDom(node), isRoot);
-  const startTable = getTable(rng.startContainer);
-  const endTable = getTable(rng.endContainer);
+  const startTable = getTable(rng.startContainer, isRoot);
+  const endTable = getTable(rng.endContainer, isRoot);
   const isStartInTable = startTable.isSome();
   const isEndInTable = endTable.isSome();
   // Partial selection - selection is not within the same table

--- a/modules/tinymce/src/core/main/ts/delete/TableDeleteUtils.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDeleteUtils.ts
@@ -24,9 +24,8 @@ const getTable = (node: Node, isRoot: IsRootFn) => TableCellSelection.getClosest
 
 const selectionInTableWithNestedTable = (details: TableSelectionDetails, rng: Range, isRoot: IsRootFn): TableSelectionDetails => {
   return Optionals.lift3(details.startTable, details.endTable, getTable(rng.commonAncestorContainer, isRoot), (startTable, endTable, ancestorTable) => {
-    const areTheSameTableAtTheStart = Compare.eq(startTable, endTable);
-    const isStartTableSameAsCommonAncestorTable = Compare.eq(startTable, ancestorTable) && !areTheSameTableAtTheStart;
-    const isEndTableSameAsCommonAncestorTable = Compare.eq(endTable, ancestorTable) && !areTheSameTableAtTheStart;
+    const isStartTableSameAsCommonAncestorTable = Compare.eq(startTable, ancestorTable) && !details.isSameTable;
+    const isEndTableSameAsCommonAncestorTable = Compare.eq(endTable, ancestorTable) && !details.isSameTable;
 
     return !isStartTableSameAsCommonAncestorTable && !isEndTableSameAsCommonAncestorTable ? details : {
       ...details,

--- a/modules/tinymce/src/core/main/ts/delete/TableDeleteUtils.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDeleteUtils.ts
@@ -29,8 +29,8 @@ const selectionInTableWithNestedTable = (details: TableSelectionDetails): TableS
 
     return !isStartTableParentOfEndTable && !isEndTableParentOfStartTable ? details : {
       ...details,
-      startTable: !isStartTableParentOfEndTable ? details.startTable : Optional.none(),
-      endTable: !isEndTableParentOfStartTable ? details.endTable : Optional.none(),
+      startTable: isStartTableParentOfEndTable ? Optional.none() : details.startTable,
+      endTable: isEndTableParentOfStartTable ? Optional.none() : details.endTable,
       isSameTable: false,
       isMultiTable: false
     };

--- a/modules/tinymce/src/core/main/ts/delete/TableDeleteUtils.ts
+++ b/modules/tinymce/src/core/main/ts/delete/TableDeleteUtils.ts
@@ -24,8 +24,8 @@ const getTable = (node: Node, isRoot: IsRootFn) => TableCellSelection.getClosest
 
 const selectionInTableWithNestedTable = (details: TableSelectionDetails): TableSelectionDetails => {
   return Optionals.lift2(details.startTable, details.endTable, (startTable, endTable) => {
-    const isStartTableParentOfEndTable = PredicateExists.descendant(startTable, (t) => Compare.eq(t, endTable)) && !details.isSameTable;
-    const isEndTableParentOfStartTable = PredicateExists.descendant(endTable, (t) => Compare.eq(t, startTable)) && !details.isSameTable;
+    const isStartTableParentOfEndTable = PredicateExists.descendant(startTable, (t) => Compare.eq(t, endTable));
+    const isEndTableParentOfStartTable = PredicateExists.descendant(endTable, (t) => Compare.eq(t, startTable));
 
     return !isStartTableParentOfEndTable && !isEndTableParentOfStartTable ? details : {
       ...details,

--- a/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
@@ -210,6 +210,8 @@ describe('browser.tinymce.core.delete.TableDeleteTest', () => {
           </tr>
         </tbody>
       </table>`);
+      // this `setCursor` is needed for FireFox since otherwinse the `setSelection` triggers an error
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0, 1, 0, 0, 1, 0 ], 0);
       TinySelections.setSelection(editor, [ 0, 0, 0, 0, 1, 0, 0, 1, 0 ], 1, [ 0, 0, 0, 0, 2, 0 ], 3);
       editor.execCommand('Delete');
       TinyAssertions.assertContent(editor,

--- a/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/TableDeleteTest.ts
@@ -182,6 +182,64 @@ describe('browser.tinymce.core.delete.TableDeleteTest', () => {
       });
       TinyAssertions.assertContent(editor, '<table><tbody><tr><td>&nbsp;</td><td>&nbsp;</td><td>c</td></tr><tr><td>&nbsp;</td><td>&nbsp;</td><td>f</td></tr></tbody></table>');
     });
+
+    it('TINY-10254: Delete a selection that involve a table and some content both inside another table should not delete the first table as well', () => {
+      const editor = hook.editor();
+      editor.setContent(`<table>
+        <tbody>
+          <tr>
+            <td>
+              <table>
+                <tbody>
+                  <tr>
+                    <td>table 1</td>
+                    <td>&nbsp;</td>
+                  </tr>
+                </tbody>
+              </table>
+              <table>
+                <tbody>
+                  <tr>
+                    <td>table 2</td>
+                    <td>abc</td>
+                  </tr>
+                </tbody>
+              </table>
+              <p>content</p>
+            </td>
+          </tr>
+        </tbody>
+      </table>`);
+      TinySelections.setSelection(editor, [ 0, 0, 0, 0, 1, 0, 0, 1, 0 ], 1, [ 0, 0, 0, 0, 2, 0 ], 3);
+      editor.execCommand('Delete');
+      TinyAssertions.assertContent(editor,
+        '<table>' +
+        '<tbody>' +
+          '<tr>' +
+            '<td>' +
+              '<table>' +
+                '<tbody>' +
+                  '<tr>' +
+                    '<td>table 1</td>' +
+                    '<td>&nbsp;</td>' +
+                  '</tr>' +
+                '</tbody>' +
+              '</table>' +
+              '<table>' +
+                '<tbody>' +
+                  '<tr>' +
+                    '<td>table 2</td>' +
+                    '<td>a</td>' +
+                  '</tr>' +
+                '</tbody>' +
+              '</table>' +
+              '<p>tent</p>' +
+            '</td>' +
+          '</tr>' +
+        '</tbody>' +
+      '</table>'
+      );
+    });
   });
 
   context('Delete all single cell content', () => {


### PR DESCRIPTION
Related Ticket: TINY-10254

Description of Changes:
The problem was that when we have a situation like this:

```
...
<td>
  <table id="table1">
    <tbody>
      <tr>
        <td>table</td>
        <td>abc</td>
      </tr>
    </tbody>
  </table>
  <p>content</p>
</td>
...
```

selecting `content` and `abc` our [getTableDetailsFromRange](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/core/main/ts/delete/TableDeleteUtils.ts#L23) returns `isSameTable: false` and `isMultiTable: true` because both `content` and `abc` result in a table, but `content` resutls in the parent table and `abc` in `table1` so not the same table.

but doing it when we go to delete the selection we manage it with [this code](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/core/main/ts/delete/TableDeleteAction.ts#L123-L124) but in this case we intercept the `getClosestCell` of the `rng.endContainer` is the parent cell so we delect also `table1`.

To solve it I changed [getTableDetailsFromRange](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/core/main/ts/delete/TableDeleteUtils.ts#L23) checking if they are 2 different tables but at least one of them is the table releated to the `rng.commonAncestorContainer`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
