### PR TITLE
TINY-10346: Cut inside a SVG with text deletes the selected text

### DIFF
--- a/modules/tinymce/src/core/main/ts/delete/DeleteCommands.ts
+++ b/modules/tinymce/src/core/main/ts/delete/DeleteCommands.ts
@@ -35,8 +35,10 @@ const deleteCommand = (editor: Editor, caret: Cell<Text | null>): void => {
     () => {
       // We can't use an `execEditorDeleteCommand` here, otherwise we'd get
       // possible infinite recursion (as it would trigger `deleteCommand` again)
-      DeleteUtils.execNativeDeleteCommand(editor);
-      DeleteUtils.paddEmptyBody(editor);
+      if (editor.selection.isEditable()) {
+        DeleteUtils.execNativeDeleteCommand(editor);
+        DeleteUtils.paddEmptyBody(editor);
+      }
     },
     Fun.call
   );
@@ -46,7 +48,11 @@ const forwardDeleteCommand = (editor: Editor, caret: Cell<Text | null>): void =>
   const result = findAction(editor, caret, true);
 
   result.fold(
-    () => DeleteUtils.execNativeForwardDeleteCommand(editor),
+    () => {
+      if (editor.selection.isEditable()) {
+        DeleteUtils.execNativeForwardDeleteCommand(editor);
+      }
+    },
     Fun.call
   );
 };

--- a/modules/tinymce/src/core/main/ts/paste/CutCopy.ts
+++ b/modules/tinymce/src/core/main/ts/paste/CutCopy.ts
@@ -80,7 +80,7 @@ const hasSelectedContent = (editor: Editor): boolean =>
   !editor.selection.isCollapsed() || isTableSelection(editor);
 
 const cut = (editor: Editor) => (evt: EditorEvent<ClipboardEvent>): void => {
-  if (!evt.isDefaultPrevented() && hasSelectedContent(editor)) {
+  if (!evt.isDefaultPrevented() && hasSelectedContent(editor) && editor.selection.isEditable()) {
     setClipboardData(evt, getData(editor), fallback(editor), () => {
       if (Env.browser.isChromium() || Env.browser.isFirefox()) {
         const rng = editor.selection.getRng();

--- a/modules/tinymce/src/core/test/ts/browser/delete/DeleteCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/DeleteCommandsTest.ts
@@ -9,7 +9,8 @@ describe('browser.tinymce.core.delete.DeleteCommandsTest', () => {
   const caret = Cell<Text | null>(null);
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
-    indent: false
+    indent: false,
+    extended_valid_elements: 'svg[*]'
   }, [], true);
 
   it('Delete should merge blocks', () => {
@@ -80,6 +81,26 @@ describe('browser.tinymce.core.delete.DeleteCommandsTest', () => {
         TinyAssertions.assertContent(editor, initialContent);
         TinyAssertions.assertSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
       });
+    });
+
+    it('TINY-10346: Delete on noneditable svg element', () => {
+      const editor = hook.editor();
+      const initialContent = '<svg width="200" height="100"><text x="20" y="60" font-family="Arial" font-size="24" fill="blue">text</text></svg>';
+
+      editor.setContent(initialContent);
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+      DeleteCommands.deleteCommand(editor, caret);
+      TinyAssertions.assertContent(editor, initialContent);
+    });
+
+    it('TINY-10346: ForwardDelete on noneditable svg element', () => {
+      const editor = hook.editor();
+      const initialContent = '<svg width="200" height="100"><text x="20" y="60" font-family="Arial" font-size="24" fill="blue">text</text></svg>';
+
+      editor.setContent(initialContent);
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
+      DeleteCommands.forwardDeleteCommand(editor, caret);
+      TinyAssertions.assertContent(editor, initialContent);
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/paste/CutNoneditableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/CutNoneditableTest.ts
@@ -1,0 +1,26 @@
+import { Clipboard, Waiter } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('webdriver.tinymce.core.paste.CutTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    toolbar: false,
+    statusbar: false,
+    extended_valid_elements: 'svg[*]'
+  }, []);
+
+  it('TINY-10346: Cut event should not delete content inside svg elements', async () => {
+    const editor = hook.editor();
+    const initialContent = '<svg width="200" height="100"><text x="20" y="60" font-family="Arial" font-size="24" fill="blue">text</text></svg>';
+    editor.setContent(initialContent);
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 2);
+    const dataTransfer = Clipboard.cut(TinyDom.body(editor));
+    assert.equal(dataTransfer.getData('text/html'), '', 'Should be empty since there is no editable content selected');
+    await Waiter.pWait(1); // The execCommand('Delete') inside the cut handler is executed using setTimeout(.., 0) to avoid command recursion.
+    TinyAssertions.assertContent(editor, initialContent);
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/paste/CutNoneditableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/CutNoneditableTest.ts
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 
-describe('webdriver.tinymce.core.paste.CutTest', () => {
+describe('browser.tinymce.core.paste.CutNoneditableTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     toolbar: false,


### PR DESCRIPTION
Related Ticket: TINY-10346

Description of Changes:
* Fixed so cut doesn't delete inside SVG elements.
* Didn't add a changelog since we never really officially supported SVGs before.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
