### PR TITLE
TINY-10670: Add importword exportpdf and exportword to default file menu

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10670-2024-02-26.yaml
+++ b/.changes/unreleased/tinymce-TINY-10670-2024-02-26.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Added
-body: Added importword, exportpdf and exportword menu items to default file menu
+body: Added importword, exportpdf and exportword menu items to default file menu.
 time: 2024-02-26T07:19:31.546619+01:00
 custom:
   Issue: TINY-10670

--- a/.changes/unreleased/tinymce-TINY-10670-2024-02-26.yaml
+++ b/.changes/unreleased/tinymce-TINY-10670-2024-02-26.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: Added importword, exportpdf and exportword menu items to default file menu
+time: 2024-02-26T07:19:31.546619+01:00
+custom:
+  Issue: TINY-10670

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
@@ -20,7 +20,7 @@ export interface MenuRegistry {
 const defaultMenubar = 'file edit view insert format tools table help';
 
 const defaultMenus: Record<string, MenuSpec> = {
-  file: { title: 'File', items: 'newdocument restoredraft | preview | export print | deleteallconversations' },
+  file: { title: 'File', items: 'newdocument restoredraft | preview | importword exportpdf exportword | export print | deleteallconversations' },
   edit: { title: 'Edit', items: 'undo redo | cut copy paste pastetext | selectall | searchreplace' },
   view: { title: 'View', items: 'code revisionhistory | visualaid visualchars visualblocks | spellchecker | preview fullscreen | showcomments' },
   insert: { title: 'Insert', items: 'image link media addcomment pageembed template inserttemplate codesample inserttable accordion | charmap emoticons hr | pagebreak nonbreaking anchor tableofcontents footnotes | mergetags | insertdatetime' },
@@ -37,9 +37,9 @@ const make = (menu: { title: string; items: string[] }, registry: MenuRegistry, 
     getItems: () => Arr.bind(menu.items, (i): Menu.NestedMenuItemContents[] => {
       const itemName = i.toLowerCase();
       if (itemName.trim().length === 0) {
-        return [ ];
+        return [];
       } else if (Arr.exists(removedMenuItems, (removedMenuItem) => removedMenuItem === itemName)) {
-        return [ ];
+        return [];
       } else if (itemName === 'separator' || itemName === '|') {
         return [{
           type: 'separator'
@@ -47,7 +47,7 @@ const make = (menu: { title: string; items: string[] }, registry: MenuRegistry, 
       } else if (registry.menuItems[itemName]) {
         return [ registry.menuItems[itemName] ];
       } else {
-        return [ ];
+        return [];
       }
     })
   };


### PR DESCRIPTION
Related Ticket: TINY-10670

Description of Changes:
* Added importword, exportpdf and exportword menu items to default file menu

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
