### PR TITLE
TINY-10781: Apply high contrast colour in WHCM, retain colour swatch

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10781-2024-04-22.yaml
+++ b/.changes/unreleased/tinymce-TINY-10781-2024-04-22.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Improved
+body: Editor now renders the currect high contrast color in Windows High Contrast
+  Mode
+time: 2024-04-22T22:21:18.646603+10:00
+custom:
+  Issue: TINY-10781

--- a/.changes/unreleased/tinymce-TINY-10781-2024-04-22.yaml
+++ b/.changes/unreleased/tinymce-TINY-10781-2024-04-22.yaml
@@ -1,7 +1,6 @@
 project: tinymce
 kind: Improved
-body: Editor now renders the currect high contrast color in Windows High Contrast
-  Mode
+body: The editor UI now renders correctly in Windows High Contrast Mode
 time: 2024-04-22T22:21:18.646603+10:00
 custom:
   Issue: TINY-10781

--- a/modules/oxide/src/less/theme/components/checkbox/checkbox.less
+++ b/modules/oxide/src/less/theme/components/checkbox/checkbox.less
@@ -44,6 +44,10 @@
     .tox-checkbox-icon__unchecked svg {
       display: block;
       fill: @checkbox-unselected-color;
+
+      @media (forced-colors: active) {
+        fill: currentColor !important;
+      }
     }
 
     .tox-checkbox-icon__indeterminate svg {

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -65,6 +65,13 @@
     //
   }
 
+  .tox-collection__item--active {
+
+    @media (forced-colors: active) {
+      filter: brightness(50%);
+    }
+  }
+
   .tox-collection--toolbar .tox-collection__group {
     display: flex;
     padding: 0;

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -65,10 +65,6 @@
     //
   }
 
-  .tox-collection__item--active {
-    //
-  }
-
   .tox-collection--toolbar .tox-collection__group {
     display: flex;
     padding: 0;

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -66,10 +66,7 @@
   }
 
   .tox-collection__item--active {
-
-    @media (forced-colors: active) {
-      filter: brightness(50%);
-    }
+    //
   }
 
   .tox-collection--toolbar .tox-collection__group {
@@ -193,6 +190,10 @@
 
   .tox-collection--list .tox-collection__item--active:not(.tox-collection__item--state-disabled) {
     color: @collection-list-item-label-active-text-color;
+
+    @media (forced-colors: active) {
+      border: solid 1px;
+    }
   }
 
   .tox-collection--toolbar .tox-collection__item--active:not(.tox-collection__item--state-disabled) {

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -151,6 +151,11 @@
   .tox-collection--toolbar .tox-collection__item--enabled.tox-collection__item--active:hover {
     background-color: @collection-toolbar-item-enabled-background-color;
     color: @collection-toolbar-item-label-enabled-text-color;
+
+    @media (forced-colors: active) {
+      border-radius: 3px;
+      outline: solid 1px;
+    }
   }
 
   .tox-collection--toolbar .tox-collection__item--active {
@@ -198,6 +203,13 @@
 
   .tox-collection--toolbar .tox-collection__item--active:not(.tox-collection__item--state-disabled) {
     color: @collection-toolbar-item-label-active-text-color;
+
+    @media (forced-colors: active) {
+      &:hover {
+        border-radius: 3px;
+        outline: solid 1px;
+      }
+    }
   }
 
   .tox-collection__item-icon,

--- a/modules/oxide/src/less/theme/components/color-picker/color-picker.less
+++ b/modules/oxide/src/less/theme/components/color-picker/color-picker.less
@@ -109,10 +109,6 @@
     border: 1px solid black;
     flex-grow: 2;
     margin-bottom: 0;
-
-    @media (forced-colors: active) {
-      forced-color-adjust: none;
-    }
   }
 }
 

--- a/modules/oxide/src/less/theme/components/color-picker/color-picker.less
+++ b/modules/oxide/src/less/theme/components/color-picker/color-picker.less
@@ -3,6 +3,14 @@
 //
 
 .tox {
+  .tox-hue-slider,
+  .tox-rgb-form .tox-rgba-preview {
+
+    @media (forced-colors: active) {
+      forced-color-adjust: none;
+    }
+  }
+
   .tox-color-picker-container {
     display: flex;
     flex-direction: row;
@@ -47,10 +55,6 @@
     box-sizing: border-box;
     height: 100%;
     width: 25px;
-
-    @media (forced-colors: active) {
-      forced-color-adjust: none;
-    }
   }
 
   .tox-hue-slider-spectrum {

--- a/modules/oxide/src/less/theme/components/color-picker/color-picker.less
+++ b/modules/oxide/src/less/theme/components/color-picker/color-picker.less
@@ -7,6 +7,8 @@
   .tox-rgb-form .tox-rgba-preview {
 
     @media (forced-colors: active) {
+      background-color: currentColor !important;
+      border: 1px solid highlight !important;
       forced-color-adjust: none;
     }
   }

--- a/modules/oxide/src/less/theme/components/color-picker/color-picker.less
+++ b/modules/oxide/src/less/theme/components/color-picker/color-picker.less
@@ -47,6 +47,10 @@
     box-sizing: border-box;
     height: 100%;
     width: 25px;
+
+    @media (forced-colors: active) {
+      forced-color-adjust: none;
+    }
   }
 
   .tox-hue-slider-spectrum {
@@ -101,6 +105,10 @@
     border: 1px solid black;
     flex-grow: 2;
     margin-bottom: 0;
+
+    @media (forced-colors: active) {
+      forced-color-adjust: none;
+    }
   }
 }
 

--- a/modules/oxide/src/less/theme/components/color-swatch/color-swatch.less
+++ b/modules/oxide/src/less/theme/components/color-swatch/color-swatch.less
@@ -23,6 +23,11 @@
   }
 
   .tox-swatches__row {
+
+    @media (forced-colors: active) {
+      forced-color-adjust: none;
+    }
+
     display: flex;
   }
 

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -237,6 +237,11 @@
   .tox-dialog__body-nav-item--active {
     border-bottom: 2px solid @dialog-body-link-color;
     color: @dialog-body-link-color;
+
+    @media (forced-colors: active) {
+      border-bottom: 2px solid highlight;
+      color: highlight;
+    }
   }
 
   .tox-dialog__body-content {

--- a/modules/oxide/src/less/theme/components/edit-area/edit-area.less
+++ b/modules/oxide/src/less/theme/components/edit-area/edit-area.less
@@ -23,6 +23,10 @@
       position: absolute;
       transition: opacity .15s;
       z-index: 1;
+
+      @media (forced-colors: active) {
+        border: @edit-area-border-width solid highlight;
+      }
     }
   }
 

