### PR TITLE
TINY-10707: Improve table row height reizing when using top corner handles

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -1,4 +1,4 @@
-import { Arr, Obj, Throttler, Type } from '@ephox/katamari';
+import { Arr, Obj, Strings, Throttler, Type } from '@ephox/katamari';
 import { SelectorFind, Selectors, SugarElement } from '@ephox/sugar';
 
 import * as NodeType from '../../dom/NodeType';
@@ -134,14 +134,15 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
     }
   };
 
-  // TODO: TINY-10658 Remove height styling from last row to allow table ghost element to visually change
   const createGhostElement = (dom: DOMUtils, elm: HTMLElement) => {
     if (isMedia(elm)) {
       return dom.create('img', { src: Env.transparentSrc });
     } else if (NodeType.isTable(elm)) {
+      const isNorth = Strings.startsWith(selectedHandle.name, 'n');
+      const rowSelect = isNorth ? Arr.head : Arr.last;
       const tableElm = elm.cloneNode(true) as HTMLTableElement;
-      // Get last row, remove all height styles
-      Arr.last(dom.select('tr', tableElm)).each((tr) => {
+      // Get row, remove all height styles
+      rowSelect(dom.select('tr', tableElm)).each((tr) => {
         const cells = dom.select('td,th', tr);
         dom.setStyle(tr, 'height', null);
         Arr.each(cells, (cell) => dom.setStyle(cell, 'height', null));
@@ -335,6 +336,7 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
             height: '100%'
           });
 
+          // TODO: Want to know selected handle
           selectedElmGhost = createGhostElement(dom, selectedElm);
           dom.addClass(selectedElmGhost, 'mce-clonedresizable');
           dom.setAttrib(selectedElmGhost, 'data-mce-bogus', 'all');

--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -336,7 +336,6 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
             height: '100%'
           });
 
-          // TODO: Want to know selected handle
           selectedElmGhost = createGhostElement(dom, selectedElm);
           dom.addClass(selectedElmGhost, 'mce-clonedresizable');
           dom.setAttrib(selectedElmGhost, 'data-mce-bogus', 'all');

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/ResizeTableTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/ResizeTableTest.ts
@@ -1,6 +1,6 @@
 import { Mouse } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
-import { Arr, Cell } from '@ephox/katamari';
+import { Arr, Cell, Strings } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { TableGridSize } from '@ephox/snooker';
 import { Html, Insert, Remove, SelectorExists, SelectorFilter, SugarBody, SugarElement } from '@ephox/sugar';
@@ -613,30 +613,32 @@ describe('browser.tinymce.models.dom.table.ResizeTableTest', () => {
       assertEventData(lastObjectResizedEvent, 'objectresized');
     });
 
-    it('TINY-6242: adjusting the entire table should resize all columns', async () => {
-      const editor = hook.editor();
-      editor.setContent('');
-      const measurements = await pInsertResizeMeasure(editor,
-        () => TableTestUtils.pDragHandle(editor, 'se', 20, 0),
-        () => TableTestUtils.insertRaw(editor, pixelTable)
-      );
+    Arr.each([ 'nw', 'ne', 'se', 'sw' ], (origin) => {
+      it(`TINY-6242: adjusting the entire table should resize all columns (origin: ${origin})`, async () => {
+        const editor = hook.editor();
+        editor.setContent('');
+        const measurements = await pInsertResizeMeasure(editor,
+          () => TableTestUtils.pDragHandle(editor, origin, Strings.endsWith(origin, 'e') ? 20 : -20, 0),
+          () => TableTestUtils.insertRaw(editor, pixelTable)
+        );
 
-      assertUnitsBeforeResize(measurements.before, { tableWidth: 'px' });
-      assertUnitsAfterResize(measurements.after, { tableWidth: 'px', tableHeight: 'px', trHeight: 'px', tdWidth: 'px' });
+        assertUnitsBeforeResize(measurements.before, { tableWidth: 'px' });
+        assertUnitsAfterResize(measurements.after, { tableWidth: 'px', tableHeight: 'px', trHeight: 'px', tdWidth: 'px' });
 
-      assertRawSizesBeforeResize(measurements.before, {
-        tableWidth: 200,
+        assertRawSizesBeforeResize(measurements.before, {
+          tableWidth: 200,
+        });
+        const tdWidthBefore = (200.0 / 2) - defaultCellBorder - defaultCellPadding;
+        assertRawSizesAfterResize(measurements.after, {
+          tableWidth: 220,
+          tableHeight: defaultCellHeightOverall,
+          trHeights: [ defaultCellHeightOverall ],
+          tdWidths: [ tdWidthBefore + 10, tdWidthBefore + 10 ]
+        });
+
+        assertEventData(lastObjectResizeStartEvent, 'objectresizestart');
+        assertEventData(lastObjectResizedEvent, 'objectresized');
       });
-      const tdWidthBefore = (200.0 / 2) - defaultCellBorder - defaultCellPadding;
-      assertRawSizesAfterResize(measurements.after, {
-        tableWidth: 220,
-        tableHeight: defaultCellHeightOverall,
-        trHeights: [ defaultCellHeightOverall ],
-        tdWidths: [ tdWidthBefore + 10, tdWidthBefore + 10 ]
-      });
-
-      assertEventData(lastObjectResizeStartEvent, 'objectresizestart');
-      assertEventData(lastObjectResizedEvent, 'objectresized');
     });
   });
 
@@ -671,30 +673,60 @@ describe('browser.tinymce.models.dom.table.ResizeTableTest', () => {
       assertEventData(lastObjectResizedEvent, 'objectresized');
     });
 
-    it('TINY-6242: adjusting the entire table should resize the last column', async () => {
-      const editor = hook.editor();
-      editor.setContent('');
-      const measurements = await pInsertResizeMeasure(editor,
-        () => TableTestUtils.pDragHandle(editor, 'ne', 20, 0),
-        () => TableTestUtils.insertRaw(editor, pixelTable)
-      );
+    Arr.each([ 'ne', 'se' ], (origin) => {
+      it(`TINY-6242: adjusting the entire table with the east corner handles should resize the last column (origin: ${origin})`, async () => {
+        const editor = hook.editor();
+        editor.setContent('');
+        const measurements = await pInsertResizeMeasure(editor,
+          () => TableTestUtils.pDragHandle(editor, origin, 20, 0),
+          () => TableTestUtils.insertRaw(editor, pixelTable)
+        );
 
-      assertUnitsBeforeResize(measurements.before, { tableWidth: 'px' });
-      assertUnitsAfterResize(measurements.after, { tableWidth: 'px', tableHeight: 'px', trHeight: 'px', tdWidth: 'px' });
+        assertUnitsBeforeResize(measurements.before, { tableWidth: 'px' });
+        assertUnitsAfterResize(measurements.after, { tableWidth: 'px', tableHeight: 'px', trHeight: 'px', tdWidth: 'px' });
 
-      assertRawSizesBeforeResize(measurements.before, {
-        tableWidth: 200,
+        assertRawSizesBeforeResize(measurements.before, {
+          tableWidth: 200,
+        });
+        const tdWidthBefore = (200.0 / 2) - defaultCellBorder - defaultCellPadding;
+        assertRawSizesAfterResize(measurements.after, {
+          tableWidth: 220,
+          tableHeight: defaultCellHeightOverall,
+          trHeights: [ defaultCellHeightOverall ],
+          tdWidths: [ tdWidthBefore, tdWidthBefore + 20 ]
+        });
+
+        assertEventData(lastObjectResizeStartEvent, 'objectresizestart');
+        assertEventData(lastObjectResizedEvent, 'objectresized');
       });
-      const tdWidthBefore = (200.0 / 2) - defaultCellBorder - defaultCellPadding;
-      assertRawSizesAfterResize(measurements.after, {
-        tableWidth: 220,
-        tableHeight: defaultCellHeightOverall,
-        trHeights: [ defaultCellHeightOverall ],
-        tdWidths: [ tdWidthBefore, tdWidthBefore + 20 ]
-      });
+    });
 
-      assertEventData(lastObjectResizeStartEvent, 'objectresizestart');
-      assertEventData(lastObjectResizedEvent, 'objectresized');
+    Arr.each([ 'nw', 'sw' ], (origin) => {
+      it(`TINY-6242: adjusting the entire table with the west corner handles should resize the first column (origin: ${origin})`, async () => {
+        const editor = hook.editor();
+        editor.setContent('');
+        const measurements = await pInsertResizeMeasure(editor,
+          () => TableTestUtils.pDragHandle(editor, origin, -20, 0),
+          () => TableTestUtils.insertRaw(editor, pixelTable)
+        );
+
+        assertUnitsBeforeResize(measurements.before, { tableWidth: 'px' });
+        assertUnitsAfterResize(measurements.after, { tableWidth: 'px', tableHeight: 'px', trHeight: 'px', tdWidth: 'px' });
+
+        assertRawSizesBeforeResize(measurements.before, {
+          tableWidth: 200,
+        });
+        const tdWidthBefore = (200.0 / 2) - defaultCellBorder - defaultCellPadding;
+        assertRawSizesAfterResize(measurements.after, {
+          tableWidth: 220,
+          tableHeight: defaultCellHeightOverall,
+          trHeights: [ defaultCellHeightOverall ],
+          tdWidths: [ tdWidthBefore + 20, tdWidthBefore ]
+        });
+
+        assertEventData(lastObjectResizeStartEvent, 'objectresizestart');
+        assertEventData(lastObjectResizedEvent, 'objectresized');
+      });
     });
   });
 
@@ -706,27 +738,54 @@ describe('browser.tinymce.models.dom.table.ResizeTableTest', () => {
       table_use_colgroups: false
     }, []);
 
-    it('TINY-6242: adjusting the entire table should not resize more than the last column width', async () => {
-      const editor = hook.editor();
-      editor.setContent('');
-      const measurements = await pInsertResizeMeasure(editor,
-        () => TableTestUtils.pDragHandle(editor, 'ne', -250, 0),
-        () => TableTestUtils.insertRaw(editor, percentTable)
-      );
+    Arr.each([ 'ne', 'se' ], (origin) => {
+      it(`TINY-6242: adjusting the entire table with the east corner handles should not resize more than the last column width (origin: ${origin})`, async () => {
+        const editor = hook.editor();
+        editor.setContent('');
+        const measurements = await pInsertResizeMeasure(editor,
+          () => TableTestUtils.pDragHandle(editor, origin, -250, 0),
+          () => TableTestUtils.insertRaw(editor, percentTable)
+        );
 
-      assertUnitsBeforeResize(measurements.before, { tableWidth: '%', tdWidth: '%' });
-      assertUnitsAfterResize(measurements.after, { tableWidth: '%', tableHeight: 'px', trHeight: 'px', tdWidth: '%' });
+        assertUnitsBeforeResize(measurements.before, { tableWidth: '%', tdWidth: '%' });
+        assertUnitsAfterResize(measurements.after, { tableWidth: '%', tableHeight: 'px', trHeight: 'px', tdWidth: '%' });
 
-      assertRawSizesBeforeResize(measurements.before, { tableWidth: 100, tdWidths: [ 50, 50 ] });
-      assertRawSizesAfterResize(measurements.after, {
-        tableWidth: 53,
-        tableHeight: defaultCellHeightOverall,
-        trHeights: [ defaultCellHeightOverall ],
-        tdWidths: [ 95, 5 ],
+        assertRawSizesBeforeResize(measurements.before, { tableWidth: 100, tdWidths: [ 50, 50 ] });
+        assertRawSizesAfterResize(measurements.after, {
+          tableWidth: 53,
+          tableHeight: defaultCellHeightOverall,
+          trHeights: [ defaultCellHeightOverall ],
+          tdWidths: [ 95, 5 ],
+        });
+
+        assertEventData(lastObjectResizeStartEvent, 'objectresizestart');
+        assertEventData(lastObjectResizedEvent, 'objectresized');
       });
+    });
 
-      assertEventData(lastObjectResizeStartEvent, 'objectresizestart');
-      assertEventData(lastObjectResizedEvent, 'objectresized');
+    Arr.each([ 'nw', 'sw' ], (origin) => {
+      it(`TINY-6242: adjusting the entire table with the west corner handles should not resize more than the first column width (origin: ${origin})`, async () => {
+        const editor = hook.editor();
+        editor.setContent('');
+        const measurements = await pInsertResizeMeasure(editor,
+          () => TableTestUtils.pDragHandle(editor, origin, 250, 0),
+          () => TableTestUtils.insertRaw(editor, percentTable)
+        );
+
+        assertUnitsBeforeResize(measurements.before, { tableWidth: '%', tdWidth: '%' });
+        assertUnitsAfterResize(measurements.after, { tableWidth: '%', tableHeight: 'px', trHeight: 'px', tdWidth: '%' });
+
+        assertRawSizesBeforeResize(measurements.before, { tableWidth: 100, tdWidths: [ 50, 50 ] });
+        assertRawSizesAfterResize(measurements.after, {
+          tableWidth: 53,
+          tableHeight: defaultCellHeightOverall,
+          trHeights: [ defaultCellHeightOverall ],
+          tdWidths: [ 5, 95 ],
+        });
+
+        assertEventData(lastObjectResizeStartEvent, 'objectresizestart');
+        assertEventData(lastObjectResizedEvent, 'objectresized');
+      });
     });
   });
 
@@ -821,13 +880,75 @@ describe('browser.tinymce.models.dom.table.ResizeTableTest', () => {
     </tbody></table>`;
 
     context('resizing with corner handle', () => {
+      Arr.each([ 'nw', 'ne', 'se', 'sw' ], (origin) => {
+        it(`TINY-10589: resizing a default table should distribute height across all trs evenly (origin: ${origin})`, async () => {
+          const editor = hook.editor();
+          editor.setContent('');
+          const measurements = await pInsertResizeMeasure(editor,
+            () => TableTestUtils.pDragHandle(editor, origin, 0, Strings.startsWith(origin, 's') ? 20 : -20),
+            () => TableTestUtils.makeInsertTable(editor, 2, 2)
+          );
+
+          assertUnitsBeforeResize(measurements.before, { tableWidth: 'px', colWidth: 'px' });
+          assertUnitsAfterResize(measurements.after, { tableWidth: 'px', tableHeight: 'px', trHeight: 'px', colWidth: 'px' });
+
+          const colWidthBefore = editorBodyInternalWidth / 2;
+          assertRawSizesBeforeResize(measurements.before, {
+            tableWidth: editorBodyInternalWidth,
+            colWidths: [ colWidthBefore, colWidthBefore ]
+          });
+          assertRawSizesAfterResize(measurements.after, {
+            tableWidth: editorBodyInternalWidth,
+            colWidths: [ colWidthBefore, colWidthBefore ],
+            tableHeight: defaultCellHeightOverall * 2 + 20,
+            trHeights: [ defaultCellHeightOverall + 10, defaultCellHeightOverall + 10 ],
+          });
+
+          assertEventData(lastObjectResizeStartEvent, 'objectresizestart');
+          assertEventData(lastObjectResizedEvent, 'objectresized');
+        });
+      });
+
+      Arr.each([ 'nw', 'ne', 'se', 'sw' ], (origin) => {
+        it(`TINY-10589: resizing a table with existing tr heights should resize the correct row (origin: ${origin})`, async () => {
+          const editor = hook.editor();
+          editor.setContent('');
+
+          const dy = 20;
+          const measurements = await pInsertResizeMeasure(editor,
+            () => TableTestUtils.pDragHandle(editor, origin, 0, Strings.startsWith(origin, 's') ? dy : -dy),
+            () => TableTestUtils.insertRaw(editor, tableWithHeightOnTableAndTrs)
+          );
+
+          assertUnitsBeforeResize(measurements.before, { tableWidth: 'px', tableHeight: 'px', colWidth: 'px', trHeight: 'px' });
+          assertUnitsAfterResize(measurements.after, { tableWidth: 'px', tableHeight: 'px', colWidth: 'px', trHeight: 'px' });
+
+          assertRawSizesBeforeResize(measurements.before, {
+            tableWidth: 50,
+            colWidths: [ 50 ],
+            tableHeight: 200,
+            trHeights: [ 100, 100 ]
+          });
+          const expectedRowToResize = Strings.startsWith(origin, 'n') ? 0 : 1;
+          assertRawSizesAfterResize(measurements.after, {
+            tableWidth: 50,
+            colWidths: [ 50 ],
+            tableHeight: 200 + dy,
+            trHeights: [ 100 + (expectedRowToResize === 0 ? dy : 0), 100 + (expectedRowToResize === 1 ? dy : 0) ],
+          });
+
+          assertEventData(lastObjectResizeStartEvent, 'objectresizestart');
+          assertEventData(lastObjectResizedEvent, 'objectresized');
+        });
+      });
+
       context('height on table, trs and tds', () => {
         Arr.each([
           { title: 'TINY-10589: resize table larger with se handle and verify only table and trs have heights', corner: 'se', dy: 50 },
           { title: 'TINY-10589: resize table smaller with se handle and verify only table and trs have heights', corner: 'se', dy: -30 },
           { title: 'TINY-10589: resize table larger with sw handle and verify only table and trs have heights', corner: 'sw', dy: 50 },
           { title: 'TINY-10589: resize table smaller with sw handle and verify only table and trs have heights', corner: 'sw', dy: -30 },
-
+          { title: 'TINY-10707: resize table smaller with sw handle and verify only table and trs have heights', corner: 'sw', dy: -30 }
         ], (scenario) => {
           const { title, corner, dy } = scenario;
 


### PR DESCRIPTION
Related Ticket: TINY-10707

Description of Changes:
* Follow up to TINY-10658 and TINY-10589
* Found that when `table_column_resizing: 'resizetable'` is set and when using either the top-left or bottom-left corner resize handles, only the first column is resized. So just making the behaviour consistent for row resizing as well

Pre-checks:
* ~~[X] Changelog entry added~~ Changelog entries from TINY-10658 and TINY-10589 should be sufficient
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [X] Docs ticket created (if applicable)

GitHub issues (if applicable):
