### PR TITLE
TINY-10535: Improve list of iframe sandboxing exclusions

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -853,9 +853,13 @@ const register = (editor: Editor): void => {
       'youtube.com',
       'youtu.be',
       'vimeo.com',
+      'player.vimeo.com',
       'dailymotion.com',
+      'embed.music.apple.com',
+      'open.spotify.com',
+      'giphy.com',
       'dai.ly',
-      'codepen.io'
+      'codepen.io',
     ]
   });
 


### PR DESCRIPTION
Related Ticket: TINY-10535

Description of Changes:
* Add more popular embed websites to list of `sandbox_iframe_exclusions` to avoid unexpected behaviour

Pre-checks:
* [x] ~Changelog entry added~ Already in TINY-10350
* [x] ~Tests have been added (if applicable)~ Already in TINY-10350
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