--- a/modules/oxide/src/less/theme/components/form/color.less
+++ b/modules/oxide/src/less/theme/components/form/color.less
@@ -29,6 +29,7 @@
 
       @media (forced-colors: active) {
         border-color: currentColor;
+        border-width: 2px !important;
         forced-color-adjust: none;
       }
 

--- a/modules/oxide/src/less/theme/components/form/color.less
+++ b/modules/oxide/src/less/theme/components/form/color.less
@@ -27,6 +27,11 @@
       top: 6px;
       width: $height;
 
+      @media (forced-colors: active) {
+        border-color: currentColor;
+        forced-color-adjust: none;
+      }
+
       &:hover:not([aria-disabled=true]),
       &:focus:not([aria-disabled=true]) {
         border-color: @input-button-focus-border-color;
@@ -51,6 +56,10 @@
         top: -1px;
         width: $height;
         z-index: -1;
+
+        @media (forced-colors: active) {
+          border: none;
+        }
       }
     }
 

--- a/modules/oxide/src/less/theme/components/form/listbox.less
+++ b/modules/oxide/src/less/theme/components/form/listbox.less
@@ -34,6 +34,10 @@
 
   .tox-listbox__select-chevron svg {
     fill: @listbox-button-chevron-color;
+
+    @media (forced-colors: active) {
+      fill: currentColor !important;
+    }
   }
 
   .tox-listboxfield .tox-listbox--select {

--- a/modules/oxide/src/less/theme/components/insert-table-picker/insert-table-picker.less
+++ b/modules/oxide/src/less/theme/components/insert-table-picker/insert-table-picker.less
@@ -42,6 +42,7 @@
 
     @media (forced-colors: active) {
       border-color: Highlight;
+      filter: contrast(50%);
     }
 
     background-color: @insert-table-picker-selected-background-color;

--- a/modules/oxide/src/less/theme/components/insert-table-picker/insert-table-picker.less
+++ b/modules/oxide/src/less/theme/components/insert-table-picker/insert-table-picker.less
@@ -42,7 +42,6 @@
 
     @media (forced-colors: active) {
       border-color: Highlight;
-      filter: brightness(50%);
     }
 
     background-color: @insert-table-picker-selected-background-color;

--- a/modules/oxide/src/less/theme/components/insert-table-picker/insert-table-picker.less
+++ b/modules/oxide/src/less/theme/components/insert-table-picker/insert-table-picker.less
@@ -39,6 +39,12 @@
 
   // Selected cell
   .tox-insert-table-picker .tox-insert-table-picker__selected {
+
+    @media (forced-colors: active) {
+      border-color: Highlight;
+      filter: brightness(50%);
+    }
+
     background-color: @insert-table-picker-selected-background-color;
     border-color: @insert-table-picker-selected-border-color;
   }

--- a/modules/oxide/src/less/theme/components/pop/pop.less
+++ b/modules/oxide/src/less/theme/components/pop/pop.less
@@ -69,6 +69,11 @@
     opacity: 1;
     position: absolute;
     width: 0;
+
+    @media (forced-colors: active) {
+      // TODO: Temporary disabled due to unable to set the colour of the arrow in forced-colors mode
+      content: none;
+    }
   }
 
   // Hide the arrows on inset layouts and make the arrow transition as it disappears

