### PR TITLE
TINY-10718: Fixed firefox not announcing the iframe title when `iframe_aria_text` option was set

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10718-2024-04-19.yaml
+++ b/.changes/unreleased/tinymce-TINY-10718-2024-04-19.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Firefox not announcing the iframe title when `iframe_aria_text` was set.
+time: 2024-04-19T22:50:45.839561+08:00
+custom:
+  Issue: TINY-10718

--- a/modules/tinymce/src/core/main/ts/init/InitIframe.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitIframe.ts
@@ -63,9 +63,10 @@ const getIframeHtml = (editor: Editor) => {
 };
 
 const createIframe = (editor: Editor, boxInfo: BoxInfo) => {
-  const iframeTitle = editor.translate('Rich Text Area');
+  const iframeTitle = Env.browser.isFirefox() ? Options.getIframeAriaText(editor) : 'Rich Text Area';
+  const translatedTitle = editor.translate(iframeTitle);
   const tabindex = Attribute.getOpt(SugarElement.fromDom(editor.getElement()), 'tabindex').bind(Strings.toInt);
-  const ifr = createIframeElement(editor.id, iframeTitle, Options.getIframeAttrs(editor), tabindex).dom;
+  const ifr = createIframeElement(editor.id, translatedTitle, Options.getIframeAttrs(editor), tabindex).dom;
 
   ifr.onload = () => {
     ifr.onload = null;

--- a/modules/tinymce/src/core/test/ts/browser/init/InitIframeAriaTextTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitIframeAriaTextTest.ts
@@ -1,4 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
+import { PlatformDetection } from '@ephox/sand';
 import { Attribute, SugarElement } from '@ephox/sugar';
 import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
@@ -8,6 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 describe('browser.tinymce.core.init.InitIframeAriaTextTest', () => {
   const defaultIframeTitle = 'Rich Text Area. Press ALT-0 for help.';
   const customIframeTitle = 'Cupidatat magna aliquip.';
+  const isFirefox = PlatformDetection.detect().browser.isFirefox();
 
   it('TINY-1264: Should use the default iframe title when iframe_aria_text is not set', async () => {
     const editor = await McEditor.pFromSettings<Editor>({
@@ -15,7 +17,7 @@ describe('browser.tinymce.core.init.InitIframeAriaTextTest', () => {
     });
     const iframe = SugarElement.fromDom(editor.iframeElement as HTMLIFrameElement);
     const iframeBody = TinyDom.body(editor);
-    assert.equal(Attribute.get(iframe, 'title'), 'Rich Text Area');
+    assert.equal(Attribute.get(iframe, 'title'), isFirefox ? defaultIframeTitle : 'Rich Text Area');
     assert.equal(Attribute.get(iframeBody, 'aria-label'), defaultIframeTitle);
     McEditor.remove(editor);
   });
@@ -27,7 +29,7 @@ describe('browser.tinymce.core.init.InitIframeAriaTextTest', () => {
     });
     const iframe = SugarElement.fromDom(editor.iframeElement as HTMLIFrameElement);
     const iframeBody = TinyDom.body(editor);
-    assert.equal(Attribute.get(iframe, 'title'), 'Rich Text Area');
+    assert.equal(Attribute.get(iframe, 'title'), isFirefox ? customIframeTitle : 'Rich Text Area');
     assert.equal(Attribute.get(iframeBody, 'aria-label'), customIframeTitle);
     McEditor.remove(editor);
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
@@ -264,7 +264,7 @@ describe('browser.tinymce.themes.silver.window.SilverInlineDialogTest', () => {
     await FocusTools.pTryOnSelector(
       'Focus should be on iframe',
       SugarDocument.getDocument(),
-      'iframe[title="Rich Text Area"]'
+      'iframe.tox-edit-area__iframe'
     );
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10718

Description of Changes:
* I've checked on NVDA, JAWS and VoiceOver

<table>
<tr>
 <td></td>
 <td>Chrome/Edge</td>
 <td>Firefox</td>
 <td>Safari </td>
</tr>
<tr>
 <td> NVDA</td>
 <td> `Rich Text Area` frame, `Rich Text Area. Press ALT-0 for help.` ` or `iframe_aria_text` option,  Edit </td>
 <td> `Rich Text Area. Press ALT-0 for help.` or `iframe_aria_text` option. Edit </td>
 <td> -  </td>
</tr>
</tr>
<tr>
 <td> JAWS </td>
 <td> Frame, `Rich Text Area` frame, document, `Rich Text Area. Press ALT-0 for help.` or `iframe_aria_text` option </td>
  <td> `Rich Text Area. Press ALT-0 for help.` or `iframe_aria_text` option frame,  `Rich Text Area. Press ALT-0 for help.` or `iframe_aria_text` option document </td>
 <td> - </td>
</tr>
<tr>
 <td> VoiceOver </td>
 <td> `Rich Text Area. Press ALT-0 for help.` or `iframe_aria_text` option, edit text</td>
 <td> Entering  `Rich Text Area. Press ALT-0 for help.` or `iframe_aria_text` option scroll area, `Rich Text Area. Press ALT-0 for help.` or `iframe_aria_text` option frame  </td>
 <td> Entering `Rich Text Area` frame, `Rich Text Area. Press ALT-0 for help.` or `iframe_aria_text` option </td>

</tr>
</table>

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
