### PR TITLE
TINY-10452: Remove incorrect `aria-placeholder` attribute from editor…

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10452-2024-02-20.yaml
+++ b/.changes/unreleased/tinymce-TINY-10452-2024-02-20.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Changed
-body: Removed incorrect `aria-placeholder` attribute from editor body.
+body: Removed incorrect `aria-placeholder` attribute from editor body when `placeholder` option is set.
 time: 2024-02-20T11:42:12.513674+08:00
 custom:
   Issue: TINY-10452

--- a/.changes/unreleased/tinymce-TINY-10452-2024-02-20.yaml
+++ b/.changes/unreleased/tinymce-TINY-10452-2024-02-20.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Changed
+body: Removed incorrect `aria-placeholder` attribute from editor body.
+time: 2024-02-20T11:42:12.513674+08:00
+custom:
+  Issue: TINY-10452

--- a/modules/tinymce/src/core/main/ts/content/Placeholder.ts
+++ b/modules/tinymce/src/core/main/ts/content/Placeholder.ts
@@ -88,9 +88,6 @@ const setup = (editor: Editor): void => {
     if (isPlaceholderShown !== showPlaceholder || initial) {
       dom.setAttrib(body, placeholderAttr, showPlaceholder ? placeholder : null);
 
-      // Also set the aria-placeholder attribute for screen readers
-      dom.setAttrib(body, 'aria-placeholder', showPlaceholder ? placeholder : null);
-
       Events.firePlaceholderToggle(editor, showPlaceholder);
 
       // Swap the key listener state

--- a/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
@@ -36,10 +36,8 @@ describe('webdriver.tinymce.core.content.PlaceholderTest', () => {
   const pAssertPlaceholder = (editor: Editor, expected: boolean) => Waiter.pTryUntil('Wait for placeholder to update', () => {
     const body = editor.getBody();
     const dataPlaceholder = editor.dom.getAttrib(body, 'data-mce-placeholder');
-    const ariaPlaceholder = editor.dom.getAttrib(body, 'aria-placeholder');
     const expectedPlaceholder = expected ? placeholder : '';
     assert.equal(dataPlaceholder, expectedPlaceholder, 'Check data-mce-placeholder attribute');
-    assert.equal(ariaPlaceholder, expectedPlaceholder, 'Check aria-placeholder attribute');
   });
 
   const pAssertPlaceholderExists = (editor: Editor) => pAssertPlaceholder(editor, true);


### PR DESCRIPTION
Related Ticket: TINY-10452

Description of Changes:
*  `aria-placeholder` should not be placed on the editor `body` when `placeholder` option is set
* Verified that `axe DevTools` does highlight that as an issue when the attribute is set on the editor body
	* <img width="925" alt="image" src="https://github.com/tinymce/tinymce/assets/111734091/1c72a6d5-16b8-4288-baa4-c6396de432fe">


Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
#9231 