### PR TITLE
TINY-10580: fix toolbar top calculation when the toolbar height is not standard

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10580-2024-01-18.yaml
+++ b/.changes/unreleased/tinymce-TINY-10580-2024-01-18.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: in the inline editor when the toolbar is higher than normal the top wasn't calculated
+  correclty
+time: 2024-01-18T10:40:44.201716295+01:00
+custom:
+  Issue: TINY-10580

--- a/.changes/unreleased/tinymce-TINY-10580-2024-01-18.yaml
+++ b/.changes/unreleased/tinymce-TINY-10580-2024-01-18.yaml
@@ -1,7 +1,7 @@
 project: tinymce
 kind: Fixed
-body: in the inline editor when the toolbar is higher than normal the top wasn't calculated
-  correclty
+body: When inline editor toolbar wrapped to multiple lines the top wasn't always calculated
+  correctly
 time: 2024-01-18T10:40:44.201716295+01:00
 custom:
   Issue: TINY-10580

--- a/.changes/unreleased/tinymce-TINY-10580-2024-01-18.yaml
+++ b/.changes/unreleased/tinymce-TINY-10580-2024-01-18.yaml
@@ -1,7 +1,7 @@
 project: tinymce
 kind: Fixed
 body: When inline editor toolbar wrapped to multiple lines the top wasn't always calculated
