### PR TITLE
TINY-10774: Fix for not being able to play video on Safari

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10774-2024-04-08.yaml
+++ b/.changes/unreleased/tinymce-TINY-10774-2024-04-08.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Video and audio elements could not be played on Safari.
+time: 2024-04-08T15:06:01.494664+02:00
+custom:
+  Issue: TINY-10774

--- a/modules/tinymce/src/core/demo/html/full_demo.html
+++ b/modules/tinymce/src/core/demo/html/full_demo.html
@@ -11,6 +11,8 @@
     <h1>Tinymce full featured Page</h1>
     <div id="ephox-ui">
       <textarea>
+	  <p><video controls="controls" width="300" height="150">
+	  <source src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm" type="video/webm"></video></p>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed augue velit. Sed viverra aliquet fringilla. Duis quis turpis rutrum, auctor
           diam vitae,

--- a/modules/tinymce/src/core/demo/html/full_demo.html
+++ b/modules/tinymce/src/core/demo/html/full_demo.html
@@ -11,8 +11,6 @@
     <h1>Tinymce full featured Page</h1>
     <div id="ephox-ui">
       <textarea>
-	  <p><video controls="controls" width="300" height="150">
-	  <source src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm" type="video/webm"></video></p>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed augue velit. Sed viverra aliquet fringilla. Duis quis turpis rutrum, auctor
           diam vitae,

--- a/modules/tinymce/src/plugins/media/main/ts/core/Selection.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Selection.ts
@@ -9,9 +9,16 @@ const isMediaElement = (element: Element): boolean =>
   element.hasAttribute('data-mce-object') || element.hasAttribute('data-ephox-embed-iri');
 
 const setup = (editor: Editor): void => {
+  // TINY-10774: On Safari all events bubble out even if you click on the video play button on other browsers the video element doesn't bubble the event
+  editor.on('mousedown', (e) => {
+    const previewObj = editor.dom.getParent(e.target, '.mce-preview-object');
+    if (previewObj && editor.dom.getAttrib(previewObj, 'data-mce-selected') === '2') {
+      e.stopImmediatePropagation();
+    }
+  });
+
   editor.on('click keyup touchend', () => {
     const selectedNode = editor.selection.getNode();
-
     if (selectedNode && editor.dom.hasClass(selectedNode, 'mce-preview-object')) {
       if (editor.dom.getAttrib(selectedNode, 'data-mce-selected')) {
         selectedNode.setAttribute('data-mce-selected', '2');

--- a/modules/tinymce/src/plugins/media/test/ts/browser/VideoMouseEventsTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/VideoMouseEventsTest.ts
@@ -1,0 +1,35 @@
+
+import { Mouse } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/media/Plugin';
+
+describe('browser.tinymce.plugins.media.core.VideoMouseEventsTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: [ 'media' ],
+    toolbar: 'media',
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ], true);
+
+  const testMouseDownOnMediaElement = (name: string) => {
+    const editor = hook.editor();
+    let mouseDownCount = 0;
+
+    const handler = () => {
+      mouseDownCount++;
+    };
+
+    editor.on('mousedown', handler);
+    editor.setContent(`<${name} src="about:blank"></${name}>`);
+    Mouse.trueClickOn(TinyDom.body(editor), name);
+    Mouse.trueClickOn(TinyDom.body(editor), name);
+    assert.equal(mouseDownCount, 1, 'Should only have emitted mousedown for the initial selection click');
+    editor.off('mousedown', handler);
+  };
+
+  it('TINY-10774: Mousedown should not bubble out of video elements when it is in a selected state', () => testMouseDownOnMediaElement('video'));
+  it('TINY-10774: Mousedown should not bubble out of audio elements when it is in a selected state', () => testMouseDownOnMediaElement('audio'));
+});


### PR DESCRIPTION
Related Ticket: TINY-10774

Description of Changes:
* Safari bubbles click event out of the video element other browsers do not.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [-] Docs ticket created (if applicable)

GitHub issues (if applicable):
