### PR TITLE
TINY-10275: Replace agar RealClipboard.sImportToClipboard with Clipboard.pPasteUrlItems

### DIFF
--- a/modules/agar/CHANGELOG.md
+++ b/modules/agar/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added `Clipboard.pPasteUrlItems` API to paste url files as clipboard items. #TINY-10275
+- Added `Files.getFileDataAsString` API to make it easier to get file data out for testing. #TINY-10275
 
 ### Removed
 - Removed the `RealClipboard.sImportToClipboard` API. #TINY-10275

--- a/modules/agar/CHANGELOG.md
+++ b/modules/agar/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- Added `Clipboard.pPasteUrlItems` API to paste url files as clipboard items. #TINY-10275
+
+### Removed
+- Removed the `RealClipboard.sImportToClipboard` API. #TINY-10275
+
 ## 7.4.0 - 2023-03-15
 
 ### Added

--- a/modules/agar/src/main/ts/ephox/agar/api/Clipboard.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Clipboard.ts
@@ -73,7 +73,7 @@ const pPasteUrlItems = async (target: SugarElement<Element>, items: PasteUrlItem
     const resp = await window.fetch(item.url);
     const blob = await resp.blob();
     const fileName = Arr.last(item.url.split('/')).getOr('filename.dat');
-    const mime = blob.type.split(';')[0];
+    const mime = blob.type.split(';')[0]; // Only grab mime type not charset encoding
 
     if (item.kind === 'string') {
       const reader = new window.FileReader();

--- a/modules/agar/src/main/ts/ephox/agar/api/Clipboard.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Clipboard.ts
@@ -75,7 +75,9 @@ const pPasteUrlItems = async (target: SugarElement<Element>, items: PasteUrlItem
     const fileName = Arr.last(item.url.split('/')).getOr('filename.dat');
     const mime = blob.type.split(';')[0]; // Only grab mime type not charset encoding
 
-    if (item.kind === 'string') {
+    if (resp.status >= 400) {
+      return Promise.reject(new Error(`Failed to load paste URL item: "${item.url}", status: ${resp.status}`));
+    } else if (item.kind === 'string') {
       const reader = new window.FileReader();
       return new Promise<{ kind: 'string'; mime: string; text: string }>((resolve, reject) => {
         reader.addEventListener('loadend', () => {

--- a/modules/agar/src/main/ts/ephox/agar/api/Clipboard.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Clipboard.ts
@@ -1,9 +1,10 @@
-import { Arr, Obj, Type } from '@ephox/katamari';
+import { Arr, Obj } from '@ephox/katamari';
 import { SugarBody, SugarElement } from '@ephox/sugar';
 
 import { createCopyEvent, createCutEvent, createPasteEvent } from '../clipboard/ClipboardEvents';
 import { createDataTransfer } from '../datatransfer/DataTransfer';
 import { getWindowFromElement } from '../dragndrop/DndEvents';
+import * as BlobReader from '../file/BlobReader';
 import { Chain } from './Chain';
 import * as ChainSequence from './ChainSequence';
 import { Step } from './Step';
@@ -78,17 +79,7 @@ const pPasteUrlItems = async (target: SugarElement<Element>, items: PasteUrlItem
     if (resp.status >= 400) {
       return Promise.reject(new Error(`Failed to load paste URL item: "${item.url}", status: ${resp.status}`));
     } else if (item.kind === 'string') {
-      const reader = new window.FileReader();
-      return new Promise<{ kind: 'string'; mime: string; text: string }>((resolve, reject) => {
-        reader.addEventListener('loadend', () => {
-          if (Type.isString(reader.result)) {
-            resolve({ kind: 'string', mime, text: reader.result });
-          } else {
-            reject(new Error('Failed to read blob as string'));
-          }
-        });
-        reader.readAsText(blob);
-      });
+      return { kind: 'string', mime, text: await BlobReader.readBlobAsString(blob) };
     } else {
       return { kind: item.kind, file: new window.File([ blob ], fileName, { type: mime }) };
     }

--- a/modules/agar/src/main/ts/ephox/agar/api/Files.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Files.ts
@@ -1,6 +1,7 @@
-import { createFile, createFileFromString } from '../file/Files';
+import { createFile, createFileFromString, getFileDataAsString } from '../file/Files';
 
 export {
   createFile,
-  createFileFromString
+  createFileFromString,
+  getFileDataAsString
 };

--- a/modules/agar/src/main/ts/ephox/agar/api/RealClipboard.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/RealClipboard.ts
@@ -1,19 +1,10 @@
 import { PlatformDetection } from '@ephox/sand';
 
 import { KeyModifiers } from '../keyboard/FakeKeys';
-import * as SeleniumAction from '../server/SeleniumAction';
 import { RealKeys } from './RealKeys';
 import { Step } from './Step';
 
 const platform = PlatformDetection.detect();
-
-const pImportToClipboard = (filename: string): Promise<{}> =>
-  SeleniumAction.pPerform('/clipboard', {
-    import: filename
-  });
-
-const sImportToClipboard = <T>(filename: string): Step<T, T> =>
-  Step.fromPromise(() => pImportToClipboard(filename));
 
 const pCopy = (selector: string): Promise<{}> => {
   const modifiers: KeyModifiers = platform.os.isMacOS() ? { metaKey: true } : { ctrlKey: true };
@@ -36,10 +27,8 @@ const sPaste = <T>(selector: string): Step<T, T> =>
   Step.fromPromise(() => pPaste(selector));
 
 export {
-  pImportToClipboard,
   pCopy,
   pPaste,
-  sImportToClipboard,
   sCopy,
   sPaste
 };

--- a/modules/agar/src/main/ts/ephox/agar/file/BlobReader.ts
+++ b/modules/agar/src/main/ts/ephox/agar/file/BlobReader.ts
@@ -1,0 +1,18 @@
+import { Type } from '@ephox/katamari';
+
+export const readBlobAsString = (blob: Blob): Promise<string> => {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new window.FileReader();
+
+    reader.addEventListener('loadend', () => {
+      if (Type.isString(reader.result)) {
+        resolve(reader.result);
+      } else {
+        reject(new Error('Failed to read blob as string'));
+      }
+    });
+
+    reader.readAsText(blob);
+  });
+};
+

--- a/modules/agar/src/main/ts/ephox/agar/file/Files.ts
+++ b/modules/agar/src/main/ts/ephox/agar/file/Files.ts
@@ -1,3 +1,5 @@
+import * as BlobReader from './BlobReader';
+
 const createFile = (name: string, lastModified: number, blob: Blob): File => {
   const newBlob: any = new Blob([ blob ], { type: blob.type });
 
@@ -9,7 +11,10 @@ const createFile = (name: string, lastModified: number, blob: Blob): File => {
 
 const createFileFromString = (name: string, lastModified: number, text: string, mime: string): File => createFile(name, lastModified, new Blob([ text ], { type: mime }));
 
+const getFileDataAsString = (file: File): Promise<string> => BlobReader.readBlobAsString(file);
+
 export {
   createFile,
-  createFileFromString
+  createFileFromString,
+  getFileDataAsString
 };

--- a/modules/agar/src/test/resources/clipboard.html
+++ b/modules/agar/src/test/resources/clipboard.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Hello world</p>
+</body>
+</html>

--- a/modules/agar/src/test/resources/clipboard.txt
+++ b/modules/agar/src/test/resources/clipboard.txt
@@ -1,0 +1,1 @@
+Hello world

--- a/modules/agar/src/test/ts/browser/api/ClipboardTest.ts
+++ b/modules/agar/src/test/ts/browser/api/ClipboardTest.ts
@@ -1,14 +1,36 @@
-import { after, Assert, before, describe, it } from '@ephox/bedrock-client';
+import { after, before, describe, it } from '@ephox/bedrock-client';
 import { Singleton } from '@ephox/katamari';
 import { DomEvent, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
 
-import { copy, cut, pasteDataTransfer, pasteFiles, pasteItems } from 'ephox/agar/api/Clipboard';
+import { copy, cut, pasteDataTransfer, pasteFiles, pasteItems, pPasteUrlItems } from 'ephox/agar/api/Clipboard';
 import { createFileFromString } from 'ephox/agar/api/Files';
 
 describe('ClipboardTest', () => {
   const pasteState = Singleton.value<DataTransfer>();
   const pastebinState = Singleton.value<SugarElement<HTMLElement>>();
   const unbinderState = Singleton.value<() => void>();
+
+  const getItemData = async (item: DataTransferItem) => {
+    return new Promise((resolve) => {
+      item.getAsString((data) => {
+        resolve(data);
+      });
+    });
+  };
+
+  const assertStringItem = async (item: DataTransferItem, expected: { type: string; data: string }): Promise<void> => {
+    assert.equal(item.type, expected.type);
+    assert.equal(item.kind, 'string');
+    assert.equal(await getItemData(item), expected.data);
+  };
+
+  const assertFileItem = async (item: DataTransferItem, expected: { type: string; name: string; data: string }): Promise<void> => {
+    assert.equal(item.type, expected.type);
+    assert.equal(item.kind, 'file');
+    assert.equal(item.getAsFile().name, expected.name);
+    assert.equal(await getItemData(item), expected.data);
+  };
 
   before(() => {
     pastebinState.set(SugarElement.fromHtml('<div class="pastebin"></div>'));
@@ -57,8 +79,9 @@ describe('ClipboardTest', () => {
 
     const dataTransfer = pasteState.get().getOrDie('Could not get dataTransfer from state');
 
-    Assert.eq('Should be expected plain text', 'Hello world!', dataTransfer.getData('text/plain'));
-    Assert.eq('Should be expected html', '<b>Hello world!</b>', dataTransfer.getData('text/html'));
+    assert.equal(dataTransfer.items.length, 2);
+    assertStringItem(dataTransfer.items[0], { type: 'text/plain', data: 'Hello world!' });
+    assertStringItem(dataTransfer.items[1], { type: 'text/html', data: '<b>Hello world!</b>' });
   });
 
   it('Paste text and html files', () => {
@@ -71,11 +94,9 @@ describe('ClipboardTest', () => {
 
     const dataTransfer = pasteState.get().getOrDie('Could not get dataTransfer from state');
 
-    Assert.eq('Should be expected mime type', 'text/plain', dataTransfer.items[0].type);
-    Assert.eq('Should be expected mime type', 'text/plain', dataTransfer.files[0].type);
-
-    Assert.eq('Should be expected mime type', 'text/html', dataTransfer.items[1].type);
-    Assert.eq('Should be expected mime type', 'text/html', dataTransfer.files[1].type);
+    assert.equal(dataTransfer.items.length, 2);
+    assertFileItem(dataTransfer.items[0], { type: 'text/plain', name: 'a.txt', data: 'Hello world!' });
+    assertFileItem(dataTransfer.items[1], { type: 'text/html', name: 'a.html', data: '<b>Hello world!</b>' });
   });
 
   it('Paste using dataTransfer mutator', () => {
@@ -88,22 +109,54 @@ describe('ClipboardTest', () => {
 
     const dataTransfer = pasteState.get().getOrDie('Could not get dataTransfer from state');
 
-    Assert.eq('Should be expected mime type', 'text/plain', dataTransfer.items[0].type);
-    Assert.eq('Should be expected mime type', 'file', dataTransfer.items[0].kind);
-
-    Assert.eq('Should be expected mime type', 'text/html', dataTransfer.items[1].type);
-    Assert.eq('Should be expected mime type', 'string', dataTransfer.items[1].kind);
+    assert.equal(dataTransfer.items.length, 2);
+    assertFileItem(dataTransfer.items[0], { type: 'text/plain', name: 'a.txt', data: 'Hello world!' });
+    assertStringItem(dataTransfer.items[1], { type: 'text/html', data: '<b>Hello world!</b>' });
   });
 
   it('Cut', () => {
     const pastebin = pastebinState.get().getOrDie('Could not get pastebin from state');
     const dataTransfer = cut(pastebin);
-    Assert.eq('Should be extracted cut data', 'cut-data', dataTransfer.getData('text/plain'));
+
+    assert.equal(dataTransfer.items.length, 1);
+    assertStringItem(dataTransfer.items[0], { type: 'text/plain', data: 'cut-data' });
   });
 
   it('Copy', () => {
     const pastebin = pastebinState.get().getOrDie('Could not get pastebin from state');
     const dataTransfer = copy(pastebin);
-    Assert.eq('Should be extracted copy data', 'copy-data', dataTransfer.getData('text/plain'));
+
+    assert.equal(dataTransfer.items.length, 1);
+    assertStringItem(dataTransfer.items[0], { type: 'text/plain', data: 'copy-data' });
+  });
+
+  it('PasteUrlItems as strings', async () => {
+    const pastebin = pastebinState.get().getOrDie('Could not get pastebin from state');
+
+    await pPasteUrlItems(pastebin, [
+      { kind: 'string', url: 'project/@ephox/agar/src/test/resources/clipboard.html' },
+      { kind: 'string', url: 'project/@ephox/agar/src/test/resources/clipboard.txt' },
+    ]);
+
+    const dataTransfer = pasteState.get().getOrDie('Could not get dataTransfer from state');
+
+    assert.equal(dataTransfer.items.length, 2);
+    assertStringItem(dataTransfer.items[0], { type: 'text/html', data: '<!DOCTYPE html>\n<html>\n<body>\n<p>Hello world</p>\n</body>\n</html>\n' });
+    assertStringItem(dataTransfer.items[1], { type: 'text/plain', data: 'Hello world\n' });
+  });
+
+  it('PasteUrlItems as files', async () => {
+    const pastebin = pastebinState.get().getOrDie('Could not get pastebin from state');
+
+    await pPasteUrlItems(pastebin, [
+      { kind: 'file', url: 'project/@ephox/agar/src/test/resources/clipboard.html' },
+      { kind: 'file', url: 'project/@ephox/agar/src/test/resources/clipboard.txt' },
+    ]);
+
+    const dataTransfer = pasteState.get().getOrDie('Could not get dataTransfer from state');
+
+    assert.equal(dataTransfer.items.length, 2);
+    assertFileItem(dataTransfer.items[0], { type: 'text/html', name: 'clipboard.html', data: '<!DOCTYPE html>\n<html>\n<body>\n<p>Hello world</p>\n</body>\n</html>\n' });
+    assertFileItem(dataTransfer.items[1], { type: 'text/plain', name: 'clipboard.txt', data: 'Hello world\n' });
   });
 });

--- a/modules/agar/src/test/ts/browser/api/ClipboardTest.ts
+++ b/modules/agar/src/test/ts/browser/api/ClipboardTest.ts
@@ -1,103 +1,109 @@
-import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { after, Assert, before, describe, it } from '@ephox/bedrock-client';
 import { Singleton } from '@ephox/katamari';
 import { DomEvent, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 
-import { Chain } from 'ephox/agar/api/Chain';
-import * as ChainSequence from 'ephox/agar/api/ChainSequence';
-import { cCopy, cCut, sPasteDataTransfer, sPasteFiles, sPasteItems } from 'ephox/agar/api/Clipboard';
+import { copy, cut, pasteDataTransfer, pasteFiles, pasteItems } from 'ephox/agar/api/Clipboard';
 import { createFileFromString } from 'ephox/agar/api/Files';
-import * as Logger from 'ephox/agar/api/Logger';
-import { Pipeline } from 'ephox/agar/api/Pipeline';
-import { Step } from 'ephox/agar/api/Step';
-import * as StepSequence from 'ephox/agar/api/StepSequence';
 
-UnitTest.asynctest('ClipboardTest', (success, failure) => {
-  const pastebin = SugarElement.fromHtml('<div class="pastebin"></div>');
+describe('ClipboardTest', () => {
   const pasteState = Singleton.value<DataTransfer>();
+  const pastebinState = Singleton.value<SugarElement<HTMLElement>>();
+  const unbinderState = Singleton.value<() => void>();
 
-  Insert.append(SugarBody.body(), pastebin);
+  before(() => {
+    pastebinState.set(SugarElement.fromHtml('<div class="pastebin"></div>'));
+    pastebinState.on((pastebin) => {
+      Insert.append(SugarBody.body(), pastebin);
 
-  const cutUnbinder = DomEvent.bind(pastebin, 'cut', (evt) => {
-    const dataTransfer = evt.raw.clipboardData;
-    dataTransfer.clearData();
-    dataTransfer.setData('text/plain', 'cut-data');
+      const cutUnbinder = DomEvent.bind(pastebin, 'cut', (evt) => {
+        const dataTransfer = evt.raw.clipboardData;
+        dataTransfer.clearData();
+        dataTransfer.setData('text/plain', 'cut-data');
+      });
+
+      const copyUnbinder = DomEvent.bind(pastebin, 'copy', (evt) => {
+        const dataTransfer = evt.raw.clipboardData;
+        dataTransfer.clearData();
+        dataTransfer.setData('text/plain', 'copy-data');
+      });
+
+      const pasteUnbinder = DomEvent.bind(pastebin, 'paste', (evt) => {
+        const dataTransfer = evt.raw.clipboardData;
+        pasteState.set(dataTransfer);
+      });
+
+      unbinderState.set(() => {
+        cutUnbinder.unbind();
+        copyUnbinder.unbind();
+        pasteUnbinder.unbind();
+      });
+    });
   });
 
-  const copyUnbinder = DomEvent.bind(pastebin, 'copy', (evt) => {
-    const dataTransfer = evt.raw.clipboardData;
-    dataTransfer.clearData();
-    dataTransfer.setData('text/plain', 'copy-data');
+  after(() => {
+    pastebinState.on(Remove.remove);
+    pastebinState.clear();
+    unbinderState.on((unbind) => unbind());
+    unbinderState.clear();
   });
 
-  const pasteUnbinder = DomEvent.bind(pastebin, 'paste', (evt) => {
-    const dataTransfer = evt.raw.clipboardData;
-    pasteState.set(dataTransfer);
+  it('Paste text and html items', () => {
+    const pastebin = pastebinState.get().getOrDie('Could not get pastebin from state');
+
+    pasteItems(pastebin, {
+      'text/plain': 'Hello world!',
+      'text/html': '<b>Hello world!</b>'
+    });
+
+    const dataTransfer = pasteState.get().getOrDie('Could not get dataTransfer from state');
+
+    Assert.eq('Should be expected plain text', 'Hello world!', dataTransfer.getData('text/plain'));
+    Assert.eq('Should be expected html', '<b>Hello world!</b>', dataTransfer.getData('text/html'));
   });
 
-  Pipeline.runStep({}, StepSequence.sequenceSame([
-    Logger.t('Paste text and html items', StepSequence.sequenceSame([
-      sPasteItems({
-        'text/plain': 'Hello world!',
-        'text/html': '<b>Hello world!</b>'
-      }, '.pastebin'),
-      Step.sync(() => {
-        const dataTransfer = pasteState.get().getOrDie('Could not get dataTransfer from state');
+  it('Paste text and html files', () => {
+    const pastebin = pastebinState.get().getOrDie('Could not get pastebin from state');
 
-        Assert.eq('Should be expected plain text', 'Hello world!', dataTransfer.getData('text/plain'));
-        Assert.eq('Should be expected html', '<b>Hello world!</b>', dataTransfer.getData('text/html'));
-      })
-    ])),
+    pasteFiles(pastebin, [
+      createFileFromString('a.txt', 123, 'Hello world!', 'text/plain'),
+      createFileFromString('a.html', 123, '<b>Hello world!</b>', 'text/html')
+    ]);
 
-    Logger.t('Paste text and html files', StepSequence.sequenceSame([
-      sPasteFiles([
-        createFileFromString('a.txt', 123, 'Hello world!', 'text/plain'),
-        createFileFromString('a.html', 123, '<b>Hello world!</b>', 'text/html')
-      ], '.pastebin'),
-      Step.sync(() => {
-        const dataTransfer = pasteState.get().getOrDie('Could not get dataTransfer from state');
+    const dataTransfer = pasteState.get().getOrDie('Could not get dataTransfer from state');
 
-        Assert.eq('Should be expected mime type', 'text/plain', dataTransfer.items[0].type);
-        Assert.eq('Should be expected mime type', 'text/plain', dataTransfer.files[0].type);
+    Assert.eq('Should be expected mime type', 'text/plain', dataTransfer.items[0].type);
+    Assert.eq('Should be expected mime type', 'text/plain', dataTransfer.files[0].type);
 
-        Assert.eq('Should be expected mime type', 'text/html', dataTransfer.items[1].type);
-        Assert.eq('Should be expected mime type', 'text/html', dataTransfer.files[1].type);
-      })
-    ])),
+    Assert.eq('Should be expected mime type', 'text/html', dataTransfer.items[1].type);
+    Assert.eq('Should be expected mime type', 'text/html', dataTransfer.files[1].type);
+  });
 
-    Logger.t('Paste using dataTransfer mutator', StepSequence.sequenceSame([
-      sPasteDataTransfer((dataTransfer) => {
-        dataTransfer.items.add(createFileFromString('a.txt', 123, 'Hello world!', 'text/plain'));
-        dataTransfer.items.add('<b>Hello world!</b>', 'text/html');
-      }, '.pastebin'),
-      Step.sync(() => {
-        const dataTransfer = pasteState.get().getOrDie('Could not get dataTransfer from state');
+  it('Paste using dataTransfer mutator', () => {
+    const pastebin = pastebinState.get().getOrDie('Could not get pastebin from state');
 
-        Assert.eq('Should be expected mime type', 'text/plain', dataTransfer.items[0].type);
-        Assert.eq('Should be expected mime type', 'file', dataTransfer.items[0].kind);
+    pasteDataTransfer(pastebin, (dataTransfer) => {
+      dataTransfer.items.add(createFileFromString('a.txt', 123, 'Hello world!', 'text/plain'));
+      dataTransfer.items.add('<b>Hello world!</b>', 'text/html');
+    });
 
-        Assert.eq('Should be expected mime type', 'text/html', dataTransfer.items[1].type);
-        Assert.eq('Should be expected mime type', 'string', dataTransfer.items[1].kind);
-      })
-    ])),
+    const dataTransfer = pasteState.get().getOrDie('Could not get dataTransfer from state');
 
-    Logger.t('Cut', Chain.isolate(pastebin, ChainSequence.sequence([
-      cCut,
-      Chain.op((dataTransfer: DataTransfer) => {
-        Assert.eq('Should be extracted cut data', 'cut-data', dataTransfer.getData('text/plain'));
-      })
-    ]))),
+    Assert.eq('Should be expected mime type', 'text/plain', dataTransfer.items[0].type);
+    Assert.eq('Should be expected mime type', 'file', dataTransfer.items[0].kind);
 
-    Logger.t('Copy', Chain.isolate(pastebin, ChainSequence.sequence([
-      cCopy,
-      Chain.op((dataTransfer: DataTransfer) => {
-        Assert.eq('Should be extracted copy data', 'copy-data', dataTransfer.getData('text/plain'));
-      })
-    ])))
-  ]), () => {
-    cutUnbinder.unbind();
-    copyUnbinder.unbind();
-    pasteUnbinder.unbind();
-    Remove.remove(pastebin);
-    success();
-  }, failure);
+    Assert.eq('Should be expected mime type', 'text/html', dataTransfer.items[1].type);
+    Assert.eq('Should be expected mime type', 'string', dataTransfer.items[1].kind);
+  });
+
+  it('Cut', () => {
+    const pastebin = pastebinState.get().getOrDie('Could not get pastebin from state');
+    const dataTransfer = cut(pastebin);
+    Assert.eq('Should be extracted cut data', 'cut-data', dataTransfer.getData('text/plain'));
+  });
+
+  it('Copy', () => {
+    const pastebin = pastebinState.get().getOrDie('Could not get pastebin from state');
+    const dataTransfer = copy(pastebin);
+    Assert.eq('Should be extracted copy data', 'copy-data', dataTransfer.getData('text/plain'));
+  });
 });

--- a/versions.txt
+++ b/versions.txt
@@ -1,5 +1,6 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
 
+agar@8.0.0
 bridge@4.7.0
 sugar@9.3.0


### PR DESCRIPTION
Related Ticket: TINY-10275

Description of Changes:
* Removed the `RealClipboard.sImportToClipboard` API that uses wink that is problematic for bedrock selenium grid.
* Added new `Clipboard.pPasteUrlItems` to paste URL files as clipboard data items.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
