### PR TITLE
TINY-10602: Theme loader now respects the suffix when loading skin CSS files

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10602-2024-04-04.yaml
+++ b/.changes/unreleased/tinymce-TINY-10602-2024-04-04.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Updated theme loader respects the suffix when loading skin CSS files
+body: Theme loader now respects the suffix when loading skin CSS files
 time: 2024-04-04T16:35:26.405336+11:00
 custom:
   Issue: TINY-10602

--- a/.changes/unreleased/tinymce-TINY-10602-2024-04-04.yaml
+++ b/.changes/unreleased/tinymce-TINY-10602-2024-04-04.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Updated theme loader respects the suffix when loading skin CSS files
+time: 2024-04-04T16:35:26.405336+11:00
+custom:
+  Issue: TINY-10602

--- a/.changes/unreleased/tinymce-TINY-10602-2024-04-04.yaml
+++ b/.changes/unreleased/tinymce-TINY-10602-2024-04-04.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Theme loader now respects the suffix when loading skin CSS files
+body: Theme loader did not respect the suffix when it was loading skin CSS files.
 time: 2024-04-04T16:35:26.405336+11:00
 custom:
   Issue: TINY-10602

--- a/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
@@ -14,8 +14,8 @@ describe('browser.tinymce.core.init.ShadowDomEditorTest', () => {
     }
   });
 
-  const isSkin = (ss: StyleSheet) => ss.href !== null && Strings.contains(ss.href, 'skin.min.css');
-  const isShadowDomSkin = (ss: StyleSheet) => ss.href !== null && Strings.contains(ss.href, 'skin.shadowdom.min.css');
+  const isSkin = (ss: StyleSheet) => ss.href !== null && Strings.contains(ss.href, 'skin.css');
+  const isShadowDomSkin = (ss: StyleSheet) => ss.href !== null && Strings.contains(ss.href, 'skin.shadowdom.css');
 
   Arr.each([
     { type: 'normal', settings: { }, numSinks: 1 },

--- a/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
+++ b/modules/tinymce/src/plugins/importcss/main/ts/core/ImportCss.ts
@@ -45,7 +45,8 @@ const isSkinContentCss = (editor: Editor, href: string): boolean => {
     const skinUrlBase = Options.getSkinUrl(editor);
     const skinUrl = skinUrlBase ? editor.documentBaseURI.toAbsolute(skinUrlBase) : EditorManager.baseURL + '/skins/ui/' + skin;
     const contentSkinUrlPart = EditorManager.baseURL + '/skins/content/';
-    return href === skinUrl + '/content' + (editor.inline ? '.inline' : '') + '.min.css' || href.indexOf(contentSkinUrlPart) !== -1;
+    const suffix = editor.editorManager.suffix;
+    return href === skinUrl + '/content' + (editor.inline ? '.inline' : '') + `${suffix}.css` || href.indexOf(contentSkinUrlPart) !== -1;
   }
 
   return false;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/skin/Loader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/skin/Loader.ts
@@ -28,9 +28,10 @@ const loadUiSkins = async (editor: Editor, skinUrl: string): Promise<void> => {
   const skinUiCss = 'ui/' + skinResourceIdentifier + '/skin.css';
   const css = tinymce.Resource.get(skinUiCss);
   if (Type.isString(css)) {
-    return Promise.resolve(loadRawCss(editor, skinUiCss, css, editor.ui.styleSheetLoader));
+    loadRawCss(editor, skinUiCss, css, editor.ui.styleSheetLoader);
   } else {
-    const skinUiCss = skinUrl + '/skin.min.css';
+    const suffix = editor.editorManager.suffix;
+    const skinUiCss = skinUrl + `/skin${suffix}.css`;
     return loadStylesheet(editor, skinUiCss, editor.ui.styleSheetLoader);
   }
 };
@@ -46,30 +47,29 @@ const loadShadowDomUiSkins = async (editor: Editor, skinUrl: string): Promise<vo
 
     if (Type.isString(css)) {
       loadRawCss(editor, shadowDomSkinCss, css, DOMUtils.DOM.styleSheetLoader);
-      return Promise.resolve();
     } else {
-      const shadowDomSkinCss = skinUrl + '/skin.shadowdom.min.css';
+      const suffix = editor.editorManager.suffix;
+      const shadowDomSkinCss = skinUrl + `/skin.shadowdom${suffix}.css`;
       return loadStylesheet(editor, shadowDomSkinCss, DOMUtils.DOM.styleSheetLoader);
     }
   }
 };
 
 const loadUrlSkin = async (isInline: boolean, editor: Editor): Promise<void> => {
-  Options.getSkinUrlOption(editor).fold(() => {
+  const unbundled = () => {
     const skinResourceIdentifier = Options.getSkinUrl(editor);
+    const suffix = editor.editorManager.suffix;
     if (skinResourceIdentifier) {
-      editor.contentCSS.push(skinResourceIdentifier + (isInline ? '/content.inline' : '/content') + '.min.css');
+      editor.contentCSS.push(skinResourceIdentifier + (isInline ? '/content.inline' : '/content') + `${suffix}.css`);
     }
-  }, (skinUrl) => {
+  };
+  Options.getSkinUrlOption(editor).fold(unbundled, (skinUrl) => {
     const skinContentCss = 'ui/' + skinUrl + (isInline ? '/content.inline' : '/content') + '.css';
     const css = tinymce.Resource.get(skinContentCss);
     if (Type.isString(css)) {
       loadRawCss(editor, skinContentCss, css, editor.ui.styleSheetLoader);
     } else {
-      const skinResourceIdentifier = Options.getSkinUrl(editor);
-      if (skinResourceIdentifier) {
-        editor.contentCSS.push(skinResourceIdentifier + (isInline ? '/content.inline' : '/content') + '.min.css');
-      }
+      unbundled();
     }
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageSinkTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageSinkTest.ts
@@ -30,7 +30,7 @@ describe('browser.tinymce.themes.silver.editor.backstage.BackstageSinkTest', () 
     setup: (ed: Editor) => {
       Options.register(ed);
       ed.on('init', () => {
-        const skinUrl = EditorManager.baseURL + '/skins/ui/oxide/skin.min.css';
+        const skinUrl = EditorManager.baseURL + '/skins/ui/oxide/skin.css';
         ed.ui.styleSheetLoader.load(skinUrl).then(
           () => {
             ed.dispatch('SkinLoaded');


### PR DESCRIPTION
Related Ticket: TINY-10602

Description of Changes:
* I swapped premium tests to load the unminified TinyMCE, but it turns out a lot of the skin files still load minified when this happens.
* Some tests had to be updated.
* I wrote a new test for using the suffix in skin URLs.
* I also applied some minor refactoring to the theme loader.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
