### PR TITLE
TINY-10177: Override selection when clicking Accordion expand arrow on Safari

### DIFF
--- a/modules/tinymce/src/plugins/accordion/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/accordion/main/ts/Plugin.ts
@@ -3,6 +3,7 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Commands from './api/Commands';
 import * as FilterContent from './core/FilterContent';
 import * as Keyboard from './core/Keyboard';
+import * as Quirks from './core/Quirks';
 import * as Buttons from './ui/Buttons';
 
 export default (): void => {
@@ -11,5 +12,6 @@ export default (): void => {
     Commands.register(editor);
     Keyboard.setup(editor);
     FilterContent.setup(editor);
+    Quirks.setup(editor);
   });
 };

--- a/modules/tinymce/src/plugins/accordion/main/ts/core/Quirks.ts
+++ b/modules/tinymce/src/plugins/accordion/main/ts/core/Quirks.ts
@@ -1,0 +1,24 @@
+import Editor from 'tinymce/core/api/Editor';
+import Env from 'tinymce/core/api/Env';
+
+import * as Utils from './Utils';
+
+const setup = (editor: Editor): void => {
+  // TINY-10177: On Safari, clicking on the expand arrow of the `details` element sets the selection before the `summary`,
+  // so we override the selection to the beginning of `summary` content
+  if (Env.browser.isSafari()) {
+    editor.on('click', (e) => {
+      if (Utils.isSummary(e.target)) {
+        const summary = e.target;
+        const rng = editor.selection.getRng();
+        if (rng.collapsed && rng.startContainer === summary.parentNode && rng.startOffset === 0) {
+          editor.selection.setCursorLocation(summary, 0);
+        }
+      }
+    });
+  }
+};
+
+export {
+  setup
+};

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/QuirksTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/QuirksTest.ts
@@ -1,4 +1,4 @@
-import { before, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
@@ -17,17 +17,16 @@ describe('browser.tinymce.plugins.accordion.QuirksTest', () => {
     },
     [ Plugin ]
   );
-  before(function () {
-    if (!browser.isSafari()) {
-      this.skip();
-    }
-  });
-
   it('TINY-10177: should override the selection to the beginning of `summary` after clicking on it.', () => {
     const editor = hook.editor();
     editor.setContent('<p>Hello</p> ' + AccordionUtils.createAccordion());
+    if (browser.isSafari()) {
     // set selection before the `summary`
-    TinySelections.setCursor(editor, [ 1 ], 0);
+      TinySelections.setCursor(editor, [ 1 ], 0);
+    } else {
+    // set selection at the beginning of the `summary`
+      TinySelections.setCursor(editor, [ 1, 0 ], 0);
+    }
     const event = { target: editor.dom.select('summary')[0] } as unknown as MouseEvent;
     editor.dispatch('click', event );
     TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/QuirksTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/QuirksTest.ts
@@ -23,7 +23,7 @@ describe('browser.tinymce.plugins.accordion.QuirksTest', () => {
     }
   });
 
-  it('TINY-10177:  should override the selection to the beginning of `summary` after clicking on it.', () => {
+  it('TINY-10177: should override the selection to the beginning of `summary` after clicking on it.', () => {
     const editor = hook.editor();
     editor.setContent('<p>Hello</p> ' + AccordionUtils.createAccordion());
     // set selection before the `summary`

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/QuirksTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/QuirksTest.ts
@@ -1,0 +1,35 @@
+import { before, describe, it } from '@ephox/bedrock-client';
+import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/accordion/Plugin';
+
+import * as AccordionUtils from '../module/AccordionUtils';
+
+describe('browser.tinymce.plugins.accordion.QuirksTest', () => {
+  const browser = PlatformDetection.detect().browser;
+  const hook = TinyHooks.bddSetup<Editor>(
+    {
+      plugins: 'accordion',
+      base_url: '/project/tinymce/js/tinymce',
+      indent: false
+    },
+    [ Plugin ]
+  );
+  before(function () {
+    if (!browser.isSafari()) {
+      this.skip();
+    }
+  });
+
+  it('TINY-10177:  should override the selection to the beginning of `summary` after clicking on it.', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>Hello</p> ' + AccordionUtils.createAccordion());
+    // set selection before the `summary`
+    TinySelections.setCursor(editor, [ 1 ], 0);
+    const event = { target: editor.dom.select('summary')[0] } as unknown as MouseEvent;
+    editor.dispatch('click', event );
+    TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-10177

Description of Changes:
* On Safari, clicking on the expand arrow of the `details` element sets the selection before the `summary`,
  so we override the selection to the beginning of `summary` content 

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
