### PR TITLE
TINY-10681: Changed minimal key length to 64 on license_key check

### DIFF
--- a/modules/tinymce/src/core/main/ts/init/LicenseKeyValidation.ts
+++ b/modules/tinymce/src/core/main/ts/init/LicenseKeyValidation.ts
@@ -7,7 +7,7 @@ type KeyStatus = 'VALID' | 'INVALID';
 
 const isGplKey = (key: string) => key.toLowerCase() === 'gpl';
 
-const isValidGeneratedKey = (key: string): boolean => key.length >= 40 && key.length <= 255;
+const isValidGeneratedKey = (key: string): boolean => key.length >= 64 && key.length <= 255;
 
 export const validateLicenseKey = (key: string): KeyStatus => isGplKey(key) || isValidGeneratedKey(key) ? 'VALID' : 'INVALID';
 

--- a/modules/tinymce/src/core/test/ts/browser/init/LicenseKeyValidationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/LicenseKeyValidationTest.ts
@@ -11,9 +11,9 @@ describe('browser.tinymce.core.init.LicenseKeyValidationTest', () => {
   let oldWarn: typeof console.warn;
   let messages: string[] = [];
   const expectedLogMessage = 'You are running TinyMCE in evaluation mode. Provide a valid license key or specify the license to \'GPL\' to agree to the open source license terms. https://www.tiny.cloud/';
-  const invalidGeneratedKeyToShort = 'foo';
+  const invalidGeneratedKeyToShort = Arr.range(63, Fun.constant('x')).join('');
   const invalidGeneratedKeyToLong = Arr.range(512, Fun.constant('x')).join('');
-  const validGeneratedKey = Arr.range(52, Fun.constant('x')).join('');
+  const validGeneratedKey = Arr.range(67, Fun.constant('x')).join('');
 
   const beforeHandler = () => {
     messages = [];


### PR DESCRIPTION
Related Ticket: TINY-10681

Description of Changes:
* We are changing the minimal key length to 64 characters to avoid `api_key` confustion

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
