### PR TITLE
TINY-10561: add import for `advcode.less`

### DIFF
--- a/modules/oxide/src/less/theme/components/advcode/advcode.less
+++ b/modules/oxide/src/less/theme/components/advcode/advcode.less
@@ -1,13 +1,17 @@
 //
 // Advance code
 //
+
+@advcode-codemirror-default-font-size: 13px;
+@advcode-codemirror-margin: 8px;
+
 .tox {
   .mce-codemirror {
     background: #fff;
     bottom: '0';
-    font-size: '13px';
+    font-size: @advcode-codemirror-default-font-size;
     left: '0';
-    margin: '8px';
+    margin: @advcode-codemirror-margin;
     position: 'absolute';
     right: '0';
     top: '0';

--- a/modules/oxide/src/less/theme/components/advcode/advcode.less
+++ b/modules/oxide/src/less/theme/components/advcode/advcode.less
@@ -12,7 +12,7 @@
     font-size: @advcode-codemirror-default-font-size;
     left: 0;
     margin: @advcode-codemirror-margin;
-    position: 'absolute';
+    position: absolute;
     right: 0;
     top: 0;
     z-index: 1;

--- a/modules/oxide/src/less/theme/components/advcode/advcode.less
+++ b/modules/oxide/src/less/theme/components/advcode/advcode.less
@@ -8,14 +8,14 @@
 .tox {
   .mce-codemirror {
     background: #fff;
-    bottom: '0';
+    bottom: 0;
     font-size: @advcode-codemirror-default-font-size;
-    left: '0';
+    left: 0;
     margin: @advcode-codemirror-margin;
     position: 'absolute';
-    right: '0';
-    top: '0';
-    z-index: '1';
+    right: 0;
+    top: 0;
+    z-index: 1;
 
     &.tox-inline-codemirror {
       position: relative;

--- a/modules/oxide/src/less/theme/theme.less
+++ b/modules/oxide/src/less/theme/theme.less
@@ -8,6 +8,7 @@
 @import 'globals/global';
 
 @import 'components/accessibility-checker/accessibility-checker';
+@import 'components/advcode/advcode.less';
 @import 'components/advtemplate/advtemplate.less';
 @import 'components/anchorbar/anchorbar';
 @import 'components/bar/bar';


### PR DESCRIPTION
Related Ticket: TINY-10561

Description of Changes:
this is just an little fix, I forgot to import the `.less` file in `theme.less` in the previous PR: https://github.com/tinymce/tinymce/pull/9337

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
