### PR TITLE
TINY-10640: Fixed issue with context toolbar not hiding on Firefox

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
@@ -280,6 +280,13 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
       }
     });
 
+    // TINY-10640: Firefox was flaking in tests and was not properly dismissing the toolbar could not reproduce it manually but adding this seems to resolve it.
+    editor.on('ExecCommand', ({ command }) => {
+      if (command.toLowerCase() === 'toggleview') {
+        close();
+      }
+    });
+
     editor.on('AfterProgressState', (event) => {
       if (event.state) {
         close();


### PR DESCRIPTION
Related Ticket: TINY-10640

Description of Changes:
* Fixes a flake that pops up here and there

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
