### PR TITLE
TINY-10414: Fix for toggle of nested list with non-list siblings

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When deleting the last row in a table, the cursor would jump to the first cell (top left), instead of moving to the next adjacent cell in some cases. #TINY-6309
 - The functions `schema.isWrapper` and `schema.isInline` didn't exclude element names that started with `#` those should not be considered elements. #TINY-10385
 - Moving focus to the outside of the editor after having clicked a menu would not fire a `blur` event as expected. #TINY-10310
+- Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10414
 
 ## 6.8.1 - 2023-11-29
 

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/ComposeList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/ComposeList.ts
@@ -48,9 +48,13 @@ const populateSegments = (segments: Segment[], entry: Entry): void => {
     if (isEntryList(entry)) {
       Attribute.setAll(segment.list, entry.listAttributes);
       Attribute.setAll(segment.item, entry.itemAttributes);
-    }
-    if (isEntryList(entry) || isEntryNoList(entry)) {
       InsertAll.append(segment.item, entry.content);
+    }
+    if (isEntryNoList(entry)) {
+      const item = SugarElement.fromTag(entry.type);
+      Attribute.setAll(item, entry.attributes);
+      InsertAll.append(item, entry.content);
+      InsertAll.append(segment.item, [ item ]);
     }
   });
 };

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/ComposeList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/ComposeList.ts
@@ -48,10 +48,8 @@ const populateSegments = (segments: Segment[], entry: EntryList | EntryFragment)
     if (isEntryList(entry)) {
       Attribute.setAll(segment.list, entry.listAttributes);
       Attribute.setAll(segment.item, entry.itemAttributes);
-      InsertAll.append(segment.item, entry.content);
-    } else {
-      InsertAll.append(segment.item, entry.content);
     }
+    InsertAll.append(segment.item, entry.content);
   });
 };
 
