### PR TITLE
TINY-9961: Added more UI tests for the Accordion plugin

### DIFF
--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionContextMenuTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionContextMenuTest.ts
@@ -1,0 +1,57 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/accordion/Plugin';
+
+import * as AccordionUtils from '../module/AccordionUtils';
+
+describe('browser.tinymce.plugins.accordion.AccordionContextMenuTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>(
+    {
+      plugins: 'accordion',
+      base_url: '/project/tinymce/js/tinymce',
+      indent: false
+    },
+    [ Plugin ],
+    true
+  );
+
+  const contextMenuSelector = '.tox-silver-sink [role="toolbar"]';
+  const toggleSelector = 'button[aria-label="Toggle accordion"]';
+  const deleteSelector = 'button[aria-label="Delete accordion"]';
+
+  it('TINY-9961: Toggle open, then closed, then delete', async () => {
+    const editor = hook.editor();
+    const startContent = AccordionUtils.createAccordion({ summary: 'heading', open: false });
+    editor.setContent(startContent);
+
+    await TinyUiActions.pTriggerContextMenu(editor, 'details', contextMenuSelector);
+
+    TinyUiActions.clickOnUi(editor, toggleSelector);
+    TinyAssertions.assertContentPresence(editor, { 'details[open="open"]': 1 });
+
+    TinyUiActions.clickOnUi(editor, toggleSelector);
+    TinyAssertions.assertContent(editor, startContent);
+
+    TinyUiActions.clickOnUi(editor, deleteSelector);
+    TinyAssertions.assertContent(editor, '');
+  });
+
+  it('TINY-9961: Toggle closed, then open, then delete', async () => {
+    const editor = hook.editor();
+    const startContent = AccordionUtils.createAccordion({ summary: 'heading', open: true });
+    editor.setContent(startContent);
+
+    await TinyUiActions.pTriggerContextMenu(editor, 'details', contextMenuSelector);
+
+    TinyUiActions.clickOnUi(editor, toggleSelector);
+    TinyAssertions.assertContentPresence(editor, { 'details[open="open"]': 0 });
+
+    TinyUiActions.clickOnUi(editor, toggleSelector);
+    TinyAssertions.assertContent(editor, startContent);
+
+    TinyUiActions.clickOnUi(editor, deleteSelector);
+    TinyAssertions.assertContent(editor, '');
+  });
+});

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionMenubarTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionMenubarTest.ts
@@ -1,0 +1,31 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/accordion/Plugin';
+
+describe('browser.tinymce.plugins.accordion.AccordionMenubarTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>(
+    {
+      plugins: 'accordion',
+      base_url: '/project/tinymce/js/tinymce',
+      indent: false,
+      menu: { insert: { title: 'Insert', items: 'accordion' }}
+    },
+    [ Plugin ],
+    true
+  );
+
+  const insertMenuSelector = '.tox-mbtn:contains("Insert")';
+  const insertAccordionSelector = '[aria-label="Accordion"]';
+
+  it('TINY-9961: Insert accordion with menubar button', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>paragraph</p>');
+
+    TinyUiActions.clickOnUi(editor, insertMenuSelector);
+    await TinyUiActions.pWaitForUi(editor, insertAccordionSelector);
+    TinyUiActions.clickOnUi(editor, insertAccordionSelector);
+    TinyAssertions.assertContentPresence(editor, { 'details[open="open"]': 1, 'p': 2 });
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-9961

Description of Changes:
- Added _AccordionContextMenuTest.ts_
- Added _AccordionMenubarTest.ts_

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~
