### PR TITLE
TINY-10942: Show autocompleter regardless of match length

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10942-2024-05-15.yaml
+++ b/.changes/unreleased/tinymce-TINY-10942-2024-05-15.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Autocompleter possible values are no longer capped at a length of 10.
+time: 2024-05-15T07:43:13.073467513+10:00
+custom:
+  Issue: TINY-10942

--- a/modules/tinymce/src/core/main/ts/keyboard/Autocompleter.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/Autocompleter.ts
@@ -100,7 +100,6 @@ export const setup = (editor: Editor): void => {
             // Ensure the active autocompleter trigger matches, as the old one may have closed
             // and a new one may have opened. If it doesn't match, then do nothing.
             if (ac.trigger !== context.trigger) {
-              cancelIfNecessary();
               return;
             }
 

--- a/modules/tinymce/src/core/main/ts/keyboard/Autocompleter.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/Autocompleter.ts
@@ -99,25 +99,23 @@ export const setup = (editor: Editor): void => {
 
             // Ensure the active autocompleter trigger matches, as the old one may have closed
             // and a new one may have opened. If it doesn't match, then do nothing.
-            if (ac.trigger === context.trigger) {
-              // close if we haven't found any matches in the last 10 chars
-              if (context.text.length - ac.matchLength >= 10) {
-                cancelIfNecessary();
-              } else {
-                activeAutocompleter.set({
-                  ...ac,
-                  matchLength: context.text.length
-                });
+            if (ac.trigger !== context.trigger) {
+              cancelIfNecessary();
+              return;
+            }
 
-                if (uiActive.get()) {
-                  Events.fireAutocompleterUpdateActiveRange(editor, { range: context.range });
-                  Events.fireAutocompleterUpdate(editor, { lookupData });
-                } else {
-                  uiActive.set(true);
-                  Events.fireAutocompleterUpdateActiveRange(editor, { range: context.range });
-                  Events.fireAutocompleterStart(editor, { lookupData });
-                }
-              }
+            activeAutocompleter.set({
+              ...ac,
+              matchLength: context.text.length
+            });
+
+            if (uiActive.get()) {
+              Events.fireAutocompleterUpdateActiveRange(editor, { range: context.range });
+              Events.fireAutocompleterUpdate(editor, { lookupData });
+            } else {
+              uiActive.set(true);
+              Events.fireAutocompleterUpdateActiveRange(editor, { range: context.range });
+              Events.fireAutocompleterStart(editor, { lookupData });
             }
           });
         });


### PR DESCRIPTION
Related Ticket: TINY-10942

Description of Changes:
Removed the `context.text.length - ac.matchLength >= 10` check.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~
