### PR TITLE
TINY-10426: Singularize accessible labels of bespoke buttons that append the current value

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Bespoke dropdown toolbar buttons including `fontfamily`, `fontsize`, `blocks`, and `styles` incorrectly used plural words in their accessible names. #TINY-10426
+
 ## 6.8.1 - 2023-11-29
 
 ### Improved

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
@@ -10,7 +10,7 @@ import Editor from 'tinymce/core/api/Editor';
 describe('browser.tinymce.core.FontSelectCustomTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
-    toolbar: 'fontsize fontfamily',
+    toolbar: 'fontfamily fontsize',
     content_style: [
       '.mce-content-body { font-family: Helvetica; font-size: 42px; }',
       '.mce-content-body p { font-family: Arial; font-size: 12px; }',
@@ -21,7 +21,7 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
   }, []);
 
   const assertSelectBoxDisplayValue = (title: string, expectedValue: string) => {
-    const selectBox = UiFinder.findIn(SugarBody.body(), '*[title^="' + title + '"]').getOrDie();
+    const selectBox = UiFinder.findIn(SugarBody.body(), `*[title^="${title}"]`).getOrDie();
     const value = Strings.trim(TextContent.get(selectBox) ?? '');
     assert.equal(value, expectedValue, 'Should be the expected display value');
   };

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
@@ -28,7 +28,7 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
 
   it('Font family and font size on initial page load', () => {
     assertSelectBoxDisplayValue('Font size', '12px');
-    assertSelectBoxDisplayValue('Fonts', 'Arial');
+    assertSelectBoxDisplayValue('Font', 'Arial');
   });
 
   it('Font family with spaces and numbers in the name with legacy font elements', () => {
@@ -38,7 +38,7 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
     editor.nodeChanged();
     assertSelectBoxDisplayValue('Font size', '8pt');
-    assertSelectBoxDisplayValue('Fonts', 'Bookshelf Symbol 7');
+    assertSelectBoxDisplayValue('Font', 'Bookshelf Symbol 7');
   });
 
   it('Font family with spaces and numbers in the name', () => {
@@ -48,7 +48,7 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
     editor.nodeChanged();
     assertSelectBoxDisplayValue('Font size', '12px');
-    assertSelectBoxDisplayValue('Fonts', 'Bookshelf Symbol 7');
+    assertSelectBoxDisplayValue('Font', 'Bookshelf Symbol 7');
   });
 
   it('Font family with quoted font names', () => {
@@ -58,6 +58,6 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
     editor.nodeChanged();
     assertSelectBoxDisplayValue('Font size', '12px');
-    assertSelectBoxDisplayValue('Fonts', 'Bauhaus 93');
+    assertSelectBoxDisplayValue('Font', 'Bauhaus 93');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
@@ -27,7 +27,7 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
   };
 
   it('Font family and font size on initial page load', () => {
-    assertSelectBoxDisplayValue('Font sizes', '12px');
+    assertSelectBoxDisplayValue('Font size', '12px');
     assertSelectBoxDisplayValue('Fonts', 'Arial');
   });
 
@@ -37,7 +37,7 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
     editor.focus();
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
     editor.nodeChanged();
-    assertSelectBoxDisplayValue('Font sizes', '8pt');
+    assertSelectBoxDisplayValue('Font size', '8pt');
     assertSelectBoxDisplayValue('Fonts', 'Bookshelf Symbol 7');
   });
 
@@ -47,7 +47,7 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
     editor.focus();
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
     editor.nodeChanged();
-    assertSelectBoxDisplayValue('Font sizes', '12px');
+    assertSelectBoxDisplayValue('Font size', '12px');
     assertSelectBoxDisplayValue('Fonts', 'Bookshelf Symbol 7');
   });
 
@@ -57,7 +57,7 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
     editor.focus();
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
     editor.nodeChanged();
-    assertSelectBoxDisplayValue('Font sizes', '12px');
+    assertSelectBoxDisplayValue('Font size', '12px');
     assertSelectBoxDisplayValue('Fonts', 'Bauhaus 93');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
@@ -33,7 +33,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
     ];
 
     it('TBA: Font family and font size on initial page load', () => {
-      assertSelectBoxDisplayValue('Font sizes', '12px');
+      assertSelectBoxDisplayValue('Font size', '12px');
       assertSelectBoxDisplayValue('Fonts', 'Arial');
     });
 
@@ -43,7 +43,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
       // p content style is 12px which does not match any pt values in the font size select values
-      assertSelectBoxDisplayValue('Font sizes', '12px');
+      assertSelectBoxDisplayValue('Font size', '12px');
       assertSelectBoxDisplayValue('Fonts', 'Arial');
     });
 
@@ -54,7 +54,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
       // h1 content style is 32px which matches 24pt in the font size select values so it should be converted
-      assertSelectBoxDisplayValue('Font sizes', '24pt');
+      assertSelectBoxDisplayValue('Font size', '24pt');
       assertSelectBoxDisplayValue('Fonts', 'Arial');
     });
 
@@ -64,7 +64,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
       // the following should be converted and pick up 12.75pt, although there's a rounded 13pt in the dropdown as well
-      assertSelectBoxDisplayValue('Font sizes', '12.75pt');
+      assertSelectBoxDisplayValue('Font size', '12.75pt');
       assertSelectBoxDisplayValue('Fonts', 'Times');
     });
 
@@ -75,7 +75,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
       // the following should stay as 18px because there's no matching pt value in the font size select values
-      assertSelectBoxDisplayValue('Font sizes', '18px');
+      assertSelectBoxDisplayValue('Font size', '18px');
       assertSelectBoxDisplayValue('Fonts', 'Times');
     });
 
@@ -84,7 +84,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.setContent('<p><font face="Times" size="1">a</font></p>', { format: 'raw' });
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
       editor.nodeChanged();
-      assertSelectBoxDisplayValue('Font sizes', '8pt');
+      assertSelectBoxDisplayValue('Font size', '8pt');
       assertSelectBoxDisplayValue('Fonts', 'Times');
     });
 
@@ -94,7 +94,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.setContent('<p style="font-family: Times; font-size: medium;">a</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
-      assertSelectBoxDisplayValue('Font sizes', '12pt');
+      assertSelectBoxDisplayValue('Font size', '12pt');
       assertSelectBoxDisplayValue('Fonts', 'Times');
     });
 
@@ -104,7 +104,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.focus();
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
-      assertSelectBoxDisplayValue('Font sizes', 'xx-small');
+      assertSelectBoxDisplayValue('Font size', 'xx-small');
       assertSelectBoxDisplayValue('Fonts', 'Times');
     });
 

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.FontSelectTest', () => {
   const assertSelectBoxDisplayValue = (title: string, expectedValue: string) => {
-    const selectBox = UiFinder.findIn(SugarBody.body(), '*[title^="' + title + '"]').getOrDie();
+    const selectBox = UiFinder.findIn(SugarBody.body(), `*[title^="${title}"]`).getOrDie();
     const value = Strings.trim(TextContent.get(selectBox) ?? '');
     assert.equal(value, expectedValue, 'Should be the expected display value');
   };
