### PR TITLE
TINY-10886: Clamp notification width to the editor width

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10886-2024-04-25.yaml
+++ b/.changes/unreleased/tinymce-TINY-10886-2024-04-25.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Notification width was not constrained to the width of the editor.
+time: 2024-04-25T08:40:24.984951+02:00
+custom:
+  Issue: TINY-10886

--- a/modules/tinymce/src/core/demo/html/full_demo.html
+++ b/modules/tinymce/src/core/demo/html/full_demo.html
@@ -9,7 +9,7 @@
 <body>
   <main>
     <h1>Tinymce full featured Page</h1>
-    <div id="ephox-ui" style="padding-left: 10%; width: 60%">
+    <div id="ephox-ui">
       <textarea>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed augue velit. Sed viverra aliquet fringilla. Duis quis turpis rutrum, auctor

--- a/modules/tinymce/src/core/demo/html/full_demo.html
+++ b/modules/tinymce/src/core/demo/html/full_demo.html
@@ -9,7 +9,7 @@
 <body>
   <main>
     <h1>Tinymce full featured Page</h1>
-    <div id="ephox-ui">
+    <div id="ephox-ui" style="padding-left: 10%; width: 60%">
       <textarea>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed augue velit. Sed viverra aliquet fringilla. Duis quis turpis rutrum, auctor

--- a/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
@@ -1,6 +1,6 @@
 import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Boxes, Docking, Gui, GuiFactory, InlineView, Keying, MaxHeight, Replacing } from '@ephox/alloy';
 import { Arr, Optional, Singleton, Type } from '@ephox/katamari';
-import { SugarElement, SugarLocation, Traverse } from '@ephox/sugar';
+import { Css, SugarElement, SugarLocation, Traverse, Width } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { NotificationApi, NotificationManagerImpl, NotificationSpec } from 'tinymce/core/api/NotificationManager';
@@ -26,6 +26,16 @@ export default (
   const getBounds = () => {
     const contentArea = Boxes.box(SugarElement.fromDom(editor.getContentAreaContainer()));
     return Optional.some(contentArea);
+  };
+
+  const clampComponentsToBounds = (components: AlloyComponent[]) => {
+    getBounds().each((bounds) => {
+      Arr.each(components, (comp) => {
+        if (Width.get(comp.element) > bounds.width) {
+          Css.set(comp.element, 'width', bounds.width + 'px');
+        }
+      });
+    });
   };
 
   const open = (settings: NotificationSpec, closeCallback: () => void, isEditorOrUIFocused: () => boolean): NotificationApi => {
@@ -159,6 +169,7 @@ export default (
         Replacing.append(notificationWrapper, notificationSpec);
         InlineView.reposition(notificationWrapper);
         Docking.refresh(notificationWrapper);
+        clampComponentsToBounds(notificationWrapper.components());
       });
     }
 
@@ -172,6 +183,7 @@ export default (
       notificationRegion.on((region) => {
         InlineView.reposition(region);
         Docking.refresh(region);
+        clampComponentsToBounds(region.components());
       });
     };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
@@ -357,7 +357,7 @@ describe('browser.tinymce.themes.silver.editor.NotificationManagerImplTest', () 
       height: 400
     }, []);
 
-    it('Should clamp the notification width to the width of the editor', async () => {
+    it('TINY-10886: Should clamp the notification width to the width of the editor', async () => {
       const editor = hook.editor();
       const longMessage = Arr.range(100, (_) => 'hello').join(' ');
       const nError = openNotification(editor, 'error', longMessage);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
@@ -348,4 +348,26 @@ describe('browser.tinymce.themes.silver.editor.NotificationManagerImplTest', () 
       nWarn.close();
     });
   });
+
+  context('Width clamping', () => {
+    const hook = TinyHooks.bddSetup<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      toolbar_location: 'bottom',
+      width: 600,
+      height: 400
+    }, []);
+
+    it('Should clamp the notification width to the width of the editor', async () => {
+      const editor = hook.editor();
+      const longMessage = Arr.range(100, (_) => 'hello').join(' ');
+      const nError = openNotification(editor, 'error', longMessage);
+      const nWarn = openNotification(editor, 'warning', 'hello');
+
+      assert.approximately(nError.getEl().clientWidth, 600, 10, 'Should be roughly the width of the editor');
+      assert.isBelow(nWarn.getEl().clientWidth, 500, 'Should be lower than editor width');
+
+      nError.close();
+      nWarn.close();
+    });
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-10886

Description of Changes:
* Added a function that sets the width of the component after it has been rendered to match the v4 behavior.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [-] Docs ticket created (if applicable)

GitHub issues (if applicable):
