### PR TITLE
TINY-10347: Prevent input events on targets inside svg elements

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/EventTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/EventTypes.ts
@@ -180,6 +180,8 @@ export interface EditorEventMap extends Omit<NativeEventMap, 'blur' | 'focus'> {
   'blur': { focusedEditor: Editor | null };
   'resize': UIEvent;
   'scroll': UIEvent;
+  'input': InputEvent;
+  'beforeinput': InputEvent;
   'detach': { };
   'remove': { };
   'init': { };

--- a/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
@@ -9,6 +9,7 @@ import * as ScrollIntoView from '../../dom/ScrollIntoView';
 import * as EditorFocus from '../../focus/EditorFocus';
 import { ClientRect } from '../../geom/ClientRect';
 import * as CaretRangeFromPoint from '../../selection/CaretRangeFromPoint';
+import * as EditableRange from '../../selection/EditableRange';
 import * as ElementSelection from '../../selection/ElementSelection';
 import * as EventProcessRanges from '../../selection/EventProcessRanges';
 import * as GetSelectionContent from '../../selection/GetSelectionContent';
@@ -269,10 +270,8 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
 
     if (fakeSelectedElements.length > 0) {
       return Arr.forall(fakeSelectedElements, (el) => dom.isEditable(el.parentElement));
-    } else if (rng.startContainer === rng.endContainer) {
-      return dom.isEditable(rng.startContainer);
     } else {
-      return dom.isEditable(rng.startContainer) && dom.isEditable(rng.endContainer);
+      return EditableRange.isEditableRange(dom, rng);
     }
   };
 

--- a/modules/tinymce/src/core/main/ts/events/EventUtils.ts
+++ b/modules/tinymce/src/core/main/ts/events/EventUtils.ts
@@ -12,6 +12,7 @@ export interface PartialEvent {
   readonly stopImmediatePropagation?: () => void;
   readonly composedPath?: () => EventTarget[];
   readonly getModifierState?: (keyArg: string) => boolean;
+  readonly getTargetRanges?: () => StaticRange[];
   returnValue?: boolean;
   defaultPrevented?: boolean;
   cancelBubble?: boolean;
@@ -74,6 +75,12 @@ const clone = <T extends PartialEvent>(originalEvent: T, data?: T): T => {
   if (Type.isNonNullable(originalEvent.getModifierState)) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     event.getModifierState = (keyArg: string) => originalEvent.getModifierState!(keyArg);
+  }
+
+  // The getTargetRanges won't work when cloned, so delegate instead
+  if (Type.isNonNullable(originalEvent.getTargetRanges)) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    event.getTargetRanges = () => originalEvent.getTargetRanges!();
   }
 
   return event as T;

--- a/modules/tinymce/src/core/main/ts/keyboard/PreventNoneditableInput.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/PreventNoneditableInput.ts
@@ -1,11 +1,13 @@
+import { Arr } from '@ephox/katamari';
+
 import Editor from '../api/Editor';
+import * as EditableRange from '../selection/EditableRange';
 
 export const setup = (editor: Editor): void => {
-  editor.on('BeforeInput', (e) => {
+  editor.on('beforeinput', (e) => {
     // Normally input is blocked on non-editable elements that have contenteditable="false" however we are also treating
-    // SVG elements as non-editable and Firefox lets you delete parts of the SVG if you manage to select a part. So this
-    // checks for that scenario and prevents the default behaviour.
-    if (!editor.selection.isEditable()) {
+    // SVG elements as non-editable and deleting inside or into is possible in some browsers so we need to detect that and prevent that.
+    if (!editor.selection.isEditable() || Arr.exists(e.getTargetRanges(), (rng) => !EditableRange.isEditableRange(editor.dom, rng))) {
       e.preventDefault();
     }
   });

--- a/modules/tinymce/src/core/main/ts/selection/EditableRange.ts
+++ b/modules/tinymce/src/core/main/ts/selection/EditableRange.ts
@@ -1,0 +1,9 @@
+import DOMUtils from '../api/dom/DOMUtils';
+
+export const isEditableRange = (dom: DOMUtils, rng: Range | StaticRange): boolean => {
+  if (rng.collapsed) {
+    return dom.isEditable(rng.startContainer);
+  } else {
+    return dom.isEditable(rng.startContainer) && dom.isEditable(rng.endContainer);
+  }
+};


### PR DESCRIPTION
Related Ticket: TINY-10347

Description of Changes:
* Added fix for delete and backspace into the SVG element.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
