### PR TITLE
TINY-10385: fix `schema.isWrapper` function

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - When deleting the last row in a table, the cursor would jump to the first cell (top left), instead of moving to the next adjacent cell in some cases. #TINY-6309
-- The function `schema.isWrapper` doesn't exclude the elements that are not eligible as a wrapper. #TINY-10385
+- The functions `schema.isWrapper` and `schema.isInline` don't exclude the elements with the name that starts with `#` that should not be considered as elements. #TINY-10385
 
 ## 6.8.0 - 2023-11-22
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - When deleting the last row in a table, the cursor would jump to the first cell (top left), instead of moving to the next adjacent cell in some cases. #TINY-6309
-- The functions `schema.isWrapper` and `schema.isInline` don't exclude the elements with the name that starts with `#` that should not be considered as elements. #TINY-10385
+- The functions `schema.isWrapper` and `schema.isInline` didn't exclude element names that started with `#` those should not be considered elements. #TINY-10385
 
 ## 6.8.0 - 2023-11-22
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - When deleting the last row in a table, the cursor would jump to the first cell (top left), instead of moving to the next adjacent cell in some cases. #TINY-6309
+- The function `schema.isWrapper` isen't exlcudin the elements that are not elegible as a wrapper. #TINY-10385
 
 ## 6.8.0 - 2023-11-22
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - When deleting the last row in a table, the cursor would jump to the first cell (top left), instead of moving to the next adjacent cell in some cases. #TINY-6309
-- The function `schema.isWrapper` isen't exlcudin the elements that are not elegible as a wrapper. #TINY-10385
+- The function `schema.isWrapper` doesn't exclude the elements that are not eligible as a wrapper. #TINY-10385
 
 ## 6.8.0 - 2023-11-22
 

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -1,4 +1,4 @@
-import { Arr, Fun, Obj, Optional, Type } from '@ephox/katamari';
+import { Arr, Fun, Obj, Optional, Strings, Type } from '@ephox/katamari';
 
 import * as CustomElementsRuleParser from '../../schema/CustomElementsRuleParser';
 import * as SchemaLookupTable from '../../schema/SchemaLookupTable';
@@ -571,12 +571,9 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
 
   const isBlock = (name: string): boolean => Obj.has(getBlockElements(), name);
 
-  const isInline = (name: string): boolean => isValid(name) && !isBlock(name);
+  const isInline = (name: string): boolean => !Strings.startsWith(name, '#') && isValid(name) && !isBlock(name);
 
-  const isWrapper = (name: string): boolean => {
-    const isNotWrapperElements = Arr.exists([ '#comment', '#text' ], (eName) => eName === name);
-    return (Obj.has(getWrapBlockElements(), name) || isInline(name)) && !isNotWrapperElements;
-  };
+  const isWrapper = (name: string): boolean => Obj.has(getWrapBlockElements(), name) || isInline(name);
 
   /**
    * Returns true/false if the specified element is valid or not

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -573,7 +573,10 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
 
   const isInline = (name: string): boolean => isValid(name) && !isBlock(name);
 
-  const isWrapper = (name: string): boolean => Obj.has(getWrapBlockElements(), name) || isInline(name);
+  const isWrapper = (name: string): boolean => {
+    const isNotWrapperElements = Arr.exists([ '#comment', '#text' ], (eName) => eName === name);
+    return (Obj.has(getWrapBlockElements(), name) || isInline(name)) && !isNotWrapperElements;
+  };
 
   /**
    * Returns true/false if the specified element is valid or not

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -607,6 +607,31 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
       checkElement('foo', (el) => schema.isInline(SugarNode.name(el)), true);
       checkElement('bar', (el) => schema.isInline(SugarNode.name(el)), true);
     });
+
+    it('TINY-10385: with valid_elements: "*[*]" elements that starts with # should not be valid', () => {
+      const schema = Schema({
+        valid_elements: '*[*]'
+      });
+
+      const cases: ({ elementName: string; expectedValue: boolean })[] = [
+        { elementName: '#text', expectedValue: false },
+        { elementName: '#comment', expectedValue: false },
+        { elementName: '#cdata', expectedValue: false },
+        { elementName: '#pi', expectedValue: false },
+        { elementName: '#doctype', expectedValue: false },
+        { elementName: '#document-fragment', expectedValue: false }
+      ];
+
+      Arr.each(cases, (c) => {
+        assert.equal(schema.isInline(c.elementName), c.expectedValue, `For schema.isInline should be ${c.expectedValue} for ${c.elementName}`);
+        assert.equal(schema.isBlock(c.elementName), c.expectedValue, `For schema.isBlock should be ${c.expectedValue} for ${c.elementName}`);
+        assert.equal(schema.isWrapper(c.elementName), c.expectedValue, `For schema.isWrapper should be ${c.expectedValue} for ${c.elementName}`);
+      });
+
+      assert.equal(schema.isInline('some-fake-element'), true, `For schema.isInline should be 'some-fake-element' for true`);
+      assert.equal(schema.isBlock('some-fake-element'), false, `For schema.isBlock should be 'some-fake-element' for false`);
+      assert.equal(schema.isWrapper('some-fake-element'), true, `For schema.isWrapper should be 'some-fake-element' for true`);
+    });
   });
 
   context('paddInEmptyBlock', () => {

--- a/modules/tinymce/src/core/test/ts/webdriver/paste/CutTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/paste/CutTest.ts
@@ -1,5 +1,5 @@
 import { RealMouse, Waiter } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -19,5 +19,24 @@ describe('webdriver.tinymce.core.paste.CutTest', () => {
     await TinyUiActions.pWaitForUi(editor, '*[role="menu"]');
     await RealMouse.pClickOn('div[title="Cut"]');
     await Waiter.pTryUntil('Cut is async now, so need to wait for content', () => TinyAssertions.assertContent(editor, '<p>ac</p>'));
+  });
+
+  context('TINY-10385: cutting a text at the first level with `valid_elements` `*[*]` should not make the editor crush', () => {
+    const hook = TinyHooks.bddSetup<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      toolbar: false,
+      statusbar: false,
+      valid_elements: '*[*]'
+    }, []);
+
+    it('TINY-10385: Set and select content, cut using edit menu and assert cut content', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p>abc</p>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
+      TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
+      await TinyUiActions.pWaitForUi(editor, '*[role="menu"]');
+      await RealMouse.pClickOn('div[title="Cut"]');
+      await Waiter.pTryUntil('Cut is async now, so need to wait for content', () => TinyAssertions.assertContent(editor, '<p>ac</p>'));
+    });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10385

Description of Changes:
~`schema.isWrapper` didn't exclude elements that can't be a wrapper element like `comments` and `text`
so `valid_elements: '*[*]'` allow us to try to wrap an element inside such non-wrapper elements~

to avoid breaking change now the check is inside `schema.isInline` and it checks if the name starts with `#`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
