### PR TITLE
TINY-10290: Added default_font_stack option

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `force_hex_color` editor option. Option `'always'` converts all RGB & RGBA colours to hex, `'rgb_only'` will only convert RGB and *not* RGBA colours to hex, `'off'` won't convert any colours to hex. #TINY-9819
+- Added `default_font_stack` editor option that makes it possible to define what is considered a system font stack. #TINY-10290
 
 ### Improved
 - Colorpicker now includes the Brightness/Saturation selector and hue slider in the keyboard navigable items. #TINY-9287

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -91,6 +91,7 @@ interface BaseEditorOptions {
   custom_elements?: string;
   custom_ui_selector?: string;
   custom_undo_redo_levels?: number;
+  default_font_stack?: string[];
   deprecation_warnings?: boolean;
   directionality?: 'ltr' | 'rtl';
   doctype?: string;
@@ -289,6 +290,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   content_css: string[];
   contextmenu: string[];
   custom_colors: boolean;
+  default_font_stack: string[];
   document_base_url: string;
   init_content_sync: boolean;
   draggable_modal: boolean;

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
@@ -1,5 +1,5 @@
 import { UiFinder } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Strings } from '@ephox/katamari';
 import { SugarBody, TextContent } from '@ephox/sugar';
 import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
@@ -8,117 +8,156 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.FontSelectTest', () => {
-  const hook = TinyHooks.bddSetupLight<Editor>({
-    base_url: '/project/tinymce/js/tinymce',
-    toolbar: 'fontsize fontfamily',
-    content_style: [
-      '.mce-content-body { font-family: Helvetica; font-size: 42px; }',
-      '.mce-content-body p { font-family: Arial; font-size: 12px; }',
-      '.mce-content-body h1 { font-family: Arial; font-size: 32px; }'
-    ].join(''),
-    font_size_formats: '8pt=1 12pt 12.75pt 13pt 24pt 32pt'
-  }, []);
-
-  const systemFontStackVariants = [
-    `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;`, // Oxide
-    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";', // Bootstrap
-    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;' // Wordpress
-  ];
-
   const assertSelectBoxDisplayValue = (title: string, expectedValue: string) => {
     const selectBox = UiFinder.findIn(SugarBody.body(), '*[title^="' + title + '"]').getOrDie();
     const value = Strings.trim(TextContent.get(selectBox) ?? '');
     assert.equal(value, expectedValue, 'Should be the expected display value');
   };
 
-  it('TBA: Font family and font size on initial page load', () => {
-    assertSelectBoxDisplayValue('Font sizes', '12px');
-    assertSelectBoxDisplayValue('Fonts', 'Arial');
-  });
+  context('Default font stack', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      toolbar: 'fontsize fontfamily',
+      content_style: [
+        '.mce-content-body { font-family: Helvetica; font-size: 42px; }',
+        '.mce-content-body p { font-family: Arial; font-size: 12px; }',
+        '.mce-content-body h1 { font-family: Arial; font-size: 32px; }'
+      ].join(''),
+      font_size_formats: '8pt=1 12pt 12.75pt 13pt 24pt 32pt'
+    }, [], true);
 
-  it('TBA: Font family and font size on paragraph with no styles', () => {
-    const editor = hook.editor();
-    editor.setContent('<p>a</p>');
-    editor.focus();
-    TinySelections.setCursor(editor, [ 0, 0 ], 0);
-    editor.nodeChanged();
-    // p content style is 12px which does not match any pt values in the font size select values
-    assertSelectBoxDisplayValue('Font sizes', '12px');
-    assertSelectBoxDisplayValue('Fonts', 'Arial');
-  });
+    const systemFontStackVariants = [
+      `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;`, // Oxide
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";', // Bootstrap
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;' // Wordpress
+    ];
 
