### PR TITLE
TINY-10885: Keep focus on Image Dialog after image upload.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10885-2024-04-30.yaml
+++ b/.changes/unreleased/tinymce-TINY-10885-2024-04-30.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Edit image modal did lose focus after image upload.
+body: Insert/Edit image dialog lost focus after the image upload completed.
 time: 2024-04-30T16:02:20.600725+03:00
 custom:
   Issue: TINY-10885

--- a/.changes/unreleased/tinymce-TINY-10885-2024-04-30.yaml
+++ b/.changes/unreleased/tinymce-TINY-10885-2024-04-30.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Edit image modal did lose focus after image upload.
+time: 2024-04-30T16:02:20.600725+03:00
+custom:
+  Issue: TINY-10885

--- a/modules/tinymce/src/plugins/image/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/Dialog.ts
@@ -235,6 +235,7 @@ const changeFileInput = (helpers: Helpers, info: ImageDialogInfo, state: ImageDi
         api.setData({ src: { value: url, meta: {}}});
         api.showTab('general');
         changeSrc(helpers, info, state, api);
+        api.focus('src');
       };
 
       Utils.blobToDataUri(file).then((dataUrl) => {

--- a/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
@@ -1,7 +1,7 @@
-import { Assertions, FileInput, Files, Mouse, UiFinder, Waiter } from '@ephox/agar';
+import { Assertions, FileInput, Files, FocusTools, Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Strings } from '@ephox/katamari';
-import { SugarBody, Value } from '@ephox/sugar';
+import { SugarBody, SugarDocument, Value } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -116,6 +116,7 @@ describe('browser.tinymce.plugins.image.UploadTabTest', () => {
     await pTriggerUpload(editor);
     await TinyUiActions.pWaitForUi(editor, '.tox-tab:contains("General")');
     await pAssertSrcTextValue('uploaded_image.jpg');
+    FocusTools.isOnSelector('Focus should be on Source field', SugarDocument.getDocument(), 'input[type="url"]');
     closeDialog(editor);
   });
 


### PR DESCRIPTION
Related Ticket: TINY-10885

Description of Changes:
* Set focus on the image Source input field after image upload

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
