### PR TITLE
TINY-6460: Correctly place cursor position for the "paste after" table operations

### DIFF
--- a/modules/snooker/CHANGELOG.md
+++ b/modules/snooker/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - `TableOperations.opEraseRows` did not calculate the correct row index for colgroup tables. #TINY-6309
+- `TableOperations.opPasteColsAfter` & `TableOperations.opPasteRowsAfter` now place the cursor in the newly pasted row/column to be consistent with the other pasting operations. #TINY-6460
 
 ## 11.0.9 - 2023-03-15
 

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
@@ -309,7 +309,7 @@ const opPasteColsAfter = (grid: Structs.RowCells[], pasteDetails: ExtractPasteRo
   const context = rows[pasteDetails.cells[0].row];
   const gridB = gridifyRows(pasteDetails.clipboard, pasteDetails.generators, context);
   const mergedGrid = TableMerge.insertCols(index, grid, gridB, pasteDetails.generators, comparator);
-  return bundle(mergedGrid, pasteDetails.cells[0].row, pasteDetails.cells[0].column);
+  return bundle(mergedGrid, pasteDetails.cells[0].row, index);
 };
 
 const opPasteRowsBefore = (grid: Structs.RowCells[], pasteDetails: ExtractPasteRows, comparator: CompElm, _genWrappers: GeneratorsModification) => {
@@ -327,7 +327,7 @@ const opPasteRowsAfter = (grid: Structs.RowCells[], pasteDetails: ExtractPasteRo
   const context = rows[pasteDetails.cells[0].row];
   const gridB = gridifyRows(pasteDetails.clipboard, pasteDetails.generators, context);
   const mergedGrid = TableMerge.insertRows(index, grid, gridB, pasteDetails.generators, comparator);
-  return bundle(mergedGrid, pasteDetails.cells[0].row, pasteDetails.cells[0].column);
+  return bundle(mergedGrid, index, pasteDetails.cells[0].column);
 };
 
 const opGetColumnsType = (table: SugarElement<HTMLTableElement>, target: TargetSelection): string => {

--- a/modules/snooker/src/test/ts/browser/PasteColumnOperationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/PasteColumnOperationsTest.ts
@@ -41,7 +41,7 @@ describe('PasteColumnOperationsTest', () => {
 
       '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
 
-      TableOperations.pasteColsAfter, 0, 0, 0
+      TableOperations.pasteColsAfter, [ 0, 0, 0 ]
     )
   );
 
@@ -81,7 +81,7 @@ describe('PasteColumnOperationsTest', () => {
 
       '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
 
-      TableOperations.pasteColsAfter, 1, 1, 1
+      TableOperations.pasteColsAfter, [ 1, 1, 1 ]
     )
   );
 
@@ -121,7 +121,7 @@ describe('PasteColumnOperationsTest', () => {
 
       '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
 
-      TableOperations.pasteColsBefore, 0, 0, 0
+      TableOperations.pasteColsBefore, [ 0, 0, 0 ]
     )
   );
 
@@ -161,7 +161,7 @@ describe('PasteColumnOperationsTest', () => {
 
       '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
 
-      TableOperations.pasteColsBefore, 1, 1, 1
+      TableOperations.pasteColsBefore, [ 1, 1, 1 ]
     )
   );
 
@@ -202,7 +202,7 @@ describe('PasteColumnOperationsTest', () => {
 
       '<tr><td colspan="2">X1</td></tr><tr><td>X2</td><td>Y2</td></tr><tr><td>X3</td><td>Y3</td></tr><tr><td>X4</td><td>Y4</td></tr>',
 
-      TableOperations.pasteColsAfter, 0, 0, 0
+      TableOperations.pasteColsAfter, [ 0, 0, 0 ]
     )
   );
 
@@ -243,7 +243,7 @@ describe('PasteColumnOperationsTest', () => {
 
       '<tr><td>X1</td></tr><tr><td rowspan="2">X2</td></tr><tr></tr><tr><td>X4</td></tr>',
 
-      TableOperations.pasteColsBefore, 1, 0, 1
+      TableOperations.pasteColsBefore, [ 1, 0, 1 ]
     )
   );
 
@@ -271,7 +271,7 @@ describe('PasteColumnOperationsTest', () => {
 
       '<tr><td>X1</td></tr>',
 
-      TableOperations.pasteColsBefore, 0, 0, 1
+      TableOperations.pasteColsBefore, [ 0, 0, 1 ]
     )
   );
 
@@ -299,7 +299,7 @@ describe('PasteColumnOperationsTest', () => {
 
       '<tr><td>X1</td></tr>',
 
-      TableOperations.pasteColsAfter, 0, 0, 0
+      TableOperations.pasteColsAfter, [ 0, 0, 0 ]
     )
   );
 
@@ -329,7 +329,7 @@ describe('PasteColumnOperationsTest', () => {
 
       '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
 
-      TableOperations.pasteColsBefore, 0, 0, 0
+      TableOperations.pasteColsBefore, [ 0, 0, 0 ]
     )
   );
 
@@ -359,7 +359,7 @@ describe('PasteColumnOperationsTest', () => {
 
       '<tr><td>X1</td></tr><tr><td>X2</td></tr><tr><td>X3</td></tr><tr><td>X4</td></tr>',
 
-      TableOperations.pasteColsAfter, 0, 0, 1
+      TableOperations.pasteColsAfter, [ 0, 0, 1 ]
     )
   );
 
@@ -387,7 +387,7 @@ describe('PasteColumnOperationsTest', () => {
 
       '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
 
-      TableOperations.pasteColsBefore, 0, 0, 0
+      TableOperations.pasteColsBefore, [ 0, 0, 0 ]
     )
   );
 
@@ -415,7 +415,7 @@ describe('PasteColumnOperationsTest', () => {
 
       '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
 
-      TableOperations.pasteColsAfter, 0, 0, 0
+      TableOperations.pasteColsAfter, [ 0, 0, 0 ]
     )
   );
 
@@ -443,7 +443,7 @@ describe('PasteColumnOperationsTest', () => {
 
       '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
 
-      TableOperations.pasteColsBefore, 0, 0, 1
+      TableOperations.pasteColsBefore, [ 0, 0, 1 ]
     )
   );
 
@@ -471,7 +471,7 @@ describe('PasteColumnOperationsTest', () => {
 
       '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
 
-      TableOperations.pasteColsAfter, 0, 0, 1
+      TableOperations.pasteColsAfter, [ 0, 0, 1 ]
     )
   );
 
@@ -499,7 +499,7 @@ describe('PasteColumnOperationsTest', () => {
 
       '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
 
-      TableOperations.pasteColsBefore, 0, 0, 1
+      TableOperations.pasteColsBefore, [ 0, 0, 1 ]
     )
   );
 
@@ -527,7 +527,7 @@ describe('PasteColumnOperationsTest', () => {
 
       '<tr><td>X1</td></tr><tr><td>X2</td></tr>',
 
-      TableOperations.pasteColsAfter, 0, 0, 1
+      TableOperations.pasteColsAfter, [ 0, 0, 1 ]
     )
   );
 
@@ -564,7 +564,7 @@ describe('PasteColumnOperationsTest', () => {
         '<tr></tr>'
       ),
 
-      TableOperations.pasteColsAfter, 0, 0, 5
+      TableOperations.pasteColsAfter, [ 0, 0, 5 ]
     )
   );
 
@@ -601,7 +601,7 @@ describe('PasteColumnOperationsTest', () => {
         '<tr></tr>'
       ),
 
-      TableOperations.pasteColsBefore, 0, 0, 5
+      TableOperations.pasteColsBefore, [ 0, 0, 5 ]
     )
   );
 
