### PR TITLE
TINY-10348 & TINY-10349: Add sandbox_iframes and convert_unsafe_embeds options

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `force_hex_color` editor option. Option `'always'` converts all RGB & RGBA colours to hex, `'rgb_only'` will only convert RGB and *not* RGBA colours to hex, `'off'` won't convert any colours to hex. #TINY-9819
 - Added `default_font_stack` editor option that makes it possible to define what is considered a system font stack. #TINY-10290
+- New `sandbox_iframes` option that controls whether iframe elements will be added a `sandbox=""` attribute to mitigate malicious intent. #TINY-10348
+- New `convert_unsafe_embeds` option that controls whether `<object>` and `<embed>` elements will be converted to more restrictive alternatives, namely `<img>` for image MIME types, `<video>` for video MIME types, `<audio>` audio MIME types, or `<iframe>` for other or unspecified MIME types. #TINY-10349
 
 ### Improved
 - Colorpicker now includes the Brightness/Saturation selector and hue slider in the keyboard navigable items. #TINY-9287

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -197,6 +197,7 @@ interface BaseEditorOptions {
   resize?: boolean | 'both';
   resize_img_proportional?: boolean;
   root_name?: string;
+  sandbox_iframes?: boolean;
   schema?: SchemaType;
   selector?: string;
   setup?: SetupCallback;
@@ -336,6 +337,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   promotion: boolean;
   readonly: boolean;
   removed_menuitems: string;
+  sandbox_iframes: boolean;
   toolbar: boolean | string | string[] | Array<ToolbarGroup>;
   toolbar_groups: Record<string, Toolbar.GroupToolbarButtonSpec>;
   toolbar_location: ToolbarLocation;

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -86,6 +86,7 @@ interface BaseEditorOptions {
   contextmenu?: string | string[] | false;
   contextmenu_never_use_native?: boolean;
   convert_fonts_to_spans?: boolean;
+  convert_unsafe_embeds?: boolean;
   convert_urls?: boolean;
   custom_colors?: boolean;
   custom_elements?: string;
@@ -290,6 +291,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   color_default_foreground: string;
   content_css: string[];
   contextmenu: string[];
+  convert_unsafe_embeds: boolean;
   custom_colors: boolean;
   default_font_stack: string[];
   document_base_url: string;

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -836,6 +836,11 @@ const register = (editor: Editor): void => {
     default: 'off',
   });
 
+  registerOption('sandbox_iframes', {
+    processor: 'boolean',
+    default: false
+  });
+
   // These options must be registered later in the init sequence due to their default values
   editor.on('ScriptsLoaded', () => {
     registerOption('directionality', {
@@ -944,28 +949,16 @@ const shouldPreserveCData = option('preserve_cdata');
 const shouldHighlightOnFocus = option('highlight_on_focus');
 const shouldSanitizeXss = option('xss_sanitization');
 const shouldUseDocumentWrite = option('init_content_sync');
-
-const hasTextPatternsLookup = (editor: Editor): boolean =>
-  editor.options.isSet('text_patterns_lookup');
-
-const getFontStyleValues = (editor: Editor): string[] =>
-  Tools.explode(editor.options.get('font_size_style_values'));
-
-const getFontSizeClasses = (editor: Editor): string[] =>
-  Tools.explode(editor.options.get('font_size_classes'));
-
-const isEncodingXml = (editor: Editor): boolean =>
-  editor.options.get('encoding') === 'xml';
-
-const getAllowedImageFileTypes = (editor: Editor): string[] =>
-  Tools.explode(editor.options.get('images_file_types'));
-
+const hasTextPatternsLookup = (editor: Editor): boolean => editor.options.isSet('text_patterns_lookup');
+const getFontStyleValues = (editor: Editor): string[] => Tools.explode(editor.options.get('font_size_style_values'));
+const getFontSizeClasses = (editor: Editor): string[] => Tools.explode(editor.options.get('font_size_classes'));
+const isEncodingXml = (editor: Editor): boolean => editor.options.get('encoding') === 'xml';
+const getAllowedImageFileTypes = (editor: Editor): string[] => Tools.explode(editor.options.get('images_file_types'));
 const hasTableTabNavigation = option('table_tab_navigation');
-
 const getDetailsInitialState = option('details_initial_state');
 const getDetailsSerializedState = option('details_serialized_state');
-
 const shouldForceHexColor = option('force_hex_color');
+const shouldSandboxIframes = option('sandbox_iframes');
 
 export {
   register,
@@ -1071,5 +1064,6 @@ export {
   getDetailsInitialState,
   getDetailsSerializedState,
   shouldUseDocumentWrite,
-  shouldForceHexColor
+  shouldForceHexColor,
+  shouldSandboxIframes
 };

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -841,6 +841,11 @@ const register = (editor: Editor): void => {
     default: false
   });
 
+  registerOption('convert_unsafe_embeds', {
+    processor: 'boolean',
+    default: false
+  });
+
   // These options must be registered later in the init sequence due to their default values
   editor.on('ScriptsLoaded', () => {
     registerOption('directionality', {
@@ -959,6 +964,7 @@ const getDetailsInitialState = option('details_initial_state');
 const getDetailsSerializedState = option('details_serialized_state');
 const shouldForceHexColor = option('force_hex_color');
 const shouldSandboxIframes = option('sandbox_iframes');
+const shouldConvertUnsafeEmbeds = option('convert_unsafe_embeds');
 
 export {
   register,
@@ -1065,5 +1071,6 @@ export {
   getDetailsSerializedState,
   shouldUseDocumentWrite,
   shouldForceHexColor,
-  shouldSandboxIframes
+  shouldSandboxIframes,
+  shouldConvertUnsafeEmbeds
 };

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -57,6 +57,7 @@ export interface DomParserSettings {
   allow_unsafe_link_target?: boolean;
   blob_cache?: BlobCache;
   convert_fonts_to_spans?: boolean;
+  convert_unsafe_embeds?: boolean;
   document?: Document;
   fix_list_elements?: boolean;
   font_size_legacy_values?: string;

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -69,6 +69,7 @@ export interface DomParserSettings {
    * @deprecated Remove trailing <br> tags functionality has been added to tinymce.dom.Serializer and option will be removed in the next major release */
   remove_trailing_brs?: boolean;
   root_name?: string;
+  sandbox_iframes?: boolean;
   sanitize?: boolean;
   validate?: boolean;
 }

--- a/modules/tinymce/src/core/main/ts/content/PrePostProcess.ts
+++ b/modules/tinymce/src/core/main/ts/content/PrePostProcess.ts
@@ -2,7 +2,7 @@ import { Result } from '@ephox/katamari';
 
 import Editor from '../api/Editor';
 import * as Events from '../api/Events';
-import DomParser from '../api/html/DomParser';
+import DomParser, { DomParserSettings } from '../api/html/DomParser';
 import HtmlSerializer from '../api/html/Serializer';
 import * as Options from '../api/Options';
 import { EditorEvent } from '../api/util/EventDispatcher';
@@ -11,7 +11,7 @@ import { Content, GetContentArgs, isTreeNode, SetContentArgs } from './ContentTy
 const serializeContent = (content: Content): string =>
   isTreeNode(content) ? HtmlSerializer({ validate: false }).serialize(content) : content;
 
-const withSerializedContent = <R extends EditorEvent<{ content: string }>>(content: Content, fireEvent: (content: string) => R, sanitize: boolean): R & { content: Content } => {
+const withSerializedContent = <R extends EditorEvent<{ content: string }>>(content: Content, fireEvent: (content: string) => R, parserSettings: DomParserSettings): R & { content: Content } => {
   const serializedContent = serializeContent(content);
   const eventArgs = fireEvent(serializedContent);
   if (eventArgs.isDefaultPrevented()) {
@@ -20,7 +20,7 @@ const withSerializedContent = <R extends EditorEvent<{ content: string }>>(conte
     // Restore the content type back to being an AstNode. If the content has changed we need to
     // re-parse the new content, otherwise we can return the input.
     if (eventArgs.content !== serializedContent) {
-      const rootNode = DomParser({ validate: false, forced_root_block: false, sanitize }).parse(eventArgs.content, { context: content.name });
+      const rootNode = DomParser({ validate: false, forced_root_block: false, ...parserSettings }).parse(eventArgs.content, { context: content.name });
       return { ...eventArgs, content: rootNode };
     } else {
       return { ...eventArgs, content };
@@ -47,7 +47,7 @@ const postProcessGetContent = <T extends GetContentArgs>(editor: Editor, content
   if (args.no_events) {
     return content;
   } else {
-    const processedEventArgs = withSerializedContent(content, (content) => Events.fireGetContent(editor, { ...args, content }), Options.shouldSanitizeXss(editor));
+    const processedEventArgs = withSerializedContent(content, (content) => Events.fireGetContent(editor, { ...args, content }), { sanitize: Options.shouldSanitizeXss(editor), sandbox_iframes: Options.shouldSandboxIframes(editor) });
     return processedEventArgs.content;
   }
 };
@@ -56,7 +56,7 @@ const preProcessSetContent = <T extends SetContentArgs>(editor: Editor, args: T)
   if (args.no_events) {
     return Result.value(args);
   } else {
-    const processedEventArgs = withSerializedContent(args.content, (content) => Events.fireBeforeSetContent(editor, { ...args, content }), Options.shouldSanitizeXss(editor));
+    const processedEventArgs = withSerializedContent(args.content, (content) => Events.fireBeforeSetContent(editor, { ...args, content }), { sanitize: Options.shouldSanitizeXss(editor), sandbox_iframes: Options.shouldSandboxIframes(editor) });
     if (processedEventArgs.isDefaultPrevented()) {
       Events.fireSetContent(editor, processedEventArgs);
       return Result.error(undefined);

--- a/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
@@ -153,6 +153,10 @@ const register = (parser: DomParser, settings: DomParserSettings): void => {
   }
 
   registerBase64ImageFilter(parser, settings);
+
+  if (settings.sandbox_iframes) {
+    parser.addNodeFilter('iframe', (nodes) => Arr.each(nodes, (node) => node.attr('sandbox', '')));
+  }
 };
 
 export {

--- a/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserFilters.ts
@@ -1,4 +1,4 @@
-import { Arr, Type } from '@ephox/katamari';
+import { Arr, Strings, Type } from '@ephox/katamari';
 
 import Env from '../api/Env';
 import DomParser, { DomParserSettings } from '../api/html/DomParser';
@@ -30,6 +30,36 @@ const registerBase64ImageFilter = (parser: DomParser, settings: DomParserSetting
 
     parser.addAttributeFilter('src', (nodes) => Arr.each(nodes, processImage));
   }
+};
+
+const isMimeType = (mime: string, type: 'image' | 'video' | 'audio'): boolean => Strings.startsWith(mime, `${type}/`);
+
+const createSafeEmbed = (mime?: string, src?: string, width?: string, height?: string, sandboxIframes?: boolean): AstNode => {
+  let name: 'iframe' | 'img' | 'video' | 'audio';
+  if (Type.isUndefined(mime)) {
+    name = 'iframe';
+  } else if (isMimeType(mime, 'image')) {
+    name = 'img';
+  } else if (isMimeType(mime, 'video')) {
+    name = 'video';
+  } else if (isMimeType(mime, 'audio')) {
+    name = 'audio';
+  } else {
+    name = 'iframe';
+  }
+
+  const embed = new AstNode(name, 1);
+  embed.attr(name === 'audio' ? { src } : { src, width, height });
+
+  // TINY-10349: Show controls for audio and video so the replaced embed is visible in editor.
+  if (name === 'audio' || name === 'video') {
+    embed.attr('controls', '');
+  }
+
+  if (name === 'iframe' && sandboxIframes) {
+    embed.attr('sandbox', '');
+  }
+  return embed;
 };
 
 const register = (parser: DomParser, settings: DomParserSettings): void => {
@@ -153,6 +183,19 @@ const register = (parser: DomParser, settings: DomParserSettings): void => {
   }
 
   registerBase64ImageFilter(parser, settings);
+
+  if (settings.convert_unsafe_embeds) {
+    parser.addNodeFilter('object,embed', (nodes) => Arr.each(nodes, (node) => {
+      node.replace(
+        createSafeEmbed(
+          node.attr('type'),
+          node.name === 'object' ? node.attr('data') : node.attr('src'),
+          node.attr('width'),
+          node.attr('height'),
+          settings.sandbox_iframes
+        ));
+    }));
+  }
 
   if (settings.sandbox_iframes) {
     parser.addNodeFilter('iframe', (nodes) => Arr.each(nodes, (node) => node.attr('sandbox', '')));

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -70,6 +70,7 @@ const mkParserSettings = (editor: Editor): DomParserSettings => {
     allow_html_in_named_anchor: getOption('allow_html_in_named_anchor'),
     allow_script_urls: getOption('allow_script_urls'),
     allow_unsafe_link_target: getOption('allow_unsafe_link_target'),
+    convert_unsafe_embeds: getOption('convert_unsafe_embeds'),
     convert_fonts_to_spans: getOption('convert_fonts_to_spans'),
     fix_list_elements: getOption('fix_list_elements'),
     font_size_legacy_values: getOption('font_size_legacy_values'),

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -78,6 +78,7 @@ const mkParserSettings = (editor: Editor): DomParserSettings => {
     preserve_cdata: getOption('preserve_cdata'),
     inline_styles: getOption('inline_styles'),
     root_name: getRootName(editor),
+    sandbox_iframes: getOption('sandbox_iframes'),
     sanitize: getOption('xss_sanitization'),
     validate: true,
     blob_cache: blobCache,

--- a/modules/tinymce/src/core/main/ts/paste/ProcessFilters.ts
+++ b/modules/tinymce/src/core/main/ts/paste/ProcessFilters.ts
@@ -11,7 +11,7 @@ interface ProcessResult {
 }
 
 const preProcess = (editor: Editor, html: string): string => {
-  const parser = DomParser({ sanitize: Options.shouldSanitizeXss(editor) }, editor.schema);
+  const parser = DomParser({ sanitize: Options.shouldSanitizeXss(editor), sandbox_iframes: Options.shouldSandboxIframes(editor) }, editor.schema);
 
   // Strip meta elements
   parser.addNodeFilter('meta', (nodes) => {

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -457,7 +457,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
               testConversion(hook, '<embed src="about:blank">', '<iframe src="about:blank"></iframe>'));
           });
 
-          context('convert_unsafe_embeds: true and sandbox_iframes: true', () => {
+          context('convert_unsafe_embeds: true, sandbox_iframes: true', () => {
             const hook = TinyHooks.bddSetupLight<Editor>({
               ...options,
               base_url: '/project/tinymce/js/tinymce',

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1533,19 +1533,78 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       });
 
       context('Sandboxing iframes', () => {
-        const serializeIframeHtml = (sandbox?: boolean): string => {
+        const serializeIframeHtml = (sandbox: boolean): string => {
           const parser = DomParser({ ...scenario.settings, sandbox_iframes: sandbox });
           return serializer.serialize(parser.parse('<iframe src="about:blank"></iframe>'));
         };
-
-        it('TINY-10348: iframes should not be sandboxed by default', () =>
-          assert.equal(serializeIframeHtml(), '<iframe src="about:blank"></iframe>'));
 
         it('TINY-10348: iframes should be sandboxed when sandbox_iframes: false', () =>
           assert.equal(serializeIframeHtml(false), '<iframe src="about:blank"></iframe>'));
 
         it('TINY-10348: iframes should be sandboxed when sandbox_iframes: true', () =>
           assert.equal(serializeIframeHtml(true), '<iframe src="about:blank" sandbox=""></iframe>'));
+      });
+
+      context('Convert unsafe embeds', () => {
+        const serializeEmbedHtml = (embedHtml: string, convert: boolean): string => {
+          const parser = DomParser({ ...scenario.settings, convert_unsafe_embeds: convert });
+          return serializer.serialize(parser.parse(embedHtml));
+        };
+
+        context('convert_unsafe_embeds: false', () => {
+          const testNoConversion = (embedHtml: string) => () => {
+            const serializedHtml = serializeEmbedHtml(embedHtml, false);
+            assert.equal(serializedHtml, embedHtml);
+          };
+
+          it('TINY-10349: Object elements should not be converted', testNoConversion('<object data="about:blank"></object>'));
+          it('TINY-10349: Object elements with a mime type should not be converted', testNoConversion('<object data="about:blank" type="image/png"></object>'));
+          it('TINY-10349: Embed elements should notr be converted', testNoConversion('<embed src="about:blank">'));
+          it('TINY-10349: Embed elements with a mime type should not be converted', testNoConversion('<embed src="about:blank" type="image/png">'));
+        });
+
+        context('convert_unsafe_embeds: true', () => {
+          const testConversion = (embedHtml: string, expectedHtml: string) => () => {
+            const serializedHtml = serializeEmbedHtml(embedHtml, true);
+            assert.equal(serializedHtml, expectedHtml);
+          };
+
+          it('TINY-10349: Object elements without a mime type should be converted to iframe',
+            testConversion('<object data="about:blank"></object>', '<iframe src="about:blank"></iframe>'));
+          it('TINY-10349: Object elements with an image mime type should be converted to img',
+            testConversion('<object data="about:blank" type="image/png"></object>', '<img src="about:blank">'));
+          it('TINY-10349: Object elements with a video mime type should be converted to video',
+            testConversion('<object data="about:blank" type="video/mp4"></object>', '<video src="about:blank" controls=""></video>'));
+          it('TINY-10349: Object elements with an audio mime type should be converted to audio',
+            testConversion('<object data="about:blank" type="audio/mpeg"></object>', '<audio src="about:blank" controls=""></audio>'));
+          it('TINY-10349: Object elements with other mime type should be converted to iframe',
+            testConversion('<object data="about:blank" type="application/pdf"></object>', '<iframe src="about:blank"></iframe>'));
+
+          it('TINY-10349: Embed elements without a mime type should be converted to iframe',
+            testConversion('<embed src="about:blank">', '<iframe src="about:blank"></iframe>'));
+          it('TINY-10349: Embed elements with an image mime type should be converted to img',
+            testConversion('<embed src="about:blank" type="image/png">', '<img src="about:blank">'));
+          it('TINY-10349: Embed elements with a video mime type should be converted to video',
+            testConversion('<embed src="about:blank" type="video/mp4">', '<video src="about:blank" controls=""></video>'));
+          it('TINY-10349: Embed elements with an audio mime type should be converted to audio',
+            testConversion('<embed src="about:blank" type="audio/mpeg">', '<audio src="about:blank" controls=""></audio>'));
+          it('TINY-10349: Embed elements with other mime type should be converted to iframe',
+            testConversion('<embed src="about:blank" type="application/pdf">', '<iframe src="about:blank"></iframe>'));
+        });
+
+        context('convert_unsafe_embeds: true and sandbox_iframes: true', () => {
+          const testSandboxedConversion = (embedHtml: string, expectedHtml: string) => () => {
+            const parser = DomParser({ ...scenario.settings, convert_unsafe_embeds: true, sandbox_iframes: true });
+            const serializedHtml = serializer.serialize(parser.parse(embedHtml));
+            assert.equal(serializedHtml, expectedHtml);
+          };
+
+          it('TINY-10349: Object elements without a mime type should be converted to sandboxed iframe',
+            testSandboxedConversion('<object data="about:blank"></object>', '<iframe src="about:blank" sandbox=""></iframe>'));
+
+          it('TINY-10349: Embed elements without a mime type should be converted to sandboxed iframe',
+            testSandboxedConversion('<embed src="about:blank">', '<iframe src="about:blank" sandbox=""></iframe>'));
+        });
       });
     });
   });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1592,7 +1592,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
             testConversion('<embed src="about:blank" type="application/pdf">', '<iframe src="about:blank"></iframe>'));
         });
 
-        context('convert_unsafe_embeds: true and sandbox_iframes: true', () => {
+        context('convert_unsafe_embeds: true, sandbox_iframes: true', () => {
           const testSandboxedConversion = (embedHtml: string, expectedHtml: string) => () => {
             const parser = DomParser({ ...scenario.settings, convert_unsafe_embeds: true, sandbox_iframes: true });
             const serializedHtml = serializer.serialize(parser.parse(embedHtml));

--- a/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
@@ -91,7 +91,8 @@ const createPreviewNode = (editor: Editor, node: AstNode): AstNode => {
   if (name === 'iframe') {
     previewNode.attr({
       allowfullscreen: node.attr('allowfullscreen'),
-      frameborder: '0'
+      frameborder: '0',
+      sandbox: node.attr('sandbox')
     });
   } else {
     // Exclude autoplay as we don't want video/audio to play by default

--- a/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/ContentFormatsTest.ts
@@ -57,6 +57,24 @@ describe('browser.tinymce.plugins.media.ContentFormatsTest', () => {
     );
   });
 
+  it('TINY-10348: Iframe retained as is with sandbox_iframes: false', async () => {
+    const editor = await McEditor.pFromSettings({ ...settings, sandbox_iframes: false });
+    editor.setContent('<iframe src="320x240.ogg" allowfullscreen></iframe>');
+    TinyAssertions.assertContent(editor,
+      '<p><iframe src="320x240.ogg" width="300" height="150" allowfullscreen="allowfullscreen"></iframe></p>'
+    );
+    McEditor.remove(editor);
+  });
+
+  it('TINY-10348: Iframe retained as is with sandbox_iframes: true', async () => {
+    const editor = await McEditor.pFromSettings({ ...settings, sandbox_iframes: true });
+    editor.setContent('<iframe src="320x240.ogg" allowfullscreen></iframe>');
+    TinyAssertions.assertContent(editor,
+      '<p><iframe src="320x240.ogg" width="300" height="150" sandbox="" allowfullscreen="allowfullscreen"></iframe></p>'
+    );
+    McEditor.remove(editor);
+  });
+
   it('TBA: Iframe with innerHTML retained as is with xss_sanitization: false', async () => {
     // TINY-8363: Iframe with innerHTML is removed by DOMPurify, so disable sanitization for this test
     const editor = await McEditor.pFromSettings<Editor>({


### PR DESCRIPTION
Related Ticket: TINY-10348, TINY-10349

Description of Changes:
`sandbox_iframes` option
* `false` (default) is existing behavior
* `true` will add a `sandbox=""` attribute to all iframes given to the editor, and the live preview iframe generated by the Media plugin

`convert_unsafe_embeds` option
* `false` (default) is existing behavior
* `true` will convert unsafe `<object>` and `<embed>` embeds to different safer alternatives using the following rules:
  * Image MIME type: `<img>`
  * Video MIME type: `<video>`
  * Audio MIME type: `<audio>`
  * Other or no type specified: `<iframe>` - the `sandbox_iframes` option will also be respected when converting to iframes.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
