### PR TITLE
TINY-10853: Added math plugin to default menu, help and content css

### DIFF
--- a/modules/oxide/src/less/theme/content-ui.less
+++ b/modules/oxide/src/less/theme/content-ui.less
@@ -9,6 +9,7 @@
 @import 'content/contenteditable/contenteditable';
 @import 'content/cursors/cursors';
 @import 'content/footnotes/footnotes';
+@import 'content/math/math';
 @import 'content/media/media';
 @import 'content/mergetags/mergetag';
 @import 'content/object/object';

--- a/modules/oxide/src/less/theme/content/math/math.less
+++ b/modules/oxide/src/less/theme/content/math/math.less
@@ -2,9 +2,12 @@
 // Math
 //
 
+@math-margin: 16px 0 16px 0;
+
 /* stylelint-disable selector-type-no-unknown */
 tiny-math-block {
   display: flex;
   justify-content: center;
+  margin: @math-margin;
 }
 /* stylelint-enable selector-type-no-unknown */

--- a/modules/oxide/src/less/theme/content/math/math.less
+++ b/modules/oxide/src/less/theme/content/math/math.less
@@ -1,0 +1,9 @@
+//
+// Math
+//
+
+/* stylelint-disable selector-type-no-unknown */
+tiny-math-block {
+  display: flex;
+}
+/* stylelint-enable selector-type-no-unknown */

--- a/modules/oxide/src/less/theme/content/math/math.less
+++ b/modules/oxide/src/less/theme/content/math/math.less
@@ -5,5 +5,6 @@
 /* stylelint-disable selector-type-no-unknown */
 tiny-math-block {
   display: flex;
+  justify-content: center;
 }
 /* stylelint-enable selector-type-no-unknown */

--- a/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
@@ -67,6 +67,7 @@ const urls = Arr.map<PartialPluginUrl, PluginUrl>([
   { key: 'importword', name: 'Import from Word', type: PluginType.Premium },
   { key: 'inlinecss', name: 'Inline CSS', type: PluginType.Premium, slug: 'inline-css' },
   { key: 'linkchecker', name: 'Link Checker', type: PluginType.Premium },
+  { key: 'math', name: 'Math', type: PluginType.Premium },
   { key: 'markdown', name: 'Markdown', type: PluginType.Premium },
   { key: 'mentions', name: 'Mentions', type: PluginType.Premium },
   { key: 'mergetags', name: 'Merge Tags', type: PluginType.Premium },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
@@ -23,7 +23,7 @@ const defaultMenus: Record<string, MenuSpec> = {
   file: { title: 'File', items: 'newdocument restoredraft | preview | importword exportpdf exportword | export print | deleteallconversations' },
   edit: { title: 'Edit', items: 'undo redo | cut copy paste pastetext | selectall | searchreplace' },
   view: { title: 'View', items: 'code revisionhistory | visualaid visualchars visualblocks | spellchecker | preview fullscreen | showcomments' },
-  insert: { title: 'Insert', items: 'image link media addcomment pageembed inserttemplate codesample inserttable accordion | charmap emoticons hr | pagebreak nonbreaking anchor tableofcontents footnotes | mergetags | insertdatetime' },
+  insert: { title: 'Insert', items: 'image link media addcomment pageembed inserttemplate codesample inserttable accordion math | charmap emoticons hr | pagebreak nonbreaking anchor tableofcontents footnotes | mergetags | insertdatetime' },
   format: { title: 'Format', items: 'bold italic underline strikethrough superscript subscript codeformat | styles blocks fontfamily fontsize align lineheight | forecolor backcolor | language | removeformat' },
   tools: { title: 'Tools', items: 'aidialog aishortcuts | spellchecker spellcheckerlanguage | autocorrect capitalization | a11ycheck code typography wordcount addtemplate' },
   table: { title: 'Table', items: 'inserttable | cell row column | advtablesort | tableprops deletetable' },


### PR DESCRIPTION
Related Ticket: TINY-10853

Description of Changes:
* Added the `math` plugin to the default insert menu.
* Added css to display the `tiny-math-block` element as `flex` this makes it possible to later have alignment on it using `justify-content` defaults to center since that is what a math element in a regular block would do and more of the norm.
* Had to disable a csslint rule since it doesn't seem to like custom elements. Might investigate that further in some other ticket.
* Added the math plugin to the help dialog.

Pre-checks:
* [-] Changelog entry added
* [-] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [-] Docs ticket created (if applicable)

GitHub issues (if applicable):
