### PR TITLE
TINY-10794: Remove role="listbox" attribute from dropdowns

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
@@ -245,7 +245,7 @@ const makeSandbox = (
       // TODO: Add aria-selected attribute
       attributes: {
         id: ariaControls.id,
-        ...detail.role.fold( Fun.constant({}), (role) => ({ role }))
+        ...detail?.role?.fold( Fun.constant({}), (role) => ({ role })) ?? {}
       }
     },
     behaviours: SketchBehaviours.augment(

--- a/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
@@ -245,7 +245,7 @@ const makeSandbox = (
       // TODO: Add aria-selected attribute
       attributes: {
         id: ariaControls.id,
-        ...detail?.role?.fold( Fun.constant({}), (role) => ({ role })) ?? {}
+        ...detail.role?.fold( Fun.constant({}), (role) => ({ role })) ?? {}
       }
     },
     behaviours: SketchBehaviours.augment(

--- a/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
@@ -245,7 +245,7 @@ const makeSandbox = (
       // TODO: Add aria-selected attribute
       attributes: {
         id: ariaControls.id,
-        role: 'listbox'
+        ...detail.role.fold( Fun.constant({}), (role) => ({ role }))
       }
     },
     behaviours: SketchBehaviours.augment(


### PR DESCRIPTION
Related Ticket: TINY-10794

Description of Changes:
* Removed hardcoded `role="listbox"` from dropdowns

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
