### PR TITLE
TINY-10596: add `Tabstopping` to customeditor component

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10596-2024-02-07.yaml
+++ b/.changes/unreleased/tinymce-TINY-10596-2024-02-07.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: Added focus behavior for CustomEditor.
+time: 2024-02-07T12:29:51.857930182+01:00
+custom:
+  Issue: TINY-10596

--- a/.changes/unreleased/tinymce-TINY-10596-2024-02-07.yaml
+++ b/.changes/unreleased/tinymce-TINY-10596-2024-02-07.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Added
-body: Added focus behavior for CustomEditor.
+body: Added onFocus callback for CustomEditor dialog component.
 time: 2024-02-07T12:29:51.857930182+01:00
 custom:
   Issue: TINY-10596

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/CustomEditor.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/CustomEditor.ts
@@ -39,6 +39,7 @@ export interface CustomEditorNew extends FormComponent {
   scriptId: string;
   scriptUrl: string;
   settings: any;
+  onFocus?: (container: HTMLElement) => void;
 }
 
 export type CustomEditor = CustomEditorOld | CustomEditorNew;

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/CustomEditor.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/CustomEditor.ts
@@ -22,6 +22,7 @@ interface CustomEditorNewSpec extends FormComponentSpec {
   tag?: string;
   scriptId: string;
   scriptUrl: string;
+  onFocus?: (e: HTMLElement) => void;
   settings?: any;
 }
 
@@ -38,6 +39,7 @@ export interface CustomEditorNew extends FormComponent {
   tag: string;
   scriptId: string;
   scriptUrl: string;
+  onFocus?: (e: HTMLElement) => void;
   settings: any;
 }
 

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/CustomEditor.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/CustomEditor.ts
@@ -23,7 +23,6 @@ interface CustomEditorNewSpec extends FormComponentSpec {
   scriptId: string;
   scriptUrl: string;
   settings?: any;
-  focusSelector?: string;
 }
 
 export type CustomEditorSpec = CustomEditorOldSpec | CustomEditorNewSpec;
@@ -40,7 +39,6 @@ export interface CustomEditorNew extends FormComponent {
   scriptId: string;
   scriptUrl: string;
   settings: any;
-  focusSelector: string;
 }
 
 export type CustomEditor = CustomEditorOld | CustomEditorNew;

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/CustomEditor.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/CustomEditor.ts
@@ -1,5 +1,5 @@
 import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
-import { Result } from '@ephox/katamari';
+import { Optional, Result } from '@ephox/katamari';
 
 import { FormComponent, formComponentFields, FormComponentSpec } from './FormComponent';
 
@@ -39,7 +39,7 @@ export interface CustomEditorNew extends FormComponent {
   tag: string;
   scriptId: string;
   scriptUrl: string;
-  onFocus?: (e: HTMLElement) => void;
+  onFocus: Optional<(e: HTMLElement) => void>;
   settings: any;
 }
 
@@ -49,6 +49,7 @@ const customEditorFields = formComponentFields.concat([
   FieldSchema.defaultedString('tag', 'textarea'),
   FieldSchema.requiredString('scriptId'),
   FieldSchema.requiredString('scriptUrl'),
+  FieldSchema.optionFunction('onFocus'),
   FieldSchema.defaultedPostMsg('settings', undefined)
 ]);
 

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/CustomEditor.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/CustomEditor.ts
@@ -23,7 +23,7 @@ interface CustomEditorNewSpec extends FormComponentSpec {
   scriptId: string;
   scriptUrl: string;
   settings?: any;
-  onFocus?: (container: HTMLElement) => void;
+  focusSelector?: string;
 }
 
 export type CustomEditorSpec = CustomEditorOldSpec | CustomEditorNewSpec;
@@ -40,7 +40,7 @@ export interface CustomEditorNew extends FormComponent {
   scriptId: string;
   scriptUrl: string;
   settings: any;
-  onFocus: (container: HTMLElement) => void;
+  focusSelector: string;
 }
 
 export type CustomEditor = CustomEditorOld | CustomEditorNew;

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/CustomEditor.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/CustomEditor.ts
@@ -23,6 +23,7 @@ interface CustomEditorNewSpec extends FormComponentSpec {
   scriptId: string;
   scriptUrl: string;
   settings?: any;
+  onFocus?: (container: HTMLElement) => void;
 }
 
 export type CustomEditorSpec = CustomEditorOldSpec | CustomEditorNewSpec;
