### PR TITLE
TINY-9932: Add itemprop, itemscope, and itemtype to HTML5 schema

### DIFF
--- a/.changes/unreleased/tinymce-TINY-9932-2024-03-06.yaml
+++ b/.changes/unreleased/tinymce-TINY-9932-2024-03-06.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Improved
-body: Included itemprop, itemscope, itemtype as valid HTML5 element
+body: Included itemprop, itemscope, itemtype as valid HTML5 attributes.
 time: 2024-03-06T15:55:10.739553+11:00
 custom:
   Issue: TINY-9932

--- a/.changes/unreleased/tinymce-TINY-9932-2024-03-06.yaml
+++ b/.changes/unreleased/tinymce-TINY-9932-2024-03-06.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Improved
-body: Added itemprop, itemscope, itemtype as valid HTML5 element
+body: Included itemprop, itemscope, itemtype as valid HTML5 element
 time: 2024-03-06T15:55:10.739553+11:00
 custom:
   Issue: TINY-9932

--- a/.changes/unreleased/tinymce-TINY-9932-2024-03-06.yaml
+++ b/.changes/unreleased/tinymce-TINY-9932-2024-03-06.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Improved
+body: Added itemprop, itemscope, itemtype as valid HTML5 element
+time: 2024-03-06T15:55:10.739553+11:00
+custom:
+  Issue: TINY-9932

--- a/.changes/unreleased/tinymce-TINY-9932-2024-03-06.yaml
+++ b/.changes/unreleased/tinymce-TINY-9932-2024-03-06.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Improved
-body: Included itemprop, itemscope, itemtype as valid HTML5 attributes.
+body: Included itemprop, itemscope, itemtype as valid HTML5 attributes in the core schema.
 time: 2024-03-06T15:55:10.739553+11:00
 custom:
   Issue: TINY-9932

