### PR TITLE
TINY-10795: Accessibility improvements for More toolbar button in sliding toolbar mode

### DIFF
--- a/.changes/unreleased/alloy-TINY-10795-2024-04-19.yaml
+++ b/.changes/unreleased/alloy-TINY-10795-2024-04-19.yaml
@@ -1,6 +1,6 @@
 project: alloy
 kind: Improved
-body: '`skipFocus` is set to true when actived in sliding toolbar mode, skipping focus
+body: '`skipFocus` is set to true when activated in sliding toolbar mode, skipping focus
   from being shifted to the first control in the expanded toolbar row.'
 time: 2024-04-19T09:44:03.456867+08:00
 custom:

--- a/.changes/unreleased/alloy-TINY-10795-2024-04-19.yaml
+++ b/.changes/unreleased/alloy-TINY-10795-2024-04-19.yaml
@@ -1,0 +1,7 @@
+project: alloy
+kind: Improved
+body: '`skipFocus` is set to true when actived in sliding toolbar mode, skipping focus
+  from being shifted to the first control in the expanded toolbar row.'
+time: 2024-04-19T09:44:03.456867+08:00
+custom:
+  Issue: TINY-10795

--- a/.changes/unreleased/alloy-TINY-10795-2024-04-19_2.yaml
+++ b/.changes/unreleased/alloy-TINY-10795-2024-04-19_2.yaml
@@ -1,0 +1,6 @@
+project: alloy
+kind: Improved
+body: Replace `aria-pressed` with `aria-expanded` in `Toggling.config` for `SplitSlidingToolbarSchema`.
+time: 2024-04-19T09:44:03.456867+08:00
+custom:
+  Issue: TINY-10795

--- a/.changes/unreleased/tinymce-TINY-10795-2024-04-19.yaml
+++ b/.changes/unreleased/tinymce-TINY-10795-2024-04-19.yaml
@@ -1,7 +1,7 @@
 project: tinymce
 kind: Improved
-body: Removed `aria-pressed` from the More tolbar button in sliding toolbar mode
-  and replace it with `aria-expanded`.
+body: Removed `aria-pressed` from the `More` button in sliding toolbar mode
+  and replaced it with `aria-expanded`.
 time: 2024-04-19T09:25:18.652068+08:00
 custom:
   Issue: TINY-10795

--- a/.changes/unreleased/tinymce-TINY-10795-2024-04-19.yaml
+++ b/.changes/unreleased/tinymce-TINY-10795-2024-04-19.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Improved
+body: Removed `aria-pressed` from the More tolbar button in sliding toolbar mode
+  and replace it with `aria-expanded`.
+time: 2024-04-19T09:25:18.652068+08:00
+custom:
+  Issue: TINY-10795

--- a/.changes/unreleased/tinymce-TINY-10795-2024-04-19_2.yaml
+++ b/.changes/unreleased/tinymce-TINY-10795-2024-04-19_2.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Improved
+body: Focus remains on the More button when activated in sliding toolbar mode, preventing focus from shifting to the first control in the expanded toolbar row.
+time: 2024-04-19T09:25:18.652068+08:00
+custom:
+  Issue: TINY-10795

