### PR TITLE
TINY-10310: Blur events not fired as expected.

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
@@ -230,6 +230,7 @@ const makeSandbox = (
 
   const onClose = (component: AlloyComponent, menu: AlloyComponent) => {
     ariaControls.unlink(hotspot.element);
+    lazySink().getOr(menu).element.dom.dispatchEvent(new window.FocusEvent('focusout'));
     if (extras !== undefined && extras.onClose !== undefined) {
       extras.onClose(component, menu);
     }

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - When deleting the last row in a table, the cursor would jump to the first cell (top left), instead of moving to the next adjacent cell in some cases. #TINY-6309
 - The functions `schema.isWrapper` and `schema.isInline` didn't exclude element names that started with `#` those should not be considered elements. #TINY-10385
+- Moving focus to the outside of the editor after having clicked a menu would not fire a `blur` event as expected. #TINY-10310
 
 ## 6.8.0 - 2023-11-22
 

--- a/modules/tinymce/src/themes/silver/main/ts/Events.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Events.ts
@@ -98,6 +98,9 @@ const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMotherships: Gui.Gui
     broadcastOn(Channels.dismissPopups(), { target: SugarElement.fromDom(event.relatedTarget.getContainer()) });
   };
 
+  const onFocusIn = (event: FocusEvent) => editor.dispatch('focusin', event);
+  const onFocusOut = (event: FocusEvent) => editor.dispatch('focusout', event);
+
   // Don't start listening to events until the UI has rendered
   editor.on('PostRender', () => {
     editor.on('click', onContentClick);
@@ -109,6 +112,11 @@ const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMotherships: Gui.Gui
     editor.on('ResizeEditor', onEditorResize);
     editor.on('AfterProgressState', onEditorProgress);
     editor.on('DismissPopups', onDismissPopups);
+
+    Arr.each([ mothership, ...uiMotherships ], (gui) => {
+      gui.element.dom.addEventListener('focusin', onFocusIn);
+      gui.element.dom.addEventListener('focusout', onFocusOut);
+    });
   });
 
   editor.on('remove', () => {
@@ -122,6 +130,11 @@ const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMotherships: Gui.Gui
     editor.off('ResizeEditor', onEditorResize);
     editor.off('AfterProgressState', onEditorProgress);
     editor.off('DismissPopups', onDismissPopups);
+
+    Arr.each([ mothership, ...uiMotherships ], (gui) => {
+      gui.element.dom.removeEventListener('focusin', onFocusIn);
+      gui.element.dom.removeEventListener('focusout', onFocusOut);
+    });
 
     onMousedown.unbind();
     onTouchstart.unbind();


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-10310

Description of Changes:
Blur event was triggered by focusin/focusout passing through the focuscontroller, these were not relayed to the focuscontroller from the ui.

Pre-checks:
* [x] Changelog entry added
* ~~[ ] Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
