### PR TITLE
TINY-10605: Added EditorOptions debug API

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10605-2024-05-03.yaml
+++ b/.changes/unreleased/tinymce-TINY-10605-2024-05-03.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Added
-body: Added `options.debug` API
+body: Added `options.debug` API that logs the initial raw editor options to console.
 time: 2024-05-03T14:26:42.74417921+10:00
 custom:
   Issue: TINY-10605

--- a/.changes/unreleased/tinymce-TINY-10605-2024-05-03.yaml
+++ b/.changes/unreleased/tinymce-TINY-10605-2024-05-03.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: Added `options.debug` API
+time: 2024-05-03T14:26:42.74417921+10:00
+custom:
+  Issue: TINY-10605

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -274,7 +274,7 @@ class Editor implements EditorObservable {
     this.hidden = false;
     const normalizedOptions = normalizeOptions(editorManager.defaultOptions, options);
 
-    this.options = createOptions(self, normalizedOptions);
+    this.options = createOptions(self, normalizedOptions, options);
     Options.register(self);
     const getOption = this.options.get;
 

--- a/modules/tinymce/src/core/main/ts/api/EditorOptions.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorOptions.ts
@@ -152,7 +152,6 @@ export interface Options {
    * Logs the initial raw editor options to the console.
    *
    * @method debug
-   * @returns {void}
    */
   debug: () => void;
 }

--- a/modules/tinymce/src/core/main/ts/api/EditorOptions.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorOptions.ts
@@ -147,6 +147,14 @@ export interface Options {
    * @return {Boolean} True if the option has a value set, otherwise false.
    */
   isSet: (name: string) => boolean;
+
+  /**
+   * Logs the initial raw editor options to the console.
+   *
+   * @method debug
+   * @returns {void}
+   */
+  debug: () => void;
 }
 
 // A string array allows comma/space separated values as well for ease of use
@@ -224,7 +232,7 @@ const processDefaultValue = <T, U>(name: string, defaultValue: T, processor: Pro
   return undefined;
 };
 
-const create = (editor: Editor, initialOptions: Record<string, unknown>): Options => {
+const create = (editor: Editor, initialOptions: Record<string, unknown>, rawInitialOptions: Record<string, unknown> = initialOptions): Options => {
   const registry: Record<string, OptionSpec<any, any>> = {};
   const values: Record<string, any> = {};
 
@@ -294,13 +302,38 @@ const create = (editor: Editor, initialOptions: Record<string, unknown>): Option
   const isSet = (name: string) =>
     Obj.has(values, name);
 
+  const debug = () => {
+    try {
+      // eslint-disable-next-line no-console
+      console.log(
+        JSON.parse(JSON.stringify(rawInitialOptions, (_key, value: unknown) => {
+          if (
+            Type.isBoolean(value) ||
+            Type.isNumber(value) ||
+            Type.isString(value) ||
+            Type.isNull(value) ||
+            Type.isArray(value) ||
+            Type.isPlainObject(value)
+          ) {
+            return value;
+          }
+          return Object.prototype.toString.call(value);
+        }))
+      );
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    }
+  };
+
   return {
     register,
     isRegistered,
     get,
     set,
     unset,
-    isSet
+    isSet,
+    debug,
   };
 };
 

--- a/modules/tinymce/src/core/main/ts/options/NormalizeOptions.ts
+++ b/modules/tinymce/src/core/main/ts/options/NormalizeOptions.ts
@@ -142,8 +142,10 @@ const combineOptions = (isMobileDevice: boolean, isPhone: boolean, defaultOption
   return processPlugins(isMobileDevice, sectionResult, defaultOverrideOptions, extendedOptions);
 };
 
-const normalizeOptions = (defaultOverrideOptions: RawEditorOptions, options: RawEditorOptions): NormalizedEditorOptions =>
-  combineOptions(isPhone || isTablet, isPhone, options, defaultOverrideOptions, options);
+const normalizeOptions = (defaultOverrideOptions: RawEditorOptions, options: RawEditorOptions): NormalizedEditorOptions => {
+  const copiedOptions = Merger.merge(options);
+  return combineOptions(isPhone || isTablet, isPhone, copiedOptions, defaultOverrideOptions, copiedOptions);
+};
 
 export {
   normalizeOptions,

--- a/modules/tinymce/src/core/test/ts/browser/EditorOptionsDebugTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorOptionsDebugTest.ts
@@ -1,0 +1,103 @@
+/* eslint-disable no-console */
+import { after, afterEach, context, describe, it } from '@ephox/bedrock-client';
+import { Fun, Arr, Obj, Type } from '@ephox/katamari';
+import { TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.EditorOptionsDebugTest', () => {
+  const createHook = (options: Record<string, unknown>) =>
+    TinyHooks.bddSetupLight<Editor>({
+      ...options,
+      base_url: '/project/tinymce/js/tinymce',
+    }, []);
+
+  const METHODS = [ 'log', 'error' ] as const;
+  const logs = METHODS.reduce(
+    (acc, method) => (acc[method] = [], acc),
+    {} as Record<typeof METHODS[number], unknown[][]>
+  );
+  const cleanup: (() => void)[] = [];
+  for (const method of METHODS) {
+    const original = console[method];
+    console[method] = (...args: unknown[]) => {
+      original(...args);
+      logs[method].push(args);
+    };
+    cleanup.push(() => {
+      console[method] = original;
+    });
+  }
+
+  const ignoredKeys = new Set([ 'promotion', 'toolbar', 'menubar', 'statusbar', 'base_url', 'selector', 'setup' ]);
+  const assertLastLog = (expected: unknown) => {
+    const log = Arr.last(logs.log)
+      .filter((args): args is [Record<string, unknown>] => Type.isObject(args[0]) && Type.isNonNullable(args[0]))
+      .map(([ log ]) => Obj.filter(log, (_, k) => !ignoredKeys.has(k)))
+      .getOrDie(`Expected a console.log`);
+    assert.deepEqual(log, expected);
+  };
+
+  after(() => {
+    let fn: (() => void) | undefined;
+    while ((fn = cleanup.pop())) {
+      fn();
+    }
+  });
+  afterEach(() => METHODS.forEach((method) => (logs[method] = [])));
+
+  // const create = (initialOptions: Record<string, any>): EditorOptions.Options =>
+  //   EditorOptions.create(hook.editor(), initialOptions);
+
+  // const logValue = (value: unknown) => {
+  //   processed.push(value);
+  //   return true;
+  // };
+
+  context('With empty options', () => {
+    const hook = createHook({});
+    it('TINY-10605: should log empty object', () => {
+      hook.editor().options.debug();
+      assertLastLog({});
+    });
+  });
+
+  context('With function', () => {
+    const hook = createHook({
+      file_picker_callback: Fun.noop
+    });
+    it('TINY-10605: Functions should log "[object Function]"', () => {
+      hook.editor().options.debug();
+      assertLastLog({ file_picker_callback: '[object Function]' });
+    });
+  });
+
+  context('With circular reference', () => {
+    const a: any = {};
+    const b: any = { a };
+    a.b = b;
+    const hook = createHook({ a, b });
+    it('TINY-10605: Circular references should error log a TypeError', () => {
+      hook.editor().options.debug();
+      const error = Arr.last(logs.error).getOrDie('Expected a console.error')[0];
+      assert.instanceOf(error, TypeError);
+    });
+  });
+
+  context('With valid values', () => {
+    const initialOptions = {
+      plugins: 'table lists image accordion code',
+      directionality: 'rtl',
+      height: 500,
+      paste_as_text: true,
+      context_menu: [ 'image', 'lists' ],
+      menu: { insert: { title: 'Insert', items: 'table | image | accordion' }},
+    };
+    const hook = createHook(initialOptions);
+    it('TINY-10605: Leaves objects, arrays and primitive values as is', () => {
+      hook.editor().options.debug();
+      assertLastLog(initialOptions);
+    });
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/EditorOptionsDebugTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorOptionsDebugTest.ts
@@ -43,6 +43,31 @@ describe('browser.tinymce.core.EditorOptionsDebugTest', () => {
       assertDebugLog(hook.editor(), { file_picker_callback: '[object Function]' });
     });
   });
+
+  context('With undefined', () => {
+    const hook = createHook({
+      encoding: undefined
+    });
+    it('TINY-10605: Undefined values should log "[object Undefined]"', () => {
+      assertDebugLog(hook.editor(), { encoding: '[object Undefined]' });
+    });
+  });
+
+  context('With RegExp', () => {
+    const hook = createHook({
+      protect: /a/
+    });
+    it('TINY-10605: RegExp values should log "[object RegExp]"', () => {
+      assertDebugLog(hook.editor(), { protect: '[object RegExp]' });
+    });
+  });
+
+  context('With div node', () => {
+    const hook = createHook({
+      fixed_toolbar_container_target: SugarElement.fromTag('div').dom
+    });
+    it('TINY-10605: Divs should log "[object HTMLDivElement]"', () => {
+      assertDebugLog(hook.editor(), { fixed_toolbar_container_target: '[object HTMLDivElement]' });
     });
   });
 
@@ -71,9 +96,10 @@ describe('browser.tinymce.core.EditorOptionsDebugTest', () => {
       paste_as_text: true,
       context_menu: [ 'image', 'lists' ],
       menu: { insert: { title: 'Insert', items: 'table | image | accordion' }},
+      inline: null
     };
     const hook = createHook(initialOptions);
-    it('TINY-10605: Leaves objects, arrays and primitive values as is', () => {
+    it('TINY-10605: Leaves objects, arrays, null, strings, number and booleans as is', () => {
       assertDebugLog(hook.editor(), initialOptions);
     });
   });


### PR DESCRIPTION
Related Ticket: TINY-10605

Description of Changes:
- Added a `debug` method to `EditorOptions`. It's functionally the same as what's described in the investigation ticket [TINY-10862](https://ephocks.atlassian.net/browse/TINY-10862).
- Added an extra optional parameter to `createOptions` to pass in the initial non-normalised options.
- `normalizeOptions` now doesn't modify its `options` param as a side effect.

Example:
```console
> tinymce.activeEditor.options.debug()
{
    "selector": "textarea.tinymce",
    "plugins": "table lists image accordion code",
    "toolbar": "table | numlist bullist | image | accordion | code",
    "menu": {
        "insert": {
            "title": "Insert",
            "items": "table | image | accordion"
        }
    },
    "details_initial_state": "inherited",
    "details_serialize_state": "inherited",
    "height": 500,
    "paste_as_text": true,
    "inline": null,
    "setup": "[object Function]",
    "encoding": "[object Undefined]",
    "protect": "[object RegExp]",
    "target": "[object HTMLDivElement]"
}

```

Pre-checks:
* [-] Changelog entry added
* [x] Tests have been added (if applicable)
* [-] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [-] Milestone set
* [x] Docs ticket created (if applicable)


[TINY-10862]: https://ephocks.atlassian.net/browse/TINY-10862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