### PR TITLE
TINY-10335: Handle immediate sink on fullscreen toggle (Remove changie )

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10335-2023-12-21.yaml
+++ b/.changes/unreleased/tinymce-TINY-10335-2023-12-21.yaml
@@ -1,7 +1,0 @@
-project: tinymce
-kind: Fixed
-body: The floating toolbar would not be fully visible when the editor was placed inside
-  a scrollable container.
-time: 2023-12-21T17:31:45.463635+02:00
-custom:
-  Issue: TINY-10335

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- The floating toolbar would not be fully visible when the editor was placed inside
+  a scrollable container. #TINY-10335
+
 ## 6.8.2 - 2023-12-11
 
 ### Fixed

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- The floating toolbar would not be fully visible when the editor was placed inside
-  a scrollable container. #TINY-10335
+- The floating toolbar would not be fully visible when the editor was placed inside a scrollable container. #TINY-10335
 
 ## 6.8.2 - 2023-12-11
 


### PR DESCRIPTION
Related Ticket: TINY-10335

This is a follow up of https://github.com/tinymce/tinymce/pull/9316#issuecomment-1922950368
Description of Changes:
* Removed `.changie` folder.
* Change log updated in a regular way.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
