### PR TITLE
 TINY-10374: add referrerpolicy atribute to the iframe

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10374-2024-05-09.yaml
+++ b/.changes/unreleased/tinymce-TINY-10374-2024-05-09.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Added
-body: Added `referrerpolicy` as a valid attribute for an iframe element
+body: Added `referrerpolicy` as a valid attribute for an iframe element.
 time: 2024-05-09T11:31:13.462781+02:00
 custom:
   Issue: TINY-10374

--- a/.changes/unreleased/tinymce-TINY-10374-2024-05-09.yaml
+++ b/.changes/unreleased/tinymce-TINY-10374-2024-05-09.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: Added `referrerpolicy` as a valid attribute for an iframe element
+time: 2024-05-09T11:31:13.462781+02:00
+custom:
+  Issue: TINY-10374

--- a/modules/tinymce/src/core/main/ts/schema/SchemaLookupTable.ts
+++ b/modules/tinymce/src/core/main/ts/schema/SchemaLookupTable.ts
@@ -193,7 +193,7 @@ export const makeSchema = (type: SchemaType): SchemaLookupTable => {
     addAttrs('a', 'download');
     addAttrs('link script img', 'crossorigin');
     addAttrs('img', 'loading');
-    addAttrs('iframe', 'sandbox seamless allow allowfullscreen loading'); // Excluded: srcdoc
+    addAttrs('iframe', 'sandbox seamless allow allowfullscreen loading referrerpolicy'); // Excluded: srcdoc
   }
 
   // Special: iframe, ruby, video, audio, label

--- a/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/core/Nodes.ts
@@ -92,7 +92,8 @@ const createPreviewNode = (editor: Editor, node: AstNode): AstNode => {
     previewNode.attr({
       allowfullscreen: node.attr('allowfullscreen'),
       frameborder: '0',
-      sandbox: node.attr('sandbox')
+      sandbox: node.attr('sandbox'),
+      referrerpolicy: node.attr('referrerpolicy')
     });
   } else {
     // Exclude autoplay as we don't want video/audio to play by default


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Added `referrerpolicy` as a valid attribute for an iframe element TINY-10374

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
