### PR TITLE
TINY-10900: Added onInit and stretched and custom preview css to HtmlPanel dialog component

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10900-2024-05-10.yaml
+++ b/.changes/unreleased/tinymce-TINY-10900-2024-05-10.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: New `onInit` and `stretched` properties to the `HtmlPanel` dialog component.
+time: 2024-05-10T13:39:59.751613+02:00
+custom:
+  Issue: TINY-10900

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/HtmlPanel.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/HtmlPanel.ts
@@ -5,7 +5,7 @@ import * as ComponentSchema from '../../core/ComponentSchema';
 
 export interface HtmlPanelSpec {
   type: 'htmlpanel';
-  html?: string;
+  html: string;
   onInit?: (el: HTMLElement) => void;
   presets?: 'presentation' | 'document';
   stretched?: boolean;
@@ -22,7 +22,7 @@ export interface HtmlPanel {
 
 const htmlPanelFields = [
   ComponentSchema.type,
-  FieldSchema.defaultedString('html', ''),
+  FieldSchema.requiredString('html'),
   FieldSchema.defaultedStringEnum('presets', 'presentation', [ 'presentation', 'document' ]),
   FieldSchema.defaultedFunction('onInit', Fun.noop),
   FieldSchema.defaultedBoolean('stretched', false),

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/HtmlPanel.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/HtmlPanel.ts
@@ -1,25 +1,31 @@
 import { FieldSchema, StructureSchema } from '@ephox/boulder';
-import { Result } from '@ephox/katamari';
+import { Fun, Result } from '@ephox/katamari';
 
 import * as ComponentSchema from '../../core/ComponentSchema';
 
 export interface HtmlPanelSpec {
   type: 'htmlpanel';
-  html: string;
+  html?: string;
+  onInit?: (el: HTMLElement) => void;
   presets?: 'presentation' | 'document';
+  stretched?: boolean;
 }
 
 export interface HtmlPanel {
   type: 'htmlpanel';
   html: string;
   // The htmlpanel can either have the attribute role = "presentation" or role = "document" and associated behaviours
+  onInit: (el: HTMLElement) => void;
   presets: 'presentation' | 'document';
+  stretched: boolean;
 }
 
 const htmlPanelFields = [
   ComponentSchema.type,
-  FieldSchema.requiredString('html'),
-  FieldSchema.defaultedStringEnum('presets', 'presentation', [ 'presentation', 'document' ])
+  FieldSchema.defaultedString('html', ''),
+  FieldSchema.defaultedStringEnum('presets', 'presentation', [ 'presentation', 'document' ]),
+  FieldSchema.defaultedFunction('onInit', Fun.noop),
+  FieldSchema.defaultedBoolean('stretched', false),
 ];
 
 export const htmlPanelSchema = StructureSchema.objOf(htmlPanelFields);

--- a/modules/oxide/src/less/theme/components/form/custom-preview.less
+++ b/modules/oxide/src/less/theme/components/form/custom-preview.less
@@ -1,0 +1,15 @@
+@custom-preview-border-color: @border-color;
+@custom-preview-border-radius: @control-border-radius;
+@custom-preview-border-width: 1px;
+
+.tox {
+  .tox-custom-preview {
+    border-color: @custom-preview-border-color;
+    border-radius: @custom-preview-border-radius;
+    border-style: solid;
+    border-width: @custom-preview-border-width;
+    flex: 1;
+    overflow: auto;
+    padding: @pad-sm;
+  }
+}

--- a/modules/oxide/src/less/theme/components/form/custom-preview.less
+++ b/modules/oxide/src/less/theme/components/form/custom-preview.less
@@ -9,7 +9,6 @@
     border-style: solid;
     border-width: @custom-preview-border-width;
     flex: 1;
-    overflow: auto;
     padding: @pad-sm;
   }
 }

--- a/modules/oxide/src/less/theme/theme.less
+++ b/modules/oxide/src/less/theme/theme.less
@@ -31,6 +31,7 @@
 @import 'components/edit-area/inline-edit-area';
 @import 'components/editor/editor';
 @import 'components/form/control-wrap';
+@import 'components/form/custom-preview';
 @import 'components/form/autocomplete';
 @import 'components/form/color';
 @import 'components/form/label';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/HtmlPanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/HtmlPanel.ts
@@ -63,8 +63,7 @@ export const renderHtmlPanel = (spec: HtmlPanelSpec, providersBackstage: UiFacto
       },
       containerBehaviours: Behaviour.derive([
         Tabstopping.config({ }),
-        Focusing.config({
-        }),
+        Focusing.config({ }),
         init
       ])
     });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/HtmlPanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/HtmlPanel.ts
