### PR TITLE
TINY-9154: Change media_url_resolver to use promises

### DIFF
--- a/.changes/unreleased/tinymce-TINY-9154-2024-02-26.yaml
+++ b/.changes/unreleased/tinymce-TINY-9154-2024-02-26.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Changed
-body: Change media_url_resolver to use promises
+body: Changed the `media_url_resolver` option to use promises.
 time: 2024-02-26T13:19:58.901491+11:00
 custom:
   Issue: TINY-9154

--- a/.changes/unreleased/tinymce-TINY-9154-2024-02-26.yaml
+++ b/.changes/unreleased/tinymce-TINY-9154-2024-02-26.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Changed
+body: Change media_url_resolver to use promises
+time: 2024-02-26T13:19:58.901491+11:00
+custom:
+  Issue: TINY-9154

--- a/modules/tinymce/src/plugins/media/main/ts/core/Service.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Service.ts
@@ -15,7 +15,7 @@ interface EmbedResponse {
   readonly html?: string;
 }
 
-export type MediaResolver = (data: { url: string }, resolve: (response: EmbedResponse) => void, reject: (reason?: any) => void) => void;
+export type MediaResolver = (data: { url: string }) => Promise<EmbedResponse>;
 
 const cache: Record<string, EmbedResponse> = {};
 

--- a/modules/tinymce/src/plugins/media/main/ts/core/Service.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Service.ts
@@ -33,7 +33,7 @@ const embedPromise = (data: MediaData, dataToHtml: DataToHtml.DataToHtmlCallback
     if (cache[data.source]) {
       wrappedResolve(cache[data.source]);
     } else {
-      handler({ url: data.source }, wrappedResolve, rej);
+      handler({ url: data.source }).then(wrappedResolve).catch(rej);
     }
   });
 };

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DataAttributeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DataAttributeTest.ts
@@ -11,7 +11,7 @@ describe('browser.tinymce.plugins.media.DataAttributeTest', () => {
     plugins: [ 'media' ],
     toolbar: 'media',
     media_url_resolver: (data: { url: string }) => {
-      Promise.resolve({ html: '<div data-ephox-embed-iri="' + data.url + '" style="max-width: 300px; max-height: 150px"></div>' });
+      return Promise.resolve({ html: '<div data-ephox-embed-iri="' + data.url + '" style="max-width: 300px; max-height: 150px"></div>' });
     },
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ]);

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DataAttributeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DataAttributeTest.ts
@@ -11,13 +11,7 @@ describe('browser.tinymce.plugins.media.DataAttributeTest', () => {
     plugins: [ 'media' ],
     toolbar: 'media',
     media_url_resolver: (data: { url: string }) => {
-      return new Promise<{ html: string }>((resolve, reject) => {
-        try {
-          resolve({ html: '<div data-ephox-embed-iri="' + data.url + '" style="max-width: 300px; max-height: 150px"></div>' });
-        } catch (error) {
-          reject(error);
-        }
-      });
+      Promise.resolve({ html: '<div data-ephox-embed-iri="' + data.url + '" style="max-width: 300px; max-height: 150px"></div>' });
     },
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ]);

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DataAttributeTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DataAttributeTest.ts
@@ -10,8 +10,14 @@ describe('browser.tinymce.plugins.media.DataAttributeTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: [ 'media' ],
     toolbar: 'media',
-    media_url_resolver: (data: { url: string }, resolve: (response: { html: string }) => void) => {
-      resolve({ html: '<div data-ephox-embed-iri="' + data.url + '" style="max-width: 300px; max-height: 150px"></div>' });
+    media_url_resolver: (data: { url: string }) => {
+      return new Promise<{ html: string }>((resolve, reject) => {
+        try {
+          resolve({ html: '<div data-ephox-embed-iri="' + data.url + '" style="max-width: 300px; max-height: 150px"></div>' });
+        } catch (error) {
+          reject(error);
+        }
+      });
     },
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ]);

