### PR TITLE
TINY-9881: Prepare for 6.8.0 Community Release

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ Tiny Technologies, Inc. supports the following community versions of TinyMCE:
 
 | Version | Supported                      |
 |---------| ------------------------------ |
-| 6.7.x   | &#10004;                       |
+| 6.8.x   | &#10004;                       |
 | 5.10.x  | &#10006;                       |
 | Other   | &#10006;                       |
 

--- a/modules/acid/CHANGELOG.md
+++ b/modules/acid/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 6.0.0 - 2023-11-22
+
 ### Changed
 - Updated alloy to latest major. #TINY-10275
 

--- a/modules/acid/package.json
+++ b/modules/acid/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@ephox/acid",
   "description": "Color library including Alloy UI component for a color picker",
-  "version": "5.2.1",
+  "version": "6.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
     "directory": "modules/acid"
   },
   "dependencies": {
-    "@ephox/alloy": "^14.0.0-alpha.0",
+    "@ephox/alloy": "^14.0.0",
     "@ephox/boulder": "^7.1.5",
     "@ephox/katamari": "^9.1.5",
-    "@ephox/sugar": "^9.2.1"
+    "@ephox/sugar": "^9.3.0"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",

--- a/modules/agar/CHANGELOG.md
+++ b/modules/agar/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 8.0.0 - 2023-11-22
+
 ### Added
 - Added `Clipboard.pPasteUrlItems` API to paste url files as clipboard items. #TINY-10275
 - Added `Files.getFileDataAsString` API to make it easier to get file data out for testing. #TINY-10275

--- a/modules/agar/package.json
+++ b/modules/agar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/agar",
-  "version": "8.0.0-alpha.0",
+  "version": "8.0.0",
   "description": "Testing infrastructure",
   "repository": {
     "type": "git",
@@ -28,7 +28,7 @@
     "@ephox/bedrock-common": "11 || 12 || 13",
     "@ephox/jax": "^7.0.9",
     "@ephox/sand": "^6.0.9",
-    "@ephox/sugar": "^9.2.1",
+    "@ephox/sugar": "^9.3.0",
     "@types/sizzle": "^2.3.3",
     "fast-check": "^2.0.0",
     "sizzle": "^2.3.4"

--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 14.0.0 - 2023-11-22
+
 ### Changed
 - Updated agar to latest major. #TINY-10275
 

--- a/modules/alloy/package.json
+++ b/modules/alloy/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@ephox/alloy",
-  "version": "14.0.0-alpha.0",
+  "version": "14.0.0",
   "description": "Ui Framework",
   "dependencies": {
-    "@ephox/agar": "^8.0.0-alpha.0",
+    "@ephox/agar": "^8.0.0",
     "@ephox/boulder": "^7.1.5",
     "@ephox/katamari": "^9.1.5",
     "@ephox/sand": "^6.0.9",
-    "@ephox/sugar": "^9.2.1"
+    "@ephox/sugar": "^9.3.0"
   },
   "files": [
     "lib/main",

--- a/modules/boss/package.json
+++ b/modules/boss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/boss",
   "description": "Generic wrapper to document models - DomUniverse vs TestUniverse",
-  "version": "6.0.9",
+  "version": "6.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "@ephox/katamari": "^9.1.5",
-    "@ephox/sugar": "^9.2.1"
+    "@ephox/sugar": "^9.3.0"
   },
   "devDependencies": {
     "@ephox/katamari-assertions": "^4.0.9"

--- a/modules/bridge/CHANGELOG.md
+++ b/modules/bridge/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 4.7.0 - 2023-11-22
+
 ### Added
 - Added `setTooltip` function to `ToolbarSplitButtonInstanceApi` and `NestedMenuItemInstanceApi`. #TINY-9796
 - Added `picker_text` optional property to `UrlInputSpec`. #TINY-10155

--- a/modules/bridge/package.json
+++ b/modules/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/bridge",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "Ui API for TinyMCE 5",
   "repository": {
     "type": "git",

--- a/modules/darwin/package.json
+++ b/modules/darwin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/darwin",
   "description": "This project's purpose is to handle selection and cursor navigation.",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -20,11 +20,11 @@
   ],
   "dependencies": {
     "@ephox/katamari": "^9.1.5",
-    "@ephox/phoenix": "^8.3.0",
-    "@ephox/robin": "^10.3.0",
+    "@ephox/phoenix": "^8.4.0",
+    "@ephox/robin": "^10.4.0",
     "@ephox/sand": "^6.0.9",
-    "@ephox/snooker": "^11.1.0",
-    "@ephox/sugar": "^9.2.1"
+    "@ephox/snooker": "^11.2.0",
+    "@ephox/sugar": "^9.3.0"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",

--- a/modules/dragster/package.json
+++ b/modules/dragster/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/dragster",
   "description": "This project handles dragging.",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -21,7 +21,7 @@
   "dependencies": {
     "@ephox/katamari": "^9.1.5",
     "@ephox/porkbun": "^7.0.9",
-    "@ephox/sugar": "^9.2.1"
+    "@ephox/sugar": "^9.3.0"
   },
   "scripts": {
     "test": "bedrock-auto -b chrome-headless -d src/test",

--- a/modules/mcagar/CHANGELOG.md
+++ b/modules/mcagar/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 9.0.0 - 2023-11-22
+
 ### Changed
 - Updated agar to latest major. #TINY-10275
 

--- a/modules/mcagar/package.json
+++ b/modules/mcagar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/mcagar",
-  "version": "9.0.0-alpha.0",
+  "version": "9.0.0",
   "description": "Tinymce agar wrapper",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",
   "dependencies": {
-    "@ephox/agar": "^8.0.0-alpha.0",
+    "@ephox/agar": "^8.0.0",
     "@ephox/katamari": "^9.1.5",
     "@ephox/sand": "^6.0.9",
-    "@ephox/sugar": "^9.2.1",
+    "@ephox/sugar": "^9.3.0",
     "fast-check": "^2.0.0"
   },
   "peerDependencies": {

--- a/modules/oxide/package.json
+++ b/modules/oxide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/oxide",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "TinyMCE 5 Oxide skin",
   "repository": {
     "type": "git",

--- a/modules/phoenix/package.json
+++ b/modules/phoenix/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/phoenix",
   "description": "DOM node text gathering library, rose from the ashes of some other projects we can't remember the names of now (edit: seek, sherlock, gift)",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -19,10 +19,10 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/boss": "^6.0.9",
+    "@ephox/boss": "^6.1.0",
     "@ephox/katamari": "^9.1.5",
     "@ephox/polaris": "^6.3.0",
-    "@ephox/sugar": "^9.2.1"
+    "@ephox/sugar": "^9.3.0"
   },
   "devDependencies": {
     "@ephox/katamari-assertions": "^4.0.9"

--- a/modules/robin/package.json
+++ b/modules/robin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/robin",
   "description": "This project is for grouping sibling DOM nodes together by boundary points, for example the list of elements and nodes representing a word.",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinymce/tinymce.git",
@@ -19,11 +19,11 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@ephox/boss": "^6.0.9",
+    "@ephox/boss": "^6.1.0",
     "@ephox/katamari": "^9.1.5",
-    "@ephox/phoenix": "^8.3.0",
+    "@ephox/phoenix": "^8.4.0",
     "@ephox/polaris": "^6.3.0",
-    "@ephox/sugar": "^9.2.1"
+    "@ephox/sugar": "^9.3.0"
   },
   "devDependencies": {
     "@ephox/katamari-assertions": "^4.0.9"

--- a/modules/snooker/package.json
+++ b/modules/snooker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ephox/snooker",
   "description": "This project implements the table model.",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "files": [
     "lib/main",
     "lib/demo",
@@ -19,11 +19,11 @@
     "directory": "modules/snooker"
   },
   "dependencies": {
-    "@ephox/dragster": "^7.2.1",
+    "@ephox/dragster": "^7.3.0",
     "@ephox/katamari": "^9.1.5",
     "@ephox/porkbun": "^7.0.9",
-    "@ephox/robin": "^10.3.0",
-    "@ephox/sugar": "^9.2.1"
+    "@ephox/robin": "^10.4.0",
+    "@ephox/sugar": "^9.3.0"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "MIT",

--- a/modules/sugar/CHANGELOG.md
+++ b/modules/sugar/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 9.3.0 - 2023-11-22
+
 ### Improved
 - The `Focus.focus` function now takes an additional `preventScroll` parameter to allow focus on an element without scrolling.
 

--- a/modules/sugar/package.json
+++ b/modules/sugar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ephox/sugar",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Basic DOM manipulation",
   "repository": {
     "type": "git",

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 6.8.0 - 2023-11-22
+
 ### Added
 - CSS files are now also generated as separate JS files to improve bundling of all resources. #TINY-10352
 - Added new `StylesheetLoader.loadRawCss` API that can be used to load CSS into a style element. #TINY-10352

--- a/versions.txt
+++ b/versions.txt
@@ -1,9 +1,3 @@
 # List of packages to bump:
 # Format: [package_name]@[new_version]
 
-acid@6.0.0
-agar@8.0.0
-mcagar@9.0.0
-alloy@14.0.0
-bridge@4.7.0
-sugar@9.3.0


### PR DESCRIPTION
Related Ticket: TINY-9881

Description of Changes:
* Updated versions and changelogs
* Bumped the oxide version to 2.8 even though there are no changes it still needs to be in sync with the oxide-premium-skins version that we need to release due to the new bundling feature (new .js files in the distribution)
* We bumped the versions of things that depend on sugar to a minor since the sugar version was a minor.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
