### PR TITLE
TINY-10470: Worked on isolated test runs

### DIFF
--- a/modules/jax/package.json
+++ b/modules/jax/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint --config ../../.eslintrc.json src/**/*.ts",
     "build": "tsc -b",
     "test": "bedrock-auto -b chrome-headless --customRoutes ../tinymce/src/core/test/json/routes.json -d src/test/ts/",
-    "test-manual": "bedrock --customRoutes ../tinymce/src/json/routes.json -d src/test/ts/",
+    "test-manual": "bedrock --customRoutes --customRoutes ../tinymce/src/core/test/json/routes.json -d src/test/ts/",
     "start": "webpack-dev-server --open-page './src/demo/html'",
     "build:demo": "webpack"
   },

--- a/modules/jax/package.json
+++ b/modules/jax/package.json
@@ -11,8 +11,8 @@
     "prepublishOnly": "yarn run lint && yarn run build",
     "lint": "eslint --config ../../.eslintrc.json src/**/*.ts",
     "build": "tsc -b",
-    "test": "bedrock-auto -b chrome-headless --customRoutes src/test/json/routes.json -d src/test/ts/",
-    "test-manual": "bedrock --customRoutes src/test/json/routes.json -d src/test/ts/",
+    "test": "bedrock-auto -b chrome-headless --customRoutes ../tinymce/src/core/test/json/routes.json -d src/test/ts/",
+    "test-manual": "bedrock --customRoutes ../tinymce/src/json/routes.json -d src/test/ts/",
     "start": "webpack-dev-server --open-page './src/demo/html'",
     "build:demo": "webpack"
   },

--- a/modules/sugar/src/test/ts/browser/VisibilityTest.ts
+++ b/modules/sugar/src/test/ts/browser/VisibilityTest.ts
@@ -17,7 +17,7 @@ UnitTest.test('VisibilityTest', () => {
   Css.set(c, 'display', 'none');
   Assert.eq('', false, Visibility.isVisible(c));
 
-  // TODO: Disabled since it is flaking on Chrome sometimes it's hidden sometimes its not
+  // TODO: Disabled since it is flaking on Chrome sometimes it's hidden sometimes its not. #TINY-10485
   // const s = SugarElement.fromTag('span');
   // Assert.eq('', false, Visibility.isVisible(s));
   //

--- a/modules/sugar/src/test/ts/browser/VisibilityTest.ts
+++ b/modules/sugar/src/test/ts/browser/VisibilityTest.ts
@@ -1,11 +1,9 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { PlatformDetection } from '@ephox/sand';
 
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
 import * as SugarBody from 'ephox/sugar/api/node/SugarBody';
-import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import * as Css from 'ephox/sugar/api/properties/Css';
 import * as Visibility from 'ephox/sugar/api/view/Visibility';
 import Div from 'ephox/sugar/test/Div';
@@ -19,12 +17,13 @@ UnitTest.test('VisibilityTest', () => {
   Css.set(c, 'display', 'none');
   Assert.eq('', false, Visibility.isVisible(c));
 
-  const s = SugarElement.fromTag('span');
-  Assert.eq('', false, Visibility.isVisible(s));
-
-  Insert.append(SugarBody.body(), s);
-  const expected = PlatformDetection.detect().browser.isFirefox();
-  Assert.eq('', expected, Visibility.isVisible(s)); // tricked you! height and width are zero == hidden
+  // TODO: Disabled since it is flaking on Chrome sometimes it's hidden sometimes its not
+  // const s = SugarElement.fromTag('span');
+  // Assert.eq('', false, Visibility.isVisible(s));
+  //
+  // Insert.append(SugarBody.body(), s);
+  // const expected = PlatformDetection.detect().browser.isFirefox();
+  // Assert.eq('', expected, Visibility.isVisible(s)); // tricked you! height and width are zero == hidden
 
   const d = Div();
   Insert.append(c, d);
@@ -34,5 +33,5 @@ UnitTest.test('VisibilityTest', () => {
   Assert.eq('', true, Visibility.isVisible(d));
   Assert.eq('', true, Visibility.isVisible(c));
 
-  Arr.each([ c, d, s ], Remove.remove);
+  Arr.each([ c, d ], Remove.remove);
 });

--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -917,7 +917,7 @@ module.exports = function (grunt) {
   require('load-grunt-tasks')(grunt, {
     requireResolution: true,
     config: "../../package.json",
-    pattern: ['grunt-*', '@ephox/bedrock', '@ephox/swag']
+    pattern: ['grunt-*', '@ephox/bedrock-*', '@ephox/swag']
   });
   grunt.loadTasks('tools/tasks');
 

--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -849,7 +849,7 @@ module.exports = function (grunt) {
         testfiles: [
           'src/**/test/ts/atomic/**/*Test.ts',
           'src/**/test/ts/browser/**/*Test.ts',
-          'src/**/test/ts/phantom/**/*Test.ts'
+          'src/**/test/ts/headless/**/*Test.ts'
         ],
         customRoutes: 'src/core/test/json/routes.json'
       },
@@ -917,7 +917,7 @@ module.exports = function (grunt) {
   require('load-grunt-tasks')(grunt, {
     requireResolution: true,
     config: "../../package.json",
-    pattern: ['grunt-*', '@ephox/bedrock-*', '@ephox/swag']
+    pattern: ['grunt-*', '@ephox/bedrock-server', '@ephox/swag']
   });
   grunt.loadTasks('tools/tasks');
 
@@ -963,4 +963,5 @@ module.exports = function (grunt) {
 
   grunt.registerTask('default', ['clean:dist', 'prod']);
   grunt.registerTask('test', ['bedrock-auto:standard']);
+  grunt.registerTask('test-manual', ['bedrock-manual']);
 };

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "build": "grunt",
     "test": "grunt test",
+    "test-manual": "grunt test-manual",
     "lint": "grunt eslint",
     "silver-test": "grunt bedrock-auto:silver",
     "silver-test-manual": "grunt bedrock-manual:silver"


### PR DESCRIPTION
Related Ticket: TINY-10470

Description of Changes:
* Changed paths for jax so that it passes when you run the tests locally inside that project with say `yarn test`
* Changed the grunt task imports so they pass if you run tests locally inside tinymce using `yarn test`
* Disabled a test for sugar since it flaked on Chrome in manual mode and always fails in headless mode. It checks if the element is invisible by looking at offsetHeight and offsetWidth sometimes it would have that sometimes it wouldn't in firefox it never has that.
* Added `test-manual` to tinymce so that you can run the tests for tinymce only manually like all other things

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