--- a/modules/dragster/src/test/ts/browser/datatransfer/DataTransferTest.ts
+++ b/modules/dragster/src/test/ts/browser/datatransfer/DataTransferTest.ts
@@ -12,6 +12,7 @@ describe('browser.dragster.datatransfer.DataTransferTest', () => {
   const browser = PlatformDetection.detect().browser;
   const isSafari = browser.isSafari();
   const isFirefox = browser.isFirefox();
+  const isChrome = browser.isChromium();
 
   const testFile1 = new window.File([ 'Lorem ipsum' ], 'file1.txt', { type: 'text/plain', lastModified: 123 });
   const testFile2 = new window.File([ '<p>Lorem ipsum</p>' ], 'file2.html', { type: 'text/html', lastModified: 456 });
@@ -227,8 +228,9 @@ describe('browser.dragster.datatransfer.DataTransferTest', () => {
       assert.strictEqual(transfer.files.length, 2, 'Should have same number of files');
 
       transfer.clearData();
-      if (isFirefox || isSafari) {
+      if (isFirefox || isSafari || isChrome) {
         // Firefox & Safari follows the spec where clearData does not remove files
+        // Chromium now also follows the spec
         // https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/clearData
         assert.deepEqual(transfer.types, [ 'Files' ], 'Should have Files type remaining');
         assert.strictEqual(transfer.files.length, 2, 'Files should not have been cleared');

--- a/modules/tinymce/src/core/main/ts/schema/GlobalAttributesSet.ts
+++ b/modules/tinymce/src/core/main/ts/schema/GlobalAttributesSet.ts
@@ -15,7 +15,7 @@ export const getGlobalAttributeSet = (type: SchemaType): readonly string[] => {
 
     // html5 and html5-strict extra attributes
     ...(
-      type !== 'html4' ? [ 'contenteditable', 'contextmenu', 'draggable', 'dropzone', 'hidden', 'spellcheck', 'translate' ] : []
+      type !== 'html4' ? [ 'contenteditable', 'contextmenu', 'draggable', 'dropzone', 'hidden', 'spellcheck', 'translate', 'itemprop', 'itemscope', 'itemtype' ] : []
     ),
 
     // html4 and html5 extra attributes

--- a/modules/tinymce/src/core/test/ts/atomic/schema/GlobalAttributesSetTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/schema/GlobalAttributesSetTest.ts
@@ -20,7 +20,7 @@ describe('atomic.tinymce.core.schema.GlobalAttributesSetTest', () => {
     type: 'html5',
     expected: [
       'id', 'accesskey', 'class', 'dir', 'lang', 'style', 'tabindex', 'title', 'role', 'contenteditable', 'contextmenu',
-      'draggable', 'dropzone', 'hidden', 'spellcheck', 'translate', 'xml:lang'
+      'draggable', 'dropzone', 'hidden', 'spellcheck', 'translate', 'xml:lang', 'itemprop', 'itemscope', 'itemtype'
     ]
   }));
 
@@ -28,7 +28,7 @@ describe('atomic.tinymce.core.schema.GlobalAttributesSetTest', () => {
     type: 'html5-strict',
     expected: [
       'id', 'accesskey', 'class', 'dir', 'lang', 'style', 'tabindex', 'title', 'role', 'contenteditable', 'contextmenu',
-      'draggable', 'dropzone', 'hidden', 'spellcheck', 'translate'
+      'draggable', 'dropzone', 'hidden', 'spellcheck', 'translate', 'itemprop', 'itemscope', 'itemtype'
     ]
   }));
 

--- a/modules/tinymce/src/core/test/ts/atomic/schema/GlobalAttributesSetTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/schema/GlobalAttributesSetTest.ts
@@ -20,7 +20,7 @@ describe('atomic.tinymce.core.schema.GlobalAttributesSetTest', () => {
     type: 'html5',
     expected: [
       'id', 'accesskey', 'class', 'dir', 'lang', 'style', 'tabindex', 'title', 'role', 'contenteditable', 'contextmenu',
-      'draggable', 'dropzone', 'hidden', 'spellcheck', 'translate', 'xml:lang', 'itemprop', 'itemscope', 'itemtype'
+      'draggable', 'dropzone', 'hidden', 'spellcheck', 'translate', 'itemprop', 'itemscope', 'itemtype', 'xml:lang'
     ]
   }));
 

--- a/modules/tinymce/src/core/test/ts/atomic/schema/SchemaLookupTableTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/schema/SchemaLookupTableTest.ts
@@ -13,18 +13,18 @@ describe('atomic.tinymce.core.schema.SchemaLookupTableTest', () => {
 
   it('HTML5 lookup table', () => testSchemaInputElementAttributes('html5', [
     'id', 'accesskey', 'class', 'dir', 'lang', 'style', 'tabindex', 'title', 'role', 'contenteditable', 'contextmenu',
-    'draggable', 'dropzone', 'hidden', 'spellcheck', 'translate', 'xml:lang', 'accept', 'alt', 'autocomplete',
+    'draggable', 'dropzone', 'hidden', 'spellcheck', 'translate', 'itemprop', 'itemscope', 'itemtype', 'xml:lang', 'accept', 'alt', 'autocomplete',
     'checked', 'dirname', 'disabled', 'form', 'formaction', 'formenctype', 'formmethod', 'formnovalidate',
     'formtarget', 'height', 'list', 'max', 'maxlength', 'min', 'multiple', 'name', 'pattern', 'readonly',
-    'required', 'size', 'src', 'step', 'type', 'value', 'width', 'usemap', 'align', 'autofocus', 'placeholder', 'itemprop', 'itemscope', 'itemtype'
+    'required', 'size', 'src', 'step', 'type', 'value', 'width', 'usemap', 'align', 'autofocus', 'placeholder'
   ]));
 
   it('HTML5-strict lookup table', () => testSchemaInputElementAttributes('html5-strict', [
     'id', 'accesskey', 'class', 'dir', 'lang', 'style', 'tabindex', 'title', 'role', 'contenteditable', 'contextmenu',
-    'draggable', 'dropzone', 'hidden', 'spellcheck', 'translate', 'accept', 'alt', 'autocomplete', 'checked',
+    'draggable', 'dropzone', 'hidden', 'spellcheck', 'translate', 'itemprop', 'itemscope', 'itemtype', 'accept', 'alt', 'autocomplete', 'checked',
     'dirname', 'disabled', 'form', 'formaction', 'formenctype', 'formmethod', 'formnovalidate', 'formtarget',
     'height', 'list', 'max', 'maxlength', 'min', 'multiple', 'name', 'pattern', 'readonly', 'required',
-    'size', 'src', 'step', 'type', 'value', 'width', 'autofocus', 'placeholder', 'itemprop', 'itemscope', 'itemtype'
+    'size', 'src', 'step', 'type', 'value', 'width', 'autofocus', 'placeholder'
   ]));
 
   it('HTML4 lookup table', () => testSchemaInputElementAttributes('html4', [

--- a/modules/tinymce/src/core/test/ts/atomic/schema/SchemaLookupTableTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/schema/SchemaLookupTableTest.ts
@@ -16,7 +16,7 @@ describe('atomic.tinymce.core.schema.SchemaLookupTableTest', () => {
     'draggable', 'dropzone', 'hidden', 'spellcheck', 'translate', 'xml:lang', 'accept', 'alt', 'autocomplete',
     'checked', 'dirname', 'disabled', 'form', 'formaction', 'formenctype', 'formmethod', 'formnovalidate',
     'formtarget', 'height', 'list', 'max', 'maxlength', 'min', 'multiple', 'name', 'pattern', 'readonly',
-    'required', 'size', 'src', 'step', 'type', 'value', 'width', 'usemap', 'align', 'autofocus', 'placeholder'
+    'required', 'size', 'src', 'step', 'type', 'value', 'width', 'usemap', 'align', 'autofocus', 'placeholder', 'itemprop', 'itemscope', 'itemtype'
   ]));
 
   it('HTML5-strict lookup table', () => testSchemaInputElementAttributes('html5-strict', [
@@ -24,7 +24,7 @@ describe('atomic.tinymce.core.schema.SchemaLookupTableTest', () => {
     'draggable', 'dropzone', 'hidden', 'spellcheck', 'translate', 'accept', 'alt', 'autocomplete', 'checked',
     'dirname', 'disabled', 'form', 'formaction', 'formenctype', 'formmethod', 'formnovalidate', 'formtarget',
     'height', 'list', 'max', 'maxlength', 'min', 'multiple', 'name', 'pattern', 'readonly', 'required',
-    'size', 'src', 'step', 'type', 'value', 'width', 'autofocus', 'placeholder'
+    'size', 'src', 'step', 'type', 'value', 'width', 'autofocus', 'placeholder', 'itemprop', 'itemscope', 'itemtype'
   ]));
 
   it('HTML4 lookup table', () => testSchemaInputElementAttributes('html4', [

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -816,12 +816,12 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
       assert.deepEqual(schema.getElementRule('foo'), {
         attributesOrder: [
           'id', 'accesskey', 'class', 'dir', 'lang', 'style', 'tabindex', 'title', 'role', 'contenteditable', 'contextmenu', 'draggable',
-          'dropzone', 'hidden', 'spellcheck', 'translate', 'xml:lang', 'bar', 'itemprop', 'itemscope', 'itemtype'
+          'dropzone', 'hidden', 'spellcheck', 'translate', 'itemprop', 'itemscope', 'itemtype', 'xml:lang', 'bar'
         ],
         attributes: {
           'id': {}, 'accesskey': {}, 'class': {}, 'dir': {}, 'lang': {}, 'style': {}, 'tabindex': {}, 'title': {}, 'role': {},
           'contenteditable': {}, 'contextmenu': {}, 'draggable': {}, 'dropzone': {}, 'hidden': {},
-          'spellcheck': {}, 'translate': {}, 'xml:lang': {}, 'bar': {}, 'itemprop': {}, 'itemscope': {}, 'itemtype': {}
+          'spellcheck': {}, 'translate': {}, 'itemprop': {}, 'itemscope': {}, 'itemtype': {}, 'xml:lang': {}, 'bar': {}
         }
       });
     });

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -816,12 +816,12 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
       assert.deepEqual(schema.getElementRule('foo'), {
         attributesOrder: [
           'id', 'accesskey', 'class', 'dir', 'lang', 'style', 'tabindex', 'title', 'role', 'contenteditable', 'contextmenu', 'draggable',
-          'dropzone', 'hidden', 'spellcheck', 'translate', 'xml:lang', 'bar'
+          'dropzone', 'hidden', 'spellcheck', 'translate', 'xml:lang', 'bar', 'itemprop', 'itemscope', 'itemtype'
         ],
         attributes: {
           'id': {}, 'accesskey': {}, 'class': {}, 'dir': {}, 'lang': {}, 'style': {}, 'tabindex': {}, 'title': {}, 'role': {},
           'contenteditable': {}, 'contextmenu': {}, 'draggable': {}, 'dropzone': {}, 'hidden': {},
-          'spellcheck': {}, 'translate': {}, 'xml:lang': {}, 'bar': {}
+          'spellcheck': {}, 'translate': {}, 'xml:lang': {}, 'bar': {}, 'itemprop': {}, 'itemscope': {}, 'itemtype': {}
         }
       });
     });

--- a/modules/tinymce/src/core/test/ts/webdriver/keyboard/SpaceKeyTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/keyboard/SpaceKeyTest.ts
@@ -27,7 +27,11 @@ describe('webdriver.tinymce.core.keyboard.SpaceKeyTest', () => {
       editor.setContent('<p>s<span style="display: block;" contenteditable="false">a</span></p>');
       TinySelections.setCursor(editor, [ 0, 0 ], 1);
       await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.text(' ') ]);
-      TinyAssertions.assertContent(editor, '<p>s&nbsp;<span style="display: block;" contenteditable="false">a</span></p>');
+      if (isFirefox) {
+        TinyAssertions.assertContent(editor, '<p>s&nbsp;<br><span style="display: block;" contenteditable="false">a</span></p>');
+      } else {
+        TinyAssertions.assertContent(editor, '<p>s&nbsp;<span style="display: block;" contenteditable="false">a</span></p>');
+      }
     });
 
     it('TINY-8588: Add two spaces just before a block', async () => {
@@ -39,7 +43,7 @@ describe('webdriver.tinymce.core.keyboard.SpaceKeyTest', () => {
       if (isSafari) { // Split due to normalization issue. See TINY-8833
         TinyAssertions.assertContent(editor, '<p>s &nbsp;<span style="display: block;" contenteditable="false">a</span></p>');
       } else if (isFirefox) { // Split due to normalization issue. See TINY-8833
-        TinyAssertions.assertContent(editor, '<p>s&nbsp; <span style="display: block;" contenteditable="false">a</span></p>');
+        TinyAssertions.assertContent(editor, '<p>s&nbsp; <br><span style="display: block;" contenteditable="false">a</span></p>');
       } else {
         TinyAssertions.assertContent(editor, '<p>s&nbsp;&nbsp;<span style="display: block;" contenteditable="false">a</span></p>');
       }
@@ -50,7 +54,11 @@ describe('webdriver.tinymce.core.keyboard.SpaceKeyTest', () => {
       editor.setContent('<p><span class="filler">s</span><span style="display: block;" contenteditable="false">a</span></p>');
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
       await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.text(' ') ]);
-      TinyAssertions.assertContent(editor, '<p><span class="filler">s&nbsp;</span><span style="display: block;" contenteditable="false">a</span></p>');
+      if (isFirefox) {
+        TinyAssertions.assertContent(editor, '<p><span class="filler">s&nbsp;<br></span><span style="display: block;" contenteditable="false">a</span></p>');
+      } else {
+        TinyAssertions.assertContent(editor, '<p><span class="filler">s&nbsp;</span><span style="display: block;" contenteditable="false">a</span></p>');
+      }
     });
 
     it('TINY-8588: Add one space before a block inside a strong', async () => {
@@ -58,7 +66,11 @@ describe('webdriver.tinymce.core.keyboard.SpaceKeyTest', () => {
       editor.setContent('<p>s<strong><span contenteditable="false" style="display: block;">a</span></strong></p>');
       TinySelections.setCursor(editor, [ 0, 0 ], 1);
       await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.text(' ') ]);
-      TinyAssertions.assertContent(editor, '<p>s&nbsp;<strong><span style="display: block;" contenteditable="false">a</span></strong></p>');
+      if (isFirefox) {
+        TinyAssertions.assertContent(editor, '<p>s&nbsp;<br><strong><span style="display: block;" contenteditable="false">a</span></strong></p>');
+      } else {
+        TinyAssertions.assertContent(editor, '<p>s&nbsp;<strong><span style="display: block;" contenteditable="false">a</span></strong></p>');
+      }
     });
 
     it('TINY-8814: Add one space just after a block', async () => {


### PR DESCRIPTION
Related Ticket: 
TINY-9932

Description of Changes:
- Add itemprop, itemscope, and itemtype to HTML5 schema
- Update test

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
