### PR TITLE
TINY-10840: Fixed errors thrown by ForceBlocks and element selections

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10840-2024-05-07.yaml
+++ b/.changes/unreleased/tinymce-TINY-10840-2024-05-07.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Deleting in a `div` with preceeding `br` elements would sometimes throw errors.
+time: 2024-05-07T11:18:49.114387+02:00
+custom:
+  Issue: TINY-10840

--- a/modules/tinymce/src/core/main/ts/ForceBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/ForceBlocks.ts
@@ -92,7 +92,7 @@ const addRootBlocks = (editor: Editor) => {
 
       if (!rootBlockNode) {
         if (!bm && editor.hasFocus()) {
-          bm = StructureBookmark.getBookmark(editor.selection.getRng());
+          bm = StructureBookmark.getBookmark(editor.selection.getRng(), () => document.createElement('span'));
         }
 
         // Firefox will remove the last BR element if you insert nodes next to it using DOM APIs like insertBefore

--- a/modules/tinymce/src/core/main/ts/ForceBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/ForceBlocks.ts
@@ -1,4 +1,4 @@
-import { Arr, Fun, Obj } from '@ephox/katamari';
+import { Arr, Obj } from '@ephox/katamari';
 import { Insert, SugarElement } from '@ephox/sugar';
 
 import Editor from './api/Editor';
@@ -95,6 +95,13 @@ const addRootBlocks = (editor: Editor) => {
           bm = StructureBookmark.getBookmark(editor.selection.getRng());
         }
 
+        // Firefox will remove the last BR element if you insert nodes next to it using DOM APIs like insertBefore
+        // so for that weird edge case we stop processing.
+        if (!node.parentNode) {
+          node = null;
+          break;
+        }
+
         rootBlockNode = createRootBlock(editor);
         rootNode.insertBefore(rootBlockNode, node);
       }
@@ -128,7 +135,7 @@ const insertEmptyLine = (editor: Editor, root: SugarElement<HTMLElement>, insert
 };
 
 const setup = (editor: Editor): void => {
-  editor.on('NodeChange', Fun.curry(addRootBlocks, editor));
+  editor.on('NodeChange', () => addRootBlocks(editor));
 };
 
 export {

--- a/modules/tinymce/src/core/main/ts/bookmark/StructureBookmark.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/StructureBookmark.ts
@@ -1,7 +1,7 @@
 import * as NodeType from '../dom/NodeType';
 
 export interface ElementBookmark {
-  marker: Element;
+  marker: Node;
   before: boolean;
 }
 
@@ -20,12 +20,12 @@ export interface StructureBookmark {
 const isTextEndpoint = (endpoint: BookmarkEndpoint): endpoint is TextBookmark => endpoint.hasOwnProperty('text');
 const isElementEndpoint = (endpoint: BookmarkEndpoint): endpoint is ElementBookmark => endpoint.hasOwnProperty('marker');
 
-export const getBookmark = (range: Range): StructureBookmark => {
+export const getBookmark = (range: Range, createMarker: () => Node): StructureBookmark => {
   const getEndpoint = (container: Node, offset: number): ElementBookmark | TextBookmark => {
     if (NodeType.isText(container)) {
       return { text: container, offset };
     } else {
-      const marker = document.createElement('span');
+      const marker = createMarker();
       const children = container.childNodes;
       if (offset < children.length) {
         container.insertBefore(marker, children[offset]);
@@ -56,7 +56,7 @@ export const resolveBookmark = (bm: StructureBookmark): Range => {
       } else {
         rng.setStartAfter(start.marker);
       }
-      start.marker.remove();
+      start.marker.parentNode?.removeChild(start.marker);
     }
   }
 
@@ -69,7 +69,7 @@ export const resolveBookmark = (bm: StructureBookmark): Range => {
       } else {
         rng.setEndAfter(end.marker);
       }
-      end.marker.remove();
+      end.marker.parentNode?.removeChild(end.marker);
     }
   }
 

--- a/modules/tinymce/src/core/main/ts/bookmark/StructureBookmark.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/StructureBookmark.ts
@@ -1,0 +1,77 @@
+import * as NodeType from '../dom/NodeType';
+
+export interface ElementBookmark {
+  marker: Element;
+  before: boolean;
+}
+
+export interface TextBookmark {
+  text: Text;
+  offset: number;
+}
+
+type BookmarkEndpoint = ElementBookmark | TextBookmark;
+
+export interface StructureBookmark {
+  start: BookmarkEndpoint;
+  end: BookmarkEndpoint;
+}
+
+const isTextEndpoint = (endpoint: BookmarkEndpoint): endpoint is TextBookmark => endpoint.hasOwnProperty('text');
+const isElementEndpoint = (endpoint: BookmarkEndpoint): endpoint is ElementBookmark => endpoint.hasOwnProperty('marker');
+
+export const getBookmark = (range: Range): StructureBookmark => {
+  const getEndpoint = (container: Node, offset: number): ElementBookmark | TextBookmark => {
+    if (NodeType.isText(container)) {
+      return { text: container, offset };
+    } else {
+      const marker = document.createElement('span');
+      const children = container.childNodes;
+      if (offset < children.length) {
+        container.insertBefore(marker, children[offset]);
+        return { marker, before: true };
+      } else {
+        container.appendChild(marker);
+        return { marker, before: false };
+      }
+    }
+  };
+
+  const end = getEndpoint(range.endContainer, range.endOffset);
+  const start = getEndpoint(range.startContainer, range.startOffset);
+
+  return { start, end };
+};
+
+export const resolveBookmark = (bm: StructureBookmark): Range => {
+  const { start, end } = bm;
+  const rng = new window.Range();
+
+  if (isTextEndpoint(start)) {
+    rng.setStart(start.text, start.offset);
+  } else {
+    if (isElementEndpoint(start)) {
+      if (start.before) {
+        rng.setStartBefore(start.marker);
+      } else {
+        rng.setStartAfter(start.marker);
+      }
+      start.marker.remove();
+    }
+  }
+
+  if (isTextEndpoint(end)) {
+    rng.setEnd(end.text, end.offset);
+  } else {
+    if (isElementEndpoint(end)) {
+      if (end.before) {
+        rng.setEndBefore(end.marker);
+      } else {
+        rng.setEndAfter(end.marker);
+      }
+      end.marker.remove();
+    }
+  }
+
+  return rng;
+};

--- a/modules/tinymce/src/core/main/ts/delete/DeleteCommands.ts
+++ b/modules/tinymce/src/core/main/ts/delete/DeleteCommands.ts
@@ -6,6 +6,7 @@ import * as BlockRangeDelete from './BlockRangeDelete';
 import * as CaretBoundaryDelete from './CaretBoundaryDelete';
 import * as CefDelete from './CefDelete';
 import * as DeleteUtils from './DeleteUtils';
+import * as DivDelete from './DivDelete';
 import * as ImageBlockDelete from './ImageBlockDelete';
 import * as InlineBoundaryDelete from './InlineBoundaryDelete';
 import * as InlineFormatDelete from './InlineFormatDelete';
@@ -25,6 +26,7 @@ const findAction = (editor: Editor, caret: Cell<Text | null>, forward: boolean) 
     MediaDelete.backspaceDelete,
     BlockRangeDelete.backspaceDelete,
     InlineFormatDelete.backspaceDelete,
+    DivDelete.backspaceDelete
   ], (item) => item(editor, forward))
     .filter((_) => editor.selection.isEditable());
 

--- a/modules/tinymce/src/core/main/ts/delete/DivDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/DivDelete.ts
@@ -1,0 +1,39 @@
+import { Optional } from '@ephox/katamari';
+
+import Editor from '../api/Editor';
+import * as StructureBookmark from '../bookmark/StructureBookmark';
+import { execNativeDeleteCommand, execNativeForwardDeleteCommand } from './DeleteUtils';
+
+export const backspaceDelete = (editor: Editor, forward: boolean): Optional<() => void> => {
+  const dom = editor.dom;
+  const startBlock = dom.getParent(editor.selection.getStart(), dom.isBlock);
+  const endBlock = dom.getParent(editor.selection.getEnd(), dom.isBlock);
+  const body = editor.getBody();
+  const startBlockName = startBlock?.nodeName?.toLowerCase();
+
+  // Only act on single root div that is not empty
+  if (startBlockName === 'div' && startBlock && endBlock && startBlock === body.firstChild && endBlock === body.lastChild && !dom.isEmpty(body)) {
+    const wrapper = startBlock.cloneNode(false) as HTMLElement;
+
+    const deleteAction = () => {
+      if (forward) {
+        execNativeForwardDeleteCommand(editor);
+      } else {
+        execNativeDeleteCommand(editor);
+      }
+
+      // Div was deleted by delete operation then lets restore it
+      if (body.firstChild !== startBlock) {
+        const bookmark = StructureBookmark.getBookmark(editor.selection.getRng(), () => document.createElement('span'));
+        Array.from(body.childNodes).forEach((node) => wrapper.appendChild(node));
+        body.appendChild(wrapper);
+        editor.selection.setRng(StructureBookmark.resolveBookmark(bookmark));
+      }
+    };
+
+    return Optional.some(deleteAction);
+  }
+
+  return Optional.none();
+};
+

--- a/modules/tinymce/src/core/main/ts/keyboard/DeleteBackspaceKeys.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/DeleteBackspaceKeys.ts
@@ -9,6 +9,7 @@ import * as BlockRangeDelete from '../delete/BlockRangeDelete';
 import * as CaretBoundaryDelete from '../delete/CaretBoundaryDelete';
 import * as CefDelete from '../delete/CefDelete';
 import * as DetailsDelete from '../delete/DetailsDelete';
+import * as DivDelete from '../delete/DivDelete';
 import * as ImageBlockDelete from '../delete/ImageBlockDelete';
 import * as InlineBoundaryDelete from '../delete/InlineBoundaryDelete';
 import * as InlineFormatDelete from '../delete/InlineFormatDelete';
@@ -66,7 +67,9 @@ const executeKeydownOverride = (editor: Editor, caret: Cell<Text | null>, evt: K
     { keyCode: VK.BACKSPACE, action: MatchKeys.action(BlockBoundaryDelete.backspaceDelete, editor, false) },
     { keyCode: VK.DELETE, action: MatchKeys.action(BlockBoundaryDelete.backspaceDelete, editor, true) },
     { keyCode: VK.BACKSPACE, action: MatchKeys.action(InlineFormatDelete.backspaceDelete, editor, false) },
-    { keyCode: VK.DELETE, action: MatchKeys.action(InlineFormatDelete.backspaceDelete, editor, true) }
+    { keyCode: VK.DELETE, action: MatchKeys.action(InlineFormatDelete.backspaceDelete, editor, true) },
+    { keyCode: VK.BACKSPACE, action: MatchKeys.action(DivDelete.backspaceDelete, editor, false) },
+    { keyCode: VK.DELETE, action: MatchKeys.action(DivDelete.backspaceDelete, editor, true) }
   ], evt)
     .filter((_) => editor.selection.isEditable())
     .each((applyAction) => {

--- a/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ForceBlocksTest.ts
@@ -119,6 +119,17 @@ describe('browser.tinymce.core.ForceBlocksTest', () => {
     assert.equal(HtmlUtils.cleanHtml(editor.getBody().innerHTML), '<span data-mce-type="bookmark">a</span>');
   });
 
+  it('TINY-10840: Wrapping should not throw error on element indexes', () => {
+    const editor = hook.editor();
+    editor.getBody().innerHTML = '<br><br>';
+    assert.doesNotThrow(() => {
+      TinySelections.setCursor(editor, [ ], 2);
+      editor.nodeChanged(); // This is needed since on some browsers selection change is async
+    });
+    TinyAssertions.assertContent(editor, '<p><br><br></p>');
+    TinyAssertions.assertCursor(editor, [ 0 ], 2);
+  });
+
   context('Transparent elements', () => {
     it('TINY-9172: Do not wrap root level transparent elements if they blocks inside', () => {
       const editor = hook.editor();

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/StructureBookmarkTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/StructureBookmarkTest.ts
@@ -1,54 +1,162 @@
-import { describe, it } from '@ephox/bedrock-client';
-import { Hierarchy, Html, SugarElement } from '@ephox/sugar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Hierarchy, Html, Insert, SugarElement, Traverse } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import * as StructureBookmark from 'tinymce/core/bookmark/StructureBookmark';
 
-describe('browser.tinymce.core.StructureBookmarkTest', () => {
-  const testBookmark = (testCase: { html: string; startPath: number[]; startOffset: number; endPath: number[]; endOffset: number }) => {
-    const scope = SugarElement.fromTag('div');
-    Html.set(scope, testCase.html);
+interface BookmarkTestCase {
+  html: string;
+  startPath: number[];
+  startOffset: number;
+  endPath: number[];
+  endOffset: number;
+  mutation?: (el: SugarElement<HTMLElement>) => void;
+  expectedHtml?: string;
+  expectedStartPath?: number[];
+  expectedStartOffset?: number;
+  expectedEndPath?: number[];
+  expectedEndOffset?: number;
+}
 
-    const startContainer = Hierarchy.follow(scope, testCase.startPath).getOrDie('Failed to get start container');
-    const endContainer = Hierarchy.follow(scope, testCase.endPath).getOrDie('Failed to get end container');
+describe('browser.tinymce.core.StructureBookmarkTest', () => {
+  const testBookmark = (testCase: BookmarkTestCase) => {
+    const { html, startPath, startOffset, endPath, endOffset, mutation } = testCase;
+    const { expectedHtml, expectedStartPath, expectedStartOffset, expectedEndPath, expectedEndOffset } = testCase;
+    const scope = SugarElement.fromTag('div');
+
+    Html.set(scope, html);
+
+    const startContainer = Hierarchy.follow(scope, startPath).getOrDie('Failed to get start container');
+    const endContainer = Hierarchy.follow(scope, endPath).getOrDie('Failed to get end container');
 
     const inputRange = new window.Range();
-    inputRange.setStart(startContainer.dom, testCase.startOffset);
-    inputRange.setEnd(endContainer.dom, testCase.endOffset);
+    inputRange.setStart(startContainer.dom, startOffset);
+    inputRange.setEnd(endContainer.dom, endOffset);
 
     const bm = StructureBookmark.getBookmark(inputRange);
+    if (mutation) {
+      mutation(scope);
+    }
     const resolvedRange = StructureBookmark.resolveBookmark(bm);
 
     const actualStartPath = Hierarchy.path(scope, SugarElement.fromDom(resolvedRange.startContainer)).getOrDie('Failed to get start container');
     const actualEndPath = Hierarchy.path(scope, SugarElement.fromDom(resolvedRange.endContainer)).getOrDie('Failed to get end container');
 
-    assert.deepEqual(actualStartPath, testCase.startPath, 'Should resolve back to the original start path');
-    assert.deepEqual(actualEndPath, testCase.endPath, 'Should resolve back to the original end path');
-    assert.equal(Html.get(scope), testCase.html, 'Should be the original html');
+    assert.deepEqual(actualStartPath, expectedStartPath ?? startPath, 'Should be the expected start path');
+    assert.deepEqual(actualEndPath, expectedEndPath ?? endPath, 'Should be the expected end path');
+    assert.deepEqual(resolvedRange.startOffset, expectedStartOffset ?? startOffset, 'Should be the expected start offset');
+    assert.deepEqual(resolvedRange.endOffset, expectedEndOffset ?? endOffset, 'Should be the expected end offset');
+    assert.equal(Html.get(scope), expectedHtml ?? html, 'Should be the expected html');
   };
 
-  it('Simple text node selection range', () => testBookmark({
-    html: 'abc', startPath: [ 0 ], startOffset: 1, endPath: [ 0 ], endOffset: 2
-  }));
+  context('Non mutation', () => {
+    it('Simple text node selection range', () => testBookmark({
+      html: 'abc', startPath: [ 0 ], startOffset: 1, endPath: [ 0 ], endOffset: 2
+    }));
 
-  it('Simple text node caret range', () => testBookmark({
-    html: 'abc', startPath: [ 0 ], startOffset: 1, endPath: [ 0 ], endOffset: 1
-  }));
+    it('Simple text node caret range', () => testBookmark({
+      html: 'abc', startPath: [ 0 ], startOffset: 1, endPath: [ 0 ], endOffset: 1
+    }));
 
-  it('Element selection', () => testBookmark({
-    html: '<div><br></div>', startPath: [ 0 ], startOffset: 0, endPath: [ 0 ], endOffset: 1
-  }));
+    it('Element selection', () => testBookmark({
+      html: '<div><br></div>', startPath: [ 0 ], startOffset: 0, endPath: [ 0 ], endOffset: 1
+    }));
 
-  it('Element selection multiple elements', () => testBookmark({
-    html: '<div><br><br></div>', startPath: [ 0 ], startOffset: 0, endPath: [ 0 ], endOffset: 2
-  }));
+    it('Element selection multiple elements', () => testBookmark({
+      html: '<div><br><br></div>', startPath: [ 0 ], startOffset: 0, endPath: [ 0 ], endOffset: 2
+    }));
 
-  it('Element selection caret before', () => testBookmark({
-    html: '<div><br></div>', startPath: [ 0 ], startOffset: 0, endPath: [ 0 ], endOffset: 0
-  }));
+    it('Element selection caret before', () => testBookmark({
+      html: '<div><br></div>', startPath: [ 0 ], startOffset: 0, endPath: [ 0 ], endOffset: 0
+    }));
 
-  it('Element selection caret after', () => testBookmark({
-    html: '<div><br></div>', startPath: [ 0 ], startOffset: 1, endPath: [ 0 ], endOffset: 1
-  }));
+    it('Element selection caret after', () => testBookmark({
+      html: '<div><br></div>', startPath: [ 0 ], startOffset: 1, endPath: [ 0 ], endOffset: 1
+    }));
+  });
+
+  context('Element selection on dom mutation', () => {
+    it('Element selection caret after should resolve back if wrapped', () => testBookmark({
+      html: '<div><br></div>',
+      startPath: [ 0 ], startOffset: 1, endPath: [ 0 ], endOffset: 1,
+      mutation: (scope) => {
+        Traverse.firstChild(scope).each((child) => Insert.wrap(child, SugarElement.fromTag('div')));
+      },
+      expectedStartPath: [ 0, 0 ], expectedStartOffset: 1, expectedEndPath: [ 0, 0 ], expectedEndOffset: 1,
+      expectedHtml: '<div><div><br></div></div>'
+    }));
+
+    it('Element selection caret after should resolve back if nodes are added before it', () => testBookmark({
+      html: '<div><br></div>',
+      startPath: [ 0 ], startOffset: 1, endPath: [ 0 ], endOffset: 1,
+      mutation: (scope) => {
+        Traverse.firstChild(scope).each((child) => Insert.prepend(child, SugarElement.fromTag('b')));
+      },
+      expectedStartPath: [ 0 ], expectedStartOffset: 2, expectedEndPath: [ 0 ], expectedEndOffset: 2,
+      expectedHtml: '<div><b></b><br></div>'
+    }));
+
+    it('Element selection caret after should resolve back if nodes are added on a parent before it', () => testBookmark({
+      html: '<div><br></div>',
+      startPath: [ 0 ], startOffset: 1, endPath: [ 0 ], endOffset: 1,
+      mutation: (scope) => {
+        Insert.prepend(scope, SugarElement.fromTag('b'));
+      },
+      expectedStartPath: [ 1 ], expectedStartOffset: 1, expectedEndPath: [ 1 ], expectedEndOffset: 1,
+      expectedHtml: '<b></b><div><br></div>'
+    }));
+
+    it('Element selection on BR should resolve back if nodes are added on a parent before it', () => testBookmark({
+      html: '<div><br></div>',
+      startPath: [ 0 ], startOffset: 0, endPath: [ 0 ], endOffset: 1,
+      mutation: (scope) => {
+        Insert.prepend(scope, SugarElement.fromTag('b'));
+      },
+      expectedStartPath: [ 1 ], expectedStartOffset: 0, expectedEndPath: [ 1 ], expectedEndOffset: 1,
+      expectedHtml: '<b></b><div><br></div>'
+    }));
+  });
+
+  context('Text selection on dom mutation', () => {
+    it('Text selection caret after should resolve back if wrapped', () => testBookmark({
+      html: '<div>foo</div>',
+      startPath: [ 0, 0 ], startOffset: 1, endPath: [ 0, 0 ], endOffset: 1,
+      mutation: (scope) => {
+        Traverse.firstChild(scope).each((child) => Insert.wrap(child, SugarElement.fromTag('div')));
+      },
+      expectedStartPath: [ 0, 0, 0 ], expectedStartOffset: 1, expectedEndPath: [ 0, 0, 0 ], expectedEndOffset: 1,
+      expectedHtml: '<div><div>foo</div></div>'
+    }));
+
+    it('Text selection caret after should resolve back if nodes are added before it', () => testBookmark({
+      html: '<div>foo</div>',
+      startPath: [ 0, 0 ], startOffset: 1, endPath: [ 0, 0 ], endOffset: 1,
+      mutation: (scope) => {
+        Traverse.firstChild(scope).each((child) => Insert.prepend(child, SugarElement.fromTag('b')));
+      },
+      expectedStartPath: [ 0, 1 ], expectedStartOffset: 1, expectedEndPath: [ 0, 1 ], expectedEndOffset: 1,
+      expectedHtml: '<div><b></b>foo</div>'
+    }));
+
+    it('Text selection caret after should resolve back if nodes are added on a parent before it', () => testBookmark({
+      html: '<div>foo</div>',
+      startPath: [ 0, 0 ], startOffset: 1, endPath: [ 0, 0 ], endOffset: 1,
+      mutation: (scope) => {
+        Insert.prepend(scope, SugarElement.fromTag('b'));
+      },
+      expectedStartPath: [ 1, 0 ], expectedStartOffset: 1, expectedEndPath: [ 1, 0 ], expectedEndOffset: 1,
+      expectedHtml: '<b></b><div>foo</div>'
+    }));
+
+    it('Text selection should resolve back if nodes are added on a parent before it', () => testBookmark({
+      html: '<div>foo</div>',
+      startPath: [ 0, 0 ], startOffset: 0, endPath: [ 0, 0 ], endOffset: 1,
+      mutation: (scope) => {
+        Insert.prepend(scope, SugarElement.fromTag('b'));
+      },
+      expectedStartPath: [ 1, 0 ], expectedStartOffset: 0, expectedEndPath: [ 1, 0 ], expectedEndOffset: 1,
+      expectedHtml: '<b></b><div>foo</div>'
+    }));
+  });
 });
 

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/StructureBookmarkTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/StructureBookmarkTest.ts
@@ -1,0 +1,54 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { Hierarchy, Html, SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
+
+import { getBookmark, resolveBookmark } from 'tinymce/core/bookmark/StructureBookmark';
+
+describe('browser.tinymce.core.StructureBookmarkTest', () => {
+  const testBookmark = (testCase: { html: string; startPath: number[]; startOffset: number; endPath: number[]; endOffset: number }) => {
+    const scope = SugarElement.fromTag('div');
+    Html.set(scope, testCase.html);
+
+    const startContainer = Hierarchy.follow(scope, testCase.startPath).getOrDie('Failed to get start container');
+    const endContainer = Hierarchy.follow(scope, testCase.endPath).getOrDie('Failed to get end container');
+
+    const inputRange = new window.Range();
+    inputRange.setStart(startContainer.dom, testCase.startOffset);
+    inputRange.setEnd(endContainer.dom, testCase.endOffset);
+
+    const bm = getBookmark(inputRange);
+    const resolvedRange = resolveBookmark(bm);
+
+    const actualStartPath = Hierarchy.path(scope, SugarElement.fromDom(resolvedRange.startContainer)).getOrDie('Failed to get start container');
+    const actualEndPath = Hierarchy.path(scope, SugarElement.fromDom(resolvedRange.endContainer)).getOrDie('Failed to get end container');
+
+    assert.deepEqual(actualStartPath, testCase.startPath, 'Should resolve back to the original start path');
+    assert.deepEqual(actualEndPath, testCase.endPath, 'Should resolve back to the original end path');
+    assert.equal(Html.get(scope), testCase.html, 'Should be the original html');
+  };
+
+  it('Simple text node selection range', () => testBookmark({
+    html: 'abc', startPath: [ 0 ], startOffset: 1, endPath: [ 0 ], endOffset: 2
+  }));
+
+  it('Simple text node caret range', () => testBookmark({
+    html: 'abc', startPath: [ 0 ], startOffset: 1, endPath: [ 0 ], endOffset: 1
+  }));
+
+  it('Element selection', () => testBookmark({
+    html: '<div><br></div>', startPath: [ 0 ], startOffset: 0, endPath: [ 0 ], endOffset: 1
+  }));
+
+  it('Element selection multiple elements', () => testBookmark({
+    html: '<div><br><br></div>', startPath: [ 0 ], startOffset: 0, endPath: [ 0 ], endOffset: 2
+  }));
+
+  it('Element selection caret before', () => testBookmark({
+    html: '<div><br></div>', startPath: [ 0 ], startOffset: 0, endPath: [ 0 ], endOffset: 0
+  }));
+
+  it('Element selection caret after', () => testBookmark({
+    html: '<div><br></div>', startPath: [ 0 ], startOffset: 1, endPath: [ 0 ], endOffset: 1
+  }));
+});
+

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/StructureBookmarkTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/StructureBookmarkTest.ts
@@ -33,7 +33,7 @@ describe('browser.tinymce.core.StructureBookmarkTest', () => {
     inputRange.setStart(startContainer.dom, startOffset);
     inputRange.setEnd(endContainer.dom, endOffset);
 
-    const bm = StructureBookmark.getBookmark(inputRange);
+    const bm = StructureBookmark.getBookmark(inputRange, () => document.createElement('span'));
     if (mutation) {
       mutation(scope);
     }

--- a/modules/tinymce/src/core/test/ts/browser/bookmark/StructureBookmarkTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/bookmark/StructureBookmarkTest.ts
@@ -2,7 +2,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { Hierarchy, Html, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import { getBookmark, resolveBookmark } from 'tinymce/core/bookmark/StructureBookmark';
+import * as StructureBookmark from 'tinymce/core/bookmark/StructureBookmark';
 
 describe('browser.tinymce.core.StructureBookmarkTest', () => {
   const testBookmark = (testCase: { html: string; startPath: number[]; startOffset: number; endPath: number[]; endOffset: number }) => {
@@ -16,8 +16,8 @@ describe('browser.tinymce.core.StructureBookmarkTest', () => {
     inputRange.setStart(startContainer.dom, testCase.startOffset);
     inputRange.setEnd(endContainer.dom, testCase.endOffset);
 
-    const bm = getBookmark(inputRange);
-    const resolvedRange = resolveBookmark(bm);
+    const bm = StructureBookmark.getBookmark(inputRange);
+    const resolvedRange = StructureBookmark.resolveBookmark(bm);
 
     const actualStartPath = Hierarchy.path(scope, SugarElement.fromDom(resolvedRange.startContainer)).getOrDie('Failed to get start container');
     const actualEndPath = Hierarchy.path(scope, SugarElement.fromDom(resolvedRange.endContainer)).getOrDie('Failed to get end container');

--- a/modules/tinymce/src/core/test/ts/browser/delete/DivDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/DivDeleteTest.ts
@@ -1,31 +1,92 @@
-import { before, describe, it } from '@ephox/bedrock-client';
-import { PlatformDetection } from '@ephox/sand';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { Keys } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.delete.DivDeleteTest', () => {
-  const isFirefox = PlatformDetection.detect().browser.isFirefox();
-
   const hook = TinyHooks.bddSetup<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     indent: false
   }, [], true);
 
-  before(function () {
-    // Firefox doesn't unwrap DIV elements if you delete inside them and it's the only child element in the BODY
-    if (isFirefox) {
-      this.skip();
-    }
+  context('Commands', () => {
+    it('TINY-10840: Delete last character unwraps divs in WebKit/Blink browsers that div should be retained', () => {
+      const editor = hook.editor();
+      editor.setContent('<div class="foo"><br><br>a</div>');
+      TinySelections.setCursor(editor, [ 0, 2 ], 1);
+      editor.execCommand('Delete');
+      TinyAssertions.assertContent(editor, '<div class="foo"><br><br><br></div>');
+      TinyAssertions.assertCursor(editor, [ 0 ], 2);
+    });
+
+    it('TINY-10840: ForwardDelete last character unwraps divs in WebKit/Blink browsers', () => {
+      const editor = hook.editor();
+      editor.setContent('<div><br><br>a</div>');
+      TinySelections.setCursor(editor, [ 0, 2 ], 0);
+      editor.execCommand('ForwardDelete');
+      TinyAssertions.assertContent(editor, '<div><br><br><br></div>');
+      TinyAssertions.assertCursor(editor, [ 0 ], 2);
+    });
+
+    it('TINY-10840: Delete last br should empty the div', () => {
+      const editor = hook.editor();
+      editor.setContent('<div><br><br></div>');
+      TinySelections.setCursor(editor, [ 0 ], 2);
+      editor.execCommand('Delete');
+      TinyAssertions.assertContent(editor, '<div>&nbsp;</div>');
+      TinyAssertions.assertCursor(editor, [ 0 ], 0);
+    });
+
+    it('TINY-10840: Delete inside a empty div should replace it with the default block', () => {
+      const editor = hook.editor();
+      editor.setContent('<div>&nbsp;</div>');
+      TinySelections.setCursor(editor, [ 0 ], 1);
+      editor.execCommand('Delete');
+      assert.equal(editor.getBody().firstChild?.nodeName, 'P');
+      TinyAssertions.assertContent(editor, '');
+      TinyAssertions.assertCursor(editor, [ 0 ], 0);
+    });
   });
 
-  it('TINY-10840: Delete last character unwraps divs in WebKit/Blink browsers', () => {
-    const editor = hook.editor();
-    editor.setContent('<div><br><br>a</div>');
-    TinySelections.setCursor(editor, [ 0, 2 ], 1);
-    editor.execCommand('Delete');
-    TinyAssertions.assertContent(editor, '<p><br><br><br></p>');
-    TinyAssertions.assertCursor(editor, [ 0 ], 2);
+  context('Keyboard', () => {
+    it('TINY-10840: Backspace last character unwraps divs in WebKit/Blink browsers', () => {
+      const editor = hook.editor();
+      editor.setContent('<div><br><br>a</div>');
+      TinySelections.setCursor(editor, [ 0, 2 ], 1);
+      TinyContentActions.keystroke(editor, Keys.backspace());
+      TinyAssertions.assertContent(editor, '<div><br><br><br></div>');
+      TinyAssertions.assertCursor(editor, [ 0 ], 2);
+    });
+
+    it('TINY-10840: Delete last character unwraps divs in WebKit/Blink browsers', () => {
+      const editor = hook.editor();
+      editor.setContent('<div><br><br>a</div>');
+      TinySelections.setCursor(editor, [ 0, 2 ], 0);
+      TinyContentActions.keystroke(editor, Keys.delete());
+      TinyAssertions.assertContent(editor, '<div><br><br><br></div>');
+      TinyAssertions.assertCursor(editor, [ 0 ], 2);
+    });
+
+    it('TINY-10840: Backspace last br should empty the div', () => {
+      const editor = hook.editor();
+      editor.setContent('<div><br><br></div>');
+      TinySelections.setCursor(editor, [ 0 ], 2);
+      TinyContentActions.keystroke(editor, Keys.backspace());
+      TinyAssertions.assertContent(editor, '<div>&nbsp;</div>');
+      TinyAssertions.assertCursor(editor, [ 0 ], 0);
+    });
+
+    it('TINY-10840: Backspace inside a empty div should replace it with the default block', () => {
+      const editor = hook.editor();
+      editor.setContent('<div>&nbsp;</div>');
+      TinySelections.setCursor(editor, [ 0 ], 1);
+      TinyContentActions.keystroke(editor, Keys.backspace());
+      assert.equal(editor.getBody().firstChild?.nodeName, 'P');
+      TinyAssertions.assertContent(editor, '');
+      TinyAssertions.assertCursor(editor, [ 0 ], 0);
+    });
   });
 });
 

--- a/modules/tinymce/src/core/test/ts/browser/delete/DivDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/DivDeleteTest.ts
@@ -1,0 +1,31 @@
+import { before, describe, it } from '@ephox/bedrock-client';
+import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.delete.DivDeleteTest', () => {
+  const isFirefox = PlatformDetection.detect().browser.isFirefox();
+
+  const hook = TinyHooks.bddSetup<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    indent: false
+  }, [], true);
+
+  before(function () {
+    // Firefox doesn't unwrap DIV elements if you delete inside them and it's the only child element in the BODY
+    if (isFirefox) {
+      this.skip();
+    }
+  });
+
+  it('TINY-10840: Delete last character unwraps divs in WebKit/Blink browsers', () => {
+    const editor = hook.editor();
+    editor.setContent('<div><br><br>a</div>');
+    TinySelections.setCursor(editor, [ 0, 2 ], 1);
+    editor.execCommand('Delete');
+    TinyAssertions.assertContent(editor, '<p><br><br><br></p>');
+    TinyAssertions.assertCursor(editor, [ 0 ], 2);
+  });
+});
+

--- a/modules/tinymce/src/core/test/ts/browser/delete/InlineFormatPostShortcutDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/InlineFormatPostShortcutDeleteTest.ts
@@ -26,7 +26,7 @@ describe('browser.tinymce.core.delete.InlineFormatPostShortcutDeleteTest', () =>
   const metaBackspaceKeyup = (editor: Editor) => {
     // using Meta + Backspace workaround trigger as macOS suppresses most keyup events when meta is engaged
     // side effect of performing backspace keydown
-    TinyContentActions.keydown(editor, Keys.backspace());
+    TinyContentActions.keydown(editor, Keys.backspace(), { meta: true });
     // firefox detects macOS Command keycode as "Command" not "Meta"
     TinyContentActions.keyup(editor, browser.isFirefox() ? 224 : 91);
   };


### PR DESCRIPTION
Related Ticket: TINY-10840

Description of Changes:
* Added a new way to store/restore selections when wrapping elements in the root so that it doesn't throw if the element indexes doesn't match after it's been wrapped.
* Had to add special code for Firefox that does strange things when the body is empty or filled.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
