### PR TITLE
TINY-10809: Add MathML parsing support

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10809-2024-04-08.yaml
+++ b/.changes/unreleased/tinymce-TINY-10809-2024-04-08.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: Added parser support for math elements.
+time: 2024-04-08T12:51:40.499266+02:00
+custom:
+  Issue: TINY-10809

--- a/modules/tinymce/src/core/main/ts/html/Namespace.ts
+++ b/modules/tinymce/src/core/main/ts/html/Namespace.ts
@@ -1,4 +1,6 @@
-export type NamespaceType = 'html' | 'svg';
+import { Singleton } from '@ephox/katamari';
+
+export type NamespaceType = 'html' | 'svg' | 'math';
 
 export interface NamespaceTracker {
   readonly track: (node: Node) => NamespaceType;
@@ -6,37 +8,43 @@ export interface NamespaceTracker {
   readonly reset: () => void;
 }
 
-export const isNonHtmlElementRootName = (name: string): boolean => name.toLowerCase() === 'svg';
+const nodeNameToNamespaceType = (name: string) => {
+  const lowerCaseName = name.toLowerCase();
+
+  if (lowerCaseName === 'svg') {
+    return 'svg';
+  } else if (lowerCaseName === 'math') {
+    return 'math';
+  } else {
+    return 'html';
+  }
+};
+
+export const isNonHtmlElementRootName = (name: string): boolean => nodeNameToNamespaceType(name) !== 'html';
 
 export const isNonHtmlElementRoot = (node: Node): boolean => isNonHtmlElementRootName(node.nodeName);
 
-export const toScopeType = (node: Node | undefined): NamespaceType => node?.nodeName === 'svg' ? 'svg' : 'html';
+export const toScopeType = (node: Node): NamespaceType => nodeNameToNamespaceType(node.nodeName);
 
-export const namespaceElements = [ 'svg' ];
+export const namespaceElements = [ 'svg', 'math' ];
 
 export const createNamespaceTracker = (): NamespaceTracker => {
-  let scopes: Node[] = [];
+  const currentScope = Singleton.value<Node>();
 
-  const peek = () => scopes[scopes.length - 1];
+  const current = () => currentScope.get().map(toScopeType).getOr('html');
 
   const track = (node: Node): NamespaceType => {
     if (isNonHtmlElementRoot(node)) {
-      scopes.push(node);
+      currentScope.set(node);
+    } else if (currentScope.get().exists((scopeNode) => !scopeNode.contains(node))) {
+      currentScope.clear();
     }
 
-    let currentScope: Node | undefined = peek();
-    if (currentScope && !currentScope.contains(node)) {
-      scopes.pop();
-      currentScope = peek();
-    }
-
-    return toScopeType(currentScope);
+    return current();
   };
 
-  const current = () => toScopeType(peek());
-
   const reset = () => {
-    scopes = [];
+    currentScope.clear();
   };
 
   return {

--- a/modules/tinymce/src/core/main/ts/html/Namespace.ts
+++ b/modules/tinymce/src/core/main/ts/html/Namespace.ts
@@ -8,7 +8,7 @@ export interface NamespaceTracker {
   readonly reset: () => void;
 }
 
-const nodeNameToNamespaceType = (name: string) => {
+const nodeNameToNamespaceType = (name: string): NamespaceType => {
   const lowerCaseName = name.toLowerCase();
 
   if (lowerCaseName === 'svg') {

--- a/modules/tinymce/src/core/main/ts/html/Sanitization.ts
+++ b/modules/tinymce/src/core/main/ts/html/Sanitization.ts
@@ -204,21 +204,34 @@ const getPurifyConfig = (settings: DomParserSettings, mimeType: string): Config 
 };
 
 const sanitizeNamespaceElement = (ele: Element) => {
-  // xlink:href used to be the way to do links in SVG 1.x https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href
-  const xlinkAttrs = [ 'type', 'href', 'role', 'arcrole', 'title', 'show', 'actuate', 'label', 'from', 'to' ].map((name) => `xlink:${name}`);
-  const config: Config = {
-    IN_PLACE: true,
-    USE_PROFILES: {
-      html: true,
-      svg: true,
-      svgFilters: true
-    },
-    ALLOWED_ATTR: xlinkAttrs
-  };
+  const namespaceType = Namespace.toScopeType(ele);
 
-  createDompurify().sanitize(ele, config);
+  if (namespaceType === 'svg') {
+    // xlink:href used to be the way to do links in SVG 1.x https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href
+    const xlinkAttrs = [ 'type', 'href', 'role', 'arcrole', 'title', 'show', 'actuate', 'label', 'from', 'to' ].map((name) => `xlink:${name}`);
+    const config: Config = {
+      IN_PLACE: true,
+      USE_PROFILES: {
+        html: true,
+        svg: true,
+        svgFilters: true
+      },
+      ALLOWED_ATTR: xlinkAttrs
+    };
 
-  return ele.innerHTML;
+    createDompurify().sanitize(ele, config);
+  } else if (namespaceType === 'math') {
+    const config: Config = {
+      IN_PLACE: true,
+      USE_PROFILES: {
+        mathMl: true
+      },
+    };
+
+    createDompurify().sanitize(ele, config);
+  } else {
+    throw new Error('Not a namespace element');
+  }
 };
 
 const getSanitizer = (settings: DomParserSettings, schema: Schema): Sanitizer => {

--- a/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
@@ -147,21 +147,38 @@ describe('browser.tinymce.core.ForceBlocksTest', () => {
     });
   });
 
-  it('TINY-10237: Should not wrap SVG elements', () => {
-    const editor = hook.editor();
+  context('Namespace elements', () => {
+    const testNamespaceElement = (testCase: { input: string; caretPath: number[]; expected: string }) => {
+      const editor = hook.editor();
 
-    editor.setContent('<svg></svg>foo', { format: 'raw' });
-    TinySelections.setCursor(editor, [ 1 ], 0);
-    pressArrowKey(editor);
-    TinyAssertions.assertRawContent(editor, '<svg></svg><p>foo</p>');
-  });
+      editor.setContent(testCase.input, { format: 'raw' });
+      TinySelections.setCursor(editor, testCase.caretPath, 0);
+      pressArrowKey(editor);
+      TinyAssertions.assertRawContent(editor, testCase.expected);
+    };
 
-  it('TINY-10273: Should not create empty paragraphs for whitespace around SVG elements', () => {
-    const editor = hook.editor();
+    it('TINY-10237: Should not wrap SVG elements', () => testNamespaceElement({
+      input: '<svg></svg>foo',
+      caretPath: [ 1 ],
+      expected: '<svg></svg><p>foo</p>'
+    }));
 
-    editor.setContent(' <svg></svg> <svg></svg> ', { format: 'raw' });
-    TinySelections.setCursor(editor, [ 0 ], 0);
-    pressArrowKey(editor);
-    TinyAssertions.assertRawContent(editor, '<svg></svg><svg></svg>');
+    it('TINY-10273: Should not create empty paragraphs for whitespace around SVG elements', () => testNamespaceElement({
+      input: ' <svg></svg> <svg></svg> ',
+      caretPath: [ 0 ],
+      expected: '<svg></svg><svg></svg>'
+    }));
+
+    it('TINY-10809: Should not wrap math elements', () => testNamespaceElement({
+      input: '<math></math>foo',
+      caretPath: [ 1 ],
+      expected: '<math></math><p>foo</p>'
+    }));
+
+    it('TINY-10809: Should not create empty paragraphs for whitespace around math elements', () => testNamespaceElement({
+      input: ' <math></math> <math></math> ',
+      caretPath: [ 0 ],
+      expected: '<math></math><math></math>'
+    }));
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/insert/NamespaceElementsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/insert/NamespaceElementsTest.ts
@@ -3,11 +3,12 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
-describe('browser.tinymce.core.content.insert.SvgTest', () => {
+describe('browser.tinymce.core.content.insert.NamespaceElementsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     base_url: '/project/tinymce/js/tinymce',
-    extended_valid_elements: 'svg[width|height]'
+    extended_valid_elements: 'svg[width|height],math',
+    valid_children: '+p[math]'
   }, [], true);
 
   it('TINY-10237: Inserting SVG elements but filter out things like scripts', () => {
@@ -16,5 +17,13 @@ describe('browser.tinymce.core.content.insert.SvgTest', () => {
     TinySelections.setCursor(editor, [ 0, 0 ], 1);
     editor.insertContent('<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><desc><script>alert(1)</script><p>hello</p></circle></a></svg>');
     TinyAssertions.assertContent(editor, '<p>a<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><desc><p>hello</p></desc></circle></svg>b</p>');
+  });
+
+  it('TINY-10809: Inserting math elements but filter out things like scripts', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>ab</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    editor.insertContent('<math><script>alert(1)</script><mrow><msup><mi>a</mi><mn>2</mn></msup></mrow></math>');
+    TinyAssertions.assertContent(editor, '<p>a<math><mrow><msup><mi>a</mi><mn>2</mn></msup></mrow></math>b</p>');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/DomUtilsTest.ts
@@ -987,5 +987,11 @@ describe('browser.tinymce.core.dom.DOMUtilsTest', () => {
       path: [ 0 ],
       expected: false
     }));
+
+    it('TINY-10809: isEditable on math element should always be considered non-editable', testIsEditable({
+      input: '<math></math>',
+      path: [ 0 ],
+      expected: false
+    }));
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/NamespaceTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/NamespaceTest.ts
@@ -9,11 +9,13 @@ describe('browser.tinymce.core.html.NamespaceTest', () => {
 
   it('isNonHtmlElementRootName', () => {
     assert.isTrue(Namespace.isNonHtmlElementRootName('svg'));
+    assert.isTrue(Namespace.isNonHtmlElementRootName('math'));
     assert.isFalse(Namespace.isNonHtmlElementRootName('span'));
   });
 
   it('isNonHtmlElementRoot', () => {
     assert.isTrue(Namespace.isNonHtmlElementRoot(createSvgElement('svg')));
+    assert.isTrue(Namespace.isNonHtmlElementRoot(createSvgElement('math')));
     assert.isFalse(Namespace.isNonHtmlElementRoot(document.createElement('span')));
   });
 
@@ -36,6 +38,14 @@ describe('browser.tinymce.core.html.NamespaceTest', () => {
             </desc>
           </circle>
         </svg>
+        <math>
+          <mrow>
+            <msup>
+              <mi>a</mi>
+              <mn>2</mn>
+            </msup>
+          </mrow>
+        </math>
         <span>baz</span>
       </div>
     `.trim());
@@ -46,12 +56,27 @@ describe('browser.tinymce.core.html.NamespaceTest', () => {
     );
 
     const states: Array<[ string, Namespace.NamespaceType ]> = [];
+
     while (walker.nextNode()) {
       const type = tracker.track(walker.currentNode);
       assert.equal(type, tracker.current(), 'Current tracker state should be the last executed track result');
       states.push([ walker.currentNode.nodeName.toLowerCase(), type ]);
     }
-    assert.deepEqual(states, [[ 'p', 'html' ], [ 'span', 'html' ], [ 'svg', 'svg' ], [ 'circle', 'svg' ], [ 'desc', 'svg' ], [ 'p', 'svg' ], [ 'span', 'html' ]]);
+
+    assert.deepEqual(states, [
+      [ 'p', 'html' ],
+      [ 'span', 'html' ],
+      [ 'svg', 'svg' ],
+      [ 'circle', 'svg' ],
+      [ 'desc', 'svg' ],
+      [ 'p', 'svg' ],
+      [ 'math', 'math' ],
+      [ 'mrow', 'math' ],
+      [ 'msup', 'math' ],
+      [ 'mi', 'math' ],
+      [ 'mn', 'math' ],
+      [ 'span', 'html' ]
+    ]);
 
     tracker.track(createSvgElement('svg'));
     assert.equal(tracker.current(), 'svg');

--- a/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
@@ -32,11 +32,13 @@ describe('browser.tinymce.core.html.SanitizationTest', () => {
 
   context('Santitize non-html', () => {
     const testNamespaceSanitizer = (testCase: { input: string; expected: string; sanitize?: boolean }) => {
-      const sanitizer = getSanitizer({ sanitize: testCase.sanitize ?? true }, Schema());
+      const sanitizer = getSanitizer({ sanitize: testCase.sanitize ?? true }, Schema({ custom_elements: 'math' }));
 
       const body = document.createElement('body');
       body.innerHTML = testCase.input;
-      sanitizer.sanitizeNamespaceElement(body);
+      if (body.firstElementChild) {
+        sanitizer.sanitizeNamespaceElement(body.firstElementChild);
+      }
 
       assert.equal(body.innerHTML, testCase.expected);
     };
@@ -64,6 +66,17 @@ describe('browser.tinymce.core.html.SanitizationTest', () => {
     it('Disabled sanitization of SVG', () => testNamespaceSanitizer({
       input: '<svg><script>alert(1)</script><a xlink:href="javascript:alert(1)"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></a></svg>',
       expected: '<svg><script>alert(1)</script><a xlink:href="javascript:alert(1)"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></circle></a></svg>',
+      sanitize: false
+    }));
+
+    it('TINY-10809: Sanitize MathML', () => testNamespaceSanitizer({
+      input: '<math><script>alert(1)</script><mrow><msup><mi>a</mi><mn>2</mn></msup></mrow></math>',
+      expected: '<math><mrow><msup><mi>a</mi><mn>2</mn></msup></mrow></math>'
+    }));
+
+    it('TINY-10809: Disabled sanitization of MathML', () => testNamespaceSanitizer({
+      input: '<math><script>alert(1)</script><mrow><msup><mi>a</mi><mn>2</mn></msup></mrow></math>',
+      expected: '<math><script>alert(1)</script><mrow><msup><mi>a</mi><mn>2</mn></msup></mrow></math>',
       sanitize: false
     }));
   });


### PR DESCRIPTION
Related Ticket: TINY-10809

Description of Changes:
* Added parsing support for mathml elements similar to SVGs.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [-] Docs ticket created (if applicable)

GitHub issues (if applicable):
