### PR TITLE
TINY-10646: Make all notifications have a close button by default

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10646-2024-02-14.yaml
+++ b/.changes/unreleased/tinymce-TINY-10646-2024-02-14.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Removed
+body: Removed `closeButton` from `NotificationSpec`, close button in notification
+  is now rendered by default.
+time: 2024-02-14T10:20:38.864209+08:00
+custom:
+  Issue: TINY-10646

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -19,7 +19,6 @@ export interface NotificationSpec {
   icon?: string;
   progressBar?: boolean;
   timeout?: number;
-  closeButton?: boolean;
 }
 
 export interface NotificationApi {

--- a/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
@@ -210,7 +210,6 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
           icon: 'warning',
           progressBar: true,
           timeout: 10,
-          closeButton: true
         };
         const notifications = editor.notificationManager.getNotifications();
 
@@ -225,7 +224,6 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
           event.notification.icon = 'user';
           event.notification.progressBar = false;
           event.notification.timeout = 5;
-          event.notification.closeButton = false;
         });
 
         editor.notificationManager.open(testMsg);
@@ -239,7 +237,6 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
         assert.equal(modified.icon, 'user', 'Should have modified icon');
         assert.isFalse(modified.progressBar, 'Should have modified progressBar');
         assert.equal(modified.timeout, 5, 'Should have modified timeout');
-        assert.isFalse(modified.closeButton, 'Should have modified closeButton');
       });
 
       it('TBA: Should not open notification if editor is removed', () => {

--- a/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
@@ -47,7 +47,6 @@ export default (editor: Editor, extras: Extras, uiMothership: Gui.GuiSystem): No
         level: Arr.contains([ 'success', 'error', 'warning', 'warn', 'info' ], settings.type) ? settings.type : undefined,
         progress: settings.progressBar === true,
         icon: settings.icon,
-        closeButton: settings.closeButton,
         onAction: close,
         iconProvider: sharedBackstage.providers.icons,
         translationProvider: sharedBackstage.providers.translate

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Notification.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Notification.ts
@@ -20,7 +20,6 @@ export interface NotificationSketchSpec extends Sketcher.SingleSketchSpec {
   readonly text: string;
   readonly level?: 'info' | 'warn' | 'warning' | 'error' | 'success';
   readonly icon?: string;
-  readonly closeButton?: boolean;
   readonly progress: boolean;
   readonly onAction: Function;
   readonly iconProvider: Icons.IconProvider;
@@ -32,7 +31,6 @@ export interface NotificationSketchDetail extends Sketcher.SingleSketchDetail {
   readonly text: string;
   readonly level: Optional<'info' | 'warn' | 'warning' | 'error' | 'success'>;
   readonly icon: Optional<string>;
-  readonly closeButton: boolean;
   readonly onAction: Function;
   readonly progress: boolean;
   readonly iconProvider: Icons.IconProvider;
@@ -196,7 +194,7 @@ const factory: UiSketcher.SingleSketchFactory<NotificationSketchDetail, Notifica
     ]),
     components: components
       .concat(detail.progress ? [ memBannerProgress.asSpec() ] : [])
-      .concat(!detail.closeButton ? [] : [ memButton.asSpec() ]),
+      .concat([ memButton.asSpec() ]),
     apis
   };
 };
@@ -212,7 +210,6 @@ export const Notification: NotificationSketcher = Sketcher.single({
     FieldSchema.required('text'),
     FieldSchema.required('iconProvider'),
     FieldSchema.required('translationProvider'),
-    FieldSchema.defaultedBoolean('closeButton', true)
   ],
   apis: {
     updateProgress: (apis: NotificationSketchApis, comp: AlloyComponent, percent: number) => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberFocusTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberFocusTest.ts
@@ -174,7 +174,6 @@ describe.skip('browser.tinymce.themes.silver.throbber.ThrobberFocusTest', () => 
 
       const notification = editor.notificationManager.open({
         text: 'Test',
-        closeButton: true
       });
       const popup = await TinyUiActions.pWaitForPopup(editor, 'div.tox-notification') as SugarElement<HTMLElement>;
       Focus.focus(popup);


### PR DESCRIPTION
Related Ticket: TINY-10646

Description of Changes:
* Make all notifications standardized to have a close button by default
* Remove `closeButton` property in NotificationSpec

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
