### PR TITLE
TINY-10676: Update reference of TinyMCE 6 to 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The world's #1 open source rich text editor.
 
-**Using an old version of TinyMCE?** We recommend you to upgrade to TinyMCE 6 to continue receiving security updates, or consider [TinyMCE 5 LTS](https://www.tiny.cloud/long-term-support/) if you need more time to upgrade.
+**Using an old version of TinyMCE?** We recommend you to upgrade to TinyMCE 7 to continue receiving security updates, or consider [TinyMCE 5 LTS](https://www.tiny.cloud/long-term-support/) if you need more time to upgrade.
 
 Used and trusted by millions of developers, TinyMCE is the world’s most customizable, scalable, and flexible rich text editor. We’ve helped launch the likes of Atlassian, Medium, Evernote (and lots more that we can’t tell you), by empowering them to create exceptional content and experiences for their users.
 

--- a/modules/oxide-icons-default/README.md
+++ b/modules/oxide-icons-default/README.md
@@ -1,6 +1,6 @@
 # Default icons for TinyMCE
 
-This project contains the default icons for TinyMCE 6. Icons is loaded into the editor using a icon pack file. You can use this project as a basis for building your own icon packs. For instructions on how to make your own icon pack, see the [TinyMCE 6 documentation](https://www.tiny.cloud/docs/tinymce/6/creating-an-icon-pack/)
+This project contains the default icons for TinyMCE 7. Icons is loaded into the editor using a icon pack file. You can use this project as a basis for building your own icon packs. For instructions on how to make your own icon pack, see the [TinyMCE 7 documentation](https://www.tiny.cloud/docs/tinymce/7/creating-an-icon-pack/)
 
 ## Building the icon pack
 The icon pack build process uses [Node](http://nodejs.org/) and [Gulp](http://gulpjs.com/). Make sure you have both installed before you continue.

--- a/modules/oxide/README.md
+++ b/modules/oxide/README.md
@@ -1,7 +1,7 @@
 # TinyMCE Oxide skin tools
-This project contains the default skins as well as tools and files needed to build your own skin for TinyMCE 6.
+This project contains the default skins as well as tools and files needed to build your own skin for TinyMCE 7.
 
-Visit the [TinyMCE 6 documentation](https://www.tiny.cloud/docs/tinymce/6/creating-a-skin/) for instructions on how to create and build skins for TinyMCE.
+Visit the [TinyMCE 7 documentation](https://www.tiny.cloud/docs/tinymce/7/creating-a-skin/) for instructions on how to create and build skins for TinyMCE.
 
 ## Building the skins
 The build process uses [Node](http://nodejs.org/) and [Gulp](http://gulpjs.com/). Make sure you have both installed before you continue.


### PR DESCRIPTION
Related Ticket: 
TINY-10676

Description of Changes:
Update reference of TinyMCE 6 to 7 in root, `oxide` and `oxide-icons-default`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
