### PR TITLE
TINY-10715: Fix for Android Firefox autocompleter bug

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10715-2024-03-14.yaml
+++ b/.changes/unreleased/tinymce-TINY-10715-2024-03-14.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Tapping inside a composed text on Firefox Android would not close the autocompleter.
+time: 2024-03-14T14:10:04.576048+01:00
+custom:
+  Issue: TINY-10715

--- a/modules/tinymce/src/core/main/ts/keyboard/Autocompleter.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/Autocompleter.ts
@@ -20,7 +20,12 @@ interface AutocompleterApi {
 const setupEditorInput = (editor: Editor, api: AutocompleterApi) => {
   const update = Throttler.last(api.load, 50);
 
-  editor.on('input', () => {
+  editor.on('input', (e) => {
+    // TINY-10715: Firefox on Android using Korean Gboard will produce stray composition events when you move the caret by tapping inside the composed text
+    if (e.inputType === 'insertCompositionText' && !editor.composing) {
+      return;
+    }
+
     update.throttle();
   });
 


### PR DESCRIPTION
Related Ticket: TINY-10715

Description of Changes:
* Hotfix for the TINY-10715 that was merged into `main` so already reviewed.

Pre-checks:
* [x] Changelog entry added
* [-] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [-] Docs ticket created (if applicable)

GitHub issues (if applicable):
