### PR TITLE
TINY-10487: Include shortcut in tooltips for `ToolbarButton` and `Too…

### DIFF
--- a/.changes/unreleased/bridge-TINY-10487-2024-01-24.yaml
+++ b/.changes/unreleased/bridge-TINY-10487-2024-01-24.yaml
@@ -1,0 +1,6 @@
+project: bridge
+kind: Added
+body: Added `shortcut` optional property to `ToolbarButton` and `ToolbarToggleButton`.
+time: 2024-01-24T11:23:58.517849+11:00
+custom:
+  Issue: TINY-10487

--- a/.changes/unreleased/tinymce-TINY-10487-2024-01-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-10487-2024-01-24.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Improved
+body: Included keyboard shortcut in custom tooltip for `ToolbarButton` and `ToolbarToggleButton`.
+time: 2024-01-24T11:27:30.524213+11:00
+custom:
+  Issue: TINY-10487

--- a/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarButton.ts
@@ -21,6 +21,7 @@ export interface BaseToolbarButtonInstanceApi {
 export interface ToolbarButtonSpec extends BaseToolbarButtonSpec<ToolbarButtonInstanceApi> {
   type?: 'button';
   onAction: (api: ToolbarButtonInstanceApi) => void;
+  shortcut?: string;
 }
 
 // tslint:disable-next-line:no-empty-interface
@@ -39,6 +40,7 @@ export interface BaseToolbarButton<I extends BaseToolbarButtonInstanceApi> {
 export interface ToolbarButton extends BaseToolbarButton<ToolbarButtonInstanceApi> {
   type: 'button';
   onAction: (api: ToolbarButtonInstanceApi) => void;
+  shortcut: Optional<string>;
 }
 
 export const baseToolbarButtonFields = [
@@ -51,7 +53,8 @@ export const baseToolbarButtonFields = [
 
 export const toolbarButtonSchema = StructureSchema.objOf([
   ComponentSchema.type,
-  ComponentSchema.onAction
+  ComponentSchema.onAction,
+  ComponentSchema.optionalShortcut
 ].concat(baseToolbarButtonFields));
 
 export const createToolbarButton = (spec: ToolbarButtonSpec): Result<ToolbarButton, StructureSchema.SchemaError<any>> =>

--- a/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarToggleButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarToggleButton.ts
@@ -1,5 +1,5 @@
 import { StructureSchema } from '@ephox/boulder';
-import { Result } from '@ephox/katamari';
+import { Optional, Result } from '@ephox/katamari';
 
 import * as ComponentSchema from '../../core/ComponentSchema';
 import { BaseToolbarButton, BaseToolbarButtonSpec, baseToolbarButtonFields, BaseToolbarButtonInstanceApi } from './ToolbarButton';
@@ -20,11 +20,13 @@ export interface BaseToolbarToggleButtonInstanceApi extends BaseToolbarButtonIns
 export interface ToolbarToggleButtonSpec extends BaseToolbarToggleButtonSpec<ToolbarToggleButtonInstanceApi> {
   type?: 'togglebutton';
   onAction: (api: ToolbarToggleButtonInstanceApi) => void;
+  shortcut?: string;
 }
 
 export interface ToolbarToggleButton extends BaseToolbarToggleButton<ToolbarToggleButtonInstanceApi> {
   type: 'togglebutton';
   onAction: (api: ToolbarToggleButtonInstanceApi) => void;
+  shortcut: Optional<string>;
 }
 
 // tslint:disable-next-line:no-empty-interface
@@ -39,7 +41,8 @@ export const baseToolbarToggleButtonFields = [
 export const toggleButtonSchema = StructureSchema.objOf(
   baseToolbarToggleButtonFields.concat([
     ComponentSchema.type,
-    ComponentSchema.onAction
+    ComponentSchema.onAction,
+    ComponentSchema.optionalShortcut
   ])
 );
 

--- a/modules/tinymce/src/plugins/fullscreen/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/fullscreen/main/ts/ui/Buttons.ts
@@ -28,7 +28,8 @@ const register = (editor: Editor, fullscreenState: Cell<FullScreenInfo | null>):
     tooltip: 'Fullscreen',
     icon: 'fullscreen',
     onAction,
-    onSetup: makeSetupHandler(editor, fullscreenState)
+    onSetup: makeSetupHandler(editor, fullscreenState),
+    shortcut: 'Meta+Shift+F'
   });
 };
 

--- a/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/Controls.ts
@@ -12,7 +12,8 @@ const setupButtons = (editor: Editor): void => {
     icon: 'link',
     tooltip: 'Insert/edit link',
     onAction: Actions.openDialog(editor),
-    onSetup: Actions.toggleLinkState(editor)
+    onSetup: Actions.toggleLinkState(editor),
+    shortcut: 'Meta+K'
   });
 
   editor.ui.registry.addButton('openlink', {

--- a/modules/tinymce/src/plugins/save/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/save/main/ts/ui/Buttons.ts
@@ -19,7 +19,8 @@ const register = (editor: Editor): void => {
     tooltip: 'Save',
     enabled: false,
     onAction: () => editor.execCommand('mceSave'),
-    onSetup: stateToggle(editor)
+    onSetup: stateToggle(editor),
+    shortcut: 'Meta+S'
   });
 
   editor.ui.registry.addButton('cancel', {

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Buttons.ts
@@ -20,7 +20,8 @@ const register = (editor: Editor, currentSearchState: Cell<SearchState>): void =
   editor.ui.registry.addButton('searchreplace', {
     tooltip: 'Find and replace',
     onAction: showDialog(editor, currentSearchState),
-    icon: 'search'
+    icon: 'search',
+    shortcut: 'Meta+F'
   });
 
   editor.shortcuts.add('Meta+F', '', showDialog(editor, currentSearchState));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/SimpleControls.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/SimpleControls.ts
@@ -9,9 +9,9 @@ const onActionToggleFormat = (editor: Editor, fmt: string) => (): void => {
 
 const registerFormatButtons = (editor: Editor): void => {
   Tools.each([
-    { name: 'bold', text: 'Bold', icon: 'bold' },
-    { name: 'italic', text: 'Italic', icon: 'italic' },
-    { name: 'underline', text: 'Underline', icon: 'underline' },
+    { name: 'bold', text: 'Bold', icon: 'bold', shortcut: 'Meta+B' },
+    { name: 'italic', text: 'Italic', icon: 'italic', shortcut: 'Meta+I' },
+    { name: 'underline', text: 'Underline', icon: 'underline', shortcut: 'Meta+U' },
     { name: 'strikethrough', text: 'Strikethrough', icon: 'strike-through' },
     { name: 'subscript', text: 'Subscript', icon: 'subscript' },
     { name: 'superscript', text: 'Superscript', icon: 'superscript' }
@@ -20,17 +20,20 @@ const registerFormatButtons = (editor: Editor): void => {
       tooltip: btn.text,
       icon: btn.icon,
       onSetup: onSetupStateToggle(editor, btn.name),
-      onAction: onActionToggleFormat(editor, btn.name)
+      onAction: onActionToggleFormat(editor, btn.name),
+      shortcut: btn.shortcut
     });
   });
 
   for (let i = 1; i <= 6; i++) {
     const name = 'h' + i;
+    const shortcut = `Alt+Shift+${i}`;
     editor.ui.registry.addToggleButton(name, {
       text: name.toUpperCase(),
       tooltip: 'Heading ' + i,
       onSetup: onSetupStateToggle(editor, name),
-      onAction: onActionToggleFormat(editor, name)
+      onAction: onActionToggleFormat(editor, name),
+      shortcut
     });
   }
 };
@@ -38,15 +41,16 @@ const registerFormatButtons = (editor: Editor): void => {
 const registerCommandButtons = (editor: Editor): void => {
   Tools.each([
     { name: 'copy', text: 'Copy', action: 'Copy', icon: 'copy' },
-    { name: 'help', text: 'Help', action: 'mceHelp', icon: 'help' },
-    { name: 'selectall', text: 'Select all', action: 'SelectAll', icon: 'select-all' },
+    { name: 'help', text: 'Help', action: 'mceHelp', icon: 'help', shortcut: 'Alt+0' },
+    { name: 'selectall', text: 'Select all', action: 'SelectAll', icon: 'select-all', shortcut: 'Meta+A' },
     { name: 'newdocument', text: 'New document', action: 'mceNewDocument', icon: 'new-document' },
-    { name: 'print', text: 'Print', action: 'mcePrint', icon: 'print' },
+    { name: 'print', text: 'Print', action: 'mcePrint', icon: 'print', shortcut: 'Meta+P' },
   ], (btn) => {
     editor.ui.registry.addButton(btn.name, {
       tooltip: btn.text,
       icon: btn.icon,
-      onAction: onActionExecCommand(editor, btn.action)
+      onAction: onActionExecCommand(editor, btn.action),
+      shortcut: btn.shortcut
     });
   });
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/UndoRedo.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/UndoRedo.ts
@@ -34,7 +34,8 @@ const registerButtons = (editor: Editor): void => {
     icon: 'undo',
     enabled: false,
     onSetup: onSetupUndoRedoState(editor, 'hasUndo'),
-    onAction: onActionExecCommand(editor, 'undo')
+    onAction: onActionExecCommand(editor, 'undo'),
+    shortcut: 'Meta+Z'
   });
 
   editor.ui.registry.addButton('redo', {
@@ -42,7 +43,8 @@ const registerButtons = (editor: Editor): void => {
     icon: 'redo',
     enabled: false,
     onSetup: onSetupUndoRedoState(editor, 'hasRedo'),
-    onAction: onActionExecCommand(editor, 'redo')
+    onAction: onActionExecCommand(editor, 'redo'),
+    shortcut: 'Meta+Y'
   });
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -329,8 +329,8 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
       ),
     setTooltip: (tooltip: string) => {
       const translatedTooltip = sharedBackstage.providers.translate(tooltip);
-      Attribute.set(comp.element, 'aria-label', translatedTooltip);
-      Tooltipping.setTooltipText(comp, sharedBackstage.providers.tooltips.getComponent({ tooltipText: translatedTooltip }));
+      // Removed title attribute, will address dynamically update tooltip in TINY-10474
+      Attribute.setAll(comp.element, { 'aria-label': translatedTooltip });
     }
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipShortcutTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipShortcutTest.ts
@@ -3,6 +3,10 @@ import { Arr } from '@ephox/katamari';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
+import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
+import LinkPlugin from 'tinymce/plugins/link/Plugin';
+import SavePlugin from 'tinymce/plugins/save/Plugin';
+import SearchReplacePlugin from 'tinymce/plugins/searchreplace/Plugin';
 
 import * as TooltipUtils from '../../../module/TooltipUtils';
 
@@ -12,7 +16,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipShortcutTest', () => {
     toolbar_mode: 'wrap',
     base_url: '/project/tinymce/js/tinymce',
     plugins: 'link save searchreplace fullscreen',
-  });
+  }, [ LinkPlugin, SavePlugin, SearchReplacePlugin, FullscreenPlugin ]);
 
   Arr.each([
     { button: 'bold', expectedTooltip: 'Bold (⌘B)' },
@@ -34,7 +38,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipShortcutTest', () => {
   ], (test) => {
     it(`TINY-10487: Assert keyboard shortcut present in tooltip for ${test.button}`, async () => {
       const editor = hook.editor();
-      const buttonSelector = `button[data-mce-label="${test.button}"]`;
+      const buttonSelector = `button[data-mce-name="${test.button}"]`;
       await TooltipUtils.pAssertTooltip(editor, () => TooltipUtils.pTriggerTooltipWithMouse(editor, buttonSelector), test.expectedTooltip);
       await TooltipUtils.pCloseTooltip(editor, buttonSelector);
     });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipShortcutTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipShortcutTest.ts
@@ -1,0 +1,42 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { TinyHooks } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+import * as TooltipUtils from '../../../module/TooltipUtils';
+
+describe('browser.tinymce.themes.silver.editor.TooltipShortcutTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    toolbar: 'bold italic underline selectall redo undo h1 h2 h3 h4 h5 h6 link save searchreplace fullscreen',
+    toolbar_mode: 'wrap',
+    base_url: '/project/tinymce/js/tinymce',
+    plugins: 'link save searchreplace fullscreen',
+  });
+
+  Arr.each([
+    { button: 'bold', expectedTooltip: 'Bold (⌘B)' },
+    { button: 'italic', expectedTooltip: 'Italic (⌘I)' },
+    { button: 'underline', expectedTooltip: 'Underline (⌘U)' },
+    { button: 'selectall', expectedTooltip: 'Select all (⌘A)' },
+    { button: 'redo', expectedTooltip: 'Redo (⌘Y)' },
+    { button: 'undo', expectedTooltip: 'Undo (⌘Z)' },
+    { button: 'h1', expectedTooltip: 'Heading 1 (⌥⇧1)' },
+    { button: 'h2', expectedTooltip: 'Heading 2 (⌥⇧2)' },
+    { button: 'h3', expectedTooltip: 'Heading 3 (⌥⇧3)' },
+    { button: 'h4', expectedTooltip: 'Heading 4 (⌥⇧4)' },
+    { button: 'h5', expectedTooltip: 'Heading 5 (⌥⇧5)' },
+    { button: 'h6', expectedTooltip: 'Heading 6 (⌥⇧6)' },
+    { button: 'link', expectedTooltip: 'Insert/edit link (⌘K)' },
+    { button: 'save', expectedTooltip: 'Save (⌘S)' },
+    { button: 'searchreplace', expectedTooltip: 'Find and replace (⌘F)' },
+    { button: 'fullscreen', expectedTooltip: 'Fullscreen (⌘⇧F)' },
+  ], (test) => {
+    it(`TINY-10487: Assert keyboard shortcut present in tooltip for ${test.button}`, async () => {
+      const editor = hook.editor();
+      const buttonSelector = `button[data-mce-label="${test.button}"]`;
+      await TooltipUtils.pAssertTooltip(editor, () => TooltipUtils.pTriggerTooltipWithMouse(editor, buttonSelector), test.expectedTooltip);
+      await TooltipUtils.pCloseTooltip(editor, buttonSelector);
+    });
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipShortcutTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipShortcutTest.ts
@@ -1,5 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
+import { PlatformDetection } from '@ephox/sand';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -17,24 +18,29 @@ describe('browser.tinymce.themes.silver.editor.TooltipShortcutTest', () => {
     base_url: '/project/tinymce/js/tinymce',
     plugins: 'link save searchreplace fullscreen',
   }, [ LinkPlugin, SavePlugin, SearchReplacePlugin, FullscreenPlugin ]);
+  const os = PlatformDetection.detect().os;
+
+  const meta = os.isMacOS() || os.isiOS() ? '\u2318' : 'Ctrl+';
+  const shift = os.isMacOS() || os.isiOS() ? '\u21E7' : 'Shift+';
+  const alt = os.isMacOS() || os.isiOS() ? '\u2325' : 'Alt+';
 
   Arr.each([
-    { button: 'bold', expectedTooltip: 'Bold (⌘B)' },
-    { button: 'italic', expectedTooltip: 'Italic (⌘I)' },
-    { button: 'underline', expectedTooltip: 'Underline (⌘U)' },
-    { button: 'selectall', expectedTooltip: 'Select all (⌘A)' },
-    { button: 'redo', expectedTooltip: 'Redo (⌘Y)' },
-    { button: 'undo', expectedTooltip: 'Undo (⌘Z)' },
-    { button: 'h1', expectedTooltip: 'Heading 1 (⌥⇧1)' },
-    { button: 'h2', expectedTooltip: 'Heading 2 (⌥⇧2)' },
-    { button: 'h3', expectedTooltip: 'Heading 3 (⌥⇧3)' },
-    { button: 'h4', expectedTooltip: 'Heading 4 (⌥⇧4)' },
-    { button: 'h5', expectedTooltip: 'Heading 5 (⌥⇧5)' },
-    { button: 'h6', expectedTooltip: 'Heading 6 (⌥⇧6)' },
-    { button: 'link', expectedTooltip: 'Insert/edit link (⌘K)' },
-    { button: 'save', expectedTooltip: 'Save (⌘S)' },
-    { button: 'searchreplace', expectedTooltip: 'Find and replace (⌘F)' },
-    { button: 'fullscreen', expectedTooltip: 'Fullscreen (⌘⇧F)' },
+    { button: 'bold', expectedTooltip: `Bold (${meta}B)` },
+    { button: 'italic', expectedTooltip: `Italic (${meta}I)` },
+    { button: 'underline', expectedTooltip: `Underline (${meta}U)` },
+    { button: 'selectall', expectedTooltip: `Select all (${meta}A)` },
+    { button: 'redo', expectedTooltip: `Redo (${meta}Y)` },
+    { button: 'undo', expectedTooltip: `Undo (${meta}Z)` },
+    { button: 'h1', expectedTooltip: `Heading 1 (${alt}${shift}1)` },
+    { button: 'h2', expectedTooltip: `Heading 2 (${alt}${shift}2)` },
+    { button: 'h3', expectedTooltip: `Heading 3 (${alt}${shift}3)` },
+    { button: 'h4', expectedTooltip: `Heading 4 (${alt}${shift}4)` },
+    { button: 'h5', expectedTooltip: `Heading 5 (${alt}${shift}5)` },
+    { button: 'h6', expectedTooltip: `Heading 6 (${alt}${shift}6)` },
+    { button: 'link', expectedTooltip: `Insert/edit link (${meta}K)` },
+    { button: 'save', expectedTooltip: `Save (${meta}S)` },
+    { button: 'searchreplace', expectedTooltip: `Find and replace (${meta}F)` },
+    { button: 'fullscreen', expectedTooltip: `Fullscreen (${meta}${shift}F)` },
   ], (test) => {
     it(`TINY-10487: Assert keyboard shortcut present in tooltip for ${test.button}`, async () => {
       const editor = hook.editor();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipTest.ts
@@ -1,11 +1,13 @@
-import { FocusTools, Mouse, UiFinder, Waiter } from '@ephox/agar';
+import { Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
-import { SugarBody, SugarElement, TextContent } from '@ephox/sugar';
+import { SugarElement, TextContent } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
+
+import * as TooltipUtils from '../../../module/TooltipUtils';
 
 interface TestScenario {
   readonly label: string;
@@ -13,54 +15,10 @@ interface TestScenario {
 }
 
 describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
-  const tooltipSelector = '.tox-silver-sink .tox-tooltip__body';
-
-  const pAssertTooltip = async (editor: Editor, pTriggerTooltip: () => Promise<void>, text: string) => {
-    await pTriggerTooltip();
-    const tooltip = await TinyUiActions.pWaitForUi(editor, tooltipSelector) as SugarElement<HTMLElement>;
-    assert.equal(TextContent.get(tooltip), text);
-  };
-
-  const pAssertNoTooltip = async (_: Editor, pTriggerTooltip: () => Promise<void>, _text: string) => {
-    await pTriggerTooltip();
-    await Waiter.pWait(300);
-    UiFinder.notExists(SugarBody.body(), tooltipSelector);
-  };
-
-  const pTriggerTooltipWithMouse = async (editor: Editor, selector: string) => {
-    const button = await TinyUiActions.pWaitForUi(editor, selector) as SugarElement<HTMLElement>;
-    Mouse.mouseOver(button);
-  };
-
-  const pTriggerTooltipWithKeyboard = (_: Editor, selector: string) => {
-    FocusTools.setFocus(SugarBody.body(), selector);
-    return Promise.resolve();
-  };
-
-  const pCloseTooltip = async (editor: Editor, selector: string) => {
-    const button = await TinyUiActions.pWaitForUi(editor, selector) as SugarElement<HTMLElement>;
-    Mouse.mouseOut(button);
-    editor.focus();
-    await Waiter.pTryUntil(
-      'Waiting for tooltip to NO LONGER be in DOM',
-      () => UiFinder.notExists(SugarBody.body(), tooltipSelector));
-  };
-
-  const closeMenu = (selector: string) => {
-    Mouse.clickOn(SugarBody.body(), selector);
-    return Waiter.pTryUntil('Waiting for menu', () =>
-      UiFinder.notExists(SugarBody.body(), '[role="menu"]')
-    );
-  };
-
-  const openMenu = (editor: Editor, buttonSelector: string) => {
-    TinyUiActions.clickOnToolbar(editor, buttonSelector);
-    return TinyUiActions.pWaitForPopup(editor, '[role="menu"]');
-  };
 
   Arr.each([
-    { label: 'Mouse', pTriggerTooltip: pTriggerTooltipWithMouse },
-    { label: 'Keyboard', pTriggerTooltip: pTriggerTooltipWithKeyboard },
+    { label: 'Mouse', pTriggerTooltip: TooltipUtils.pTriggerTooltipWithMouse },
+    { label: 'Keyboard', pTriggerTooltip: TooltipUtils.pTriggerTooltipWithKeyboard },
   ], (test: TestScenario) => {
     context('Basic buttons', () => {
       const hook = TinyHooks.bddSetup<Editor>({
@@ -146,53 +104,53 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addButton`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-name="basic-button"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Button');
-        await pCloseTooltip(editor, buttonSelector);
+        const buttonSelector = 'button[data-mce-label="basic-button"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Button');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addToggleButton`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-name="toggle-button"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Toggle Button');
-        await pCloseTooltip(editor, buttonSelector);
+        const buttonSelector = 'button[data-mce-label="toggle-button"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Toggle Button');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addMenuButton`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-name="menu-button"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Menu Button');
-        await pCloseTooltip(editor, buttonSelector);
+        const buttonSelector = 'button[data-mce-label="menu-button"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Menu Button');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addSplitButton`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-name="split-button"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Split Button');
-        await pCloseTooltip(editor, buttonSelector);
+        const buttonSelector = 'div[data-mce-label="split-button"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Split Button');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar Split Button Menu - forecolor`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-name="forecolor"] > .tox-tbtn + .tox-split-button__chevron';
-        await openMenu(editor, buttonSelector);
+        const buttonSelector = 'div[data-mce-label="forecolor"] > .tox-tbtn + .tox-split-button__chevron';
+        await TooltipUtils.pOpenMenu(editor, buttonSelector);
         await Waiter.pWait(300);
         const menuSelector = 'div[data-mce-name="Red"]';
         await test.pTriggerTooltip(editor, menuSelector);
         const tooltip = await TinyUiActions.pWaitForUi(editor, '.tox-silver-sink .tox-tooltip__body:contains("Red")') as SugarElement<HTMLElement>;
         assert.equal(TextContent.get(tooltip), 'Red');
