### PR TITLE
TINY-10684: Fix inline header `max-width` calculations

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10684-2024-03-23.yaml
+++ b/.changes/unreleased/tinymce-TINY-10684-2024-03-23.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Inline header now calculates `max-width` correctly using the viewport-relative
+  positioning.
+time: 2024-03-23T21:42:30.928799+08:00
+custom:
+  Issue: TINY-10684

--- a/.changes/unreleased/tinymce-TINY-10684-2024-03-23.yaml
+++ b/.changes/unreleased/tinymce-TINY-10684-2024-03-23.yaml
@@ -1,7 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Inline header now calculates `max-width` correctly using the viewport-relative
-  positioning.
+body: An inline editor toolbar now behaves correctly in horizontally scrolled containers.
 time: 2024-03-23T21:42:30.928799+08:00
 custom:
   Issue: TINY-10684

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
@@ -1,6 +1,6 @@
 import { AlloyComponent, Boxes, Channels, Docking, OffsetOrigin, VerticalDir } from '@ephox/alloy';
 import { Arr, Cell, Fun, Optional, Optionals, Singleton } from '@ephox/katamari';
-import { Attribute, Compare, Css, Height, Scroll, SugarBody, SugarElement, SugarLocation, Traverse, Width } from '@ephox/sugar';
+import { Attribute, Compare, Css, Height, Scroll, SugarBody, SugarElement, SugarLocation, Traverse, Width, WindowVisualViewport } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
@@ -111,7 +111,7 @@ export const InlineHeader = (
       const maxWidth = editorMaxWidthOpt.getOrThunk(() => {
         // No max width, so use the body width, minus the left pos as the maximum
         const bodyMargin = Utils.parseToInt(Css.get(SugarBody.body(), 'margin-left')).getOr(0);
-        return Width.get(SugarBody.body()) - SugarLocation.absolute(targetElm).left + bodyMargin;
+        return WindowVisualViewport.getBounds().width - SugarLocation.viewport(targetElm).left + bodyMargin;
       });
       Css.set(container.element, 'max-width', maxWidth + 'px');
     });
@@ -210,7 +210,7 @@ export const InlineHeader = (
               width: width + 'px'
             };
           }
