### PR TITLE
Consistent use of single quote entity

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/html/Entities.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Entities.ts
@@ -40,7 +40,7 @@ const asciiMap: Record<number, string> = {
 // Raw entities
 const baseEntities: EntitiesMap = {
   '\"': '&quot;', // Needs to be escaped since the YUI compressor would otherwise break the code
-  '\'': '&#39;',
+  '\'': '&apos;',
   '<': '&lt;',
   '>': '&gt;',
   '&': '&amp;',


### PR DESCRIPTION
Using &#39 is problematic with certain frameworks. We used to get around this using the following code in v4

setup: function (editor: Editor) {
    editor.on("SaveContent", function (i) {
      i.content = i.content.replace(/&#39/g, "&apos");
    });


However this doesn't work in v6 anymore.