### PR TITLE
TINY-10314: Fix mutiple caret display on Firefox

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Accessible names of bespoke select toolbar buttons including `align`, `fontfamily`, `fontsize`, `blocks`, and `styles` were incorrectly translated. #TINY-10426 #TINY-10435
 - Clicking inside table cells with heavily nested content could cause the browser to hang. #TINY-10380
 - Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10414
+- By clicking to the left or right of a non-editable `div` in Firefox we get 2 carets. #TINY-10314
 
 ## 6.8.1 - 2023-11-29
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Accessible names of bespoke select toolbar buttons including `align`, `fontfamily`, `fontsize`, `blocks`, and `styles` were incorrectly translated. #TINY-10426 #TINY-10435
 - Clicking inside table cells with heavily nested content could cause the browser to hang. #TINY-10380
 - Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10414
-- By clicking to the left or right of a non-editable `div` in Firefox we get 2 carets. #TINY-10314
+- Clicking to the left or right of a non-editable `div` in Firefox would show two cursors. #TINY-10314
 
 ## 6.8.1 - 2023-11-29
 

--- a/modules/tinymce/src/core/main/ts/caret/FakeCaret.ts
+++ b/modules/tinymce/src/core/main/ts/caret/FakeCaret.ts
@@ -114,6 +114,7 @@ export const FakeCaret = (editor: Editor, root: HTMLElement, isBlock: (node: Nod
       const caretContainer = CaretContainer.insertBlock(caretBlock, element, before);
       const clientRect = getAbsoluteClientRect(root, element, before);
       dom.setStyle(caretContainer, 'top', clientRect.top);
+      dom.setStyle(caretContainer, 'caret-color', 'transparent');
       caretContainerNode = caretContainer;
 
       const caret = dom.create('div', { 'class': 'mce-visual-caret', 'data-mce-bogus': 'all' });

--- a/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretTest.ts
@@ -123,7 +123,7 @@ describe('browser.tinymce.core.caret.FakeCaretTest', () => {
     assert.equal(isFakeCaretTarget(createElement('<table></table>').dom), isFakeCaretTableBrowser(), 'Should on some browsers need a fake caret');
   });
 
-  it('TINY-10314: fakeCaretContainer after/before a block should have caret-color setted to `transparent` to avoid double caret in FireFox', () => {
+  it('TINY-10314: fakeCaretContainer after/before a block should have caret-color set to `transparent` to avoid double caret in FireFox', () => {
     Arr.each([ true, false ], (before) => {
       Html.set(getRoot(), '<div>a</div><div id="nonEditable" contenteditable="false">b</div>');
 


### PR DESCRIPTION
Related Ticket: TINY-10314

Description of Changes:
by clicking to the left or right of a non-editable `div` in Firefox we get 2 carets.

This seems to happen when we put the selection inside of our fake caret container. When we do so the caret is showed in Firefox but not in Chrome.

To fix it I added a `caret-color: 'transparent'` to our fake care container to don't have the double caret in Firefox

NOTE: I tried to make a test for it, testing the presence of `caret-color: 'transparent'`, I don't know how it make sense, but I didn't find a better check to do :/

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
