### PR TITLE
TINY-10795: Partial revert 6db5421c

### DIFF
--- a/.changes/unreleased/alloy-TINY-10795-2024-04-19.yaml
+++ b/.changes/unreleased/alloy-TINY-10795-2024-04-19.yaml
@@ -1,7 +1,0 @@
-project: alloy
-kind: Improved
-body: '`skipFocus` is set to true when activated in sliding toolbar mode, skipping focus
-  from being shifted to the first control in the expanded toolbar row.'
-time: 2024-04-19T09:44:03.456867+08:00
-custom:
-  Issue: TINY-10795

--- a/.changes/unreleased/tinymce-TINY-10795-2024-04-19_2.yaml
+++ b/.changes/unreleased/tinymce-TINY-10795-2024-04-19_2.yaml
@@ -1,6 +1,0 @@
-project: tinymce
-kind: Improved
-body: Focus now remains on the `More` button when activated in sliding toolbar mode, rather than moving to the first control in the expanded toolbar row.
-time: 2024-04-19T09:25:18.652068+08:00
-custom:
-  Issue: TINY-10795

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitSlidingToolbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitSlidingToolbar.ts
@@ -108,7 +108,7 @@ const factory: CompositeSketchFactory<SplitSlidingToolbarDetail, SplitSlidingToo
         }),
         AddEventsBehaviour.config('toolbar-toggle-events', [
           AlloyEvents.run(toolbarToggleEvent, (toolbar) => {
-            toggleToolbar(toolbar, detail, true);
+            toggleToolbar(toolbar, detail, false);
           })
         ])
       ]

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -1,7 +1,7 @@
-import { TestStore, Waiter, FocusTools, Assertions, ApproxStructure, Keys } from '@ephox/agar';
+import { TestStore, Waiter, FocusTools, Assertions, ApproxStructure } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { Focus, SugarDocument } from '@ephox/sugar';
+import { SugarDocument } from '@ephox/sugar';
 import { McEditor, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -162,22 +162,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest',
       });
     });
 
-    context('Focus should still be on overflow button when using sliding toolbar mode', () => {
-      it(`TINY-10795: Focus should still be on overflow button when toggled`, async () => {
-        const editor = await McEditor.pFromSettings<Editor>({
-          menubar: false,
-          statusbar: false,
-          width: 200,
-          toolbar_mode: 'sliding',
-          base_url: '/project/tinymce/js/tinymce'
-        });
-        const toolbarButton = TinyUiActions.clickOnToolbar<HTMLElement>(editor, 'button[data-mce-name="overflow-button"]');
-        Focus.focus(toolbarButton);
-        TinyUiActions.keystroke(editor, Keys.enter());
-        await FocusTools.pTryOnSelector('Focus should still be on overflow-button', SugarDocument.getDocument(), 'button[data-mce-name="overflow-button"]');
-        McEditor.remove(editor);
-      });
-
+    context('Assert overflow button structure when in sliding mode', () => {
       it(`TINY-10795: Overflow button should have aria-expanded when toggled`, async () => {
         const editor = await McEditor.pFromSettings<Editor>({
           menubar: false,


### PR DESCRIPTION
Related Ticket: TINY-10795

Description of Changes:
* Reverting changes made to focus not being sent to the expanded toolbar

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
