### PR TITLE
TINY-10284: Update styles of Revision History UI

### DIFF
--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -8,16 +8,21 @@
 @revisionhistory-text-lineheight: 24px;
 
 .tox {
-  .tox-view__pane {
-    border-top: @revisionhistory-border;
-    margin-top: @pad-sm;
-    padding: 0 !important;
+  .tox-revisionhistory__pane {
+    display: flex;
+    flex-direction: column;
+    padding: 0 !important;      /* Override the default padding of tox-view__pane */
   }
 
   .tox-revisionhistory {
     background-color: @revisionhistory-background-color;
+    border-radius: 4px;
+    border-top: @revisionhistory-border;
     display: flex;
+    flex: 1;
     height: 100%;
+    margin-top: 8px;
+    overflow: 'auto';
     position: relative;
     width: 100%;
   }


### PR DESCRIPTION
Related Ticket:  TINY-10284

Description of Changes:
* Update the styles of Revision History UI after Alloy is replaced with Preact

Snapshots of revision history UI with this change:

![Normal](https://github.com/tinymce/tinymce/assets/97494111/b028bcc7-ca78-4b2c-b655-b351ecd71e0a)

![Overflow sidebar and content](https://github.com/tinymce/tinymce/assets/97494111/b3812628-4af0-4550-a45c-4a339164690a)

Pre-checks:

* ~[x] Changelog entry added~
* ~[x] Tests have been added (if applicable)~
* ~[x] Branch prefixed with `feature/`, `hotfix/` or `spike/`~

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
