### PR TITLE
TINY-10890: Render inline math equations as inline-block

### DIFF
--- a/modules/oxide/src/less/theme/content/math/math.less
+++ b/modules/oxide/src/less/theme/content/math/math.less
@@ -10,4 +10,8 @@ tiny-math-block {
   justify-content: center;
   margin: @math-margin;
 }
+
+tiny-math-inline {
+  display: inline-block;
+}
 /* stylelint-enable selector-type-no-unknown */


### PR DESCRIPTION
Related Ticket: TINY-10890

Description of Changes:
* Changes the CSS so that inline math equations becomes inline blocks. Should fix two things both the border issue and the selection issue of math elements with `display="block"` inside a `tiny-math-inline`.

Pre-checks:
* [-] Changelog entry added
* [-] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [-] Docs ticket created (if applicable)

GitHub issues (if applicable):
