### PR TITLE
TINY-10391: Fix open link context menu not enabled for image with embedded link

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10391-2024-04-26.yaml
+++ b/.changes/unreleased/tinymce-TINY-10391-2024-04-26.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Open link menu not enabled for image with embedded link.
+time: 2024-04-26T17:26:20.867461+09:30
+custom:
+  Issue: TINY-10391

--- a/.changes/unreleased/tinymce-TINY-10391-2024-04-26.yaml
+++ b/.changes/unreleased/tinymce-TINY-10391-2024-04-26.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Open link menu not enabled for image with embedded link.
+body: Open link context menu action was not enabled for links on images.
 time: 2024-04-26T17:26:20.867461+09:30
 custom:
   Issue: TINY-10391

--- a/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
@@ -6,9 +6,16 @@ import VK from 'tinymce/core/api/util/VK';
 import * as OpenUrl from './OpenUrl';
 import * as Utils from './Utils';
 
-const getLinks = (editor: Editor) => editor.selection.isCollapsed() ?
-  Utils.getLinks(editor.dom.getParents(editor.selection.getStart())) as [HTMLAnchorElement] :
-  Utils.getLinksInSelection(editor.selection.getRng());
+const isSelectionOnImageWithEmbeddedLink = (editor: Editor) => {
+  const rng = editor.selection.getRng();
+  const node = rng.startContainer;
+  // Handle a case where an image embedded with a link is selected
+  return Utils.isLink(node) && rng.startContainer === rng.endContainer && editor.dom.select('img', node).length === 1;
+};
+
+const getLinks = (editor: Editor) => editor.selection.isCollapsed() || isSelectionOnImageWithEmbeddedLink(editor)
+  ? Utils.getLinks(editor.dom.getParents(editor.selection.getStart())) as [HTMLAnchorElement]
+  : Utils.getLinksInSelection(editor.selection.getRng()) as [HTMLAnchorElement];
 
 const getSelectedLink = (editor: Editor): HTMLAnchorElement | undefined => getLinks(editor)[0];
 

--- a/modules/tinymce/src/plugins/link/test/ts/browser/LinkContextMenuTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/LinkContextMenuTest.ts
@@ -6,15 +6,14 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/link/Plugin';
 
+import { pAssertFocusOnItem } from '../module/Utils';
+
 describe('browser.tinymce.plugins.link.LinkContextMenuTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     plugins: 'link',
     toolbar: 'link',
     base_url: '/project/tinymce/js/tinymce',
   }, [ Plugin ]);
-
-  const pAssertFocusOnItem = (label: string, selector: string) =>
-    FocusTools.pTryOnSelector(`Focus should be on: ${label}`, SugarDocument.getDocument(), selector);
 
   const pressDownArrowKey = (editor: Editor) => TinyUiActions.keydown(editor, Keys.down());
 

--- a/modules/tinymce/src/plugins/link/test/ts/browser/OpenLinkContextMenuTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/OpenLinkContextMenuTest.ts
@@ -1,4 +1,4 @@
-import { FocusTools, Keyboard, Keys, TestStore } from '@ephox/agar';
+import { FocusTools, Keyboard, Keys, TestStore, Waiter } from '@ephox/agar';
 import { after, afterEach, before, describe, it } from '@ephox/bedrock-client';
 import { PlatformDetection } from '@ephox/sand';
 import { DomEvent, EventUnbinder, SugarBody, SugarDocument } from '@ephox/sugar';
@@ -45,7 +45,7 @@ describe('browser.tinymce.plugins.link.OpenLinkContextMenuTest', () => {
     await TinyUiActions.pTriggerContextMenu(editor, 'a', '.tox-silver-sink [role="menuitem"]');
     Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.down());
     Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.down());
