### PR TITLE
TINY-10289: manage delete/backspace involving a nested list

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/api/RealKeys.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/RealKeys.ts
@@ -5,12 +5,11 @@ import * as SeleniumAction from '../server/SeleniumAction';
 import { Step } from './Step';
 
 export interface KeyPressAdt {
-  fold: <T> (combo: (modifiers: Modifiers, letters: string) => T, text: (s: string) => T, backspace: () => T, deleteKey: () => T) => T;
+  fold: <T> (combo: (modifiers: Modifiers, letters: string) => T, text: (s: string) => T, backspace: () => T) => T;
   match: <T>(branches: {
     combo: (modifiers: Modifiers, letters: string) => T;
     text: (s: string) => T;
     backspace: () => T;
-    deleteKey: () => T;
   }) => T;
   log: (label: string) => void;
 }
@@ -19,12 +18,10 @@ const adt: {
   combo: (modifiers: Modifiers, letter: string) => KeyPressAdt;
   text: (s: string) => KeyPressAdt;
   backspace: () => KeyPressAdt;
-  deleteKey: () => KeyPressAdt;
 } = Adt.generate([
   { combo: [ 'modifiers', 'letter' ] },
   { text: [ 's' ] },
-  { backspace: [] },
-  { deleteKey: [] },
+  { backspace: [] }
 ]);
 
 interface Modifiers {
@@ -50,7 +47,7 @@ const toSimpleFormat = (keys: KeyPressAdt[]) =>
       altKey: modifiers.altKey.getOr(false),
       key: letter
     }
-  }), (s: string) => ({ text: s }), () => ({ text: '\u0008' }), () => ({ text: '\u007F' })));
+  }), (s: string) => ({ text: s }), () => ({ text: '\u0008' })));
 
 const sSendKeysOn = <T>(selector: string, keys: KeyPressAdt[]): Step<T, T> =>
   SeleniumAction.sPerform<T>('/keys', {
@@ -70,14 +67,12 @@ const combo = (modifiers: MixedKeyModifiers, letter: string): KeyPressAdt => {
 };
 
 const backspace = adt.backspace;
-const deleteKey = adt.deleteKey;
 
 const text = adt.text;
 
 export const RealKeys = {
   combo,
   backspace,
-  deleteKey,
   text,
   sSendKeysOn,
   pSendKeysOn

--- a/modules/agar/src/main/ts/ephox/agar/api/RealKeys.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/RealKeys.ts
@@ -5,11 +5,12 @@ import * as SeleniumAction from '../server/SeleniumAction';
 import { Step } from './Step';
 
 export interface KeyPressAdt {
-  fold: <T> (combo: (modifiers: Modifiers, letters: string) => T, text: (s: string) => T, backspace: () => T) => T;
+  fold: <T> (combo: (modifiers: Modifiers, letters: string) => T, text: (s: string) => T, backspace: () => T, deleteKey: () => T) => T;
   match: <T>(branches: {
     combo: (modifiers: Modifiers, letters: string) => T;
     text: (s: string) => T;
     backspace: () => T;
+    deleteKey: () => T;
   }) => T;
   log: (label: string) => void;
 }
@@ -18,10 +19,12 @@ const adt: {
   combo: (modifiers: Modifiers, letter: string) => KeyPressAdt;
   text: (s: string) => KeyPressAdt;
   backspace: () => KeyPressAdt;
+  deleteKey: () => KeyPressAdt;
 } = Adt.generate([
   { combo: [ 'modifiers', 'letter' ] },
   { text: [ 's' ] },
-  { backspace: [] }
+  { backspace: [] },
+  { deleteKey: [] },
 ]);
 
 interface Modifiers {
@@ -47,7 +50,7 @@ const toSimpleFormat = (keys: KeyPressAdt[]) =>
       altKey: modifiers.altKey.getOr(false),
       key: letter
     }
-  }), (s: string) => ({ text: s }), () => ({ text: '\u0008' })));
+  }), (s: string) => ({ text: s }), () => ({ text: '\u0008' }), () => ({ text: '\u007F' })));
 
 const sSendKeysOn = <T>(selector: string, keys: KeyPressAdt[]): Step<T, T> =>
   SeleniumAction.sPerform<T>('/keys', {
@@ -67,12 +70,14 @@ const combo = (modifiers: MixedKeyModifiers, letter: string): KeyPressAdt => {
 };
 
 const backspace = adt.backspace;
+const deleteKey = adt.deleteKey;
 
 const text = adt.text;
 
 export const RealKeys = {
   combo,
   backspace,
+  deleteKey,
   text,
   sSendKeysOn,
   pSendKeysOn

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Search and replace plugin would incorrectly find matching text inside non-editable root elements. #TINY-10162
 - Search and replace plugin would incorrectly find matching text inside SVG elements. #TINY-10162
 - Removed use of `async` for editor rendering which caused visual blinking when reloading the editor in-place. #TINY-10249
-- Merging an exernal `p` inside a `list` via `delete`/`backspace` would incorreclty try to move a parent element inside a child element. #TINY-10289
+- Merging an external `p` inside a `list` via delete or backspace would incorrectly try to move a parent element inside a child element. #TINY-10289
 
 ## 6.7.2 - 2023-10-25
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Search and replace plugin would incorrectly find matching text inside non-editable root elements. #TINY-10162
 - Search and replace plugin would incorrectly find matching text inside SVG elements. #TINY-10162
 - Removed use of `async` for editor rendering which caused visual blinking when reloading the editor in-place. #TINY-10249
+- Merging an exernal `p` inside a `list` via `delete`/`backspace` would incorreclty try to move a parent element inside a child element. #TINY-10289
 
 ## 6.7.2 - 2023-10-25
 

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -171,7 +171,7 @@ const backspaceDeleteFromListToListCaret = (editor: Editor, isForward: boolean):
 
     const rng = ListRangeUtils.normalizeRange(selection.getRng());
     const otherLi = dom.getParent(findNextCaretContainer(editor, rng, isForward, root), 'LI', root) as HTMLLIElement;
-    const willMergeParentIntoChild = li && otherLi && (isForward ? dom.isChildOf(li, otherLi) : dom.isChildOf(otherLi, li));
+    const willMergeParentIntoChild = otherLi && (isForward ? dom.isChildOf(li, otherLi) : dom.isChildOf(otherLi, li));
 
     if (otherLi && otherLi !== li && !willMergeParentIntoChild) {
       editor.undoManager.transact(() => {

--- a/modules/tinymce/src/plugins/lists/test/ts/webdriver/DeleteTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/webdriver/DeleteTest.ts
@@ -52,7 +52,7 @@ describe('webdriver.tinymce.plugins.lists.DeleteTest', () => {
 
       editor.setContent(initialContent, { format: 'raw' });
       TinySelections.setCursor(editor, [ 0, 1, 1, 0, 0 ], 'List 1-1'.length);
-      await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.deleteKey() ]);
+      await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.combo({}, 'Delete') ]);
       TinyAssertions.assertContent(editor, expectedContent, { format: 'raw' });
     });
   });

