### PR TITLE
TINY-10316: inserting `li` via `enter` makes it inherit styles

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Directionality would not be consistently applied to the entire `accordion` block. #TINY-10291
 - The `fontsizeinput` toolbar item was causing console warnings when toolbar items were clicked. #TINY-10330
 - Menubar buttons with more than one word would sometimes wrap into two lines. #TINY-10343
+- Creating a new `li` via enter inside a nested list would not inherit styles from the source `li`. #TINY-10316
 
 ## 6.7.3 - 2023-11-15
 

--- a/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
@@ -207,14 +207,15 @@ const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>): void => {
 
   const collapsedAndCef = rng.collapsed && isCef;
 
-  const createNewBlock = (name?: string) => {
+  const createNewBlock = (name?: string, styles?: Record<string, string>) => {
     return NewLineUtils.createNewBlock(
       editor,
       container,
       parentBlock,
       editableRoot,
       Options.shouldKeepStyles(editor),
-      name);
+      name,
+      styles);
   };
 
   // Returns true/false if the caret is at the start/end of the parent block element

--- a/modules/tinymce/src/core/main/ts/newline/InsertLi.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertLi.ts
@@ -1,5 +1,5 @@
-import { Arr, Obj, Type } from '@ephox/katamari';
-import { Css, SugarElement, SugarNode } from '@ephox/sugar';
+import { Arr, Fun, Obj, Type } from '@ephox/katamari';
+import { Css, Insert, SugarElement, SugarNode } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import * as NodeType from '../dom/NodeType';
@@ -69,11 +69,10 @@ const insert = (editor: Editor, createNewBlock: (name: string, styles?: Record<s
     newBlockName = 'LI';
   }
 
-  let newBlock = createNewBlock(newBlockName);
   const parentBlockStyles = isListItem(parentBlock) ? getStyles(parentBlock) : undefined;
-  if (parentBlockStyles) {
-    newBlock = createNewBlock(newBlockName, { style: parentBlockStyles });
-  }
+  let newBlock = isListItem(parentBlock) && parentBlockStyles
+    ? createNewBlock(newBlockName, { style: getStyles(parentBlock) })
+    : createNewBlock(newBlockName);
 
   if (isFirstOrLastLi(containerBlock, parentBlock, true) && isFirstOrLastLi(containerBlock, parentBlock, false)) {
     if (hasParent(containerBlock, 'LI')) {
@@ -116,14 +115,14 @@ const insert = (editor: Editor, createNewBlock: (name: string, styles?: Record<s
 
     if (newBlockName === 'LI' && hasFirstChild(fragment, 'LI')) {
       const previousChildren = Arr.filter(
-        Arr.map(Arr.from(newBlock.children), SugarElement.fromDom),
-        (child) => !SugarNode.isTag('br')(child)
+        Arr.map(newBlock.children, SugarElement.fromDom),
+        Fun.not(SugarNode.isTag('br'))
       );
 
       newBlock = fragment.firstChild as HTMLLIElement;
       dom.insertAfter(fragment, containerBlock);
 
-      Arr.each(previousChildren, (child) => newBlock.prepend(child.dom));
+      Arr.each(previousChildren, (child) => Insert.prepend(SugarElement.fromDom(newBlock), child));
       if (parentBlockStyles) {
         newBlock.setAttribute('style', parentBlockStyles);
       }

--- a/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
@@ -172,7 +172,8 @@ const createNewBlock = (
   parentBlock: Node,
   editableRoot: HTMLElement | undefined,
   keepStyles: boolean = true,
-  name?: string
+  name?: string,
+  styles?: Record<string, string>
 ): Element => {
   const dom = editor.dom;
   const schema = editor.schema;
@@ -183,7 +184,7 @@ const createNewBlock = (
 
   let block: Element;
   if (name || parentBlockName === 'TABLE' || parentBlockName === 'HR') {
-    block = dom.create(name || newBlockName);
+    block = dom.create(name || newBlockName, styles || {});
   } else {
     block = parentBlock.cloneNode(false) as Element;
   }

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/StyleTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/StyleTest.ts
@@ -1,0 +1,67 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import * as InsertNewLine from 'tinymce/core/newline/InsertNewLine';
+import Plugin from 'tinymce/plugins/lists/Plugin';
+
+describe('browser.tinymce.plugins.lists.StyleTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    plugins: 'lists',
+    toolbar: false,
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  it('TINY-10316: Create a new `li` from a nexted list should preserve the style', () => {
+    const editor = hook.editor();
+    editor.setContent(`<ol>
+      <li style="color: black; list-style-type: square;">1</li>
+      <li style="color: green; list-style-type: disc;">parent
+        <ol>
+          <li style="color: red;"><span style="color: blue;">nested</span></li>
+        </ol>
+      </li>
+    </ol>`);
+    TinySelections.setCursor(editor, [ 0, 1, 1, 0, 0, 0 ], 'nested'.length);
+    InsertNewLine.insert(editor);
+    InsertNewLine.insert(editor);
+    editor.insertContent('abc');
+    TinyAssertions.assertContent(editor, '<ol>' +
+      '<li style="color: black; list-style-type: square;">1</li>' +
+      '<li style="color: green; list-style-type: disc;">parent' +
+        '<ol>' +
+          '<li style="color: red;"><span style="color: blue;">nested</span></li>' +
+        '</ol>' +
+      '</li>' +
+      '<li style="color: red;"><span style="color: blue;">abc</span></li>' +
+    '</ol>');
+
+    editor.setContent(`<ol>
+      <li style="color: black; list-style-type: square;">1</li>
+      <li style="color: green; list-style-type: disc;">parent
+        <ol>
+          <li style="color: red;"><span style="color: blue;">nested</span></li>
+          <li style="color: yellow;"><span style="color: purple;">nested mid</span></li>
+          <li style="color: red;"><span style="color: blue;">nested</span></li>
+        </ol>
+      </li>
+    </ol>`);
+    TinySelections.setCursor(editor, [ 0, 1, 1, 1, 0, 0 ], 'nested mid'.length);
+    InsertNewLine.insert(editor);
+    InsertNewLine.insert(editor);
+    editor.insertContent('abc');
+    TinyAssertions.assertContent(editor, '<ol>' +
+      '<li style="color: black; list-style-type: square;">1</li>' +
+      '<li style="color: green; list-style-type: disc;">parent' +
+        '<ol>' +
+          '<li style="color: red;"><span style="color: blue;">nested</span></li>' +
+          '<li style="color: yellow;"><span style="color: purple;">nested mid</span></li>' +
+        '</ol>' +
+      '</li>' +
+      '<li style="color: green; list-style-type: disc;"><span style="color: purple;">abc</span>' +
+        '<ol><li style="color: red;"><span style="color: blue;">nested</span></li></ol>' +
+      '</li>' +
+    '</ol>');
+  });
+});

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/StyleTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/StyleTest.ts
@@ -41,9 +41,9 @@ describe('browser.tinymce.plugins.lists.StyleTest', () => {
       <li style="color: black; list-style-type: square;">1</li>
       <li style="color: green; list-style-type: disc;">parent
         <ol>
-          <li style="color: red;"><span style="color: blue;">nested</span></li>
+          <li style="color: red;"><span style="color: blue;">nested 1</span></li>
           <li style="color: yellow;"><span style="color: purple;">nested mid</span></li>
-          <li style="color: red;"><span style="color: blue;">nested</span></li>
+          <li style="color: red;"><span style="color: blue;">nested 2</span></li>
         </ol>
       </li>
     </ol>`);
@@ -55,12 +55,12 @@ describe('browser.tinymce.plugins.lists.StyleTest', () => {
       '<li style="color: black; list-style-type: square;">1</li>' +
       '<li style="color: green; list-style-type: disc;">parent' +
         '<ol>' +
-          '<li style="color: red;"><span style="color: blue;">nested</span></li>' +
+          '<li style="color: red;"><span style="color: blue;">nested 1</span></li>' +
           '<li style="color: yellow;"><span style="color: purple;">nested mid</span></li>' +
         '</ol>' +
       '</li>' +
       '<li style="color: green; list-style-type: disc;"><span style="color: purple;">abc</span>' +
-        '<ol><li style="color: red;"><span style="color: blue;">nested</span></li></ol>' +
+        '<ol><li style="color: red;"><span style="color: blue;">nested 2</span></li></ol>' +
       '</li>' +
     '</ol>');
   });

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/StyleTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/StyleTest.ts
@@ -1,4 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -6,62 +7,70 @@ import * as InsertNewLine from 'tinymce/core/newline/InsertNewLine';
 import Plugin from 'tinymce/plugins/lists/Plugin';
 
 describe('browser.tinymce.plugins.lists.StyleTest', () => {
-  const hook = TinyHooks.bddSetup<Editor>({
-    plugins: 'lists',
-    toolbar: false,
-    indent: false,
-    base_url: '/project/tinymce/js/tinymce'
-  }, [ Plugin ], true);
+  Arr.each([
+    { plugins: '', setupModules: [] },
+    { plugins: 'lists', setupModules: [ Plugin ] },
+  ], ({ plugins, setupModules }) => {
+    const hook = TinyHooks.bddSetup<Editor>({
+      plugins,
+      toolbar: false,
+      indent: false,
+      base_url: '/project/tinymce/js/tinymce'
+    }, setupModules);
 
-  it('TINY-10316: Create a new `li` from a nexted list should preserve the style', () => {
-    const editor = hook.editor();
-    editor.setContent(`<ol>
-      <li style="color: black; list-style-type: square;">1</li>
-      <li style="color: green; list-style-type: disc;">parent
-        <ol>
-          <li style="color: red;"><span style="color: blue;">nested</span></li>
-        </ol>
-      </li>
-    </ol>`);
-    TinySelections.setCursor(editor, [ 0, 1, 1, 0, 0, 0 ], 'nested'.length);
-    InsertNewLine.insert(editor);
-    InsertNewLine.insert(editor);
-    editor.insertContent('abc');
-    TinyAssertions.assertContent(editor, '<ol>' +
-      '<li style="color: black; list-style-type: square;">1</li>' +
-      '<li style="color: green; list-style-type: disc;">parent' +
-        '<ol>' +
-          '<li style="color: red;"><span style="color: blue;">nested</span></li>' +
-        '</ol>' +
-      '</li>' +
-      '<li style="color: red;"><span style="color: blue;">abc</span></li>' +
-    '</ol>');
+    it('TINY-10316: Create a new `li` from a nested list should preserve the style', () => {
+      const editor = hook.editor();
+      editor.setContent(`<ol>
+        <li style="color: black; list-style-type: square;">1</li>
+        <li style="color: green; list-style-type: disc;">parent
+          <ol>
+            <li style="color: red;"><span style="color: blue;">nested</span></li>
+          </ol>
+        </li>
+      </ol>`);
+      TinySelections.setCursor(editor, [ 0, 1, 1, 0, 0, 0 ], 'nested'.length);
+      InsertNewLine.insert(editor);
+      InsertNewLine.insert(editor);
+      editor.insertContent('abc');
+      TinyAssertions.assertContent(editor, '<ol>' +
+        '<li style="color: black; list-style-type: square;">1</li>' +
+        '<li style="color: green; list-style-type: disc;">parent' +
+          '<ol>' +
+            '<li style="color: red;"><span style="color: blue;">nested</span></li>' +
+          '</ol>' +
+        '</li>' +
+        '<li style="color: red;"><span style="color: blue;">abc</span></li>' +
+      '</ol>');
+    });
 
-    editor.setContent(`<ol>
-      <li style="color: black; list-style-type: square;">1</li>
-      <li style="color: green; list-style-type: disc;">parent
-        <ol>
-          <li style="color: red;"><span style="color: blue;">nested 1</span></li>
-          <li style="color: yellow;"><span style="color: purple;">nested mid</span></li>
-          <li style="color: red;"><span style="color: blue;">nested 2</span></li>
-        </ol>
-      </li>
-    </ol>`);
-    TinySelections.setCursor(editor, [ 0, 1, 1, 1, 0, 0 ], 'nested mid'.length);
-    InsertNewLine.insert(editor);
-    InsertNewLine.insert(editor);
-    editor.insertContent('abc');
-    TinyAssertions.assertContent(editor, '<ol>' +
-      '<li style="color: black; list-style-type: square;">1</li>' +
-      '<li style="color: green; list-style-type: disc;">parent' +
-        '<ol>' +
-          '<li style="color: red;"><span style="color: blue;">nested 1</span></li>' +
-          '<li style="color: yellow;"><span style="color: purple;">nested mid</span></li>' +
-        '</ol>' +
-      '</li>' +
-      '<li style="color: green; list-style-type: disc;"><span style="color: purple;">abc</span>' +
-        '<ol><li style="color: red;"><span style="color: blue;">nested 2</span></li></ol>' +
-      '</li>' +
-    '</ol>');
+    it('TINY-10316: Create a new `li` from a nested list with multiple `li`s should preserve the style', () => {
+      const editor = hook.editor();
+      editor.setContent(`<ol>
+        <li style="color: black; list-style-type: square;">1</li>
+        <li style="color: green; list-style-type: disc;">parent
+          <ol>
+            <li style="color: red;"><span style="color: blue;">nested 1</span></li>
+            <li style="color: yellow;"><span style="color: purple;">nested mid</span></li>
+            <li style="color: red;"><span style="color: blue;">nested 2</span></li>
+          </ol>
+        </li>
+      </ol>`);
+      TinySelections.setCursor(editor, [ 0, 1, 1, 1, 0, 0 ], 'nested mid'.length);
+      InsertNewLine.insert(editor);
+      InsertNewLine.insert(editor);
+      editor.insertContent('abc');
+      TinyAssertions.assertContent(editor, '<ol>' +
+        '<li style="color: black; list-style-type: square;">1</li>' +
+        '<li style="color: green; list-style-type: disc;">parent' +
+          '<ol>' +
+            '<li style="color: red;"><span style="color: blue;">nested 1</span></li>' +
+            '<li style="color: yellow;"><span style="color: purple;">nested mid</span></li>' +
+          '</ol>' +
+        '</li>' +
+        '<li style="color: green; list-style-type: disc;"><span style="color: purple;">abc</span>' +
+          '<ol><li style="color: red;"><span style="color: blue;">nested 2</span></li></ol>' +
+        '</li>' +
+      '</ol>');
+    });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10316

Description of Changes:
Here the problem was that `InsertLi.insert` was creating a new `li` but ignoring the `styles` of the "source li", to solve this now the `new li` will inherit styles of the `li` inside that we pressed enter to create a new li.

NOTE:
since in the case when we are in a case where the "source li" is between to `li` we split the list and we use a new `li` with inside a new `list` this case need to be managed differently

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
