### PR TITLE
TINY-10446: Remove unused param in generateSelectItems in BespokeSelect module

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
@@ -63,7 +63,7 @@ const createAlignButton = (editor: Editor, backstage: UiFactoryBackstage): Sketc
   createSelectButton(editor, backstage, getSpec(editor), btnTooltip, 'AlignTextUpdate');
 
 const createAlignMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
-  const menuItems = createMenuItems(editor, backstage, getSpec(editor));
+  const menuItems = createMenuItems(backstage, getSpec(editor));
   editor.ui.registry.addNestedMenuItem('align', {
     text: backstage.shared.providers.translate(menuTitle),
     onSetup: onSetupEditableToggle(editor),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -94,7 +94,7 @@ const enum IrrelevantStyleItemResponse {
   Disable
 }
 
-const generateSelectItems = (_editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec) => {
+const generateSelectItems = (backstage: UiFactoryBackstage, spec: SelectSpec) => {
   const generateItem = (rawItem: FormatItem, response: IrrelevantStyleItemResponse, invalid: boolean, value: Optional<SelectedFormat>): Optional<Menu.NestedMenuItemContents> => {
     const translatedText = backstage.shared.providers.translate(rawItem.title);
     if (rawItem.type === 'separator') {
@@ -168,19 +168,19 @@ const generateSelectItems = (_editor: Editor, backstage: UiFactoryBackstage, spe
   };
 };
 
-const createMenuItems = (editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec): BespokeMenuItems => {
+const createMenuItems = (backstage: UiFactoryBackstage, spec: SelectSpec): BespokeMenuItems => {
   const dataset = spec.dataset; // needs to be a var for tsc to understand the ternary
   const getStyleItems = dataset.type === 'basic' ?
     () => Arr.map(dataset.data, (d) => FormatRegister.processBasic(d, spec.isSelectedFor, spec.getPreviewFor)) :
     dataset.getData;
   return {
-    items: generateSelectItems(editor, backstage, spec),
+    items: generateSelectItems(backstage, spec),
     getStyleItems
   };
 };
 
 const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec, tooltipWithPlaceholder: string, textUpdateEventName: string): SketchSpec => {
-  const { items, getStyleItems } = createMenuItems(editor, backstage, spec);
+  const { items, getStyleItems } = createMenuItems(backstage, spec);
 
   const getApi = (comp: AlloyComponent): BespokeSelectApi => ({
     getComponent: Fun.constant(comp),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
@@ -64,7 +64,7 @@ const createBlocksButton = (editor: Editor, backstage: UiFactoryBackstage): Sket
 
 // FIX: Test this!
 const createBlocksMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
-  const menuItems = createMenuItems(editor, backstage, getSpec(editor));
+  const menuItems = createMenuItems(backstage, getSpec(editor));
   editor.ui.registry.addNestedMenuItem('blocks', {
     text: menuTitle,
     onSetup: onSetupEditableToggle(editor),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
@@ -114,7 +114,7 @@ const createFontFamilyButton = (editor: Editor, backstage: UiFactoryBackstage): 
 
 // TODO: Test this!
 const createFontFamilyMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
-  const menuItems = createMenuItems(editor, backstage, getSpec(editor));
+  const menuItems = createMenuItems(backstage, getSpec(editor));
   editor.ui.registry.addNestedMenuItem('fontfamily', {
     text: backstage.shared.providers.translate(menuTitle),
     onSetup: onSetupEditableToggle(editor),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -184,7 +184,7 @@ const createFontSizeInputButton = (editor: Editor, backstage: UiFactoryBackstage
 
 // TODO: Test this!
 const createFontSizeMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
-  const menuItems = createMenuItems(editor, backstage, getSpec(editor));
+  const menuItems = createMenuItems(backstage, getSpec(editor));
   editor.ui.registry.addNestedMenuItem('fontsize', {
     text: menuTitle,
     onSetup: onSetupEditableToggle(editor),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
@@ -72,7 +72,7 @@ const createStylesButton = (editor: Editor, backstage: UiFactoryBackstage): Sket
 
 const createStylesMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
   const dataset: AdvancedSelectDataset = { type: 'advanced', ...backstage.styles };
-  const menuItems = createMenuItems(editor, backstage, getSpec(editor, dataset));
+  const menuItems = createMenuItems(backstage, getSpec(editor, dataset));
   editor.ui.registry.addNestedMenuItem('styles', {
     text: menuTitle,
     onSetup: onSetupEditableToggle(editor),


### PR DESCRIPTION
Related Ticket: TINY-10446

Description of Changes:
* Remove unused param in generateSelectItems in BespokeSelect module

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