@@ -39,7 +40,7 @@ export interface CustomEditorNew extends FormComponent {
   scriptId: string;
   scriptUrl: string;
   settings: any;
-  onFocus?: (container: HTMLElement) => void;
+  onFocus: (container: HTMLElement) => void;
 }
 
 export type CustomEditor = CustomEditorOld | CustomEditorNew;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
@@ -24,10 +24,10 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
   });
 
   const initialValue = Singleton.value<string>();
-  const focusBehaviour = !isOldCustomEditor(spec) && spec.focusSelector ? [
+  const focusBehaviour = !isOldCustomEditor(spec) && spec.settings.focusSelector ? [
     Focusing.config({
       onFocus: (comp) => {
-        SelectorFind.descendant(comp.element, spec.focusSelector).each((elementToFocus) => {
+        SelectorFind.descendant(comp.element, spec.settings.focusSelector).each((elementToFocus) => {
           Focus.focus(elementToFocus as SugarElement<HTMLElement>);
         });
       }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
@@ -1,4 +1,4 @@
-import { AddEventsBehaviour, AlloyEvents, Behaviour, Memento, SimpleSpec, Tabstopping } from '@ephox/alloy';
+import { AddEventsBehaviour, AlloyEvents, Behaviour, Focusing, Memento, SimpleSpec, Tabstopping } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Obj, Optional, Singleton } from '@ephox/katamari';
 
@@ -23,6 +23,16 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
   });
 
   const initialValue = Singleton.value<string>();
+
+  const focusBehaviour = !isOldCustomEditor(spec) && spec.onFocus ? [ Focusing.config({
+    onFocus: (comp) => {
+      if (spec.onFocus) {
+        spec.onFocus(comp.element.dom);
+      }
+    }
+  }),
+  Tabstopping.config({}),
+  ComposingConfigs.self() ] : [];
 
   return {
     dom: {
@@ -62,9 +72,7 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
           );
         }
       ),
-      Tabstopping.config({}),
-      ComposingConfigs.self()
-    ]),
+    ].concat(focusBehaviour)),
     components: [ memReplaced.asSpec() ]
   };
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
@@ -23,13 +23,12 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
   });
 
   const initialValue = Singleton.value<string>();
-
-  const focusBehaviour = !isOldCustomEditor(spec) && spec.onFocus ? [
-    Focusing.config({
-      onFocus: (comp) => spec.onFocus(comp.element.dom)
-    }),
-    Tabstopping.config({})
-  ] : [];
+  // const focusBehaviour = !isOldCustomEditor(spec) && spec.onFocus ? [
+  //   Focusing.config({
+  //     onFocus: (comp) => spec.onFocus(comp.element.dom)
+  //   }),
+  //   Tabstopping.config({})
+  // ] : [];
 
   return {
     dom: {
@@ -69,8 +68,10 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
           );
         }
       ),
-      ComposingConfigs.self()
-    ].concat(focusBehaviour)),
+      ComposingConfigs.self(),
+      Tabstopping.config({}),
+      Focusing.config({})
+    ]/* .concat(focusBehaviour) */),
     components: [ memReplaced.asSpec() ]
   };
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
@@ -24,7 +24,7 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
   });
 
   const initialValue = Singleton.value<string>();