@@ -106,18 +104,16 @@ const composeList = (scope: Document, entries: Entry[]): Optional<SugarElement<H
   let firstCommentEntryOpt: Optional<Entry> = Optional.none();
 
   const cast = Arr.foldl(entries, (cast, entry, i) => {
-    if (isEntryList(entry)) {
+    if (!isEntryComment(entry)) {
       return entry.depth > cast.length ? writeDeep(scope, cast, entry) : writeShallow(scope, cast, entry);
     } else {
       // this is needed becuase if the first element of the list is a comment we would not have the data to create the new list
-      if (i === 0 && isEntryComment(entry)) {
+      if (i === 0) {
         firstCommentEntryOpt = Optional.some(entry);
         return cast;
       }
 
-      return (entry.depth > cast.length && !isEntryComment(entry))
-        ? writeDeep(scope, cast, entry)
-        : writeShallow(scope, cast, entry);
+      return writeShallow(scope, cast, entry);
     }
   }, [] as Segment[]);
 

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/ComposeList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/ComposeList.ts
@@ -40,7 +40,7 @@ const createSegments = (scope: Document, entry: EntryList | EntryNoList, size: n
   return segments;
 };
 
-const populateSegments = (segments: Segment[], entry: Entry): void => {
+const populateSegments = (segments: Segment[], entry: EntryList | EntryNoList): void => {
   for (let i = 0; i < segments.length - 1; i++) {
     Css.set(segments[i].item, 'list-style-type', 'none');
   }
@@ -49,8 +49,7 @@ const populateSegments = (segments: Segment[], entry: Entry): void => {
       Attribute.setAll(segment.list, entry.listAttributes);
       Attribute.setAll(segment.item, entry.itemAttributes);
       InsertAll.append(segment.item, entry.content);
-    }
-    if (isEntryNoList(entry)) {
+    } else {
       const item = SugarElement.fromTag(entry.type);
       Attribute.setAll(item, entry.attributes);
       InsertAll.append(item, entry.content);

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/Entry.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/Entry.ts
@@ -51,7 +51,7 @@ export interface EntryComment {
 
 const isEntryList = (entry: Entry): entry is EntryList => 'listAttributes' in entry;
 
-const isEntryNoList = (entry: Entry): entry is EntryNoList => 'isInPreviousLi' in entry;
+const isEntryNoList = (entry: Entry): entry is EntryNoList => 'parentListType' in entry;
 
 const isEntryComment = (entry: Entry): entry is EntryComment => 'isComment' in entry;
 

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/Entry.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/Entry.ts
@@ -37,6 +37,7 @@ export interface EntryNoList {
   isSelected: boolean;
   type: string;
   attributes: Record<string, any>;
+  parentListType: ListType;
   isInPreviousLi: boolean;
 }
 

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/Entry.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/Entry.ts
@@ -18,7 +18,7 @@ General workflow: Parse lists to entries -> Manipulate entries -> Compose entrie
 0-------1---2--------->Depth
 */
 
-export type Entry = EntryList | EntryNoList | EntryComment;
+export type Entry = EntryList | EntryComment | EntryFragment;
 
 export interface EntryList {
   depth: number;
@@ -30,15 +30,13 @@ export interface EntryList {
   itemAttributes: Record<string, any>;
 }
 
-export interface EntryNoList {
+export interface EntryFragment {
+  isFragment: true;
   depth: number;
-  dirty: boolean;
   content: SugarElement<Node>[];
   isSelected: boolean;
-  type: string;
-  attributes: Record<string, any>;
+  dirty: boolean;
   parentListType: ListType;
-  isInPreviousLi: boolean;
 }
 
 export interface EntryComment {
@@ -51,9 +49,9 @@ export interface EntryComment {
 
 const isEntryList = (entry: Entry): entry is EntryList => 'listAttributes' in entry;
 
-const isEntryNoList = (entry: Entry): entry is EntryNoList => 'parentListType' in entry;
-
 const isEntryComment = (entry: Entry): entry is EntryComment => 'isComment' in entry;
+
+const isEntryFragment = (entry: Entry): entry is EntryFragment => 'isFragment' in entry;
 
 const isIndented = (entry: Entry): boolean => entry.depth > 0;
 
@@ -79,8 +77,8 @@ const createEntry = (li: SugarElement, depth: number, isSelected: boolean): Opti
 export {
   createEntry,
   isEntryComment,
+  isEntryFragment,
   isEntryList,
-  isEntryNoList,
   isIndented,
   isSelected
 };

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/ParseLists.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/ParseLists.ts
@@ -1,8 +1,8 @@
 import { Arr, Cell, Optional } from '@ephox/katamari';
 import { Compare, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
-import { createEntry, Entry, EntryComment, EntryNoList, isEntryList } from './Entry';
-import { isList, ListType } from './Util';
+import { createEntry, Entry, EntryFragment } from './Entry';
+import { isList, isListItem, ListType } from './Util';
 
 type Parser = (depth: number, itemSelection: Optional<ItemSelection>, selectionState: Cell<boolean>, element: SugarElement) => Entry[];
 
@@ -15,23 +15,6 @@ export interface EntrySet {
   readonly entries: Entry[];
   readonly sourceList: SugarElement<HTMLElement>;
 }
-
-const entryToEntryNoList = (entry: Entry, type: string, isInPreviousLi: boolean, parentListType: ListType): EntryNoList | EntryComment => {
-  if (isEntryList(entry)) {
-    return ({
-      depth: entry.depth,
-      dirty: entry.dirty,
-      content: entry.content,
-      isSelected: entry.isSelected,
-      type,
-      attributes: entry.itemAttributes,
-      isInPreviousLi,
-      parentListType
-    });
-  } else {
-    return entry;
-  }
-};
 
 const parseSingleItem: Parser = (depth: number, itemSelection: Optional<ItemSelection>, selectionState: Cell<boolean>, item: SugarElement<HTMLElement>): Entry[] => {
   if (SugarNode.isComment(item)) {
@@ -71,18 +54,23 @@ const parseItem: Parser = (depth: number, itemSelection: Optional<ItemSelection>
   Traverse.firstChild(item).filter(isList).fold(
     () => parseSingleItem(depth, itemSelection, selectionState, item),
     (list) => {
-      const parsedSiblings = Arr.foldl(Traverse.children(item), (acc: Entry[], s, i) => {
+      const parsedSiblings = Arr.foldl(Traverse.children(item), (acc: Entry[], liChild, i) => {
         if (i === 0) {
           return acc;
         } else {
-          const parsedSibling = parseSingleItem(depth, itemSelection, selectionState, s)
-            .map((e) => entryToEntryNoList(
-              e,
-              s.dom.nodeName.toLowerCase(),
-              true,
-              Traverse.parent(item).filter(SugarNode.isElement).map(SugarNode.name).getOr(ListType.UL) as ListType
-            ));
-          return acc.concat(parsedSibling);
+          if (isListItem(liChild)) {
+            return acc.concat(parseSingleItem(depth, itemSelection, selectionState, liChild));
+          } else {
+            const fragment: EntryFragment = {
+              isFragment: true,
+              depth,
+              content: [ liChild ],
+              isSelected: false,
+              dirty: false,
+              parentListType: SugarNode.name(list) as ListType
+            };
+            return acc.concat(fragment);
+          }
         }
       }, []);
 

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/Util.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/Util.ts
@@ -8,6 +8,9 @@ export const enum ListType {
 const isList = (el: SugarElement<Node>): el is SugarElement<HTMLOListElement | HTMLUListElement> =>
   Compare.is(el, 'OL,UL');
 
+const isListItem = (el: SugarElement<Node>): el is SugarElement<HTMLLIElement> =>
+  Compare.is(el, 'LI');
+
 const hasFirstChildList = (el: SugarElement<HTMLElement>): boolean =>
   Traverse.firstChild(el).exists(isList);
 
@@ -15,7 +18,7 @@ const hasLastChildList = (el: SugarElement<HTMLElement>): boolean =>
   Traverse.lastChild(el).exists(isList);
 
 export {
-  isList,
   hasFirstChildList,
-  hasLastChildList
+  hasLastChildList, isList,
+  isListItem
 };

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -552,7 +552,7 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
         '<li style="list-style-type: none;">' +
           '<ul>' +
             '<li>' +
-              'C' +
+              '<p>C</p>' +
               '<p>D</p>' +
             '</li>' +
           '</ul>' +

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -522,6 +522,45 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
     assert.equal(editor.selection.getNode().nodeName, 'LI');
   });
 
+  it('TINY-10414: toggle a list inside a `li` with non-list siblings should not delete the siblings', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<ul>' +
+        '<li>A' +
+          '<ul>' +
+            '<li style="list-style-type: none;">' +
+              '<ul>' +
+                '<li>B</li>' +
+              '</ul>' +
+              '<p>C</p>' +
+              '<p>D</p>' +
+            '</li>' +
+          '</ul>' +
+        '</li>' +
+      '</ul>'
+    );
+
+    TinySelections.setCursor(editor, [ 0, 0, 1, 0, 0, 0 ], 0);
+    editor.execCommand('InsertUnorderedList');
+
+    TinyAssertions.assertContent(editor,
+      '<ul>' +
+        '<li>A</li>' +
+      '</ul>' +
+      '<p>B</p>' +
+      '<ul>' +
+        '<li style="list-style-type: none;">' +
+          '<ul>' +
+            '<li>' +
+              'C' +
+              '<p>D</p>' +
+            '</li>' +
+          '</ul>' +
+        '</li>' +
+      '</ul>'
+    );
+  });
+
   it('TINY-10268: a `list` inside a `li` surrounded by 2 not element should allow the user to indent/outdent its `li`', () => {
     const editor = hook.editor();
     editor.setContent(`<ul>

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -453,16 +453,16 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
     const editor = hook.editor();
     editor.setContent(
       '<ol>' +
-      '<li>a</li>' +
-      '<!-- c1 -->' +
-      '<li>' +
-      '<ol>' +
-      '<li>b</li>' +
-      '</ol>' +
-      '<p data-fake-attr="something">p1</p>' +
-      '<p data-fake-attr="something">p2</p>' +
-      '</li>' +
-      '<!-- c2 -->' +
+        '<li>a</li>' +
+        '<!-- c1 -->' +
+        '<li>' +
+          '<ol>' +
+            '<li>b</li>' +
+          '</ol>' +
+          '<p data-fake-attr="something">p1</p>' +
+          '<p data-fake-attr="something">p2</p>' +
+        '</li>' +
+        '<!-- c2 -->' +
       '</ol>'
     );
 
@@ -472,15 +472,15 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
     TinyAssertions.assertContent(editor,
       '<p>a</p>' +
       '<ol>' +
-      '<!-- c1 -->' +
-      '<li style="list-style-type: none;">' +
-      '<ol>' +
-      '<li>b</li>' +
-      '</ol>' +
-      '<p data-fake-attr="something">p1</p>' +
-      '<p data-fake-attr="something">p2</p>' +
-      '</li>' +
-      '<!-- c2 -->' +
+        '<!-- c1 -->' +
+        '<li style="list-style-type: none;">' +
+          '<ol>' +
+            '<li>b</li>' +
+          '</ol>' +
+          '<p data-fake-attr="something">p1</p>' +
+          '<p data-fake-attr="something">p2</p>' +
+        '</li>' +
+        '<!-- c2 -->' +
       '</ol>'
     );
 
@@ -488,16 +488,16 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
 
     editor.setContent(
       '<ol start="2">' +
-      '<li>a</li>' +
-      '<!-- c1 -->' +
-      '<li>' +
-      '<ol start="5">' +
-      '<li>b</li>' +
-      '</ol>' +
-      '<p data-fake-attr="something">p1</p>' +
-      '<p data-fake-attr="something">p2</p>' +
-      '</li>' +
-      '<!-- c2 -->' +
+        '<li>a</li>' +
+        '<!-- c1 -->' +
+        '<li>' +
+          '<ol start="5">' +
+            '<li>b</li>' +
+          '</ol>' +
+          '<p data-fake-attr="something">p1</p>' +
+          '<p data-fake-attr="something">p2</p>' +
+        '</li>' +
+        '<!-- c2 -->' +
       '</ol>'
     );
 
@@ -506,16 +506,16 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
 
     TinyAssertions.assertContent(editor,
       '<ol>' +
-      '<li style="list-style-type: none;">' +
-      '<ol start="5">' +
-      '<li>a</li>' +
-      '<!-- c1 -->' +
-      '<li>b</li>' +
-      '</ol>' +
-      '<p data-fake-attr="something">p1</p>' +
-      '<p data-fake-attr="something">p2</p>' +
-      '</li>' +
-      '<!-- c2 -->' +
+        '<li style="list-style-type: none;">' +
+          '<ol start="5">' +
+            '<li>a</li>' +
+            '<!-- c1 -->' +
+            '<li>b</li>' +
+          '</ol>' +
+          '<p data-fake-attr="something">p1</p>' +
+          '<p data-fake-attr="something">p2</p>' +
+        '</li>' +
+        '<!-- c2 -->' +
       '</ol>'
     );
 

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/IndentTest.ts
@@ -540,7 +540,7 @@ describe('browser.tinymce.plugins.lists.IndentTest', () => {
       '</ul>'
     );
 
-    TinySelections.setCursor(editor, [ 0, 0, 1, 0, 0, 0 ], 0);
+    TinySelections.setCursor(editor, [ 0, 0, 1, 0, 0, 0, 0 ], 0);
     editor.execCommand('InsertUnorderedList');
 
     TinyAssertions.assertContent(editor,

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/RetainContentTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/RetainContentTest.ts
@@ -1,0 +1,95 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Fun, Optional } from '@ephox/katamari';
+import { TinyHooks } from '@ephox/mcagar';
+import { SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
+import * as fc from 'fast-check';
+
+import Editor from 'tinymce/core/api/Editor';
+import { composeList } from 'tinymce/plugins/lists/listmodel/ComposeList';
+import { parseLists } from 'tinymce/plugins/lists/listmodel/ParseLists';
+import Plugin from 'tinymce/plugins/lists/Plugin';
+
+import * as ArbList from '../module/ArbList';
+
+describe('browser.tinymce.plugins.lists.RetainContentTest', () => {
+  const getListTextContent = (el: Element) => el.textContent;
+
+  context('Model tests', () => {
+    const numRuns = 1;
+
+    it('TINY-10414: Parse and compose should not throw away content', () => {
+      fc.assert(fc.property(ArbList.domListGenerator, (list) => {
+        const listTextContent = getListTextContent(list);
+        const { entries } = parseLists([ SugarElement.fromDom(list) ], Optional.none())[0];
+        const listEl = composeList(document, entries).getOrDie('Should produce a list element');
+        assert.equal(getListTextContent(listEl.dom), listTextContent, 'Text content should not been removed');
+      }), {
+        seed: -757675458,
+        numRuns
+      });
+    });
+  });
+
+  context('Editor operations', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      indent: false,
+      plugins: 'lists',
+      base_url: '/project/tinymce/js/tinymce'
+    }, [ Plugin ], true);
+    const numRuns = 10;
+
+    const setArbListToEditor = (editor: Editor, { list, range }: ArbList.ArbDomListElementWithSelection) => {
+      editor.getBody().textContent = '';
+      editor.getBody().appendChild(list);
+      editor.selection.setRng(range);
+    };
+
+    const getEditorTextContent = (editor: Editor) => {
+      const editorContent = editor.getContent();
+      const el = document.createElement('body');
+      el.innerHTML = editorContent;
+      return el.textContent;
+    };
+
+    const testEditorEffectOnList = (f: (editor: Editor) => void) => {
+      fc.assert(fc.property(ArbList.domListWithSelectionGenerator, (arbList) => {
+        const editor = hook.editor();
+        const listTextContent = getListTextContent(arbList.list);
+
+        setArbListToEditor(editor, arbList);
+
+        f(editor);
+
+        assert.equal(getEditorTextContent(editor), listTextContent, 'Should be the original list content');
+      }), { numRuns });
+    };
+
+    const testEditorCommandOnList = (cmd: string) => testEditorEffectOnList((editor) => editor.execCommand(cmd));
+
+    it('TINY-10414: Setting and getting the list back should always retain all content', () =>
+      testEditorEffectOnList(Fun.noop)
+    );
+
+    it('TINY-10414: Applying bold to a list should not affect the text content', () =>
+      testEditorCommandOnList('Bold')
+    );
+
+    it('TINY-10414: Indenting a list should not affect the text content', () =>
+      testEditorCommandOnList('Indent')
+    );
+
+    it('TINY-10414: Outdenting a list should not affect the text content', () =>
+      testEditorCommandOnList('Outdent')
+    );
+
+    it('TINY-10414: Toggling unordered list should should not affect the text content', () =>
+      testEditorCommandOnList('InsertUnorderedList')
+    );
+
+    it('TINY-10414: Toggling ordered list should not affect the text content', () =>
+      testEditorCommandOnList('InsertOrderedList')
+    );
+  });
+});
+

--- a/modules/tinymce/src/plugins/lists/test/ts/module/ArbList.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/module/ArbList.ts
@@ -1,0 +1,204 @@
+import { Arr } from '@ephox/katamari';
+import * as fc from 'fast-check';
+
+interface ArbTextNode {
+  readonly type: '#text';
+  readonly value: string;
+}
+
+interface ArbCommentNode {
+  readonly type: '#comment';
+  readonly value: string;
+}
+
+interface ArbElementNode {
+  readonly type: 'strong' | 'em' | 'h3' | 'div';
+  readonly children: Array<ArbTextNode | ArbCommentNode>;
+}
+
+type ArbListItemChildNode = ArbListElement | ArbTextNode | ArbCommentNode | ArbElementNode;
+
+interface ArbListItem {
+  readonly type: 'li';
+  readonly children: ArbListItemChildNode[];
+}
+
+interface ArbListElement {
+  readonly type: 'ul' | 'ol';
+  readonly children: ArbListItem[];
+}
+
+interface ArbListElementWithSelection {
+  readonly list: ArbListElement;
+  readonly startTextNodeIndex: number;
+  readonly endTextNodeIndex: number;
+}
+
+export interface ArbDomListElementWithSelection {
+  readonly list: HTMLOListElement | HTMLUListElement;
+  readonly range: Range;
+}
+
+const isArbListElement = (arb: ArbListItemChildNode): arb is ArbListElement => arb.type === 'ol' || arb.type === 'ul';
+const isArbTextNode = (arb: ArbListItemChildNode): arb is ArbTextNode => arb.type === '#text';
+const isArbCommentNode = (arb: ArbListItemChildNode): arb is ArbCommentNode => arb.type === '#comment';
+
+const textGenerator = fc.hexaString({ minLength: 1, maxLength: 5 });
+
+const textNodeGenerator: fc.Arbitrary<ArbTextNode> = fc.record({
+  type: fc.constant('#text'),
+  value: textGenerator
+});
+
+const commentNodeGenerator: fc.Arbitrary<ArbCommentNode> = fc.record({
+  type: fc.constant('#comment'),
+  value: textGenerator
+});
+
+const elementNodeGenerator: fc.Arbitrary<ArbElementNode> = fc.record({
+  type: fc.constantFrom('strong', 'em', 'h3', 'div'),
+  children: fc.array(fc.oneof(textNodeGenerator, commentNodeGenerator), { minLength: 1, maxLength: 5 })
+});
+
+const depthIdentifier = fc.createDepthIdentifier();
+
+const listElementGenerator = fc.letrec((tie) => ({
+  node: fc.record({
+    type: fc.constantFrom('ul', 'ol'),
+    children: fc.array(
+      fc.oneof(
+        { maxDepth: 5, depthIdentifier },
+        fc.record({
+          type: fc.constant('li'),
+          children: fc.array(
+            fc.oneof(
+              { maxDepth: 5, depthIdentifier },
+              textNodeGenerator,
+              commentNodeGenerator,
+              elementNodeGenerator,
+              tie('node')
+            ),
+            { minLength: 1, maxLength: 5 }
+          )
+        })
+      ),
+      { minLength: 1, maxLength: 5 }
+    ),
+  }),
+})).node as unknown as fc.Arbitrary<ArbListElement>; // Need magic lie here since tie are unknowns but they are not in the generated output
+
+const getTextNodes = (list: ArbListElement) => {
+  const textNodes: ArbTextNode[] = [];
+
+  const helper = (list: ArbListElement) => {
+    const collectTextNodesInElement = (child: ArbElementNode) => {
+      Arr.each(child.children, (child) => {
+        if (isArbTextNode(child)) {
+          textNodes.push(child);
+        }
+      });
+    };
+
+    Arr.each(list.children, (li) => {
+      Arr.each(li.children, (child) => {
+        if (isArbTextNode(child)) {
+          textNodes.push(child);
+        } else if (isArbListElement(child)) {
+          helper(child);
+        } else if (!isArbCommentNode(child)) {
+          collectTextNodesInElement(child);
+        }
+      });
+    });
+  };
+
+  helper(list);
+
+  return textNodes;
+};
+
+const listElementWithSelectionGenerator: fc.Arbitrary<ArbListElementWithSelection> = listElementGenerator.chain((list) => {
+  const textNodes = getTextNodes(list);
+  const numTextNodes = textNodes.length;
+
+  return fc.record<ArbListElementWithSelection>({
+    list: fc.constant(list),
+    startTextNodeIndex: fc.nat(numTextNodes),
+    endTextNodeIndex: fc.nat(numTextNodes)
+  });
+}).filter(({ startTextNodeIndex, endTextNodeIndex }) => startTextNodeIndex > 0 && endTextNodeIndex > 0).map((list) => {
+  return { ...list, startTextNodeIndex: list.startTextNodeIndex - 1, endTextNodeIndex: list.endTextNodeIndex - 1 };
+});
+
+const toDomListElementWithSelection = (arbList: ArbListElementWithSelection) => {
+  const textNodes: Text[] = [];
+
+  const helper = (list: ArbListElement) => {
+    const listEl = document.createElement(list.type);
+
+    const toDomElement = (child: ArbElementNode) => {
+      const el = document.createElement(child.type);
+
+      Arr.each(child.children, (child) => {
+        if (isArbTextNode(child)) {
+          const textNode = document.createTextNode(child.value);
+          el.appendChild(textNode);
+          textNodes.push(textNode);
+        } else if (isArbCommentNode(child)) {
+          const commentNode = document.createComment(child.value);
+          el.appendChild(commentNode);
+        }
+      });
+
+      return el;
+    };
+
+    Arr.each(list.children, (li) => {
+      const liEl = document.createElement(li.type);
+
+      Arr.each(li.children, (child) => {
+        if (isArbTextNode(child)) {
+          const textNode = document.createTextNode(child.value);
+          liEl.appendChild(textNode);
+          textNodes.push(textNode);
+        } else if (isArbCommentNode(child)) {
+          liEl.appendChild(document.createComment(child.value));
+        } else if (isArbListElement(child)) {
+          liEl.appendChild(helper(child));
+        } else {
+          liEl.appendChild(toDomElement(child));
+        }
+      });
+
+      listEl.appendChild(liEl);
+    });
+
+    return listEl;
+  };
+
+  const listElement = helper(arbList.list);
+  const { startTextNodeIndex, endTextNodeIndex } = arbList;
+  const startContainer = textNodes[startTextNodeIndex > endTextNodeIndex ? endTextNodeIndex : startTextNodeIndex];
+  const endContainer = textNodes[endTextNodeIndex < startTextNodeIndex ? startTextNodeIndex : endTextNodeIndex];
+  const startOffset = 0;
+  const endOffset = endContainer.data.length;
+
+  return { listElement, startContainer, startOffset, endContainer, endOffset };
+};
+
+// TODO: This can be optimized so that it doesn't produce a DOM Range and then just throws it away
+export const domListGenerator: fc.Arbitrary<HTMLUListElement | HTMLOListElement> = listElementWithSelectionGenerator.chain((arbList) => fc.constant(toDomListElementWithSelection(arbList).listElement));
+
+export const domListWithSelectionGenerator: fc.Arbitrary<ArbDomListElementWithSelection> = listElementWithSelectionGenerator.chain((arbList) => {
+  const { listElement, startContainer, startOffset, endContainer, endOffset } = toDomListElementWithSelection(arbList);
+
+  const range = document.createRange();
+  range.setStart(startContainer, startOffset);
+  range.setEnd(endContainer, endOffset);
+
+  return fc.record<ArbDomListElementWithSelection>({
+    list: fc.constant(listElement),
+    range: fc.constant(range)
+  });
+});
+


### PR DESCRIPTION
Related Ticket: TINY-10414

Description of Changes:
the problem was that `composeList` if the result contains only `EntryNoList` that were be ignored

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