-    await pAssertFocusOnItem('Open Link', '.tox-collection__item:contains("Open link")');
+    await pAssertFocusOnItem('Open link', '.tox-collection__item:contains("Open link")');
     Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.enter());
     store.assertEq('Should open the targeted link', [
       'https://www.exampleone.com/'
@@ -60,7 +60,7 @@ describe('browser.tinymce.plugins.link.OpenLinkContextMenuTest', () => {
     await TinyUiActions.pTriggerContextMenu(editor, 'a[href="https://www.exampletwo.com"]', '.tox-silver-sink [role="menuitem"]');
     Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.down());
     Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.down());
-    await pAssertFocusOnItem('Open Link', '.tox-collection__item:contains("Open link")');
+    await pAssertFocusOnItem('Open link', '.tox-collection__item:contains("Open link")');
     Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.enter());
     store.assertEq('Should open the targeted link', [
       'https://www.exampletwo.com/'
@@ -90,6 +90,20 @@ describe('browser.tinymce.plugins.link.OpenLinkContextMenuTest', () => {
     editor.dispatch('click', { target: editor.dom.select('a')[0], ...keyConfig } as any);
     store.assertEq('Should open the targeted link', [
       'https://www.one.com/'
+    ]);
+  });
+
+  it('TINY-10391: Should open a new tab when triggering open link on an image with embedded link', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="https://www.exampleimage.com"><img src="http://www.example.image/image"></a></p>');
+    // Open link context menu on the link
+    await TinyUiActions.pTriggerContextMenu(editor, 'a[href="https://www.exampleimage.com"]', '.tox-silver-sink [role="menuitem"]');
+    Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.down());
+    Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.down());
+    await pAssertFocusOnItem('Open link', '.tox-collection__item:contains("Open link")');
+    Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.enter());
+    store.assertEq('Should open the targeted link', [
+      'https://www.exampleimage.com/'
     ]);
   });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/OpenLinkContextMenuTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/OpenLinkContextMenuTest.ts
@@ -1,11 +1,13 @@
-import { FocusTools, Keyboard, Keys, TestStore, Waiter } from '@ephox/agar';
+import { Keys, TestStore } from '@ephox/agar';
 import { after, afterEach, before, describe, it } from '@ephox/bedrock-client';
 import { PlatformDetection } from '@ephox/sand';
