### PR TITLE
TINY-10734: Fix the bottom part of the revision history diff iframe hidden behind its container

### DIFF
--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -17,9 +17,13 @@
 
 .tox {
   .tox-revisionhistory__pane {
+    padding: 0 !important;      /* Override the default padding of tox-view__pane */
+  }
+
+  .tox-revisionhistory__container {
     display: flex;
     flex-direction: column;
-    padding: 0 !important;      /* Override the default padding of tox-view__pane */
+    height: 100%;
   }
 
   .tox-revisionhistory {


### PR DESCRIPTION
Related Ticket: TINY-10734

Description of Changes:
* Update the layout CSS to make sure the revision history diff iframe is not clipped off.


Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
