### PR TITLE
TINY-9980: Updated API docs for addCustomElements

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -713,10 +713,11 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
    */
 
   /**
-   * Adds custom non-HTML elements to the schema.
+   * Adds custom non-HTML elements to the schema. For more information about adding custom elements see:
+   * <a href="https://www.tiny.cloud/docs/tinymce/latest/content-filtering/#custom_elements">custom_elements</a>
    *
    * @method addCustomElements
-   * @param {String} custom_elements Comma separated list of custom elements to add.
+   * @param {String/Object} custom_elements Comma separated list or record of custom elements to add.
    */
 
   /**


### PR DESCRIPTION
Related Ticket: TINY-9980 (API docs follow up)

Description of Changes:
* Adds shallow API docs that references the more complete structure in the `tinymce-docs` section.
* Unsure if we should use `Object` or `Record<string, CustomElementSpec>` here since the types are pascal case for `String` but in TS that should really be `string` so we are not really TS compatible in the type information anyway?

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
