### PR TITLE
TINY-10380: Optimized the ClosestCaretCandidate

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When deleting the last row in a table, the cursor would jump to the first cell (top left), instead of moving to the next adjacent cell in some cases. #TINY-6309
 - The functions `schema.isWrapper` and `schema.isInline` didn't exclude element names that started with `#` those should not be considered elements. #TINY-10385
 - Moving focus to the outside of the editor after having clicked a menu would not fire a `blur` event as expected. #TINY-10310
-- Clicking at specific sports inside table cells with heavily nested content could cause the browser to hang. #TINY-10380
+- Clicking inside table cells with heavily nested content could cause the browser to hang. #TINY-10380
 
 ## 6.8.1 - 2023-11-29
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When deleting the last row in a table, the cursor would jump to the first cell (top left), instead of moving to the next adjacent cell in some cases. #TINY-6309
 - The functions `schema.isWrapper` and `schema.isInline` didn't exclude element names that started with `#` those should not be considered elements. #TINY-10385
 - Moving focus to the outside of the editor after having clicked a menu would not fire a `blur` event as expected. #TINY-10310
+- Clicking at specific sports inside table cells with heavily nested content could cause the browser to hang. #TINY-10380
 
 ## 6.8.1 - 2023-11-29
 

--- a/modules/tinymce/src/core/main/ts/caret/ClosestCaretCandidate.ts
+++ b/modules/tinymce/src/core/main/ts/caret/ClosestCaretCandidate.ts
@@ -56,12 +56,12 @@ const clientInfo = (rect: NodeClientRect, clientX: number): FakeCaretInfo => {
 const horizontalDistance: DistanceFn = (rect, x, _y) =>
   x > rect.left && x < rect.right ? 0 : Math.min(Math.abs(rect.left - x), Math.abs(rect.right - x));
 
-const closestChildCaretCandidateNodeRect = (children: ChildNode[], clientX: number, clientY: number): Optional<NodeClientRect> => {
+const closestChildCaretCandidateNodeRect = (children: ChildNode[], clientX: number, clientY: number, findCloserTextNode: boolean) => {
   const caretCandidateRect = (rect: NodeClientRect) => {
     if (CaretCandidate.isCaretCandidate(rect.node)) {
       return Optional.some(rect);
     } else if (NodeType.isElement(rect.node)) {
-      return closestChildCaretCandidateNodeRect(Arr.from(rect.node.childNodes), clientX, clientY);
+      return closestChildCaretCandidateNodeRect(Arr.from(rect.node.childNodes), clientX, clientY, false);
     } else {
       return Optional.none();
     }
@@ -80,7 +80,7 @@ const closestChildCaretCandidateNodeRect = (children: ChildNode[], clientX: numb
     const sortedRects = Arr.sort(rects, (r1, r2) => distance(r1, clientX, clientY) - distance(r2, clientX, clientY));
     return Arr.findMap(sortedRects, caretCandidateRect).map((closest) => {
       // If the closest rect is not a text node then lets try to see if the second rect has a text node that is close enough
-      if (!NodeType.isText(closest.node) && sortedRects.length > 1) {
+      if (findCloserTextNode && !NodeType.isText(closest.node) && sortedRects.length > 1) {
         return tryFindSecondBestTextNode(closest, sortedRects[1], distance).getOr(closest);
       } else {
         return closest;
@@ -102,10 +102,10 @@ const traverseUp = (rootElm: SugarElement<Node>, scope: SugarElement<Element>, c
     const childNodesWithoutGhost = Arr.filter(scope.dom.childNodes, Fun.not(isDragGhostContainer));
 
     return prevScope.fold(
-      () => closestChildCaretCandidateNodeRect(childNodesWithoutGhost, clientX, clientY),
+      () => closestChildCaretCandidateNodeRect(childNodesWithoutGhost, clientX, clientY, true),
       (prevScope) => {
         const uncheckedChildren = Arr.filter(childNodesWithoutGhost, (node) => node !== prevScope.dom);
-        return closestChildCaretCandidateNodeRect(uncheckedChildren, clientX, clientY);
+        return closestChildCaretCandidateNodeRect(uncheckedChildren, clientX, clientY, true);
       }
     ).orThunk(() => {
       const parent = Compare.eq(scope, rootElm) ? Optional.none() : Traverse.parentElement(scope);

--- a/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
@@ -267,15 +267,13 @@ describe('browser.tinymce.core.ClosestCaretCandidateTest', () => {
           return child;
         }, el);
 
-        const expectedPath = Arr.range(depth + 2, Fun.constant(0));
-
         Insert.append(innerMost, SugarElement.fromText('xx xx'));
 
         testClosestCaretCandidate({
           html: Html.getOuter(el),
           targetPath: [ 0 ],
           dx: 10, dy: 60,
-          expected: Optional.some(expectedPath)
+          expected: Optional.some(Arr.range(depth + 2, Fun.constant(0)))
         });
       });
     });

--- a/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
@@ -260,7 +260,7 @@ describe('browser.tinymce.core.ClosestCaretCandidateTest', () => {
 
       it('TINY-10380: should not take long to find the text candidate in next to a deeply nested structure', () => {
         const el: SugarElement<HTMLElement> = SugarElement.fromHtml('<div style="height: 100px; width: 20px"></div>');
-        const depth = 10;
+        const depth = 32;
 
         const innerMost = Arr.foldl(Arr.range(depth, (_) => SugarElement.fromTag('em')), (el, child) => {
           Insert.append(el, child);
@@ -280,7 +280,7 @@ describe('browser.tinymce.core.ClosestCaretCandidateTest', () => {
 
       it('TINY-10380: should not take long to find the img candidate in next to a deeply nested structure', () => {
         const el: SugarElement<HTMLElement> = SugarElement.fromHtml('<div style="height: 100px; width: 20px"></div>');
-        const depth = 10;
+        const depth = 32;
 
         const innerMost = Arr.foldl(Arr.range(depth, (_) => SugarElement.fromTag('em')), (el, child) => {
           Insert.append(el, child);

--- a/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
@@ -1,6 +1,6 @@
 import { Cursors } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { Optional } from '@ephox/katamari';
+import { Arr, Fun, Optional } from '@ephox/katamari';
 import { ContentEditable, Css, Html, Insert, Remove, SugarBody, SugarElement, SugarLocation } from '@ephox/sugar';
 import { assert } from 'chai';
 
@@ -257,6 +257,27 @@ describe('browser.tinymce.core.ClosestCaretCandidateTest', () => {
           expected: Optional.some([ 0 ])
         })
       );
+
+      it('TINY-10380: should not take long to find the candidate in next to a deeply nested structure', () => {
+        const el: SugarElement<HTMLElement> = SugarElement.fromHtml('<div style="height: 100px; width: 20px"></div>');
+        const depth = 32;
+
+        const innerMost = Arr.foldl(Arr.range(depth, (_) => SugarElement.fromTag('em')), (el, child) => {
+          Insert.append(el, child);
+          return child;
+        }, el);
+
+        const expectedPath = Arr.range(depth + 2, Fun.constant(0));
+
+        Insert.append(innerMost, SugarElement.fromText('xx xx'));
+
+        testClosestCaretCandidate({
+          html: Html.getOuter(el),
+          targetPath: [ 0 ],
+          dx: 10, dy: 60,
+          expected: Optional.some(expectedPath)
+        });
+      });
     });
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/ClosestCaretCandidateTest.ts
@@ -258,16 +258,37 @@ describe('browser.tinymce.core.ClosestCaretCandidateTest', () => {
         })
       );
 
-      it('TINY-10380: should not take long to find the candidate in next to a deeply nested structure', () => {
+      it('TINY-10380: should not take long to find the text candidate in next to a deeply nested structure', () => {
         const el: SugarElement<HTMLElement> = SugarElement.fromHtml('<div style="height: 100px; width: 20px"></div>');
-        const depth = 32;
+        const depth = 10;
 
         const innerMost = Arr.foldl(Arr.range(depth, (_) => SugarElement.fromTag('em')), (el, child) => {
           Insert.append(el, child);
+          Insert.append(el, SugarElement.fromTag('b'));
           return child;
         }, el);
 
         Insert.append(innerMost, SugarElement.fromText('xx xx'));
+
+        testClosestCaretCandidate({
+          html: Html.getOuter(el),
+          targetPath: [ 0 ],
+          dx: 10, dy: 60,
+          expected: Optional.some(Arr.range(depth + 2, Fun.constant(0)))
+        });
+      });
+
+      it('TINY-10380: should not take long to find the img candidate in next to a deeply nested structure', () => {
+        const el: SugarElement<HTMLElement> = SugarElement.fromHtml('<div style="height: 100px; width: 20px"></div>');
+        const depth = 10;
+
+        const innerMost = Arr.foldl(Arr.range(depth, (_) => SugarElement.fromTag('em')), (el, child) => {
+          Insert.append(el, child);
+          Insert.append(el, SugarElement.fromTag('b'));
+          return child;
+        }, el);
+
+        Insert.append(innerMost, SugarElement.fromHtml('<img src="#">'));
 
         testClosestCaretCandidate({
           html: Html.getOuter(el),


### PR DESCRIPTION
Related Ticket: TINY-10380

Description of Changes:
* Optimized the ClosestCaretCandidate code it would check for a first and second best match even if it already had a good match. It would also re-check something that it already checked. That caused a insane amount of recursion a time complexity of O(2^n) so the checks would double on every level of depth added.
* Added a test that hangs if the code is the old code but is fine now.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
