### PR TITLE
TINY-10755: fix some edge cases of `selection.setContent`

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10755-2024-04-12.yaml
+++ b/.changes/unreleased/tinymce-TINY-10755-2024-04-12.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: In some cases the selection after `setContent` was in the wrong place.
+time: 2024-04-12T09:05:13.486192033+02:00
+custom:
+  Issue: TINY-10755


### PR DESCRIPTION
Related Ticket: TINY-10755

Description of Changes:
The problem was that after `setContent` the selection is moved to the next element if that element is a text node, but if this text node is wrapped by a `pre+code` or an `h1` the selection was moved in the wrong place and it cause an error on insert new line.

I chose to change how the selection after `setContent` works because at the moment the insertion is impossible navigating the context to go back to the wrong selection

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
