### PR TITLE
TINY-10275: Bumped alloy dependency

### DIFF
--- a/modules/acid/CHANGELOG.md
+++ b/modules/acid/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- Updated alloy to latest major. #TINY-10275
+
 ## 5.0.8 - 2023-03-15
 
 ### Fixed

--- a/modules/acid/package.json
+++ b/modules/acid/package.json
@@ -8,7 +8,7 @@
     "directory": "modules/acid"
   },
   "dependencies": {
-    "@ephox/alloy": "^13.1.1",
+    "@ephox/alloy": "^14.0.0-alpha.0",
     "@ephox/boulder": "^7.1.5",
     "@ephox/katamari": "^9.1.5",
     "@ephox/sugar": "^9.2.1"

--- a/versions.txt
+++ b/versions.txt
@@ -1,6 +1,7 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
 
+acid@6.0.0
 agar@8.0.0
 mcagar@9.0.0
 alloy@14.0.0


### PR DESCRIPTION
Related Ticket: TINY-10275

Description of Changes:
* Apparently I forgot to commit this change didn't notice that acid is dependent on alloy
* I think we should bump acid to latest major since alloy is a major and agar is a major

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
