### PR TITLE
TINY-9176: improved showing which ui element has focus

### DIFF
--- a/.changes/unreleased/tinymce-TINY-9176-2024-01-26.yaml
+++ b/.changes/unreleased/tinymce-TINY-9176-2024-01-26.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Improved
+body: Improved showing which element has focus for keyboard navigation
+time: 2024-01-26T10:57:16.397607+01:00
+custom:
+  Issue: TINY-9176

--- a/.changes/unreleased/tinymce-TINY-9176-2024-01-26.yaml
+++ b/.changes/unreleased/tinymce-TINY-9176-2024-01-26.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Improved
-body: Improved showing which element has focus for keyboard navigation
+body: Improved showing which element has focus for keyboard navigation.
 time: 2024-01-26T10:57:16.397607+01:00
 custom:
   Issue: TINY-9176

--- a/modules/oxide/src/less/skins/ui/dark/skin.less
+++ b/modules/oxide/src/less/skins/ui/dark/skin.less
@@ -8,8 +8,7 @@
 @tinymce-separator-color: rgba(255,255,255,.15);
 @tooltip-background-color: #324053;
 
-@keyboard-focus-outline: 0 0 0 2px @color-white;
-@keyboard-focus-outline-inset: 0 0 0 2px @color-white inset;
+@keyboard-focus-outline-color: @color-white;
 
 @editor-header-border: 1px solid @tinymce-separator-color;
 @editor-header-box-shadow: none;

--- a/modules/oxide/src/less/skins/ui/dark/skin.less
+++ b/modules/oxide/src/less/skins/ui/dark/skin.less
@@ -8,6 +8,9 @@
 @tinymce-separator-color: rgba(255,255,255,.15);
 @tooltip-background-color: #324053;
 
+@keyboard-focus-outline: 0 0 0 2px @color-white;
+@keyboard-focus-outline-inset: 0 0 0 2px @color-white inset;
+
 @editor-header-border: 1px solid @tinymce-separator-color;
 @editor-header-box-shadow: none;
 @editor-header-sticky-box-shadow: @editor-header-box-shadow;

--- a/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
@@ -35,7 +35,8 @@
 @toolbar-separator-color: @border-color;
 @toolbar-padding-y: 0px;
 @toolbar-padding-x: 0px;
-@keyboard-focus-outline: none;
+@keyboard-focus-outline-color: transparent;
+@keyboard-focus-outline-width: 0;
 @toolbar-button-focus-background-color: @toolbar-button-hover-background-color;
 @toolbar-button-bespoke-background-color: transparent;
 @toolbar-button-bespoke-spacing-x: @toolbar-button-spacing-x;

--- a/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
@@ -34,6 +34,8 @@
 @toolbar-separator-color: @border-color;
 @toolbar-padding-y: 0px;
 @toolbar-padding-x: 0px;
+@toolbar-button-keyboard-focus-outline: none;
+@toolbar-button-focus-background-color: @toolbar-button-hover-background-color;
 @toolbar-button-bespoke-background-color: transparent;
 @toolbar-button-bespoke-spacing-x: @toolbar-button-spacing-x;
 @toolbar-separator-distance: 0;

--- a/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
@@ -35,7 +35,7 @@
 @toolbar-separator-color: @border-color;
 @toolbar-padding-y: 0px;
 @toolbar-padding-x: 0px;
-@toolbar-button-keyboard-focus-outline: none;
+@keyboard-focus-outline: none;
 @toolbar-button-focus-background-color: @toolbar-button-hover-background-color;
 @toolbar-button-bespoke-background-color: transparent;
 @toolbar-button-bespoke-spacing-x: @toolbar-button-spacing-x;

--- a/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
@@ -5,6 +5,7 @@
 //
 @border-color: darken(@background-color, 20);
 @collection-item-separator-color: contrast(@background-color, @border-color, lighten(@border-color, 10%));
+@collection-list-item-active-background-color: @toolbar-button-hover-background-color;
 @dialog-border-radius: @panel-border-radius;
 @dialog-border-width: 1px;
 @dialog-footer-separator-border: 1px solid @dialog-border-color;
@@ -68,6 +69,8 @@
 @button-naked-active-border-color: @button-secondary-active-border-color;
 @button-naked-active-box-shadow: @button-secondary-active-box-shadow;
 @button-naked-active-icon-color: @button-secondary-active-text-color;
