### PR TITLE
TINY-10426: Revert bespoke button tooltip changes for 6.8.2

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Bespoke dropdown toolbar buttons including `fontfamily`, `fontsize`, `blocks`, and `styles` incorrectly used plural words in their accessible names. #TINY-10426
 - Clicking inside table cells with heavily nested content could cause the browser to hang. #TINY-10380
 - Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10414
 

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Bespoke dropdown toolbar buttons including `fontfamily`, `fontsize`, `blocks`, and `styles` incorrectly used plural words in their accessible names. #TINY-10426
-- Tooltips of bespoke dropdown toolbar buttons including `align`, `fontfamily`, `fontsize`, `blocks`, and `styles` were incorrectly translated. #TINY-10435
 - Clicking inside table cells with heavily nested content could cause the browser to hang. #TINY-10380
 - Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10414
 

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
@@ -10,7 +10,7 @@ import Editor from 'tinymce/core/api/Editor';
 describe('browser.tinymce.core.FontSelectCustomTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
-    toolbar: 'fontfamily fontsize',
+    toolbar: 'fontsize fontfamily',
     content_style: [
       '.mce-content-body { font-family: Helvetica; font-size: 42px; }',
       '.mce-content-body p { font-family: Arial; font-size: 12px; }',
@@ -21,14 +21,14 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
   }, []);
 
   const assertSelectBoxDisplayValue = (title: string, expectedValue: string) => {
-    const selectBox = UiFinder.findIn(SugarBody.body(), `*[title^="${title}"]`).getOrDie();
+    const selectBox = UiFinder.findIn(SugarBody.body(), '*[title^="' + title + '"]').getOrDie();
     const value = Strings.trim(TextContent.get(selectBox) ?? '');
     assert.equal(value, expectedValue, 'Should be the expected display value');
   };
 
   it('Font family and font size on initial page load', () => {
-    assertSelectBoxDisplayValue('Font size', '12px');
-    assertSelectBoxDisplayValue('Font', 'Arial');
+    assertSelectBoxDisplayValue('Font sizes', '12px');
+    assertSelectBoxDisplayValue('Fonts', 'Arial');
   });
 
   it('Font family with spaces and numbers in the name with legacy font elements', () => {
@@ -37,8 +37,8 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
     editor.focus();
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
     editor.nodeChanged();
-    assertSelectBoxDisplayValue('Font size', '8pt');
-    assertSelectBoxDisplayValue('Font', 'Bookshelf Symbol 7');
+    assertSelectBoxDisplayValue('Font sizes', '8pt');
+    assertSelectBoxDisplayValue('Fonts', 'Bookshelf Symbol 7');
   });
 
   it('Font family with spaces and numbers in the name', () => {
@@ -47,8 +47,8 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
     editor.focus();
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
     editor.nodeChanged();
-    assertSelectBoxDisplayValue('Font size', '12px');
-    assertSelectBoxDisplayValue('Font', 'Bookshelf Symbol 7');
+    assertSelectBoxDisplayValue('Font sizes', '12px');
+    assertSelectBoxDisplayValue('Fonts', 'Bookshelf Symbol 7');
   });
 
   it('Font family with quoted font names', () => {
@@ -57,7 +57,7 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
     editor.focus();
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
     editor.nodeChanged();
-    assertSelectBoxDisplayValue('Font size', '12px');
-    assertSelectBoxDisplayValue('Font', 'Bauhaus 93');
+    assertSelectBoxDisplayValue('Font sizes', '12px');
+    assertSelectBoxDisplayValue('Fonts', 'Bauhaus 93');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.FontSelectTest', () => {
   const assertSelectBoxDisplayValue = (title: string, expectedValue: string) => {
-    const selectBox = UiFinder.findIn(SugarBody.body(), `*[title^="${title}"]`).getOrDie();
+    const selectBox = UiFinder.findIn(SugarBody.body(), '*[title^="' + title + '"]').getOrDie();
     const value = Strings.trim(TextContent.get(selectBox) ?? '');
     assert.equal(value, expectedValue, 'Should be the expected display value');
   };
@@ -17,7 +17,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
   context('Default font stack', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       base_url: '/project/tinymce/js/tinymce',
-      toolbar: 'fontfamily fontsize',
+      toolbar: 'fontsize fontfamily',
       content_style: [
         '.mce-content-body { font-family: Helvetica; font-size: 42px; }',
         '.mce-content-body p { font-family: Arial; font-size: 12px; }',
@@ -33,8 +33,8 @@ describe('browser.tinymce.core.FontSelectTest', () => {
     ];
 
     it('TBA: Font family and font size on initial page load', () => {
-      assertSelectBoxDisplayValue('Font size', '12px');
-      assertSelectBoxDisplayValue('Font', 'Arial');
+      assertSelectBoxDisplayValue('Font sizes', '12px');
+      assertSelectBoxDisplayValue('Fonts', 'Arial');
     });
 
     it('TBA: Font family and font size on paragraph with no styles', () => {
@@ -43,8 +43,8 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
       // p content style is 12px which does not match any pt values in the font size select values
-      assertSelectBoxDisplayValue('Font size', '12px');
-      assertSelectBoxDisplayValue('Font', 'Arial');
+      assertSelectBoxDisplayValue('Font sizes', '12px');
+      assertSelectBoxDisplayValue('Fonts', 'Arial');
     });
 
     it('TBA: Font family and font size on heading with no styles', () => {
@@ -54,8 +54,8 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
       // h1 content style is 32px which matches 24pt in the font size select values so it should be converted
-      assertSelectBoxDisplayValue('Font size', '24pt');
-      assertSelectBoxDisplayValue('Font', 'Arial');
+      assertSelectBoxDisplayValue('Font sizes', '24pt');
+      assertSelectBoxDisplayValue('Fonts', 'Arial');
     });
 
     it('TBA: Font family and font size on paragraph with styles that do match font size select values', () => {
@@ -64,8 +64,8 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
       // the following should be converted and pick up 12.75pt, although there's a rounded 13pt in the dropdown as well
-      assertSelectBoxDisplayValue('Font size', '12.75pt');
-      assertSelectBoxDisplayValue('Font', 'Times');
+      assertSelectBoxDisplayValue('Font sizes', '12.75pt');
+      assertSelectBoxDisplayValue('Fonts', 'Times');
     });
 
     it('TBA: Font family and font size on paragraph with styles that do not match font size select values', () => {
@@ -75,8 +75,8 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
       // the following should stay as 18px because there's no matching pt value in the font size select values
-      assertSelectBoxDisplayValue('Font size', '18px');
-      assertSelectBoxDisplayValue('Font', 'Times');
+      assertSelectBoxDisplayValue('Font sizes', '18px');
+      assertSelectBoxDisplayValue('Fonts', 'Times');
     });
 
     it('TBA: Font family and font size on paragraph with legacy font elements', () => {
@@ -84,8 +84,8 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.setContent('<p><font face="Times" size="1">a</font></p>', { format: 'raw' });
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
       editor.nodeChanged();
-      assertSelectBoxDisplayValue('Font size', '8pt');
-      assertSelectBoxDisplayValue('Font', 'Times');
+      assertSelectBoxDisplayValue('Font sizes', '8pt');
+      assertSelectBoxDisplayValue('Fonts', 'Times');
     });
 
     // https://websemantics.uk/articles/font-size-conversion/
@@ -94,8 +94,8 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.setContent('<p style="font-family: Times; font-size: medium;">a</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
-      assertSelectBoxDisplayValue('Font size', '12pt');
-      assertSelectBoxDisplayValue('Font', 'Times');
+      assertSelectBoxDisplayValue('Font sizes', '12pt');
+      assertSelectBoxDisplayValue('Fonts', 'Times');
     });
 
     it('TINY-6291: xx-small will fall back to showing raw font size due to missing 7pt fontsize_format', () => {
@@ -104,8 +104,8 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.focus();
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
-      assertSelectBoxDisplayValue('Font size', 'xx-small');
-      assertSelectBoxDisplayValue('Font', 'Times');
+      assertSelectBoxDisplayValue('Font sizes', 'xx-small');
+      assertSelectBoxDisplayValue('Fonts', 'Times');
     });
 
     it('TBA: System font stack variants on a paragraph show "System Font" as the font name', () => {
@@ -114,7 +114,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       Arr.each(systemFontStackVariants, (_, idx) => {
         TinySelections.setCursor(editor, [ idx, 0 ], 0);
         editor.nodeChanged();
-        assertSelectBoxDisplayValue('Font', 'System Font');
+        assertSelectBoxDisplayValue('Fonts', 'System Font');
       });
     });
 
@@ -124,14 +124,14 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.focus();
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
-      assertSelectBoxDisplayValue('Font', '-apple-system,Arial');
+      assertSelectBoxDisplayValue('Fonts', '-apple-system,Arial');
     });
   });
 
   context('Custom default font stack', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       base_url: '/project/tinymce/js/tinymce',
-      toolbar: 'fontfamily fontsize',
+      toolbar: 'fontsize fontfamily',
       content_style: [
         '.mce-content-body { font-family: -apple-system, Arial; }',
         '.mce-content-body h1 { font-family: Helvetica; }',
@@ -145,7 +145,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.setContent(testCase.html);
       TinySelections.setCursor(editor, testCase.path, testCase.offset);
       editor.nodeChanged();
-      assertSelectBoxDisplayValue('Font', testCase.expectedValue);
+      assertSelectBoxDisplayValue('Fonts', testCase.expectedValue);
     };
 
     it('TINY-10290: Should show System Font for the specified custom stack', () => testCustomStack({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
@@ -12,7 +12,6 @@ import { buildBasicStaticDataset } from './SelectDatasets';
 import * as Tooltip from './utils/Tooltip';
 
 const title = 'Align';
-const tooltip = 'Align {0}';
 const fallbackAlignment = 'left';
 
 const alignMenuItems = [
@@ -45,7 +44,7 @@ const getSpec = (editor: Editor): SelectSpec => {
       .each((item) => editor.execCommand(item.command));
 
   return {
-    tooltip: Tooltip.makeTooltipText(editor, tooltip, fallbackAlignment),
+    tooltip: Tooltip.getTooltipText(editor, title, fallbackAlignment),
     text: Optional.none(),
     icon: Optional.some('align-left'),
     isSelectedFor,
@@ -60,7 +59,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const createAlignButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createSelectButton(editor, backstage, getSpec(editor), tooltip, 'AlignTextUpdate');
+  createSelectButton(editor, backstage, getSpec(editor), title, 'AlignTextUpdate');
 
 const createAlignMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
   const menuItems = createMenuItems(editor, backstage, getSpec(editor));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
@@ -7,15 +7,12 @@ import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 import * as Events from '../../../api/Events';
 import { updateMenuIcon } from '../../dropdown/CommonDropdown';
 import { onSetupEditableToggle } from '../ControlUtils';
-import { BespokeSelectTooltip, createMenuItems, createSelectButton, FormatterFormatItem, SelectedFormat, SelectSpec } from './BespokeSelect';
+import { createMenuItems, createSelectButton, FormatterFormatItem, SelectedFormat, SelectSpec } from './BespokeSelect';
 import { buildBasicStaticDataset } from './SelectDatasets';
 import * as Tooltip from './utils/Tooltip';
 
 const title = 'Align';
-const btnTooltip: BespokeSelectTooltip = {
-  tooltip: title,
-  hasPlaceholder: false
-};
+const tooltip = 'Align {0}';
 const fallbackAlignment = 'left';
 
 const alignMenuItems = [
@@ -48,7 +45,7 @@ const getSpec = (editor: Editor): SelectSpec => {
       .each((item) => editor.execCommand(item.command));
 
   return {
-    tooltip: Tooltip.makeTooltip(editor, btnTooltip, fallbackAlignment),
+    tooltip: Tooltip.makeTooltipText(editor, tooltip, fallbackAlignment),
     text: Optional.none(),
     icon: Optional.some('align-left'),
     isSelectedFor,
@@ -63,7 +60,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const createAlignButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createSelectButton(editor, backstage, getSpec(editor), btnTooltip, 'AlignTextUpdate');
+  createSelectButton(editor, backstage, getSpec(editor), tooltip, 'AlignTextUpdate');
 
 const createAlignMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
   const menuItems = createMenuItems(editor, backstage, getSpec(editor));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -71,11 +71,6 @@ export interface SelectSpec {
   readonly dataset: SelectDataset;
 }
 
-export interface BespokeSelectTooltip {
-  tooltip: string;
-  hasPlaceholder: boolean;
-}
-
 interface BespokeSelectApi {
   readonly getComponent: () => AlloyComponent;
   readonly setTooltip: (tooltip: string) => void;
@@ -179,7 +174,7 @@ const createMenuItems = (editor: Editor, backstage: UiFactoryBackstage, spec: Se
   };
 };
 
-const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec, bespokeTooltip: BespokeSelectTooltip, textUpdateEventName: string): SketchSpec => {
+const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec, tooltipWithPlaceholder: string, textUpdateEventName: string): SketchSpec => {
   const { items, getStyleItems } = createMenuItems(editor, backstage, spec);
 
   const getApi = (comp: AlloyComponent): BespokeSelectApi => ({
@@ -192,8 +187,8 @@ const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec:
 
   // Set the initial text when the component is attached and then update on node changes
   const onSetup = (api: BespokeSelectApi) => {
-    const handler = ({ value }: EditorEvent<{ value: string }>) =>
-      api.setTooltip(Tooltip.makeTooltip(editor, bespokeTooltip, value));
+    const handler = (e: EditorEvent<{ value: string }>) =>
+      api.setTooltip(Tooltip.makeTooltipText(editor, tooltipWithPlaceholder, e.value));
     editor.on(textUpdateEventName, handler);
     return composeUnbinders(
       onSetupEvent(editor, 'NodeChange', (api: BespokeSelectApi) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -174,7 +174,7 @@ const createMenuItems = (editor: Editor, backstage: UiFactoryBackstage, spec: Se
   };
 };
 
-const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec, tooltipWithPlaceholder: string, textUpdateEventName: string): SketchSpec => {
+const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec, title: string, textUpdateEventName: string): SketchSpec => {
   const { items, getStyleItems } = createMenuItems(editor, backstage, spec);
 
   const getApi = (comp: AlloyComponent): BespokeSelectApi => ({
@@ -188,7 +188,7 @@ const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec:
   // Set the initial text when the component is attached and then update on node changes
   const onSetup = (api: BespokeSelectApi) => {
     const handler = (e: EditorEvent<{ value: string }>) =>
-      api.setTooltip(Tooltip.makeTooltipText(editor, tooltipWithPlaceholder, e.value));
+      api.setTooltip(Tooltip.getTooltipText(editor, title, e.value));
     editor.on(textUpdateEventName, handler);
     return composeUnbinders(
       onSetupEvent(editor, 'NodeChange', (api: BespokeSelectApi) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
@@ -13,8 +13,7 @@ import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import { findNearest } from './utils/FormatDetection';
 import * as Tooltip from './utils/Tooltip';
 
-const menuTitle = 'Blocks';
-const btnTooltip = 'Block {0}';
+const title = 'Blocks';
 const fallbackFormat = 'Paragraph';
 
 const getSpec = (editor: Editor): SelectSpec => {
@@ -45,7 +44,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'block_formats', Delimiter.SemiColon);
 
   return {
-    tooltip: Tooltip.makeTooltipText(editor, btnTooltip, fallbackFormat),
+    tooltip: Tooltip.getTooltipText(editor, title, fallbackFormat),
     text: Optional.some(fallbackFormat),
     icon: Optional.none(),
     isSelectedFor,
@@ -60,13 +59,13 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const createBlocksButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createSelectButton(editor, backstage, getSpec(editor), btnTooltip, 'BlocksTextUpdate');
+  createSelectButton(editor, backstage, getSpec(editor), title, 'BlocksTextUpdate');
 
 // FIX: Test this!
 const createBlocksMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
   const menuItems = createMenuItems(editor, backstage, getSpec(editor));
   editor.ui.registry.addNestedMenuItem('blocks', {
-    text: menuTitle,
+    text: title,
     onSetup: onSetupEditableToggle(editor),
     getSubmenuItems: () => menuItems.items.validateItems(menuItems.getStyleItems())
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
@@ -8,16 +8,13 @@ import * as Events from '../../../api/Events';
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
 import { onActionToggleFormat, onSetupEditableToggle } from '../ControlUtils';
-import { BespokeSelectTooltip, createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
+import { createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import { findNearest } from './utils/FormatDetection';
 import * as Tooltip from './utils/Tooltip';
 
 const menuTitle = 'Blocks';
-const btnTooltip: BespokeSelectTooltip = {
-  tooltip: 'Block {0}',
-  hasPlaceholder: true
-};
+const btnTooltip = 'Block {0}';
 const fallbackFormat = 'Paragraph';
 
 const getSpec = (editor: Editor): SelectSpec => {
@@ -48,7 +45,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'block_formats', Delimiter.SemiColon);
 
   return {
-    tooltip: Tooltip.makeTooltip(editor, btnTooltip, fallbackFormat),
+    tooltip: Tooltip.makeTooltipText(editor, btnTooltip, fallbackFormat),
     text: Optional.some(fallbackFormat),
     icon: Optional.none(),
     isSelectedFor,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
@@ -12,8 +12,7 @@ import { createMenuItems, createSelectButton, FormatterFormatItem, PreviewSpec, 
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import * as Tooltip from './utils/Tooltip';
 
-const menuTitle = 'Fonts';
-const btnTooltip = 'Font {0}';
+const title = 'Fonts';
 const systemFont = 'System Font';
 
 // A list of fonts that must be in a font family for the font to be recognised as the system stack
@@ -95,7 +94,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'font_family_formats', Delimiter.SemiColon);
 
   return {
-    tooltip: Tooltip.makeTooltipText(editor, btnTooltip, systemFont),
+    tooltip: Tooltip.getTooltipText(editor, title, systemFont),
     text: Optional.some(systemFont),
     icon: Optional.none(),
     isSelectedFor,
@@ -110,13 +109,13 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const createFontFamilyButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createSelectButton(editor, backstage, getSpec(editor), btnTooltip, 'FontFamilyTextUpdate');
+  createSelectButton(editor, backstage, getSpec(editor), title, 'FontFamilyTextUpdate');
 
 // TODO: Test this!
 const createFontFamilyMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
   const menuItems = createMenuItems(editor, backstage, getSpec(editor));
   editor.ui.registry.addNestedMenuItem('fontfamily', {
-    text: backstage.shared.providers.translate(menuTitle),
+    text: backstage.shared.providers.translate(title),
     onSetup: onSetupEditableToggle(editor),
     getSubmenuItems: () => menuItems.items.validateItems(menuItems.getStyleItems())
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
@@ -8,15 +8,12 @@ import * as Options from '../../../api/Options';
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
 import { onSetupEditableToggle } from '../ControlUtils';
-import { BespokeSelectTooltip, createMenuItems, createSelectButton, FormatterFormatItem, PreviewSpec, SelectedFormat, SelectSpec } from './BespokeSelect';
+import { createMenuItems, createSelectButton, FormatterFormatItem, PreviewSpec, SelectedFormat, SelectSpec } from './BespokeSelect';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import * as Tooltip from './utils/Tooltip';
 
 const menuTitle = 'Fonts';
-const btnTooltip: BespokeSelectTooltip = {
-  tooltip: 'Font {0}',
-  hasPlaceholder: true
-};
+const btnTooltip = 'Font {0}';
 const systemFont = 'System Font';
 
 // A list of fonts that must be in a font family for the font to be recognised as the system stack
@@ -98,7 +95,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'font_family_formats', Delimiter.SemiColon);
 
   return {
-    tooltip: Tooltip.makeTooltip(editor, btnTooltip, systemFont),
+    tooltip: Tooltip.makeTooltipText(editor, btnTooltip, systemFont),
     text: Optional.some(systemFont),
     icon: Optional.none(),
     isSelectedFor,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -25,8 +25,7 @@ export interface NumberInputSpec {
   getNewValue: (text: string, updateFunction: (value: number, step: number) => number) => string;
 }
 
-const menuTitle = 'Font sizes';
-const btnTooltip = 'Font size {0}';
+const title = 'Font sizes';
 const fallbackFontSize = '12pt';
 
 // See https://websemantics.uk/articles/font-size-conversion/ for conversions
@@ -114,7 +113,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'font_size_formats', Delimiter.Space);
 
   return {
-    tooltip: Tooltip.makeTooltipText(editor, btnTooltip, fallbackFontSize),
+    tooltip: Tooltip.getTooltipText(editor, title, fallbackFontSize),
     text: Optional.some(fallbackFontSize),
     icon: Optional.none(),
     isSelectedFor,
@@ -129,7 +128,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const createFontSizeButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createSelectButton(editor, backstage, getSpec(editor), btnTooltip, 'FontSizeTextUpdate');
+  createSelectButton(editor, backstage, getSpec(editor), title, 'FontSizeTextUpdate');
 
 const getConfigFromUnit = (unit: string): Config => {
   const baseConfig = { step: 1 };
@@ -186,7 +185,7 @@ const createFontSizeInputButton = (editor: Editor, backstage: UiFactoryBackstage
 const createFontSizeMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
   const menuItems = createMenuItems(editor, backstage, getSpec(editor));
   editor.ui.registry.addNestedMenuItem('fontsize', {
-    text: menuTitle,
+    text: title,
     onSetup: onSetupEditableToggle(editor),
     getSubmenuItems: () => menuItems.items.validateItems(menuItems.getStyleItems())
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -10,7 +10,7 @@ import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
 import { onSetupEditableToggle } from '../ControlUtils';
 import { createBespokeNumberInput } from './BespokeNumberInput';
-import { BespokeSelectTooltip, createMenuItems, createSelectButton, FormatterFormatItem, SelectedFormat, SelectSpec } from './BespokeSelect';
+import { createMenuItems, createSelectButton, FormatterFormatItem, SelectedFormat, SelectSpec } from './BespokeSelect';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import * as FormatRegister from './utils/FormatRegister';
 import * as Tooltip from './utils/Tooltip';
@@ -26,10 +26,7 @@ export interface NumberInputSpec {
 }
 
 const menuTitle = 'Font sizes';
-const btnTooltip: BespokeSelectTooltip = {
-  tooltip: 'Font size {0}',
-  hasPlaceholder: true
-};
+const btnTooltip = 'Font size {0}';
 const fallbackFontSize = '12pt';
 
 // See https://websemantics.uk/articles/font-size-conversion/ for conversions
@@ -117,7 +114,7 @@ const getSpec = (editor: Editor): SelectSpec => {
   const dataset = buildBasicSettingsDataset(editor, 'font_size_formats', Delimiter.Space);
 
   return {
-    tooltip: Tooltip.makeTooltip(editor, btnTooltip, fallbackFontSize),
+    tooltip: Tooltip.makeTooltipText(editor, btnTooltip, fallbackFontSize),
     text: Optional.some(fallbackFontSize),
     icon: Optional.none(),
     isSelectedFor,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
@@ -15,8 +15,7 @@ import { getStyleFormats, isFormatReference, isNestedFormat, StyleFormatType } f
 import { findNearest } from './utils/FormatDetection';
 import * as Tooltip from './utils/Tooltip';
 
-const menuTitle = 'Formats';
-const btnTooltip = 'Format {0}';
+const title = 'Formats';
 
 const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
   const fallbackFormat = 'Paragraph';
@@ -51,7 +50,7 @@ const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
   };
 
   return {
-    tooltip: Tooltip.makeTooltipText(editor, btnTooltip, fallbackFormat),
+    tooltip: Tooltip.getTooltipText(editor, title, fallbackFormat),
     text: Optional.some(fallbackFormat),
     icon: Optional.none(),
     isSelectedFor,
@@ -67,14 +66,14 @@ const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
 
 const createStylesButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec => {
   const dataset: AdvancedSelectDataset = { type: 'advanced', ...backstage.styles };
-  return createSelectButton(editor, backstage, getSpec(editor, dataset), btnTooltip, 'StylesTextUpdate');
+  return createSelectButton(editor, backstage, getSpec(editor, dataset), title, 'StylesTextUpdate');
 };
 
 const createStylesMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
   const dataset: AdvancedSelectDataset = { type: 'advanced', ...backstage.styles };
   const menuItems = createMenuItems(editor, backstage, getSpec(editor, dataset));
   editor.ui.registry.addNestedMenuItem('styles', {
-    text: menuTitle,
+    text: title,
     onSetup: onSetupEditableToggle(editor),
     getSubmenuItems: () => menuItems.items.validateItems(menuItems.getStyleItems())
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
@@ -9,17 +9,14 @@ import * as Options from '../../../api/Options';
 import { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
 import { onActionToggleFormat, onSetupEditableToggle } from '../ControlUtils';
-import { BespokeSelectTooltip, createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
+import { createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
 import { AdvancedSelectDataset, BasicSelectItem, SelectDataset } from './SelectDatasets';
 import { getStyleFormats, isFormatReference, isNestedFormat, StyleFormatType } from './StyleFormat';
 import { findNearest } from './utils/FormatDetection';
 import * as Tooltip from './utils/Tooltip';
 
 const menuTitle = 'Formats';
-const btnTooltip: BespokeSelectTooltip = {
-  tooltip: 'Format {0}',
-  hasPlaceholder: true
-};
+const btnTooltip = 'Format {0}';
 
 const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
   const fallbackFormat = 'Paragraph';
@@ -54,7 +51,7 @@ const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
   };
 
   return {
-    tooltip: Tooltip.makeTooltip(editor, btnTooltip, fallbackFormat),
+    tooltip: Tooltip.makeTooltipText(editor, btnTooltip, fallbackFormat),
     text: Optional.some(fallbackFormat),
     icon: Optional.none(),
     isSelectedFor,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/Tooltip.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/Tooltip.ts
@@ -1,8 +1,8 @@
 import Editor from 'tinymce/core/api/Editor';
 
-const makeTooltipText = (editor: Editor, labelWithPlaceholder: string, value: string): string =>
-  editor.translate([ labelWithPlaceholder, editor.translate(value) ]);
+const getTooltipText = (editor: Editor, prefix: string, value: string): string =>
+  editor.translate([ `${prefix} {0}`, editor.translate(value) ]);
 
 export {
-  makeTooltipText
+  getTooltipText
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/Tooltip.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/Tooltip.ts
@@ -1,16 +1,8 @@
 import Editor from 'tinymce/core/api/Editor';
 
-import { BespokeSelectTooltip } from '../BespokeSelect';
-
-const makeConcatenatedTooltip = (editor: Editor, label: string, value: string) =>
-  editor.translate(`${label} ${value}`);
-
-const makePlaceholderTooltip = (editor: Editor, labelWithPlaceholder: string, value: string) =>
+const makeTooltipText = (editor: Editor, labelWithPlaceholder: string, value: string): string =>
   editor.translate([ labelWithPlaceholder, editor.translate(value) ]);
 
-const makeTooltip = (editor: Editor, { tooltip, hasPlaceholder }: BespokeSelectTooltip, value: string): string =>
-  (hasPlaceholder ? makePlaceholderTooltip : makeConcatenatedTooltip)(editor, tooltip, value);
-
 export {
-  makeTooltip
+  makeTooltipText
 };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -47,11 +47,11 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
         toolbar: 'styles'
       },
       initial: [{
-        clickOn: 'button[title^="Format"]',
+        clickOn: 'button[title^="Formats"]',
         waitFor: 'div[role="menu"]'
       }],
       assertAbove: 'div[role="menu"]',
-      assertBelow: 'button[title^="Format"]'
+      assertBelow: 'button[title^="Formats"]'
     }));
 
     it('SplitButton menu should open above button', () => pTest({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/DropdownAriaLabelTest.ts
@@ -60,7 +60,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.DropdownAriaLabelTest', (
       scenario.initialItem,
       scenario.finalItem,
       (item) => `${scenario.label} ${item.toLowerCase()}`,
-      Fun.curry(MenuUtils.pOpenMenuWithSelector, scenario.label),
+      () => MenuUtils.pOpenAlignMenu(scenario.label),
       TinyUiActions.pWaitForUi
     );
 
@@ -154,21 +154,14 @@ describe('browser.tinymce.themes.silver.editor.bespoke.DropdownAriaLabelTest', (
       language: 'test',
       setup: () => {
         I18n.add('test', {
+          'left': 'left translated',
+          'right': 'right translated',
           'Left': 'Left translated',
           'Right': 'Right translated',
-          'Align left': 'Aalign left translated',
-          'Align right': 'Aalign right translated',
-
-          'Font {0}': 'Ffont {0}',
           'Verdana': 'Verdana translated',
           'Arial': 'Arial translated',
-
-          'Font size {0}': 'Ffont size {0}',
           '12pt': '12pt translated',
           '8pt': '8pt translated',
-
-          'Block {0}': 'Bblock {0}',
-          'Format {0}': 'Fformat {0}',
           'Paragraph': 'Paragraph translated',
           'Heading 1': 'Heading 1 translated',
           'Div': 'Div translated'
@@ -179,61 +172,61 @@ describe('browser.tinymce.themes.silver.editor.bespoke.DropdownAriaLabelTest', (
     afterEach(makeCleanupFn(hook));
 
     it('TINY-10426: align dropdown should not update aria-label if displayed text does not change', testAlignDropdownAriaLabel(hook, {
-      label: 'Aalign',
+      label: 'Align',
       initialItem: 'Left translated',
       finalItem: 'Left translated'
     }));
 
     it('TINY-10426: align dropdown should update aria-label if displayed text changes', testAlignDropdownAriaLabel(hook, {
-      label: 'Aalign',
+      label: 'Align',
       initialItem: 'Left translated',
       finalItem: 'Right translated'
     }));
 
     it('TINY-10426: fontfamily dropdown should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel(hook, {
-      label: 'Ffont',
+      label: 'Font',
       initialItem: 'Verdana translated',
       finalItem: 'Verdana translated'
     }));
 
     it('TINY-10426: fontfamily dropdown should update aria-label if displayed text changes', testStandardDropdownAriaLabel(hook, {
-      label: 'Ffont',
+      label: 'Font',
       initialItem: 'Verdana translated',
       finalItem: 'Arial translated'
     }));
 
     it('TINY-10426: fontsize dropdown should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel(hook, {
-      label: 'Ffont size',
+      label: 'Font size',
       initialItem: '12pt translated',
       finalItem: '12pt translated'
     }));
 
     it('TINY-10426: fontsize dropdown should update aria-label if displayed text changes', testStandardDropdownAriaLabel(hook, {
-      label: 'Ffont size',
+      label: 'Font size',
       initialItem: '12pt translated',
       finalItem: '8pt translated'
     }));
 
     it('TINY-10426: blocks dropdown should not update aria-label if displayed text does not change', testStandardDropdownAriaLabel(hook, {
-      label: 'Bblock',
+      label: 'Block',
       initialItem: 'Paragraph translated',
       finalItem: 'Paragraph translated'
     }));
 
     it('TINY-10426: blocks dropdown should update aria-label if displayed text changes', testStandardDropdownAriaLabel(hook, {
-      label: 'Bblock',
+      label: 'Block',
       initialItem: 'Paragraph translated',
       finalItem: 'Heading 1 translated'
     }));
 
     it('TINY-10426: styles dropdown should not update aria-label if displayed text does not change', testFormatsDropdownAriaLabel(hook, {
-      label: 'Fformat',
+      label: 'Format',
       initialItem: 'Paragraph translated',
       finalItem: 'Paragraph translated'
     }));
 
     it('TINY-10426: styles dropdown should update aria-label if displayed text changes', testFormatsDropdownAriaLabel(hook, {
-      label: 'Fformat',
+      label: 'Format',
       initialItem: 'Paragraph translated',
       finalItem: 'Div translated'
     }));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
@@ -277,9 +277,9 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
       TinyUiActions.keydown(editor, Keys.down());
       await pAssertFocusOnItem('Code');
       TinyUiActions.keydown(editor, Keys.down());
-      await pAssertFocusOnItem('Format');
+      await pAssertFocusOnItem('Formats');
       TinyUiActions.keydown(editor, Keys.down());
-      await pAssertFocusOnItem('Block');
+      await pAssertFocusOnItem('Blocks');
       TinyUiActions.keydown(editor, Keys.right());
       await pAssertFocusOnItem('Paragraph');
       assertItemTicks('Checking blocks in menu', [ false, true ].concat(Arr.range(6, Fun.never)));
@@ -343,7 +343,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
       TinyUiActions.keydown(editor, Keys.down());
       await pAssertFocusOnItem('Code');
       TinyUiActions.keydown(editor, Keys.down());
-      await pAssertFocusOnItem('Format');
+      await pAssertFocusOnItem('Formats');
       TinyUiActions.keydown(editor, Keys.right());
       await pAssertFocusOnItem('Headings');
       TinyUiActions.keydown(editor, Keys.right());
@@ -386,9 +386,9 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
     };
 
     it('TINY-9669: Disable align on noneditable content', testDisableOnNoneditable('Align'));
-    it('TINY-9669: Disable fontfamily on noneditable content', testDisableOnNoneditable('Font'));
-    it('TINY-9669: Disable fontsize on noneditable content', testDisableOnNoneditable('Font size'));
-    it('TINY-9669: Disable blocks on noneditable content', testDisableOnNoneditable('Block'));
-    it('TINY-9669: Disable styles on noneditable content', testDisableOnNoneditable('Format'));
+    it('TINY-9669: Disable fontfamily on noneditable content', testDisableOnNoneditable('Fonts'));
+    it('TINY-9669: Disable fontsize on noneditable content', testDisableOnNoneditable('Font sizes'));
+    it('TINY-9669: Disable blocks on noneditable content', testDisableOnNoneditable('Blocks'));
+    it('TINY-9669: Disable styles on noneditable content', testDisableOnNoneditable('Formats'));
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -100,7 +100,7 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
           {
             // first open this menu
             label: 'Open nested formats dropdown',
-            selector: 'button[aria-label^=Format]'
+            selector: 'button[aria-label^=Formats]'
           },
           {
             // opening the first menu should reveal the next menu which contains Align, open Align
@@ -113,7 +113,7 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
       it('Open menubar Formats menu => Formats => Inline => check sticky states', async () => {
         await StickyUtils.pOpenMenuAndTestScrolling(() => MenuUtils.pOpenNestedMenus([
           {
-            label: 'Open menu bar Format menu',
+            label: 'Open menu bar Formats menu',
             selector: 'button:contains(Format)[role=menuitem]'
           },
           {


### PR DESCRIPTION
Related Ticket: TINY-10426

Description of Changes:
* Revert TINY-10426 and TINY-10435

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
