### PR TITLE
TINY-10290: Fixed issue with empty stacks

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
@@ -117,6 +117,15 @@ describe('browser.tinymce.core.FontSelectTest', () => {
         assertSelectBoxDisplayValue('Fonts', 'System Font');
       });
     });
+
+    it('TINY-10290: Should not display "System Font" since Arial is not part of the default stack', () => {
+      const editor = hook.editor();
+      editor.setContent('<p style="font-family: -apple-system, Arial;">a</p>');
+      editor.focus();
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+      editor.nodeChanged();
+      assertSelectBoxDisplayValue('Fonts', '-apple-system,Arial');
+    });
   });
 
   context('Custom default font stack', () => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
@@ -29,7 +29,7 @@ const splitFonts = (fontFamily: string): string[] => {
   return Arr.map(fonts, (font) => font.replace(/^['"]+|['"]+$/g, ''));
 };
 
-const matchesStack = (fonts: string[], stack: string[]): boolean => Arr.forall(stack, (font) => fonts.indexOf(font.toLowerCase()) > -1);
+const matchesStack = (fonts: string[], stack: string[]): boolean => stack.length > 0 && Arr.forall(stack, (font) => fonts.indexOf(font.toLowerCase()) > -1);
 
 const isSystemFontStack = (fontFamily: string, userStack: string[]): boolean => {
   if (fontFamily.indexOf('-apple-system') === 0 || userStack.length > 0) {


### PR DESCRIPTION
Related Ticket: TINY-10290

Description of Changes:
* The `Arr.forall` becoming `true` for the empty set bites me again. This is a follow up to make sure that we only consider non empty sets. Issue found when trying the fiddle in the QA notes.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
