### PR TITLE
TINY-10343: change `iframe.render` from `PostRender` to `SkinLoaded`

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hex colors are no longer always converted to RGB. #TINY-9819
 - Merging an external `p` inside a `list` via delete or backspace would incorrectly try to move a parent element inside a child element. #TINY-10289
 - The `fontsizeinput` toolbar item was causing console warnings when toolbar items were clicked. #TINY-10330
+- Menubar's button with more than 1 word sometime were rendered with one word above the other. #TINY-10343
 
 ## 6.7.2 - 2023-10-25
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hex colors are no longer always converted to RGB. #TINY-9819
 - Merging an external `p` inside a `list` via delete or backspace would incorrectly try to move a parent element inside a child element. #TINY-10289
 - The `fontsizeinput` toolbar item was causing console warnings when toolbar items were clicked. #TINY-10330
-- Menubar's button with more than 1 word sometime were rendered with one word above the other. #TINY-10343
+- Menubar buttons with more than one word would sometimes wrap into two lines. #TINY-10343
 
 ## 6.7.2 - 2023-10-25
 

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -99,11 +99,6 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
   const lastToolbarWidth = Cell(0);
   const outerContainer = mainUi.outerContainer;
 
-  editor.on('SkinLoaded', () => {
-    setToolbar(editor, uiRefs, rawUiConfig, backstage);
-    lastToolbarWidth.set(editor.getWin().innerWidth);
-  });
-
   loadIframeSkin(editor);
 
   const eTargetNode = SugarElement.fromDom(args.targetNode);
@@ -112,7 +107,8 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
   Attachment.attachSystemAfter(eTargetNode, mainUi.mothership);
   attachUiMotherships(editor, uiRoot, uiRefs);
 
-  editor.on('PostRender', () => {
+  // TINY-10343: here is used `SkinLoaded` instead of `PostRender` because if the skin load takes too much time it gives some rendering problem
+  editor.on('SkinLoaded', () => {
     // Set the sidebar before the toolbar and menubar
     // - each sidebar has an associated toggle toolbar button that needs to check the
     //   sidebar that is set to determine its active state on setup
@@ -121,6 +117,9 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
       rawUiConfig.sidebar,
       Options.getSidebarShow(editor)
     );
+
+    setToolbar(editor, uiRefs, rawUiConfig, backstage);
+    lastToolbarWidth.set(editor.getWin().innerWidth);
 
     OuterContainer.setMenubar(
       outerContainer,

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -107,7 +107,7 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
   Attachment.attachSystemAfter(eTargetNode, mainUi.mothership);
   attachUiMotherships(editor, uiRoot, uiRefs);
 
-  // TINY-10343: here is used `SkinLoaded` instead of `PostRender` because if the skin load takes too much time it gives some rendering problem
+  // TINY-10343: Using `SkinLoaded` instead of `PostRender` because if the skin loading takes too long you run in to rendering problems since things are measured before the CSS is being applied
   editor.on('SkinLoaded', () => {
     // Set the sidebar before the toolbar and menubar
     // - each sidebar has an associated toggle toolbar button that needs to check the

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarRenderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarRenderTest.ts
@@ -1,4 +1,4 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { after, describe, it } from '@ephox/bedrock-client';
 import { Css } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
@@ -25,6 +25,11 @@ describe('browser.tinymce.themes.silver.editor.menubar.EditorMenubarRenderTest',
 
   tinymce.addI18n('en', {
     File: 'File foo'
+  });
+  after(() => {
+    tinymce.addI18n('en', {
+      File: 'File'
+    });
   });
 
   it('TINY-10343: editor menu button with more that one word should not render the word one above the other', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarRenderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarRenderTest.ts
@@ -19,14 +19,10 @@ describe('browser.tinymce.themes.silver.editor.menubar.EditorMenubarRenderTest',
           });
         };
       });
-      editor.ui.registry.addMenuItem('fakeItem', {
-        text: 'some text',
-        onAction: () => undefined
-      });
     },
     menubar: 'menutest file',
     menu: {
-      menutest: { title: 'File foo', items: 'fakeItem' }
+      menutest: { title: 'File foo', items: 'cut' }
     },
   }, []);
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarRenderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarRenderTest.ts
@@ -35,7 +35,7 @@ describe('browser.tinymce.themes.silver.editor.menubar.EditorMenubarRenderTest',
 
     const menuButtonText = await TinyUiActions.pWaitForUi(editor, 'button:contains("File foo") span');
 
-    const delta = 4;
+    const delta = 6;
     // Status at the moment of writting of this test:
     // when the height is `32px` the words are rendered one above the other
     // when the height is `16px` the words are rendered on the same line

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarRenderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarRenderTest.ts
@@ -1,10 +1,9 @@
-import { after, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { Css } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import { tinymce } from 'tinymce/core/api/Tinymce';
 
 describe('browser.tinymce.themes.silver.editor.menubar.EditorMenubarRenderTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
@@ -20,17 +19,16 @@ describe('browser.tinymce.themes.silver.editor.menubar.EditorMenubarRenderTest',
           });
         };
       });
