### PR TITLE
TINY-10684: The scroll position should be maintained in a horizontal scrollable container

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
@@ -285,15 +285,15 @@ export const InlineHeader = (
 
     // Positioning
     if (!useFixedToolbarContainer) {
-      // Getting the current scroll as the previously step may have reset the scroll,
-      // We also want calculation based on the previous scroll, then restoring the scroll everything is set.
+      // Getting the current scroll as the previous step may have reset the scroll,
+      // We also want calculation based on the previous scroll, then restoring the scroll when everything is set.
       const currentScroll = Scroll.get();
       const optScroll = Optionals.someIf(prevScroll.left !== currentScroll.left, prevScroll);
 
       // This will position the container in the right spot.
       updateChromePosition(isOuterContainerWidthRestored, optScroll);
 
-      // Restore scroll left position only if they are different, keeping the current scroll, that shouldn't be changed
+      // Restore scroll left position only if they are different, keeping the current scroll top, that shouldn't be changed
       optScroll.each((scroll) => {
         Scroll.to(scroll.left, currentScroll.top);
       });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
@@ -1,6 +1,6 @@
 import { AlloyComponent, Boxes, Channels, Docking, OffsetOrigin, VerticalDir } from '@ephox/alloy';
 import { Arr, Cell, Fun, Optional, Optionals, Singleton } from '@ephox/katamari';
-import { Attribute, Compare, Css, Height, Scroll, SugarBody, SugarElement, SugarLocation, Traverse, Width, WindowVisualViewport } from '@ephox/sugar';
+import { Attribute, Compare, Css, Height, Scroll, SugarBody, SugarElement, SugarLocation, SugarPosition, Traverse, Width, WindowVisualViewport } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
@@ -115,7 +115,7 @@ export const InlineHeader = (
     });
   };
 
-  const updateChromePosition = (isOuterContainerWidthRestored: boolean) => {
+  const updateChromePosition = (isOuterContainerWidthRestored: boolean, prevScroll: Optional<SugarPosition>) => {
     floatContainer.on((container) => {
       const toolbar = OuterContainer.getToolbar(mainUi.outerContainer);
       const offset = calcToolbarOffset(toolbar);
@@ -179,7 +179,7 @@ export const InlineHeader = (
       // the calculate width isn't correct
         .filter((w) => w > minimumToolbarWidth).map(
           (toolbarWidth: number) => {
-            const scroll = Scroll.get();
+            const scroll = prevScroll.getOr(Scroll.get());
 
             /*
           As the editor container can wrap its elements (due to flex-wrap), the width of the container impacts also its height. Adding a minimum width works around two problems:
@@ -272,6 +272,7 @@ export const InlineHeader = (
       updateChromeWidth();
     }
 
+    const prevScroll = Scroll.get();
     const isOuterContainerWidthRestored = useFixedToolbarContainer ? false : restoreOuterContainerWidth();
 
     /*
@@ -284,8 +285,18 @@ export const InlineHeader = (
 
     // Positioning
     if (!useFixedToolbarContainer) {
+      // Getting the current scroll as the previously step may have reset the scroll,
+      // We also want calculation based on the previous scroll, then restoring the scroll everything is set.
+      const currentScroll = Scroll.get();
+      const optScroll = Optionals.someIf(prevScroll.left !== currentScroll.left, prevScroll);
+
       // This will position the container in the right spot.
-      updateChromePosition(isOuterContainerWidthRestored);
+      updateChromePosition(isOuterContainerWidthRestored, optScroll);
+
+      // Restore scroll left position only if they are different, keeping the current scroll, that shouldn't be changed
+      optScroll.each((scroll) => {
+        Scroll.to(scroll.left, currentScroll.top);
+      });
     }
 
     // Docking


### PR DESCRIPTION
Related Ticket: TINY-10684

Description of Changes:
* Preserving the scroll when the toolbar item is focused in the toolbar overflow drawer

https://github.com/tinymce/tinymce/assets/111734091/b7d25a89-c023-4fb5-951b-c4fe243b004d

https://github.com/tinymce/tinymce/assets/111734091/758c2406-af8a-4bd1-b446-c58ffad85c6d

Pre-checks:
* [x] ~Changelog entry added~ (Follow up PR)
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
