### PR TITLE
TINY-10570: Improve toolbar width recalculation on window resize

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10570-2024-02-19.yaml
+++ b/.changes/unreleased/tinymce-TINY-10570-2024-02-19.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Floating toolbar buttons in inline editor incorrectly wrapped into multiple rows on window resizing or zooming.
+time: 2024-02-19T10:14:06.839626+02:00
+custom:
+  Issue: TINY-10570

--- a/modules/alloy/src/main/ts/ephox/alloy/toolbar/SplitToolbarUtils.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/toolbar/SplitToolbarUtils.ts
@@ -45,7 +45,7 @@ const refresh = (toolbar: AlloyComponent, detail: SplitToolbarBaseDetail, setOve
 
   const availableWidth = Width.get(primary.element);
 
-  const overflows = Overflows.partition(availableWidth, detail.builtGroups.get(), (comp) => Width.get(comp.element), overflowGroup);
+  const overflows = Overflows.partition(availableWidth, detail.builtGroups.get(), (comp) => Math.ceil(comp.element.dom.getBoundingClientRect().width), overflowGroup);
 
   if (overflows.extra.length === 0) {
     // Not ideal. Breaking abstraction somewhat, though remove is better than insert


### PR DESCRIPTION
Related Ticket: TINY-10570

Description of Changes:
* Move the setting of inline header width after the toolbar being refreshed on window resize.
* Refine the toolbar width calculation by using getBoundingClientRect when the browser is zoomed
* No unit tests, since it needs browser zooming and window resize. Also the measurement requires the subpixel accuracy - might be flaky.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
