### PR TITLE
TINY-10574: now `highlight_on_focus` default is `true`

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10574-2024-01-15.yaml
+++ b/.changes/unreleased/tinymce-TINY-10574-2024-01-15.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Changed
-body: The `highlight_on_focus` option now defaults to true, adding a focus outline to every editor
+body: The `highlight_on_focus` option now defaults to true, adding a focus outline to every editor.
 time: 2024-01-15T14:35:01.822328906+01:00
 custom:
   Issue: TINY-10574

--- a/.changes/unreleased/tinymce-TINY-10574-2024-01-15.yaml
+++ b/.changes/unreleased/tinymce-TINY-10574-2024-01-15.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Changed
+body: now `highlight_on_focus` default is true
+time: 2024-01-15T14:35:01.822328906+01:00
+custom:
+  Issue: TINY-10574

--- a/.changes/unreleased/tinymce-TINY-10574-2024-01-15.yaml
+++ b/.changes/unreleased/tinymce-TINY-10574-2024-01-15.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Changed
-body: now `highlight_on_focus` default is true
+body: The `highlight_on_focus` option now defaults to true, adding a focus outline to every editor
 time: 2024-01-15T14:35:01.822328906+01:00
 custom:
   Issue: TINY-10574

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -793,7 +793,7 @@ const register = (editor: Editor): void => {
 
   registerOption('highlight_on_focus', {
     processor: 'boolean',
-    default: false
+    default: true
   });
 
   registerOption('xss_sanitization', {

--- a/modules/tinymce/src/core/test/ts/browser/focus/HighlightOnFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/HighlightOnFocusTest.ts
@@ -24,7 +24,7 @@ describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
     assertIsHighlighted(editor);
   };
 
-  context('with highlight_on_focus: true', () => {
+  context('without highlight_on_focus option', () => {
     const hook = TinyHooks.bddSetup<Editor>({
       base_url: '/project/tinymce/js/tinymce',
       toolbar: 'forecolor',
@@ -131,9 +131,10 @@ describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
     });
   });
 
-  context('without highlight_on_focus option', () => {
+  context('with highlight_on_focus: false', () => {
     const hook = TinyHooks.bddSetup<Editor>({
-      base_url: '/project/tinymce/js/tinymce'
+      base_url: '/project/tinymce/js/tinymce',
+      highlight_on_focus: false
     });
 
     it('TINY-9277: Content area should not be highlighted on focus', () => {

--- a/modules/tinymce/src/core/test/ts/browser/focus/HighlightOnFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/HighlightOnFocusTest.ts
@@ -27,8 +27,7 @@ describe('browser.tinymce.core.focus.HighlightOnFocus', () => {
   context('without highlight_on_focus option', () => {
     const hook = TinyHooks.bddSetup<Editor>({
       base_url: '/project/tinymce/js/tinymce',
-      toolbar: 'forecolor',
-      highlight_on_focus: true
+      toolbar: 'forecolor'
     }, []);
 
     before(() => {


### PR DESCRIPTION
Related Ticket: TINY-10574

Description of Changes:
switch `highlight_on_focus` default to `true`

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (DOC-2245)

GitHub issues (if applicable):
