### PR TITLE
TINY-10291: Fix applying directionality on accordion

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Search and replace plugin would incorrectly find matching text inside SVG elements. #TINY-10162
 - Removed use of `async` for editor rendering which caused visual blinking when reloading the editor in-place. #TINY-10249
 - Merging an external `p` inside a `list` via delete or backspace would incorrectly try to move a parent element inside a child element. #TINY-10289
+- Directionality would not be consistently applied to the entire `accordion` block. #TINY-10291
 
 ## 6.7.2 - 2023-10-25
 

--- a/modules/tinymce/src/core/main/ts/selection/NormalizeRange.ts
+++ b/modules/tinymce/src/core/main/ts/selection/NormalizeRange.ts
@@ -175,6 +175,10 @@ const normalizeEndPoint = (dom: DOMUtils, collapsed: boolean, start: boolean, rn
         return Optional.none();
       }
 
+      if (NodeType.isDetails(container)) {
+        return Optional.none();
+      }
+
       // Don't walk into elements that doesn't have any child nodes like a IMG
       if (container.hasChildNodes() && !NodeType.isTable(container)) {
         // Walk the DOM to find a text node to place the caret at or a BR

--- a/modules/tinymce/src/plugins/accordion/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/accordion/main/ts/core/Actions.ts
@@ -19,7 +19,7 @@ const insertAccordion = (editor: Editor): void => {
   const bodyText = editor.dom.encode(editor.translate('Accordion body...'));
 
   const accordionSummaryHtml = `<summary class="${Identifiers.accordionSummaryClass}">${summaryText}</summary>`;
-  const accordionBodyHtml = `<${Identifiers.accordionBodyWrapperTag} data-mce-bogus="1" class="${Identifiers.accordionBodyWrapperClass}"><p>${bodyText}</p></${Identifiers.accordionBodyWrapperTag}>`;
+  const accordionBodyHtml = `<${Identifiers.accordionBodyWrapperTag} class="${Identifiers.accordionBodyWrapperClass}"><p>${bodyText}</p></${Identifiers.accordionBodyWrapperTag}>`;
 
   editor.undoManager.transact(() => {
     editor.insertContent([

--- a/modules/tinymce/src/plugins/accordion/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/accordion/main/ts/core/Actions.ts
@@ -19,7 +19,7 @@ const insertAccordion = (editor: Editor): void => {
   const bodyText = editor.dom.encode(editor.translate('Accordion body...'));
 
   const accordionSummaryHtml = `<summary class="${Identifiers.accordionSummaryClass}">${summaryText}</summary>`;
-  const accordionBodyHtml = `<${Identifiers.accordionBodyWrapperTag} class="${Identifiers.accordionBodyWrapperClass}"><p>${bodyText}</p></${Identifiers.accordionBodyWrapperTag}>`;
+  const accordionBodyHtml = `<${Identifiers.accordionBodyWrapperTag} data-mce-bogus="1" class="${Identifiers.accordionBodyWrapperClass}"><p>${bodyText}</p></${Identifiers.accordionBodyWrapperTag}>`;
 
   editor.undoManager.transact(() => {
     editor.insertContent([

--- a/modules/tinymce/src/plugins/accordion/main/ts/core/FilterContent.ts
+++ b/modules/tinymce/src/plugins/accordion/main/ts/core/FilterContent.ts
@@ -101,6 +101,7 @@ const setup = (editor: Editor): void => {
 
           const hasWrapperNode = Type.isNonNullable(wrapperNode);
           const newWrapperNode = hasWrapperNode ? wrapperNode : new AstNode(Identifiers.accordionBodyWrapperTag, 1);
+          newWrapperNode.attr('data-mce-bogus', '1');
           addClasses(newWrapperNode, [ Identifiers.accordionBodyWrapperClass ]);
           if (otherNodes.length > 0) {
             for (let j = 0; j < otherNodes.length; j++) {

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionNavigationTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionNavigationTest.ts
@@ -41,7 +41,7 @@ describe('browser.tinymce.plugins.accordion.AccordionNavigationTest', () => {
     TinyAssertions.assertCursor(editor, [ 1 ], 0);
   });
 
-  it('TINY-10291: status bar should not represent accordion body div in element path', async () => {
+  it('TINY-10291: status bar should not represent accordion body div in element path', () => {
     const editor = hook.editor();
     editor.execCommand('InsertAccordion');
     TinySelections.setCursor(editor, [ 0, 1, 0 ], 0);

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionNavigationTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionNavigationTest.ts
@@ -1,6 +1,8 @@
-import { Keys } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { Keys, UiFinder } from '@ephox/agar';
+import { beforeEach, describe, it } from '@ephox/bedrock-client';
+import { SugarBody, TextContent } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyAssertions, TinyContentActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/accordion/Plugin';
@@ -17,9 +19,12 @@ describe('browser.tinymce.plugins.accordion.AccordionNavigationTest', () => {
     [ Plugin ]
   );
 
+  beforeEach(() => {
+    hook.editor().resetContent();
+  });
+
   it('TINY-9827: should move cursor above the first child accordion on ArrowUp key pressing', () => {
     const editor = hook.editor();
-    editor.resetContent();
     editor.execCommand('InsertAccordion');
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
     TinyContentActions.keystroke(editor, Keys.up());
@@ -29,11 +34,23 @@ describe('browser.tinymce.plugins.accordion.AccordionNavigationTest', () => {
 
   it('TINY-9827: should move cursor below the last child accordion on ArrowDown key pressing', () => {
     const editor = hook.editor();
-    editor.resetContent();
     editor.execCommand('InsertAccordion');
     TinySelections.setCursor(editor, [ 0, 1, 0 ], 0);
     TinyContentActions.keystroke(editor, Keys.down());
     TinyAssertions.assertContent(editor, AccordionUtils.createAccordion() + `<p>&nbsp;</p>`);
     TinyAssertions.assertCursor(editor, [ 1 ], 0);
+  });
+
+  it('TINY-10291: status bar should not represent accordion body div in element path', async () => {
+    const editor = hook.editor();
+    editor.execCommand('InsertAccordion');
+    TinySelections.setCursor(editor, [ 0, 1, 0 ], 0);
+    const pathElm = UiFinder.findIn(SugarBody.body(), '.tox-statusbar__path').getOrDie();
+    // In the absence of the data-mce-bogus attribute being set on the auxiliary accordion body div,
+    // the status bar would display 'details › div › p'
+    assert.equal(TextContent.get(pathElm), 'details › p');
+    editor.execCommand('InsertAccordion');
+    TinySelections.setCursor(editor, [ 0, 1, 0, 1, 0 ], 0);
+    assert.equal(TextContent.get(pathElm), 'details › details › p');
   });
 });

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/DirectionalityTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/DirectionalityTest.ts
@@ -1,0 +1,57 @@
+/* eslint-disable max-len */
+import { beforeEach, describe, it } from '@ephox/bedrock-client';
+import { TinyHooks, TinySelections, TinyAssertions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/accordion/Plugin';
+
+describe('browser.tinymce.plugins.accordion.DirectionalityTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>(
+    {
+      plugins: 'accordion directionality',
+      base_url: '/project/tinymce/js/tinymce',
+      indent: false,
+    },
+    [ Plugin ]
+  );
+
+  beforeEach(() => {
+    hook.editor().resetContent();
+  });
+
+  it('TINY-10291: should apply RTL on entire `details` and change children directionality', () => {
+    const editor = hook.editor();
+    editor.execCommand('InsertAccordion');
+    // select entire accordion
+    TinySelections.setSelection(editor, [], 0, [], 1);
+    editor.execCommand('mceDirectionRTL');
+    TinyAssertions.assertContent(editor, '<details class="mce-accordion" dir="rtl" open="open"><summary>Accordion summary...</summary><p>Accordion body...</p></details>');
+    // select summary content
+    TinySelections.setCursor(editor, [ 0, 0 ], 0);
+    editor.execCommand('mceDirectionLTR');
+    TinyAssertions.assertContent(editor, '<details class="mce-accordion" dir="rtl" open="open"><summary dir="ltr">Accordion summary...</summary><p>Accordion body...</p></details>');
+    // select accordion body content
+    TinySelections.setCursor(editor, [ 0, 1, 0, 0 ], 0);
+    editor.execCommand('mceDirectionLTR');
+    TinyAssertions.assertContent(editor, '<details class="mce-accordion" dir="rtl" open="open"><summary dir="ltr">Accordion summary...</summary><p dir="ltr">Accordion body...</p></details>');
+  });
+
+  it('TINY-10291: should apply RTL on nested `details` and change children directionality', () => {
+    const editor = hook.editor();
+    editor.execCommand('InsertAccordion');
+    TinySelections.setCursor(editor, [ 0, 1, 0, 0 ], 0);
+    editor.execCommand('InsertAccordion');
+    // select entire nested accordion
+    TinySelections.setSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 1);
+    editor.execCommand('mceDirectionRTL');
+    TinyAssertions.assertContent(editor, '<details class="mce-accordion" open="open"><summary>Accordion summary...</summary><details class="mce-accordion" dir="rtl" open="open"><summary>Accordion summary...</summary><p>Accordion body...</p></details><p>Accordion body...</p></details>');
+    // select nested summary content
+    TinySelections.setCursor(editor, [ 0, 1, 0, 0 ], 0);
+    editor.execCommand('mceDirectionLTR');
+    TinyAssertions.assertContent(editor, '<details class="mce-accordion" open="open"><summary>Accordion summary...</summary><details class="mce-accordion" dir="rtl" open="open"><summary dir="ltr">Accordion summary...</summary><p>Accordion body...</p></details><p>Accordion body...</p></details>');
+    // select nested accordion body content
+    TinySelections.setCursor(editor, [ 0, 1, 0, 1, 0 ], 0);
+    editor.execCommand('mceDirectionLTR');
+    TinyAssertions.assertContent(editor, '<details class="mce-accordion" open="open"><summary>Accordion summary...</summary><details class="mce-accordion" dir="rtl" open="open"><summary dir="ltr">Accordion summary...</summary><p dir="ltr">Accordion body...</p></details><p>Accordion body...</p></details>');
+  });
+});

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/DirectionalityTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/DirectionalityTest.ts
@@ -3,7 +3,8 @@ import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { TinyHooks, TinySelections, TinyAssertions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
-import Plugin from 'tinymce/plugins/accordion/Plugin';
+import AccordionPlugin from 'tinymce/plugins/accordion/Plugin';
+import DirectionalityPlugin from 'tinymce/plugins/directionality/Plugin';
 
 describe('browser.tinymce.plugins.accordion.DirectionalityTest', () => {
   const hook = TinyHooks.bddSetup<Editor>(
@@ -12,7 +13,7 @@ describe('browser.tinymce.plugins.accordion.DirectionalityTest', () => {
       base_url: '/project/tinymce/js/tinymce',
       indent: false,
     },
-    [ Plugin ]
+    [ AccordionPlugin, DirectionalityPlugin ]
   );
 
   beforeEach(() => {


### PR DESCRIPTION
Related Ticket:  TINY-10291

Description of Changes:
* When applying directionality to the `accordion`, the `dir` attribute was modified in both the `summary` and auxiliary `accordion` body `div` element. However, the auxiliary `accordion` body `div` element disappeared during the editor serialization process, resulting in the loss of the applied `dir` value for the `accordion` content.
* When the TinyMCE editor is focused, a selection normalization process refines the editor selection directly to the element contents. Previously, when selecting an `accordion`, only the `summary` and `accordion` body were included in the selection instead of the entire `details` element. To address this, the `details` element has been intentionally excluded from this selection normalization process.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
