### PR TITLE
TINY-10435: Convert Align bespoke button tooltips to use concatenated literal

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Bespoke dropdown toolbar buttons including `fontfamily`, `fontsize`, `blocks`, and `styles` incorrectly used plural words in their accessible names. #TINY-10426
+- Tooltips of bespoke dropdown toolbar buttons including `align`, `fontfamily`, `fontsize`, `blocks`, and `styles` were incorrectly translated. #TINY-10435
 - Clicking inside table cells with heavily nested content could cause the browser to hang. #TINY-10380
 - Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10414
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
@@ -7,12 +7,15 @@ import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 import * as Events from '../../../api/Events';
 import { updateMenuIcon } from '../../dropdown/CommonDropdown';
 import { onSetupEditableToggle } from '../ControlUtils';
-import { createMenuItems, createSelectButton, FormatterFormatItem, SelectedFormat, SelectSpec } from './BespokeSelect';
+import { BespokeSelectTooltip, createMenuItems, createSelectButton, FormatterFormatItem, SelectedFormat, SelectSpec } from './BespokeSelect';
 import { buildBasicStaticDataset } from './SelectDatasets';
 import * as Tooltip from './utils/Tooltip';
 
 const title = 'Align';
-const tooltip = 'Align {0}';
+const btnTooltip: BespokeSelectTooltip = {
+  tooltip: title,
+  hasPlaceholder: false
+};
 const fallbackAlignment = 'left';
 
 const alignMenuItems = [
@@ -45,7 +48,7 @@ const getSpec = (editor: Editor): SelectSpec => {
       .each((item) => editor.execCommand(item.command));
 
   return {
-    tooltip: Tooltip.makeTooltipText(editor, tooltip, fallbackAlignment),
+    tooltip: Tooltip.makeTooltip(editor, btnTooltip, fallbackAlignment),
     text: Optional.none(),
     icon: Optional.some('align-left'),
     isSelectedFor,
@@ -60,7 +63,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const createAlignButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createSelectButton(editor, backstage, getSpec(editor), tooltip, 'AlignTextUpdate');
+  createSelectButton(editor, backstage, getSpec(editor), btnTooltip, 'AlignTextUpdate');
 
 const createAlignMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
   const menuItems = createMenuItems(editor, backstage, getSpec(editor));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -71,6 +71,11 @@ export interface SelectSpec {
   readonly dataset: SelectDataset;
 }
 
+export interface BespokeSelectTooltip {
+  tooltip: string;
+  hasPlaceholder: boolean;
+}
+
 interface BespokeSelectApi {
   readonly getComponent: () => AlloyComponent;
   readonly setTooltip: (tooltip: string) => void;
@@ -174,7 +179,7 @@ const createMenuItems = (editor: Editor, backstage: UiFactoryBackstage, spec: Se
   };
 };
 
-const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec, tooltipWithPlaceholder: string, textUpdateEventName: string): SketchSpec => {
+const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec, bespokeTooltip: BespokeSelectTooltip, textUpdateEventName: string): SketchSpec => {
   const { items, getStyleItems } = createMenuItems(editor, backstage, spec);
 
   const getApi = (comp: AlloyComponent): BespokeSelectApi => ({
@@ -187,8 +192,8 @@ const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec:
 
   // Set the initial text when the component is attached and then update on node changes
   const onSetup = (api: BespokeSelectApi) => {
-    const handler = (e: EditorEvent<{ value: string }>) =>
-      api.setTooltip(Tooltip.makeTooltipText(editor, tooltipWithPlaceholder, e.value));
+    const handler = ({ value }: EditorEvent<{ value: string }>) =>
+      api.setTooltip(Tooltip.makeTooltip(editor, bespokeTooltip, value));
     editor.on(textUpdateEventName, handler);
     return composeUnbinders(
       onSetupEvent(editor, 'NodeChange', (api: BespokeSelectApi) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
@@ -8,13 +8,16 @@ import * as Events from '../../../api/Events';
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
 import { onActionToggleFormat, onSetupEditableToggle } from '../ControlUtils';
-import { createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
+import { BespokeSelectTooltip, createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import { findNearest } from './utils/FormatDetection';
 import * as Tooltip from './utils/Tooltip';
 
 const menuTitle = 'Blocks';
-const btnTooltip = 'Block {0}';
+const btnTooltip: BespokeSelectTooltip = {
+  tooltip: 'Block {0}',
+  hasPlaceholder: true
+};
 const fallbackFormat = 'Paragraph';
 
 const getSpec = (editor: Editor): SelectSpec => {
@@ -45,7 +48,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'block_formats', Delimiter.SemiColon);
 
   return {
-    tooltip: Tooltip.makeTooltipText(editor, btnTooltip, fallbackFormat),
+    tooltip: Tooltip.makeTooltip(editor, btnTooltip, fallbackFormat),
     text: Optional.some(fallbackFormat),
     icon: Optional.none(),
     isSelectedFor,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
@@ -8,12 +8,15 @@ import * as Options from '../../../api/Options';
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
 import { onSetupEditableToggle } from '../ControlUtils';
-import { createMenuItems, createSelectButton, FormatterFormatItem, PreviewSpec, SelectedFormat, SelectSpec } from './BespokeSelect';
+import { BespokeSelectTooltip, createMenuItems, createSelectButton, FormatterFormatItem, PreviewSpec, SelectedFormat, SelectSpec } from './BespokeSelect';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import * as Tooltip from './utils/Tooltip';
 
 const menuTitle = 'Fonts';
-const btnTooltip = 'Font {0}';
+const btnTooltip: BespokeSelectTooltip = {
+  tooltip: 'Font {0}',
+  hasPlaceholder: true
+};
 const systemFont = 'System Font';
 
 // A list of fonts that must be in a font family for the font to be recognised as the system stack
@@ -95,7 +98,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'font_family_formats', Delimiter.SemiColon);
 
   return {
-    tooltip: Tooltip.makeTooltipText(editor, btnTooltip, systemFont),
+    tooltip: Tooltip.makeTooltip(editor, btnTooltip, systemFont),
     text: Optional.some(systemFont),
     icon: Optional.none(),
     isSelectedFor,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -10,7 +10,7 @@ import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
 import { onSetupEditableToggle } from '../ControlUtils';
 import { createBespokeNumberInput } from './BespokeNumberInput';
-import { createMenuItems, createSelectButton, FormatterFormatItem, SelectedFormat, SelectSpec } from './BespokeSelect';
+import { BespokeSelectTooltip, createMenuItems, createSelectButton, FormatterFormatItem, SelectedFormat, SelectSpec } from './BespokeSelect';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import * as FormatRegister from './utils/FormatRegister';
 import * as Tooltip from './utils/Tooltip';
@@ -26,7 +26,10 @@ export interface NumberInputSpec {
 }
 
 const menuTitle = 'Font sizes';
-const btnTooltip = 'Font size {0}';
+const btnTooltip: BespokeSelectTooltip = {
+  tooltip: 'Font size {0}',
+  hasPlaceholder: true
+};
 const fallbackFontSize = '12pt';
 
 // See https://websemantics.uk/articles/font-size-conversion/ for conversions
@@ -114,7 +117,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'font_size_formats', Delimiter.Space);
 
   return {
-    tooltip: Tooltip.makeTooltipText(editor, btnTooltip, fallbackFontSize),
+    tooltip: Tooltip.makeTooltip(editor, btnTooltip, fallbackFontSize),
     text: Optional.some(fallbackFontSize),
     icon: Optional.none(),
     isSelectedFor,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
@@ -9,14 +9,17 @@ import * as Options from '../../../api/Options';
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
 import { onActionToggleFormat, onSetupEditableToggle } from '../ControlUtils';
-import { createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
+import { BespokeSelectTooltip, createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
 import { AdvancedSelectDataset, BasicSelectItem, SelectDataset } from './SelectDatasets';
 import { getStyleFormats, isFormatReference, isNestedFormat, StyleFormatType } from './StyleFormat';
 import { findNearest } from './utils/FormatDetection';
 import * as Tooltip from './utils/Tooltip';
 
 const menuTitle = 'Formats';
-const btnTooltip = 'Format {0}';
+const btnTooltip: BespokeSelectTooltip = {
+  tooltip: 'Format {0}',
+  hasPlaceholder: true
+};
 
 const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
   const fallbackFormat = 'Paragraph';
@@ -51,7 +54,7 @@ const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
   };
 
   return {
-    tooltip: Tooltip.makeTooltipText(editor, btnTooltip, fallbackFormat),
+    tooltip: Tooltip.makeTooltip(editor, btnTooltip, fallbackFormat),
     text: Optional.some(fallbackFormat),
     icon: Optional.none(),
     isSelectedFor,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/Tooltip.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/Tooltip.ts
@@ -1,8 +1,16 @@
 import Editor from 'tinymce/core/api/Editor';
 
-const makeTooltipText = (editor: Editor, labelWithPlaceholder: string, value: string): string =>
+import { BespokeSelectTooltip } from '../BespokeSelect';
+
+const makeConcatenatedTooltip = (editor: Editor, label: string, value: string) =>
+  editor.translate(`${label} ${value}`);
+
+const makePlaceholderTooltip = (editor: Editor, labelWithPlaceholder: string, value: string) =>
   editor.translate([ labelWithPlaceholder, editor.translate(value) ]);
 
+const makeTooltip = (editor: Editor, { tooltip, hasPlaceholder }: BespokeSelectTooltip, value: string): string =>
+  (hasPlaceholder ? makePlaceholderTooltip : makeConcatenatedTooltip)(editor, tooltip, value);
+
 export {
-  makeTooltipText
+  makeTooltip
 };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
@@ -60,7 +60,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.DropdownAriaLabelTest', (
       scenario.initialItem,
       scenario.finalItem,
       (item) => `${scenario.label} ${item.toLowerCase()}`,
-      () => MenuUtils.pOpenAlignMenu(scenario.label),
+      Fun.curry(MenuUtils.pOpenMenuWithSelector, scenario.label),
       TinyUiActions.pWaitForUi
     );
 
@@ -154,14 +154,21 @@ describe('browser.tinymce.themes.silver.editor.bespoke.DropdownAriaLabelTest', (
       language: 'test',
       setup: () => {
         I18n.add('test', {
-          'left': 'left translated',
-          'right': 'right translated',
           'Left': 'Left translated',
           'Right': 'Right translated',
+          'Align left': 'Aalign left translated',
+          'Align right': 'Aalign right translated',
+
+          'Font {0}': 'Ffont {0}',
           'Verdana': 'Verdana translated',
           'Arial': 'Arial translated',
+
+          'Font size {0}': 'Ffont size {0}',
           '12pt': '12pt translated',
           '8pt': '8pt translated',
+
+          'Block {0}': 'Bblock {0}',
+          'Format {0}': 'Fformat {0}',
           'Paragraph': 'Paragraph translated',
           'Heading 1': 'Heading 1 translated',
           'Div': 'Div translated'
@@ -172,61 +179,61 @@ describe('browser.tinymce.themes.silver.editor.bespoke.DropdownAriaLabelTest', (
     afterEach(makeCleanupFn(hook));
 
     it('TINY-10426: align dropdown should not update aria-label if displayed text does not change', testAlignDropdownAriaLabel(hook, {
-      label: 'Align',
+      label: 'Aalign',
       initialItem: 'Left translated',
       finalItem: 'Left translated'
     }));
 
     it('TINY-10426: align dropdown should update aria-label if displayed text changes', testAlignDropdownAriaLabel(hook, {
-      label: 'Align',
+      label: 'Aalign',
       initialItem: 'Left translated',
       finalItem: 'Right translated'
     }));
 
     it('TINY-10426: fontfamily dropdown should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel(hook, {
-      label: 'Font',
+      label: 'Ffont',
       initialItem: 'Verdana translated',
       finalItem: 'Verdana translated'
     }));
 
     it('TINY-10426: fontfamily dropdown should update aria-label if displayed text changes', testStandardDropdownAriaLabel(hook, {
-      label: 'Font',
+      label: 'Ffont',
       initialItem: 'Verdana translated',
       finalItem: 'Arial translated'
     }));
 
     it('TINY-10426: fontsize dropdown should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel(hook, {
-      label: 'Font size',
+      label: 'Ffont size',
       initialItem: '12pt translated',
       finalItem: '12pt translated'
     }));
 
     it('TINY-10426: fontsize dropdown should update aria-label if displayed text changes', testStandardDropdownAriaLabel(hook, {
-      label: 'Font size',
+      label: 'Ffont size',
       initialItem: '12pt translated',
       finalItem: '8pt translated'
     }));
 
     it('TINY-10426: blocks dropdown should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel(hook, {
-      label: 'Block',
+      label: 'Bblock',
       initialItem: 'Paragraph translated',
       finalItem: 'Paragraph translated'
     }));
 
     it('TINY-10426: blocks dropdown should update aria-label if displayed text changes', testStandardDropdownAriaLabel(hook, {
-      label: 'Block',
+      label: 'Bblock',
       initialItem: 'Paragraph translated',
       finalItem: 'Heading 1 translated'
     }));
 
     it('TINY-10426: styles dropdown should not update aria-label if displayed text does not change', testFormatsDropdownAriaLabel(hook, {
-      label: 'Format',
+      label: 'Fformat',
       initialItem: 'Paragraph translated',
       finalItem: 'Paragraph translated'
     }));
 
     it('TINY-10426: styles dropdown should update aria-label if displayed text changes', testFormatsDropdownAriaLabel(hook, {
-      label: 'Format',
+      label: 'Fformat',
       initialItem: 'Paragraph translated',
       finalItem: 'Div translated'
     }));


### PR DESCRIPTION
Related Ticket: TINY-10435

Description of Changes:
* Convert Align bespoke button tooltips to use concatenated literals since we don't have `Align {0}` as a translation source string but we have `Align left`, `Align right` etc. literals in translations

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
