### PR TITLE
TINY-10806: Remove `role` attribute from Color Swatch menu item.

### DIFF
--- a/.changes/unreleased/alloy-TINY-10806-2024-04-19.yaml
+++ b/.changes/unreleased/alloy-TINY-10806-2024-04-19.yaml
@@ -1,0 +1,7 @@
+project: alloy
+kind: Added
+body: Added a new boolean `menuRole` property to `MenuSpec`, which affects the rendering
+  of the `role` attribute on the menu component.
+time: 2024-04-19T14:34:23.744021+03:00
+custom:
+  Issue: TINY-10806

--- a/.changes/unreleased/tinymce-TINY-10806-2024-04-12.yaml
+++ b/.changes/unreleased/tinymce-TINY-10806-2024-04-12.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Fixed accessibility issue by removing duplicate `role="menu"` attribute from
+  color swatches.
+time: 2024-04-12T10:36:16.480977+03:00
+custom:
+  Issue: TINY-10806

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/MenuSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/MenuSchema.ts
@@ -124,7 +124,8 @@ const schema = Fun.constant([
   FieldSchema.defaulted('fakeFocus', false),
   FieldSchema.defaulted('focusManager', FocusManagers.dom()),
   Fields.onHandler('onHighlight'),
-  Fields.onHandler('onDehighlight')
+  Fields.onHandler('onDehighlight'),
+  FieldSchema.defaulted('menuRole', true),
 ]);
 
 const name = Fun.constant('menu');

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/single/MenuSpec.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/single/MenuSpec.ts
@@ -88,11 +88,13 @@ const make: CompositeSketchFactory<MenuDetail, MenuSpec> = (detail, components, 
   components,
   eventOrder: detail.eventOrder,
 
-  domModification: {
-    attributes: {
-      role: 'menu'
+  ...detail.menuRole ? {
+    domModification: {
+      attributes: {
+        role: 'menu'
+      }
     }
-  }
+  } : {}
 });
 
 export {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/MenuTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/MenuTypes.ts
@@ -76,6 +76,7 @@ export interface MenuDetail extends CompositeSketchDetail {
 
   focusManager: FocusManager;
   eventOrder: Record<string, string[]>;
+  menuRole: boolean;
 }
 
 export interface MenuSpec extends CompositeSketchSpec {
@@ -99,6 +100,7 @@ export interface MenuSpec extends CompositeSketchSpec {
   onHighlight?: (comp: AlloyComponent, target: AlloyComponent) => void;
   onDehighlight?: (comp: AlloyComponent, target: AlloyComponent) => void;
   eventOrder?: Record<string, string[]>;
+  menuRole?: boolean;
 }
 
 export interface MenuSketcher extends CompositeSketch<MenuSpec> { }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
@@ -1,6 +1,6 @@
-import { ItemTypes, ItemWidget, Menu as AlloyMenu, MenuTypes, SketchSpec } from '@ephox/alloy';
+import { ItemTypes, ItemWidget, Menu as AlloyMenu, MenuTypes } from '@ephox/alloy';
 import { Menu } from '@ephox/bridge';
-import { Fun, Id, Optional, Resolve } from '@ephox/katamari';
+import { Fun, Id } from '@ephox/katamari';
 
 import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 import * as ColorSwatch from 'tinymce/themes/silver/ui/core/color/ColorSwatch';
@@ -9,14 +9,6 @@ import { createPartialChoiceMenu } from '../../menu/MenuChoice';
 import { deriveMenuMovement } from '../../menu/MenuMovement';
 import * as MenuParts from '../../menu/MenuParts';
 import ItemResponse from '../ItemResponse';
-
-const removeRoleAttr = (spec: SketchSpec): SketchSpec => {
-  Optional.from(Resolve.resolve<{ role?: string }>('domModification.attributes', spec))
-    .each((domModificationAttributes) => {
-      delete domModificationAttributes.role;
-    });
-  return spec;
-};
 
 export const renderColorSwatchItem = (spec: Menu.ColorSwatchMenuItem, backstage: UiFactoryBackstage): ItemTypes.WidgetItemSpec => {
   const items = getColorItems(spec, backstage);
@@ -39,11 +31,12 @@ export const renderColorSwatchItem = (spec: Menu.ColorSwatchMenuItem, backstage:
   const widgetSpec: MenuTypes.MenuSpec = {
     ...menuSpec,
     markers: MenuParts.markers(presets),
-    movement: deriveMenuMovement(columns, presets)
+    movement: deriveMenuMovement(columns, presets),
+    // TINY-10806: Avoid duplication of ARIA role="menu" in the accessibility tree for Color Swatch menu item.
+    menuRole: false
   };
 
-  // TINY-10806: Avoid duplication of ARIA role="menu" in the accessibility tree for Color Swatch menu item.
-  const widgetSketchSpec = removeRoleAttr(AlloyMenu.sketch(widgetSpec));
+  const widgetSketchSpec = AlloyMenu.sketch(widgetSpec);
 
   return {
     type: 'widget',

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
@@ -36,8 +36,6 @@ export const renderColorSwatchItem = (spec: Menu.ColorSwatchMenuItem, backstage:
     menuRole: false
   };
 
-  const widgetSketchSpec = AlloyMenu.sketch(widgetSpec);
-
   return {
     type: 'widget',
     data: { value: Id.generate('widget-id') },
@@ -47,7 +45,7 @@ export const renderColorSwatchItem = (spec: Menu.ColorSwatchMenuItem, backstage:
     },
     autofocus: true,
     components: [
-      ItemWidget.parts.widget(widgetSketchSpec)
+      ItemWidget.parts.widget(AlloyMenu.sketch(widgetSpec))
     ]
   };
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
@@ -1,6 +1,6 @@
-import { ItemTypes, ItemWidget, Menu as AlloyMenu, MenuTypes } from '@ephox/alloy';
+import { ItemTypes, ItemWidget, Menu as AlloyMenu, MenuTypes, SketchSpec } from '@ephox/alloy';
 import { Menu } from '@ephox/bridge';
-import { Fun, Id } from '@ephox/katamari';
+import { Fun, Id, Optional, Resolve } from '@ephox/katamari';
 
 import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 import * as ColorSwatch from 'tinymce/themes/silver/ui/core/color/ColorSwatch';
@@ -9,6 +9,14 @@ import { createPartialChoiceMenu } from '../../menu/MenuChoice';
 import { deriveMenuMovement } from '../../menu/MenuMovement';
 import * as MenuParts from '../../menu/MenuParts';
 import ItemResponse from '../ItemResponse';
+
+const removeRoleAttr = (spec: SketchSpec): SketchSpec => {
+  Optional.from(Resolve.resolve<{ role?: string }>('domModification.attributes', spec))
+    .each((domModificationAttributes) => {
+      delete domModificationAttributes.role;
+    });
+  return spec;
+};
 
 export const renderColorSwatchItem = (spec: Menu.ColorSwatchMenuItem, backstage: UiFactoryBackstage): ItemTypes.WidgetItemSpec => {
   const items = getColorItems(spec, backstage);
@@ -34,6 +42,9 @@ export const renderColorSwatchItem = (spec: Menu.ColorSwatchMenuItem, backstage:
     movement: deriveMenuMovement(columns, presets)
   };
 
+  // TINY-10806: Avoid duplication of ARIA role="menu" in the accessibility tree for Color Swatch menu item.
+  const widgetSketchSpec = removeRoleAttr(AlloyMenu.sketch(widgetSpec));
+
   return {
     type: 'widget',
     data: { value: Id.generate('widget-id') },
@@ -43,7 +54,7 @@ export const renderColorSwatchItem = (spec: Menu.ColorSwatchMenuItem, backstage:
     },
     autofocus: true,
     components: [
-      ItemWidget.parts.widget(AlloyMenu.sketch(widgetSpec))
+      ItemWidget.parts.widget(widgetSketchSpec)
     ]
   };
 };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
@@ -149,6 +149,9 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
       'Checking menu structure for color swatches',
       ApproxStructure.build((s, str, arr) => s.element('div', {
         classes: [ arr.has('tox-menu') ],
+        attrs: {
+          role: str.is('menu')
+        },
         children: [
           s.element('div', {
             classes: [ arr.has('tox-swatches') ],
@@ -206,6 +209,9 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
       'Checking menu structure for color swatches',
       ApproxStructure.build((s, str, arr) => s.element('div', {
         classes: [ arr.has('tox-menu') ],
+        attrs: {
+          role: str.none('The role should not be present')
+        },
         children: [
           s.element('div', {
             classes: [ arr.has('tox-swatches') ],


### PR DESCRIPTION
Related Ticket: TINY-10806

Description of Changes:
* Added the `menuRole` boolean field to Alloy Menu Schema defaulted to true. Set it to false for the Color  Swatch  menu item.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
