### PR TITLE
TINY-10590: Tree dom structure could confuse block merge boundary detection

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10590-2024-03-06.yaml
+++ b/.changes/unreleased/tinymce-TINY-10590-2024-03-06.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Backspacing in certain html setups resulted in data moving around unexpectedly.
+time: 2024-03-06T16:07:38.830652013+01:00
+custom:
+  Issue: TINY-10590

--- a/modules/tinymce/src/core/main/ts/delete/BlockMergeBoundary.ts
+++ b/modules/tinymce/src/core/main/ts/delete/BlockMergeBoundary.ts
@@ -36,6 +36,9 @@ const getBlockPosition = (rootNode: HTMLElement, pos: CaretPosition): Optional<B
   return DeleteUtils.getParentBlock(rootElm, containerElm).map((block) => blockPosition(block, pos));
 };
 
+const isNotAncestorial = (blockBoundary: BlockBoundary) =>
+  !(Compare.contains(blockBoundary.to.block, blockBoundary.from.block) || Compare.contains(blockBoundary.from.block, blockBoundary.to.block));
+
 const isDifferentBlocks = (blockBoundary: BlockBoundary): boolean =>
   !Compare.eq(blockBoundary.from.block, blockBoundary.to.block);
 
@@ -81,7 +84,7 @@ const readFromRange = (schema: Schema, rootNode: HTMLElement, forward: boolean, 
   );
 
   return Optionals.lift2(fromBlockPos, toBlockPos, blockBoundary).filter((blockBoundary) =>
-    isDifferentBlocks(blockBoundary) && hasSameHost(rootNode, blockBoundary) && isEditable(blockBoundary) && hasValidBlocks(blockBoundary));
+    isDifferentBlocks(blockBoundary) && hasSameHost(rootNode, blockBoundary) && isEditable(blockBoundary) && hasValidBlocks(blockBoundary) && isNotAncestorial(blockBoundary));
 };
 
 const read = (schema: Schema, rootNode: HTMLElement, forward: boolean, rng: Range): Optional<BlockBoundary> =>

--- a/modules/tinymce/src/core/test/ts/browser/delete/BlockMergeBoundaryTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/BlockMergeBoundaryTest.ts
@@ -72,6 +72,24 @@ describe('browser.tinymce.core.delete.BlockMergeBoundary', () => {
       const boundaryOpt = readBlockBoundary(true, [ 1, 0 ], 1);
       assertBlockBoundaryNone(boundaryOpt);
     });
+
+    it('TINY-10590: If the cursor is between an internal block and a text-node it should not count as a block boundary', () => {
+      setHtml('<div>A<p>B</p>C</div>');
+      const boundaryOpt = readBlockBoundary(false, [ 0 ], 2);
+      assertBlockBoundaryNone(boundaryOpt);
+    });
+
+    it('TINY-10590: If the cursor is in a text node and attempt to go outside of it, going backwards, it should not count as a boundary', () => {
+      setHtml('<div>A<p>B</p>C</div>');
+      const boundaryOpt = readBlockBoundary(false, [ 0, 1 ], 0);
+      assertBlockBoundaryNone(boundaryOpt);
+    });
+
+    it('TINY-10590: If the cursor is in a text node and attempt to go outside of it, going forwards, it should not count as a boundary', () => {
+      setHtml('<div>A<p>B</p>C</div>');
+      const boundaryOpt = readBlockBoundary(true, [ 0, 1 ], 1);
+      assertBlockBoundaryNone(boundaryOpt);
+    });
   });
 
   context('Some block boundaries', () => {


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-10590

Description of Changes:
Backport of #9474

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
