### PR TITLE
TINY-10488: fix list pattern with `forced_root_block: 'div'`

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10488-2024-02-29.yaml
+++ b/.changes/unreleased/tinymce-TINY-10488-2024-02-29.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Toggle list behavior generated wrong html when the root block is forced to `div`
+body: Toggle list behavior generated wrong html when the `forced_root_block` option was set to `div`.
 time: 2024-02-29T09:33:25.529271935+01:00
 custom:
   Issue: TINY-10488

--- a/.changes/unreleased/tinymce-TINY-10488-2024-02-29.yaml
+++ b/.changes/unreleased/tinymce-TINY-10488-2024-02-29.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Toggle list behavior generated wrong html when the root block is forced to `div`
+time: 2024-02-29T09:33:25.529271935+01:00
+custom:
+  Issue: TINY-10488

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -187,8 +187,7 @@ const getSelectedTextBlocks = (editor: Editor, rng: Range, root: Node): HTMLElem
 
     block.appendChild(node);
     if (nextSibling && BookmarkManager.isBookmarkNode(nextSibling) && !(nextSibling?.nextSibling)) {
-      block.appendChild(nextSibling);
-      nextSibling.remove();
+      block.append(nextSibling);
     }
   });
 

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -173,7 +173,12 @@ const getSelectedTextBlocks = (editor: Editor, rng: Range, root: Node): HTMLElem
 
     const nextSibling = node.nextSibling;
     if (BookmarkManager.isBookmarkNode(node)) {
-      if (NodeType.isListNode(nextSibling) || NodeType.isTextBlock(editor, nextSibling) || (!nextSibling && node.parentNode === root)) {
+      if (!nextSibling && node.parentNode === root) {
+        node.previousSibling?.appendChild(node);
+        block = null;
+        return;
+      }
+      if (NodeType.isListNode(nextSibling) || NodeType.isTextBlock(editor, nextSibling)) {
         block = null;
         return;
       }

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -173,12 +173,7 @@ const getSelectedTextBlocks = (editor: Editor, rng: Range, root: Node): HTMLElem
 
     const nextSibling = node.nextSibling;
     if (BookmarkManager.isBookmarkNode(node)) {
-      if (!nextSibling && node.parentNode === root) {
-        node.previousSibling?.appendChild(node);
-        block = null;
-        return;
-      }
-      if (NodeType.isListNode(nextSibling) || NodeType.isTextBlock(editor, nextSibling)) {
+      if (NodeType.isListNode(nextSibling) || NodeType.isTextBlock(editor, nextSibling) || (!nextSibling && node.parentNode === root)) {
         block = null;
         return;
       }
@@ -191,6 +186,10 @@ const getSelectedTextBlocks = (editor: Editor, rng: Range, root: Node): HTMLElem
     }
 
     block.appendChild(node);
+    if (nextSibling && BookmarkManager.isBookmarkNode(nextSibling) && !(nextSibling?.nextSibling)) {
+      block.appendChild(nextSibling);
+      nextSibling.remove();
+    }
   });
 
   return textBlocks;

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -1,6 +1,5 @@
 import { Arr, Optional, Type, Unicode } from '@ephox/katamari';
 import { Has, SugarElement } from '@ephox/sugar';
-import createDompurify from 'dompurify';
 
 import BookmarkManager from 'tinymce/core/api/dom/BookmarkManager';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
@@ -187,9 +186,6 @@ const getSelectedTextBlocks = (editor: Editor, rng: Range, root: Node): HTMLElem
     }
 
     block.appendChild(node);
-    if (nextSibling && BookmarkManager.isBookmarkNode(nextSibling) && !(nextSibling?.nextSibling)) {
-      block.append(createDompurify().sanitize(nextSibling));
-    }
   });
 
   return textBlocks;

--- a/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -1,5 +1,6 @@
 import { Arr, Optional, Type, Unicode } from '@ephox/katamari';
 import { Has, SugarElement } from '@ephox/sugar';