-  const focusBehaviour = !isOldCustomEditor(spec) && spec.settings.focusSelector ? [
+  const focusBehaviour = !isOldCustomEditor(spec) && spec.settings?.focusSelector ? [
     Focusing.config({
       onFocus: (comp) => {
         SelectorFind.descendant(comp.element, spec.settings.focusSelector).each((elementToFocus) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
@@ -23,15 +23,12 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
   });
 
   const initialValue = Singleton.value<string>();
-  const focusBehaviour = !isOldCustomEditor(spec) && spec.onFocus.isSome() /* && spec.settings?.focusSelector */ ? [
+  const focusBehaviour = !isOldCustomEditor(spec) && spec.onFocus.isSome() ? [
     Focusing.config({
       onFocus: (comp) => {
         spec.onFocus.each((onFocusFn) => {
           onFocusFn(comp.element.dom);
         });
-        // SelectorFind.descendant(comp.element, spec.settings.focusSelector).each((elementToFocus) => {
-        //   Focus.focus(elementToFocus as SugarElement<HTMLElement>);
-        // });
       }
     }),
     Tabstopping.config({})

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
@@ -23,12 +23,12 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
   });
 
   const initialValue = Singleton.value<string>();
-  const focusBehaviour = !isOldCustomEditor(spec) && spec.onFocus /* && spec.settings?.focusSelector */ ? [
+  const focusBehaviour = !isOldCustomEditor(spec) && spec.onFocus.isSome() /* && spec.settings?.focusSelector */ ? [
     Focusing.config({
       onFocus: (comp) => {
-        if (spec.onFocus) {
-          spec.onFocus(comp.element.dom);
-        }
+        spec.onFocus.each((onFocusFn) => {
+          onFocusFn(comp.element.dom);
+        });
         // SelectorFind.descendant(comp.element, spec.settings.focusSelector).each((elementToFocus) => {
         //   Focus.focus(elementToFocus as SugarElement<HTMLElement>);
         // });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
@@ -28,8 +28,7 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
     Focusing.config({
       onFocus: (comp) => spec.onFocus(comp.element.dom)
     }),
-    Tabstopping.config({}),
-    ComposingConfigs.self()
+    Tabstopping.config({})
   ] : [];
 
   return {
@@ -70,6 +69,7 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
           );
         }
       ),
+      ComposingConfigs.self()
     ].concat(focusBehaviour)),
     components: [ memReplaced.asSpec() ]
   };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
@@ -24,15 +24,13 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
 
   const initialValue = Singleton.value<string>();
 
-  const focusBehaviour = !isOldCustomEditor(spec) && spec.onFocus ? [ Focusing.config({
-    onFocus: (comp) => {
-      if (spec.onFocus) {
-        spec.onFocus(comp.element.dom);
-      }
-    }
-  }),
-  Tabstopping.config({}),
-  ComposingConfigs.self() ] : [];
+  const focusBehaviour = !isOldCustomEditor(spec) && spec.onFocus ? [
+    Focusing.config({
+      onFocus: (comp) => spec.onFocus(comp.element.dom)
+    }),
+    Tabstopping.config({}),
+    ComposingConfigs.self()
+  ] : [];
 
   return {
     dom: {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
@@ -1,6 +1,7 @@
 import { AddEventsBehaviour, AlloyEvents, Behaviour, Focusing, Memento, SimpleSpec, Tabstopping } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Obj, Optional, Singleton } from '@ephox/katamari';
+import { Focus, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import Resource from 'tinymce/core/api/Resource';
 
@@ -23,12 +24,16 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
   });
 
   const initialValue = Singleton.value<string>();
-  // const focusBehaviour = !isOldCustomEditor(spec) && spec.onFocus ? [
-  //   Focusing.config({
-  //     onFocus: (comp) => spec.onFocus(comp.element.dom)
-  //   }),
-  //   Tabstopping.config({})
-  // ] : [];
+  const focusBehaviour = !isOldCustomEditor(spec) && spec.focusSelector ? [
+    Focusing.config({
+      onFocus: (comp) => {
+        SelectorFind.descendant(comp.element, spec.focusSelector).each((elementToFocus) => {
+          Focus.focus(elementToFocus as SugarElement<HTMLElement>);
+        });
+      }
+    }),
+    Tabstopping.config({})
+  ] : [];
 
   return {
     dom: {
@@ -68,10 +73,8 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
           );
         }
       ),
-      ComposingConfigs.self(),
-      Tabstopping.config({}),
-      Focusing.config({})
-    ]/* .concat(focusBehaviour) */),
+      ComposingConfigs.self()
+    ].concat(focusBehaviour)),
     components: [ memReplaced.asSpec() ]
   };
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
@@ -1,7 +1,6 @@
 import { AddEventsBehaviour, AlloyEvents, Behaviour, Focusing, Memento, SimpleSpec, Tabstopping } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Obj, Optional, Singleton } from '@ephox/katamari';
-import { Focus, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import Resource from 'tinymce/core/api/Resource';
 
@@ -24,12 +23,15 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
   });
 
   const initialValue = Singleton.value<string>();
