### PR TITLE
TINY-9287: Revert the changes to sliders since it caused a regression with editimage

### DIFF
--- a/modules/acid/src/demo/ts/ephox/acid/demo/Demo.ts
+++ b/modules/acid/src/demo/ts/ephox/acid/demo/Demo.ts
@@ -1,8 +1,7 @@
 import { Channels, Debugging, Gui, GuiFactory } from '@ephox/alloy';
-import { Fun, Optional, Type } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import { Class, DomEvent, Insert, SugarElement } from '@ephox/sugar';
 
-import { Untranslated } from 'ephox/acid/alien/I18n';
 import * as ColourPicker from 'ephox/acid/gui/ColourPicker';
 
 import { strings } from '../../../../i18n/en';
@@ -20,17 +19,12 @@ DomEvent.bind(SugarElement.fromDom(document), 'mouseup', (evt) => {
   }
 });
 
-const fakeTranslate = (key: Untranslated): string => {
-  if (Type.isString(key)) {
-    return Optional.from(strings[key]).getOrThunk(() => {
+const fakeTranslate = (key: string): string =>
+  Optional.from(strings[key]).getOrThunk(() => {
     // eslint-disable-next-line no-console
-      console.error('Missing translation for ' + key);
-      return key;
-    });
-  } else {
-    return 'Untranslated, complex string';
-  }
-};
+    console.error('Missing translation for ' + key);
+    return key;
+  });
 
 const colourPickerFactory = ColourPicker.makeFactory(fakeTranslate, Fun.identity);
 

--- a/modules/acid/src/main/ts/ephox/acid/alien/I18n.ts
+++ b/modules/acid/src/main/ts/ephox/acid/alien/I18n.ts
@@ -1,9 +1,0 @@
-export interface RawString {
-  raw: string;
-}
-
-type Primitive = string | number | boolean | Record<string | number, any> | Function;
-
-export type TokenisedString = [ string, ...Primitive[] ];
-
-export type Untranslated = Primitive | TokenisedString | RawString | null | undefined;

