### PR TITLE
TINY-10672: Change tooltip in `DialogFooterToggleButton` from required to optional

### DIFF
--- a/.changes/unreleased/bridge-TINY-10672-2024-02-21.yaml
+++ b/.changes/unreleased/bridge-TINY-10672-2024-02-21.yaml
@@ -1,0 +1,6 @@
+project: bridge
+kind: Changed
+body: Tooltip property in `DialogFooterToggleButton` is now optional.
+time: 2024-02-21T10:18:55.438108+08:00
+custom:
+  Issue: TINY-10672

--- a/.changes/unreleased/tinymce-TINY-10672-2024-02-21.yaml
+++ b/.changes/unreleased/tinymce-TINY-10672-2024-02-21.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Changed
+body: The `tooltip` property for dialog's footer `togglebutton` is now optional.
+time: 2024-02-21T10:31:44.623621+08:00
+custom:
+  Issue: TINY-10672

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/DialogFooterButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/DialogFooterButton.ts
@@ -66,7 +66,7 @@ export interface DialogFooterMenuButton extends BaseDialogFooterButton {
 
 export interface DialogFooterToggleButton extends BaseDialogFooterButton {
   type: 'togglebutton';
-  tooltip: string;
+  tooltip: Optional<string>;
   text: Optional<string>;
   active: boolean;
 }
@@ -106,7 +106,7 @@ const menuFooterButtonFields = [
 const toggleButtonSpecFields = [
   ...baseFooterButtonFields,
   FieldSchema.requiredStringEnum('type', [ 'togglebutton' ]),
-  FieldSchema.requiredString('tooltip'),
+  ComponentSchema.optionalTooltip,
   ComponentSchema.optionalIcon,
   ComponentSchema.optionalText,
   FieldSchema.defaultedBoolean('active', false)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -240,7 +240,10 @@ const renderToggleButton = (spec: FooterToggleButtonSpec, providers: UiFactoryBa
       ...(spec.active ? [ ViewButtonClasses.Ticked ] : []),
       ...(showIconAndText ? [ 'tox-button--icon-and-text' ] : [])
     ],
-    attributes: { ...tooltipAttributes, ...(Type.isNonNullable(btnName) ? { 'data-mce-name': btnName } : {} ) }
+    attributes: {
+      ...tooltipAttributes,
+      ...(Type.isNonNullable(btnName) ? { 'data-mce-name': btnName } : {} )
+    }
   };
   const extraBehaviours: Behaviours = [];
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -275,7 +275,7 @@ export const renderFooterButton = (spec: FooterButtonSpec, buttonType: string, b
       fetch: getFetch(menuButtonSpec.items, getButton, backstage)
     };
 
-    const memButton = Memento.record(renderMenuButton(fixedSpec, ToolbarButtonClasses.Button, backstage, Optional.none(), true, spec.text.getOr(spec.tooltip.getOrUndefined())));
+    const memButton = Memento.record(renderMenuButton(fixedSpec, ToolbarButtonClasses.Button, backstage, Optional.none(), true, spec.text.or(spec.tooltip).getOrUndefined();
 
     return memButton.asSpec();
   } else if (isNormalFooterButtonSpec(spec, buttonType)) {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -8,7 +8,7 @@ import {
   RawDomSchema, Replacing, SimpleOrSketchSpec, SketchSpec, Tabstopping, Tooltipping
 } from '@ephox/alloy';
 import { Dialog, Toolbar } from '@ephox/bridge';
-import { Fun, Merger, Optional } from '@ephox/katamari';
+import { Fun, Merger, Optional, Type } from '@ephox/katamari';
 
 import { UiFactoryBackstage, UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as ReadOnly from '../../ReadOnly';
@@ -195,7 +195,7 @@ const isNormalFooterButtonSpec = (spec: FooterButtonSpec, buttonType: string): s
 
 const isToggleButtonSpec = (spec: FooterButtonSpec, buttonType: string): spec is Dialog.DialogFooterToggleButton => buttonType === 'togglebutton';
 
-const renderToggleButton = (spec: FooterToggleButtonSpec, providers: UiFactoryBackstageProviders): SimpleOrSketchSpec => {
+const renderToggleButton = (spec: FooterToggleButtonSpec, providers: UiFactoryBackstageProviders, btnName?: string): SimpleOrSketchSpec => {
   const optMemIcon = spec.icon
     .map((memIcon) => renderReplaceableIconFromPack(memIcon, providers.icons))
     .map(Memento.record);
@@ -222,14 +222,13 @@ const renderToggleButton = (spec: FooterToggleButtonSpec, providers: UiFactoryBa
     ...spec,
     name: spec.name ?? '',
     primary: buttonType === 'primary',
-    tooltip: Optional.from(spec.tooltip),
+    tooltip: spec.tooltip,
     enabled: spec.enabled ?? false,
     borderless: false
   };
 
   const tooltipAttributes = buttonSpec.tooltip.map<{}>((tooltip) => ({
     'aria-label': providers.translate(tooltip),
-    'title': providers.translate(tooltip)
   })).getOr({});
 
   const buttonTypeClasses = calculateClassesFromButtonType(buttonType ?? 'secondary');
@@ -241,7 +240,7 @@ const renderToggleButton = (spec: FooterToggleButtonSpec, providers: UiFactoryBa
       ...(spec.active ? [ ViewButtonClasses.Ticked ] : []),
       ...(showIconAndText ? [ 'tox-button--icon-and-text' ] : [])
     ],
-    attributes: tooltipAttributes
+    attributes: { ...tooltipAttributes, ...(Type.isNonNullable(btnName) ? { 'data-mce-name': btnName } : {} ) }
   };
   const extraBehaviours: Behaviours = [];
 
@@ -254,7 +253,7 @@ const renderToggleButton = (spec: FooterToggleButtonSpec, providers: UiFactoryBa
     ...(spec.text.isSome() ? [ translatedTextComponed ] : [])
   ];
 
-  const iconButtonSpec = renderCommonSpec(buttonSpec, Optional.some(action), extraBehaviours, dom, components, Optional.from(spec.tooltip), providers);
+  const iconButtonSpec = renderCommonSpec(buttonSpec, Optional.some(action), extraBehaviours, dom, components, spec.tooltip, providers);
   return AlloyButton.sketch(iconButtonSpec);
 };
 
@@ -276,7 +275,7 @@ export const renderFooterButton = (spec: FooterButtonSpec, buttonType: string, b
       fetch: getFetch(menuButtonSpec.items, getButton, backstage)
     };
 
-    const memButton = Memento.record(renderMenuButton(fixedSpec, ToolbarButtonClasses.Button, backstage, Optional.none(), true, spec.tooltip.getOrUndefined()));
+    const memButton = Memento.record(renderMenuButton(fixedSpec, ToolbarButtonClasses.Button, backstage, Optional.none(), true, spec.text.getOr(spec.tooltip.getOrUndefined())));
 
     return memButton.asSpec();
   } else if (isNormalFooterButtonSpec(spec, buttonType)) {
@@ -287,7 +286,7 @@ export const renderFooterButton = (spec: FooterButtonSpec, buttonType: string, b
     };
     return renderButton(buttonSpec, action, backstage.shared.providers, [ ]);
   } else if (isToggleButtonSpec(spec, buttonType)) {
-    return renderToggleButton(spec, backstage.shared.providers);
+    return renderToggleButton(spec, backstage.shared.providers, spec.text.getOr(spec.tooltip.getOrUndefined()));
   } else {
     // eslint-disable-next-line no-console
     console.error('Unknown footer button type: ', buttonType);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -275,7 +275,7 @@ export const renderFooterButton = (spec: FooterButtonSpec, buttonType: string, b
       fetch: getFetch(menuButtonSpec.items, getButton, backstage)
     };
 
-    const memButton = Memento.record(renderMenuButton(fixedSpec, ToolbarButtonClasses.Button, backstage, Optional.none(), true, spec.text.or(spec.tooltip).getOrUndefined();
+    const memButton = Memento.record(renderMenuButton(fixedSpec, ToolbarButtonClasses.Button, backstage, Optional.none(), true, spec.text.or(spec.tooltip).getOrUndefined()));
 
     return memButton.asSpec();
   } else if (isNormalFooterButtonSpec(spec, buttonType)) {
@@ -286,7 +286,7 @@ export const renderFooterButton = (spec: FooterButtonSpec, buttonType: string, b
     };
     return renderButton(buttonSpec, action, backstage.shared.providers, [ ]);
   } else if (isToggleButtonSpec(spec, buttonType)) {
-    return renderToggleButton(spec, backstage.shared.providers, spec.text.getOr(spec.tooltip.getOrUndefined()));
+    return renderToggleButton(spec, backstage.shared.providers, spec.text.or(spec.tooltip).getOrUndefined());
   } else {
     // eslint-disable-next-line no-console
     console.error('Unknown footer button type: ', buttonType);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/view/ViewButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/view/ViewButtons.ts
@@ -105,6 +105,6 @@ export const renderButton = (spec: ViewButtonWithoutGroup, providers: UiFactoryB
   };
   const extraBehaviours: Behaviours = [];
 
-  const iconButtonSpec = renderCommonSpec(buttonSpec, Optional.some(action), extraBehaviours, dom, components, Optional.none(), providers);
+  const iconButtonSpec = renderCommonSpec(buttonSpec, Optional.some(action), extraBehaviours, dom, components, spec.tooltip, providers);
   return AlloyButton.sketch(iconButtonSpec);
 };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipTest.ts
@@ -194,18 +194,25 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
                     },
                   ]
                 },
-                buttons: [{
-                  type: 'menu',
-                  name: 'options',
-                  icon: 'Preferences',
-                  tooltip: 'Preferences',
-                  align: 'start',
-                  items: [{
-                    type: 'togglemenuitem',
-                    name: 'menuitem1',
-                    text: 'Menu item 1',
-                  }]
-                }]
+                buttons: [
+                  {
+                    type: 'menu',
+                    name: 'options',
+                    icon: 'Preferences',
+                    tooltip: 'Preferences',
+                    align: 'start',
+                    items: [{
+                      type: 'togglemenuitem',
+                      name: 'menuitem1',
+                      text: 'Menu item 1',
+                    }]
+                  },
+                  {
+                    type: 'togglebutton',
+                    text: 'notooltip',
+                    align: 'start',
+                  },
+                ]
               });
             }
           });
