### PR TITLE
TINY-10611: Removed template from supported elements

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10611-2024-02-13.yaml
+++ b/.changes/unreleased/tinymce-TINY-10611-2024-02-13.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Added
-body: Added `data` and `template` to Schema as valid elements.
+body: Added `data` to Schema as a valid element.
 time: 2024-02-13T11:30:56.228405+01:00
 custom:
   Issue: TINY-10611

--- a/modules/tinymce/src/core/main/ts/schema/SchemaElementSets.ts
+++ b/modules/tinymce/src/core/main/ts/schema/SchemaElementSets.ts
@@ -12,6 +12,7 @@ export interface ElementSets<T> {
 //  math - currently not supported.
 //  meta - Only allowed if the `itemprop` attribute is set so very special.
 //  slot - We only want these to be accepted in registered custom components.
+//  template - Not supported since the HTML inside it is stored in a `content` property fragment so needs special treatment.
 // Extra element in `phrasing`: command keygen
 //
 // Missing elements in `flow` compared to HTML5 spec at 2034-01-30 (timestamped since the spec is constantly evolving)
@@ -35,7 +36,7 @@ export const getElementSetsAsStrings = (type: SchemaType): ElementSets<string> =
     const transparentContent = 'a ins del canvas map';
     blockContent += ' article aside details dialog figure main header footer hgroup section nav ' + transparentContent;
     phrasingContent += ' audio canvas command data datalist mark meter output picture ' +
-      'progress template time wbr video ruby bdi keygen svg';
+      'progress time wbr video ruby bdi keygen svg';
   }
 
   // Add HTML4 elements unless it's html5-strict

--- a/modules/tinymce/src/core/main/ts/schema/SchemaLookupTable.ts
+++ b/modules/tinymce/src/core/main/ts/schema/SchemaLookupTable.ts
@@ -136,7 +136,6 @@ export const makeSchema = (type: SchemaType): SchemaLookupTable => {
     add('article section nav aside main header footer', '', flowContent);
     add('hgroup', '', 'h1 h2 h3 h4 h5 h6');
     add('figure', '', [ flowContent, 'figcaption' ].join(' '));
-    add('template', 'shadowrootmode', flowContent);
     add('time', 'datetime', phrasingContent);
     add('dialog', 'open', flowContent);
     add('command', 'type label icon disabled checked radiogroup command');

--- a/modules/tinymce/src/core/test/ts/atomic/schema/SchemaElementSetsTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/schema/SchemaElementSetsTest.ts
@@ -52,7 +52,7 @@ describe('atomic.tinymce.core.schema.SchemaElementSetsTest', () => {
         'a', 'abbr', 'b', 'bdo', 'br', 'button', 'cite', 'code', 'del', 'dfn', 'em', 'embed', 'i', 'iframe', 'img',
         'input', 'ins', 'kbd', 'label', 'map', 'noscript', 'object', 'q', 's', 'samp', 'script', 'select', 'small',
         'span', 'strong', 'sub', 'sup', 'textarea', 'u', 'var', '#text', '#comment', 'audio', 'canvas', 'command',
-        'data', 'datalist', 'mark', 'meter', 'output', 'picture', 'progress', 'template', 'time', 'wbr', 'video',
+        'data', 'datalist', 'mark', 'meter', 'output', 'picture', 'progress', 'time', 'wbr', 'video',
         'ruby', 'bdi', 'keygen', 'svg', 'acronym', 'applet', 'basefont', 'big', 'font', 'strike', 'tt'
       ],
       flowContent: [
@@ -62,7 +62,7 @@ describe('atomic.tinymce.core.schema.SchemaElementSetsTest', () => {
         'abbr', 'b', 'bdo', 'br', 'button', 'cite', 'code', 'del', 'dfn', 'em', 'embed', 'i', 'iframe', 'img', 'input',
         'ins', 'kbd', 'label', 'map', 'noscript', 'object', 'q', 's', 'samp', 'script', 'select', 'small', 'span', 'strong',
         'sub', 'sup', 'textarea', 'u', 'var', '#text', '#comment', 'audio', 'canvas', 'command', 'data', 'datalist', 'mark',
-        'meter', 'output', 'picture', 'progress', 'template', 'time', 'wbr', 'video', 'ruby', 'bdi', 'keygen', 'svg', 'acronym',
+        'meter', 'output', 'picture', 'progress', 'time', 'wbr', 'video', 'ruby', 'bdi', 'keygen', 'svg', 'acronym',
         'applet', 'basefont', 'big', 'font', 'strike', 'tt'
       ]
     }
@@ -80,7 +80,7 @@ describe('atomic.tinymce.core.schema.SchemaElementSetsTest', () => {
         'a', 'abbr', 'b', 'bdo', 'br', 'button', 'cite', 'code', 'del', 'dfn', 'em', 'embed', 'i', 'iframe', 'img',
         'input', 'ins', 'kbd', 'label', 'map', 'noscript', 'object', 'q', 's', 'samp', 'script', 'select', 'small',
         'span', 'strong', 'sub', 'sup', 'textarea', 'u', 'var', '#text', '#comment', 'audio', 'canvas', 'command',
-        'data', 'datalist', 'mark', 'meter', 'output', 'picture', 'progress', 'template', 'time', 'wbr', 'video',
+        'data', 'datalist', 'mark', 'meter', 'output', 'picture', 'progress', 'time', 'wbr', 'video',
         'ruby', 'bdi', 'keygen', 'svg'
       ],
       flowContent: [
@@ -90,7 +90,7 @@ describe('atomic.tinymce.core.schema.SchemaElementSetsTest', () => {
         'code', 'del', 'dfn', 'em', 'embed', 'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'label', 'map', 'noscript',
         'object', 'q', 's', 'samp', 'script', 'select', 'small', 'span', 'strong', 'sub', 'sup', 'textarea', 'u',
         'var', '#text', '#comment', 'audio', 'canvas', 'command', 'data', 'datalist', 'mark', 'meter', 'output', 'picture',
-        'progress', 'template', 'time', 'wbr', 'video', 'ruby', 'bdi', 'keygen', 'svg'
+        'progress', 'time', 'wbr', 'video', 'ruby', 'bdi', 'keygen', 'svg'
       ]
     }
   }));


### PR DESCRIPTION
Related Ticket: TINY-10611

Description of Changes:
* Made a mistake of adding the `template` element in the previous PR didn't test it enough it more complex than I thought and the ticket is more about aligning more with the HTML5 spec we do already deviate some. So I will reduce the scope to only include the `data` element since `template` will require some additional work in the parser to retain it's inner contents.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