-  it('TBA: Font family and font size on heading with no styles', () => {
-    const editor = hook.editor();
-    editor.setContent('<h1>a</h1>');
-    editor.focus();
-    TinySelections.setCursor(editor, [ 0, 0 ], 0);
-    editor.nodeChanged();
-    // h1 content style is 32px which matches 24pt in the font size select values so it should be converted
-    assertSelectBoxDisplayValue('Font sizes', '24pt');
-    assertSelectBoxDisplayValue('Fonts', 'Arial');
-  });
-
-  it('TBA: Font family and font size on paragraph with styles that do match font size select values', () => {
-    const editor = hook.editor();
-    editor.setContent('<p style="font-family: Times; font-size: 17px;">a</p>');
-    editor.focus();
-    TinySelections.setCursor(editor, [ 0, 0 ], 0);
-    editor.nodeChanged();
-    // the following should be converted and pick up 12.75pt, although there's a rounded 13pt in the dropdown as well
-    assertSelectBoxDisplayValue('Font sizes', '12.75pt');
-    assertSelectBoxDisplayValue('Fonts', 'Times');
-  });
-
-  it('TBA: Font family and font size on paragraph with styles that do not match font size select values', () => {
-    const editor = hook.editor();
-    editor.setContent('<p style="font-family: Times; font-size: 18px;">a</p>');
-    editor.focus();
-    TinySelections.setCursor(editor, [ 0, 0 ], 0);
-    editor.nodeChanged();
-    // the following should stay as 18px because there's no matching pt value in the font size select values
-    assertSelectBoxDisplayValue('Font sizes', '18px');
-    assertSelectBoxDisplayValue('Fonts', 'Times');
-  });
-
-  it('TBA: Font family and font size on paragraph with legacy font elements', () => {
-    const editor = hook.editor();
-    editor.setContent('<p><font face="Times" size="1">a</font></p>', { format: 'raw' });
-    editor.focus();
-    TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
-    editor.nodeChanged();
-    assertSelectBoxDisplayValue('Font sizes', '8pt');
-    assertSelectBoxDisplayValue('Fonts', 'Times');
-  });
-
-  // https://websemantics.uk/articles/font-size-conversion/
-  it('TINY-6291: Font size on paragraph with keyword font size is translated to default size', () => {
-    const editor = hook.editor();
-    editor.setContent('<p style="font-family: Times; font-size: medium;">a</p>');
-    editor.focus();
-    TinySelections.setCursor(editor, [ 0, 0 ], 0);
-    editor.nodeChanged();
-    assertSelectBoxDisplayValue('Font sizes', '12pt');
-    assertSelectBoxDisplayValue('Fonts', 'Times');
-  });
-
-  it('TINY-6291: xx-small will fall back to showing raw font size due to missing 7pt fontsize_format', () => {
-    const editor = hook.editor();
-    editor.setContent('<p style="font-family: Times; font-size: xx-small;">a</p>');
-    editor.focus();
-    TinySelections.setCursor(editor, [ 0, 0 ], 0);
-    editor.nodeChanged();
-    assertSelectBoxDisplayValue('Font sizes', 'xx-small');
-    assertSelectBoxDisplayValue('Fonts', 'Times');
-  });
-
-  it('TBA: System font stack variants on a paragraph show "System Font" as the font name', () => {
-    const editor = hook.editor();
-    editor.setContent(Arr.foldl(systemFontStackVariants, (acc, font) => acc + '<p style="font-family: ' + font.replace(/"/g, `'`) + '"></p>', ''));
-    editor.focus();
-    Arr.each(systemFontStackVariants, (_, idx) => {
-      TinySelections.setCursor(editor, [ idx, 0 ], 0);
-      editor.nodeChanged();
-      assertSelectBoxDisplayValue('Fonts', 'System Font');
+    it('TBA: Font family and font size on initial page load', () => {
+      assertSelectBoxDisplayValue('Font sizes', '12px');
+      assertSelectBoxDisplayValue('Fonts', 'Arial');
     });
+
+    it('TBA: Font family and font size on paragraph with no styles', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>a</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+      editor.nodeChanged();
+      // p content style is 12px which does not match any pt values in the font size select values
+      assertSelectBoxDisplayValue('Font sizes', '12px');
+      assertSelectBoxDisplayValue('Fonts', 'Arial');
+    });
+
+    it('TBA: Font family and font size on heading with no styles', () => {
+      const editor = hook.editor();
+      editor.setContent('<h1>a</h1>');
+      editor.focus();
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+      editor.nodeChanged();
+      // h1 content style is 32px which matches 24pt in the font size select values so it should be converted
+      assertSelectBoxDisplayValue('Font sizes', '24pt');
+      assertSelectBoxDisplayValue('Fonts', 'Arial');
+    });
+
+    it('TBA: Font family and font size on paragraph with styles that do match font size select values', () => {
+      const editor = hook.editor();
+      editor.setContent('<p style="font-family: Times; font-size: 17px;">a</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+      editor.nodeChanged();
+      // the following should be converted and pick up 12.75pt, although there's a rounded 13pt in the dropdown as well
+      assertSelectBoxDisplayValue('Font sizes', '12.75pt');
+      assertSelectBoxDisplayValue('Fonts', 'Times');
+    });
+
+    it('TBA: Font family and font size on paragraph with styles that do not match font size select values', () => {
+      const editor = hook.editor();
+      editor.setContent('<p style="font-family: Times; font-size: 18px;">a</p>');
+      editor.focus();
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+      editor.nodeChanged();
+      // the following should stay as 18px because there's no matching pt value in the font size select values
+      assertSelectBoxDisplayValue('Font sizes', '18px');
+      assertSelectBoxDisplayValue('Fonts', 'Times');
+    });
+
+    it('TBA: Font family and font size on paragraph with legacy font elements', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><font face="Times" size="1">a</font></p>', { format: 'raw' });
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
+      editor.nodeChanged();
+      assertSelectBoxDisplayValue('Font sizes', '8pt');
+      assertSelectBoxDisplayValue('Fonts', 'Times');
+    });
+
+    // https://websemantics.uk/articles/font-size-conversion/
+    it('TINY-6291: Font size on paragraph with keyword font size is translated to default size', () => {
+      const editor = hook.editor();
+      editor.setContent('<p style="font-family: Times; font-size: medium;">a</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+      editor.nodeChanged();
+      assertSelectBoxDisplayValue('Font sizes', '12pt');
+      assertSelectBoxDisplayValue('Fonts', 'Times');
+    });
+
+    it('TINY-6291: xx-small will fall back to showing raw font size due to missing 7pt fontsize_format', () => {
+      const editor = hook.editor();
+      editor.setContent('<p style="font-family: Times; font-size: xx-small;">a</p>');
+      editor.focus();
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+      editor.nodeChanged();
+      assertSelectBoxDisplayValue('Font sizes', 'xx-small');
+      assertSelectBoxDisplayValue('Fonts', 'Times');
+    });
+
+    it('TBA: System font stack variants on a paragraph show "System Font" as the font name', () => {
+      const editor = hook.editor();
+      editor.setContent(Arr.foldl(systemFontStackVariants, (acc, font) => acc + '<p style="font-family: ' + font.replace(/"/g, `'`) + '"></p>', ''));
+      Arr.each(systemFontStackVariants, (_, idx) => {
+        TinySelections.setCursor(editor, [ idx, 0 ], 0);
+        editor.nodeChanged();
+        assertSelectBoxDisplayValue('Fonts', 'System Font');
+      });
+    });
+  });
+
+  context('Custom default font stack', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      toolbar: 'fontsize fontfamily',
+      content_style: [
+        '.mce-content-body { font-family: -apple-system, Arial; }',
+        '.mce-content-body h1 { font-family: Helvetica; }',
+        '.mce-content-body h2 { font-family: Arial; }'
+      ].join(''),
+      default_font_stack: [ '-apple-system', 'Arial' ]
+    }, []);
+
+    const testCustomStack = (testCase: { html: string; path: number[]; offset: 0; expectedValue: string }) => {
+      const editor = hook.editor();
+      editor.setContent(testCase.html);
+      TinySelections.setCursor(editor, testCase.path, testCase.offset);
+      editor.nodeChanged();
+      assertSelectBoxDisplayValue('Fonts', testCase.expectedValue);
+    };
+
+    it('TINY-10290: Should show System Font for the specified custom stack', () => testCustomStack({
+      html: '<p>foo</p>',
+      path: [ 0, 0 ],
+      offset: 0,
+      expectedValue: 'System Font'
+    }));
+
+    it('TINY-10290: Should show Helvetica since H1 is not using the system font stack', () => testCustomStack({
+      html: '<h1>foo</h1>',
+      path: [ 0, 0 ],
+      offset: 0,
+      expectedValue: 'Helvetica'
+    }));
+
+    it('TINY-10290: Should show Arial since the H2 is not using the system font stack', () => testCustomStack({
+      html: '<h2>foo</h2>',
+      path: [ 0, 0 ],
+      offset: 0,
+      expectedValue: 'Arial'
+    }));
   });
 });

--- a/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
@@ -289,13 +289,7 @@ const register = (editor: Editor): void => {
   });
 
   registerOption('default_font_stack', {
-    processor: (value) => {
-      if (Type.isArray(value) && Arr.forall(value, Type.isString)) {
-        return { value, valid: true };
-      } else {
-        return { valid: false, message: 'Must be an array with font family names.' };
-      }
-    },
+    processor: 'string[]',
     default: []
   });
 };

--- a/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
@@ -287,6 +287,17 @@ const register = (editor: Editor): void => {
     processor: 'boolean',
     default: editor.hasPlugin('help')
   });
