### PR TITLE
TINY-10710: Add focus style for the revisions list

### DIFF
--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -67,6 +67,22 @@
       overflow-y: auto;
       padding: @revisionhistory-card-padding;
 
+      &:focus {
+        height: 100%;
+        position: relative;   // Override static which prevents z-index to have any effect
+        z-index: 1; // Ensure focus outline is on top of other buttons
+
+        &::after {
+          .keyboard-focus-outline-mixin();
+
+          border-radius: @control-border-radius;
+          bottom: 1px;
+          left: 1px;
+          right: 1px;
+          top: 1px;
+        }
+      }
+
       .tox-revisionhistory__card {
         border: @revisionhistory-border;
         border-radius: @control-border-radius;


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Add an outline to indicate when the revisions list is focused which is when there is no revisions

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
