### PR TITLE
TINY-10475: Change delay before the tooltip to show up

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10475-2024-01-22.yaml
+++ b/.changes/unreleased/tinymce-TINY-10475-2024-01-22.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Changed
+body: Delay before the tooltip to show up, from 800ms to 300ms.
+time: 2024-01-22T10:17:13.194831+11:00
+custom:
+  Issue: TINY-10475

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/TooltipsBackstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/TooltipsBackstage.ts
@@ -9,8 +9,7 @@ export const TooltipsBackstage = (
   getSink: () => Result<AlloyComponent, any>
 ): TooltipsProvider => {
 
-  // TODO: TINY-10475: Update delay to find suitable duration on hover to show tooltip
-  const tooltipDelay = 800;
+  const tooltipDelay = 300;
   const intervalDelay = tooltipDelay * 0.2;   // Arbitrary value
 
   let numActiveTooltips = 0;


### PR DESCRIPTION
Related Ticket: TINY-10475

Description of Changes:
* Change delay to show tooltip from `800ms` to `300ms`

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
