### PR TITLE
TINY-10705: Fix status bar disappearing when the editor's height becomes too short

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10705-2024-03-25.yaml
+++ b/.changes/unreleased/tinymce-TINY-10705-2024-03-25.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: The status bar was invisible when the editor's height is short
+body: The status bar was invisible when the editor's height is short.
 time: 2024-03-25T10:41:06.226617+10:30
 custom:
   Issue: TINY-10705

--- a/.changes/unreleased/tinymce-TINY-10705-2024-03-25.yaml
+++ b/.changes/unreleased/tinymce-TINY-10705-2024-03-25.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: The status bar was invisible when the editor's height is short
+time: 2024-03-25T10:41:06.226617+10:30
+custom:
+  Issue: TINY-10705

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -388,7 +388,7 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
       components: Arr.flatten<AlloySpec>([
         editorComponents,
         // Inline mode does not have a status bar
-        isInline ? [ ] : [ memBottomAnchorBar.asSpec(), ...statusbar.toArray() ]
+        isInline ? [ ] : [ memBottomAnchorBar.asSpec() ]
       ])
     });
 
@@ -419,7 +419,7 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
         },
         components: [
           editorContainer,
-          ...isInline ? [] : [ partViewWrapper ],
+          ...isInline ? [] : [ partViewWrapper, ...statusbar.toArray() ],
           partThrobber,
         ],
         behaviours: Behaviour.derive([

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -387,7 +387,6 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
     const editorContainer = OuterContainer.parts.editorContainer({
       components: Arr.flatten<AlloySpec>([
         editorComponents,
-        // Inline mode does not have a status bar
         isInline ? [ ] : [ memBottomAnchorBar.asSpec() ]
       ])
     });
@@ -419,6 +418,7 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
         },
         components: [
           editorContainer,
+          // Inline mode does not have a status bar
           ...isInline ? [] : [ partViewWrapper, ...statusbar.toArray() ],
           partThrobber,
         ],

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -3,7 +3,7 @@ import {
 } from '@ephox/alloy';
 import { FieldSchema } from '@ephox/boulder';
 import { Arr, Id, Optional, Optionals, Result } from '@ephox/katamari';
-import { Attribute, Css } from '@ephox/sugar';
+import { Attribute, Css, SelectorFind } from '@ephox/sugar';
 
 import { ToolbarMode } from '../../api/Options';
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
@@ -190,7 +190,11 @@ const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, Out
 
       Composite.parts.getPart(comp, detail, 'editorContainer').each((editorContainer) => {
         const element = editorContainer.element;
-
+        SelectorFind.sibling(element, '.tox-statusbar').each((statusBar) => {
+          console.log('hide status bar', statusBar);
+          Css.set(statusBar, 'display', 'none');
+          Attribute.set(statusBar, 'aria-hidden', 'true');
+        });
         Css.set(element, 'display', 'none');
         Attribute.set(element, 'aria-hidden', 'true');
       });
@@ -202,7 +206,11 @@ const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, Out
 
       Composite.parts.getPart(comp, detail, 'editorContainer').each((editorContainer) => {
         const element = editorContainer.element;
-
+        SelectorFind.sibling(element, '.tox-statusbar').each((statusBar) => {
+          console.log('show status bar', statusBar);
+          Css.remove(statusBar, 'display');
+          Attribute.remove(statusBar, 'aria-hidden');
+        });
         Css.remove(element, 'display');
         Attribute.remove(element, 'aria-hidden');
       });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -3,7 +3,7 @@ import {
 } from '@ephox/alloy';
 import { FieldSchema } from '@ephox/boulder';
 import { Arr, Id, Optional, Optionals, Result } from '@ephox/katamari';
-import { Attribute, Css, SelectorFind } from '@ephox/sugar';
+import { Attribute, Css, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import { ToolbarMode } from '../../api/Options';
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
@@ -89,6 +89,18 @@ interface ToolbarApis {
 
 const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, OuterContainerSketchSpec> = (detail, components, _spec) => {
   let toolbarDrawerOpenState = false;
+
+  const toggleStatusbar = (editorContainer: SugarElement<Element>) => {
+    SelectorFind.sibling(editorContainer, '.tox-statusbar').each((statusBar) => {
+      if (Css.get(statusBar, 'display') === 'none' && Attribute.get(statusBar, 'aria-hidden') === 'true') {
+        Css.remove(statusBar, 'display');
+        Attribute.remove(statusBar, 'aria-hidden');
+      } else {
+        Css.set(statusBar, 'display', 'none');
+        Attribute.set(statusBar, 'aria-hidden', 'true');
+      }
+    });
+  };
 
   const apis: OuterContainerApis = {
     getSocket: (comp) => {
@@ -190,11 +202,7 @@ const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, Out
 
       Composite.parts.getPart(comp, detail, 'editorContainer').each((editorContainer) => {
         const element = editorContainer.element;
-        SelectorFind.sibling(element, '.tox-statusbar').each((statusBar) => {
-          console.log('hide status bar', statusBar);
-          Css.set(statusBar, 'display', 'none');
-          Attribute.set(statusBar, 'aria-hidden', 'true');
-        });
+        toggleStatusbar(element);
         Css.set(element, 'display', 'none');
         Attribute.set(element, 'aria-hidden', 'true');
       });
@@ -206,11 +214,7 @@ const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, Out
 
       Composite.parts.getPart(comp, detail, 'editorContainer').each((editorContainer) => {
         const element = editorContainer.element;
-        SelectorFind.sibling(element, '.tox-statusbar').each((statusBar) => {
-          console.log('show status bar', statusBar);
-          Css.remove(statusBar, 'display');
-          Attribute.remove(statusBar, 'aria-hidden');
-        });
+        toggleStatusbar(element);
         Css.remove(element, 'display');
         Attribute.remove(element, 'aria-hidden');
       });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
@@ -314,14 +314,14 @@ describe('browser.tinymce.themes.silver.editor.SilverEditorTest', () => {
               }),
               s.element('div', {
                 classes: [ arr.has('tox-bottom-anchorbar') ]
-              }),
-              s.element('div', {
-                classes: [ arr.has('tox-statusbar') ]
               })
             ]
           }),
           s.element('div', {
             classes: [ arr.has('tox-view-wrap') ]
+          }),
+          s.element('div', {
+            classes: [ arr.has('tox-statusbar') ]
           }),
           s.element('div', {
             classes: [ arr.has('tox-throbber') ]

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/HeaderLocationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/HeaderLocationTest.ts
@@ -37,14 +37,14 @@ describe('browser.tinymce.themes.silver.editor.header.HeaderLocationTest', () =>
             }),
             s.element('div', {
               classes: [ arr.has('tox-bottom-anchorbar') ]
-            }),
-            s.element('div', {
-              classes: [ arr.has('tox-statusbar') ]
-            }),
+            })
           ]
         }),
         s.element('div', {
           classes: [ arr.has('tox-view-wrap') ]
+        }),
+        s.element('div', {
+          classes: [ arr.has('tox-statusbar') ]
         }),
         s.element('div', {
           classes: [ arr.has('tox-throbber') ]

--- a/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
@@ -102,23 +102,17 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
     (s, str, arr) => s.element('div', {
       classes: [ arr.has('tox-tinymce') ],
       children: [
+        s.anything(),
+        s.anything(),
         s.element('div', {
-          classes: [ arr.has('tox-editor-container') ],
+          classes: [ arr.has('tox-statusbar') ],
           children: [
             s.anything(),
-            s.anything(),
-            s.anything(),
             s.element('div', {
-              classes: [ arr.has('tox-statusbar') ],
-              children: [
-                s.anything(),
-                s.element('div', {
-                  classes: [ arr.has('tox-statusbar__resize-handle') ],
-                  attrs: {
-                    'aria-label': str.is(label)
-                  }
-                })
-              ]
+              classes: [ arr.has('tox-statusbar__resize-handle') ],
+              attrs: {
+                'aria-label': str.is(label)
+              }
             })
           ]
         }),
@@ -143,17 +137,11 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
     ApproxStructure.build((s, str, arr) => s.element('div', {
       classes: [ arr.has('tox-tinymce') ],
       children: [
+        s.anything(),
+        s.anything(),
         s.element('div', {
-          classes: [ arr.has('tox-editor-container') ],
-          children: [
-            s.anything(),
-            s.anything(),
-            s.anything(),
-            s.element('div', {
-              classes: [ arr.has('tox-statusbar') ],
-              children: fullStatusbarSpec(s, str, arr)
-            })
-          ]
+          classes: [ arr.has('tox-statusbar') ],
+          children: fullStatusbarSpec(s, str, arr)
         }),
         s.theRest()
       ]
@@ -166,17 +154,11 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
     ApproxStructure.build((s, str, arr) => s.element('div', {
       classes: [ arr.has('tox-tinymce') ],
       children: [
+        s.anything(),
+        s.anything(),
         s.element('div', {
-          classes: [ arr.has('tox-editor-container') ],
-          children: [
-            s.anything(),
-            s.anything(),
-            s.anything(),
-            s.element('div', {
-              classes: [ arr.has('tox-statusbar') ],
-              children: statusbarWithoutWordcountSpec(s, str, arr)
-            })
-          ]
+          classes: [ arr.has('tox-statusbar') ],
+          children: statusbarWithoutWordcountSpec(s, str, arr)
         }),
         s.theRest()
       ]
@@ -189,26 +171,20 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
     ApproxStructure.build((s, str, arr) => s.element('div', {
       classes: [ arr.has('tox-tinymce') ],
       children: [
+        s.anything(),
+        s.anything(),
         s.element('div', {
-          classes: [ arr.has('tox-editor-container') ],
+          classes: [ arr.has('tox-statusbar') ],
           children: [
-            s.anything(),
-            s.anything(),
-            s.anything(),
             s.element('div', {
-              classes: [ arr.has('tox-statusbar') ],
+              classes: [ arr.has('tox-statusbar__text-container') ],
               children: [
-                s.element('div', {
-                  classes: [ arr.has('tox-statusbar__text-container') ],
-                  children: [
-                    elementPathSpec(s, str, arr),
-                    rightContainerSpec(s, str, arr)
-                  ]
-                }),
-                s.element('div', {
-                  classes: [ arr.has('tox-statusbar__resize-handle') ]
-                })
+                elementPathSpec(s, str, arr),
+                rightContainerSpec(s, str, arr)
               ]
+            }),
+            s.element('div', {
+              classes: [ arr.has('tox-statusbar__resize-handle') ]
             })
           ]
         }),
@@ -223,17 +199,11 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
     ApproxStructure.build((s, str, arr) => s.element('div', {
       classes: [ arr.has('tox-tinymce') ],
       children: [
+        s.anything(),
+        s.anything(),
         s.element('div', {
-          classes: [ arr.has('tox-editor-container') ],
-          children: [
-            s.anything(),
-            s.anything(),
-            s.anything(),
-            s.element('div', {
-              classes: [ arr.has('tox-statusbar') ],
-              children: statusbarWithoutResizeSpec(s, str, arr)
-            })
-          ]
+          classes: [ arr.has('tox-statusbar') ],
+          children: statusbarWithoutResizeSpec(s, str, arr)
         }),
         s.theRest()
       ]
@@ -275,26 +245,20 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
       ApproxStructure.build((s, str, arr) => s.element('div', {
         classes: [ arr.has('tox-tinymce') ],
         children: [
+          s.anything(),
+          s.anything(),
           s.element('div', {
-            classes: [ arr.has('tox-editor-container') ],
+            classes: [ arr.has('tox-statusbar') ],
             children: [
-              s.anything(),
-              s.anything(),
-              s.anything(),
               s.element('div', {
-                classes: [ arr.has('tox-statusbar') ],
+                classes: [ arr.has('tox-statusbar__text-container') ],
                 children: [
                   s.element('div', {
-                    classes: [ arr.has('tox-statusbar__text-container') ],
+                    classes: [ arr.has('tox-statusbar__path') ],
                     children: [
-                      s.element('div', {
-                        classes: [ arr.has('tox-statusbar__path') ],
-                        children: [
-                          s.element('div', { children: [ s.text(str.is('p')) ] }),
-                          s.element('div', { children: [ s.text(str.is(' › ')) ] }),
-                          s.element('div', { children: [ s.text(str.is('strong')) ] })
-                        ]
-                      })
+                      s.element('div', { children: [ s.text(str.is('p')) ] }),
+                      s.element('div', { children: [ s.text(str.is(' › ')) ] }),
+                      s.element('div', { children: [ s.text(str.is('strong')) ] })
                     ]
                   })
                 ]
@@ -314,28 +278,22 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
       ApproxStructure.build((s, str, arr) => s.element('div', {
         classes: [ arr.has('tox-tinymce') ],
         children: [
+          s.anything(),
+          s.anything(),
           s.element('div', {
-            classes: [ arr.has('tox-editor-container') ],
+            classes: [ arr.has('tox-statusbar') ],
             children: [
-              s.anything(),
-              s.anything(),
-              s.anything(),
               s.element('div', {
-                classes: [ arr.has('tox-statusbar') ],
+                classes: [ arr.has('tox-statusbar__text-container') ],
                 children: [
                   s.element('div', {
-                    classes: [ arr.has('tox-statusbar__text-container') ],
+                    classes: [ arr.has('tox-statusbar__path') ],
                     children: [
-                      s.element('div', {
-                        classes: [ arr.has('tox-statusbar__path') ],
-                        children: [
-                          s.element('div', { children: [ s.text(str.is('p')) ] })
-                        ]
-                      })
+                      s.element('div', { children: [ s.text(str.is('p')) ] })
                     ]
                   })
                 ]
-              }),
+              })
             ]
           }),
           s.theRest()

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderUtils.ts
@@ -13,14 +13,6 @@ const staticPartsOuter = (s: ApproxStructure.StructApi, arr: ApproxStructure.Arr
     })
   ];
 
-const statusbar = (s: ApproxStructure.StructApi, arr: ApproxStructure.ArrayApi): StructAssert[] =>
-  // should not change
-  [
-    s.element('div', {
-      classes: [ arr.has('tox-statusbar') ]
-    })
-  ];
-
 const bottomAnchorbar = (s: ApproxStructure.StructApi, arr: ApproxStructure.ArrayApi): StructAssert[] =>
   // should not change
   [
@@ -165,8 +157,8 @@ const pAssertEditorContainer = async (isToolbarTop: boolean, expectedPart: Appro
       ApproxStructure.build((s, str, arr) => s.element('div', {
         classes: [ arr.has('tox-editor-container') ],
         children: isToolbarTop ?
-          expectedPart(s, str, arr).concat(staticPartsOuter(s, arr)).concat(bottomAnchorbar(s, arr)).concat(statusbar(s, arr)) :
-          staticPartsOuter(s, arr).concat(expectedPart(s, str, arr)).concat(bottomAnchorbar(s, arr)).concat(statusbar(s, arr))
+          expectedPart(s, str, arr).concat(staticPartsOuter(s, arr)).concat(bottomAnchorbar(s, arr)) :
+          staticPartsOuter(s, arr).concat(expectedPart(s, str, arr)).concat(bottomAnchorbar(s, arr))
       })),
       container
     )
@@ -182,8 +174,8 @@ const pScrollAndAssertStructure = async (isToolbarTop: boolean, scrollYDelta: nu
       ApproxStructure.build((s, str, arr) => s.element('div', {
         classes: [ arr.has('tox-editor-container') ],
         children: isToolbarTop ?
-          expectedPart(s, str, arr).concat(staticPartsOuter(s, arr)).concat(bottomAnchorbar(s, arr)).concat(statusbar(s, arr)) :
-          staticPartsOuter(s, arr).concat(expectedPart(s, str, arr)).concat(bottomAnchorbar(s, arr)).concat(statusbar(s, arr))
+          expectedPart(s, str, arr).concat(staticPartsOuter(s, arr)).concat(bottomAnchorbar(s, arr)) :
+          staticPartsOuter(s, arr).concat(expectedPart(s, str, arr)).concat(bottomAnchorbar(s, arr))
       })),
       container
     )


### PR DESCRIPTION
Related Ticket: TINY-10705	

Description of Changes:
* Moved the status bar out of the editor container, which is a revert in #8164
* Added `toggleStatusBar` function to be called when toggling a view

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
