### PR TITLE
TINY-6925: Make notifications focusable

### DIFF
--- a/modules/oxide/src/less/theme/components/notification/notification.less
+++ b/modules/oxide/src/less/theme/components/notification/notification.less
@@ -11,6 +11,8 @@
 @notification-link-hover-text-decoration: underline;
 @notification-link-active-text-decoration: underline;
 @notification-link-focus-outline-border-radius: 1px;
+@notification-focus-border-color: @textfield-focus-border-color;
+@notification-focus-box-shadow: @textfield-focus-box-shadow;
 
 @notification-success-background-color: mix(@background-color, @color-success, 80%);
 @notification-success-border-color: mix(@background-color, @color-success, 70%);
@@ -82,6 +84,11 @@
     p {
       font-size: @notification-font-size;
       font-weight: @notification-font-weight;
+    }
+
+    &:focus {
+      border-color: @notification-focus-border-color;
+      box-shadow: @notification-focus-box-shadow;
     }
   }
 

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -155,7 +155,7 @@ const NotificationManager = (editor: Editor): NotificationManager => {
       });
     });
 
-    editor.addShortcut('alt+F12', 'focus on the first notification', () =>
+    editor.addShortcut('alt+F12', 'Focus to notification', () =>
       getTopNotification()
         .map((notificationApi) => SugarElement.fromDom(notificationApi.getEl()))
         .each((elm) => Focus.focus(elm)));

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -1,4 +1,5 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
+import { Focus, SugarElement } from '@ephox/sugar';
 
 import * as EditorView from '../EditorView';
 import * as EditorFocus from '../focus/EditorFocus';
@@ -153,6 +154,11 @@ const NotificationManager = (editor: Editor): NotificationManager => {
         getImplementation().close(notification);
       });
     });
+
+    editor.addShortcut('alt+F12', 'focus on the first notification', () =>
+      getTopNotification()
+        .map((notificationApi) => SugarElement.fromDom(notificationApi.getEl()))
+        .each((elm) => Focus.focus(elm)));
   };
 
   registerEvents(editor);

--- a/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
@@ -152,11 +152,11 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
         const hasFocus = (node: Node) => Focus.search(SugarElement.fromDom(node)).isSome();
 
         TinyContentActions.keystroke(editor, 123, { alt: true });
-        await FocusTools.pTryOnSelector('Assert focus should be on notification 1', root, '.tox-notification__dismiss');
+        await FocusTools.pTryOnSelector('Assert focus should be on notification 1', root, '.tox-notification');
         assert.isTrue(hasFocus(n1.getEl()), 'Focus should be on notification 1');
 
         n1.close();
-        await FocusTools.pTryOnSelector('Assert focus should on notification 2', root, '.tox-notification__dismiss');
+        await FocusTools.pTryOnSelector('Assert focus should on notification 2', root, '.tox-notification');
         assert.isTrue(hasFocus(n2.getEl()), 'Focus should be on notification 2');
 
         n2.close();

--- a/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
@@ -1,4 +1,4 @@
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Boxes, Docking, Gui, GuiFactory, InlineView, Keying, MaxHeight, Replacing } from '@ephox/alloy';
+import { AlloyComponent, Behaviour, Boxes, Docking, Gui, GuiFactory, InlineView, Keying, MaxHeight, Replacing } from '@ephox/alloy';
 import { Arr, Optional, Singleton, Type } from '@ephox/katamari';
 import { SugarElement, SugarLocation, Traverse } from '@ephox/sugar';
 
@@ -95,12 +95,8 @@ export default (
           inlineBehaviours: Behaviour.derive([
             Keying.config({
               mode: 'cyclic',
+              selector: '.tox-notification, .tox-notification a, .tox-notification button',
             }),
-            AddEventsBehaviour.config('notification-events', [
-              AlloyEvents.runOnAttached((comp) => {
-                editor.shortcuts.add('alt+F12', 'focus on notification region', () => Keying.focusIn(comp));
-              }),
-            ]),
             Replacing.config({}),
             ...(
               Options.isStickyToolbar(editor) && !sharedBackstage.header.isPositionedAtTop()

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Notification.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Notification.ts
@@ -199,8 +199,7 @@ const factory: UiSketcher.SingleSketchFactory<NotificationSketchDetail, Notifica
       Tabstopping.config({ }),
       Focusing.config({ }),
       Keying.config({
-        mode: 'acyclic',
-        selector: 'button, a',
+        mode: 'special',
         onEscape: (comp) => {
           detail.onAction(comp);
           return Optional.some(true);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
@@ -269,6 +269,10 @@ describe('browser.tinymce.themes.silver.editor.NotificationManagerImplTest', () 
       const hasFocus = (node: Node) => Focus.search(SugarElement.fromDom(node)).isSome();
       TinyContentActions.keystroke(editor, 123, { alt: true });
 
+      await FocusTools.pTryOnSelector('Notification has focus', doc, '.tox-notification');
+      assert.isTrue(hasFocus(notification.getEl()), 'Focus should be on notification 1');
+
+      TinyUiActions.keystroke(editor, Keys.tab());
       await FocusTools.pTryOnSelector('Link in notification has focus', doc, 'a[href="example.com"]');
       assert.isTrue(hasFocus(notification.getEl()), 'Focus should be on notification 1');
 
@@ -281,6 +285,11 @@ describe('browser.tinymce.themes.silver.editor.NotificationManagerImplTest', () 
       assert.isTrue(hasFocus(notification.getEl()), 'Focus should be on notification 1');
 
       TinyUiActions.keystroke(editor, Keys.tab());
+      TinyUiActions.keystroke(editor, Keys.tab());
+
+      await FocusTools.pTryOnSelector('Notification has focus', doc, '.tox-notification');
+      assert.isTrue(hasFocus(notification2.getEl()), 'Focus should be on notification 2');
+
       TinyUiActions.keystroke(editor, Keys.tab());
       await FocusTools.pTryOnSelector('Dismiss button in notification 2 has focus', doc, '.tox-notification__dismiss');
       assert.isTrue(hasFocus(notification2.getEl()), 'Focus should be on notification 2');
@@ -298,7 +307,7 @@ describe('browser.tinymce.themes.silver.editor.NotificationManagerImplTest', () 
       const hasFocus = (node: Node) => Focus.search(SugarElement.fromDom(node)).isSome();
       TinyContentActions.keystroke(editor, 123, { alt: true });
 
-      await FocusTools.pTryOnSelector('Dismiss button in notification has focus', doc, '.tox-notification__dismiss');
+      await FocusTools.pTryOnSelector('Notification has focus', doc, '.tox-notification');
       assert.isTrue(hasFocus(notification.getEl()), 'Focus should on notification 1');
 
       TinyUiActions.keystroke(editor, Keys.escape());


### PR DESCRIPTION
Related Ticket: TINY-6925

Description of Changes:
* Little improvement to the previous PR, now notification is focusable, tabbing flow and shortcut still remains the same

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
