### PR TITLE
TINY-10901: Fixed rendering issue with rounded borders on iframes

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10901-2024-05-14.yaml
+++ b/.changes/unreleased/tinymce-TINY-10901-2024-05-14.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Iframes in dialogs was not rendering rounded borders correctly.
+time: 2024-05-14T11:06:22.403781+02:00
+custom:
+  Issue: TINY-10901

--- a/.changes/unreleased/tinymce-TINY-10901-2024-05-14.yaml
+++ b/.changes/unreleased/tinymce-TINY-10901-2024-05-14.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Iframes in dialogs was not rendering rounded borders correctly.
+body: Iframes in dialogs were not rendering rounded borders correctly.
 time: 2024-05-14T11:06:22.403781+02:00
 custom:
   Issue: TINY-10901

--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -503,6 +503,10 @@
       position: absolute;
       z-index: 1;
     }
+
+    iframe {
+      border-radius: @dialog-iframe-bordered-border-radius;
+    }
   }
 
   .tox-navobj-bordered-focus.tox-navobj-bordered::before {


### PR DESCRIPTION
Related Ticket: TINY-10901

Description of Changes:
* Fixes issue with rendering of rounded borders on iframes in dialogs.

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