+@insert-table-picker-selected-background-color: fade(@color-tint, 50%);
+@insert-table-picker-selected-border-color: @insert-table-picker-selected-background-color;
 
 .tox {
   &:not(.tox-tinymce-inline) .tox-editor-header {

--- a/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
@@ -51,6 +51,7 @@
 @menubar-background: url("data:image/svg+xml;charset=utf8,%3Csvg height='@{_menubar-height}' viewBox='0 0 40 @{_menubar-height}' width='40' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='0' y='@{_menubar-divider-height}' width='100' height='1' fill='@{_menubar-row-separator-color}'/%3E%3C/svg%3E") left 0 top 0 @menubar-background-color;
 @menubar-separator-color: @border-color;
 @menubar-row-separator-color: @border-color;
+@menubar-select-focus-background-color: @toolbar-button-hover-background-color;
 @_menubar-row-separator-color: escape('@{menubar-row-separator-color}');
 @_menubar-divider-height: @_menubar-height - 1px;
 @statusbar-padding-x: @pad-sm;

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -171,6 +171,12 @@
   .tox-collection--grid .tox-collection__item--active:not(.tox-collection__item--state-disabled) {
     background-color: @collection-grid-item-active-background-color;
     color: @collection-grid-item-label-active-text-color;
+    position: relative;
+    z-index: 1;
+
+    &:focus::after {
+      .toolbar-button-keyboard-focus-outline-mixin(0 0 0 2px @color-tint inset);
+    }
   }
 
   .tox-collection--list .tox-collection__item--active:not(.tox-collection__item--state-disabled) {

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -22,8 +22,10 @@
 @collection-list-item-enabled-background-color: @menu-background-color;
 @collection-list-item-label-enabled-text-color: contrast(@collection-list-item-enabled-background-color, @color-black, @color-white);
 
-@collection-toolbar-item-active-background-color: @toolbar-button-hover-background-color;
+@collection-toolbar-item-active-background-color: @menu-background-color;
 @collection-toolbar-item-label-active-text-color: contrast(@collection-toolbar-item-active-background-color, @color-black, @color-white);
+@collection-toolbar-item-active-hover-background-color: @toolbar-button-hover-background-color;
+@collection-toolbar-item-label-active-hover-text-color: contrast(@collection-toolbar-item-active-hover-background-color, @color-black, @color-white);
 @collection-toolbar-item-enabled-background-color: @toolbar-button-enabled-background-color;
 @collection-toolbar-item-label-enabled-text-color: contrast(@collection-toolbar-item-enabled-background-color, @color-black, @color-white);
 
@@ -140,13 +142,25 @@
     background-color: @collection-list-item-active-background-color;
   }
 
-  .tox-collection--toolbar .tox-collection__item--enabled {
+  .tox-collection--toolbar .tox-collection__item--enabled,
+  .tox-collection--toolbar .tox-collection__item--enabled.tox-collection__item--active,
+  .tox-collection--toolbar .tox-collection__item--enabled.tox-collection__item--active:hover {
     background-color: @collection-toolbar-item-enabled-background-color;
     color: @collection-toolbar-item-label-enabled-text-color;
   }
 
   .tox-collection--toolbar .tox-collection__item--active {
     background-color: @collection-toolbar-item-active-background-color;
+    position: relative;
+
+    &:hover {
+      background-color: @collection-toolbar-item-active-hover-background-color;
+      color: @collection-toolbar-item-label-active-hover-text-color;
+    }
+
+    &:focus::after {
+      .toolbar-button-keyboard-focus-outline-mixin();
+    }
   }
 
   .tox-collection--grid .tox-collection__item--enabled {

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -159,7 +159,7 @@
     }
 
     &:focus::after {
-      .toolbar-button-keyboard-focus-outline-mixin();
+      .keyboard-focus-outline-mixin();
     }
   }
 
@@ -175,7 +175,7 @@
     z-index: 1;
 
     &:focus::after {
-      .toolbar-button-keyboard-focus-outline-mixin(0 0 0 2px @color-tint inset);
+      .keyboard-focus-outline-mixin(@keyboard-focus-outline-inset);
     }
   }
 

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -17,7 +17,7 @@
 @collection-item-label-disabled-text-color: fade(@collection-item-label-text-color, 50%);
 @collection-item-caret-disabled-text-color: fade(@collection-item-label-text-color, 50%);
 
-@collection-list-item-active-background-color: @toolbar-button-hover-background-color;
+@collection-list-item-active-background-color: @color-tint;
 @collection-list-item-label-active-text-color: contrast(@collection-list-item-active-background-color, @color-black, @color-white);
 @collection-list-item-enabled-background-color: @menu-background-color;
 @collection-list-item-label-enabled-text-color: contrast(@collection-list-item-enabled-background-color, @color-black, @color-white);
@@ -199,7 +199,7 @@
   }
 
   .tox-collection__item-accessory {
-    color: @text-color-muted;
+    color: currentColor;
     display: inline-block;
     font-size: @font-size-sm;
     height: @collection-item-list-icon-height;
@@ -220,7 +220,7 @@
     }
 
     svg {
-      fill: @collection-item-label-text-color;
+      fill: currentColor;
     }
   }
 

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -175,7 +175,7 @@
     z-index: 1;
 
     &:focus::after {
-      .keyboard-focus-outline-mixin(@keyboard-focus-outline-inset);
+      .keyboard-focus-outline-mixin('inset');
     }
   }
 