--- a/modules/tinymce/src/plugins/lists/test/ts/webdriver/DeleteTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/webdriver/DeleteTest.ts
@@ -18,7 +18,7 @@ describe('webdriver.tinymce.plugins.lists.DeleteTest', () => {
 
       const initialContent = '<ol>' +
           '<li>' +
-            '<span>List 1</span>' +
+            'List 1' +
           '</li>' +
           '<li>' +
             '<h2>Header</h2>' +
@@ -29,27 +29,27 @@ describe('webdriver.tinymce.plugins.lists.DeleteTest', () => {
           '</li>' +
         '</ol>';
 
-      const expectedContent = '<ol>' +
+      const expectedContent = '<ol>\n' +
           '<li>' +
-            '<span>List 1</span>' +
-          '</li>' +
-          '<li>' +
-            '<h2>Header</h2>' +
-            '<ol>' +
-              '<li>List 1-1Place custor at the start of this line and hit backspace.</li>' +
-            '</ol>' +
-          '</li>' +
+            'List 1' +
+          '</li>\n' +
+          '<li>\n' +
+            '<h2>Header</h2>\n' +
+            '<ol>\n' +
+              '<li>List 1-1Place custor at the start of this line and hit backspace.</li>\n' +
+            '</ol>\n' +
+          '</li>\n' +
         '</ol>';
 
-      editor.setContent(initialContent, { format: 'raw' });
+      editor.setContent(initialContent);
       TinySelections.setCursor(editor, [ 0, 1, 2 ], 0);
       await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.backspace() ]);
-      TinyAssertions.assertContent(editor, expectedContent, { format: 'raw' });
+      TinyAssertions.assertContent(editor, expectedContent);
 
-      editor.setContent(initialContent, { format: 'raw' });
+      editor.setContent(initialContent);
       TinySelections.setCursor(editor, [ 0, 1, 1, 0, 0 ], 'List 1-1'.length);
       await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.combo({}, 'Delete') ]);
-      TinyAssertions.assertContent(editor, expectedContent, { format: 'raw' });
+      TinyAssertions.assertContent(editor, expectedContent);
     });
   });
 });

