### PR TITLE
TINY-10561: fix CSS for advcode dialog and view mode

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10561-2024-01-29.yaml
+++ b/.changes/unreleased/tinymce-TINY-10561-2024-01-29.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Changed
+body: 'Now `tox-view__pane` has `position: relative` instead of `static`.'
+time: 2024-01-29T13:44:03.824960967+01:00
+custom:
+  Issue: TINY-10561

--- a/modules/oxide/src/less/theme/components/advcode/advcode.less
+++ b/modules/oxide/src/less/theme/components/advcode/advcode.less
@@ -1,0 +1,20 @@
+//
+// Advance code
+//
+.tox {
+  .mce-codemirror {
+    position: 'absolute';
+    top: '0';
+    left: '0';
+    bottom: '0';
+    right: '0';
+    z-index: '1';
+    background: #fff;
+    font-size: '13px';
+    margin: '8px';
+
+    &.tox-inline-codemirror {
+      position: relative;
+    }
+  }
+}

--- a/modules/oxide/src/less/theme/components/advcode/advcode.less
+++ b/modules/oxide/src/less/theme/components/advcode/advcode.less
@@ -3,15 +3,15 @@
 //
 .tox {
   .mce-codemirror {
-    position: 'absolute';
-    top: '0';
-    left: '0';
-    bottom: '0';
-    right: '0';
-    z-index: '1';
     background: #fff;
+    bottom: '0';
     font-size: '13px';
+    left: '0';
     margin: '8px';
+    position: 'absolute';
+    right: '0';
+    top: '0';
+    z-index: '1';
 
     &.tox-inline-codemirror {
       position: relative;

--- a/modules/oxide/src/less/theme/components/view/view.less
+++ b/modules/oxide/src/less/theme/components/view/view.less
@@ -76,9 +76,9 @@
   }
 
   .tox-view__pane {
-    position: relative;
     height: 100%;
     padding: @view-pane-padding;
+    position: relative;
     width: 100%;
   }
 

--- a/modules/oxide/src/less/theme/components/view/view.less
+++ b/modules/oxide/src/less/theme/components/view/view.less
@@ -76,6 +76,7 @@
   }
 
   .tox-view__pane {
+    position: relative;
     height: 100%;
     padding: @view-pane-padding;
     width: 100%;


### PR DESCRIPTION
Related Ticket: TINY-10561

Description of Changes:

- added correct styles for `mce-codemirror`
- changed `tox-view__pane` to `position: 'relative'` since the position was the default (`static`), this shouldn't impact other implementation of the view

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