--- a/modules/oxide/src/less/theme/components/insert-table-picker/insert-table-picker.less
+++ b/modules/oxide/src/less/theme/components/insert-table-picker/insert-table-picker.less
@@ -3,12 +3,15 @@
 //
 
 @insert-table-picker-cell-size: @base-value + 1; // Add 1 to account for the border size
-@insert-table-picker-selected-background-color: fade(@color-tint, 50%);
+@insert-table-picker-background-color: @background-color;
+@insert-table-picker-selected-background-color: @color-tint;
 @insert-table-picker-border-color: @border-color;
+@insert-table-picker-selected-border-color: @insert-table-picker-border-color;
 @insert-table-picker-label-color: contrast(@menu-background-color, @text-color-muted, @color-white);
 
 .tox {
   .tox-insert-table-picker {
+    background-color: @insert-table-picker-background-color;
     display: flex;
     flex-wrap: wrap;
     width: @insert-table-picker-cell-size * 10;
@@ -37,7 +40,7 @@
   // Selected cell
   .tox-insert-table-picker .tox-insert-table-picker__selected {
     background-color: @insert-table-picker-selected-background-color;
-    border-color: @insert-table-picker-selected-background-color;
+    border-color: @insert-table-picker-selected-border-color;
   }
 
   // Label for selected cells

--- a/modules/oxide/src/less/theme/components/menubar/menubar-button.less
+++ b/modules/oxide/src/less/theme/components/menubar/menubar-button.less
@@ -16,8 +16,6 @@
 @menubar-select-text-color: @toolbar-button-text-color;
 @menubar-select-text-transform: @toolbar-button-text-transform;
 
-@menubar-select-keyboard-focus-outline: @keyboard-focus-outline;
-
 @menubar-select-disabled-background-color: @toolbar-button-background-color;
 @menubar-select-disabled-border: @menubar-select-border;
 @menubar-select-disabled-border-color: @toolbar-button-background-color; /* Deprecated. Remove in next major release */

--- a/modules/oxide/src/less/theme/components/menubar/menubar-button.less
+++ b/modules/oxide/src/less/theme/components/menubar/menubar-button.less
@@ -16,7 +16,7 @@
 @menubar-select-text-color: @toolbar-button-text-color;
 @menubar-select-text-transform: @toolbar-button-text-transform;
 
-@menubar-select-keyboard-focus-outline: @toolbar-button-keyboard-focus-outline;
+@menubar-select-keyboard-focus-outline: @keyboard-focus-outline;
 
 @menubar-select-disabled-background-color: @toolbar-button-background-color;
 @menubar-select-disabled-border: @menubar-select-border;
@@ -78,7 +78,7 @@
     z-index: 1; // Ensure focus outline is on top of other buttons
 
     &::after {
-      .toolbar-button-keyboard-focus-outline-mixin();
+      .keyboard-focus-outline-mixin();
     }
   }
 

--- a/modules/oxide/src/less/theme/components/menubar/menubar-button.less
+++ b/modules/oxide/src/less/theme/components/menubar/menubar-button.less
@@ -16,6 +16,8 @@
 @menubar-select-text-color: @toolbar-button-text-color;
 @menubar-select-text-transform: @toolbar-button-text-transform;
 
+@menubar-select-keyboard-focus-outline: @toolbar-button-keyboard-focus-outline;
+
 @menubar-select-disabled-background-color: @toolbar-button-background-color;
 @menubar-select-disabled-border: @menubar-select-border;
 @menubar-select-disabled-border-color: @toolbar-button-background-color; /* Deprecated. Remove in next major release */
@@ -54,7 +56,6 @@
     justify-content: center;
     margin: @menubar-select-spacing-y @menubar-select-spacing-x (@menubar-select-spacing-y + 1px) 0;
     outline: none;
-    overflow: hidden;
     padding: 0 4px;
     text-transform: @menubar-select-text-transform;
     width: auto;
@@ -73,6 +74,12 @@
     border: @menubar-select-focus-border;
     box-shadow: @menubar-select-focus-box-shadow;
     color: @menubar-select-focus-text-color;
+    position: relative;
+    z-index: 1; // Ensure focus outline is on top of other buttons
+
+    &::after {
+      .toolbar-button-keyboard-focus-outline-mixin();
+    }
   }
 
   // Active state applied using class

