### PR TITLE
TINY-10611: Added missing phrasing content elements

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10611-2024-02-13.yaml
+++ b/.changes/unreleased/tinymce-TINY-10611-2024-02-13.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: Added `data` and `template` to Schema as valid elements.
+time: 2024-02-13T11:30:56.228405+01:00
+custom:
+  Issue: TINY-10611

--- a/modules/tinymce/src/core/main/ts/schema/SchemaElementSets.ts
+++ b/modules/tinymce/src/core/main/ts/schema/SchemaElementSets.ts
@@ -13,7 +13,6 @@ export interface ElementSets<T> {
 //  meta - Only allowed if the `itemprop` attribute is set so very special.
 //  slot - We only want these to be accepted in registered custom components.
 // Extra element in `phrasing`: command keygen
-// TODO: Add missing `data` and `template` logged in: TINY-10611
 //
 // Missing elements in `flow` compared to HTML5 spec at 2034-01-30 (timestamped since the spec is constantly evolving)
 //  search - Can be both in a block and inline position but is not a transparent element. So not supported at this time.
@@ -35,8 +34,8 @@ export const getElementSetsAsStrings = (type: SchemaType): ElementSets<string> =
   if (type !== 'html4') {
     const transparentContent = 'a ins del canvas map';
     blockContent += ' article aside details dialog figure main header footer hgroup section nav ' + transparentContent;
-    phrasingContent += ' audio canvas command datalist mark meter output picture ' +
-      'progress time wbr video ruby bdi keygen svg';
+    phrasingContent += ' audio canvas command data datalist mark meter output picture ' +
+      'progress template time wbr video ruby bdi keygen svg';
   }
 
   // Add HTML4 elements unless it's html5-strict

--- a/modules/tinymce/src/core/main/ts/schema/SchemaLookupTable.ts
+++ b/modules/tinymce/src/core/main/ts/schema/SchemaLookupTable.ts
@@ -124,6 +124,7 @@ export const makeSchema = (type: SchemaType): SchemaLookupTable => {
     add('mark rt rp bdi', '', phrasingContent);
     add('summary', '', [ phrasingContent, 'h1 h2 h3 h4 h5 h6' ].join(' '));
     add('canvas', 'width height', flowContent);
+    add('data', 'value', phrasingContent);
     add('video', 'src crossorigin poster preload autoplay mediagroup loop ' +
       'muted controls width height buffered', [ flowContent, 'track source' ].join(' '));
     add('audio', 'src crossorigin preload autoplay mediagroup loop muted controls ' +
@@ -135,6 +136,7 @@ export const makeSchema = (type: SchemaType): SchemaLookupTable => {
     add('article section nav aside main header footer', '', flowContent);
     add('hgroup', '', 'h1 h2 h3 h4 h5 h6');
     add('figure', '', [ flowContent, 'figcaption' ].join(' '));
+    add('template', 'shadowrootmode', flowContent);
     add('time', 'datetime', phrasingContent);
     add('dialog', 'open', flowContent);
     add('command', 'type label icon disabled checked radiogroup command');

--- a/modules/tinymce/src/core/test/ts/atomic/schema/SchemaElementSetsTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/schema/SchemaElementSetsTest.ts
@@ -52,8 +52,8 @@ describe('atomic.tinymce.core.schema.SchemaElementSetsTest', () => {
         'a', 'abbr', 'b', 'bdo', 'br', 'button', 'cite', 'code', 'del', 'dfn', 'em', 'embed', 'i', 'iframe', 'img',
         'input', 'ins', 'kbd', 'label', 'map', 'noscript', 'object', 'q', 's', 'samp', 'script', 'select', 'small',
         'span', 'strong', 'sub', 'sup', 'textarea', 'u', 'var', '#text', '#comment', 'audio', 'canvas', 'command',
-        'datalist', 'mark', 'meter', 'output', 'picture', 'progress', 'time', 'wbr', 'video', 'ruby', 'bdi', 'keygen',
-        'svg', 'acronym', 'applet', 'basefont', 'big', 'font', 'strike', 'tt'
+        'data', 'datalist', 'mark', 'meter', 'output', 'picture', 'progress', 'template', 'time', 'wbr', 'video',
+        'ruby', 'bdi', 'keygen', 'svg', 'acronym', 'applet', 'basefont', 'big', 'font', 'strike', 'tt'
       ],
       flowContent: [
         'address', 'blockquote', 'div', 'dl', 'fieldset', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'menu',
@@ -61,9 +61,9 @@ describe('atomic.tinymce.core.schema.SchemaElementSetsTest', () => {
         'hgroup', 'section', 'nav', 'a', 'ins', 'del', 'canvas', 'map', 'center', 'dir', 'isindex', 'noframes', 'a',
         'abbr', 'b', 'bdo', 'br', 'button', 'cite', 'code', 'del', 'dfn', 'em', 'embed', 'i', 'iframe', 'img', 'input',
         'ins', 'kbd', 'label', 'map', 'noscript', 'object', 'q', 's', 'samp', 'script', 'select', 'small', 'span', 'strong',
-        'sub', 'sup', 'textarea', 'u', 'var', '#text', '#comment', 'audio', 'canvas', 'command', 'datalist', 'mark',
-        'meter', 'output', 'picture', 'progress', 'time', 'wbr', 'video', 'ruby', 'bdi', 'keygen', 'svg', 'acronym', 'applet',
-        'basefont', 'big', 'font', 'strike', 'tt'
+        'sub', 'sup', 'textarea', 'u', 'var', '#text', '#comment', 'audio', 'canvas', 'command', 'data', 'datalist', 'mark',
+        'meter', 'output', 'picture', 'progress', 'template', 'time', 'wbr', 'video', 'ruby', 'bdi', 'keygen', 'svg', 'acronym',
+        'applet', 'basefont', 'big', 'font', 'strike', 'tt'
       ]
     }
   }));
@@ -80,7 +80,8 @@ describe('atomic.tinymce.core.schema.SchemaElementSetsTest', () => {
         'a', 'abbr', 'b', 'bdo', 'br', 'button', 'cite', 'code', 'del', 'dfn', 'em', 'embed', 'i', 'iframe', 'img',
         'input', 'ins', 'kbd', 'label', 'map', 'noscript', 'object', 'q', 's', 'samp', 'script', 'select', 'small',
         'span', 'strong', 'sub', 'sup', 'textarea', 'u', 'var', '#text', '#comment', 'audio', 'canvas', 'command',
-        'datalist', 'mark', 'meter', 'output', 'picture', 'progress', 'time', 'wbr', 'video', 'ruby', 'bdi', 'keygen', 'svg'
+        'data', 'datalist', 'mark', 'meter', 'output', 'picture', 'progress', 'template', 'time', 'wbr', 'video',
+        'ruby', 'bdi', 'keygen', 'svg'
       ],
       flowContent: [
         'address', 'blockquote', 'div', 'dl', 'fieldset', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'menu',
@@ -88,8 +89,8 @@ describe('atomic.tinymce.core.schema.SchemaElementSetsTest', () => {
         'hgroup', 'section', 'nav', 'a', 'ins', 'del', 'canvas', 'map', 'a', 'abbr', 'b', 'bdo', 'br', 'button', 'cite',
         'code', 'del', 'dfn', 'em', 'embed', 'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'label', 'map', 'noscript',
         'object', 'q', 's', 'samp', 'script', 'select', 'small', 'span', 'strong', 'sub', 'sup', 'textarea', 'u',
-        'var', '#text', '#comment', 'audio', 'canvas', 'command', 'datalist', 'mark', 'meter', 'output', 'picture',
-        'progress', 'time', 'wbr', 'video', 'ruby', 'bdi', 'keygen', 'svg'
+        'var', '#text', '#comment', 'audio', 'canvas', 'command', 'data', 'datalist', 'mark', 'meter', 'output', 'picture',
+        'progress', 'template', 'time', 'wbr', 'video', 'ruby', 'bdi', 'keygen', 'svg'
       ]
     }
   }));


### PR DESCRIPTION
Related Ticket: TINY-10611

Description of Changes:
* Adds `data` and `template` to phrasing element set. This makes the schema more up to date with the current HTML5 spec.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