@@ -1,4 +1,4 @@
-import { AlloyComponent, Behaviour, Bubble, Container as AlloyContainer, Focusing, Layout, SketchSpec, Tabstopping, Tooltipping } from '@ephox/alloy';
+import { AlloyComponent, Behaviour, Bubble, Container as AlloyContainer, Focusing, Layout, SketchSpec, Tabstopping, Tooltipping, AddEventsBehaviour, AlloyEvents } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Fun } from '@ephox/katamari';
 import { Attribute, Focus, SelectorFind } from '@ephox/sugar';
@@ -8,11 +8,18 @@ import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 type HtmlPanelSpec = Omit<Dialog.HtmlPanel, 'type'>;
 
 export const renderHtmlPanel = (spec: HtmlPanelSpec, providersBackstage: UiFactoryBackstageProviders): SketchSpec => {
+  const classes = [ 'tox-form__group', ...(spec.stretched ? [ 'tox-form__group--stretched' ] : []) ];
+  const init = AddEventsBehaviour.config('htmlpanel', [
+    AlloyEvents.runOnAttached((comp) => {
+      spec.onInit(comp.element.dom);
+    })
+  ]);
+
   if (spec.presets === 'presentation') {
     return AlloyContainer.sketch({
       dom: {
         tag: 'div',
-        classes: [ 'tox-form__group' ],
+        classes,
         innerHtml: spec.html
       },
       containerBehaviours: Behaviour.derive([
@@ -40,14 +47,15 @@ export const renderHtmlPanel = (spec: HtmlPanelSpec, providersBackstage: UiFacto
             },
             bubble: Bubble.nu(0, -2, {}),
           })
-        })
+        }),
+        init
       ])
     });
   } else {
     return AlloyContainer.sketch({
       dom: {
         tag: 'div',
-        classes: [ 'tox-form__group' ],
+        classes,
         innerHtml: spec.html,
         attributes: {
           role: 'document'
@@ -55,7 +63,9 @@ export const renderHtmlPanel = (spec: HtmlPanelSpec, providersBackstage: UiFacto
       },
       containerBehaviours: Behaviour.derive([
         Tabstopping.config({ }),
-        Focusing.config({ })
+        Focusing.config({
+        }),
+        init
       ])
     });
   }

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/htmlpanel/HtmlPanelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/htmlpanel/HtmlPanelTest.ts
@@ -1,62 +1,104 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
 import { GuiFactory, TestHelpers } from '@ephox/alloy';
 import { context, describe, it } from '@ephox/bedrock-client';
+import { Singleton } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
 
 import { renderHtmlPanel } from 'tinymce/themes/silver/ui/general/HtmlPanel';
 
 import TestBackstage from '../../../module/TestBackstage';
 
 describe('headless.tinymce.themes.silver.components.htmlpanel.HtmlPanelTest', () => {
+  const innerHtml = '<br><br><hr>';
+
+  const assertPanelStructure = (hook: TestHelpers.GuiSetup.Hook<SugarElement<Document>>, role: string, stretched: boolean) => {
+    Assertions.assertStructure(
+      'Checking initial structure',
+      ApproxStructure.build((s, str, _arr) => s.element('div', {
+        attrs: {
+          role: str.is(role),
+          class: str.is(stretched ? 'tox-form__group tox-form__group--stretched' : 'tox-form__group')
+        },
+        children: [
+          s.element('br', {}),
+          s.element('br', {}),
+          s.element('hr', {})
+        ]
+      })),
+      hook.component().element
+    );
+  };
+
   context('Presentation', () => {
+    const initEl = Singleton.value<HTMLElement>();
     const backstage = TestBackstage();
     const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(
       renderHtmlPanel({
-        html: '<br /><br /><hr />',
-        presets: 'presentation'
+        html: innerHtml,
+        presets: 'presentation',
+        onInit: (el) => initEl.set(el),
+        stretched: false
       }, backstage.shared.providers)
     ));
 
     it('Check basic structure', () => {
-      Assertions.assertStructure(
-        'Checking initial structure',
-        ApproxStructure.build((s, str, _arr) => s.element('div', {
-          attrs: {
-            role: str.is('presentation')
-          },
-          children: [
-            s.element('br', {}),
-            s.element('br', {}),
-            s.element('hr', {})
-          ]
-        })),
-        hook.component().element
-      );
+      assertPanelStructure(hook, 'presentation', false);
+      assert.equal(initEl.get().getOrDie(), hook.component().element.dom, 'Should call onInit with component element');
+    });
+  });
+
+  context('Presentation stretched', () => {
+    const initEl = Singleton.value<HTMLElement>();
+    const backstage = TestBackstage();
+    const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(
+      renderHtmlPanel({
+        html: innerHtml,
+        presets: 'presentation',
+        onInit: (el) => initEl.set(el),
+        stretched: true
+      }, backstage.shared.providers)
+    ));
+
+    it('Check basic structure', () => {
+      assertPanelStructure(hook, 'presentation', true);
+      assert.equal(initEl.get().getOrDie(), hook.component().element.dom, 'Should call onInit with component element');
     });
   });
 
   context('Document', () => {
+    const initEl = Singleton.value<HTMLElement>();
     const backstage = TestBackstage();
     const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(
       renderHtmlPanel({
-        html: '<br /><hr />',
-        presets: 'document'
+        html: innerHtml,
+        presets: 'document',
+        onInit: (el) => initEl.set(el),
+        stretched: false
       }, backstage.shared.providers)
     ));
 
     it('Check basic structure', () => {
-      Assertions.assertStructure(
-        'Checking initial structure',
-        ApproxStructure.build((s, str, _arr) => s.element('div', {
-          attrs: {
-            role: str.is('document')
-          },
-          children: [
-            s.element('br', {}),
-            s.element('hr', {})
-          ]
-        })),
-        hook.component().element
-      );
+      assertPanelStructure(hook, 'document', false);
+      assert.equal(initEl.get().getOrDie(), hook.component().element.dom, 'Should call onInit with component element');
+    });
+  });
+
+  context('Document stretched', () => {
+    const initEl = Singleton.value<HTMLElement>();
+    const backstage = TestBackstage();
+    const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(
+      renderHtmlPanel({
+        html: innerHtml,
+        presets: 'document',
+        onInit: (el) => initEl.set(el),
+        stretched: true
+      }, backstage.shared.providers)
+    ));
+
+    it('Check basic structure', () => {
+      assertPanelStructure(hook, 'document', true);
+      assert.equal(initEl.get().getOrDie(), hook.component().element.dom, 'Should call onInit with component element');
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-10900

Re-target for 7.2 of this PR: https://github.com/tinymce/tinymce/pull/9641

Description of Changes:
* Added `onInit` that gives you a raw DOM reference to the HtmlPanel
* Added `stretched` so that you can control how the panel stretches.
* Added `custom-preview` css used by the math plugin.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [-] Docs ticket created (if applicable)

GitHub issues (if applicable):