--- a/modules/oxide/src/less/theme/components/menubar/menubar-button.less
+++ b/modules/oxide/src/less/theme/components/menubar/menubar-button.less
@@ -29,7 +29,7 @@
 @menubar-select-hover-box-shadow: @toolbar-button-hover-box-shadow;
 @menubar-select-hover-text-color: @toolbar-button-hover-text-color;
 
-@menubar-select-focus-background-color: @menubar-select-hover-background-color;
+@menubar-select-focus-background-color: @menubar-select-background-color;
 @menubar-select-focus-border: @menubar-select-hover-border;
 @menubar-select-focus-box-shadow: @menubar-select-hover-box-shadow;
 @menubar-select-focus-text-color: @menubar-select-hover-text-color;
@@ -83,7 +83,8 @@
   }
 
   // Active state applied using class
-  .tox-mbtn--active {
+  .tox-mbtn--active,
+  .tox-mbtn:not(:disabled).tox-mbtn--active:focus {
     background: @menubar-select-active-background-color;
     border: @menubar-select-active-border;
     box-shadow: @menubar-select-active-box-shadow;

--- a/modules/oxide/src/less/theme/components/statusbar/statusbar.less
+++ b/modules/oxide/src/less/theme/components/statusbar/statusbar.less
@@ -4,7 +4,6 @@
 
 @statusbar-background-color: @background-color;
 @statusbar-focus-background-color: transparent;
-@statusbar-keyboard-focus-outline: 0 0 0 2px @color-tint;
 @statusbar-font-size: @font-size-sm;
 @statusbar-font-weight: @font-weight-normal;
 @statusbar-height: 25px;

--- a/modules/oxide/src/less/theme/components/statusbar/statusbar.less
+++ b/modules/oxide/src/less/theme/components/statusbar/statusbar.less
@@ -117,7 +117,7 @@
     }
 
     &:focus-visible::after {
-      .toolbar-button-keyboard-focus-outline-mixin();
+      .keyboard-focus-outline-mixin();
     }
   }
 
@@ -173,7 +173,7 @@
       box-shadow: 0 0 0 2px @statusbar-focus-background-color;
 
       &::after {
-        .toolbar-button-keyboard-focus-outline-mixin();
+        .keyboard-focus-outline-mixin();
       }
     }
   }

--- a/modules/oxide/src/less/theme/components/statusbar/statusbar.less
+++ b/modules/oxide/src/less/theme/components/statusbar/statusbar.less
@@ -116,7 +116,7 @@
       }
     }
 
-    &:focus::after {
+    &:focus-visible::after {
       .toolbar-button-keyboard-focus-outline-mixin();
     }
   }
@@ -167,7 +167,7 @@
       }
     }
 
