### PR TITLE
TINY-6561 Add includes to shortcuts and check included shortcuts for …

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
+++ b/modules/tinymce/src/core/main/ts/api/Shortcuts.ts
@@ -198,6 +198,23 @@ class Shortcuts {
 
     return false;
   }
+  
+  /**
+   * Includes a keyboard shortcut by pattern.
+   *
+   * @method includes
+   * @param {String} pattern Shortcut pattern. Like for example: ctrl+alt+o.
+   * @return {Boolean} true/false state if the shortcut exists.
+   */
+  public includes(pattern: string): boolean {
+    const shortcut = this.createShortcut(pattern);
+
+    if (this.shortcuts[shortcut.id]) {
+      return true;
+    }
+
+    return false;
+  }
 
   private normalizeCommandFunc(cmdFunc: CommandFunc): () => void {
     const self = this;

--- a/modules/tinymce/src/plugins/help/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/Dialog.ts
@@ -49,7 +49,7 @@ const getNamesFromTabs = (tabs: TabSpecs): TabData => {
 };
 
 const pParseCustomTabs = async (editor: Editor, customTabs: CustomTabSpecs, pluginUrl: string): Promise<TabData> => {
-  const shortcuts = KeyboardShortcutsTab.tab();
+  const shortcuts = KeyboardShortcutsTab.tab(editor);
   const nav = await KeyboardNavTab.pTab(pluginUrl);
   const plugins = PluginsTab.tab(editor);
   const versions = VersionTab.tab();

--- a/modules/tinymce/src/plugins/help/main/ts/ui/KeyboardShortcutsTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/KeyboardShortcutsTab.ts
@@ -4,17 +4,20 @@ import { Dialog } from 'tinymce/core/api/ui/Ui';
 
 import * as ConvertShortcut from '../alien/ConvertShortcut';
 import * as KeyboardShortcuts from '../data/KeyboardShortcuts';
+import Editor from 'tinymce/core/api/Editor';
 
 export interface ShortcutActionPairType {
   shortcuts: string[];
   action: string;
 }
 
-const tab = (): Dialog.TabSpec & { name: string } => {
-  const shortcutList = Arr.map(KeyboardShortcuts.shortcuts, (shortcut: ShortcutActionPairType) => {
-    const shortcutText = Arr.map(shortcut.shortcuts, ConvertShortcut.convertText).join(' or ');
+const tab = (editor: Editor): Dialog.TabSpec & { name: string } => {
+  const shortcutList = Arr.filter(Arr.map(KeyboardShortcuts.shortcuts, (shortcut: ShortcutActionPairType) => {
+    const existingShortcutPatterns = Arr.filter(shortcut.shortcuts, (pattern: string) => editor.shortcuts.includes(pattern));
+    if (existingShortcutPatterns.length === 0) return undefined;
+    const shortcutText = Arr.map(existingShortcutPatterns, ConvertShortcut.convertText).join(' or ');
     return [ shortcut.action, shortcutText ];
-  });
+  }), (shortcut: any) => shortcut !== undefined);
 
   const tablePanel: Dialog.TableSpec = {
     type: 'table',


### PR DESCRIPTION
…help plugin

Description of Changes:
* Add public method "includes" to editor.shortcuts
* Removes shortcuts from help modal - shortcuts tab if not included in editor.shortcuts

Pre-checks:
* [-] Changelog entry added
* [X] Tests have been added (if applicable)
* [-] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
[Issue 6561](https://github.com/tinymce/tinymce/issues/6561)