### PR TITLE
TINY-10383: Re-merging the accessibility fixes to the color-picker

### DIFF
--- a/modules/acid/src/demo/ts/ephox/acid/demo/Demo.ts
+++ b/modules/acid/src/demo/ts/ephox/acid/demo/Demo.ts
@@ -1,7 +1,8 @@
 import { Channels, Debugging, Gui, GuiFactory } from '@ephox/alloy';
-import { Fun, Optional } from '@ephox/katamari';
+import { Fun, Optional, Type } from '@ephox/katamari';
 import { Class, DomEvent, Insert, SugarElement } from '@ephox/sugar';
 
+import { Untranslated } from 'ephox/acid/alien/I18n';
 import * as ColourPicker from 'ephox/acid/gui/ColourPicker';
 
 import { strings } from '../../../../i18n/en';
@@ -19,12 +20,17 @@ DomEvent.bind(SugarElement.fromDom(document), 'mouseup', (evt) => {
   }
 });
 
-const fakeTranslate = (key: string): string =>
-  Optional.from(strings[key]).getOrThunk(() => {
+const fakeTranslate = (key: Untranslated): string => {
+  if (Type.isString(key)) {
+    return Optional.from(strings[key]).getOrThunk(() => {
     // eslint-disable-next-line no-console
-    console.error('Missing translation for ' + key);
-    return key;
-  });
+      console.error('Missing translation for ' + key);
+      return key;
+    });
+  } else {
+    return 'Untranslated, complex string';
+  }
+};
 
 const colourPickerFactory = ColourPicker.makeFactory(fakeTranslate, Fun.identity);
 

--- a/modules/acid/src/main/ts/ephox/acid/alien/I18n.ts
+++ b/modules/acid/src/main/ts/ephox/acid/alien/I18n.ts
@@ -1,0 +1,9 @@
+export interface RawString {
+  raw: string;
+}
+
+type Primitive = string | number | boolean | Record<string | number, any> | Function;
+
+export type TokenisedString = [ string, ...Primitive[] ];
+
+export type Untranslated = Primitive | TokenisedString | RawString | null | undefined;

