### PR TITLE
TINY-10308: Fix table borders when using `table_style_by_css`

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10308-2024-02-22.yaml
+++ b/.changes/unreleased/tinymce-TINY-10308-2024-02-22.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: 'When setting table border width and `table_style_with_css` is true, only the border attribute is set to 0 and border-width styling is no longer used'
+body: 'When setting table border width and `table_style_by_css` is true, only the border attribute is set to 0 and border-width styling is no longer used'
 time: 2024-02-22T09:27:00.437918021+11:00
 custom:
   Issue: TINY-10308

--- a/.changes/unreleased/tinymce-TINY-10308-2024-02-22.yaml
+++ b/.changes/unreleased/tinymce-TINY-10308-2024-02-22.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: 'When setting table border width and `table_style_with_css` is true, only the border attribute is set to 0 and border-width styling is no longer used'
+time: 2024-02-22T09:27:00.437918021+11:00
+custom:
+  Issue: TINY-10308

--- a/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
@@ -48,7 +48,7 @@ const applyDataToElement = (editor: Editor, tableElm: HTMLTableElement, data: Ta
 
   const shouldStyleWithCss = Options.shouldStyleWithCss(editor);
   const hasAdvancedTableTab = Options.hasAdvancedTableTab(editor);
-  const borderIsZero = data.border.includes?.('0');
+  const borderIsZero = data.border?.includes?.('0');
 
   if (!Type.isUndefined(data.class) && data.class !== 'mce-no-match') {
     attrs.class = data.class;

--- a/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
@@ -48,7 +48,7 @@ const applyDataToElement = (editor: Editor, tableElm: HTMLTableElement, data: Ta
 
   const shouldStyleWithCss = Options.shouldStyleWithCss(editor);
   const hasAdvancedTableTab = Options.hasAdvancedTableTab(editor);
-  const borderIsZero = data.border?.includes?.('0');
+  const borderIsZero = parseFloat(data.border) === 0;
 
   if (!Type.isUndefined(data.class) && data.class !== 'mce-no-match') {
     attrs.class = data.class;

--- a/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
@@ -48,6 +48,7 @@ const applyDataToElement = (editor: Editor, tableElm: HTMLTableElement, data: Ta
 
   const shouldStyleWithCss = Options.shouldStyleWithCss(editor);
   const hasAdvancedTableTab = Options.hasAdvancedTableTab(editor);
+  const borderIsZero = data.border.includes?.('0');
 
   if (!Type.isUndefined(data.class) && data.class !== 'mce-no-match') {
     attrs.class = data.class;
@@ -62,10 +63,15 @@ const applyDataToElement = (editor: Editor, tableElm: HTMLTableElement, data: Ta
   }
 
   if (shouldStyleWithCss) {
-    styles['border-width'] = Utils.addPxSuffix(data.border);
+    if (borderIsZero) {
+      attrs.border = 0;
+      styles['border-width'] = '';
+    } else {
+      styles['border-width'] = Utils.addPxSuffix(data.border);
+    }
     styles['border-spacing'] = Utils.addPxSuffix(data.cellspacing);
   } else {
-    attrs.border = data.border;
+    attrs.border = borderIsZero ? 0 : data.border;
     attrs.cellpadding = data.cellpadding;
     attrs.cellspacing = data.cellspacing;
   }
@@ -73,7 +79,9 @@ const applyDataToElement = (editor: Editor, tableElm: HTMLTableElement, data: Ta
   // TINY-9837: Relevant data are applied on child TD/THs only if they have been modified since the previous dialog submission
   if (shouldStyleWithCss && tableElm.children) {
     const cellStyles: StyleMap = {};
-    if (shouldApplyOnCell.border) {
+    if (borderIsZero) {
+      cellStyles['border-width'] = '';
+    } else if (shouldApplyOnCell.border) {
       cellStyles['border-width'] = Utils.addPxSuffix(data.border);
     }
     if (shouldApplyOnCell.cellpadding) {

--- a/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
@@ -68,6 +68,7 @@ const applyDataToElement = (editor: Editor, tableElm: HTMLTableElement, data: Ta
       styles['border-width'] = '';
     } else {
       styles['border-width'] = Utils.addPxSuffix(data.border);
+      attrs.border = 1;
     }
     styles['border-spacing'] = Utils.addPxSuffix(data.cellspacing);
   } else {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogWithoutCssTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogWithoutCssTest.ts
@@ -82,4 +82,16 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     TableTestUtils.assertDialogValues(getExpectedData(2, '100%'), false, generalSelectors);
     await TableTestUtils.pClickDialogButton(editor, false);
   });
+
+  it('TINY-10308: Setting border to 0px should remove border-width styles and set border="0"', async () => {
+    const editor = hook.editor();
+    for (const border of [ '0', '0px' ]) {
+      editor.setContent('<table style="border-collapse: collapse;" border="1"><tbody><tr><td>&nbsp;</td></tr></tbody></table>');
+      setCursor(editor);
+      await TableTestUtils.pOpenTableDialog(editor);
+      TableTestUtils.setDialogValues({ border }, false, generalSelectors);
+      await TableTestUtils.pClickDialogButton(editor, true);
+      TinyAssertions.assertContent(editor, '<table style="border-collapse: collapse;" border="0" width="100%"><tbody><tr><td>&nbsp;</td></tr></tbody></table>');
+    }
+  });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogWithoutCssTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogWithoutCssTest.ts
@@ -82,16 +82,4 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     TableTestUtils.assertDialogValues(getExpectedData(2, '100%'), false, generalSelectors);
     await TableTestUtils.pClickDialogButton(editor, false);
   });
-
-  it('TINY-10308: Setting border to 0px should remove border-width styles and set border="0"', async () => {
-    const editor = hook.editor();
-    for (const border of [ '0', '0px' ]) {
-      editor.setContent('<table style="border-collapse: collapse;" border="1"><tbody><tr><td>&nbsp;</td></tr></tbody></table>');
-      setCursor(editor);
-      await TableTestUtils.pOpenTableDialog(editor);
-      TableTestUtils.setDialogValues({ border }, false, generalSelectors);
-      await TableTestUtils.pClickDialogButton(editor, true);
-      TinyAssertions.assertContent(editor, '<table style="border-collapse: collapse;" border="0" width="100%"><tbody><tr><td>&nbsp;</td></tr></tbody></table>');
-    }
-  });
 });


### PR DESCRIPTION
Related Ticket: TINY-10308

Description of Changes:
When settting table border to '0' or '0px', `border-width` styling is no longer used and only the `border` attribute is set to 0.
Only applies to the table properties dialog and when `table_style_with_css` is set to true.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [x] Docs ticket created (if applicable)