-        await pCloseTooltip(editor, menuSelector);
-        await closeMenu(menuSelector);
+        await TooltipUtils.pCloseTooltip(editor, menuSelector);
+        await TooltipUtils.pCloseMenu(menuSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar Split Button Menu - listpreview`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-name="split-button-with-icon"]  > .tox-tbtn + .tox-split-button__chevron';
-        await openMenu(editor, buttonSelector);
+        const buttonSelector = 'div[data-mce-label="split-button-with-icon"]  > .tox-tbtn + .tox-split-button__chevron';
+        await TooltipUtils.pOpenMenu(editor, buttonSelector);
         const menuSelector = 'div[aria-label="Lower Alpha 1"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, menuSelector), 'Lower Alpha 1');
-        await pCloseTooltip(editor, menuSelector);
-        await closeMenu(menuSelector);
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, menuSelector), 'Lower Alpha 1');
+        await TooltipUtils.pCloseTooltip(editor, menuSelector);
+        await TooltipUtils.pCloseMenu(menuSelector);
       });
     });
 
@@ -280,9 +238,9 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
         const toolbarButtonSelector = '[data-mce-name="dialog-button"]';
         TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
         await TinyUiActions.pWaitForDialog(editor);
-        const buttonSelector = '[data-mce-name="Test-Button"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Test-Button');
-        await pCloseTooltip(editor, buttonSelector);
+        const buttonSelector = '[data-mce-label="Test-Button"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Test-Button');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
         TinyUiActions.closeDialog(editor);
       });
 
@@ -291,9 +249,9 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
         const toolbarButtonSelector = '[data-mce-name="size-input-dialog-button"]';
         TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
         await TinyUiActions.pWaitForDialog(editor);
-        const buttonSelector = '[data-mce-name="Constrain proportions"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Constrain proportions');
-        await pCloseTooltip(editor, buttonSelector);
+        const buttonSelector = '[data-mce-label="Constrain proportions"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Constrain proportions');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
         TinyUiActions.closeDialog(editor);
       });
 
@@ -302,9 +260,9 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
         const toolbarButtonSelector = '[data-mce-name="dialog-footer-button"]';
         TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
         await TinyUiActions.pWaitForDialog(editor);
-        const buttonSelector = '[data-mce-name="Preferences"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Preferences');
-        await pCloseTooltip(editor, buttonSelector);
+        const buttonSelector = '[data-mce-label="Preferences"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Preferences');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
         TinyUiActions.closeDialog(editor);
       });
 
@@ -313,9 +271,9 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
         const toolbarButtonSelector = '[data-mce-name="dialog-footer-button"]';
         TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
         await TinyUiActions.pWaitForDialog(editor);
-        const buttonSelector = '[data-mce-name="close"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Close');
-        await pCloseTooltip(editor, buttonSelector);
+        const buttonSelector = '[data-mce-label="close"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Close');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
         TinyUiActions.closeDialog(editor);
       });
     });
@@ -328,50 +286,51 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - fontsizeinput - Decrease font size`, async () => {
         const editor = hook.editor();
-        const buttonSelector = '[data-mce-name="fontsizeinput"] > [data-mce-name="minus"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Decrease font size');
-        await pCloseTooltip(editor, buttonSelector);
+        const buttonSelector = '[data-mce-label="fontsizeinput"] > [data-mce-label="minus"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Decrease font size');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - fontsizeinput - Increase font size`, async () => {
         const editor = hook.editor();
-        const buttonSelector = '[data-mce-name="fontsizeinput"] > [data-mce-name="plus"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Increase font size');
-        await pCloseTooltip(editor, buttonSelector);
+        const buttonSelector = '[data-mce-label="fontsizeinput"] > [data-mce-label="plus"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Increase font size');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
+
       it(`TINY-10453: Should trigger tooltip with ${test.label} - fontsize`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-name="fontsize"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Font size 12pt');
-        await pCloseTooltip(editor, buttonSelector);
+        const buttonSelector = 'button[data-mce-label="fontsize"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Font size 12pt');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - fontfamily`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-name="fontfamily"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Font System Font');
-        await pCloseTooltip(editor, buttonSelector);
+        const buttonSelector = 'button[data-mce-label="fontfamily"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Font System Font');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - align`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-name="align"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Alignment left');
-        await pCloseTooltip(editor, buttonSelector);
+        const buttonSelector = 'button[data-mce-label="align"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Alignment left');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - blocks`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-name="blocks"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Block Paragraph');
-        await pCloseTooltip(editor, buttonSelector);
+        const buttonSelector = 'button[data-mce-label="blocks"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Block Paragraph');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - styles`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-name="styles"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Format Paragraph');
-        await pCloseTooltip(editor, buttonSelector);
+        const buttonSelector = 'button[data-mce-label="styles"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Format Paragraph');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
     });
 
@@ -383,9 +342,9 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - resize handle`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-name="resize-handle"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Resize');
-        await pCloseTooltip(editor, buttonSelector);
+        const buttonSelector = 'div[data-mce-label="resize-handle"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Resize');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
     });
 
