### PR TITLE
TINY-10834: Bumped all docs links from 6 to 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Used and trusted by millions of developers, TinyMCE is the world’s most custom
 
 With more than 350M+ downloads every year, we’re also one of the most trusted enterprise-grade open source HTML editors on the internet. There’s currently more than 100M+ products worldwide, powered by Tiny. As a high powered WYSIWYG editor, TinyMCE is built to scale, designed to innovate, and thrives on delivering results to difficult edge-cases.
 
-You can access a [full featured demo of TinyMCE](https://www.tiny.cloud/docs/tinymce/6/premium-full-featured/) in the docs on the TinyMCE website.
+You can access a [full featured demo of TinyMCE](https://www.tiny.cloud/docs/tinymce/7/premium-full-featured/) in the docs on the TinyMCE website.
 
 <p align="center">
   <img alt="Screenshot of the TinyMCE Editor" src="https://www.tiny.cloud/storage/github-readme-images/tinymce-editor-6x.png"\>
@@ -18,17 +18,17 @@ You can access a [full featured demo of TinyMCE](https://www.tiny.cloud/docs/tin
 
 Getting started with the TinyMCE rich text editor is easy, and for simple configurations can be done in less than 5 minutes.
 
-[TinyMCE Cloud Deployment Quick Start Guide](https://www.tiny.cloud/docs/tinymce/6/cloud-quick-start/)
+[TinyMCE Cloud Deployment Quick Start Guide](https://www.tiny.cloud/docs/tinymce/7/cloud-quick-start/)
 
-[TinyMCE Self-hosted Deployment Guide](https://www.tiny.cloud/docs/tinymce/6/npm-projects/)
+[TinyMCE Self-hosted Deployment Guide](https://www.tiny.cloud/docs/tinymce/7/npm-projects/)
 
-TinyMCE provides a range of configuration options that allow you to integrate it into your application. Start customizing with a [basic setup](https://www.tiny.cloud/docs/tinymce/6/basic-setup/).
+TinyMCE provides a range of configuration options that allow you to integrate it into your application. Start customizing with a [basic setup](https://www.tiny.cloud/docs/tinymce/7/basic-setup/).
 
 Configure it for one of three modes of editing:
 
-- [TinyMCE classic editing mode](https://www.tiny.cloud/docs/tinymce/6/use-tinymce-classic/).
-- [TinyMCE inline editing mode](https://www.tiny.cloud/docs/tinymce/6/use-tinymce-inline/).
-- [TinyMCE distraction-free editing mode](https://www.tiny.cloud/docs/tinymce/6/use-tinymce-distraction-free/).
+- [TinyMCE classic editing mode](https://www.tiny.cloud/docs/tinymce/7/use-tinymce-classic/).
+- [TinyMCE inline editing mode](https://www.tiny.cloud/docs/tinymce/7/use-tinymce-inline/).
+- [TinyMCE distraction-free editing mode](https://www.tiny.cloud/docs/tinymce/7/use-tinymce-distraction-free/).
 
 ## Features
 
@@ -40,11 +40,11 @@ TinyMCE is easily integrated into your projects with the help of components such
 - [tinymce-vue](https://github.com/tinymce/tinymce-vue)
 - [tinymce-angular](https://github.com/tinymce/tinymce-angular)
 
-With over 29 integrations, and 400+ APIs, see the TinyMCE docs for a full list of editor [integrations](https://www.tiny.cloud/docs/tinymce/6/integrations/).
+With over 29 integrations, and 400+ APIs, see the TinyMCE docs for a full list of editor [integrations](https://www.tiny.cloud/docs/tinymce/7/integrations/).
 
 ### Customization
 
-It is easy to [configure the UI](https://www.tiny.cloud/docs/tinymce/6/customize-ui/) of your rich text editor to match the design of your site, product or application. Due to its flexibility, you can [configure the editor](https://www.tiny.cloud/docs/tinymce/6/basic-setup/) with as much or as little functionality as you like, depending on your requirements.
+It is easy to [configure the UI](https://www.tiny.cloud/docs/tinymce/7/customize-ui/) of your rich text editor to match the design of your site, product or application. Due to its flexibility, you can [configure the editor](https://www.tiny.cloud/docs/tinymce/7/basic-setup/) with as much or as little functionality as you like, depending on your requirements.
 
 With [50+ powerful plugins available](https://www.tiny.cloud/tinymce/features/), and content editable as the basis of TinyMCE, adding additional functionality is as simple as including a single line of code.
 
@@ -54,7 +54,7 @@ Realizing the full power of most plugins requires only a few lines more.
 
 Sometimes your editor requirements can be quite unique, and you need the freedom and flexibility to innovate. Thanks to TinyMCE being open source, you can view the source code and develop your own extensions for custom functionality to meet your own requirements.
 
-The TinyMCE [API](https://www.tiny.cloud/docs/tinymce/6/apis/tinymce.root/) is exposed to make it easier for you to write custom functionality that fits within the existing framework of TinyMCE [UI components](https://www.tiny.cloud/docs/tinymce/6/custom-ui-components/).
+The TinyMCE [API](https://www.tiny.cloud/docs/tinymce/7/apis/tinymce.root/) is exposed to make it easier for you to write custom functionality that fits within the existing framework of TinyMCE [UI components](https://www.tiny.cloud/docs/tinymce/7/custom-ui-components/).
 
 ### Extended Features and Support
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ In line with the United States National Infrastructure Advisory Council (NIAC) [
 
 Tiny will communicate with you regarding the status of your report and will, with your permission, publicly attribute the security issue’s discovery to you after the issue has been fixed and disclosed.
 
-For details on how to report security issues to Tiny, refer to the [Reporting TinyMCE security issues documentation](https://tiny.cloud/docs/tinymce/6/security/#reportingtinymcesecurityissues).
+For details on how to report security issues to Tiny, refer to the [Reporting TinyMCE security issues documentation](https://tiny.cloud/docs/tinymce/7/security/#reportingtinymcesecurityissues).
 
 ## Supported Versions
 
@@ -23,4 +23,4 @@ Tiny Technologies, Inc. supports the following community versions of TinyMCE:
 | 5.10.x  | &#10006;                       |
 | Other   | &#10006;                       |
 
-For supported enterprise versions of TinyMCE, refer to the enterprise [Supported TinyMCE versions documentation](https://www.tiny.cloud/docs/tinymce/6/support/#supportedversionsandplatforms).
+For supported enterprise versions of TinyMCE, refer to the enterprise [Supported TinyMCE versions documentation](https://www.tiny.cloud/docs/tinymce/7/support/#supportedversionsandplatforms).

--- a/modules/tinymce/README.md
+++ b/modules/tinymce/README.md
@@ -82,6 +82,6 @@ Docs are hosted on Github in the [tinymce-docs](https://github.com/tinymce/tinym
 
 [How to contribute](https://github.com/tinymce/tinymce-docs/blob/main/CONTRIBUTING.md) to the docs, including a style guide, can be found on the GitHub repo.
 
-[Documentation](https://www.tiny.cloud/docs/tinymce/6/)
+[Documentation](https://www.tiny.cloud/docs/tinymce/7/)
 
 [Log feedback](https://github.com/tinymce/tinymce/labels/6.x)

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -320,7 +320,7 @@ const EditorManager: EditorManager = {
   /**
    * Initializes a set of editors. This method will create editors based on various settings.
    * <br /><br />
-   * For information on basic usage of <code>init</code>, see: <a href="https://www.tiny.cloud/docs/tinymce/6/basic-setup/">Basic setup</a>.
+   * For information on basic usage of <code>init</code>, see: <a href="https://www.tiny.cloud/docs/tinymce/7/basic-setup/">Basic setup</a>.
    *
    * @method init
    * @param {Object} options Options object to be passed to each editor instance.
@@ -375,7 +375,7 @@ const EditorManager: EditorManager = {
       if (Env.browser.isIE() || Env.browser.isEdge()) {
         ErrorReporter.initError(
           'TinyMCE does not support the browser you are using. For a list of supported' +
-          ' browsers please see: https://www.tiny.cloud/docs/tinymce/6/support/#supportedwebbrowsers'
+          ' browsers please see: https://www.tiny.cloud/docs/tinymce/7/support/#supportedwebbrowsers'
         );
         return [];
       } else if (isQuirksMode) {

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -173,7 +173,7 @@ const NotificationManager = (editor: Editor): NotificationManager => {
      * @method open
      * @param {Object} args A <code>name: value</code> collection containing settings such as: <code>timeout</code>, <code>type</code>, and message (<code>text</code>).
      * <br /><br />
-     * For information on the available settings, see: <a href="https://www.tiny.cloud/docs/tinymce/6/creating-custom-notifications/">Create custom notifications</a>.
+     * For information on the available settings, see: <a href="https://www.tiny.cloud/docs/tinymce/7/creating-custom-notifications/">Create custom notifications</a>.
      */
     open,
 

--- a/modules/tinymce/src/core/main/ts/api/WindowManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/WindowManager.ts
@@ -144,8 +144,8 @@ const WindowManager = (editor: Editor): WindowManager => {
      * Opens a new window.
      *
      * @method open
-     * @param {Object} config For information on the available options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/dialog-configuration/#options">Dialog - Configuration options</a>.
-     * @param {Object} params (Optional) For information on the available options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/dialog-configuration/#configuration-parameters">Dialog - Configuration parameters</a>.
+     * @param {Object} config For information on the available options, see: <a href="https://www.tiny.cloud/docs/tinymce/7/dialog-configuration/#options">Dialog - Configuration options</a>.
+     * @param {Object} params (Optional) For information on the available options, see: <a href="https://www.tiny.cloud/docs/tinymce/7/dialog-configuration/#configuration-parameters">Dialog - Configuration parameters</a>.
      * @returns {WindowManager.DialogInstanceApi} A new dialog instance.
      */
     open,
@@ -154,7 +154,7 @@ const WindowManager = (editor: Editor): WindowManager => {
      * Opens a new window for the specified url.
      *
      * @method openUrl
-     * @param {Object} config For information on the available options, see: <a href="https://www.tiny.cloud/docs/tinymce/6/urldialog/#configuration">URL dialog - Configuration</a>.
+     * @param {Object} config For information on the available options, see: <a href="https://www.tiny.cloud/docs/tinymce/7/urldialog/#configuration">URL dialog - Configuration</a>.
      * @returns {WindowManager.UrlDialogInstanceApi} A new URL dialog instance.
      */
     openUrl,

--- a/modules/tinymce/src/core/main/ts/api/fmt/StyleFormat.ts
+++ b/modules/tinymce/src/core/main/ts/api/fmt/StyleFormat.ts
@@ -1,6 +1,6 @@
 import { BlockFormat, InlineFormat, SelectorFormat } from './Format';
 
-// somewhat documented at https://www.tiny.cloud/docs/tinymce/6/content-formatting/#formats
+// somewhat documented at https://www.tiny.cloud/docs/tinymce/7/content-formatting/#formats
 export type StyleFormat = BlockStyleFormat | InlineStyleFormat | SelectorStyleFormat;
 export type AllowedFormat = Separator | FormatReference | StyleFormat | NestedFormatting;
 

--- a/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
+++ b/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
@@ -76,7 +76,7 @@ const registry = (): Registry.Registry => {
      * the cursor is on an image element.
      * <br>
      * For information on creating context toolbars, see:
-     * <a href="https://www.tiny.cloud/docs/tinymce/6/contexttoolbar/">
+     * <a href="https://www.tiny.cloud/docs/tinymce/7/contexttoolbar/">
      * UI Components - Context Toolbar</a>.
      *
      * @method addContextToolbar

--- a/modules/tinymce/src/core/main/ts/api/util/Observable.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Observable.ts
@@ -45,7 +45,7 @@ const getEventDispatcher = (obj: ObservableObject): EventDispatcher<any> => {
 const Observable: Observable<any> = {
   /**
    * Fires the specified event by name. Consult the
-   * <a href="https://www.tiny.cloud/docs/tinymce/6/events/">event reference</a> for more details on each event.
+   * <a href="https://www.tiny.cloud/docs/tinymce/7/events/">event reference</a> for more details on each event.
    * <br>
    * <em>Deprecated in TinyMCE 6.0 and has been marked for removal in TinyMCE 7.0. Use <code>dispatch</code> instead.</em>
    *
@@ -64,7 +64,7 @@ const Observable: Observable<any> = {
 
   /**
    * Dispatches the specified event by name. Consult the
-   * <a href="https://www.tiny.cloud/docs/tinymce/6/events/">event reference</a> for more details on each event.
+   * <a href="https://www.tiny.cloud/docs/tinymce/7/events/">event reference</a> for more details on each event.
    *
    * @method dispatch
    * @param {String} name Name of the event to dispatch.
@@ -98,7 +98,7 @@ const Observable: Observable<any> = {
 
   /**
    * Binds an event listener to a specific event by name. Consult the
-   * <a href="https://www.tiny.cloud/docs/tinymce/6/events/">event reference</a> for more details on each event.
+   * <a href="https://www.tiny.cloud/docs/tinymce/7/events/">event reference</a> for more details on each event.
    *
    * @method on
    * @param {String} name Event name or space separated list of events to bind.
@@ -116,7 +116,7 @@ const Observable: Observable<any> = {
 
   /**
    * Unbinds an event listener to a specific event by name. Consult the
-   * <a href="https://www.tiny.cloud/docs/tinymce/6/events/">event reference</a> for more details on each event.
+   * <a href="https://www.tiny.cloud/docs/tinymce/7/events/">event reference</a> for more details on each event.
    *
    * @method off
    * @param {String?} name Name of the event to unbind.
@@ -138,7 +138,7 @@ const Observable: Observable<any> = {
 
   /**
    * Bind the event callback and once it fires the callback is removed. Consult the
-   * <a href="https://www.tiny.cloud/docs/tinymce/6/events/">event reference</a> for more details on each event.
+   * <a href="https://www.tiny.cloud/docs/tinymce/7/events/">event reference</a> for more details on each event.
    *
    * @method once
    * @param {String} name Name of the event to bind.


### PR DESCRIPTION
Related Ticket: TINY-10834

Description of Changes:
* Changed all readme links
* Changed all JSDoc links since 7 might add new events etc

Pre-checks:
* [-] Changelog entry added
* [-] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [-] Docs ticket created (if applicable)

GitHub issues (if applicable):
