### PR TITLE
TINY-10335: Handle immediate sink on fullscreen toggle

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10335-2023-12-21.yaml
+++ b/.changes/unreleased/tinymce-TINY-10335-2023-12-21.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: The floating toolbar would not be fully visible when the editor was placed inside
+  a scrollable container.
+time: 2023-12-21T17:31:45.463635+02:00
+custom:
+  Issue: TINY-10335

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/Plugin.ts
@@ -5,12 +5,12 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Api from './api/Api';
 import * as Commands from './api/Commands';
 import * as Options from './api/Options';
-import { ScrollInfo } from './core/Actions';
+import { FullScreenInfo } from './core/Actions';
 import * as Buttons from './ui/Buttons';
 
 export default (): void => {
   PluginManager.add('fullscreen', (editor) => {
-    const fullscreenState = Cell<ScrollInfo | null>(null);
+    const fullscreenState = Cell<FullScreenInfo | null>(null);
 
     if (editor.inline) {
       return Api.get(fullscreenState);

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/api/Api.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/api/Api.ts
@@ -1,12 +1,12 @@
 import { Cell } from '@ephox/katamari';
 
-import { ScrollInfo } from '../core/Actions';
+import { FullScreenInfo } from '../core/Actions';
 
 export interface Api {
   readonly isFullscreen: () => boolean;
 }
 
-const get = (fullscreenState: Cell<ScrollInfo | null>): Api => ({
+const get = (fullscreenState: Cell<FullScreenInfo | null>): Api => ({
   isFullscreen: () => fullscreenState.get() !== null
 });
 

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/api/Commands.ts
@@ -4,7 +4,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Actions from '../core/Actions';
 
-const register = (editor: Editor, fullscreenState: Cell<Actions.ScrollInfo | null>): void => {
+const register = (editor: Editor, fullscreenState: Cell<Actions.FullScreenInfo | null>): void => {
   editor.addCommand('mceFullScreen', () => {
     Actions.toggleFullscreen(editor, fullscreenState);
   });

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/core/Actions.ts
@@ -1,5 +1,5 @@
-import { Cell, Fun, Optional, Singleton, Throttler } from '@ephox/katamari';
-import { Css, DomEvent, EventUnbinder, SugarElement, SugarShadowDom, Traverse, WindowVisualViewport } from '@ephox/sugar';
+import { Cell, Fun, Optional, Optionals, Singleton, Throttler } from '@ephox/katamari';
+import { Class, Css, DomEvent, EventUnbinder, SugarElement, SugarShadowDom, Traverse, WindowVisualViewport, SugarNode } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
@@ -15,7 +15,7 @@ interface ScrollPos {
   readonly y: number;
 }
 
-export interface ScrollInfo {
+export interface FullScreenInfo {
   readonly scrollPos: ScrollPos;
   readonly containerWidth: string;
   readonly containerHeight: string;
@@ -24,6 +24,7 @@ export interface ScrollInfo {
   readonly iframeWidth: string;
   readonly iframeHeight: string;
   readonly fullscreenChangeHandler: EventUnbinder;
+  readonly sinkCssPosition: Optional<string>;
 }
 
 const DOM = DOMUtils.DOM;
@@ -84,14 +85,17 @@ const viewportUpdate = WindowVisualViewport.get().fold(
   }
 );
 
-const toggleFullscreen = (editor: Editor, fullscreenState: Cell<ScrollInfo | null>): void => {
+const toggleFullscreen = (editor: Editor, fullscreenState: Cell<FullScreenInfo | null>): void => {
   const body = document.body;
   const documentElement = document.documentElement;
   const editorContainer = editor.getContainer();
   const editorContainerS = SugarElement.fromDom(editorContainer);
+  const sinkContainerS = Traverse.nextSibling(editorContainerS)
+    .filter((elm): elm is SugarElement<HTMLElement> => SugarNode.isHTMLElement(elm) && Class.has(elm, 'tox-silver-sink'));
+
   const fullscreenRoot = getFullscreenRoot(editor);
 
-  const fullscreenInfo: ScrollInfo | null = fullscreenState.get();
+  const fullscreenInfo: FullScreenInfo | null = fullscreenState.get();
   const editorBody = SugarElement.fromDom(editor.getBody());
 
   const isTouch = Env.deviceType.isTouch();
@@ -134,7 +138,7 @@ const toggleFullscreen = (editor: Editor, fullscreenState: Cell<ScrollInfo | nul
       }
     });
 
-    const newFullScreenInfo = {
+    const newFullScreenInfo: FullScreenInfo = {
       scrollPos: getScrollPos(),
       containerWidth: editorContainerStyle.width,
       containerHeight: editorContainerStyle.height,
@@ -142,7 +146,8 @@ const toggleFullscreen = (editor: Editor, fullscreenState: Cell<ScrollInfo | nul
       containerLeft: editorContainerStyle.left,
       iframeWidth: iframeStyle.width,
       iframeHeight: iframeStyle.height,
-      fullscreenChangeHandler
+      fullscreenChangeHandler,
+      sinkCssPosition: sinkContainerS.map((elm) => Css.get(elm, 'position'))
     };
 
     if (isTouch) {
@@ -153,6 +158,9 @@ const toggleFullscreen = (editor: Editor, fullscreenState: Cell<ScrollInfo | nul
     editorContainerStyle.width = editorContainerStyle.height = '';
 
     handleClasses(DOM.addClass);
+    sinkContainerS.each((elm) => {
+      Css.set(elm, 'position', 'fixed');
+    });
 
     viewportUpdate.bind(editorContainerS);
 
@@ -175,6 +183,10 @@ const toggleFullscreen = (editor: Editor, fullscreenState: Cell<ScrollInfo | nul
     editorContainerStyle.height = fullscreenInfo.containerHeight;
     editorContainerStyle.top = fullscreenInfo.containerTop;
     editorContainerStyle.left = fullscreenInfo.containerLeft;
+
+    Optionals.lift2(sinkContainerS, fullscreenInfo.sinkCssPosition, (elm, val) => {
+      Css.set(elm, 'position', val);
+    });
 
     cleanup();
     setScrollPos(fullscreenInfo.scrollPos);

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/ui/Buttons.ts
@@ -4,16 +4,16 @@ import Editor from 'tinymce/core/api/Editor';
 import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
-import { ScrollInfo } from '../core/Actions';
+import { FullScreenInfo } from '../core/Actions';
 
-const makeSetupHandler = (editor: Editor, fullscreenState: Cell<ScrollInfo | null>) => (api: Toolbar.ToolbarToggleButtonInstanceApi | Menu.ToggleMenuItemInstanceApi) => {
+const makeSetupHandler = (editor: Editor, fullscreenState: Cell<FullScreenInfo | null>) => (api: Toolbar.ToolbarToggleButtonInstanceApi | Menu.ToggleMenuItemInstanceApi) => {
   api.setActive(fullscreenState.get() !== null);
   const editorEventCallback = (e: EditorEvent<{ state: boolean }>) => api.setActive(e.state);
   editor.on('FullscreenStateChanged', editorEventCallback);
   return () => editor.off('FullscreenStateChanged', editorEventCallback);
 };
 
-const register = (editor: Editor, fullscreenState: Cell<ScrollInfo | null>): void => {
+const register = (editor: Editor, fullscreenState: Cell<FullScreenInfo | null>): void => {
   const onAction = () => editor.execCommand('mceFullScreen');
 
   editor.ui.registry.addToggleMenuItem('fullscreen', {

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenSinkTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenSinkTest.ts
@@ -1,0 +1,27 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { Css, SelectorFind } from '@ephox/sugar';
+import { TinyHooks, TinyDom } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
+
+describe('browser.tinymce.plugins.fullscreen.FullScreenSinkTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'fullscreen',
+    toolbar: 'fullscreen',
+    base_url: '/project/tinymce/js/tinymce',
+    ui_mode: 'split'
+  }, [ FullscreenPlugin ]);
+
+  it('TINY-10335: Sink should have fixed css position when fullscreen is on (ui_mode="split")', () => {
+    const editor = hook.editor();
+    const container = TinyDom.container(editor);
+    const sink = SelectorFind.sibling(container, '.tox-silver-sink').getOrDie('Could not find sink');
+    assert.equal(Css.get(sink, 'position'), 'relative');
+    editor.execCommand('mceFullScreen');
+    assert.equal(Css.get(sink, 'position'), 'fixed');
+    editor.execCommand('mceFullScreen');
+    assert.equal(Css.get(sink, 'position'), 'relative');
+  });
+});

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -89,7 +89,7 @@ const enum IrrelevantStyleItemResponse {
   Disable
 }
 
-const generateSelectItems = (_editor: Editor, backstage: UiFactoryBackstage, spec: SelectSpec) => {
+const generateSelectItems = (backstage: UiFactoryBackstage, spec: SelectSpec) => {
   const generateItem = (rawItem: FormatItem, response: IrrelevantStyleItemResponse, invalid: boolean, value: Optional<SelectedFormat>): Optional<Menu.NestedMenuItemContents> => {
     const translatedText = backstage.shared.providers.translate(rawItem.title);
     if (rawItem.type === 'separator') {
@@ -169,7 +169,7 @@ const createMenuItems = (editor: Editor, backstage: UiFactoryBackstage, spec: Se
     () => Arr.map(dataset.data, (d) => FormatRegister.processBasic(d, spec.isSelectedFor, spec.getPreviewFor)) :
     dataset.getData;
   return {
-    items: generateSelectItems(editor, backstage, spec),
+    items: generateSelectItems(backstage, spec),
     getStyleItems
   };
 };


### PR DESCRIPTION
Related Ticket: TINY-10335

Description of Changes:
* hotfix port of [#9268](https://github.com/tinymce/tinymce/pull/9268)
* fixed one DeepScan issue in `BespokeSelect` module

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
