### PR TITLE
TINY-10174: Allow dialog collection items to use icons from icon pack

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed use of `async` for editor rendering which caused visual blinking when reloading the editor in-place. #TINY-10249
 - Hex colors are no longer always converted to RGB. #TINY-9819
 - Merging an external `p` inside a `list` via delete or backspace would incorrectly try to move a parent element inside a child element. #TINY-10289
+- Dialog collection items would not display any icons chosen from icon pack. #TINY-10174
 
 ## 6.7.2 - 2023-10-25
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Collection.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Collection.ts
@@ -29,6 +29,12 @@ export const renderCollection = (
   // DUPE with TextField.
   const pLabel = spec.label.map((label) => renderLabel(label, providersBackstage));
 
+  const icons = providersBackstage.icons();
+
+  const fetchIcon = (icon: string) => Optional.from(icons[icon]).getOr(icon);
+
+  const iconIsChar = (icon: string) => icon.length === 1;
+
   const runOnItem = <T extends EventFormat>(f: ItemCallback<T>) => (comp: AlloyComponent, se: SimulatedEvent<T>) => {
     SelectorFind.closest<HTMLElement>(se.event.target, '[data-collection-item-value]').each((target) => {
       f(comp, se, target, Attribute.get(target, 'data-collection-item-value'));
@@ -39,8 +45,9 @@ export const renderCollection = (
     const htmlLines = Arr.map(items, (item) => {
       const itemText = I18n.translate(item.text);
       const textContent = spec.columns === 1 ? `<div class="tox-collection__item-label">${itemText}</div>` : '';
+      const icon = iconIsChar(item.icon) ? item.icon : fetchIcon(item.icon);
 
-      const iconContent = `<div class="tox-collection__item-icon">${item.icon}</div>`;
+      const iconContent = `<div class="tox-collection__item-icon">${icon}</div>`;
 
       // Replacing the hyphens and underscores in collection items with spaces
       // to ensure the screen readers pronounce the words correctly.

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Collection.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Collection.ts
@@ -31,9 +31,8 @@ export const renderCollection = (
 
   const icons = providersBackstage.icons();
 
-  const fetchIcon = (icon: string) => Optional.from(icons[icon]).getOr(icon);
-
-  const iconIsChar = (icon: string) => icon.length === 1;
+  // icon string is either in icon pack or displayed directly
+  const getIcon = (icon: string) => icons[icon] ?? icon;
 
   const runOnItem = <T extends EventFormat>(f: ItemCallback<T>) => (comp: AlloyComponent, se: SimulatedEvent<T>) => {
     SelectorFind.closest<HTMLElement>(se.event.target, '[data-collection-item-value]').each((target) => {
@@ -45,9 +44,8 @@ export const renderCollection = (
     const htmlLines = Arr.map(items, (item) => {
       const itemText = I18n.translate(item.text);
       const textContent = spec.columns === 1 ? `<div class="tox-collection__item-label">${itemText}</div>` : '';
-      const icon = iconIsChar(item.icon) ? item.icon : fetchIcon(item.icon);
 
-      const iconContent = `<div class="tox-collection__item-icon">${icon}</div>`;
+      const iconContent = `<div class="tox-collection__item-icon">${getIcon(item.icon)}</div>`;
 
       // Replacing the hyphens and underscores in collection items with spaces
       // to ensure the screen readers pronounce the words correctly.

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Collection.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Collection.ts
@@ -31,7 +31,7 @@ export const renderCollection = (
 
   const icons = providersBackstage.icons();
 
-  // icon string is either in icon pack or displayed directly
+  // TINY-10174: Icon string is either in icon pack or displayed directly
   const getIcon = (icon: string) => icons[icon] ?? icon;
 
   const runOnItem = <T extends EventFormat>(f: ItemCallback<T>) => (comp: AlloyComponent, se: SimulatedEvent<T>) => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
@@ -6,105 +6,102 @@ import { Attribute, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar'
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
+import { Dialog } from 'tinymce/core/api/ui/Ui';
 
 describe('browser.tinymce.themes.silver.skin.OxideCollectionComponentTest', () => {
-  before(function () {
-    // TODO: TINY-3229 implement collection columns properly
-    this.skip();
-  });
-
-  const hook = TinyHooks.bddSetup<Editor>({
-    toolbar: 'dialog-button',
-    base_url: '/project/tinymce/js/tinymce',
-    setup: (ed: Editor) => {
-      ed.ui.registry.addButton('dialog-button', {
-        type: 'button',
-        text: 'Go',
-        onAction: () => {
-          ed.windowManager.open({
-            title: 'Testing list component',
-            initialData: {
-              'stuff-1': [
-                { value: 'a', text: 'text-A', icon: 'icon-A' },
-                { value: 'b', text: 'text-B', icon: 'icon-B' },
-                { value: 'b', text: 'text-C', icon: 'icon-C' }
-              ],
-
-              'stuff-auto': [
-                { value: 'd', text: 'text-D', icon: 'icon-D' },
-                { value: 'e', text: 'text-E', icon: 'icon-E' },
-                { value: 'f', text: 'text-F', icon: 'icon-F' }
-              ],
-
-              'stuff-2': [
-                { value: 'g', text: 'text-G', icon: 'icon-G' },
-                { value: 'h', text: 'text-H', icon: 'icon-H' },
-                { value: 'i', text: 'text-I', icon: 'icon-I' }
-              ],
-              'input1': ''
-            },
-            body: {
-              type: 'panel',
-              items: [
-                {
-                  name: 'input1',
-                  type: 'input'
-                },
-                {
-                  name: 'stuff-1',
-                  type: 'collection',
-                  columns: 1
-                },
-                {
-                  name: 'stuff-auto',
-                  type: 'collection',
-                  columns: 'auto'
-                },
-                {
-                  name: 'stuff-2',
-                  type: 'collection',
-                  columns: 2
-                }
-              // TODO: TINY-3229 implement collection columns properly
-              ] as any[]
-            },
-            buttons: []
-          });
-        }
-      });
-    }
-  }, []);
-
-  const structureItem = (optText: Optional<string>, optIcon: Optional<string>): ApproxStructure.Builder<StructAssert> =>
-    (s, str, arr) => s.element('div', {
-      classes: [ arr.has('tox-collection__item') ],
-      children: Optionals.cat([
-        optIcon.map((icon) => s.element('div', {
-          classes: [ arr.has('tox-collection__item-icon') ],
-          html: str.is(icon)
-        })),
-
-        optText.map((text) => s.element('div', {
-          classes: [ arr.has('tox-collection__item-label') ],
-          html: str.is(text)
-        }))
-      ])
-    });
-
-  const findNthIn = (selector: string, n: number, elem: SugarElement<Node>) => {
-    const matches = UiFinder.findAllIn(elem, selector);
-    return Arr.get(matches, n).getOrDie(`Could not find match ${n} of selector: ${selector}`);
-  };
-
   context('Check structure of collection in a dialog', () => {
+    const structureItem = (optText: Optional<string>, optIcon: Optional<string>): ApproxStructure.Builder<StructAssert> =>
+      (s, str, arr) => s.element('div', {
+        classes: [ arr.has('tox-collection__item') ],
+        children: Optionals.cat([
+          optIcon.map((icon) => s.element('div', {
+            classes: [ arr.has('tox-collection__item-icon') ],
+            html: str.is(icon)
+          })),
+
+          optText.map((text) => s.element('div', {
+            classes: [ arr.has('tox-collection__item-label') ],
+            html: str.is(text)
+          }))
+        ])
+      });
+
+    const findNthIn = (selector: string, n: number, elem: SugarElement<Node>) => {
+      const matches = UiFinder.findAllIn(elem, selector);
+      return Arr.get(matches, n).getOrDie(`Could not find match ${n} of selector: ${selector}`);
+    };
+
+    const hook = TinyHooks.bddSetup<Editor>({
+      toolbar: 'dialog-button',
+      base_url: '/project/tinymce/js/tinymce',
+      setup: (ed: Editor) => {
+        ed.ui.registry.addButton('dialog-button', {
+          type: 'button',
+          text: 'Go',
+          onAction: () => {
+            ed.windowManager.open({
+              title: 'Testing list component',
+              initialData: {
+                'stuff-1': [
+                  { value: 'a', text: 'text-A', icon: 'icon-A' },
+                  { value: 'b', text: 'text-B', icon: 'icon-B' },
+                  { value: 'b', text: 'text-C', icon: 'icon-C' }
+                ],
+
+                'stuff-auto': [
+                  { value: 'd', text: 'text-D', icon: 'icon-D' },
+                  { value: 'e', text: 'text-E', icon: 'icon-E' },
+                  { value: 'f', text: 'text-F', icon: 'icon-F' }
+                ],
+
+                'stuff-2': [
+                  { value: 'g', text: 'text-G', icon: 'icon-G' },
+                  { value: 'h', text: 'text-H', icon: 'icon-H' },
+                  { value: 'i', text: 'text-I', icon: 'icon-I' }
+                ],
+                'input1': ''
+              },
+              body: {
+                type: 'panel',
+                items: [
+                  {
+                    name: 'input1',
+                    type: 'input'
+                  },
+                  {
+                    name: 'stuff-1',
+                    type: 'collection',
+                    columns: 1
+                  },
+                  {
+                    name: 'stuff-auto',
+                    type: 'collection',
+                    columns: 'auto'
+                  },
+                  {
+                    name: 'stuff-2',
+                    type: 'collection',
+                    columns: 2
+                  }
+                // TODO: TINY-3229 implement collection columns properly
+                ] as any[]
+              },
+              buttons: []
+            });
+          }
+        });
+      }
+    }, []);
+
     TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [
       ':focus { outline: 2px solid green; }'
     ]);
 
-    before(async () => {
-      const editor = hook.editor();
-      TinyUiActions.clickOnToolbar(editor, 'button');
-      await TinyUiActions.pWaitForDialog(editor);
+    before(function () {
+      this.skip();
+      // const editor = hook.editor();
+      // TinyUiActions.clickOnToolbar(editor, 'button');
+      // await TinyUiActions.pWaitForDialog(editor);
     });
 
     it('Checking the first collection: columns = 1, list', async () => {
@@ -206,6 +203,121 @@ describe('browser.tinymce.themes.silver.skin.OxideCollectionComponentTest', () =
       const activeElem = UiFinder.findIn(SugarBody.body(), '.tox-collection__item--active').getOrDie();
       const value = Attribute.get(activeElem, 'data-collection-item-value');
       Assertions.assertEq('Checking selected value', 'g', value);
+    });
+  });
+
+  context('Collection items display both icons and characters', () => {
+    const hook = TinyHooks.bddSetup<Editor>({
+      toolbar: 'collectiondialog',
+      base_url: '/project/tinymce/js/tinymce',
+      setup: (editor: Editor) => {
+        const collectionSpec: Dialog.DialogSpec<{ collect: Dialog.CollectionItem[] }> = {
+          title: 'Collection',
+          size: 'normal',
+          body: {
+            type: 'panel',
+            items: [
+              {
+                type: 'collection',
+                name: 'collect'
+              }
+            ]
+          },
+          initialData: {
+            collect: [
+              {
+                text: 'delete',
+                value: 'delete',
+                icon: 'remove'
+              },
+              {
+                text: 'A',
+                value: 'A',
+                icon: 'A'
+              },
+              {
+                text: 'dollar',
+                value: '$',
+                icon: '$'
+              },
+              {
+                text: 'star',
+                value: '&#9733;',
+                icon: '&#9733;'
+              },
+              {
+                text: 'star',
+                value: '★',
+                icon: '★'
+              }
+            ]
+          },
+        };
+        editor.ui.registry.addButton('collectiondialog', {
+          text: 'Collection Dialog',
+          onAction: () => editor.windowManager.open(collectionSpec)
+        });
+      }
+    });
+
+    const openDialog = async (editor: Editor) => {
+      TinyUiActions.clickOnToolbar(editor, '.tox-tbtn.tox-tbtn--select:has(.tox-tbtn__select-label:contains("Collection Dialog"))');
+      return await TinyUiActions.pWaitForDialog(editor);
+    };
+
+    const chars = [ 'A', '$', '★', '★' ];
+    const icons = [ 'delete', ...chars ];
+
+    const buttonSelectors = Arr.map(icons, (label) => `.tox-collection__item[aria-label="${label}"]`);
+
+    it('TINY-10174: Buttons are rendered', async () => {
+      const editor = hook.editor();
+      editor.selection.expand();
+      const dialog = await openDialog(editor);
+      Arr.each(buttonSelectors, (selector) => UiFinder.findIn(dialog, selector));
+      TinyUiActions.closeDialog(editor);
+    });
+
+    it('TINY-10174: Icons are rendered', async () => {
+      const editor = hook.editor();
+      editor.selection.expand();
+      const dialog = await openDialog(editor);
+      const collection = UiFinder.findIn(dialog, '.tox-form__group .tox-collection').getOrDie();
+      Assertions.assertStructure(
+        'Checking structure',
+        ApproxStructure.build((s, str, arr) => s.element('div', {
+          classes: [ arr.has('tox-collection'), arr.has('tox-collection--grid'), arr.not('tox-menu') ],
+          children: [
+            s.element('div', {
+              classes: [ arr.has('tox-collection__group') ],
+              children: [
+                s.element('div', {
+                  classes: [ arr.has('tox-collection__item') ],
+                  children: [
+                    s.element('div', {
+                      classes: [ arr.has('tox-collection__item-icon') ],
+                      children: [
+                        s.element('svg', {})
+                      ]
+                    })
+                  ]
+                }),
+                ...Arr.map(chars, (char) => s.element('div', {
+                  classes: [ arr.has('tox-collection__item') ],
+                  children: [
+                    s.element('div', {
+                      classes: [ arr.has('tox-collection__item-icon') ],
+                      html: str.is(char)
+                    })
+                  ]
+                }))
+              ]
+            }),
+          ]
+        })),
+        collection
+      );
+      TinyUiActions.closeDialog(editor);
     });
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
@@ -98,10 +98,12 @@ describe('browser.tinymce.themes.silver.skin.OxideCollectionComponentTest', () =
     ]);
 
     before(function () {
-      this.skip();
       // const editor = hook.editor();
       // TinyUiActions.clickOnToolbar(editor, 'button');
       // await TinyUiActions.pWaitForDialog(editor);
+
+      // TODO: TINY-3229 implement collection columns properly
+      this.skip();
     });
 
     it('Checking the first collection: columns = 1, list', async () => {


### PR DESCRIPTION
Related Ticket: TINY-10174

Description of Changes:
* Collection item icons are now retrieved from the icon pack before using the string as a fallback
* This will not affect charmap or emoticons dialogs, as those characters are not registered as icons

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
