### PR TITLE
TINY-10813: Fixed issue with colon characters in custom block elements

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10813-2024-04-04.yaml
+++ b/.changes/unreleased/tinymce-TINY-10813-2024-04-04.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Custom block elements with colon characters would throw errors.
+time: 2024-04-04T10:21:20.297165+02:00
+custom:
+  Issue: TINY-10813

--- a/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
+++ b/modules/tinymce/src/core/main/ts/content/TransparentElements.ts
@@ -16,7 +16,8 @@ export const elementNames = (map: SchemaMap): string[] => Arr.filter(Obj.keys(ma
 const makeSelectorFromSchemaMap = (map: SchemaMap) =>
   Arr.map(elementNames(map), (name) => {
     // Exclude namespace elements from processing
-    return `${name}:` + Arr.map(Namespace.namespaceElements, (ns) => `not(${ns} ${name})`).join(':');
+    const escapedName = CSS.escape(name);
+    return `${escapedName}:` + Arr.map(Namespace.namespaceElements, (ns) => `not(${ns} ${escapedName})`).join(':');
   }).join(',');
 
 const updateTransparent = (blocksSelector: string, transparent: Element) => {

--- a/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/TransparentElementsTest.ts
@@ -92,6 +92,23 @@ describe('browser.tinymce.core.content.TransparentElementsTest', () => {
       expected: '<div><h1>a</h1><p>b</p><h1>c</h1></div>'
     }));
 
+    it('TINY-10813: Should escape elements with characters that needs to be escaped like colon', () => {
+      withScratchDiv('', (root) => {
+        const anchor = SugarElement.fromHtml('<a href="#1"><ns:block>link</ns:block></a>');
+        Insert.append(root, anchor);
+
+        const customElementsSchema = Schema({
+          custom_elements: 'ns:block' // This custom element needs to be escaped in querySelectors
+        });
+
+        assert.doesNotThrow(() => {
+          TransparentElements.updateChildren(customElementsSchema, root.dom);
+        });
+
+        assert.equal(Html.get(root), '<a href="#1" data-mce-block="true"><ns:block>link</ns:block></a>', 'Should make anchor block');
+      });
+    });
+
     it('TINY-9172: Should update all anchors in element closest to the root only', () => testUpdateCaret({
       input: '<div><a href="#"><p>link</p></a><a href="#"><p>link</p></a></div><a href="#">not this</a><a href="#"><p>not this</p></a>',
       path: [ 0, 0, 0 ],


### PR DESCRIPTION
Related Ticket: TINY-10813

Description of Changes:
* Escaping element names in the query selector so that we don't get an exception thrown if colon is used.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [-] Docs ticket created (if applicable)

GitHub issues (if applicable):