@@ -17,7 +17,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
   context('Default font stack', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       base_url: '/project/tinymce/js/tinymce',
-      toolbar: 'fontsize fontfamily',
+      toolbar: 'fontfamily fontsize',
       content_style: [
         '.mce-content-body { font-family: Helvetica; font-size: 42px; }',
         '.mce-content-body p { font-family: Arial; font-size: 12px; }',
@@ -131,7 +131,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
   context('Custom default font stack', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       base_url: '/project/tinymce/js/tinymce',
-      toolbar: 'fontsize fontfamily',
+      toolbar: 'fontfamily fontsize',
       content_style: [
         '.mce-content-body { font-family: -apple-system, Arial; }',
         '.mce-content-body h1 { font-family: Helvetica; }',

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
@@ -34,7 +34,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
 
     it('TBA: Font family and font size on initial page load', () => {
       assertSelectBoxDisplayValue('Font size', '12px');
-      assertSelectBoxDisplayValue('Fonts', 'Arial');
+      assertSelectBoxDisplayValue('Font', 'Arial');
     });
 
     it('TBA: Font family and font size on paragraph with no styles', () => {
@@ -44,7 +44,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.nodeChanged();
       // p content style is 12px which does not match any pt values in the font size select values
       assertSelectBoxDisplayValue('Font size', '12px');
-      assertSelectBoxDisplayValue('Fonts', 'Arial');
+      assertSelectBoxDisplayValue('Font', 'Arial');
     });
 
     it('TBA: Font family and font size on heading with no styles', () => {
@@ -55,7 +55,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.nodeChanged();
       // h1 content style is 32px which matches 24pt in the font size select values so it should be converted
       assertSelectBoxDisplayValue('Font size', '24pt');
-      assertSelectBoxDisplayValue('Fonts', 'Arial');
+      assertSelectBoxDisplayValue('Font', 'Arial');
     });
 
     it('TBA: Font family and font size on paragraph with styles that do match font size select values', () => {
@@ -65,7 +65,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.nodeChanged();
       // the following should be converted and pick up 12.75pt, although there's a rounded 13pt in the dropdown as well
       assertSelectBoxDisplayValue('Font size', '12.75pt');
-      assertSelectBoxDisplayValue('Fonts', 'Times');
+      assertSelectBoxDisplayValue('Font', 'Times');
     });
 
     it('TBA: Font family and font size on paragraph with styles that do not match font size select values', () => {
@@ -76,7 +76,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.nodeChanged();
       // the following should stay as 18px because there's no matching pt value in the font size select values
       assertSelectBoxDisplayValue('Font size', '18px');
-      assertSelectBoxDisplayValue('Fonts', 'Times');
+      assertSelectBoxDisplayValue('Font', 'Times');
     });
 
     it('TBA: Font family and font size on paragraph with legacy font elements', () => {
@@ -85,7 +85,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
       editor.nodeChanged();
       assertSelectBoxDisplayValue('Font size', '8pt');
-      assertSelectBoxDisplayValue('Fonts', 'Times');
+      assertSelectBoxDisplayValue('Font', 'Times');
     });
 
     // https://websemantics.uk/articles/font-size-conversion/
@@ -95,7 +95,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
       assertSelectBoxDisplayValue('Font size', '12pt');
-      assertSelectBoxDisplayValue('Fonts', 'Times');
+      assertSelectBoxDisplayValue('Font', 'Times');
     });
 
     it('TINY-6291: xx-small will fall back to showing raw font size due to missing 7pt fontsize_format', () => {
@@ -105,7 +105,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
       assertSelectBoxDisplayValue('Font size', 'xx-small');
-      assertSelectBoxDisplayValue('Fonts', 'Times');
+      assertSelectBoxDisplayValue('Font', 'Times');
     });
 
     it('TBA: System font stack variants on a paragraph show "System Font" as the font name', () => {
@@ -114,7 +114,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       Arr.each(systemFontStackVariants, (_, idx) => {
         TinySelections.setCursor(editor, [ idx, 0 ], 0);
         editor.nodeChanged();
-        assertSelectBoxDisplayValue('Fonts', 'System Font');
+        assertSelectBoxDisplayValue('Font', 'System Font');
       });
     });
 
@@ -124,7 +124,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.focus();
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
-      assertSelectBoxDisplayValue('Fonts', '-apple-system,Arial');
+      assertSelectBoxDisplayValue('Font', '-apple-system,Arial');
     });
   });
 
@@ -145,7 +145,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.setContent(testCase.html);
       TinySelections.setCursor(editor, testCase.path, testCase.offset);
       editor.nodeChanged();
-      assertSelectBoxDisplayValue('Fonts', testCase.expectedValue);
+      assertSelectBoxDisplayValue('Font', testCase.expectedValue);
     };
 
     it('TINY-10290: Should show System Font for the specified custom stack', () => testCustomStack({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -138,11 +138,10 @@ const getToolTipText = (editor: Editor, format: ColorFormat, lastColor: string) 
     return format === 'forecolor' ? 'Text color' : 'Background color';
   }
 
-  const tooltipPrefix = format === 'forecolor' ? 'Text color {0}' : 'Background color {0}';
   const colors = getColors(Options.getColors(editor, format), format, false);
   const colorText = Arr.find(colors, (c) => c.value === lastColor).getOr({ text: '' }).text;
 
-  return editor.translate([ tooltipPrefix, editor.translate(colorText) ]);
+  return editor.translate([ `${format === 'forecolor' ? 'Text color' : 'Background color'} {0}`, colorText ]);
 };
 
 const registerTextColorButton = (editor: Editor, name: string, format: ColorFormat, lastColor: Cell<string>) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -138,10 +138,11 @@ const getToolTipText = (editor: Editor, format: ColorFormat, lastColor: string) 
     return format === 'forecolor' ? 'Text color' : 'Background color';
   }
 
+  const tooltipPrefix = format === 'forecolor' ? 'Text color {0}' : 'Background color {0}';
   const colors = getColors(Options.getColors(editor, format), format, false);
   const colorText = Arr.find(colors, (c) => c.value === lastColor).getOr({ text: '' }).text;
 
-  return editor.translate([ `${format === 'forecolor' ? 'Text color' : 'Background color'} {0}`, colorText ]);
+  return editor.translate([ tooltipPrefix, editor.translate(colorText) ]);
 };
 
 const registerTextColorButton = (editor: Editor, name: string, format: ColorFormat, lastColor: Cell<string>) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
@@ -12,6 +12,7 @@ import { buildBasicStaticDataset } from './SelectDatasets';
 import * as Tooltip from './utils/Tooltip';
 
 const title = 'Align';
