### PR TITLE
TINY-10726: Fix `ToggleToolbarDrawer` command in sliding mode

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10726-2024-04-09.yaml
+++ b/.changes/unreleased/tinymce-TINY-10726-2024-04-09.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: '`ToggleToolbarDrawer` command did not toggle the toolbar in `sliding` mode
+  when `{skipFocus: true}` parameter was passed.'
+time: 2024-04-09T23:36:48.55386+03:00
+custom:
+  Issue: TINY-10726

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitSlidingToolbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitSlidingToolbar.ts
@@ -120,11 +120,9 @@ const factory: CompositeSketchFactory<SplitSlidingToolbarDetail, SplitSlidingToo
       },
       refresh: (toolbar: AlloyComponent) => refresh(toolbar, detail),
       toggle: (toolbar: AlloyComponent) => {
-        console.log('toggle');
         toggleToolbar(toolbar, detail, false);
       },
       toggleWithoutFocusing: (toolbar: AlloyComponent) => {
-        console.log('toggleWithoutFocusing');
         toggleToolbar(toolbar, detail, true);
       },
       isOpen: (toolbar: AlloyComponent) => isOpen(toolbar, detail)

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitSlidingToolbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitSlidingToolbar.ts
@@ -8,6 +8,8 @@ import {
 } from '../../ui/types/SplitSlidingToolbarTypes';
 import * as AddEventsBehaviour from '../behaviour/AddEventsBehaviour';
 import { Coupling } from '../behaviour/Coupling';
+import { Focusing } from '../behaviour/Focusing';
+import { Keying } from '../behaviour/Keying';
 import { Sliding } from '../behaviour/Sliding';
 import { Toggling } from '../behaviour/Toggling';
 import { AlloyComponent } from '../component/ComponentApi';
@@ -25,13 +27,33 @@ import { CompositeSketchFactory } from './UiSketcher';
 const isOpen = (toolbar: AlloyComponent, detail: SplitSlidingToolbarDetail) =>
   AlloyParts.getPart(toolbar, detail, 'overflow').map(Sliding.hasGrown).getOr(false);
 
-const toggleToolbar = (toolbar: AlloyComponent, detail: SplitSlidingToolbarDetail) => {
+const toggleToolbar = (toolbar: AlloyComponent, detail: SplitSlidingToolbarDetail, skipFocus: boolean) => {
   // Make sure that the toolbar needs to toggled by checking for overflow button presence
   AlloyParts.getPart(toolbar, detail, 'overflow-button')
-    .bind(() => AlloyParts.getPart(toolbar, detail, 'overflow'))
-    .each((overf) => {
-      refresh(toolbar, detail);
-      Sliding.toggleGrow(overf);
+    .each((oveflowButton) => {
+      AlloyParts.getPart(toolbar, detail, 'overflow').each((overf) => {
+        refresh(toolbar, detail);
+        if (Sliding.hasShrunk(overf)) {
+          const fn = detail.onOpened;
+          detail.onOpened = (comp) => {
+            if (!skipFocus) {
+              Keying.focusIn(overf);
+            }
+            fn(comp);
+            detail.onOpened = fn;
+          };
+        } else {
+          const fn = detail.onClosed;
+          detail.onClosed = (comp) => {
+            if (!skipFocus) {
+              Focusing.focus(oveflowButton);
+            }
+            fn(comp);
+            detail.onClosed = fn;
+          };
+        }
+        Sliding.toggleGrow(overf);
+      });
     });
 };
 
@@ -86,7 +108,7 @@ const factory: CompositeSketchFactory<SplitSlidingToolbarDetail, SplitSlidingToo
         }),
         AddEventsBehaviour.config('toolbar-toggle-events', [
           AlloyEvents.run(toolbarToggleEvent, (toolbar) => {
-            toggleToolbar(toolbar, detail);
+            toggleToolbar(toolbar, detail, false);
           })
         ])
       ]
@@ -97,7 +119,14 @@ const factory: CompositeSketchFactory<SplitSlidingToolbarDetail, SplitSlidingToo
         refresh(toolbar, detail);
       },
       refresh: (toolbar: AlloyComponent) => refresh(toolbar, detail),
