### PR TITLE
TINY-10439: read `link_default_target` using quicklink

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10439-2024-01-12.yaml
+++ b/.changes/unreleased/tinymce-TINY-10439-2024-01-12.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: inserting a link via `quicklink` `link_default_target` wasn't considered
+body: The `link_default_target` option wasn't considered when inserting a link via `quicklink` toolbar.
 time: 2024-01-12T15:12:04.121884844+01:00
 custom:
   Issue: TINY-10439

--- a/.changes/unreleased/tinymce-TINY-10439-2024-01-12.yaml
+++ b/.changes/unreleased/tinymce-TINY-10439-2024-01-12.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: inserting a link via `quicklink` `link_default_target` wasn't considered
+time: 2024-01-12T15:12:04.121884844+01:00
+custom:
+  Issue: TINY-10439

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -131,7 +131,7 @@ const setupContextToolbars = (editor: Editor): void => {
             text,
             title: Optional.none(),
             rel: Optional.none(),
-            target: Optional.none(),
+            target: Optional.from(Options.getDefaultLinkTarget(editor)),
             class: Optional.none()
           });
           collapseSelectionToEnd(editor);

--- a/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
@@ -1,8 +1,8 @@
 import { FocusTools, Keys, UiFinder, Waiter } from '@ephox/agar';
-import { describe, it, before, after } from '@ephox/bedrock-client';
+import { after, before, describe, it } from '@ephox/bedrock-client';
 import { PlatformDetection } from '@ephox/sand';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
-import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions, TinyContentActions } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
@@ -191,5 +191,20 @@ describe('browser.tinymce.plugins.link.QuickLinkTest', () => {
     FocusTools.setActiveValue(doc, 'http://tiny.cloud/2');
     TinyUiActions.keydown(editor, Keys.enter());
     TinyAssertions.assertContent(editor, '<p>Lorem <a href="http://tiny.cloud/2"><em><strong>ipsum</strong></em></a> dolor sit amet</p>');
+  });
+
+  it('TINY-10439: `link_default_target` should work inserting link via quicklink', async () => {
+    const editor = hook.editor();
+    editor.options.set('link_default_target', '_blank');
+
+    editor.setContent('<p>Word</p>');
+    // add link to word
+    TinySelections.setSelection(editor, [ 0, 0 ], ''.length, [ 0, 0 ], 'Word'.length);
+    await pOpenQuickLink(editor);
+    FocusTools.setActiveValue(doc, 'http://tiny.cloud/5');
+    TinyUiActions.keydown(editor, Keys.enter());
+    TinyAssertions.assertContent(editor, '<p><a href="http://tiny.cloud/5" target="_blank" rel="noopener">Word</a></p>');
+
+    editor.options.unset('link_default_target');
   });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
@@ -193,7 +193,7 @@ describe('browser.tinymce.plugins.link.QuickLinkTest', () => {
     TinyAssertions.assertContent(editor, '<p>Lorem <a href="http://tiny.cloud/2"><em><strong>ipsum</strong></em></a> dolor sit amet</p>');
   });
 
-  it('TINY-10439: `link_default_target` should work inserting link via quicklink', async () => {
+  it('TINY-10439: `link_default_target` should be used when inserting link via quicklink', async () => {
     const editor = hook.editor();
 
     editor.setContent('<p>Word</p>');

--- a/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/QuickLinkTest.ts
@@ -195,6 +195,15 @@ describe('browser.tinymce.plugins.link.QuickLinkTest', () => {
 
   it('TINY-10439: `link_default_target` should work inserting link via quicklink', async () => {
     const editor = hook.editor();
+
+    editor.setContent('<p>Word</p>');
+    // add link to word
+    TinySelections.setSelection(editor, [ 0, 0 ], ''.length, [ 0, 0 ], 'Word'.length);
+    await pOpenQuickLink(editor);
+    FocusTools.setActiveValue(doc, 'http://tiny.cloud/5');
+    TinyUiActions.keydown(editor, Keys.enter());
+    TinyAssertions.assertContent(editor, '<p><a href="http://tiny.cloud/5">Word</a></p>');
+
     editor.options.set('link_default_target', '_blank');
 
     editor.setContent('<p>Word</p>');


### PR DESCRIPTION
Related Ticket: TINY-10439

Description of Changes:
`link_default_target` wasn't consider by quicklink

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