--- a/.changes/unreleased/tinymce-TINY-10795-2024-04-19_2.yaml
+++ b/.changes/unreleased/tinymce-TINY-10795-2024-04-19_2.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Improved
-body: Focus remains on the More button when activated in sliding toolbar mode, preventing focus from shifting to the first control in the expanded toolbar row.
+body: Focus now remains on the `More` button when activated in sliding toolbar mode, rather than moving to the first control in the expanded toolbar row.
 time: 2024-04-19T09:25:18.652068+08:00
 custom:
   Issue: TINY-10795

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitSlidingToolbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitSlidingToolbar.ts
@@ -108,7 +108,7 @@ const factory: CompositeSketchFactory<SplitSlidingToolbarDetail, SplitSlidingToo
         }),
         AddEventsBehaviour.config('toolbar-toggle-events', [
           AlloyEvents.run(toolbarToggleEvent, (toolbar) => {
-            toggleToolbar(toolbar, detail, false);
+            toggleToolbar(toolbar, detail, true);
           })
         ])
       ]

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/SplitSlidingToolbarSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/SplitSlidingToolbarSchema.ts
@@ -77,7 +77,7 @@ const parts: () => PartType.PartTypeAdt[] = Fun.constant([
         Toggling.config({
           toggleClass: detail.markers.overflowToggledClass,
           aria: {
-            mode: 'pressed'
+            mode: 'expanded'
           },
           toggleOnExecute: false
         })

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -1,8 +1,8 @@
-import { TestStore, Waiter, FocusTools } from '@ephox/agar';
+import { TestStore, Waiter, FocusTools, Assertions, ApproxStructure, Keys } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { SugarDocument } from '@ephox/sugar';
-import { McEditor, TinyUiActions } from '@ephox/wrap-mcagar';
+import { Focus, SugarDocument } from '@ephox/sugar';
+import { McEditor, TinyAssertions, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -158,6 +158,43 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest',
         await Waiter.pTryUntil('Wait for toolbar to be completely closed', () => {
           assert.notEqual(initialFocusedElement, document.activeElement, 'Focus should not be preserved');
         });
+        McEditor.remove(editor);
+      });
+    });
+
+    context('Focus should still be on overflow button when using sliding toolbar mode', () => {
+      it(`TINY-10795: Focus should still be on overflow button when toggled`, async () => {
+        const editor = await McEditor.pFromSettings<Editor>({
+          menubar: false,
+          statusbar: false,
+          width: 200,
+          toolbar_mode: 'sliding',
+          base_url: '/project/tinymce/js/tinymce'
+        });
+        const toolbarButton = TinyUiActions.clickOnToolbar<HTMLElement>(editor, 'button[data-mce-name="overflow-button"]');
+        Focus.focus(toolbarButton);
+        TinyUiActions.keystroke(editor, Keys.enter());
+        await FocusTools.pTryOnSelector('Focus should still be on overflow-button', SugarDocument.getDocument(), 'button[data-mce-name="overflow-button"]');
+        McEditor.remove(editor);
+      });
+
+      it(`TINY-10795: Overflow button should have aria-expanded when toggled`, async () => {
+        const editor = await McEditor.pFromSettings<Editor>({
+          menubar: false,
+          statusbar: false,
+          width: 200,
+          toolbar_mode: 'sliding',
+          base_url: '/project/tinymce/js/tinymce'
+        });
+        const toolbarButton = TinyUiActions.clickOnToolbar(editor, 'button[data-mce-name="overflow-button"]');
+        await pWaitForOverflowToolbar(editor, 'sliding');
+        Assertions.assertStructure('overflow button stucture', ApproxStructure.build((s, str) =>
+          s.element('button', {
+            attrs: {
+              'aria-expanded': str.is('true')
+            }
+          })
+        ), toolbarButton);
         McEditor.remove(editor);
       });
     });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -2,7 +2,7 @@ import { TestStore, Waiter, FocusTools, Assertions, ApproxStructure, Keys } from
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { Focus, SugarDocument } from '@ephox/sugar';
-import { McEditor, TinyAssertions, TinyUiActions } from '@ephox/wrap-mcagar';
+import { McEditor, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -191,7 +191,8 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest',
         Assertions.assertStructure('overflow button stucture', ApproxStructure.build((s, str) =>
           s.element('button', {
             attrs: {
-              'aria-expanded': str.is('true')
+              'aria-expanded': str.is('true'),
+              'aria-pressed': str.none()
             }
           })
         ), toolbarButton);


### PR DESCRIPTION
Related Ticket: TINY-10795

Description of Changes:
* It was discovered that the More button in sliding toolbar mode was using `aria-pressed` instead of `aria-expanded` when pressed.
* Focus should also be maintained on the current More button instead of shifting to the first control in the expanded toolbar row.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
