### PR TITLE
TINY-9393: Screen readers now announce the active autocompleter item

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `fontsizeinput` toolbar item was causing console warnings when toolbar items were clicked. #TINY-10330
 - Menubar buttons with more than one word would sometimes wrap into two lines. #TINY-10343
 - Creating a new `li` via enter inside a nested list would not inherit styles from the source `li`. #TINY-10316
+- Screen readers now announce the active autocompleter item. #TINY-9393
 
 ## 6.7.3 - 2023-11-15
 

--- a/modules/tinymce/src/themes/silver/main/ts/Autocompleter.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Autocompleter.ts
@@ -1,7 +1,7 @@
 import { AddEventsBehaviour, AlloyEvents, Behaviour, GuiFactory, Highlighting, InlineView, ItemTypes, SystemEvents } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
-import { Arr, Cell, Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import { Arr, Cell, Id, Optional } from '@ephox/katamari';
+import { Attribute, Css, Replication, SelectorFind, SugarElement, Traverse } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
@@ -23,6 +23,8 @@ const getAutocompleterRange = (dom: DOMUtils, initRange: Range): Optional<Range>
 };
 
 const register = (editor: Editor, sharedBackstage: UiFactoryBackstageShared): void => {
+  const autocompleterId = Id.generate('autocompleter');
+
   const processingAction = Cell<boolean>(false);
   const activeState = Cell<boolean>(false);
 
@@ -30,13 +32,19 @@ const register = (editor: Editor, sharedBackstage: UiFactoryBackstageShared): vo
     InlineView.sketch({
       dom: {
         tag: 'div',
-        classes: [ 'tox-autocompleter' ]
+        classes: [ 'tox-autocompleter' ],
+        attributes: {
+          id: autocompleterId
+        }
       },
       components: [ ],
       fireDismissalEventInstead: { },
       inlineBehaviours: Behaviour.derive([
         AddEventsBehaviour.config('dismissAutocompleter', [
-          AlloyEvents.run(SystemEvents.dismissRequested(), () => cancelIfNecessary())
+          AlloyEvents.run(SystemEvents.dismissRequested(), () => cancelIfNecessary()),
+          AlloyEvents.run(SystemEvents.highlight(), (_, se) => {
+            Attribute.getOpt(se.event.target, 'id').each((id: string) => Attribute.set(SugarElement.fromDom(editor.getBody()), 'aria-activedescendant', id));
+          }),
         ])
       ]),
       lazySink: sharedBackstage.getSink
@@ -49,6 +57,11 @@ const register = (editor: Editor, sharedBackstage: UiFactoryBackstageShared): vo
   const hideIfNecessary = () => {
     if (isMenuOpen()) {
       InlineView.hide(autocompleter);
+
+      editor.dom.remove(autocompleterId, false);
+      const editorBody = SugarElement.fromDom(editor.getBody());
+      Attribute.remove(editorBody, 'aria-owns');
+      Attribute.remove(editorBody, 'aria-activedescendant');
     }
   };
 
@@ -131,9 +144,44 @@ const register = (editor: Editor, sharedBackstage: UiFactoryBackstageShared): vo
     // Open the autocompleter if there are items to show
     if (combinedItems.length > 0) {
       display(lookupData, combinedItems);
+      Attribute.set(SugarElement.fromDom(editor.getBody()), 'aria-owns', autocompleterId);
+      if (!editor.inline) {
+        cloneAutocompleterToBody();
+      }
     } else {
       hideIfNecessary();
     }
+  };
+
+  const cloneAutocompleterToBody = () => {
+    if (editor.dom.get(autocompleterId)) {
+      editor.dom.remove(autocompleterId, false);
+    }
+
+    const rootElement = Traverse.parentElement(SugarElement.fromDom(editor.getBody()));
+    rootElement.each((root) => {
+      const selection = editor.selection.getNode();
+      const newElm = Replication.deep<Element>(autocompleter.element);
+      Css.setAll(newElm, {
+        border: '0',
+        clip: 'rect(0 0 0 0)',
+        height: '1px',
+        margin: '-1px',
+        overflow: 'hidden',
+        padding: '0',
+        position: 'absolute',
+        width: '1px',
+        top: `${selection.offsetTop}px`,
+        left: `${selection.offsetLeft}px`,
+      });
+      editor.dom.add(root.dom, newElm.dom);
+
+      // Clean up positioning styles so that the "hidden" autocompleter is around the selection
+      SelectorFind.descendant(newElm, '[role="menu"]').each((child) => {
+        Css.remove(child, 'position');
+        Css.remove(child, 'max-height');
+      });
+    });
   };
 
   editor.on('AutocompleterStart', ({ lookupData }) => {

--- a/modules/tinymce/src/themes/silver/main/ts/Autocompleter.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Autocompleter.ts
@@ -60,8 +60,12 @@ const register = (editor: Editor, sharedBackstage: UiFactoryBackstageShared): vo
 
       editor.dom.remove(autocompleterId, false);
       const editorBody = SugarElement.fromDom(editor.getBody());
-      Attribute.remove(editorBody, 'aria-owns');
-      Attribute.remove(editorBody, 'aria-activedescendant');
+      Attribute.getOpt(editorBody, 'aria-owns')
+        .filter((ariaOwnsAttr) => ariaOwnsAttr === autocompleterId)
+        .each(() => {
+          Attribute.remove(editorBody, 'aria-owns');
+          Attribute.remove(editorBody, 'aria-activedescendant');
+        });
     }
   };
 
@@ -146,14 +150,14 @@ const register = (editor: Editor, sharedBackstage: UiFactoryBackstageShared): vo
       display(lookupData, combinedItems);
       Attribute.set(SugarElement.fromDom(editor.getBody()), 'aria-owns', autocompleterId);
       if (!editor.inline) {
-        cloneAutocompleterToBody();
+        cloneAutocompleterToEditorDoc();
       }
     } else {
       hideIfNecessary();
     }
   };
 
