### PR TITLE
TINY-10560: fix newline after using `selection.setContent` with a `<pre>`

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10560-2024-02-15.yaml
+++ b/.changes/unreleased/tinymce-TINY-10560-2024-02-15.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Adding newline after using `selection.setContent` with a `<pre>` caused a crash
+body: Adding newline after using `selection.setContent` to insert a block element would throw an unhandled exception.
 time: 2024-02-15T11:41:14.948838122+01:00
 custom:
   Issue: TINY-10560

--- a/.changes/unreleased/tinymce-TINY-10560-2024-02-15.yaml
+++ b/.changes/unreleased/tinymce-TINY-10560-2024-02-15.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Adding newline after using `selection.setContent` with a `<pre>` caused a crash
+time: 2024-02-15T11:41:14.948838122+01:00
+custom:
+  Issue: TINY-10560

--- a/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
@@ -228,7 +228,7 @@ const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>): void => {
     }
 
     // If after the last element in block node edge case for #5091
-    if (container.parentNode === parentBlock && isAfterLastNodeInContainer && !start) {
+    if ((container.parentNode === parentBlock || container === parentBlock) && isAfterLastNodeInContainer && !start) {
       return true;
     }
 

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -836,4 +836,15 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
     TinyAssertions.assertContent(editor, '<blockquote><p>A</p></blockquote><p>&nbsp;</p>');
     TinyAssertions.assertCursor(editor, [ 1, 0, 0, 0 ], 0);
   });
+
+  it('TINY-10560: Press Enter after a `selection.setContent` should create a new line and not throw errors', () => {
+    const editor = hook.editor();
+    editor.setContent('abc');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
+
+    editor.selection.setContent('<pre><code>hello</code></pre>');
+    TinyAssertions.assertContent(editor, '<p>&nbsp;</p><pre><code>hello</code></pre><p>&nbsp;</p>');
+    insertNewline(editor, { });
+    TinyAssertions.assertContent(editor, '<p>&nbsp;</p><pre><code>hello</code></pre><p>&nbsp;</p><p>&nbsp;</p>');
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -3,6 +3,7 @@ import { after, before, context, describe, it } from '@ephox/bedrock-client';
 import { Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
@@ -844,7 +845,9 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
 
     editor.selection.setContent('<pre><code>hello</code></pre>');
     TinyAssertions.assertContent(editor, '<p>&nbsp;</p><pre><code>hello</code></pre><p>&nbsp;</p>');
-    insertNewline(editor, { });
+    assert.doesNotThrow(() => {
+      insertNewline(editor, { });
+    });
     TinyAssertions.assertContent(editor, '<p>&nbsp;</p><pre><code>hello</code></pre><p>&nbsp;</p><p>&nbsp;</p>');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, Cursors } from '@ephox/agar';
 import { after, before, context, describe, it } from '@ephox/bedrock-client';
-import { Type } from '@ephox/katamari';
+import { Arr, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
@@ -840,14 +840,14 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
 
   it('TINY-10560: Press Enter after a `selection.setContent` should create a new line and not throw errors', () => {
     const editor = hook.editor();
-    editor.setContent('abc');
-    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
+    Arr.each([ 'pre', 'h1', 'div', 'p' ], (tagName) => {
+      editor.setContent('abc');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
 
-    editor.selection.setContent('<pre>hello</pre>');
-    TinyAssertions.assertContent(editor, '<p>&nbsp;</p><pre>hello</pre><p>&nbsp;</p>');
-    assert.doesNotThrow(() => {
-      insertNewline(editor, { });
+      editor.selection.setContent(`<${tagName}>hello</${tagName}>`);
+      assert.doesNotThrow(() => {
+        insertNewline(editor, { });
+      });
     });
-    TinyAssertions.assertContent(editor, '<p>&nbsp;</p><pre>hello</pre><p>&nbsp;</p><p>&nbsp;</p>');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -843,11 +843,11 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
     editor.setContent('abc');
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
 
-    editor.selection.setContent('<pre><code>hello</code></pre>');
-    TinyAssertions.assertContent(editor, '<p>&nbsp;</p><pre><code>hello</code></pre><p>&nbsp;</p>');
+    editor.selection.setContent('<pre>hello</pre>');
+    TinyAssertions.assertContent(editor, '<p>&nbsp;</p><pre>hello</pre><p>&nbsp;</p>');
     assert.doesNotThrow(() => {
       insertNewline(editor, { });
     });
-    TinyAssertions.assertContent(editor, '<p>&nbsp;</p><pre><code>hello</code></pre><p>&nbsp;</p><p>&nbsp;</p>');
+    TinyAssertions.assertContent(editor, '<p>&nbsp;</p><pre>hello</pre><p>&nbsp;</p><p>&nbsp;</p>');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10560

Description of Changes:
using `editor.selection.setContent('<pre><code>hello</code></pre>')` and then press enter, the problem was that we have this [newBlock](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts#L410) undefined.

even though if we are at the end of line [this check](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts#L396) returns false.

This is cuased by the fact that [this check](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts#L231) doesn't pass because the `container.parentNode` and the `parentBlock` are differend in particular `container.parentNode` is the body and the `parentBlock` is the `<pre>`.

That is the result of this [range normalization](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts#L304) behave different for the [pre](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/core/main/ts/selection/NormalizeRange.ts#L203).

Since that normalizzation seems to be intented to work in that way my idea was to modify the comparison of the [container.parentNode === parentBlock](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts#L231) putting it in `or` with `container === parentBlock`



Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
