### PR TITLE
TINY-9681: Fixed some focus issues related to TinyMCE 5 skin and premium skins

### DIFF
--- a/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
@@ -42,7 +42,7 @@
 @toolbar-button-bespoke-focus-background-color: @toolbar-button-focus-background-color;
 @toolbar-button-bespoke-spacing-x: @toolbar-button-spacing-x;
 @toolbar-separator-distance: 0;
-@color-tint: #ff00FF;
+@color-tint: #207ab7;
 @panel-border-radius: 3px;
 @control-border-radius: 3px;
 @tinymce-border-radius: 0;

--- a/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
@@ -39,6 +39,7 @@
 @keyboard-focus-outline-width: 0;
 @toolbar-button-focus-background-color: @toolbar-button-hover-background-color;
 @toolbar-button-bespoke-background-color: transparent;
+@toolbar-button-bespoke-focus-background-color: @toolbar-button-focus-background-color;
 @toolbar-button-bespoke-spacing-x: @toolbar-button-spacing-x;
 @toolbar-separator-distance: 0;
 @color-tint: #207ab7;

--- a/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
@@ -42,7 +42,7 @@
 @toolbar-button-bespoke-focus-background-color: @toolbar-button-focus-background-color;
 @toolbar-button-bespoke-spacing-x: @toolbar-button-spacing-x;
 @toolbar-separator-distance: 0;
-@color-tint: #207ab7;
+@color-tint: #ff00FF;
 @panel-border-radius: 3px;
 @control-border-radius: 3px;
 @tinymce-border-radius: 0;

--- a/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
+++ b/modules/oxide/src/less/skins/ui/tinymce-5/skin.less
@@ -72,6 +72,8 @@
 @button-naked-active-icon-color: @button-secondary-active-text-color;
 @insert-table-picker-selected-background-color: fade(@color-tint, 50%);
 @insert-table-picker-selected-border-color: @insert-table-picker-selected-background-color;