-  const focusBehaviour = !isOldCustomEditor(spec) && spec.settings?.focusSelector ? [
+  const focusBehaviour = !isOldCustomEditor(spec) && spec.onFocus /* && spec.settings?.focusSelector */ ? [
     Focusing.config({
       onFocus: (comp) => {
-        SelectorFind.descendant(comp.element, spec.settings.focusSelector).each((elementToFocus) => {
-          Focus.focus(elementToFocus as SugarElement<HTMLElement>);
-        });
+        if (spec.onFocus) {
+          spec.onFocus(comp.element.dom);
+        }
+        // SelectorFind.descendant(comp.element, spec.settings.focusSelector).each((elementToFocus) => {
+        //   Focus.focus(elementToFocus as SugarElement<HTMLElement>);
+        // });
       }
     }),
     Tabstopping.config({})

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
@@ -1,4 +1,4 @@
-import { AddEventsBehaviour, AlloyEvents, Behaviour, Memento, SimpleSpec } from '@ephox/alloy';
+import { AddEventsBehaviour, AlloyEvents, Behaviour, Memento, SimpleSpec, Tabstopping } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Obj, Optional, Singleton } from '@ephox/katamari';
 
@@ -55,14 +55,14 @@ export const renderCustomEditor = (spec: CustomEditorSpec): SimpleSpec => {
           () => initialValue.get().getOr(''),
           (ed) => ed.getValue()
         ),
-        (component, value) => {
+        (_component, value) => {
           editorApi.get().fold(
             () => initialValue.set(value),
             (ed) => ed.setValue(value)
           );
         }
       ),
-
+      Tabstopping.config({}),
       ComposingConfigs.self()
     ]),
     components: [ memReplaced.asSpec() ]

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/customeditor/BasicCustomEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/customeditor/BasicCustomEditorTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, Waiter } from '@ephox/agar';
 import { GuiFactory, TestHelpers } from '@ephox/alloy';
 import { after, before, describe, it } from '@ephox/bedrock-client';
-import { Cell, Fun, Global } from '@ephox/katamari';
+import { Cell, Fun, Global, Optional } from '@ephox/katamari';
 import { Class, SugarElement } from '@ephox/sugar';
 
 import Resource from 'tinymce/core/api/Resource';
@@ -50,7 +50,8 @@ describe('headless.tinymce.themes.silver.components.customeditor.BasicCustomEdit
       tag: 'textarea',
       scriptId: 'BasicCustomEditorTest',
       scriptUrl: '/custom/404', // using the cache
-      settings: undefined
+      settings: undefined,
+      onFocus: Optional.none()
     })
   ));
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/customeditor/BasicCustomEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/customeditor/BasicCustomEditorTest.ts
@@ -50,7 +50,8 @@ describe('headless.tinymce.themes.silver.components.customeditor.BasicCustomEdit
       tag: 'textarea',
       scriptId: 'BasicCustomEditorTest',
       scriptUrl: '/custom/404', // using the cache
-      settings: undefined
+      settings: undefined,
+      onFocus: Fun.noop
     })
   ));
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/customeditor/BasicCustomEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/customeditor/BasicCustomEditorTest.ts
@@ -50,8 +50,7 @@ describe('headless.tinymce.themes.silver.components.customeditor.BasicCustomEdit
       tag: 'textarea',
       scriptId: 'BasicCustomEditorTest',
       scriptUrl: '/custom/404', // using the cache
-      settings: undefined,
-      focusSelector: ''
+      settings: undefined
     })
   ));
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/customeditor/BasicCustomEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/customeditor/BasicCustomEditorTest.ts
@@ -51,7 +51,7 @@ describe('headless.tinymce.themes.silver.components.customeditor.BasicCustomEdit
       scriptId: 'BasicCustomEditorTest',
       scriptUrl: '/custom/404', // using the cache
       settings: undefined,
-      onFocus: Fun.noop
+      focusSelector: ''
     })
   ));
 


### PR DESCRIPTION
Related Ticket: TINY-10596

Description of Changes:
I added an `focusBehaviour` for the `customEditor` in dialog, this relay on a `focusSelector` in settings, I tried to use a callback instead of a selector but I get an error, and if I remember correctly we can pass a callback in the specs.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
