### PR TITLE
TINY-10289: fix caret position after merging a `p` in an `li` in nested list

### DIFF
--- a/modules/tinymce/src/plugins/lists/test/ts/webdriver/DeleteTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/webdriver/DeleteTest.ts
@@ -43,14 +43,22 @@ describe('webdriver.tinymce.plugins.lists.DeleteTest', () => {
         '</ol>';
 
       editor.setContent(initialContent);
+      editor.undoManager.add();
       TinySelections.setCursor(editor, [ 0, 1, 2 ], 0);
       await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.backspace() ]);
+      TinyAssertions.assertCursor(editor, [ 0, 1, 1, 0, 0 ], 'List 1-1'.length);
       TinyAssertions.assertContent(editor, expectedContent);
+      editor.execCommand('undo');
+      TinyAssertions.assertContent(editor, initialContent);
 
       editor.setContent(initialContent);
+      editor.undoManager.add();
       TinySelections.setCursor(editor, [ 0, 1, 1, 0, 0 ], 'List 1-1'.length);
       await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.combo({}, 'Delete') ]);
+      TinyAssertions.assertCursor(editor, [ 0, 1, 1, 0, 0 ], 'List 1-1'.length);
       TinyAssertions.assertContent(editor, expectedContent);
+      editor.execCommand('undo');
+      TinyAssertions.assertContent(editor, initialContent);
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10289

Description of Changes:
this is a fix for a problem with the solution of `TINY-10289` that in case of `backspace` doesn't put the caret in the correct position

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
