### PR TITLE
TINY-10617: Update table cell and row dialogs for table row height changes

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10617-2024-02-18.yaml
+++ b/.changes/unreleased/tinymce-TINY-10617-2024-02-18.yaml
@@ -1,7 +1,6 @@
 project: tinymce
 kind: Changed
-body: Remove height field from `table` plugin cell dialog. Update row dialog to remove
-  unnecessary cell heights
+body: Remove the height field from the `table` plugin cell dialog. The `table` plugin row dialog now controls the row height by setting the height on the `tr` element, not the `td` elements.
 time: 2024-02-18T21:49:45.126737287+10:00
 custom:
   Issue: TINY-10617

--- a/.changes/unreleased/tinymce-TINY-10617-2024-02-18.yaml
+++ b/.changes/unreleased/tinymce-TINY-10617-2024-02-18.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Changed
+body: Remove height field from `table` plugin cell dialog. Update row dialog to remove
+  unnecessary cell heights
+time: 2024-02-18T21:49:45.126737287+10:00
+custom:
+  Issue: TINY-10617

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
@@ -45,9 +45,6 @@ const updateSimpleProps = (modifier: DomModifier, colModifier: DomModifier, data
   if (shouldUpdate('class') && data.class !== 'mce-no-match') {
     modifier.setAttrib('class', data.class);
   }
-  if (shouldUpdate('height')) {
-    modifier.setStyle('height', Utils.addPxSuffix(data.height));
-  }
   if (shouldUpdate('width')) {
     colModifier.setStyle('width', Utils.addPxSuffix(data.width));
   }

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
@@ -23,11 +23,6 @@ const children: Dialog.BodyComponentSpec[] = [
     label: 'Width'
   },
   {
-    name: 'height',
-    type: 'input',
-    label: 'Height'
-  },
-  {
     name: 'celltype',
     type: 'listbox',
     label: 'Cell type',

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
@@ -54,7 +54,6 @@ export type RowData = {
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type CellData = {
   readonly width: string;
-  readonly height: string;
   readonly scope: string;
   readonly celltype: 'td' | 'th';
   readonly class: string;
@@ -224,7 +223,6 @@ const extractDataFromCellElement = (editor: Editor, cell: HTMLTableCellElement, 
 
   return {
     width: getStyle(colElm, 'width'),
-    height: getStyle(cell, 'height'),
     scope: dom.getAttrib(cell, 'scope'),
     celltype: Utils.getNodeName(cell) as 'td' | 'th',
     class: dom.getAttrib(cell, 'class', ''),

--- a/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
@@ -1,6 +1,6 @@
 import { Arr, Fun, Obj } from '@ephox/katamari';
 import { TableLookup } from '@ephox/snooker';
-import { SugarElement } from '@ephox/sugar';
+import { SelectorFilter, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
@@ -43,12 +43,20 @@ const applyStyleData = (editor: Editor, rows: HTMLTableRowElement[], data: RowDa
   const isSingleRow = rows.length === 1;
   const shouldOverrideCurrentValue = isSingleRow ? Fun.always : wasChanged;
   Arr.each(rows, (rowElm) => {
+    const rowCells = SelectorFilter.children<HTMLTableCellElement>(SugarElement.fromDom(rowElm), 'td,th');
     const modifier = DomModifier.normal(editor, rowElm);
 
     updateSimpleProps(modifier, data, shouldOverrideCurrentValue);
 
     if (Options.hasAdvancedRowTab(editor)) {
       updateAdvancedProps(modifier, data as Required<RowData>, shouldOverrideCurrentValue);
+    }
+
+    // TINY-10617: Simplify number of height styles when applying height on tr
+    if (wasChanged('height')) {
+      Arr.each(rowCells, (cell) => {
+        editor.dom.setStyle(cell.dom, 'height', null);
+      });
     }
 
     if (wasChanged('align')) {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/HelpersTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/HelpersTest.ts
@@ -30,17 +30,19 @@ describe('browser.tinymce.plugins.table.HelpersTest', () => {
     );
     const td = UiFinder.findIn<HTMLTableCellElement>(TinyDom.body(editor), 'td.foo').getOrDie();
     const cellData = Helpers.extractDataFromCellElement(editor, td.dom, true, Optional.none());
+    assert.hasAllKeys(cellData, [ 'class', 'scope', 'celltype', 'halign', 'valign', 'width', 'backgroundcolor', 'bordercolor', 'borderstyle', 'borderwidth' ]);
     assert.equal(cellData.class, 'foo', 'Extracts class');
     assert.equal(cellData.scope, 'row', 'Extracts scope');
     assert.equal(cellData.celltype, 'td', 'Extracts celltype');
     assert.equal(cellData.halign, 'left', 'Extracts halign');
     assert.equal(cellData.valign, 'middle', 'Extracts valign');
     assert.equal(cellData.width, '20', 'Extracts width');
-    assert.equal(cellData.height, '30', 'Extracts height');
 
     assert.equal(cellData.backgroundcolor, '#333333', 'Extracts background-color');
     assert.equal(cellData.bordercolor, '#D91111', 'Extracts border-color');
     assert.equal(cellData.borderstyle, 'dashed', 'Extracts border-style');
+
+    assert.equal(cellData.borderwidth, '', 'Extracts border-width');
   });
 
   it('TBA: extractDataFromCellElement 1 with colgroup', () => {
@@ -59,17 +61,19 @@ describe('browser.tinymce.plugins.table.HelpersTest', () => {
     );
     const elements = UiFinder.findAllIn(TinyDom.body(editor), '.foo') as [ SugarElement<HTMLTableColElement>, SugarElement<HTMLTableCellElement> ];
     const cellData = Helpers.extractDataFromCellElement(editor, elements[1].dom, true, Optional.some(elements[0].dom));
+    assert.hasAllKeys(cellData, [ 'class', 'scope', 'celltype', 'halign', 'valign', 'width', 'backgroundcolor', 'bordercolor', 'borderstyle', 'borderwidth' ]);
     assert.equal(cellData.class, 'foo', 'Extracts class');
     assert.equal(cellData.scope, 'row', 'Extracts scope');
     assert.equal(cellData.celltype, 'td', 'Extracts celltype');
     assert.equal(cellData.halign, 'left', 'Extracts halign');
     assert.equal(cellData.valign, 'middle', 'Extracts valign');
     assert.equal(cellData.width, '20', 'Does Not Extracts width');
-    assert.equal(cellData.height, '30', 'Extracts height');
 
     assert.equal(cellData.backgroundcolor, '#333333', 'Extracts background-color');
     assert.equal(cellData.bordercolor, '#D91111', 'Extracts border-color');
     assert.equal(cellData.borderstyle, 'dashed', 'Extracts border-style');
+
+    assert.equal(cellData.borderwidth, '', 'Extracts border-width');
   });
 
   it('TBA: extractDataFromCellElement 2', () => {
@@ -85,10 +89,19 @@ describe('browser.tinymce.plugins.table.HelpersTest', () => {
     );
     const td = UiFinder.findIn<HTMLTableCellElement>(TinyDom.body(editor), 'td.foo').getOrDie();
     const cellData = Helpers.extractDataFromCellElement(editor, td.dom, true, Optional.none());
+    assert.hasAllKeys(cellData, [ 'class', 'scope', 'celltype', 'halign', 'valign', 'width', 'backgroundcolor', 'bordercolor', 'borderstyle', 'borderwidth' ]);
     assert.equal(cellData.width, '20px', 'Extracts width from style');
-    assert.equal(cellData.height, '30px', 'Extracts height from style');
+    assert.equal(cellData.class, 'foo', 'Extracts class');
+    assert.equal(cellData.celltype, 'td', 'Extracts celltype');
+
     assert.equal(cellData.backgroundcolor, '#333333', 'Extracts background-color from rgb');
     assert.equal(cellData.bordercolor, '#D91111', 'Extracts border-color from rgb');
+
+    assert.equal(cellData.scope, '', 'Extracts scope');
+    assert.equal(cellData.halign, '', 'Extracts halign');
+    assert.equal(cellData.valign, '', 'Extracts valign');
+    assert.equal(cellData.borderwidth, '', 'Extracts border-width');
+    assert.equal(cellData.borderstyle, '', 'Extracts border-style');
   });
 
   it('TBA: extractDataFromCellElement 2 with colgroup', () => {
@@ -107,10 +120,18 @@ describe('browser.tinymce.plugins.table.HelpersTest', () => {
     );
     const elements = UiFinder.findAllIn(TinyDom.body(editor), '.foo') as [ SugarElement<HTMLTableColElement>, SugarElement<HTMLTableCellElement> ];
     const cellData = Helpers.extractDataFromCellElement(editor, elements[1].dom, true, Optional.some(elements[0].dom));
+    assert.hasAllKeys(cellData, [ 'class', 'scope', 'celltype', 'halign', 'valign', 'width', 'backgroundcolor', 'bordercolor', 'borderstyle', 'borderwidth' ]);
     assert.equal(cellData.width, '20px', 'Extracts width from style');
-    assert.equal(cellData.height, '30px', 'Extracts height from style');
     assert.equal(cellData.backgroundcolor, '#333333', 'Extracts background-color from rgb');
     assert.equal(cellData.bordercolor, '#D91111', 'Extracts border-color from rgb');
+    assert.equal(cellData.class, 'foo', 'Extracts class');
+    assert.equal(cellData.celltype, 'td', 'Extracts celltype');
+
+    assert.equal(cellData.scope, '', 'Extracts scope');
+    assert.equal(cellData.halign, '', 'Extracts halign');
+    assert.equal(cellData.valign, '', 'Extracts valign');
+    assert.equal(cellData.borderwidth, '', 'Extracts border-width');
+    assert.equal(cellData.borderstyle, '', 'Extracts border-style');
   });
 
   it('TBA: extractDataFromCellElement 3', () => {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
@@ -31,7 +31,6 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
 
   const generalSelectors = {
     width: 'label.tox-label:contains(Width) + input.tox-textfield',
-    height: 'label.tox-label:contains(Height) + input.tox-textfield',
     celltype: 'label.tox-label:contains(Cell type) + div.tox-listboxfield > .tox-listbox',
     scope: 'label.tox-label:contains(Scope) + div.tox-listboxfield > .tox-listbox',
     halign: 'label.tox-label:contains(Horizontal align) + div.tox-listboxfield > .tox-listbox',
@@ -82,7 +81,6 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
 
   const baseData = {
     width: '',
-    height: '',
     celltype: 'td',
     halign: '',
     valign: '',
@@ -91,7 +89,6 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
 
   const baseAdvData = {
     width: '',
-    height: '',
     celltype: 'td',
     halign: '',
     valign: '',
@@ -128,14 +125,13 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
     TableTestUtils.assertDialogValues(baseData, false, generalSelectors);
     TableTestUtils.setDialogValues({
       width: '100',
-      height: '101',
       celltype: 'td',
       scope: '',
       halign: '',
       valign: ''
     }, false, generalSelectors);
     await TableTestUtils.pClickDialogButton(editor, true);
-    TinyAssertions.assertContent(editor, '<table><tbody><tr><td style="width: 100px; height: 101px;">a</td><td>b</td></tr></tbody></table>');
+    TinyAssertions.assertContent(editor, '<table><tbody><tr><td style="width: 100px;">a</td><td>b</td></tr></tbody></table>');
     assertEventsOrder();
   });
 
@@ -145,7 +141,6 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
 
     const complexData = {
       width: '10px',
-      height: '11px',
       celltype: 'th',
       scope: 'row',
       halign: 'right',
@@ -169,7 +164,6 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
   it('TBA: Table cell properties dialog (update all, including advanced)', async () => {
     const advData = {
       width: '10',
-      height: '11',
       scope: 'row',
       celltype: 'th',
       halign: 'right',
@@ -180,7 +174,7 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
       borderwidth: ''
     };
 
-    const advHtml = '<table><tbody><tr><th style="width: 10px; height: 11px; vertical-align: top; text-align: right; ' +
+    const advHtml = '<table><tbody><tr><th style="width: 10px; vertical-align: top; text-align: right; ' +
     'border-color: red; border-style: dashed; background-color: blue;" scope="row">X</th></tr></tbody></table>';
 
     const editor = hook.editor();
@@ -200,8 +194,8 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
     const initialHtml = '<table>' +
       '<tbody>' +
       '<tr>' +
-      '<td data-mce-selected="1">a</td>' +
-      '<td data-mce-selected="1">b</td>' +
+      '<td data-mce-selected="1" style="height: 10px;">a</td>' +
+      '<td data-mce-selected="1" style="height: 10px;">b</td>' +
       '</tr>' +
       '</tbody>' +
       '</table>';
@@ -209,15 +203,14 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
     const newHtml = '<table>' +
         '<tbody>' +
           '<tr>' +
-            '<td style="height: 20px; vertical-align: bottom; border-style: dashed; background-color: red;">a</td>' +
-            '<td style="height: 20px; vertical-align: bottom; border-style: dashed; background-color: red;">b</td>' +
+            '<td style="height: 10px; vertical-align: bottom; border-style: dashed; background-color: red;">a</td>' +
+            '<td style="height: 10px; vertical-align: bottom; border-style: dashed; background-color: red;">b</td>' +
           '</tr>' +
         '</tbody>' +
       '</table>';
 
     const newData = {
       width: '',
-      height: '20',
       celltype: 'td',
       scope: '',
       valign: 'bottom',
@@ -256,7 +249,6 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
 
     const initialDialogValues = {
       width: '',
-      height: '200px',
       celltype: 'td',
       halign: '',
       valign: '',
@@ -274,14 +266,13 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
       '</colgroup>' +
       '<tbody>' +
         '<tr>' +
-          '<td style="height: 20px; text-align: center; border-color: blue; background-color: red;">&nbsp;</td>' +
-          '<td style="height: 20px; text-align: center; border-color: red; background-color: red;">&nbsp;</td>' +
+          '<td style="height: 200px; text-align: center; border-color: blue; background-color: red;">&nbsp;</td>' +
+          '<td style="height: 200px; text-align: center; border-color: red; background-color: red;">&nbsp;</td>' +
         '</tr>' +
       '</tbody>' +
     '</table>';
 
     const newData = {
-      height: '20',
       halign: 'center',
       backgroundcolor: 'red'
     };
@@ -314,7 +305,6 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
 
     const initialDialogValues = {
       width: '',
-      height: '200px',
       celltype: 'td',
       halign: 'center',
       valign: 'bottom',
@@ -332,16 +322,16 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
       '</colgroup>' +
       '<tbody>' +
         '<tr>' +
-          '<td>&nbsp;</td>' +
-          '<td>&nbsp;</td>' +
+          '<td style="height: 200px;">&nbsp;</td>' +
+          '<td style="height: 200px;">&nbsp;</td>' +
         '</tr>' +
       '</tbody>' +
     '</table>';
 
     const newData = {
       height: '',
-      halign: '',
       valign: '',
+      halign: '',
       backgroundcolor: '',
       bordercolor: '',
       borderstyle: '',
@@ -361,12 +351,11 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
   });
 
   it('TBA: Remove all styles', async () => {
-    const advHtml = '<table><tbody><tr><th style="width: 10px; height: 11px; vertical-align: top; text-align: right; ' +
+    const advHtml = '<table><tbody><tr><th style="width: 10px; vertical-align: top; text-align: right; ' +
     'border-color: red; border-style: dashed; background-color: blue;" scope="row">X</th></tr></tbody></table>';
 
     const advData = {
       width: '10px',
-      height: '11px',
       celltype: 'th',
       scope: 'row',
       halign: 'right',
@@ -381,7 +370,6 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
 
     const emptyData = {
       width: '',
-      height: '',
       scope: '',
       celltype: 'th', // is never empty
       halign: '',
@@ -434,7 +422,6 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
   it('TBA: Test cancel changes nothing and save does', async () => {
     const advData = {
       width: '10px',
-      height: '11px',
       scope: 'row',
       celltype: 'th',
       halign: 'right',
@@ -445,7 +432,7 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
       borderwidth: ''
     };
 
-    const advHtml = '<table><tbody><tr><th style="width: 10px; height: 11px; vertical-align: top; text-align: right; ' +
+    const advHtml = '<table><tbody><tr><th style="width: 10px; vertical-align: top; text-align: right; ' +
     'border-color: red; border-style: dashed; background-color: blue;" scope="row">a</th><td>b</td></tr></tbody></table>';
 
     const editor = hook.editor();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
@@ -253,16 +253,16 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
   it('TINY-8625: Table row properties dialog updates multiple rows, but does not override unchanged values', async () => {
     const initialHtml =
       '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
-        '<tbody>' +
-          '<tr style="height: 20px; border-color: blue;">' +
-            '<td data-mce-selected="1">a</td>' +
-            '<td data-mce-selected="1">b</td>' +
-          '</tr>' +
-          '<tr style="height: 20px; border-color: red;">' +
-            '<td data-mce-selected="1">c</td>' +
-            '<td data-mce-selected="1">d</td>' +
-          '</tr>' +
-        '</tbody>' +
+      '<tbody>' +
+      '<tr style="height: 20px; border-color: blue;">' +
+      '<td data-mce-selected="1">a</td>' +
+      '<td data-mce-selected="1">b</td>' +
+      '</tr>' +
+      '<tr style="height: 20px; border-color: red;">' +
+      '<td data-mce-selected="1">c</td>' +
+      '<td data-mce-selected="1">d</td>' +
+      '</tr>' +
+      '</tbody>' +
       '</table>';
 
     const initialData = {
@@ -283,16 +283,16 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
 
     const newHtml =
       '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
-        '<tbody>' +
-          '<tr style="height: 30px; text-align: center; border-color: blue; background-color: red;">' +
-            '<td>a</td>' +
-            '<td>b</td>' +
-          '</tr>' +
-          '<tr style="height: 30px; text-align: center; border-color: red; background-color: red;">' +
-            '<td>c</td>' +
-            '<td>d</td>' +
-          '</tr>' +
-        '</tbody>' +
+      '<tbody>' +
+      '<tr style="height: 30px; text-align: center; border-color: blue; background-color: red;">' +
+      '<td>a</td>' +
+      '<td>b</td>' +
+      '</tr>' +
+      '<tr style="height: 30px; text-align: center; border-color: red; background-color: red;">' +
+      '<td>c</td>' +
+      '<td>d</td>' +
+      '</tr>' +
+      '</tbody>' +
       '</table>';
 
     const editor = hook.editor();
@@ -309,16 +309,16 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
   it('TINY-8625: Table row properties dialog updates multiple rows and allows resetting values', async () => {
     const initialHtml =
       '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
-        '<tbody>' +
-          '<tr style="height: 20px; text-align: center; border-color: blue; border-style: dotted; background-color: red;">' +
-            '<td data-mce-selected="1">a</td>' +
-            '<td data-mce-selected="1">b</td>' +
-          '</tr>' +
-          '<tr style="height: 20px; text-align: center; border-color: blue; border-style: dotted; background-color: red;">' +
-            '<td data-mce-selected="1">c</td>' +
-            '<td data-mce-selected="1">d</td>' +
-          '</tr>' +
-        '</tbody>' +
+      '<tbody>' +
+      '<tr style="height: 20px; text-align: center; border-color: blue; border-style: dotted; background-color: red;">' +
+      '<td data-mce-selected="1">a</td>' +
+      '<td data-mce-selected="1">b</td>' +
+      '</tr>' +
+      '<tr style="height: 20px; text-align: center; border-color: blue; border-style: dotted; background-color: red;">' +
+      '<td data-mce-selected="1">c</td>' +
+      '<td data-mce-selected="1">d</td>' +
+      '</tr>' +
+      '</tbody>' +
       '</table>';
 
     const initialData = {
@@ -341,16 +341,16 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
 
     const newHtml =
       '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
-        '<tbody>' +
-          '<tr>' +
-            '<td>a</td>' +
-            '<td>b</td>' +
-          '</tr>' +
-          '<tr>' +
-            '<td>c</td>' +
-            '<td>d</td>' +
-          '</tr>' +
-        '</tbody>' +
+      '<tbody>' +
+      '<tr>' +
+      '<td>a</td>' +
+      '<td>b</td>' +
+      '</tr>' +
+      '<tr>' +
+      '<td>c</td>' +
+      '<td>d</td>' +
+      '</tr>' +
+      '</tbody>' +
       '</table>';
 
     const editor = hook.editor();
@@ -411,5 +411,257 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
       editor.execCommand('mceTableRowProps');
       UiFinder.notExists(SugarBody.body(), '.tox-dialog');
     });
+  });
+
+  it('TINY-10617: should not remove td/th heights when not changing height of row (single row)', async () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+      '<tbody>' +
+      '<tr>' +
+      '<td style="height: 20px;">a</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+    TinySelections.select(editor, 'td', [ 0 ]);
+    await TableTestUtils.pOpenTableDialog(editor);
+
+    TableTestUtils.assertDialogValues({
+      align: '',
+      height: '',
+      type: 'body',
+      backgroundcolor: '',
+      bordercolor: '',
+      borderstyle: ''
+    }, true, generalSelectors);
+
+    TableTestUtils.setDialogValues({
+      align: '',
+      height: '',
+      type: 'body',
+      bordercolor: 'blue',
+      borderstyle: 'dotted',
+      backgroundcolor: '#ff0000'
+    }, true, generalSelectors);
+    await TableTestUtils.pClickDialogButton(editor, true);
+
+    TinyAssertions.assertContent(editor,
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+      '<tbody>' +
+      '<tr style="border-color: blue; border-style: dotted; background-color: rgb(255, 0, 0);">' +
+      '<td style="height: 20px;">a</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+    assertEvents();
+  });
+
+  it('TINY-10617: should not remove td/th heights when not changing height of row (multiple rows)', async () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+      '<tbody>' +
+      '<tr style="height: 20px; border-color: blue;">' +
+      '<td data-mce-selected="1" style="height: 20px;">a</td>' +
+      '<td data-mce-selected="1" style="height: 20px;">b</td>' +
+      '</tr>' +
+      '<tr style="height: 20px; border-color: red;">' +
+      '<td data-mce-selected="1" style="height: 20px;">c</td>' +
+      '<td data-mce-selected="1" style="height: 20px;">d</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+    TinySelections.select(editor, 'tr:nth-child(2) td:nth-child(2)', [ 0 ]);
+    await TableTestUtils.pOpenTableDialog(editor);
+    TableTestUtils.assertDialogValues({
+      align: '',
+      height: '20px',
+      type: 'body',
+      backgroundcolor: '',
+      bordercolor: '',
+      borderstyle: ''
+    }, true, generalSelectors);
+
+    TableTestUtils.setDialogValues({
+      align: 'center',
+      backgroundcolor: 'red'
+    }, true, generalSelectors);
+    await TableTestUtils.pClickDialogButton(editor, true);
+
+    TinyAssertions.assertContent(editor,
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+      '<tbody>' +
+      '<tr style="height: 20px; text-align: center; border-color: blue; background-color: red;">' +
+      '<td style="height: 20px;">a</td>' +
+      '<td style="height: 20px;">b</td>' +
+      '</tr>' +
+      '<tr style="height: 20px; text-align: center; border-color: red; background-color: red;">' +
+      '<td style="height: 20px;">c</td>' +
+      '<td style="height: 20px;">d</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+    assertEvents();
+  });
+
+  it('TINY-10617: should remove td/th heights when changing height of row (single row)', async () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+      '<tbody>' +
+      '<tr>' +
+      '<td style="height: 20px; border-color: green;">a</td>' +
+      '<td style="height: 10px; border-color: yellow;">b</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+    TinySelections.select(editor, 'td', [ 0 ]);
+    await TableTestUtils.pOpenTableDialog(editor);
+
+    TableTestUtils.assertDialogValues({
+      align: '',
+      height: '',
+      type: 'body',
+      backgroundcolor: '',
+      bordercolor: '',
+      borderstyle: ''
+    }, true, generalSelectors);
+
+    TableTestUtils.setDialogValues({
+      align: '',
+      height: '50px',
+      type: 'body',
+      bordercolor: 'blue',
+    }, true, generalSelectors);
+    await TableTestUtils.pClickDialogButton(editor, true);
+
+    TinyAssertions.assertContent(editor,
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+      '<tbody>' +
+      '<tr style="height: 50px; border-color: blue;">' +
+      '<td style="border-color: green;">a</td>' +
+      '<td style="border-color: yellow;">b</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+    assertEvents();
+  });
+
+  it('TINY-10617: should remove td/th heights when changing height of row (multiple rows)', async () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+      '<tbody>' +
+      '<tr>' +
+      '<td data-mce-selected="1" style="height: 20px; border-color: green;">a</td>' +
+      '<td style="height: 10px; border-color: yellow;">b</td>' +
+      '</tr>' +
+      '<tr style="height: 40px;">' +
+      '<td data-mce-selected="1" style="height: 40px; border-color: red;">c</td>' +
+      '<td style="height: 40px; border-color: blue;">d</td>' +
+      '</tr>' +
+      '<tr style="height: 30px;">' +
+      '<td style="height: 30px; border-color: purple;">e</td>' +
+      '<td style="height: 30px; border-color: pink;">f</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+    TinySelections.select(editor, 'tr:nth-child(2) td:nth-child(1)', [ 0 ]);
+    await TableTestUtils.pOpenTableDialog(editor);
+
+    TableTestUtils.assertDialogValues({
+      align: '',
+      height: '',
+      type: 'body',
+      backgroundcolor: '',
+      bordercolor: '',
+      borderstyle: ''
+    }, true, generalSelectors);
+
+    TableTestUtils.setDialogValues({
+      align: '',
+      height: '50px',
+      type: 'body',
+      bordercolor: 'blue',
+    }, true, generalSelectors);
+    await TableTestUtils.pClickDialogButton(editor, true);
+
+    TinyAssertions.assertContent(editor,
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+      '<tbody>' +
+      '<tr style="height: 50px; border-color: blue;">' +
+      '<td style="border-color: green;">a</td>' +
+      '<td style="border-color: yellow;">b</td>' +
+      '</tr>' +
+      '<tr style="height: 50px; border-color: blue;">' +
+      '<td style="border-color: red;">c</td>' +
+      '<td style="border-color: blue;">d</td>' +
+      '</tr>' +
+      '<tr style="height: 30px;">' +
+      '<td style="height: 30px; border-color: purple;">e</td>' +
+      '<td style="height: 30px; border-color: pink;">f</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+    assertEvents();
+  });
+
+  it('TINY-10617: should remove td/th heights when changing height of row (cells with rowpan)', async () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+      '<tbody>' +
+      '<tr>' +
+      '<td style="height: 20px; border-color: green;">a</td>' +
+      '<td rowspan="2" style="height: 10px; border-color: yellow;">b</td>' +
+      '</tr>' +
+      '<tr style="height: 30px;">' +
+      '<td style="height: 30px; border-color: blue;">c</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+    TinySelections.select(editor, 'td', [ 0 ]);
+    await TableTestUtils.pOpenTableDialog(editor);
+
+    TableTestUtils.assertDialogValues({
+      align: '',
+      height: '',
+      type: 'body',
+      backgroundcolor: '',
+      bordercolor: '',
+      borderstyle: ''
+    }, true, generalSelectors);
+
+    TableTestUtils.setDialogValues({
+      align: '',
+      height: '50px',
+      type: 'body',
+      bordercolor: 'blue',
+    }, true, generalSelectors);
+    await TableTestUtils.pClickDialogButton(editor, true);
+
+    TinyAssertions.assertContent(editor,
+      '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
+      '<tbody>' +
+      '<tr style="height: 50px; border-color: blue;">' +
+      '<td style="border-color: green;">a</td>' +
+      '<td style="border-color: yellow;" rowspan="2">b</td>' +
+      '</tr>' +
+      '<tr style="height: 30px;">' +
+      '<td style="height: 30px; border-color: blue;">c</td>' +
+      '</tr>' +
+      '</tbody>' +
+      '</table>'
+    );
+    assertEvents();
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10617

Description of Changes:
* Remove `height` field from the table cell dialog
* Update table row dialog to remove height styles from td/th that are children of the row(s) that have their height changed

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
