### PR TITLE
TINY-10837: Fix for style attribute not being retained when toggling lists

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10837-2024-04-18.yaml
+++ b/.changes/unreleased/tinymce-TINY-10837-2024-04-18.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Styles was not retained when toggling a list on and off.
+time: 2024-04-18T10:57:01.817028+02:00
+custom:
+  Issue: TINY-10837

--- a/.changes/unreleased/tinymce-TINY-10837-2024-04-18.yaml
+++ b/.changes/unreleased/tinymce-TINY-10837-2024-04-18.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Styles was not retained when toggling a list on and off.
+body: Styles were not retained when toggling a list on and off.
 time: 2024-04-18T10:57:01.817028+02:00
 custom:
   Issue: TINY-10837

--- a/modules/tinymce/src/plugins/lists/main/ts/core/TextBlock.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/TextBlock.ts
@@ -1,9 +1,10 @@
+
 import Editor from 'tinymce/core/api/Editor';
 
 import * as Options from '../api/Options';
 import * as NodeType from './NodeType';
 
-const createTextBlock = (editor: Editor, contentNode: Node): DocumentFragment => {
+const createTextBlock = (editor: Editor, contentNode: Node, attrs: Record<string, string> = {}): DocumentFragment => {
   const dom = editor.dom;
   const blockElements = editor.schema.getBlockElements();
   const fragment = dom.createFragment();
@@ -13,7 +14,10 @@ const createTextBlock = (editor: Editor, contentNode: Node): DocumentFragment =>
   let textBlock: Element | null;
   let hasContentNode = false;
 
-  textBlock = dom.create(blockName, blockAttrs);
+  textBlock = dom.create(blockName, {
+    ...blockAttrs,
+    ...(attrs.style ? { style: attrs.style } : {})
+  });
 
   if (!NodeType.isBlock(contentNode.firstChild, blockElements)) {
     fragment.appendChild(textBlock);
@@ -50,3 +54,4 @@ const createTextBlock = (editor: Editor, contentNode: Node): DocumentFragment =>
 export {
   createTextBlock
 };
+

--- a/modules/tinymce/src/plugins/lists/main/ts/listmodel/ListsIndendation.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/listmodel/ListsIndendation.ts
@@ -8,7 +8,7 @@ import { ListAction } from '../core/ListAction';
 import * as Selection from '../core/Selection';
 import { createTextBlock } from '../core/TextBlock';
 import { composeList } from './ComposeList';
-import { Entry, isEntryComment, isIndented, isSelected } from './Entry';
+import { Entry, isEntryComment, isEntryList, isIndented, isSelected } from './Entry';
 import { Indentation, indentEntry } from './Indentation';
 import { normalizeEntries } from './NormalizeEntries';
 import { EntrySet, ItemSelection, parseLists } from './ParseLists';
@@ -20,7 +20,8 @@ const outdentedComposer = (editor: Editor, entries: Entry[]): SugarElement<Docum
     const content = !isEntryComment(entry)
       ? SugarFragment.fromElements(entry.content)
       : SugarFragment.fromElements([ SugarElement.fromHtml(`<!--${entry.content}-->`) ]);
-    return SugarElement.fromDom(createTextBlock(editor, content.dom));
+    const listItemAttrs = isEntryList(entry) ? entry.itemAttributes : {};
+    return SugarElement.fromDom(createTextBlock(editor, content.dom, listItemAttrs));
   });
 };
 

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/RetainListItemStylesTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/RetainListItemStylesTest.ts
@@ -1,0 +1,28 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/lists/Plugin';
+
+describe('browser.tinymce.plugins.lists.RetainListItemStylesTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'lists',
+    indent: false,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ]);
+
+  it('TINY-10837: Toggle list on/off on paragraphs should retain styles like color and alignment', () => {
+    const editor = hook.editor();
+    const initialContent = '<p style="color: red; text-align: center;">a</p><p style="color: green; text-align: right;">b</p>';
+
+    editor.setContent(initialContent);
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 1, 0 ], 1);
+
+    editor.execCommand('InsertUnorderedList');
+    TinyAssertions.assertContent(editor, '<ul><li style="color: red; text-align: center;">a</li><li style="color: green; text-align: right;">b</li></ul>');
+
+    editor.execCommand('InsertUnorderedList');
+    TinyAssertions.assertContent(editor, initialContent);
+  });
+});
+


### PR DESCRIPTION
Related Ticket: TINY-10837

Description of Changes:
* Fixes so the `style` attribute gets applied from the LI model element to the block element only styles right now not sure if all attributes should be retained or not maybe we expand it later.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [-] Docs ticket created (if applicable)

GitHub issues (if applicable):