+const tooltip = 'Align {0}';
 const fallbackAlignment = 'left';
 
 const alignMenuItems = [
@@ -44,7 +45,7 @@ const getSpec = (editor: Editor): SelectSpec => {
       .each((item) => editor.execCommand(item.command));
 
   return {
-    tooltip: Tooltip.makeTooltipText(editor, `${title} {0}`, fallbackAlignment),
+    tooltip: Tooltip.makeTooltipText(editor, tooltip, fallbackAlignment),
     text: Optional.none(),
     icon: Optional.some('align-left'),
     isSelectedFor,
@@ -59,7 +60,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const createAlignButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createSelectButton(editor, backstage, getSpec(editor), title, 'AlignTextUpdate');
+  createSelectButton(editor, backstage, getSpec(editor), tooltip, 'AlignTextUpdate');
 
 const createAlignMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
   const menuItems = createMenuItems(editor, backstage, getSpec(editor));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
@@ -44,7 +44,7 @@ const getSpec = (editor: Editor): SelectSpec => {
       .each((item) => editor.execCommand(item.command));
 
   return {
-    tooltip: Tooltip.getTooltipText(editor, title, fallbackAlignment),
+    tooltip: Tooltip.makeTooltipText(editor, `${title} {0}`, fallbackAlignment),
     text: Optional.none(),
     icon: Optional.some('align-left'),
     isSelectedFor,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -174,7 +174,7 @@ const createMenuItems = (editor: Editor, backstage: UiFactoryBackstage, spec: Se
   };
 };
 
-const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec, title: string, textUpdateEventName: string): SketchSpec => {
+const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec, tooltipWithPlaceholder: string, textUpdateEventName: string): SketchSpec => {
   const { items, getStyleItems } = createMenuItems(editor, backstage, spec);
 
   const getApi = (comp: AlloyComponent): BespokeSelectApi => ({
@@ -188,7 +188,7 @@ const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec:
   // Set the initial text when the component is attached and then update on node changes
   const onSetup = (api: BespokeSelectApi) => {
     const handler = (e: EditorEvent<{ value: string }>) =>
-      api.setTooltip(Tooltip.makeTooltipText(editor, `${title} {0}`, e.value));
+      api.setTooltip(Tooltip.makeTooltipText(editor, tooltipWithPlaceholder, e.value));
     editor.on(textUpdateEventName, handler);
     return composeUnbinders(
       onSetupEvent(editor, 'NodeChange', (api: BespokeSelectApi) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -188,7 +188,7 @@ const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec:
   // Set the initial text when the component is attached and then update on node changes
   const onSetup = (api: BespokeSelectApi) => {
     const handler = (e: EditorEvent<{ value: string }>) =>
-      api.setTooltip(Tooltip.getTooltipText(editor, title, e.value));
+      api.setTooltip(Tooltip.makeTooltipText(editor, `${title} {0}`, e.value));
     editor.on(textUpdateEventName, handler);
     return composeUnbinders(
       onSetupEvent(editor, 'NodeChange', (api: BespokeSelectApi) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
@@ -13,8 +13,8 @@ import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import { findNearest } from './utils/FormatDetection';
 import * as Tooltip from './utils/Tooltip';
 
-const btnTitle = 'Block';
 const menuTitle = 'Blocks';
+const btnTooltip = 'Block {0}';
 const fallbackFormat = 'Paragraph';
 
 const getSpec = (editor: Editor): SelectSpec => {
@@ -45,7 +45,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'block_formats', Delimiter.SemiColon);
 
   return {
-    tooltip: Tooltip.makeTooltipText(editor, `${btnTitle} {0}`, fallbackFormat),
+    tooltip: Tooltip.makeTooltipText(editor, btnTooltip, fallbackFormat),
     text: Optional.some(fallbackFormat),
     icon: Optional.none(),
     isSelectedFor,
@@ -60,7 +60,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const createBlocksButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createSelectButton(editor, backstage, getSpec(editor), btnTitle, 'BlocksTextUpdate');
+  createSelectButton(editor, backstage, getSpec(editor), btnTooltip, 'BlocksTextUpdate');
 
 // FIX: Test this!
 const createBlocksMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
@@ -13,7 +13,7 @@ import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import { findNearest } from './utils/FormatDetection';
 import * as Tooltip from './utils/Tooltip';
 
-const title = 'Blocks';
+const title = 'Block';
 const fallbackFormat = 'Paragraph';
 
 const getSpec = (editor: Editor): SelectSpec => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
@@ -45,7 +45,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'block_formats', Delimiter.SemiColon);
 
   return {
-    tooltip: Tooltip.getTooltipText(editor, btnTitle, fallbackFormat),
+    tooltip: Tooltip.makeTooltipText(editor, `${btnTitle} {0}`, fallbackFormat),
     text: Optional.some(fallbackFormat),
     icon: Optional.none(),
     isSelectedFor,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
@@ -13,7 +13,8 @@ import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import { findNearest } from './utils/FormatDetection';
 import * as Tooltip from './utils/Tooltip';
 
-const title = 'Block';
+const btnTitle = 'Block';
+const menuTitle = 'Blocks';
 const fallbackFormat = 'Paragraph';
 
 const getSpec = (editor: Editor): SelectSpec => {
@@ -44,7 +45,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'block_formats', Delimiter.SemiColon);
 
   return {
-    tooltip: Tooltip.getTooltipText(editor, title, fallbackFormat),
+    tooltip: Tooltip.getTooltipText(editor, btnTitle, fallbackFormat),
     text: Optional.some(fallbackFormat),
     icon: Optional.none(),
     isSelectedFor,
@@ -59,13 +60,13 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const createBlocksButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createSelectButton(editor, backstage, getSpec(editor), title, 'BlocksTextUpdate');
+  createSelectButton(editor, backstage, getSpec(editor), btnTitle, 'BlocksTextUpdate');
 
 // FIX: Test this!
 const createBlocksMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
   const menuItems = createMenuItems(editor, backstage, getSpec(editor));
   editor.ui.registry.addNestedMenuItem('blocks', {
-    text: title,
+    text: menuTitle,
     onSetup: onSetupEditableToggle(editor),
     getSubmenuItems: () => menuItems.items.validateItems(menuItems.getStyleItems())
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
@@ -12,8 +12,8 @@ import { createMenuItems, createSelectButton, FormatterFormatItem, PreviewSpec, 
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import * as Tooltip from './utils/Tooltip';
 
-const btnTitle = 'Font';
 const menuTitle = 'Fonts';
+const btnTooltip = 'Font {0}';
 const systemFont = 'System Font';
 
 // A list of fonts that must be in a font family for the font to be recognised as the system stack
@@ -95,7 +95,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'font_family_formats', Delimiter.SemiColon);
 
   return {
-    tooltip: Tooltip.makeTooltipText(editor, `${btnTitle} {0}`, systemFont),
+    tooltip: Tooltip.makeTooltipText(editor, btnTooltip, systemFont),
     text: Optional.some(systemFont),
     icon: Optional.none(),
     isSelectedFor,
@@ -110,7 +110,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const createFontFamilyButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createSelectButton(editor, backstage, getSpec(editor), btnTitle, 'FontFamilyTextUpdate');
+  createSelectButton(editor, backstage, getSpec(editor), btnTooltip, 'FontFamilyTextUpdate');
 
 // TODO: Test this!
 const createFontFamilyMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
@@ -12,7 +12,8 @@ import { createMenuItems, createSelectButton, FormatterFormatItem, PreviewSpec, 
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import * as Tooltip from './utils/Tooltip';
 
-const title = 'Font';
+const btnTitle = 'Font';
+const menuTitle = 'Fonts';
 const systemFont = 'System Font';
 
 // A list of fonts that must be in a font family for the font to be recognised as the system stack
@@ -94,7 +95,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'font_family_formats', Delimiter.SemiColon);
 
   return {
-    tooltip: Tooltip.getTooltipText(editor, title, systemFont),
+    tooltip: Tooltip.getTooltipText(editor, btnTitle, systemFont),
     text: Optional.some(systemFont),
     icon: Optional.none(),
     isSelectedFor,
@@ -109,13 +110,13 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const createFontFamilyButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createSelectButton(editor, backstage, getSpec(editor), title, 'FontFamilyTextUpdate');
+  createSelectButton(editor, backstage, getSpec(editor), btnTitle, 'FontFamilyTextUpdate');
 
 // TODO: Test this!
 const createFontFamilyMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
   const menuItems = createMenuItems(editor, backstage, getSpec(editor));
   editor.ui.registry.addNestedMenuItem('fontfamily', {
-    text: backstage.shared.providers.translate(title),
+    text: backstage.shared.providers.translate(menuTitle),
     onSetup: onSetupEditableToggle(editor),
     getSubmenuItems: () => menuItems.items.validateItems(menuItems.getStyleItems())
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
@@ -12,7 +12,7 @@ import { createMenuItems, createSelectButton, FormatterFormatItem, PreviewSpec, 
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import * as Tooltip from './utils/Tooltip';
 
-const title = 'Fonts';
+const title = 'Font';
 const systemFont = 'System Font';
 
 // A list of fonts that must be in a font family for the font to be recognised as the system stack

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
@@ -95,7 +95,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'font_family_formats', Delimiter.SemiColon);
 
   return {
-    tooltip: Tooltip.getTooltipText(editor, btnTitle, systemFont),
+    tooltip: Tooltip.makeTooltipText(editor, `${btnTitle} {0}`, systemFont),
     text: Optional.some(systemFont),
     icon: Optional.none(),
     isSelectedFor,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -25,8 +25,8 @@ export interface NumberInputSpec {
   getNewValue: (text: string, updateFunction: (value: number, step: number) => number) => string;
 }
 
-const btnTitle = 'Font size';
 const menuTitle = 'Font sizes';
+const btnTooltip = 'Font size {0}';
 const fallbackFontSize = '12pt';
 
 // See https://websemantics.uk/articles/font-size-conversion/ for conversions
@@ -114,7 +114,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'font_size_formats', Delimiter.Space);
 
   return {
-    tooltip: Tooltip.makeTooltipText(editor, `${btnTitle} {0}`, fallbackFontSize),
+    tooltip: Tooltip.makeTooltipText(editor, btnTooltip, fallbackFontSize),
     text: Optional.some(fallbackFontSize),
     icon: Optional.none(),
     isSelectedFor,
@@ -129,7 +129,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const createFontSizeButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createSelectButton(editor, backstage, getSpec(editor), btnTitle, 'FontSizeTextUpdate');
+  createSelectButton(editor, backstage, getSpec(editor), btnTooltip, 'FontSizeTextUpdate');
 
 const getConfigFromUnit = (unit: string): Config => {
   const baseConfig = { step: 1 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -114,7 +114,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'font_size_formats', Delimiter.Space);
 
   return {
-    tooltip: Tooltip.getTooltipText(editor, btnTitle, fallbackFontSize),
+    tooltip: Tooltip.makeTooltipText(editor, `${btnTitle} {0}`, fallbackFontSize),
     text: Optional.some(fallbackFontSize),
     icon: Optional.none(),
     isSelectedFor,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -25,7 +25,8 @@ export interface NumberInputSpec {
   getNewValue: (text: string, updateFunction: (value: number, step: number) => number) => string;
 }
 
-const title = 'Font size';
+const btnTitle = 'Font size';
+const menuTitle = 'Font sizes';
 const fallbackFontSize = '12pt';
 
 // See https://websemantics.uk/articles/font-size-conversion/ for conversions
@@ -113,7 +114,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'font_size_formats', Delimiter.Space);
 
   return {
-    tooltip: Tooltip.getTooltipText(editor, title, fallbackFontSize),
+    tooltip: Tooltip.getTooltipText(editor, btnTitle, fallbackFontSize),
     text: Optional.some(fallbackFontSize),
     icon: Optional.none(),
     isSelectedFor,
@@ -128,7 +129,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const createFontSizeButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createSelectButton(editor, backstage, getSpec(editor), title, 'FontSizeTextUpdate');
+  createSelectButton(editor, backstage, getSpec(editor), btnTitle, 'FontSizeTextUpdate');
 
 const getConfigFromUnit = (unit: string): Config => {
   const baseConfig = { step: 1 };
@@ -185,7 +186,7 @@ const createFontSizeInputButton = (editor: Editor, backstage: UiFactoryBackstage
 const createFontSizeMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
   const menuItems = createMenuItems(editor, backstage, getSpec(editor));
   editor.ui.registry.addNestedMenuItem('fontsize', {
-    text: title,
+    text: menuTitle,
     onSetup: onSetupEditableToggle(editor),
     getSubmenuItems: () => menuItems.items.validateItems(menuItems.getStyleItems())
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -25,7 +25,7 @@ export interface NumberInputSpec {
   getNewValue: (text: string, updateFunction: (value: number, step: number) => number) => string;
 }
 
-const title = 'Font sizes';
+const title = 'Font size';
 const fallbackFontSize = '12pt';
 
 // See https://websemantics.uk/articles/font-size-conversion/ for conversions

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
@@ -15,7 +15,7 @@ import { getStyleFormats, isFormatReference, isNestedFormat, StyleFormatType } f
 import { findNearest } from './utils/FormatDetection';
 import * as Tooltip from './utils/Tooltip';
 
-const title = 'Formats';
+const title = 'Format';
 
 const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
   const fallbackFormat = 'Paragraph';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
@@ -15,7 +15,8 @@ import { getStyleFormats, isFormatReference, isNestedFormat, StyleFormatType } f
 import { findNearest } from './utils/FormatDetection';
 import * as Tooltip from './utils/Tooltip';
 
-const title = 'Format';
+const btnTitle = 'Format';
+const menuTitle = 'Formats';
 
 const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
   const fallbackFormat = 'Paragraph';
@@ -50,7 +51,7 @@ const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
   };
 
   return {
-    tooltip: Tooltip.getTooltipText(editor, title, fallbackFormat),
+    tooltip: Tooltip.getTooltipText(editor, btnTitle, fallbackFormat),
     text: Optional.some(fallbackFormat),
     icon: Optional.none(),
     isSelectedFor,
@@ -66,14 +67,14 @@ const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
 
 const createStylesButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec => {
   const dataset: AdvancedSelectDataset = { type: 'advanced', ...backstage.styles };
-  return createSelectButton(editor, backstage, getSpec(editor, dataset), title, 'StylesTextUpdate');
+  return createSelectButton(editor, backstage, getSpec(editor, dataset), btnTitle, 'StylesTextUpdate');
 };
 
 const createStylesMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
   const dataset: AdvancedSelectDataset = { type: 'advanced', ...backstage.styles };
   const menuItems = createMenuItems(editor, backstage, getSpec(editor, dataset));
   editor.ui.registry.addNestedMenuItem('styles', {
-    text: title,
+    text: menuTitle,
     onSetup: onSetupEditableToggle(editor),
     getSubmenuItems: () => menuItems.items.validateItems(menuItems.getStyleItems())
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
@@ -51,7 +51,7 @@ const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
   };
 
   return {
-    tooltip: Tooltip.getTooltipText(editor, btnTitle, fallbackFormat),
+    tooltip: Tooltip.makeTooltipText(editor, `${btnTitle} {0}`, fallbackFormat),
     text: Optional.some(fallbackFormat),
     icon: Optional.none(),
     isSelectedFor,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
@@ -15,8 +15,8 @@ import { getStyleFormats, isFormatReference, isNestedFormat, StyleFormatType } f
 import { findNearest } from './utils/FormatDetection';
 import * as Tooltip from './utils/Tooltip';
 
-const btnTitle = 'Format';
 const menuTitle = 'Formats';
+const btnTooltip = 'Format {0}';
 
 const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
   const fallbackFormat = 'Paragraph';
@@ -51,7 +51,7 @@ const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
   };
 
   return {
-    tooltip: Tooltip.makeTooltipText(editor, `${btnTitle} {0}`, fallbackFormat),
+    tooltip: Tooltip.makeTooltipText(editor, btnTooltip, fallbackFormat),
     text: Optional.some(fallbackFormat),
     icon: Optional.none(),
     isSelectedFor,
@@ -67,7 +67,7 @@ const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
 
 const createStylesButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec => {
   const dataset: AdvancedSelectDataset = { type: 'advanced', ...backstage.styles };
-  return createSelectButton(editor, backstage, getSpec(editor, dataset), btnTitle, 'StylesTextUpdate');
+  return createSelectButton(editor, backstage, getSpec(editor, dataset), btnTooltip, 'StylesTextUpdate');
 };
 
 const createStylesMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/Tooltip.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/Tooltip.ts
@@ -1,7 +1,7 @@
 import Editor from 'tinymce/core/api/Editor';
 
 const getTooltipText = (editor: Editor, prefix: string, value: string): string =>
-  editor.translate([ `${prefix} {0}`, value ]);
+  editor.translate([ `${prefix} {0}`, editor.translate(value) ]);
 
 export {
   getTooltipText

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/Tooltip.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/Tooltip.ts
@@ -1,8 +1,8 @@
 import Editor from 'tinymce/core/api/Editor';
 
-const getTooltipText = (editor: Editor, prefix: string, value: string): string =>
-  editor.translate([ `${prefix} {0}`, editor.translate(value) ]);
+const makeTooltipText = (editor: Editor, labelWithPlaceholder: string, value: string): string =>
+  editor.translate([ labelWithPlaceholder, editor.translate(value) ]);
 
 export {
-  getTooltipText
+  makeTooltipText
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/Tooltip.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/Tooltip.ts
@@ -1,7 +1,7 @@
 import Editor from 'tinymce/core/api/Editor';
 
 const getTooltipText = (editor: Editor, prefix: string, value: string): string =>
-  editor.translate([ `${prefix} {0}`, editor.translate(value) ]);
+  editor.translate([ `${prefix} {0}`, value ]);
 
 export {
   getTooltipText

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -47,11 +47,11 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
         toolbar: 'styles'
       },
       initial: [{
-        clickOn: 'button[title^="Formats"]',
+        clickOn: 'button[title^="Format"]',
         waitFor: 'div[role="menu"]'
       }],
       assertAbove: 'div[role="menu"]',
-      assertBelow: 'button[title^="Formats"]'
+      assertBelow: 'button[title^="Format"]'
     }));
 
     it('SplitButton menu should open above button', () => pTest({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
@@ -66,7 +66,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.DropdownAriaLabelTest', (
       (item) => `${scenario.menuLabel} ${item}`,
       Fun.curry(MenuUtils.pOpenMenuWithSelector, scenario.menuLabel),
       (editor) => {
-        const submenuSelector = 'div[title="Block"]';
+        const submenuSelector = 'div[title="Blocks"]';
         return TinyUiActions.pWaitForUi(editor, submenuSelector).then(() => TinyUiActions.clickOnUi(editor, submenuSelector));
       }
     );

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
@@ -125,13 +125,13 @@ describe('browser.tinymce.themes.silver.editor.bespoke.DropdownAriaLabelTest', (
   }));
 
   it('TINY-10147: styles menu should not update aria-label if displayed text does not change', testFormatsDropdownAriaLabel({
-    menuLabel: 'Formats',
+    menuLabel: 'Format',
     initialItem: 'Paragraph',
     finalItem: 'Paragraph'
   }));
 
   it('TINY-10147: styles menu should update aria-label if displayed text changes', testFormatsDropdownAriaLabel({
-    menuLabel: 'Formats',
+    menuLabel: 'Format',
     initialItem: 'Paragraph',
     finalItem: 'Div'
   }));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
@@ -1,5 +1,5 @@
 import { UiFinder } from '@ephox/agar';
-import { after, afterEach, before, context, describe, it } from '@ephox/bedrock-client';
+import { afterEach, context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { Attribute, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
@@ -149,28 +149,24 @@ describe('browser.tinymce.themes.silver.editor.bespoke.DropdownAriaLabelTest', (
   });
 
   context('With translations', () => {
-    const hook = TinyHooks.bddSetup<Editor>(settings);
-
-    before(() => {
-      I18n.add('test', {
-        'left': 'left translated',
-        'right': 'right translated',
-        'Left': 'Left translated',
-        'Right': 'Right translated',
-        'Verdana': 'Verdana translated',
-        'Arial': 'Arial translated',
-        '12pt': '12pt translated',
-        '8pt': '8pt translated',
-        'Paragraph': 'Paragraph translated',
-        'Heading 1': 'Heading 1 translated',
-        'Div': 'Div translated'
-      });
-
-      I18n.setCode('test');
-    });
-
-    after(() => {
-      I18n.setCode('en');
+    const hook = TinyHooks.bddSetup<Editor>({
+      ...settings,
+      language: 'test',
+      setup: () => {
+        I18n.add('test', {
+          'left': 'left translated',
+          'right': 'right translated',
+          'Left': 'Left translated',
+          'Right': 'Right translated',
+          'Verdana': 'Verdana translated',
+          'Arial': 'Arial translated',
+          '12pt': '12pt translated',
+          '8pt': '8pt translated',
+          'Paragraph': 'Paragraph translated',
+          'Heading 1': 'Heading 1 translated',
+          'Div': 'Div translated'
+        });
+      }
     });
 
     afterEach(makeCleanupFn(hook));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
@@ -101,13 +101,13 @@ describe('browser.tinymce.themes.silver.editor.bespoke.DropdownAriaLabelTest', (
   }));
 
   it('TINY-10147: Font size menu should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel({
-    menuLabel: 'Font sizes',
+    menuLabel: 'Font size',
     initialItem: '12pt',
     finalItem: '12pt'
   }));
 
   it('TINY-10147: Font size menu should update aria-label if displayed text changes', testStandardDropdownAriaLabel({
-    menuLabel: 'Font sizes',
+    menuLabel: 'Font size',
     initialItem: '12pt',
     finalItem: '8pt'
   }));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
@@ -66,7 +66,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.DropdownAriaLabelTest', (
       (item) => `${scenario.menuLabel} ${item}`,
       Fun.curry(MenuUtils.pOpenMenuWithSelector, scenario.menuLabel),
       (editor) => {
-        const submenuSelector = 'div[title="Blocks"]';
+        const submenuSelector = 'div[title="Block"]';
         return TinyUiActions.pWaitForUi(editor, submenuSelector).then(() => TinyUiActions.clickOnUi(editor, submenuSelector));
       }
     );
@@ -76,61 +76,61 @@ describe('browser.tinymce.themes.silver.editor.bespoke.DropdownAriaLabelTest', (
     editor.setContent('');
   });
 
-  it('TINY-10147: Align menu should not update aria-label if displayed text does not change', testAlignDropdownAriaLabel({
+  it('TINY-10147: align menu should not update aria-label if displayed text does not change', testAlignDropdownAriaLabel({
     menuLabel: 'Align',
     initialItem: 'Left',
     finalItem: 'Left'
   }));
 
-  it('TINY-10147: Align menu should update aria-label if displayed text changes', testAlignDropdownAriaLabel({
+  it('TINY-10147: align menu should update aria-label if displayed text changes', testAlignDropdownAriaLabel({
     menuLabel: 'Align',
     initialItem: 'Left',
     finalItem: 'Right'
   }));
 
-  it('TINY-10147: Font family menu should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel({
+  it('TINY-10147: fontfamily menu should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel({
     menuLabel: 'Font',
     initialItem: 'Verdana',
     finalItem: 'Verdana'
   }));
 
-  it('TINY-10147: Font family menu should update aria-label if displayed text changes', testStandardDropdownAriaLabel({
+  it('TINY-10147: fontfamily menu should update aria-label if displayed text changes', testStandardDropdownAriaLabel({
     menuLabel: 'Font',
     initialItem: 'Verdana',
     finalItem: 'Arial'
   }));
 
-  it('TINY-10147: Font size menu should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel({
+  it('TINY-10147: fontsize menu should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel({
     menuLabel: 'Font size',
     initialItem: '12pt',
     finalItem: '12pt'
   }));
 
-  it('TINY-10147: Font size menu should update aria-label if displayed text changes', testStandardDropdownAriaLabel({
+  it('TINY-10147: fontsize menu should update aria-label if displayed text changes', testStandardDropdownAriaLabel({
     menuLabel: 'Font size',
     initialItem: '12pt',
     finalItem: '8pt'
   }));
 
-  it('TINY-10147: Blocks menu should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel({
-    menuLabel: 'Blocks',
+  it('TINY-10147: blocks menu should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel({
+    menuLabel: 'Block',
     initialItem: 'Paragraph',
     finalItem: 'Paragraph'
   }));
 
-  it('TINY-10147: Blocks menu should update aria-label if displayed text changes', testStandardDropdownAriaLabel({
-    menuLabel: 'Blocks',
+  it('TINY-10147: blocks menu should update aria-label if displayed text changes', testStandardDropdownAriaLabel({
+    menuLabel: 'Block',
     initialItem: 'Paragraph',
     finalItem: 'Heading 1'
   }));
 
-  it('TINY-10147: Styles menu should not update aria-label if displayed text does not change', testFormatsDropdownAriaLabel({
+  it('TINY-10147: styles menu should not update aria-label if displayed text does not change', testFormatsDropdownAriaLabel({
     menuLabel: 'Formats',
     initialItem: 'Paragraph',
     finalItem: 'Paragraph'
   }));
 
-  it('TINY-10147: Styles menu should update aria-label if displayed text changes', testFormatsDropdownAriaLabel({
+  it('TINY-10147: styles menu should update aria-label if displayed text changes', testFormatsDropdownAriaLabel({
     menuLabel: 'Formats',
     initialItem: 'Paragraph',
     finalItem: 'Div'

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
@@ -89,13 +89,13 @@ describe('browser.tinymce.themes.silver.editor.bespoke.DropdownAriaLabelTest', (
   }));
 
   it('TINY-10147: Font family menu should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel({
-    menuLabel: 'Fonts',
+    menuLabel: 'Font',
     initialItem: 'Verdana',
     finalItem: 'Verdana'
   }));
 
   it('TINY-10147: Font family menu should update aria-label if displayed text changes', testStandardDropdownAriaLabel({
-    menuLabel: 'Fonts',
+    menuLabel: 'Font',
     initialItem: 'Verdana',
     finalItem: 'Arial'
   }));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
@@ -1,28 +1,30 @@
 import { UiFinder } from '@ephox/agar';
-import { afterEach, describe, it } from '@ephox/bedrock-client';
+import { after, afterEach, before, context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { Attribute, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+import I18n from 'tinymce/core/api/util/I18n';
 
 import * as MenuUtils from '../../../module/MenuUtils';
 
 interface Scenario {
-  readonly menuLabel: string;
+  readonly label: string;
   readonly initialItem: string;
   readonly finalItem: string;
 }
 
 describe('browser.tinymce.themes.silver.editor.bespoke.DropdownAriaLabelTest', () => {
-  const hook = TinyHooks.bddSetup<Editor>({
+  const settings = {
     base_url: '/project/tinymce/js/tinymce',
     content_css: '/project/tinymce/src/themes/silver/test/css/content.css',
     toolbar: 'align fontfamily fontsize blocks styles'
-  });
+  };
 
   const testDropdownAriaLabel = (
+    hook: TinyHooks.Hook<Editor>,
     initialItem: string,
     finalItem: string,
     makeLabel: (item: string) => string,
@@ -31,108 +33,206 @@ describe('browser.tinymce.themes.silver.editor.bespoke.DropdownAriaLabelTest', (
   ) => async () => {
     const editor = hook.editor();
     const buttonSelector = `button[title="${makeLabel(initialItem)}"]`;
-    const button = UiFinder.findIn(SugarBody.body(), `.tox-toolbar__group ${buttonSelector}`).getOrDie();
 
     await pOpenMenu(buttonSelector);
     const itemSelector = `div[role="menuitemcheckbox"][title="${finalItem}"]`;
     await pWaitForMenu(editor, itemSelector);
+
+    const button = UiFinder.findIn(SugarBody.body(), `.tox-toolbar__group ${buttonSelector}`).getOrDie();
     assert.equal(Attribute.get(button, 'aria-label'), makeLabel(initialItem));
     TinyUiActions.clickOnUi(editor, itemSelector);
     assert.equal(Attribute.get(button, 'aria-label'), makeLabel(finalItem));
   };
 
-  const testStandardDropdownAriaLabel = (scenario: Scenario) =>
+  const testStandardDropdownAriaLabel = (hook: TinyHooks.Hook<Editor>, scenario: Scenario) =>
     testDropdownAriaLabel(
+      hook,
       scenario.initialItem,
       scenario.finalItem,
-      (item) => `${scenario.menuLabel} ${item}`,
-      Fun.curry(MenuUtils.pOpenMenuWithSelector, scenario.menuLabel),
+      (item) => `${scenario.label} ${item}`,
+      Fun.curry(MenuUtils.pOpenMenuWithSelector, scenario.label),
       TinyUiActions.pWaitForUi
     );
 
-  const testAlignDropdownAriaLabel = (scenario: Scenario) =>
+  const testAlignDropdownAriaLabel = (hook: TinyHooks.Hook<Editor>, scenario: Scenario) =>
     testDropdownAriaLabel(
+      hook,
       scenario.initialItem,
       scenario.finalItem,
-      (item) => `${scenario.menuLabel} ${item.toLowerCase()}`,
-      () => MenuUtils.pOpenAlignMenu(scenario.menuLabel),
+      (item) => `${scenario.label} ${item.toLowerCase()}`,
+      () => MenuUtils.pOpenAlignMenu(scenario.label),
       TinyUiActions.pWaitForUi
     );
 
-  const testFormatsDropdownAriaLabel = (scenario: Scenario) =>
+  const testFormatsDropdownAriaLabel = (hook: TinyHooks.Hook<Editor>, scenario: Scenario) =>
     testDropdownAriaLabel(
+      hook,
       scenario.initialItem,
       scenario.finalItem,
-      (item) => `${scenario.menuLabel} ${item}`,
-      Fun.curry(MenuUtils.pOpenMenuWithSelector, scenario.menuLabel),
+      (item) => `${scenario.label} ${item}`,
+      Fun.curry(MenuUtils.pOpenMenuWithSelector, scenario.label),
       (editor) => {
         const submenuSelector = 'div[title="Blocks"]';
         return TinyUiActions.pWaitForUi(editor, submenuSelector).then(() => TinyUiActions.clickOnUi(editor, submenuSelector));
       }
     );
 
-  afterEach(() => {
+  const makeCleanupFn = (hook: TinyHooks.Hook<Editor>) => () => {
     const editor = hook.editor();
     editor.setContent('');
+  };
+
+  context('No translation', () => {
+    const hook = TinyHooks.bddSetup<Editor>(settings);
+
+    afterEach(makeCleanupFn(hook));
+
+    it('TINY-10147: align dropdown should not update aria-label if displayed text does not change', testAlignDropdownAriaLabel(hook, {
+      label: 'Align',
+      initialItem: 'Left',
+      finalItem: 'Left'
+    }));
+
+    it('TINY-10147: align dropdown should update aria-label if displayed text changes', testAlignDropdownAriaLabel(hook, {
+      label: 'Align',
+      initialItem: 'Left',
+      finalItem: 'Right'
+    }));
+
+    it('TINY-10147: fontfamily dropdown should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel(hook, {
+      label: 'Font',
+      initialItem: 'Verdana',
+      finalItem: 'Verdana'
+    }));
+
+    it('TINY-10147: fontfamily dropdown should update aria-label if displayed text changes', testStandardDropdownAriaLabel(hook, {
+      label: 'Font',
+      initialItem: 'Verdana',
+      finalItem: 'Arial'
+    }));
+
+    it('TINY-10147: fontsize dropdown should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel(hook, {
+      label: 'Font size',
+      initialItem: '12pt',
+      finalItem: '12pt'
+    }));
+
+    it('TINY-10147: fontsize dropdown should update aria-label if displayed text changes', testStandardDropdownAriaLabel(hook, {
+      label: 'Font size',
+      initialItem: '12pt',
+      finalItem: '8pt'
+    }));
+
+    it('TINY-10147: blocks dropdown should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel(hook, {
+      label: 'Block',
+      initialItem: 'Paragraph',
+      finalItem: 'Paragraph'
+    }));
+
+    it('TINY-10147: blocks dropdown should update aria-label if displayed text changes', testStandardDropdownAriaLabel(hook, {
+      label: 'Block',
+      initialItem: 'Paragraph',
+      finalItem: 'Heading 1'
+    }));
+
+    it('TINY-10147: styles dropdown should not update aria-label if displayed text does not change', testFormatsDropdownAriaLabel(hook, {
+      label: 'Format',
+      initialItem: 'Paragraph',
+      finalItem: 'Paragraph'
+    }));
+
+    it('TINY-10147: styles dropdown should update aria-label if displayed text changes', testFormatsDropdownAriaLabel(hook, {
+      label: 'Format',
+      initialItem: 'Paragraph',
+      finalItem: 'Div'
+    }));
   });
 
-  it('TINY-10147: align menu should not update aria-label if displayed text does not change', testAlignDropdownAriaLabel({
-    menuLabel: 'Align',
-    initialItem: 'Left',
-    finalItem: 'Left'
-  }));
+  context('With translations', () => {
+    const hook = TinyHooks.bddSetup<Editor>(settings);
 
-  it('TINY-10147: align menu should update aria-label if displayed text changes', testAlignDropdownAriaLabel({
-    menuLabel: 'Align',
-    initialItem: 'Left',
-    finalItem: 'Right'
-  }));
+    before(() => {
+      I18n.add('test', {
+        'left': 'left translated',
+        'right': 'right translated',
+        'Left': 'Left translated',
+        'Right': 'Right translated',
+        'Verdana': 'Verdana translated',
+        'Arial': 'Arial translated',
+        '12pt': '12pt translated',
+        '8pt': '8pt translated',
+        'Paragraph': 'Paragraph translated',
+        'Heading 1': 'Heading 1 translated',
+        'Div': 'Div translated'
+      });
 
-  it('TINY-10147: fontfamily menu should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel({
-    menuLabel: 'Font',
-    initialItem: 'Verdana',
-    finalItem: 'Verdana'
-  }));
+      I18n.setCode('test');
+    });
 
-  it('TINY-10147: fontfamily menu should update aria-label if displayed text changes', testStandardDropdownAriaLabel({
-    menuLabel: 'Font',
-    initialItem: 'Verdana',
-    finalItem: 'Arial'
-  }));
+    after(() => {
+      I18n.setCode('en');
+    });
 
-  it('TINY-10147: fontsize menu should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel({
-    menuLabel: 'Font size',
-    initialItem: '12pt',
-    finalItem: '12pt'
-  }));
+    afterEach(makeCleanupFn(hook));
 
-  it('TINY-10147: fontsize menu should update aria-label if displayed text changes', testStandardDropdownAriaLabel({
-    menuLabel: 'Font size',
-    initialItem: '12pt',
-    finalItem: '8pt'
-  }));
+    it('TINY-10426: align dropdown should not update aria-label if displayed text does not change', testAlignDropdownAriaLabel(hook, {
+      label: 'Align',
+      initialItem: 'Left translated',
+      finalItem: 'Left translated'
+    }));
 
-  it('TINY-10147: blocks menu should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel({
-    menuLabel: 'Block',
-    initialItem: 'Paragraph',
-    finalItem: 'Paragraph'
-  }));
+    it('TINY-10426: align dropdown should update aria-label if displayed text changes', testAlignDropdownAriaLabel(hook, {
+      label: 'Align',
+      initialItem: 'Left translated',
+      finalItem: 'Right translated'
+    }));
 
-  it('TINY-10147: blocks menu should update aria-label if displayed text changes', testStandardDropdownAriaLabel({
-    menuLabel: 'Block',
-    initialItem: 'Paragraph',
-    finalItem: 'Heading 1'
-  }));
+    it('TINY-10426: fontfamily dropdown should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel(hook, {
+      label: 'Font',
+      initialItem: 'Verdana translated',
+      finalItem: 'Verdana translated'
+    }));
 
-  it('TINY-10147: styles menu should not update aria-label if displayed text does not change', testFormatsDropdownAriaLabel({
-    menuLabel: 'Format',
-    initialItem: 'Paragraph',
-    finalItem: 'Paragraph'
-  }));
+    it('TINY-10426: fontfamily dropdown should update aria-label if displayed text changes', testStandardDropdownAriaLabel(hook, {
+      label: 'Font',
+      initialItem: 'Verdana translated',
+      finalItem: 'Arial translated'
+    }));
 
-  it('TINY-10147: styles menu should update aria-label if displayed text changes', testFormatsDropdownAriaLabel({
-    menuLabel: 'Format',
-    initialItem: 'Paragraph',
-    finalItem: 'Div'
-  }));
+    it('TINY-10426: fontsize dropdown should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel(hook, {
+      label: 'Font size',
+      initialItem: '12pt translated',
+      finalItem: '12pt translated'
+    }));
+
+    it('TINY-10426: fontsize dropdown should update aria-label if displayed text changes', testStandardDropdownAriaLabel(hook, {
+      label: 'Font size',
+      initialItem: '12pt translated',
+      finalItem: '8pt translated'
+    }));
+
+    it('TINY-10426: blocks dropdown should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel(hook, {
+      label: 'Block',
+      initialItem: 'Paragraph translated',
+      finalItem: 'Paragraph translated'
+    }));
+
+    it('TINY-10426: blocks dropdown should update aria-label if displayed text changes', testStandardDropdownAriaLabel(hook, {
+      label: 'Block',
+      initialItem: 'Paragraph translated',
+      finalItem: 'Heading 1 translated'
+    }));
+
+    it('TINY-10426: styles dropdown should not update aria-label if displayed text does not change', testFormatsDropdownAriaLabel(hook, {
+      label: 'Format',
+      initialItem: 'Paragraph translated',
+      finalItem: 'Paragraph translated'
+    }));
+
+    it('TINY-10426: styles dropdown should update aria-label if displayed text changes', testFormatsDropdownAriaLabel(hook, {
+      label: 'Format',
+      initialItem: 'Paragraph translated',
+      finalItem: 'Div translated'
+    }));
+  });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
@@ -387,7 +387,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
 
     it('TINY-9669: Disable align on noneditable content', testDisableOnNoneditable('Align'));
     it('TINY-9669: Disable fontfamily on noneditable content', testDisableOnNoneditable('Fonts'));
-    it('TINY-9669: Disable fontsize on noneditable content', testDisableOnNoneditable('Font sizes'));
+    it('TINY-9669: Disable fontsize on noneditable content', testDisableOnNoneditable('Font size'));
     it('TINY-9669: Disable blocks on noneditable content', testDisableOnNoneditable('Blocks'));
     it('TINY-9669: Disable styles on noneditable content', testDisableOnNoneditable('Formats'));
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
@@ -386,7 +386,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
     };
 
     it('TINY-9669: Disable align on noneditable content', testDisableOnNoneditable('Align'));
-    it('TINY-9669: Disable fontfamily on noneditable content', testDisableOnNoneditable('Fonts'));
+    it('TINY-9669: Disable fontfamily on noneditable content', testDisableOnNoneditable('Font'));
     it('TINY-9669: Disable fontsize on noneditable content', testDisableOnNoneditable('Font size'));
     it('TINY-9669: Disable blocks on noneditable content', testDisableOnNoneditable('Blocks'));
     it('TINY-9669: Disable styles on noneditable content', testDisableOnNoneditable('Formats'));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
@@ -277,7 +277,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
       TinyUiActions.keydown(editor, Keys.down());
       await pAssertFocusOnItem('Code');
       TinyUiActions.keydown(editor, Keys.down());
-      await pAssertFocusOnItem('Formats');
+      await pAssertFocusOnItem('Format');
       TinyUiActions.keydown(editor, Keys.down());
       await pAssertFocusOnItem('Block');
       TinyUiActions.keydown(editor, Keys.right());
@@ -343,7 +343,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
       TinyUiActions.keydown(editor, Keys.down());
       await pAssertFocusOnItem('Code');
       TinyUiActions.keydown(editor, Keys.down());
-      await pAssertFocusOnItem('Formats');
+      await pAssertFocusOnItem('Format');
       TinyUiActions.keydown(editor, Keys.right());
       await pAssertFocusOnItem('Headings');
       TinyUiActions.keydown(editor, Keys.right());
@@ -389,6 +389,6 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
     it('TINY-9669: Disable fontfamily on noneditable content', testDisableOnNoneditable('Font'));
     it('TINY-9669: Disable fontsize on noneditable content', testDisableOnNoneditable('Font size'));
     it('TINY-9669: Disable blocks on noneditable content', testDisableOnNoneditable('Block'));
-    it('TINY-9669: Disable styles on noneditable content', testDisableOnNoneditable('Formats'));
+    it('TINY-9669: Disable styles on noneditable content', testDisableOnNoneditable('Format'));
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
@@ -279,7 +279,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
       TinyUiActions.keydown(editor, Keys.down());
       await pAssertFocusOnItem('Formats');
       TinyUiActions.keydown(editor, Keys.down());
-      await pAssertFocusOnItem('Blocks');
+      await pAssertFocusOnItem('Block');
       TinyUiActions.keydown(editor, Keys.right());
       await pAssertFocusOnItem('Paragraph');
       assertItemTicks('Checking blocks in menu', [ false, true ].concat(Arr.range(6, Fun.never)));
@@ -388,7 +388,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
     it('TINY-9669: Disable align on noneditable content', testDisableOnNoneditable('Align'));
     it('TINY-9669: Disable fontfamily on noneditable content', testDisableOnNoneditable('Font'));
     it('TINY-9669: Disable fontsize on noneditable content', testDisableOnNoneditable('Font size'));
-    it('TINY-9669: Disable blocks on noneditable content', testDisableOnNoneditable('Blocks'));
+    it('TINY-9669: Disable blocks on noneditable content', testDisableOnNoneditable('Block'));
     it('TINY-9669: Disable styles on noneditable content', testDisableOnNoneditable('Formats'));
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -114,7 +114,7 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
         await StickyUtils.pOpenMenuAndTestScrolling(() => MenuUtils.pOpenNestedMenus([
           {
             label: 'Open menu bar Formats menu',
-            selector: 'button:contains(Format)[role=menuitem]'
+            selector: 'button:contains(Formats)[role=menuitem]'
           },
           {
             label: 'then Formats submenu',

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -113,8 +113,8 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
       it('Open menubar Formats menu => Formats => Inline => check sticky states', async () => {
         await StickyUtils.pOpenMenuAndTestScrolling(() => MenuUtils.pOpenNestedMenus([
           {
-            label: 'Open menu bar Formats menu',
-            selector: 'button:contains(Formats)[role=menuitem]'
+            label: 'Open menu bar Format menu',
+            selector: 'button:contains(Format)[role=menuitem]'
           },
           {
             label: 'then Formats submenu',

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -100,7 +100,7 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
           {
             // first open this menu
             label: 'Open nested formats dropdown',
-            selector: 'button[aria-label^=Formats]'
+            selector: 'button[aria-label^=Format]'
           },
           {
             // opening the first menu should reveal the next menu which contains Align, open Align


### PR DESCRIPTION
Related Ticket: TINY-10426

Description of Changes:
* Singularize labels of `fontfamily`, `fontsize`, `blocks`, and `styles` bespoke toolbar buttons
* Keep menu item text plural
* Remove string concatenation in Tooltip module
* Add translation tests for bespoke button aria labels

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
