### PR TITLE
TINY-10141: Fix broken translation in table grid announcement

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Translation syntax for announcement text in the table grid was incorrectly formatted. #TINY-10141
+
 ## 6.8.0 - 2023-11-22
 
 ### Added

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/InsertTableMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/InsertTableMenuItem.ts
@@ -16,7 +16,7 @@ interface CellEvent extends CustomEvent {
 }
 
 const makeAnnouncementText = (backstage: UiFactoryBackstage) => (row: number, col: number): string =>
-  backstage.shared.providers.translate(`${col} columns, ${row} rows`);
+  backstage.shared.providers.translate([ '{0} columns, {1} rows', col, row ]);
 
 const makeCell = (row: number, col: number, label: string): AlloyComponent => {
   const emitCellOver = (c: AlloyComponent) => AlloyTriggers.emitWith(c, cellOverEvent, { row, col } );


### PR DESCRIPTION
Related Ticket: TINY-10141, TINY-10140

Description of Changes:
* Fix incorrect translation syntax for table grid announcement text

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