@@ -404,9 +363,9 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - overflow more button`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-name="overflow-button"]';
-        await pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Reveal or hide additional toolbar items');
-        await pCloseTooltip(editor, buttonSelector);
+        const buttonSelector = 'button[data-mce-label="overflow-button"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Reveal or hide additional toolbar items');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
     });
 
@@ -435,11 +394,11 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should not show tooltip with ${test.label} - Contains text and no icon`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-name="split-button"] > .tox-tbtn + .tox-split-button__chevron';
-        await openMenu(editor, buttonSelector);
+        const buttonSelector = 'div[data-mce-label="split-button"] > .tox-tbtn + .tox-split-button__chevron';
+        await TooltipUtils.pOpenMenu(editor, buttonSelector);
         const menuSelector = '[aria-label="Choice item 1"]';
-        await pAssertNoTooltip(editor, () => test.pTriggerTooltip(editor, menuSelector), '');
-        await closeMenu(menuSelector);
+        await TooltipUtils.pAssertNoTooltip(editor, () => test.pTriggerTooltip(editor, menuSelector), '');
+        await TooltipUtils.pCloseMenu(menuSelector);
       });
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipTest.ts
@@ -104,35 +104,35 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addButton`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="basic-button"]';
+        const buttonSelector = 'button[data-mce-name="basic-button"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Button');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addToggleButton`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="toggle-button"]';
+        const buttonSelector = 'button[data-mce-name="toggle-button"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Toggle Button');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addMenuButton`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="menu-button"]';
+        const buttonSelector = 'button[data-mce-name="menu-button"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Menu Button');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar addSplitButton`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-label="split-button"]';
+        const buttonSelector = 'div[data-mce-name="split-button"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Split Button');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar Split Button Menu - forecolor`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-label="forecolor"] > .tox-tbtn + .tox-split-button__chevron';
+        const buttonSelector = 'div[data-mce-name="forecolor"] > .tox-tbtn + .tox-split-button__chevron';
         await TooltipUtils.pOpenMenu(editor, buttonSelector);
         await Waiter.pWait(300);
         const menuSelector = 'div[data-mce-name="Red"]';
@@ -145,7 +145,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar Split Button Menu - listpreview`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-label="split-button-with-icon"]  > .tox-tbtn + .tox-split-button__chevron';
+        const buttonSelector = 'div[data-mce-name="split-button-with-icon"]  > .tox-tbtn + .tox-split-button__chevron';
         await TooltipUtils.pOpenMenu(editor, buttonSelector);
         const menuSelector = 'div[aria-label="Lower Alpha 1"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, menuSelector), 'Lower Alpha 1');