-  correctly
+  correctly.
 time: 2024-01-18T10:40:44.201716295+01:00
 custom:
   Issue: TINY-10580

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
@@ -1,12 +1,13 @@
-import { Waiter } from '@ephox/agar';
+import { UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Css, Insert, Remove, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 
 // TODO TINY-10480: Investigate flaky tests
-describe.skip('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', () => {
+describe('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', () => {
   const wrapper = SugarElement.fromTag('div');
   const editorTarget = SugarElement.fromTag('div');
   const hook = TinyHooks.bddSetupFromElement<Editor>({
@@ -60,19 +61,36 @@ describe.skip('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', ()
       }
     });
 
-  it('TINY-9646: The width should remain on the editor', () =>
+  it.skip('TINY-9646: The width should remain on the editor', () =>
     pRunToolbarWidthTest(500, '400px')
   );
 
-  it('TINY-8977: If the editor does not fit within the view', () =>
+  it.skip('TINY-8977: If the editor does not fit within the view', () =>
     pRunToolbarWidthTest(200, '200px')
   );
 
-  it('TINY-8977: If the visible editor is smaller than the minimum', () =>
+  it.skip('TINY-8977: If the visible editor is smaller than the minimum', () =>
     pRunToolbarWidthTest(50, '150px')
   );
 
-  it('TINY-8977: If the editor is not visible at all', () =>
+  it.skip('TINY-8977: If the editor is not visible at all', () =>
     pRunToolbarWidthTest(-50, '150px')
   );
+
+  it('TINY-10580: when the inline editor is on the edge the bottom of the toolbar should be close to the top of the content', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>Content</p>');
+    const totalWidth = editor.getDoc().documentElement.clientWidth;
+    Css.set(editorTarget, 'margin-left', totalWidth - 200 + 'px');
+    editor.focus();
+
+    const toolbar = await UiFinder.pWaitFor('the toolbar should be visible', SugarBody.body(), '.tox-editor-header');
+    const toolbarRect = editor.dom.getRect(toolbar.dom as HTMLElement);
+    const toolbarBottom = toolbarRect.y + toolbarRect.h;
+
+    const editorTargetRect = editor.dom.getRect(editorTarget.dom);
+    const editorTargetTop = editorTargetRect.y;
+
+    assert.closeTo(editorTargetTop, toolbarBottom, 5);
+  });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
@@ -85,10 +85,12 @@ describe('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', () => {
     editor.focus();
 
     const toolbar = await UiFinder.pWaitFor('the toolbar should be visible', SugarBody.body(), '.tox-editor-header');
-    const toolbarRect = editor.dom.getRect(toolbar.dom as HTMLElement);
-    const toolbarBottom = toolbarRect.y + toolbarRect.h;
+    // const toolbarRect = editor.dom.getRect(toolbar.dom as HTMLElement);
+    const toolbarRect = toolbar.dom.getBoundingClientRect();
+    const toolbarBottom = toolbarRect.y + toolbarRect.height;
 
-    const editorBodyRect = editor.dom.getRect(editor.getBody());
+    // const editorBodyRect = editor.dom.getRect(editor.getBody());
+    const editorBodyRect = editor.getBody().getBoundingClientRect();
     const editorBodyTop = editorBodyRect.y;
 
     // assert.isAtLeast(editorTargetTop, toolbarBottom, 'toolbarBottom should be above editorTargetTop');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
@@ -88,10 +88,10 @@ describe('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', () => {
     const toolbarRect = editor.dom.getRect(toolbar.dom as HTMLElement);
     const toolbarBottom = toolbarRect.y + toolbarRect.h;
 
-    const editorTargetRect = editor.dom.getRect(editorTarget.dom);
-    const editorTargetTop = editorTargetRect.y;
+    const editorBodyRect = editor.dom.getRect(editor.getBody());
+    const editorBodyTop = editorBodyRect.y;
 
     // assert.isAtLeast(editorTargetTop, toolbarBottom, 'toolbarBottom should be above editorTargetTop');
-    assert.approximately(editorTargetTop, toolbarBottom, 5, 'toolbarBottom should be above editorTargetTop');
+    assert.approximately(editorBodyTop, toolbarBottom, 5, 'toolbarBottom should be above editorBodyTop');
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
@@ -91,6 +91,6 @@ describe('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', () => {
     const editorTargetRect = editor.dom.getRect(editorTarget.dom);
     const editorTargetTop = editorTargetRect.y;
 
-    assert.closeTo(editorTargetTop, toolbarBottom, 5);
+    assert.closeTo(editorTargetTop, toolbarBottom, 10);
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
@@ -91,6 +91,6 @@ describe('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', () => {
     const editorTargetRect = editor.dom.getRect(editorTarget.dom);
     const editorTargetTop = editorTargetRect.y;
 
-    assert.isAtMost(editorTargetTop, toolbarBottom, 'toolbarBottom should be above editorTargetTop');
+    assert.isAtLeast(editorTargetTop, toolbarBottom, 'toolbarBottom should be above editorTargetTop');
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
@@ -91,6 +91,7 @@ describe('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', () => {
     const editorTargetRect = editor.dom.getRect(editorTarget.dom);
     const editorTargetTop = editorTargetRect.y;
 
-    assert.isAtLeast(editorTargetTop, toolbarBottom, 'toolbarBottom should be above editorTargetTop');
+    // assert.isAtLeast(editorTargetTop, toolbarBottom, 'toolbarBottom should be above editorTargetTop');
+    assert.approximately(editorTargetTop, toolbarBottom, 5, 'toolbarBottom should be above editorTargetTop');
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
@@ -91,6 +91,6 @@ describe('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', () => {
     const editorTargetRect = editor.dom.getRect(editorTarget.dom);
     const editorTargetTop = editorTargetRect.y;
 
-    assert.closeTo(editorTargetTop, toolbarBottom, 10);
+    assert.isAtMost(editorTargetTop, toolbarBottom, 'toolbarBottom should be above editorTargetTop');
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
@@ -85,15 +85,12 @@ describe('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', () => {
     editor.focus();
 
     const toolbar = await UiFinder.pWaitFor('the toolbar should be visible', SugarBody.body(), '.tox-editor-header');
-    // const toolbarRect = editor.dom.getRect(toolbar.dom as HTMLElement);
-    const toolbarRect = toolbar.dom.getBoundingClientRect();
-    const toolbarBottom = toolbarRect.bottom;
+    const toolbarRect = editor.dom.getRect(toolbar.dom as HTMLElement);
+    const toolbarBottom = toolbarRect.y + toolbarRect.h;
 
-    // const editorBodyRect = editor.dom.getRect(editor.getBody());
-    const editorBodyRect = editor.getBody().getBoundingClientRect();
-    const editorBodyTop = editorBodyRect.y;
+    const editorTargetRect = editor.dom.getRect(editorTarget.dom);
+    const editorTargetTop = editorTargetRect.y;
 
-    // assert.isAtLeast(editorTargetTop, toolbarBottom, 'toolbarBottom should be above editorTargetTop');
-    assert.approximately(editorBodyTop, toolbarBottom, 5, 'toolbarBottom should be above editorBodyTop');
+    assert.approximately(editorTargetTop, toolbarBottom, 5, 'toolbarBottom should be above editorBodyTop');
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
@@ -87,7 +87,7 @@ describe('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', () => {
     const toolbar = await UiFinder.pWaitFor('the toolbar should be visible', SugarBody.body(), '.tox-editor-header');
     // const toolbarRect = editor.dom.getRect(toolbar.dom as HTMLElement);
     const toolbarRect = toolbar.dom.getBoundingClientRect();
-    const toolbarBottom = toolbarRect.y + toolbarRect.height;
+    const toolbarBottom = toolbarRect.bottom;
 
     // const editorBodyRect = editor.dom.getRect(editor.getBody());
     const editorBodyRect = editor.getBody().getBoundingClientRect();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
@@ -81,7 +81,7 @@ describe('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', () => {
     const editor = hook.editor();
     editor.setContent('<p>Content</p>');
     const totalWidth = editor.getDoc().documentElement.clientWidth;
-    Css.set(editorTarget, 'margin-left', totalWidth - 200 + 'px');
+    Css.set(editorTarget, 'margin-left', totalWidth - 250 + 'px');
     editor.focus();
 
     const toolbar = await UiFinder.pWaitFor('the toolbar should be visible', SugarBody.body(), '.tox-editor-header');
@@ -92,12 +92,6 @@ describe('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', () => {
     // const editorBodyRect = editor.dom.getRect(editor.getBody());
     const editorBodyRect = editor.getBody().getBoundingClientRect();
     const editorBodyTop = editorBodyRect.y;
-
-    assert.equal(parseInt(Css.get(toolbar, 'margin-bottom'), 10), 0, 'toolbar margin-bottom = 0');
-    assert.equal(parseInt(Css.get(toolbar, 'margin-top'), 10), 0, 'toolbar margin-top = 0');
-
-    assert.equal(parseInt(Css.get(SugarBody.body(), 'margin-bottom'), 10), 0, 'body margin-bottom = 0');
-    assert.equal(parseInt(Css.get(SugarBody.body(), 'margin-top'), 10), 0, 'body margin-top = 0');
 
     // assert.isAtLeast(editorTargetTop, toolbarBottom, 'toolbarBottom should be above editorTargetTop');
     assert.approximately(editorBodyTop, toolbarBottom, 5, 'toolbarBottom should be above editorBodyTop');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
@@ -93,6 +93,12 @@ describe('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', () => {
     const editorBodyRect = editor.getBody().getBoundingClientRect();
     const editorBodyTop = editorBodyRect.y;
 
+    assert.equal(parseInt(Css.get(toolbar, 'margin-bottom'), 10), 0, 'toolbar margin-bottom = 0');
+    assert.equal(parseInt(Css.get(toolbar, 'margin-top'), 10), 0, 'toolbar margin-top = 0');
+
+    assert.equal(parseInt(Css.get(SugarBody.body(), 'margin-bottom'), 10), 0, 'body margin-bottom = 0');
+    assert.equal(parseInt(Css.get(SugarBody.body(), 'margin-top'), 10), 0, 'body margin-top = 0');
+
     // assert.isAtLeast(editorTargetTop, toolbarBottom, 'toolbarBottom should be above editorTargetTop');
     assert.approximately(editorBodyTop, toolbarBottom, 5, 'toolbarBottom should be above editorBodyTop');
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 
-// TODO TINY-10480: Investigate flaky tests
 describe('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', () => {
   const wrapper = SugarElement.fromTag('div');
   const editorTarget = SugarElement.fromTag('div');
@@ -61,18 +60,22 @@ describe('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', () => {
       }
     });
 
+  // TODO TINY-10480: Investigate flaky tests
   it.skip('TINY-9646: The width should remain on the editor', () =>
     pRunToolbarWidthTest(500, '400px')
   );
 
+  // TODO TINY-10480: Investigate flaky tests
   it.skip('TINY-8977: If the editor does not fit within the view', () =>
     pRunToolbarWidthTest(200, '200px')
   );
 
+  // TODO TINY-10480: Investigate flaky tests
   it.skip('TINY-8977: If the visible editor is smaller than the minimum', () =>
     pRunToolbarWidthTest(50, '150px')
   );
 
+  // TODO TINY-10480: Investigate flaky tests
   it.skip('TINY-8977: If the editor is not visible at all', () =>
     pRunToolbarWidthTest(-50, '150px')
   );


### PR DESCRIPTION
Related Ticket: TINY-10580

Description of Changes:
the problem was that if the toolbar has few space and need to be increase in height we need to apply the width before calculating the top to calculate it correctly

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
