### PR TITLE
TINY-10808 & TINY-10800: Dialog accessibility fixes, dialog title markup changed to use an `h1` element

### DIFF
--- a/.changes/unreleased/alloy-TINY-10808-2024-04-02.yaml
+++ b/.changes/unreleased/alloy-TINY-10808-2024-04-02.yaml
@@ -1,0 +1,7 @@
+project: alloy
+kind: Fixed
+body: Dialog title not being announced VoiceOver MacOS, dialog contains `aria-label`
+  instead of `aria-labelledby` on MacOS.
+time: 2024-04-02T21:45:37.708669+08:00
+custom:
+  Issue: TINY-10808

--- a/.changes/unreleased/alloy-TINY-10808-2024-04-02.yaml
+++ b/.changes/unreleased/alloy-TINY-10808-2024-04-02.yaml
@@ -1,7 +1,7 @@
 project: alloy
 kind: Fixed
-body: Dialog title not being announced VoiceOver MacOS, dialog contains `aria-label`
-  instead of `aria-labelledby` on MacOS.
+body: Dialog title was not announced in macOS VoiceOver, dialogs now use `aria-label`
+ instead of `aria-labelledby` on macOS.
 time: 2024-04-02T21:45:37.708669+08:00
 custom:
   Issue: TINY-10808

--- a/.changes/unreleased/tinymce-TINY-10800-2024-04-02.yaml
+++ b/.changes/unreleased/tinymce-TINY-10800-2024-04-02.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Dialog title markup changed to use an `h1` element instead of `div`.
+time: 2024-04-02T21:41:45.987934+08:00
+custom:
+  Issue: TINY-10800

--- a/.changes/unreleased/tinymce-TINY-10808-2024-04-02.yaml
+++ b/.changes/unreleased/tinymce-TINY-10808-2024-04-02.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Dialog title not being announced VoiceOver MacOS, dialog contains `aria-label`
+  instead of `aria-labelledby` on MacOS.
+time: 2024-04-02T21:42:19.730734+08:00
+custom:
+  Issue: TINY-10808

--- a/.changes/unreleased/tinymce-TINY-10808-2024-04-02.yaml
+++ b/.changes/unreleased/tinymce-TINY-10808-2024-04-02.yaml
@@ -1,7 +1,7 @@
 project: tinymce
 kind: Fixed
-body: Dialog title not being announced VoiceOver MacOS, dialog contains `aria-label`
-  instead of `aria-labelledby` on MacOS.
+body: Dialog title was not announced in macOS VoiceOver, dialogs now use `aria-label`
+ instead of `aria-labelledby` on macOS.
 time: 2024-04-02T21:42:19.730734+08:00
 custom:
   Issue: TINY-10808

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/ModalDialog.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/ModalDialog.ts
@@ -117,11 +117,12 @@ const factory: CompositeSketchFactory<ModalDialogDetail, ModalDialogSpec> = (det
         AddEventsBehaviour.config(modalEventsId, [
           AlloyEvents.runOnAttached((c) => {
             // TINY-10808 - Workaround to address the dialog header not being announced on VoiceOver with aria-labelledby, ideally we should use the aria-labelledby
-            const title = TextContent.get(AlloyParts.getPartOrDie(c, detail, 'title').element);
+            const titleElm = AlloyParts.getPartOrDie(c, detail, 'title').element;
+            const title = TextContent.get(titleElm);
             if (browser.os.isMacOS() && Type.isNonNullable(title)) {
               Attribute.set(c.element, 'aria-label', title);
             } else {
-              AriaLabel.labelledBy(c.element, AlloyParts.getPartOrDie(c, detail, 'title').element);
+              AriaLabel.labelledBy(c.element, titleElm);
             }
           })
         ])

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/ModalDialog.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/ModalDialog.ts
@@ -1,5 +1,6 @@
-import { Fun, Id, Singleton } from '@ephox/katamari';
-import { Traverse } from '@ephox/sugar';
+import { Fun, Id, Singleton, Type } from '@ephox/katamari';
+import { PlatformDetection } from '@ephox/sand';
+import { Attribute, TextContent, Traverse } from '@ephox/sugar';
 
 import * as AriaLabel from '../../aria/AriaLabel';
 import * as AlloyParts from '../../parts/AlloyParts';
@@ -79,6 +80,7 @@ const factory: CompositeSketchFactory<ModalDialogDetail, ModalDialogSpec> = (det
     [SystemEvents.attachedToDom()]: [ modalEventsId ].concat(detail.eventOrder['alloy.system.attached'] || [])
   };
 
+  const browser = PlatformDetection.detect();
   return {
     uid: detail.uid,
     dom: detail.dom,
@@ -114,7 +116,13 @@ const factory: CompositeSketchFactory<ModalDialogDetail, ModalDialogSpec> = (det
         }),
         AddEventsBehaviour.config(modalEventsId, [
           AlloyEvents.runOnAttached((c) => {
-            AriaLabel.labelledBy(c.element, AlloyParts.getPartOrDie(c, detail, 'title').element);
+            // TINY-10808 - Workaround to address the dialog header not being announced on VoiceOver with aria-labelledby, ideally we should use the aria-labelledby
+            const title = TextContent.get(AlloyParts.getPartOrDie(c, detail, 'title').element);
+            if (browser.os.isMacOS() && Type.isNonNullable(title)) {
+              Attribute.set(c.element, 'aria-label', title);
+            } else {
+              AriaLabel.labelledBy(c.element, AlloyParts.getPartOrDie(c, detail, 'title').element);
+            }
           })
         ])
       ]

