### PR TITLE
TINY-10702: Render tooltips in `dialog` sink to resolve stacking issue

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -58,7 +58,7 @@ const init = (lazySinks: { popup: () => Result<AlloyComponent, string>; dialog: 
     translate: I18n.translate,
     isDisabled: () => editor.mode.isReadOnly() || !editor.ui.isEnabled(),
     getOption: editor.options.get,
-    tooltips: TooltipsBackstage(lazySinks.popup)
+    tooltips: TooltipsBackstage(lazySinks.dialog)
   };
 
   const urlinput = UrlInputBackstage(editor);


### PR DESCRIPTION
Related Ticket: TINY-10702

Description of Changes:
* Popup sink and dialog sink has the same z-index, even though tooltip was set to a higher z-index, it is not shown on top of a modal dialog (see ticket for more info)
* Moving tooltip to dialog sink when `ui_mode: split` to address this issue, when `ui_mode: combined` , the tooltip is still rendered in the dialog sink, so it will show on top because the modal and tooltip is within the same sink
  
Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
 