@@ -638,7 +638,7 @@ describe('PasteColumnOperationsTest', () => {
         '<tr></tr>'
       ),
 
-      TableOperations.pasteColsBefore, 0, 0, 5
+      TableOperations.pasteColsBefore, [ 0, 0, 5 ]
     )
   );
 
@@ -675,7 +675,7 @@ describe('PasteColumnOperationsTest', () => {
         '<tr></tr>'
       ),
 
-      TableOperations.pasteColsBefore, 0, 0, 5
+      TableOperations.pasteColsBefore, [ 0, 0, 5 ]
     )
   );
 
@@ -712,7 +712,61 @@ describe('PasteColumnOperationsTest', () => {
         '<tr></tr>'
       ),
 
-      TableOperations.pasteColsBefore, 0, 0, 5
+      TableOperations.pasteColsBefore, [ 0, 0, 5 ]
+    )
+  );
+
+  it('TINY-6460: Cursor should move to the new column after pasting after the current one', () =>
+    Assertions.checkPaste(
+      'Test pasteColsAfter cursor position',
+
+      generateTestTable(
+        [
+          '<tr><td>A1</td><td>pasted</td><td>A2</td></tr>',
+        ],
+        [], [],
+        { numCols: 2, colgroup: false, lockedColumns: [] }
+      ),
+
+      generateTestTable(
+        [
+          '<tr><td>A1</td><td>A2</td></tr>',
+        ],
+        [], [],
+        { numCols: 2, colgroup: false, lockedColumns: [] }
+      ),
+
+      '<tr><td>pasted</td></tr>',
+
+      TableOperations.pasteColsAfter, [ 0, 0, 0 ],
+      [ 0, 0, 1 ]
+    )
+  );
+
+  it('TINY-6460: Cursor should move to the new column after pasting before the current one', () =>
+    Assertions.checkPaste(
+      'Test pasteColsBefore',
+
+      generateTestTable(
+        [
+          '<tr><td>A1</td><td>pasted</td><td>A2</td></tr>',
+        ],
+        [], [],
+        { numCols: 2, colgroup: false, lockedColumns: [] }
+      ),
+
+      generateTestTable(
+        [
+          '<tr><td>A1</td><td>A2</td></tr>',
+        ],
+        [], [],
+        { numCols: 2, colgroup: false, lockedColumns: [] }
+      ),
+
+      '<tr><td>pasted</td></tr>',
+
+      TableOperations.pasteColsBefore, [ 0, 0, 1 ],
+      [ 0, 0, 1 ]
     )
   );
 

