### PR TITLE
TINY-10710: Fix revision cards not having the same width

### DIFF
--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -62,6 +62,7 @@
         cursor: pointer;
         margin-bottom: @pad-sm;
         padding: @pad-sm;
+        width: 100%;
 
         &:hover {
           background-color: @button-hover-background-color;


### PR DESCRIPTION
Related Ticket: TINY-10710

Description of Changes:
* Make sure the revision cards to grow full width

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
