### PR TITLE
TINY-9980: Added new custom elements spec

### DIFF
--- a/.changes/unreleased/tinymce-TINY-9980-2024-02-13.yaml
+++ b/.changes/unreleased/tinymce-TINY-9980-2024-02-13.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: More advanced schema config for custom elements.
+time: 2024-02-13T14:09:01.056842+01:00
+custom:
+  Issue: TINY-9980

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -5,7 +5,7 @@ import Editor from './Editor';
 import { PastePostProcessEvent, PastePreProcessEvent } from './EventTypes';
 import { Formats } from './fmt/Format';
 import { AllowedFormat } from './fmt/StyleFormat';
-import { SchemaType } from './html/Schema';
+import { CustomElementSpec, SchemaType } from './html/Schema';
 import { EditorUiApi, Toolbar } from './ui/Ui';
 
 export type EntityEncoding = 'named' | 'numeric' | 'raw' | 'named,numeric' | 'named+numeric' | 'numeric,named' | 'numeric+named';
@@ -89,7 +89,7 @@ interface BaseEditorOptions {
   convert_unsafe_embeds?: boolean;
   convert_urls?: boolean;
   custom_colors?: boolean;
-  custom_elements?: string;
+  custom_elements?: string | Record<string, CustomElementSpec>;
   custom_ui_selector?: string;
   custom_undo_redo_levels?: number;
   default_font_stack?: string[];

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -609,7 +609,7 @@ const register = (editor: Editor): void => {
   });
 
   registerOption('custom_elements', {
-    processor: 'string'
+    processor: stringOrObjectProcessor
   });
 
   registerOption('extended_valid_elements', {

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -203,9 +203,6 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
   };
 
   const addCustomElement = (name: string, spec: CustomElementSpec) => {
-    const parseName = (name: string) =>
-      Optional.from(/(@?)(\w+)/.exec(name)).map((matches) => ({ preset: matches[1] === '@', name: matches[2] }));
-
     // Flush cached items since we are altering the default maps
     delete mapCache.text_block_elements;
     delete mapCache.block_elements;
@@ -257,7 +254,7 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
 
       Arr.each(spec.attributes, (attrName) => {
         const globalAttrs = GlobalAttributesSet.getGlobalAttributeSet(schemaType);
-        parseName(attrName).each(({ preset, name }) => {
+        ValidChildrenRuleParser.parseValidChild(attrName).each(({ preset, name }) => {
           if (preset) {
             if (name === 'global') {
               Arr.each(globalAttrs, processAttrName);
@@ -293,7 +290,7 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
       };
 
       Arr.each(spec.children, (child) => {
-        parseName(child).each(({ preset, name }) => {
+        ValidChildrenRuleParser.parseValidChild(child).each(({ preset, name }) => {
           if (preset) {
             processPreset(name);
           } else {

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -3,7 +3,7 @@ import { Arr, Fun, Obj, Optional, Strings, Type } from '@ephox/katamari';
 import * as CustomElementsRuleParser from '../../schema/CustomElementsRuleParser';
 import * as Presets from '../../schema/Presets';
 import * as SchemaLookupTable from '../../schema/SchemaLookupTable';
-import { ElementSettings, SchemaElement, SchemaMap, SchemaRegExpMap, SchemaSettings, SchemaType } from '../../schema/SchemaTypes';
+import { CustomElementSpec, ElementSettings, SchemaElement, SchemaMap, SchemaRegExpMap, SchemaSettings, SchemaType } from '../../schema/SchemaTypes';
 import * as SchemaUtils from '../../schema/SchemaUtils';
 import * as ValidChildrenRuleParser from '../../schema/ValidChildrenRuleParser';
 import * as ValidElementsRuleParser from '../../schema/ValidElementsRuleParser';
@@ -38,7 +38,7 @@ interface Schema {
   getCustomElements: () => SchemaMap;
   addValidElements: (validElements: string) => void;
   setValidElements: (validElements: string) => void;
-  addCustomElements: (customElements: string) => void;
+  addCustomElements: (customElements: string | Record<string, CustomElementSpec>) => void;
   addValidChildren: (validChildren: any) => void;
 }
 
@@ -201,45 +201,89 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
     addValidElements(validElements);
   };
 
-  // Adds custom non HTML elements to the schema
-  const addCustomElements = (customElements: string | undefined) => {
+  const addCustomElement = (name: string, spec: CustomElementSpec) => {
     // Flush cached items since we are altering the default maps
     delete mapCache.text_block_elements;
     delete mapCache.block_elements;
 
-    Arr.each(CustomElementsRuleParser.parseCustomElementsRules(customElements ?? ''), ({ inline, name, cloneName }) => {
-      children[name] = children[cloneName];
-      customElementsMap[name] = cloneName;
+    const inline = spec.extends ? !isBlock(spec.extends) : false;
+    const cloneName = spec.extends;
 
-      // Treat all custom elements as being non-empty by default
-      nonEmptyElementsMap[name.toUpperCase()] = {};
-      nonEmptyElementsMap[name] = {};
+    children[name] = cloneName ? children[cloneName] : {};
+    customElementsMap[name] = cloneName ?? name;
 
-      // If it's not marked as inline then add it to valid block elements
-      if (!inline) {
-        blockElementsMap[name.toUpperCase()] = {};
-        blockElementsMap[name] = {};
-      }
+    // Treat all custom elements as being non-empty by default
+    nonEmptyElementsMap[name.toUpperCase()] = {};
+    nonEmptyElementsMap[name] = {};
 
-      // Add elements clone if needed
-      if (!elements[name]) {
-        let customRule = elements[cloneName];
+    // If it's not marked as inline then add it to valid block elements
+    if (!inline) {
+      blockElementsMap[name.toUpperCase()] = {};
+      blockElementsMap[name] = {};
+    }
 
-        customRule = extend({}, customRule);
-        delete customRule.removeEmptyAttrs;
-        delete customRule.removeEmpty;
+    // Add elements clone if needed
+    if (cloneName && !elements[name] && elements[cloneName]) {
+      const customRule = SchemaUtils.deepCloneElementRule(elements[cloneName]);
 
-        elements[name] = customRule;
-      }
+      delete customRule.removeEmptyAttrs;
+      delete customRule.removeEmpty;
 
-      // Add custom elements at span/div positions
+      elements[name] = customRule;
+    } else {
+      elements[name] = { attributesOrder: [], attributes: { }};
+    }
+
+    // Add custom attributes
+    if (Type.isString(spec.attributes)) {
+      const customRule = elements[name] ?? {};
+
+      delete customRule.attributesDefault;
+      delete customRule.attributesForced;
+      delete customRule.attributePatterns;
+      delete customRule.attributesRequired;
+
+      customRule.attributesOrder = Arr.filter(spec.attributes, Type.isString);
+      customRule.attributes = Arr.mapToObject(customRule.attributesOrder, (_) => ({}));
+
+      elements[name] = customRule;
+    }
+
+    // Add custom pad empty rule
+    if (Type.isBoolean(spec.padEmpty)) {
+      const customRule = elements[name] ?? {};
+      customRule.paddEmpty = spec.padEmpty;
+      elements[name] = customRule;
+    }
+
+    // Add custom children
+    if (Type.isArray(spec.children)) {
+      children[name] = Arr.mapToObject(spec.children, (_) => ({}));
+    }
+
+    // Add custom elements at extends positions
+    if (cloneName) {
       Obj.each(children, (element, elmName) => {
         if (element[cloneName]) {
           children[elmName] = element = extend({}, children[elmName]);
           element[name] = element[cloneName];
         }
       });
+    }
+  };
+
+  const addCustomElementsFromString = (customElements: string) => {
+    Arr.each(CustomElementsRuleParser.parseCustomElementsRules(customElements ?? ''), ({ name, cloneName }) => {
+      addCustomElement(name, { extends: cloneName });
     });
+  };
+
+  const addCustomElements = (customElements: string | Record<string, CustomElementSpec> | undefined) => {
+    if (Type.isObject(customElements)) {
+      Obj.each(customElements as Record<string, CustomElementSpec>, (spec, name) => addCustomElement(name, spec));
+    } else if (Type.isString(customElements)) {
+      addCustomElementsFromString(customElements);
+    }
   };
 
   // Adds valid children to the schema object
@@ -293,113 +337,115 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
     return undefined;
   };
 
-  if (!settings.valid_elements) {
-    // No valid elements defined then clone the elements from the schema spec
-    each(schemaItems, (element, name) => {
-      elements[name] = {
-        attributes: element.attributes,
-        attributesOrder: element.attributesOrder
-      };
+  const setup = () => {
+    if (!settings.valid_elements) {
+      // No valid elements defined then clone the elements from the schema spec
+      each(schemaItems, (element, name) => {
+        elements[name] = {
+          attributes: element.attributes,
+          attributesOrder: element.attributesOrder
+        };
 
-      children[name] = element.children;
-    });
+        children[name] = element.children;
+      });
 
-    // Prefer strong/em over b/i
-    each(SchemaUtils.split('strong/b em/i'), (item) => {
-      const items = SchemaUtils.split(item, '/');
-      elements[items[1]].outputName = items[0];
-    });
+      // Prefer strong/em over b/i
+      each(SchemaUtils.split('strong/b em/i'), (item) => {
+        const items = SchemaUtils.split(item, '/');
+        elements[items[1]].outputName = items[0];
+      });
 
-    // Add default alt attribute for images, removed since alt="" is treated as presentational.
-    // elements.img.attributesDefault = [{name: 'alt', value: ''}];
+      // Add default alt attribute for images, removed since alt="" is treated as presentational.
+      // elements.img.attributesDefault = [{name: 'alt', value: ''}];
 
-    // By default,
-    // - padd the text inline element if it is empty and also a child of an empty root block
-    // - in all other cases, remove the text inline element if it is empty
-    each(textInlineElementsMap, (_val, name) => {
-      if (elements[name]) {
-        if (settings.padd_empty_block_inline_children) {
-          elements[name].paddInEmptyBlock = true;
+      // By default,
+      // - padd the text inline element if it is empty and also a child of an empty root block
+      // - in all other cases, remove the text inline element if it is empty
+      each(textInlineElementsMap, (_val, name) => {
+        if (elements[name]) {
+          if (settings.padd_empty_block_inline_children) {
+            elements[name].paddInEmptyBlock = true;
+          }
+          elements[name].removeEmpty = true;
         }
-        elements[name].removeEmpty = true;
-      }
-    });
+      });
 
-    // Remove these if they are empty by default
-    each(SchemaUtils.split('ol ul blockquote a table tbody'), (name) => {
-      if (elements[name]) {
-        elements[name].removeEmpty = true;
-      }
-    });
+      // Remove these if they are empty by default
+      each(SchemaUtils.split('ol ul blockquote a table tbody'), (name) => {
+        if (elements[name]) {
+          elements[name].removeEmpty = true;
+        }
+      });
 
-    // Padd these by default
-    each(SchemaUtils.split('p h1 h2 h3 h4 h5 h6 th td pre div address caption li summary'), (name) => {
-      if (elements[name]) {
-        elements[name].paddEmpty = true;
-      }
-    });
+      // Padd these by default
+      each(SchemaUtils.split('p h1 h2 h3 h4 h5 h6 th td pre div address caption li summary'), (name) => {
+        if (elements[name]) {
+          elements[name].paddEmpty = true;
+        }
+      });
 
-    // Remove these if they have no attributes
-    each(SchemaUtils.split('span'), (name) => {
-      elements[name].removeEmptyAttrs = true;
-    });
+      // Remove these if they have no attributes
+      each(SchemaUtils.split('span'), (name) => {
+        elements[name].removeEmptyAttrs = true;
+      });
 
-    // Remove these by default
-    // TODO: Reenable in 4.1
-    /* each(split('script style'), function(name) {
-     delete elements[name];
-     });*/
-  } else {
-    setValidElements(settings.valid_elements);
+      // Remove these by default
+      // TODO: Reenable in 4.1
+      /* each(split('script style'), function(name) {
+       delete elements[name];
+       });*/
+    } else {
+      setValidElements(settings.valid_elements);
 
-    each(schemaItems, (element, name) => {
-      children[name] = element.children;
-    });
-  }
-
-  // Opt in is done with options like `extended_valid_elements`
-  delete elements.svg;
-
-  addCustomElements(settings.custom_elements);
-  addValidChildren(settings.valid_children);
-  addValidElements(settings.extended_valid_elements);
-
-  // Todo: Remove this when we fix list handling to be valid
-  addValidChildren('+ol[ul|ol],+ul[ul|ol]');
-
-  // Some elements are not valid by themselves - require parents
-  each({
-    dd: 'dl',
-    dt: 'dl',
-    li: 'ul ol',
-    td: 'tr',
-    th: 'tr',
-    tr: 'tbody thead tfoot',
-    tbody: 'table',
-    thead: 'table',
-    tfoot: 'table',
-    legend: 'fieldset',
-    area: 'map',
-    param: 'video audio object'
-  }, (parents, item) => {
-    if (elements[item]) {
-      elements[item].parentsRequired = SchemaUtils.split(parents);
+      each(schemaItems, (element, name) => {
+        children[name] = element.children;
+      });
     }
-  });
 
-  // Delete invalid elements
-  if (settings.invalid_elements) {
-    each(explode(settings.invalid_elements), (item) => {
+    // Opt in is done with options like `extended_valid_elements`
+    delete elements.svg;
+
+    addCustomElements(settings.custom_elements);
+    addValidChildren(settings.valid_children);
+    addValidElements(settings.extended_valid_elements);
+
+    // Todo: Remove this when we fix list handling to be valid
+    addValidChildren('+ol[ul|ol],+ul[ul|ol]');
+
+    // Some elements are not valid by themselves - require parents
+    each({
+      dd: 'dl',
+      dt: 'dl',
+      li: 'ul ol',
+      td: 'tr',
+      th: 'tr',
+      tr: 'tbody thead tfoot',
+      tbody: 'table',
+      thead: 'table',
+      tfoot: 'table',
+      legend: 'fieldset',
+      area: 'map',
+      param: 'video audio object'
+    }, (parents, item) => {
       if (elements[item]) {
-        delete elements[item];
+        elements[item].parentsRequired = SchemaUtils.split(parents);
       }
     });
-  }
 
-  // If the user didn't allow span only allow internal spans
-  if (!getElementRule('span')) {
-    addValidElements('span[!data-mce-type|*]');
-  }
+    // Delete invalid elements
+    if (settings.invalid_elements) {
+      each(explode(settings.invalid_elements), (item) => {
+        if (elements[item]) {
+          delete elements[item];
+        }
+      });
+    }
+
+    // If the user didn't allow span only allow internal spans
+    if (!getElementRule('span')) {
+      addValidElements('span[!data-mce-type|*]');
+    }
+  };
 
   /**
    * Name/value map object with valid parents and children to those parents.
@@ -639,6 +685,8 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
    * @method addValidChildren
    * @param {String} valid_children Valid children elements string to parse
    */
+
+  setup();
 
   return {
     type: schemaType,

--- a/modules/tinymce/src/core/main/ts/schema/CustomElementsRuleParser.ts
+++ b/modules/tinymce/src/core/main/ts/schema/CustomElementsRuleParser.ts
@@ -3,7 +3,6 @@ import { Arr } from '@ephox/katamari';
 import * as SchemaUtils from './SchemaUtils';
 
 export interface CustomElementRule {
-  readonly inline: boolean;
   readonly cloneName: 'div' | 'span';
   readonly name: string;
 }
@@ -17,7 +16,7 @@ export const parseCustomElementsRules = (value: string): CustomElementRule[] => 
       const cloneName = inline ? 'span' : 'div';
       const name = matches[2];
 
-      return [{ inline, cloneName, name }];
+      return [{ cloneName, name }];
     } else {
       return [];
     }

--- a/modules/tinymce/src/core/main/ts/schema/SchemaTypes.ts
+++ b/modules/tinymce/src/core/main/ts/schema/SchemaTypes.ts
@@ -15,7 +15,7 @@ export interface ElementSettings {
 }
 
 export interface SchemaSettings extends ElementSettings {
-  custom_elements?: string;
+  custom_elements?: string | Record<string, CustomElementSpec>;
   extended_valid_elements?: string;
   invalid_elements?: string;
   invalid_styles?: string | Record<string, string>;
@@ -69,5 +69,12 @@ export interface SchemaMap {
 
 export interface SchemaRegExpMap {
   [name: string]: RegExp;
+}
+
+export interface CustomElementSpec {
+  extends?: string;
+  attributes?: string[];
+  children?: string[];
+  padEmpty?: boolean;
 }
 

--- a/modules/tinymce/src/core/main/ts/schema/SchemaUtils.ts
+++ b/modules/tinymce/src/core/main/ts/schema/SchemaUtils.ts
@@ -1,4 +1,7 @@
+import { Arr, Obj, Type } from '@ephox/katamari';
+
 import Tools from '../api/util/Tools';
+import { ElementRule } from './SchemaTypes';
 
 export const split = (items: string | undefined, delim?: string): string[] => {
   items = Tools.trim(items);
@@ -7,4 +10,22 @@ export const split = (items: string | undefined, delim?: string): string[] => {
 
 // Converts a wildcard expression string to a regexp for example *a will become /.*a/.
 export const patternToRegExp = (str: string): RegExp => new RegExp('^' + str.replace(/([?+*])/g, '.$1') + '$');
+
+const isRegExp = (obj: any): obj is RegExp => Type.isObject(obj) && obj.source && Object.prototype.toString.call(obj) === '[object RegExp]';
+
+export const deepCloneElementRule = (obj: ElementRule): ElementRule => {
+  const helper = (value: unknown): unknown => {
+    if (Type.isArray(value)) {
+      return Arr.map(value, helper);
+    } else if (isRegExp(value)) {
+      return new RegExp(value.source, value.flags);
+    } else if (Type.isObject(value)) {
+      return Obj.map(value, helper);
+    } else {
+      return value;
+    }
+  };
+
+  return helper(obj) as ElementRule;
+};
 

--- a/modules/tinymce/src/core/main/ts/schema/ValidChildrenRuleParser.ts
+++ b/modules/tinymce/src/core/main/ts/schema/ValidChildrenRuleParser.ts
@@ -1,4 +1,4 @@
-import { Arr, Fun, Optional } from '@ephox/katamari';
+import { Arr, Optional } from '@ephox/katamari';
 
 import * as SchemaUtils from './SchemaUtils';
 

--- a/modules/tinymce/src/core/main/ts/schema/ValidChildrenRuleParser.ts
+++ b/modules/tinymce/src/core/main/ts/schema/ValidChildrenRuleParser.ts
@@ -39,7 +39,7 @@ export const parseValidChildrenRules = (value: string): ValidChildrenRule[] => {
       const operation = prefix ? prefixToOperation(prefix) : 'replace';
       const name = matches[2];
       const validChildren = Arr.bind(SchemaUtils.split(matches[3], '|'), (validChild) =>
-        parseValidChild(validChild).fold(Fun.constant([]), Arr.pure)
+        parseValidChild(validChild).toArray()
       );
 
       return [{ operation, name, validChildren }];

--- a/modules/tinymce/src/core/main/ts/schema/ValidElementsRuleParser.ts
+++ b/modules/tinymce/src/core/main/ts/schema/ValidElementsRuleParser.ts
@@ -1,7 +1,7 @@
 import { Arr, Obj, Optional } from '@ephox/katamari';
 
 import Tools from '../api/util/Tools';
-import { Attribute, AttributePattern, SchemaElement } from './SchemaTypes';
+import { Attribute, AttributePattern, ElementRule, SchemaElement } from './SchemaTypes';
 import * as SchemaUtils from './SchemaUtils';
 
 export interface SchemaElementPair {
@@ -10,7 +10,7 @@ export interface SchemaElementPair {
   readonly aliasName?: string;
 }
 
-const parseValidElementsAttrDataIntoElement = (attrData: string, targetElement: SchemaElement) => {
+const parseValidElementsAttrDataIntoElement = (attrData: string, targetElement: ElementRule) => {
   const attrRuleRegExp = /^([!\-])?(\w+[\\:]:\w+|[^=~<]+)?(?:([=~<])(.*))?$/;
   const hasPatternsRegExp = /[*?+]/;
   const { attributes, attributesOrder } = targetElement;

--- a/modules/tinymce/src/core/test/ts/atomic/schema/CustomElementsRuleParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/schema/CustomElementsRuleParserTest.ts
@@ -19,7 +19,6 @@ describe('atomic.tinymce.core.schema.CustomElementsRuleParserTest', () => {
       input: '~foo',
       expected: [
         {
-          inline: true,
           cloneName: 'span',
           name: 'foo'
         }
@@ -30,7 +29,6 @@ describe('atomic.tinymce.core.schema.CustomElementsRuleParserTest', () => {
       input: 'foo',
       expected: [
         {
-          inline: false,
           cloneName: 'div',
           name: 'foo'
         }
@@ -41,12 +39,10 @@ describe('atomic.tinymce.core.schema.CustomElementsRuleParserTest', () => {
       input: 'foo,~bar',
       expected: [
         {
-          inline: false,
           cloneName: 'div',
           name: 'foo'
         },
         {
-          inline: true,
           cloneName: 'span',
           name: 'bar'
         }

--- a/modules/tinymce/src/core/test/ts/atomic/schema/ValidChildrenRuleParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/schema/ValidChildrenRuleParserTest.ts
@@ -144,6 +144,20 @@ describe('atomic.tinymce.core.schema.ValidChildrenRuleParserTest', () => {
         }
       ]
     }));
+
+    it('Replace children with exotic names', () => testValidChildrenRuleParser({
+      input: 'foo.-bar[bar.-baz]',
+      expected: [
+        {
+          name: 'foo.-bar',
+          operation: 'replace',
+          validChildren: [
+            { preset: false, name: 'bar.-baz' },
+          ]
+        }
+      ]
+    }));
+
   });
 });
 

--- a/modules/tinymce/src/core/test/ts/atomic/schema/ValidChildrenRuleParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/schema/ValidChildrenRuleParserTest.ts
@@ -4,160 +4,172 @@ import { assert } from 'chai';
 import * as ValidChildrenRuleParser from 'tinymce/core/schema/ValidChildrenRuleParser';
 
 describe('atomic.tinymce.core.schema.ValidChildrenRuleParserTest', () => {
-  const testValidChildrenRuleParser = (testCase: { input: string; expected: ValidChildrenRuleParser.ValidChildrenRule[] }) => {
-    const elements = ValidChildrenRuleParser.parseValidChildrenRules(testCase.input);
-    assert.deepEqual(elements, testCase.expected);
-  };
+  context('parseValidChild', () => {
+    const testParseValidChild = (testCase: { input: string; expected: null | { preset: boolean; name: string }}) => {
+      const elements = ValidChildrenRuleParser.parseValidChild(testCase.input).getOrNull();
+      assert.deepEqual(elements, testCase.expected);
+    };
 
-  context('Empty rules', () => {
-    it('Parse empty string', () => testValidChildrenRuleParser({ input: '', expected: [ ] }));
-    it('Parse whitespace string', () => testValidChildrenRuleParser({ input: '   ', expected: [ ] }));
+    it('Simple element name', () => testParseValidChild({ input: 'foo', expected: { preset: false, name: 'foo' }}));
+    it('Preset name', () => testParseValidChild({ input: '@foo', expected: { preset: true, name: 'foo' }}));
+    it('Invalid name', () => testParseValidChild({ input: 'foo@bar', expected: null }));
   });
 
-  context('Inline and block rules', () => {
-    it('Replace children', () => testValidChildrenRuleParser({
-      input: 'foo[bar|baz]',
-      expected: [
-        {
-          name: 'foo',
-          operation: 'replace',
-          validChildren: [
-            { preset: false, name: 'bar' },
-            { preset: false, name: 'baz' }
-          ]
-        }
-      ]
-    }));
+  context('parseValidChildrenRules', () => {
+    const testValidChildrenRuleParser = (testCase: { input: string; expected: ValidChildrenRuleParser.ValidChildrenRule[] }) => {
+      const elements = ValidChildrenRuleParser.parseValidChildrenRules(testCase.input);
+      assert.deepEqual(elements, testCase.expected);
+    };
 
-    it('Replace children in multiple parents', () => testValidChildrenRuleParser({
-      input: 'foo1[bar],foo2[baz]',
-      expected: [
-        {
-          name: 'foo1',
-          operation: 'replace',
-          validChildren: [
-            { preset: false, name: 'bar' }
-          ]
-        },
-        {
-          name: 'foo2',
-          operation: 'replace',
-          validChildren: [
-            { preset: false, name: 'baz' }
-          ]
-        }
-      ]
-    }));
+    context('Empty rules', () => {
+      it('Parse empty string', () => testValidChildrenRuleParser({ input: '', expected: [ ] }));
+      it('Parse whitespace string', () => testValidChildrenRuleParser({ input: '   ', expected: [ ] }));
+    });
 
-    it('Add children', () => testValidChildrenRuleParser({
-      input: '+foo[bar|baz]',
-      expected: [
-        {
-          name: 'foo',
-          operation: 'add',
-          validChildren: [
-            { preset: false, name: 'bar' },
-            { preset: false, name: 'baz' }
-          ]
-        }
-      ]
-    }));
+    context('Inline and block rules', () => {
+      it('Replace children', () => testValidChildrenRuleParser({
+        input: 'foo[bar|baz]',
+        expected: [
+          {
+            name: 'foo',
+            operation: 'replace',
+            validChildren: [
+              { preset: false, name: 'bar' },
+              { preset: false, name: 'baz' }
+            ]
+          }
+        ]
+      }));
 
-    it('Add children to multiple parents', () => testValidChildrenRuleParser({
-      input: '+foo1[bar],+foo2[baz]',
-      expected: [
-        {
-          name: 'foo1',
-          operation: 'add',
-          validChildren: [
-            { preset: false, name: 'bar' }
-          ]
-        },
-        {
-          name: 'foo2',
-          operation: 'add',
-          validChildren: [
-            { preset: false, name: 'baz' }
-          ]
-        }
-      ]
-    }));
+      it('Replace children in multiple parents', () => testValidChildrenRuleParser({
+        input: 'foo1[bar],foo2[baz]',
+        expected: [
+          {
+            name: 'foo1',
+            operation: 'replace',
+            validChildren: [
+              { preset: false, name: 'bar' }
+            ]
+          },
+          {
+            name: 'foo2',
+            operation: 'replace',
+            validChildren: [
+              { preset: false, name: 'baz' }
+            ]
+          }
+        ]
+      }));
 
-    it('Add children presets', () => testValidChildrenRuleParser({
-      input: '+foo[@bar|@baz]',
-      expected: [
-        {
-          name: 'foo',
-          operation: 'add',
-          validChildren: [
-            { preset: true, name: 'bar' },
-            { preset: true, name: 'baz' }
-          ]
-        }
-      ]
-    }));
+      it('Add children', () => testValidChildrenRuleParser({
+        input: '+foo[bar|baz]',
+        expected: [
+          {
+            name: 'foo',
+            operation: 'add',
+            validChildren: [
+              { preset: false, name: 'bar' },
+              { preset: false, name: 'baz' }
+            ]
+          }
+        ]
+      }));
 
-    it('Remove children', () => testValidChildrenRuleParser({
-      input: '-foo[bar|baz]',
-      expected: [
-        {
-          name: 'foo',
-          operation: 'remove',
-          validChildren: [
-            { preset: false, name: 'bar' },
-            { preset: false, name: 'baz' }
-          ]
-        }
-      ]
-    }));
+      it('Add children to multiple parents', () => testValidChildrenRuleParser({
+        input: '+foo1[bar],+foo2[baz]',
+        expected: [
+          {
+            name: 'foo1',
+            operation: 'add',
+            validChildren: [
+              { preset: false, name: 'bar' }
+            ]
+          },
+          {
+            name: 'foo2',
+            operation: 'add',
+            validChildren: [
+              { preset: false, name: 'baz' }
+            ]
+          }
+        ]
+      }));
 
-    it('Remove children from multiple parents', () => testValidChildrenRuleParser({
-      input: '-foo1[bar],-foo2[baz]',
-      expected: [
-        {
-          name: 'foo1',
-          operation: 'remove',
-          validChildren: [
-            { preset: false, name: 'bar' }
-          ]
-        },
-        {
-          name: 'foo2',
-          operation: 'remove',
-          validChildren: [
-            { preset: false, name: 'baz' }
-          ]
-        }
-      ]
-    }));
+      it('Add children presets', () => testValidChildrenRuleParser({
+        input: '+foo[@bar|@baz]',
+        expected: [
+          {
+            name: 'foo',
+            operation: 'add',
+            validChildren: [
+              { preset: true, name: 'bar' },
+              { preset: true, name: 'baz' }
+            ]
+          }
+        ]
+      }));
 
-    it('Remove children presets', () => testValidChildrenRuleParser({
-      input: '-foo[@bar|@baz]',
-      expected: [
-        {
-          name: 'foo',
-          operation: 'remove',
-          validChildren: [
-            { preset: true, name: 'bar' },
-            { preset: true, name: 'baz' }
-          ]
-        }
-      ]
-    }));
+      it('Remove children', () => testValidChildrenRuleParser({
+        input: '-foo[bar|baz]',
+        expected: [
+          {
+            name: 'foo',
+            operation: 'remove',
+            validChildren: [
+              { preset: false, name: 'bar' },
+              { preset: false, name: 'baz' }
+            ]
+          }
+        ]
+      }));
 
-    it('Replace children with exotic names', () => testValidChildrenRuleParser({
-      input: 'foo.-bar[bar.-baz]',
-      expected: [
-        {
-          name: 'foo.-bar',
-          operation: 'replace',
-          validChildren: [
-            { preset: false, name: 'bar.-baz' },
-          ]
-        }
-      ]
-    }));
+      it('Remove children from multiple parents', () => testValidChildrenRuleParser({
+        input: '-foo1[bar],-foo2[baz]',
+        expected: [
+          {
+            name: 'foo1',
+            operation: 'remove',
+            validChildren: [
+              { preset: false, name: 'bar' }
+            ]
+          },
+          {
+            name: 'foo2',
+            operation: 'remove',
+            validChildren: [
+              { preset: false, name: 'baz' }
+            ]
+          }
+        ]
+      }));
 
+      it('Remove children presets', () => testValidChildrenRuleParser({
+        input: '-foo[@bar|@baz]',
+        expected: [
+          {
+            name: 'foo',
+            operation: 'remove',
+            validChildren: [
+              { preset: true, name: 'bar' },
+              { preset: true, name: 'baz' }
+            ]
+          }
+        ]
+      }));
+
+      it('Replace children with exotic names', () => testValidChildrenRuleParser({
+        input: 'foo.-bar[bar.-baz]',
+        expected: [
+          {
+            name: 'foo.-bar',
+            operation: 'replace',
+            validChildren: [
+              { preset: false, name: 'bar.-baz' },
+            ]
+          }
+        ]
+      }));
+    });
   });
 });
 

--- a/modules/tinymce/src/core/test/ts/browser/content/CustomElementsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/CustomElementsTest.ts
@@ -1,0 +1,39 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.content.CustomElementsTest', () => {
+  context('Custom elements using spec', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      custom_elements: {
+        foo: {
+          extends: 'div'
+        },
+        bar: {
+          extends: 'span'
+        }
+      },
+    }, []);
+
+    it('TINY-9880: Custom elements that is treated as span/div', () => {
+      const editor = hook.editor();
+      editor.setContent('<foo>hello<em>world</em><bar>!!</bar>');
+      TinyAssertions.assertContent(editor, '<foo>hello<em>world</em><bar>!!</bar></foo>');
+    });
+  });
+
+  context('Custom elements using names', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      custom_elements: 'foo,~bar'
+    }, []);
+
+    it('TINY-9880: Custom elements that is treated as span/div', () => {
+      const editor = hook.editor();
+      editor.setContent('<foo>hello<em>world</em><bar>!!</bar>');
+      TinyAssertions.assertContent(editor, '<foo>hello<em>world</em><bar>!!</bar></foo>');
+    });
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -367,6 +367,14 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
     assert.isFalse(schema.isValidChild('body', 'p'));
   });
 
+  it('addValidChildren with exotic names', () => {
+    const schema = Schema();
+
+    assert.isFalse(schema.isValidChild('foo.-bar', 'bar.-baz'));
+    schema.addValidChildren('foo.-bar[bar.-baz]');
+    assert.isTrue(schema.isValidChild('foo.-bar', 'bar.-baz'));
+  });
+
   it('addValidChildren replace should remove all children except the specified ones', () => {
     const schema = Schema();
 
@@ -827,6 +835,16 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
 
       assert.isTrue(schema.isBlock('foo'));
       assert.isTrue(schema.isInline('bar'));
+    });
+
+    it('TINY-9980: Add custom elements with exotic names', () => {
+      const schema = Schema({});
+      schema.addCustomElements({
+        'foo.-bar': { extends: 'div', children: [ 'bar.-baz' ] }
+      });
+
+      assert.isTrue(schema.isValid('foo.-bar'));
+      assert.isTrue(schema.isValidChild('foo.-bar', 'bar.-baz'));
     });
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -817,6 +817,17 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
         }
       });
     });
+
+    it('TINY-9980: Add custom elements that extends the block/inline state type', () => {
+      const schema = Schema({});
+      schema.addCustomElements({
+        foo: { extends: 'div' },
+        bar: { extends: 'span' }
+      });
+
+      assert.isTrue(schema.isBlock('foo'));
+      assert.isTrue(schema.isInline('bar'));
+    });
   });
 
   context('custom_elements with spec record', () => {

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -710,4 +710,149 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
       assert.isTrue(rules.length > 0 && Arr.forall(rules, (rule) => rule.paddInEmptyBlock === true));
     });
   });
+
+  context('addCustomElements with spec', () => {
+    it('TINY-9980: Add custom element by name only', () => {
+      const schema = Schema({});
+      schema.addCustomElements({
+        foo: {},
+        bar: {}
+      });
+
+      assert.isTrue(schema.isValid('foo'));
+      assert.isTrue(schema.isValid('bar'));
+      assert.deepEqual(schema.getElementRule('foo'), { attributes: {}, attributesOrder: [] });
+      assert.deepEqual(schema.getElementRule('bar'), { attributes: {}, attributesOrder: [] });
+      assert.isFalse(schema.isValidChild('div', 'foo'));
+      assert.isFalse(schema.isValidChild('span', 'foo'));
+      assert.isFalse(schema.isValidChild('div', 'bar'));
+      assert.isFalse(schema.isValidChild('span', 'bar'));
+      assert.isFalse(schema.isValidChild('foo', 'div'));
+      assert.isFalse(schema.isValidChild('foo', 'span'));
+      assert.isFalse(schema.isValidChild('bar', 'div'));
+      assert.isFalse(schema.isValidChild('bar', 'span'));
+    });
+
+    it('TINY-9980: Add custom element with custom attributes', () => {
+      const schema = Schema({});
+      schema.addCustomElements({
+        foo: { attributes: [ 'a', 'b' ] }
+      });
+
+      assert.deepEqual(schema.getElementRule('foo'), { attributes: { a: {}, b: {}}, attributesOrder: [ 'a', 'b' ] });
+    });
+
+    it('TINY-9980: Add custom element with padEmpty', () => {
+      const schema = Schema({});
+      schema.addCustomElements({
+        foo: { padEmpty: true }
+      });
+
+      assert.deepEqual(schema.getElementRule('foo'), { attributes: {}, attributesOrder: [], paddEmpty: true });
+    });
+
+    it('TINY-9980: Add custom element with custom children', () => {
+      const schema = Schema({});
+      schema.addCustomElements({
+        foo: { children: [ 'span', 'div' ] }
+      });
+
+      assert.isTrue(schema.isValidChild('foo', 'span'));
+      assert.isTrue(schema.isValidChild('foo', 'div'));
+      assert.isFalse(schema.isValidChild('foo', 'strong'));
+      assert.isFalse(schema.isValidChild('foo', 'h1'));
+    });
+
+    it('TINY-9980: Add custom element that extends div', () => {
+      const schema = Schema({});
+      schema.addCustomElements({
+        foo: { extends: 'div' }
+      });
+
+      assert.isTrue(schema.isValidChild('div', 'foo'), 'Foo should be accepted where div is accepted');
+      assert.deepEqual(schema.getElementRule('foo'), schema.getElementRule('div'), 'foo should have all the rules that div have');
+      assert.isTrue(schema.isValidChild('foo', 'span'), 'foo should be able to contain the same children as div');
+      assert.isTrue(schema.isValidChild('foo', 'div'), 'foo should be able to contain the same children as div');
+    });
+
+    it('TINY-9980: Add custom element that extends div but overrides attributes and children', () => {
+      const schema = Schema({});
+      schema.addCustomElements({
+        foo: { extends: 'div', attributes: [ 'a', 'b' ], children: [ 'span', 'div' ] }
+      });
+
+      assert.deepEqual(schema.getElementRule('foo'), { attributes: { a: {}, b: {}}, attributesOrder: [ 'a', 'b' ], paddEmpty: true });
+      assert.isTrue(schema.isValidChild('foo', 'span'));
+      assert.isTrue(schema.isValidChild('foo', 'div'));
+      assert.isFalse(schema.isValidChild('foo', 'strong'));
+      assert.isFalse(schema.isValidChild('foo', 'h1'));
+    });
+
+    it('TINY-9980: Add custom element with preset children', () => {
+      const schema = Schema({});
+      schema.addCustomElements({
+        foo: { children: [ 'div', '@phrasing' ] }
+      });
+
+      assert.isTrue(schema.isValidChild('foo', 'span'));
+      assert.isTrue(schema.isValidChild('foo', 'div'));
+      assert.isFalse(schema.isValidChild('foo', 'h1'));
+    });
+
+    it('TINY-9980: Add custom element with preset attributes', () => {
+      const schema = Schema({});
+      schema.addCustomElements({
+        foo: { attributes: [ '@global', 'bar' ] }
+      });
+
+      assert.deepEqual(schema.getElementRule('foo'), {
+        attributesOrder: [
+          'id', 'accesskey', 'class', 'dir', 'lang', 'style', 'tabindex', 'title', 'role', 'contenteditable', 'contextmenu', 'draggable',
+          'dropzone', 'hidden', 'spellcheck', 'translate', 'xml:lang', 'bar'
+        ],
+        attributes: {
+          'id': {}, 'accesskey': {}, 'class': {}, 'dir': {}, 'lang': {}, 'style': {}, 'tabindex': {}, 'title': {}, 'role': {},
+          'contenteditable': {}, 'contextmenu': {}, 'draggable': {}, 'dropzone': {}, 'hidden': {},
+          'spellcheck': {}, 'translate': {}, 'xml:lang': {}, 'bar': {}
+        }
+      });
+    });
+  });
+
+  context('custom_elements with spec record', () => {
+    it('TINY-9980: Add custom elements', () => {
+      const schema = Schema({
+        custom_elements: {
+          foo: { extends: 'div' },
+          bar: { extends: 'span' }
+        }
+      });
+
+      assert.isTrue(schema.isValidChild('div', 'foo'));
+      assert.isTrue(schema.isValidChild('h1', 'bar'));
+    });
+
+    it('TINY-9980: Add custom elements with extended_valid_elements', () => {
+      const schema = Schema({
+        custom_elements: {
+          foo: { extends: 'div' }
+        },
+        extended_valid_elements: 'foo[a|b]'
+      });
+
+      assert.deepEqual(schema.getElementRule('foo'), { attributes: { a: {}, b: {}}, attributesOrder: [ 'a', 'b' ] });
+    });
+
+    it('TINY-9980: Add custom elements with valid_children', () => {
+      const schema = Schema({
+        custom_elements: {
+          foo: { extends: 'div' }
+        },
+        valid_children: 'foo[span]'
+      });
+
+      assert.isTrue(schema.isValidChild('foo', 'span'));
+      assert.isFalse(schema.isValidChild('foo', 'strong'));
+    });
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-9980

Description of Changes:
* Adds a more powerful custom elements spec to the `custom_elements` option and `addCustomElements` API
* Wraps the setup of the schema into a function that gets invoked so that all the functions are defined before that is executed.
* Changes the custom_elements parser slightly so that it doesn't use the inline property instead it bases the block/inline rules based on what it extends so it if it extends a div then it's a block if it extends a span then it's an inline.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