--- a/modules/tinymce/src/plugins/lists/test/ts/webdriver/DeleteTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/webdriver/DeleteTest.ts
@@ -1,0 +1,59 @@
+import { RealKeys } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/lists/Plugin';
+
+describe('webdriver.tinymce.plugins.lists.DeleteTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'lists',
+    toolbar: 'numlist bullist',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  context('backspace and delete', () => {
+    it('TINY-10289: backspace from a `p` after an `ol` or delete from the last `li` inside the `ol` should merge the `p` inside the `li`', async () => {
+      const editor = hook.editor();
+      editor.on('keyup keydown', (e) => {
+        // eslint-disable-next-line no-console
+        console.log('e: ', e.isDefaultPrevented());
+      });
+
+      const initialContent = '<ol>' +
+          '<li>' +
+            '<span>List 1</span>' +
+          '</li>' +
+          '<li>' +
+            '<h2>Header</h2>' +
+            '<ol>' +
+              '<li>List 1-1</li>' +
+            '</ol>' +
+            '<p>Place custor at the start of this line and hit backspace.</p>' +
+          '</li>' +
+        '</ol>';
+
+      const expectedContent = '<ol>' +
+          '<li>' +
+            '<span>List 1</span>' +
+          '</li>' +
+          '<li>' +
+            '<h2>Header</h2>' +
+            '<ol>' +
+              '<li>List 1-1Place custor at the start of this line and hit backspace.</li>' +
+            '</ol>' +
+          '</li>' +
+        '</ol>';
+
+      editor.setContent(initialContent, { format: 'raw' });
+      TinySelections.setCursor(editor, [ 0, 1, 2 ], 0);
+      await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.backspace() ]);
+      TinyAssertions.assertContent(editor, expectedContent, { format: 'raw' });
+
+      editor.setContent(initialContent, { format: 'raw' });
+      TinySelections.setCursor(editor, [ 0, 1, 1, 0, 0 ], 'List 1-1'.length);
+      await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.deleteKey() ]);
+      TinyAssertions.assertContent(editor, expectedContent, { format: 'raw' });
+    });
+  });
+});

--- a/modules/tinymce/src/plugins/lists/test/ts/webdriver/DeleteTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/webdriver/DeleteTest.ts
@@ -9,6 +9,7 @@ describe('webdriver.tinymce.plugins.lists.DeleteTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'lists',
     toolbar: 'numlist bullist',
+    indent: false,
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
 
@@ -29,16 +30,16 @@ describe('webdriver.tinymce.plugins.lists.DeleteTest', () => {
           '</li>' +
         '</ol>';
 
-      const expectedContent = '<ol>\n' +
+      const expectedContent = '<ol>' +
           '<li>' +
             'List 1' +
-          '</li>\n' +
-          '<li>\n' +
-            '<h2>Header</h2>\n' +
-            '<ol>\n' +
-              '<li>List 1-1Place custor at the start of this line and hit backspace.</li>\n' +
-            '</ol>\n' +
-          '</li>\n' +
+          '</li>' +
+          '<li>' +
+            '<h2>Header</h2>' +
+            '<ol>' +
+              '<li>List 1-1Place custor at the start of this line and hit backspace.</li>' +
+            '</ol>' +
+          '</li>' +
         '</ol>';
 
       editor.setContent(initialContent);

--- a/modules/tinymce/src/plugins/lists/test/ts/webdriver/DeleteTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/webdriver/DeleteTest.ts
@@ -15,10 +15,6 @@ describe('webdriver.tinymce.plugins.lists.DeleteTest', () => {
   context('backspace and delete', () => {
     it('TINY-10289: backspace from a `p` after an `ol` or delete from the last `li` inside the `ol` should merge the `p` inside the `li`', async () => {
       const editor = hook.editor();
-      editor.on('keyup keydown', (e) => {
-        // eslint-disable-next-line no-console
-        console.log('e: ', e.isDefaultPrevented());
-      });
 
       const initialContent = '<ol>' +
           '<li>' +


### PR DESCRIPTION
Related Ticket: TINY-10289

Description of Changes:
when we are in a situation like this:
```
<ol>
  <li>
    <span>List 1</span>
  </li>
  <li>
    <h2>Header</h2>
    <ol>
      <li>List 1-1</li>
    </ol>
    <p>Place custor at the start of this line and hit backspace.1</p>
  </li>
</ol>
```
and we try to use delete or backspace to merge the `p` with the `li` we get an error since we went in a case where we are trying to merge the parent `li` inside the child `li`.

to manage this I added a check that in case of `backspace` from the `p` it moves the current selection container inside the `otherLi` which is the nested `li`

in case of `delete` from `li` we just have to return false since that case is well managed from other part of the code

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
