### PR TITLE
TINY-10717: Fixed Esc and arrow keys and IME not starting

### DIFF
--- a/modules/tinymce/src/core/main/ts/keyboard/Autocompleter.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/Autocompleter.ts
@@ -32,13 +32,14 @@ const setupEditorInput = (editor: Editor, api: AutocompleterApi) => {
       update.throttle();
     // Pressing <esc> closes the autocompleter
     } else if (keyCode === 27) {
+      update.cancel(); // We need to cancel here since Esc cancels the IME composition and triggers an input event
       api.cancelIfNecessary();
     } else if (keyCode === 38 || keyCode === 40) {
       // Arrow up and down keys needs to cancel the update since while composing arrow up or down will end the compose and issue a input event
       // that causes the list to update and then the focus moves up to the first item in the auto completer list.
       update.cancel();
     }
-  });
+  }, true); // Need to add this to the top so that it exectued before the silver keyboard event
 
   editor.on('remove', update.cancel);
 };
@@ -58,8 +59,7 @@ export const setup = (editor: Editor): void => {
   };
 
   const commenceIfNecessary = (context: AutocompleteContext) => {
-    /* Autocompleter works by moving the content into a newly generated element. When combined with composing this creates issues where unexpected data input and visual issues */
-    if (!isActive() && !editor.composing) {
+    if (!isActive()) {
       // store the element/context
       activeAutocompleter.set({
         trigger: context.trigger,


### PR DESCRIPTION
Related Ticket: TINY-10717

Description of Changes:
* Fixed the Esc key not properly closing the autocompleter when in IME
* Fixed the arrow down key re-rendering the autocomplete list
* Fixed issue where the autocompleter would not start in a IME session on other browsers than Safari

Pre-checks:
* [-] Changelog entry added
* [-] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