-import { DomEvent, EventUnbinder, SugarBody, SugarDocument } from '@ephox/sugar';
+import { DomEvent, EventUnbinder, SugarBody } from '@ephox/sugar';
 import { TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
+
+import { pAssertFocusOnItem } from '../module/Utils';
 
 describe('browser.tinymce.plugins.link.OpenLinkContextMenuTest', () => {
   let unbinder: EventUnbinder;
@@ -17,9 +19,6 @@ describe('browser.tinymce.plugins.link.OpenLinkContextMenuTest', () => {
     base_url: '/project/tinymce/js/tinymce',
     image_caption: true,
   }, [ LinkPlugin ], true);
-
-  const pAssertFocusOnItem = (label: string, selector: string) =>
-    FocusTools.pTryOnSelector(`Focus should be on: ${label}`, SugarDocument.getDocument(), selector);
 
   before(() => {
     unbinder = DomEvent.bind(SugarBody.body(), 'click', (e) => {
@@ -43,10 +42,10 @@ describe('browser.tinymce.plugins.link.OpenLinkContextMenuTest', () => {
     editor.setContent('<p>one <a href="https://www.exampleone.com/">Example</a> two</p>');
     TinySelections.select(editor, 'p', []);
     await TinyUiActions.pTriggerContextMenu(editor, 'a', '.tox-silver-sink [role="menuitem"]');
-    Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.down());
-    Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.down());
+    TinyUiActions.keydown(editor, Keys.down());
+    TinyUiActions.keydown(editor, Keys.down());
     await pAssertFocusOnItem('Open link', '.tox-collection__item:contains("Open link")');
-    Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.enter());
+    TinyUiActions.keydown(editor, Keys.enter());
     store.assertEq('Should open the targeted link', [
       'https://www.exampleone.com/'
     ]);
@@ -58,10 +57,10 @@ describe('browser.tinymce.plugins.link.OpenLinkContextMenuTest', () => {
     // Select `e Example`
     TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 0, 1, 0 ], 6);
     await TinyUiActions.pTriggerContextMenu(editor, 'a[href="https://www.exampletwo.com"]', '.tox-silver-sink [role="menuitem"]');
-    Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.down());
-    Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.down());
+    TinyUiActions.keydown(editor, Keys.down());
+    TinyUiActions.keydown(editor, Keys.down());
     await pAssertFocusOnItem('Open link', '.tox-collection__item:contains("Open link")');
-    Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.enter());
+    TinyUiActions.keydown(editor, Keys.enter());
     store.assertEq('Should open the targeted link', [
       'https://www.exampletwo.com/'
     ]);
@@ -98,10 +97,10 @@ describe('browser.tinymce.plugins.link.OpenLinkContextMenuTest', () => {
     editor.setContent('<p><a href="https://www.exampleimage.com"><img src="http://www.example.image/image"></a></p>');
     // Open link context menu on the link
     await TinyUiActions.pTriggerContextMenu(editor, 'a[href="https://www.exampleimage.com"]', '.tox-silver-sink [role="menuitem"]');
-    Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.down());
-    Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.down());
-    await pAssertFocusOnItem('Open link', '.tox-collection__item:contains("Open link")');
-    Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.enter());
+    TinyUiActions.keydown(editor, Keys.down());
+    TinyUiActions.keydown(editor, Keys.down());
+    await pAssertFocusOnItem('Open link', '.tox-collection__item:contains("Open link"):not([aria-disabled="true"])');
+    TinyUiActions.keydown(editor, Keys.enter());
     store.assertEq('Should open the targeted link', [
       'https://www.exampleimage.com/'
     ]);

--- a/modules/tinymce/src/plugins/link/test/ts/browser/OpenLinkContextMenuTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/OpenLinkContextMenuTest.ts
@@ -96,7 +96,7 @@ describe('browser.tinymce.plugins.link.OpenLinkContextMenuTest', () => {
     const editor = hook.editor();
     editor.setContent('<p><a href="https://www.exampleimage.com"><img src="http://www.example.image/image"></a></p>');
     // Open link context menu on the link
-    await TinyUiActions.pTriggerContextMenu(editor, 'a[href="https://www.exampleimage.com"]', '.tox-silver-sink [role="menuitem"]');
+    await TinyUiActions.pTriggerContextMenu(editor, 'img', '.tox-silver-sink [role="menuitem"]');
     TinyUiActions.keydown(editor, Keys.down());
     TinyUiActions.keydown(editor, Keys.down());
     await pAssertFocusOnItem('Open link', '.tox-collection__item:contains("Open link"):not([aria-disabled="true"])');

--- a/modules/tinymce/src/plugins/link/test/ts/module/Utils.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/module/Utils.ts
@@ -1,0 +1,19 @@
+import { FocusTools, Waiter } from '@ephox/agar';
+import { TinyUiActions } from '@ephox/mcagar';
+import { SugarDocument, SugarElement } from '@ephox/sugar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+const pOpenContextMenu = async (editor: Editor, target: string): Promise<void> => {
+  // Not sure why this is needed, but without the browser deselects the contextmenu target
+  await Waiter.pWait(0);
+  await TinyUiActions.pTriggerContextMenu(editor, target, '.tox-silver-sink [role="menuitem"]');
+};
+
+const pAssertFocusOnItem = (label: string, selector: string): Promise<SugarElement<HTMLElement>> =>
+  FocusTools.pTryOnSelector(`Focus should be on: ${label}`, SugarDocument.getDocument(), selector);
+
+export {
+  pOpenContextMenu,
+  pAssertFocusOnItem
+};


### PR DESCRIPTION
Related Ticket: TINY-10391

Description of Changes:
* Updated the logic of getting links so the open link menu can be enabled for image with embedded link
* Moved some common assertions into `Utils.ts`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [X] Docs ticket created (if applicable)

GitHub issues (if applicable):