+@edit-area-border-color: transparent; // Hide focus outline around editor container
+@edit-area-border-width: 0; // Hide focus outline around editor container
 
 .tox {
   &:not(.tox-tinymce-inline) .tox-editor-header {

--- a/modules/oxide/src/less/theme/components/button/button.less
+++ b/modules/oxide/src/less/theme/components/button/button.less
@@ -35,7 +35,7 @@
 @button-focus-border-color: @button-hover-border-color;
 @button-focus-box-shadow: @button-hover-box-shadow;
 @button-focus-text-color: @button-hover-text-color;
-@button-focus-outline: inset 0 0 0 2px @color-white, 0 0 0 1px @color-tint, 0 0 0 3px fade(@color-tint, 25%);
+@button-focus-outline: inset 0 0 0 1px @color-white, 0 0 0 2px @color-tint;
 
 @button-hover-background-color: darken(@button-background-color, 5%);
 @button-hover-background-image: @button-background-image;
@@ -132,9 +132,7 @@
       border-color: @button-focus-border-color;
       box-shadow: @button-focus-box-shadow;
       color: @button-focus-text-color;
-    }
 
-    &:focus-visible:not(:disabled) {
       &::before {
         opacity: 1;
       }

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -158,8 +158,13 @@
       color: @collection-toolbar-item-label-active-hover-text-color;
     }
 
-    &:focus::after {
-      .keyboard-focus-outline-mixin();
+    &:focus {
+      background-color: @collection-toolbar-item-active-hover-background-color;
+      color: @collection-toolbar-item-label-active-hover-text-color;
+
+      &::after {
+        .keyboard-focus-outline-mixin();
+      }
     }
   }
 

--- a/modules/oxide/src/less/theme/components/edit-area/edit-area.less
+++ b/modules/oxide/src/less/theme/components/edit-area/edit-area.less
@@ -4,7 +4,7 @@
 
 @edit-area-iframe-background-color: @color-white;
 @edit-area-border: 0;
-@edit-area-border-color: #2D6ADF;
+@edit-area-border-color: @keyboard-focus-outline-color;
 @edit-area-border-width: 2px;
 
 .tox {

--- a/modules/oxide/src/less/theme/components/form/textfield.less
+++ b/modules/oxide/src/less/theme/components/form/textfield.less
@@ -22,7 +22,7 @@
 
 @textfield-focus-background-color: @textfield-background-color;
 @textfield-focus-border-color: @color-tint;
-@textfield-focus-box-shadow: 0 0 0 2px fade(@color-tint, 25%);
+@textfield-focus-box-shadow: 0 0 0 1px @color-tint;
 @textfield-focus-outline: none;
 
 .tox {

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-number-input.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-number-input.less
@@ -18,7 +18,7 @@
     width: auto;
 
     &:focus {
-      background: @toolbar-button-bespoke-background-color; // Prevent toolbar button focus background to override bespoke background
+      background: @toolbar-button-bespoke-focus-background-color; // Prevent toolbar button focus background to override bespoke background
     }
 
     &:focus::after {
@@ -32,6 +32,7 @@
       text-align: center;
 
       &:focus {
+        background-color: @toolbar-button-bespoke-focus-background-color;
         z-index: 1; // Ensure focus outline is on top of other buttons
 
         &::after {
@@ -58,6 +59,10 @@
         color: @toolbar-button-hover-text-color;
       }
 
+      &:focus {
+        background-color: @toolbar-button-bespoke-focus-background-color;
+      }
+
       &:disabled {
         background: @toolbar-button-disabled-background-color;
         border: @toolbar-button-disabled-border;
@@ -82,7 +87,7 @@
       }
 
       &:focus {
-        background: @toolbar-button-bespoke-background-color;
+        background: @toolbar-button-bespoke-focus-background-color;
         z-index: 1; // Ensure focus outline is on top of other buttons
 
         &::after {
@@ -136,6 +141,6 @@
 
   .tox-number-input:focus:not(:active) > button,
   .tox-number-input:focus:not(:active) > .tox-input-wrapper {
-    background: @toolbar-button-bespoke-background-color;
+    background: @toolbar-button-bespoke-focus-background-color;
   }
 }

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-select-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-select-button.less
@@ -5,6 +5,7 @@
 
 @toolbar-button-select-padding: 4px;
 @toolbar-button-bespoke-background-color: contrast(@background-color, darken(@background-color, 3%), lighten(@background-color, 7%));
+@toolbar-button-bespoke-focus-background-color: @toolbar-button-bespoke-background-color;
 @toolbar-button-bespoke-label-max-width: 7em;
 @toolbar-button-bespoke-spacing-x: 4px;
 
@@ -42,7 +43,7 @@
     background: @toolbar-button-bespoke-background-color;
 
     &:focus {
-      background: @toolbar-button-bespoke-background-color; // Prevent toolbar button focus background to override bespoke background
+      background: @toolbar-button-bespoke-focus-background-color; // Prevent toolbar button focus background to override bespoke background
     }
 
     & + .tox-tbtn--bespoke {

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-split-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-split-button.less
@@ -8,6 +8,7 @@
 .tox {
   .tox-split-button {
     border: 0;
+    border-radius: @toolbar-button-border-radius;
     box-sizing: border-box;
     display: flex;
     margin: (@toolbar-button-spacing-y + 1px) @toolbar-button-spacing-x @toolbar-button-spacing-y 0;
@@ -25,6 +26,7 @@
     z-index: 1; // Ensure focus outline is on top of other buttons
 
     &::after {
+      pointer-events: none; // Prevent the focus outline from opening the menu
       .keyboard-focus-outline-mixin();
     }
   }
@@ -55,6 +57,10 @@
 
   .tox-split-button .tox-tbtn {
     margin: 0;
+  }
+
+  .tox-split-button:focus .tox-tbtn {
+    background-color: transparent; // Prevent the toolbar button background to cover the parent split button's background color
   }
 
   .tox-split-button.tox-tbtn--disabled:hover,

--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -13,7 +13,7 @@
 @background-color: #fff;
 @base-value: 16px;
 @color-black: #222f3e;
-@color-tint: #006ce7;
+@color-tint: #ff0000;
 @color-white: #fff;
 @color-error: #c00;
 @color-success: #78AB46;

--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -13,7 +13,7 @@
 @background-color: #fff;
 @base-value: 16px;
 @color-black: #222f3e;
-@color-tint: #ff0000;
+@color-tint: #006ce7;
 @color-white: #fff;
 @color-error: #c00;
 @color-success: #78AB46;


### PR DESCRIPTION
Related Ticket: TINY-9681:

Description of Changes:
* Adressed a couple of instances where the toolbar background background didn't show up for the `tinymce-5` skin.
* The editable area focus outline is turned of for `TinyMCE-5` skins and the premium skins that inherit it.
* Fixed a better variable inheritance for the editable area focus outline color
* Made input field and button focus styles look like the new toolbar button focus outline.

Pre-checks:
* [x] ~~Changelog entry added~~ This is a correction of [TINY-9176](https://ephocks.atlassian.net/browse/TINY-9176)
* [x] ~~Tests have been added (if applicable)~~
* [x] ~~Branch prefixed with `feature/`, `hotfix/` or `spike/`~~

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
N/a

[TINY-9176]: https://ephocks.atlassian.net/browse/TINY-9176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