--- a/modules/snooker/src/test/ts/browser/PasteRowOperationsTest.ts
+++ b/modules/snooker/src/test/ts/browser/PasteRowOperationsTest.ts
@@ -41,7 +41,7 @@ UnitTest.test('PasteRowOperationsTest', () => {
 
     '<tr><td>X1</td><td>X2</td></tr>',
 
-    TableOperations.pasteRowsAfter, 0, 0, 0
+    TableOperations.pasteRowsAfter, [ 0, 0, 0 ]
   );
 
   Assertions.checkPaste(
@@ -80,7 +80,7 @@ UnitTest.test('PasteRowOperationsTest', () => {
 
     '<tr><td>X1</td><td>X2</td></tr>',
 
-    TableOperations.pasteRowsAfter, 1, 1, 0
+    TableOperations.pasteRowsAfter, [ 1, 1, 0 ]
   );
 
   Assertions.checkPaste(
@@ -119,7 +119,7 @@ UnitTest.test('PasteRowOperationsTest', () => {
 
     '<tr><td>X1</td><td>X2</td></tr>',
 
-    TableOperations.pasteRowsAfter, 2, 0, 0
+    TableOperations.pasteRowsAfter, [ 2, 0, 0 ]
   );
 
   Assertions.checkPaste(
@@ -158,7 +158,7 @@ UnitTest.test('PasteRowOperationsTest', () => {
 
     '<tr><td>X1</td><td>X2</td></tr>',
 
-    TableOperations.pasteRowsBefore, 0, 0, 0
+    TableOperations.pasteRowsBefore, [ 0, 0, 0 ]
   );
 
   Assertions.checkPaste(
@@ -197,7 +197,7 @@ UnitTest.test('PasteRowOperationsTest', () => {
 
     '<tr><td>X1</td><td>X2</td></tr>',
 
-    TableOperations.pasteRowsBefore, 1, 1, 0
+    TableOperations.pasteRowsBefore, [ 1, 1, 0 ]
   );
 
   Assertions.checkPaste(
@@ -236,7 +236,7 @@ UnitTest.test('PasteRowOperationsTest', () => {
 
     '<tr><td>X1</td><td>X2</td></tr>',
 
-    TableOperations.pasteRowsBefore, 2, 0, 0
+    TableOperations.pasteRowsBefore, [ 2, 0, 0 ]
   );
 
   Assertions.checkPaste(
@@ -263,7 +263,7 @@ UnitTest.test('PasteRowOperationsTest', () => {
 
     '<tr><td>X1</td></tr>',
 
-    TableOperations.pasteRowsBefore, 0, 0, 0
+    TableOperations.pasteRowsBefore, [ 0, 0, 0 ]
   );
 
   Assertions.checkPaste(
@@ -290,7 +290,7 @@ UnitTest.test('PasteRowOperationsTest', () => {
 
     '<tr><td>X1</td></tr>',
 
-    TableOperations.pasteRowsAfter, 0, 0, 0
+    TableOperations.pasteRowsAfter, [ 0, 0, 0 ]
   );
 
   Assertions.checkPaste(
@@ -317,7 +317,7 @@ UnitTest.test('PasteRowOperationsTest', () => {
 
     '<tr><td>X1</td><td>X2</td><td>X3</td><td>X4</td></tr>',
 
-    TableOperations.pasteRowsBefore, 0, 0, 0
+    TableOperations.pasteRowsBefore, [ 0, 0, 0 ]
   );
 
   Assertions.checkPaste(
@@ -344,7 +344,7 @@ UnitTest.test('PasteRowOperationsTest', () => {
 
     '<tr><td>X1</td><td>X2</td><td>X3</td><td>X4</td></tr>',
 
-    TableOperations.pasteRowsAfter, 0, 1, 0
+    TableOperations.pasteRowsAfter, [ 0, 1, 0 ]
   );
 
   Assertions.checkPaste(
@@ -371,7 +371,7 @@ UnitTest.test('PasteRowOperationsTest', () => {
 
     '<tr><td>X1</td><td>X2</td></tr>',
 
-    TableOperations.pasteRowsBefore, 0, 1, 0
+    TableOperations.pasteRowsBefore, [ 0, 1, 0 ]
   );
 
   Assertions.checkPaste(
@@ -398,7 +398,7 @@ UnitTest.test('PasteRowOperationsTest', () => {
 
     '<tr><td>X1</td><td>X2</td></tr>',
 
-    TableOperations.pasteRowsAfter, 0, 1, 0
+    TableOperations.pasteRowsAfter, [ 0, 1, 0 ]
   );
 
   Assertions.checkPaste(
@@ -425,7 +425,7 @@ UnitTest.test('PasteRowOperationsTest', () => {
 
     '<tr><td>X1</td><td>X2</td></tr>',
 
-    TableOperations.pasteRowsAfter, 0, 0, 0
+    TableOperations.pasteRowsAfter, [ 0, 0, 0 ]
   );
 
   Assertions.checkPaste(
@@ -452,6 +452,62 @@ UnitTest.test('PasteRowOperationsTest', () => {
 
     '<tr><td>X1</td><td>X2</td></tr>',
 
-    TableOperations.pasteRowsBefore, 0, 1, 0
+    TableOperations.pasteRowsBefore, [ 0, 1, 0 ]
+  );
+
+  Assertions.checkPaste(
+    'TINY-6460: Cursor should move to the new row after pasting after the current one',
+
+    generateTestTable(
+      [
+        '<tr><td>A2</td><td>B2</td><td>C2</td></tr>',
+        '<tr><td>A3</td><td>B3</td><td>C3</td></tr>',
+        '<tr><td>X1</td><td>X2</td><td>X3</td></tr>',
+      ],
+      [], [],
+      { numCols: 3, colgroup: true, lockedColumns: [] }
+    ),
+
+    generateTestTable(
+      [
+        '<tr><td>A2</td><td>B2</td><td>C2</td></tr>',
+        '<tr><td>A3</td><td>B3</td><td>C3</td></tr>'
+      ],
+      [], [],
+      { numCols: 3, colgroup: true, lockedColumns: [] }
+    ),
+
+    '<tr><td>X1</td><td>X2</td><td>X3</td></tr>',
+
+    TableOperations.pasteRowsAfter, [ 1, 1, 0 ],
+    [ 1, 2, 0 ]
+  );
+
+  Assertions.checkPaste(
+    'TINY-6460: Cursor should move to the new row after pasting before the current one',
+
+    generateTestTable(
+      [
+        '<tr><td>A2</td><td>B2</td><td>C2</td></tr>',
+        '<tr><td>X1</td><td>X2</td><td>X3</td></tr>',
+        '<tr><td>A3</td><td>B3</td><td>C3</td></tr>',
+      ],
+      [], [],
+      { numCols: 3, colgroup: true, lockedColumns: [] }
+    ),
+
+    generateTestTable(
+      [
+        '<tr><td>A2</td><td>B2</td><td>C2</td></tr>',
+        '<tr><td>A3</td><td>B3</td><td>C3</td></tr>'
+      ],
+      [], [],
+      { numCols: 3, colgroup: true, lockedColumns: [] }
+    ),
+
+    '<tr><td>X1</td><td>X2</td><td>X3</td></tr>',
+
+    TableOperations.pasteRowsBefore, [ 1, 1, 0 ],
+    [ 1, 1, 0 ]
   );
 });

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/Assertions.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/Assertions.ts
@@ -20,6 +20,8 @@ interface ExpCell {
   readonly column: number;
 }
 
+type CellTuple = [section: number, row: number, column: number];
+
 const makeContainer = () =>
   SugarElement.fromHtml<HTMLDivElement>('<div contenteditable="true"></div>');
 
@@ -104,9 +106,8 @@ const checkPaste = (
   input: string,
   pasteHtml: string,
   operation: OperationCallback<TargetPasteRows>,
-  section: number,
-  row: number,
-  column: number
+  pasteAtCursor: CellTuple,
+  expCursor?: CellTuple
 ): void => {
   const table = SugarElement.fromHtml<HTMLTableElement>(input);
   const container = makeContainer();
@@ -114,15 +115,26 @@ const checkPaste = (
   Insert.append(SugarBody.body(), container);
 
   const pasteTable = SugarElement.fromHtml<HTMLTableElement>('<table><tbody>' + pasteHtml + '</tbody></table>');
-  operation(
+  const result = operation(
     table,
     {
-      selection: [ Hierarchy.follow(table, [ section, row, column, 0 ]).getOrDie(label + ': could not follow selection') ],
+      selection: [
+        Hierarchy.follow(table, [ ...pasteAtCursor, 0 ])
+          .getOrDie(label + `: could not follow selection [${pasteAtCursor}]`)
+      ],
       clipboard: SelectorFilter.descendants(pasteTable, 'tr'),
       generators: Bridge.pasteGenerators
     },
     Bridge.generators
   );
+
+  // Optionally check for the cursor position after the paste operation:
+  if (expCursor) {
+    const actualCursor = result.getOrDie(label + ': could not get table operation result')
+      .cursor.getOrDie(label + ': could not get cursor');
+    const actualPath = Hierarchy.path(table, actualCursor).getOrDie(label + ': could not find path to cursor');
+    Assert.eq('Cursor is not in expected cell.', expCursor, actualPath);
+  }
 
   Assertions.assertHtml(label, expectedHtml, Html.getOuter(table));
   Remove.remove(container);


### PR DESCRIPTION
Related Ticket: TINY-6460

Description of Changes:
As in what's described in the Jira ticket. This fix is just using the new pasted `index` instead. This fix only affects the "pasting after" table operations, but I've put in tests for checking the cursor postions for pasting before _and_ after anyway.
So now all pasting operations have consistent cursor postions, as in placing the cursor in the newly pasted row/column.

Pre-checks:
* [x] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable): https://github.com/tinymce/tinymce/issues/6059