--- a/modules/acid/src/main/ts/ephox/acid/gui/ColourPicker.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/ColourPicker.ts
@@ -4,7 +4,6 @@ import {
 import { FieldSchema } from '@ephox/boulder';
 import { Arr, Cell, Fun } from '@ephox/katamari';
 
-import { Untranslated } from '../alien/I18n';
 import { Hex } from '../api/colour/ColourTypes';
 import * as HsvColour from '../api/colour/HsvColour';
 import * as RgbaColour from '../api/colour/RgbaColour';
@@ -30,7 +29,7 @@ export interface ColourPickerSketcher extends Sketcher.SingleSketch<ColourPicker
 }
 
 const makeFactory = (
-  translate: (key: Untranslated) => string,
+  translate: (key: string) => string,
   getClass: (key: string) => string
 ): ColourPickerSketcher => {
   const factory = (detail: ColourPickerDetail) => {

--- a/modules/acid/src/main/ts/ephox/acid/gui/components/HueSlider.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/HueSlider.ts
@@ -1,4 +1,4 @@
-import { AlloyComponent, AlloyTriggers, Behaviour, Focusing, SketchSpec, Slider } from '@ephox/alloy';
+import { AlloyComponent, AlloyTriggers, Behaviour, Focusing, SketchSpec, Slider, Tabstopping } from '@ephox/alloy';
 import { Fun } from '@ephox/katamari';
 import { Attribute } from '@ephox/sugar';
 
@@ -46,6 +46,7 @@ const sliderFactory = (translate: (key: string) => string, getClass: (key: strin
       thumb
     ],
     sliderBehaviours: Behaviour.derive([
+      Tabstopping.config({ }),
       Focusing.config({ })
     ]),
 

--- a/modules/acid/src/main/ts/ephox/acid/gui/components/HueSlider.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/HueSlider.ts
@@ -1,6 +1,5 @@
-import { AlloyComponent, AlloyTriggers, Behaviour, Focusing, SketchSpec, Slider, Tabstopping } from '@ephox/alloy';
+import { AlloyComponent, AlloyTriggers, Behaviour, Focusing, SketchSpec, Slider } from '@ephox/alloy';
 import { Fun } from '@ephox/katamari';
-import { Attribute } from '@ephox/sugar';
 
 import { sliderUpdate } from '../ColourEvents';
 
@@ -30,10 +29,7 @@ const sliderFactory = (translate: (key: string) => string, getClass: (key: strin
       tag: 'div',
       classes: [ getClass('hue-slider') ],
       attributes: {
-        'role': 'slider',
-        'aria-valuemin': 0,
-        'aria-valuemax': 360,
-        'aria-valuenow': 120,
+        role: 'presentation'
       }
     },
     rounded: false,
@@ -46,12 +42,10 @@ const sliderFactory = (translate: (key: string) => string, getClass: (key: strin
       thumb
     ],
     sliderBehaviours: Behaviour.derive([
-      Tabstopping.config({ }),
       Focusing.config({ })
     ]),
 
     onChange: (slider: AlloyComponent, _thumb: any, value: any) => {
-      Attribute.set(slider.element, 'aria-valuenow', Math.floor(360 - (value * 3.6)));
       AlloyTriggers.emitWith(slider, sliderUpdate, {
         value
       });

--- a/modules/acid/src/main/ts/ephox/acid/gui/components/SaturationBrightnessPalette.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/SaturationBrightnessPalette.ts
@@ -1,8 +1,6 @@
 import { AlloyComponent, AlloyTriggers, Behaviour, Composing, Focusing, Sketcher, SketchSpec, Slider, SliderTypes, UiSketcher } from '@ephox/alloy';
-import { Fun, Optional, Type } from '@ephox/katamari';
-import { Attribute } from '@ephox/sugar';
+import { Fun, Optional } from '@ephox/katamari';
 
-import { Untranslated } from '../../alien/I18n';
 import { Hex } from '../../api/colour/ColourTypes';
 import * as HsvColour from '../../api/colour/HsvColour';
 import * as RgbaColour from '../../api/colour/RgbaColour';
@@ -21,8 +19,7 @@ export interface SaturationBrightnessPaletteSketcher extends Sketcher.SingleSket
   setThumb: (slider: AlloyComponent, hex: Hex) => void;
 }
 
-const paletteFactory = (translate: (key: Untranslated) => string, getClass: (key: string) => string): SaturationBrightnessPaletteSketcher => {
-
+const paletteFactory = (_translate: (key: string) => string, getClass: (key: string) => string): SaturationBrightnessPaletteSketcher => {
   const spectrumPart = Slider.parts.spectrum({
     dom: {
       tag: 'canvas',
@@ -77,7 +74,6 @@ const paletteFactory = (translate: (key: Untranslated) => string, getClass: (key
   const setPaletteThumb = (slider: AlloyComponent, hex: Hex): void => {
     const hsv = HsvColour.fromRgb(RgbaColour.fromHex(hex));
     Slider.setValue(slider, { x: hsv.saturation, y: 100 - hsv.value });
-    Attribute.set(slider.element, 'aria-valuetext', translate([ 'Saturation {0}%, Brightness {1}%', hsv.saturation, hsv.value ]));
   };
 
   const factory: UiSketcher.SingleSketchFactory<SaturationBrightnessPaletteDetail, SaturationBrightnessPaletteSpec> = (_detail): SketchSpec => {
@@ -87,9 +83,6 @@ const paletteFactory = (translate: (key: Untranslated) => string, getClass: (key
     });
 
     const onChange = (slider: AlloyComponent, _thumb: AlloyComponent, value: number | SliderTypes.SliderValue) => {
-      if (!Type.isNumber(value)) {
-        Attribute.set(slider.element, 'aria-valuetext', translate([ 'Saturation {0}%, Brightness {1}%', Math.floor(value.x), Math.floor(100 - value.y) ]));
-      }
       AlloyTriggers.emitWith(slider, ColourEvents.paletteUpdate, {
         value
       });
@@ -111,8 +104,7 @@ const paletteFactory = (translate: (key: Untranslated) => string, getClass: (key
       dom: {
         tag: 'div',
         attributes: {
-          'role': 'slider',
-          'aria-valuetext': translate([ 'Saturation {0}%, Brightness {1}%', 0, 0 ])
+          role: 'presentation'
         },
         classes: [ getClass('sv-palette') ]
       },

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/HorizontalModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/HorizontalModel.ts
@@ -57,15 +57,15 @@ const setToMax = (spectrum: AlloyComponent, detail: HorizontalSliderDetail): voi
 };
 
 // move in a direction by step size. Fire change at the end
-const moveBy = (direction: number, spectrum: AlloyComponent, detail: HorizontalSliderDetail, useMultiplier?: boolean): Optional<number> => {
+const moveBy = (direction: number, spectrum: AlloyComponent, detail: HorizontalSliderDetail): Optional<number> => {
   const f = (direction > 0) ? SliderModel.increaseBy : SliderModel.reduceBy;
-  const xValue = f(currentValue(detail), minX(detail), maxX(detail), step(detail, useMultiplier));
+  const xValue = f(currentValue(detail), minX(detail), maxX(detail), step(detail));
   fireSliderChange(spectrum, xValue);
   return Optional.some(xValue);
 };
 
-const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail: HorizontalSliderDetail, useMultiplier?: boolean): Optional<boolean> =>
-  moveBy(direction, spectrum, detail, useMultiplier).map<boolean>(Fun.always);
+const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail: HorizontalSliderDetail): Optional<boolean> =>
+  moveBy(direction, spectrum, detail).map<boolean>(Fun.always);
 
 // get x offset from event
 const getValueFromEvent = (simulatedEvent: NativeSimulatedEvent<MouseEvent | TouchEvent>): Optional<number> => {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderParts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderParts.ts
@@ -5,13 +5,11 @@ import { EventArgs, SugarPosition } from '@ephox/sugar';
 import * as Behaviour from '../../api/behaviour/Behaviour';
 import { Focusing } from '../../api/behaviour/Focusing';
 import { Keying } from '../../api/behaviour/Keying';
-import { Tabstopping } from '../../api/behaviour/Tabstopping';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { OptionalDomSchema } from '../../api/component/SpecTypes';
 import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as NativeEvents from '../../api/events/NativeEvents';
 import { NativeSimulatedEvent } from '../../events/SimulatedEvent';
-import * as KeyMatch from '../../navigation/KeyMatch';
 import * as PartType from '../../parts/PartType';
 import { EdgeActions, SliderDetail } from '../types/SliderTypes';
 
@@ -92,8 +90,6 @@ const thumbPart = PartType.required<SliderDetail, { dom: OptionalDomSchema; even
   }
 });
 
-const isShift = (event: NativeSimulatedEvent<KeyboardEvent>) => KeyMatch.isShift(event.event);
-
 const spectrumPart = PartType.required({
   schema: [
     FieldSchema.customField('mouseIsDown', () => Cell(false))
@@ -112,13 +108,12 @@ const spectrumPart = PartType.required({
         Keying.config(
           {
             mode: 'special',
-            onLeft: (spectrum, event) => model.onLeft(spectrum, detail, isShift(event)),
-            onRight: (spectrum, event) => model.onRight(spectrum, detail, isShift(event)),
-            onUp: (spectrum, event) => model.onUp(spectrum, detail, isShift(event)),
-            onDown: (spectrum, event) => model.onDown(spectrum, detail, isShift(event))
+            onLeft: (spectrum) => model.onLeft(spectrum, detail),
+            onRight: (spectrum) => model.onRight(spectrum, detail),
+            onUp: (spectrum) => model.onUp(spectrum, detail),
+            onDown: (spectrum) => model.onDown(spectrum, detail)
           }
         ),
-        Tabstopping.config({ }),
         Focusing.config({})
       ]),
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderSchema.ts
@@ -18,7 +18,6 @@ interface SliderModelSpec {
 
 const SliderSchema: FieldProcessor[] = [
   FieldSchema.defaulted('stepSize', 1),
-  FieldSchema.defaulted('speedMultiplier', 10),
   FieldSchema.defaulted('onChange', Fun.noop),
   FieldSchema.defaulted('onChoose', Fun.noop),
   FieldSchema.defaulted('onInit', Fun.noop),

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderUi.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderUi.ts
@@ -1,5 +1,4 @@
-import { Optional } from '@ephox/katamari';
-import { EventArgs } from '@ephox/sugar';
+import { Fun, Optional } from '@ephox/katamari';
 
 import { Keying } from '../../api/behaviour/Keying';
 import { Receiving } from '../../api/behaviour/Receiving';
@@ -87,10 +86,6 @@ const sketch: CompositeSketchFactory<SliderDetail, SliderSpec> = (detail: Slider
     choose(slider);
   };
 
-  const focusWidget = (component: AlloyComponent) => {
-    AlloyParts.getPart(component, detail, 'spectrum').map(Keying.focusIn);
-  };
-
   return {
     uid: detail.uid,
     dom: detail.dom,
@@ -101,7 +96,9 @@ const sketch: CompositeSketchFactory<SliderDetail, SliderSpec> = (detail: Slider
       [
         Keying.config({
           mode: 'special',
-          focusIn: focusWidget
+          focusIn: (slider) => {
+            return AlloyParts.getPart(slider, detail, 'spectrum').map(Keying.focusIn).map(Fun.always);
+          }
         }),
         Representing.config({
           store: {
@@ -142,8 +139,7 @@ const sketch: CompositeSketchFactory<SliderDetail, SliderSpec> = (detail: Slider
       AlloyEvents.run(NativeEvents.touchstart(), onDragStart),
       AlloyEvents.run(NativeEvents.touchend(), onDragEnd),
       AlloyEvents.run(NativeEvents.mousedown(), onDragStart),
-      AlloyEvents.run(NativeEvents.mouseup(), onDragEnd),
-      AlloyEvents.run<EventArgs>(NativeEvents.mousedown(), focusWidget)
+      AlloyEvents.run(NativeEvents.mouseup(), onDragEnd)
     ]),
 
     apis: {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderValues.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderValues.ts
@@ -30,7 +30,7 @@ const yRange = (detail: VerticalSliderDetail): number => range(detail, maxY, min
 const halfX = (detail: HorizontalSliderDetail): number => xRange(detail) / 2;
 const halfY = (detail: VerticalSliderDetail): number => yRange(detail) / 2;
 
-const step = (detail: SliderDetail, useMultiplier?: boolean): number => useMultiplier ? detail.stepSize * detail.speedMultiplier : detail.stepSize;
+const step = (detail: SliderDetail): number => detail.stepSize;
 const snap = (detail: SliderDetail): boolean => detail.snapToGrid;
 const snapStart = (detail: SliderDetail): Optional<number> => detail.snapStart;
 const rounded = (detail: SliderDetail): boolean => detail.rounded;

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/TwoDModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/TwoDModel.ts
@@ -33,19 +33,19 @@ const setValueFrom = (spectrum: AlloyComponent, detail: TwoDSliderDetail, value:
 };
 
 // move in a direction by step size. Fire change at the end
-const moveBy = (direction: number, isVerticalMovement: boolean, spectrum: AlloyComponent, detail: TwoDSliderDetail, useMultiplier?: boolean): Optional<number> => {
+const moveBy = (direction: number, isVerticalMovement: boolean, spectrum: AlloyComponent, detail: TwoDSliderDetail): Optional<number> => {
   const f = (direction > 0) ? SliderModel.increaseBy : SliderModel.reduceBy;
   const xValue = isVerticalMovement ? currentValue(detail).x :
-    f(currentValue(detail).x, minX(detail), maxX(detail), step(detail, useMultiplier));
+    f(currentValue(detail).x, minX(detail), maxX(detail), step(detail));
   const yValue = !isVerticalMovement ? currentValue(detail).y :
-    f(currentValue(detail).y, minY(detail), maxY(detail), step(detail, useMultiplier));
+    f(currentValue(detail).y, minY(detail), maxY(detail), step(detail));
 
   fireSliderChange(spectrum, sliderValue(xValue, yValue));
   return Optional.some(xValue);
 };
 
-const handleMovement = (direction: number, isVerticalMovement: boolean) => (spectrum: AlloyComponent, detail: TwoDSliderDetail, useMultiplier?: boolean): Optional<boolean> =>
-  moveBy(direction, isVerticalMovement, spectrum, detail, useMultiplier).map<boolean>(Fun.always);
+const handleMovement = (direction: number, isVerticalMovement: boolean) => (spectrum: AlloyComponent, detail: TwoDSliderDetail): Optional<boolean> =>
+  moveBy(direction, isVerticalMovement, spectrum, detail).map<boolean>(Fun.always);
 
 // fire a slider change event with the minimum value
 const setToMin = (spectrum: AlloyComponent, detail: TwoDSliderDetail): void => {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/VerticalModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/VerticalModel.ts
@@ -57,15 +57,15 @@ const setToMax = (spectrum: AlloyComponent, detail: VerticalSliderDetail): void 
 };
 
 // move in a direction by step size. Fire change at the end
-const moveBy = (direction: number, spectrum: AlloyComponent, detail: VerticalSliderDetail, useMultiplier?: boolean): Optional<number> => {
+const moveBy = (direction: number, spectrum: AlloyComponent, detail: VerticalSliderDetail): Optional<number> => {
   const f = (direction > 0) ? SliderModel.increaseBy : SliderModel.reduceBy;
-  const yValue = f(currentValue(detail), minY(detail), maxY(detail), step(detail, useMultiplier));
+  const yValue = f(currentValue(detail), minY(detail), maxY(detail), step(detail));
   fireSliderChange(spectrum, yValue);
   return Optional.some(yValue);
 };
 
-const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail: VerticalSliderDetail, useMultiplier?: boolean): Optional<boolean> =>
-  moveBy(direction, spectrum, detail, useMultiplier).map<boolean>(Fun.always);
+const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail: VerticalSliderDetail): Optional<boolean> =>
+  moveBy(direction, spectrum, detail).map<boolean>(Fun.always);
 
 // get y offset from event
 const getValueFromEvent = (simulatedEvent: NativeSimulatedEvent<MouseEvent | TouchEvent>): Optional<number> => {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/SliderTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/SliderTypes.ts
@@ -48,10 +48,10 @@ export interface Manager {
   setToMax: (spectrum: AlloyComponent, detail: SliderDetail) => void;
   getValueFromEvent: (simulatedEvent: NativeSimulatedEvent<MouseEvent | TouchEvent>) => Optional<number | SugarPosition>;
   setPositionFromValue: (slider: AlloyComponent, thumb: AlloyComponent, detail: SliderDetail, parts: SliderModelDetailParts) => void;
-  onLeft: (spectrum: AlloyComponent, detail: SliderDetail, useMultiplier?: boolean) => Optional<boolean>;
-  onRight: (spectrum: AlloyComponent, detail: SliderDetail, useMultiplier?: boolean) => Optional<boolean>;
-  onUp: (spectrum: AlloyComponent, detail: SliderDetail, useMultiplier?: boolean) => Optional<boolean>;
-  onDown: (spectrum: AlloyComponent, detail: SliderDetail, useMultiplier?: boolean) => Optional<boolean>;
+  onLeft: (spectrum: AlloyComponent, detail: SliderDetail) => Optional<boolean>;
+  onRight: (spectrum: AlloyComponent, detail: SliderDetail) => Optional<boolean>;
+  onUp: (spectrum: AlloyComponent, detail: SliderDetail) => Optional<boolean>;
+  onDown: (spectrum: AlloyComponent, detail: SliderDetail) => Optional<boolean>;
   edgeActions: EdgeActions;
 }
 
@@ -91,7 +91,6 @@ export interface SliderDetail extends CompositeSketchDetail {
   model: SliderModelDetail;
   rounded: boolean;
   stepSize: number;
-  speedMultiplier: number;
   snapToGrid: boolean;
   snapStart: Optional<number>;
 

--- a/modules/oxide/src/less/theme/components/color-picker/color-picker.less
+++ b/modules/oxide/src/less/theme/components/color-picker/color-picker.less
@@ -61,11 +61,6 @@
     width: 20px;
   }
 
-  .tox-hue-slider-spectrum:focus,
-  .tox-sv-palette-spectrum:focus {
-    outline: #08f solid;
-  }
-
   .tox-hue-slider-thumb {
     background: white;
     border: 1px solid black;

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Improved
-- Colorpicker now includes the Brightness/Saturation selector and hue slider in the keyboard navigable items. #TINY-9287
 - Improved the tooltips of picker buttons for the urlinput components in the "Insert/Edit Image" and "Insert/Edit Link" dialogs. #TINY-10155
 - Inline dialog will now respect `size: 'large'` argument in the dialog spec. #TINY-10209
 - SVG elements and their children are now retained when configured as valid elements. #TINY-10237

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
@@ -1,9 +1,7 @@
 import { ColourPicker } from '@ephox/acid';
 import { AlloyComponent, AlloyTriggers, Behaviour, Composing, Form, Memento, NativeEvents, Representing, SimpleSpec } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Arr, Optional, Strings, Type } from '@ephox/katamari';
-
-import { Untranslated } from 'tinymce/core/api/util/I18n';
+import { Arr, Optional, Strings } from '@ephox/katamari';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
@@ -24,12 +22,8 @@ const english: Record<string, string> = {
   'aria.input.invalid': 'Invalid input'
 };
 
-const translate = (providerBackstage: UiFactoryBackstageProviders) => (key: Untranslated) => {
-  if (Type.isString(key)) {
-    return providerBackstage.translate(english[key]);
-  } else {
-    return providerBackstage.translate(key);
-  }
+const translate = (providerBackstage: UiFactoryBackstageProviders) => (key: string) => {
+  return providerBackstage.translate(english[key]);
 };
 
 type ColorPickerSpec = Omit<Dialog.ColorPicker, 'type'>;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -1,4 +1,4 @@
-import { FocusTools, Keys, Mouse, UiFinder, Waiter } from '@ephox/agar';
+import { FocusTools, Keys, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
 import { Attribute, SelectorFilter, SugarDocument, SugarElement, SugarShadowDom } from '@ephox/sugar';
@@ -200,38 +200,6 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         await FocusTools.pTryOnSelector('Should have selected the hue slider', doc, '.tox-hue-slider-spectrum');
         TinyUiActions.keydown(editor, Keys.tab());
         await FocusTools.pTryOnSelector('Should have selected the next input', doc, '.tox-textfield');
-        await pCancelDialog(editor);
-      });
-
-      it('TINY-9287: Keyboard tab navigation works as expected, starting at the canvas, shift-tab should go backwards', async () => {
-        const editor = hook.editor();
-        const elem = TinyDom.targetElement(editor);
-        const doc = SugarShadowDom.getShadowRoot(elem).getOrThunk(() => SugarDocument.getDocument());
-        await pOpenDialog(editor);
-        await FocusTools.pTryOnSelector('Should have selected the main view', doc, 'canvas');
-        TinyUiActions.keydown(editor, Keys.tab());
-        await FocusTools.pTryOnSelector('Should have selected the hue slider', doc, '.tox-hue-slider-spectrum');
-        TinyUiActions.keydown(editor, Keys.tab());
-        await FocusTools.pTryOnSelector('Should have selected the next input', doc, '.tox-textfield');
-        TinyUiActions.keydown(editor, Keys.tab(), { shiftKey: true });
-        await FocusTools.pTryOnSelector('Should have selected the hue slider', doc, '.tox-hue-slider-spectrum');
-        TinyUiActions.keydown(editor, Keys.tab(), { shiftKey: true });
-        await FocusTools.pTryOnSelector('Should have selected the main view', doc, 'canvas');
-        await pCancelDialog(editor);
-      });
-
-      it('TINY-9287: Clicking changes focus as expected', async () => {
-        const editor = hook.editor();
-        const element = TinyDom.targetElement(editor);
-        const doc = SugarShadowDom.getShadowRoot(element).getOrThunk(() => SugarDocument.getDocument());
-        await pOpenDialog(editor);
-        await FocusTools.pTryOnSelector('Should have started on the main view', doc, 'canvas');
-        let targetElement = UiFinder.findIn(TinyUiActions.getUiRoot(editor), '.tox-hue-slider-spectrum').getOrDie();
-        Mouse.mouseDown(targetElement);
-        await FocusTools.pTryOnSelector('Should have selected the hue slider', doc, '.tox-hue-slider-spectrum');
-        targetElement = UiFinder.findIn(TinyUiActions.getUiRoot(editor), 'canvas').getOrDie();
-        Mouse.mouseDown(targetElement);
-        await FocusTools.pTryOnSelector('Should have ended on the main view', doc, 'canvas');
         await pCancelDialog(editor);
       });
     });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -1,7 +1,7 @@
-import { FocusTools, Keys, UiFinder, Waiter } from '@ephox/agar';
+import { UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
-import { Attribute, SelectorFilter, SugarDocument, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { SelectorFilter, SugarElement, SugarShadowDom } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -117,13 +117,6 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         await Waiter.pTryUntil('Dialog should close', () => UiFinder.notExists(getBody(editor), dialogSelector));
       };
 
-      const assertAriaValues = (editor: Editor, hue: number, saturation: number, brightness: number) => {
-        const palette = UiFinder.findIn(getBody(editor), '.tox-sv-palette').getOrDie();
-        const slider = UiFinder.findIn(getBody(editor), '.tox-hue-slider').getOrDie();
-        assert.equal(Attribute.get(palette, 'aria-valuetext'), `Saturation ${saturation}%, Brightness ${brightness}%`);
-        assert.equal(Attribute.get(slider, 'aria-valuenow'), '' + hue);
-      };
-
       it('TBA: Open dialog, click Save and assert color is white', async () => {
         const editor = hook.editor();
         await pOpenDialog(editor);
@@ -146,13 +139,11 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         // Change color to black
         await pOpenDialog(editor);
         await pSetHexBlack(editor);
-        assertAriaValues(editor, 120, 0, 0);
         TinyUiActions.submitDialog(editor);
         await pWaitForDialogClose(editor);
         // Change color in the dialog but cancel
         await pOpenDialog(editor);
         await pSetHexWhite(editor);
-        assertAriaValues(editor, 120, 0, 100);
         await pCancelDialog(editor);
         assertColorBlack();
       });
@@ -188,19 +179,6 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         await pSetHex('invalid')(editor);
         TinyUiActions.submitDialog(editor);
         await pAssertExpectedAlert(editor, 'Invalid hex color code: #invalid');
-      });
-
-      it('TINY-9287: Keyboard tab navigation works as expected, starting at the canvas', async () => {
-        const editor = hook.editor();
-        const elem = TinyDom.targetElement(editor);
-        const doc = SugarShadowDom.getShadowRoot(elem).getOrThunk(() => SugarDocument.getDocument());
-        await pOpenDialog(editor);
-        await FocusTools.pTryOnSelector('Should have selected the main view', doc, 'canvas');
-        TinyUiActions.keydown(editor, Keys.tab());
-        await FocusTools.pTryOnSelector('Should have selected the hue slider', doc, '.tox-hue-slider-spectrum');
-        TinyUiActions.keydown(editor, Keys.tab());
-        await FocusTools.pTryOnSelector('Should have selected the next input', doc, '.tox-textfield');
-        await pCancelDialog(editor);
       });
     });
   });


### PR DESCRIPTION
Related Ticket: TINY-9287

Description of Changes:
* Reverted the two changes made by TINY-9287 since it was causing a regression with the `editimage` plugin

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