--- a/modules/tinymce/src/plugins/media/test/ts/browser/EphoxEmbedTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/EphoxEmbedTest.ts
@@ -38,7 +38,7 @@ describe('browser.tinymce.plugins.media.core.EphoxEmbedTest', () => {
       plugins: [ 'media' ],
       toolbar: 'media',
       media_url_resolver: (data: { url: string }) => {
-        Promise.resolve({ html: '<video width="300" height="150" controls="controls">\n<source src="' + data.url + '" />\n</video>' });
+        return Promise.resolve({ html: '<video width="300" height="150" controls="controls">\n<source src="' + data.url + '" />\n</video>' });
       },
       base_url: '/project/tinymce/js/tinymce'
     }, [ Plugin ], true);

--- a/modules/tinymce/src/plugins/media/test/ts/browser/EphoxEmbedTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/EphoxEmbedTest.ts
@@ -38,15 +38,7 @@ describe('browser.tinymce.plugins.media.core.EphoxEmbedTest', () => {
       plugins: [ 'media' ],
       toolbar: 'media',
       media_url_resolver: (data: { url: string }) => {
-        return new Promise<{ html: string }>((resolve, reject) => {
-          try {
-            resolve({
-              html: '<video width="300" height="150" controls="controls">\n<source src="' + data.url + '" />\n</video>'
-            });
-          } catch (error) {
-            reject(error);
-          }
-        });
+        Promise.resolve({ html: '<video width="300" height="150" controls="controls">\n<source src="' + data.url + '" />\n</video>' });
       },
       base_url: '/project/tinymce/js/tinymce'
     }, [ Plugin ], true);