@@ -238,7 +238,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
         const toolbarButtonSelector = '[data-mce-name="dialog-button"]';
         TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
         await TinyUiActions.pWaitForDialog(editor);
-        const buttonSelector = '[data-mce-label="Test-Button"]';
+        const buttonSelector = '[data-mce-name="Test-Button"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Test-Button');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
         TinyUiActions.closeDialog(editor);
@@ -249,7 +249,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
         const toolbarButtonSelector = '[data-mce-name="size-input-dialog-button"]';
         TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
         await TinyUiActions.pWaitForDialog(editor);
-        const buttonSelector = '[data-mce-label="Constrain proportions"]';
+        const buttonSelector = '[data-mce-name="Constrain proportions"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Constrain proportions');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
         TinyUiActions.closeDialog(editor);
@@ -260,7 +260,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
         const toolbarButtonSelector = '[data-mce-name="dialog-footer-button"]';
         TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
         await TinyUiActions.pWaitForDialog(editor);
-        const buttonSelector = '[data-mce-label="Preferences"]';
+        const buttonSelector = '[data-mce-name="Preferences"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Preferences');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
         TinyUiActions.closeDialog(editor);
@@ -271,7 +271,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
         const toolbarButtonSelector = '[data-mce-name="dialog-footer-button"]';
         TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
         await TinyUiActions.pWaitForDialog(editor);
