### PR TITLE
TINY-10616: Add tooltip styles

### DIFF
--- a/modules/oxide/src/less/theme/components/tooltip/tooltip.less
+++ b/modules/oxide/src/less/theme/components/tooltip/tooltip.less
@@ -13,10 +13,12 @@
 @tooltip-padding-y: @pad-xs;
 @tooltip-text-color: @color-white;
 @tooltip-text-transform: none;
+@tooltip-max-width: 15em;
 
 .tox {
   .tox-tooltip {
     display: inline-block;
+    max-width: @tooltip-max-width;
     padding: @tooltip-arrow-size;
 
     /*
@@ -38,6 +40,7 @@
     font-size: @tooltip-font-size;
     font-style: @tooltip-font-style;
     font-weight: @tooltip-font-weight;
+    overflow-wrap: break-word;
     padding: @tooltip-padding-y @tooltip-padding-x;
     text-transform: @tooltip-text-transform;
   }


### PR DESCRIPTION
Related Ticket: TINY-10616

Description of Changes:
* Add tooltip styles, mainly setting the max width and `overflow-wrap: break-word` to limit the width and ensure consistencies of tooltip. 

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