+
+  registerOption('default_font_stack', {
+    processor: (value) => {
+      if (Type.isArray(value) && Arr.forall(value, Type.isString)) {
+        return { value, valid: true };
+      } else {
+        return { valid: false, message: 'Must be an array with font family names.' };
+      }
+    },
+    default: []
+  });
 };
 
 const isReadOnly = option('readonly');
@@ -326,6 +337,7 @@ const getPasteAsText = option('paste_as_text');
 const getSidebarShow = option('sidebar_show');
 const promotionEnabled = option('promotion');
 const useHelpAccessibility = option('help_accessibility');
+const getDefaultFontStack = option('default_font_stack');
 
 const isSkinDisabled = (editor: Editor): boolean =>
   editor.options.get('skin') === false;
@@ -476,5 +488,6 @@ export {
   getResize,
   getPasteAsText,
   getSidebarShow,
-  useHelpAccessibility
+  useHelpAccessibility,
+  getDefaultFontStack
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
@@ -4,6 +4,7 @@ import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 
 import * as Events from '../../../api/Events';
+import * as Options from '../../../api/Options';
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
 import { onSetupEditableToggle } from '../ControlUtils';
@@ -16,6 +17,10 @@ const systemFont = 'System Font';
 
 // A list of fonts that must be in a font family for the font to be recognised as the system stack
 // Note: Don't include 'BlinkMacSystemFont', as Chrome on Mac converts it to different names
+// The system font stack will be similar to the following. (Note: each has minor variants)
+// Oxide: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+// Bootstrap: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+// Wordpress: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 const systemStackFonts = [ '-apple-system', 'Segoe UI', 'Roboto', 'Helvetica Neue', 'sans-serif' ];
 
 // Split the fonts into an array and strip away any start/end quotes
@@ -24,33 +29,31 @@ const splitFonts = (fontFamily: string): string[] => {
   return Arr.map(fonts, (font) => font.replace(/^['"]+|['"]+$/g, ''));
 };
 
-const isSystemFontStack = (fontFamily: string): boolean => {
-  // The system font stack will be similar to the following. (Note: each has minor variants)
-  // Oxide: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-  // Bootstrap: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  // Wordpress: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-  const matchesSystemStack = (): boolean => {
-    const fonts = splitFonts(fontFamily.toLowerCase());
-    return Arr.forall(systemStackFonts, (font) => fonts.indexOf(font.toLowerCase()) > -1);
-  };
+const matchesStack = (fonts: string[], stack: string[]): boolean => Arr.forall(stack, (font) => fonts.indexOf(font.toLowerCase()) > -1);
 
-  return fontFamily.indexOf('-apple-system') === 0 && matchesSystemStack();
+const isSystemFontStack = (fontFamily: string, userStack: string[]): boolean => {
+  if (fontFamily.indexOf('-apple-system') === 0 || userStack.length > 0) {
+    const fonts = splitFonts(fontFamily.toLowerCase());
+    return matchesStack(fonts, systemStackFonts) || matchesStack(fonts, userStack);
+  } else {
+    return false;
+  }
 };
 
 const getSpec = (editor: Editor): SelectSpec => {
-
   const getMatchingValue = () => {
     const getFirstFont = (fontFamily: string | undefined) => fontFamily ? splitFonts(fontFamily)[0] : '';
 
     const fontFamily = editor.queryCommandValue('FontName');
     const items = dataset.data;
     const font = fontFamily ? fontFamily.toLowerCase() : '';
+    const userStack = Options.getDefaultFontStack(editor);
 
     const matchOpt = Arr.find(items, (item) => {
       const format = item.format;
       return (format.toLowerCase() === font) || (getFirstFont(format).toLowerCase() === getFirstFont(font).toLowerCase());
     }).orThunk(() => {
-      return Optionals.someIf(isSystemFontStack(font), {
+      return Optionals.someIf(isSystemFontStack(font, userStack), {
         title: systemFont,
         format: font
       });


### PR DESCRIPTION
Related Ticket: TINY-10290

Description of Changes:
* Adds a new option to configure the default font stack.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