-    &:focus {
+    &:focus-visible {
       background-color: @statusbar-focus-background-color;
       border-radius: 1px 1px @statusbar-resize-handle-radius 1px;
       box-shadow: 0 0 0 2px @statusbar-focus-background-color;

--- a/modules/oxide/src/less/theme/components/statusbar/statusbar.less
+++ b/modules/oxide/src/less/theme/components/statusbar/statusbar.less
@@ -3,13 +3,15 @@
 //
 
 @statusbar-background-color: @background-color;
-@statusbar-focus-background-color: multiply(white, contrast(@background-color, fade(@color-black, 15), fade(@color-black, 85)));
+@statusbar-focus-background-color: transparent;
+@statusbar-keyboard-focus-outline: 0 0 0 2px @color-tint;
 @statusbar-font-size: @font-size-sm;
 @statusbar-font-weight: @font-weight-normal;
 @statusbar-height: 25px;
 @statusbar-padding-x: @pad-sm;
 @statusbar-separator-color: @tinymce-separator-color;
 @statusbar-text-color: contrast(@statusbar-background-color, @text-color-muted, fade(@color-white, 75));
+@statusbar-focus-text-color: @text-color;
 @statusbar-text-transform: none;
 @statusbar-not-disabled-selector: ~'&:not(:disabled):not([aria-disabled=true])';
 @statusbar-logo-color: fade(@text-color, 80);
@@ -37,7 +39,6 @@
   .tox-statusbar__path {
     display: flex;
     flex: 1 1 auto;
-    overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
@@ -56,7 +57,6 @@
     display: flex;
     flex: 1 1 auto;
     justify-content: space-between;
-    overflow: hidden;
 
     @media @breakpoint-gt-sm {
       &.tox-statusbar__text-container-3-cols > .tox-statusbar__help-text,
@@ -105,14 +105,19 @@
   .tox-statusbar__path-item,
   .tox-statusbar__wordcount {
     color: @statusbar-text-color;
+    position: relative;
     text-decoration: none;
 
     &:hover,
     &:focus {
       @{statusbar-not-disabled-selector} {
-        color: @text-color;
+        color: @statusbar-focus-text-color;
         cursor: pointer;
       }
+    }
+
+    &:focus::after {
+      .toolbar-button-keyboard-focus-outline-mixin();
     }
   }
 
@@ -141,22 +146,34 @@
     display: flex;
     flex: 0 0 auto;
     justify-content: flex-end;
-    margin-left: auto;
-    margin-right: -@statusbar-padding-x;
-    padding-bottom: 3px;
-    padding-left: 1ch;
-    padding-right: 3px;
+    margin-bottom: 3px;
+    margin-left: @pad-xs;
+    margin-right: calc(3px - @statusbar-padding-x);
+    margin-top: 3px;
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    position: relative;
 
     svg {
       display: block;
       fill: @statusbar-resize-handle-color;
     }
 
+    &:hover,
     &:focus {
       svg {
-        background-color: @statusbar-focus-background-color;
-        border-radius: 1px 1px @statusbar-resize-handle-radius 1px;
-        box-shadow: 0 0 0 2px @statusbar-focus-background-color;
+        fill: @statusbar-focus-text-color;
+      }
+    }
+
+    &:focus {
+      background-color: @statusbar-focus-background-color;
+      border-radius: 1px 1px @statusbar-resize-handle-radius 1px;
+      box-shadow: 0 0 0 2px @statusbar-focus-background-color;
+
+      &::after {
+        .toolbar-button-keyboard-focus-outline-mixin();
       }
     }
   }

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
@@ -20,7 +20,7 @@
 @toolbar-button-text-transform: none;
 @toolbar-button-width: 34px;
 
-@toolbar-button-hover-background-color: contrast(@background-color, darken(@background-color, 6%), lighten(@background-color, 7%)); // Differentiating against the enabled color //multiply(white, contrast(@background-color, fade(@color-tint, 20), fade(@color-tint, 80)));
+@toolbar-button-hover-background-color: contrast(@background-color, darken(@background-color, 6%), lighten(@background-color, 7%)); // Differentiating against the enabled color
 @toolbar-button-hover-border: @toolbar-button-border;
 @toolbar-button-hover-box-shadow: @toolbar-button-box-shadow;
 @toolbar-button-hover-icon-color: @toolbar-button-icon-color;

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
@@ -3,7 +3,7 @@
 // When making changes here, please review menubar/menubar.less and menubar/menubar-button.less
 //
 
-@toolbar-button-background-color: transparent;
+@toolbar-button-background-color: @background-color;
 @toolbar-button-border-radius: 3px;
 @toolbar-button-border: 0;
 @toolbar-button-box-shadow: none;

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
@@ -20,8 +20,6 @@
 @toolbar-button-text-transform: none;
 @toolbar-button-width: 34px;
 
-@toolbar-button-keyboard-focus-outline: 0 0 0 2px @color-tint; // Uses box shadow property
-
 @toolbar-button-hover-background-color: contrast(@background-color, darken(@background-color, 6%), lighten(@background-color, 7%)); // Differentiating against the enabled color //multiply(white, contrast(@background-color, fade(@color-tint, 20), fade(@color-tint, 80)));
 @toolbar-button-hover-border: @toolbar-button-border;
 @toolbar-button-hover-box-shadow: @toolbar-button-box-shadow;
@@ -53,17 +51,6 @@
 @toolbar-button-disabled-box-shadow: @toolbar-button-box-shadow;
 @toolbar-button-disabled-icon-color: fade(@toolbar-button-icon-color, 50%);
 @toolbar-button-disabled-text-color: fade(@toolbar-button-text-color, 50%);
-
-.toolbar-button-keyboard-focus-outline-mixin(@_box-shadow: @toolbar-button-keyboard-focus-outline) {
-  border-radius: @toolbar-button-border-radius;
-  bottom: 0;
-  box-shadow: @_box-shadow;
-  content: '';
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-}
 
 .tox {
   .tox-tbtn {
@@ -108,7 +95,7 @@
     z-index: 1; // Ensure focus outline is on top of other buttons
 
     &::after {
-      .toolbar-button-keyboard-focus-outline-mixin();
+      .keyboard-focus-outline-mixin();
     }
   }
 
@@ -186,7 +173,7 @@
   }
 
   .tox-tbtn--enabled:focus::after {
-    .toolbar-button-keyboard-focus-outline-mixin();
+    .keyboard-focus-outline-mixin();
   }
 
   .tox-tbtn:focus:not(.tox-tbtn--disabled) {

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
@@ -158,6 +158,7 @@
   }
 
   // An toggle on/off button's on state.
+  .tox-tbtn--active,
   .tox-tbtn--enabled,
   .tox-tbtn--enabled:hover,
   .tox-tbtn--enabled:focus {

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
@@ -54,10 +54,10 @@
 @toolbar-button-disabled-icon-color: fade(@toolbar-button-icon-color, 50%);
 @toolbar-button-disabled-text-color: fade(@toolbar-button-text-color, 50%);
 
-.toolbar-button-keyboard-focus-outline-mixin() {
+.toolbar-button-keyboard-focus-outline-mixin(@_box-shadow: @toolbar-button-keyboard-focus-outline) {
   border-radius: @toolbar-button-border-radius;
   bottom: 0;
-  box-shadow: @toolbar-button-keyboard-focus-outline;
+  box-shadow: @_box-shadow;
   content: '';
   left: 0;
   position: absolute;

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
@@ -20,15 +20,17 @@
 @toolbar-button-text-transform: none;
 @toolbar-button-width: 34px;
 
-@toolbar-button-hover-background-color: multiply(white, contrast(@background-color, fade(@color-tint, 20), fade(@color-tint, 80)));
+@toolbar-button-keyboard-focus-outline: 0 0 0 2px @color-tint; // Uses box shadow property
+
+@toolbar-button-hover-background-color: contrast(@background-color, darken(@background-color, 6%), lighten(@background-color, 7%)); // Differentiating against the enabled color //multiply(white, contrast(@background-color, fade(@color-tint, 20), fade(@color-tint, 80)));
 @toolbar-button-hover-border: @toolbar-button-border;
 @toolbar-button-hover-box-shadow: @toolbar-button-box-shadow;
 @toolbar-button-hover-icon-color: @toolbar-button-icon-color;
 @toolbar-button-hover-text-color: @toolbar-button-text-color;
 
-@toolbar-button-focus-background-color: @toolbar-button-hover-background-color;
+@toolbar-button-focus-background-color: @toolbar-button-background-color;
 @toolbar-button-focus-border: @toolbar-button-hover-border;
-@toolbar-button-focus-box-shadow: @toolbar-button-hover-box-shadow;
+@toolbar-button-focus-box-shadow: @toolbar-button-box-shadow;
 @toolbar-button-focus-icon-color: @toolbar-button-hover-icon-color;
 @toolbar-button-focus-text-color: @toolbar-button-hover-text-color;
 
@@ -52,6 +54,17 @@
 @toolbar-button-disabled-icon-color: fade(@toolbar-button-icon-color, 50%);
 @toolbar-button-disabled-text-color: fade(@toolbar-button-text-color, 50%);
 
+.toolbar-button-keyboard-focus-outline-mixin() {
+  border-radius: @toolbar-button-border-radius;
+  bottom: 0;
+  box-shadow: @toolbar-button-keyboard-focus-outline;
+  content: '';
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
 .tox {
   .tox-tbtn {
     align-items: center;
@@ -69,7 +82,6 @@
     justify-content: center;
     margin: (@toolbar-button-spacing-y + 1px) @toolbar-button-spacing-x @toolbar-button-spacing-y 0;
     outline: none;
-    overflow: hidden;
     padding: 0;
     text-transform: @toolbar-button-text-transform;
     width: @toolbar-button-width;
@@ -92,6 +104,12 @@
     background: @toolbar-button-focus-background-color;
     border: @toolbar-button-focus-border;
     box-shadow: @toolbar-button-focus-box-shadow;
+    position: relative;
+    z-index: 1; // Ensure focus outline is on top of other buttons
+
+    &::after {
+      .toolbar-button-keyboard-focus-outline-mixin();
+    }
   }
 
   .tox-tbtn:hover {
@@ -141,11 +159,13 @@
 
   // An toggle on/off button's on state.
   .tox-tbtn--enabled,
-  .tox-tbtn--enabled:hover {
+  .tox-tbtn--enabled:hover,
+  .tox-tbtn--enabled:focus {
     background: @toolbar-button-enabled-background-color;
     border: @toolbar-button-enabled-border;
     box-shadow: @toolbar-button-enabled-box-shadow;
     color: @toolbar-button-enabled-text-color;
+    position: relative;
 
     > * {
       transform: @toolbar-button-enabled-transform;
@@ -162,6 +182,10 @@
         fill: @toolbar-button-disabled-icon-color;
       }
     }
+  }
+
+  .tox-tbtn--enabled:focus::after {
+    .toolbar-button-keyboard-focus-outline-mixin();
   }
 
   .tox-tbtn:focus:not(.tox-tbtn--disabled) {

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-number-input.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-number-input.less
@@ -22,7 +22,7 @@
     }
 
     &:focus::after {
-      .toolbar-button-keyboard-focus-outline-mixin();
+      .keyboard-focus-outline-mixin();
     }
 
     .tox-input-wrapper {
@@ -35,12 +35,12 @@
         z-index: 1; // Ensure focus outline is on top of other buttons
 
         &::after {
-          .toolbar-button-keyboard-focus-outline-mixin();
+          .keyboard-focus-outline-mixin();
         }
       }
 
       &:has(input:focus)::after {
-        .toolbar-button-keyboard-focus-outline-mixin();
+        .keyboard-focus-outline-mixin();
       }
     }
 
@@ -86,7 +86,7 @@
         z-index: 1; // Ensure focus outline is on top of other buttons
 
         &::after {
-          .toolbar-button-keyboard-focus-outline-mixin();
+          .keyboard-focus-outline-mixin();
         }
       }
 

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-number-input.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-number-input.less
@@ -10,20 +10,37 @@
 
 .tox {
   .tox-number-input {
+    background: @toolbar-button-bespoke-background-color;
     border-radius: @toolbar-button-border-radius;
     display: flex;
     margin: (@toolbar-button-spacing-y + 1px) @toolbar-button-spacing-x @toolbar-button-spacing-y 0;
-    padding: 0 @toolbar-button-select-padding;
+    position: relative;
     width: auto;
 
+    &:focus {
+      background: @toolbar-button-bespoke-background-color; // Prevent toolbar button focus background to override bespoke background
+    }
+
+    &:focus::after {
+      .toolbar-button-keyboard-focus-outline-mixin();
+    }
+
     .tox-input-wrapper {
-      background: @toolbar-button-bespoke-background-color;
       display: flex;
       pointer-events: none;
+      position: relative;
       text-align: center;
 
       &:focus {
-        background: @toolbar-button-focus-background-color;
+        z-index: 1; // Ensure focus outline is on top of other buttons
+
+        &::after {
+          .toolbar-button-keyboard-focus-outline-mixin();
+        }
+      }
+
+      &:has(input:focus)::after {
+        .toolbar-button-keyboard-focus-outline-mixin();
       }
     }
 
@@ -33,16 +50,12 @@
       font-size: @toolbar-number-input-input-wrapper-font-size;
       margin: @toolbar-number-input-button-margin 0;
       pointer-events: all;
+      position: relative;
       width: @toolbar-number-input-input-wrapper-width;
 
       &:hover {
         background: @toolbar-button-hover-background-color;
         color: @toolbar-button-hover-text-color;
-      }
-
-      &:focus {
-        background: @color-white;
-        color: @color-black;
       }
 
       &:disabled {
@@ -55,9 +68,9 @@
     }
 
     button {
-      background: @toolbar-button-bespoke-background-color;
       color: @toolbar-button-text-color;
       height: @toolbar-button-height;
+      position: relative;
       text-align: center;
       width: @toolbar-number-input-button-width;
 
@@ -70,6 +83,11 @@
 
       &:focus {
         background: @toolbar-button-focus-background-color;
+        z-index: 1; // Ensure focus outline is on top of other buttons
+
+        &::after {
+          .toolbar-button-keyboard-focus-outline-mixin();
+        }
       }
 
       &:hover {

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-number-input.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-number-input.less
@@ -82,7 +82,7 @@
       }
 
       &:focus {
-        background: @toolbar-button-focus-background-color;
+        background: @toolbar-button-bespoke-background-color;
         z-index: 1; // Ensure focus outline is on top of other buttons
 
         &::after {
@@ -136,6 +136,6 @@
 
   .tox-number-input:focus:not(:active) > button,
   .tox-number-input:focus:not(:active) > .tox-input-wrapper {
-    background: @toolbar-button-focus-background-color;
+    background: @toolbar-button-bespoke-background-color;
   }
 }

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-select-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-select-button.less
@@ -41,6 +41,10 @@
   .tox-tbtn--bespoke {
     background: @toolbar-button-bespoke-background-color;
 
+    &:focus {
+      background: @toolbar-button-bespoke-background-color; // Prevent toolbar button focus background to override bespoke background
+    }
+
     & + .tox-tbtn--bespoke {
       margin-inline-start: @toolbar-button-bespoke-spacing-x;
     }

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-split-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-split-button.less
@@ -12,7 +12,6 @@
     box-sizing: border-box;
     display: flex;
     margin: (@toolbar-button-spacing-y + 1px) @toolbar-button-spacing-x @toolbar-button-spacing-y 0;
-    overflow: hidden;
   }
 
   .tox-split-button:hover {
@@ -23,6 +22,11 @@
     background: @toolbar-button-focus-background-color;
     box-shadow: @toolbar-button-focus-box-shadow;
     color: @toolbar-button-focus-text-color;
+    position: relative;
+
+    &::after {
+      .toolbar-button-keyboard-focus-outline-mixin();
+    }
   }
 
   .tox-split-button > * {

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-split-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-split-button.less
@@ -23,6 +23,7 @@
     box-shadow: @toolbar-button-focus-box-shadow;
     color: @toolbar-button-focus-text-color;
     position: relative;
+    z-index: 1; // Ensure focus outline is on top of other buttons
 
     &::after {
       .toolbar-button-keyboard-focus-outline-mixin();

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-split-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-split-button.less
@@ -25,7 +25,7 @@
     z-index: 1; // Ensure focus outline is on top of other buttons
 
     &::after {
-      .toolbar-button-keyboard-focus-outline-mixin();
+      .keyboard-focus-outline-mixin();
     }
   }
 

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-split-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-split-button.less
@@ -8,7 +8,6 @@
 .tox {
   .tox-split-button {
     border: 0;
-    border-radius: @toolbar-button-border-radius;
     box-sizing: border-box;
     display: flex;
     margin: (@toolbar-button-spacing-y + 1px) @toolbar-button-spacing-x @toolbar-button-spacing-y 0;
@@ -32,6 +31,18 @@
 
   .tox-split-button > * {
     border-radius: 0;
+
+    // Cannot use first and last child selectors because of a hidden element
+    // used for screen reader accessibility
+    &:nth-child(1) {
+      border-bottom-left-radius: @toolbar-button-border-radius;
+      border-top-left-radius: @toolbar-button-border-radius;
+    }
+
+    &:nth-child(2) {
+      border-bottom-right-radius: @toolbar-button-border-radius;
+      border-top-right-radius: @toolbar-button-border-radius;
+    }
   }
 
   .tox-split-button__chevron {

--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -32,6 +32,10 @@
 @panel-border-radius: 6px; // Dialogs, menues etc.
 @control-border-radius: 6px; // Buttons, input fields etc.
 
+// Focus outline
+@keyboard-focus-outline: 0 0 0 2px @color-tint; // Uses box shadow property
+@keyboard-focus-outline-inset: 0 0 0 2px @color-tint inset; // Some instances such as collection grid elements requires having the outline on the inside to not be cut off by overflow hidden
+
 // Font
 @line-height-base: 1.3;
 @font-weight-normal: normal;

--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -33,8 +33,8 @@
 @control-border-radius: 6px; // Buttons, input fields etc.
 
 // Focus outline
-@keyboard-focus-outline: 0 0 0 2px @color-tint; // Uses box shadow property
-@keyboard-focus-outline-inset: 0 0 0 2px @color-tint inset; // Some instances such as collection grid elements requires having the outline on the inside to not be cut off by overflow hidden
+@keyboard-focus-outline-width: 2px;
+@keyboard-focus-outline-color: @color-tint;
 
 // Font
 @line-height-base: 1.3;

--- a/modules/oxide/src/less/theme/globals/global.less
+++ b/modules/oxide/src/less/theme/globals/global.less
@@ -52,6 +52,17 @@
   outline: none;
 }
 
+.keyboard-focus-outline-mixin(@_box-shadow: @keyboard-focus-outline) {
+  border-radius: @toolbar-button-border-radius;
+  bottom: 0;
+  box-shadow: @_box-shadow;
+  content: '';
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
 // Reset firefox focus states
 button::-moz-focus-inner {
   border: 0;

--- a/modules/oxide/src/less/theme/globals/global.less
+++ b/modules/oxide/src/less/theme/globals/global.less
@@ -52,10 +52,10 @@
   outline: none;
 }
 
-.keyboard-focus-outline-mixin(@_box-shadow: @keyboard-focus-outline) {
+.keyboard-focus-outline-mixin(@_inset: ~'') {
   border-radius: @toolbar-button-border-radius;
   bottom: 0;
-  box-shadow: @_box-shadow;
+  box-shadow: 0 0 0 @keyboard-focus-outline-width @keyboard-focus-outline-color @_inset;
   content: '';
   left: 0;
   position: absolute;


### PR DESCRIPTION
Related Ticket: TINY-9176

Description of Changes:
* This accessibility improvement adds a clear outline around the element that has focus, and does not rely solely on color.
* The statusbar uses :focus-visible which makes the outline only show up when navigating using the keyboard. This does not work optimally on Safari, but I deem it an acceptable trade-off to not have the outline show up on click.
* Some ui elements like menu items and list menu has a different technical implementation, interlocking the focus and active states. Therefore they behave slightly differently.

Some examples
![focus-outlines](https://github.com/tinymce/tinymce/assets/3122929/efdce759-be4e-412b-8f51-787b82fad7db)

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
https://github.com/tinymce/tinymce/issues/5506
