### PR TITLE
TINY-10275: Updated to alpha versions of mcagar

### DIFF
--- a/modules/agar/package.json
+++ b/modules/agar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/agar",
-  "version": "7.4.4",
+  "version": "8.0.0-alpha.0",
   "description": "Testing infrastructure",
   "repository": {
     "type": "git",

--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- Updated agar to latest major. #TINY-10275
+
 ### Fixed
 - Incorrect typing on `DropdownSpec`, `getAnchorOverrides`. Function returns an object, not another function. #TINY-9978
 - Going back from a view to the editor in mobile caused an error. #TINY-10003

--- a/modules/alloy/package.json
+++ b/modules/alloy/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@ephox/alloy",
-  "version": "13.1.1",
+  "version": "14.0.0-alpha.0",
   "description": "Ui Framework",
   "dependencies": {
-    "@ephox/agar": "^7.4.4",
+    "@ephox/agar": "^8.0.0-alpha.0",
     "@ephox/boulder": "^7.1.5",
     "@ephox/katamari": "^9.1.5",
     "@ephox/sand": "^6.0.9",

--- a/modules/mcagar/CHANGELOG.md
+++ b/modules/mcagar/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- Updated agar to latest major. #TINY-10275
+
 ### Fixed
 - Changed so `TinyState.withNoneditableRootEditor` and `TinyState.withNoneditableRootEditorAsync` calls the setEditableRoot API instead of using direct dom mutation. #TINY-10304
 

--- a/modules/mcagar/package.json
+++ b/modules/mcagar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/mcagar",
-  "version": "8.4.2",
+  "version": "9.0.0-alpha.0",
   "description": "Tinymce agar wrapper",
   "repository": {
     "type": "git",
@@ -24,7 +24,7 @@
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
-    "@ephox/agar": "^7.4.4",
+    "@ephox/agar": "^8.0.0-alpha.0",
     "@ephox/katamari": "^9.1.5",
     "@ephox/sand": "^6.0.9",
     "@ephox/sugar": "^9.2.1",

--- a/versions.txt
+++ b/versions.txt
@@ -2,5 +2,7 @@
 # Format: [package_name]@[new_version]
 
 agar@8.0.0
+mcagar@9.0.0
+alloy@14.0.0
 bridge@4.7.0
 sugar@9.3.0


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Updated agar, mcagar and alloy to major alpha versions since the agar is updated to a major I think it makes sense to bump them all to majors even though technically mcagar and alloy are not breaking their API surface.

- [ ] Don't squash merge since that is likely going to mess up the tags that is currently pointing to this PRs commit

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
