### PR TITLE
TINY-10713: Change Advanced List plugin name to List Styles

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
+++ b/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
@@ -163,7 +163,7 @@ const registry = (): Registry.Registry => {
     addSidebar: bridge.addSidebar,
 
     /**
-     * Registers a new split button for the toolbar. The advanced list plugin uses
+     * Registers a new split button for the toolbar. The list styles plugin uses
      * a split button to simplify its functionality.
      * <br>
      * For information on creating a split toolbar button, see:

--- a/modules/tinymce/src/plugins/advlist/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/Plugin.ts
@@ -12,7 +12,7 @@ export default (): void => {
       Commands.register(editor);
     } else {
       // eslint-disable-next-line no-console
-      console.error('Please use the Lists plugin together with the Advanced List plugin.');
+      console.error('Please use the Lists plugin together with the List Styles plugin.');
     }
   });
 };

--- a/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
@@ -20,7 +20,6 @@ export interface PluginUrl extends PartialPluginUrl {
 // These lists are automatically sorted when generating the dialog.
 const urls = Arr.map<PartialPluginUrl, PluginUrl>([
   { key: 'accordion', name: 'Accordion' },
-  { key: 'advlist', name: 'List Styles' },
   { key: 'anchor', name: 'Anchor' },
   { key: 'autolink', name: 'Autolink' },
   { key: 'autoresize', name: 'Autoresize' },
@@ -38,6 +37,7 @@ const urls = Arr.map<PartialPluginUrl, PluginUrl>([
   { key: 'insertdatetime', name: 'Insert Date/Time' },
   { key: 'link', name: 'Link' },
   { key: 'lists', name: 'Lists' },
+  { key: 'advlist', name: 'List Styles' },
   { key: 'media', name: 'Media' },
   { key: 'nonbreaking', name: 'Nonbreaking' },
   { key: 'pagebreak', name: 'Page Break' },

--- a/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
@@ -20,7 +20,7 @@ export interface PluginUrl extends PartialPluginUrl {
 // These lists are automatically sorted when generating the dialog.
 const urls = Arr.map<PartialPluginUrl, PluginUrl>([
   { key: 'accordion', name: 'Accordion' },
-  { key: 'advlist', name: 'Advanced List' },
+  { key: 'advlist', name: 'List Styles' },
   { key: 'anchor', name: 'Anchor' },
   { key: 'autolink', name: 'Autolink' },
   { key: 'autoresize', name: 'Autoresize' },


### PR DESCRIPTION
Related Ticket: TINY-10713

Description of Changes:
* Change Advanced List plugin name to List Styles

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
