### PR TITLE
TINY-9811: Cursor is invisible in Windows High Contrast Mode when Autoresize plugin is active

### DIFF
--- a/.changes/unreleased/tinymce-TINY-9811-2024-04-19.yaml
+++ b/.changes/unreleased/tinymce-TINY-9811-2024-04-19.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Improved
+body: Addressed caret and placeholder text is invisible in Windows High Contrast Mode
+time: 2024-04-19T15:46:47.295442+10:00
+custom:
+  Issue: TINY-9811

--- a/.changes/unreleased/tinymce-TINY-9811-2024-04-19.yaml
+++ b/.changes/unreleased/tinymce-TINY-9811-2024-04-19.yaml
@@ -1,6 +1,6 @@
 project: tinymce
-kind: Improved
-body: Addressed caret and placeholder text is invisible in Windows High Contrast Mode
+kind: Fixed
+body: Caret and placeholder text were invisible in Windows High Contrast Mode
 time: 2024-04-19T15:46:47.295442+10:00
 custom:
   Issue: TINY-9811

--- a/modules/oxide/src/less/theme/content/placeholder/placeholder.less
+++ b/modules/oxide/src/less/theme/content/placeholder/placeholder.less
@@ -18,11 +18,23 @@
 .mce-content-body:not([dir=rtl])[data-mce-placeholder] {
   &:not(.mce-visualblocks)::before {
     left: 1px;
+
+    @media (forced-colors: active) {
+      color: highlight;
+      filter: brightness(30%);
+      z-index: -1;
+    }
   }
 }
 
 .mce-content-body[dir=rtl][data-mce-placeholder] {
   &:not(.mce-visualblocks)::before {
     right: 1px;
+
+    @media (forced-colors: active) {
+      color: highlight;
+      filter: brightness(30%);
+      z-index: -1;
+    }
   }
 }

--- a/modules/oxide/src/less/theme/content/placeholder/placeholder.less
+++ b/modules/oxide/src/less/theme/content/placeholder/placeholder.less
@@ -12,29 +12,23 @@
     color: @placeholder-text-color;
     content: attr(data-mce-placeholder);
     position: absolute;
+
+    @media (forced-colors: active) {
+      color: highlight;
+      filter: brightness(30%);
+      z-index: -1;
+    }
   }
 }
 
 .mce-content-body:not([dir=rtl])[data-mce-placeholder] {
   &:not(.mce-visualblocks)::before {
     left: 1px;
-
-    @media (forced-colors: active) {
-      color: highlight;
-      filter: brightness(30%);
-      z-index: -1;
-    }
   }
 }
 
 .mce-content-body[dir=rtl][data-mce-placeholder] {
   &:not(.mce-visualblocks)::before {
     right: 1px;
-
-    @media (forced-colors: active) {
-      color: highlight;
-      filter: brightness(30%);
-      z-index: -1;
-    }
   }
 }

--- a/modules/tinymce/src/plugins/autoresize/demo/html/demo.html
+++ b/modules/tinymce/src/plugins/autoresize/demo/html/demo.html
@@ -7,7 +7,7 @@
   <body>
   <h2>Plugin: autoresize Demo Page</h2>
     <div id="ephox-ui">
-      <textarea cols="30" rows="10" class="tinymce" placeholder="test saflajdlsfal"></textarea>
+      <textarea cols="30" rows="10" class="tinymce"></textarea>
     </div>
   </body>
   <script src="../../../../../js/tinymce/tinymce.js"></script>

--- a/modules/tinymce/src/plugins/autoresize/demo/html/demo.html
+++ b/modules/tinymce/src/plugins/autoresize/demo/html/demo.html
@@ -7,7 +7,7 @@
   <body>
   <h2>Plugin: autoresize Demo Page</h2>
     <div id="ephox-ui">
-      <textarea cols="30" rows="10" class="tinymce"></textarea>
+      <textarea cols="30" rows="10" class="tinymce" placeholder="test saflajdlsfal"></textarea>
     </div>
   </body>
   <script src="../../../../../js/tinymce/tinymce.js"></script>


### PR DESCRIPTION
Related Ticket: 
TINY-9811

Description of Changes:
- Added `z-index` to unblock caret in windows high contrast mode
- Changed colour of the placeholder text to be visible in windows high contrast mode

Pre-checks:
* [x] <s>Changelog entry added</s>
* [x] <s>Tests have been added (if applicable)</s>
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] <s>Docs ticket created (if applicable)</s>

GitHub issues (if applicable):