-      toggle: (toolbar: AlloyComponent) => toggleToolbar(toolbar, detail),
+      toggle: (toolbar: AlloyComponent) => {
+        console.log('toggle');
+        toggleToolbar(toolbar, detail, false);
+      },
+      toggleWithoutFocusing: (toolbar: AlloyComponent) => {
+        console.log('toggleWithoutFocusing');
+        toggleToolbar(toolbar, detail, true);
+      },
       isOpen: (toolbar: AlloyComponent) => isOpen(toolbar, detail)
     },
     domModification: {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/SplitSlidingToolbarSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/SplitSlidingToolbarSchema.ts
@@ -48,12 +48,10 @@ const parts: () => PartType.PartTypeAdt[] = Fun.constant([
             onShrunk: (comp) => {
               AlloyParts.getPart(comp, detail, 'overflow-button').each((button) => {
                 Toggling.off(button);
-                Focusing.focus(button);
               });
               detail.onClosed(comp);
             },
             onGrown: (comp) => {
-              Keying.focusIn(comp);
               detail.onOpened(comp);
             },
             onStartGrow: (comp) => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -11,11 +11,16 @@ import { RawEditorOptions, ToolbarMode } from 'tinymce/core/api/OptionTypes';
 import * as UiUtils from '../../../module/UiUtils';
 
 // TODO TINY-10480: Investigate flaky tests
-describe.skip('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest', () => {
+describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest', () => {
 
   const assertToolbarToggleState = (editor: Editor, expected: boolean) => {
     const state = editor.queryCommandState('ToggleToolbarDrawer');
     assert.equal(state, expected, 'Expected toolbar toggle state to be ' + expected);
+  };
+
+  const pWaitForOverflowToolbar = async (editor: Editor, toolbarMode: ToolbarMode) => {
+    const selector = `.tox-toolbar__overflow${toolbarMode === 'sliding' ? '--open' : ''}`;
+    await TinyUiActions.pWaitForUi(editor, selector);
   };
 
   const pTestToggle = async (options: RawEditorOptions, shouldToggle: boolean) => {
@@ -37,7 +42,7 @@ describe.skip('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleT
     McEditor.remove(editor);
   };
 
-  context(`Using the 'ToggleToolbarDrawer' command should toggle the toolbar if applicable`, () => {
+  context.skip(`Using the 'ToggleToolbarDrawer' command should toggle the toolbar if applicable`, () => {
     Arr.each<{ mode: ToolbarMode; shouldToggle: boolean }>([
       { mode: 'floating', shouldToggle: true },
       { mode: 'sliding', shouldToggle: true },
@@ -90,7 +95,7 @@ describe.skip('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleT
     });
 
     command(editor);
-    await TinyUiActions.pWaitForUi(editor, '.tox-toolbar__overflow');
+    await pWaitForOverflowToolbar(editor, toolbarMode);
     command(editor);
     await Waiter.pTryUntil('Wait for toolbar to be completely open', () => {
       store.sAssertEq('Assert store contains opened state', [ true, false ]);
@@ -126,7 +131,7 @@ describe.skip('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleT
         const doc = SugarDocument.getDocument();
         FocusTools.isOnSelector('Root element is focused', doc, 'iframe');
         editor.execCommand('ToggleToolbarDrawer', false, { skipFocus: true });
-        await TinyUiActions.pWaitForUi(editor, '.tox-toolbar__overflow');
+        await pWaitForOverflowToolbar(editor, toolbarMode);
         await FocusTools.pTryOnSelector('Focus should be preserved', doc, 'iframe');
         editor.execCommand('ToggleToolbarDrawer', false, { skipFocus: true });
         await FocusTools.pTryOnSelector('Focus should be preserved', doc, 'iframe');
@@ -145,7 +150,7 @@ describe.skip('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleT
         editor.focus();
         const initialFocusedElement = document.activeElement;
         editor.execCommand('ToggleToolbarDrawer', false, { skipFocus: false });
-        await TinyUiActions.pWaitForUi(editor, '.tox-toolbar__overflow');
+        await pWaitForOverflowToolbar(editor, toolbarMode);
         await Waiter.pTryUntil('Wait for toolbar to be completely open', () => {
           assert.notEqual(initialFocusedElement, document.activeElement, 'Focus should not be preserved');
         });


### PR DESCRIPTION
Related Ticket: TINY-10726

Description of Changes:
* Added `toggleWithoutFocusing` api to `SplitSlidingToolbar` component

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