@@ -273,6 +280,17 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
         await TinyUiActions.pWaitForDialog(editor);
         const buttonSelector = '[data-mce-name="close"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Close');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
+        TinyUiActions.closeDialog(editor);
+      });
+
+      it(`TINY-10453: Should trigger tooltip with ${test.label} - dialog footer button - togglebutton`, async () => {
+        const editor = hook.editor();
+        const toolbarButtonSelector = '[data-mce-name="dialog-footer-button"]';
+        TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
+        await TinyUiActions.pWaitForDialog(editor);
+        const buttonSelector = '[data-mce-name="notooltip"]';
+        await TooltipUtils.pAssertNoTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), '');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
         TinyUiActions.closeDialog(editor);
       });
@@ -399,6 +417,88 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
         const menuSelector = '[aria-label="Choice item 1"]';
         await TooltipUtils.pAssertNoTooltip(editor, () => test.pTriggerTooltip(editor, menuSelector), '');
         await TooltipUtils.pCloseMenu(menuSelector);
+      });
+    });
+
+    context.only('View', () => {
+      const hook = TinyHooks.bddSetup<Editor>({
+        base_url: '/project/tinymce/js/tinymce',
+        toolbar: 'test-view',
+        setup: (ed: Editor) => {
+          ed.ui.registry.addButton('test-view', {
+            text: 'Test View',
+            onAction: () => {
+              ed.execCommand('ToggleView', false, 'view');
+            }
+          });
+          ed.ui.registry.addView('view', {
+            buttons: [
+              {
+                type: 'group',
+                buttons: [
+                  {
+                    type: 'togglebutton' as const,
+                    icon: 'fullscreen',
+                    tooltip: 'Fullscreen',
+                    onAction: Fun.noop
+                  },
+                  {
+                    type: 'togglebutton',
+                    icon: 'copy',
+                    text: 'Copy code',
+                    onAction: Fun.noop
+                  },
+                  {
+                    type: 'togglebutton',
+                    text: 'Copy code 2',
+                    onAction: Fun.noop
+                  },
+                  {
+                    type: 'togglebutton',
+                    icon: 'Bold',
+                    tooltip: 'Bold',
+                    onAction: Fun.noop
+                  },
+                ]
+              }
+            ],
+            onShow: Fun.noop,
+            onHide: Fun.noop
+          });
+        }
+      });
+
+      it(`TINY-10672: Should trigger tooltip with ${test.label} - View togglebutton - with tooltip and icon, no text`, async () => {
+        const editor = hook.editor();
+        const toolbarButtonSelector = '[data-mce-name="test-view"]';
+        TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
+        await TinyUiActions.pWaitForUi(editor, '.tox-view-wrap');
+        const buttonSelector = 'button[aria-label="Fullscreen"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Fullscreen');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
+        editor.execCommand('ToggleView', false, 'view');
+      });
+
+      it(`TINY-10672: Should not trigger tooltip with ${test.label} - View togglebutton - with text and icon, no tooltip`, async () => {
+        const editor = hook.editor();
+        const toolbarButtonSelector = '[data-mce-name="test-view"]';
+        TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
+        await TinyUiActions.pWaitForUi(editor, '.tox-view-wrap');
+        const buttonSelector = 'button[aria-label="Copy code"]';
+        await TooltipUtils.pAssertNoTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), '');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
+        editor.execCommand('ToggleView', false, 'view');
+      });
+
+      it(`TINY-10672: Should not trigger tooltip with ${test.label} - View togglebutton - with text, no icon and tooltip`, async () => {
+        const editor = hook.editor();
+        const toolbarButtonSelector = '[data-mce-name="test-view"]';
+        TinyUiActions.clickOnToolbar(editor, toolbarButtonSelector);
+        await TinyUiActions.pWaitForUi(editor, '.tox-view-wrap');
+        const buttonSelector = 'button[aria-label="Copy code 2"]';
+        await TooltipUtils.pAssertNoTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), '');
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
+        editor.execCommand('ToggleView', false, 'view');
       });
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipTest.ts
@@ -420,7 +420,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
       });
     });
 
-    context.only('View', () => {
+    context('View', () => {
       const hook = TinyHooks.bddSetup<Editor>({
         base_url: '/project/tinymce/js/tinymce',
         toolbar: 'test-view',


### PR DESCRIPTION
Related Ticket: TINY-10672

Description of Changes:
* Change tooltip in `DialogFooterToggleButton` from required to optional
* Revert changes to `ViewButtons.ts` in https://github.com/tinymce/tinymce/pull/9312

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
