### PR TITLE
TINY-10389: Revert manually dispatching dragend event on drop event in firefox

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10389-2024-01-23.yaml
+++ b/.changes/unreleased/tinymce-TINY-10389-2024-01-23.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Removed
+body: Removed manually dispatching dragend event on drop in Firefox
+time: 2024-01-23T00:02:33.888058+01:00
+custom:
+  Issue: TINY-10389

--- a/.changes/unreleased/tinymce-TINY-10389-2024-01-23.yaml
+++ b/.changes/unreleased/tinymce-TINY-10389-2024-01-23.yaml
@@ -1,5 +1,5 @@
 project: tinymce
-kind: Removed
+kind: Fixed
 body: Removed manually dispatching dragend event on drop in Firefox.
 time: 2024-01-23T00:02:33.888058+01:00
 custom:

--- a/.changes/unreleased/tinymce-TINY-10389-2024-01-23.yaml
+++ b/.changes/unreleased/tinymce-TINY-10389-2024-01-23.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Removed
-body: Removed manually dispatching dragend event on drop in Firefox
+body: Removed manually dispatching dragend event on drop in Firefox.
 time: 2024-01-23T00:02:33.888058+01:00
 custom:
   Issue: TINY-10389

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -1,4 +1,4 @@
-import { Fun, Type } from '@ephox/katamari';
+import { Fun } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
@@ -20,8 +20,8 @@ import * as Rtc from '../Rtc';
  */
 
 interface Quirks {
-  refreshContentEditable (): void;
-  isHidden (): boolean;
+  refreshContentEditable(): void;
+  isHidden(): boolean;
 }
 
 const Quirks = (editor: Editor): Quirks => {
@@ -680,15 +680,6 @@ const Quirks = (editor: Editor): Quirks => {
     }
   };
 
-  const dropDragEndEvent = () => {
-    editor.on('drop', (event) => {
-      const data = event.dataTransfer?.getData('text/html');
-      if (Type.isString(data) && /^<img[^>]*>$/.test(data)) {
-        editor.dispatch('dragend', new window.DragEvent('dragend', event));
-      }
-    });
-  };
-
   const setup = () => {
     // All browsers
     removeBlockQuoteOnBackSpace();
@@ -731,7 +722,6 @@ const Quirks = (editor: Editor): Quirks => {
       showBrokenImageIcon();
       blockCmdArrowNavigation();
       disableBackspaceIntoATable();
-      dropDragEndEvent();
     }
   };
 

--- a/modules/tinymce/src/core/test/ts/browser/util/QuirksFirefoxTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/util/QuirksFirefoxTest.ts
@@ -1,6 +1,7 @@
-import { ApproxStructure } from '@ephox/agar';
+import { ApproxStructure, DragnDrop } from '@ephox/agar';
 import { before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
-import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+import { SelectorFind } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -80,11 +81,21 @@ describe('browser.tinymce.core.util.QuirksFirefoxTest', () => {
 
   it('TINY-9694: dragend should fire when drop fires with an image', () => {
     const editor = hook.editor();
-    const transfer = new window.DataTransfer();
-    transfer.setData('text/html', '<img src="test">');
-    editor.dispatch('drop', new window.DragEvent('drop', {
-      dataTransfer: transfer
-    }));
-    assertEvents([ 'drop', 'dragend' ]);
+    editor.setContent(`
+      <table style="border-collapse: collapse; width: 103.363%; height: 355px;" border="1"><colgroup><col style="width: 23.1332%;"><col style="width: 53.8799%;"><col style="width: 23.1332%;"></colgroup>
+        <tbody>
+          <tr>
+            <td>&nbsp;</td>
+            <td><img src="https://google.com/logos/google.jpg" alt=""></td>
+          </tr>
+        </tbody>
+      </table>
+`);
+    DragnDrop.dragnDrop(
+      SelectorFind.descendant(TinyDom.body(editor), 'img').getOrDie(),
+      SelectorFind.descendant(TinyDom.body(editor), 'td').getOrDie(),
+      false
+    );
+    assertEvents([ 'dragstart', 'drop', 'dragend' ]);
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10389

Description of Changes:
*  Revert manually dispatching dragend event on drop event in firefox

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
