### PR TITLE
Add Github Stale bot in debug mode for testing

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,21 @@
+name: 'Close stale issues'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 365 days with no activity. Please comment if you wish to keep this issue open or it will be closed in 30 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 30 days with no activity.'
+          days-before-stale: 365
+          days-before-close: 30
+          days-before-pr-close: -1
+          days-before-pr-stale: -1
+
+          debug-only: true
+          enable-statistics: true
+          operations-per-run: 50

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+      # pull-requests: write # only makes issues stale, not PRs
+
     steps:
       - uses: actions/stale@v9
         with:
@@ -18,4 +23,4 @@ jobs:
 
           debug-only: true
           enable-statistics: true
-          operations-per-run: 50
+          operations-per-run: 1500


### PR DESCRIPTION
Related Ticket: TINY-10876

Description of Changes:
* Add Github Action for marking Issues that have `updated_at` over a year ago as `stale`, then closing them after a further 30 days of no updates.
* Daily cron job @ midnight UTC
* Put bot into debug mode - no action will take place but it will log all actions it would normally take.

Pre-checks:
* [X] Changelog entry added - N/A
* [X] Tests have been added (if applicable) - N/A
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set - N/A
* [X] Docs ticket created (if applicable) - N/A

GitHub issues (if applicable):