--- a/modules/oxide/src/less/theme/components/statusbar/statusbar.less
+++ b/modules/oxide/src/less/theme/components/statusbar/statusbar.less
@@ -122,6 +122,11 @@
 
   .tox-statusbar__branding {
     svg {
+
+      @media (forced-colors: active) {
+        fill: currentColor;
+      }
+
       fill: @statusbar-logo-color;
       height: 1.14em;
       vertical-align: -.28em;

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
@@ -73,9 +73,41 @@
     text-transform: @toolbar-button-text-transform;
     width: @toolbar-button-width;
 
+    @media (forced-colors: active) {
+      &:hover {
+        filter: brightness(70%);
+      }
+
+      &.tox-tbtn--active,
+      &.tox-tbtn--enabled,
+      &.tox-tbtn--enabled:hover,
+      &.tox-tbtn--enabled:focus,
+      &:focus:not(.tox-tbtn--disabled) {
+        filter: brightness(50%);
+      }
+    }
+
     svg {
       display: block;
       fill: @toolbar-button-icon-color;
+
+      @media (forced-colors: active) {
+        &,
+        &:hover,
+        &.tox-tbtn--enabled,
+        &.tox-tbtn--enabled:hover,
+        &.tox-tbtn--enabled:focus,
+        &:focus:not(.tox-tbtn--disabled) {
+          fill: #f0f !important;
+        }
+
+        &.tox-tbtn--disabled,
+        &.tox-tbtn--disabled:hover,
+        .tox-tbtn:disabled,
+        .tox-tbtn:disabled:hover {
+          filter: contrast(0%);
+        }
+      }
     }
   }
 

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
@@ -74,11 +74,11 @@
     width: @toolbar-button-width;
 
     @media (forced-colors: active) {
-      &:hover {
-        outline: 1px solid currentColor;
+      &:hover,
+      &.tox-tbtn:hover {
+        outline: 1px dashed currentColor;
       }
 
-      &.tox-tbtn:hover,
       &.tox-tbtn--active,
       &.tox-tbtn--enabled,
       &.tox-tbtn--enabled:hover,

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
@@ -75,15 +75,18 @@
 
     @media (forced-colors: active) {
       &:hover {
-        filter: brightness(70%);
+        border: 1px solid currentColor;
+        border-radius: 3px;
       }
 
+      &.tox-tbtn:hover,
       &.tox-tbtn--active,
       &.tox-tbtn--enabled,
       &.tox-tbtn--enabled:hover,
       &.tox-tbtn--enabled:focus,
       &:focus:not(.tox-tbtn--disabled) {
-        filter: brightness(50%);
+        border: 1px solid currentColor;
+        border-radius: 3px;
       }
     }
 
@@ -92,13 +95,13 @@
       fill: @toolbar-button-icon-color;
 
       @media (forced-colors: active) {
-        &,
-        &:hover,
+        & {
+          fill: currentColor !important;
+        }
+
         &.tox-tbtn--enabled,
-        &.tox-tbtn--enabled:hover,
-        &.tox-tbtn--enabled:focus,
         &:focus:not(.tox-tbtn--disabled) {
-          fill: #f0f !important;
+          fill: currentColor !important;
         }
 
         &.tox-tbtn--disabled,

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
@@ -75,8 +75,7 @@
 
     @media (forced-colors: active) {
       &:hover {
-        border: 1px solid currentColor;
-        border-radius: 3px;
+        outline: 1px solid currentColor;
       }
 
       &.tox-tbtn:hover,
@@ -85,8 +84,8 @@
       &.tox-tbtn--enabled:hover,
       &.tox-tbtn--enabled:focus,
       &:focus:not(.tox-tbtn--disabled) {
-        border: 1px solid currentColor;
-        border-radius: 3px;
+        outline: 1px solid currentColor;
+        position: relative;
       }
     }
 

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-number-input.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-number-input.less
@@ -83,8 +83,7 @@
         &:hover,
         &:focus,
         &:active {
-          border: 1px solid currentColor !important;
-          border-radius: 3px !important;
+          outline: 1px solid currentColor !important;
         }
       }
 

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-number-input.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-number-input.less
@@ -79,6 +79,15 @@
       text-align: center;
       width: @toolbar-number-input-button-width;
 
+      @media (forced-colors: active) {
+        &:hover,
+        &:focus,
+        &:active {
+          border: 1px solid currentColor !important;
+          border-radius: 3px !important;
+        }
+      }
+
       svg {
         display: block;
         fill: @toolbar-button-icon-color;
@@ -87,13 +96,9 @@
 
         @media (forced-colors: active) {
           &,
-          &:active {
-            fill: currentColor;
-          }
-
+          &:active,
           &:hover {
-            fill: currentColor;
-            filter: brightness(50%);
+            fill: currentColor !important;
           }
 
           &:disabled {

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-number-input.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-number-input.less
@@ -84,6 +84,22 @@
         fill: @toolbar-button-icon-color;
         margin: 0 auto;
         transform: scale(@toolbar-number-input-button-icon-ratio);
+
+        @media (forced-colors: active) {
+          &,
+          &:active {
+            fill: currentColor;
+          }
+
+          &:hover {
+            fill: currentColor;
+            filter: brightness(50%);
+          }
+
+          &:disabled {
+            filter: contrast(0);
+          }
+        }
       }
 
       &:focus {

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-select-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-select-button.less
@@ -34,6 +34,11 @@
   }
 
   .tox-tbtn__select-chevron svg {
+
+    @media (forced-colors: active) {
+      fill: currentColor;
+    }
+
     fill: @toolbar-button-chevron-color;
   }
 

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-split-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-split-button.less
@@ -52,6 +52,11 @@
   }
 
   .tox-split-button__chevron svg {
+
+    @media (forced-colors: active) {
+      fill: currentColor;
+    }
+
     fill: @toolbar-button-chevron-color;
   }
 

--- a/modules/oxide/src/less/theme/components/toolbar/toolbar.less
+++ b/modules/oxide/src/less/theme/components/toolbar/toolbar.less
@@ -81,7 +81,7 @@
     padding-top: @toolbar-separator-distance + @toolbar-padding-y;
 
     @media (forced-colors: active) {
-      border: 1px solid currentColor;
+      outline: 1px solid currentColor;
     }
   }
 

--- a/modules/oxide/src/less/theme/components/toolbar/toolbar.less
+++ b/modules/oxide/src/less/theme/components/toolbar/toolbar.less
@@ -79,6 +79,10 @@
     margin-top: @toolbar-separator-distance - 1px;
     padding-bottom: @toolbar-padding-y;
     padding-top: @toolbar-separator-distance + @toolbar-padding-y;
+
+    @media (forced-colors: active) {
+      border: 1px solid currentColor;
+    }
   }
 
   .tox-toolbar--scrolling {
@@ -127,6 +131,10 @@
   box-shadow: @pop-box-shadow;
   overscroll-behavior: none;
   padding: @pad-xs 0;
+
+  @media (forced-colors: active) {
+    border: solid;
+  }
 }
 
 // Context toolbar

--- a/modules/oxide/src/less/theme/components/tooltip/tooltip.less
+++ b/modules/oxide/src/less/theme/components/tooltip/tooltip.less
@@ -43,6 +43,10 @@
     overflow-wrap: break-word;
     padding: @tooltip-padding-y @tooltip-padding-x;
     text-transform: @tooltip-text-transform;
+
+    @media (forced-colors: active) {
+      outline: outset 1px;
+    }
   }
 
   .tox-tooltip__arrow {

--- a/modules/oxide/src/less/theme/globals/global.less
+++ b/modules/oxide/src/less/theme/globals/global.less
@@ -63,7 +63,7 @@
   top: 0;
 
   @media (forced-colors: active) {
-    border: solid 2px currentColor;
+    border: 2px solid highlight;
   }
 }
 

--- a/modules/oxide/src/less/theme/globals/global.less
+++ b/modules/oxide/src/less/theme/globals/global.less
@@ -61,6 +61,10 @@
   position: absolute;
   right: 0;
   top: 0;
+
+  @media (forced-colors: active) {
+    border: solid 2px currentColor;
+  }
 }
 
 // Reset firefox focus states


### PR DESCRIPTION
Related Ticket: 
TINY-10781

Description of Changes:
```
WHCM: Windows high contrast mode
```

- Apply high contrast colour in WHCM
- Apply reduced brightness property on `hover` and `active` to indicate `hover` and `active` action
- Retain colour swatch colour (although this will not show up when applying to editor content. adding `forced-colour-adjust:none` to coloured content will not undo the forced colour change from OS) 

Pre-checks:
* [x] Changelog entry added
* <s> Tests have been added (if applicable) </s>
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
