### PR TITLE
TINY-10973: Resize bottom margin not always applied.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10793-2024-05-13.yaml
+++ b/.changes/unreleased/tinymce-TINY-10793-2024-05-13.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: '`autoresize_bottom_margin` was not reliably applied in some situations.'
+time: 2024-05-13T11:51:58.035022388+02:00
+custom:
+  Issue: TINY-10793

--- a/modules/tinymce/src/plugins/autoresize/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/Plugin.ts
@@ -25,7 +25,7 @@ export default (): void => {
       const oldSize = Cell<Resize.ResizeData>({
         totalHeight: 0,
         contentHeight: 0,
-        initiated: false,
+        set: false,
       });
       Commands.register(editor, oldSize);
       Resize.setup(editor, oldSize);

--- a/modules/tinymce/src/plugins/autoresize/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/Plugin.ts
@@ -22,7 +22,11 @@ export default (): void => {
       editor.options.set('resize', false);
     }
     if (!editor.inline) {
-      const oldSize = Cell(0);
+      const oldSize = Cell<Resize.PreviousData>({
+        totalHeight: 0,
+        contentHeight: 0,
+        initiated: false,
+      });
       Commands.register(editor, oldSize);
       Resize.setup(editor, oldSize);
     }

--- a/modules/tinymce/src/plugins/autoresize/main/ts/Plugin.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/Plugin.ts
@@ -22,7 +22,7 @@ export default (): void => {
       editor.options.set('resize', false);
     }
     if (!editor.inline) {
-      const oldSize = Cell<Resize.PreviousData>({
+      const oldSize = Cell<Resize.ResizeData>({
         totalHeight: 0,
         contentHeight: 0,
         initiated: false,

--- a/modules/tinymce/src/plugins/autoresize/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/api/Commands.ts
@@ -4,7 +4,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Resize from '../core/Resize';
 
-const register = (editor: Editor, oldSize: Cell<Resize.PreviousData>): void => {
+const register = (editor: Editor, oldSize: Cell<Resize.ResizeData>): void => {
   editor.addCommand('mceAutoResize', () => {
     Resize.resize(editor, oldSize);
   });

--- a/modules/tinymce/src/plugins/autoresize/main/ts/api/Commands.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/api/Commands.ts
@@ -4,7 +4,7 @@ import Editor from 'tinymce/core/api/Editor';
 
 import * as Resize from '../core/Resize';
 
-const register = (editor: Editor, oldSize: Cell<number>): void => {
+const register = (editor: Editor, oldSize: Cell<Resize.PreviousData>): void => {
   editor.addCommand('mceAutoResize', () => {
     Resize.resize(editor, oldSize);
   });

--- a/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
@@ -29,7 +29,7 @@ const toggleScrolling = (editor: Editor, state: boolean): void => {
   }
 };
 
-interface PreviousData {
+interface ResizeData {
   readonly totalHeight: number;
   readonly contentHeight: number;
   readonly initiated: boolean;
@@ -56,7 +56,7 @@ const shouldScrollIntoView = (trigger: EditorEvent<unknown> | undefined) => {
 /**
  * This method gets executed each time the editor needs to resize.
  */
-const resize = (editor: Editor, oldSize: Cell<PreviousData>, trigger?: EditorEvent<unknown>, getExtraMarginBottom?: () => number): void => {
+const resize = (editor: Editor, oldSize: Cell<ResizeData>, trigger?: EditorEvent<unknown>, getExtraMarginBottom?: () => number): void => {
   const dom = editor.dom;
 
   const doc = editor.getDoc();
@@ -141,7 +141,7 @@ const resize = (editor: Editor, oldSize: Cell<PreviousData>, trigger?: EditorEve
   }
 };
 
-const setup = (editor: Editor, oldSize: Cell<PreviousData>): void => {
+const setup = (editor: Editor, oldSize: Cell<ResizeData>): void => {
   const getExtraMarginBottom = () => Options.getAutoResizeBottomMargin(editor);
 
   editor.on('init', (e) => {
@@ -176,8 +176,8 @@ const setup = (editor: Editor, oldSize: Cell<PreviousData>): void => {
 };
 
 export {
-  PreviousData,
   resize,
+  ResizeData,
   setup
 };
 

--- a/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
@@ -1,4 +1,4 @@
-import { Cell, Fun } from '@ephox/katamari';
+import { Cell } from '@ephox/katamari';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import Editor from 'tinymce/core/api/Editor';
@@ -29,6 +29,12 @@ const toggleScrolling = (editor: Editor, state: boolean): void => {
   }
 };
 
+interface PreviousData {
+  readonly totalHeight: number;
+  readonly contentHeight: number;
+  readonly initiated: boolean;
+}
+
 const parseCssValueToInt = (dom: DOMUtils, elm: Element, name: string, computed: boolean): number => {
   const value = parseInt(dom.getStyle(elm, name, computed) ?? '', 10);
   // The value maybe be an empty string, so in that case treat it as being 0
@@ -50,7 +56,7 @@ const shouldScrollIntoView = (trigger: EditorEvent<unknown> | undefined) => {
 /**
  * This method gets executed each time the editor needs to resize.
  */
-const resize = (editor: Editor, oldSize: Cell<number>, trigger?: EditorEvent<unknown>, getExtraMarginBottom?: () => number): void => {
+const resize = (editor: Editor, oldSize: Cell<PreviousData>, trigger?: EditorEvent<unknown>, getExtraMarginBottom?: () => number): void => {
   const dom = editor.dom;
 
   const doc = editor.getDoc();
@@ -98,11 +104,21 @@ const resize = (editor: Editor, oldSize: Cell<number>, trigger?: EditorEvent<unk
     toggleScrolling(editor, false);
   }
 
+  const old = oldSize.get();
+
+  if (old.initiated) {
+    editor.dom.setStyles(editor.getDoc().documentElement, { 'min-height': 0 });
+    editor.dom.setStyles(editor.getBody(), { 'min-height': 'inherit' });
+  }
   // Resize content element
-  if (resizeHeight !== oldSize.get()) {
-    const deltaSize = resizeHeight - oldSize.get();
+  if (resizeHeight !== old.totalHeight && (contentHeight - resizeBottomMargin !== old.contentHeight || !old.initiated)) {
+    const deltaSize = (resizeHeight - old.totalHeight);
     dom.setStyle(editor.getContainer(), 'height', resizeHeight + 'px');
-    oldSize.set(resizeHeight);
+    oldSize.set({
+      totalHeight: resizeHeight,
+      contentHeight,
+      initiated: true,
+    });
     Events.fireResizeEditor(editor);
 
     // iPadOS has an issue where it won't rerender the body when the iframe is resized
@@ -125,13 +141,10 @@ const resize = (editor: Editor, oldSize: Cell<number>, trigger?: EditorEvent<unk
   }
 };
 
-const setup = (editor: Editor, oldSize: Cell<number>): void => {
-  let getExtraMarginBottom = () => Options.getAutoResizeBottomMargin(editor);
-  let resizeCounter: number;
-  let sizeAfterFirstResize: number;
+const setup = (editor: Editor, oldSize: Cell<PreviousData>): void => {
+  const getExtraMarginBottom = () => Options.getAutoResizeBottomMargin(editor);
 
   editor.on('init', (e) => {
-    resizeCounter = 0;
     const overflowPadding = Options.getAutoResizeOverflowPadding(editor);
     const dom = editor.dom;
 
@@ -155,33 +168,16 @@ const setup = (editor: Editor, oldSize: Cell<number>): void => {
     }
 
     resize(editor, oldSize, e, getExtraMarginBottom);
-    resizeCounter += 1;
   });
 
   editor.on('NodeChange SetContent keyup FullscreenStateChanged ResizeContent', (e) => {
-    if (resizeCounter === 1) {
-      sizeAfterFirstResize = editor.getContainer().offsetHeight;
-      resize(editor, oldSize, e, getExtraMarginBottom);
-      resizeCounter += 1;
-    } else if (resizeCounter === 2) {
-      // After the first check, this code checks if the editor's container is resized again, if so it means that the resize is in a loop
-      // in this case, the CSS is changed to let the document and body adapt to the height of the content
-      const isLooping = sizeAfterFirstResize < editor.getContainer().offsetHeight;
-      if (isLooping) {
-        const dom = editor.dom;
-        const doc = editor.getDoc();
-        dom.setStyles(doc.documentElement, { 'min-height': 0 });
-        dom.setStyles(editor.getBody(), { 'min-height': 'inherit' });
-      }
-      getExtraMarginBottom = isLooping ? Fun.constant(0) : getExtraMarginBottom;
-      resizeCounter += 1;
-    } else {
-      resize(editor, oldSize, e, getExtraMarginBottom);
-    }
+    resize(editor, oldSize, e, getExtraMarginBottom);
   });
 };
 
 export {
-  setup,
-  resize
+  PreviousData,
+  resize,
+  setup
 };
+

--- a/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
+++ b/modules/tinymce/src/plugins/autoresize/main/ts/core/Resize.ts
@@ -32,7 +32,7 @@ const toggleScrolling = (editor: Editor, state: boolean): void => {
 interface ResizeData {
   readonly totalHeight: number;
   readonly contentHeight: number;
-  readonly initiated: boolean;
+  readonly set: boolean;
 }
 
 const parseCssValueToInt = (dom: DOMUtils, elm: Element, name: string, computed: boolean): number => {
@@ -106,18 +106,18 @@ const resize = (editor: Editor, oldSize: Cell<ResizeData>, trigger?: EditorEvent
 
   const old = oldSize.get();
 
-  if (old.initiated) {
+  if (old.set) {
     editor.dom.setStyles(editor.getDoc().documentElement, { 'min-height': 0 });
     editor.dom.setStyles(editor.getBody(), { 'min-height': 'inherit' });
   }
   // Resize content element
-  if (resizeHeight !== old.totalHeight && (contentHeight - resizeBottomMargin !== old.contentHeight || !old.initiated)) {
+  if (resizeHeight !== old.totalHeight && (contentHeight - resizeBottomMargin !== old.contentHeight || !old.set)) {
     const deltaSize = (resizeHeight - old.totalHeight);
     dom.setStyle(editor.getContainer(), 'height', resizeHeight + 'px');
     oldSize.set({
       totalHeight: resizeHeight,
       contentHeight,
-      initiated: true,
+      set: true,
     });
     Events.fireResizeEditor(editor);
 

--- a/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginDocumentTest.ts
+++ b/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginDocumentTest.ts
@@ -1,0 +1,78 @@
+import { ApproxStructure, Assertions, Waiter } from '@ephox/agar';
+import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
+import { Cell } from '@ephox/katamari';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import AutoresizePlugin from 'tinymce/plugins/autoresize/Plugin';
+import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
+
+describe('browser.tinymce.plugins.autoresize.AutoresizePluginTest', () => {
+  const assertEditorHeightAbove = (editor: Editor, minHeight: number) => {
+    const editorHeight = editor.getContainer().offsetHeight;
+    assert.isAtLeast(editorHeight, minHeight, `editor height should be above: ${editorHeight}>=${minHeight}`);
+  };
+
+  const assertEditorContentApproxHeight = (editor: Editor, height: number, diff: number = 5) => {
+    // Get the editor height, but exclude the 10px margin from the calculations
+    const editorContentHeight = editor.getContentAreaContainer().offsetHeight - 10;
+    assert.isAtMost(Math.abs(editorContentHeight - height), diff, `editor content height should be approx (within ${diff}px): ${editorContentHeight} ~= ${height}`);
+  };
+
+  context('common tests', () => {
+    const resizeEventsCount = Cell(0);
+    const hook = TinyHooks.bddSetup<Editor>({
+      plugins: 'autoresize fullscreen',
+      menubar: false,
+      toolbar: 'autoresize',
+      base_url: '/project/tinymce/js/tinymce',
+      autoresize_bottom_margin: 3000,
+      content_css: 'document',
+      toolbar_mode: 'floating',
+      // Override the content css margins, so they don't come into play
+      content_style: 'body { margin: 0; margin-top: 10px; }',
+      setup: (editor: Editor) => {
+        editor.on('ResizeEditor', () => {
+          resizeEventsCount.set(resizeEventsCount.get() + 1);
+        });
+      }
+    }, [ AutoresizePlugin, FullscreenPlugin ], true);
+
+    beforeEach(() => {
+      resizeEventsCount.set(0);
+    });
+
+    it('TBA: Should not have a resize handle visible by default', async () => {
+      const editor = hook.editor();
+      const statusbar = await TinyUiActions.pWaitForUi(editor, '.tox-statusbar');
+      Assertions.assertStructure('Check the statusbar does not have a resize handle', ApproxStructure.build((s, str, arr) => {
+        return s.element('div', {
+          children: [
+            s.element('div', {
+              classes: [ arr.has('tox-statusbar__text-container') ],
+              children: [
+                s.element('div', { classes: [ arr.has('tox-statusbar__path') ] }),
+                s.element('div', {
+                  classes: [ arr.has('tox-statusbar__right-container') ],
+                  children: [
+                    s.element('span', { classes: [ arr.has('tox-statusbar__branding') ] })
+                  ]
+                })
+              ]
+            })
+          ]
+        });
+      }), statusbar);
+    });
+
+    it('TINY-10793: Editor size increase based on content size', async () => {
+      const editor = hook.editor();
+      editor.setContent('<div style="height: 5000px;">a</div>');
+      // content ( 5000 ) + margin ( 3000 ) + chrome(?) ( 160 )
+      await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 8000 + 160), 10, 3000);
+      await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightAbove(editor, 8000 + 160), 10, 3000);
+      assert.isAtLeast(resizeEventsCount.get(), 1, 'Should have fired a ResizeEditor event');
+    });
+  });
+});

--- a/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginDocumentTest.ts
+++ b/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginDocumentTest.ts
@@ -43,7 +43,7 @@ describe('browser.tinymce.plugins.autoresize.AutoresizePluginTest', () => {
       resizeEventsCount.set(0);
     });
 
-    it('TBA: Should not have a resize handle visible by default', async () => {
+    it('TINY-10793: Should not have a resize handle visible by default', async () => {
       const editor = hook.editor();
       const statusbar = await TinyUiActions.pWaitForUi(editor, '.tox-statusbar');
       Assertions.assertStructure('Check the statusbar does not have a resize handle', ApproxStructure.build((s, str, arr) => {

--- a/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
+++ b/modules/tinymce/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
@@ -123,8 +123,8 @@ describe('browser.tinymce.plugins.autoresize.AutoresizePluginTest', () => {
       const image = editor.dom.select('img')[0];
       editor.dom.setAttrib(image, 'src', 'http://moxiecode.cachefly.net/tinymce/v9/images/logo.png');
       // Content height + div image height (84px) + bottom margin = 5634
-      await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5634), 10, 3000);
-      await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightAbove(editor, 5634), 10, 3000);
+      await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5584), 10, 3000);
+      await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightAbove(editor, 5632), 10, 3000);
     });
 
     it('TBA: Editor size content set to 10 and autoresize_bottom_margin set to 100', async () => {
@@ -186,7 +186,7 @@ describe('browser.tinymce.plugins.autoresize.AutoresizePluginTest', () => {
     });
   });
 
-  context('TINY-9123', () => {
+  context('TINY-8872', () => {
     const resizeEventsCount = Cell(0);
     const hook = TinyHooks.bddSetup<Editor>({
       plugins: 'autoresize fullscreen',
@@ -205,14 +205,14 @@ describe('browser.tinymce.plugins.autoresize.AutoresizePluginTest', () => {
       resizeEventsCount.set(0);
     });
 
-    it('TINY-9123: it should not continue to resize when the CSS forces the content to have a margin-bottom lesser than autoresize_bottom_margin', async () => {
+    it('TINY-8872: it should not continue to resize when the CSS forces the content to have a margin-bottom lesser than autoresize_bottom_margin', async () => {
       const editor = hook.editor();
       editor.setContent('<div style="height: 250px;">a</div>');
       await Waiter.pWait(2000);
       assert.isAtMost(resizeEventsCount.get(), 10, 'Should have fired a ResizeEditor event at most 10 time');
     });
 
-    it('TINY-9123: it should continue to resize if the content expands or contract', async () => {
+    it('TINY-8872: it should continue to resize if the content expands or contract', async () => {
       const editor = hook.editor();
       const content = '<p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p><p>a</p>';
       editor.setContent('<div>' + content + '</div>');


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-10793

Description of Changes:
`autoresize_bottom_margin` was not applied in some situations.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
