### PR TITLE
TINY-10839: Fixed failing test for Firefox 124

### DIFF
--- a/modules/sugar/src/test/ts/browser/LocationTest.ts
+++ b/modules/sugar/src/test/ts/browser/LocationTest.ts
@@ -328,8 +328,8 @@ UnitTest.asynctest('LocationTest', (success, failure) => {
     // Chrome has a weird 2px bug where the offsetTop of a table cell is 2px less than every other browser, even though
     // the difference between table.getBoundingClientRect() and cell.getBoundingClientRect() is correct.
     // I don't want to make every browser pay for Chrome's mistake in a scenario we don't need for TBIO, so we're living with it.
-    // Firefox 71 has also started behaving the same as chrome
-    if (platform.browser.isChromium() || platform.browser.isFirefox() && platform.browser.version.major >= 71) {
+    // Firefox 71 has also started behaving the same as chrome but seems to be fixed in 124
+    if (platform.browser.isChromium() || platform.browser.isFirefox() && platform.browser.version.major >= 71 && platform.browser.version.major < 124) {
       const chromeDifference = -2;
       Arr.each(tests, (t) => {
         if (t.id !== 'table-1') {


### PR DESCRIPTION
Related Ticket: TINY-10839

Description of Changes:
* Fun times some of the browsers have updated to Firefox 124 and that fixes an issue that we have a workaround for in the test so we need to change the check to for that range of affected browsers. It only fails on Mac nodes so they have been updated to 124 but the Windows nodes are still on 123.

Once this is approved I will cherrypick this into release/7 that is also affected but this issue.

Pre-checks:
* [-] Changelog entry added
* [-] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [-] Docs ticket created (if applicable)

GitHub issues (if applicable):