-        const buttonSelector = '[data-mce-label="close"]';
+        const buttonSelector = '[data-mce-name="close"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Close');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
         TinyUiActions.closeDialog(editor);
@@ -286,49 +286,49 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - fontsizeinput - Decrease font size`, async () => {
         const editor = hook.editor();
-        const buttonSelector = '[data-mce-label="fontsizeinput"] > [data-mce-label="minus"]';
+        const buttonSelector = '[data-mce-name="fontsizeinput"] > [data-mce-name="minus"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Decrease font size');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - fontsizeinput - Increase font size`, async () => {
         const editor = hook.editor();
-        const buttonSelector = '[data-mce-label="fontsizeinput"] > [data-mce-label="plus"]';
+        const buttonSelector = '[data-mce-name="fontsizeinput"] > [data-mce-name="plus"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Increase font size');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - fontsize`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="fontsize"]';
+        const buttonSelector = 'button[data-mce-name="fontsize"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Font size 12pt');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - fontfamily`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="fontfamily"]';
+        const buttonSelector = 'button[data-mce-name="fontfamily"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Font System Font');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - align`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="align"]';
+        const buttonSelector = 'button[data-mce-name="align"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Alignment left');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - blocks`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="blocks"]';
+        const buttonSelector = 'button[data-mce-name="blocks"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Block Paragraph');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - styles`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="styles"]';
+        const buttonSelector = 'button[data-mce-name="styles"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Format Paragraph');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
@@ -342,7 +342,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - resize handle`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-label="resize-handle"]';
+        const buttonSelector = 'div[data-mce-name="resize-handle"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Resize');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
@@ -363,7 +363,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - overflow more button`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'button[data-mce-label="overflow-button"]';
+        const buttonSelector = 'button[data-mce-name="overflow-button"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Reveal or hide additional toolbar items');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
       });
@@ -394,7 +394,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
 
       it(`TINY-10453: Should not show tooltip with ${test.label} - Contains text and no icon`, async () => {
         const editor = hook.editor();
-        const buttonSelector = 'div[data-mce-label="split-button"] > .tox-tbtn + .tox-split-button__chevron';
+        const buttonSelector = 'div[data-mce-name="split-button"] > .tox-tbtn + .tox-split-button__chevron';
         await TooltipUtils.pOpenMenu(editor, buttonSelector);
         const menuSelector = '[aria-label="Choice item 1"]';
         await TooltipUtils.pAssertNoTooltip(editor, () => test.pTriggerTooltip(editor, menuSelector), '');

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
@@ -30,6 +30,7 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
         components: [
           renderToolbarButton({
             type: 'button',
+            shortcut: Optional.none(),
             enabled: true,
             tooltip: Optional.some('tooltip'),
             icon: Optional.none(),
@@ -54,6 +55,7 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
         components: [
           renderToolbarToggleButton({
             type: 'togglebutton',
+            shortcut: Optional.none(),
             enabled: true,
             active: false,
             tooltip: Optional.some('tooltip'),

--- a/modules/tinymce/src/themes/silver/test/ts/module/TooltipUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TooltipUtils.ts
@@ -1,0 +1,61 @@
+import { FocusTools, Mouse, UiFinder, Waiter } from '@ephox/agar';
+import { SugarBody, SugarElement, TextContent } from '@ephox/sugar';
+import { TinyUiActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+const tooltipSelector = '.tox-silver-sink .tox-tooltip__body';
+
+const pAssertTooltip = async (editor: Editor, pTriggerTooltip: () => Promise<void>, text: string): Promise<void> => {
+  await pTriggerTooltip();
+  const tooltip = await TinyUiActions.pWaitForUi(editor, tooltipSelector) as SugarElement<HTMLElement>;
+  assert.equal(TextContent.get(tooltip), text);
+};
+
+const pAssertNoTooltip = async (_: Editor, pTriggerTooltip: () => Promise<void>, _text: string): Promise<void> => {
+  await pTriggerTooltip();
+  await Waiter.pWait(300);
+  UiFinder.notExists(SugarBody.body(), tooltipSelector);
+};
+
+const pTriggerTooltipWithMouse = async (editor: Editor, selector: string): Promise<void> => {
+  const button = await TinyUiActions.pWaitForUi(editor, selector) as SugarElement<HTMLElement>;
+  Mouse.mouseOver(button);
+};
+
+const pTriggerTooltipWithKeyboard = (_: Editor, selector: string): Promise<void> => {
+  FocusTools.setFocus(SugarBody.body(), selector);
+  return Promise.resolve();
+};
+
+const pCloseTooltip = async (editor: Editor, selector: string): Promise<void> => {
+  const button = await TinyUiActions.pWaitForUi(editor, selector) as SugarElement<HTMLElement>;
+  Mouse.mouseOut(button);
+  editor.focus();
+  await Waiter.pTryUntil(
+    'Waiting for tooltip to NO LONGER be in DOM',
+    () => UiFinder.notExists(SugarBody.body(), tooltipSelector));
+};
+
+const pCloseMenu = (selector: string): Promise<void> => {
+  Mouse.clickOn(SugarBody.body(), selector);
+  return Waiter.pTryUntil('Waiting for menu', () =>
+    UiFinder.notExists(SugarBody.body(), '[role="menu"]')
+  );
+};
+
+const pOpenMenu = (editor: Editor, buttonSelector: string): Promise<SugarElement<HTMLElement>> => {
+  TinyUiActions.clickOnToolbar(editor, buttonSelector);
+  return TinyUiActions.pWaitForPopup(editor, '[role="menu"]');
+};
+
+export {
+  pAssertTooltip,
+  pAssertNoTooltip,
+  pTriggerTooltipWithMouse,
+  pTriggerTooltipWithKeyboard,
+  pCloseTooltip,
+  pCloseMenu,
+  pOpenMenu
+};


### PR DESCRIPTION
Related Ticket: TINY-10476

Description of Changes:
* Added `shortcut` optional property to `ToolbarButton` and `ToolbarToggleButton`
* Shortcut is concatenated to the tooltip string. 
* Added shortcut to the core button which has already been defined in the help dialog.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
