### PR TITLE
TINY-10878: Update the cdn link for the twitter emoji database

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10878-2024-05-13.yaml
+++ b/.changes/unreleased/tinymce-TINY-10878-2024-05-13.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Resolved an issue where emojis were not loading correctly due to a broken CDN
+time: 2024-05-13T14:39:18.242413+10:00
+custom:
+  Issue: TINY-10878

--- a/modules/tinymce/src/plugins/emoticons/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/emoticons/main/ts/api/Options.ts
@@ -40,7 +40,7 @@ const register = (editor: Editor, pluginUrl: string): void => {
 
   registerOption('emoticons_images_url', {
     processor: 'string',
-    default: 'https://twemoji.maxcdn.com/v/13.0.1/72x72/'
+    default: 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/15.1.0/72x72/'
   });
 };
 


### PR DESCRIPTION
Related Ticket: 
TINY-10878

Description of Changes:
- Original CDN no longer valid, changed to a new on

Pre-checks:
* [x] Changelog entry added
* [x] <s>Tests have been added (if applicable)</s>
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
