### PR TITLE
TINY-9638: Add custom tooltips to autocompleter

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/SingleMenu.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/SingleMenu.ts
@@ -127,7 +127,7 @@ export const createAutocompleteItems = (
               itemResponse,
               sharedBackstage,
               {
-                itemBehaviours: tooltipBehaviour(d.meta, sharedBackstage),
+                itemBehaviours: tooltipBehaviour(d.meta, sharedBackstage, Optional.none()),
                 cardText: {
                   matchText,
                   highlightOn

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/AutocompleterTooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/AutocompleterTooltipTest.ts
@@ -1,4 +1,4 @@
-import { Keys, UiFinder } from '@ephox/agar';
+import { Keys, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
@@ -21,8 +21,10 @@ describe('browser.tinymce.themes.silver.editor.AutocompleterTooltipTest', () => 
 
   const pCloseAutocompleterByKey = async (editor: Editor) => {
     TinyContentActions.keydown(editor, Keys.escape());
-    // Wait 50ms for the keypress to process
     await AutocompleterUtils.pWaitForAutocompleteToClose();
+    await Waiter.pTryUntil(
+      'Waiting for tooltip to NO LONGER be in DOM',
+      () => UiFinder.notExists(SugarBody.body(), '.tox-silver-sink .tox-tooltip__body'));
   };
 
   context('AutocompleteItem, columns = auto', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/AutocompleterTooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/AutocompleterTooltipTest.ts
@@ -1,0 +1,155 @@
+import { Keys, UiFinder } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr, Fun } from '@ephox/katamari';
+import { SugarBody } from '@ephox/sugar';
+import { TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+import * as Assets from '../../../module/Assets';
+import * as AutocompleterUtils from '../../../module/AutocompleterUtils';
+import * as TooltipUtils from '../../../module/TooltipUtils';
+
+describe('browser.tinymce.themes.silver.editor.AutocompleterTooltipTest', () => {
+  const pOpenAutocompleter = async (editor: Editor, triggerChar: string) => {
+    editor.focus();
+    editor.setContent(`<p>${triggerChar}</p>`);
+    TinySelections.setCursor(editor, [ 0, 0 ], triggerChar.length);
+    TinyContentActions.keypress(editor, triggerChar.charCodeAt(0));
+    await UiFinder.pWaitForVisible('Wait for autocompleter to appear', SugarBody.body(), '.tox-autocompleter');
+  };
+
+  const pCloseAutocompleterByKey = async (editor: Editor) => {
+    TinyContentActions.keydown(editor, Keys.escape());
+    // Wait 50ms for the keypress to process
+    await AutocompleterUtils.pWaitForAutocompleteToClose();
+  };
+
+  context('AutocompleteItem, columns = auto', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      setup: (ed: Editor) => {
+        ed.ui.registry.addAutocompleter('test', {
+          trigger: '+',
+          minChars: 0,
+          columns: 'auto',
+          fetch: () => {
+            return Promise.resolve(Arr.map([ 'aa', 'ab' ], (letter) => ({
+              value: `${letter}`,
+              text: `p-${letter}`,
+              icon: letter
+            })));
+          },
+          onAction: Fun.noop
+        });
+      }
+    });
+
+    it('TINY-9638: Should show tooltip when autocompleter is shown', async () => {
+      const editor = hook.editor();
+      await TooltipUtils.pAssertTooltip(editor, async () => await pOpenAutocompleter(editor, '+'), 'p-aa');
+      await pCloseAutocompleterByKey(editor);
+    });
+
+    it('TINY-9638: Should show tooltip when autocompleter is shown and navigate with keyboard', async () => {
+      const editor = hook.editor();
+      editor.focus();
+      await TooltipUtils.pAssertTooltip(editor, async () => await pOpenAutocompleter(editor, '+'), 'p-aa');
+      await TooltipUtils.pAssertTooltip(editor, async () => {
+        TinyContentActions.keydown(editor, Keys.right());
+        await TinyUiActions.pWaitForUi(editor, '.tox-silver-sink .tox-tooltip__body:contains("p-ab")');
+        return Promise.resolve();
+      }, 'p-ab');
+      await pCloseAutocompleterByKey(editor);
+    });
+
+    it('TINY-9638: Should show tooltip when autocompleter is shown and navigate with mouse', async () => {
+      const editor = hook.editor();
+      editor.focus();
+      await TooltipUtils.pAssertTooltip(editor, async () => await pOpenAutocompleter(editor, '+'), 'p-aa');
+      await TooltipUtils.pAssertTooltip(editor, async () => {
+        TooltipUtils.pTriggerTooltipWithMouse(editor, '.tox-collection__item .tox-collection__item-icon:contains("ab")');
+        await TinyUiActions.pWaitForUi(editor, '.tox-silver-sink .tox-tooltip__body:contains("p-ab")');
+        return Promise.resolve();
+      }, 'p-ab');
+      await pCloseAutocompleterByKey(editor);
+    });
+  });
+
+  context('AutocompleteItem, columns = 1', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      setup: (ed: Editor) => {
+        ed.ui.registry.addAutocompleter('test', {
+          trigger: '+',
+          minChars: 0,
+          columns: 1,
+          fetch: () => {
+            return Promise.resolve(Arr.map([ 'aa', 'ab' ], (letter) => ({
+              value: `${letter}`,
+              text: `p-${letter}`,
+              icon: letter
+            })));
+          },
+          onAction: Fun.noop
+        });
+      }
+    });
+
+    it('TINY-9638: Tooltip should not be shown when columns = 1, as text will be shown', async () => {
+      const editor = hook.editor();
+      await TooltipUtils.pAssertNoTooltip(editor, async () => await pOpenAutocompleter(editor, '+'), '');
+      await pCloseAutocompleterByKey(editor);
+    });
+  });
+
+  context('CardMenuItem', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      setup: (ed: Editor) => {
+        ed.ui.registry.addAutocompleter('test', {
+          trigger: '+',
+          minChars: 0,
+          columns: 1,
+          fetch: () => {
+            return Promise.resolve(Arr.map([ 'aa', 'ab' ], (letter) => ({
+              value: `euro-${letter}`,
+              ariaLabel: letter,
+              type: 'cardmenuitem',
+              label: letter,
+              items: [
+                {
+                  type: 'cardimage',
+                  src: Assets.getGreenImageDataUrl(),
+                  classes: [ 'my_autocompleter_avatar_class' ]
+                },
+                {
+                  type: 'cardcontainer',
+                  direction: 'vertical',
+                  align: 'right',
+                  valign: 'bottom',
+                  items: [
+                    {
+                      type: 'cardtext',
+                      text: letter,
+                      classes: [ 'my_text_class' ],
+                      name: 'my_text_to_highlight'
+                    }
+                  ]
+                }
+              ]
+
+            })));
+          },
+          onAction: Fun.noop
+        });
+      }
+    });
+
+    it('TINY-9638: Tooltip should not be shown when using CardMenuItem in autocompleter', async () => {
+      const editor = hook.editor();
+      await TooltipUtils.pAssertNoTooltip(editor, async () => await pOpenAutocompleter(editor, '+'), '');
+      await pCloseAutocompleterByKey(editor);
+    });
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/module/TooltipUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TooltipUtils.ts
@@ -1,0 +1,61 @@
+import { FocusTools, Mouse, UiFinder, Waiter } from '@ephox/agar';
+import { SugarBody, SugarElement, TextContent } from '@ephox/sugar';
+import { TinyUiActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+const tooltipSelector = '.tox-silver-sink .tox-tooltip__body';
+
+const pAssertTooltip = async (editor: Editor, pTriggerTooltip: () => Promise<void>, text: string): Promise<void> => {
+  await pTriggerTooltip();
+  const tooltip = await TinyUiActions.pWaitForUi(editor, tooltipSelector) as SugarElement<HTMLElement>;
+  assert.equal(TextContent.get(tooltip), text);
+};
+
+const pAssertNoTooltip = async (_: Editor, pTriggerTooltip: () => Promise<void>, _text: string): Promise<void> => {
+  await pTriggerTooltip();
+  await Waiter.pWait(300);
+  UiFinder.notExists(SugarBody.body(), tooltipSelector);
+};
+
+const pTriggerTooltipWithMouse = async (editor: Editor, selector: string): Promise<void> => {
+  const button = await TinyUiActions.pWaitForUi(editor, selector) as SugarElement<HTMLElement>;
+  Mouse.mouseOver(button);
+};
+
+const pTriggerTooltipWithKeyboard = (_: Editor, selector: string): Promise<void> => {
+  FocusTools.setFocus(SugarBody.body(), selector);
+  return Promise.resolve();
+};
+
+const pCloseTooltip = async (editor: Editor, selector: string): Promise<void> => {
+  const button = await TinyUiActions.pWaitForUi(editor, selector) as SugarElement<HTMLElement>;
+  Mouse.mouseOut(button);
+  editor.focus();
+  await Waiter.pTryUntil(
+    'Waiting for tooltip to NO LONGER be in DOM',
+    () => UiFinder.notExists(SugarBody.body(), tooltipSelector));
+};
+
+const pCloseMenu = (selector: string): Promise<void> => {
+  Mouse.clickOn(SugarBody.body(), selector);
+  return Waiter.pTryUntil('Waiting for menu', () =>
+    UiFinder.notExists(SugarBody.body(), '[role="menu"]')
+  );
+};
+
+const pOpenMenu = (editor: Editor, buttonSelector: string): Promise<SugarElement<HTMLElement>> => {
+  TinyUiActions.clickOnToolbar(editor, buttonSelector);
+  return TinyUiActions.pWaitForPopup(editor, '[role="menu"]');
+};
+
+export {
+  pAssertTooltip,
+  pAssertNoTooltip,
+  pTriggerTooltipWithMouse,
+  pTriggerTooltipWithKeyboard,
+  pCloseTooltip,
+  pCloseMenu,
+  pOpenMenu
+};


### PR DESCRIPTION
Related Ticket: TINY-9638

Description of Changes:
* Add custom tooltip to autocompleter, this is only for `AutocompleteItem` 
* Only when `AutocompleteItem` columns is not equals to 1, then there will be tooltips. When columns equals to 1, they *usually* have text, so tooltip is omitted
* <img width="442" alt="image" src="https://github.com/tinymce/tinymce/assets/111734091/a1530bc0-7883-4961-be33-9bbef9107534">

Pre-checks:
* [x] ~Changelog entry added~  (Part of tooltip?)
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