--- a/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
+++ b/modules/tinymce/src/plugins/fullscreen/test/ts/browser/FullScreenPluginTest.ts
@@ -2,7 +2,7 @@ import { UiFinder } from '@ephox/agar';
 import { afterEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { Attribute, Classes, Css, Html, SelectorFind, SugarBody, SugarDocument, SugarElement, SugarShadowDom, Traverse } from '@ephox/sugar';
+import { Attribute, Classes, Css, Html, SelectorFind, SugarBody, SugarDocument, SugarElement, SugarShadowDom, TextContent, Traverse } from '@ephox/sugar';
 import { McEditor, TinyContentActions, TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -31,12 +31,18 @@ describe('browser.tinymce.plugins.fullscreen.FullScreenPluginTest', () => {
 
   const pWaitForDialog = async (editor: Editor, ariaLabel: string) => {
     const dialog = await TinyUiActions.pWaitForDialog(editor);
-    if (Attribute.has(dialog, 'aria-labelledby')) {
-      const labelledby = Attribute.get(dialog, 'aria-labelledby');
-      const dialogLabel = SelectorFind.descendant<HTMLLabelElement>(dialog, '#' + labelledby).getOrDie('Could not find labelledby');
-      assert.equal(Html.get(dialogLabel), ariaLabel, 'Checking label text');
+    if (!Attribute.has(dialog, 'aria-labelledby') && !Attribute.has(dialog, 'aria-label')) {
+      throw new Error('Dialog did not have correct aria attribute');
+    }
+
+    if (platform.os.isMacOS()) {
+      const ariaLabel = Attribute.get(dialog, 'aria-label');
+      const dialogLabel = SelectorFind.descendant<HTMLHeadingElement>(dialog, 'h1').getOrDie('Could not find dialog title');
+      assert.equal(TextContent.get(dialogLabel), ariaLabel, 'Checking aria-label text');
     } else {
-      throw new Error('Dialog did not have an aria-labelledby');
+      const labelledby = Attribute.get(dialog, 'aria-labelledby');
+      const dialogLabel = SelectorFind.descendant<HTMLHeadingElement>(dialog, '#' + labelledby).getOrDie('Could not find labelledby');
+      assert.equal(Html.get(dialogLabel), ariaLabel, 'Checking label text');
     }
   };
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableGridFalseTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableGridFalseTest.ts
@@ -19,7 +19,7 @@ describe('browser.tinymce.plugins.table.TableGridFalse', () => {
       TinyUiActions.clickOnUi(editor, 'div.tox-menu div.tox-collection__item .tox-collection__item-label:contains("Table")')
     );
     const dialog = await TinyUiActions.pWaitForDialog(editor);
-    UiFinder.exists(dialog, 'div.tox-dialog__title:contains("Table Properties")');
+    UiFinder.exists(dialog, 'h1.tox-dialog__title:contains("Table Properties")');
     Assertions.assertPresence(
       'assert presence of col and row input',
       {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
@@ -52,7 +52,7 @@ const renderTitle = (
 
   return {
     dom: {
-      tag: 'div',
+      tag: 'h1',
       classes: [ 'tox-dialog__title' ],
       attributes: {
         ...titleId.map((x) => ({ id: x })).getOr({})

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -5,6 +5,7 @@ import {
 } from '@ephox/alloy';
 import { Dialog, DialogManager } from '@ephox/bridge';
 import { Cell, Fun, Id, Optional, Optionals } from '@ephox/katamari';
+import { PlatformDetection } from '@ephox/sand';
 import { Attribute, Height, SugarNode } from '@ephox/sugar';
 
 import * as Backstage from '../../backstage/Backstage';
@@ -94,6 +95,8 @@ const renderInlineDialog = <T extends Dialog.DialogData>(
 
   const inlineClass = 'tox-dialog-inline';
 
+  const os = PlatformDetection.detect().os;
+
   // TODO: Disable while validating?
   const dialog = GuiFactory.build({
     dom: {
@@ -101,7 +104,9 @@ const renderInlineDialog = <T extends Dialog.DialogData>(
       classes: [ 'tox-dialog', inlineClass, ...dialogSizeClass ],
       attributes: {
         role: 'dialog',
-        ['aria-labelledby']: dialogLabelId
+        // TINY-10808 - Workaround to address the dialog header not being announced on VoiceOver,
+        // ideally we should use the aria-labelledby
+        ...os.isMacOS() ? { 'aria-label': internalDialog.title } : { 'aria-labelledby': dialogLabelId }
       }
     },
     eventOrder: {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -104,8 +104,7 @@ const renderInlineDialog = <T extends Dialog.DialogData>(
       classes: [ 'tox-dialog', inlineClass, ...dialogSizeClass ],
       attributes: {
         role: 'dialog',
-        // TINY-10808 - Workaround to address the dialog header not being announced on VoiceOver,
-        // ideally we should use the aria-labelledby
+        // TINY-10808 - Workaround to address the dialog header not being announced on VoiceOver with aria-labelledby, ideally we should use the aria-labelledby
         ...os.isMacOS() ? { 'aria-label': internalDialog.title } : { 'aria-labelledby': dialogLabelId }
       }
     },

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogAriaLabelTest.ts
@@ -2,8 +2,10 @@ import { UiFinder } from '@ephox/agar';
 import { TestHelpers } from '@ephox/alloy';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { Attribute, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
+import { PlatformDetection } from '@ephox/sand';
+import { Attribute, SugarBody, SugarDocument, SugarElement, TextContent } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
@@ -29,6 +31,8 @@ describe('browser.tinymce.themes.silver.window.SilverDialogAriaLabelTest', () =>
     initialData: {}
   };
 
+  const os = PlatformDetection.detect().os;
+
   const getDialogLabelId = (dialog: SugarElement<HTMLElement>) => {
     if (Attribute.has(dialog, 'aria-labelledby')) {
       return Attribute.getOpt(dialog, 'aria-labelledby')
@@ -39,10 +43,27 @@ describe('browser.tinymce.themes.silver.window.SilverDialogAriaLabelTest', () =>
     }
   };
 
+  const getAndAssertDialogAriaLabel = (dialog: SugarElement<HTMLElement>) => {
+    if (Attribute.has(dialog, 'aria-label')) {
+      return Attribute.getOpt(dialog, 'aria-label')
+        .filter((labelId) => labelId.length > 0)
+        .getOrDie('Dialog has zero length aria-label attribute');
+    } else {
+      throw new Error('Dialog has no aria-label attribute');
+    }
+  };
+
   const assertDialogLabelledBy = () => {
     const dialog = UiFinder.findIn<HTMLElement>(SugarBody.body(), '[role="dialog"]').getOrDie();
     const labelId = getDialogLabelId(dialog);
     UiFinder.exists(dialog, `#${labelId}`);
+  };
+
+  const assertDialogAriaLabel = () => {
+    const dialog = UiFinder.findIn<HTMLElement>(SugarBody.body(), '[role="dialog"]').getOrDie();
+    const ariaLabelAttribute = getAndAssertDialogAriaLabel(dialog);
+    const dialogTitle = TextContent.get(UiFinder.findIn<HTMLElement>(dialog, 'h1').getOrDie());
+    assert.equal(ariaLabelAttribute, dialogTitle, 'Dialog aria-label should match the dialog title');
   };
 
   Arr.each([
@@ -50,10 +71,10 @@ describe('browser.tinymce.themes.silver.window.SilverDialogAriaLabelTest', () =>
     { label: 'Inline', params: { inline: 'toolbar' as 'toolbar' }}
   ], (test) => {
     context(test.label, () => {
-      it(`Dialog should have "aria-labelledby" for config "${JSON.stringify(test.params)}"`, () => {
+      it(`Dialog should have "aria-label" or "aria-labelledby" for config "${JSON.stringify(test.params)}"`, () => {
         const editor = hook.editor();
         DialogUtils.open(editor, dialogSpec, test.params);
-        assertDialogLabelledBy();
+        os.isMacOS() ? assertDialogAriaLabel() : assertDialogLabelledBy();
         DialogUtils.close(editor);
       });
     });

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogReuseTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogReuseTest.ts
@@ -54,7 +54,7 @@ describe('headless.tinymce.themes.silver.window.SilverDialogReuseTest', () => {
             s.element('div', {
               classes: [ arr.has('tox-dialog__header') ],
               children: [
-                s.element('div', {
+                s.element('h1', {
                   classes: [ arr.has('tox-dialog__title') ],
                   html: str.is('Silver Test Modal Dialog')
                 }),

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerAlertTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerAlertTest.ts
@@ -55,7 +55,7 @@ describe.skip('headless.tinymce.themes.silver.window.WindowManagerAlertTest', ()
                       display: str.is('none')
                     },
                     children: [
-                      s.element('div', {
+                      s.element('h1', {
                         classes: [ arr.has('tox-dialog__title') ],
                         styles: {
                           display: str.is('none')

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerConfirmTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerConfirmTest.ts
@@ -55,7 +55,7 @@ describe.skip('headless.tinymce.themes.silver.window.WindowManagerConfirmTest', 
                       display: str.is('none')
                     },
                     children: [
-                      s.element('div', {
+                      s.element('h1', {
                         classes: [ arr.has('tox-dialog__title') ],
                         styles: {
                           display: str.is('none')

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerTest.ts
@@ -225,7 +225,7 @@ describe('headless.tinymce.themes.silver.window.WindowManagerTest', () => {
         return s.element('div', {
           classes: [ arr.has('tox-dialog__header') ],
           children: [
-            s.element('div', { classes: [ arr.has('tox-dialog__title') ] }),
+            s.element('h1', { classes: [ arr.has('tox-dialog__title') ] }),
             s.element('div', { classes: [ arr.has('tox-dialog__draghandle') ] }),
             s.element('button', { classes: [ arr.has('tox-button') ] })
           ]
@@ -236,7 +236,7 @@ describe('headless.tinymce.themes.silver.window.WindowManagerTest', () => {
         return s.element('div', {
           classes: [ arr.has('tox-dialog__header') ],
           children: [
-            s.element('div', { classes: [ arr.has('tox-dialog__title') ] }),
+            s.element('h1', { classes: [ arr.has('tox-dialog__title') ] }),
             s.element('button', { classes: [ arr.has('tox-button') ] })
           ]
         });

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/DialogFocusTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/DialogFocusTest.ts
@@ -26,7 +26,7 @@ describe('webdriver.tinymce.themes.silver.dialogs.DialogFocusTest', () => {
 
   TestHelpers.GuiSetup.bddAddStyles(SugarDocument.getDocument(), [
     '[role="dialog"] { border: 1px solid black; padding: 2em; background-color: rgb(131,193,249); top: 40px; position: absolute; }',
-
+    '[role="dialog"] h1 { font-size: 15px; background: none; border: none; padding: 0px; margin: 0px; }',
     ':focus { outline: 3px solid green; !important; }'
   ]);
 


### PR DESCRIPTION
Related Ticket: TINY-10800 & TINY-10808

Description of Changes:
* Dialog title markup changed to use an `h1` element instead of `div`
* Don't think we've used platform detection in alloy, but it requires since the `aria-labelledby` is not announced with  `role="dialog"` so that has been changed to `aria-label` only on MacOS
* Ideally we should still use `aria-labelledby` since the dialog already has a visible label, this is a workaround for dialog title to be announced on MacOS VoiceOver. (See: [Dialog Modal Pattern](https://arc.net/l/quote/pchpomfw))
* Changes only impact MacOS, other screen reader like JAWS and NVDA do support usage of `aria-labelledby` in `role="dialog"`. [Assistive Technology Support](https://arc.net/l/quote/jmovypin)

https://github.com/tinymce/tinymce/assets/111734091/dae9d813-bbc3-4fa2-a053-320a40ff7849

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