--- a/modules/tinymce/src/plugins/media/test/ts/browser/EphoxEmbedTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/EphoxEmbedTest.ts
@@ -37,10 +37,15 @@ describe('browser.tinymce.plugins.media.core.EphoxEmbedTest', () => {
     const hook = TinyHooks.bddSetupLight<Editor>({
       plugins: [ 'media' ],
       toolbar: 'media',
-      media_url_resolver: (data: { url: string }, resolve: (response: { html: string }) => void) => {
-        resolve({
-          html: '<video width="300" height="150" ' +
-            'controls="controls">\n<source src="' + data.url + '" />\n</video>'
+      media_url_resolver: (data: { url: string }) => {
+        return new Promise<{ html: string }>((resolve, reject) => {
+          try {
+            resolve({
+              html: '<video width="300" height="150" controls="controls">\n<source src="' + data.url + '" />\n</video>'
+            });
+          } catch (error) {
+            reject(error);
+          }
         });
       },
       base_url: '/project/tinymce/js/tinymce'

--- a/modules/tinymce/src/plugins/media/test/ts/browser/IsCachedResponseTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/IsCachedResponseTest.ts
@@ -13,7 +13,7 @@ describe('browser.tinymce.plugins.media.IsCachedResponseTest', () => {
     plugins: [ 'media' ],
     toolbar: 'media',
     media_url_resolver: () => {
-      Promise.resolve({ html: '<div>x</div>' });
+      return Promise.resolve({ html: '<div>x</div>' });
     },
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);

--- a/modules/tinymce/src/plugins/media/test/ts/browser/IsCachedResponseTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/IsCachedResponseTest.ts
@@ -12,8 +12,16 @@ describe('browser.tinymce.plugins.media.IsCachedResponseTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: [ 'media' ],
     toolbar: 'media',
-    media_url_resolver: () => {
-      return Promise.resolve({ html: '<div>x</div>' });
+    media_url_resolver: (data: { url: string }) => {
+      return new Promise<{ html: string }>((resolve, reject) => {
+        if (data.url === 'test') {
+          resolve({
+            html: '<div>x</div>'
+          });
+        } else {
+          reject('error');
+        }
+      });
     },
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);

--- a/modules/tinymce/src/plugins/media/test/ts/browser/IsCachedResponseTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/IsCachedResponseTest.ts
@@ -12,14 +12,8 @@ describe('browser.tinymce.plugins.media.IsCachedResponseTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: [ 'media' ],
     toolbar: 'media',
-    media_url_resolver: (data: { url: string }) => {
-      return new Promise<{ html: string }>((resolve, reject) => {
-        if (data.url === 'test') {
-          resolve({ html: '<div>x</div>' });
-        } else {
-          reject('error');
-        }
-      });
+    media_url_resolver: () => {
+      Promise.resolve({ html: '<div>x</div>' });
     },
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);

--- a/modules/tinymce/src/plugins/media/test/ts/browser/IsCachedResponseTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/IsCachedResponseTest.ts
@@ -12,13 +12,14 @@ describe('browser.tinymce.plugins.media.IsCachedResponseTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: [ 'media' ],
     toolbar: 'media',
-    media_url_resolver: (data: { url: string }, resolve: (response: { html: string }) => void, reject: (msg: string) => void) => {
-      if (data.url === 'test') {
-        resolve({
-          html: '<div>x</div>' });
-      } else {
-        reject('error');
-      }
+    media_url_resolver: (data: { url: string }) => {
+      return new Promise<{ html: string }>((resolve, reject) => {
+        if (data.url === 'test') {
+          resolve({ html: '<div>x</div>' });
+        } else {
+          reject('error');
+        }
+      });
     },
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);

--- a/modules/tinymce/src/plugins/media/test/ts/browser/MediaEmbedTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/MediaEmbedTest.ts
@@ -11,10 +11,16 @@ describe.skip('browser.tinymce.plugins.media.core.MediaEmbedTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: [ 'media' ],
     toolbar: 'media',
-    media_url_resolver: (data: { url: string }, resolve: (response: { html: string }) => void) => {
-      resolve({
-        html: '<video width="300" height="150" ' +
-          'controls="controls">\n<source src="' + data.url + '" />\n</video>'
+    media_url_resolver: (data: { url: string }) => {
+      return new Promise<{ html: string }>((resolve, reject) => {
+        try {
+          resolve({
+            html: '<video width="300" height="150" ' +
+              'controls="controls">\n<source src="' + data.url + '" />\n</video>'
+          });
+        } catch (error) {
+          reject(error);
+        }
       });
     },
     base_url: '/project/tinymce/js/tinymce'

--- a/modules/tinymce/src/plugins/media/test/ts/browser/MediaEmbedTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/MediaEmbedTest.ts
@@ -12,7 +12,7 @@ describe.skip('browser.tinymce.plugins.media.core.MediaEmbedTest', () => {
     plugins: [ 'media' ],
     toolbar: 'media',
     media_url_resolver: (data: { url: string }) => {
-      Promise.resolve({ html: '<video width="300" height="150" ' + 'controls="controls">\n<source src="' + data.url + '" />\n</video>' });
+      return Promise.resolve({ html: '<video width="300" height="150" ' + 'controls="controls">\n<source src="' + data.url + '" />\n</video>' });
     },
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ]);

--- a/modules/tinymce/src/plugins/media/test/ts/browser/MediaEmbedTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/MediaEmbedTest.ts
@@ -12,16 +12,7 @@ describe.skip('browser.tinymce.plugins.media.core.MediaEmbedTest', () => {
     plugins: [ 'media' ],
     toolbar: 'media',
     media_url_resolver: (data: { url: string }) => {
-      return new Promise<{ html: string }>((resolve, reject) => {
-        try {
-          resolve({
-            html: '<video width="300" height="150" ' +
-              'controls="controls">\n<source src="' + data.url + '" />\n</video>'
-          });
-        } catch (error) {
-          reject(error);
-        }
-      });
+      Promise.resolve({ html: '<video width="300" height="150" ' + 'controls="controls">\n<source src="' + data.url + '" />\n</video>' });
     },
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ]);

--- a/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/SubmitTest.ts
@@ -17,12 +17,14 @@ describe('browser.tinymce.plugins.media.core.SubmitTest', () => {
       base_url: '/project/tinymce/js/tinymce'
     }, [ Plugin ]);
 
-    const mediaUrlResolver = (data: { url: string }, resolve: (data: { html: string }) => void) => {
-      setTimeout(() => {
-        resolve({
-          html: '<span id="fake">' + data.url + '</span>'
-        });
-      }, 500);
+    const mediaUrlResolver = (data: { url: string }) => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({
+            html: '<span id="fake">' + data.url + '</span>'
+          });
+        }, 500);
+      });
     };
 
     const customEmbed =


### PR DESCRIPTION
Related Ticket: 
TINY-9154

Description of Changes:
Change media_url_resolver to use promises

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
