### PR TITLE
TINY-8929:  Remove the autocompleter `ch` configuration property.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-8929-2024-02-19.yaml
+++ b/.changes/unreleased/tinymce-TINY-8929-2024-02-19.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Removed
+body: The autocompleter `ch` configuration property has been removed. Use the `trigger` property instead.
+time: 2024-02-19T15:48:53.973594+02:00
+custom:
+  Issue: TINY-8929

--- a/modules/bridge/src/main/ts/ephox/bridge/components/content/Autocompleter.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/content/Autocompleter.ts
@@ -30,9 +30,7 @@ export interface AutocompleterItem {
 
 export interface AutocompleterSpec {
   type?: 'autocompleter';
-  // TODO: TINY-8929: Remove 'trigger' fallback to 'ch'
-  ch?: string;
-  trigger?: string;
+  trigger: string;
   minChars?: number;
   columns?: ColumnTypes;
   matches?: (rng: Range, text: string, pattern: string) => boolean;
@@ -89,5 +87,4 @@ export const createAutocompleterItem = (spec: AutocompleterItemSpec): Result<Aut
   StructureSchema.asRaw<AutocompleterItem>('Autocompleter.Item', autocompleterItemSchema, spec);
 
 export const createAutocompleter = (spec: AutocompleterSpec): Result<Autocompleter, StructureSchema.SchemaError<any>> =>
-  // TODO: TINY-8929: Remove 'trigger' fallback to 'ch'
-  StructureSchema.asRaw<Autocompleter>('Autocompleter', autocompleterSchema, { trigger: spec.ch, ...spec });
+  StructureSchema.asRaw<Autocompleter>('Autocompleter', autocompleterSchema, spec );


### PR DESCRIPTION
Related Ticket: TINY-8929

Description of Changes:
* Remove the `ch` configuration property

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
