### PR TITLE
TINY-10383: Sliders could not be dragged.

### DIFF
--- a/modules/alloy/CHANGELOG.md
+++ b/modules/alloy/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Slider could not be dragged as expected. TINY-10383
+
 ## 14.0.0 - 2023-11-22
 
 ### Changed

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderUi.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderUi.ts
@@ -1,5 +1,4 @@
 import { Optional } from '@ephox/katamari';
-import { EventArgs } from '@ephox/sugar';
 
 import { Keying } from '../../api/behaviour/Keying';
 import { Receiving } from '../../api/behaviour/Receiving';
@@ -141,9 +140,11 @@ const sketch: CompositeSketchFactory<SliderDetail, SliderSpec> = (detail: Slider
       }),
       AlloyEvents.run(NativeEvents.touchstart(), onDragStart),
       AlloyEvents.run(NativeEvents.touchend(), onDragEnd),
-      AlloyEvents.run(NativeEvents.mousedown(), onDragStart),
+      AlloyEvents.run(NativeEvents.mousedown(), (component, event: NativeSimulatedEvent<DragEvent>) => {
+        focusWidget(component);
+        onDragStart(component, event);
+      }),
       AlloyEvents.run(NativeEvents.mouseup(), onDragEnd),
-      AlloyEvents.run<EventArgs>(NativeEvents.mousedown(), focusWidget)
     ]),
 
     apis: {


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-10383

Sliders could not be dragged. Combined event listeners into one, and calling the functions one at a time. Dragging now works.

Pre-checks:
* [x] Changelog entry added
* ~~[ ] Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
