### PR TITLE
TINY-10797: Add `width` style to tooltips

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10797-2024-03-23.yaml
+++ b/.changes/unreleased/tinymce-TINY-10797-2024-03-23.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Tooltips unintended shrinking and incorrectly positioned when shown in horizontally scrollable container.
+time: 2024-03-23T22:09:42.567199+08:00
+custom:
+  Issue: TINY-10797

--- a/modules/oxide/src/less/theme/components/tooltip/tooltip.less
+++ b/modules/oxide/src/less/theme/components/tooltip/tooltip.less
@@ -29,6 +29,7 @@
      */
     pointer-events: none;
     position: relative;
+    width: max-content;
     z-index: @z-index-menu;
   }
 


### PR DESCRIPTION
Related Ticket: TINY-10797

Description of Changes:
* Introduced `width` property for tooltips as they are absolute positioned elements to prevent unintended shrinking.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
