### PR TITLE
TINY-10732:  Fallback `FooterToggleButton` in dialog to use `spec.text` to set the `aria-label` attribute

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -227,7 +227,7 @@ const renderToggleButton = (spec: FooterToggleButtonSpec, providers: UiFactoryBa
     borderless: false
   };
 
-  const tooltipAttributes = buttonSpec.tooltip.map<{}>((tooltip) => ({
+  const tooltipAttributes = buttonSpec.tooltip.or(spec.text).map((tooltip) => ({
     'aria-label': providers.translate(tooltip),
   })).getOr({});
 


### PR DESCRIPTION
Related Ticket: TINY-10732

Description of Changes:
* The `aria-label` still takes tooltip property as the priority, otherwise will fallback to the spec.text for those buttons with visible labels.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