--- a/modules/acid/src/main/ts/ephox/acid/gui/ColourPicker.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/ColourPicker.ts
@@ -4,6 +4,7 @@ import {
 import { FieldSchema } from '@ephox/boulder';
 import { Arr, Cell, Fun } from '@ephox/katamari';
 
+import { Untranslated } from '../alien/I18n';
 import { Hex } from '../api/colour/ColourTypes';
 import * as HsvColour from '../api/colour/HsvColour';
 import * as RgbaColour from '../api/colour/RgbaColour';
@@ -29,7 +30,7 @@ export interface ColourPickerSketcher extends Sketcher.SingleSketch<ColourPicker
 }
 
 const makeFactory = (
-  translate: (key: string) => string,
+  translate: (key: Untranslated) => string,
   getClass: (key: string) => string
 ): ColourPickerSketcher => {
   const factory = (detail: ColourPickerDetail) => {

--- a/modules/acid/src/main/ts/ephox/acid/gui/components/HueSlider.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/HueSlider.ts
@@ -1,4 +1,4 @@
-import { AlloyComponent, AlloyTriggers, Behaviour, Focusing, SketchSpec, Slider, Tabstopping } from '@ephox/alloy';
+import { AlloyComponent, AlloyTriggers, Behaviour, Focusing, SketchSpec, Slider } from '@ephox/alloy';
 import { Fun } from '@ephox/katamari';
 import { Attribute } from '@ephox/sugar';
 
@@ -46,7 +46,6 @@ const sliderFactory = (translate: (key: string) => string, getClass: (key: strin
       thumb
     ],
     sliderBehaviours: Behaviour.derive([
-      Tabstopping.config({ }),
       Focusing.config({ })
     ]),
 

--- a/modules/acid/src/main/ts/ephox/acid/gui/components/HueSlider.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/HueSlider.ts
@@ -1,5 +1,6 @@
-import { AlloyComponent, AlloyTriggers, Behaviour, Focusing, SketchSpec, Slider } from '@ephox/alloy';
+import { AlloyComponent, AlloyTriggers, Behaviour, Focusing, SketchSpec, Slider, Tabstopping } from '@ephox/alloy';
 import { Fun } from '@ephox/katamari';
+import { Attribute } from '@ephox/sugar';
 
 import { sliderUpdate } from '../ColourEvents';
 
@@ -29,7 +30,10 @@ const sliderFactory = (translate: (key: string) => string, getClass: (key: strin
       tag: 'div',
       classes: [ getClass('hue-slider') ],
       attributes: {
-        role: 'presentation'
+        'role': 'slider',
+        'aria-valuemin': 0,
+        'aria-valuemax': 360,
+        'aria-valuenow': 120,
       }
     },
     rounded: false,
@@ -42,10 +46,12 @@ const sliderFactory = (translate: (key: string) => string, getClass: (key: strin
       thumb
     ],
     sliderBehaviours: Behaviour.derive([
+      Tabstopping.config({ }),
       Focusing.config({ })
     ]),
 
     onChange: (slider: AlloyComponent, _thumb: any, value: any) => {
+      Attribute.set(slider.element, 'aria-valuenow', Math.floor(360 - (value * 3.6)));
       AlloyTriggers.emitWith(slider, sliderUpdate, {
         value
       });

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/HorizontalModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/HorizontalModel.ts
@@ -57,15 +57,15 @@ const setToMax = (spectrum: AlloyComponent, detail: HorizontalSliderDetail): voi
 };
 
 // move in a direction by step size. Fire change at the end
-const moveBy = (direction: number, spectrum: AlloyComponent, detail: HorizontalSliderDetail): Optional<number> => {
+const moveBy = (direction: number, spectrum: AlloyComponent, detail: HorizontalSliderDetail, useMultiplier?: boolean): Optional<number> => {
   const f = (direction > 0) ? SliderModel.increaseBy : SliderModel.reduceBy;
-  const xValue = f(currentValue(detail), minX(detail), maxX(detail), step(detail));
+  const xValue = f(currentValue(detail), minX(detail), maxX(detail), step(detail, useMultiplier));
   fireSliderChange(spectrum, xValue);
   return Optional.some(xValue);
 };
 
-const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail: HorizontalSliderDetail): Optional<boolean> =>
-  moveBy(direction, spectrum, detail).map<boolean>(Fun.always);
+const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail: HorizontalSliderDetail, useMultiplier?: boolean): Optional<boolean> =>
+  moveBy(direction, spectrum, detail, useMultiplier).map<boolean>(Fun.always);
 
 // get x offset from event
 const getValueFromEvent = (simulatedEvent: NativeSimulatedEvent<MouseEvent | TouchEvent>): Optional<number> => {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderParts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderParts.ts
@@ -5,11 +5,13 @@ import { EventArgs, SugarPosition } from '@ephox/sugar';
 import * as Behaviour from '../../api/behaviour/Behaviour';
 import { Focusing } from '../../api/behaviour/Focusing';
 import { Keying } from '../../api/behaviour/Keying';
+import { Tabstopping } from '../../api/behaviour/Tabstopping';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { OptionalDomSchema } from '../../api/component/SpecTypes';
 import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as NativeEvents from '../../api/events/NativeEvents';
 import { NativeSimulatedEvent } from '../../events/SimulatedEvent';
+import * as KeyMatch from '../../navigation/KeyMatch';
 import * as PartType from '../../parts/PartType';
 import { EdgeActions, SliderDetail } from '../types/SliderTypes';
 
@@ -90,6 +92,8 @@ const thumbPart = PartType.required<SliderDetail, { dom: OptionalDomSchema; even
   }
 });
 
+const isShift = (event: NativeSimulatedEvent<KeyboardEvent>) => KeyMatch.isShift(event.event);
+
 const spectrumPart = PartType.required({
   schema: [
     FieldSchema.customField('mouseIsDown', () => Cell(false))
@@ -108,12 +112,13 @@ const spectrumPart = PartType.required({
         Keying.config(
           {
             mode: 'special',
-            onLeft: (spectrum) => model.onLeft(spectrum, detail),
-            onRight: (spectrum) => model.onRight(spectrum, detail),
-            onUp: (spectrum) => model.onUp(spectrum, detail),
-            onDown: (spectrum) => model.onDown(spectrum, detail)
+            onLeft: (spectrum, event) => model.onLeft(spectrum, detail, isShift(event)),
+            onRight: (spectrum, event) => model.onRight(spectrum, detail, isShift(event)),
+            onUp: (spectrum, event) => model.onUp(spectrum, detail, isShift(event)),
+            onDown: (spectrum, event) => model.onDown(spectrum, detail, isShift(event))
           }
         ),
+        Tabstopping.config({ }),
         Focusing.config({})
       ]),
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderSchema.ts
@@ -18,6 +18,7 @@ interface SliderModelSpec {
 
 const SliderSchema: FieldProcessor[] = [
   FieldSchema.defaulted('stepSize', 1),
+  FieldSchema.defaulted('speedMultiplier', 10),
   FieldSchema.defaulted('onChange', Fun.noop),
   FieldSchema.defaulted('onChoose', Fun.noop),
   FieldSchema.defaulted('onInit', Fun.noop),

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderUi.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderUi.ts
@@ -1,4 +1,5 @@
-import { Fun, Optional } from '@ephox/katamari';
+import { Optional } from '@ephox/katamari';
+import { EventArgs } from '@ephox/sugar';
 
 import { Keying } from '../../api/behaviour/Keying';
 import { Receiving } from '../../api/behaviour/Receiving';
@@ -86,6 +87,10 @@ const sketch: CompositeSketchFactory<SliderDetail, SliderSpec> = (detail: Slider
     choose(slider);
   };
 
+  const focusWidget = (component: AlloyComponent) => {
+    AlloyParts.getPart(component, detail, 'spectrum').map(Keying.focusIn);
+  };
+
   return {
     uid: detail.uid,
     dom: detail.dom,
@@ -96,9 +101,7 @@ const sketch: CompositeSketchFactory<SliderDetail, SliderSpec> = (detail: Slider
       [
         Keying.config({
           mode: 'special',
-          focusIn: (slider) => {
-            return AlloyParts.getPart(slider, detail, 'spectrum').map(Keying.focusIn).map(Fun.always);
-          }
+          focusIn: focusWidget
         }),
         Representing.config({
           store: {
@@ -139,7 +142,8 @@ const sketch: CompositeSketchFactory<SliderDetail, SliderSpec> = (detail: Slider
       AlloyEvents.run(NativeEvents.touchstart(), onDragStart),
       AlloyEvents.run(NativeEvents.touchend(), onDragEnd),
       AlloyEvents.run(NativeEvents.mousedown(), onDragStart),
-      AlloyEvents.run(NativeEvents.mouseup(), onDragEnd)
+      AlloyEvents.run(NativeEvents.mouseup(), onDragEnd),
+      AlloyEvents.run<EventArgs>(NativeEvents.mousedown(), focusWidget)
     ]),
 
     apis: {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderValues.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderValues.ts
@@ -30,7 +30,7 @@ const yRange = (detail: VerticalSliderDetail): number => range(detail, maxY, min
 const halfX = (detail: HorizontalSliderDetail): number => xRange(detail) / 2;
 const halfY = (detail: VerticalSliderDetail): number => yRange(detail) / 2;
 
-const step = (detail: SliderDetail): number => detail.stepSize;
+const step = (detail: SliderDetail, useMultiplier?: boolean): number => useMultiplier ? detail.stepSize * detail.speedMultiplier : detail.stepSize;
 const snap = (detail: SliderDetail): boolean => detail.snapToGrid;
 const snapStart = (detail: SliderDetail): Optional<number> => detail.snapStart;
 const rounded = (detail: SliderDetail): boolean => detail.rounded;

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/TwoDModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/TwoDModel.ts
@@ -33,19 +33,19 @@ const setValueFrom = (spectrum: AlloyComponent, detail: TwoDSliderDetail, value:
 };
 
 // move in a direction by step size. Fire change at the end
-const moveBy = (direction: number, isVerticalMovement: boolean, spectrum: AlloyComponent, detail: TwoDSliderDetail): Optional<number> => {
+const moveBy = (direction: number, isVerticalMovement: boolean, spectrum: AlloyComponent, detail: TwoDSliderDetail, useMultiplier?: boolean): Optional<number> => {
   const f = (direction > 0) ? SliderModel.increaseBy : SliderModel.reduceBy;
   const xValue = isVerticalMovement ? currentValue(detail).x :
-    f(currentValue(detail).x, minX(detail), maxX(detail), step(detail));
+    f(currentValue(detail).x, minX(detail), maxX(detail), step(detail, useMultiplier));
   const yValue = !isVerticalMovement ? currentValue(detail).y :
-    f(currentValue(detail).y, minY(detail), maxY(detail), step(detail));
+    f(currentValue(detail).y, minY(detail), maxY(detail), step(detail, useMultiplier));
 
   fireSliderChange(spectrum, sliderValue(xValue, yValue));
   return Optional.some(xValue);
 };
 
-const handleMovement = (direction: number, isVerticalMovement: boolean) => (spectrum: AlloyComponent, detail: TwoDSliderDetail): Optional<boolean> =>
-  moveBy(direction, isVerticalMovement, spectrum, detail).map<boolean>(Fun.always);
+const handleMovement = (direction: number, isVerticalMovement: boolean) => (spectrum: AlloyComponent, detail: TwoDSliderDetail, useMultiplier?: boolean): Optional<boolean> =>
+  moveBy(direction, isVerticalMovement, spectrum, detail, useMultiplier).map<boolean>(Fun.always);
 
 // fire a slider change event with the minimum value
 const setToMin = (spectrum: AlloyComponent, detail: TwoDSliderDetail): void => {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/VerticalModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/VerticalModel.ts
@@ -57,15 +57,15 @@ const setToMax = (spectrum: AlloyComponent, detail: VerticalSliderDetail): void 
 };
 
 // move in a direction by step size. Fire change at the end
-const moveBy = (direction: number, spectrum: AlloyComponent, detail: VerticalSliderDetail): Optional<number> => {
+const moveBy = (direction: number, spectrum: AlloyComponent, detail: VerticalSliderDetail, useMultiplier?: boolean): Optional<number> => {
   const f = (direction > 0) ? SliderModel.increaseBy : SliderModel.reduceBy;
-  const yValue = f(currentValue(detail), minY(detail), maxY(detail), step(detail));
+  const yValue = f(currentValue(detail), minY(detail), maxY(detail), step(detail, useMultiplier));
   fireSliderChange(spectrum, yValue);
   return Optional.some(yValue);
 };
 
-const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail: VerticalSliderDetail): Optional<boolean> =>
-  moveBy(direction, spectrum, detail).map<boolean>(Fun.always);
+const handleMovement = (direction: number) => (spectrum: AlloyComponent, detail: VerticalSliderDetail, useMultiplier?: boolean): Optional<boolean> =>
+  moveBy(direction, spectrum, detail, useMultiplier).map<boolean>(Fun.always);
 
 // get y offset from event
 const getValueFromEvent = (simulatedEvent: NativeSimulatedEvent<MouseEvent | TouchEvent>): Optional<number> => {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/SliderTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/SliderTypes.ts
@@ -48,10 +48,10 @@ export interface Manager {
   setToMax: (spectrum: AlloyComponent, detail: SliderDetail) => void;
   getValueFromEvent: (simulatedEvent: NativeSimulatedEvent<MouseEvent | TouchEvent>) => Optional<number | SugarPosition>;
   setPositionFromValue: (slider: AlloyComponent, thumb: AlloyComponent, detail: SliderDetail, parts: SliderModelDetailParts) => void;
-  onLeft: (spectrum: AlloyComponent, detail: SliderDetail) => Optional<boolean>;
-  onRight: (spectrum: AlloyComponent, detail: SliderDetail) => Optional<boolean>;
-  onUp: (spectrum: AlloyComponent, detail: SliderDetail) => Optional<boolean>;
-  onDown: (spectrum: AlloyComponent, detail: SliderDetail) => Optional<boolean>;
+  onLeft: (spectrum: AlloyComponent, detail: SliderDetail, useMultiplier?: boolean) => Optional<boolean>;
+  onRight: (spectrum: AlloyComponent, detail: SliderDetail, useMultiplier?: boolean) => Optional<boolean>;
+  onUp: (spectrum: AlloyComponent, detail: SliderDetail, useMultiplier?: boolean) => Optional<boolean>;
+  onDown: (spectrum: AlloyComponent, detail: SliderDetail, useMultiplier?: boolean) => Optional<boolean>;
   edgeActions: EdgeActions;
 }
 
@@ -91,6 +91,7 @@ export interface SliderDetail extends CompositeSketchDetail {
   model: SliderModelDetail;
   rounded: boolean;
   stepSize: number;
+  speedMultiplier: number;
   snapToGrid: boolean;
   snapStart: Optional<number>;
 

--- a/modules/oxide/src/less/theme/components/color-picker/color-picker.less
+++ b/modules/oxide/src/less/theme/components/color-picker/color-picker.less
@@ -61,6 +61,11 @@
     width: 20px;
   }
 
+  .tox-hue-slider-spectrum:focus,
+  .tox-sv-palette-spectrum:focus {
+    outline: #08f solid;
+  }
+
   .tox-hue-slider-thumb {
     background: white;
     border: 1px solid black;

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `convert_unsafe_embeds` option that controls whether `<object>` and `<embed>` elements will be converted to more restrictive alternatives, namely `<img>` for image MIME types, `<video>` for video MIME types, `<audio>` audio MIME types, or `<iframe>` for other or unspecified MIME types. #TINY-10349
 
 ### Improved
+- Colorpicker now includes the Brightness/Saturation selector and hue slider in the keyboard navigable items. #TINY-9287
 - Improved the tooltips of picker buttons for the urlinput components in the "Insert/Edit Image" and "Insert/Edit Link" dialogs. #TINY-10155
 - Inline dialog will now respect `size: 'large'` argument in the dialog spec. #TINY-10209
 - SVG elements and their children are now retained when configured as valid elements. #TINY-10237

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
@@ -1,7 +1,9 @@
 import { ColourPicker } from '@ephox/acid';
 import { AlloyComponent, AlloyTriggers, Behaviour, Composing, Form, Memento, NativeEvents, Representing, SimpleSpec } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Arr, Optional, Strings } from '@ephox/katamari';
+import { Arr, Optional, Strings, Type } from '@ephox/katamari';
+
+import { Untranslated } from 'tinymce/core/api/util/I18n';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
@@ -22,8 +24,12 @@ const english: Record<string, string> = {
   'aria.input.invalid': 'Invalid input'
 };
 
-const translate = (providerBackstage: UiFactoryBackstageProviders) => (key: string) => {
-  return providerBackstage.translate(english[key]);
+const translate = (providerBackstage: UiFactoryBackstageProviders) => (key: Untranslated) => {
+  if (Type.isString(key)) {
+    return providerBackstage.translate(english[key]);
+  } else {
+    return providerBackstage.translate(key);
+  }
 };
 
 type ColorPickerSpec = Omit<Dialog.ColorPicker, 'type'>;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -1,4 +1,4 @@
-import { FocusTools, Keys, UiFinder, Waiter } from '@ephox/agar';
+import { FocusTools, Keys, Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
 import { Attribute, SelectorFilter, SugarDocument, SugarElement, SugarShadowDom } from '@ephox/sugar';
@@ -200,6 +200,38 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         await FocusTools.pTryOnSelector('Should have selected the hue slider', doc, '.tox-hue-slider-spectrum');
         TinyUiActions.keydown(editor, Keys.tab());
         await FocusTools.pTryOnSelector('Should have selected the next input', doc, '.tox-textfield');
+        await pCancelDialog(editor);
+      });
+
+      it('TINY-9287: Keyboard tab navigation works as expected, starting at the canvas, shift-tab should go backwards', async () => {
+        const editor = hook.editor();
+        const elem = TinyDom.targetElement(editor);
+        const doc = SugarShadowDom.getShadowRoot(elem).getOrThunk(() => SugarDocument.getDocument());
+        await pOpenDialog(editor);
+        await FocusTools.pTryOnSelector('Should have selected the main view', doc, 'canvas');
+        TinyUiActions.keydown(editor, Keys.tab());
+        await FocusTools.pTryOnSelector('Should have selected the hue slider', doc, '.tox-hue-slider-spectrum');
+        TinyUiActions.keydown(editor, Keys.tab());
+        await FocusTools.pTryOnSelector('Should have selected the next input', doc, '.tox-textfield');
+        TinyUiActions.keydown(editor, Keys.tab(), { shiftKey: true });
+        await FocusTools.pTryOnSelector('Should have selected the hue slider', doc, '.tox-hue-slider-spectrum');
+        TinyUiActions.keydown(editor, Keys.tab(), { shiftKey: true });
+        await FocusTools.pTryOnSelector('Should have selected the main view', doc, 'canvas');
+        await pCancelDialog(editor);
+      });
+
+      it('TINY-9287: Clicking changes focus as expected', async () => {
+        const editor = hook.editor();
+        const element = TinyDom.targetElement(editor);
+        const doc = SugarShadowDom.getShadowRoot(element).getOrThunk(() => SugarDocument.getDocument());
+        await pOpenDialog(editor);
+        await FocusTools.pTryOnSelector('Should have started on the main view', doc, 'canvas');
+        let targetElement = UiFinder.findIn(TinyUiActions.getUiRoot(editor), '.tox-hue-slider-spectrum').getOrDie();
+        Mouse.mouseDown(targetElement);
+        await FocusTools.pTryOnSelector('Should have selected the hue slider', doc, '.tox-hue-slider-spectrum');
+        targetElement = UiFinder.findIn(TinyUiActions.getUiRoot(editor), 'canvas').getOrDie();
+        Mouse.mouseDown(targetElement);
+        await FocusTools.pTryOnSelector('Should have ended on the main view', doc, 'canvas');
         await pCancelDialog(editor);
       });
     });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -1,7 +1,7 @@
-import { UiFinder, Waiter } from '@ephox/agar';
+import { FocusTools, Keys, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional } from '@ephox/katamari';
-import { SelectorFilter, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { Attribute, SelectorFilter, SugarDocument, SugarElement, SugarShadowDom } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -117,6 +117,13 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         await Waiter.pTryUntil('Dialog should close', () => UiFinder.notExists(getBody(editor), dialogSelector));
       };
 
+      const assertAriaValues = (editor: Editor, hue: number, saturation: number, brightness: number) => {
+        const palette = UiFinder.findIn(getBody(editor), '.tox-sv-palette').getOrDie();
+        const slider = UiFinder.findIn(getBody(editor), '.tox-hue-slider').getOrDie();
+        assert.equal(Attribute.get(palette, 'aria-valuetext'), `Saturation ${saturation}%, Brightness ${brightness}%`);
+        assert.equal(Attribute.get(slider, 'aria-valuenow'), '' + hue);
+      };
+
       it('TBA: Open dialog, click Save and assert color is white', async () => {
         const editor = hook.editor();
         await pOpenDialog(editor);
@@ -139,11 +146,13 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         // Change color to black
         await pOpenDialog(editor);
         await pSetHexBlack(editor);
+        assertAriaValues(editor, 120, 0, 0);
         TinyUiActions.submitDialog(editor);
         await pWaitForDialogClose(editor);
         // Change color in the dialog but cancel
         await pOpenDialog(editor);
         await pSetHexWhite(editor);
+        assertAriaValues(editor, 120, 0, 100);
         await pCancelDialog(editor);
         assertColorBlack();
       });
@@ -179,6 +188,19 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         await pSetHex('invalid')(editor);
         TinyUiActions.submitDialog(editor);
         await pAssertExpectedAlert(editor, 'Invalid hex color code: #invalid');
+      });
+
+      it('TINY-9287: Keyboard tab navigation works as expected, starting at the canvas', async () => {
+        const editor = hook.editor();
+        const elem = TinyDom.targetElement(editor);
+        const doc = SugarShadowDom.getShadowRoot(elem).getOrThunk(() => SugarDocument.getDocument());
+        await pOpenDialog(editor);
+        await FocusTools.pTryOnSelector('Should have selected the main view', doc, 'canvas');
+        TinyUiActions.keydown(editor, Keys.tab());
+        await FocusTools.pTryOnSelector('Should have selected the hue slider', doc, '.tox-hue-slider-spectrum');
+        TinyUiActions.keydown(editor, Keys.tab());
+        await FocusTools.pTryOnSelector('Should have selected the next input', doc, '.tox-textfield');
+        await pCancelDialog(editor);
       });
     });
   });


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-10383

Description of Changes:
These already-approved things were found to cause a regression with regards to slider behavior and was hurriedly removed prior to release. This re-introduces it, so that the fix can be applied in a separate PR ( as to allow it to be properly reviewd without being mixed in with all of the previous things )

No changes has been made to this code, it is only the previously removed commits.

Pre-checks:
* ~~[ ] Changelog entry added~~
* ~~[ ] Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* ~~[ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):
