### PR TITLE
Set table border using css

### DIFF
--- a/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
@@ -64,11 +64,11 @@ const applyDataToElement = (editor: Editor, tableElm: HTMLTableElement, data: Ta
 
   if (shouldStyleWithCss) {
     if (borderIsZero) {
-      attrs.border = 0;
+      styles['border'] = 'none';
       styles['border-width'] = '';
     } else {
       styles['border-width'] = Utils.addPxSuffix(data.border);
-      attrs.border = 1;
+      styles['border'] = '1px solid black';
     }
     styles['border-spacing'] = Utils.addPxSuffix(data.cellspacing);
   } else {
@@ -83,6 +83,7 @@ const applyDataToElement = (editor: Editor, tableElm: HTMLTableElement, data: Ta
     if (borderIsZero) {
       cellStyles['border-width'] = '';
     } else if (shouldApplyOnCell.border) {
+      cellStyles['border'] = '1px solid black';
       cellStyles['border-width'] = Utils.addPxSuffix(data.border);
     }
     if (shouldApplyOnCell.cellpadding) {


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
The `table.border` attribute not valid in HTML5. HTML5 is now the the default doctype for TinyMCE so it does not make sense to use deprecated attributes. I would also expect that given `table_style_by_css` defaults to `true` in v6, deprecated attributes should not be used.

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
