### PR TITLE
TINY-10378: Added confidence tests for the resource css loading functionality

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Resource.ts
+++ b/modules/tinymce/src/core/main/ts/api/Resource.ts
@@ -6,6 +6,7 @@ interface Resource {
   has: (id: string) => boolean;
   get: (id: string) => any;
   unload: (id: string) => void;
+  remove: (id: string) => void;
 }
 
 const awaiter = (resolveCb: (data: any) => void, rejectCb: (err?: any) => void, timeout = 1000) => {
@@ -65,6 +66,11 @@ const create = (): Resource => {
     resources[id] = data;
   };
 
+  const remove = (id: string) => {
+    delete tasks[id];
+    delete resources[id];
+  };
+
   const has = (id: string) => {
     return id in resources;
   };
@@ -76,6 +82,7 @@ const create = (): Resource => {
   const get = (id: string) => resources[id];
 
   return {
+    remove,
     load,
     add,
     has,

--- a/modules/tinymce/src/core/main/ts/api/Resource.ts
+++ b/modules/tinymce/src/core/main/ts/api/Resource.ts
@@ -6,7 +6,6 @@ interface Resource {
   has: (id: string) => boolean;
   get: (id: string) => any;
   unload: (id: string) => void;
-  remove: (id: string) => void;
 }
 
 const awaiter = (resolveCb: (data: any) => void, rejectCb: (err?: any) => void, timeout = 1000) => {
@@ -66,23 +65,18 @@ const create = (): Resource => {
     resources[id] = data;
   };
 
-  const remove = (id: string) => {
-    delete tasks[id];
-    delete resources[id];
-  };
-
   const has = (id: string) => {
     return id in resources;
   };
 
   const unload = (id: string) => {
     delete tasks[id];
+    delete resources[id];
   };
 
   const get = (id: string) => resources[id];
 
   return {
-    remove,
     load,
     add,
     has,

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ResourceLoadingCssTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ResourceLoadingCssTest.ts
@@ -1,0 +1,41 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { McEditor, TinyDom } from '@ephox/mcagar';
+import { Css } from '@ephox/sugar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import { tinymce } from 'tinymce/core/api/Tinymce';
+
+describe('browser.tinymce.themes.silver.editor.ResourceLoadingCssTest', () => {
+  const pGetEditor = () =>
+    McEditor.pFromSettings<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+    });
+
+  it('TINY-10378: No extra resource added', async () => {
+    const editor = await pGetEditor();
+    assert.equal(Css.get(TinyDom.container(editor), 'background-color'), 'rgba(0, 0, 0, 0)');
+    McEditor.remove(editor);
+  });
+
+  it('TINY-10378: A resource is added, but it is not relevant to our skins', async () => {
+    tinymce.Resource.add('key', 'no valuable data here');
+    const editor = await pGetEditor();
+    assert.equal(Css.get(TinyDom.container(editor), 'background-color'), 'rgba(0, 0, 0, 0)');
+    tinymce.Resource.remove('key');
+    McEditor.remove(editor);
+  });
+
+  it('TINY-10378: A resource is added, and it is relevant to our skins', async () => {
+    tinymce.Resource.add('ui/default/skin.css', '* {background-color: red !important;}');
+    const editor = await pGetEditor();
+    assert.equal(Css.get(TinyDom.container(editor), 'background-color'), 'rgb(255, 0, 0)');
+    tinymce.Resource.remove('ui/default/skin.css');
+    McEditor.remove(editor);
+
+    // confidence check that subsequent editor aren't also red.
+    const editor2 = await pGetEditor();
+    assert.equal(Css.get(TinyDom.container(editor2), 'background-color'), 'rgba(0, 0, 0, 0)');
+    McEditor.remove(editor2);
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ResourceLoadingCssTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ResourceLoadingCssTest.ts
@@ -22,7 +22,7 @@ describe('browser.tinymce.themes.silver.editor.ResourceLoadingCssTest', () => {
     tinymce.Resource.add('key', 'no valuable data here');
     const editor = await pGetEditor();
     assert.equal(Css.get(TinyDom.container(editor), 'background-color'), 'rgba(0, 0, 0, 0)');
-    tinymce.Resource.remove('key');
+    tinymce.Resource.unload('key');
     McEditor.remove(editor);
   });
 
@@ -30,7 +30,7 @@ describe('browser.tinymce.themes.silver.editor.ResourceLoadingCssTest', () => {
     tinymce.Resource.add('ui/default/skin.css', '* {background-color: red !important;}');
     const editor = await pGetEditor();
     assert.equal(Css.get(TinyDom.container(editor), 'background-color'), 'rgb(255, 0, 0)');
-    tinymce.Resource.remove('ui/default/skin.css');
+    tinymce.Resource.unload('ui/default/skin.css');
     McEditor.remove(editor);
 
     // confidence check that subsequent editor aren't also red.


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-10378

Description of Changes:
Minor confidence test. No changelog added as it's internal only.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
