### PR TITLE
TINY-10559: Roll back local testing

### DIFF
--- a/modules/tinymce/src/core/test/ts/webdriver/keyboard/IframeTabfocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/keyboard/IframeTabfocusTest.ts
@@ -6,7 +6,8 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 
-describe('webdriver.tinymce.core.keyboard.IframeTabfocusTest', () => {
+// Disabled investigation ticket logged: #TINY-10579
+describe.skip('webdriver.tinymce.core.keyboard.IframeTabfocusTest', () => {
   context('Focus shift on pressing tab', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       base_url: '/project/tinymce/js/tinymce',

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapDialogHeightTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapDialogHeightTest.ts
@@ -10,7 +10,8 @@ import Plugin from 'tinymce/plugins/charmap/Plugin';
 
 import { fakeEvent } from '../module/Helpers';
 
-describe('browser.tinymce.plugins.charmap.DialogHeightTest', () => {
+// Disabled investigation ticket logged: #TINY-10579
+describe.skip('browser.tinymce.plugins.charmap.DialogHeightTest', () => {
   Arr.each([
     { label: 'IFrame Editor', setup: TinyHooks.bddSetupLight },
     { label: 'Shadow Dom Editor', setup: TinyHooks.bddSetupInShadowRoot },

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
@@ -9,7 +9,8 @@ import { renderIFrame } from 'tinymce/themes/silver/ui/dialog/IFrame';
 
 import TestProviders from '../../../module/TestProviders';
 
-describe('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
+// Disabled investigation ticket logged: #TINY-10579
+describe.skip('headless.tinymce.themes.silver.components.iframe.IFrameTest', () => {
   const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(
     Container.sketch({
       dom: {


### PR DESCRIPTION
Related Ticket: TINY-10559

Description of Changes:
* This should replace all instances of remote testing with azure and mac nodes

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [- ] Milestone set
* [- ] Docs ticket created (if applicable)

GitHub issues (if applicable):