-        ).getOr({ });
+        ).getOr({ width: 'max-content' });
 
       const baseProperties = {
         position: 'absolute',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
@@ -1,99 +1,368 @@
 import { UiFinder, Waiter } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
-import { Css, Insert, Remove, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Css, Insert, Remove, Scroll, SelectorFind, SugarBody, SugarElement, TextContent, Traverse } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', () => {
-  const wrapper = SugarElement.fromTag('div');
-  const editorTarget = SugarElement.fromTag('div');
-  const hook = TinyHooks.bddSetupFromElement<Editor>({
-    base_url: '/project/tinymce/js/tinymce',
-    toolbar: 'undo redo sidebar1 | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | align lineheight fontsize fontfamily blocks styles insertfile | styles | ' +
-    'bullist numlist outdent indent | link image | print preview media | forecolor backcolor emoticons table codesample code language | ltr rtl',
-    inline: true,
-    width: '400px'
-  }, () => {
-    Insert.append(wrapper, editorTarget);
-    Insert.append(SugarBody.body(), wrapper);
+  context('horizontal ', () => {
+    const wrapper = SugarElement.fromTag('div');
+    const editorTarget = SugarElement.fromTag('div');
+    const hook = TinyHooks.bddSetupFromElement<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      toolbar: 'undo redo sidebar1 | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | align lineheight fontsize fontfamily blocks styles insertfile | styles | ' +
+      'bullist numlist outdent indent | link image | print preview media | forecolor backcolor emoticons table codesample code language | ltr rtl',
+      inline: true,
+      width: '400px'
+    }, () => {
+      Insert.append(wrapper, editorTarget);
+      Insert.append(SugarBody.body(), wrapper);
 
-    return {
-      element: editorTarget,
-      teardown: () => {
-        Remove.remove(wrapper);
-      }
-    };
-  });
-
-  const pRunToolbarWidthTest = async (remainingWidth: number, expectedWidth: string) => {
-    const editor = setupEditor(remainingWidth);
-
-    editor.setContent('<p>Content</p>');
-    editor.focus();
-    editor.fire('ScrollWindow');
-
-    await pAssertHeaderWidth(expectedWidth, '400px');
-  };
-
-  const setupEditor = (remainingWidth: number) => {
-    const editor = hook.editor();
-    const totalWidth = editor.getDoc().documentElement.clientWidth;
-    Css.set(wrapper, 'width', 2 * totalWidth + 'px');
-    Css.set(editorTarget, 'margin-left', totalWidth - remainingWidth + 'px');
-
-    return editor;
-  };
-
-  const pAssertHeaderWidth = (expectedWidth: string, expectedMaxWidth: string) =>
-    Waiter.pTryUntil('Could not verify width', () => {
-      const header = SelectorFind.descendant(SugarBody.body(), '.tox-editor-header').getOrDie();
-      const headerWrapper = SelectorFind.descendant(SugarBody.body(), '.tox-tinymce--toolbar-sticky-off').getOrDie();
-      const width = Css.getRaw(headerWrapper, 'width');
-      const maxWidth = Css.getRaw(header, 'max-width');
-      if (maxWidth.getOrDie() !== expectedMaxWidth) {
-        throw new Error(`maxWidth is ${maxWidth.isSome()}, ${maxWidth.getOrNull()} and expectedMaxWidth is ${expectedMaxWidth}`);
-      }
-      if (width.getOrDie() !== expectedWidth) {
-        throw new Error(`Width is ${width.isSome()}, ${width.getOrNull()} and expectedWidth is ${expectedWidth}`);
-      }
+      return {
+        element: editorTarget,
+        teardown: () => {
+          Remove.remove(wrapper);
+        }
+      };
     });
 
-  // TODO TINY-10480: Investigate flaky tests
-  it.skip('TINY-9646: The width should remain on the editor', () =>
-    pRunToolbarWidthTest(500, '400px')
-  );
+    const pRunToolbarWidthTest = async (remainingWidth: number, expectedWidth: string) => {
+      const editor = setupEditor(remainingWidth);
 
-  // TODO TINY-10480: Investigate flaky tests
-  it.skip('TINY-8977: If the editor does not fit within the view', () =>
-    pRunToolbarWidthTest(200, '200px')
-  );
+      editor.setContent('<p>Content</p>');
+      editor.focus();
+      editor.fire('ScrollWindow');
 
-  // TODO TINY-10480: Investigate flaky tests
-  it.skip('TINY-8977: If the visible editor is smaller than the minimum', () =>
-    pRunToolbarWidthTest(50, '150px')
-  );
+      await pAssertHeaderWidth(expectedWidth, '400px');
+    };
 
-  // TODO TINY-10480: Investigate flaky tests
-  it.skip('TINY-8977: If the editor is not visible at all', () =>
-    pRunToolbarWidthTest(-50, '150px')
-  );
+    const setupEditor = (remainingWidth: number) => {
+      const editor = hook.editor();
+      const totalWidth = editor.getDoc().documentElement.clientWidth;
+      Css.set(wrapper, 'width', 2 * totalWidth + 'px');
+      Css.set(editorTarget, 'margin-left', totalWidth - remainingWidth + 'px');
 
-  it('TINY-10580: when the inline editor is on the edge the bottom of the toolbar should be close to the top of the content', async () => {
-    const editor = hook.editor();
-    editor.setContent('<p>Content</p>');
-    const totalWidth = editor.getDoc().documentElement.clientWidth;
-    Css.set(editorTarget, 'margin-left', totalWidth - 250 + 'px');
-    editor.focus();
+      return editor;
+    };
 
-    const toolbar = await UiFinder.pWaitFor('the toolbar should be visible', SugarBody.body(), '.tox-editor-header');
-    const toolbarRect = editor.dom.getRect(toolbar.dom as HTMLElement);
-    const toolbarBottom = toolbarRect.y + toolbarRect.h;
+    const pAssertHeaderWidth = (expectedWidth: string, expectedMaxWidth: string) =>
+      Waiter.pTryUntil('Could not verify width', () => {
+        const header = SelectorFind.descendant(SugarBody.body(), '.tox-editor-header').getOrDie();
+        const headerWrapper = SelectorFind.descendant(SugarBody.body(), '.tox-tinymce--toolbar-sticky-off').getOrDie();
+        const width = Css.getRaw(headerWrapper, 'width');
+        const maxWidth = Css.getRaw(header, 'max-width');
+        if (maxWidth.getOrDie() !== expectedMaxWidth) {
+          throw new Error(`maxWidth is ${maxWidth.isSome()}, ${maxWidth.getOrNull()} and expectedMaxWidth is ${expectedMaxWidth}`);
+        }
+        if (width.getOrDie() !== expectedWidth) {
+          throw new Error(`Width is ${width.isSome()}, ${width.getOrNull()} and expectedWidth is ${expectedWidth}`);
+        }
+      });
 
-    const editorTargetRect = editor.dom.getRect(editorTarget.dom);
-    const editorTargetTop = editorTargetRect.y;
+    // TODO TINY-10480: Investigate flaky tests
+    it.skip('TINY-9646: The width should remain on the editor', () =>
+      pRunToolbarWidthTest(500, '400px')
+    );
 
-    assert.approximately(editorTargetTop, toolbarBottom, 5, 'toolbarBottom should be above editorBodyTop');
+    // TODO TINY-10480: Investigate flaky tests
+    it.skip('TINY-8977: If the editor does not fit within the view', () =>
+      pRunToolbarWidthTest(200, '200px')
+    );
+
+    // TODO TINY-10480: Investigate flaky tests
+    it.skip('TINY-8977: If the visible editor is smaller than the minimum', () =>
+      pRunToolbarWidthTest(50, '150px')
+    );
+
+    // TODO TINY-10480: Investigate flaky tests
+    it.skip('TINY-8977: If the editor is not visible at all', () =>
+      pRunToolbarWidthTest(-50, '150px')
+    );
+
+    it('TINY-10580: when the inline editor is on the edge the bottom of the toolbar should be close to the top of the content', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p>Content</p>');
+      const totalWidth = editor.getDoc().documentElement.clientWidth;
+      Css.set(editorTarget, 'margin-left', totalWidth - 250 + 'px');
+      editor.focus();
+
+      const toolbar = await UiFinder.pWaitFor('the toolbar should be visible', SugarBody.body(), '.tox-editor-header');
+      const toolbarRect = editor.dom.getRect(toolbar.dom as HTMLElement);
+      const toolbarBottom = toolbarRect.y + toolbarRect.h;
+
+      const editorTargetRect = editor.dom.getRect(editorTarget.dom);
+      const editorTargetTop = editorTargetRect.y;
+
+      assert.approximately(editorTargetTop, toolbarBottom, 5, 'toolbarBottom should be above editorBodyTop');
+    });
+  });
+
+  const makeHook = (setup: () => TinyHooks.SetupElement) => TinyHooks.bddSetupFromElement<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    menubar: false,
+    toolbar: 'undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | outdent indent outdent indent | bold bold',
+    inline: true,
+  }, setup);
+
+  const pAssertToolbarGroupsAtleast = async (expectedGroups: number) => {
+    const toolbar = await UiFinder.pWaitFor('the toolbar should be visible', SugarBody.body(), '.tox-toolbar__primary');
+    const toolbarGroups = Traverse.children(toolbar);
+    assert.isAtLeast(toolbarGroups.length, expectedGroups, `Toolbar should have more than ${expectedGroups} groups`);
+    if (expectedGroups < 5) {
+      UiFinder.exists(toolbar, '[data-mce-name="overflow-button"]');
+    }
+  };
+
+  const pBlurAndScrollX = async (element: SugarElement<HTMLElement>, scrollToX: number) => {
+    element.dom.blur();
+    await Waiter.pTryUntil('Wait until toolbar is hidden', async () => UiFinder.pWaitForHidden('Wait for toolbar to be hidden', SugarBody.body(), '.tox-toolbar__primary'));
+    Scroll.to(scrollToX, 0);
+  };
+
+  context('editor in horizontal scrollable table, showing more button', () => {
+    const wrapper = SugarElement.fromTag('div');
+    const editorTarget = SugarElement.fromTag('div');
+    const table = SugarElement.fromTag('table');
+    const row = SugarElement.fromTag('tr');
+    const td = SugarElement.fromTag('td');
+    const td2 = SugarElement.fromTag('td');
+
+    const hook = makeHook(() => {
+      Insert.append(SugarBody.body(), wrapper);
+      Insert.append(wrapper, table);
+      Insert.append(table, row);
+      Insert.append(row, td);
+      Insert.append(row, td2);
+      Insert.append(td2, editorTarget);
+
+      Css.set(td, 'width', '90vw');
+      Css.set(td2, 'width', '30vw');
+      Css.setAll(table, {
+        'table-layout': 'fixed',
+        'width': '120vw',
+        'margin-top': '50px'
+      });
+
+      TextContent.set(td, 'Some text');
+
+      return {
+        element: editorTarget,
+        teardown: () => {
+          Remove.remove(wrapper);
+        }
+      };
+    });
+
+    it('TINY-10684: Toolbar should only show more button, then expanded when scrolled, but not all items are rendered due to width constraint (scrolling left)', async () => {
+      const editor = hook.editor();
+      Scroll.to(0, 0);
+      editor.setContent('<p>Content</p>');
+      editor.focus();
+      await Waiter.pTryUntil('Wait for toolbar to be rendered and contains at least 1 group', async () => await pAssertToolbarGroupsAtleast(1));
+      await pBlurAndScrollX(editorTarget, document.documentElement.scrollWidth);
+      editor.focus();
+      await Waiter.pTryUntil('Wait for toolbar to be rendered and contains at least 2 group', async () => await pAssertToolbarGroupsAtleast(2));
+    });
+
+    it('TINY-10684: Toolbar should only show more button, then expanded when scrolled, but not all items are rendered due to width constraint (scrolling right)', async () => {
+      const editor = hook.editor();
+      Scroll.to(0, 0);
+      editor.setContent('<p>Content</p>');
+      editor.focus();
+      await pBlurAndScrollX(editorTarget, document.documentElement.scrollWidth);
+      editor.focus();
+      await Waiter.pTryUntil('Wait for toolbar to be rendered and contains at least 2 group', async () => await pAssertToolbarGroupsAtleast(2));
+      await pBlurAndScrollX(editorTarget, 0);
+      editor.focus();
+      await Waiter.pTryUntil('Wait for toolbar to be rendered and contains at least 1 group', async () => await pAssertToolbarGroupsAtleast(1));
+      editor.focus();
+    });
+  });
+
+  context('editor in horizontal scrollable table, sufficient width to render all toolbar items', () => {
+    const wrapper = SugarElement.fromTag('div');
+    const editorTarget = SugarElement.fromTag('div');
+    const table = SugarElement.fromTag('table');
+    const row = SugarElement.fromTag('tr');
+    const td = SugarElement.fromTag('td');
+    const cellWithEditor = SugarElement.fromTag('td');
+    const td3 = SugarElement.fromTag('td');
+
+    const hook = makeHook(() => {
+      Insert.append(SugarBody.body(), wrapper);
+      Insert.append(wrapper, table);
+      Insert.append(table, row);
+      Insert.append(row, td);
+      Insert.append(row, cellWithEditor);
+      Insert.append(cellWithEditor, editorTarget);
+      Insert.append(row, td3);
+
+      Css.set(td, 'width', '90vw');
+      Css.set(cellWithEditor, 'width', '30vw');
+      Css.set(td3, 'width', '60vw');
+      Css.setAll(table, {
+        'table-layout': 'fixed',
+        'width': '180vw',
+        'margin-top': '50px'
+      });
+
+      TextContent.set(td, 'Some text');
+
+      return {
+        element: editorTarget,
+        teardown: () => {
+          Remove.remove(wrapper);
+        }
+      };
+    });
+
+    it('TINY-10684: Toolbar should expand the width of viewport when there\'s sufficient space, all items should be rendered, showing only show more button when width is constrained', async () => {
+      const editor = hook.editor();
+      Scroll.to(0, 0);
+      editor.setContent('<p>Content</p>');
+      editor.focus();
+      await pBlurAndScrollX(editorTarget, document.documentElement.scrollWidth);
+      editor.focus();
+      await Waiter.pTryUntil('Wait until toolbar is shown', async () => await pAssertToolbarGroupsAtleast(5));
+      await pBlurAndScrollX(editorTarget, 0);
+      editor.focus();
+      await Waiter.pTryUntil('Wait until toolbar is shown', async () => await pAssertToolbarGroupsAtleast(1));
+    });
+
+    it('TINY-10684: Toolbar should only show show more button, then expanded the width of viewport when there\'s sufficient space, all items should be rendered', async () => {
+      const editor = hook.editor();
+      Scroll.to(0, 0);
+      editor.setContent('<p>Content</p>');
+      editor.focus();
+      await Waiter.pTryUntil('Wait until toolbar is shown', async () => await pAssertToolbarGroupsAtleast(1));
+      await pBlurAndScrollX(editorTarget, document.documentElement.scrollWidth);
+      editor.focus();
+      await Waiter.pTryUntil('Wait until toolbar is shown', async () => await pAssertToolbarGroupsAtleast(5));
+    });
+  });
+
+  context('editor in horizontal scrollable table, editor in different location', () => {
+    const wrapper = SugarElement.fromTag('div');
+    const editorTarget = SugarElement.fromTag('div');
+    const table = SugarElement.fromTag('table');
+    const row = SugarElement.fromTag('tr');
+    const td = SugarElement.fromTag('td');
+    const cellWithEditor = SugarElement.fromTag('td');
+    const td3 = SugarElement.fromTag('td');
+
+    const hook = makeHook(() => {
+      Insert.append(SugarBody.body(), wrapper);
+      Insert.append(wrapper, table);
+      Insert.append(table, row);
+      Insert.append(row, td);
+      Insert.append(row, cellWithEditor);
+      Insert.append(cellWithEditor, editorTarget);
+      Insert.append(row, td3);
+
+      Css.set(td, 'width', '120vw');
+      Css.set(cellWithEditor, 'width', '30vw');
+      Css.set(td3, 'width', '30vw');
+      Css.setAll(table, {
+        'table-layout': 'fixed',
+        'width': '180vw',
+        'margin-top': '50px'
+      });
+
+      TextContent.set(td, 'Some text');
+
+      return {
+        element: editorTarget,
+        teardown: () => {
+          Remove.remove(wrapper);
+        }
+      };
+    });
+
+    it('TINY-10684: Toolbar should expand the width of viewport when there\'s sufficient space, all items should be rendered (scrolling right)', async () => {
+      const editor = hook.editor();
+      Scroll.to(0, 0);
+      editor.setContent('<p>Content</p>');
+      editor.focus();
+      await pBlurAndScrollX(editorTarget, 500);
+      editor.focus();
+      await Waiter.pTryUntil('Wait until toolbar is shown', async () => await pAssertToolbarGroupsAtleast(1));
+      await pBlurAndScrollX(editorTarget, document.documentElement.scrollWidth);
+      editor.focus();
+      await Waiter.pTryUntil('Wait until toolbar is shown', async () => await pAssertToolbarGroupsAtleast(5));
+    });
+
+    it('TINY-10684: Toolbar should expand the width of viewport when there\'s sufficient space, all items should be rendered (scrolling left)', async () => {
+      const editor = hook.editor();
+      Scroll.to(0, 0);
+      editor.setContent('<p>Content</p>');
+      editor.focus();
+      await pBlurAndScrollX(editorTarget, document.documentElement.scrollWidth);
+      editor.focus();
+      await Waiter.pTryUntil('Wait until toolbar is shown', async () => await pAssertToolbarGroupsAtleast(5));
+      await pBlurAndScrollX(editorTarget, 500);
+      editor.focus();
+      await Waiter.pTryUntil('Wait until toolbar is shown', async () => await pAssertToolbarGroupsAtleast(1));
+    });
+  });
+
+  context('editor in horizontal scrollable table, editor is off screen', () => {
+    const wrapper = SugarElement.fromTag('div');
+    const editorTarget = SugarElement.fromTag('div');
+    const table = SugarElement.fromTag('table');
+    const row = SugarElement.fromTag('tr');
+    const td = SugarElement.fromTag('td');
+    const cellWithEditor = SugarElement.fromTag('td');
+
+    const hook = makeHook(() => {
+      Insert.append(SugarBody.body(), wrapper);
+      Insert.append(wrapper, table);
+      Insert.append(row, td);
+      Insert.append(row, cellWithEditor);
+      Insert.append(cellWithEditor, editorTarget);
+      Insert.append(table, row);
+
+      Css.set(td, 'width', '150vw');
+      Css.set(cellWithEditor, 'width', '30vw');
+      Css.setAll(table, {
+        'table-layout': 'fixed',
+        'width': '180vw',
+        'margin-top': '50px'
+      });
+
+      TextContent.set(td, 'Some text');
+
+      return {
+        element: editorTarget,
+        teardown: () => {
+          Remove.remove(wrapper);
+        }
+      };
+    });
+
+    it('TINY-10684: Toolbar should only show more button, then expanded when scrolled, but not all items are rendered due to width constraint (scrolling left)', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p>Content</p>');
+      editor.focus();
+      await pBlurAndScrollX(editorTarget, document.documentElement.scrollWidth);
+      editor.focus();
+      await Waiter.pTryUntil('Wait until toolbar is shown', async () => await pAssertToolbarGroupsAtleast(2));
+      await pBlurAndScrollX(editorTarget, 800);
+      editor.focus();
+      await Waiter.pTryUntil('Wait until toolbar is shown', async () => await pAssertToolbarGroupsAtleast(1));
+    });
+
+    it('TINY-10684: Toolbar should only show more button, then expanded when scrolled, but not all items are rendered due to width constraint (scrolling right)', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p>Content</p>');
+      editor.focus();
+      await pBlurAndScrollX(editorTarget, 800);
+      editor.focus();
+      await Waiter.pTryUntil('Wait until toolbar is shown', async () => await pAssertToolbarGroupsAtleast(1));
+      await pBlurAndScrollX(editorTarget, document.documentElement.scrollWidth);
+      editor.focus();
+      await Waiter.pTryUntil('Wait until toolbar is shown', async () => await pAssertToolbarGroupsAtleast(2));
+    });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10684

Description of Changes:
* Fixed the `max-width` calculation to use the viewport width instead of body width and use `SugarLocation.viewport` instead of `SugarLocation.absolute`, we want to exclude scrolls and calculate the location of the `targetElement`
* Tests are written to assert at least x number of toolbar groups instead of width since it has been flakey, and that should work across different screen sizes.
* Previous behaviour

https://github.com/tinymce/tinymce/assets/111734091/54720d9e-6b84-4afb-983d-6415194ede8a

*  `width: max-content` is set because the toolbar is absolute positioned, and they will `shrink-wrap` to fit their contents unless the dimensions are specified. See: [link](https://www.w3.org/wiki/CSS_absolute_and_fixed_positioning?source=post_page#:~:text=Absolutely%20positioned%20elements%20will%20shrink,by%20setting%20the%20height%20property)


https://github.com/tinymce/tinymce/assets/111734091/24b5ad08-f7f7-45d2-8de5-89c2c727336f


* Behaviour after fixing

https://github.com/tinymce/tinymce/assets/111734091/1c35312e-b849-4f7d-a7f7-7520e3840797


Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
