### PR TITLE
TINY-10206: Disallow SVG iframes and sandbox iframes in editor content

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inline dialog will now respect `size: 'large'` argument in the dialog spec. #TINY-10209
 - SVG elements and their children are now retained when configured as valid elements. #TINY-10237
 - Bespoke dropdown toolbar buttons including `align`, `fontfamily`, `fontsize`, `blocks`, and `styles` did not include their visible text labels in their accessible names. #TINY-10147
+- SVG iframes are now disallowed. #TINY-10206
+- Iframes in editor content are now sandboxed. #TINY-10206
 
 ### Fixed
 - Editor would convert urls that are not http/s or relative resulting in broken links. #TINY-10153

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -51,6 +51,7 @@ export interface ParserFilter extends FilterRegistry.Filter<ParserFilterCallback
 export interface DomParserSettings {
   allow_html_data_urls?: boolean;
   allow_svg_data_urls?: boolean;
+  allow_svg_iframes?: boolean;
   allow_conditional_comments?: boolean;
   allow_html_in_named_anchor?: boolean;
   allow_script_urls?: boolean;

--- a/modules/tinymce/src/core/main/ts/api/util/URI.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/URI.ts
@@ -37,6 +37,7 @@ interface SafeUriOptions {
   readonly allow_html_data_urls?: boolean;
   readonly allow_script_urls?: boolean;
   readonly allow_svg_data_urls?: boolean;
+  readonly allow_svg_iframes?: boolean;
 }
 
 const safeSvgDataUrlElements = [ 'img', 'video' ];
@@ -73,7 +74,7 @@ export const isInvalidUri = (settings: SafeUriOptions, uri: string, tagName?: st
     return false;
   } else if (/^data:image\//i.test(decodedUri)) {
     return blockSvgDataUris(settings.allow_svg_data_urls, tagName) && /^data:image\/svg\+xml/i.test(decodedUri);
-  } else if (tagName === 'iframe' && Strings.endsWith(decodedUri, '.svg')) {
+  } else if (!settings.allow_svg_iframes && tagName === 'iframe' && Strings.endsWith(decodedUri, '.svg')) {
     return true;
   } else {
     return /^data:/i.test(decodedUri);

--- a/modules/tinymce/src/core/main/ts/api/util/URI.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/URI.ts
@@ -1,4 +1,4 @@
-import { Arr, Type } from '@ephox/katamari';
+import { Arr, Strings, Type } from '@ephox/katamari';
 
 import Entities from '../html/Entities';
 import Tools from './Tools';
@@ -73,6 +73,8 @@ export const isInvalidUri = (settings: SafeUriOptions, uri: string, tagName?: st
     return false;
   } else if (/^data:image\//i.test(decodedUri)) {
     return blockSvgDataUris(settings.allow_svg_data_urls, tagName) && /^data:image\/svg\+xml/i.test(decodedUri);
+  } else if (tagName === 'iframe' && Strings.endsWith(decodedUri, '.svg')) {
+    return true;
   } else {
     return /^data:/i.test(decodedUri);
   }

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
@@ -201,7 +201,8 @@ const register = (htmlParser: DomParser, settings: DomSerializerSettings, dom: D
   // TINY-10206: Restore and remove internal iframe sandbox attribute
   htmlParser.addAttributeFilter('data-mce-sandbox', (nodes, name) =>
     Arr.each((nodes), (node) => {
-      node.attr('sandbox', node.attr(name));
+      const value = node.attr(name);
+      node.attr('sandbox', value === 'none' ? null : value);
       node.attr(name, null);
     }));
 };

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
@@ -198,7 +198,7 @@ const register = (htmlParser: DomParser, settings: DomSerializerSettings, dom: D
     RemoveTrailingBr.addNodeFilter(settings, htmlParser, htmlParser.schema);
   }
 
-  // TINY-10206: Restore and remove internal iframe sandbox attribute
+  // TINY-10206: Normalize internal iframe sandbox attribute
   htmlParser.addAttributeFilter('data-mce-sandbox', (nodes, name) =>
     Arr.each((nodes), (node) => {
       const value = node.attr(name);

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
@@ -199,10 +199,9 @@ const register = (htmlParser: DomParser, settings: DomSerializerSettings, dom: D
   }
 
   // TINY-10206: Normalize internal iframe sandbox attribute
-  htmlParser.addAttributeFilter('data-mce-sandbox', (nodes, name) =>
+  htmlParser.addAttributeFilter('data-mce-sandbox,data-mce-no-sandbox', (nodes, name) =>
     Arr.each((nodes), (node) => {
-      const value = node.attr(name);
-      node.attr('sandbox', value === 'none' ? null : value);
+      node.attr('sandbox', name === 'data-mce-no-sandbox' ? null : node.attr(name));
       node.attr(name, null);
     }));
 };

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
@@ -197,6 +197,13 @@ const register = (htmlParser: DomParser, settings: DomSerializerSettings, dom: D
   if (settings.remove_trailing_brs) {
     RemoveTrailingBr.addNodeFilter(settings, htmlParser, htmlParser.schema);
   }
+
+  // TINY-10206: Restore and remove internal iframe sandbox attribute
+  htmlParser.addAttributeFilter('data-mce-sandbox', (nodes, name) =>
+    Arr.each((nodes), (node) => {
+      node.attr('sandbox', node.attr(name));
+      node.attr(name, null);
+    }));
 };
 
 /**

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
@@ -201,8 +201,10 @@ const register = (htmlParser: DomParser, settings: DomSerializerSettings, dom: D
   // TINY-10206: Normalize internal iframe sandbox attribute
   htmlParser.addAttributeFilter('data-mce-sandbox,data-mce-no-sandbox', (nodes, name) =>
     Arr.each((nodes), (node) => {
-      node.attr('sandbox', name === 'data-mce-no-sandbox' ? null : node.attr(name));
-      node.attr(name, null);
+      if (node.name === 'iframe') {
+        node.attr('sandbox', name === 'data-mce-no-sandbox' ? null : node.attr(name));
+        node.attr(name, null);
+      }
     }));
 };
 

--- a/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
@@ -153,6 +153,12 @@ const register = (parser: DomParser, settings: DomParserSettings): void => {
   }
 
   registerBase64ImageFilter(parser, settings);
+
+  parser.addNodeFilter('iframe', (nodes) =>
+    Arr.each(nodes, (node) => {
+      node.attr('data-mce-sandbox', node.attr('sandbox'));
+      node.attr('sandbox', 'allow-scripts');
+    }));
 };
 
 export {

--- a/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
@@ -156,8 +156,10 @@ const register = (parser: DomParser, settings: DomParserSettings): void => {
 
   parser.addNodeFilter('iframe', (nodes) =>
     Arr.each(nodes, (node) => {
-      node.attr('data-mce-sandbox', node.attr('sandbox') ?? 'none');
-      node.attr('sandbox', 'allow-scripts');
+      if (Type.isNullable(node.attr('data-mce-sandbox'))) {
+        node.attr('data-mce-sandbox', node.attr('sandbox') ?? 'none');
+        node.attr('sandbox', 'allow-scripts');
+      }
     }));
 };
 

--- a/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
@@ -156,9 +156,15 @@ const register = (parser: DomParser, settings: DomParserSettings): void => {
 
   parser.addNodeFilter('iframe', (nodes) =>
     Arr.each(nodes, (node) => {
-      if (Type.isNullable(node.attr('data-mce-sandbox'))) {
-        node.attr('data-mce-sandbox', node.attr('sandbox') ?? 'none');
-        node.attr('sandbox', 'allow-scripts');
+      if (Type.isNullable(node.attr('data-mce-sandbox')) && Type.isNullable(node.attr('data-mce-no-sandbox'))) {
+        const sandboxAttr = node.attr('sandbox');
+        if (Type.isNullable(sandboxAttr)) {
+          node.attr('data-mce-no-sandbox', '');
+          node.attr('sandbox', 'allow-scripts');
+        } else {
+          node.attr('data-mce-sandbox', sandboxAttr);
+          node.attr('sandbox', sandboxAttr.includes('allow-scripts') ? 'allow-scripts' : '');
+        }
       }
     }));
 };

--- a/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
@@ -156,7 +156,7 @@ const register = (parser: DomParser, settings: DomParserSettings): void => {
 
   parser.addNodeFilter('iframe', (nodes) =>
     Arr.each(nodes, (node) => {
-      node.attr('data-mce-sandbox', node.attr('sandbox'));
+      node.attr('data-mce-sandbox', node.attr('sandbox') ?? 'none');
       node.attr('sandbox', 'allow-scripts');
     }));
 };

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -316,6 +316,24 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
           editor.setContent('<iframe src="https://example.com/test.svg"></iframe>');
           TinyAssertions.assertContent(editor, '<p><iframe></iframe></p>');
         });
+
+        context('iframe sandboxing', () => {
+          const sandboxValue = 'allow-scripts';
+
+          it('TINY-10206: Iframe without sandbox attribute should be sandboxed when in editor', () => {
+            const editor = hook.editor();
+            editor.setContent('<iframe src="https://example.com/"></iframe>');
+            TinyAssertions.assertRawContent(editor, `<p><iframe src="https://example.com/" data-mce-sandbox="none" sandbox="${sandboxValue}" data-mce-src="https://example.com/"></iframe></p>`);
+            TinyAssertions.assertContent(editor, '<p><iframe src="https://example.com/"></iframe></p>');
+          });
+
+          it('TINY-10206: Iframe with sandbox attribute should be sandboxed when in editor and original sandbox attribute should be preserved', () => {
+            const editor = hook.editor();
+            editor.setContent('<iframe src="https://example.com/" sandbox="allow-forms"></iframe>');
+            TinyAssertions.assertRawContent(editor, `<p><iframe src="https://example.com/" sandbox="${sandboxValue}" data-mce-sandbox="allow-forms" data-mce-src="https://example.com/"></iframe></p>`);
+            TinyAssertions.assertContent(editor, '<p><iframe src="https://example.com/" sandbox="allow-forms"></iframe></p>');
+          });
+        });
       });
     }
   );

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -392,7 +392,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         editor.setContent('<p><iframe><p>test</p></iframe></p>');
         const content = editor.getContent();
         assert.equal(content,
-          // TINY-9624: Investigate Safari-specific HTML output
+          // Safari seems to encode the contents of iframes
           PlatformDetection.detect().browser.isSafari()
             ? '<p><iframe>&lt;p&gt;test&lt;/p&gt;</iframe></p>'
             : '<p><iframe><p>test</p></iframe></p>',

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -310,6 +310,12 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
             TinyAssertions.assertContent(editor, result);
           });
         });
+
+        it('TINY-10206: Svg iframes should be disallowed', () => {
+          const editor = hook.editor();
+          editor.setContent('<iframe src="https://example.com/test.svg"></iframe>');
+          TinyAssertions.assertContent(editor, '<p><iframe></iframe></p>');
+        });
       });
     }
   );

--- a/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SerializerTest.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, it } from '@ephox/bedrock-client';
+import { afterEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { assert } from 'chai';
 
@@ -921,6 +921,55 @@ describe('browser.tinymce.core.dom.SerializerTest', () => {
       ser.serialize(getTestElement(), { getInner: true }),
       '',
       'Should remove br');
+  });
+
+  context('Normalizing sandboxed iframes', () => {
+    const ser = DomSerializer({});
+
+    it('TINY-10206: iframe with data-mce-no-sandbox attribute', () => {
+      setTestHtml('<iframe src="about:blank" data-mce-no-sandbox="" sandbox="allow-scripts"></iframe>');
+      assert.equal(
+        ser.serialize(getTestElement(), { getInner: true }),
+        '<iframe src="about:blank"></iframe>',
+        'Should remove sandbox attribute'
+      );
+    });
+
+    it('TINY-10206: iframe with data-mce-no-sandbox attribute and no existing sandbox attribute', () => {
+      setTestHtml('<iframe src="about:blank" data-mce-no-sandbox=""></iframe>');
+      assert.equal(
+        ser.serialize(getTestElement(), { getInner: true }),
+        '<iframe src="about:blank"></iframe>',
+        'Should not add any sandbox attribute'
+      );
+    });
+
+    it('TINY-10206: iframe with data-mce-sandbox attribute', () => {
+      setTestHtml('<iframe src="about:blank" data-mce-sandbox="allow-forms allow-scripts" sandbox="allow-scripts"></iframe>');
+      assert.equal(
+        ser.serialize(getTestElement(), { getInner: true }),
+        '<iframe src="about:blank" sandbox="allow-forms allow-scripts"></iframe>',
+        'Should overwrite sandbox attribute'
+      );
+    });
+
+    it('TINY-10206: iframe with empty data-mce-sandbox attribute', () => {
+      setTestHtml('<iframe src="about:blank" data-mce-sandbox="" sandbox="allow-scripts allow-forms"></iframe>');
+      assert.equal(
+        ser.serialize(getTestElement(), { getInner: true }),
+        '<iframe src="about:blank" sandbox=""></iframe>',
+        'Should overwrite sandbox attribute'
+      );
+    });
+
+    it('TINY-10206: iframe with data-mce-sandbox attribute and no existing sandbox attribute', () => {
+      setTestHtml('<iframe src="about:blank" data-mce-sandbox="allow-forms allow-scripts"></iframe>');
+      assert.equal(
+        ser.serialize(getTestElement(), { getInner: true }),
+        '<iframe src="about:blank" sandbox="allow-forms allow-scripts"></iframe>',
+        'Should add sandbox attribute'
+      );
+    });
   });
 });
 

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1552,6 +1552,31 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
               assert.equal(serializedHtml, '<iframe src="https://example.com/test.svg"></iframe>');
             });
           });
+
+          context('Sandboxing iframes', () => {
+            const standardSandbox = 'allow-scripts';
+            const strictSandbox = '';
+
+            const testSandboxedIframes = (originalSandbox: string, expectedSandbox: string) => () => {
+              const parser = DomParser(scenario.settings);
+              const html = `<iframe src="about:blank" sandbox="${originalSandbox}"></iframe>`;
+              const serializedHtml = serializer.serialize(parser.parse(html));
+              assert.equal(serializedHtml, `<iframe src="about:blank" sandbox="${expectedSandbox}" data-mce-sandbox="${originalSandbox}"></iframe>`);
+            };
+
+            it('TINY-10206: iframe without sandbox attribute', () => {
+              const parser = DomParser(scenario.settings);
+              const html = '<iframe src="about:blank"></iframe>';
+              const serializedHtml = serializer.serialize(parser.parse(html));
+              assert.equal(serializedHtml, `<iframe src="about:blank" data-mce-no-sandbox="" sandbox="${standardSandbox}"></iframe>`);
+            });
+
+            it('TINY-10206: iframe with sandbox attribute containing allow-scripts', testSandboxedIframes('allow-scripts', standardSandbox));
+
+            it('TINY-10206: iframe with sandbox attribute that does not contain allow-scripts', testSandboxedIframes('allow-popups', strictSandbox));
+
+            it('TINY-10206: iframe with empty sandbox attribute', testSandboxedIframes('', strictSandbox));
+          });
         });
       });
     });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1530,11 +1530,27 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
             }
           }));
 
-          it('TINY-10206: Svg iframes should be disallowed', () => {
-            const parser = DomParser(scenario.settings);
-            const html = '<iframe src="https://example.com/test.svg""></iframe>';
-            const serializedHtml = serializer.serialize(parser.parse(html));
-            assert.equal(serializedHtml, '<iframe></iframe>');
+          context('Svg iframes', () => {
+            it('TINY-10206: Svg iframes should be disallowed by default', () => {
+              const parser = DomParser(scenario.settings);
+              const html = '<iframe src="https://example.com/test.svg"></iframe>';
+              const serializedHtml = serializer.serialize(parser.parse(html));
+              assert.equal(serializedHtml, '<iframe></iframe>');
+            });
+
+            it('TINY-10206: Svg iframes should be disallowed if allow_svg_iframes: false', () => {
+              const parser = DomParser({ ...scenario.settings, allow_svg_iframes: false });
+              const html = '<iframe src="https://example.com/test.svg"></iframe>';
+              const serializedHtml = serializer.serialize(parser.parse(html));
+              assert.equal(serializedHtml, '<iframe></iframe>');
+            });
+
+            it('TINY-10206: Svg iframes should be allowed if allow_svg_iframes: true', () => {
+              const parser = DomParser({ ...scenario.settings, allow_svg_iframes: true });
+              const html = '<iframe src="https://example.com/test.svg"></iframe>';
+              const serializedHtml = serializer.serialize(parser.parse(html));
+              assert.equal(serializedHtml, '<iframe src="https://example.com/test.svg"></iframe>');
+            });
           });
         });
       });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -829,7 +829,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
 
         assert.equal(
           serializer.serialize(DomParser(scenario.settings).parse('<iframe><textarea></iframe><img src="a" onerror="alert(document.domain)" />')),
-          browser.isSafari() || !scenario.isSanitizeEnabled ? '<iframe><textarea></iframe><img src="a">' : '<img src="a">'
+          browser.isSafari() || !scenario.isSanitizeEnabled ? '<iframe sandbox="allow-scripts" data-mce-no-sandbox=""><textarea></iframe><img src="a">' : '<img src="a">'
         );
       });
 
@@ -945,7 +945,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
           '<video poster="data:image/svg+xml;base64,x"></video>'
         ));
         assert.equal(serializedHtml,
-          '<iframe></iframe>' +
+          '<iframe data-mce-no-sandbox="" sandbox="allow-scripts"></iframe>' +
           '<a>1</a>' +
           '<object></object>' +
           '<img src="data:image/svg+xml;base64,x">' +
@@ -964,7 +964,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
           '<video poster="data:image/svg+xml;base64,x"></video>'
         ));
         assert.equal(serializedHtml,
-          '<iframe src="data:image/svg+xml;base64,x"></iframe>' +
+          '<iframe src="data:image/svg+xml;base64,x" data-mce-no-sandbox="" sandbox="allow-scripts"></iframe>' +
           '<a href="data:image/svg+xml;base64,x">1</a>' +
           '<object data="data:image/svg+xml;base64,x"></object>' +
           '<img src="data:image/svg+xml;base64,x">' +
@@ -982,7 +982,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
           '<video poster="data:image/svg+xml;base64,x"></video>'
         ));
         assert.equal(serializedHtml,
-          '<iframe></iframe>' +
+          '<iframe data-mce-no-sandbox="" sandbox="allow-scripts"></iframe>' +
           '<a>1</a>' +
           '<object></object>' +
           '<img>' +
@@ -1535,21 +1535,21 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
               const parser = DomParser(scenario.settings);
               const html = '<iframe src="https://example.com/test.svg"></iframe>';
               const serializedHtml = serializer.serialize(parser.parse(html));
-              assert.equal(serializedHtml, '<iframe></iframe>');
+              assert.equal(serializedHtml, '<iframe data-mce-no-sandbox="" sandbox="allow-scripts"></iframe>');
             });
 
             it('TINY-10206: Svg iframes should be disallowed if allow_svg_iframes: false', () => {
               const parser = DomParser({ ...scenario.settings, allow_svg_iframes: false });
               const html = '<iframe src="https://example.com/test.svg"></iframe>';
               const serializedHtml = serializer.serialize(parser.parse(html));
-              assert.equal(serializedHtml, '<iframe></iframe>');
+              assert.equal(serializedHtml, '<iframe data-mce-no-sandbox="" sandbox="allow-scripts"></iframe>');
             });
 
             it('TINY-10206: Svg iframes should be allowed if allow_svg_iframes: true', () => {
               const parser = DomParser({ ...scenario.settings, allow_svg_iframes: true });
               const html = '<iframe src="https://example.com/test.svg"></iframe>';
               const serializedHtml = serializer.serialize(parser.parse(html));
-              assert.equal(serializedHtml, '<iframe src="https://example.com/test.svg"></iframe>');
+              assert.equal(serializedHtml, '<iframe src="https://example.com/test.svg" data-mce-no-sandbox="" sandbox="allow-scripts"></iframe>');
             });
           });
 
@@ -1619,8 +1619,8 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     context('with default schema', () => {
       testDisablingSanitization([
         '',
-        '<iframe src="https://example.com"><p>Lorem ipsum</p></iframe>',
-        '<iframe></iframe>',
+        '<iframe src="https://example.com" sandbox="allow-scripts" data-mce-no-sandbox=""><p>Lorem ipsum</p></iframe>',
+        '<iframe sandbox="allow-scripts" data-mce-no-sandbox=""></iframe>',
         '<p><a>XSS</a></p>',
         ''
       ], {});
@@ -1629,8 +1629,8 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     context('with valid_elements: \'*[*]\' schema', () => {
       testDisablingSanitization([
         '<script>alert(1)</script>',
-        '<iframe src="https://example.com"><p>Lorem ipsum</p></iframe>',
-        '<iframe srcdoc="Lorem ipsum"></iframe>',
+        '<iframe src="https://example.com" data-mce-no-sandbox="" sandbox="allow-scripts"><p>Lorem ipsum</p></iframe>',
+        '<iframe srcdoc="Lorem ipsum" data-mce-no-sandbox="" sandbox="allow-scripts"></iframe>',
         '<p><a>XSS</a></p>',
         '<svg><circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow"></circle></svg>'
       ], { valid_elements: '*[*]' });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -822,8 +822,8 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
         );
       });
 
-      // TODO: TINY-9624 - the iframe innerHTML on safari is `&lt;textarea&gt;` whereas on other browsers
-      //       is `<textarea>`. This causes the mXSS cleaner in DOMPurify to run and causes the different assertions below
+      // TINY-9624: Safari encodes the iframe innerHTML is `&lt;textarea&gt;`. On Chrome and Firefox, the innerHTML is `<textarea>`, causing
+      // the mXSS cleaner in DOMPurify to run and remove the iframe.
       it('parse iframe XSS', () => {
         const serializer = HtmlSerializer();
 
@@ -1529,6 +1529,13 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
               forced_root_block: 'p'
             }
           }));
+
+          it('TINY-10206: Svg iframes should be disallowed', () => {
+            const parser = DomParser(scenario.settings);
+            const html = '<iframe src="https://example.com/test.svg""></iframe>';
+            const serializedHtml = serializer.serialize(parser.parse(html));
+            assert.equal(serializedHtml, '<iframe></iframe>');
+          });
         });
       });
     });

--- a/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
@@ -1,4 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { assert } from 'chai';
 
@@ -9,7 +10,7 @@ describe('browser.tinymce.core.html.SanitizationTest', () => {
   context('Sanitize html', () => {
     const isSafari = PlatformDetection.detect().browser.isSafari();
 
-    const testHtmlSanitizer = (testCase: { input: string; expected: string; mimeType: MimeType; sanitize?: boolean }) => {
+    const testHtmlSanitizer = (testCase: { input: string; expected: string; mimeType: MimeType; sanitize?: boolean }) => () => {
       const sanitizer = getSanitizer({ sanitize: testCase.sanitize ?? true }, Schema());
 
       const body = document.createElement('body');
@@ -19,24 +20,33 @@ describe('browser.tinymce.core.html.SanitizationTest', () => {
       assert.equal(body.innerHTML, testCase.expected);
     };
 
-    it('Sanitize iframe HTML', () => testHtmlSanitizer({
+    it('Sanitize iframe HTML', testHtmlSanitizer({
       input: '<iframe src="x"><script>alert(1)</script></iframe><iframe src="javascript:alert(1)"></iframe>',
       // Safari seems to encode the contents of iframes
       expected: isSafari ? '<iframe src="x">&lt;script&gt;alert(1)&lt;/script&gt;</iframe><iframe></iframe>' : '<iframe></iframe>',
       mimeType: 'text/html'
     }));
 
-    it('Disabled sanitization of iframe HTML', () => testHtmlSanitizer({
+    it('Disabled sanitization of iframe HTML', testHtmlSanitizer({
       input: '<iframe src="x"><script>alert(1)</script></iframe><iframe src="javascript:alert(1)"></iframe>',
       // Safari seems to encode the contents of iframes
       expected: isSafari ? '<iframe src="x">&lt;script&gt;alert(1)&lt;/script&gt;</iframe><iframe></iframe>' : '<iframe src="x"><script>alert(1)</script></iframe><iframe></iframe>',
       mimeType: 'text/html',
       sanitize: false
     }));
+
+    Arr.each([ true, false ], (sanitize) => {
+      it(`TINY-10206: Svg iframes should be disallowed when sanitize: ${sanitize}`, testHtmlSanitizer({
+        input: '<iframe src="https://example.com/test.svg"></iframe>',
+        expected: '<iframe></iframe>',
+        mimeType: 'text/html',
+        sanitize
+      }));
+    });
   });
 
   context('Santitize non-html', () => {
-    const testNamespaceSanitizer = (testCase: { input: string; expected: string; sanitize?: boolean }) => {
+    const testNamespaceSanitizer = (testCase: { input: string; expected: string; sanitize?: boolean }) => () => {
       const sanitizer = getSanitizer({ sanitize: testCase.sanitize ?? true }, Schema());
 
       const body = document.createElement('body');
@@ -46,27 +56,27 @@ describe('browser.tinymce.core.html.SanitizationTest', () => {
       assert.equal(body.innerHTML, testCase.expected);
     };
 
-    it('Sanitize SVG', () => testNamespaceSanitizer({
+    it('Sanitize SVG', testNamespaceSanitizer({
       input: '<svg><script>alert(1)</script><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></svg>',
       expected: '<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></circle></svg>'
     }));
 
-    it('Sanitize SVG with xlink', () => testNamespaceSanitizer({
+    it('Sanitize SVG with xlink', testNamespaceSanitizer({
       input: '<svg><script>alert(1)</script><a xlink:href="url"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></a></svg>',
       expected: '<svg><a xlink:href="url"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></circle></a></svg>'
     }));
 
-    it('Sanitize SVG with mixed HTML', () => testNamespaceSanitizer({
+    it('Sanitize SVG with mixed HTML', testNamespaceSanitizer({
       input: '<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><desc><script>alert(1)</script><p>hello</p></circle></a></svg>',
       expected: '<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><desc><p>hello</p></desc></circle></svg>'
     }));
 
-    it('Sanitize SVG with xlink with script url', () => testNamespaceSanitizer({
+    it('Sanitize SVG with xlink with script url', testNamespaceSanitizer({
       input: '<svg><script>alert(1)</script><a xlink:href="javascript:alert(1)"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></a></svg>',
       expected: '<svg><a><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></circle></a></svg>'
     }));
 
-    it('Disabled sanitization of SVG', () => testNamespaceSanitizer({
+    it('Disabled sanitization of SVG', testNamespaceSanitizer({
       input: '<svg><script>alert(1)</script><a xlink:href="javascript:alert(1)"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></a></svg>',
       expected: '<svg><script>alert(1)</script><a xlink:href="javascript:alert(1)"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></circle></a></svg>',
       sanitize: false

--- a/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
@@ -1,5 +1,4 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { Arr } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { assert } from 'chai';
 
@@ -34,15 +33,6 @@ describe('browser.tinymce.core.html.SanitizationTest', () => {
       mimeType: 'text/html',
       sanitize: false
     }));
-
-    Arr.each([ true, false ], (sanitize) => {
-      it(`TINY-10206: Svg iframes should be disallowed when sanitize: ${sanitize}`, testHtmlSanitizer({
-        input: '<iframe src="https://example.com/test.svg"></iframe>',
-        expected: '<iframe></iframe>',
-        mimeType: 'text/html',
-        sanitize
-      }));
-    });
   });
 
   context('Santitize non-html', () => {

--- a/modules/tinymce/src/plugins/media/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/FilterContent.ts
@@ -51,7 +51,8 @@ const setup = (editor: Editor): void => {
           if (className && className.indexOf('mce-preview-object') !== -1 && node.firstChild) {
             realElm.attr({
               width: node.firstChild.attr('width'),
-              height: node.firstChild.attr('height')
+              height: node.firstChild.attr('height'),
+              sandbox: realElmName === 'iframe' ? node.firstChild.attr('sandbox') : undefined
             });
           } else {
             realElm.attr({

--- a/modules/tinymce/src/plugins/media/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/FilterContent.ts
@@ -52,8 +52,14 @@ const setup = (editor: Editor): void => {
             realElm.attr({
               width: node.firstChild.attr('width'),
               height: node.firstChild.attr('height'),
-              sandbox: realElmName === 'iframe' ? node.firstChild.attr('sandbox') : undefined
             });
+
+            // TINY-10206: Normalize internal iframe sandbox attribute
+            if (realElmName === 'iframe') {
+              const sandboxVal = node.firstChild.attr('data-mce-sandbox');
+              realElm.attr('sandbox', sandboxVal === 'none' ? null : sandboxVal);
+              realElm.attr('data-mce-sandbox', null);
+            }
           } else {
             realElm.attr({
               width: node.attr('width'),

--- a/modules/tinymce/src/plugins/media/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/FilterContent.ts
@@ -53,13 +53,6 @@ const setup = (editor: Editor): void => {
               width: node.firstChild.attr('width'),
               height: node.firstChild.attr('height'),
             });
-
-            // TINY-10206: Normalize internal iframe sandbox attribute
-            if (realElmName === 'iframe') {
-              const sandboxVal = node.firstChild.attr('data-mce-sandbox');
-              realElm.attr('sandbox', sandboxVal === 'none' ? null : sandboxVal);
-              realElm.attr('data-mce-sandbox', null);
-            }
           } else {
             realElm.attr({
               width: node.attr('width'),
@@ -72,14 +65,19 @@ const setup = (editor: Editor): void => {
           style: node.attr('style')
         });
 
-        // Unprefix all placeholder attributes
         const attribs = node.attributes ?? [];
         let ai = attribs.length;
         while (ai--) {
           const attrName = attribs[ai].name;
 
+          // Unprefix all placeholder attributes and
+          // TINY-10206: Normalize internal iframe sandbox attribute
           if (attrName.indexOf('data-mce-p-') === 0) {
             realElm.attr(attrName.substr(11), attribs[ai].value);
+          } else if (attrName === 'data-mce-sandbox') {
+            realElm.attr('sandbox', attribs[ai].value);
+          } else if (attrName === 'data-mce-no-sandbox') {
+            realElm.attr('sandbox', null);
           }
         }
 

--- a/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
@@ -90,10 +90,9 @@ const createPreviewNode = (editor: Editor, node: AstNode): AstNode => {
 
   if (name === 'iframe') {
     previewNode.attr({
-      'allowfullscreen': node.attr('allowfullscreen'),
-      'frameborder': '0',
-      'sandbox': node.attr('sandbox'),
-      'data-mce-sandbox': node.attr('data-mce-sandbox')
+      allowfullscreen: node.attr('allowfullscreen'),
+      frameborder: '0',
+      sandbox: node.attr('sandbox')
     });
   } else {
     // Exclude autoplay as we don't want video/audio to play by default
@@ -119,20 +118,24 @@ const createPreviewNode = (editor: Editor, node: AstNode): AstNode => {
 };
 
 const retainAttributesAndInnerHtml = (editor: Editor, sourceNode: AstNode, targetNode: AstNode): void => {
-  // Prefix all attributes except internal (data-mce-*), width, height and style since we
-  // will add these to the placeholder
   const attribs = sourceNode.attributes ?? [];
   let ai = attribs.length;
   while (ai--) {
     const attrName = attribs[ai].name;
     let attrValue = attribs[ai].value;
 
+    // Prefix all attributes except internal (data-mce-*), width, height, style, and sandbox since we
+    // will add these to the placeholder
     if (attrName !== 'width' && attrName !== 'height' && attrName !== 'style' && attrName !== 'sandbox' && !Strings.startsWith(attrName, 'data-mce-')) {
       if (attrName === 'data' || attrName === 'src') {
         attrValue = editor.convertURL(attrValue, attrName);
       }
 
       targetNode.attr('data-mce-p-' + attrName, attrValue);
+    }
+
+    if (attrName === 'data-mce-sandbox' || attrName === 'data-mce-no-sandbox') {
+      targetNode.attr(attrName, attrValue);
     }
   }
 

--- a/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
@@ -90,8 +90,10 @@ const createPreviewNode = (editor: Editor, node: AstNode): AstNode => {
 
   if (name === 'iframe') {
     previewNode.attr({
-      allowfullscreen: node.attr('allowfullscreen'),
-      frameborder: '0'
+      'allowfullscreen': node.attr('allowfullscreen'),
+      'frameborder': '0',
+      'sandbox': node.attr('sandbox'),
+      'data-mce-sandbox': node.attr('data-mce-sandbox')
     });
   } else {
     // Exclude autoplay as we don't want video/audio to play by default
@@ -125,7 +127,7 @@ const retainAttributesAndInnerHtml = (editor: Editor, sourceNode: AstNode, targe
     const attrName = attribs[ai].name;
     let attrValue = attribs[ai].value;
 
-    if (attrName !== 'width' && attrName !== 'height' && attrName !== 'style' && !Strings.startsWith(attrName, 'data-mce-')) {
+    if (attrName !== 'width' && attrName !== 'height' && attrName !== 'style' && attrName !== 'sandbox' && !Strings.startsWith(attrName, 'data-mce-')) {
       if (attrName === 'data' || attrName === 'src') {
         attrValue = editor.convertURL(attrValue, attrName);
       }

--- a/modules/tinymce/src/plugins/media/main/ts/core/Types.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Types.ts
@@ -15,6 +15,9 @@ export type MediaData = {
   allowfullscreen?: string | boolean;
   src?: string;
   'data-ephox-embed'?: string;
+  sandbox?: string;
+  'data-mce-sandbox'?: string;
+  'data-mce-no-sandbox'?: string;
 };
 
 export type MediaDataType = 'ephox-embed-iri' | 'object' | 'iframe' | 'embed' | 'video' | 'audio';

--- a/modules/tinymce/src/plugins/media/test/ts/atomic/HtmlToDataTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/atomic/HtmlToDataTest.ts
@@ -40,56 +40,64 @@ describe('atomic.tinymce.plugins.media.core.HtmlToDataTest', () => {
     it('Convert iframe with URL without protocol to data', () => testHtmlToData(
       '<iframe src="www.youtube.com/embed/b3XFjWInBog" width="560" height="314" allowFullscreen="1"></iframe>',
       {
-        src: 'www.youtube.com/embed/b3XFjWInBog',
-        width: '560',
-        height: '314',
-        allowfullscreen: 'allowfullscreen',
-        type: 'iframe',
-        source: 'www.youtube.com/embed/b3XFjWInBog',
-        altsource: '',
-        poster: ''
+        'src': 'www.youtube.com/embed/b3XFjWInBog',
+        'width': '560',
+        'height': '314',
+        'allowfullscreen': 'allowfullscreen',
+        'type': 'iframe',
+        'source': 'www.youtube.com/embed/b3XFjWInBog',
+        'altsource': '',
+        'poster': '',
+        'sandbox': 'allow-scripts',
+        'data-mce-no-sandbox': ''
       }
     ));
 
     it('Convert iframe with protocol relative URL to data', () => testHtmlToData(
       '<iframe src="//www.youtube.com/embed/b3XFjWInBog" width="560" height="314" allowFullscreen="1"></iframe>',
       {
-        src: '//www.youtube.com/embed/b3XFjWInBog',
-        width: '560',
-        height: '314',
-        allowfullscreen: 'allowfullscreen',
-        type: 'iframe',
-        source: '//www.youtube.com/embed/b3XFjWInBog',
-        altsource: '',
-        poster: ''
+        'src': '//www.youtube.com/embed/b3XFjWInBog',
+        'width': '560',
+        'height': '314',
+        'allowfullscreen': 'allowfullscreen',
+        'type': 'iframe',
+        'source': '//www.youtube.com/embed/b3XFjWInBog',
+        'altsource': '',
+        'poster': '',
+        'sandbox': 'allow-scripts',
+        'data-mce-no-sandbox': ''
       }
     ));
 
     it('Convert iframe with http URL to data', () => testHtmlToData(
       '<iframe src="http://www.youtube.com/embed/b3XFjWInBog" width="560" height="314" allowFullscreen="1"></iframe>',
       {
-        src: 'http://www.youtube.com/embed/b3XFjWInBog',
-        width: '560',
-        height: '314',
-        allowfullscreen: 'allowfullscreen',
-        type: 'iframe',
-        source: 'http://www.youtube.com/embed/b3XFjWInBog',
-        altsource: '',
-        poster: ''
+        'src': 'http://www.youtube.com/embed/b3XFjWInBog',
+        'width': '560',
+        'height': '314',
+        'allowfullscreen': 'allowfullscreen',
+        'type': 'iframe',
+        'source': 'http://www.youtube.com/embed/b3XFjWInBog',
+        'altsource': '',
+        'poster': '',
+        'sandbox': 'allow-scripts',
+        'data-mce-no-sandbox': ''
       }
     ));
 
     it('Convert iframe with https URL to data', () => testHtmlToData(
       '<iframe src="https://www.youtube.com/embed/b3XFjWInBog" width="560" height="314" allowFullscreen="1"></iframe>',
       {
-        src: 'https://www.youtube.com/embed/b3XFjWInBog',
-        width: '560',
-        height: '314',
-        allowfullscreen: 'allowfullscreen',
-        type: 'iframe',
-        source: 'https://www.youtube.com/embed/b3XFjWInBog',
-        altsource: '',
-        poster: ''
+        'src': 'https://www.youtube.com/embed/b3XFjWInBog',
+        'width': '560',
+        'height': '314',
+        'allowfullscreen': 'allowfullscreen',
+        'type': 'iframe',
+        'source': 'https://www.youtube.com/embed/b3XFjWInBog',
+        'altsource': '',
+        'poster': '',
+        'sandbox': 'allow-scripts',
+        'data-mce-no-sandbox': ''
       }
     ));
   });

--- a/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
@@ -57,6 +57,14 @@ describe('browser.tinymce.plugins.media.ContentFormatsTest', () => {
     );
   });
 
+  it('TBA: Iframe retained as is', () => {
+    const editor = hook.editor();
+    editor.setContent('<iframe src="320x240.ogg" allowfullscreen></iframe>');
+    TinyAssertions.assertContent(editor,
+      '<p><iframe src="320x240.ogg" width="300" height="150" allowfullscreen="allowfullscreen"></iframe></p>'
+    );
+  });
+
   it('TBA: Iframe with innerHTML retained as is with xss_sanitization: false', async () => {
     // TINY-8363: Iframe with innerHTML is removed by DOMPurify, so disable sanitization for this test
     const editor = await McEditor.pFromSettings<Editor>({
@@ -70,6 +78,22 @@ describe('browser.tinymce.plugins.media.ContentFormatsTest', () => {
       '<p><iframe src="320x240.ogg" width="300" height="150" allowfullscreen="allowfullscreen">text<a href="#">link</a></iframe></p>'
     );
     McEditor.remove(editor);
+  });
+
+  it('TINY-10206: Iframe with empty string sandbox attribute retained as is', () => {
+    const editor = hook.editor();
+    editor.setContent('<iframe src="320x240.ogg" sandbox="" allowfullscreen></iframe>');
+    TinyAssertions.assertContent(editor,
+      '<p><iframe src="320x240.ogg" width="300" height="150" sandbox="" allowfullscreen="allowfullscreen"></iframe></p>'
+    );
+  });
+
+  it('TINY-10206: Iframe with sandbox attribute retained as is', () => {
+    const editor = hook.editor();
+    editor.setContent('<iframe src="320x240.ogg" sandbox="allow-forms" allowfullscreen></iframe>');
+    TinyAssertions.assertContent(editor,
+      '<p><iframe src="320x240.ogg" width="300" height="150" sandbox="allow-forms" allowfullscreen="allowfullscreen"></iframe></p>'
+    );
   });
 
   it('TBA: Audio retained as is', () => {

--- a/modules/tinymce/src/plugins/media/test/ts/browser/LiveEmbedNodeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/LiveEmbedNodeTest.ts
@@ -132,32 +132,26 @@ describe('browser.tinymce.plugins.media.core.LiveEmbedNodeTest', () => {
     ]);
   });
 
-  context('sandboxed iframes', () => {
-    const iframeStandardSandbox = 'allow-scripts';
-    const iframeStrictSandbox = '';
+  context('Sandboxing iframes', () => {
+    const standardSandbox = 'allow-scripts';
+    const strictSandbox = '';
+
+    const testSandboxedIframes = (originalSandbox: string, expectedSandbox: string) => () => {
+      const editor = hook.editor();
+      editor.setContent(`<iframe src="about:blank" sandbox="${originalSandbox}"></iframe>`);
+      assertStructure(editor, 'iframe', [ ], { sandbox: expectedSandbox }, { });
+    };
 
     it('TINY-10206: iframe with no sandbox attribute', () => {
       const editor = hook.editor();
       editor.setContent('<iframe src="about:blank"></iframe>');
-      assertStructure(editor, 'iframe', [ ], { sandbox: iframeStandardSandbox }, { });
+      assertStructure(editor, 'iframe', [ ], { sandbox: standardSandbox }, { });
     });
 
-    it('TINY-10206: iframe with sandbox attribute containing allow-scripts', () => {
-      const editor = hook.editor();
-      editor.setContent('<iframe src="about:blank" sandbox="allow-scripts allow-forms"></iframe>');
-      assertStructure(editor, 'iframe', [ ], { sandbox: iframeStandardSandbox }, { });
-    });
+    it('TINY-10206: iframe with sandbox attribute containing allow-scripts', testSandboxedIframes('allow-scripts allow-forms', standardSandbox));
 
-    it('TINY-10206: iframe with sandbox attribute without allow-scripts', () => {
-      const editor = hook.editor();
-      editor.setContent('<iframe src="about:blank" sandbox="allow-forms"></iframe>');
-      assertStructure(editor, 'iframe', [ ], { sandbox: iframeStrictSandbox }, { });
-    });
+    it('TINY-10206: iframe with sandbox attribute without allow-scripts', testSandboxedIframes('allow-forms', strictSandbox));
 
-    it('TINY-10206: iframe with empty sandbox attribute', () => {
-      const editor = hook.editor();
-      editor.setContent('<iframe src="about:blank" sandbox=""></iframe>');
-      assertStructure(editor, 'iframe', [ ], { sandbox: iframeStrictSandbox }, { });
-    });
+    it('TINY-10206: iframe with empty sandbox attribute', testSandboxedIframes('', strictSandbox));
   });
 });

--- a/modules/tinymce/src/plugins/media/test/ts/browser/LiveEmbedNodeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/LiveEmbedNodeTest.ts
@@ -1,5 +1,5 @@
 import { ApproxStructure, Assertions, StructAssert, UiFinder } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun, Obj } from '@ephox/katamari';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
@@ -130,5 +130,34 @@ describe('browser.tinymce.plugins.media.core.LiveEmbedNodeTest', () => {
         }
       })
     ]);
+  });
+
+  context('sandboxed iframes', () => {
+    const iframeStandardSandbox = 'allow-scripts';
+    const iframeStrictSandbox = '';
+
+    it('TINY-10206: iframe with no sandbox attribute', () => {
+      const editor = hook.editor();
+      editor.setContent('<iframe src="about:blank"></iframe>');
+      assertStructure(editor, 'iframe', [ ], { sandbox: iframeStandardSandbox }, { });
+    });
+
+    it('TINY-10206: iframe with sandbox attribute containing allow-scripts', () => {
+      const editor = hook.editor();
+      editor.setContent('<iframe src="about:blank" sandbox="allow-scripts allow-forms"></iframe>');
+      assertStructure(editor, 'iframe', [ ], { sandbox: iframeStandardSandbox }, { });
+    });
+
+    it('TINY-10206: iframe with sandbox attribute without allow-scripts', () => {
+      const editor = hook.editor();
+      editor.setContent('<iframe src="about:blank" sandbox="allow-forms"></iframe>');
+      assertStructure(editor, 'iframe', [ ], { sandbox: iframeStrictSandbox }, { });
+    });
+
+    it('TINY-10206: iframe with empty sandbox attribute', () => {
+      const editor = hook.editor();
+      editor.setContent('<iframe src="about:blank" sandbox=""></iframe>');
+      assertStructure(editor, 'iframe', [ ], { sandbox: iframeStrictSandbox }, { });
+    });
   });
 });

--- a/modules/tinymce/src/plugins/media/test/ts/browser/PlaceholderTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/PlaceholderTest.ts
@@ -25,14 +25,17 @@ describe('browser.tinymce.plugins.media.core.PlaceholderTest', () => {
     editor.setContent('');
   };
 
-  const placeholderStructure = ApproxStructure.build((s, str) => {
+  const createPlaceholderStructure = (hasSandboxPlaceholder: boolean) => ApproxStructure.build((s, str) => {
     return s.element('body', {
       children: [
         s.element('p', {
           children: [
             s.element('img', {
               attrs: {
-                src: str.is(Env.transparentSrc)
+                src: str.is(Env.transparentSrc),
+                ...hasSandboxPlaceholder
+                  ? { 'data-mce-no-sandbox': str.is(''), 'data-mce-sandbox': str.none() }
+                  : { 'data-mce-no-sandbox': str.none(), 'data-mce-sandbox': str.none() }
               }
             })
           ]
@@ -70,20 +73,20 @@ describe('browser.tinymce.plugins.media.core.PlaceholderTest', () => {
       'https://www.youtube.com/watch?v=P_205ZY52pY',
       '<p><iframe src="https://www.youtube.com/embed/P_205ZY52pY" width="560" ' +
       'height="314" allowfullscreen="allowfullscreen"></iframe></p>',
-      placeholderStructure
+      createPlaceholderStructure(true)
     ));
 
     it('TBA: Set and assert video placeholder structure', () => pTestPlaceholder(hook.editor(),
       '/custom/video.mp4',
       '<p><video controls="controls" width="300" height="150">\n' +
       '<source src="custom/video.mp4" type="video/mp4"></video></p>',
-      placeholderStructure
+      createPlaceholderStructure(false)
     ));
 
     it('TBA: Set and assert audio placeholder structure', () => pTestPlaceholder(hook.editor(),
       '/custom/audio.mp3',
       '<p><audio src="custom/audio.mp3" controls="controls"></audio></p>',
-      placeholderStructure
+      createPlaceholderStructure(false)
     ));
   });
 

--- a/modules/tinymce/src/plugins/media/test/ts/browser/PlaceholderTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/PlaceholderTest.ts
@@ -45,24 +45,6 @@ describe('browser.tinymce.plugins.media.core.PlaceholderTest', () => {
     });
   });
 
-  const iframeStructure = ApproxStructure.build((s) => {
-    return s.element('body', {
-      children: [
-        s.element('p', {
-          children: [
-            s.element('span', {
-              children: [
-                s.element('iframe', {}),
-                s.element('span', {})
-              ]
-            })
-          ]
-        }),
-        s.theRest()
-      ]
-    });
-  });
-
   context('media_live_embeds=false', () => {
     before(() => {
       const editor = hook.editor();
@@ -91,6 +73,28 @@ describe('browser.tinymce.plugins.media.core.PlaceholderTest', () => {
   });
 
   context('media_live_embeds=true', () => {
+    const createIframeStructure = (sandbox: string) => ApproxStructure.build((s, str) => {
+      return s.element('body', {
+        children: [
+          s.element('p', {
+            children: [
+              s.element('span', {
+                children: [
+                  s.element('iframe', {
+                    attrs: {
+                      sandbox: str.is(sandbox)
+                    }
+                  }),
+                  s.element('span', {})
+                ]
+              })
+            ]
+          }),
+          s.theRest()
+        ]
+      });
+    });
+
     before(() => {
       const editor = hook.editor();
       editor.options.set('media_live_embeds', true);
@@ -100,7 +104,7 @@ describe('browser.tinymce.plugins.media.core.PlaceholderTest', () => {
       'https://www.youtube.com/watch?v=P_205ZY52pY',
       '<p><iframe src="https://www.youtube.com/embed/P_205ZY52pY" width="560" ' +
       'height="314" allowfullscreen="allowfullscreen"></iframe></p>',
-      iframeStructure
+      createIframeStructure('allow-scripts')
     ));
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10206

Description of Changes:
* Iframes with an SVG as `src` will have their `src` attributes stripped by DomParser
* Iframes will be added either of the following attributes when parsed in the editor body:
  * `sandbox="allow-scripts"` (if they don't have a `sandbox` attribute or their original `sandbox` attribute contains the `allow-scripts` directive), or
  * `sandbox=""` (if their original `sandbox` attribute doesn't contain the `allow-scripts` directive)
* Their original sandbox attribute (or lack thereof) will be restored when serialised.
* Further sandboxing considerations added for the placeholders generated by the Media plugin.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
