### PR TITLE
TINY-10741: Improve the visibility of focus outline on the view toolbar buttons

### DIFF
--- a/modules/oxide/src/less/theme/components/view/view.less
+++ b/modules/oxide/src/less/theme/components/view/view.less
@@ -1,4 +1,4 @@
-@view-header-padding: @pad-sm @pad-sm 0 @pad-sm;
+@view-header-padding: 10px 10px 2px 10px;
 @view-header-padding-mobile: @pad-sm;
 @view-pane-padding: @pad-sm;
 

--- a/modules/oxide/src/less/theme/components/view/view.less
+++ b/modules/oxide/src/less/theme/components/view/view.less
@@ -1,4 +1,4 @@
-@view-header-padding: (@pad-sm + 2) (@pad-sm + 2) 2px (@pad-sm + 2);    // Add 2px to account for outline
+@view-header-padding: (@pad-sm + @keyboard-focus-outline-width) (@pad-sm + @keyboard-focus-outline-width) @keyboard-focus-outline-width (@pad-sm + @keyboard-focus-outline-width);    // Account for outline/border of the buttons
 @view-header-padding-mobile: @pad-sm;
 @view-pane-padding: @pad-sm;
 

--- a/modules/oxide/src/less/theme/components/view/view.less
+++ b/modules/oxide/src/less/theme/components/view/view.less
@@ -1,4 +1,4 @@
-@view-header-padding: @pad-sm @pad-sm 0 @pad-sm;
+@view-header-padding: (@pad-sm + 2) (@pad-sm + 2) 2px (@pad-sm + 2);    // Add 2px to account for outline
 @view-header-padding-mobile: @pad-sm;
 @view-pane-padding: @pad-sm;
 
@@ -64,7 +64,7 @@
     gap: @view-toolbar-button-spacing-x; // spacing between buttons within a group
     justify-content: space-between;
     overflow-x: auto;           // Show horizontal scrollbar on small screens
-    padding: 10px 10px 2px 10px;
+    padding: @view-header-padding;
   }
 
   .tox-view__toolbar__group {

--- a/modules/oxide/src/less/theme/components/view/view.less
+++ b/modules/oxide/src/less/theme/components/view/view.less
@@ -1,4 +1,4 @@
-@view-header-padding: 10px 10px 2px 10px;
+@view-header-padding: @pad-sm @pad-sm 0 @pad-sm;
 @view-header-padding-mobile: @pad-sm;
 @view-pane-padding: @pad-sm;
 
@@ -64,7 +64,7 @@
     gap: @view-toolbar-button-spacing-x; // spacing between buttons within a group
     justify-content: space-between;
     overflow-x: auto;           // Show horizontal scrollbar on small screens
-    padding: @view-header-padding;
+    padding: 10px 10px 2px 10px;
   }
 
   .tox-view__toolbar__group {


### PR DESCRIPTION
Related Ticket: TINY-10741

Description of Changes:
* Increased the padding of the view toolbar so the focus outline of the buttons are not obscured by the scrollbar

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
