### PR TITLE
TINY-10386: Fixed so agar DataTransfer is an instance of window.DataTransfer

### DIFF
--- a/modules/agar/CHANGELOG.md
+++ b/modules/agar/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Fixed
-- Creating native events using DragEvent or ClipboardEvent constructors using agar DataTransfer instances would fail on Firefo. #TINY-10386
+- Creating native events using DragEvent or ClipboardEvent constructors using agar DataTransfer instances would fail on Firefox. #TINY-10386
 
 ## 8.0.0 - 2023-11-22
 

--- a/modules/agar/CHANGELOG.md
+++ b/modules/agar/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Fixed
-- Simulating cut on Firefox would fail if the DataTransfer wasn't an instance of a actual DataTransfer. #TINY-10386
+- Creating native events using DragEvent or ClipboardEvent constructors using agar DataTransfer instances would fail on Firefo. #TINY-10386
 
 ## 8.0.0 - 2023-11-22
 

--- a/modules/agar/CHANGELOG.md
+++ b/modules/agar/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Simulating cut on Firefox would fail if the DataTransfer wasn't an instance of a actual DataTransfer. #TINY-10386
+
 ## 8.0.0 - 2023-11-22
 
 ### Added

--- a/modules/agar/src/main/ts/ephox/agar/datatransfer/DataTransfer.ts
+++ b/modules/agar/src/main/ts/ephox/agar/datatransfer/DataTransfer.ts
@@ -45,92 +45,109 @@ const createDataTransfer = (): DataTransfer => {
   let dropEffect: DropEffect = 'move';
   let effectAllowed: EffectAllowed = 'all';
 
-  const dataTransfer: DataTransfer = {
-    get dropEffect() {
-      return dropEffect;
-    },
+  const dataTransfer: DataTransfer = new window.DataTransfer();
 
-    set dropEffect(effect: DropEffect) {
-      if (Arr.contains(validDropEffects, effect)) {
-        dropEffect = effect;
-      }
-    },
+  Object.defineProperties(dataTransfer, {
+    dropEffect: {
+      get: () => {
+        return dropEffect;
+      },
 
-    get effectAllowed() {
-      return effectAllowed;
-    },
-
-    set effectAllowed(allowed: EffectAllowed) {
-      if (Arr.contains(validEffectAlloweds, allowed)) {
-        effectAllowed = allowed;
-      }
-    },
-
-    get items() {
-      return items;
-    },
-
-    get files() {
-      if (isInProtectedMode(dataTransfer)) {
-        return createFileList([]);
-      }
-
-      const files = Arr.bind(Arr.from(items), (item) => {
-        if (item.kind === 'file') {
-          const file = item.getAsFile();
-          return Type.isNull(file) ? [] : [ file ];
-        } else {
-          return [];
+      set: (effect: DropEffect) => {
+        if (Arr.contains(validDropEffects, effect)) {
+          dropEffect = effect;
         }
-      });
-
-      return createFileList(files);
-    },
-
-    get types() {
-      const types = Arr.map(Arr.from(items), (item) => item.type);
-      const hasFiles = Arr.exists(Arr.from(items), (item) => item.kind === 'file');
-      return types.concat(hasFiles ? [ 'Files' ] : []);
-    },
-
-    setDragImage: (image: Element, x: number, y: number) => {
-      if (isInReadWriteMode(dataTransfer)) {
-        setDragImage(dataTransfer, { image, x, y });
       }
     },
 
-    getData: (format: string) => {
-      if (isInProtectedMode(dataTransfer)) {
-        return '';
-      }
-
-      return Arr.find(Arr.from(items), (item) => item.type === normalize(format)).bind((item) => getData(item)).getOr('');
-    },
-
-    setData: (format: string, data: string) => {
-      if (isInReadWriteMode(dataTransfer)) {
-        dataTransfer.clearData(normalize(format));
-        items.add(data, normalize(format));
+    effectAllowed: {
+      get: () => effectAllowed,
+      set: (allowed: EffectAllowed) => {
+        if (Arr.contains(validEffectAlloweds, allowed)) {
+          effectAllowed = allowed;
+        }
       }
     },
 
-    clearData: (format?: string) => {
-      if (isInReadWriteMode(dataTransfer)) {
-        if (Type.isString(format)) {
-          const normalizedFormat = normalize(format);
-          Arr.findIndex(Arr.from(items), (item) => item.type === normalizedFormat).each((idx) => {
-            items.remove(idx);
-          });
-        } else {
-          for (let i = items.length - 1; i >= 0; i--) {
-            if (items[i].kind === 'string') {
-              items.remove(i);
+    items: {
+      get: () => {
+        return items;
+      }
+    },
+
+    files: {
+      get: () => {
+        if (isInProtectedMode(dataTransfer)) {
+          return createFileList([]);
+        }
+
+        const files = Arr.bind(Arr.from(items), (item) => {
+          if (item.kind === 'file') {
+            const file = item.getAsFile();
+            return Type.isNull(file) ? [] : [ file ];
+          } else {
+            return [];
+          }
+        });
+
+        return createFileList(files);
+      }
+    },
+
+    types: {
+      get: () => {
+        const types = Arr.map(Arr.from(items), (item) => item.type);
+        const hasFiles = Arr.exists(Arr.from(items), (item) => item.kind === 'file');
+        return types.concat(hasFiles ? [ 'Files' ] : []);
+      }
+    },
+
+    setDragImage: {
+      value: (image: Element, x: number, y: number) => {
+        if (isInReadWriteMode(dataTransfer)) {
+          setDragImage(dataTransfer, { image, x, y });
+        }
+      }
+    },
+
+    getData: {
+      value: (format: string) => {
+        if (isInProtectedMode(dataTransfer)) {
+          return '';
+        }
+
+        return Arr.find(Arr.from(items), (item) => item.type === normalize(format)).bind((item) => getData(item)).getOr('');
+      }
+    },
+
+    setData: {
+      value: (format: string, data: string) => {
+        if (isInReadWriteMode(dataTransfer)) {
+          dataTransfer.clearData(normalize(format));
+          items.add(data, normalize(format));
+        }
+      }
+    },
+
+    clearData: {
+      value: (format?: string) => {
+        if (isInReadWriteMode(dataTransfer)) {
+          if (Type.isString(format)) {
+            const normalizedFormat = normalize(format);
+            Arr.findIndex(Arr.from(items), (item) => item.type === normalizedFormat).each((idx) => {
+              items.remove(idx);
+            });
+          } else {
+            for (let i = items.length - 1; i >= 0; i--) {
+              if (items[i].kind === 'string') {
+                items.remove(i);
+              }
             }
           }
         }
       }
     }
-  };
+  });
 
   const items = createDataTransferItemList(dataTransfer);
 

--- a/modules/agar/src/test/ts/browser/api/ClipboardTest.ts
+++ b/modules/agar/src/test/ts/browser/api/ClipboardTest.ts
@@ -1,4 +1,4 @@
-import { after, before, beforeEach, describe, it } from '@ephox/bedrock-client';
+import { after, before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Singleton } from '@ephox/katamari';
 import { DomEvent, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
@@ -166,5 +166,26 @@ describe('ClipboardTest', () => {
     assert.equal(dataTransfer.items.length, 2);
     await assertFileItem(dataTransfer.items[0], { type: 'text/html', name: 'clipboard.html', data: '<!DOCTYPE html>\n<html>\n<body>\n<p>Hello world</p>\n</body>\n</html>\n' });
     await assertFileItem(dataTransfer.items[1], { type: 'text/plain', name: 'clipboard.txt', data: 'Hello world\n' });
+  });
+
+  context('DataTransfer instance type', () => {
+    const testDataTransferInstance = (eventName: 'cut' | 'copy', operation: (target: SugarElement<HTMLElement>) => DataTransfer) => {
+      const pastebin = pastebinState.get().getOrDie('Could not get pastebin from state');
+      let event: ClipboardEvent = null;
+
+      const unbinder = DomEvent.bind(pastebin, eventName, (evt) => {
+        event = evt.raw;
+      });
+
+      const dataTransfer = operation(pastebin);
+
+      assert.instanceOf(event.clipboardData, window.DataTransfer);
+      assert.instanceOf(dataTransfer, window.DataTransfer);
+
+      unbinder.unbind();
+    };
+
+    it('TINY-10386: Cut dataTransfer should be an instanceof DataTransfer', () => testDataTransferInstance('cut', cut));
+    it('TINY-10386: Copy dataTransfer should be an instanceof DataTransfer', () => testDataTransferInstance('copy', copy));
   });
 });

--- a/modules/agar/src/test/ts/browser/datatransfer/DataTransferTest.ts
+++ b/modules/agar/src/test/ts/browser/datatransfer/DataTransferTest.ts
@@ -162,4 +162,17 @@ describe('DataTransfer', () => {
       new window.ClipboardEvent('paste', { clipboardData: createDataTransfer() });
     });
   });
+
+  it('TINY-10386: DataTransfer on native event should work as a regular dataTransfer', () => {
+    assert.doesNotThrow(() => {
+      const dataTransfer = createDataTransfer();
+
+      dataTransfer.setData('text/plain', '123');
+      dataTransfer.items.add(createFile('test.gif', 123, new Blob([ '' ], { type: 'image/gif' })));
+
+      const dragEvent = new window.DragEvent('drop', { dataTransfer });
+      assert.equal(dragEvent.dataTransfer.files.length, 1, 'Should be able to access files length');
+      assert.equal(dragEvent.dataTransfer.getData('text/plain'), '123', 'Should be able to access data');
+    });
+  });
 });

--- a/modules/agar/src/test/ts/browser/datatransfer/DataTransferTest.ts
+++ b/modules/agar/src/test/ts/browser/datatransfer/DataTransferTest.ts
@@ -155,4 +155,11 @@ describe('DataTransfer', () => {
   it('TINY-10386: DataTransfer instanceof window.DataTransfer', () => {
     assert.instanceOf(createDataTransfer(), window.DataTransfer);
   });
+
+  it('TINY-10386: DataTransfer passed into DragEvent/ClipboardEvent should not throw an error', () => {
+    assert.doesNotThrow(() => {
+      new window.DragEvent('drop', { dataTransfer: createDataTransfer() });
+      new window.ClipboardEvent('paste', { clipboardData: createDataTransfer() });
+    });
+  });
 });

--- a/modules/agar/src/test/ts/browser/datatransfer/DataTransferTest.ts
+++ b/modules/agar/src/test/ts/browser/datatransfer/DataTransferTest.ts
@@ -1,4 +1,4 @@
-import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { KAssert } from '@ephox/katamari-assertions';
 
@@ -6,146 +6,149 @@ import { createFile } from 'ephox/agar/api/Files';
 import { createDataTransfer, getDragImage } from 'ephox/agar/datatransfer/DataTransfer';
 import { setProtectedMode, setReadOnlyMode } from 'ephox/agar/datatransfer/Mode';
 
-UnitTest.test('DataTransfer: setEffects', () => {
-  const transfer = createDataTransfer();
+describe('DataTransfer', () => {
+  it('DataTransfer: setEffects', () => {
+    const transfer = createDataTransfer();
 
-  Assert.eq('Should be expected initial dropEffect', 'move', transfer.dropEffect);
-  Assert.eq('Should be expected initial effectAllowed', 'all', transfer.effectAllowed);
+    Assert.eq('Should be expected initial dropEffect', 'move', transfer.dropEffect);
+    Assert.eq('Should be expected initial effectAllowed', 'all', transfer.effectAllowed);
 
-  transfer.dropEffect = 'copy';
-  Assert.eq('Should be expected new value', 'copy', transfer.dropEffect);
+    transfer.dropEffect = 'copy';
+    Assert.eq('Should be expected new value', 'copy', transfer.dropEffect);
 
-  transfer.dropEffect = 'xyz' as any;
-  Assert.eq('Should be unchanged', 'copy', transfer.dropEffect);
+    transfer.dropEffect = 'xyz' as any;
+    Assert.eq('Should be unchanged', 'copy', transfer.dropEffect);
 
-  transfer.effectAllowed = 'copyLink';
-  Assert.eq('Should be expected new value', 'copyLink', transfer.effectAllowed);
+    transfer.effectAllowed = 'copyLink';
+    Assert.eq('Should be expected new value', 'copyLink', transfer.effectAllowed);
 
-  transfer.effectAllowed = 'xyz' as any;
-  Assert.eq('Should be unchanged', 'copyLink', transfer.effectAllowed);
+    transfer.effectAllowed = 'xyz' as any;
+    Assert.eq('Should be unchanged', 'copyLink', transfer.effectAllowed);
+  });
+
+  it('DataTransfer: setData', () => {
+    const transfer = createDataTransfer();
+
+    transfer.setData('text/plain', '123');
+    Assert.eq('Should the expected text', '123', transfer.getData('text/plain'));
+    Assert.eq('Should the expected type in items', 'text/plain', transfer.items[0].type);
+
+    transfer.setData('text/plain', '1234');
+    Assert.eq('Should the expected new text', '1234', transfer.getData('text/plain'));
+    Assert.eq('Should the expected type in items', 'text/plain', transfer.items[0].type);
+
+    transfer.setData('text', '12345');
+    Assert.eq('Should the expected text', '12345', transfer.getData('text/plain'));
+    Assert.eq('Should the expected type in items', 'text/plain', transfer.items[0].type);
+
+    transfer.setData('url', 'http://tiny.cloud');
+    Assert.eq('Should the expected url', 'http://tiny.cloud', transfer.getData('text/uri-list'));
+    Assert.eq('Should the expected type in items', 'text/uri-list', transfer.items[1].type);
+  });
+
+  it('DataTransfer: setDragImage', () => {
+    const transfer = createDataTransfer();
+
+    KAssert.eqNone('Should not have a drag image', getDragImage(transfer));
+
+    transfer.setDragImage(document.createElement('div'), 10, 20);
+
+    KAssert.eqSome('Should be expected element', 'DIV', getDragImage(transfer).map((x) => x.image.nodeName));
+    KAssert.eqSome('Should be expected x cord', 10, getDragImage(transfer).map((x) => x.x));
+    KAssert.eqSome('Should be expected y cord', 20, getDragImage(transfer).map((x) => x.y));
+  });
+
+  it('DataTransfer: testTypes', () => {
+    const transfer = createDataTransfer();
+
+    transfer.setData('text/plain', '123');
+
+    Assert.eq('Should the length', 1, transfer.types.length);
+    Assert.eq('Should the expected type', 'text/plain', transfer.types[0]);
+
+    transfer.setData('text/html', '123');
+
+    Assert.eq('Should the length', 2, transfer.types.length);
+    Assert.eq('Should the expected type', 'text/plain', transfer.types[0]);
+    Assert.eq('Should the expected type', 'text/html', transfer.types[1]);
+
+    transfer.items.add(createFile('test.gif', 1234, new Blob([ '123' ], { type: 'image/gif' })));
+
+    Assert.eq('Should the length', 4, transfer.types.length);
+    Assert.eq('Should the expected type 1', 'text/plain', transfer.types[0]);
+    Assert.eq('Should the expected type 2', 'text/html', transfer.types[1]);
+    Assert.eq('Should the expected type 3', 'image/gif', transfer.types[2]);
+    Assert.eq('Should the expected type 4', 'Files', transfer.types[3]);
+  });
+
+  it('DataTransfer: mutation in protected mode', () => {
+    const transfer = createDataTransfer();
+
+    transfer.setData('text/html', '123');
+    transfer.items.add(createFile('test.gif', 123, new Blob([ '' ], { type: 'image/gif' })));
+
+    setProtectedMode(transfer);
+
+    transfer.setData('text/plain', '123');
+    Assert.eq('Should not be any text/plain data', '', transfer.getData('text/plain'));
+    Assert.eq('Should not be any text/html data', '', transfer.getData('text/html'));
+
+    Assert.eq('Should only expected length', 3, transfer.types.length);
+    Assert.eq('Should only expected mime', 'text/html', transfer.types[0]);
+    Assert.eq('Should only expected mime', 'image/gif', transfer.types[1]);
+    Assert.eq('Should only expected Files', 'Files', transfer.types[2]);
+
+    transfer.clearData();
+
+    Assert.eq('Should still be expected items', 3, transfer.types.length);
+
+    transfer.clearData('text/html');
+
+    Assert.eq('Should still be expected items', 3, transfer.types.length);
+  });
+
+  it('DataTransfer: mutation in read-only mode', () => {
+    const transfer = createDataTransfer();
+
+    transfer.setData('text/html', '123');
+    transfer.items.add(createFile('test.gif', 123, new Blob([ '' ], { type: 'image/gif' })));
+
+    setReadOnlyMode(transfer);
+
+    transfer.setData('text/plain', '123');
+    Assert.eq('Should not be any text/plain data', '', transfer.getData('text/plain'));
+    Assert.eq('Should not be any text/html data', '123', transfer.getData('text/html'));
+
+    Assert.eq('Should only expected length', 3, transfer.types.length);
+    Assert.eq('Should only expected mime', 'text/html', transfer.types[0]);
+    Assert.eq('Should only expected mime', 'image/gif', transfer.types[1]);
+    Assert.eq('Should only expected Files', 'Files', transfer.types[2]);
+
+    Assert.eq('Should be able to access files length', 1, transfer.files.length);
+    Assert.eq('Should be able to access name', 'test.gif', transfer.files[0].name);
+    Assert.eq('Should be able to access type', 'image/gif', transfer.files[0].type);
+
+    transfer.clearData();
+
+    Assert.eq('Should still be expected items', 3, transfer.types.length);
+
+    transfer.clearData('text/html');
+
+    Assert.eq('Should still be expected items', 3, transfer.types.length);
+  });
+
+  it('DataTransfer: add files', () => {
+    const transfer = createDataTransfer();
+
+    transfer.items.add(createFile('test.gif', 123, new Blob([ '' ], { type: 'image/gif' })));
+
+    Assert.eq('Should be able to access files length', 1, transfer.files.length);
+    Assert.eq('Types', [ 'image/gif' ], Arr.map(transfer.files, (x) => x.type));
+
+    transfer.items.add(createFile('test.jpg', 123, new Blob([ '' ], { type: 'image/jpg' })));
+
+    Assert.eq('Expected file types', [ 'image/gif', 'image/jpg' ], Arr.map(transfer.files, (x) => x.type));
+    Assert.eq('Expected file kinds', [ 'file', 'file' ], Arr.map(transfer.items, (x) => x.kind));
+  });
 });
 
-UnitTest.test('DataTransfer: setData', () => {
-  const transfer = createDataTransfer();
-
-  transfer.setData('text/plain', '123');
-  Assert.eq('Should the expected text', '123', transfer.getData('text/plain'));
-  Assert.eq('Should the expected type in items', 'text/plain', transfer.items[0].type);
-
-  transfer.setData('text/plain', '1234');
-  Assert.eq('Should the expected new text', '1234', transfer.getData('text/plain'));
-  Assert.eq('Should the expected type in items', 'text/plain', transfer.items[0].type);
-
-  transfer.setData('text', '12345');
-  Assert.eq('Should the expected text', '12345', transfer.getData('text/plain'));
-  Assert.eq('Should the expected type in items', 'text/plain', transfer.items[0].type);
-
-  transfer.setData('url', 'http://tiny.cloud');
-  Assert.eq('Should the expected url', 'http://tiny.cloud', transfer.getData('text/uri-list'));
-  Assert.eq('Should the expected type in items', 'text/uri-list', transfer.items[1].type);
-});
-
-UnitTest.test('DataTransfer: setDragImage', () => {
-  const transfer = createDataTransfer();
-
-  KAssert.eqNone('Should not have a drag image', getDragImage(transfer));
-
-  transfer.setDragImage(document.createElement('div'), 10, 20);
-
-  KAssert.eqSome('Should be expected element', 'DIV', getDragImage(transfer).map((x) => x.image.nodeName));
-  KAssert.eqSome('Should be expected x cord', 10, getDragImage(transfer).map((x) => x.x));
-  KAssert.eqSome('Should be expected y cord', 20, getDragImage(transfer).map((x) => x.y));
-});
-
-UnitTest.test('DataTransfer: testTypes', () => {
-  const transfer = createDataTransfer();
-
-  transfer.setData('text/plain', '123');
-
-  Assert.eq('Should the length', 1, transfer.types.length);
-  Assert.eq('Should the expected type', 'text/plain', transfer.types[0]);
-
-  transfer.setData('text/html', '123');
-
-  Assert.eq('Should the length', 2, transfer.types.length);
-  Assert.eq('Should the expected type', 'text/plain', transfer.types[0]);
-  Assert.eq('Should the expected type', 'text/html', transfer.types[1]);
-
-  transfer.items.add(createFile('test.gif', 1234, new Blob([ '123' ], { type: 'image/gif' })));
-
-  Assert.eq('Should the length', 4, transfer.types.length);
-  Assert.eq('Should the expected type 1', 'text/plain', transfer.types[0]);
-  Assert.eq('Should the expected type 2', 'text/html', transfer.types[1]);
-  Assert.eq('Should the expected type 3', 'image/gif', transfer.types[2]);
-  Assert.eq('Should the expected type 4', 'Files', transfer.types[3]);
-});
-
-UnitTest.test('DataTransfer: mutation in protected mode', () => {
-  const transfer = createDataTransfer();
-
-  transfer.setData('text/html', '123');
-  transfer.items.add(createFile('test.gif', 123, new Blob([ '' ], { type: 'image/gif' })));
-
-  setProtectedMode(transfer);
-
-  transfer.setData('text/plain', '123');
-  Assert.eq('Should not be any text/plain data', '', transfer.getData('text/plain'));
-  Assert.eq('Should not be any text/html data', '', transfer.getData('text/html'));
-
-  Assert.eq('Should only expected length', 3, transfer.types.length);
-  Assert.eq('Should only expected mime', 'text/html', transfer.types[0]);
-  Assert.eq('Should only expected mime', 'image/gif', transfer.types[1]);
-  Assert.eq('Should only expected Files', 'Files', transfer.types[2]);
-
-  transfer.clearData();
-
-  Assert.eq('Should still be expected items', 3, transfer.types.length);
-
-  transfer.clearData('text/html');
-
-  Assert.eq('Should still be expected items', 3, transfer.types.length);
-});
-
-UnitTest.test('DataTransfer: mutation in read-only mode', () => {
-  const transfer = createDataTransfer();
-
-  transfer.setData('text/html', '123');
-  transfer.items.add(createFile('test.gif', 123, new Blob([ '' ], { type: 'image/gif' })));
-
-  setReadOnlyMode(transfer);
-
-  transfer.setData('text/plain', '123');
-  Assert.eq('Should not be any text/plain data', '', transfer.getData('text/plain'));
-  Assert.eq('Should not be any text/html data', '123', transfer.getData('text/html'));
-
-  Assert.eq('Should only expected length', 3, transfer.types.length);
-  Assert.eq('Should only expected mime', 'text/html', transfer.types[0]);
-  Assert.eq('Should only expected mime', 'image/gif', transfer.types[1]);
-  Assert.eq('Should only expected Files', 'Files', transfer.types[2]);
-
-  Assert.eq('Should be able to access files length', 1, transfer.files.length);
-  Assert.eq('Should be able to access name', 'test.gif', transfer.files[0].name);
-  Assert.eq('Should be able to access type', 'image/gif', transfer.files[0].type);
-
-  transfer.clearData();
-
-  Assert.eq('Should still be expected items', 3, transfer.types.length);
-
-  transfer.clearData('text/html');
-
-  Assert.eq('Should still be expected items', 3, transfer.types.length);
-});
-
-UnitTest.test('DataTransfer: add files', () => {
-  const transfer = createDataTransfer();
-
-  transfer.items.add(createFile('test.gif', 123, new Blob([ '' ], { type: 'image/gif' })));
-
-  Assert.eq('Should be able to access files length', 1, transfer.files.length);
-  Assert.eq('Types', [ 'image/gif' ], Arr.map(transfer.files, (x) => x.type));
-
-  transfer.items.add(createFile('test.jpg', 123, new Blob([ '' ], { type: 'image/jpg' })));
-
-  Assert.eq('Expected file types', [ 'image/gif', 'image/jpg' ], Arr.map(transfer.files, (x) => x.type));
-  Assert.eq('Expected file kinds', [ 'file', 'file' ], Arr.map(transfer.items, (x) => x.kind));
-});

--- a/modules/agar/src/test/ts/browser/datatransfer/DataTransferTest.ts
+++ b/modules/agar/src/test/ts/browser/datatransfer/DataTransferTest.ts
@@ -1,6 +1,7 @@
-import { Assert, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { KAssert } from '@ephox/katamari-assertions';
+import { assert } from 'chai';
 
 import { createFile } from 'ephox/agar/api/Files';
 import { createDataTransfer, getDragImage } from 'ephox/agar/datatransfer/DataTransfer';
@@ -10,40 +11,40 @@ describe('DataTransfer', () => {
   it('DataTransfer: setEffects', () => {
     const transfer = createDataTransfer();
 
-    Assert.eq('Should be expected initial dropEffect', 'move', transfer.dropEffect);
-    Assert.eq('Should be expected initial effectAllowed', 'all', transfer.effectAllowed);
+    assert.equal(transfer.dropEffect, 'move', 'Should be expected initial dropEffect');
+    assert.equal(transfer.effectAllowed, 'all', 'Should be expected initial effectAllowed');
 
     transfer.dropEffect = 'copy';
-    Assert.eq('Should be expected new value', 'copy', transfer.dropEffect);
+    assert.equal(transfer.dropEffect, 'copy', 'Should be expected new value');
 
     transfer.dropEffect = 'xyz' as any;
-    Assert.eq('Should be unchanged', 'copy', transfer.dropEffect);
+    assert.equal(transfer.dropEffect, 'copy', 'Should be unchanged');
 
     transfer.effectAllowed = 'copyLink';
-    Assert.eq('Should be expected new value', 'copyLink', transfer.effectAllowed);
+    assert.equal(transfer.effectAllowed, 'copyLink', 'Should be expected new value');
 
     transfer.effectAllowed = 'xyz' as any;
-    Assert.eq('Should be unchanged', 'copyLink', transfer.effectAllowed);
+    assert.equal(transfer.effectAllowed, 'copyLink', 'Should be unchanged');
   });
 
   it('DataTransfer: setData', () => {
     const transfer = createDataTransfer();
 
     transfer.setData('text/plain', '123');
-    Assert.eq('Should the expected text', '123', transfer.getData('text/plain'));
-    Assert.eq('Should the expected type in items', 'text/plain', transfer.items[0].type);
+    assert.equal(transfer.getData('text/plain'), '123', 'Should the expected text');
+    assert.equal(transfer.items[0].type, 'text/plain', 'Should the expected type in items');
 
     transfer.setData('text/plain', '1234');
-    Assert.eq('Should the expected new text', '1234', transfer.getData('text/plain'));
-    Assert.eq('Should the expected type in items', 'text/plain', transfer.items[0].type);
+    assert.equal(transfer.getData('text/plain'), '1234', 'Should the expected new text');
+    assert.equal(transfer.items[0].type, 'text/plain', 'Should the expected type in items');
 
     transfer.setData('text', '12345');
-    Assert.eq('Should the expected text', '12345', transfer.getData('text/plain'));
-    Assert.eq('Should the expected type in items', 'text/plain', transfer.items[0].type);
+    assert.equal(transfer.getData('text/plain'), '12345', 'Should the expected text');
+    assert.equal(transfer.items[0].type, 'text/plain', 'Should the expected type in items');
 
     transfer.setData('url', 'http://tiny.cloud');
-    Assert.eq('Should the expected url', 'http://tiny.cloud', transfer.getData('text/uri-list'));
-    Assert.eq('Should the expected type in items', 'text/uri-list', transfer.items[1].type);
+    assert.equal(transfer.getData('text/uri-list'), 'http://tiny.cloud', 'Should the expected url');
+    assert.equal(transfer.items[1].type, 'text/uri-list', 'Should the expected type in items');
   });
 
   it('DataTransfer: setDragImage', () => {
@@ -63,22 +64,22 @@ describe('DataTransfer', () => {
 
     transfer.setData('text/plain', '123');
 
-    Assert.eq('Should the length', 1, transfer.types.length);
-    Assert.eq('Should the expected type', 'text/plain', transfer.types[0]);
+    assert.equal(transfer.types.length, 1, 'Should the length');
+    assert.equal(transfer.types[0], 'text/plain', 'Should the expected type');
 
     transfer.setData('text/html', '123');
 
-    Assert.eq('Should the length', 2, transfer.types.length);
-    Assert.eq('Should the expected type', 'text/plain', transfer.types[0]);
-    Assert.eq('Should the expected type', 'text/html', transfer.types[1]);
+    assert.equal(transfer.types.length, 2, 'Should the length');
+    assert.equal(transfer.types[0], 'text/plain', 'Should the expected type');
+    assert.equal(transfer.types[1], 'text/html', 'Should the expected type');
 
     transfer.items.add(createFile('test.gif', 1234, new Blob([ '123' ], { type: 'image/gif' })));
 
-    Assert.eq('Should the length', 4, transfer.types.length);
-    Assert.eq('Should the expected type 1', 'text/plain', transfer.types[0]);
-    Assert.eq('Should the expected type 2', 'text/html', transfer.types[1]);
-    Assert.eq('Should the expected type 3', 'image/gif', transfer.types[2]);
-    Assert.eq('Should the expected type 4', 'Files', transfer.types[3]);
+    assert.equal(transfer.types.length, 4, 'Should the length');
+    assert.equal(transfer.types[0], 'text/plain', 'Should the expected type 1');
+    assert.equal(transfer.types[1], 'text/html', 'Should the expected type 2');
+    assert.equal(transfer.types[2], 'image/gif', 'Should the expected type 3');
+    assert.equal(transfer.types[3], 'Files', 'Should the expected type 4');
   });
 
   it('DataTransfer: mutation in protected mode', () => {
@@ -90,21 +91,21 @@ describe('DataTransfer', () => {
     setProtectedMode(transfer);
 
     transfer.setData('text/plain', '123');
-    Assert.eq('Should not be any text/plain data', '', transfer.getData('text/plain'));
-    Assert.eq('Should not be any text/html data', '', transfer.getData('text/html'));
+    assert.equal(transfer.getData('text/plain'), '', 'Should not be any text/plain data');
+    assert.equal(transfer.getData('text/html'), '', 'Should not be any text/html data');
 
-    Assert.eq('Should only expected length', 3, transfer.types.length);
-    Assert.eq('Should only expected mime', 'text/html', transfer.types[0]);
-    Assert.eq('Should only expected mime', 'image/gif', transfer.types[1]);
-    Assert.eq('Should only expected Files', 'Files', transfer.types[2]);
+    assert.equal(transfer.types.length, 3, 'Should only expected length');
+    assert.equal(transfer.types[0], 'text/html', 'Should only expected mime');
+    assert.equal(transfer.types[1], 'image/gif', 'Should only expected mime');
+    assert.equal(transfer.types[2], 'Files', 'Should only expected Files');
 
     transfer.clearData();
 
-    Assert.eq('Should still be expected items', 3, transfer.types.length);
+    assert.equal(transfer.types.length, 3, 'Should still be expected items');
 
     transfer.clearData('text/html');
 
-    Assert.eq('Should still be expected items', 3, transfer.types.length);
+    assert.equal(transfer.types.length, 3, 'Should still be expected items');
   });
 
   it('DataTransfer: mutation in read-only mode', () => {
@@ -116,25 +117,25 @@ describe('DataTransfer', () => {
     setReadOnlyMode(transfer);
 
     transfer.setData('text/plain', '123');
-    Assert.eq('Should not be any text/plain data', '', transfer.getData('text/plain'));
-    Assert.eq('Should not be any text/html data', '123', transfer.getData('text/html'));
+    assert.equal(transfer.getData('text/plain'), '', 'Should not be any text/plain data');
+    assert.equal(transfer.getData('text/html'), '123', 'Should not be any text/html data');
 
-    Assert.eq('Should only expected length', 3, transfer.types.length);
-    Assert.eq('Should only expected mime', 'text/html', transfer.types[0]);
-    Assert.eq('Should only expected mime', 'image/gif', transfer.types[1]);
-    Assert.eq('Should only expected Files', 'Files', transfer.types[2]);
+    assert.equal(transfer.types.length, 3, 'Should only expected length');
+    assert.equal(transfer.types[0], 'text/html', 'Should only expected mime');
+    assert.equal(transfer.types[1], 'image/gif', 'Should only expected mime');
+    assert.equal(transfer.types[2], 'Files', 'Should only expected Files');
 
-    Assert.eq('Should be able to access files length', 1, transfer.files.length);
-    Assert.eq('Should be able to access name', 'test.gif', transfer.files[0].name);
-    Assert.eq('Should be able to access type', 'image/gif', transfer.files[0].type);
+    assert.equal(transfer.files.length, 1, 'Should be able to access files length');
+    assert.equal(transfer.files[0].name, 'test.gif', 'Should be able to access name');
+    assert.equal(transfer.files[0].type, 'image/gif', 'Should be able to access type');
 
     transfer.clearData();
 
-    Assert.eq('Should still be expected items', 3, transfer.types.length);
+    assert.equal(transfer.types.length, 3, 'Should still be expected items');
 
     transfer.clearData('text/html');
 
-    Assert.eq('Should still be expected items', 3, transfer.types.length);
+    assert.equal(transfer.types.length, 3, 'Should still be expected items');
   });
 
   it('DataTransfer: add files', () => {
@@ -142,13 +143,12 @@ describe('DataTransfer', () => {
 
     transfer.items.add(createFile('test.gif', 123, new Blob([ '' ], { type: 'image/gif' })));
 
-    Assert.eq('Should be able to access files length', 1, transfer.files.length);
-    Assert.eq('Types', [ 'image/gif' ], Arr.map(transfer.files, (x) => x.type));
+    assert.equal(transfer.files.length, 1, 'Should be able to access files length');
+    assert.equal(Arr.map(transfer.files, (x) => x.type), [ 'image/gif' ], 'Types');
 
     transfer.items.add(createFile('test.jpg', 123, new Blob([ '' ], { type: 'image/jpg' })));
 
-    Assert.eq('Expected file types', [ 'image/gif', 'image/jpg' ], Arr.map(transfer.files, (x) => x.type));
-    Assert.eq('Expected file kinds', [ 'file', 'file' ], Arr.map(transfer.items, (x) => x.kind));
+    assert.equal(Arr.map(transfer.files, (x) => x.type), [ 'image/gif', 'image/jpg' ], 'Expected file types');
+    assert.equal(Arr.map(transfer.items, (x) => x.kind), [ 'file', 'file' ], 'Expected file kinds');
   });
 });
-

--- a/modules/agar/src/test/ts/browser/datatransfer/DataTransferTest.ts
+++ b/modules/agar/src/test/ts/browser/datatransfer/DataTransferTest.ts
@@ -144,11 +144,15 @@ describe('DataTransfer', () => {
     transfer.items.add(createFile('test.gif', 123, new Blob([ '' ], { type: 'image/gif' })));
 
     assert.equal(transfer.files.length, 1, 'Should be able to access files length');
-    assert.equal(Arr.map(transfer.files, (x) => x.type), [ 'image/gif' ], 'Types');
+    assert.deepEqual(Arr.map(transfer.files, (x) => x.type), [ 'image/gif' ], 'Types');
 
     transfer.items.add(createFile('test.jpg', 123, new Blob([ '' ], { type: 'image/jpg' })));
 
-    assert.equal(Arr.map(transfer.files, (x) => x.type), [ 'image/gif', 'image/jpg' ], 'Expected file types');
-    assert.equal(Arr.map(transfer.items, (x) => x.kind), [ 'file', 'file' ], 'Expected file kinds');
+    assert.deepEqual(Arr.map(transfer.files, (x) => x.type), [ 'image/gif', 'image/jpg' ], 'Expected file types');
+    assert.deepEqual(Arr.map(transfer.items, (x) => x.kind), [ 'file', 'file' ], 'Expected file kinds');
+  });
+
+  it('TINY-10386: DataTransfer instanceof window.DataTransfer', () => {
+    assert.instanceOf(createDataTransfer(), window.DataTransfer);
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10386

Description of Changes:
* Makes the custom DataTransfer instance in agar be an instance of window.DataTransfer
* Converted test to mocha style
* Added test for this change

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