-  const cloneAutocompleterToBody = () => {
+  const cloneAutocompleterToEditorDoc = () => {
     if (editor.dom.get(autocompleterId)) {
       editor.dom.remove(autocompleterId, false);
     }

--- a/modules/tinymce/src/themes/silver/main/ts/Autocompleter.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Autocompleter.ts
@@ -1,7 +1,7 @@
 import { AddEventsBehaviour, AlloyEvents, Behaviour, GuiFactory, Highlighting, InlineView, ItemTypes, SystemEvents } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Arr, Cell, Id, Optional } from '@ephox/katamari';
-import { Attribute, Css, Replication, SelectorFind, SugarElement, Traverse } from '@ephox/sugar';
+import { Attribute, Css, Replication, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
@@ -158,29 +158,27 @@ const register = (editor: Editor, sharedBackstage: UiFactoryBackstageShared): vo
       editor.dom.remove(autocompleterId, false);
     }
 
-    const rootElement = Traverse.parentElement(SugarElement.fromDom(editor.getBody()));
-    rootElement.each((root) => {
-      const selection = editor.selection.getNode();
-      const newElm = Replication.deep<Element>(autocompleter.element);
-      Css.setAll(newElm, {
-        border: '0',
-        clip: 'rect(0 0 0 0)',
-        height: '1px',
-        margin: '-1px',
-        overflow: 'hidden',
-        padding: '0',
-        position: 'absolute',
-        width: '1px',
-        top: `${selection.offsetTop}px`,
-        left: `${selection.offsetLeft}px`,
-      });
-      editor.dom.add(root.dom, newElm.dom);
+    const docElm = editor.getDoc().documentElement;
+    const selection = editor.selection.getNode();
+    const newElm = Replication.deep<Element>(autocompleter.element);
+    Css.setAll(newElm, {
+      border: '0',
+      clip: 'rect(0 0 0 0)',
+      height: '1px',
+      margin: '-1px',
+      overflow: 'hidden',
+      padding: '0',
+      position: 'absolute',
+      width: '1px',
+      top: `${selection.offsetTop}px`,
+      left: `${selection.offsetLeft}px`,
+    });
+    editor.dom.add(docElm, newElm.dom);
 
-      // Clean up positioning styles so that the "hidden" autocompleter is around the selection
-      SelectorFind.descendant(newElm, '[role="menu"]').each((child) => {
-        Css.remove(child, 'position');
-        Css.remove(child, 'max-height');
-      });
+    // Clean up positioning styles so that the "hidden" autocompleter is around the selection
+    SelectorFind.descendant(newElm, '[role="menu"]').each((child) => {
+      Css.remove(child, 'position');
+      Css.remove(child, 'max-height');
     });
   };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteAriaTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteAriaTest.ts
@@ -1,0 +1,179 @@
+import { Keys, UiFinder, Waiter } from '@ephox/agar';
+import { afterEach, context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { Attribute, SelectorFilter, SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+import * as Assets from '../../../module/Assets';
+import * as AutocompleterUtils from '../../../module/AutocompleterUtils';
+
+interface TestScenario {
+  readonly triggerChar: string;
+  readonly label: string;
+}
+
+describe('browser.tinymce.themes.silver.editor.autocomplete.AutocompleteAriaTest', () => {
+  Arr.each([ 'iframe', 'inline' ], (mode: string) => {
+    context(mode, () => {
+      afterEach(() => assertAutocompleteClosed());
+
+      const assertAutocompleteClosed = () => {
+        const editor = hook.editor();
+        assert.isUndefined(Attribute.get(TinyDom.body(editor), 'aria-owns'));
+        assert.isUndefined(Attribute.get(TinyDom.body(editor), 'aria-activedescendant'));
+        UiFinder.notExists(TinyDom.documentElement(editor), '.tox-autocompleter');
+      };
+
+      const pSetContentAndTrigger = async (editor: Editor, triggerChar: string) => {
+        const initialContent = triggerChar;
+
+        editor.setContent(`<p>${initialContent}</p>`);
+        TinySelections.setCursor(editor, [ 0, 0 ], initialContent.length);
+        TinyContentActions.keypress(editor, triggerChar.charCodeAt(0));
+        // Wait 50ms for the keypress to process
+        await Waiter.pWait(50);
+      };
+
+      const pCloseAutocomplete = async (editor: Editor) => {
+        TinyContentActions.keydown(editor, Keys.escape());
+        return AutocompleterUtils.pWaitForAutocompleteToClose();
+      };
+
+      const getMenuItemIdByIndex = (autocompleter: SugarElement<Element>, index: number) => {
+        const child = SelectorFilter.descendants(autocompleter, '[role="menuitem"]')[index];
+        return Attribute.get(child, 'id');
+      };
+
+      const assertBodyAttributes = (editor: Editor, autocompleterId?: string, activeMenuItemId?: string) => {
+        assert.equal(Attribute.get(TinyDom.body(editor), 'aria-owns'), autocompleterId);
+        assert.equal(Attribute.get(TinyDom.body(editor), 'aria-activedescendant'), activeMenuItemId);
+      };
+
+      const hook = TinyHooks.bddSetupLight<Editor>({
+        base_url: '/project/tinymce/js/tinymce',
+        inline: mode === 'inline',
+        setup: (ed: Editor) => {
+          ed.ui.registry.addAutocompleter('Plus1', {
+            trigger: '+',
+            minChars: 0,
+            columns: 1,
+            fetch: (pattern, _maxResults) => new Promise((resolve) => {
+              const filteredItems = Arr.filter([ 'aA', 'bB', 'cC', 'dD' ], (letter) => letter.indexOf(pattern) !== -1);
+              resolve(
+                Arr.map(filteredItems, (letter) => ({
+                  value: `plus-${letter}`,
+                  text: `p-${letter}`,
+                  icon: '+'
+                }))
+              );
+            }),
+            onAction: (autocompleteApi, rng, value) => {
+              ed.selection.setRng(rng);
+              ed.insertContent(value);
+              autocompleteApi.hide();
+            }
+          });
+
+          ed.ui.registry.addAutocompleter('Card items', {
+            trigger: ':',
+            minChars: 0,
+            columns: 1,
+            highlightOn: [ 'my_text_to_highlight' ],
+            fetch: (pattern, _maxResults) => {
+              const filteredItems = Arr.filter([
+                { text: 'equals sign', value: '=' },
+                { text: 'plus sign - D', value: '+' }
+              ], (item) => item.text.indexOf(pattern) !== -1);
+              return new Promise((resolve) => {
+                resolve(
+                  Arr.map(filteredItems, (item) => ({
+                    value: `euro-${item.value}`,
+                    ariaLabel: item.text,
+                    type: 'cardmenuitem',
+                    label: item.text,
+                    items: [
+                      {
+                        type: 'cardimage',
+                        src: Assets.getGreenImageDataUrl(),
+                        classes: [ 'my_autocompleter_avatar_class' ]
+                      },
+                      {
+                        type: 'cardcontainer',
+                        direction: 'vertical',
+                        align: 'right',
+                        valign: 'bottom',
+                        items: [
+                          {
+                            type: 'cardtext',
+                            text: item.text,
+                            classes: [ 'my_text_class' ],
+                            name: 'my_text_to_highlight'
+                          }
+                        ]
+                      }
+                    ]
+                  }))
+                );
+              });
+            },
+            onAction: (autocompleteApi, rng, value) => {
+              ed.selection.setRng(rng);
+              ed.insertContent(value);
+              autocompleteApi.hide();
+            }
+          });
+        }
+      }, [], true);
+
+      Arr.each([
+        { triggerChar: '+', label: 'autocomplete item' },
+        { triggerChar: ':', label: 'cardmenu item' }
+      ], (scenario: TestScenario) => {
+        context(scenario.label, () => {
+          it('TINY-9393: Attributes of editor body should be updated when autocomplete is shown', async () => {
+            const editor = hook.editor();
+            await pSetContentAndTrigger(editor, scenario.triggerChar);
+            const autocompleter = await UiFinder.pWaitForVisible('Wait for autocompleter to appear', SugarBody.body(), '.tox-autocompleter');
+            const autocompleterId = Attribute.get(autocompleter, 'id');
+            const activeMenuItemId = getMenuItemIdByIndex(autocompleter, 0);
+            assertBodyAttributes(editor, autocompleterId, activeMenuItemId);
+            await pCloseAutocomplete(editor);
+          });
+
+          it('TINY-9393: Attributes of editor body should be updated when autocomplete is shown - changing active item', async () => {
+            const editor = hook.editor();
+            await pSetContentAndTrigger(editor, scenario.triggerChar);
+            const autocompleter = await UiFinder.pWaitForVisible('Wait for autocompleter to appear', SugarBody.body(), '.tox-autocompleter');
+            const autocompleterId = Attribute.get(autocompleter, 'id');
+            const activeMenuItemId = getMenuItemIdByIndex(autocompleter, 0);
+            assertBodyAttributes(editor, autocompleterId, activeMenuItemId);
+            TinyContentActions.keydown(editor, Keys.down());
+            const activeMenuItemId2 = getMenuItemIdByIndex(autocompleter, 1);
+            assertBodyAttributes(editor, autocompleterId, activeMenuItemId2);
+            await pCloseAutocomplete(editor);
+          });
+
+          it('TINY-9393: Attributes of editor body should be updated when autocomplete is shown - filtering autocompleter', async () => {
+            const editor = hook.editor();
+            await pSetContentAndTrigger(editor, scenario.triggerChar);
+            const autocompleter = await UiFinder.pWaitForVisible('Wait for autocompleter to appear', SugarBody.body(), '.tox-autocompleter');
+            const autocompleterId = Attribute.get(autocompleter, 'id');
+            const activeMenuItemId = getMenuItemIdByIndex(autocompleter, 0);
+            assertBodyAttributes(editor, autocompleterId, activeMenuItemId);
+
+            editor.insertContent('D');
+            TinyContentActions.keypress(editor, 'D'.charCodeAt(0));
+            await Waiter.pWait(50);
+
+            const activeMenuItemId2 = getMenuItemIdByIndex(autocompleter, 0);
+            assertBodyAttributes(editor, autocompleterId, activeMenuItemId2);
+            await pCloseAutocomplete(editor);
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-9393

Description of Changes:
* Set `aria-owns` and `aria-activedescendant` attributes when autocompleter is shown, and when the focus is shifted, update the `aria-activedescendant` attribute
* For iframe mode, clone a "hidden" autcompleter and insert it into the `editor.getDoc().documentElement) (sibling of the editor body)
* Clean up when autocompleter is closed/no match
	* Removed associated attributes
	* Removed the cloned element
* See the latest comment in the ticket for video reference

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
