### PR TITLE
TINY-10451: ShadowDOM skin was not imported correctly when using js bundling feature

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10451-2024-01-11.yaml
+++ b/.changes/unreleased/tinymce-TINY-10451-2024-01-11.yaml
@@ -1,6 +1,0 @@
-project: tinymce
-kind: Fixed
-body: ShadowDOM skin was not loaded properly when used with js bundling feature.
-time: 2024-01-11T15:39:53.32712+01:00
-custom:
-  Issue: TINY-10451

--- a/.changes/unreleased/tinymce-TINY-10451-2024-01-11.yaml
+++ b/.changes/unreleased/tinymce-TINY-10451-2024-01-11.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: ShadowDOM skin was not loaded properly when used with js bundling feature.
+time: 2024-01-11T15:39:53.32712+01:00
+custom:
+  Issue: TINY-10451

--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - The floating toolbar would not be fully visible when the editor was placed inside a scrollable container. #TINY-10335
+- ShadowDOM skin was not loaded properly when used with js bundling feature. #TINY-10451
 
 ## 6.8.2 - 2023-12-11
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/skin/Loader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/skin/Loader.ts
@@ -24,8 +24,8 @@ const loadRawCss = (editor: Editor, key: string, css: string, styleSheetLoader: 
 };
 
 const loadUiSkins = async (editor: Editor, skinUrl: string): Promise<void> => {
-  const skinUrl_ = Options.getSkinUrlOption(editor).getOr('default');
-  const skinUiCss = 'ui/' + skinUrl_ + '/skin.css';
+  const skinResourceIdentifier = Options.getSkinUrlOption(editor).getOr('default');
+  const skinUiCss = 'ui/' + skinResourceIdentifier + '/skin.css';
   const css = tinymce.Resource.get(skinUiCss);
   if (Type.isString(css)) {
     return Promise.resolve(loadRawCss(editor, skinUiCss, css, editor.ui.styleSheetLoader));
@@ -39,7 +39,9 @@ const loadShadowDomUiSkins = async (editor: Editor, skinUrl: string): Promise<vo
   const isInShadowRoot = SugarShadowDom.isInShadowRoot(SugarElement.fromDom(editor.getElement()));
   if (isInShadowRoot) {
 
-    const shadowDomSkinCss = skinUrl + '/skin.shadowdom.css';
+    const skinResourceIdentifier = Options.getSkinUrlOption(editor).getOr('default');
+
+    const shadowDomSkinCss = 'ui/' + skinResourceIdentifier + '/skin.shadowdom.css';
     const css = tinymce.Resource.get(shadowDomSkinCss);
 
     if (Type.isString(css)) {
@@ -54,9 +56,9 @@ const loadShadowDomUiSkins = async (editor: Editor, skinUrl: string): Promise<vo
 
 const loadUrlSkin = async (isInline: boolean, editor: Editor): Promise<void> => {
   Options.getSkinUrlOption(editor).fold(() => {
-    const skinUrl_ = Options.getSkinUrl(editor);
-    if (skinUrl_) {
-      editor.contentCSS.push(skinUrl_ + (isInline ? '/content.inline' : '/content') + '.min.css');
+    const skinResourceIdentifier = Options.getSkinUrl(editor);
+    if (skinResourceIdentifier) {
+      editor.contentCSS.push(skinResourceIdentifier + (isInline ? '/content.inline' : '/content') + '.min.css');
     }
   }, (skinUrl) => {
     const skinContentCss = 'ui/' + skinUrl + (isInline ? '/content.inline' : '/content') + '.css';
@@ -64,9 +66,9 @@ const loadUrlSkin = async (isInline: boolean, editor: Editor): Promise<void> => 
     if (Type.isString(css)) {
       loadRawCss(editor, skinContentCss, css, editor.ui.styleSheetLoader);
     } else {
-      const skinUrl_ = Options.getSkinUrl(editor);
-      if (skinUrl_) {
-        editor.contentCSS.push(skinUrl_ + (isInline ? '/content.inline' : '/content') + '.min.css');
+      const skinResourceIdentifier = Options.getSkinUrl(editor);
+      if (skinResourceIdentifier) {
+        editor.contentCSS.push(skinResourceIdentifier + (isInline ? '/content.inline' : '/content') + '.min.css');
       }
     }
   });


### PR DESCRIPTION
Related Ticket: TINY-10451

Description of Changes:
* Backport ShadowDOM skin fix from develop to master

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* ~~[X] Docs ticket created (if applicable)~~

GitHub issues (if applicable):