+import createDompurify from 'dompurify';
 
 import BookmarkManager from 'tinymce/core/api/dom/BookmarkManager';
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
@@ -187,7 +188,7 @@ const getSelectedTextBlocks = (editor: Editor, rng: Range, root: Node): HTMLElem
 
     block.appendChild(node);
     if (nextSibling && BookmarkManager.isBookmarkNode(nextSibling) && !(nextSibling?.nextSibling)) {
-      block.append(nextSibling);
+      block.append(createDompurify().sanitize(nextSibling));
     }
   });
 

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Selection.ts
@@ -5,6 +5,7 @@ import Editor from 'tinymce/core/api/Editor';
 import Schema from 'tinymce/core/api/html/Schema';
 import Tools from 'tinymce/core/api/util/Tools';
 
+import * as Options from '../api/Options';
 import * as NodeType from './NodeType';
 
 const listNames = [ 'OL', 'UL', 'DL' ];
@@ -63,7 +64,8 @@ const isListHost = (schema: Schema, node: Node): boolean =>
 
 const getClosestListHost = (editor: Editor, elm: Node): HTMLElement => {
   const parentBlocks = editor.dom.getParents<HTMLElement>(elm, editor.dom.isBlock);
-  const parentBlock = Arr.find(parentBlocks, (elm) => isListHost(editor.schema, elm));
+  const isNotForcedRootBlock = (elm: HTMLElement) => elm.nodeName.toLowerCase() !== Options.getForcedRootBlock(editor);
+  const parentBlock = Arr.find(parentBlocks, (elm) => isNotForcedRootBlock(elm) && isListHost(editor.schema, elm));
 
   return parentBlock.getOr(editor.getBody());
 };

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/TableInListWithRootDivTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/TableInListWithRootDivTest.ts
@@ -1,0 +1,28 @@
+import { Keys } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/lists/Plugin';
+
+describe('browser.tinymce.plugins.lists.TableInListTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'lists',
+    toolbar: 'bullist numlist indent outdent',
+    text_patterns: [
+      { start: '*', cmd: 'InsertUnorderedList', trigger: 'enter' },
+    ],
+    forced_root_block: 'div',
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ]);
+
+  it('TINY-10488: trigger lists via enter patterns should work also with forced_root_block: "div"', () => {
+    const editor = hook.editor();
+    editor.setContent('* abc');
+    TinySelections.setCursor(editor, [ 0, 0 ], '* abc'.length);
+
+    TinyContentActions.keystroke(editor, Keys.enter());
+    TinyAssertions.assertContent(editor, '<div><ul><li>abc</li><li>&nbsp;</li></ul></div>');
+  });
+});

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/TableInListWithRootDivTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/TableInListWithRootDivTest.ts
@@ -23,6 +23,6 @@ describe('browser.tinymce.plugins.lists.TableInListTest', () => {
     TinySelections.setCursor(editor, [ 0, 0 ], '* abc'.length);
 
     TinyContentActions.keystroke(editor, Keys.enter());
-    TinyAssertions.assertContent(editor, '<div><ul><li>abc</li><li>&nbsp;</li></ul></div>');
+    TinyAssertions.assertContent(editor, '<ul><li>abc</li><li>&nbsp;</li></ul>');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10488

Description of Changes:

I splitted the behavior for the last condition of [this if](https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/src/plugins/lists/main/ts/actions/ToggleList.ts#L176)

the previos behavior was:
`* abc` -> `* abc[plugin-bookmark]` -> `<p></p>* abc[plugin-bookmark]` -> `<p>* abc</p>[plugin-bookmark]` -`if`> END

now is:
`* abc` -> `* abc[plugin-bookmark]` -> `<p></p>* abc[plugin-bookmark]` -> `<p>* abc</p>[plugin-bookmark]` -> `<p>* abc[plugin-bookmark]</p>` -> END

P.S. cherry picked from: https://github.com/tinymce/tinymce/pull/9449

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
