### PR TITLE
TINY-10581: Fix render for inline editor with vertical scroll

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10581-2024-01-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-10581-2024-01-24.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: In some cases having a vertical scroll made the toolbar width calculation wrong.
+time: 2024-01-24T14:49:10.32493272+01:00
+custom:
+  Issue: TINY-10581

--- a/.changes/unreleased/tinymce-TINY-10581-2024-01-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-10581-2024-01-24.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: In some cases having a vertical scroll made the toolbar width calculation wrong.
+body: The toolbar width was miscalculated for the inline editor positioned inside a scrollable container.
 time: 2024-01-24T14:49:10.32493272+01:00
 custom:
   Issue: TINY-10581

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
@@ -40,6 +40,7 @@ export const InlineHeader = (
   const editorMaxWidthOpt = Options.getMaxWidthOption(editor).or(EditorSize.getWidth(editor));
   const headerBackstage = backstage.shared.header;
   const isPositionedAtTop = headerBackstage.isPositionedAtTop;
+  const minimumToolbarWidth = 150; // Value is arbitrary.
 
   const toolbarMode = Options.getToolbarMode(editor);
   const isSplitToolbar = toolbarMode === ToolbarMode.sliding || toolbarMode === ToolbarMode.floating;
@@ -184,8 +185,6 @@ export const InlineHeader = (
 
           Note: this is entirely determined on the number of items in the menu and the toolbar, because when they wrap, that's what causes the height. Also, having multiple toolbars can also make it higher.
           */
-          const minimumToolbarWidth = 150; // Value is arbitrary.
-
           const availableWidth = window.innerWidth - (left - scroll.left);
 
           const width = Math.max(
@@ -249,7 +248,7 @@ export const InlineHeader = (
 
         // this check is needed because if the toolbar is rendered outside of the `outerContainer` because the toolbar have `position: "fixed"`
         // the calculate width isn't correct
-        return w !== 0 ? Optional.some(w) : Optional.none();
+        return w > minimumToolbarWidth ? Optional.some(w) : Optional.none();
       } else {
         return Optional.none();
       }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
@@ -246,7 +246,10 @@ export const InlineHeader = (
         Css.set(mainUi.outerContainer.element, 'left', '0px');
         Css.remove(mainUi.outerContainer.element, 'width');
         const w = Width.getOuter(mainUi.outerContainer.element);
-        return Optional.some(w);
+
+        // this check is needed because if the toolbar is rendered outside of the `outerContainer` because the toolbar have `position: "fixed"`
+        // the calculate width isn't correct
+        return w !== 0 ? Optional.some(w) : Optional.none();
       } else {
         return Optional.none();
       }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
@@ -1,5 +1,5 @@
 import { AlloyComponent, Boxes, Channels, Docking, OffsetOrigin, VerticalDir } from '@ephox/alloy';
-import { Arr, Cell, Fun, Optional, Singleton } from '@ephox/katamari';
+import { Arr, Cell, Fun, Optional, Optionals, Singleton } from '@ephox/katamari';
 import { Attribute, Compare, Css, Height, Scroll, SugarBody, SugarElement, SugarLocation, Traverse, Width } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
@@ -248,7 +248,7 @@ export const InlineHeader = (
 
         // this check is needed because if the toolbar is rendered outside of the `outerContainer` because the toolbar have `position: "fixed"`
         // the calculate width isn't correct
-        return w > minimumToolbarWidth ? Optional.some(w) : Optional.none();
+        return Optionals.someIf(w > minimumToolbarWidth, w);
       } else {
         return Optional.none();
       }

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -206,7 +206,7 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
 
       window.scrollTo(0, 5000);
       // this is needed to give the time to the toolbar to resize
-      await Waiter.pWait(10);
+      await Waiter.pWait(0);
       const currentWidth = getRect(toolbar).width;
 
       assert.equal(initialWidth, currentWidth, 'initial toolbar width should be equal to the current toolbar width');

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -188,6 +188,7 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
       const editor = hook.editor();
       const getRect = (element: SugarElement<any>): DOMRect =>
         (element as SugarElement<HTMLElement>).dom.getBoundingClientRect();
+      let isScrolled = false;
 
       element.dom.focus();
       element.dom.scrollIntoView(false);
@@ -204,9 +205,15 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
       editor.focus();
       await UiFinder.pWaitForVisible('Wait for the editor to show', SugarBody.body(), '.tox-editor-header');
 
+      const scrollHandler = () => {
+        isScrolled = true;
+      };
+
+      window.addEventListener('scroll', scrollHandler);
       window.scrollTo(0, 5000);
-      // this is needed to give the time to the toolbar to resize
-      await Waiter.pWait(10);
+      await Waiter.pTryUntilPredicate('it should be scrolled', () => isScrolled);
+      window.removeEventListener('scroll', scrollHandler);
+
       const currentWidth = getRect(toolbar).width;
 
       assert.equal(initialWidth, currentWidth, 'initial toolbar width should be equal to the current toolbar width');

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -206,7 +206,7 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
 
       window.scrollTo(0, 5000);
       // this is needed to give the time to the toolbar to resize
-      await Waiter.pWait(0);
+      await Waiter.pWait(10);
       const currentWidth = getRect(toolbar).width;
 
       assert.equal(initialWidth, currentWidth, 'initial toolbar width should be equal to the current toolbar width');

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -184,12 +184,6 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
 
     PageScroll.bddSetup(hook.editor, 5000);
 
-    before(async () => {
-      // Need to wait for a fraction for some reason on safari,
-      // otherwise the initial scrolling doesn't work
-      await Waiter.pWait(100);
-    });
-
     it('TINY-10581: Scroll to the end of the content, open and close the editor, and then scroll to the top of the content the editor should not shrink', async () => {
       const editor = hook.editor();
       const getRect = (element: SugarElement<any>): DOMRect =>

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -212,7 +212,7 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
 
       window.scrollTo(0, 5000);
       // this is needed to give the time to the toolbar to resize
-      await Waiter.pWait(0);
+      await Waiter.pWait(10);
       const currentWidth = getRect(toolbar).width;
 
       assert.equal(initialWidth, currentWidth, 'initial toolbar width should be equal to the current toolbar width');


### PR DESCRIPTION
Related Ticket: TINY-10581

Description of Changes:
the problem here is that when we have a vertical scroll and we render the inline editor the second time.

When the position of the `editor-header` is `fixed` and there is a space between the top of the `<body>` and the top of the editor's content the `editor-header` is rendered outside of the  `mainUi.outerContainer.element` so when we calculate the `mainUi.outerContainer.element` width to `restoreAndGetCompleteOuterContainerWidth`, it is 0 and not the `editor-header` width.

To solve this I add a condition to check if the `mainUi.outerContainer.element` has a width lesser that the `minimumToolbarWidth`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
