### PR TITLE
TINY-10453: Remove `title` attribute for menu items, add `data-mce-label` for toolbar and dialog buttons

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10453-2024-01-22.yaml
+++ b/.changes/unreleased/tinymce-TINY-10453-2024-01-22.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Removed
+body: Removed `title` attribute for buttons with visible label.
+time: 2024-01-22T09:55:21.247474+11:00
+custom:
+  Issue: TINY-10453

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/ThemeSelectors.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/ThemeSelectors.ts
@@ -36,7 +36,7 @@ const SilverThemeSelectors: ThemeSelectors = {
   menuBarSelector: '.tox-menubar',
   dialogSelector: 'div[role="dialog"]',
   dialogCancelSelector: '.tox-button:contains("Cancel")',
-  dialogCloseSelector: '.tox-button[data-mce-btn="close"]',
+  dialogCloseSelector: '.tox-button[data-mce-label="close"]',
   dialogSubmitSelector: '.tox-button:contains("Save")'
 };
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/ThemeSelectors.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/ThemeSelectors.ts
@@ -36,7 +36,7 @@ const SilverThemeSelectors: ThemeSelectors = {
   menuBarSelector: '.tox-menubar',
   dialogSelector: 'div[role="dialog"]',
   dialogCancelSelector: '.tox-button:contains("Cancel")',
-  dialogCloseSelector: '.tox-button[title="Close"]',
+  dialogCloseSelector: '.tox-button[data-mce-btn="close"]',
   dialogSubmitSelector: '.tox-button:contains("Save")'
 };
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/ThemeSelectors.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/ThemeSelectors.ts
@@ -36,7 +36,7 @@ const SilverThemeSelectors: ThemeSelectors = {
   menuBarSelector: '.tox-menubar',
   dialogSelector: 'div[role="dialog"]',
   dialogCancelSelector: '.tox-button:contains("Cancel")',
-  dialogCloseSelector: '.tox-button[data-mce-label="close"]',
+  dialogCloseSelector: '.tox-button[data-mce-name="close"]',
   dialogSubmitSelector: '.tox-button:contains("Save")'
 };
 

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
@@ -21,14 +21,14 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
   }, []);
 
   const assertSelectBoxDisplayValue = (title: string, expectedValue: string) => {
-    const selectBox = UiFinder.findIn(SugarBody.body(), `*[title^="${title}"]`).getOrDie();
+    const selectBox = UiFinder.findIn(SugarBody.body(), `*[data-mce-btn="${title}"]`).getOrDie();
     const value = Strings.trim(TextContent.get(selectBox) ?? '');
     assert.equal(value, expectedValue, 'Should be the expected display value');
   };
 
   it('Font family and font size on initial page load', () => {
-    assertSelectBoxDisplayValue('Font size', '12px');
-    assertSelectBoxDisplayValue('Font', 'Arial');
+    assertSelectBoxDisplayValue('fontsize', '12px');
+    assertSelectBoxDisplayValue('fontfamily', 'Arial');
   });
 
   it('Font family with spaces and numbers in the name with legacy font elements', () => {
@@ -37,8 +37,8 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
     editor.focus();
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
     editor.nodeChanged();
-    assertSelectBoxDisplayValue('Font size', '8pt');
-    assertSelectBoxDisplayValue('Font', 'Bookshelf Symbol 7');
+    assertSelectBoxDisplayValue('fontsize', '8pt');
+    assertSelectBoxDisplayValue('fontfamily', 'Bookshelf Symbol 7');
   });
 
   it('Font family with spaces and numbers in the name', () => {
@@ -47,8 +47,8 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
     editor.focus();
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
     editor.nodeChanged();
-    assertSelectBoxDisplayValue('Font size', '12px');
-    assertSelectBoxDisplayValue('Font', 'Bookshelf Symbol 7');
+    assertSelectBoxDisplayValue('fontsize', '12px');
+    assertSelectBoxDisplayValue('fontfamily', 'Bookshelf Symbol 7');
   });
 
   it('Font family with quoted font names', () => {
@@ -57,7 +57,7 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
     editor.focus();
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
     editor.nodeChanged();
-    assertSelectBoxDisplayValue('Font size', '12px');
-    assertSelectBoxDisplayValue('Font', 'Bauhaus 93');
+    assertSelectBoxDisplayValue('fontsize', '12px');
+    assertSelectBoxDisplayValue('fontfamily', 'Bauhaus 93');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
@@ -21,7 +21,7 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
   }, []);
 
   const assertSelectBoxDisplayValue = (title: string, expectedValue: string) => {
-    const selectBox = UiFinder.findIn(SugarBody.body(), `*[data-mce-btn="${title}"]`).getOrDie();
+    const selectBox = UiFinder.findIn(SugarBody.body(), `*[data-mce-label="${title}"]`).getOrDie();
     const value = Strings.trim(TextContent.get(selectBox) ?? '');
     assert.equal(value, expectedValue, 'Should be the expected display value');
   };

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectCustomTest.ts
@@ -21,7 +21,7 @@ describe('browser.tinymce.core.FontSelectCustomTest', () => {
   }, []);
 
   const assertSelectBoxDisplayValue = (title: string, expectedValue: string) => {
-    const selectBox = UiFinder.findIn(SugarBody.body(), `*[data-mce-label="${title}"]`).getOrDie();
+    const selectBox = UiFinder.findIn(SugarBody.body(), `*[data-mce-name="${title}"]`).getOrDie();
     const value = Strings.trim(TextContent.get(selectBox) ?? '');
     assert.equal(value, expectedValue, 'Should be the expected display value');
   };

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.FontSelectTest', () => {
   const assertSelectBoxDisplayValue = (title: string, expectedValue: string) => {
-    const selectBox = UiFinder.findIn(SugarBody.body(), `*[data-mce-label^="${title}"]`).getOrDie();
+    const selectBox = UiFinder.findIn(SugarBody.body(), `*[data-mce-name^="${title}"]`).getOrDie();
     const value = Strings.trim(TextContent.get(selectBox) ?? '');
     assert.equal(value, expectedValue, 'Should be the expected display value');
   };

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.FontSelectTest', () => {
   const assertSelectBoxDisplayValue = (title: string, expectedValue: string) => {
-    const selectBox = UiFinder.findIn(SugarBody.body(), `*[data-mce-btn^="${title}"]`).getOrDie();
+    const selectBox = UiFinder.findIn(SugarBody.body(), `*[data-mce-label^="${title}"]`).getOrDie();
     const value = Strings.trim(TextContent.get(selectBox) ?? '');
     assert.equal(value, expectedValue, 'Should be the expected display value');
   };

--- a/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FontSelectTest.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.FontSelectTest', () => {
   const assertSelectBoxDisplayValue = (title: string, expectedValue: string) => {
-    const selectBox = UiFinder.findIn(SugarBody.body(), `*[title^="${title}"]`).getOrDie();
+    const selectBox = UiFinder.findIn(SugarBody.body(), `*[data-mce-btn^="${title}"]`).getOrDie();
     const value = Strings.trim(TextContent.get(selectBox) ?? '');
     assert.equal(value, expectedValue, 'Should be the expected display value');
   };
@@ -33,8 +33,8 @@ describe('browser.tinymce.core.FontSelectTest', () => {
     ];
 
     it('TBA: Font family and font size on initial page load', () => {
-      assertSelectBoxDisplayValue('Font size', '12px');
-      assertSelectBoxDisplayValue('Font', 'Arial');
+      assertSelectBoxDisplayValue('fontsize', '12px');
+      assertSelectBoxDisplayValue('fontfamily', 'Arial');
     });
 
     it('TBA: Font family and font size on paragraph with no styles', () => {
@@ -43,8 +43,8 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
       // p content style is 12px which does not match any pt values in the font size select values
-      assertSelectBoxDisplayValue('Font size', '12px');
-      assertSelectBoxDisplayValue('Font', 'Arial');
+      assertSelectBoxDisplayValue('fontsize', '12px');
+      assertSelectBoxDisplayValue('fontfamily', 'Arial');
     });
 
     it('TBA: Font family and font size on heading with no styles', () => {
@@ -54,8 +54,8 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
       // h1 content style is 32px which matches 24pt in the font size select values so it should be converted
-      assertSelectBoxDisplayValue('Font size', '24pt');
-      assertSelectBoxDisplayValue('Font', 'Arial');
+      assertSelectBoxDisplayValue('fontsize', '24pt');
+      assertSelectBoxDisplayValue('fontfamily', 'Arial');
     });
 
     it('TBA: Font family and font size on paragraph with styles that do match font size select values', () => {
@@ -64,8 +64,8 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
       // the following should be converted and pick up 12.75pt, although there's a rounded 13pt in the dropdown as well
-      assertSelectBoxDisplayValue('Font size', '12.75pt');
-      assertSelectBoxDisplayValue('Font', 'Times');
+      assertSelectBoxDisplayValue('fontsize', '12.75pt');
+      assertSelectBoxDisplayValue('fontfamily', 'Times');
     });
 
     it('TBA: Font family and font size on paragraph with styles that do not match font size select values', () => {
@@ -75,8 +75,8 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
       // the following should stay as 18px because there's no matching pt value in the font size select values
-      assertSelectBoxDisplayValue('Font size', '18px');
-      assertSelectBoxDisplayValue('Font', 'Times');
+      assertSelectBoxDisplayValue('fontsize', '18px');
+      assertSelectBoxDisplayValue('fontfamily', 'Times');
     });
 
     it('TBA: Font family and font size on paragraph with legacy font elements', () => {
@@ -84,8 +84,8 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.setContent('<p><font face="Times" size="1">a</font></p>', { format: 'raw' });
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
       editor.nodeChanged();
-      assertSelectBoxDisplayValue('Font size', '8pt');
-      assertSelectBoxDisplayValue('Font', 'Times');
+      assertSelectBoxDisplayValue('fontsize', '8pt');
+      assertSelectBoxDisplayValue('fontfamily', 'Times');
     });
 
     // https://websemantics.uk/articles/font-size-conversion/
@@ -94,8 +94,8 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.setContent('<p style="font-family: Times; font-size: medium;">a</p>');
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
-      assertSelectBoxDisplayValue('Font size', '12pt');
-      assertSelectBoxDisplayValue('Font', 'Times');
+      assertSelectBoxDisplayValue('fontsize', '12pt');
+      assertSelectBoxDisplayValue('fontfamily', 'Times');
     });
 
     it('TINY-6291: xx-small will fall back to showing raw font size due to missing 7pt fontsize_format', () => {
@@ -104,8 +104,8 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.focus();
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
-      assertSelectBoxDisplayValue('Font size', 'xx-small');
-      assertSelectBoxDisplayValue('Font', 'Times');
+      assertSelectBoxDisplayValue('fontsize', 'xx-small');
+      assertSelectBoxDisplayValue('fontfamily', 'Times');
     });
 
     it('TBA: System font stack variants on a paragraph show "System Font" as the font name', () => {
@@ -114,7 +114,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       Arr.each(systemFontStackVariants, (_, idx) => {
         TinySelections.setCursor(editor, [ idx, 0 ], 0);
         editor.nodeChanged();
-        assertSelectBoxDisplayValue('Font', 'System Font');
+        assertSelectBoxDisplayValue('fontfamily', 'System Font');
       });
     });
 
@@ -124,7 +124,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.focus();
       TinySelections.setCursor(editor, [ 0, 0 ], 0);
       editor.nodeChanged();
-      assertSelectBoxDisplayValue('Font', '-apple-system,Arial');
+      assertSelectBoxDisplayValue('fontfamily', '-apple-system,Arial');
     });
   });
 
@@ -145,7 +145,7 @@ describe('browser.tinymce.core.FontSelectTest', () => {
       editor.setContent(testCase.html);
       TinySelections.setCursor(editor, testCase.path, testCase.offset);
       editor.nodeChanged();
-      assertSelectBoxDisplayValue('Font', testCase.expectedValue);
+      assertSelectBoxDisplayValue('fontfamily', testCase.expectedValue);
     };
 
     it('TINY-10290: Should show System Font for the specified custom stack', () => testCustomStack({

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
@@ -76,7 +76,7 @@ describe('browser.tinymce.core.ReadOnlyModeTest', () => {
   };
 
   const assertToolbarDisabled = (expectedState: boolean) => {
-    const elm = UiFinder.findIn(SugarBody.body(), 'button[title="Bold"]').getOrDie();
+    const elm = UiFinder.findIn(SugarBody.body(), 'button[data-mce-btn="bold"]').getOrDie();
     assert.equal(Class.has(elm, 'tox-tbtn--disabled'), expectedState, 'Button should have expected disabled state');
   };
 

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
@@ -76,7 +76,7 @@ describe('browser.tinymce.core.ReadOnlyModeTest', () => {
   };
 
   const assertToolbarDisabled = (expectedState: boolean) => {
-    const elm = UiFinder.findIn(SugarBody.body(), 'button[data-mce-label="bold"]').getOrDie();
+    const elm = UiFinder.findIn(SugarBody.body(), 'button[data-mce-name="bold"]').getOrDie();
     assert.equal(Class.has(elm, 'tox-tbtn--disabled'), expectedState, 'Button should have expected disabled state');
   };
 

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
@@ -76,7 +76,7 @@ describe('browser.tinymce.core.ReadOnlyModeTest', () => {
   };
 
   const assertToolbarDisabled = (expectedState: boolean) => {
-    const elm = UiFinder.findIn(SugarBody.body(), 'button[data-mce-btn="bold"]').getOrDie();
+    const elm = UiFinder.findIn(SugarBody.body(), 'button[data-mce-label="bold"]').getOrDie();
     assert.equal(Class.has(elm, 'tox-tbtn--disabled'), expectedState, 'Button should have expected disabled state');
   };
 

--- a/modules/tinymce/src/core/test/ts/browser/paste/PasteOptionsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/PasteOptionsTest.ts
@@ -18,7 +18,7 @@ describe('browser.tinymce.core.paste.PasteOptionsTest', () => {
       toolbar: 'pastetext'
     });
     editor.focus();
-    await TinyUiActions.pWaitForUi(editor, 'button.tox-tbtn--enabled[data-mce-btn="pastetext"]');
+    await TinyUiActions.pWaitForUi(editor, 'button.tox-tbtn--enabled[data-mce-label="pastetext"]');
     McEditor.remove(editor);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/paste/PasteOptionsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/PasteOptionsTest.ts
@@ -18,7 +18,7 @@ describe('browser.tinymce.core.paste.PasteOptionsTest', () => {
       toolbar: 'pastetext'
     });
     editor.focus();
-    await TinyUiActions.pWaitForUi(editor, 'button.tox-tbtn--enabled[data-mce-label="pastetext"]');
+    await TinyUiActions.pWaitForUi(editor, 'button.tox-tbtn--enabled[data-mce-name="pastetext"]');
     McEditor.remove(editor);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/paste/PasteOptionsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/PasteOptionsTest.ts
@@ -18,7 +18,7 @@ describe('browser.tinymce.core.paste.PasteOptionsTest', () => {
       toolbar: 'pastetext'
     });
     editor.focus();
-    await TinyUiActions.pWaitForUi(editor, 'button.tox-tbtn--enabled[title="Paste as text"]');
+    await TinyUiActions.pWaitForUi(editor, 'button.tox-tbtn--enabled[data-mce-btn="pastetext"]');
     McEditor.remove(editor);
   });
 });

--- a/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
@@ -87,9 +87,9 @@ describe('webdriver.tinymce.core.content.PlaceholderTest', () => {
     await pAssertPlaceholderExists(editor);
     await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text('t') ]);
     await pAssertPlaceholderNotExists(editor);
-    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[title="Undo"]');
+    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-btn="undo"]');
     await pAssertPlaceholderExists(editor);
-    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[title="Redo"]');
+    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-btn="redo"]');
     await pAssertPlaceholderNotExists(editor);
     assertCount(3);
   });
@@ -98,7 +98,7 @@ describe('webdriver.tinymce.core.content.PlaceholderTest', () => {
     const editor = hook.editor();
     setContent(editor, '<p></p>');
     await pAssertPlaceholderExists(editor);
-    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[title="Bold"]');
+    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-btn="bold"]');
     await pAssertPlaceholderExists(editor);
     await pTypeTextAndDelete(editor);
     assertCount(2);

--- a/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
@@ -87,9 +87,9 @@ describe('webdriver.tinymce.core.content.PlaceholderTest', () => {
     await pAssertPlaceholderExists(editor);
     await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text('t') ]);
     await pAssertPlaceholderNotExists(editor);
-    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-btn="undo"]');
+    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-label="undo"]');
     await pAssertPlaceholderExists(editor);
-    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-btn="redo"]');
+    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-label="redo"]');
     await pAssertPlaceholderNotExists(editor);
     assertCount(3);
   });
@@ -98,7 +98,7 @@ describe('webdriver.tinymce.core.content.PlaceholderTest', () => {
     const editor = hook.editor();
     setContent(editor, '<p></p>');
     await pAssertPlaceholderExists(editor);
-    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-btn="bold"]');
+    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-label="bold"]');
     await pAssertPlaceholderExists(editor);
     await pTypeTextAndDelete(editor);
     assertCount(2);

--- a/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
@@ -87,9 +87,9 @@ describe('webdriver.tinymce.core.content.PlaceholderTest', () => {
     await pAssertPlaceholderExists(editor);
     await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.text('t') ]);
     await pAssertPlaceholderNotExists(editor);
-    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-label="undo"]');
+    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-name="undo"]');
     await pAssertPlaceholderExists(editor);
-    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-label="redo"]');
+    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-name="redo"]');
     await pAssertPlaceholderNotExists(editor);
     assertCount(3);
   });
@@ -98,7 +98,7 @@ describe('webdriver.tinymce.core.content.PlaceholderTest', () => {
     const editor = hook.editor();
     setContent(editor, '<p></p>');
     await pAssertPlaceholderExists(editor);
-    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-label="bold"]');
+    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-name="bold"]');
     await pAssertPlaceholderExists(editor);
     await pTypeTextAndDelete(editor);
     assertCount(2);

--- a/modules/tinymce/src/core/test/ts/webdriver/paste/CutTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/paste/CutTest.ts
@@ -17,7 +17,7 @@ describe('webdriver.tinymce.core.paste.CutTest', () => {
     TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
     TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
     await TinyUiActions.pWaitForUi(editor, '*[role="menu"]');
-    await RealMouse.pClickOn('div[title="Cut"]');
+    await RealMouse.pClickOn('div[aria-label="Cut"]');
     await Waiter.pTryUntil('Cut is async now, so need to wait for content', () => TinyAssertions.assertContent(editor, '<p>ac</p>'));
   });
 
@@ -35,7 +35,7 @@ describe('webdriver.tinymce.core.paste.CutTest', () => {
       TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
       await TinyUiActions.pWaitForUi(editor, '*[role="menu"]');
-      await RealMouse.pClickOn('div[title="Cut"]');
+      await RealMouse.pClickOn('div[aria-label="Cut"]');
       await Waiter.pTryUntil('Cut is async now, so need to wait for content', () => TinyAssertions.assertContent(editor, '<p>ac</p>'));
     });
   });

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistOptionsAndToolbarTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistOptionsAndToolbarTest.ts
@@ -55,7 +55,7 @@ describe('browser.tinymce.plugins.advlist.AdvlistOptionsAndToolbarTest', () => {
               [ arr.not('tox-tbtn'), arr.has('tox-split-button') ] :
               [ arr.has('tox-tbtn'), arr.not('tox-split-button') ],
             attrs: {
-              title: str.is('Numbered list')
+              'data-mce-btn': str.is('numlist'),
             }
           }),
           s.element(splitBtns.bullet ? 'div' : 'button', {
@@ -63,7 +63,7 @@ describe('browser.tinymce.plugins.advlist.AdvlistOptionsAndToolbarTest', () => {
               [ arr.not('tox-tbtn'), arr.has('tox-split-button') ] :
               [ arr.has('tox-tbtn'), arr.not('tox-split-button') ],
             attrs: {
-              title: str.is('Bullet list')
+              'data-mce-btn': str.is('bullist'),
             }
           })
         ]

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistOptionsAndToolbarTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistOptionsAndToolbarTest.ts
@@ -55,7 +55,7 @@ describe('browser.tinymce.plugins.advlist.AdvlistOptionsAndToolbarTest', () => {
               [ arr.not('tox-tbtn'), arr.has('tox-split-button') ] :
               [ arr.has('tox-tbtn'), arr.not('tox-split-button') ],
             attrs: {
-              'data-mce-btn': str.is('numlist'),
+              'data-mce-label': str.is('numlist'),
             }
           }),
           s.element(splitBtns.bullet ? 'div' : 'button', {
@@ -63,7 +63,7 @@ describe('browser.tinymce.plugins.advlist.AdvlistOptionsAndToolbarTest', () => {
               [ arr.not('tox-tbtn'), arr.has('tox-split-button') ] :
               [ arr.has('tox-tbtn'), arr.not('tox-split-button') ],
             attrs: {
-              'data-mce-btn': str.is('bullist'),
+              'data-mce-label': str.is('bullist'),
             }
           })
         ]

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistOptionsAndToolbarTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/AdvlistOptionsAndToolbarTest.ts
@@ -55,7 +55,7 @@ describe('browser.tinymce.plugins.advlist.AdvlistOptionsAndToolbarTest', () => {
               [ arr.not('tox-tbtn'), arr.has('tox-split-button') ] :
               [ arr.has('tox-tbtn'), arr.not('tox-split-button') ],
             attrs: {
-              'data-mce-label': str.is('numlist'),
+              'data-mce-name': str.is('numlist'),
             }
           }),
           s.element(splitBtns.bullet ? 'div' : 'button', {
@@ -63,7 +63,7 @@ describe('browser.tinymce.plugins.advlist.AdvlistOptionsAndToolbarTest', () => {
               [ arr.not('tox-tbtn'), arr.has('tox-split-button') ] :
               [ arr.has('tox-tbtn'), arr.not('tox-split-button') ],
             attrs: {
-              'data-mce-label': str.is('bullist'),
+              'data-mce-name': str.is('bullist'),
             }
           })
         ]

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/ChangeListStyleTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/ChangeListStyleTest.ts
@@ -29,7 +29,7 @@ describe('browser.tinymce.plugins.advlist.ChangeListStyleTest', () => {
         TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
         TinyUiActions.clickOnToolbar(editor, '[aria-label="Numbered list"] > .tox-tbtn + .tox-split-button__chevron');
         await pWaitForMenu(editor);
-        TinyUiActions.clickOnUi(editor, 'div.tox-selected-menu[role="menu"] div[title="Lower Alpha"]');
+        TinyUiActions.clickOnUi(editor, 'div.tox-selected-menu[role="menu"] div[aria-label="Lower Alpha"]');
         TinyAssertions.assertContent(editor, '<ol style="list-style-type: lower-alpha;"><li>a</li><ul><li>b</li></ul></ol>');
         TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0);
       });
@@ -40,7 +40,7 @@ describe('browser.tinymce.plugins.advlist.ChangeListStyleTest', () => {
         TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1);
         TinyUiActions.clickOnToolbar(editor, '[aria-label="Numbered list"] > .tox-tbtn + .tox-split-button__chevron');
         await pWaitForMenu(editor);
-        TinyUiActions.clickOnUi(editor, 'div.tox-selected-menu[role="menu"] div[title="Lower Alpha"]');
+        TinyUiActions.clickOnUi(editor, 'div.tox-selected-menu[role="menu"] div[aria-label="Lower Alpha"]');
         TinyAssertions.assertContent(editor, '<ol style="list-style-type: lower-alpha;"><li>a</li><ol style="list-style-type: lower-alpha;"><li>b</li></ol></ol>');
         TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1);
       });
@@ -69,7 +69,7 @@ describe('browser.tinymce.plugins.advlist.ChangeListStyleTest', () => {
         TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
         TinyUiActions.clickOnToolbar(editor, '[aria-label="Numbered list"] > .tox-tbtn + .tox-split-button__chevron');
         await pWaitForMenu(editor);
-        TinyUiActions.clickOnUi(editor, 'div.tox-selected-menu[role="menu"] div[title="Default"]');
+        TinyUiActions.clickOnUi(editor, 'div.tox-selected-menu[role="menu"] div[aria-label="Default"]');
         TinyAssertions.assertContent(editor, '<ol><li>a</li><ol style="list-style-type: lower-alpha;"><li>b</li></ol></ol>');
         TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0);
       });
@@ -80,7 +80,7 @@ describe('browser.tinymce.plugins.advlist.ChangeListStyleTest', () => {
         TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1);
         TinyUiActions.clickOnToolbar(editor, '[aria-label="Numbered list"] > .tox-tbtn + .tox-split-button__chevron');
         await pWaitForMenu(editor);
-        TinyUiActions.clickOnUi(editor, 'div.tox-selected-menu[role="menu"] div[title="Default"]');
+        TinyUiActions.clickOnUi(editor, 'div.tox-selected-menu[role="menu"] div[aria-label="Default"]');
         TinyAssertions.assertContent(editor, '<ol><li>a</li><ol><li>b</li></ol></ol>');
         TinyAssertions.assertSelection(editor, [ 0, 0, 0 ], 0, [ 0, 1, 0, 0 ], 1);
       });

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
@@ -27,8 +27,8 @@ describe('browser.tinymce.plugins.advlist.NoneditableRootTest', () => {
       TinyState.withNoneditableRootEditor<Editor>(hook.editor(), (editor) => {
         setupEditor(editor);
 
-        UiFinder.exists(TinyDom.container(editor), 'div[data-mce-btn="numlist"][aria-disabled="true"]');
-        UiFinder.exists(TinyDom.container(editor), 'div[data-mce-btn="bullist"][aria-disabled="true"]');
+        UiFinder.exists(TinyDom.container(editor), 'div[data-mce-label="numlist"][aria-disabled="true"]');
+        UiFinder.exists(TinyDom.container(editor), 'div[data-mce-label="bullist"][aria-disabled="true"]');
       });
     });
 
@@ -36,10 +36,10 @@ describe('browser.tinymce.plugins.advlist.NoneditableRootTest', () => {
       TinyState.withNoneditableRootEditor<Editor>(hook.editor(), (editor) => {
         setupEditor(editor);
 
-        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="outdent"]');
+        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="outdent"]');
         TinyAssertions.assertContent(editor, initialListContent);
 
-        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="indent"]');
+        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="indent"]');
         TinyAssertions.assertContent(editor, initialListContent);
       });
     });

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
@@ -27,8 +27,8 @@ describe('browser.tinymce.plugins.advlist.NoneditableRootTest', () => {
       TinyState.withNoneditableRootEditor<Editor>(hook.editor(), (editor) => {
         setupEditor(editor);
 
-        UiFinder.exists(TinyDom.container(editor), 'div[data-mce-label="numlist"][aria-disabled="true"]');
-        UiFinder.exists(TinyDom.container(editor), 'div[data-mce-label="bullist"][aria-disabled="true"]');
+        UiFinder.exists(TinyDom.container(editor), 'div[data-mce-name="numlist"][aria-disabled="true"]');
+        UiFinder.exists(TinyDom.container(editor), 'div[data-mce-name="bullist"][aria-disabled="true"]');
       });
     });
 
@@ -36,10 +36,10 @@ describe('browser.tinymce.plugins.advlist.NoneditableRootTest', () => {
       TinyState.withNoneditableRootEditor<Editor>(hook.editor(), (editor) => {
         setupEditor(editor);
 
-        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="outdent"]');
+        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="outdent"]');
         TinyAssertions.assertContent(editor, initialListContent);
 
-        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="indent"]');
+        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="indent"]');
         TinyAssertions.assertContent(editor, initialListContent);
       });
     });

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/NoneditableRootTest.ts
@@ -27,8 +27,8 @@ describe('browser.tinymce.plugins.advlist.NoneditableRootTest', () => {
       TinyState.withNoneditableRootEditor<Editor>(hook.editor(), (editor) => {
         setupEditor(editor);
 
-        UiFinder.exists(TinyDom.container(editor), 'div[title="Numbered list"][aria-disabled="true"]');
-        UiFinder.exists(TinyDom.container(editor), 'div[title="Bullet list"][aria-disabled="true"]');
+        UiFinder.exists(TinyDom.container(editor), 'div[data-mce-btn="numlist"][aria-disabled="true"]');
+        UiFinder.exists(TinyDom.container(editor), 'div[data-mce-btn="bullist"][aria-disabled="true"]');
       });
     });
 
@@ -36,10 +36,10 @@ describe('browser.tinymce.plugins.advlist.NoneditableRootTest', () => {
       TinyState.withNoneditableRootEditor<Editor>(hook.editor(), (editor) => {
         setupEditor(editor);
 
-        TinyUiActions.clickOnToolbar(editor, 'button[title="Decrease indent"]');
+        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="outdent"]');
         TinyAssertions.assertContent(editor, initialListContent);
 
-        TinyUiActions.clickOnToolbar(editor, 'button[title="Increase indent"]');
+        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="indent"]');
         TinyAssertions.assertContent(editor, initialListContent);
       });
     });

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/SplitButtonTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/SplitButtonTest.ts
@@ -45,8 +45,8 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item--active')
                     ],
                     attrs: {
-                      role: str.is('menuitemradio'),
-                      title: str.is('Default')
+                      'role': str.is('menuitemradio'),
+                      'aria-label': str.is('Default')
                     },
                     children: [
                       s.element('div', {
@@ -60,8 +60,8 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item')
                     ],
                     attrs: {
-                      role: str.is('menuitemradio'),
-                      title: str.is('Circle')
+                      'role': str.is('menuitemradio'),
+                      'aria-label': str.is('Circle')
                     },
                     children: [
                       s.element('div', {
@@ -75,8 +75,8 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item')
                     ],
                     attrs: {
-                      role: str.is('menuitemradio'),
-                      title: str.is('Square')
+                      'role': str.is('menuitemradio'),
+                      'aria-label': str.is('Square')
                     },
                     children: [
                       s.element('div', {
@@ -118,8 +118,8 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item--active')
                     ],
                     attrs: {
-                      role: str.is('menuitemradio'),
-                      title: str.is('Default')
+                      'role': str.is('menuitemradio'),
+                      'aria-label': str.is('Default')
                     },
                     children: [
                       s.element('div', {
@@ -133,8 +133,8 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item')
                     ],
                     attrs: {
-                      role: str.is('menuitemradio'),
-                      title: str.is('Lower Alpha')
+                      'role': str.is('menuitemradio'),
+                      'aria-label': str.is('Lower Alpha')
                     },
                     children: [
                       s.element('div', {
@@ -148,8 +148,8 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item')
                     ],
                     attrs: {
-                      role: str.is('menuitemradio'),
-                      title: str.is('Lower Greek')
+                      'role': str.is('menuitemradio'),
+                      'aria-label': str.is('Lower Greek')
                     },
                     children: [
                       s.element('div', {
@@ -169,8 +169,8 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item')
                     ],
                     attrs: {
-                      role: str.is('menuitemradio'),
-                      title: str.is('Lower Roman')
+                      'role': str.is('menuitemradio'),
+                      'aria-label': str.is('Lower Roman')
                     },
                     children: [
                       s.element('div', {
@@ -184,8 +184,8 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item')
                     ],
                     attrs: {
-                      role: str.is('menuitemradio'),
-                      title: str.is('Upper Alpha')
+                      'role': str.is('menuitemradio'),
+                      'aria-label': str.is('Upper Alpha')
                     },
                     children: [
                       s.element('div', {
@@ -199,8 +199,8 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                       arr.has('tox-collection__item')
                     ],
                     attrs: {
-                      role: str.is('menuitemradio'),
-                      title: str.is('Upper Roman')
+                      'role': str.is('menuitemradio'),
+                      'aria-label': str.is('Upper Roman')
                     },
                     children: [
                       s.element('div', {

--- a/modules/tinymce/src/plugins/anchor/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/anchor/test/ts/browser/NoneditableRootTest.ts
@@ -28,11 +28,11 @@ describe('browser.tinymce.plugins.anchor.NoneditableRootTest', () => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Anchor..."][aria-disabled="true"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Anchor..."][aria-disabled="true"]');
       TinyUiActions.keystroke(editor, Keys.escape());
       TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Anchor..."][aria-disabled="false"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Anchor..."][aria-disabled="false"]');
       TinyUiActions.keystroke(editor, Keys.escape());
     });
   });

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/NoneditableRootTest.ts
@@ -28,11 +28,11 @@ describe('browser.tinymce.plugins.charmap.NoneditableRootTest', () => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Special character..."][aria-disabled="true"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Special character..."][aria-disabled="true"]');
       TinyUiActions.keystroke(editor, Keys.escape());
       TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Special character..."][aria-disabled="false"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Special character..."][aria-disabled="false"]');
       TinyUiActions.keystroke(editor, Keys.escape());
     });
   });

--- a/modules/tinymce/src/plugins/codesample/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/browser/NoneditableRootTest.ts
@@ -28,11 +28,11 @@ describe('browser.tinymce.plugins.codesample.NoneditableRootTest', () => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Code sample..."][aria-disabled="true"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Code sample..."][aria-disabled="true"]');
       TinyUiActions.keystroke(editor, Keys.escape());
       TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Code sample..."][aria-disabled="false"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Code sample..."][aria-disabled="false"]');
       TinyUiActions.keystroke(editor, Keys.escape());
     });
   });

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -21,7 +21,7 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
   const pClickEditMenu = async (editor: Editor, item: string): Promise<void> => {
     TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
     await TinyUiActions.pWaitForUi(editor, '*[role="menu"]');
-    await RealMouse.pClickOn(`div[title=${item}]`);
+    await RealMouse.pClickOn(`div[aria-label=${item}]`);
   };
 
   const pPaste = async (editor: Editor): Promise<void> => {

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionStyleTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionStyleTest.ts
@@ -8,7 +8,7 @@ type Dir = 'rtl' | 'ltr';
 
 describe('browser.tinymce.plugins.directionality.DirectionStyleTest', () => {
   const applyDir = (editor: Editor, dir: Dir) =>
-    TinyUiActions.clickOnToolbar(editor, dir === 'ltr' ? 'button[data-mce-label="ltr"]' : 'button[data-mce-label="rtl"]');
+    TinyUiActions.clickOnToolbar(editor, dir === 'ltr' ? 'button[data-mce-name="ltr"]' : 'button[data-mce-name="rtl"]');
 
   const testDirectionStyle = (editor: Editor, content: string, dir: Dir, expected: string, cursorPath: number[] = [ 0, 0 ]) => {
     editor.setContent(content);

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionStyleTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionStyleTest.ts
@@ -8,7 +8,7 @@ type Dir = 'rtl' | 'ltr';
 
 describe('browser.tinymce.plugins.directionality.DirectionStyleTest', () => {
   const applyDir = (editor: Editor, dir: Dir) =>
-    TinyUiActions.clickOnToolbar(editor, dir === 'ltr' ? 'button[data-mce-btn="ltr"]' : 'button[data-mce-btn="rtl"]');
+    TinyUiActions.clickOnToolbar(editor, dir === 'ltr' ? 'button[data-mce-label="ltr"]' : 'button[data-mce-label="rtl"]');
 
   const testDirectionStyle = (editor: Editor, content: string, dir: Dir, expected: string, cursorPath: number[] = [ 0, 0 ]) => {
     editor.setContent(content);

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionStyleTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionStyleTest.ts
@@ -8,7 +8,7 @@ type Dir = 'rtl' | 'ltr';
 
 describe('browser.tinymce.plugins.directionality.DirectionStyleTest', () => {
   const applyDir = (editor: Editor, dir: Dir) =>
-    TinyUiActions.clickOnToolbar(editor, dir === 'ltr' ? 'button[title="Left to right"]' : 'button[title="Right to left"]');
+    TinyUiActions.clickOnToolbar(editor, dir === 'ltr' ? 'button[data-mce-btn="ltr"]' : 'button[data-mce-btn="rtl"]');
 
   const testDirectionStyle = (editor: Editor, content: string, dir: Dir, expected: string, cursorPath: number[] = [ 0, 0 ]) => {
     editor.setContent(content);

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
@@ -15,7 +15,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     const editor = hook.editor();
     editor.setContent('a');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="rtl"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="rtl"]');
     TinyAssertions.assertContent(editor, '<p dir="rtl">a</p>');
   });
 
@@ -23,7 +23,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     const editor = hook.editor();
     editor.setContent('<p dir="rtl">a</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="ltr"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="ltr"]');
     TinyAssertions.assertContent(editor, '<p>a</p>'); // as the default dir is ltr it just removes the dir attr
   });
 
@@ -31,9 +31,9 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     const editor = hook.editor();
     editor.setContent('<p>foo</p><p>bar</p>');
     TinySelections.setSelection(editor, [ 0 ], 0, [ 1 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="rtl"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="rtl"]');
     TinyAssertions.assertContent(editor, '<p dir="rtl">foo</p><p dir="rtl">bar</p>');
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="ltr"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="ltr"]');
     TinyAssertions.assertContent(editor, '<p>foo</p><p>bar</p>');
   });
 
@@ -41,9 +41,9 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     const editor = hook.editor();
     editor.setContent('<ul><li>foo</li><li>bar</li></ul>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="rtl"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="rtl"]');
     TinyAssertions.assertContent(editor, '<ul dir="rtl"><li>foo</li><li>bar</li></ul>');
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="ltr"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="ltr"]');
     TinyAssertions.assertContent(editor, '<ul><li>foo</li><li>bar</li></ul>');
   });
 
@@ -62,7 +62,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
       '</ul>'
     );
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="rtl"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="rtl"]');
     TinyAssertions.assertContent(editor,
       '<ul dir="rtl">' +
         '<li>foo' +
@@ -90,7 +90,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     '</ul>';
     editor.setContent(editorContent);
     TinySelections.setSelection(editor, [ 0, 0, 1, 0 ], 0, [ 0, 0, 1, 0 ], 1); // foo
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="ltr"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="ltr"]');
     TinyAssertions.assertContent(editor, editorContent);
   });
 
@@ -107,7 +107,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
       '</ul>'
     );
     TinySelections.setSelection(editor, [ 0, 0, 1, 0 ], 0, [ 0, 0, 1, 0 ], 1); // foo
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="rtl"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="rtl"]');
     TinyAssertions.assertContent(editor,
       '<ul dir="rtl">' +
         '<li dir="ltr">ini' +
@@ -124,9 +124,9 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     const editor = hook.editor();
     editor.setContent('<div dir="ltr"><p>foo</p><p>bar</p></div>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="rtl"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="rtl"]');
     TinyAssertions.assertContent(editor, '<div dir="ltr"><p dir="rtl">foo</p><p>bar</p></div>');
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="ltr"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="ltr"]');
     TinyAssertions.assertContent(editor, '<div dir="ltr"><p>foo</p><p>bar</p></div>');
   });
 
@@ -143,7 +143,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
       '</div>'
     );
     TinySelections.setSelection(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 1); // foo
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="rtl"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="rtl"]');
     TinyAssertions.assertContent(editor,
       '<div dir="rtl">' +
         '<div id="target-elm" dir="ltr">' +
@@ -154,7 +154,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
         '</div>' +
       '</div>'
     );
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="ltr"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="ltr"]');
     TinyAssertions.assertContent(editor,
       '<div dir="rtl">' +
         '<div id="target-elm" dir="ltr">' +

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
@@ -15,7 +15,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     const editor = hook.editor();
     editor.setContent('a');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="rtl"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="rtl"]');
     TinyAssertions.assertContent(editor, '<p dir="rtl">a</p>');
   });
 
@@ -23,7 +23,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     const editor = hook.editor();
     editor.setContent('<p dir="rtl">a</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="ltr"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="ltr"]');
     TinyAssertions.assertContent(editor, '<p>a</p>'); // as the default dir is ltr it just removes the dir attr
   });
 
@@ -31,9 +31,9 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     const editor = hook.editor();
     editor.setContent('<p>foo</p><p>bar</p>');
     TinySelections.setSelection(editor, [ 0 ], 0, [ 1 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="rtl"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="rtl"]');
     TinyAssertions.assertContent(editor, '<p dir="rtl">foo</p><p dir="rtl">bar</p>');
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="ltr"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="ltr"]');
     TinyAssertions.assertContent(editor, '<p>foo</p><p>bar</p>');
   });
 
@@ -41,9 +41,9 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     const editor = hook.editor();
     editor.setContent('<ul><li>foo</li><li>bar</li></ul>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="rtl"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="rtl"]');
     TinyAssertions.assertContent(editor, '<ul dir="rtl"><li>foo</li><li>bar</li></ul>');
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="ltr"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="ltr"]');
     TinyAssertions.assertContent(editor, '<ul><li>foo</li><li>bar</li></ul>');
   });
 
@@ -62,7 +62,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
       '</ul>'
     );
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="rtl"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="rtl"]');
     TinyAssertions.assertContent(editor,
       '<ul dir="rtl">' +
         '<li>foo' +
@@ -90,7 +90,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     '</ul>';
     editor.setContent(editorContent);
     TinySelections.setSelection(editor, [ 0, 0, 1, 0 ], 0, [ 0, 0, 1, 0 ], 1); // foo
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="ltr"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="ltr"]');
     TinyAssertions.assertContent(editor, editorContent);
   });
 
@@ -107,7 +107,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
       '</ul>'
     );
     TinySelections.setSelection(editor, [ 0, 0, 1, 0 ], 0, [ 0, 0, 1, 0 ], 1); // foo
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="rtl"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="rtl"]');
     TinyAssertions.assertContent(editor,
       '<ul dir="rtl">' +
         '<li dir="ltr">ini' +
@@ -124,9 +124,9 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     const editor = hook.editor();
     editor.setContent('<div dir="ltr"><p>foo</p><p>bar</p></div>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="rtl"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="rtl"]');
     TinyAssertions.assertContent(editor, '<div dir="ltr"><p dir="rtl">foo</p><p>bar</p></div>');
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="ltr"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="ltr"]');
     TinyAssertions.assertContent(editor, '<div dir="ltr"><p>foo</p><p>bar</p></div>');
   });
 
@@ -143,7 +143,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
       '</div>'
     );
     TinySelections.setSelection(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 1); // foo
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="rtl"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="rtl"]');
     TinyAssertions.assertContent(editor,
       '<div dir="rtl">' +
         '<div id="target-elm" dir="ltr">' +
@@ -154,7 +154,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
         '</div>' +
       '</div>'
     );
-    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="ltr"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="ltr"]');
     TinyAssertions.assertContent(editor,
       '<div dir="rtl">' +
         '<div id="target-elm" dir="ltr">' +

--- a/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
+++ b/modules/tinymce/src/plugins/directionality/test/ts/browser/DirectionalitySanityTest.ts
@@ -15,7 +15,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     const editor = hook.editor();
     editor.setContent('a');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="rtl"]');
     TinyAssertions.assertContent(editor, '<p dir="rtl">a</p>');
   });
 
@@ -23,7 +23,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     const editor = hook.editor();
     editor.setContent('<p dir="rtl">a</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="ltr"]');
     TinyAssertions.assertContent(editor, '<p>a</p>'); // as the default dir is ltr it just removes the dir attr
   });
 
@@ -31,9 +31,9 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     const editor = hook.editor();
     editor.setContent('<p>foo</p><p>bar</p>');
     TinySelections.setSelection(editor, [ 0 ], 0, [ 1 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="rtl"]');
     TinyAssertions.assertContent(editor, '<p dir="rtl">foo</p><p dir="rtl">bar</p>');
-    TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="ltr"]');
     TinyAssertions.assertContent(editor, '<p>foo</p><p>bar</p>');
   });
 
@@ -41,9 +41,9 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     const editor = hook.editor();
     editor.setContent('<ul><li>foo</li><li>bar</li></ul>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="rtl"]');
     TinyAssertions.assertContent(editor, '<ul dir="rtl"><li>foo</li><li>bar</li></ul>');
-    TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="ltr"]');
     TinyAssertions.assertContent(editor, '<ul><li>foo</li><li>bar</li></ul>');
   });
 
@@ -62,7 +62,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
       '</ul>'
     );
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="rtl"]');
     TinyAssertions.assertContent(editor,
       '<ul dir="rtl">' +
         '<li>foo' +
@@ -90,7 +90,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     '</ul>';
     editor.setContent(editorContent);
     TinySelections.setSelection(editor, [ 0, 0, 1, 0 ], 0, [ 0, 0, 1, 0 ], 1); // foo
-    TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="ltr"]');
     TinyAssertions.assertContent(editor, editorContent);
   });
 
@@ -107,7 +107,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
       '</ul>'
     );
     TinySelections.setSelection(editor, [ 0, 0, 1, 0 ], 0, [ 0, 0, 1, 0 ], 1); // foo
-    TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="rtl"]');
     TinyAssertions.assertContent(editor,
       '<ul dir="rtl">' +
         '<li dir="ltr">ini' +
@@ -124,9 +124,9 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
     const editor = hook.editor();
     editor.setContent('<div dir="ltr"><p>foo</p><p>bar</p></div>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
-    TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="rtl"]');
     TinyAssertions.assertContent(editor, '<div dir="ltr"><p dir="rtl">foo</p><p>bar</p></div>');
-    TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="ltr"]');
     TinyAssertions.assertContent(editor, '<div dir="ltr"><p>foo</p><p>bar</p></div>');
   });
 
@@ -143,7 +143,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
       '</div>'
     );
     TinySelections.setSelection(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 1); // foo
-    TinyUiActions.clickOnToolbar(editor, 'button[title="Right to left"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="rtl"]');
     TinyAssertions.assertContent(editor,
       '<div dir="rtl">' +
         '<div id="target-elm" dir="ltr">' +
@@ -154,7 +154,7 @@ describe('browser.tinymce.plugins.directionality.DirectionalitySanityTest', () =
         '</div>' +
       '</div>'
     );
-    TinyUiActions.clickOnToolbar(editor, 'button[title="Left to right"]');
+    TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="ltr"]');
     TinyAssertions.assertContent(editor,
       '<div dir="rtl">' +
         '<div id="target-elm" dir="ltr">' +

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/NoneditableRootTest.ts
@@ -28,11 +28,11 @@ describe('browser.tinymce.plugins.emoticons.NoneditableRootTest', () => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Emojis..."][aria-disabled="true"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Emojis..."][aria-disabled="true"]');
       TinyUiActions.keystroke(editor, Keys.escape());
       TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Emojis..."][aria-disabled="false"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Emojis..."][aria-disabled="false"]');
       TinyUiActions.keystroke(editor, Keys.escape());
     });
   });

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/webdriver/FullscreenPluginNativeModeTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/webdriver/FullscreenPluginNativeModeTest.ts
@@ -30,9 +30,9 @@ describe('webdriver.tinymce.plugins.fullscreen.FullScreenPluginNativeModeTest', 
 
   it('TBA: Toggle fullscreen on with real click, check document.fullscreenElement, toggle fullscreen off, check document.fullscreenElement', async () => {
     await pIsFullscreen(false);
-    await RealMouse.pClickOn('button[title="Fullscreen"]');
+    await RealMouse.pClickOn('button[data-mce-btn="fullscreen"]');
     await pIsFullscreen(true);
-    await RealMouse.pClickOn('button[title="Fullscreen"]');
+    await RealMouse.pClickOn('button[data-mce-btn="fullscreen"]');
     await pIsFullscreen(false);
   });
 });

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/webdriver/FullscreenPluginNativeModeTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/webdriver/FullscreenPluginNativeModeTest.ts
@@ -30,9 +30,9 @@ describe('webdriver.tinymce.plugins.fullscreen.FullScreenPluginNativeModeTest', 
 
   it('TBA: Toggle fullscreen on with real click, check document.fullscreenElement, toggle fullscreen off, check document.fullscreenElement', async () => {
     await pIsFullscreen(false);
-    await RealMouse.pClickOn('button[data-mce-label="fullscreen"]');
+    await RealMouse.pClickOn('button[data-mce-name="fullscreen"]');
     await pIsFullscreen(true);
-    await RealMouse.pClickOn('button[data-mce-label="fullscreen"]');
+    await RealMouse.pClickOn('button[data-mce-name="fullscreen"]');
     await pIsFullscreen(false);
   });
 });

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/webdriver/FullscreenPluginNativeModeTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/webdriver/FullscreenPluginNativeModeTest.ts
@@ -30,9 +30,9 @@ describe('webdriver.tinymce.plugins.fullscreen.FullScreenPluginNativeModeTest', 
 
   it('TBA: Toggle fullscreen on with real click, check document.fullscreenElement, toggle fullscreen off, check document.fullscreenElement', async () => {
     await pIsFullscreen(false);
-    await RealMouse.pClickOn('button[data-mce-btn="fullscreen"]');
+    await RealMouse.pClickOn('button[data-mce-label="fullscreen"]');
     await pIsFullscreen(true);
-    await RealMouse.pClickOn('button[data-mce-btn="fullscreen"]');
+    await RealMouse.pClickOn('button[data-mce-label="fullscreen"]');
     await pIsFullscreen(false);
   });
 });

--- a/modules/tinymce/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
@@ -45,7 +45,7 @@ describe('browser.tinymce.plugins.help.DialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-btn="close"]');
+    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-label="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('Handy Shortcuts Tab', '.tox-dialog__body-nav-item:contains("Handy Shortcuts")');
     pressDownArrowKey(editor);
@@ -60,7 +60,7 @@ describe('browser.tinymce.plugins.help.DialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-btn="close"]');
+    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-label="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('Keyboard Nav Tab', '.tox-dialog__body-nav-item:contains("Keyboard Navigation")');
     pressDownArrowKey(editor);
@@ -82,7 +82,7 @@ describe('browser.tinymce.plugins.help.DialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-btn="close"]');
+    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-label="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('Plugins Tab', '.tox-dialog__body-nav-item:contains("Plugins")');
     pressDownArrowKey(editor);
@@ -99,7 +99,7 @@ describe('browser.tinymce.plugins.help.DialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-btn="close"]');
+    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-label="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('Version Tab', '.tox-dialog__body-nav-item:contains("Version")');
   });

--- a/modules/tinymce/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
@@ -45,7 +45,7 @@ describe('browser.tinymce.plugins.help.DialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('"x" Close Button', '.tox-button[title="Close"]');
+    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-btn="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('Handy Shortcuts Tab', '.tox-dialog__body-nav-item:contains("Handy Shortcuts")');
     pressDownArrowKey(editor);
@@ -60,7 +60,7 @@ describe('browser.tinymce.plugins.help.DialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('"x" Close Button', '.tox-button[title="Close"]');
+    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-btn="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('Keyboard Nav Tab', '.tox-dialog__body-nav-item:contains("Keyboard Navigation")');
     pressDownArrowKey(editor);
@@ -82,7 +82,7 @@ describe('browser.tinymce.plugins.help.DialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('"x" Close Button', '.tox-button[title="Close"]');
+    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-btn="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('Plugins Tab', '.tox-dialog__body-nav-item:contains("Plugins")');
     pressDownArrowKey(editor);
@@ -99,7 +99,7 @@ describe('browser.tinymce.plugins.help.DialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('"x" Close Button', '.tox-button[title="Close"]');
+    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-btn="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('Version Tab', '.tox-dialog__body-nav-item:contains("Version")');
   });

--- a/modules/tinymce/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
@@ -45,7 +45,7 @@ describe('browser.tinymce.plugins.help.DialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-label="close"]');
+    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-name="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('Handy Shortcuts Tab', '.tox-dialog__body-nav-item:contains("Handy Shortcuts")');
     pressDownArrowKey(editor);
@@ -60,7 +60,7 @@ describe('browser.tinymce.plugins.help.DialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-label="close"]');
+    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-name="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('Keyboard Nav Tab', '.tox-dialog__body-nav-item:contains("Keyboard Navigation")');
     pressDownArrowKey(editor);
@@ -82,7 +82,7 @@ describe('browser.tinymce.plugins.help.DialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-label="close"]');
+    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-name="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('Plugins Tab', '.tox-dialog__body-nav-item:contains("Plugins")');
     pressDownArrowKey(editor);
@@ -99,7 +99,7 @@ describe('browser.tinymce.plugins.help.DialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-label="close"]');
+    await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-name="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('Version Tab', '.tox-dialog__body-nav-item:contains("Version")');
   });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -59,7 +59,7 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
     editor.execCommand('mceImage');
     await TinyUiActions.pWaitForDialog(editor);
-    Mouse.clickOn(SugarBody.body(), 'button[data-mce-label="Browse files"]');
+    Mouse.clickOn(SugarBody.body(), 'button[data-mce-name="Browse files"]');
     await Waiter.pTryUntil('Wait for width to be populated', () => assertInputValue(generalTabSelectors.width, '200'));
     TinyUiActions.submitDialog(editor);
     assertCleanHtml('Checking output', editor, '<p><img src="https://www.google.com/logos/google.jpg" alt="" width="200"></p>');

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -59,7 +59,7 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
     editor.execCommand('mceImage');
     await TinyUiActions.pWaitForDialog(editor);
-    Mouse.clickOn(SugarBody.body(), 'button[title="Browse files"]');
+    Mouse.clickOn(SugarBody.body(), 'button[data-mce-btn="Browse files"]');
     await Waiter.pTryUntil('Wait for width to be populated', () => assertInputValue(generalTabSelectors.width, '200'));
     TinyUiActions.submitDialog(editor);
     assertCleanHtml('Checking output', editor, '<p><img src="https://www.google.com/logos/google.jpg" alt="" width="200"></p>');

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -59,7 +59,7 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
     editor.execCommand('mceImage');
     await TinyUiActions.pWaitForDialog(editor);
-    Mouse.clickOn(SugarBody.body(), 'button[data-mce-btn="Browse files"]');
+    Mouse.clickOn(SugarBody.body(), 'button[data-mce-label="Browse files"]');
     await Waiter.pTryUntil('Wait for width to be populated', () => assertInputValue(generalTabSelectors.width, '200'));
     TinyUiActions.submitDialog(editor);
     assertCleanHtml('Checking output', editor, '<p><img src="https://www.google.com/logos/google.jpg" alt="" width="200"></p>');

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
@@ -208,10 +208,10 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
     editor.setContent('<p>Content</p><p><img src="image.png"></p>');
 
     TinySelections.setCursor(editor, [ 0, 0 ], 4);
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[title="Insert/edit image"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[data-mce-btn="image"]:not(.tox-tbtn--enabled)');
 
     TinySelections.setSelection(editor, [ 1 ], 0, [ 1 ], 1);
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled[title="Insert/edit image"]');
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn.tox-tbtn--enabled[title="Insert/edit image"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled[data-mce-btn="image"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn.tox-tbtn--enabled[data-mce-btn="image"]');
   });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
@@ -208,10 +208,10 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
     editor.setContent('<p>Content</p><p><img src="image.png"></p>');
 
     TinySelections.setCursor(editor, [ 0, 0 ], 4);
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[data-mce-label="image"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[data-mce-name="image"]:not(.tox-tbtn--enabled)');
 
     TinySelections.setSelection(editor, [ 1 ], 0, [ 1 ], 1);
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled[data-mce-label="image"]');
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn.tox-tbtn--enabled[data-mce-label="image"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled[data-mce-name="image"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn.tox-tbtn--enabled[data-mce-name="image"]');
   });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
@@ -208,10 +208,10 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
     editor.setContent('<p>Content</p><p><img src="image.png"></p>');
 
     TinySelections.setCursor(editor, [ 0, 0 ], 4);
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[data-mce-btn="image"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[data-mce-label="image"]:not(.tox-tbtn--enabled)');
 
     TinySelections.setSelection(editor, [ 1 ], 0, [ 1 ], 1);
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled[data-mce-btn="image"]');
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn.tox-tbtn--enabled[data-mce-btn="image"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled[data-mce-label="image"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn.tox-tbtn--enabled[data-mce-label="image"]');
   });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/NoneditableRootTest.ts
@@ -28,11 +28,11 @@ describe('browser.tinymce.plugins.image.NoneditableRootTest', () => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Image..."][aria-disabled="true"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Image..."][aria-disabled="true"]');
       TinyUiActions.keystroke(editor, Keys.escape());
       TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Image..."][aria-disabled="false"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Image..."][aria-disabled="false"]');
       TinyUiActions.keystroke(editor, Keys.escape());
     });
   });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageAlignTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/core/ImageAlignTest.ts
@@ -132,8 +132,8 @@ describe('browser.tinymce.plugins.image.ImageAlignTest', () => {
     const ariaLabel = ariaLabels[alignment];
 
     TinyUiActions.clickOnToolbar(editor, `button[aria-label^="Align"].tox-tbtn--select`);
-    await TinyUiActions.pWaitForUi(editor, `div[title="${ariaLabel}"]`);
-    TinyUiActions.clickOnUi(editor, `div[title="${ariaLabel}"]`);
+    await TinyUiActions.pWaitForUi(editor, `div[aria-label="${ariaLabel}"]`);
+    TinyUiActions.clickOnUi(editor, `div[aria-label="${ariaLabel}"]`);
   };
 
   const pApplyAlignmentFromToolbar = (editor: Editor, alignment: Alignment) => {

--- a/modules/tinymce/src/plugins/insertdatetime/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/test/ts/browser/NoneditableRootTest.ts
@@ -28,11 +28,11 @@ describe('browser.tinymce.plugins.insertdatetime.NoneditableRootTest', () => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Date/time"][aria-disabled="true"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Date/time"][aria-disabled="true"]');
       TinyUiActions.keystroke(editor, Keys.escape());
       TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Date/time"][aria-disabled="false"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Date/time"][aria-disabled="false"]');
       TinyUiActions.keystroke(editor, Keys.escape());
     });
   });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/ContextMenuTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/ContextMenuTest.ts
@@ -42,7 +42,7 @@ describe('browser.tinymce.plugins.link.ContextMenuTest', () => {
     );
     Mouse.contextMenuOn(TinyDom.body(editor), 'a');
     await pOpenContextMenu(editor, 'a');
-    UiFinder.notExists(SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(TinyDom.targetElement(editor))), 'div[title="Link..."');
+    UiFinder.notExists(SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(TinyDom.targetElement(editor))), 'div[aria-label="Link..."');
   });
 
   it('TINY-9491: Opening context not on a cef', async () => {
@@ -53,6 +53,6 @@ describe('browser.tinymce.plugins.link.ContextMenuTest', () => {
     );
     Mouse.contextMenuOn(TinyDom.body(editor), 'a');
     await pOpenContextMenu(editor, 'a');
-    UiFinder.exists(SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(TinyDom.targetElement(editor))), 'div[title="Link..."');
+    UiFinder.exists(SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(TinyDom.targetElement(editor))), 'div[aria-label="Link..."');
   });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DialogOpenTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DialogOpenTest.ts
@@ -45,7 +45,7 @@ describe('browser.tinymce.plugins.link.DialogOpenTest', () => {
   const pTestOpenBothDialog = async (editor: Editor) => {
     TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
     await TinyUiActions.pWaitForUi(editor, '[role="menu"]');
-    TinyUiActions.clickOnUi(editor, `[role="menu"] [title="Link..."]`);
+    TinyUiActions.clickOnUi(editor, `[role="menu"] [aria-label="Link..."]`);
     await pDialogCheck(editor);
     TinyUiActions.clickOnToolbar(editor, 'div.tox-toolbar__group > button');
     await pDialogCheck(editor);

--- a/modules/tinymce/src/plugins/link/test/ts/browser/LinkDialogOverrideTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/LinkDialogOverrideTest.ts
@@ -52,18 +52,18 @@ describe('browser.tinymce.plugins.link.LinkDialogOverrideTest', () => {
     await TinyUiActions.pWaitForDialog(editor);
 
     // Assert save button disabled
-    UiFinder.exists(sugarBody, 'button[data-mce-btn="Save"][disabled="disabled"]');
+    UiFinder.exists(sugarBody, 'button[data-mce-label="Save"][disabled="disabled"]');
     const input = UiFinder.findIn<HTMLInputElement>(sugarBody, 'input[type="url"]').getOrDie();
 
     // Set value and fire 'input' event
     UiControls.setValue(input, 'https://www.google.com', 'input');
 
     // Button is now enabled
-    UiFinder.exists(sugarBody, 'button[data-mce-btn="Save"]:not([disabled])');
+    UiFinder.exists(sugarBody, 'button[data-mce-label="Save"]:not([disabled])');
 
     // Button is disabled again when field is empty
     UiControls.setValue(input, '', 'input');
-    UiFinder.exists(sugarBody, 'button[data-mce-btn="Save"][disabled="disabled"]');
+    UiFinder.exists(sugarBody, 'button[data-mce-label="Save"][disabled="disabled"]');
     TinyUiActions.closeDialog(editor);
   });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/LinkDialogOverrideTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/LinkDialogOverrideTest.ts
@@ -52,18 +52,18 @@ describe('browser.tinymce.plugins.link.LinkDialogOverrideTest', () => {
     await TinyUiActions.pWaitForDialog(editor);
 
     // Assert save button disabled
-    UiFinder.exists(sugarBody, 'button[data-mce-label="Save"][disabled="disabled"]');
+    UiFinder.exists(sugarBody, 'button[data-mce-name="Save"][disabled="disabled"]');
     const input = UiFinder.findIn<HTMLInputElement>(sugarBody, 'input[type="url"]').getOrDie();
 
     // Set value and fire 'input' event
     UiControls.setValue(input, 'https://www.google.com', 'input');
 
     // Button is now enabled
-    UiFinder.exists(sugarBody, 'button[data-mce-label="Save"]:not([disabled])');
+    UiFinder.exists(sugarBody, 'button[data-mce-name="Save"]:not([disabled])');
 
     // Button is disabled again when field is empty
     UiControls.setValue(input, '', 'input');
-    UiFinder.exists(sugarBody, 'button[data-mce-label="Save"][disabled="disabled"]');
+    UiFinder.exists(sugarBody, 'button[data-mce-name="Save"][disabled="disabled"]');
     TinyUiActions.closeDialog(editor);
   });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/LinkDialogOverrideTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/LinkDialogOverrideTest.ts
@@ -52,18 +52,18 @@ describe('browser.tinymce.plugins.link.LinkDialogOverrideTest', () => {
     await TinyUiActions.pWaitForDialog(editor);
 
     // Assert save button disabled
-    UiFinder.exists(sugarBody, 'button[title="Save"][disabled="disabled"]');
+    UiFinder.exists(sugarBody, 'button[data-mce-btn="Save"][disabled="disabled"]');
     const input = UiFinder.findIn<HTMLInputElement>(sugarBody, 'input[type="url"]').getOrDie();
 
     // Set value and fire 'input' event
     UiControls.setValue(input, 'https://www.google.com', 'input');
 
     // Button is now enabled
-    UiFinder.exists(sugarBody, 'button[title="Save"]:not([disabled])');
+    UiFinder.exists(sugarBody, 'button[data-mce-btn="Save"]:not([disabled])');
 
     // Button is disabled again when field is empty
     UiControls.setValue(input, '', 'input');
-    UiFinder.exists(sugarBody, 'button[title="Save"][disabled="disabled"]');
+    UiFinder.exists(sugarBody, 'button[data-mce-btn="Save"][disabled="disabled"]');
     TinyUiActions.closeDialog(editor);
   });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/NoneditableRootTest.ts
@@ -41,11 +41,11 @@ describe('browser.tinymce.plugins.link.NoneditableRootTest', () => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Link..."][aria-disabled="true"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Link..."][aria-disabled="true"]');
       TinyUiActions.keystroke(editor, Keys.escape());
       TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Link..."][aria-disabled="false"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Link..."][aria-disabled="false"]');
       TinyUiActions.keystroke(editor, Keys.escape());
     });
   });
@@ -55,11 +55,11 @@ describe('browser.tinymce.plugins.link.NoneditableRootTest', () => {
       editor.setContent('<div><a href="#">Noneditable content</a></div><div contenteditable="true"><a href="#">Editable content</a></div>');
       TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Remove link"][aria-disabled="true"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Remove link"][aria-disabled="true"]');
       TinyUiActions.keystroke(editor, Keys.escape());
       TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 1, 0, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Remove link"][aria-disabled="false"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Remove link"][aria-disabled="false"]');
       TinyUiActions.keystroke(editor, Keys.escape());
     });
   });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
@@ -43,7 +43,7 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
     const editor = hook.editor();
     editor.setContent('<p><a href="http://tiny.cloud">tiny</a> content <a href="http://tiny.cloud">link</a> with <a href="http://tiny.cloud">other</a></p>');
     TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 4, 0 ], 2);
-    TinyUiActions.clickOnUi(editor, 'button[data-mce-label="unlink"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-name="unlink"]');
     TinyAssertions.assertContentPresence(editor, { a: 0 });
     TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 4 ], 2);
   });
@@ -53,7 +53,7 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
       const editor = hook.editor();
       editor.setContent('<a href="#"><p>tiny</p></a>');
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
-      TinyUiActions.clickOnUi(editor, 'button[data-mce-label="unlink"]');
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-name="unlink"]');
       TinyAssertions.assertContent(editor, '<p>tiny</p>');
       TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
     });
@@ -62,7 +62,7 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
       const editor = hook.editor();
       editor.setContent('<div><a href="#"><p>tiny</p></a></div>');
       TinySelections.setCursor(editor, [ 0, 0, 0, 0 ], 1);
-      TinyUiActions.clickOnUi(editor, 'button[data-mce-label="unlink"]');
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-name="unlink"]');
       TinyAssertions.assertContent(editor, '<div><p>tiny</p></div>');
       TinyAssertions.assertCursor(editor, [ 0, 0, 0 ], 1);
     });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
@@ -17,7 +17,7 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
     editor.setContent('<p><a href="http://tiny.cloud">tiny</a></p>');
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
     await TinyUiActions.pTriggerContextMenu(editor, 'a[href="http://tiny.cloud"]', '.tox-silver-sink [role="menuitem"]');
-    TinyUiActions.clickOnUi(editor, 'div[title="Remove link"]');
+    TinyUiActions.clickOnUi(editor, 'div[aria-label="Remove link"]');
     TinyAssertions.assertContentPresence(editor, { 'a[href="http://tiny.cloud"]': 0 });
   });
 
@@ -26,7 +26,7 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
     editor.setContent('<p><a href="http://tiny.cloud">tiny</a></p>');
     TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2);
     await TinyUiActions.pTriggerContextMenu(editor, 'a[href="http://tiny.cloud"]', '.tox-silver-sink [role="menuitem"]');
-    TinyUiActions.clickOnUi(editor, 'div[title="Remove link"]');
+    TinyUiActions.clickOnUi(editor, 'div[aria-label="Remove link"]');
     TinyAssertions.assertContentPresence(editor, { 'a[href="http://tiny.cloud"]': 0 });
   });
 
@@ -35,7 +35,7 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
     editor.setContent('<p><a href="http://tiny.cloud"><img src="http://moxiecode.cachefly.net/tinymce/v9/images/logo.png" /></a></p>');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     await TinyUiActions.pTriggerContextMenu(editor, 'a[href="http://tiny.cloud"]', '.tox-silver-sink [role="menuitem"]');
-    TinyUiActions.clickOnUi(editor, 'div[title="Remove link"]');
+    TinyUiActions.clickOnUi(editor, 'div[aria-label="Remove link"]');
     TinyAssertions.assertContentPresence(editor, { 'a[href="http://tiny.cloud"]': 0 });
   });
 
@@ -43,7 +43,7 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
     const editor = hook.editor();
     editor.setContent('<p><a href="http://tiny.cloud">tiny</a> content <a href="http://tiny.cloud">link</a> with <a href="http://tiny.cloud">other</a></p>');
     TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 4, 0 ], 2);
-    TinyUiActions.clickOnToolbar(editor, 'button[title="Remove link"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="unlink"]');
     TinyAssertions.assertContentPresence(editor, { a: 0 });
     TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 4 ], 2);
   });
@@ -53,7 +53,7 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
       const editor = hook.editor();
       editor.setContent('<a href="#"><p>tiny</p></a>');
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
-      TinyUiActions.clickOnToolbar(editor, 'button[title="Remove link"]');
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="unlink"]');
       TinyAssertions.assertContent(editor, '<p>tiny</p>');
       TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
     });
@@ -62,7 +62,7 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
       const editor = hook.editor();
       editor.setContent('<div><a href="#"><p>tiny</p></a></div>');
       TinySelections.setCursor(editor, [ 0, 0, 0, 0 ], 1);
-      TinyUiActions.clickOnToolbar(editor, 'button[title="Remove link"]');
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="unlink"]');
       TinyAssertions.assertContent(editor, '<div><p>tiny</p></div>');
       TinyAssertions.assertCursor(editor, [ 0, 0, 0 ], 1);
     });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
@@ -43,7 +43,7 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
     const editor = hook.editor();
     editor.setContent('<p><a href="http://tiny.cloud">tiny</a> content <a href="http://tiny.cloud">link</a> with <a href="http://tiny.cloud">other</a></p>');
     TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 4, 0 ], 2);
-    TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="unlink"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-label="unlink"]');
     TinyAssertions.assertContentPresence(editor, { a: 0 });
     TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 4 ], 2);
   });
@@ -53,7 +53,7 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
       const editor = hook.editor();
       editor.setContent('<a href="#"><p>tiny</p></a>');
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
-      TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="unlink"]');
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-label="unlink"]');
       TinyAssertions.assertContent(editor, '<p>tiny</p>');
       TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
     });
@@ -62,7 +62,7 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
       const editor = hook.editor();
       editor.setContent('<div><a href="#"><p>tiny</p></a></div>');
       TinySelections.setCursor(editor, [ 0, 0, 0, 0 ], 1);
-      TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="unlink"]');
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-label="unlink"]');
       TinyAssertions.assertContent(editor, '<div><p>tiny</p></div>');
       TinyAssertions.assertCursor(editor, [ 0, 0, 0 ], 1);
     });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
@@ -32,13 +32,13 @@ describe('browser.tinymce.plugins.link.SelectedImageFigureTest', () => {
       </figure>
     `);
 
-    await TinyUiActions.pWaitForUi(editor, '[data-mce-btn="link"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, '[data-mce-label="link"]:not(.tox-tbtn--enabled)');
 
     TinySelections.select(editor, 'figure.has-link', []);
-    await TinyUiActions.pWaitForUi(editor, '[data-mce-btn="link"].tox-tbtn--enabled');
+    await TinyUiActions.pWaitForUi(editor, '[data-mce-label="link"].tox-tbtn--enabled');
 
     TinySelections.select(editor, 'figure.no-link', []);
-    await TinyUiActions.pWaitForUi(editor, '[data-mce-btn="link"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, '[data-mce-label="link"]:not(.tox-tbtn--enabled)');
   });
 
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
@@ -32,13 +32,13 @@ describe('browser.tinymce.plugins.link.SelectedImageFigureTest', () => {
       </figure>
     `);
 
-    await TinyUiActions.pWaitForUi(editor, '[data-mce-label="link"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, '[data-mce-name="link"]:not(.tox-tbtn--enabled)');
 
     TinySelections.select(editor, 'figure.has-link', []);
-    await TinyUiActions.pWaitForUi(editor, '[data-mce-label="link"].tox-tbtn--enabled');
+    await TinyUiActions.pWaitForUi(editor, '[data-mce-name="link"].tox-tbtn--enabled');
 
     TinySelections.select(editor, 'figure.no-link', []);
-    await TinyUiActions.pWaitForUi(editor, '[data-mce-label="link"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, '[data-mce-name="link"]:not(.tox-tbtn--enabled)');
   });
 
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedImageFigureLinkTest.ts
@@ -32,13 +32,13 @@ describe('browser.tinymce.plugins.link.SelectedImageFigureTest', () => {
       </figure>
     `);
 
-    await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, '[data-mce-btn="link"]:not(.tox-tbtn--enabled)');
 
     TinySelections.select(editor, 'figure.has-link', []);
-    await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"].tox-tbtn--enabled');
+    await TinyUiActions.pWaitForUi(editor, '[data-mce-btn="link"].tox-tbtn--enabled');
 
     TinySelections.select(editor, 'figure.no-link', []);
-    await TinyUiActions.pWaitForUi(editor, '[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, '[data-mce-btn="link"]:not(.tox-tbtn--enabled)');
   });
 
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedLinkTest.ts
@@ -35,16 +35,16 @@ describe('browser.tinymce.plugins.link.SelectedLinkTest', () => {
     editor.setContent('<p><a href="http://tinymce.com">a</a> b <a href="http://tinymce.com">c</a></p>');
     // Check the link button is enabled (single link)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="link"].tox-tbtn--enabled');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="link"].tox-tbtn--enabled');
     // Check the link button is enabled (collapsed in link)
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="link"].tox-tbtn--enabled');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="link"].tox-tbtn--enabled');
     // Check the link button is disabled (text)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 3);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="link"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="link"]:not(.tox-tbtn--enabled)');
     // Check the link button is disabled (multiple links)
     TinySelections.setSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 2);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="link"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="link"]:not(.tox-tbtn--enabled)');
   });
 
   it('TINY-4867: openlink should be disabled when multiple links or plain text selected', async () => {
@@ -52,16 +52,16 @@ describe('browser.tinymce.plugins.link.SelectedLinkTest', () => {
     editor.setContent('<p><a href="http://tinymce.com">a</a> b <a href="http://tinymce.com">c</a></p>');
     // Check the open link button is enabled (single link)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="openlink"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="openlink"]:not(.tox-tbtn--disabled)');
     // Check the open link button is enabled (collapsed in link)
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="openlink"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="openlink"]:not(.tox-tbtn--disabled)');
     // Check the open link button is disabled (text)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 3);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="openlink"].tox-tbtn--disabled');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="openlink"].tox-tbtn--disabled');
     // Check the open link button is disabled (multiple links)
     TinySelections.setSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 2);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="openlink"].tox-tbtn--disabled');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="openlink"].tox-tbtn--disabled');
   });
 
   it('TINY-4867: unlink should be enabled when single link or multiple links selected', async () => {
@@ -69,15 +69,15 @@ describe('browser.tinymce.plugins.link.SelectedLinkTest', () => {
     editor.setContent('<p><a href="http://tinymce.com">a</a> b <a href="http://tinymce.com">c</a></p>');
     // Check the unlink button is enabled (single link)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 3);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="unlink"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="unlink"]:not(.tox-tbtn--disabled)');
     // Check the unlink button is enabled (collapsed in link)
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="unlink"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="unlink"]:not(.tox-tbtn--disabled)');
     // Check the unlink button is disabled (text)
     TinySelections.setSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 2);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="unlink"].tox-tbtn--disabled');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="unlink"].tox-tbtn--disabled');
     // Check the unlink button is enabled (multiple links)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="unlink"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="unlink"]:not(.tox-tbtn--disabled)');
   });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedLinkTest.ts
@@ -35,16 +35,16 @@ describe('browser.tinymce.plugins.link.SelectedLinkTest', () => {
     editor.setContent('<p><a href="http://tinymce.com">a</a> b <a href="http://tinymce.com">c</a></p>');
     // Check the link button is enabled (single link)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="link"].tox-tbtn--enabled');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-name="link"].tox-tbtn--enabled');
     // Check the link button is enabled (collapsed in link)
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="link"].tox-tbtn--enabled');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-name="link"].tox-tbtn--enabled');
     // Check the link button is disabled (text)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 3);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="link"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-name="link"]:not(.tox-tbtn--enabled)');
     // Check the link button is disabled (multiple links)
     TinySelections.setSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 2);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="link"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-name="link"]:not(.tox-tbtn--enabled)');
   });
 
   it('TINY-4867: openlink should be disabled when multiple links or plain text selected', async () => {
@@ -52,16 +52,16 @@ describe('browser.tinymce.plugins.link.SelectedLinkTest', () => {
     editor.setContent('<p><a href="http://tinymce.com">a</a> b <a href="http://tinymce.com">c</a></p>');
     // Check the open link button is enabled (single link)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="openlink"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-name="openlink"]:not(.tox-tbtn--disabled)');
     // Check the open link button is enabled (collapsed in link)
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="openlink"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-name="openlink"]:not(.tox-tbtn--disabled)');
     // Check the open link button is disabled (text)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 3);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="openlink"].tox-tbtn--disabled');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-name="openlink"].tox-tbtn--disabled');
     // Check the open link button is disabled (multiple links)
     TinySelections.setSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 2);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="openlink"].tox-tbtn--disabled');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-name="openlink"].tox-tbtn--disabled');
   });
 
   it('TINY-4867: unlink should be enabled when single link or multiple links selected', async () => {
@@ -69,15 +69,15 @@ describe('browser.tinymce.plugins.link.SelectedLinkTest', () => {
     editor.setContent('<p><a href="http://tinymce.com">a</a> b <a href="http://tinymce.com">c</a></p>');
     // Check the unlink button is enabled (single link)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 3);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="unlink"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-name="unlink"]:not(.tox-tbtn--disabled)');
     // Check the unlink button is enabled (collapsed in link)
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="unlink"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-name="unlink"]:not(.tox-tbtn--disabled)');
     // Check the unlink button is disabled (text)
     TinySelections.setSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 2);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="unlink"].tox-tbtn--disabled');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-name="unlink"].tox-tbtn--disabled');
     // Check the unlink button is enabled (multiple links)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
-    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-label="unlink"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-name="unlink"]:not(.tox-tbtn--disabled)');
   });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedLinkTest.ts
@@ -35,16 +35,16 @@ describe('browser.tinymce.plugins.link.SelectedLinkTest', () => {
     editor.setContent('<p><a href="http://tinymce.com">a</a> b <a href="http://tinymce.com">c</a></p>');
     // Check the link button is enabled (single link)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
-    await TinyUiActions.pWaitForUi(editor, 'button[title="Insert/edit link"].tox-tbtn--enabled');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="link"].tox-tbtn--enabled');
     // Check the link button is enabled (collapsed in link)
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
-    await TinyUiActions.pWaitForUi(editor, 'button[title="Insert/edit link"].tox-tbtn--enabled');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="link"].tox-tbtn--enabled');
     // Check the link button is disabled (text)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 3);
-    await TinyUiActions.pWaitForUi(editor, 'button[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="link"]:not(.tox-tbtn--enabled)');
     // Check the link button is disabled (multiple links)
     TinySelections.setSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 2);
-    await TinyUiActions.pWaitForUi(editor, 'button[title="Insert/edit link"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="link"]:not(.tox-tbtn--enabled)');
   });
 
   it('TINY-4867: openlink should be disabled when multiple links or plain text selected', async () => {
@@ -52,16 +52,16 @@ describe('browser.tinymce.plugins.link.SelectedLinkTest', () => {
     editor.setContent('<p><a href="http://tinymce.com">a</a> b <a href="http://tinymce.com">c</a></p>');
     // Check the open link button is enabled (single link)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
-    await TinyUiActions.pWaitForUi(editor, 'button[title="Open link"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="openlink"]:not(.tox-tbtn--disabled)');
     // Check the open link button is enabled (collapsed in link)
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
-    await TinyUiActions.pWaitForUi(editor, 'button[title="Open link"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="openlink"]:not(.tox-tbtn--disabled)');
     // Check the open link button is disabled (text)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 3);
-    await TinyUiActions.pWaitForUi(editor, 'button[title="Open link"].tox-tbtn--disabled');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="openlink"].tox-tbtn--disabled');
     // Check the open link button is disabled (multiple links)
     TinySelections.setSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 2);
-    await TinyUiActions.pWaitForUi(editor, 'button[title="Open link"].tox-tbtn--disabled');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="openlink"].tox-tbtn--disabled');
   });
 
   it('TINY-4867: unlink should be enabled when single link or multiple links selected', async () => {
@@ -69,15 +69,15 @@ describe('browser.tinymce.plugins.link.SelectedLinkTest', () => {
     editor.setContent('<p><a href="http://tinymce.com">a</a> b <a href="http://tinymce.com">c</a></p>');
     // Check the unlink button is enabled (single link)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 3);
-    await TinyUiActions.pWaitForUi(editor, 'button[title="Remove link"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="unlink"]:not(.tox-tbtn--disabled)');
     // Check the unlink button is enabled (collapsed in link)
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
-    await TinyUiActions.pWaitForUi(editor, 'button[title="Remove link"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="unlink"]:not(.tox-tbtn--disabled)');
     // Check the unlink button is disabled (text)
     TinySelections.setSelection(editor, [ 0, 1 ], 0, [ 0, 1 ], 2);
-    await TinyUiActions.pWaitForUi(editor, 'button[title="Remove link"].tox-tbtn--disabled');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="unlink"].tox-tbtn--disabled');
     // Check the unlink button is enabled (multiple links)
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
-    await TinyUiActions.pWaitForUi(editor, 'button[title="Remove link"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, 'button[data-mce-btn="unlink"]:not(.tox-tbtn--disabled)');
   });
 });

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/NoneditableRootTest.ts
@@ -160,8 +160,8 @@ describe('browser.tinymce.plugins.lists.NoneditableRootTest', () => {
       TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
         setupEditor(editor);
 
-        UiFinder.exists(SugarBody.body(), 'button[data-mce-label="numlist"][aria-disabled="true"]');
-        UiFinder.exists(SugarBody.body(), 'button[data-mce-label="bullist"][aria-disabled="true"]');
+        UiFinder.exists(SugarBody.body(), 'button[data-mce-name="numlist"][aria-disabled="true"]');
+        UiFinder.exists(SugarBody.body(), 'button[data-mce-name="bullist"][aria-disabled="true"]');
       });
     });
 
@@ -169,10 +169,10 @@ describe('browser.tinymce.plugins.lists.NoneditableRootTest', () => {
       TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
         setupEditor(editor);
 
-        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="outdent"]');
+        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="outdent"]');
         TinyAssertions.assertContent(editor, initialListContent);
 
-        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="indent"]');
+        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="indent"]');
         TinyAssertions.assertContent(editor, initialListContent);
       });
     });

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/NoneditableRootTest.ts
@@ -160,8 +160,8 @@ describe('browser.tinymce.plugins.lists.NoneditableRootTest', () => {
       TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
         setupEditor(editor);
 
-        UiFinder.exists(SugarBody.body(), 'button[data-mce-btn="numlist"][aria-disabled="true"]');
-        UiFinder.exists(SugarBody.body(), 'button[data-mce-btn="bullist"][aria-disabled="true"]');
+        UiFinder.exists(SugarBody.body(), 'button[data-mce-label="numlist"][aria-disabled="true"]');
+        UiFinder.exists(SugarBody.body(), 'button[data-mce-label="bullist"][aria-disabled="true"]');
       });
     });
 
@@ -169,10 +169,10 @@ describe('browser.tinymce.plugins.lists.NoneditableRootTest', () => {
       TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
         setupEditor(editor);
 
-        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="outdent"]');
+        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="outdent"]');
         TinyAssertions.assertContent(editor, initialListContent);
 
-        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="indent"]');
+        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="indent"]');
         TinyAssertions.assertContent(editor, initialListContent);
       });
     });

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/NoneditableRootTest.ts
@@ -160,8 +160,8 @@ describe('browser.tinymce.plugins.lists.NoneditableRootTest', () => {
       TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
         setupEditor(editor);
 
-        UiFinder.exists(SugarBody.body(), 'button[title="Numbered list"][aria-disabled="true"]');
-        UiFinder.exists(SugarBody.body(), 'button[title="Bullet list"][aria-disabled="true"]');
+        UiFinder.exists(SugarBody.body(), 'button[data-mce-btn="numlist"][aria-disabled="true"]');
+        UiFinder.exists(SugarBody.body(), 'button[data-mce-btn="bullist"][aria-disabled="true"]');
       });
     });
 
@@ -169,10 +169,10 @@ describe('browser.tinymce.plugins.lists.NoneditableRootTest', () => {
       TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
         setupEditor(editor);
 
-        TinyUiActions.clickOnToolbar(editor, 'button[title="Decrease indent"]');
+        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="outdent"]');
         TinyAssertions.assertContent(editor, initialListContent);
 
-        TinyUiActions.clickOnToolbar(editor, 'button[title="Increase indent"]');
+        TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="indent"]');
         TinyAssertions.assertContent(editor, initialListContent);
       });
     });

--- a/modules/tinymce/src/plugins/lists/test/ts/webdriver/ContextMenuTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/webdriver/ContextMenuTest.ts
@@ -25,6 +25,6 @@ describe('webdriver.tinymce.plugins.lists.ContextMenuTest', () => {
       </ol>`
     );
     await RealMouse.pRightClickOn('iframe => ol > li');
-    UiFinder.exists(SugarBody.body(), '[title="List properties..."][aria-disabled="false"]');
+    UiFinder.exists(SugarBody.body(), '[aria-label="List properties..."][aria-disabled="false"]');
   });
 });

--- a/modules/tinymce/src/plugins/media/test/ts/browser/MediaPluginSanityTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/MediaPluginSanityTest.ts
@@ -77,11 +77,11 @@ describe.skip('browser.tinymce.plugins.media.MediaPluginSanityTest', () => {
     editor.setContent('<p>Content</p><p><iframe src="https://www.youtube.com/embed/b3XFjWInBog" width="560" height="314" allowFullscreen="1"></iframe></p>');
 
     TinySelections.setCursor(editor, [ 0, 0 ], 4);
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[title="Insert/edit media"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[data-mce-btn="media"]:not(.tox-tbtn--enabled)');
 
     TinySelections.setSelection(editor, [ 1 ], 0, [ 1 ], 1);
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled[title="Insert/edit media"]');
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn.tox-tbtn--enabled[title="Insert/edit media"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled[data-mce-btn="media"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn.tox-tbtn--enabled[data-mce-btn="media"]');
   });
 
   it('TINY-8660: Iframe media can be updated after being inserted', async () => {

--- a/modules/tinymce/src/plugins/media/test/ts/browser/MediaPluginSanityTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/MediaPluginSanityTest.ts
@@ -77,11 +77,11 @@ describe.skip('browser.tinymce.plugins.media.MediaPluginSanityTest', () => {
     editor.setContent('<p>Content</p><p><iframe src="https://www.youtube.com/embed/b3XFjWInBog" width="560" height="314" allowFullscreen="1"></iframe></p>');
 
     TinySelections.setCursor(editor, [ 0, 0 ], 4);
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[data-mce-label="media"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[data-mce-name="media"]:not(.tox-tbtn--enabled)');
 
     TinySelections.setSelection(editor, [ 1 ], 0, [ 1 ], 1);
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled[data-mce-label="media"]');
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn.tox-tbtn--enabled[data-mce-label="media"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled[data-mce-name="media"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn.tox-tbtn--enabled[data-mce-name="media"]');
   });
 
   it('TINY-8660: Iframe media can be updated after being inserted', async () => {

--- a/modules/tinymce/src/plugins/media/test/ts/browser/MediaPluginSanityTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/MediaPluginSanityTest.ts
@@ -77,11 +77,11 @@ describe.skip('browser.tinymce.plugins.media.MediaPluginSanityTest', () => {
     editor.setContent('<p>Content</p><p><iframe src="https://www.youtube.com/embed/b3XFjWInBog" width="560" height="314" allowFullscreen="1"></iframe></p>');
 
     TinySelections.setCursor(editor, [ 0, 0 ], 4);
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[data-mce-btn="media"]:not(.tox-tbtn--enabled)');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[data-mce-label="media"]:not(.tox-tbtn--enabled)');
 
     TinySelections.setSelection(editor, [ 1 ], 0, [ 1 ], 1);
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled[data-mce-btn="media"]');
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn.tox-tbtn--enabled[data-mce-btn="media"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn.tox-tbtn--enabled[data-mce-label="media"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn.tox-tbtn--enabled[data-mce-label="media"]');
   });
 
   it('TINY-8660: Iframe media can be updated after being inserted', async () => {

--- a/modules/tinymce/src/plugins/media/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/NoneditableRootTest.ts
@@ -28,11 +28,11 @@ describe('browser.tinymce.plugins.media.NoneditableRootTest', () => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Media..."][aria-disabled="true"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Media..."][aria-disabled="true"]');
       TinyUiActions.keystroke(editor, Keys.escape());
       TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Media..."][aria-disabled="false"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Media..."][aria-disabled="false"]');
       TinyUiActions.keystroke(editor, Keys.escape());
     });
   });

--- a/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/test/ts/browser/NoneditableRootTest.ts
@@ -28,11 +28,11 @@ describe('browser.tinymce.plugins.nonbreaking.NoneditableRootTest', () => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Nonbreaking space"][aria-disabled="true"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Nonbreaking space"][aria-disabled="true"]');
       TinyUiActions.keystroke(editor, Keys.escape());
       TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Nonbreaking space"][aria-disabled="false"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Nonbreaking space"][aria-disabled="false"]');
       TinyUiActions.keystroke(editor, Keys.escape());
     });
   });

--- a/modules/tinymce/src/plugins/pagebreak/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/pagebreak/test/ts/browser/NoneditableRootTest.ts
@@ -28,11 +28,11 @@ describe('browser.tinymce.plugins.pagebreak.NoneditableRootTest', () => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Page break"][aria-disabled="true"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Page break"][aria-disabled="true"]');
       TinyUiActions.keystroke(editor, Keys.escape());
       TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Page break"][aria-disabled="false"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Page break"][aria-disabled="false"]');
       TinyUiActions.keystroke(editor, Keys.escape());
     });
   });

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceKeyboardNavigationTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceKeyboardNavigationTest.ts
@@ -60,7 +60,7 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceKeyboardNavigationT
     pressEnter(editor);
     await pAssertFocused('Placeholder menu button', '.tox-tbtn--select[aria-label="Preferences"]');
     pressTab(editor);
-    await pAssertFocused('Find button', '.tox-button[data-mce-btn="Find"]');
+    await pAssertFocused('Find button', '.tox-button[data-mce-label="Find"]');
     pressEsc(editor);
   });
 
@@ -74,13 +74,13 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceKeyboardNavigationT
     pressTab(editor);
     await pAssertFocused('Placeholder menu button', '.tox-tbtn--select[aria-label="Preferences"]');
     pressTab(editor);
-    await pAssertFocused('Find button', '.tox-button[data-mce-btn="Find"]');
+    await pAssertFocused('Find button', '.tox-button[data-mce-label="Find"]');
     await Utils.pSetFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'fish');
     pressEnter(editor);
     pressTab(editor);
-    await pAssertFocused('Find button', '.tox-button[data-mce-btn="Replace"]');
+    await pAssertFocused('Find button', '.tox-button[data-mce-label="Replace"]');
     pressTab(editor);
-    await pAssertFocused('Find button', '.tox-button[data-mce-btn="Replace all"]');
+    await pAssertFocused('Find button', '.tox-button[data-mce-label="Replace all"]');
     pressEnter(editor);
     await pAssertFocused('Find input', '.tox-textfield[placeholder="Find"]');
     pressEsc(editor);

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceKeyboardNavigationTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceKeyboardNavigationTest.ts
@@ -54,13 +54,13 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceKeyboardNavigationT
     pressTab(editor);
     await pAssertFocused('Replace with input', '.tox-textfield[placeholder="Replace with"]');
     pressTab(editor);
-    await pAssertFocused('Placeholder menu button', '.tox-tbtn--select[title="Preferences"]');
+    await pAssertFocused('Placeholder menu button', '.tox-tbtn--select[aria-label="Preferences"]');
     pressDown(editor);
     await pAssertFocused('Match case menu item', '.tox-collection__item:contains("Match case")'); // Menu items can be reached by keyboard
     pressEnter(editor);
-    await pAssertFocused('Placeholder menu button', '.tox-tbtn--select[title="Preferences"]');
+    await pAssertFocused('Placeholder menu button', '.tox-tbtn--select[aria-label="Preferences"]');
     pressTab(editor);
-    await pAssertFocused('Find button', '.tox-button[title="Find"]');
+    await pAssertFocused('Find button', '.tox-button[data-mce-btn="Find"]');
     pressEsc(editor);
   });
 
@@ -72,15 +72,15 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceKeyboardNavigationT
     pressTab(editor);
     await pAssertFocused('Replace with input', '.tox-textfield[placeholder="Replace with"]');
     pressTab(editor);
-    await pAssertFocused('Placeholder menu button', '.tox-tbtn--select[title="Preferences"]');
+    await pAssertFocused('Placeholder menu button', '.tox-tbtn--select[aria-label="Preferences"]');
     pressTab(editor);
-    await pAssertFocused('Find button', '.tox-button[title="Find"]');
+    await pAssertFocused('Find button', '.tox-button[data-mce-btn="Find"]');
     await Utils.pSetFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'fish');
     pressEnter(editor);
     pressTab(editor);
-    await pAssertFocused('Find button', '.tox-button[title="Replace"]');
+    await pAssertFocused('Find button', '.tox-button[data-mce-btn="Replace"]');
     pressTab(editor);
-    await pAssertFocused('Find button', '.tox-button[title="Replace all"]');
+    await pAssertFocused('Find button', '.tox-button[data-mce-btn="Replace all"]');
     pressEnter(editor);
     await pAssertFocused('Find input', '.tox-textfield[placeholder="Find"]');
     pressEsc(editor);

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceKeyboardNavigationTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplaceKeyboardNavigationTest.ts
@@ -60,7 +60,7 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceKeyboardNavigationT
     pressEnter(editor);
     await pAssertFocused('Placeholder menu button', '.tox-tbtn--select[aria-label="Preferences"]');
     pressTab(editor);
-    await pAssertFocused('Find button', '.tox-button[data-mce-label="Find"]');
+    await pAssertFocused('Find button', '.tox-button[data-mce-name="Find"]');
     pressEsc(editor);
   });
 
@@ -74,13 +74,13 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplaceKeyboardNavigationT
     pressTab(editor);
     await pAssertFocused('Placeholder menu button', '.tox-tbtn--select[aria-label="Preferences"]');
     pressTab(editor);
-    await pAssertFocused('Find button', '.tox-button[data-mce-label="Find"]');
+    await pAssertFocused('Find button', '.tox-button[data-mce-name="Find"]');
     await Utils.pSetFieldValue(editor, 'input.tox-textfield[placeholder="Find"]', 'fish');
     pressEnter(editor);
     pressTab(editor);
-    await pAssertFocused('Find button', '.tox-button[data-mce-label="Replace"]');
+    await pAssertFocused('Find button', '.tox-button[data-mce-name="Replace"]');
     pressTab(editor);
-    await pAssertFocused('Find button', '.tox-button[data-mce-label="Replace all"]');
+    await pAssertFocused('Find button', '.tox-button[data-mce-name="Replace all"]');
     pressEnter(editor);
     await pAssertFocused('Find input', '.tox-textfield[placeholder="Find"]');
     pressEsc(editor);

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePrevNextTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePrevNextTest.ts
@@ -18,14 +18,14 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplacePrevNextTest', () =
   const body = SugarBody.body();
 
   const pAssertButtonsEnabled = async () => {
-    await UiFinder.pWaitFor('next button enabled', body, 'button[data-mce-btn="Next"]:not([disabled])');
-    await UiFinder.pWaitFor('prev button enabled', body, 'button[data-mce-btn="Previous"]:not([disabled])');
-    await UiFinder.pWaitFor('replace button enabled', body, 'button[data-mce-btn="Replace"]:not([disabled])');
+    await UiFinder.pWaitFor('next button enabled', body, 'button[data-mce-label="Next"]:not([disabled])');
+    await UiFinder.pWaitFor('prev button enabled', body, 'button[data-mce-label="Previous"]:not([disabled])');
+    await UiFinder.pWaitFor('replace button enabled', body, 'button[data-mce-label="Replace"]:not([disabled])');
   };
 
   const pAssertNextPrevButtonsDisabled = async () => {
-    await UiFinder.pWaitFor('next button disabled', body, 'button[data-mce-btn="Next"][disabled]');
-    await UiFinder.pWaitFor('prev button disabled', body, 'button[data-mce-btn="Previous"][disabled]');
+    await UiFinder.pWaitFor('next button disabled', body, 'button[data-mce-label="Next"][disabled]');
+    await UiFinder.pWaitFor('prev button disabled', body, 'button[data-mce-label="Previous"][disabled]');
   };
 
   it('TBA: Test Prev and Next buttons become enabled and disabled at right places when multiple matches exist', async () => {
@@ -58,7 +58,7 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplacePrevNextTest', () =
     await pAssertNextPrevButtonsDisabled();
 
     // Ensure the replace button is still enabled, for the last match
-    await UiFinder.pWaitFor('wait for replace button to be enabled', body, 'button[data-mce-btn="Replace"]:not([disabled])');
+    await UiFinder.pWaitFor('wait for replace button to be enabled', body, 'button[data-mce-label="Replace"]:not([disabled])');
     TinyAssertions.assertContent(editor, '<p>squid squid fish</p>');
   });
 });

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePrevNextTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePrevNextTest.ts
@@ -18,14 +18,14 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplacePrevNextTest', () =
   const body = SugarBody.body();
 
   const pAssertButtonsEnabled = async () => {
-    await UiFinder.pWaitFor('next button enabled', body, 'button[data-mce-label="Next"]:not([disabled])');
-    await UiFinder.pWaitFor('prev button enabled', body, 'button[data-mce-label="Previous"]:not([disabled])');
-    await UiFinder.pWaitFor('replace button enabled', body, 'button[data-mce-label="Replace"]:not([disabled])');
+    await UiFinder.pWaitFor('next button enabled', body, 'button[data-mce-name="Next"]:not([disabled])');
+    await UiFinder.pWaitFor('prev button enabled', body, 'button[data-mce-name="Previous"]:not([disabled])');
+    await UiFinder.pWaitFor('replace button enabled', body, 'button[data-mce-name="Replace"]:not([disabled])');
   };
 
   const pAssertNextPrevButtonsDisabled = async () => {
-    await UiFinder.pWaitFor('next button disabled', body, 'button[data-mce-label="Next"][disabled]');
-    await UiFinder.pWaitFor('prev button disabled', body, 'button[data-mce-label="Previous"][disabled]');
+    await UiFinder.pWaitFor('next button disabled', body, 'button[data-mce-name="Next"][disabled]');
+    await UiFinder.pWaitFor('prev button disabled', body, 'button[data-mce-name="Previous"][disabled]');
   };
 
   it('TBA: Test Prev and Next buttons become enabled and disabled at right places when multiple matches exist', async () => {
@@ -58,7 +58,7 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplacePrevNextTest', () =
     await pAssertNextPrevButtonsDisabled();
 
     // Ensure the replace button is still enabled, for the last match
-    await UiFinder.pWaitFor('wait for replace button to be enabled', body, 'button[data-mce-label="Replace"]:not([disabled])');
+    await UiFinder.pWaitFor('wait for replace button to be enabled', body, 'button[data-mce-name="Replace"]:not([disabled])');
     TinyAssertions.assertContent(editor, '<p>squid squid fish</p>');
   });
 });

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePrevNextTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/SearchReplacePrevNextTest.ts
@@ -18,14 +18,14 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplacePrevNextTest', () =
   const body = SugarBody.body();
 
   const pAssertButtonsEnabled = async () => {
-    await UiFinder.pWaitFor('next button enabled', body, 'button[title="Next"]:not([disabled])');
-    await UiFinder.pWaitFor('prev button enabled', body, 'button[title="Previous"]:not([disabled])');
-    await UiFinder.pWaitFor('replace button enabled', body, 'button[title="Replace"]:not([disabled])');
+    await UiFinder.pWaitFor('next button enabled', body, 'button[data-mce-btn="Next"]:not([disabled])');
+    await UiFinder.pWaitFor('prev button enabled', body, 'button[data-mce-btn="Previous"]:not([disabled])');
+    await UiFinder.pWaitFor('replace button enabled', body, 'button[data-mce-btn="Replace"]:not([disabled])');
   };
 
   const pAssertNextPrevButtonsDisabled = async () => {
-    await UiFinder.pWaitFor('next button disabled', body, 'button[title="Next"][disabled]');
-    await UiFinder.pWaitFor('prev button disabled', body, 'button[title="Previous"][disabled]');
+    await UiFinder.pWaitFor('next button disabled', body, 'button[data-mce-btn="Next"][disabled]');
+    await UiFinder.pWaitFor('prev button disabled', body, 'button[data-mce-btn="Previous"][disabled]');
   };
 
   it('TBA: Test Prev and Next buttons become enabled and disabled at right places when multiple matches exist', async () => {
@@ -58,7 +58,7 @@ describe('browser.tinymce.plugins.searchreplace.SearchReplacePrevNextTest', () =
     await pAssertNextPrevButtonsDisabled();
 
     // Ensure the replace button is still enabled, for the last match
-    await UiFinder.pWaitFor('wait for replace button to be enabled', body, 'button[title="Replace"]:not([disabled])');
+    await UiFinder.pWaitFor('wait for replace button to be enabled', body, 'button[data-mce-btn="Replace"]:not([disabled])');
     TinyAssertions.assertContent(editor, '<p>squid squid fish</p>');
   });
 });

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/module/test/Utils.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/module/test/Utils.ts
@@ -50,14 +50,14 @@ const pOpenDialogWithKeyboard = async (editor: Editor): Promise<void> => {
   await TinyUiActions.pWaitForDialog(editor);
 };
 
-const clickFind = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-label="Find"]');
-const clickNext = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-label="Next"]');
-const clickPrev = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-label="Previous"]');
-const clickReplace = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-label="Replace"]');
+const clickFind = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-name="Find"]');
+const clickNext = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-name="Next"]');
+const clickPrev = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-name="Previous"]');
+const clickReplace = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-name="Replace"]');
 const clickClose = (editor: Editor): void => TinyUiActions.closeDialog(editor);
 
 const pSelectPreference = async (editor: Editor, name: string): Promise<void> => {
-  TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Preferences"');
+  TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Preferences"');
   await TinyUiActions.pWaitForPopup(editor, '.tox-selected-menu[role=menu]');
   TinyUiActions.clickOnUi(editor, '.tox-selected-menu[role=menu] div[aria-label="' + name + '"]');
 };

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/module/test/Utils.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/module/test/Utils.ts
@@ -50,16 +50,16 @@ const pOpenDialogWithKeyboard = async (editor: Editor): Promise<void> => {
   await TinyUiActions.pWaitForDialog(editor);
 };
 
-const clickFind = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[title="Find"]');
-const clickNext = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[title="Next"]');
-const clickPrev = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[title="Previous"]');
-const clickReplace = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[title="Replace"]');
+const clickFind = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-btn="Find"]');
+const clickNext = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-btn="Next"]');
+const clickPrev = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-btn="Previous"]');
+const clickReplace = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-btn="Replace"]');
 const clickClose = (editor: Editor): void => TinyUiActions.closeDialog(editor);
 
 const pSelectPreference = async (editor: Editor, name: string): Promise<void> => {
-  TinyUiActions.clickOnUi(editor, 'button[title="Preferences"]');
+  TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Preferences"');
   await TinyUiActions.pWaitForPopup(editor, '.tox-selected-menu[role=menu]');
-  TinyUiActions.clickOnUi(editor, '.tox-selected-menu[role=menu] div[title="' + name + '"]');
+  TinyUiActions.clickOnUi(editor, '.tox-selected-menu[role=menu] div[aria-label="' + name + '"]');
 };
 
 export {

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/module/test/Utils.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/module/test/Utils.ts
@@ -50,14 +50,14 @@ const pOpenDialogWithKeyboard = async (editor: Editor): Promise<void> => {
   await TinyUiActions.pWaitForDialog(editor);
 };
 
-const clickFind = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-btn="Find"]');
-const clickNext = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-btn="Next"]');
-const clickPrev = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-btn="Previous"]');
-const clickReplace = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-btn="Replace"]');
+const clickFind = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-label="Find"]');
+const clickNext = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-label="Next"]');
+const clickPrev = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-label="Previous"]');
+const clickReplace = (editor: Editor): SugarElement<HTMLElement> => TinyUiActions.clickOnUi(editor, '[role=dialog] button[data-mce-label="Replace"]');
 const clickClose = (editor: Editor): void => TinyUiActions.closeDialog(editor);
 
 const pSelectPreference = async (editor: Editor, name: string): Promise<void> => {
-  TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Preferences"');
+  TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Preferences"');
   await TinyUiActions.pWaitForPopup(editor, '.tox-selected-menu[role=menu]');
   TinyUiActions.clickOnUi(editor, '.tox-selected-menu[role=menu] div[aria-label="' + name + '"]');
 };

--- a/modules/tinymce/src/plugins/table/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/NoneditableRootTest.ts
@@ -150,11 +150,11 @@ describe('browser.tinymce.plugins.table.NoneditableRootTest', () => {
         );
         TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 2);
         TinyUiActions.clickOnMenu(editor, 'button:contains("Table")');
-        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="true"]`);
+        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [aria-label="${menuitem}"][aria-disabled="true"]`);
         TinyUiActions.keystroke(editor, Keys.escape());
         TinySelections.setSelection(editor, [ 1, 0, 0, 0, 0, 0 ], 0, [ 1, 0, 0, 0, 0, 0 ], 2);
         TinyUiActions.clickOnMenu(editor, 'button:contains("Table")');
-        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="false"]`);
+        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [aria-label="${menuitem}"][aria-disabled="false"]`);
         TinyUiActions.keystroke(editor, Keys.escape());
       });
     };
@@ -188,11 +188,11 @@ describe('browser.tinymce.plugins.table.NoneditableRootTest', () => {
         editor.setContent(`<div>${table}</div><div contenteditable="true">${table}</div>`);
         TinySelections.setSelection(editor, [ 0, 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0, 0 ], 1);
         TinyUiActions.clickOnMenu(editor, 'button:contains("Table")');
-        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="Split cell"][aria-disabled="true"]`);
+        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [aria-label="Split cell"][aria-disabled="true"]`);
         TinyUiActions.keystroke(editor, Keys.escape());
         TinySelections.setSelection(editor, [ 1, 0, 0, 0, 0, 0 ], 0, [ 1, 0, 0, 0, 0, 0 ], 1);
         TinyUiActions.clickOnMenu(editor, 'button:contains("Table")');
-        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="Split cell"][aria-disabled="false"]`);
+        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [aria-label="Split cell"][aria-disabled="false"]`);
         TinyUiActions.keystroke(editor, Keys.escape());
       });
     });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
@@ -37,15 +37,15 @@ describe('browser.tinymce.plugins.table.TableToolbarTest', () => {
     editor.setContent(tableWithCaptionHtml);
     TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1);
     // Ensure the copy/paste row buttons are disabled
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[data-mce-label="tablecopyrow"]');
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[data-mce-label="tablepasterowbefore"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[data-mce-name="tablecopyrow"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[data-mce-name="tablepasterowbefore"]');
     TinySelections.setCursor(editor, [ 0, 1, 0, 0, 0 ], 0);
     // Ensure the copy row button is enabled, but the paste row button is disabled
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn[data-mce-label="tablecopyrow"]:not(.tox-tbtn--disabled)');
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[data-mce-label="tablepasterowbefore"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn[data-mce-name="tablecopyrow"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[data-mce-name="tablepasterowbefore"]');
     editor.execCommand('mceTableCopyRow');
     // The paste row button should now be enabled
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn[data-mce-label="tablepasterowbefore"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn[data-mce-name="tablepasterowbefore"]:not(.tox-tbtn--disabled)');
     McEditor.remove(editor);
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
@@ -37,15 +37,15 @@ describe('browser.tinymce.plugins.table.TableToolbarTest', () => {
     editor.setContent(tableWithCaptionHtml);
     TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1);
     // Ensure the copy/paste row buttons are disabled
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[data-mce-btn="tablecopyrow"]');
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[data-mce-btn="tablepasterowbefore"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[data-mce-label="tablecopyrow"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[data-mce-label="tablepasterowbefore"]');
     TinySelections.setCursor(editor, [ 0, 1, 0, 0, 0 ], 0);
     // Ensure the copy row button is enabled, but the paste row button is disabled
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn[data-mce-btn="tablecopyrow"]:not(.tox-tbtn--disabled)');
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[data-mce-btn="tablepasterowbefore"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn[data-mce-label="tablecopyrow"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[data-mce-label="tablepasterowbefore"]');
     editor.execCommand('mceTableCopyRow');
     // The paste row button should now be enabled
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn[data-mce-btn="tablepasterowbefore"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn[data-mce-label="tablepasterowbefore"]:not(.tox-tbtn--disabled)');
     McEditor.remove(editor);
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
@@ -37,15 +37,15 @@ describe('browser.tinymce.plugins.table.TableToolbarTest', () => {
     editor.setContent(tableWithCaptionHtml);
     TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1);
     // Ensure the copy/paste row buttons are disabled
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[title="Copy row"]');
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[title="Paste row before"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[data-mce-btn="tablecopyrow"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[data-mce-btn="tablepasterowbefore"]');
     TinySelections.setCursor(editor, [ 0, 1, 0, 0, 0 ], 0);
     // Ensure the copy row button is enabled, but the paste row button is disabled
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn[title="Copy row"]:not(.tox-tbtn--disabled)');
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[title="Paste row before"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn[data-mce-btn="tablecopyrow"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[data-mce-btn="tablepasterowbefore"]');
     editor.execCommand('mceTableCopyRow');
     // The paste row button should now be enabled
-    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn[title="Paste row before"]:not(.tox-tbtn--disabled)');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn[data-mce-btn="tablepasterowbefore"]:not(.tox-tbtn--disabled)');
     McEditor.remove(editor);
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/ToolbarButtonDisplayTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/ToolbarButtonDisplayTest.ts
@@ -14,13 +14,13 @@ describe('browser.tinymce.plugins.table.ToolbarButtonDisplayTest', () => {
   const pDisplayTest = async (startPath: number[], startOffset: number, endPath: number[], endOffset: number, shouldBeEnabled: boolean) => {
     const editor = hook.editor();
     editor.setContent('<p>A</p><table><tbody><tr><td>B</td></tr></tbody></table><p>C</p>');
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[data-mce-btn="tablecaption"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[data-mce-label="tablecaption"]');
     TinySelections.setSelection(editor, startPath, startOffset, endPath, endOffset);
 
     if (shouldBeEnabled) {
-      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[data-mce-btn="tablecaption"]:not(.tox-tbtn-disabled)');
+      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[data-mce-label="tablecaption"]:not(.tox-tbtn-disabled)');
     } else {
-      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[data-mce-btn="tablecaption"]');
+      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[data-mce-label="tablecaption"]');
     }
   };
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/ToolbarButtonDisplayTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/ToolbarButtonDisplayTest.ts
@@ -14,13 +14,13 @@ describe('browser.tinymce.plugins.table.ToolbarButtonDisplayTest', () => {
   const pDisplayTest = async (startPath: number[], startOffset: number, endPath: number[], endOffset: number, shouldBeEnabled: boolean) => {
     const editor = hook.editor();
     editor.setContent('<p>A</p><table><tbody><tr><td>B</td></tr></tbody></table><p>C</p>');
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[data-mce-btn="tablecaption"]');
     TinySelections.setSelection(editor, startPath, startOffset, endPath, endOffset);
 
     if (shouldBeEnabled) {
-      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[title="Table caption"]:not(.tox-tbtn-disabled)');
+      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[data-mce-btn="tablecaption"]:not(.tox-tbtn-disabled)');
     } else {
-      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[title="Table caption"]');
+      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[data-mce-btn="tablecaption"]');
     }
   };
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/ToolbarButtonDisplayTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/ToolbarButtonDisplayTest.ts
@@ -14,13 +14,13 @@ describe('browser.tinymce.plugins.table.ToolbarButtonDisplayTest', () => {
   const pDisplayTest = async (startPath: number[], startOffset: number, endPath: number[], endOffset: number, shouldBeEnabled: boolean) => {
     const editor = hook.editor();
     editor.setContent('<p>A</p><table><tbody><tr><td>B</td></tr></tbody></table><p>C</p>');
-    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[data-mce-label="tablecaption"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[data-mce-name="tablecaption"]');
     TinySelections.setSelection(editor, startPath, startOffset, endPath, endOffset);
 
     if (shouldBeEnabled) {
-      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[data-mce-label="tablecaption"]:not(.tox-tbtn-disabled)');
+      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn[data-mce-name="tablecaption"]:not(.tox-tbtn-disabled)');
     } else {
-      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[data-mce-label="tablecaption"]');
+      await TinyUiActions.pWaitForUi(editor, '.tox-tbtn--disabled[data-mce-name="tablecaption"]');
     }
   };
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/LockedColumnDisabledButtonsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/LockedColumnDisabledButtonsTest.ts
@@ -123,7 +123,7 @@ describe('browser.tinymce.plugins.table.LockedColumnDisabledButtonsTest', () => 
     TinyUiActions.pWaitForUi(editor, `button[aria-label="${selector}"][aria-disabled="${disabled}"]`);
 
   const pAssertMenuButtonState = (editor: Editor, selector: string, disabled: boolean) =>
-    TinyUiActions.pWaitForUi(editor, `div.tox-collection__item[title="${selector}"][aria-disabled="${disabled}"]`);
+    TinyUiActions.pWaitForUi(editor, `div.tox-collection__item[aria-label="${selector}"][aria-disabled="${disabled}"]`);
 
   const pAssertToolbarButtons = async (editor: Editor, buttons: ButtonDetails[], expectedDisabledState: boolean) => {
     for (const button of buttons) {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCaptionTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCaptionTest.ts
@@ -108,7 +108,7 @@ describe('browser.tinymce.plugins.table.ui.TableCaptionTest', () => {
     }
 
     if (toolbar) {
-      clickOnButton(editor, 'Table caption');
+      clickOnButton(editor, 'tablecaption');
     } else {
       await pClickOnMenuItem(editor, 'Table caption');
     }

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableColumnHeaderUiTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableColumnHeaderUiTest.ts
@@ -59,7 +59,7 @@ describe('browser.tinymce.plugins.table.ui.TableColumnHeaderUiTest', () => {
     const editor = hook.editor();
     setEditorAndSelectionForOn(editor, 'td');
 
-    clickOnButton(editor, 'Column header');
+    clickOnButton(editor, 'tablecolheader');
     TinyAssertions.assertContent(editor, getStructure('th'));
   });
 
@@ -75,7 +75,7 @@ describe('browser.tinymce.plugins.table.ui.TableColumnHeaderUiTest', () => {
     const editor = hook.editor();
     setEditorAndSelectionForOn(editor, 'th');
 
-    clickOnButton(editor, 'Column header');
+    clickOnButton(editor, 'tablecolheader');
     TinyAssertions.assertContent(editor, getStructure('td'));
   });
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogKeyboardNavTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogKeyboardNavTest.ts
@@ -57,7 +57,7 @@ describe('browser.tinymce.plugins.table.TableDialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Save', '.tox-button:contains("Save")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('x Close Button', '.tox-button[data-mce-btn="close"]');
+    await pAssertFocusOnItem('x Close Button', '.tox-button[data-mce-label="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('General Tab', '.tox-dialog__body-nav-item:contains("General")');
 
@@ -81,7 +81,7 @@ describe('browser.tinymce.plugins.table.TableDialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Save', '.tox-button:contains("Save")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('x Close Button', '.tox-button[data-mce-btn="close"]');
+    await pAssertFocusOnItem('x Close Button', '.tox-button[data-mce-label="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('Advanced Tab', '.tox-dialog__body-nav-item:contains("Advanced")');
   });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogKeyboardNavTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogKeyboardNavTest.ts
@@ -57,7 +57,7 @@ describe('browser.tinymce.plugins.table.TableDialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Save', '.tox-button:contains("Save")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('x Close Button', '.tox-button[data-mce-label="close"]');
+    await pAssertFocusOnItem('x Close Button', '.tox-button[data-mce-name="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('General Tab', '.tox-dialog__body-nav-item:contains("General")');
 
@@ -81,7 +81,7 @@ describe('browser.tinymce.plugins.table.TableDialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Save', '.tox-button:contains("Save")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('x Close Button', '.tox-button[data-mce-label="close"]');
+    await pAssertFocusOnItem('x Close Button', '.tox-button[data-mce-name="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('Advanced Tab', '.tox-dialog__body-nav-item:contains("Advanced")');
   });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogKeyboardNavTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogKeyboardNavTest.ts
@@ -57,7 +57,7 @@ describe('browser.tinymce.plugins.table.TableDialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Save', '.tox-button:contains("Save")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('x Close Button', '.tox-button[title="Close"]');
+    await pAssertFocusOnItem('x Close Button', '.tox-button[data-mce-btn="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('General Tab', '.tox-dialog__body-nav-item:contains("General")');
 
@@ -81,7 +81,7 @@ describe('browser.tinymce.plugins.table.TableDialogKeyboardNavTest', () => {
     pressTabKey(editor);
     await pAssertFocusOnItem('Save', '.tox-button:contains("Save")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('x Close Button', '.tox-button[title="Close"]');
+    await pAssertFocusOnItem('x Close Button', '.tox-button[data-mce-btn="close"]');
     pressTabKey(editor);
     await pAssertFocusOnItem('Advanced Tab', '.tox-dialog__body-nav-item:contains("Advanced")');
   });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowHeaderUiTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowHeaderUiTest.ts
@@ -71,7 +71,7 @@ describe('browser.tinymce.plugins.table.ui.TableRowHeaderUiTest', () => {
     const editor = hook.editor();
     setEditorContentAndSelection(editor, 'tbody');
 
-    clickOnButton(editor, 'Row header');
+    clickOnButton(editor, 'tablerowheader');
 
     TinyAssertions.assertContent(editor, tableWithRowHeaders);
   });
@@ -89,7 +89,7 @@ describe('browser.tinymce.plugins.table.ui.TableRowHeaderUiTest', () => {
     const editor = hook.editor();
     setEditorContentAndSelection(editor, 'thead');
 
-    clickOnButton(editor, 'Row header');
+    clickOnButton(editor, 'tablerowheader');
 
     TinyAssertions.assertContent(editor, tableWithoutRowHeaders);
   });

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableModifiersTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableModifiersTestUtils.ts
@@ -96,7 +96,7 @@ const closeMenu = (editor: Editor): void => {
 };
 
 const clickOnButton = (editor: Editor, title: string): void => {
-  TinyUiActions.clickOnToolbar(editor, `button[data-mce-label="${title}"]`);
+  TinyUiActions.clickOnToolbar(editor, `button[data-mce-name="${title}"]`);
 };
 
 const pClickOnMenuItem = async (editor: Editor, title: string): Promise<void> => {

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableModifiersTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableModifiersTestUtils.ts
@@ -96,7 +96,7 @@ const closeMenu = (editor: Editor): void => {
 };
 
 const clickOnButton = (editor: Editor, title: string): void => {
-  TinyUiActions.clickOnToolbar(editor, `button[data-mce-btn="${title}"]`);
+  TinyUiActions.clickOnToolbar(editor, `button[data-mce-label="${title}"]`);
 };
 
 const pClickOnMenuItem = async (editor: Editor, title: string): Promise<void> => {

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableModifiersTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableModifiersTestUtils.ts
@@ -14,6 +14,16 @@ interface AssertStyleOptions {
   readonly customStyle: string;
 }
 
+const menuTitleToToolbarBarMap: Record<string, string> = {
+  'Border style': 'tablecellborderstyle',
+  'Border width': 'tablecellborderwidth',
+  'Vertical align': 'tablecellvalign',
+  'Background color': 'tablecellbackgroundcolor',
+  'Border color': 'tablecellbordercolor',
+  'Table styles': 'tableclass',
+  'Cell styles': 'tablecellclass',
+};
+
 interface AssertStyleOptionsWithCheckmarks extends AssertStyleOptions {
   readonly checkMarkEntries: number;
 }
@@ -86,13 +96,13 @@ const closeMenu = (editor: Editor): void => {
 };
 
 const clickOnButton = (editor: Editor, title: string): void => {
-  TinyUiActions.clickOnToolbar(editor, `button[title="${title}"]`);
+  TinyUiActions.clickOnToolbar(editor, `button[data-mce-btn="${title}"]`);
 };
 
 const pClickOnMenuItem = async (editor: Editor, title: string): Promise<void> => {
   TinyUiActions.clickOnMenu(editor, 'span:contains("Table")');
-  await TinyUiActions.pWaitForUi(editor, `div[title="${title}"]`);
-  TinyUiActions.clickOnUi(editor, `div[title="${title}"]`);
+  await TinyUiActions.pWaitForUi(editor, `div[aria-label="${title}"]`);
+  TinyUiActions.clickOnUi(editor, `div[aria-label="${title}"]`);
 };
 
 const pAssertMenuPresence = async (
@@ -103,10 +113,11 @@ const pAssertMenuPresence = async (
   container: SugarElement<HTMLElement>,
   useMenuOrToolbar: 'toolbar' | 'menuitem'
 ): Promise<void> => {
+  const title = useMenuOrToolbar === 'toolbar' ? menuTitleToToolbarBarMap[menuTitle] : menuTitle;
   if (useMenuOrToolbar === 'toolbar') {
-    clickOnButton(editor, menuTitle);
+    clickOnButton(editor, title);
   } else {
-    await pClickOnMenuItem(editor, menuTitle);
+    await pClickOnMenuItem(editor, title);
   }
   await Waiter.pTryUntil('Ensure the correct values are present', () =>
     Assertions.assertPresence(label, expected, container)
@@ -117,7 +128,7 @@ const pAssertMenuPresence = async (
 const pAssertCheckmarkOn = async (editor: Editor, menuTitle: string, itemTitle: string, totalNumberOfEntries: number, sugarContainer: SugarElement<HTMLElement>, useMenuOrToolbar: 'toolbar' | 'menuitem') => {
   const expected = {
     '.tox-menu': useMenuOrToolbar === 'toolbar' ? 1 : 2,
-    [`.tox-collection__item[aria-checked="true"][title="${itemTitle}"]`]: 1,
+    [`.tox-collection__item[aria-checked="true"][aria-label="${itemTitle}"]`]: 1,
     '.tox-collection__item[aria-checked="false"]': (totalNumberOfEntries - 1),
     '.tox-collection__item[aria-checked="true"]': 1,
   };
@@ -125,13 +136,14 @@ const pAssertCheckmarkOn = async (editor: Editor, menuTitle: string, itemTitle: 
 };
 
 const pClickOnSubMenu = async (editor: Editor, menuTitle: string, itemTitle: string, useMenuOrToolbar: 'toolbar' | 'menuitem'): Promise<void> => {
+  const title = useMenuOrToolbar === 'toolbar' ? menuTitleToToolbarBarMap[menuTitle] : menuTitle;
   if (useMenuOrToolbar === 'toolbar') {
-    clickOnButton(editor, menuTitle);
+    clickOnButton(editor, title);
   } else {
-    await pClickOnMenuItem(editor, menuTitle);
+    await pClickOnMenuItem(editor, title);
   }
-  await TinyUiActions.pWaitForUi(editor, `div[title="${itemTitle}"]`);
-  TinyUiActions.clickOnUi(editor, `div[title="${itemTitle}"]`);
+  await TinyUiActions.pWaitForUi(editor, `div[aria-label="${itemTitle}"]`);
+  TinyUiActions.clickOnUi(editor, `div[aria-label="${itemTitle}"]`);
   closeMenu(editor);
 };
 
@@ -164,6 +176,7 @@ const pAssertStyleCanBeToggledWithoutCheckmarks = async (editor: Editor, options
 const pAssertStyleCanBeToggled = async (editor: Editor, options: AssertStyleOptionsWithCheckmarks, useMenuOrToolbar: 'toolbar' | 'menuitem'): Promise<void> => {
   const sugarContainer = SugarBody.body();
   setEditorContentTableAndSelection(editor, options.rows, options.columns);
+
   await pAssertCheckmarkOn(editor, options.menuTitle, options.subMenuRemoveTitle, options.checkMarkEntries, sugarContainer, useMenuOrToolbar);
 
   await pClickOnSubMenu(editor, options.menuTitle, options.subMenuTitle, useMenuOrToolbar);

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
@@ -247,9 +247,9 @@ const openPropsDialog = async (editor: Editor, dialogCommand: `mceTable${'' | 'C
 };
 
 const selectListBoxValue = async (editor: Editor, section: string, title: string): Promise<void> => {
-  TinyUiActions.clickOnUi(editor, `button[title="${section}"].tox-listbox--select`);
+  TinyUiActions.clickOnUi(editor, `button[aria-label="${section}"].tox-listbox--select`);
   await TinyUiActions.pWaitForUi(editor, 'div[role="menu"].tox-menu.tox-collection--list');
-  TinyUiActions.clickOnUi(editor, `div[title="${title}"].tox-collection__item`);
+  TinyUiActions.clickOnUi(editor, `div[aria-label="${title}"].tox-collection__item`);
 };
 
 export {

--- a/modules/tinymce/src/plugins/template/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/template/test/ts/browser/NoneditableRootTest.ts
@@ -28,11 +28,11 @@ describe('browser.tinymce.plugins.template.NoneditableRootTest', () => {
       editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
       TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Insert template..."][aria-disabled="true"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Insert template..."][aria-disabled="true"]');
       TinyUiActions.keystroke(editor, Keys.escape());
       TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
       TinyUiActions.clickOnMenu(editor, 'button:contains("Insert")');
-      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][title="Insert template..."][aria-disabled="false"]');
+      await TinyUiActions.pWaitForUi(editor, '[role="menuitem"][aria-label="Insert template..."][aria-disabled="false"]');
       TinyUiActions.keystroke(editor, Keys.escape());
     });
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/button/MenuButton.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/button/MenuButton.ts
@@ -50,11 +50,12 @@ const getMenuButtonApi = (component: AlloyComponent): Toolbar.ToolbarMenuButtonI
   })
 });
 
-const renderMenuButton = (spec: MenuButtonSpec, prefix: string, backstage: UiFactoryBackstage, role: Optional<string>, tabstopping = true): SketchSpec => {
+const renderMenuButton = (spec: MenuButtonSpec, prefix: string, backstage: UiFactoryBackstage, role: Optional<string>, tabstopping = true, btnName?: string): SketchSpec => {
   return renderCommonDropdown({
     text: spec.text,
     icon: spec.icon,
     tooltip: spec.tooltip,
+    ariaLabel: spec.tooltip,
     searchable: spec.search.isSome(),
     // https://www.w3.org/TR/wai-aria-practices/examples/menubar/menubar-2/menubar-2.html
     role,
@@ -92,7 +93,8 @@ const renderMenuButton = (spec: MenuButtonSpec, prefix: string, backstage: UiFac
     ]
   },
   prefix,
-  backstage.shared);
+  backstage.shared,
+  btnName);
 };
 
 const getFetch = (items: StoredMenuItem[], getButton: () => MementoRecord, backstage: UiFactoryBackstage): FetchCallback => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
@@ -60,7 +60,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const createAlignButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createSelectButton(editor, backstage, getSpec(editor), btnTooltip, 'AlignTextUpdate');
+  createSelectButton(editor, backstage, getSpec(editor), btnTooltip, 'AlignTextUpdate', 'align');
 
 const createAlignMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {
   const menuItems = createMenuItems(backstage, getSpec(editor));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -90,7 +90,7 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
         tag: 'button',
         attributes: {
           'aria-label': translatedTooltip,
-          'data-mce-btn': title
+          'data-mce-label': title
         },
         classes: classes.concat(title)
       },
@@ -208,7 +208,7 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
       tag: 'div',
       classes: [ 'tox-number-input' ],
       attributes: {
-        ...(Type.isNonNullable(btnName) ? { 'data-mce-btn': btnName } : {})
+        ...(Type.isNonNullable(btnName) ? { 'data-mce-label': btnName } : {})
       }
     },
     components: [

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -90,7 +90,7 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
         tag: 'button',
         attributes: {
           'aria-label': translatedTooltip,
-          'data-mce-label': title
+          'data-mce-name': title
         },
         classes: classes.concat(title)
       },
@@ -208,7 +208,7 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
       tag: 'div',
       classes: [ 'tox-number-input' ],
       attributes: {
-        ...(Type.isNonNullable(btnName) ? { 'data-mce-label': btnName } : {})
+        ...(Type.isNonNullable(btnName) ? { 'data-mce-name': btnName } : {})
       }
     },
     components: [

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Button, Disabling, Focusing, FocusInsideModes, Input, Keying, Memento, NativeEvents, Representing } from '@ephox/alloy';
-import { Arr, Cell, Fun, Id, Optional } from '@ephox/katamari';
+import { AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Button, Disabling, Focusing, FocusInsideModes, Input, Keying, Memento, NativeEvents, Representing, SystemEvents, Tooltipping } from '@ephox/alloy';
+import { Arr, Cell, Fun, Id, Optional, Type } from '@ephox/katamari';
 import { Focus, SugarElement, Traverse } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -16,7 +16,7 @@ interface BespokeSelectApi {
   readonly getComponent: () => AlloyComponent;
 }
 
-const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage, spec: NumberInputSpec): AlloySpec => {
+const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage, spec: NumberInputSpec, btnName?: string): AlloySpec => {
   let currentComp: Optional<AlloyComponent> = Optional.none();
 
   const getValueFromCurrentComp = (comp: Optional<AlloyComponent>): string =>
@@ -89,8 +89,8 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
       dom: {
         tag: 'button',
         attributes: {
-          'title': translatedTooltip,
-          'aria-label': translatedTooltip
+          'aria-label': translatedTooltip,
+          'data-mce-btn': title
         },
         classes: classes.concat(title)
       },
@@ -99,6 +99,11 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
       ],
       buttonBehaviours: Behaviour.derive([
         Disabling.config({}),
+        Tooltipping.config(
+          backstage.shared.providers.tooltips.getConfig({
+            tooltipText: translatedTooltip
+          })
+        ),
         AddEventsBehaviour.config(altExecuting, [
           onControlAttached({ onSetup, getApi }, editorOffCellStepButton),
           onControlDetached({ getApi }, editorOffCellStepButton),
@@ -116,7 +121,9 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
       eventOrder: {
         [NativeEvents.keydown()]: [ altExecuting, 'keying' ],
         [NativeEvents.click()]: [ altExecuting, 'alloy.base.behaviour' ],
-        [NativeEvents.touchend()]: [ altExecuting, 'alloy.base.behaviour' ]
+        [NativeEvents.touchend()]: [ altExecuting, 'alloy.base.behaviour' ],
+        [SystemEvents.attachedToDom()]: [ 'alloy.base.behaviour', altExecuting, 'tooltipping' ],
+        [SystemEvents.detachedFromDom()]: [ altExecuting, 'tooltipping' ]
       }
     });
   };
@@ -199,7 +206,10 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
   return {
     dom: {
       tag: 'div',
-      classes: [ 'tox-number-input' ]
+      classes: [ 'tox-number-input' ],
+      attributes: {
+        ...(Type.isNonNullable(btnName) ? { 'data-mce-btn': btnName } : {})
+      }
     },
     components: [
       memMinus.asSpec(),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -179,14 +179,15 @@ const createMenuItems = (backstage: UiFactoryBackstage, spec: SelectSpec): Bespo
   };
 };
 
-const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec, tooltipWithPlaceholder: string, textUpdateEventName: string): SketchSpec => {
+const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec, tooltipWithPlaceholder: string, textUpdateEventName: string, btnName?: string): SketchSpec => {
   const { items, getStyleItems } = createMenuItems(backstage, spec);
 
   const getApi = (comp: AlloyComponent): BespokeSelectApi => ({
     getComponent: Fun.constant(comp),
     setTooltip: (tooltip: string) => {
       const translatedTooltip = backstage.shared.providers.translate(tooltip);
-      Attribute.setAll(comp.element, { 'aria-label': translatedTooltip, 'title': translatedTooltip });
+      // Removed title attribute, will address dynamically update tooltip in TINY-10474
+      Attribute.setAll(comp.element, { 'aria-label': translatedTooltip });
     }
   });
 
@@ -209,6 +210,7 @@ const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec:
     {
       text: spec.icon.isSome() ? Optional.none() : spec.text,
       icon: spec.icon,
+      ariaLabel: Optional.some(spec.tooltip),
       tooltip: Optional.from(spec.tooltip),
       role: Optional.none(),
       fetch: items.getFetch(backstage, getStyleItems),
@@ -220,7 +222,8 @@ const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec:
       dropdownBehaviours: []
     },
     ToolbarButtonClasses.Button,
-    backstage.shared
+    backstage.shared,
+    btnName
   );
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -179,7 +179,7 @@ const createMenuItems = (backstage: UiFactoryBackstage, spec: SelectSpec): Bespo
   };
 };
 
-const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec, tooltipWithPlaceholder: string, textUpdateEventName: string, btnName?: string): SketchSpec => {
+const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec, tooltipWithPlaceholder: string, textUpdateEventName: string, btnName: string): SketchSpec => {
   const { items, getStyleItems } = createMenuItems(backstage, spec);
 
   const getApi = (comp: AlloyComponent): BespokeSelectApi => ({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
@@ -60,7 +60,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const createBlocksButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createSelectButton(editor, backstage, getSpec(editor), btnTooltip, 'BlocksTextUpdate');
+  createSelectButton(editor, backstage, getSpec(editor), btnTooltip, 'BlocksTextUpdate', 'blocks');
 
 // FIX: Test this!
 const createBlocksMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
@@ -110,7 +110,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const createFontFamilyButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createSelectButton(editor, backstage, getSpec(editor), btnTooltip, 'FontFamilyTextUpdate');
+  createSelectButton(editor, backstage, getSpec(editor), btnTooltip, 'FontFamilyTextUpdate', 'fontfamily');
 
 // TODO: Test this!
 const createFontFamilyMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -129,7 +129,7 @@ const getSpec = (editor: Editor): SelectSpec => {
 };
 
 const createFontSizeButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec =>
-  createSelectButton(editor, backstage, getSpec(editor), btnTooltip, 'FontSizeTextUpdate');
+  createSelectButton(editor, backstage, getSpec(editor), btnTooltip, 'FontSizeTextUpdate', 'fontsize');
 
 const getConfigFromUnit = (unit: string): Config => {
   const baseConfig = { step: 1 };
@@ -180,7 +180,7 @@ const getNumberInputSpec = (editor: Editor): NumberInputSpec => {
 };
 
 const createFontSizeInputButton = (editor: Editor, backstage: UiFactoryBackstage): AlloySpec =>
-  createBespokeNumberInput(editor, backstage, getNumberInputSpec(editor));
+  createBespokeNumberInput(editor, backstage, getNumberInputSpec(editor), 'fontsizeinput');
 
 // TODO: Test this!
 const createFontSizeMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
@@ -67,7 +67,7 @@ const getSpec = (editor: Editor, dataset: SelectDataset): SelectSpec => {
 
 const createStylesButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec => {
   const dataset: AdvancedSelectDataset = { type: 'advanced', ...backstage.styles };
-  return createSelectButton(editor, backstage, getSpec(editor, dataset), btnTooltip, 'StylesTextUpdate');
+  return createSelectButton(editor, backstage, getSpec(editor, dataset), btnTooltip, 'StylesTextUpdate', 'styles');
 };
 
 const createStylesMenu = (editor: Editor, backstage: UiFactoryBackstage): void => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ListBox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ListBox.ts
@@ -67,9 +67,9 @@ export const renderListBox = (spec: ListBoxSpec, backstage: UiFactoryBackstage, 
         uid: sketchSpec.uid,
         text: initialItem.map((item) => item.text),
         icon: Optional.none(),
-        // TINY-10453: Remove this tooltip, we don't want duplicate tooltips and until we figured a better way to test, it's here now so that tests would pass
-        tooltip: spec.label,
+        tooltip: Optional.none(),
         role: Optional.none(),
+        ariaLabel: spec.label,
         fetch: (comp, callback) => {
           const items = fetchItems(comp, spec.name, spec.items, Representing.getValue(comp));
           callback(

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
@@ -34,8 +34,7 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
       classes: [ 'tox-lock', 'tox-button', 'tox-button--naked', 'tox-button--icon' ],
       attributes: {
         'aria-label': translatedLabel,
-        // TINY-10453: Remove this tooltip, we don't want duplicate tooltips and until we figured a better way to test, it's here now so that tests would pass
-        'title': translatedLabel
+        'data-mce-btn': spec.label.getOr('Constrain proportions')
       }
     },
     components: [

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
@@ -27,14 +27,15 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
   const makeIcon = (iconName: string) =>
     Icons.render(iconName, { tag: 'span', classes: [ 'tox-icon', 'tox-lock-icon__' + iconName ] }, providersBackstage.icons);
 
-  const translatedLabel = providersBackstage.translate(spec.label.getOr('Constrain proportions'));
+  const label = spec.label.getOr('Constrain proportions');
+  const translatedLabel = providersBackstage.translate(label);
   const pLock = AlloyFormCoupledInputs.parts.lock({
     dom: {
       tag: 'button',
       classes: [ 'tox-lock', 'tox-button', 'tox-button--naked', 'tox-button--icon' ],
       attributes: {
         'aria-label': translatedLabel,
-        'data-mce-btn': spec.label.getOr('Constrain proportions')
+        'data-mce-btn': label
       }
     },
     components: [

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
@@ -35,7 +35,7 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
       classes: [ 'tox-lock', 'tox-button', 'tox-button--naked', 'tox-button--icon' ],
       attributes: {
         'aria-label': translatedLabel,
-        'data-mce-label': label
+        'data-mce-name': label
       }
     },
     components: [

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
@@ -35,7 +35,7 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
       classes: [ 'tox-lock', 'tox-button', 'tox-button--naked', 'tox-button--icon' ],
       attributes: {
         'aria-label': translatedLabel,
-        'data-mce-btn': label
+        'data-mce-label': label
       }
     },
     components: [

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
@@ -58,7 +58,6 @@ const renderLabel = (text: string ): SimpleSpec => ({
     tag: 'span',
     classes: [ 'tox-tree__label' ],
     attributes: {
-      'title': text,
       'aria-label': text,
     }
   },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
@@ -134,7 +134,7 @@ const renderCommonDropdown = <T>(
         classes: [ prefix, `${prefix}--select` ].concat(Arr.map(spec.classes, (c) => `${prefix}--${c}`)),
         attributes: {
           ...ariaLabelAttribute,
-          ...(Type.isNonNullable(btnName) ? { 'data-mce-btn': btnName } : {})
+          ...(Type.isNonNullable(btnName) ? { 'data-mce-label': btnName } : {})
         }
       },
       components: componentRenderPipeline([

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
@@ -134,7 +134,7 @@ const renderCommonDropdown = <T>(
         classes: [ prefix, `${prefix}--select` ].concat(Arr.map(spec.classes, (c) => `${prefix}--${c}`)),
         attributes: {
           ...ariaLabelAttribute,
-          ...(Type.isNonNullable(btnName) ? { 'data-mce-label': btnName } : {})
+          ...(Type.isNonNullable(btnName) ? { 'data-mce-name': btnName } : {})
         }
       },
       components: componentRenderPipeline([

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
@@ -3,7 +3,7 @@ import {
   Keying, MaxHeight, Memento, NativeEvents, Replacing, Representing, SimulatedEvent, SketchSpec, SystemEvents, TieredData, Tooltipping, Unselecting
 } from '@ephox/alloy';
 import { Toolbar } from '@ephox/bridge';
-import { Arr, Cell, Fun, Future, Id, Merger, Optional } from '@ephox/katamari';
+import { Arr, Cell, Fun, Future, Id, Merger, Optional, Type } from '@ephox/katamari';
 import { EventArgs, SugarElement } from '@ephox/sugar';
 
 import { toolbarButtonEventOrder } from 'tinymce/themes/silver/ui/toolbar/button/ButtonEvents';
@@ -46,13 +46,15 @@ export interface CommonDropdownSpec<T> {
   readonly classes: string[];
   readonly dropdownBehaviours: Behaviour.NamedConfiguredBehaviour<any, any, any>[];
   readonly searchable?: boolean;
+  readonly ariaLabel: Optional<string>;
 }
 
 // TODO: Use renderCommonStructure here.
 const renderCommonDropdown = <T>(
   spec: CommonDropdownSpec<T>,
   prefix: string,
-  sharedBackstage: UiFactoryBackstageShared
+  sharedBackstage: UiFactoryBackstageShared,
+  btnName?: string
 ): SketchSpec => {
   const editorOffCell = Cell(Fun.noop);
 
@@ -104,14 +106,12 @@ const renderCommonDropdown = <T>(
 
   const role = spec.role.fold(() => ({}), (role) => ({ role }));
 
-  const tooltipAttributes = spec.tooltip.fold(
+  const ariaLabelAttribute = spec.ariaLabel.fold(
     () => ({}),
-    (tooltip) => {
-      const translatedTooltip = sharedBackstage.providers.translate(tooltip);
+    (ariaLabel) => {
+      const translatedAriaLabel = sharedBackstage.providers.translate(ariaLabel);
       return {
-        // TINY-10453: Remove this tooltip, we don't want duplicate tooltips and until we figured a better way to test, it's here now so that tests would pass
-        'title': translatedTooltip,
-        'aria-label': translatedTooltip
+        'aria-label': translatedAriaLabel
       };
     }
   );
@@ -133,7 +133,8 @@ const renderCommonDropdown = <T>(
         tag: 'button',
         classes: [ prefix, `${prefix}--select` ].concat(Arr.map(spec.classes, (c) => `${prefix}--${c}`)),
         attributes: {
-          ...tooltipAttributes
+          ...ariaLabelAttribute,
+          ...(Type.isNonNullable(btnName) ? { 'data-mce-btn': btnName } : {})
         }
       },
       components: componentRenderPipeline([

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -79,16 +79,16 @@ export const renderIconButtonSpec = (
   spec: IconButtonWrapper,
   action: Optional<(comp: AlloyComponent) => void>,
   providersBackstage: UiFactoryBackstageProviders,
-  extraBehaviours: Behaviours = []
+  extraBehaviours: Behaviours = [],
+  btnName: string
 ): AlloyButtonSpec => {
   const tooltipAttributes = spec.tooltip.map<{}>((tooltip) => ({
     'aria-label': providersBackstage.translate(tooltip),
-    'title': providersBackstage.translate(tooltip)
   })).getOr({});
   const dom = {
     tag: 'button',
     classes: [ ToolbarButtonClasses.Button ],
-    attributes: tooltipAttributes
+    attributes: { ...tooltipAttributes, 'data-mce-btn': btnName }
   };
   const icon = spec.icon.map((iconName) => renderIconFromPack(iconName, providersBackstage.icons));
   const components = componentRenderPipeline([
@@ -137,12 +137,13 @@ const renderButtonSpec = (
     ...extraClasses
   ];
 
+  console.log(spec.text, translatedText);
   const dom = {
     tag: 'button',
     classes,
     attributes: {
-      // TINY-10453: Look into this, we might want to remove this title attribute since it has already contain a label
-      title: translatedText
+      'aria-label': translatedText,
+      'data-mce-btn': spec.text
     }
   };
 
@@ -276,7 +277,7 @@ export const renderFooterButton = (spec: FooterButtonSpec, buttonType: string, b
       fetch: getFetch(menuButtonSpec.items, getButton, backstage)
     };
 
-    const memButton = Memento.record(renderMenuButton(fixedSpec, ToolbarButtonClasses.Button, backstage, Optional.none()));
+    const memButton = Memento.record(renderMenuButton(fixedSpec, ToolbarButtonClasses.Button, backstage, Optional.none(), true, spec.tooltip.getOrUndefined()));
 
     return memButton.asSpec();
   } else if (isNormalFooterButtonSpec(spec, buttonType)) {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -88,7 +88,7 @@ export const renderIconButtonSpec = (
   const dom = {
     tag: 'button',
     classes: [ ToolbarButtonClasses.Button ],
-    attributes: { ...tooltipAttributes, 'data-mce-label': btnName }
+    attributes: { ...tooltipAttributes, 'data-mce-name': btnName }
   };
   const icon = spec.icon.map((iconName) => renderIconFromPack(iconName, providersBackstage.icons));
   const components = componentRenderPipeline([
@@ -142,7 +142,7 @@ const renderButtonSpec = (
     classes,
     attributes: {
       'aria-label': translatedText,
-      'data-mce-label': spec.text
+      'data-mce-name': spec.text
     }
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -137,7 +137,6 @@ const renderButtonSpec = (
     ...extraClasses
   ];
 
-  console.log(spec.text, translatedText);
   const dom = {
     tag: 'button',
     classes,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -88,7 +88,7 @@ export const renderIconButtonSpec = (
   const dom = {
     tag: 'button',
     classes: [ ToolbarButtonClasses.Button ],
-    attributes: { ...tooltipAttributes, 'data-mce-btn': btnName }
+    attributes: { ...tooltipAttributes, 'data-mce-label': btnName }
   };
   const icon = spec.icon.map((iconName) => renderIconFromPack(iconName, providersBackstage.icons));
   const components = componentRenderPipeline([
@@ -142,7 +142,7 @@ const renderButtonSpec = (
     classes,
     attributes: {
       'aria-label': translatedText,
-      'data-mce-btn': spec.text
+      'data-mce-label': spec.text
     }
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/NestedMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/NestedMenuItem.ts
@@ -23,7 +23,7 @@ const renderNestedItem = (spec: Menu.NestedMenuItem, itemResponse: ItemResponse,
     },
     setTooltip: (tooltip: string) => {
       const translatedTooltip = providersBackstage.translate(tooltip);
-      Attribute.setAll(component.element, { 'aria-label': translatedTooltip, 'title': translatedTooltip });
+      Attribute.set(component.element, 'aria-label', translatedTooltip);
     }
   });
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -37,7 +37,7 @@ const renderColorStructure = (item: ItemStructureSpec, providerBackstage: UiFact
   const attributes = item.ariaLabel.map(
     (al) => ({
       'aria-label': providerBackstage.translate(al),
-      'data-mce-label': al
+      'data-mce-name': al
     })
   ).getOr({ });
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -37,8 +37,7 @@ const renderColorStructure = (item: ItemStructureSpec, providerBackstage: UiFact
   const attributes = item.ariaLabel.map(
     (al) => ({
       'aria-label': providerBackstage.translate(al),
-      // TINY-10453: Remove this tooltip, we don't want duplicate tooltips and until we figured a better way to test, it's here now so that tests would pass
-      'title': providerBackstage.translate(al)
+      'data-mce-btn': al
     })
   ).getOr({ });
 
@@ -89,10 +88,8 @@ const renderColorStructure = (item: ItemStructureSpec, providerBackstage: UiFact
 };
 
 const renderItemDomStructure = (ariaLabel: Optional<string>): RawDomSchema => {
-  const domTitle = ariaLabel.map((label): { attributes?: { title: string; id?: string; 'aria-label': string }} => ({
+  const domTitle = ariaLabel.map((label): { attributes?: { id?: string; 'aria-label': string }} => ({
     attributes: {
-      // TINY-10453: Remove this tooltip, we don't want duplicate tooltips and until we figured a better way to test, it's here now so that tests would pass
-      'title': I18n.translate(label),
       'id': Id.generate('menu-item'),
       'aria-label': I18n.translate(label)
     }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -37,7 +37,7 @@ const renderColorStructure = (item: ItemStructureSpec, providerBackstage: UiFact
   const attributes = item.ariaLabel.map(
     (al) => ({
       'aria-label': providerBackstage.translate(al),
-      'data-mce-btn': al
+      'data-mce-label': al
     })
   ).getOr({ });
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
@@ -42,7 +42,7 @@ export const renderResizeHandler = (editor: Editor, providersBackstage: UiFactor
     classes: [ 'tox-statusbar__resize-handle' ],
     attributes: {
       'aria-label': providersBackstage.translate(resizeLabel),
-      'data-mce-label': 'resize-handle'
+      'data-mce-name': 'resize-handle'
     },
     behaviours: [
       Dragging.config({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
@@ -41,8 +41,8 @@ export const renderResizeHandler = (editor: Editor, providersBackstage: UiFactor
     tag: 'div',
     classes: [ 'tox-statusbar__resize-handle' ],
     attributes: {
-      'title': providersBackstage.translate('Resize'), // TODO: tooltips AP-213
       'aria-label': providersBackstage.translate(resizeLabel),
+      'data-mce-btn': 'resize-handle'
     },
     behaviours: [
       Dragging.config({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
@@ -42,7 +42,7 @@ export const renderResizeHandler = (editor: Editor, providersBackstage: UiFactor
     classes: [ 'tox-statusbar__resize-handle' ],
     attributes: {
       'aria-label': providersBackstage.translate(resizeLabel),
-      'data-mce-btn': 'resize-handle'
+      'data-mce-label': 'resize-handle'
     },
     behaviours: [
       Dragging.config({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -116,7 +116,7 @@ const renderMoreToolbarCommon = (toolbarSpec: MoreDrawerToolbarSpec) => {
         primary: false,
         buttonType: Optional.none(),
         borderless: false
-      }, Optional.none(), toolbarSpec.providers)
+      }, Optional.none(), toolbarSpec.providers, [], 'overflow-button')
     },
     splitToolbarBehaviours: getToolbarBehaviours(toolbarSpec, modeName)
   };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
@@ -26,7 +26,7 @@ export interface RenderToolbarConfig {
   readonly allowToolbarGroups: boolean;
 }
 
-type BridgeRenderFn<S> = (spec: S, backstage: UiFactoryBackstage, editor: Editor) => AlloySpec;
+type BridgeRenderFn<S> = (spec: S, backstage: UiFactoryBackstage, editor: Editor, btnName: string) => AlloySpec;
 
 const defaultToolbar = [
   {
@@ -56,35 +56,35 @@ const defaultToolbar = [
 ];
 
 const renderFromBridge = <BI, BO>(bridgeBuilder: (i: BI) => Result<BO, StructureSchema.SchemaError<any>>, render: BridgeRenderFn<BO>) =>
-  (spec: BI, backstage: UiFactoryBackstage, editor: Editor) => {
+  (spec: BI, backstage: UiFactoryBackstage, editor: Editor, btnName: string) => {
     const internal = bridgeBuilder(spec).mapError((errInfo) => StructureSchema.formatError(errInfo)).getOrDie();
-    return render(internal, backstage, editor);
+    return render(internal, backstage, editor, btnName);
   };
 
 const types: Record<string, BridgeRenderFn<any>> = {
   button: renderFromBridge(
     Toolbar.createToolbarButton,
-    (s, backstage) => renderToolbarButton(s, backstage.shared.providers)
+    (s, backstage, _, btnName) => renderToolbarButton(s, backstage.shared.providers, btnName)
   ),
 
   togglebutton: renderFromBridge(
     Toolbar.createToggleButton,
-    (s, backstage) => renderToolbarToggleButton(s, backstage.shared.providers)
+    (s, backstage, _, btnName) => renderToolbarToggleButton(s, backstage.shared.providers, btnName)
   ),
 
   menubutton: renderFromBridge(
     Toolbar.createMenuButton,
-    (s, backstage) => renderMenuButton(s, ToolbarButtonClasses.Button, backstage, Optional.none(), false)
+    (s, backstage, _, btnName) => renderMenuButton(s, ToolbarButtonClasses.Button, backstage, Optional.none(), false, btnName)
   ),
 
   splitbutton: renderFromBridge(
     Toolbar.createSplitButton,
-    (s, backstage) => renderSplitButton(s, backstage.shared)
+    (s, backstage, _, btnName) => renderSplitButton(s, backstage.shared, btnName)
   ),
 
   grouptoolbarbutton: renderFromBridge(
     Toolbar.createGroupToolbarButton,
-    (s, backstage, editor) => {
+    (s, backstage, editor, btnName) => {
       const buttons = editor.ui.registry.getAll().buttons;
       const identify = (toolbar: string | ToolbarGroupOption[]) =>
         identifyButtons(editor, { buttons, toolbar, allowToolbarGroups: false }, backstage, Optional.none());
@@ -94,7 +94,7 @@ const types: Record<string, BridgeRenderFn<any>> = {
 
       switch (getToolbarMode(editor)) {
         case ToolbarMode.floating:
-          return renderFloatingToolbarButton(s, backstage, identify, attributes);
+          return renderFloatingToolbarButton(s, backstage, identify, attributes, btnName);
         default:
           // TODO change this message and add a case when sliding is available
           throw new Error('Toolbar groups are only supported when using floating toolbar mode');
@@ -103,7 +103,7 @@ const types: Record<string, BridgeRenderFn<any>> = {
   )
 };
 
-const extractFrom = (spec: ToolbarButton & { type: string }, backstage: UiFactoryBackstage, editor: Editor): Optional<AlloySpec> =>
+const extractFrom = (spec: ToolbarButton & { type: string }, backstage: UiFactoryBackstage, editor: Editor, btnName: string): Optional<AlloySpec> =>
   Obj.get(types, spec.type).fold(
     () => {
       // eslint-disable-next-line no-console
@@ -111,7 +111,7 @@ const extractFrom = (spec: ToolbarButton & { type: string }, backstage: UiFactor
       return Optional.none();
     },
     (render) => Optional.some(
-      render(spec, backstage, editor)
+      render(spec, backstage, editor, btnName)
     )
   );
 
@@ -186,7 +186,7 @@ const lookupButton = (editor: Editor, buttons: Record<string, any>, toolbarItem:
           console.warn(`Ignoring the '${toolbarItem}' toolbar button. Group toolbar buttons are only supported when using floating toolbar mode and cannot be nested.`);
           return Optional.none();
         } else {
-          return extractFrom(spec, backstage, editor);
+          return extractFrom(spec, backstage, editor, toolbarItem.toLowerCase());
         }
       }
     );

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -109,7 +109,7 @@ const renderCommonStructure = (
       classes: [ ToolbarButtonClasses.Button ].concat(optText.isSome() ? [ ToolbarButtonClasses.MatchWidth ] : []),
       attributes: {
         ...getTooltipAttributes(tooltip, providersBackstage),
-        ...(Type.isNonNullable(btnName) ? { 'data-mce-btn': btnName } : {})
+        ...(Type.isNonNullable(btnName) ? { 'data-mce-label': btnName } : {})
       }
     },
     components: componentRenderPipeline([
@@ -344,7 +344,7 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
       attributes: {
         'aria-pressed': false,
         ...getTooltipAttributes(spec.tooltip, sharedBackstage.providers),
-        ...(Type.isNonNullable(btnName) ? { 'data-mce-btn': btnName } : {})
+        ...(Type.isNonNullable(btnName) ? { 'data-mce-label': btnName } : {})
       }
     },
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -109,7 +109,7 @@ const renderCommonStructure = (
       classes: [ ToolbarButtonClasses.Button ].concat(optText.isSome() ? [ ToolbarButtonClasses.MatchWidth ] : []),
       attributes: {
         ...getTooltipAttributes(tooltip, providersBackstage),
-        ...(Type.isNonNullable(btnName) ? { 'data-mce-label': btnName } : {})
+        ...(Type.isNonNullable(btnName) ? { 'data-mce-name': btnName } : {})
       }
     },
     components: componentRenderPipeline([
@@ -344,7 +344,7 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
       attributes: {
         'aria-pressed': false,
         ...getTooltipAttributes(spec.tooltip, sharedBackstage.providers),
-        ...(Type.isNonNullable(btnName) ? { 'data-mce-label': btnName } : {})
+        ...(Type.isNonNullable(btnName) ? { 'data-mce-name': btnName } : {})
       }
     },
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -6,7 +6,7 @@ import {
   Unselecting
 } from '@ephox/alloy';
 import { Toolbar } from '@ephox/bridge';
-import { Arr, Cell, Fun, Future, Id, Merger, Optional } from '@ephox/katamari';
+import { Arr, Cell, Fun, Future, Id, Merger, Optional, Type } from '@ephox/katamari';
 import { Attribute, EventArgs, SelectorFind } from '@ephox/sugar';
 
 import { ToolbarGroupOption } from '../../../api/Options';
@@ -85,8 +85,6 @@ const getToggleApi = (component: AlloyComponent): Toolbar.ToolbarToggleButtonIns
 
 const getTooltipAttributes = (tooltip: Optional<string>, providersBackstage: UiFactoryBackstageProviders) => tooltip.map<{}>((tooltip) => ({
   'aria-label': providersBackstage.translate(tooltip),
-  // TINY-10453: Remove this tooltip, we don't want duplicate tooltips and until we figured a better way to test, it's here now so that tests would pass
-  'title': providersBackstage.translate(tooltip)
 })).getOr({});
 
 const focusButtonEvent = Id.generate('focus-button');
@@ -96,7 +94,8 @@ const renderCommonStructure = (
   optText: Optional<string>,
   tooltip: Optional<string>,
   behaviours: Optional<Behaviours>,
-  providersBackstage: UiFactoryBackstageProviders
+  providersBackstage: UiFactoryBackstageProviders,
+  btnName?: string
 ): AlloyButtonSpec => {
   const optMemDisplayText = optText.map(
     (text) => Memento.record(renderLabel(text, ToolbarButtonClasses.Button, providersBackstage))
@@ -108,7 +107,10 @@ const renderCommonStructure = (
     dom: {
       tag: 'button',
       classes: [ ToolbarButtonClasses.Button ].concat(optText.isSome() ? [ ToolbarButtonClasses.MatchWidth ] : []),
-      attributes: getTooltipAttributes(tooltip, providersBackstage)
+      attributes: {
+        ...getTooltipAttributes(tooltip, providersBackstage),
+        ...(Type.isNonNullable(btnName) ? { 'data-mce-btn': btnName } : {})
+      }
     },
     components: componentRenderPipeline([
       optMemDisplayIcon.map((mem) => mem.asSpec()),
@@ -150,7 +152,7 @@ const renderCommonStructure = (
   };
 };
 
-const renderFloatingToolbarButton = (spec: Toolbar.GroupToolbarButton, backstage: UiFactoryBackstage, identifyButtons: (toolbar: string | ToolbarGroupOption[]) => ToolbarGroup[], attributes: Record<string, string>): SketchSpec => {
+const renderFloatingToolbarButton = (spec: Toolbar.GroupToolbarButton, backstage: UiFactoryBackstage, identifyButtons: (toolbar: string | ToolbarGroupOption[]) => ToolbarGroup[], attributes: Record<string, string>, btnName?: string): SketchSpec => {
   const sharedBackstage = backstage.shared;
   const editorOffCell = Cell(Fun.noop);
   const specialisation = {
@@ -174,7 +176,7 @@ const renderFloatingToolbarButton = (spec: Toolbar.GroupToolbarButton, backstage
       toggledClass: ToolbarButtonClasses.Ticked
     },
     parts: {
-      button: renderCommonStructure(spec.icon, spec.text, spec.tooltip, Optional.some(behaviours), sharedBackstage.providers),
+      button: renderCommonStructure(spec.icon, spec.text, spec.tooltip, Optional.some(behaviours), sharedBackstage.providers, btnName),
       toolbar: {
         dom: {
           tag: 'div',
@@ -194,9 +196,9 @@ const generateTooltippingBehaviour = (text: Optional<string>, providersBackstage
   )
 ).toArray();
 
-const renderCommonToolbarButton = <T>(spec: GeneralToolbarButton<T>, specialisation: Specialisation<T>, providersBackstage: UiFactoryBackstageProviders): SketchSpec => {
+const renderCommonToolbarButton = <T>(spec: GeneralToolbarButton<T>, specialisation: Specialisation<T>, providersBackstage: UiFactoryBackstageProviders, btnName?: string): SketchSpec => {
   const editorOffCell = Cell(Fun.noop);
-  const structure = renderCommonStructure(spec.icon, spec.text, spec.tooltip, Optional.none(), providersBackstage);
+  const structure = renderCommonStructure(spec.icon, spec.text, spec.tooltip, Optional.none(), providersBackstage, btnName);
   return AlloyButton.sketch({
     dom: structure.dom,
     components: structure.components,
@@ -227,10 +229,10 @@ const renderCommonToolbarButton = <T>(spec: GeneralToolbarButton<T>, specialisat
   });
 };
 
-const renderToolbarButton = (spec: Toolbar.ToolbarButton, providersBackstage: UiFactoryBackstageProviders): SketchSpec =>
-  renderToolbarButtonWith(spec, providersBackstage, [ ]);
+const renderToolbarButton = (spec: Toolbar.ToolbarButton, providersBackstage: UiFactoryBackstageProviders, btnName?: string): SketchSpec =>
+  renderToolbarButtonWith(spec, providersBackstage, [ ], btnName);
 
-const renderToolbarButtonWith = (spec: Toolbar.ToolbarButton, providersBackstage: UiFactoryBackstageProviders, bonusEvents: AlloyEvents.AlloyEventKeyAndHandler<any>[]): SketchSpec =>
+const renderToolbarButtonWith = (spec: Toolbar.ToolbarButton, providersBackstage: UiFactoryBackstageProviders, bonusEvents: AlloyEvents.AlloyEventKeyAndHandler<any>[], btnName?: string): SketchSpec =>
   renderCommonToolbarButton(spec, {
     toolbarButtonBehaviours: (bonusEvents.length > 0 ? [
       // TODO: May have to pass through eventOrder if events start clashing
@@ -238,12 +240,12 @@ const renderToolbarButtonWith = (spec: Toolbar.ToolbarButton, providersBackstage
     ] : [ ]),
     getApi: getButtonApi,
     onSetup: spec.onSetup
-  }, providersBackstage);
+  }, providersBackstage, btnName);
 
-const renderToolbarToggleButton = (spec: Toolbar.ToolbarToggleButton, providersBackstage: UiFactoryBackstageProviders): SketchSpec =>
-  renderToolbarToggleButtonWith(spec, providersBackstage, [ ]);
+const renderToolbarToggleButton = (spec: Toolbar.ToolbarToggleButton, providersBackstage: UiFactoryBackstageProviders, btnName?: string): SketchSpec =>
+  renderToolbarToggleButtonWith(spec, providersBackstage, [ ], btnName);
 
-const renderToolbarToggleButtonWith = (spec: Toolbar.ToolbarToggleButton, providersBackstage: UiFactoryBackstageProviders, bonusEvents: AlloyEvents.AlloyEventKeyAndHandler<any>[]): SketchSpec =>
+const renderToolbarToggleButtonWith = (spec: Toolbar.ToolbarToggleButton, providersBackstage: UiFactoryBackstageProviders, bonusEvents: AlloyEvents.AlloyEventKeyAndHandler<any>[], btnName?: string): SketchSpec =>
   renderCommonToolbarButton(spec,
     {
       toolbarButtonBehaviours: [
@@ -256,7 +258,8 @@ const renderToolbarToggleButtonWith = (spec: Toolbar.ToolbarToggleButton, provid
       getApi: getToggleApi,
       onSetup: spec.onSetup
     },
-    providersBackstage
+    providersBackstage,
+    btnName
   );
 
 const fetchChoices = (getApi: (comp: AlloyComponent) => Toolbar.ToolbarSplitButtonInstanceApi, spec: ChoiceFetcher, providersBackstage: UiFactoryBackstageProviders) =>
@@ -290,8 +293,7 @@ const fetchChoices = (getApi: (comp: AlloyComponent) => Toolbar.ToolbarSplitButt
       )));
 
 // TODO: hookup onSetup and onDestroy
-const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: UiFactoryBackstageShared): SketchSpec => {
-
+const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: UiFactoryBackstageShared, btnName?: string): SketchSpec => {
   const getApi = (comp: AlloyComponent): Toolbar.ToolbarSplitButtonInstanceApi => ({
     isEnabled: () => !Disabling.isDisabled(comp),
     setEnabled: (state: boolean) => Disabling.set(comp, !state),
@@ -325,7 +327,8 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
       ),
     setTooltip: (tooltip: string) => {
       const translatedTooltip = sharedBackstage.providers.translate(tooltip);
-      Attribute.setAll(comp.element, { 'aria-label': translatedTooltip, 'title': translatedTooltip });
+      // Removed title attribute, will address dynamically update tooltip in TINY-10474
+      Attribute.setAll(comp.element, { 'aria-label': translatedTooltip });
     }
   });
 
@@ -338,7 +341,11 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
     dom: {
       tag: 'div',
       classes: [ ToolbarButtonClasses.SplitButton ],
-      attributes: { 'aria-pressed': false, ...getTooltipAttributes(spec.tooltip, sharedBackstage.providers) }
+      attributes: {
+        'aria-pressed': false,
+        ...getTooltipAttributes(spec.tooltip, sharedBackstage.providers),
+        ...(Type.isNonNullable(btnName) ? { 'data-mce-btn': btnName } : {})
+      }
     },
 
     onExecute: (button: AlloyComponent) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/view/ViewButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/view/ViewButtons.ts
@@ -85,9 +85,8 @@ export const renderButton = (spec: ViewButtonWithoutGroup, providers: UiFactoryB
   const optTranslatedText = isToggleButton ? spec.text.map(providers.translate) : Optional.some(providers.translate(spec.text));
   const optTranslatedTextComponed = optTranslatedText.map(GuiFactory.text);
 
-  const tooltipAttributes = buttonSpec.tooltip.or(optTranslatedText).map<{}>((tooltip) => ({
-    'aria-label': providers.translate(tooltip),
-    'title': providers.translate(tooltip)
+  const ariaLabelAttributes = buttonSpec.tooltip.or(optTranslatedText).map<{}>((al) => ({
+    'aria-label': providers.translate(al),
   })).getOr({});
 
   const optIconSpec = optMemIcon.map((memIcon) => memIcon.asSpec());
@@ -102,10 +101,10 @@ export const renderButton = (spec: ViewButtonWithoutGroup, providers: UiFactoryB
       .concat(...hasIconAndText ? [ 'tox-button--icon-and-text' ] : [])
       .concat(...spec.borderless ? [ 'tox-button--naked' ] : [])
       .concat(...spec.type === 'togglebutton' && spec.active ? [ ViewButtonClasses.Ticked ] : []),
-    attributes: tooltipAttributes
+    attributes: ariaLabelAttributes
   };
   const extraBehaviours: Behaviours = [];
 
-  const iconButtonSpec = renderCommonSpec(buttonSpec, Optional.some(action), extraBehaviours, dom, components, spec.tooltip, providers);
+  const iconButtonSpec = renderCommonSpec(buttonSpec, Optional.some(action), extraBehaviours, dom, components, Optional.none(), providers);
   return AlloyButton.sketch(iconButtonSpec);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
@@ -23,7 +23,7 @@ const renderClose = (providersBackstage: UiFactoryBackstageProviders) => Button.
     attributes: {
       'type': 'button',
       'aria-label': providersBackstage.translate('Close'),
-      'data-mce-btn': 'close'
+      'data-mce-label': 'close'
     }
   },
   buttonBehaviours: Behaviour.derive([

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
@@ -23,8 +23,7 @@ const renderClose = (providersBackstage: UiFactoryBackstageProviders) => Button.
     attributes: {
       'type': 'button',
       'aria-label': providersBackstage.translate('Close'),
-      // TINY-10453: Remove this tooltip, we don't want duplicate tooltips and until we figured a better way to test, it's here now so that tests would pass
-      'title': providersBackstage.translate('Close')
+      'data-mce-btn': 'close'
     }
   },
   buttonBehaviours: Behaviour.derive([

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
@@ -23,7 +23,7 @@ const renderClose = (providersBackstage: UiFactoryBackstageProviders) => Button.
     attributes: {
       'type': 'button',
       'aria-label': providersBackstage.translate('Close'),
-      'data-mce-label': 'close'
+      'data-mce-name': 'close'
     }
   },
   buttonBehaviours: Behaviour.derive([

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -47,11 +47,11 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
         toolbar: 'styles'
       },
       initial: [{
-        clickOn: 'button[data-mce-btn="styles"]',
+        clickOn: 'button[data-mce-label="styles"]',
         waitFor: 'div[role="menu"]'
       }],
       assertAbove: 'div[role="menu"]',
-      assertBelow: 'button[data-mce-btn="styles"]'
+      assertBelow: 'button[data-mce-label="styles"]'
     }));
 
     it('SplitButton menu should open above button', () => pTest({
@@ -89,11 +89,11 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
         toolbar: Arr.range(10, Fun.constant('bold | italic ')).join('')
       },
       initial: [{
-        clickOn: 'button[data-mce-btn="overflow-button"]',
+        clickOn: 'button[data-mce-label="overflow-button"]',
         waitFor: '.tox-toolbar__overflow'
       }],
       assertAbove: '.tox-toolbar__overflow',
-      assertBelow: 'button[data-mce-btn="overflow-button"]'
+      assertBelow: 'button[data-mce-label="overflow-button"]'
     }));
 
     it('Menu button in overflow toolbar should open up', () => pTest({
@@ -104,15 +104,15 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
       },
       initial: [
         {
-          clickOn: 'button[data-mce-btn="overflow-button"]',
+          clickOn: 'button[data-mce-label="overflow-button"]',
           waitFor: '.tox-toolbar__overflow'
         }, {
-          clickOn: 'button[data-mce-btn="align"]',
+          clickOn: 'button[data-mce-label="align"]',
           waitFor: 'div[role="menu"]'
         }
       ],
       assertAbove: 'div[role="menu"]',
-      assertBelow: 'button[data-mce-btn="align"]'
+      assertBelow: 'button[data-mce-label="align"]'
     }));
 
     it('Menubar menu should open above button', () => pTest({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -47,11 +47,11 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
         toolbar: 'styles'
       },
       initial: [{
-        clickOn: 'button[title^="Format"]',
+        clickOn: 'button[data-mce-btn="styles"]',
         waitFor: 'div[role="menu"]'
       }],
       assertAbove: 'div[role="menu"]',
-      assertBelow: 'button[title^="Format"]'
+      assertBelow: 'button[data-mce-btn="styles"]'
     }));
 
     it('SplitButton menu should open above button', () => pTest({
@@ -89,11 +89,11 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
         toolbar: Arr.range(10, Fun.constant('bold | italic ')).join('')
       },
       initial: [{
-        clickOn: 'button[title="Reveal or hide additional toolbar items"]',
+        clickOn: 'button[data-mce-btn="overflow-button"]',
         waitFor: '.tox-toolbar__overflow'
       }],
       assertAbove: '.tox-toolbar__overflow',
-      assertBelow: 'button[title="Reveal or hide additional toolbar items"]'
+      assertBelow: 'button[data-mce-btn="overflow-button"]'
     }));
 
     it('Menu button in overflow toolbar should open up', () => pTest({
@@ -104,15 +104,15 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
       },
       initial: [
         {
-          clickOn: 'button[title="Reveal or hide additional toolbar items"]',
+          clickOn: 'button[data-mce-btn="overflow-button"]',
           waitFor: '.tox-toolbar__overflow'
         }, {
-          clickOn: 'button[title^="Align"]',
+          clickOn: 'button[data-mce-btn="align"]',
           waitFor: 'div[role="menu"]'
         }
       ],
       assertAbove: 'div[role="menu"]',
-      assertBelow: 'button[title^="Align"]'
+      assertBelow: 'button[data-mce-btn="align"]'
     }));
 
     it('Menubar menu should open above button', () => pTest({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -47,11 +47,11 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
         toolbar: 'styles'
       },
       initial: [{
-        clickOn: 'button[data-mce-label="styles"]',
+        clickOn: 'button[data-mce-name="styles"]',
         waitFor: 'div[role="menu"]'
       }],
       assertAbove: 'div[role="menu"]',
-      assertBelow: 'button[data-mce-label="styles"]'
+      assertBelow: 'button[data-mce-name="styles"]'
     }));
 
     it('SplitButton menu should open above button', () => pTest({
@@ -89,11 +89,11 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
         toolbar: Arr.range(10, Fun.constant('bold | italic ')).join('')
       },
       initial: [{
-        clickOn: 'button[data-mce-label="overflow-button"]',
+        clickOn: 'button[data-mce-name="overflow-button"]',
         waitFor: '.tox-toolbar__overflow'
       }],
       assertAbove: '.tox-toolbar__overflow',
-      assertBelow: 'button[data-mce-label="overflow-button"]'
+      assertBelow: 'button[data-mce-name="overflow-button"]'
     }));
 
     it('Menu button in overflow toolbar should open up', () => pTest({
@@ -104,15 +104,15 @@ describe('browser.tinymce.themes.silver.editor.ToolbarBottomTest', () => {
       },
       initial: [
         {
-          clickOn: 'button[data-mce-label="overflow-button"]',
+          clickOn: 'button[data-mce-name="overflow-button"]',
           waitFor: '.tox-toolbar__overflow'
         }, {
-          clickOn: 'button[data-mce-label="align"]',
+          clickOn: 'button[data-mce-name="align"]',
           waitFor: 'div[role="menu"]'
         }
       ],
       assertAbove: 'div[role="menu"]',
-      assertBelow: 'button[data-mce-label="align"]'
+      assertBelow: 'button[data-mce-name="align"]'
     }));
 
     it('Menubar menu should open above button', () => pTest({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipTest.ts
@@ -433,7 +433,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
         base_url: '/project/tinymce/js/tinymce'
       });
 
-      it(`TINY-10453: Should trigger tooltip with ${test.label} - no split button`, async () => {
+      it(`TINY-10453: Should not show tooltip with ${test.label} - Contains text and no icon`, async () => {
         const editor = hook.editor();
         const buttonSelector = 'div[data-mce-label="split-button"] > .tox-tbtn + .tox-split-button__chevron';
         await openMenu(editor, buttonSelector);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipTest.ts
@@ -53,11 +53,9 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
     );
   };
 
-  const openAndGetMenu = (selector: string) => {
-    Mouse.clickOn(SugarBody.body(), selector);
-    return Waiter.pTryUntil('Waiting for menu', () =>
-      UiFinder.findIn(SugarBody.body(), '[role="menu"]').getOrDie()
-    );
+  const openMenu = (editor: Editor, buttonSelector: string) => {
+    TinyUiActions.clickOnToolbar(editor, buttonSelector);
+    return TinyUiActions.pWaitForPopup(editor, '[role="menu"]');
   };
 
   Arr.each([
@@ -177,9 +175,12 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar Split Button Menu - forecolor`, async () => {
         const editor = hook.editor();
         const buttonSelector = 'div[data-mce-btn="forecolor"] > .tox-tbtn + .tox-split-button__chevron';
-        await openAndGetMenu(buttonSelector);
-        const menuSelector = 'div[data-mce-btn="Light Green"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, menuSelector), 'Light Green');
+        await openMenu(editor, buttonSelector);
+        await Waiter.pWait(300);
+        const menuSelector = 'div[data-mce-btn="Red"]';
+        await test.pTriggerTooltip(editor, menuSelector);
+        const tooltip = await TinyUiActions.pWaitForUi(editor, '.tox-silver-sink .tox-tooltip__body:contains("Red")') as SugarElement<HTMLElement>;
+        assert.equal(TextContent.get(tooltip), 'Red');
         await pCloseTooltip(editor, menuSelector);
         await closeMenu(menuSelector);
       });
@@ -187,7 +188,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar Split Button Menu - listpreview`, async () => {
         const editor = hook.editor();
         const buttonSelector = 'div[data-mce-btn="split-button-with-icon"]  > .tox-tbtn + .tox-split-button__chevron';
-        await openAndGetMenu(buttonSelector);
+        await openMenu(editor, buttonSelector);
         const menuSelector = 'div[aria-label="Lower Alpha 1"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, menuSelector), 'Lower Alpha 1');
         await pCloseTooltip(editor, menuSelector);
@@ -435,7 +436,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
       it(`TINY-10453: Should trigger tooltip with ${test.label} - no split button`, async () => {
         const editor = hook.editor();
         const buttonSelector = 'div[data-mce-btn="split-button"] > .tox-tbtn + .tox-split-button__chevron';
-        await openAndGetMenu(buttonSelector);
+        await openMenu(editor, buttonSelector);
         const menuSelector = '[aria-label="Choice item 1"]';
         await pAssertNoTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), '');
         await closeMenu(menuSelector);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipTest.ts
@@ -146,38 +146,38 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addButton`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-btn="basic-button"]';
+        const buttonSelector = 'button[data-mce-label="basic-button"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Button');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addToggleButton`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-btn="toggle-button"]';
+        const buttonSelector = 'button[data-mce-label="toggle-button"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Toggle Button');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addMenuButton`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-btn="menu-button"]';
+        const buttonSelector = 'button[data-mce-label="menu-button"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Menu Button');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addSplitButton`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-btn="split-button"]';
+        const buttonSelector = 'div[data-mce-label="split-button"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Split Button');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar Split Button Menu - forecolor`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-btn="forecolor"] > .tox-tbtn + .tox-split-button__chevron';
+        const buttonSelector = 'div[data-mce-label="forecolor"] > .tox-tbtn + .tox-split-button__chevron';
         await openMenu(editor, buttonSelector);
         await Waiter.pWait(300);
-        const menuSelector = 'div[data-mce-btn="Red"]';
+        const menuSelector = 'div[data-mce-label="Red"]';
         await test.pTriggerTooltip(editor, menuSelector);
         const tooltip = await TinyUiActions.pWaitForUi(editor, '.tox-silver-sink .tox-tooltip__body:contains("Red")') as SugarElement<HTMLElement>;
         assert.equal(TextContent.get(tooltip), 'Red');
@@ -187,7 +187,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar Split Button Menu - listpreview`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-btn="split-button-with-icon"]  > .tox-tbtn + .tox-split-button__chevron';
+        const buttonSelector = 'div[data-mce-label="split-button-with-icon"]  > .tox-tbtn + .tox-split-button__chevron';
         await openMenu(editor, buttonSelector);
         const menuSelector = 'div[aria-label="Lower Alpha 1"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, menuSelector), 'Lower Alpha 1');
@@ -277,10 +277,10 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - button without label in Dialog`, async () => {
         const editor = hook.editor();
-        const toolbarButtonSelector = '[data-mce-btn="dialog-button"]';
+        const toolbarButtonSelector = '[data-mce-label="dialog-button"]';
         TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
         await TinyUiActions.pWaitForDialog(editor);
-        const buttonSelector = '[data-mce-btn="Test-Button"]';
+        const buttonSelector = '[data-mce-label="Test-Button"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Test-Button');
         await pCloseTooltip(editor, buttonSelector);
         TinyUiActions.closeDialog(editor);
@@ -288,10 +288,10 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - sizeinput - 'Constrain Proportions' in Dialog`, async () => {
         const editor = hook.editor();
-        const toolbarButtonSelector = '[data-mce-btn="size-input-dialog-button"]';
+        const toolbarButtonSelector = '[data-mce-label="size-input-dialog-button"]';
         TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
         await TinyUiActions.pWaitForDialog(editor);
-        const buttonSelector = '[data-mce-btn="Constrain proportions"]';
+        const buttonSelector = '[data-mce-label="Constrain proportions"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Constrain proportions');
         await pCloseTooltip(editor, buttonSelector);
         TinyUiActions.closeDialog(editor);
@@ -299,10 +299,10 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - dialog footer button`, async () => {
         const editor = hook.editor();
-        const toolbarButtonSelector = '[data-mce-btn="dialog-footer-button"]';
+        const toolbarButtonSelector = '[data-mce-label="dialog-footer-button"]';
         TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
         await TinyUiActions.pWaitForDialog(editor);
-        const buttonSelector = '[data-mce-btn="Preferences"]';
+        const buttonSelector = '[data-mce-label="Preferences"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Preferences');
         await pCloseTooltip(editor, buttonSelector);
         TinyUiActions.closeDialog(editor);
@@ -310,10 +310,10 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - dialog close button`, async () => {
         const editor = hook.editor();
-        const toolbarButtonSelector = '[data-mce-btn="dialog-footer-button"]';
+        const toolbarButtonSelector = '[data-mce-label="dialog-footer-button"]';
         TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
         await TinyUiActions.pWaitForDialog(editor);
-        const buttonSelector = '[data-mce-btn="close"]';
+        const buttonSelector = '[data-mce-label="close"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Close');
         await pCloseTooltip(editor, buttonSelector);
         TinyUiActions.closeDialog(editor);
@@ -328,48 +328,48 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - fontsizeinput - Decrease font size`, async () => {
         const editor = hook.editor();
-        const buttonSelector = '[data-mce-btn="fontsizeinput"] > [data-mce-btn="minus"]';
+        const buttonSelector = '[data-mce-label="fontsizeinput"] > [data-mce-label="minus"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Decrease font size');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - fontsizeinput - Increase font size`, async () => {
         const editor = hook.editor();
-        const buttonSelector = '[data-mce-btn="fontsizeinput"] > [data-mce-btn="plus"]';
+        const buttonSelector = '[data-mce-label="fontsizeinput"] > [data-mce-label="plus"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Increase font size');
         await pCloseTooltip(editor, buttonSelector);
       });
       it(`TINY-10453: Should trigger tooltip with ${test.label} - fontsize`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-btn="fontsize"]';
+        const buttonSelector = 'button[data-mce-label="fontsize"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Font size 12pt');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - fontfamily`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-btn="fontfamily"]';
+        const buttonSelector = 'button[data-mce-label="fontfamily"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Font System Font');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - align`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-btn="align"]';
+        const buttonSelector = 'button[data-mce-label="align"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Alignment left');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - blocks`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-btn="blocks"]';
+        const buttonSelector = 'button[data-mce-label="blocks"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Block Paragraph');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - styles`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-btn="styles"]';
+        const buttonSelector = 'button[data-mce-label="styles"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Format Paragraph');
         await pCloseTooltip(editor, buttonSelector);
       });
@@ -383,7 +383,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - resize handle`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-btn="resize-handle"]';
+        const buttonSelector = 'div[data-mce-label="resize-handle"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Resize');
         await pCloseTooltip(editor, buttonSelector);
       });
@@ -404,7 +404,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - overflow more button`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-btn="overflow-button"]';
+        const buttonSelector = 'button[data-mce-label="overflow-button"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Reveal or hide additional toolbar items');
         await pCloseTooltip(editor, buttonSelector);
       });
@@ -435,7 +435,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - no split button`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-btn="split-button"] > .tox-tbtn + .tox-split-button__chevron';
+        const buttonSelector = 'div[data-mce-label="split-button"] > .tox-tbtn + .tox-split-button__chevron';
         await openMenu(editor, buttonSelector);
         const menuSelector = '[aria-label="Choice item 1"]';
         await pAssertNoTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), '');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipTest.ts
@@ -1,67 +1,445 @@
-import { FocusTools, Keys, Mouse, UiFinder, Waiter } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
-import { SugarBody, SugarElement } from '@ephox/sugar';
-import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+import { FocusTools, Mouse, UiFinder, Waiter } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr, Fun } from '@ephox/katamari';
+import { SugarBody, SugarElement, TextContent } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import ImagePlugin from 'tinymce/plugins/image/Plugin';
-import LinkPlugin from 'tinymce/plugins/link/Plugin';
+
+interface TestScenario {
+  readonly label: string;
+  readonly pTriggerTooltip: (editor: Editor, selector: string) => Promise<void>;
+}
 
 describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
-  const hook = TinyHooks.bddSetup<Editor>({
-    base_url: '/project/tinymce/js/tinymce',
-    plugins: [ 'link', 'image' ],
-    toolbar: 'link image | fontsize'
-  }, [ ImagePlugin, LinkPlugin ]);
-
   const tooltipSelector = '.tox-silver-sink .tox-tooltip__body';
-  const insertLinkSelector = 'button.tox-tbtn[aria-label="Insert/edit link"]';
-  const assertTooltip = async (editor: Editor, text: string) => {
+
+  const pAssertTooltip = async (editor: Editor, pTriggerTooltip: () => Promise<void>, text: string) => {
+    await pTriggerTooltip();
     const tooltip = await TinyUiActions.pWaitForUi(editor, tooltipSelector) as SugarElement<HTMLElement>;
-    assert.equal(tooltip.dom.textContent, text);
+    assert.equal(TextContent.get(tooltip), text);
   };
 
-  // TODO: TINY-10465 - Improve tests
-  it('TINY-9275: should be rendered after a delay on mouse over', async () => {
-    const editor = hook.editor();
-
-    // Mouse over the font sizes dropdown
-    Mouse.mouseOver(UiFinder.findIn(TinyDom.container(editor), 'button.tox-tbtn.tox-tbtn--select.tox-tbtn--bespoke').getOrDie());
-    // Not expecting the tooltip to be rendered immedilately
+  const pAssertNoTooltip = async (_: Editor, pTriggerTooltip: () => Promise<void>, _text: string) => {
+    await pTriggerTooltip();
+    await Waiter.pWait(300);
     UiFinder.notExists(SugarBody.body(), tooltipSelector);
-    // This is a slightly higher than the default delay for showing a tooltip to take renderinging time into account
-    await assertTooltip(editor, 'Font size 12pt');
+  };
 
-    // Then move mouse over the insert link button
-    const insertLinkButton = await TinyUiActions.pWaitForUi(editor, insertLinkSelector);
-    Mouse.mouseOver(insertLinkButton);
+  const pTriggerTooltipWithMouse = async (editor: Editor, selector: string) => {
+    const button = await TinyUiActions.pWaitForUi(editor, selector) as SugarElement<HTMLElement>;
+    Mouse.mouseOver(button);
+  };
 
-    await Waiter.pWait(500);
-    // There is a small delay between hiding the current tooltip and showing another one
-    await assertTooltip(editor, 'Insert/edit link');
+  const pTriggerTooltipWithKeyboard = (_: Editor, selector: string) => {
+    FocusTools.setFocus(SugarBody.body(), selector);
+    return Promise.resolve();
+  };
 
-    // Mouseovering another element doesn't trigger `mouseout` event on tooltip
-    Mouse.mouseOut(insertLinkButton);
+  const pCloseTooltip = async (editor: Editor, selector: string) => {
+    const button = await TinyUiActions.pWaitForUi(editor, selector) as SugarElement<HTMLElement>;
+    Mouse.mouseOut(button);
+    editor.focus();
     await Waiter.pTryUntil(
-      'wait for tooltip to be removed',
-      () => UiFinder.notExists(SugarBody.body(), tooltipSelector)
+      'Waiting for tooltip to NO LONGER be in DOM',
+      () => UiFinder.notExists(SugarBody.body(), tooltipSelector));
+  };
+
+  const closeMenu = (selector: string) => {
+    Mouse.clickOn(SugarBody.body(), selector);
+    return Waiter.pTryUntil('Waiting for menu', () =>
+      UiFinder.notExists(SugarBody.body(), '[role="menu"]')
     );
-  });
+  };
 
-  it('TINY-9275: should be rendered immediately when navigating by keyboard', async () => {
-    const editor = hook.editor();
-    // Focus on the first toolbar button
+  const openAndGetMenu = (selector: string) => {
+    Mouse.clickOn(SugarBody.body(), selector);
+    return Waiter.pTryUntil('Waiting for menu', () =>
+      UiFinder.findIn(SugarBody.body(), '[role="menu"]').getOrDie()
+    );
+  };
 
-    await TinyUiActions.pWaitForUi(editor, insertLinkSelector);
-    FocusTools.setFocus(SugarBody.body(), insertLinkSelector);
-    // Wait for the tooltip to be visible. Notice that the waiting is significant less
-    await Waiter.pWait(500);
-    await assertTooltip(editor, 'Insert/edit link');
+  Arr.each([
+    { label: 'Mouse', pTriggerTooltip: pTriggerTooltipWithMouse },
+    { label: 'Keyboard', pTriggerTooltip: pTriggerTooltipWithKeyboard },
+  ], (test: TestScenario) => {
+    context('Basic buttons', () => {
+      const hook = TinyHooks.bddSetup<Editor>({
+        base_url: '/project/tinymce/js/tinymce',
+        toolbar: 'basic-button toggle-button menu-button split-button forecolor split-button-with-icon',
+        setup: (ed: Editor) => {
+          ed.ui.registry.addButton('basic-button', {
+            text: 'Button',
+            tooltip: 'Button',
+            onAction: Fun.noop
+          });
 
-    // Navigate to another button in the toolbar
-    TinyUiActions.keydown(editor, Keys.tab());
-    await Waiter.pWait(500);
-    await assertTooltip(editor, 'Font size 12pt');
+          ed.ui.registry.addToggleButton('toggle-button', {
+            text: 'Toggle Button',
+            tooltip: 'Toggle Button',
+            onAction: Fun.noop
+          });
+
+          ed.ui.registry.addMenuButton('menu-button', {
+            text: 'Menu Button',
+            tooltip: 'Menu Button',
+            fetch: (success) => {
+              success([
+                {
+                  type: 'togglemenuitem',
+                  text: 'Toggle menu item',
+                  onAction: Fun.noop,
+                  active: true
+                }
+              ]);
+            },
+          });
+
+          ed.ui.registry.addSplitButton('split-button', {
+            text: 'Split Button',
+            tooltip: 'Split Button',
+            fetch: (success) => {
+              success([
+                {
+                  text: 'Choice item 1',
+                  type: 'choiceitem',
+                }
+              ]);
+            },
+            onAction: Fun.noop,
+            onItemAction: Fun.noop
+          });
+
+          ed.ui.registry.addSplitButton('split-button-with-icon', {
+            icon: 'bold',
+            tooltip: 'Split Button with Icon',
+            presets: 'listpreview',
+            columns: 3,
+            fetch: (success) => {
+              success([
+                {
+                  type: 'choiceitem',
+                  value: 'lower-alpha-1',
+                  icon: 'list-num-lower-alpha',
+                  text: 'Lower Alpha 1'
+                },
+                {
+                  type: 'choiceitem',
+                  value: 'lower-alpha-2',
+                  icon: 'list-num-lower-alpha',
+                  text: 'Lower Alpha 2'
+                },
+                {
+                  type: 'choiceitem',
+                  value: 'lower-alpha-3',
+                  icon: 'list-num-lower-alpha',
+                  text: 'Lower Alpha 3'
+                }
+              ]);
+            },
+            onAction: Fun.noop,
+            onItemAction: Fun.noop,
+            select: Fun.always,
+            onSetup: () => Fun.noop
+          });
+        }
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addButton`, async () => {
+        const editor = hook.editor();
+        const buttonSelector = 'button[data-mce-btn="basic-button"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Button');
+        await pCloseTooltip(editor, buttonSelector);
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addToggleButton`, async () => {
+        const editor = hook.editor();
+        const buttonSelector = 'button[data-mce-btn="toggle-button"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Toggle Button');
+        await pCloseTooltip(editor, buttonSelector);
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addMenuButton`, async () => {
+        const editor = hook.editor();
+        const buttonSelector = 'button[data-mce-btn="menu-button"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Menu Button');
+        await pCloseTooltip(editor, buttonSelector);
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addSplitButton`, async () => {
+        const editor = hook.editor();
+        const buttonSelector = 'div[data-mce-btn="split-button"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Split Button');
+        await pCloseTooltip(editor, buttonSelector);
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar Split Button Menu - forecolor`, async () => {
+        const editor = hook.editor();
+        const buttonSelector = 'div[data-mce-btn="forecolor"] > .tox-tbtn + .tox-split-button__chevron';
+        await openAndGetMenu(buttonSelector);
+        const menuSelector = 'div[data-mce-btn="Light Green"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, menuSelector), 'Light Green');
+        await pCloseTooltip(editor, menuSelector);
+        await closeMenu(menuSelector);
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar Split Button Menu - listpreview`, async () => {
+        const editor = hook.editor();
+        const buttonSelector = 'div[data-mce-btn="split-button-with-icon"]  > .tox-tbtn + .tox-split-button__chevron';
+        await openAndGetMenu(buttonSelector);
+        const menuSelector = 'div[aria-label="Lower Alpha 1"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, menuSelector), 'Lower Alpha 1');
+        await pCloseTooltip(editor, menuSelector);
+        await closeMenu(menuSelector);
+      });
+    });
+
+    context('Dialog related buttons', () => {
+      const hook = TinyHooks.bddSetup<Editor>({
+        base_url: '/project/tinymce/js/tinymce',
+        toolbar: 'dialog-button dialog-footer-button size-input-dialog-button',
+        setup: (ed: Editor) => {
+          ed.ui.registry.addButton('dialog-button', {
+            text: 'Dialog Button',
+            onAction: () => {
+              ed.windowManager.open({
+                title: 'Test Dialog',
+                size: 'normal',
+                body: {
+                  type: 'panel',
+                  items: [{
+                    type: 'button',
+                    name: 'prev',
+                    text: 'Test-Button',
+                    icon: 'action-prev',
+                  }]
+                }
+              });
+            }
+          });
+
+          ed.ui.registry.addButton('dialog-footer-button', {
+            text: 'Dialog Footer Button',
+            onAction: () => {
+              ed.windowManager.open({
+                title: 'Test Dialog',
+                size: 'normal',
+                body: {
+                  type: 'panel',
+                  items: [
+                    {
+                      type: 'input',
+                      name: 'width',
+                      label: 'Width'
+                    },
+                  ]
+                },
+                buttons: [{
+                  type: 'menu',
+                  name: 'options',
+                  icon: 'Preferences',
+                  tooltip: 'Preferences',
+                  align: 'start',
+                  items: [{
+                    type: 'togglemenuitem',
+                    name: 'menuitem1',
+                    text: 'Menu item 1',
+                  }]
+                }]
+              });
+            }
+          });
+
+          ed.ui.registry.addButton('size-input-dialog-button', {
+            text: 'Dialog Button',
+            onAction: () => {
+              ed.windowManager.open({
+                title: 'Test Dialog',
+                size: 'normal',
+                body: {
+                  type: 'panel',
+                  items: [
+                    {
+                      type: 'sizeinput',
+                      name: 'dimensions',
+                      label: 'Constrain proportions',
+                      constrain: true
+                    }
+                  ]
+                }
+              });
+            }
+          });
+        }
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - button without label in Dialog`, async () => {
+        const editor = hook.editor();
+        const toolbarButtonSelector = '[data-mce-btn="dialog-button"]';
+        TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
+        await TinyUiActions.pWaitForDialog(editor);
+        const buttonSelector = '[data-mce-btn="Test-Button"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Test-Button');
+        await pCloseTooltip(editor, buttonSelector);
+        TinyUiActions.closeDialog(editor);
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - sizeinput - 'Constrain Proportions' in Dialog`, async () => {
+        const editor = hook.editor();
+        const toolbarButtonSelector = '[data-mce-btn="size-input-dialog-button"]';
+        TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
+        await TinyUiActions.pWaitForDialog(editor);
+        const buttonSelector = '[data-mce-btn="Constrain proportions"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Constrain proportions');
+        await pCloseTooltip(editor, buttonSelector);
+        TinyUiActions.closeDialog(editor);
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - dialog footer button`, async () => {
+        const editor = hook.editor();
+        const toolbarButtonSelector = '[data-mce-btn="dialog-footer-button"]';
+        TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
+        await TinyUiActions.pWaitForDialog(editor);
+        const buttonSelector = '[data-mce-btn="Preferences"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Preferences');
+        await pCloseTooltip(editor, buttonSelector);
+        TinyUiActions.closeDialog(editor);
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - dialog close button`, async () => {
+        const editor = hook.editor();
+        const toolbarButtonSelector = '[data-mce-btn="dialog-footer-button"]';
+        TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
+        await TinyUiActions.pWaitForDialog(editor);
+        const buttonSelector = '[data-mce-btn="close"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Close');
+        await pCloseTooltip(editor, buttonSelector);
+        TinyUiActions.closeDialog(editor);
+      });
+    });
+
+    context('Bespoke buttons', () => {
+      const hook = TinyHooks.bddSetup<Editor>({
+        base_url: '/project/tinymce/js/tinymce',
+        toolbar: 'fontsizeinput fontsize fontfamily align styles blocks',
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - fontsizeinput - Decrease font size`, async () => {
+        const editor = hook.editor();
+        const buttonSelector = '[data-mce-btn="fontsizeinput"] > [data-mce-btn="minus"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Decrease font size');
+        await pCloseTooltip(editor, buttonSelector);
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - fontsizeinput - Increase font size`, async () => {
+        const editor = hook.editor();
+        const buttonSelector = '[data-mce-btn="fontsizeinput"] > [data-mce-btn="plus"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Increase font size');
+        await pCloseTooltip(editor, buttonSelector);
+      });
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - fontsize`, async () => {
+        const editor = hook.editor();
+        const buttonSelector = 'button[data-mce-btn="fontsize"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Font size 12pt');
+        await pCloseTooltip(editor, buttonSelector);
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - fontfamily`, async () => {
+        const editor = hook.editor();
+        const buttonSelector = 'button[data-mce-btn="fontfamily"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Font System Font');
+        await pCloseTooltip(editor, buttonSelector);
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - align`, async () => {
+        const editor = hook.editor();
+        const buttonSelector = 'button[data-mce-btn="align"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Alignment left');
+        await pCloseTooltip(editor, buttonSelector);
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - blocks`, async () => {
+        const editor = hook.editor();
+        const buttonSelector = 'button[data-mce-btn="blocks"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Block Paragraph');
+        await pCloseTooltip(editor, buttonSelector);
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - styles`, async () => {
+        const editor = hook.editor();
+        const buttonSelector = 'button[data-mce-btn="styles"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Format Paragraph');
+        await pCloseTooltip(editor, buttonSelector);
+      });
+    });
+
+    context('Resize handle', () => {
+      const hook = TinyHooks.bddSetup<Editor>({
+        base_url: '/project/tinymce/js/tinymce',
+        resize: 'both'
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - resize handle`, async () => {
+        const editor = hook.editor();
+        const buttonSelector = 'div[data-mce-btn="resize-handle"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Resize');
+        await pCloseTooltip(editor, buttonSelector);
+      });
+    });
+
+    context('overflow-button', () => {
+      const hook = TinyHooks.bddSetup<Editor>({
+        toolbar: Arr.range(25, Fun.constant('bold | italic | test-button')).join(' '),
+        toolbar_mode: 'floating',
+        setup: (ed: Editor) => {
+          ed.ui.registry.addButton('test-button', {
+            text: 'Test Button for Overflow Button',
+            onAction: Fun.noop
+          });
+        },
+        base_url: '/project/tinymce/js/tinymce'
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - overflow more button`, async () => {
+        const editor = hook.editor();
+        const buttonSelector = 'button[data-mce-btn="overflow-button"]';
+        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Reveal or hide additional toolbar items');
+        await pCloseTooltip(editor, buttonSelector);
+      });
+    });
+
+    context('No tooltip', () => {
+      const hook = TinyHooks.bddSetup<Editor>({
+        toolbar: 'split-button',
+        toolbar_mode: 'floating',
+        setup: (ed: Editor) => {
+          ed.ui.registry.addSplitButton('split-button', {
+            text: 'Split Button',
+            tooltip: 'Split Button',
+            fetch: (success) => {
+              success([
+                {
+                  text: 'Choice item 1',
+                  type: 'choiceitem',
+                }
+              ]);
+            },
+            onAction: Fun.noop,
+            onItemAction: Fun.noop
+          });
+        },
+        base_url: '/project/tinymce/js/tinymce'
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - no split button`, async () => {
+        const editor = hook.editor();
+        const buttonSelector = 'div[data-mce-btn="split-button"] > .tox-tbtn + .tox-split-button__chevron';
+        await openAndGetMenu(buttonSelector);
+        const menuSelector = '[aria-label="Choice item 1"]';
+        await pAssertNoTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), '');
+        await closeMenu(menuSelector);
+      });
+    });
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipTest.ts
@@ -438,7 +438,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
         const buttonSelector = 'div[data-mce-label="split-button"] > .tox-tbtn + .tox-split-button__chevron';
         await openMenu(editor, buttonSelector);
         const menuSelector = '[aria-label="Choice item 1"]';
-        await pAssertNoTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), '');
+        await pAssertNoTooltip(editor, () => test.pTriggerTooltip(editor, menuSelector), '');
         await closeMenu(menuSelector);
       });
     });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipTest.ts
@@ -146,38 +146,38 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addButton`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="basic-button"]';
+        const buttonSelector = 'button[data-mce-name="basic-button"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Button');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addToggleButton`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="toggle-button"]';
+        const buttonSelector = 'button[data-mce-name="toggle-button"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Toggle Button');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addMenuButton`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="menu-button"]';
+        const buttonSelector = 'button[data-mce-name="menu-button"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Menu Button');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addSplitButton`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-label="split-button"]';
+        const buttonSelector = 'div[data-mce-name="split-button"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Split Button');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar Split Button Menu - forecolor`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-label="forecolor"] > .tox-tbtn + .tox-split-button__chevron';
+        const buttonSelector = 'div[data-mce-name="forecolor"] > .tox-tbtn + .tox-split-button__chevron';
         await openMenu(editor, buttonSelector);
         await Waiter.pWait(300);
-        const menuSelector = 'div[data-mce-label="Red"]';
+        const menuSelector = 'div[data-mce-name="Red"]';
         await test.pTriggerTooltip(editor, menuSelector);
         const tooltip = await TinyUiActions.pWaitForUi(editor, '.tox-silver-sink .tox-tooltip__body:contains("Red")') as SugarElement<HTMLElement>;
         assert.equal(TextContent.get(tooltip), 'Red');
@@ -187,7 +187,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar Split Button Menu - listpreview`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-label="split-button-with-icon"]  > .tox-tbtn + .tox-split-button__chevron';
+        const buttonSelector = 'div[data-mce-name="split-button-with-icon"]  > .tox-tbtn + .tox-split-button__chevron';
         await openMenu(editor, buttonSelector);
         const menuSelector = 'div[aria-label="Lower Alpha 1"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, menuSelector), 'Lower Alpha 1');
@@ -277,10 +277,10 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - button without label in Dialog`, async () => {
         const editor = hook.editor();
-        const toolbarButtonSelector = '[data-mce-label="dialog-button"]';
+        const toolbarButtonSelector = '[data-mce-name="dialog-button"]';
         TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
         await TinyUiActions.pWaitForDialog(editor);
-        const buttonSelector = '[data-mce-label="Test-Button"]';
+        const buttonSelector = '[data-mce-name="Test-Button"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Test-Button');
         await pCloseTooltip(editor, buttonSelector);
         TinyUiActions.closeDialog(editor);
@@ -288,10 +288,10 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - sizeinput - 'Constrain Proportions' in Dialog`, async () => {
         const editor = hook.editor();
-        const toolbarButtonSelector = '[data-mce-label="size-input-dialog-button"]';
+        const toolbarButtonSelector = '[data-mce-name="size-input-dialog-button"]';
         TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
         await TinyUiActions.pWaitForDialog(editor);
-        const buttonSelector = '[data-mce-label="Constrain proportions"]';
+        const buttonSelector = '[data-mce-name="Constrain proportions"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Constrain proportions');
         await pCloseTooltip(editor, buttonSelector);
         TinyUiActions.closeDialog(editor);
@@ -299,10 +299,10 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - dialog footer button`, async () => {
         const editor = hook.editor();
-        const toolbarButtonSelector = '[data-mce-label="dialog-footer-button"]';
+        const toolbarButtonSelector = '[data-mce-name="dialog-footer-button"]';
         TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
         await TinyUiActions.pWaitForDialog(editor);
-        const buttonSelector = '[data-mce-label="Preferences"]';
+        const buttonSelector = '[data-mce-name="Preferences"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Preferences');
         await pCloseTooltip(editor, buttonSelector);
         TinyUiActions.closeDialog(editor);
@@ -310,10 +310,10 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - dialog close button`, async () => {
         const editor = hook.editor();
-        const toolbarButtonSelector = '[data-mce-label="dialog-footer-button"]';
+        const toolbarButtonSelector = '[data-mce-name="dialog-footer-button"]';
         TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
         await TinyUiActions.pWaitForDialog(editor);
-        const buttonSelector = '[data-mce-label="close"]';
+        const buttonSelector = '[data-mce-name="close"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Close');
         await pCloseTooltip(editor, buttonSelector);
         TinyUiActions.closeDialog(editor);
@@ -328,48 +328,48 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - fontsizeinput - Decrease font size`, async () => {
         const editor = hook.editor();
-        const buttonSelector = '[data-mce-label="fontsizeinput"] > [data-mce-label="minus"]';
+        const buttonSelector = '[data-mce-name="fontsizeinput"] > [data-mce-name="minus"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Decrease font size');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - fontsizeinput - Increase font size`, async () => {
         const editor = hook.editor();
-        const buttonSelector = '[data-mce-label="fontsizeinput"] > [data-mce-label="plus"]';
+        const buttonSelector = '[data-mce-name="fontsizeinput"] > [data-mce-name="plus"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Increase font size');
         await pCloseTooltip(editor, buttonSelector);
       });
       it(`TINY-10453: Should trigger tooltip with ${test.label} - fontsize`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="fontsize"]';
+        const buttonSelector = 'button[data-mce-name="fontsize"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Font size 12pt');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - fontfamily`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="fontfamily"]';
+        const buttonSelector = 'button[data-mce-name="fontfamily"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Font System Font');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - align`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="align"]';
+        const buttonSelector = 'button[data-mce-name="align"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Alignment left');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - blocks`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="blocks"]';
+        const buttonSelector = 'button[data-mce-name="blocks"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Block Paragraph');
         await pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - styles`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="styles"]';
+        const buttonSelector = 'button[data-mce-name="styles"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Format Paragraph');
         await pCloseTooltip(editor, buttonSelector);
       });
@@ -383,7 +383,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - resize handle`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-label="resize-handle"]';
+        const buttonSelector = 'div[data-mce-name="resize-handle"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Resize');
         await pCloseTooltip(editor, buttonSelector);
       });
@@ -404,7 +404,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - overflow more button`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="overflow-button"]';
+        const buttonSelector = 'button[data-mce-name="overflow-button"]';
         await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Reveal or hide additional toolbar items');
         await pCloseTooltip(editor, buttonSelector);
       });
@@ -435,7 +435,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should not show tooltip with ${test.label} - Contains text and no icon`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-label="split-button"] > .tox-tbtn + .tox-split-button__chevron';
+        const buttonSelector = 'div[data-mce-name="split-button"] > .tox-tbtn + .tox-split-button__chevron';
         await openMenu(editor, buttonSelector);
         const menuSelector = '[aria-label="Choice item 1"]';
         await pAssertNoTooltip(editor, () => test.pTriggerTooltip(editor, menuSelector), '');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
@@ -694,7 +694,7 @@ describe('browser.tinymce.themes.silver.editor.autocomplete.AutocompleteTest', (
           (s, str, arr) => s.element('div', {
             classes: [ arr.has('tox-collection__item') ],
             attrs: {
-              title: str.is('equals sign')
+              'aria-label': str.is('equals sign')
             },
             children: [
               s.element('div', {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/BespokeSelectAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/BespokeSelectAriaLabelTest.ts
@@ -32,10 +32,10 @@ describe('browser.tinymce.themes.silver.editor.bespoke.BespokeSelectAriaLabelTes
     pWaitForMenu: (editor: Editor, itemSelector: string) => Promise<SugarElement<Element>>
   ) => async () => {
     const editor = hook.editor();
-    const buttonSelector = `button[title="${makeLabel(initialItem)}"]`;
+    const buttonSelector = `button[aria-label="${makeLabel(initialItem)}"]`;
 
     await pOpenMenu(buttonSelector);
-    const itemSelector = `div[role="menuitemcheckbox"][title="${finalItem}"]`;
+    const itemSelector = `div[role="menuitemcheckbox"][aria-label="${finalItem}"]`;
     await pWaitForMenu(editor, itemSelector);
 
     const button = UiFinder.findIn(SugarBody.body(), `.tox-toolbar__group ${buttonSelector}`).getOrDie();
@@ -72,7 +72,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.BespokeSelectAriaLabelTes
       (item) => `${scenario.label} ${item}`,
       Fun.curry(MenuUtils.pOpenMenuWithSelector, scenario.label),
       (editor) => {
-        const submenuSelector = 'div[title="Blocks"]';
+        const submenuSelector = 'div[aria-label="Blocks"]';
         return TinyUiActions.pWaitForUi(editor, submenuSelector).then(() => TinyUiActions.clickOnUi(editor, submenuSelector));
       }
     );

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/StyleSelectFormatNamesTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/StyleSelectFormatNamesTest.ts
@@ -61,8 +61,8 @@ describe('browser.tinymce.themes.silver.editor.bespoke.StyleSelectFormatNamesTes
       classes: [ arr.has('tox-collection__group') ],
       children: Arr.map(expectedItems, (expected) => s.element('div', {
         attrs: {
-          role: str.is('menuitemcheckbox'),
-          title: str.is(expected.title)
+          'role': str.is('menuitemcheckbox'),
+          'aria-label': str.is(expected.title)
         },
         children: [
           s.element('div', {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
@@ -30,7 +30,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
         classes: [ arr.has('tox-toolbar__group') ],
         children: [
           s.element('button', {
-            attrs: { title: str.is('Bold') }
+            attrs: { 'data-mce-btn': str.is('bold') }
           })
         ]
       }),
@@ -38,7 +38,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
         classes: [ arr.has('tox-toolbar__group') ],
         children: [
           s.element('button', {
-            attrs: { title: str.is('Italic') }
+            attrs: { 'data-mce-btn': str.is('italic') }
           })
         ]
       })
@@ -71,7 +71,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
 
   it('TINY-4229: Register floating group toolbar button via editor settings', testToolbarGroup(
     defaultToolbarGroupOptions,
-    'button[title="Formatting"]',
+    'button[data-mce-btn="formatting"]',
     '.tox-toolbar__overflow',
     defaultToolbarGroupStruct
   ));
@@ -89,7 +89,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
         });
       }
     },
-    'button[title="Alignment"]',
+    'button[data-mce-btn="alignment"]',
     '.tox-toolbar__overflow',
     ApproxStructure.build((s, str, arr) => s.element('div', {
       classes: [ arr.has('tox-toolbar__overflow') ],
@@ -98,13 +98,13 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
           classes: [ arr.has('tox-toolbar__group') ],
           children: [
             s.element('button', {
-              attrs: { title: str.is('Align left') }
+              attrs: { 'data-mce-btn': str.is('alignleft') }
             }),
             s.element('button', {
-              attrs: { title: str.is('Align center') }
+              attrs: { 'data-mce-btn': str.is('aligncenter') }
             }),
             s.element('button', {
-              attrs: { title: str.is('Align right') }
+              attrs: { 'data-mce-btn': str.is('alignright') }
             })
           ]
         })
@@ -118,8 +118,8 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
       toolbar: 'formatting | underline',
       toolbar_mode: 'wrap'
     }, () => {
-      UiFinder.notExists(SugarBody.body(), 'button[title="Formatting"]');
-      UiFinder.exists(SugarBody.body(), 'button[title="Underline"]');
+      UiFinder.notExists(SugarBody.body(), 'button[data-mce-btn="formatting"]');
+      UiFinder.exists(SugarBody.body(), 'button[data-mce-btn="underline"]');
       return Promise.resolve();
     })
   );

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
@@ -30,7 +30,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
         classes: [ arr.has('tox-toolbar__group') ],
         children: [
           s.element('button', {
-            attrs: { 'data-mce-btn': str.is('bold') }
+            attrs: { 'data-mce-label': str.is('bold') }
           })
         ]
       }),
@@ -38,7 +38,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
         classes: [ arr.has('tox-toolbar__group') ],
         children: [
           s.element('button', {
-            attrs: { 'data-mce-btn': str.is('italic') }
+            attrs: { 'data-mce-label': str.is('italic') }
           })
         ]
       })
@@ -71,7 +71,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
 
   it('TINY-4229: Register floating group toolbar button via editor settings', testToolbarGroup(
     defaultToolbarGroupOptions,
-    'button[data-mce-btn="formatting"]',
+    'button[data-mce-label="formatting"]',
     '.tox-toolbar__overflow',
     defaultToolbarGroupStruct
   ));
@@ -89,7 +89,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
         });
       }
     },
-    'button[data-mce-btn="alignment"]',
+    'button[data-mce-label="alignment"]',
     '.tox-toolbar__overflow',
     ApproxStructure.build((s, str, arr) => s.element('div', {
       classes: [ arr.has('tox-toolbar__overflow') ],
@@ -98,13 +98,13 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
           classes: [ arr.has('tox-toolbar__group') ],
           children: [
             s.element('button', {
-              attrs: { 'data-mce-btn': str.is('alignleft') }
+              attrs: { 'data-mce-label': str.is('alignleft') }
             }),
             s.element('button', {
-              attrs: { 'data-mce-btn': str.is('aligncenter') }
+              attrs: { 'data-mce-label': str.is('aligncenter') }
             }),
             s.element('button', {
-              attrs: { 'data-mce-btn': str.is('alignright') }
+              attrs: { 'data-mce-label': str.is('alignright') }
             })
           ]
         })
@@ -118,8 +118,8 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
       toolbar: 'formatting | underline',
       toolbar_mode: 'wrap'
     }, () => {
-      UiFinder.notExists(SugarBody.body(), 'button[data-mce-btn="formatting"]');
-      UiFinder.exists(SugarBody.body(), 'button[data-mce-btn="underline"]');
+      UiFinder.notExists(SugarBody.body(), 'button[data-mce-label="formatting"]');
+      UiFinder.exists(SugarBody.body(), 'button[data-mce-label="underline"]');
       return Promise.resolve();
     })
   );

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
@@ -30,7 +30,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
         classes: [ arr.has('tox-toolbar__group') ],
         children: [
           s.element('button', {
-            attrs: { 'data-mce-label': str.is('bold') }
+            attrs: { 'data-mce-name': str.is('bold') }
           })
         ]
       }),
@@ -38,7 +38,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
         classes: [ arr.has('tox-toolbar__group') ],
         children: [
           s.element('button', {
-            attrs: { 'data-mce-label': str.is('italic') }
+            attrs: { 'data-mce-name': str.is('italic') }
           })
         ]
       })
@@ -71,7 +71,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
 
   it('TINY-4229: Register floating group toolbar button via editor settings', testToolbarGroup(
     defaultToolbarGroupOptions,
-    'button[data-mce-label="formatting"]',
+    'button[data-mce-name="formatting"]',
     '.tox-toolbar__overflow',
     defaultToolbarGroupStruct
   ));
@@ -89,7 +89,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
         });
       }
     },
-    'button[data-mce-label="alignment"]',
+    'button[data-mce-name="alignment"]',
     '.tox-toolbar__overflow',
     ApproxStructure.build((s, str, arr) => s.element('div', {
       classes: [ arr.has('tox-toolbar__overflow') ],
@@ -98,13 +98,13 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
           classes: [ arr.has('tox-toolbar__group') ],
           children: [
             s.element('button', {
-              attrs: { 'data-mce-label': str.is('alignleft') }
+              attrs: { 'data-mce-name': str.is('alignleft') }
             }),
             s.element('button', {
-              attrs: { 'data-mce-label': str.is('aligncenter') }
+              attrs: { 'data-mce-name': str.is('aligncenter') }
             }),
             s.element('button', {
-              attrs: { 'data-mce-label': str.is('alignright') }
+              attrs: { 'data-mce-name': str.is('alignright') }
             })
           ]
         })
@@ -118,8 +118,8 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
       toolbar: 'formatting | underline',
       toolbar_mode: 'wrap'
     }, () => {
-      UiFinder.notExists(SugarBody.body(), 'button[data-mce-label="formatting"]');
-      UiFinder.exists(SugarBody.body(), 'button[data-mce-label="underline"]');
+      UiFinder.notExists(SugarBody.body(), 'button[data-mce-name="formatting"]');
+      UiFinder.exists(SugarBody.body(), 'button[data-mce-name="underline"]');
       return Promise.resolve();
     })
   );

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/UpdateToolbarButtonTextAndIconTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/UpdateToolbarButtonTextAndIconTest.ts
@@ -105,7 +105,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.UpdateToolbarButtonTextAn
     const button = await TinyUi(editor).pWaitForUi(selectorForToolbarButtonWithLabel('MenuBefore'));
     const initialWidth = Css.get(button, 'width');
     TinyUiActions.clickOnToolbar(editor, selectorForToolbarButtonWithLabel('MenuBefore'));
-    const menuItem = await TinyUi(editor).pWaitForUi( '[title="Change MenuLabel"]');
+    const menuItem = await TinyUi(editor).pWaitForUi( '[aria-label="Change MenuLabel"]');
     Mouse.click(menuItem);
     await TinyUiActions.pWaitForUi(editor, selectorForToolbarButtonWithLabel('Menu After After After After After After'));
     const currentWidth = Css.get(button, 'width');
@@ -123,7 +123,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.UpdateToolbarButtonTextAn
     const currentWidth = Css.get(button, 'width');
     assert.equal(initialWidth, currentWidth);
     TinyUiActions.clickOnToolbar(editor, `${selectorForToolbarButtonWithLabel('Split After After After After After After')} + .tox-split-button__chevron`);
-    const menuItem = await TinyUi(editor).pWaitForUi( '[title="Menu item 1"]');
+    const menuItem = await TinyUi(editor).pWaitForUi( '[aria-label="Menu item 1"]');
     Mouse.click(menuItem);
     await TinyUiActions.pWaitForUi(editor, selectorForToolbarButtonWithLabel('Split Item After After After After After After'));
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorAriaLabelTest.ts
@@ -28,7 +28,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorAriaLabelTest', () => 
     forecolorMenuItem: (color: string = '') => Strings.isEmpty(color) ? `[role="menu"] div[aria-label^="Text color"]` : `[role="menu"] div[aria-label^="Text color ${color}"]`,
     forecolorMenu: 'button:contains("forecolor")',
     backcolorMenu: 'button:contains("backcolor")',
-    swatchItemColor: (color: string = '') => `[role="menuitemradio"][data-mce-label="${color}"]`
+    swatchItemColor: (color: string = '') => `[role="menuitemradio"][data-mce-name="${color}"]`
   };
 
   const pResetColorToDefault = async (editor: Editor, selector: string) => {
@@ -60,7 +60,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorAriaLabelTest', () => 
   const pSelectCustomAndAssertToolbar = async (editor: Editor, selector: string, expectedSelector: string) => {
     TinyUiActions.clickOnToolbar(editor, selector);
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-    TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Custom color"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Custom color"]');
     const dialog = await TinyUiActions.pWaitForDialog(editor);
     const input = UiFinder.findIn<HTMLInputElement>(dialog, 'label:contains("#") + input').getOrDie();
     UiControls.setValue(input, '123123');
@@ -70,7 +70,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorAriaLabelTest', () => 
     });
     input.dom.dispatchEvent(evt);
     await Waiter.pTryUntil('Dialog has changed', () => input.dom.value === '123123');
-    TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Save"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Save"]');
     UiFinder.exists(SugarBody.body(), expectedSelector);
   };
 
@@ -99,7 +99,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorAriaLabelTest', () => 
   const pSelectCustomAndAssertMenu = async (editor: Editor, menuSelector: string, menuItemSelector: string, expectedSelector: string) => {
     await pOpenMenuAndSwatch(editor, menuSelector, menuItemSelector);
 
-    TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Custom color"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Custom color"]');
     const dialog = await TinyUiActions.pWaitForDialog(editor);
     const input = UiFinder.findIn<HTMLInputElement>(dialog, 'label:contains("#") + input').getOrDie();
     UiControls.setValue(input, '123123');
@@ -109,7 +109,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorAriaLabelTest', () => 
     });
     input.dom.dispatchEvent(evt);
     await Waiter.pTryUntil('Dialog has changed', () => input.dom.value === '123123');
-    TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Save"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Save"]');
     TinyUiActions.clickOnMenu(editor, menuSelector);
     await TinyUiActions.pWaitForUi(editor, expectedSelector);
     UiFinder.exists(SugarBody.body(), expectedSelector);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorAriaLabelTest.ts
@@ -28,7 +28,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorAriaLabelTest', () => 
     forecolorMenuItem: (color: string = '') => Strings.isEmpty(color) ? `[role="menu"] div[aria-label^="Text color"]` : `[role="menu"] div[aria-label^="Text color ${color}"]`,
     forecolorMenu: 'button:contains("forecolor")',
     backcolorMenu: 'button:contains("backcolor")',
-    swatchItemColor: (color: string = '') => `[role="menuitemradio"][data-mce-btn="${color}"]`
+    swatchItemColor: (color: string = '') => `[role="menuitemradio"][data-mce-label="${color}"]`
   };
 
   const pResetColorToDefault = async (editor: Editor, selector: string) => {
@@ -60,7 +60,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorAriaLabelTest', () => 
   const pSelectCustomAndAssertToolbar = async (editor: Editor, selector: string, expectedSelector: string) => {
     TinyUiActions.clickOnToolbar(editor, selector);
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-    TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Custom color"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Custom color"]');
     const dialog = await TinyUiActions.pWaitForDialog(editor);
     const input = UiFinder.findIn<HTMLInputElement>(dialog, 'label:contains("#") + input').getOrDie();
     UiControls.setValue(input, '123123');
@@ -70,7 +70,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorAriaLabelTest', () => 
     });
     input.dom.dispatchEvent(evt);
     await Waiter.pTryUntil('Dialog has changed', () => input.dom.value === '123123');
-    TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Save"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Save"]');
     UiFinder.exists(SugarBody.body(), expectedSelector);
   };
 
@@ -99,7 +99,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorAriaLabelTest', () => 
   const pSelectCustomAndAssertMenu = async (editor: Editor, menuSelector: string, menuItemSelector: string, expectedSelector: string) => {
     await pOpenMenuAndSwatch(editor, menuSelector, menuItemSelector);
 
-    TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Custom color"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Custom color"]');
     const dialog = await TinyUiActions.pWaitForDialog(editor);
     const input = UiFinder.findIn<HTMLInputElement>(dialog, 'label:contains("#") + input').getOrDie();
     UiControls.setValue(input, '123123');
@@ -109,7 +109,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorAriaLabelTest', () => 
     });
     input.dom.dispatchEvent(evt);
     await Waiter.pTryUntil('Dialog has changed', () => input.dom.value === '123123');
-    TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Save"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Save"]');
     TinyUiActions.clickOnMenu(editor, menuSelector);
     await TinyUiActions.pWaitForUi(editor, expectedSelector);
     UiFinder.exists(SugarBody.body(), expectedSelector);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorAriaLabelTest.ts
@@ -28,7 +28,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorAriaLabelTest', () => 
     forecolorMenuItem: (color: string = '') => Strings.isEmpty(color) ? `[role="menu"] div[aria-label^="Text color"]` : `[role="menu"] div[aria-label^="Text color ${color}"]`,
     forecolorMenu: 'button:contains("forecolor")',
     backcolorMenu: 'button:contains("backcolor")',
-    swatchItemColor: (color: string = '') => `[role="menuitemradio"][title="${color}"]`
+    swatchItemColor: (color: string = '') => `[role="menuitemradio"][data-mce-btn="${color}"]`
   };
 
   const pResetColorToDefault = async (editor: Editor, selector: string) => {
@@ -60,7 +60,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorAriaLabelTest', () => 
   const pSelectCustomAndAssertToolbar = async (editor: Editor, selector: string, expectedSelector: string) => {
     TinyUiActions.clickOnToolbar(editor, selector);
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-    TinyUiActions.clickOnUi(editor, 'button[title="Custom color"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Custom color"]');
     const dialog = await TinyUiActions.pWaitForDialog(editor);
     const input = UiFinder.findIn<HTMLInputElement>(dialog, 'label:contains("#") + input').getOrDie();
     UiControls.setValue(input, '123123');
@@ -70,7 +70,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorAriaLabelTest', () => 
     });
     input.dom.dispatchEvent(evt);
     await Waiter.pTryUntil('Dialog has changed', () => input.dom.value === '123123');
-    TinyUiActions.clickOnUi(editor, 'button[title="Save"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Save"]');
     UiFinder.exists(SugarBody.body(), expectedSelector);
   };
 
@@ -99,7 +99,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorAriaLabelTest', () => 
   const pSelectCustomAndAssertMenu = async (editor: Editor, menuSelector: string, menuItemSelector: string, expectedSelector: string) => {
     await pOpenMenuAndSwatch(editor, menuSelector, menuItemSelector);
 
-    TinyUiActions.clickOnUi(editor, 'button[title="Custom color"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Custom color"]');
     const dialog = await TinyUiActions.pWaitForDialog(editor);
     const input = UiFinder.findIn<HTMLInputElement>(dialog, 'label:contains("#") + input').getOrDie();
     UiControls.setValue(input, '123123');
@@ -109,7 +109,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorAriaLabelTest', () => 
     });
     input.dom.dispatchEvent(evt);
     await Waiter.pTryUntil('Dialog has changed', () => input.dom.value === '123123');
-    TinyUiActions.clickOnUi(editor, 'button[title="Save"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Save"]');
     TinyUiActions.clickOnMenu(editor, menuSelector);
     await TinyUiActions.pWaitForUi(editor, expectedSelector);
     UiFinder.exists(SugarBody.body(), expectedSelector);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -31,7 +31,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         TinySelections.setCursor(editor, [ 0, 0 ], 2);
         TinyUiActions.clickOnToolbar(editor, selectors.backcolorToolbar);
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-        TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Custom color"]');
+        TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Custom color"]');
         const backgroundDialog = await TinyUiActions.pWaitForDialog(editor);
         const backgroundDialogResult = UiFinder.findIn<HTMLInputElement>(backgroundDialog, 'label:contains("#") + input').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(backgroundDialogResult.dom.value, '80FF80'));
@@ -43,7 +43,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         editor.setContent('<p>Text</p>');
         TinyUiActions.clickOnToolbar(editor, selectors.forecolorToolbar);
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-        TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Custom color"]');
+        TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Custom color"]');
         const textDialog = await TinyUiActions.pWaitForDialog(editor);
         const textDialogResult = UiFinder.findIn<HTMLInputElement>(textDialog, 'label:contains("#") + input').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(textDialogResult.dom.value, 'FFC0CB'));
@@ -163,7 +163,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         TinySelections.setCursor(editor, [ 0, 0 ], 2);
         TinyUiActions.clickOnToolbar(editor, selectors.backcolorToolbar);
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-        TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Custom color"]');
+        TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Custom color"]');
         const backgroundDialog = await TinyUiActions.pWaitForDialog(editor);
         const backgroundDialogResult = UiFinder.findIn<HTMLInputElement>(backgroundDialog, 'label:contains("#") + input').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(backgroundDialogResult.dom.value, '00FF00'));
@@ -175,7 +175,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         editor.setContent('<p style="color: #FF00FF;background-color: #00FF00;">Text</p>', { format: 'raw' });
         TinyUiActions.clickOnToolbar(editor, selectors.forecolorToolbar);
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-        TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Custom color"]');
+        TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Custom color"]');
         const textDialog = await TinyUiActions.pWaitForDialog(editor);
         const textDialogResult = UiFinder.findIn<HTMLInputElement>(textDialog, 'label:contains("#") + input').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(textDialogResult.dom.value, 'FF00FF'));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -31,7 +31,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         TinySelections.setCursor(editor, [ 0, 0 ], 2);
         TinyUiActions.clickOnToolbar(editor, selectors.backcolorToolbar);
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-        TinyUiActions.clickOnUi(editor, 'button[title="Custom color"]');
+        TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Custom color"]');
         const backgroundDialog = await TinyUiActions.pWaitForDialog(editor);
         const backgroundDialogResult = UiFinder.findIn<HTMLInputElement>(backgroundDialog, 'label:contains("#") + input').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(backgroundDialogResult.dom.value, '80FF80'));
@@ -43,7 +43,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         editor.setContent('<p>Text</p>');
         TinyUiActions.clickOnToolbar(editor, selectors.forecolorToolbar);
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-        TinyUiActions.clickOnUi(editor, 'button[title="Custom color"]');
+        TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Custom color"]');
         const textDialog = await TinyUiActions.pWaitForDialog(editor);
         const textDialogResult = UiFinder.findIn<HTMLInputElement>(textDialog, 'label:contains("#") + input').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(textDialogResult.dom.value, 'FFC0CB'));
@@ -163,7 +163,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         TinySelections.setCursor(editor, [ 0, 0 ], 2);
         TinyUiActions.clickOnToolbar(editor, selectors.backcolorToolbar);
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-        TinyUiActions.clickOnUi(editor, 'button[title="Custom color"]');
+        TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Custom color"]');
         const backgroundDialog = await TinyUiActions.pWaitForDialog(editor);
         const backgroundDialogResult = UiFinder.findIn<HTMLInputElement>(backgroundDialog, 'label:contains("#") + input').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(backgroundDialogResult.dom.value, '00FF00'));
@@ -175,7 +175,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         editor.setContent('<p style="color: #FF00FF;background-color: #00FF00;">Text</p>', { format: 'raw' });
         TinyUiActions.clickOnToolbar(editor, selectors.forecolorToolbar);
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-        TinyUiActions.clickOnUi(editor, 'button[title="Custom color"]');
+        TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Custom color"]');
         const textDialog = await TinyUiActions.pWaitForDialog(editor);
         const textDialogResult = UiFinder.findIn<HTMLInputElement>(textDialog, 'label:contains("#") + input').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(textDialogResult.dom.value, 'FF00FF'));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -31,7 +31,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         TinySelections.setCursor(editor, [ 0, 0 ], 2);
         TinyUiActions.clickOnToolbar(editor, selectors.backcolorToolbar);
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-        TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Custom color"]');
+        TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Custom color"]');
         const backgroundDialog = await TinyUiActions.pWaitForDialog(editor);
         const backgroundDialogResult = UiFinder.findIn<HTMLInputElement>(backgroundDialog, 'label:contains("#") + input').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(backgroundDialogResult.dom.value, '80FF80'));
@@ -43,7 +43,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         editor.setContent('<p>Text</p>');
         TinyUiActions.clickOnToolbar(editor, selectors.forecolorToolbar);
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-        TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Custom color"]');
+        TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Custom color"]');
         const textDialog = await TinyUiActions.pWaitForDialog(editor);
         const textDialogResult = UiFinder.findIn<HTMLInputElement>(textDialog, 'label:contains("#") + input').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(textDialogResult.dom.value, 'FFC0CB'));
@@ -163,7 +163,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         TinySelections.setCursor(editor, [ 0, 0 ], 2);
         TinyUiActions.clickOnToolbar(editor, selectors.backcolorToolbar);
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-        TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Custom color"]');
+        TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Custom color"]');
         const backgroundDialog = await TinyUiActions.pWaitForDialog(editor);
         const backgroundDialogResult = UiFinder.findIn<HTMLInputElement>(backgroundDialog, 'label:contains("#") + input').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(backgroundDialogResult.dom.value, '00FF00'));
@@ -175,7 +175,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         editor.setContent('<p style="color: #FF00FF;background-color: #00FF00;">Text</p>', { format: 'raw' });
         TinyUiActions.clickOnToolbar(editor, selectors.forecolorToolbar);
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-        TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Custom color"]');
+        TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Custom color"]');
         const textDialog = await TinyUiActions.pWaitForDialog(editor);
         const textDialogResult = UiFinder.findIn<HTMLInputElement>(textDialog, 'label:contains("#") + input').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(textDialogResult.dom.value, 'FF00FF'));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/NoneditableRootTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/NoneditableRootTest.ts
@@ -33,11 +33,11 @@ describe('browser.tinymce.themes.silver.editor.color.NoneditableRootTest', () =>
         editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
         TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
         TinyUiActions.clickOnMenu(editor, `button:contains("${menu}")`);
-        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title^="${menuitem}"][aria-disabled="true"]`);
+        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [aria-label^="${menuitem}"][aria-disabled="true"]`);
         TinyUiActions.keystroke(editor, Keys.escape());
         TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
         TinyUiActions.clickOnMenu(editor, `button:contains("${menu}")`);
-        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title^="${menuitem}"][aria-disabled="false"]`);
+        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [aria-label^="${menuitem}"][aria-disabled="false"]`);
         TinyUiActions.keystroke(editor, Keys.escape());
       });
     };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorFormattingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorFormattingTest.ts
@@ -137,7 +137,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorFormattingTest', (
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, selectors.forecolorSplitButton);
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-    TinyUiActions.clickOnUi(editor, 'div[data-mce-btn="Red"]');
+    TinyUiActions.clickOnUi(editor, 'div[data-mce-label="Red"]');
     TinyAssertions.assertContentStructure(editor, forecolorTitleStruct);
   });
 
@@ -147,7 +147,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorFormattingTest', (
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
     TinyUiActions.clickOnToolbar(editor, '[aria-label^="Background color"] > .tox-tbtn + .tox-split-button__chevron');
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-    TinyUiActions.clickOnUi(editor, 'div[data-mce-btn="Red"]');
+    TinyUiActions.clickOnUi(editor, 'div[data-mce-label="Red"]');
     TinyAssertions.assertContentStructure(editor, backcolorTitleStruct);
   });
 
@@ -155,13 +155,13 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorFormattingTest', (
     const editor = hook.editor();
     editor.setContent(`Hello${Unicode.nbsp}world`);
     TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 0, 0 ], 2);
-    TinyUiActions.clickOnToolbar(editor, '[data-mce-btn="forecolor"] > .tox-tbtn + .tox-split-button__chevron');
+    TinyUiActions.clickOnToolbar(editor, '[data-mce-label="forecolor"] > .tox-tbtn + .tox-split-button__chevron');
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
     TinyUiActions.clickOnUi(editor, 'div[data-mce-color="#3598DB"]');
     TinyAssertions.assertContentStructure(editor, forecolorTextStruct);
-    TinyUiActions.clickOnToolbar(editor, '[data-mce-btn="forecolor"] > .tox-tbtn + .tox-split-button__chevron');
+    TinyUiActions.clickOnToolbar(editor, '[data-mce-label="forecolor"] > .tox-tbtn + .tox-split-button__chevron');
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-    TinyUiActions.clickOnUi(editor, 'div[data-mce-btn="Remove color"]');
+    TinyUiActions.clickOnUi(editor, 'div[data-mce-label="Remove color"]');
     TinyAssertions.assertContent(editor, '<p>Hello&nbsp;world</p>');
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorFormattingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorFormattingTest.ts
@@ -137,7 +137,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorFormattingTest', (
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, selectors.forecolorSplitButton);
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-    TinyUiActions.clickOnUi(editor, 'div[data-mce-label="Red"]');
+    TinyUiActions.clickOnUi(editor, 'div[data-mce-name="Red"]');
     TinyAssertions.assertContentStructure(editor, forecolorTitleStruct);
   });
 
@@ -147,7 +147,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorFormattingTest', (
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
     TinyUiActions.clickOnToolbar(editor, '[aria-label^="Background color"] > .tox-tbtn + .tox-split-button__chevron');
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-    TinyUiActions.clickOnUi(editor, 'div[data-mce-label="Red"]');
+    TinyUiActions.clickOnUi(editor, 'div[data-mce-name="Red"]');
     TinyAssertions.assertContentStructure(editor, backcolorTitleStruct);
   });
 
@@ -155,13 +155,13 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorFormattingTest', (
     const editor = hook.editor();
     editor.setContent(`Hello${Unicode.nbsp}world`);
     TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 0, 0 ], 2);
-    TinyUiActions.clickOnToolbar(editor, '[data-mce-label="forecolor"] > .tox-tbtn + .tox-split-button__chevron');
+    TinyUiActions.clickOnToolbar(editor, '[data-mce-name="forecolor"] > .tox-tbtn + .tox-split-button__chevron');
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
     TinyUiActions.clickOnUi(editor, 'div[data-mce-color="#3598DB"]');
     TinyAssertions.assertContentStructure(editor, forecolorTextStruct);
-    TinyUiActions.clickOnToolbar(editor, '[data-mce-label="forecolor"] > .tox-tbtn + .tox-split-button__chevron');
+    TinyUiActions.clickOnToolbar(editor, '[data-mce-name="forecolor"] > .tox-tbtn + .tox-split-button__chevron');
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-    TinyUiActions.clickOnUi(editor, 'div[data-mce-label="Remove color"]');
+    TinyUiActions.clickOnUi(editor, 'div[data-mce-name="Remove color"]');
     TinyAssertions.assertContent(editor, '<p>Hello&nbsp;world</p>');
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorFormattingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorFormattingTest.ts
@@ -137,7 +137,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorFormattingTest', (
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     TinyUiActions.clickOnToolbar(editor, selectors.forecolorSplitButton);
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-    TinyUiActions.clickOnUi(editor, 'div[title="Red"]');
+    TinyUiActions.clickOnUi(editor, 'div[data-mce-btn="Red"]');
     TinyAssertions.assertContentStructure(editor, forecolorTitleStruct);
   });
 
@@ -147,7 +147,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorFormattingTest', (
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
     TinyUiActions.clickOnToolbar(editor, '[aria-label^="Background color"] > .tox-tbtn + .tox-split-button__chevron');
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-    TinyUiActions.clickOnUi(editor, 'div[title="Red"]');
+    TinyUiActions.clickOnUi(editor, 'div[data-mce-btn="Red"]');
     TinyAssertions.assertContentStructure(editor, backcolorTitleStruct);
   });
 
@@ -155,13 +155,13 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorFormattingTest', (
     const editor = hook.editor();
     editor.setContent(`Hello${Unicode.nbsp}world`);
     TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 0, 0 ], 2);
-    TinyUiActions.clickOnToolbar(editor, '[aria-label^="Text color"] > .tox-tbtn + .tox-split-button__chevron');
+    TinyUiActions.clickOnToolbar(editor, '[data-mce-btn="forecolor"] > .tox-tbtn + .tox-split-button__chevron');
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
     TinyUiActions.clickOnUi(editor, 'div[data-mce-color="#3598DB"]');
     TinyAssertions.assertContentStructure(editor, forecolorTextStruct);
-    TinyUiActions.clickOnToolbar(editor, '[aria-label^="Text color"] > .tox-tbtn + .tox-split-button__chevron');
+    TinyUiActions.clickOnToolbar(editor, '[data-mce-btn="forecolor"] > .tox-tbtn + .tox-split-button__chevron');
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
-    TinyUiActions.clickOnUi(editor, 'div[title="Remove color"]');
+    TinyUiActions.clickOnUi(editor, 'div[data-mce-btn="Remove color"]');
     TinyAssertions.assertContent(editor, '<p>Hello&nbsp;world</p>');
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
@@ -11,8 +11,8 @@ import { getColorCols } from 'tinymce/themes/silver/ui/core/color/Options';
 
 describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () => {
   const selectors = {
-    backcolorButton: 'div[title^="Background color"] .tox-tbtn',
-    forecolorButton: 'div[title^="Text color"] .tox-tbtn',
+    backcolorButton: 'div[data-mce-btn="backcolor"] .tox-tbtn',
+    forecolorButton: 'div[data-mce-btn="forecolor"] .tox-tbtn',
     backcolorSplitButton: '[aria-label^="Background color"] > .tox-tbtn + .tox-split-button__chevron',
     forecolorSplitButton: '[aria-label^="Text color"] > .tox-tbtn + .tox-split-button__chevron'
   };
@@ -157,7 +157,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
       TinyUiActions.clickOnToolbar(editor, selectors.backcolorSplitButton);
       await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
       UiFinder.notExists(SugarBody.body(), 'div[data-mce-color="#FF0000"]');
-      TinyUiActions.clickOnUi(editor, 'button[title="Custom color"]');
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Custom color"]');
       const dialog = await TinyUiActions.pWaitForDialog(editor);
       const input = UiFinder.findIn<HTMLInputElement>(dialog, 'label:contains("R") + input').getOrDie();
       UiControls.setValue(input, '255');
@@ -168,7 +168,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
       input.dom.dispatchEvent(evt);
       const dialogResult = UiFinder.findIn<HTMLInputElement>(dialog, 'label:contains("#") + input').getOrDie();
       await Waiter.pTryUntil('Dialog has changed', () => dialogResult.dom.value === 'FF0000');
-      TinyUiActions.clickOnUi(editor, 'button[title="Save"]');
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Save"]');
       TinyUiActions.clickOnToolbar(editor, selectors.backcolorSplitButton);
       await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
       UiFinder.exists(SugarBody.body(), 'div[data-mce-color="#FF0000"]');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
@@ -11,8 +11,8 @@ import { getColorCols } from 'tinymce/themes/silver/ui/core/color/Options';
 
 describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () => {
   const selectors = {
-    backcolorButton: 'div[data-mce-label="backcolor"] .tox-tbtn',
-    forecolorButton: 'div[data-mce-label="forecolor"] .tox-tbtn',
+    backcolorButton: 'div[data-mce-name="backcolor"] .tox-tbtn',
+    forecolorButton: 'div[data-mce-name="forecolor"] .tox-tbtn',
     backcolorSplitButton: '[aria-label^="Background color"] > .tox-tbtn + .tox-split-button__chevron',
     forecolorSplitButton: '[aria-label^="Text color"] > .tox-tbtn + .tox-split-button__chevron'
   };
@@ -157,7 +157,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
       TinyUiActions.clickOnToolbar(editor, selectors.backcolorSplitButton);
       await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
       UiFinder.notExists(SugarBody.body(), 'div[data-mce-color="#FF0000"]');
-      TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Custom color"]');
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Custom color"]');
       const dialog = await TinyUiActions.pWaitForDialog(editor);
       const input = UiFinder.findIn<HTMLInputElement>(dialog, 'label:contains("R") + input').getOrDie();
       UiControls.setValue(input, '255');
@@ -168,7 +168,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
       input.dom.dispatchEvent(evt);
       const dialogResult = UiFinder.findIn<HTMLInputElement>(dialog, 'label:contains("#") + input').getOrDie();
       await Waiter.pTryUntil('Dialog has changed', () => dialogResult.dom.value === 'FF0000');
-      TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Save"]');
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Save"]');
       TinyUiActions.clickOnToolbar(editor, selectors.backcolorSplitButton);
       await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
       UiFinder.exists(SugarBody.body(), 'div[data-mce-color="#FF0000"]');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
@@ -11,8 +11,8 @@ import { getColorCols } from 'tinymce/themes/silver/ui/core/color/Options';
 
 describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () => {
   const selectors = {
-    backcolorButton: 'div[data-mce-btn="backcolor"] .tox-tbtn',
-    forecolorButton: 'div[data-mce-btn="forecolor"] .tox-tbtn',
+    backcolorButton: 'div[data-mce-label="backcolor"] .tox-tbtn',
+    forecolorButton: 'div[data-mce-label="forecolor"] .tox-tbtn',
     backcolorSplitButton: '[aria-label^="Background color"] > .tox-tbtn + .tox-split-button__chevron',
     forecolorSplitButton: '[aria-label^="Text color"] > .tox-tbtn + .tox-split-button__chevron'
   };
@@ -157,7 +157,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
       TinyUiActions.clickOnToolbar(editor, selectors.backcolorSplitButton);
       await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
       UiFinder.notExists(SugarBody.body(), 'div[data-mce-color="#FF0000"]');
-      TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Custom color"]');
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Custom color"]');
       const dialog = await TinyUiActions.pWaitForDialog(editor);
       const input = UiFinder.findIn<HTMLInputElement>(dialog, 'label:contains("R") + input').getOrDie();
       UiControls.setValue(input, '255');
@@ -168,7 +168,7 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
       input.dom.dispatchEvent(evt);
       const dialogResult = UiFinder.findIn<HTMLInputElement>(dialog, 'label:contains("#") + input').getOrDie();
       await Waiter.pTryUntil('Dialog has changed', () => dialogResult.dom.value === 'FF0000');
-      TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Save"]');
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Save"]');
       TinyUiActions.clickOnToolbar(editor, selectors.backcolorSplitButton);
       await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
       UiFinder.exists(SugarBody.body(), 'div[data-mce-color="#FF0000"]');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/CustomContextMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/CustomContextMenuTest.ts
@@ -91,10 +91,10 @@ describe('browser.tinymce.themes.silver.editor.contextmenu.CustomContextMenuTest
       // Open submenu
       Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.right());
       await Waiter.pTryUntil('menu items visible', () => {
-        UiFinder.exists(SugarBody.body(), 'div[title="customSubMenuItem"][aria-disabled="false"]');
-        UiFinder.exists(SugarBody.body(), 'div[title="disabledCustomNestedMenuItem"][aria-disabled="true"]');
-        UiFinder.exists(SugarBody.body(), 'div[title="customNestedMenuItem"][aria-disabled="false"]');
-        UiFinder.exists(SugarBody.body(), 'div[title="disabledCustomMenuItem"][aria-disabled="true"]');
+        UiFinder.exists(SugarBody.body(), 'div[aria-label="customSubMenuItem"][aria-disabled="false"]');
+        UiFinder.exists(SugarBody.body(), 'div[aria-label="disabledCustomNestedMenuItem"][aria-disabled="true"]');
+        UiFinder.exists(SugarBody.body(), 'div[aria-label="customNestedMenuItem"][aria-disabled="false"]');
+        UiFinder.exists(SugarBody.body(), 'div[aria-label="disabledCustomMenuItem"][aria-disabled="true"]');
       });
     });
 
@@ -106,8 +106,8 @@ describe('browser.tinymce.themes.silver.editor.contextmenu.CustomContextMenuTest
       // Open submenu
       Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.right());
       await Waiter.pTryUntil('menu items visible', () => {
-        UiFinder.exists(SugarBody.body(), 'div[title="customSubMenuItem"] div.tox-collection__item-accessory:contains("custom-shortcut")');
-        UiFinder.exists(SugarBody.body(), 'div[title="customNestedMenuItem"] div.tox-collection__item-accessory:contains("custom-nested-shortcut")');
+        UiFinder.exists(SugarBody.body(), 'div[aria-label="customSubMenuItem"] div.tox-collection__item-accessory:contains("custom-shortcut")');
+        UiFinder.exists(SugarBody.body(), 'div[aria-label="customNestedMenuItem"] div.tox-collection__item-accessory:contains("custom-nested-shortcut")');
       });
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/AlignmentButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/AlignmentButtonsTest.ts
@@ -25,19 +25,19 @@ describe('browser.tinymce.themes.silver.editor.core.AlignmentButtonsTest', () =>
             classes: [ arr.has('tox-toolbar__group') ],
             children: [
               s.element('button', {
-                attrs: { 'data-mce-btn': str.is('alignleft') }
+                attrs: { 'data-mce-label': str.is('alignleft') }
               }),
               s.element('button', {
-                attrs: { 'data-mce-btn': str.is('aligncenter') }
+                attrs: { 'data-mce-label': str.is('aligncenter') }
               }),
               s.element('button', {
-                attrs: { 'data-mce-btn': str.is('alignright') }
+                attrs: { 'data-mce-label': str.is('alignright') }
               }),
               s.element('button', {
-                attrs: { 'data-mce-btn': str.is('alignjustify') }
+                attrs: { 'data-mce-label': str.is('alignjustify') }
               }),
               s.element('button', {
-                attrs: { 'data-mce-btn': str.is('alignnone') }
+                attrs: { 'data-mce-label': str.is('alignnone') }
               })
             ]
           })

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/AlignmentButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/AlignmentButtonsTest.ts
@@ -25,19 +25,19 @@ describe('browser.tinymce.themes.silver.editor.core.AlignmentButtonsTest', () =>
             classes: [ arr.has('tox-toolbar__group') ],
             children: [
               s.element('button', {
-                attrs: { title: str.is('Align left') }
+                attrs: { 'data-mce-btn': str.is('alignleft') }
               }),
               s.element('button', {
-                attrs: { title: str.is('Align center') }
+                attrs: { 'data-mce-btn': str.is('aligncenter') }
               }),
               s.element('button', {
-                attrs: { title: str.is('Align right') }
+                attrs: { 'data-mce-btn': str.is('alignright') }
               }),
               s.element('button', {
-                attrs: { title: str.is('Justify') }
+                attrs: { 'data-mce-btn': str.is('alignjustify') }
               }),
               s.element('button', {
-                attrs: { title: str.is('No alignment') }
+                attrs: { 'data-mce-btn': str.is('alignnone') }
               })
             ]
           })

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/AlignmentButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/AlignmentButtonsTest.ts
@@ -25,19 +25,19 @@ describe('browser.tinymce.themes.silver.editor.core.AlignmentButtonsTest', () =>
             classes: [ arr.has('tox-toolbar__group') ],
             children: [
               s.element('button', {
-                attrs: { 'data-mce-label': str.is('alignleft') }
+                attrs: { 'data-mce-name': str.is('alignleft') }
               }),
               s.element('button', {
-                attrs: { 'data-mce-label': str.is('aligncenter') }
+                attrs: { 'data-mce-name': str.is('aligncenter') }
               }),
               s.element('button', {
-                attrs: { 'data-mce-label': str.is('alignright') }
+                attrs: { 'data-mce-name': str.is('alignright') }
               }),
               s.element('button', {
-                attrs: { 'data-mce-label': str.is('alignjustify') }
+                attrs: { 'data-mce-name': str.is('alignjustify') }
               }),
               s.element('button', {
-                attrs: { 'data-mce-label': str.is('alignnone') }
+                attrs: { 'data-mce-name': str.is('alignnone') }
               })
             ]
           })

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
@@ -21,10 +21,10 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
   const toolbarSpec: ToolbarOrMenuSpec = {
     name: 'Toolbar',
     pOpen: async (editor, title) => {
-      TinyUiActions.clickOnToolbar(editor, `[title="${title}"]`);
+      TinyUiActions.clickOnToolbar(editor, `[aria-label="${title}"]`);
       await TinyUiActions.pWaitForUi(editor, '[role="menu"]');
     },
-    close: (editor, title) => TinyUiActions.clickOnToolbar(editor, `[title="${title}"]`),
+    close: (editor, title) => TinyUiActions.clickOnToolbar(editor, `[aria-label="${title}"]`),
     menuSelector: '[role="menu"]'
   };
 
@@ -34,7 +34,7 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
     pOpen: async (editor, title) => {
       TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
       await TinyUiActions.pWaitForUi(editor, '[role="menu"]');
-      TinyUiActions.clickOnUi(editor, `[role="menu"] [title="${title}"]`);
+      TinyUiActions.clickOnUi(editor, `[role="menu"] [aria-label="${title}"]`);
     },
     close: (editor) => TinyUiActions.clickOnMenu(editor, 'button:contains("Format")'),
     menuSelector: '[role="menu"]~[role="menu"]' // the line-height submenu is always the *second* menu in the sink
@@ -42,7 +42,7 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
 
   const pSelectItem = async (editor: Editor, selector: string, value: string) => {
     await TinyUiActions.pWaitForUi(editor, selector);
-    TinyUiActions.clickOnUi(editor, `[role="menuitemcheckbox"][title="${value}"]`);
+    TinyUiActions.clickOnUi(editor, `[role="menuitemcheckbox"][aria-label="${value}"]`);
   };
 
   const pAssertOptions = async (editor: Editor, selector: string, ideal: string[], current: Optional<string>) => {
@@ -52,11 +52,11 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
     // ensure that the checked option (if it exists) lines up with what we expect
     current.fold(
       () => UiFinder.notExists(menu, '[aria-checked="true"]'),
-      (current) => UiFinder.exists(menu, `[aria-checked="true"][title="${current}"]`)
+      (current) => UiFinder.exists(menu, `[aria-checked="true"][aria-label="${current}"]`)
     );
     // ensure that the list of options is correct
     const elements = UiFinder.findAllIn(menu, '[role="menuitemcheckbox"]');
-    const actual = Arr.map(elements, (element) => Attribute.get(element, 'title'));
+    const actual = Arr.map(elements, (element) => Attribute.get(element, 'aria-label'));
     assert.deepEqual(actual, ideal, 'Correct menu items are displayed');
   };
 
@@ -135,11 +135,11 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
         TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
         await TinyUiActions.pWaitForUi(editor, '[role="menu"]');
         // Open line height
-        TinyUiActions.clickOnUi(editor, `[role="menu"] [title="Line height"]`);
+        TinyUiActions.clickOnUi(editor, `[role="menu"] [aria-label="Line height"]`);
         // Close line height
-        TinyUiActions.clickOnUi(editor, `[role="menu"] [title="Align"]`);
+        TinyUiActions.clickOnUi(editor, `[role="menu"] [aria-label="Align"]`);
         // Open line height a second time, to make sure the state has been reset properly
-        TinyUiActions.clickOnUi(editor, `[role="menu"] [title="Line height"]`);
+        TinyUiActions.clickOnUi(editor, `[role="menu"] [aria-label="Line height"]`);
 
         await pAssertOptions(editor, menuSpec.menuSelector, [ '1', '1.1', '1.2', '1.3', '1.4', '1.5', '2' ], Optional.some('1.4'));
         menuSpec.close(editor, 'Line height');
@@ -160,11 +160,11 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
           editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
           TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
           TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
-          await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Line height"][aria-disabled="true"]');
+          await TinyUiActions.pWaitForUi(editor, '[role="menu"] [aria-label="Line height"][aria-disabled="true"]');
           TinyUiActions.keystroke(editor, Keys.escape());
           TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
           TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
-          await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Line height"][aria-disabled="false"]');
+          await TinyUiActions.pWaitForUi(editor, '[role="menu"] [aria-label="Line height"][aria-disabled="false"]');
           TinyUiActions.keystroke(editor, Keys.escape());
         });
       });
@@ -327,11 +327,11 @@ describe('browser.tinymce.themes.silver.editor.core.ChoiceControlsTest', () => {
             editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
             TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
             TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
-            await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Language"][aria-disabled="true"]');
+            await TinyUiActions.pWaitForUi(editor, '[role="menu"] [aria-label="Language"][aria-disabled="true"]');
             TinyUiActions.keystroke(editor, Keys.escape());
             TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
             TinyUiActions.clickOnMenu(editor, 'button:contains("Format")');
-            await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Language"][aria-disabled="false"]');
+            await TinyUiActions.pWaitForUi(editor, '[role="menu"] [aria-label="Language"][aria-disabled="false"]');
             TinyUiActions.keystroke(editor, Keys.escape());
           });
         });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/PasteControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/PasteControlsTest.ts
@@ -28,11 +28,11 @@ describe('browser.tinymce.themes.silver.editor.core.PasteControlsTest', () => {
         editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
         TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
         TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
-        await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Paste as text"][aria-disabled="true"]');
+        await TinyUiActions.pWaitForUi(editor, '[role="menu"] [aria-label="Paste as text"][aria-disabled="true"]');
         TinyUiActions.keystroke(editor, Keys.escape());
         TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
         TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
-        await TinyUiActions.pWaitForUi(editor, '[role="menu"] [title="Paste as text"][aria-disabled="false"]');
+        await TinyUiActions.pWaitForUi(editor, '[role="menu"] [aria-label="Paste as text"][aria-disabled="false"]');
         TinyUiActions.keystroke(editor, Keys.escape());
       });
     });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
@@ -13,7 +13,7 @@ describe('browser.tinymce.themes.silver.editor.core.SimpleControlsTest', () => {
   }, []);
 
   const assertToolbarButtonPressed = (title: string) =>
-    UiFinder.exists(SugarBody.body(), `button[data-mce-label="${title}"][aria-pressed="true"]`);
+    UiFinder.exists(SugarBody.body(), `button[data-mce-name="${title}"][aria-pressed="true"]`);
 
   it('TBA: b tag is recognized as valid tag for bold', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
@@ -13,7 +13,7 @@ describe('browser.tinymce.themes.silver.editor.core.SimpleControlsTest', () => {
   }, []);
 
   const assertToolbarButtonPressed = (title: string) =>
-    UiFinder.exists(SugarBody.body(), `button[data-mce-btn="${title}"][aria-pressed="true"]`);
+    UiFinder.exists(SugarBody.body(), `button[data-mce-label="${title}"][aria-pressed="true"]`);
 
   it('TBA: b tag is recognized as valid tag for bold', () => {
     const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
@@ -13,83 +13,83 @@ describe('browser.tinymce.themes.silver.editor.core.SimpleControlsTest', () => {
   }, []);
 
   const assertToolbarButtonPressed = (title: string) =>
-    UiFinder.exists(SugarBody.body(), `button[title="${title}"][aria-pressed="true"]`);
+    UiFinder.exists(SugarBody.body(), `button[data-mce-btn="${title}"][aria-pressed="true"]`);
 
   it('TBA: b tag is recognized as valid tag for bold', () => {
     const editor = hook.editor();
     editor.setContent('<p><b>bold text</b></p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 1);
-    assertToolbarButtonPressed('Bold');
+    assertToolbarButtonPressed('bold');
   });
 
   it('TBA: strong tag is recognized as valid tag for bold', () => {
     const editor = hook.editor();
     editor.setContent('<p><strong>bold text</strong></p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 1);
-    assertToolbarButtonPressed('Bold');
+    assertToolbarButtonPressed('bold');
   });
 
   it('TBA: Style "font-weight: bold" is recognized as valid style for bold', () => {
     const editor = hook.editor();
     editor.setContent('<p><span style="font-weight: bold;">bold text</span></p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 1);
-    assertToolbarButtonPressed('Bold');
+    assertToolbarButtonPressed('bold');
   });
 
   it('TBA: em tag is recognized as valid tag for italic', () => {
     const editor = hook.editor();
     editor.setContent('<p><em>italic text</em></p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 1);
-    assertToolbarButtonPressed('Italic');
+    assertToolbarButtonPressed('italic');
   });
 
   it('TBA: i tag is recognized as valid tag for italic', () => {
     const editor = hook.editor();
     editor.setContent('<p><i>italic text</i></p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 1);
-    assertToolbarButtonPressed('Italic');
+    assertToolbarButtonPressed('italic');
   });
 
   it('TBA: Style "font-style: italic" is recognized as valid style for italic', () => {
     const editor = hook.editor();
     editor.setContent('<p><span style="font-style: italic;">italic text</span></p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 1);
-    assertToolbarButtonPressed('Italic');
+    assertToolbarButtonPressed('italic');
   });
 
   it('TBA: Style "text-decoration: underline" is recognized as valid style for underline', () => {
     const editor = hook.editor();
     editor.setContent('<p><span style="text-decoration: underline;">underlined text</span></p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 1);
-    assertToolbarButtonPressed('Underline');
+    assertToolbarButtonPressed('underline');
   });
 
   it('TBA: u tag is recognized as valid tag for underline', () => {
     const editor = hook.editor();
     editor.setContent('<p><u>underlined text</u></p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 1);
-    assertToolbarButtonPressed('Underline');
+    assertToolbarButtonPressed('underline');
   });
 
   it('TINY-6681: strike tag is recognized as valid tag for strikethrough', () => {
     const editor = hook.editor();
     editor.setContent('<p><strike>strikethrough text</strike></p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 1);
-    assertToolbarButtonPressed('Strikethrough');
+    assertToolbarButtonPressed('strikethrough');
   });
 
   it('TINY-6681: s tag is recognized as valid tag for strikethrough', () => {
     const editor = hook.editor();
     editor.setContent('<p><s>strikethrough text</s></p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 1);
-    assertToolbarButtonPressed('Strikethrough');
+    assertToolbarButtonPressed('strikethrough');
   });
 
   it('TINY-6681: Style "text-decoration: line-through" is recognized as valid style for strikethrough', () => {
     const editor = hook.editor();
     editor.setContent('<p><span style="text-decoration: line-through;">strikethrough text</span></p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 1);
-    assertToolbarButtonPressed('Strikethrough');
+    assertToolbarButtonPressed('strikethrough');
   });
 
   it('TINY-8314: Assert print button exists', async () => {
@@ -147,11 +147,11 @@ describe('browser.tinymce.themes.silver.editor.core.SimpleControlsTest', () => {
         editor.setContent('<div>Noneditable content</div><div contenteditable="true">Editable content</div>');
         TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 2);
         TinyUiActions.clickOnMenu(editor, `button:contains("${menu}")`);
-        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="true"]`);
+        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [aria-label="${menuitem}"][aria-disabled="true"]`);
         TinyUiActions.keystroke(editor, Keys.escape());
         TinySelections.setSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 2);
         TinyUiActions.clickOnMenu(editor, `button:contains("${menu}")`);
-        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [title="${menuitem}"][aria-disabled="false"]`);
+        await TinyUiActions.pWaitForUi(editor, `[role="menu"] [aria-label="${menuitem}"][aria-disabled="false"]`);
         TinyUiActions.keystroke(editor, Keys.escape());
       });
     };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/UndoRedoTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/UndoRedoTest.ts
@@ -13,7 +13,7 @@ describe('browser.tinymce.themes.silver.editor.core.UndoRedoTest', () => {
   }, []);
 
   const assertToolbarButtonState = (title: string, disabled: boolean) =>
-    UiFinder.exists(SugarBody.body(), `button[data-mce-label="${title}"][aria-disabled="${disabled}"]`);
+    UiFinder.exists(SugarBody.body(), `button[data-mce-name="${title}"][aria-disabled="${disabled}"]`);
 
   const assertMenuItemState = (editor: Editor, item: string, disabled: boolean) =>
     TinyUiActions.pWaitForUi(editor, `div[aria-label="${item}"][role="menuitem"][aria-disabled="${disabled}"]`);
@@ -57,7 +57,7 @@ describe('browser.tinymce.themes.silver.editor.core.UndoRedoTest', () => {
     TinyUiActions.keyup(hook.editor(), Keys.escape());
 
     // 2. Redo should be enabled after undo being clicked
-    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-label="undo"]');
+    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-name="undo"]');
     assertToolbarButtonState('redo', false);
     assertToolbarButtonState('undo', true);
     TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/UndoRedoTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/UndoRedoTest.ts
@@ -13,7 +13,7 @@ describe('browser.tinymce.themes.silver.editor.core.UndoRedoTest', () => {
   }, []);
 
   const assertToolbarButtonState = (title: string, disabled: boolean) =>
-    UiFinder.exists(SugarBody.body(), `button[data-mce-btn="${title}"][aria-disabled="${disabled}"]`);
+    UiFinder.exists(SugarBody.body(), `button[data-mce-label="${title}"][aria-disabled="${disabled}"]`);
 
   const assertMenuItemState = (editor: Editor, item: string, disabled: boolean) =>
     TinyUiActions.pWaitForUi(editor, `div[aria-label="${item}"][role="menuitem"][aria-disabled="${disabled}"]`);
@@ -57,7 +57,7 @@ describe('browser.tinymce.themes.silver.editor.core.UndoRedoTest', () => {
     TinyUiActions.keyup(hook.editor(), Keys.escape());
 
     // 2. Redo should be enabled after undo being clicked
-    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-btn="undo"]');
+    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-label="undo"]');
     assertToolbarButtonState('redo', false);
     assertToolbarButtonState('undo', true);
     TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/UndoRedoTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/UndoRedoTest.ts
@@ -13,10 +13,10 @@ describe('browser.tinymce.themes.silver.editor.core.UndoRedoTest', () => {
   }, []);
 
   const assertToolbarButtonState = (title: string, disabled: boolean) =>
-    UiFinder.exists(SugarBody.body(), `button[title="${title}"][aria-disabled="${disabled}"]`);
+    UiFinder.exists(SugarBody.body(), `button[data-mce-btn="${title}"][aria-disabled="${disabled}"]`);
 
   const assertMenuItemState = (editor: Editor, item: string, disabled: boolean) =>
-    TinyUiActions.pWaitForUi(editor, `div[title="${item}"][role="menuitem"][aria-disabled="${disabled}"]`);
+    TinyUiActions.pWaitForUi(editor, `div[aria-label="${item}"][role="menuitem"][aria-disabled="${disabled}"]`);
 
   const pWaitForToolbarState = async (editor: Editor, disabled: boolean) => {
     const overlord = UiFinder.findIn(SugarBody.body(), '.tox-toolbar-overlord').getOrDie();
@@ -36,8 +36,8 @@ describe('browser.tinymce.themes.silver.editor.core.UndoRedoTest', () => {
 
   it('TINY-8101: Undo/redo should be disabled by default', async () => {
     const editor = hook.editor();
-    assertToolbarButtonState('Redo', true);
-    assertToolbarButtonState('Undo', true);
+    assertToolbarButtonState('redo', true);
+    assertToolbarButtonState('undo', true);
     TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
     await assertMenuItemState(editor, 'Redo', true);
     await assertMenuItemState(editor, 'Undo', true);
@@ -49,17 +49,17 @@ describe('browser.tinymce.themes.silver.editor.core.UndoRedoTest', () => {
     // 1. Insert content, undo should be enabled and redo should be still disabled
     editor.resetContent('');
     editor.insertContent('<p>test</p>');
-    assertToolbarButtonState('Redo', true);
-    assertToolbarButtonState('Undo', false);
+    assertToolbarButtonState('redo', true);
+    assertToolbarButtonState('undo', false);
     TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
     await assertMenuItemState(editor, 'Redo', true);
     await assertMenuItemState(editor, 'Undo', false);
     TinyUiActions.keyup(hook.editor(), Keys.escape());
 
     // 2. Redo should be enabled after undo being clicked
-    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[title="Undo"]');
-    assertToolbarButtonState('Redo', false);
-    assertToolbarButtonState('Undo', true);
+    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-btn="undo"]');
+    assertToolbarButtonState('redo', false);
+    assertToolbarButtonState('undo', true);
     TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
     await assertMenuItemState(editor, 'Redo', false);
     await assertMenuItemState(editor, 'Undo', true);
@@ -75,14 +75,14 @@ describe('browser.tinymce.themes.silver.editor.core.UndoRedoTest', () => {
     // 2. switch to readonly mode
     editor.mode.set('readonly');
     await pWaitForToolbarState(editor, true);
-    assertToolbarButtonState('Redo', true);
-    assertToolbarButtonState('Undo', true);
+    assertToolbarButtonState('redo', true);
+    assertToolbarButtonState('undo', true);
 
     // 3. switch back to design mode. Expect undo to be re-enabled
     editor.mode.set('design');
     await pWaitForToolbarState(editor, false);
-    assertToolbarButtonState('Redo', true);
-    assertToolbarButtonState('Undo', false);
+    assertToolbarButtonState('redo', true);
+    assertToolbarButtonState('undo', false);
     TinyUiActions.clickOnMenu(editor, 'button:contains("Edit")');
     await assertMenuItemState(editor, 'Redo', true);
     await assertMenuItemState(editor, 'Undo', false);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
@@ -42,7 +42,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.InlineToolbarDrawerFloati
     editor.setContent('<p>Line 1</p><p>Line 2</p><p>Line 3</p>');
     editor.focus();
     TinySelections.setCursor(editor, [ 2, 0 ], 'Line 3'.length);
-    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[title="Reveal or hide additional toolbar items"]');
+    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[data-mce-btn="overflow-button"]');
     await pRunTests(editor);
     McEditor.remove(editor);
   };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
@@ -42,7 +42,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.InlineToolbarDrawerFloati
     editor.setContent('<p>Line 1</p><p>Line 2</p><p>Line 3</p>');
     editor.focus();
     TinySelections.setCursor(editor, [ 2, 0 ], 'Line 3'.length);
-    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[data-mce-label="overflow-button"]');
+    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[data-mce-name="overflow-button"]');
     await pRunTests(editor);
     McEditor.remove(editor);
   };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
@@ -42,7 +42,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.InlineToolbarDrawerFloati
     editor.setContent('<p>Line 1</p><p>Line 2</p><p>Line 3</p>');
     editor.focus();
     TinySelections.setCursor(editor, [ 2, 0 ], 'Line 3'.length);
-    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[data-mce-btn="overflow-button"]');
+    await UiFinder.pWaitForVisible('Wait for editor to be visible', SugarBody.body(), '.tox-editor-header button[data-mce-label="overflow-button"]');
     await pRunTests(editor);
     McEditor.remove(editor);
   };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
@@ -69,7 +69,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ReadonlyToolbarResizeTest
       s.element('button', {
         classes: [ arr.has('tox-tbtn'), arr.has('tox-tbtn--disabled') ],
         attrs: {
-          'title': str.is(buttonName),
+          'data-mce-btn': str.is(buttonName),
           'aria-disabled': str.is('true')
         }
       })
@@ -82,7 +82,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ReadonlyToolbarResizeTest
       s.element('button', {
         classes: [ arr.has('tox-tbtn'), arr.not('tox-tbtn--disabled') ],
         attrs: {
-          'title': str.is(buttonName),
+          'data-mce-btn': str.is(buttonName),
           'aria-disabled': str.is('false')
         }
       })
@@ -103,21 +103,21 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ReadonlyToolbarResizeTest
     const editor = hook.editor();
     Css.set(TinyDom.container(editor), 'width', '300px');
     await pAssertToolbarButtonState('Assert the first toolbar button, Bold is disabled', true, (s, str, arr) => [
-      disabledButtonStruct(s, str, arr, 'Bold'),
+      disabledButtonStruct(s, str, arr, 'bold'),
       s.theRest()
     ]);
 
     resizeTo(300, 400, 550, 400);
 
     await pAssertToolbarButtonState('Assert the toolbar buttons are disabled after resizing the editor', true, (s, str, arr) => [
-      disabledButtonStruct(s, str, arr, 'Bold'),
-      disabledButtonStruct(s, str, arr, 'Italic'),
-      disabledButtonStruct(s, str, arr, 'Underline'),
-      disabledButtonStruct(s, str, arr, 'Strikethrough'),
-      disabledButtonStruct(s, str, arr, 'Cut'),
-      disabledButtonStruct(s, str, arr, 'Copy'),
-      disabledButtonStruct(s, str, arr, 'Paste'),
-      disabledButtonStruct(s, str, arr, 'Increase indent'),
+      disabledButtonStruct(s, str, arr, 'bold'),
+      disabledButtonStruct(s, str, arr, 'italic'),
+      disabledButtonStruct(s, str, arr, 'underline'),
+      disabledButtonStruct(s, str, arr, 'strikethrough'),
+      disabledButtonStruct(s, str, arr, 'cut'),
+      disabledButtonStruct(s, str, arr, 'copy'),
+      disabledButtonStruct(s, str, arr, 'paste'),
+      disabledButtonStruct(s, str, arr, 'indent'),
       s.theRest()
     ]);
   });
@@ -126,46 +126,46 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ReadonlyToolbarResizeTest
     const editor = hook.editor();
     Css.set(TinyDom.container(editor), 'width', '550px');
     await pAssertToolbarButtonState('Assert the first toolbar button, Bold is disabled', true, (s, str, arr) => [
-      disabledButtonStruct(s, str, arr, 'Bold'),
+      disabledButtonStruct(s, str, arr, 'bold'),
       s.theRest()
     ]);
     editor.mode.set('design');
     await pOpenMore(ToolbarMode.floating);
     await pAssertToolbarButtonState('Assert the toolbar buttons are enabled', false, (s, str, arr) => [
-      enabledButtonStruct(s, str, arr, 'Bold'),
-      enabledButtonStruct(s, str, arr, 'Italic'),
-      enabledButtonStruct(s, str, arr, 'Underline'),
-      enabledButtonStruct(s, str, arr, 'Strikethrough'),
-      enabledButtonStruct(s, str, arr, 'Cut'),
-      enabledButtonStruct(s, str, arr, 'Copy'),
-      enabledButtonStruct(s, str, arr, 'Paste'),
-      enabledButtonStruct(s, str, arr, 'Increase indent'),
+      enabledButtonStruct(s, str, arr, 'bold'),
+      enabledButtonStruct(s, str, arr, 'italic'),
+      enabledButtonStruct(s, str, arr, 'underline'),
+      enabledButtonStruct(s, str, arr, 'strikethrough'),
+      enabledButtonStruct(s, str, arr, 'cut'),
+      enabledButtonStruct(s, str, arr, 'copy'),
+      enabledButtonStruct(s, str, arr, 'paste'),
+      enabledButtonStruct(s, str, arr, 'indent'),
       s.theRest()
     ]);
     await pAssertToolbarDrawerButtonState('Assert the toolbar drawer buttons are enabled', (s, str, arr) => [
-      enabledButtonStruct(s, str, arr, 'Subscript'),
-      enabledButtonStruct(s, str, arr, 'Superscript'),
-      enabledButtonStruct(s, str, arr, 'Clear formatting'),
+      enabledButtonStruct(s, str, arr, 'subscript'),
+      enabledButtonStruct(s, str, arr, 'superscript'),
+      enabledButtonStruct(s, str, arr, 'removeformat'),
       s.theRest()
     ]);
 
     resizeTo(400, 400, 500, 400);
 
     await pAssertToolbarButtonState('Assert the toolbar buttons are enabled and now include subscript', false, (s, str, arr) => [
-      enabledButtonStruct(s, str, arr, 'Bold'),
-      enabledButtonStruct(s, str, arr, 'Italic'),
-      enabledButtonStruct(s, str, arr, 'Underline'),
-      enabledButtonStruct(s, str, arr, 'Strikethrough'),
-      enabledButtonStruct(s, str, arr, 'Cut'),
-      enabledButtonStruct(s, str, arr, 'Copy'),
-      enabledButtonStruct(s, str, arr, 'Paste'),
-      enabledButtonStruct(s, str, arr, 'Increase indent'),
-      enabledButtonStruct(s, str, arr, 'Subscript'),
+      enabledButtonStruct(s, str, arr, 'bold'),
+      enabledButtonStruct(s, str, arr, 'italic'),
+      enabledButtonStruct(s, str, arr, 'underline'),
+      enabledButtonStruct(s, str, arr, 'strikethrough'),
+      enabledButtonStruct(s, str, arr, 'cut'),
+      enabledButtonStruct(s, str, arr, 'copy'),
+      enabledButtonStruct(s, str, arr, 'paste'),
+      enabledButtonStruct(s, str, arr, 'indent'),
+      enabledButtonStruct(s, str, arr, 'subscript'),
       s.theRest()
     ]);
     await pAssertToolbarDrawerButtonState('Assert the toolbar drawer buttons are enabled', (s, str, arr) => [
-      enabledButtonStruct(s, str, arr, 'Superscript'),
-      enabledButtonStruct(s, str, arr, 'Clear formatting'),
+      enabledButtonStruct(s, str, arr, 'superscript'),
+      enabledButtonStruct(s, str, arr, 'removeformat'),
       s.theRest()
     ]);
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
@@ -69,7 +69,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ReadonlyToolbarResizeTest
       s.element('button', {
         classes: [ arr.has('tox-tbtn'), arr.has('tox-tbtn--disabled') ],
         attrs: {
-          'data-mce-label': str.is(buttonName),
+          'data-mce-name': str.is(buttonName),
           'aria-disabled': str.is('true')
         }
       })
@@ -82,7 +82,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ReadonlyToolbarResizeTest
       s.element('button', {
         classes: [ arr.has('tox-tbtn'), arr.not('tox-tbtn--disabled') ],
         attrs: {
-          'data-mce-label': str.is(buttonName),
+          'data-mce-name': str.is(buttonName),
           'aria-disabled': str.is('false')
         }
       })

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
@@ -69,7 +69,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ReadonlyToolbarResizeTest
       s.element('button', {
         classes: [ arr.has('tox-tbtn'), arr.has('tox-tbtn--disabled') ],
         attrs: {
-          'data-mce-btn': str.is(buttonName),
+          'data-mce-label': str.is(buttonName),
           'aria-disabled': str.is('true')
         }
       })
@@ -82,7 +82,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ReadonlyToolbarResizeTest
       s.element('button', {
         classes: [ arr.has('tox-tbtn'), arr.not('tox-tbtn--disabled') ],
         attrs: {
-          'data-mce-btn': str.is(buttonName),
+          'data-mce-label': str.is(buttonName),
           'aria-disabled': str.is('false')
         }
       })

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/SplitFloatingToolbarKeyboardNavigationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/SplitFloatingToolbarKeyboardNavigationTest.ts
@@ -26,8 +26,8 @@ describe('browser.tinymce.themes.silver.editor.toolbar.SplitFloatingToolbarKeybo
 
   it('TINY-9723: Menu toolbar items should not be tabstoppable', async () => {
     const editor = hook.editor();
-    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[title="Reveal or hide additional toolbar items"]');
-    const menubutton = await TinyUiActions.pWaitForPopup(editor, '.tox-tbtn[title="menubutton"]');
+    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-btn="overflow-button"]');
+    const menubutton = await TinyUiActions.pWaitForPopup(editor, '.tox-tbtn[aria-label="menubutton"]');
     assert.isFalse(Attribute.has(menubutton, 'data-alloy-tabstop'));
     // Focus is on the first toolbar__group on the fontsize button
     TinyUiActions.keystroke(editor, Keys.tab());

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/SplitFloatingToolbarKeyboardNavigationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/SplitFloatingToolbarKeyboardNavigationTest.ts
@@ -26,7 +26,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.SplitFloatingToolbarKeybo
 
   it('TINY-9723: Menu toolbar items should not be tabstoppable', async () => {
     const editor = hook.editor();
-    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-label="overflow-button"]');
+    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-name="overflow-button"]');
     const menubutton = await TinyUiActions.pWaitForPopup(editor, '.tox-tbtn[aria-label="menubutton"]');
     assert.isFalse(Attribute.has(menubutton, 'data-alloy-tabstop'));
     // Focus is on the first toolbar__group on the fontsize button

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/SplitFloatingToolbarKeyboardNavigationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/SplitFloatingToolbarKeyboardNavigationTest.ts
@@ -26,7 +26,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.SplitFloatingToolbarKeybo
 
   it('TINY-9723: Menu toolbar items should not be tabstoppable', async () => {
     const editor = hook.editor();
-    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-btn="overflow-button"]');
+    TinyUiActions.clickOnToolbar(editor, '.tox-tbtn[data-mce-label="overflow-button"]');
     const menubutton = await TinyUiActions.pWaitForPopup(editor, '.tox-tbtn[aria-label="menubutton"]');
     assert.isFalse(Attribute.has(menubutton, 'data-alloy-tabstop'));
     // Focus is on the first toolbar__group on the fontsize button

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -105,7 +105,7 @@ describe.skip('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleT
       });
 
       it(`TINY-9271: Emits 'ToggleToolbarDrawer' in ${toolbarMode} via user click`, async () => {
-        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="overflow-button"]'));
+        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="overflow-button"]'));
       });
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -105,7 +105,7 @@ describe.skip('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleT
       });
 
       it(`TINY-9271: Emits 'ToggleToolbarDrawer' in ${toolbarMode} via user click`, async () => {
-        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[title="Reveal or hide additional toolbar items"]'));
+        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="overflow-button"]'));
       });
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -105,7 +105,7 @@ describe.skip('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleT
       });
 
       it(`TINY-9271: Emits 'ToggleToolbarDrawer' in ${toolbarMode} via user click`, async () => {
-        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[data-mce-btn="overflow-button"]'));
+        await pTestEvent(toolbarMode, (editor) => TinyUiActions.clickOnToolbar(editor, 'button[data-mce-label="overflow-button"]'));
       });
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
@@ -87,7 +87,7 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
 
   const openAndGetMenu = (title: string) =>
     () => {
-      Mouse.clickOn(SugarBody.body(), `[title^="${title}"] .tox-split-button__chevron`);
+      Mouse.clickOn(SugarBody.body(), `[data-mce-btn="${title}"] .tox-split-button__chevron`);
       return Waiter.pTryUntil('Waiting for menu', () =>
         UiFinder.findIn(SugarBody.body(), '[role="menu"]').getOrDie()
       );
@@ -95,7 +95,7 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
 
   const closeMenu = (title: string) =>
     () => {
-      Mouse.clickOn(SugarBody.body(), `[title^="${title}"] .tox-split-button__chevron`);
+      Mouse.clickOn(SugarBody.body(), `[data-mce-btn="${title}"] .tox-split-button__chevron`);
       return Waiter.pTryUntil('Waiting for menu', () =>
         UiFinder.notExists(SugarBody.body(), '[role="menu"]')
       );
@@ -103,11 +103,11 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
 
   const openAndGetSwatchButtonMenu = openAndGetMenu('swatch-button');
   const closeSwatchButtonMenu = closeMenu('swatch-button');
-  const openAndGetForecolorMenu = openAndGetMenu('Text color');
-  const closeForecolorMenu = closeMenu('Text color');
+  const openAndGetForecolorMenu = openAndGetMenu('forecolor');
+  const closeForecolorMenu = closeMenu('forecolor');
   const pOpenAndGetMenuColorMenu = async (editor: Editor) => {
     const mainButton = 'button:contains("Color")';
-    const submenuButton = '[role="menu"] div[title^="Background color"]';
+    const submenuButton = '[role="menu"] div[aria-label^="Background color"]';
     TinyUiActions.clickOnMenu(editor, mainButton);
     await TinyUiActions.pWaitForUi(editor, submenuButton);
     TinyUiActions.clickOnUi(editor, submenuButton);
@@ -118,7 +118,7 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
 
   const pOpenAndGetMenuForecolorMenu = async (editor: Editor) => {
     const mainButton = 'button:contains("Forecolor")';
-    const submenuButton = '[role="menu"] div[title^="Text color"]';
+    const submenuButton = '[role="menu"] div[aria-label^="Text color"]';
     TinyUiActions.clickOnMenu(editor, mainButton);
     await TinyUiActions.pWaitForUi(editor, submenuButton);
     TinyUiActions.clickOnUi(editor, submenuButton);
@@ -128,11 +128,11 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
   const pCloseMenuForecolorMenu = (editor: Editor) => {
     const mainButton = 'button:contains("Forecolor")';
     TinyUiActions.clickOnMenu(editor, mainButton);
-    return Waiter.pTryUntil('The menu should have closed', () => UiFinder.notExists(TinyUiActions.getUiRoot(editor), '[role="menu"] div[title^="Text color"]'));
+    return Waiter.pTryUntil('The menu should have closed', () => UiFinder.notExists(TinyUiActions.getUiRoot(editor), '[role="menu"] div[aria-label^="Text color"]'));
   };
 
-  const openAndGetBackcolorMenu = openAndGetMenu('Background color');
-  const closeBackcolorMenu = closeMenu('Background color');
+  const openAndGetBackcolorMenu = openAndGetMenu('backcolor');
+  const closeBackcolorMenu = closeMenu('backcolor');
 
   TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [
     ':focus { transform: scale(0.8) }'
@@ -299,7 +299,7 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
     TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2, true);
     await pOpenAndGetMenuColorMenu(editor);
     await UiFinder.pWaitFor('The color should be black in the icon', TinyUiActions.getUiRoot(editor), 'path[class="tox-icon-highlight-bg-color__color"][fill="#000000"]');
-    TinyUiActions.clickOnUi(editor, '[role="menuitemradio"][title="red"]');
+    TinyUiActions.clickOnUi(editor, '[role="menuitemradio"][aria-label="red"]');
     await pOpenAndGetMenuColorMenu(editor);
     await UiFinder.pWaitFor('The color should be red in the icon', TinyUiActions.getUiRoot(editor), 'path[class="tox-icon-highlight-bg-color__color"][fill="#E03E2D"]');
     closeMenuColorMenu(editor);
@@ -310,13 +310,13 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
     editor.setContent('<p>black</p><p style="color: rgb(224, 62, 45);">red</p>');
     TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 2, true);
     await pOpenAndGetMenuColorMenu(editor);
-    TinyUiActions.clickOnUi(editor, '[role="menuitemradio"][title="red"]');
+    TinyUiActions.clickOnUi(editor, '[role="menuitemradio"][aria-label="red"]');
 
     await openAndGetBackcolorMenu();
     assertFocusIsOnColor('rgb(224, 62, 45)');
     closeBackcolorMenu();
     await pOpenAndGetMenuForecolorMenu(editor);
-    TinyUiActions.clickOnUi(editor, '[role="menuitemradio"][title="Light Gray"]');
+    TinyUiActions.clickOnUi(editor, '[role="menuitemradio"][aria-label="Light Gray"]');
     await openAndGetForecolorMenu();
     assertFocusIsOnColor('rgb(236, 240, 241)');
     await pCloseMenuForecolorMenu(editor);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
@@ -87,7 +87,7 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
 
   const openAndGetMenu = (title: string) =>
     () => {
-      Mouse.clickOn(SugarBody.body(), `[data-mce-label="${title}"] .tox-split-button__chevron`);
+      Mouse.clickOn(SugarBody.body(), `[data-mce-name="${title}"] .tox-split-button__chevron`);
       return Waiter.pTryUntil('Waiting for menu', () =>
         UiFinder.findIn(SugarBody.body(), '[role="menu"]').getOrDie()
       );
@@ -95,7 +95,7 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
 
   const closeMenu = (title: string) =>
     () => {
-      Mouse.clickOn(SugarBody.body(), `[data-mce-label="${title}"] .tox-split-button__chevron`);
+      Mouse.clickOn(SugarBody.body(), `[data-mce-name="${title}"] .tox-split-button__chevron`);
       return Waiter.pTryUntil('Waiting for menu', () =>
         UiFinder.notExists(SugarBody.body(), '[role="menu"]')
       );

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
@@ -87,7 +87,7 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
 
   const openAndGetMenu = (title: string) =>
     () => {
-      Mouse.clickOn(SugarBody.body(), `[data-mce-btn="${title}"] .tox-split-button__chevron`);
+      Mouse.clickOn(SugarBody.body(), `[data-mce-label="${title}"] .tox-split-button__chevron`);
       return Waiter.pTryUntil('Waiting for menu', () =>
         UiFinder.findIn(SugarBody.body(), '[role="menu"]').getOrDie()
       );
@@ -95,7 +95,7 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
 
   const closeMenu = (title: string) =>
     () => {
-      Mouse.clickOn(SugarBody.body(), `[data-mce-btn="${title}"] .tox-split-button__chevron`);
+      Mouse.clickOn(SugarBody.body(), `[data-mce-label="${title}"] .tox-split-button__chevron`);
       return Waiter.pTryUntil('Waiting for menu', () =>
         UiFinder.notExists(SugarBody.body(), '[role="menu"]')
       );

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideGridCollectionMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideGridCollectionMenuTest.ts
@@ -52,7 +52,7 @@ describe('browser.tinymce.themes.silver.skin.OxideGridCollectionMenuTest', () =>
             children: Arr.map([ '1', '2', '3', '4', '5', '6', '7', '8' ], (num) => s.element('div', {
               classes: [ arr.has('tox-collection__item') ],
               attrs: {
-                title: str.is(num)
+                'aria-label': str.is(num)
               },
               children: [
                 // NOTE: The oxide demo page has div, but I think that's just a mistake
@@ -70,10 +70,10 @@ describe('browser.tinymce.themes.silver.skin.OxideGridCollectionMenuTest', () =>
       menu
     );
 
-    await FocusTools.pTryOnSelector('Focus should be on 1', doc, '.tox-collection__item[title="1"]');
+    await FocusTools.pTryOnSelector('Focus should be on 1', doc, '.tox-collection__item[aria-label="1"]');
     TinyUiActions.keydown(editor, Keys.right());
-    await FocusTools.pTryOnSelector('Focus should be on 2', doc, '.tox-collection__item[title="2"]');
+    await FocusTools.pTryOnSelector('Focus should be on 2', doc, '.tox-collection__item[aria-label="2"]');
     TinyUiActions.keydown(editor, Keys.right());
-    await FocusTools.pTryOnSelector('Focus should be on 3', doc, '.tox-collection__item[title="3"]');
+    await FocusTools.pTryOnSelector('Focus should be on 3', doc, '.tox-collection__item[aria-label="3"]');
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideListCollectionMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideListCollectionMenuTest.ts
@@ -67,7 +67,7 @@ describe('browser.tinymce.themes.silver.skin.OxideListCollectionMenuTest', () =>
               s.element('div', {
                 classes: [ arr.has('tox-collection__item') ],
                 attrs: {
-                  title: str.is('Alpha')
+                  'aria-label': str.is('Alpha')
                 },
                 children: [
                   s.element('div', {
@@ -93,7 +93,7 @@ describe('browser.tinymce.themes.silver.skin.OxideListCollectionMenuTest', () =>
               s.element('div', {
                 classes: [ arr.has('tox-collection__item') ],
                 attrs: {
-                  title: str.is('Beta')
+                  'aria-label': str.is('Beta')
                 },
                 children: [
                   s.element('div', {
@@ -118,7 +118,7 @@ describe('browser.tinymce.themes.silver.skin.OxideListCollectionMenuTest', () =>
               s.element('div', {
                 classes: [ arr.has('tox-collection__item') ],
                 attrs: {
-                  title: str.is('Gamma')
+                  'aria-label': str.is('Gamma')
                 },
                 children: [
                   s.element('div', {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideToolbarCollectionMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideToolbarCollectionMenuTest.ts
@@ -54,7 +54,7 @@ describe('browser.tinymce.themes.silver.skin.OxideToolbarCollectionMenuTest', ()
               s.element('div', {
                 classes: [ arr.has('tox-collection__item'), arr.not('tox-tbtn') ],
                 attrs: {
-                  title: str.is('A-button')
+                  'aria-label': str.is('A-button')
                 },
                 children: [
                   s.element('div', {
@@ -68,7 +68,7 @@ describe('browser.tinymce.themes.silver.skin.OxideToolbarCollectionMenuTest', ()
               s.element('div', {
                 classes: [ arr.has('tox-collection__item'), arr.not('tox-tbtn') ],
                 attrs: {
-                  title: str.is('B-button')
+                  'aria-label': str.is('B-button')
                 },
                 children: [
                   s.element('div', {
@@ -82,7 +82,7 @@ describe('browser.tinymce.themes.silver.skin.OxideToolbarCollectionMenuTest', ()
               s.element('div', {
                 classes: [ arr.has('tox-collection__item'), arr.not('tox-tbtn') ],
                 attrs: {
-                  title: str.is('C-button')
+                  'aria-label': str.is('C-button')
                 },
                 children: [
                   s.element('div', {
@@ -101,7 +101,7 @@ describe('browser.tinymce.themes.silver.skin.OxideToolbarCollectionMenuTest', ()
               s.element('div', {
                 classes: [ arr.has('tox-collection__item'), arr.not('tox-tbtn') ],
                 attrs: {
-                  title: str.is('D-button')
+                  'aria-label': str.is('D-button')
                 },
                 children: [
                   s.element('div', {
@@ -115,7 +115,7 @@ describe('browser.tinymce.themes.silver.skin.OxideToolbarCollectionMenuTest', ()
               s.element('div', {
                 classes: [ arr.has('tox-collection__item'), arr.not('tox-tbtn') ],
                 attrs: {
-                  title: str.is('E-button')
+                  'aria-label': str.is('E-button')
                 },
                 children: [
                   s.element('div', {
@@ -129,7 +129,7 @@ describe('browser.tinymce.themes.silver.skin.OxideToolbarCollectionMenuTest', ()
               s.element('div', {
                 classes: [ arr.has('tox-collection__item'), arr.not('tox-tbtn') ],
                 attrs: {
-                  title: str.is('F-button')
+                  'aria-label': str.is('F-button')
                 },
                 children: [
                   s.element('div', {
@@ -147,10 +147,10 @@ describe('browser.tinymce.themes.silver.skin.OxideToolbarCollectionMenuTest', ()
       menu
     );
 
-    await FocusTools.pTryOnSelector('Focus should start on A', doc, '.tox-collection__item[title="A-button"]');
+    await FocusTools.pTryOnSelector('Focus should start on A', doc, '.tox-collection__item[aria-label="A-button"]');
     TinyUiActions.keydown(editor, Keys.down());
-    await FocusTools.pTryOnSelector('Focus should move to D', doc, '.tox-collection__item[title="D-button"]');
+    await FocusTools.pTryOnSelector('Focus should move to D', doc, '.tox-collection__item[aria-label="D-button"]');
     TinyUiActions.keydown(editor, Keys.right());
-    await FocusTools.pTryOnSelector('Focus should move to E', doc, '.tox-collection__item[title="E-button"]');
+    await FocusTools.pTryOnSelector('Focus should move to E', doc, '.tox-collection__item[aria-label="E-button"]');
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
@@ -115,7 +115,6 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
                 s.element('div', {
                   classes: [ arr.has('tox-statusbar__resize-handle') ],
                   attrs: {
-                    'title': str.is('Resize'),
                     'aria-label': str.is(label)
                   }
                 })

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewButtonsTest.ts
@@ -89,13 +89,13 @@ describe('browser.tinymce.themes.silver.view.ViewButtonsTest', () => {
       editor.execCommand('ToggleView', false, name);
     };
 
-    const clickViewButton = (editor: Editor, tooltip: string) => TinyUiActions.clickOnUi(editor, `.tox-view button[title='${tooltip}']`);
+    const clickViewButton = (editor: Editor, tooltip: string) => TinyUiActions.clickOnUi(editor, `.tox-view button[aria-label='${tooltip}']`);
 
-    const getSvg = (editor: Editor, name: string) => UiFinder.findIn<HTMLElement>(TinyDom.container(editor), `.tox-view button[title='${name}'] svg`).getOrDie().dom.innerHTML;
+    const getSvg = (editor: Editor, name: string) => UiFinder.findIn<HTMLElement>(TinyDom.container(editor), `.tox-view button[aria-label='${name}'] svg`).getOrDie().dom.innerHTML;
 
     const getButtonByTitle = (title: string) => {
       const editor = hook.editor();
-      return UiFinder.findIn<HTMLElement>(TinyDom.container(editor), `.tox-view button[title='${title}']`).getOrDie();
+      return UiFinder.findIn<HTMLElement>(TinyDom.container(editor), `.tox-view button[aria-label='${title}']`).getOrDie();
     };
 
     it('TINY-9523: tooglable button can be toggled with the correct implementation', () => {
@@ -121,7 +121,7 @@ describe('browser.tinymce.themes.silver.view.ViewButtonsTest', () => {
     it('TINY-9616: if is active is true the button should have ViewButtonClasses.Ticked', async () => {
       const editor = hook.editor();
       toggleView('myview2');
-      await UiFinder.pWaitFor('buttons should be showed', TinyDom.container(editor), '[title="button-active-true"]');
+      await UiFinder.pWaitFor('buttons should be showed', TinyDom.container(editor), '[aria-label="button-active-true"]');
 
       const buttonActiveTrue = getButtonByTitle('button-active-true');
       assert.isTrue(Class.has(buttonActiveTrue, ViewButtonClasses.Ticked), 'button with active true should have ticked class');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -419,13 +419,13 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       const editor = hook.editor();
 
       editor.setContent('<p>ab</p>');
-      TinyUiActions.clickOnToolbar(editor, '[data-mce-label="overflow-button"]');
+      TinyUiActions.clickOnToolbar(editor, '[data-mce-name="overflow-button"]');
 
       editor.execCommand('ToggleView', false, 'myview1');
       assertViewHtml(0, '<button>myview1</button>');
       editor.execCommand('ToggleView', false, 'myview1');
       assertMainViewVisible();
-      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[data-mce-label="overflow-button"]');
+      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[data-mce-name="overflow-button"]');
       assert.isTrue(moreButton.isValue(), 'Reveal or hide additional toolbar items button should be there');
     });
   });
@@ -497,7 +497,7 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       editor.execCommand('ToggleView', false, 'myview1');
       assertMainViewVisible();
 
-      const boldButton = await TinyUiActions.pWaitForUi(editor, '.tox-toolbar__primary [data-mce-label="bold"]');
+      const boldButton = await TinyUiActions.pWaitForUi(editor, '.tox-toolbar__primary [data-mce-name="bold"]');
       assert.isDefined(boldButton, 'Bold button should be in `tox-toolbar__primary`');
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -420,13 +420,13 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       const editor = hook.editor();
 
       editor.setContent('<p>ab</p>');
-      TinyUiActions.clickOnToolbar(editor, '[data-mce-btn="overflow-button"]');
+      TinyUiActions.clickOnToolbar(editor, '[data-mce-label="overflow-button"]');
 
       editor.execCommand('ToggleView', false, 'myview1');
       assertViewHtml(0, '<button>myview1</button>');
       editor.execCommand('ToggleView', false, 'myview1');
       assertMainViewVisible();
-      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[data-mce-btn="overflow-button"]');
+      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[data-mce-label="overflow-button"]');
       assert.isTrue(moreButton.isValue(), 'Reveal or hide additional toolbar items button should be there');
     });
   });
@@ -498,7 +498,7 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       editor.execCommand('ToggleView', false, 'myview1');
       assertMainViewVisible();
 
-      const boldButton = await TinyUiActions.pWaitForUi(editor, '.tox-toolbar__primary [data-mce-btn="bold"]');
+      const boldButton = await TinyUiActions.pWaitForUi(editor, '.tox-toolbar__primary [data-mce-label="bold"]');
       assert.isDefined(boldButton, 'Bold button should be in `tox-toolbar__primary`');
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -420,13 +420,13 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       const editor = hook.editor();
 
       editor.setContent('<p>ab</p>');
-      TinyUiActions.clickOnToolbar(editor, '[title="Reveal or hide additional toolbar items"]');
+      TinyUiActions.clickOnToolbar(editor, '[data-mce-btn="overflow-button"]');
 
       editor.execCommand('ToggleView', false, 'myview1');
       assertViewHtml(0, '<button>myview1</button>');
       editor.execCommand('ToggleView', false, 'myview1');
       assertMainViewVisible();
-      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[title="Reveal or hide additional toolbar items"]');
+      const moreButton = UiFinder.findIn(TinyDom.container(editor), '[data-mce-btn="overflow-button"]');
       assert.isTrue(moreButton.isValue(), 'Reveal or hide additional toolbar items button should be there');
     });
   });
@@ -498,7 +498,7 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       editor.execCommand('ToggleView', false, 'myview1');
       assertMainViewVisible();
 
-      const boldButton = await TinyUiActions.pWaitForUi(editor, '.tox-toolbar__primary [title="Bold"]');
+      const boldButton = await TinyUiActions.pWaitForUi(editor, '.tox-toolbar__primary [data-mce-btn="bold"]');
       assert.isDefined(boldButton, 'Bold button should be in `tox-toolbar__primary`');
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -75,7 +75,7 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       }
     }, []);
 
-    const clickViewButton = (editor: Editor, tooltip: string) => TinyUiActions.clickOnUi(editor, `.tox-view button[title='${tooltip}']`);
+    const clickViewButton = (editor: Editor, tooltip: string) => TinyUiActions.clickOnUi(editor, `.tox-view button[aria-label='${tooltip}']`);
 
     const toggleView = (name: string) => {
       const editor = hook.editor();
@@ -130,7 +130,6 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
           s.element('button', {
             classes: Arr.map(classes, (cls) => arr.has(cls)),
             attrs: {
-              'title': str.is(title),
               'type': str.is('button'),
               'tabindex': str.is('-1'),
               'data-alloy-tabstop': str.is('true')
@@ -327,19 +326,19 @@ describe('browser.tinymce.themes.silver.view.ViewTest', () => {
       await FocusTools.pTryOnSelector('Focus should be on the view header', root, '.tox-view__header');
 
       TinyUiActions.keystroke(editor, Keys.enter());
-      await FocusTools.pTryOnSelector('Button 1 should be the first selection', root, '.tox-view__header [title="Button 1"]');
+      await FocusTools.pTryOnSelector('Button 1 should be the first selection', root, '.tox-view__header [aria-label="Button 1"]');
 
       TinyUiActions.keystroke(editor, Keys.right());
-      await FocusTools.pTryOnSelector('With right it should pass from Button 1 to Button 2', root, '.tox-view__header [title="Button 2"]');
+      await FocusTools.pTryOnSelector('With right it should pass from Button 1 to Button 2', root, '.tox-view__header [aria-label="Button 2"]');
 
       TinyUiActions.keystroke(editor, Keys.right());
-      await FocusTools.pTryOnSelector('Pressing right again it should move to Button 1', root, '.tox-view__header [title="Button 1"]');
+      await FocusTools.pTryOnSelector('Pressing right again it should move to Button 1', root, '.tox-view__header [aria-label="Button 1"]');
 
       TinyUiActions.keystroke(editor, Keys.left());
-      await FocusTools.pTryOnSelector('With left it should pass from Button 1 to Button 2', root, '.tox-view__header [title="Button 2"]');
+      await FocusTools.pTryOnSelector('With left it should pass from Button 1 to Button 2', root, '.tox-view__header [aria-label="Button 2"]');
 
       TinyUiActions.keystroke(editor, Keys.left());
-      await FocusTools.pTryOnSelector('Pressing left again it should move to Button 1', root, '.tox-view__header [title="Button 1"]');
+      await FocusTools.pTryOnSelector('Pressing left again it should move to Button 1', root, '.tox-view__header [aria-label="Button 1"]');
       toggleView('myview1');
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
@@ -48,7 +48,7 @@ describe('browser.tinymce.themes.silver.window.SilverDialogBlockTest', () => {
   };
 
   const clickableButtonSelector = 'button:contains("Clickable?")';
-  const closeButtonSelector = '.tox-button[data-mce-label="close"]';
+  const closeButtonSelector = '.tox-button[data-mce-name="close"]';
 
   const pClick = async (editor: Editor, selector: string) => {
     const button = await TinyUiActions.pWaitForUi(editor, selector) as SugarElement<HTMLButtonElement>;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
@@ -48,7 +48,7 @@ describe('browser.tinymce.themes.silver.window.SilverDialogBlockTest', () => {
   };
 
   const clickableButtonSelector = 'button:contains("Clickable?")';
-  const closeButtonSelector = '.tox-button[data-mce-btn="close"]';
+  const closeButtonSelector = '.tox-button[data-mce-label="close"]';
 
   const pClick = async (editor: Editor, selector: string) => {
     const button = await TinyUiActions.pWaitForUi(editor, selector) as SugarElement<HTMLButtonElement>;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
@@ -48,7 +48,7 @@ describe('browser.tinymce.themes.silver.window.SilverDialogBlockTest', () => {
   };
 
   const clickableButtonSelector = 'button:contains("Clickable?")';
-  const closeButtonSelector = '.tox-button[title="Close"]';
+  const closeButtonSelector = '.tox-button[data-mce-btn="close"]';
 
   const pClick = async (editor: Editor, selector: string) => {
     const button = await TinyUiActions.pWaitForUi(editor, selector) as SugarElement<HTMLButtonElement>;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPersistenceTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPersistenceTest.ts
@@ -145,7 +145,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogPersistenceTest
             const editor = hook.editor();
             const api = DialogUtils.open(editor, dialogSpec, { inline: dialogLocation.location, persistent: persistentMode.persistent });
             await TinyUiActions.pWaitForDialog(editor);
-            Mouse.trueClickOn(TinyDom.container(editor), '.tox-tbtn[title="Bold"]');
+            Mouse.trueClickOn(TinyDom.container(editor), '.tox-tbtn[data-mce-btn="bold"]');
             assertDialogVisibility(persistentMode.persistent);
             api.close();
           });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPersistenceTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPersistenceTest.ts
@@ -145,7 +145,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogPersistenceTest
             const editor = hook.editor();
             const api = DialogUtils.open(editor, dialogSpec, { inline: dialogLocation.location, persistent: persistentMode.persistent });
             await TinyUiActions.pWaitForDialog(editor);
-            Mouse.trueClickOn(TinyDom.container(editor), '.tox-tbtn[data-mce-btn="bold"]');
+            Mouse.trueClickOn(TinyDom.container(editor), '.tox-tbtn[data-mce-label="bold"]');
             assertDialogVisibility(persistentMode.persistent);
             api.close();
           });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPersistenceTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPersistenceTest.ts
@@ -145,7 +145,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogPersistenceTest
             const editor = hook.editor();
             const api = DialogUtils.open(editor, dialogSpec, { inline: dialogLocation.location, persistent: persistentMode.persistent });
             await TinyUiActions.pWaitForDialog(editor);
-            Mouse.trueClickOn(TinyDom.container(editor), '.tox-tbtn[data-mce-label="bold"]');
+            Mouse.trueClickOn(TinyDom.container(editor), '.tox-tbtn[data-mce-name="bold"]');
             assertDialogVisibility(persistentMode.persistent);
             api.close();
           });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
@@ -216,25 +216,25 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogTest', () => {
       await FocusTools.pTryOnSelector(
         'Focus should be on barny button',
         SugarDocument.getDocument(),
-        'button[title="Barny Text"]'
+        'button[data-mce-btn="Barny Text"]'
       );
       TinyUiActions.keydown(editor, Keys.tab());
       await FocusTools.pTryOnSelector(
         'Focus should be on alert button',
         SugarDocument.getDocument(),
-        'button[title="Alert"]'
+        'button[data-mce-btn="Alert"]'
       );
       TinyUiActions.keydown(editor, Keys.tab());
       await FocusTools.pTryOnSelector(
         'Focus should be on confirm button',
         SugarDocument.getDocument(),
-        'button[title="Confirm"]'
+        'button[data-mce-btn="Confirm"]'
       );
       TinyUiActions.keydown(editor, Keys.tab());
       await FocusTools.pTryOnSelector(
         'Focus should be on x close button',
         SugarDocument.getDocument(),
-        '.tox-button[title="Close"]'
+        '.tox-button[data-mce-btn="close"]'
       );
       DialogUtils.close(editor);
     });
@@ -259,7 +259,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogTest', () => {
     const editor = hook.editor();
     openDialog(editor, { inline: 'toolbar' }, createDialogWithIframeSpec());
     await TinyUiActions.pWaitForDialog(editor);
-    TinyUiActions.clickOnUi(editor, 'button[title="Random"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Random"]');
     UiFinder.notExists(SugarBody.body(), 'tox-dialog-inline');
     await FocusTools.pTryOnSelector(
       'Focus should be on iframe',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
@@ -216,25 +216,25 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogTest', () => {
       await FocusTools.pTryOnSelector(
         'Focus should be on barny button',
         SugarDocument.getDocument(),
-        'button[data-mce-label="Barny Text"]'
+        'button[data-mce-name="Barny Text"]'
       );
       TinyUiActions.keydown(editor, Keys.tab());
       await FocusTools.pTryOnSelector(
         'Focus should be on alert button',
         SugarDocument.getDocument(),
-        'button[data-mce-label="Alert"]'
+        'button[data-mce-name="Alert"]'
       );
       TinyUiActions.keydown(editor, Keys.tab());
       await FocusTools.pTryOnSelector(
         'Focus should be on confirm button',
         SugarDocument.getDocument(),
-        'button[data-mce-label="Confirm"]'
+        'button[data-mce-name="Confirm"]'
       );
       TinyUiActions.keydown(editor, Keys.tab());
       await FocusTools.pTryOnSelector(
         'Focus should be on x close button',
         SugarDocument.getDocument(),
-        '.tox-button[data-mce-label="close"]'
+        '.tox-button[data-mce-name="close"]'
       );
       DialogUtils.close(editor);
     });
@@ -259,7 +259,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogTest', () => {
     const editor = hook.editor();
     openDialog(editor, { inline: 'toolbar' }, createDialogWithIframeSpec());
     await TinyUiActions.pWaitForDialog(editor);
-    TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Random"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Random"]');
     UiFinder.notExists(SugarBody.body(), 'tox-dialog-inline');
     await FocusTools.pTryOnSelector(
       'Focus should be on iframe',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
@@ -216,25 +216,25 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogTest', () => {
       await FocusTools.pTryOnSelector(
         'Focus should be on barny button',
         SugarDocument.getDocument(),
-        'button[data-mce-btn="Barny Text"]'
+        'button[data-mce-label="Barny Text"]'
       );
       TinyUiActions.keydown(editor, Keys.tab());
       await FocusTools.pTryOnSelector(
         'Focus should be on alert button',
         SugarDocument.getDocument(),
-        'button[data-mce-btn="Alert"]'
+        'button[data-mce-label="Alert"]'
       );
       TinyUiActions.keydown(editor, Keys.tab());
       await FocusTools.pTryOnSelector(
         'Focus should be on confirm button',
         SugarDocument.getDocument(),
-        'button[data-mce-btn="Confirm"]'
+        'button[data-mce-label="Confirm"]'
       );
       TinyUiActions.keydown(editor, Keys.tab());
       await FocusTools.pTryOnSelector(
         'Focus should be on x close button',
         SugarDocument.getDocument(),
-        '.tox-button[data-mce-btn="close"]'
+        '.tox-button[data-mce-label="close"]'
       );
       DialogUtils.close(editor);
     });
@@ -259,7 +259,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogTest', () => {
     const editor = hook.editor();
     openDialog(editor, { inline: 'toolbar' }, createDialogWithIframeSpec());
     await TinyUiActions.pWaitForDialog(editor);
-    TinyUiActions.clickOnUi(editor, 'button[data-mce-btn="Random"]');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-label="Random"]');
     UiFinder.notExists(SugarBody.body(), 'tox-dialog-inline');
     await FocusTools.pTryOnSelector(
       'Focus should be on iframe',

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
@@ -152,8 +152,8 @@ describe('headless.tinymce.themes.silver.tree.TreeTest', () => {
 
     store.clear();
     Mouse.clickOn(dir.element, '.tox-mbtn');
-    await UiFinder.pWaitFor('Wait for menu item to show up', SugarBody.body(), '[title="menuitem"]');
-    Mouse.clickOn(SugarBody.body(), '[title="menuitem"]');
+    await UiFinder.pWaitFor('Wait for menu item to show up', SugarBody.body(), '[aria-label="menuitem"]');
+    Mouse.clickOn(SugarBody.body(), '[aria-label="menuitem"]');
     store.assertEq('menuitem', [ 'menuitem' ]);
 
     Mouse.clickOn(dir.element, '.tox-tree--directory .tox-trbtn.tox-tree--directory__label');

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
@@ -292,9 +292,10 @@ describe('headless.tinymce.themes.silver.components.urlinput.UrlInputTest', () =
     closeMenu();
   });
 
-  it('TINY-10155: Title attribute of picker button should be specified by picker_text property', () =>
+  // TINY-10465 - Address tests below, these are using custom tooltips so querying for title attributes are no longer relevant
+  it.skip('TINY-10155: Title attribute of picker button should be specified by picker_text property', () =>
     assert.equal(Attribute.get(getPicker(true).element, 'title'), 'UrlInput picker text'));
 
-  it('TINY-10155: Title attribute of picker button should fall back to label when picker_text property is not specified', () =>
+  it.skip('TINY-10155: Title attribute of picker button should fall back to label when picker_text property is not specified', () =>
     assert.equal(Attribute.get(getPicker(false).element, 'title'), 'UrlInput label'));
 });

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
@@ -192,7 +192,6 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
         classes: [ arr.has('tox-tbtn') ],
         attrs: {
           'type': str.is('button'),
-          'title': str.is('tooltip'),
           'aria-label': str.is('tooltip')
         },
         children: [
@@ -264,7 +263,6 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
         classes: [ arr.has('tox-split-button') ],
         attrs: {
           'role': str.is('button'),
-          'title': str.is('tooltip'),
           'aria-label': str.is('tooltip'),
           'aria-expanded': str.is('false'),
           'aria-haspopup': str.is('true'),
@@ -358,7 +356,6 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
         ],
         attrs: {
           'type': str.is('button'),
-          'title': str.is('tooltip'),
           'aria-label': str.is('tooltip'),
           'aria-expanded': str.is('false'),
           'aria-haspopup': str.is('true')

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/CustomDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/CustomDialogTest.ts
@@ -56,7 +56,7 @@ describe('headless.tinymce.themes.silver.window.CustomDialogTest', () => {
     field7: 'label:contains("nested2") + input',
     field8: 'button:contains("Cancel")',
     field9: 'button:contains("Save")',
-    browseButton: 'button[title=F3]'
+    browseButton: 'button[data-mce-btn="F3"]'
   };
 
   it('', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/CustomDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/CustomDialogTest.ts
@@ -56,7 +56,7 @@ describe('headless.tinymce.themes.silver.window.CustomDialogTest', () => {
     field7: 'label:contains("nested2") + input',
     field8: 'button:contains("Cancel")',
     field9: 'button:contains("Save")',
-    browseButton: 'button[data-mce-label="F3"]'
+    browseButton: 'button[data-mce-name="F3"]'
   };
 
   it('', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/CustomDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/CustomDialogTest.ts
@@ -56,7 +56,7 @@ describe('headless.tinymce.themes.silver.window.CustomDialogTest', () => {
     field7: 'label:contains("nested2") + input',
     field8: 'button:contains("Cancel")',
     field9: 'button:contains("Save")',
-    browseButton: 'button[data-mce-btn="F3"]'
+    browseButton: 'button[data-mce-label="F3"]'
   };
 
   it('', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/module/AutocompleterUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/AutocompleterUtils.ts
@@ -39,7 +39,7 @@ const structWithTitleAndIconAndText = (d: TitleWithTextAndIconItem): ApproxStruc
   (s, str, arr) => s.element('div', {
     classes: [ arr.has('tox-collection__item') ],
     attrs: {
-      title: str.is(d.title)
+      'aria-label': str.is(d.title)
     },
     children: [
       s.element('div', {
@@ -59,7 +59,7 @@ const structWithTitleAndText = (d: TitleWithTextItem): ApproxStructure.Builder<S
   (s, str, arr) => s.element('div', {
     classes: [ arr.has('tox-collection__item') ],
     attrs: {
-      title: str.is(d.title)
+      'aria-label': str.is(d.title)
     },
     children: [
       s.element('div', {
@@ -73,7 +73,7 @@ const structWithTitleAndIcon = (d: TitleWithIconItem): ApproxStructure.Builder<S
   (s, str, arr) => s.element('div', {
     classes: [ arr.has('tox-collection__item') ],
     attrs: {
-      title: str.is(d.title)
+      'aria-label': str.is(d.title)
     },
     children: [
       s.element('div', {

--- a/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
@@ -25,12 +25,12 @@ const pOpenMenuWithSelector = async (label: string, selector: string): Promise<v
 };
 
 const pOpenMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[data-mce-btn="overflow-button"]');
+  Mouse.clickOn(SugarBody.body(), 'button[data-mce-label="overflow-button"]');
   await UiFinder.pWaitForVisible('Waiting for more drawer to open', SugarBody.body(), getToolbarSelector(type, true));
 };
 
 const pCloseMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[data-mce-btn="overflow-button"]');
+  Mouse.clickOn(SugarBody.body(), 'button[data-mce-label="overflow-button"]');
   await Waiter.pTryUntil('Waiting for more drawer to close', () => UiFinder.notExists(SugarBody.body(), getToolbarSelector(type, false)));
 };
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
@@ -25,12 +25,12 @@ const pOpenMenuWithSelector = async (label: string, selector: string): Promise<v
 };
 
 const pOpenMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[data-mce-label="overflow-button"]');
+  Mouse.clickOn(SugarBody.body(), 'button[data-mce-name="overflow-button"]');
   await UiFinder.pWaitForVisible('Waiting for more drawer to open', SugarBody.body(), getToolbarSelector(type, true));
 };
 
 const pCloseMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[data-mce-label="overflow-button"]');
+  Mouse.clickOn(SugarBody.body(), 'button[data-mce-name="overflow-button"]');
   await Waiter.pTryUntil('Waiting for more drawer to close', () => UiFinder.notExists(SugarBody.body(), getToolbarSelector(type, false)));
 };
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
@@ -25,12 +25,12 @@ const pOpenMenuWithSelector = async (label: string, selector: string): Promise<v
 };
 
 const pOpenMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[title="Reveal or hide additional toolbar items"]');
+  Mouse.clickOn(SugarBody.body(), 'button[data-mce-btn="overflow-button"]');
   await UiFinder.pWaitForVisible('Waiting for more drawer to open', SugarBody.body(), getToolbarSelector(type, true));
 };
 
 const pCloseMore = async (type: ToolbarMode): Promise<void> => {
-  Mouse.clickOn(SugarBody.body(), 'button[title="Reveal or hide additional toolbar items"]');
+  Mouse.clickOn(SugarBody.body(), 'button[data-mce-btn="overflow-button"]');
   await Waiter.pTryUntil('Waiting for more drawer to close', () => UiFinder.notExists(SugarBody.body(), getToolbarSelector(type, false)));
 };
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -131,7 +131,7 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
         await StickyUtils.pOpenMenuAndTestScrolling(() => MenuUtils.pOpenNestedMenus([
           {
             label: 'Open splitmenu item, color palette',
-            selector: 'div[data-mce-label="forecolor"][aria-expanded=false]'
+            selector: 'div[data-mce-name="forecolor"][aria-expanded=false]'
           }
         ]), 1, isToolbarTop);
       });

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -105,7 +105,7 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
           {
             // opening the first menu should reveal the next menu which contains Align, open Align
             label: 'Open Align menu item',
-            selector: 'div[title=Align][role=menuitem]' // note we are using title instead of aria-label for some items here.
+            selector: 'div[aria-label=Align][role=menuitem]' // note we are using title instead of aria-label for some items here.
           }
         ]), 2, isToolbarTop);
       });
@@ -118,11 +118,11 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
           },
           {
             label: 'then Formats submenu',
-            selector: 'div[title=Formats][role=menuitem]'
+            selector: 'div[aria-label=Formats][role=menuitem]'
           },
           {
             label: 'then Inline submenu',
-            selector: 'div[title=Inline][role=menuitem]'
+            selector: 'div[aria-label=Inline][role=menuitem]'
           }
         ]), 3, isToolbarTop);
       });
@@ -131,7 +131,7 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
         await StickyUtils.pOpenMenuAndTestScrolling(() => MenuUtils.pOpenNestedMenus([
           {
             label: 'Open splitmenu item, color palette',
-            selector: 'div[title^="Text color"][aria-expanded=false]'
+            selector: 'div[data-mce-btn="forecolor"][aria-expanded=false]'
           }
         ]), 1, isToolbarTop);
       });

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -131,7 +131,7 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
         await StickyUtils.pOpenMenuAndTestScrolling(() => MenuUtils.pOpenNestedMenus([
           {
             label: 'Open splitmenu item, color palette',
-            selector: 'div[data-mce-btn="forecolor"][aria-expanded=false]'
+            selector: 'div[data-mce-label="forecolor"][aria-expanded=false]'
           }
         ]), 1, isToolbarTop);
       });

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/DisabledNestedMenuItemTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/DisabledNestedMenuItemTest.ts
@@ -8,8 +8,8 @@ import Editor from 'tinymce/core/api/Editor';
 describe('webdriver.tinymce.themes.silver.editor.menubar.DisabledNestedMenuItemTest', () => {
 
   const codeMenuItemSelector = '[role="menuitem"]:contains("Code")';
-  const preferencesMenuItemSelector = '[title="Preferences"]';
-  const servicesMenuItemSelector = '[title="Services"]';
+  const preferencesMenuItemSelector = '[aria-label="Preferences"]';
+  const servicesMenuItemSelector = '[aria-label="Services"]';
   const highlightedCodeMenuSelector = '.tox-mbtn--active .tox-mbtn__select-label:contains("Code")';
   const highlightedEditMenuSelector = '.tox-mbtn--active .tox-mbtn__select-label:contains("Edit")';
   const disabledClass = '.tox-collection__item--state-disabled';

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/SimpleControlsInlineTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/SimpleControlsInlineTest.ts
@@ -13,7 +13,7 @@ describe('browser.tinymce.themes.silver.editor.core.SimpleControlsInlineTest', (
   };
 
   const pAssertToolbarButtonPressed = (title: string, pressed: boolean) =>
-    Waiter.pTryUntil('button pressed', () => UiFinder.exists(SugarBody.body(), `button[data-mce-btn="${title}"][aria-pressed="${pressed ? 'true' : 'false'}"]`));
+    Waiter.pTryUntil('button pressed', () => UiFinder.exists(SugarBody.body(), `button[data-mce-label="${title}"][aria-pressed="${pressed ? 'true' : 'false'}"]`));
 
   it('TINY-6675: Button state on multiple inline editors is correct', async () => {
     const editorOne = await McEditor.pFromSettings<Editor>(settings);

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/SimpleControlsInlineTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/SimpleControlsInlineTest.ts
@@ -13,7 +13,7 @@ describe('browser.tinymce.themes.silver.editor.core.SimpleControlsInlineTest', (
   };
 
   const pAssertToolbarButtonPressed = (title: string, pressed: boolean) =>
-    Waiter.pTryUntil('button pressed', () => UiFinder.exists(SugarBody.body(), `button[title="${title}"][aria-pressed="${pressed ? 'true' : 'false'}"]`));
+    Waiter.pTryUntil('button pressed', () => UiFinder.exists(SugarBody.body(), `button[data-mce-btn="${title}"][aria-pressed="${pressed ? 'true' : 'false'}"]`));
 
   it('TINY-6675: Button state on multiple inline editors is correct', async () => {
     const editorOne = await McEditor.pFromSettings<Editor>(settings);
@@ -21,9 +21,9 @@ describe('browser.tinymce.themes.silver.editor.core.SimpleControlsInlineTest', (
     editorOne.setContent('<p id="number1"><strong>blarg</strong></p>');
     editorTwo.setContent('<p id="number2">blarg</p>');
     await RealMouse.pClickOn('#number1');
-    await pAssertToolbarButtonPressed('Bold', true);
+    await pAssertToolbarButtonPressed('bold', true);
     await RealMouse.pClickOn('#number2');
-    await pAssertToolbarButtonPressed('Bold', false);
+    await pAssertToolbarButtonPressed('bold', false);
     McEditor.remove(editorOne);
     McEditor.remove(editorTwo);
   });

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/SimpleControlsInlineTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/SimpleControlsInlineTest.ts
@@ -13,7 +13,7 @@ describe('browser.tinymce.themes.silver.editor.core.SimpleControlsInlineTest', (
   };
 
   const pAssertToolbarButtonPressed = (title: string, pressed: boolean) =>
-    Waiter.pTryUntil('button pressed', () => UiFinder.exists(SugarBody.body(), `button[data-mce-label="${title}"][aria-pressed="${pressed ? 'true' : 'false'}"]`));
+    Waiter.pTryUntil('button pressed', () => UiFinder.exists(SugarBody.body(), `button[data-mce-name="${title}"][aria-pressed="${pressed ? 'true' : 'false'}"]`));
 
   it('TINY-6675: Button state on multiple inline editors is correct', async () => {
     const editorOne = await McEditor.pFromSettings<Editor>(settings);


### PR DESCRIPTION
Related Ticket: TINY-10453

Description of Changes:
* Attribute changes to buttons are made in this commit: https://github.com/tinymce/tinymce/commit/37c5adf55ecd972e0bc975ebc5f0c85b6843499f
	* Added `data-mce-label` for toolbar and dialog buttons
	* Removed `title` attribute for buttons that have visible label, see notion link for more detail
	* `renderCommonDropdown` now takes `tooltip` and `ariaLabel` properties, `listBox` requires the `aria-label` attribute but not the tooltip
* Tests changes for attribute changes (removal of title attribute and `data-mce-label` are made in this commit: https://github.com/tinymce/tinymce/commit/49ee66a1af030f33d9e4e54ebd5bf6e8082cfb41
* Tootip tests for different buttons: https://github.com/tinymce/tinymce/commit/83c10ed0fe42a4382e135cbe1aeacf88c5aedb9e
* Remove the `title` attribute from directory and tree item: https://github.com/tinymce/tinymce/pull/9312/commits/98e9eb383072dee91c8a5633342291a828792c46
* Removed the `title` attribute for `ViewButton` as it already has a visible label. Also removed title attribute when dynamically updating the `aria-label` for `MenuItem`  when state changes . https://github.com/tinymce/tinymce/pull/9312/commits/77a0f1a94410d1b72cfc227b01f922597c72d38c

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