-    }
+      editor.ui.registry.addMenuItem('fakeItem', {
+        text: 'some text',
+        onAction: () => undefined
+      });
+    },
+    menubar: 'menutest file',
+    menu: {
+      menutest: { title: 'File foo', items: 'fakeItem' }
+    },
   }, []);
-
-  tinymce.addI18n('en', {
-    File: 'File foo'
-  });
-  after(() => {
-    tinymce.addI18n('en', {
-      File: 'File'
-    });
-  });
 
   it('TINY-10343: editor menu button with more that one word should not render the word one above the other', async () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarRenderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarRenderTest.ts
@@ -1,0 +1,38 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { Css } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import { tinymce } from 'tinymce/core/api/Tinymce';
+
+describe('browser.tinymce.themes.silver.editor.menubar.EditorMenubarRenderTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    setup: (editor: Editor) => {
+      editor.on('ScriptsLoaded', () => {
+        const orgLoad = editor.ui.styleSheetLoader.load;
+        editor.ui.styleSheetLoader.load = (url) => {
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              return orgLoad(url).then(resolve);
+            }, 100);
+          });
+        };
+      });
+    }
+  }, []);
+
+  tinymce.addI18n('en', {
+    File: 'File foo'
+  });
+
+  it('TINY-10343: editor menu button with more that one word should not render the word one above the other', async () => {
+    const editor = hook.editor();
+
+    const menuButton = await TinyUiActions.pWaitForUi(editor, 'button:contains("File foo")');
+    // when the width is `59.7109px` the words are rendered one above the other
+    // when the width is `63.8672px` the words are rendered on the same line
+    assert.isAtLeast(parseFloat(Css.get(menuButton, 'width')), 61);
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarRenderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarRenderTest.ts
@@ -30,9 +30,13 @@ describe('browser.tinymce.themes.silver.editor.menubar.EditorMenubarRenderTest',
   it('TINY-10343: editor menu button with more that one word should not render the word one above the other', async () => {
     const editor = hook.editor();
 
-    const menuButton = await TinyUiActions.pWaitForUi(editor, 'button:contains("File foo")');
-    // when the width is `59.7109px` the words are rendered one above the other
-    // when the width is `63.8672px` the words are rendered on the same line
-    assert.isAtLeast(parseFloat(Css.get(menuButton, 'width')), 61);
+    const menuButtonText = await TinyUiActions.pWaitForUi(editor, 'button:contains("File foo") span');
+
+    const delta = 4;
+    // Status at the moment of writting of this test:
+    // when the height is `32px` the words are rendered one above the other
+    // when the height is `16px` the words are rendered on the same line
+    // font-size is 14px so I added a delta for the test
+    assert.isBelow(parseFloat(Css.get(menuButtonText, 'height')), parseInt(Css.get(menuButtonText, 'font-size'), 10) + delta);
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10343

Description of Changes:
to avoid various render problems caused by a slow load of the skin, all render activities that were on `PostRender` are now on `SkinLoaded`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
