### PR TITLE
TINY-10370: Cover `{$caret}` placeholder feature of editor.insertContent API with tests.

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/InsertContentTest.ts
@@ -859,4 +859,65 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
       TinyAssertions.assertContent(editor, '<p>a<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><desc><p>hello</p></desc></circle></svg>b</p>');
     });
   });
+
+  context('${caret) placeholder of caret position after insert', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      indent: false,
+      base_url: '/project/tinymce/js/tinymce',
+    }, [], true);
+
+    it('TINY-10370: should position the cursor at the beginning', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>cd</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+      editor.insertContent('{$caret}ab');
+      TinyAssertions.assertContent(editor, '<p>abcd</p>');
+      TinyAssertions.assertCursor(editor, [ 0 ], 0);
+    });
+
+    it('TINY-10370: should position the cursor in the middle', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>ad</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      editor.insertContent('b{$caret}c');
+      TinyAssertions.assertContent(editor, '<p>abcd</p>');
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 2);
+    });
+
+    it('TINY-10370: should position the cursor in the end', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>ab</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 2);
+      editor.insertContent('cd{$caret}');
+      TinyAssertions.assertContent(editor, '<p>abcd</p>');
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 4);
+    });
+
+    it('TINY-10370: should handle only first placeholder', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>ae</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      editor.insertContent('b{$caret}c{$caret}d');
+      TinyAssertions.assertContent(editor, '<p>abc{$caret}de</p>');
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 2);
+    });
+
+    it('TINY-10370: should pass over the placeholder in the content', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>a{$caret}be</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 10);
+      editor.insertContent('c{$caret}d');
+      TinyAssertions.assertContent(editor, '<p>a{$caret}bcde</p>');
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 11);
+    });
+
+    it('TINY-10370: more complex nested content', () => {
+      const editor = hook.editor();
+      editor.setContent('<ul><li>abc</li></ul>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+      editor.insertContent('<p><strong>d{$caret}<em>ef</em></strong></p>');
+      TinyAssertions.assertContent(editor, '<ul><li>ab<p><strong>d<em>ef</em></strong></p>c</li></ul>');
+      TinyAssertions.assertCursor(editor, [ 0, 0, 1, 0, 0 ], 1);
+    });
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/insert/CaretPlaceholderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/insert/CaretPlaceholderTest.ts
@@ -1,0 +1,65 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.content.insert.CaretPlaceholderTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce',
+  }, [], true);
+
+  it('TINY-10370: should position the cursor at the beginning', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>cd</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 0);
+    editor.insertContent('{$caret}ab');
+    TinyAssertions.assertContent(editor, '<p>abcd</p>');
+    TinyAssertions.assertCursor(editor, [ 0 ], 0);
+  });
+
+  it('TINY-10370: should position the cursor in the middle', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>ad</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    editor.insertContent('b{$caret}c');
+    TinyAssertions.assertContent(editor, '<p>abcd</p>');
+    TinyAssertions.assertCursor(editor, [ 0, 0 ], 2);
+  });
+
+  it('TINY-10370: should position the cursor in the end', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>ab</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 2);
+    editor.insertContent('cd{$caret}');
+    TinyAssertions.assertContent(editor, '<p>abcd</p>');
+    TinyAssertions.assertCursor(editor, [ 0, 0 ], 4);
+  });
+
+  it('TINY-10370: should handle only first placeholder', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>ae</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    editor.insertContent('b{$caret}c{$caret}d');
+    TinyAssertions.assertContent(editor, '<p>abc{$caret}de</p>');
+    TinyAssertions.assertCursor(editor, [ 0, 0 ], 2);
+  });
+
+  it('TINY-10370: should pass over the placeholder in the content', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>a{$caret}be</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 10);
+    editor.insertContent('c{$caret}d');
+    TinyAssertions.assertContent(editor, '<p>a{$caret}bcde</p>');
+    TinyAssertions.assertCursor(editor, [ 0, 0 ], 11);
+  });
+
+  it('TINY-10370: more complex nested content', () => {
+    const editor = hook.editor();
+    editor.setContent('<ul><li>abc</li></ul>');
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+    editor.insertContent('<p><strong>d{$caret}<em>ef</em></strong></p>');
+    TinyAssertions.assertContent(editor, '<ul><li>ab<p><strong>d<em>ef</em></strong></p>c</li></ul>');
+    TinyAssertions.assertCursor(editor, [ 0, 0, 1, 0, 0 ], 1);
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentCommandTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentCommandTest.ts
@@ -4,7 +4,7 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 
-describe('browser.tinymce.core.content.InsertContentCommandTest', () => {
+describe('browser.tinymce.core.content.insert.InsertContentCommandTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     add_unload_trigger: false,
     disable_nodechange: true,

--- a/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentTest.ts
@@ -7,7 +7,7 @@ import { SetContentEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import * as InsertContent from 'tinymce/core/content/InsertContent';
 
-describe('browser.tinymce.core.content.InsertContentTest', () => {
+describe('browser.tinymce.core.content.insert.InsertContentTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     add_unload_trigger: false,
     disable_nodechange: true,
@@ -841,83 +841,6 @@ describe('browser.tinymce.core.content.InsertContentTest', () => {
       editor.insertContent('<!--\ufeff><iframe onload=alert(document.domain)>-></body>-->');
       // TINY-10305: Safari escapes text nodes within <iframe>.
       TinyAssertions.assertRawContent(editor, '<p><!---->initial</p>');
-    });
-  });
-
-  context('SVG elements', () => {
-    const hook = TinyHooks.bddSetupLight<Editor>({
-      indent: false,
-      base_url: '/project/tinymce/js/tinymce',
-      extended_valid_elements: 'svg[width|height]'
-    }, [], true);
-
-    it('TINY-10237: Inserting SVG elements but filter out things like scripts', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>ab</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      editor.insertContent('<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><desc><script>alert(1)</script><p>hello</p></circle></a></svg>');
-      TinyAssertions.assertContent(editor, '<p>a<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><desc><p>hello</p></desc></circle></svg>b</p>');
-    });
-  });
-
-  context('${caret) placeholder of caret position after insert', () => {
-    const hook = TinyHooks.bddSetupLight<Editor>({
-      indent: false,
-      base_url: '/project/tinymce/js/tinymce',
-    }, [], true);
-
-    it('TINY-10370: should position the cursor at the beginning', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>cd</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 0);
-      editor.insertContent('{$caret}ab');
-      TinyAssertions.assertContent(editor, '<p>abcd</p>');
-      TinyAssertions.assertCursor(editor, [ 0 ], 0);
-    });
-
-    it('TINY-10370: should position the cursor in the middle', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>ad</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      editor.insertContent('b{$caret}c');
-      TinyAssertions.assertContent(editor, '<p>abcd</p>');
-      TinyAssertions.assertCursor(editor, [ 0, 0 ], 2);
-    });
-
-    it('TINY-10370: should position the cursor in the end', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>ab</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 2);
-      editor.insertContent('cd{$caret}');
-      TinyAssertions.assertContent(editor, '<p>abcd</p>');
-      TinyAssertions.assertCursor(editor, [ 0, 0 ], 4);
-    });
-
-    it('TINY-10370: should handle only first placeholder', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>ae</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      editor.insertContent('b{$caret}c{$caret}d');
-      TinyAssertions.assertContent(editor, '<p>abc{$caret}de</p>');
-      TinyAssertions.assertCursor(editor, [ 0, 0 ], 2);
-    });
-
-    it('TINY-10370: should pass over the placeholder in the content', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>a{$caret}be</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 10);
-      editor.insertContent('c{$caret}d');
-      TinyAssertions.assertContent(editor, '<p>a{$caret}bcde</p>');
-      TinyAssertions.assertCursor(editor, [ 0, 0 ], 11);
-    });
-
-    it('TINY-10370: more complex nested content', () => {
-      const editor = hook.editor();
-      editor.setContent('<ul><li>abc</li></ul>');
-      TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
-      editor.insertContent('<p><strong>d{$caret}<em>ef</em></strong></p>');
-      TinyAssertions.assertContent(editor, '<ul><li>ab<p><strong>d<em>ef</em></strong></p>c</li></ul>');
-      TinyAssertions.assertCursor(editor, [ 0, 0, 1, 0, 0 ], 1);
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentWebKitBugs.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentWebKitBugs.ts
@@ -3,7 +3,7 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
-describe('browser.tinymce.core.content.InsertContentTest', () => {
+describe('browser.tinymce.core.content.insert.InsertContentTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce',

--- a/modules/tinymce/src/core/test/ts/browser/content/insert/InsertListTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/insert/InsertListTest.ts
@@ -7,7 +7,7 @@ import AstNode from 'tinymce/core/api/html/Node';
 import Schema from 'tinymce/core/api/html/Schema';
 import * as InsertList from 'tinymce/core/content/InsertList';
 
-describe('browser.tinymce.core.content.InsertListTest', () => {
+describe('browser.tinymce.core.content.insert.InsertListTest', () => {
   const schema = Schema({});
 
   const createFragment = (html: string): AstNode => {

--- a/modules/tinymce/src/core/test/ts/browser/content/insert/InsertUnsanitizedContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/insert/InsertUnsanitizedContentTest.ts
@@ -3,7 +3,7 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
-describe('browser.tinymce.core.content.InsertUnsanitizedContentTest', () => {
+describe('browser.tinymce.core.content.insert.InsertUnsanitizedContentTest', () => {
   const unsanitizedHtml = '<p id="action">XSS</p>';
   const sanitizedHtml = '<p>XSS</p>';
   const testInsertContent = (editor: Editor, content: string, expected: string) => {

--- a/modules/tinymce/src/core/test/ts/browser/content/insert/SvgTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/insert/SvgTest.ts
@@ -1,0 +1,20 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.content.insert.SvgTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce',
+    extended_valid_elements: 'svg[width|height]'
+  }, [], true);
+
+  it('TINY-10237: Inserting SVG elements but filter out things like scripts', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>ab</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    editor.insertContent('<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><desc><script>alert(1)</script><p>hello</p></circle></a></svg>');
+    TinyAssertions.assertContent(editor, '<p>a<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><desc><p>hello</p></desc></circle></svg>b</p>');
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-10370

Description of Changes:
* Cover undocumented {$caret} placeholder feature of editor.insertContent API.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] ~Milestone set~
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
