### PR TITLE
TINY-10916: Transparent color is converted into #00000

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10916-2024-05-15.yaml
+++ b/.changes/unreleased/tinymce-TINY-10916-2024-05-15.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Fixed a bug where applying a transparent color resulted in it being converted to black.
+time: 2024-05-15T17:05:18.42363+10:00
+custom:
+  Issue: TINY-10916

--- a/.changes/unreleased/tinymce-TINY-10916-2024-05-15.yaml
+++ b/.changes/unreleased/tinymce-TINY-10916-2024-05-15.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Fixed a bug where transparent colors were converted to black.
+body: CSS color values set to `transparent` were incorrectly converted to '#000000`.
 time: 2024-05-15T17:05:18.42363+10:00
 custom:
   Issue: TINY-10916

--- a/.changes/unreleased/tinymce-TINY-10916-2024-05-15.yaml
+++ b/.changes/unreleased/tinymce-TINY-10916-2024-05-15.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Fixed a bug where applying a transparent color resulted in it being converted to black.
+body: Fixed a bug where transparent colors were converted to black.
 time: 2024-05-15T17:05:18.42363+10:00
 custom:
   Issue: TINY-10916

--- a/modules/acid/src/main/ts/ephox/acid/api/colour/RgbaColour.ts
+++ b/modules/acid/src/main/ts/ephox/acid/api/colour/RgbaColour.ts
@@ -9,7 +9,9 @@ const max = Math.max;
 const round = Math.round;
 
 const rgbRegex = /^\s*rgb\s*\(\s*(\d+)\s*[,\s]\s*(\d+)\s*[,\s]\s*(\d+)\s*\)\s*$/i;
-const rgbaRegex = /^\s*rgba\s*\(\s*(\d+)\s*[,\s]\s*(\d+)\s*[,\s]\s*(\d+)\s*[,\s]\s*(\d?(?:\.\d+)?)\s*\)\s*$/i;
+
+// This regex will match rgba(0, 0, 0, 0.5) or rgba(0, 0, 0, 50%) or rgb(0, 0, 0, 1), or without commas
+const rgbaRegex = /^\s*(rgba|rgb)\s*\(\s*(\d{1,3})\s*[,\s]\s*(\d{1,3})\s*[,\s]\s*(\d{1,3})\s*[,\s]\s*(1|0|0?\.\d+|\d{1,3}%)\s*\)\s*$/i;
 
 const rgbaColour = (red: number, green: number, blue: number, alpha: number): Rgba => ({
   red,
@@ -113,7 +115,7 @@ const getColorFormat = (colorString: string): string => {
   } else if (rgbaRegex.test(colorString)) {
     return 'rgba';
   }
-  return 'other'; // Add a return statement for the default case
+  return 'other';
 };
 
 const fromString = (rgbaString: string): Optional<Rgba> => {

--- a/modules/acid/src/main/ts/ephox/acid/api/colour/RgbaColour.ts
+++ b/modules/acid/src/main/ts/ephox/acid/api/colour/RgbaColour.ts
@@ -10,8 +10,8 @@ const round = Math.round;
 
 const rgbRegex = /^\s*rgb\s*\(\s*(\d+)\s*[,\s]\s*(\d+)\s*[,\s]\s*(\d+)\s*\)\s*$/i;
 
-// This regex will match rgba(0, 0, 0, 0.5) or rgba(0, 0, 0, 50%) or rgb(0, 0, 0, 1), or without commas
-const rgbaRegex = /^\s*(rgba|rgb)\s*\(\s*(\d{1,3})\s*[,\s]\s*(\d{1,3})\s*[,\s]\s*(\d{1,3})\s*[,\s]\s*(1|0|0?\.\d+|\d{1,3}%)\s*\)\s*$/i;
+// This regex will match rgba(0, 0, 0, 0.5) or rgba(0, 0, 0, 50%) , or without commas
+const rgbaRegex = /^\s*rgba\s*\(\s*(\d+)\s*[,\s]\s*(\d+)\s*[,\s]\s*(\d+)\s*[,\s]\s*((?:\d?\.\d+|\d+)%?)\s*\)\s*$/i;
 
 const rgbaColour = (red: number, green: number, blue: number, alpha: number): Rgba => ({
   red,

--- a/modules/acid/src/main/ts/ephox/acid/api/colour/RgbaColour.ts
+++ b/modules/acid/src/main/ts/ephox/acid/api/colour/RgbaColour.ts
@@ -106,9 +106,6 @@ const fromStringValues = (red: string, green: string, blue: string, alpha: strin
 };
 
 const fromString = (rgbaString: string): Optional<Rgba> => {
-  if (rgbaString === 'transparent') {
-    return Optional.some(rgbaColour(0, 0, 0, 0));
-  }
   const rgbMatch = rgbRegex.exec(rgbaString);
   if (rgbMatch !== null) {
     return Optional.some(fromStringValues(rgbMatch[1], rgbMatch[2], rgbMatch[3], '1'));

--- a/modules/acid/src/main/ts/ephox/acid/api/colour/RgbaColour.ts
+++ b/modules/acid/src/main/ts/ephox/acid/api/colour/RgbaColour.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { Optional } from '@ephox/katamari';
 
 import { Hex, Hsv, Rgba } from './ColourTypes';
@@ -7,8 +8,8 @@ const min = Math.min;
 const max = Math.max;
 const round = Math.round;
 
-const rgbRegex = /^\s*rgb\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)\s*$/i;
-const rgbaRegex = /^\s*rgba\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d?(?:\.\d+)?)\s*\)\s*$/i;
+const rgbRegex = /^\s*rgb\s*\(\s*(\d+)\s*[,\s]\s*(\d+)\s*[,\s]\s*(\d+)\s*\)\s*$/i;
+const rgbaRegex = /^\s*rgba\s*\(\s*(\d+)\s*[,\s]\s*(\d+)\s*[,\s]\s*(\d+)\s*[,\s]\s*(\d?(?:\.\d+)?)\s*\)\s*$/i;
 
 const rgbaColour = (red: number, green: number, blue: number, alpha: number): Rgba => ({
   red,
@@ -102,7 +103,17 @@ const fromStringValues = (red: string, green: string, blue: string, alpha: strin
   const g = parseInt(green, 10);
   const b = parseInt(blue, 10);
   const a = parseFloat(alpha);
+
   return rgbaColour(r, g, b, a);
+};
+
+const getColorFormat = (colorString: string): string => {
+  if (rgbRegex.test(colorString)) {
+    return 'rgb';
+  } else if (rgbaRegex.test(colorString)) {
+    return 'rgba';
+  }
+  return 'other'; // Add a return statement for the default case
 };
 
 const fromString = (rgbaString: string): Optional<Rgba> => {
@@ -127,6 +138,7 @@ export {
   fromHsv,
   fromHex,
   fromString,
+  getColorFormat,
   toString,
   red
 };

--- a/modules/acid/src/test/ts/browser/RgbaColourTest.ts
+++ b/modules/acid/src/test/ts/browser/RgbaColourTest.ts
@@ -10,11 +10,11 @@ describe('RgbaColourTest', () => {
       Arr.each([
         { colour: 'rgb(0, 0, 0)', expected: 'rgb' },
         { colour: 'rgba(0, 0, 0, 0)', expected: 'rgba' },
-        // rgb with alpha value is effectively rgba, we do not convert rgba to hex
-        { colour: 'rgb(0, 0, 0, 0)', expected: 'rgba' },
+        // rgb with alpha value is invalid
+        { colour: 'rgb(0, 0, 0, 0)', expected: 'other' },
         { colour: 'rgb(0 0 0)', expected: 'rgb' },
         { colour: 'rgba(0 0 0 0)', expected: 'rgba' },
-        // We currently don't support this format, however we still recognise it as an rgb colour
+        // We currently don't support converting this format
         { colour: 'rgb(0 0 0 / 10%)', expected: 'other' },
       ], (test) => {
         const { colour, expected } = test;

--- a/modules/acid/src/test/ts/browser/RgbaColourTest.ts
+++ b/modules/acid/src/test/ts/browser/RgbaColourTest.ts
@@ -1,0 +1,26 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { assert } from 'chai';
+
+import * as RgbaColour from 'ephox/acid/api/colour/RgbaColour';
+
+describe('RgbaColourTest', () => {
+  context('colour identify', () => {
+    it('TINY-7480: identify rgb colours', () => {
+      Arr.each([
+        { colour: 'rgb(0, 0, 0)', expected: 'rgb' },
+        { colour: 'rgba(0, 0, 0, 0)', expected: 'rgba' },
+        // rgb with alpha value is effectively rgba, we do not convert rgba to hex
+        { colour: 'rgb(0, 0, 0, 0)', expected: 'rgba' },
+        { colour: 'rgb(0 0 0)', expected: 'rgb' },
+        { colour: 'rgba(0 0 0 0)', expected: 'rgba' },
+        // We currently don't support this format, however we still recognise it as an rgb colour
+        { colour: 'rgb(0 0 0 / 10%)', expected: 'other' },
+      ], (test) => {
+        const { colour, expected } = test;
+        const result = RgbaColour.getColorFormat(colour);
+        assert.equal(result, expected);
+      });
+    });
+  });
+});

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -42,7 +42,6 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
   const urlOrStrRegExp = /(?:url(?:(?:\(\s*\"([^\"]+)\"\s*\))|(?:\(\s*\'([^\']+)\'\s*\))|(?:\(\s*([^)\s]+)\s*\))))|(?:\'([^\']+)\')|(?:\"([^\"]+)\")/gi;
   const styleRegExp = /\s*([^:]+):\s*([^;]+);?/g;
   const trimRightRegExp = /\s+$/;
-  const rgbRegExp = /rgb\s*\(\s*([0-9]+)\s*,\s*([0-9]+)\s*,\s*([0-9]+)\s*\)/i;
   const encodingLookup: Record<string, string> = {};
   let validStyles: Record<string, string[]> | undefined;
   let invalidStyles: Record<string, SchemaMap> | undefined;
@@ -266,7 +265,7 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
             }
 
             // Convert RGB colors to HEX
-            if (rgbRegExp.test(value)) {
+            if (RgbaColour.getColorFormat(value) === 'rgb') {
               RgbaColour.fromString(value).each((rgba) => {
                 value = Transformations.rgbaToHexString(RgbaColour.toString(rgba)).toLowerCase();
               });

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -247,9 +247,6 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
             name = decodeHexSequences(name);
             value = decodeHexSequences(value);
 
-            console.log('name', name);
-            console.log('value', value);
-
             // Skip properties with double quotes and sequences like \" \' in their names
             // See 'mXSS Attacks: Attacking well-secured Web-Applications by using innerHTML Mutations'
             // https://cure53.de/fp170.pdf
@@ -269,13 +266,8 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
               value = value.toLowerCase();
             }
 
-            // Convert transparent to fully transparent black
-            if (value === 'transparent') {
-              value = '#00000000';
-            }
-
             // Convert RGB colors to HEX
-            if (!rgbaRegExp.test(value)) {
+            if (!rgbaRegExp.test(value) && value.toLowerCase() !== 'transparent') {
               RgbaColour.fromString(value).each((rgba) => {
                 value = Transformations.rgbaToHexString(RgbaColour.toString(rgba)).toLowerCase();
               });

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /**
  * This class is used to parse CSS styles. It also compresses styles to reduce the output size.
  *
@@ -43,7 +42,7 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
   const urlOrStrRegExp = /(?:url(?:(?:\(\s*\"([^\"]+)\"\s*\))|(?:\(\s*\'([^\']+)\'\s*\))|(?:\(\s*([^)\s]+)\s*\))))|(?:\'([^\']+)\')|(?:\"([^\"]+)\")/gi;
   const styleRegExp = /\s*([^:]+):\s*([^;]+);?/g;
   const trimRightRegExp = /\s+$/;
-  const rgbaRegExp = /rgba *\(/i;
+  const rgbaRegExp = /rgba\s*\(\s*([0-9]+)\s*,\s*([0-9]+)\s*,\s*([0-9]+)\s*,\s*(0|1|0?\.\d+)\s*\)/i;
   const encodingLookup: Record<string, string> = {};
   let validStyles: Record<string, string[]> | undefined;
   let invalidStyles: Record<string, SchemaMap> | undefined;
@@ -267,7 +266,7 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
             }
 
             // Convert RGB colors to HEX
-            if (!rgbaRegExp.test(value) && value.toLowerCase() !== 'transparent') {
+            if (!rgbaRegExp.test(value)) {
               RgbaColour.fromString(value).each((rgba) => {
                 value = Transformations.rgbaToHexString(RgbaColour.toString(rgba)).toLowerCase();
               });

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /**
  * This class is used to parse CSS styles. It also compresses styles to reduce the output size.
  *
@@ -246,6 +247,9 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
             name = decodeHexSequences(name);
             value = decodeHexSequences(value);
 
+            console.log('name', name);
+            console.log('value', value);
+
             // Skip properties with double quotes and sequences like \" \' in their names
             // See 'mXSS Attacks: Attacking well-secured Web-Applications by using innerHTML Mutations'
             // https://cure53.de/fp170.pdf
@@ -263,6 +267,11 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
               value = 'bold';
             } else if (name === 'color' || name === 'background-color') { // Lowercase colors like RED
               value = value.toLowerCase();
+            }
+
+            // Convert transparent to fully transparent black
+            if (value === 'transparent') {
+              value = '#00000000';
             }
 
             // Convert RGB colors to HEX

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -42,7 +42,7 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
   const urlOrStrRegExp = /(?:url(?:(?:\(\s*\"([^\"]+)\"\s*\))|(?:\(\s*\'([^\']+)\'\s*\))|(?:\(\s*([^)\s]+)\s*\))))|(?:\'([^\']+)\')|(?:\"([^\"]+)\")/gi;
   const styleRegExp = /\s*([^:]+):\s*([^;]+);?/g;
   const trimRightRegExp = /\s+$/;
-  const rgbRegExp = /rgb\s*\(\s*([0-9]+)\s*,\s*([0-9]+)\s*,\s*([0-9]+)\s*\)/gi;
+  const rgbRegExp = /rgb\s*\(\s*([0-9]+)\s*,\s*([0-9]+)\s*,\s*([0-9]+)\s*\)/i;
   const encodingLookup: Record<string, string> = {};
   let validStyles: Record<string, string[]> | undefined;
   let invalidStyles: Record<string, SchemaMap> | undefined;

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -42,7 +42,7 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
   const urlOrStrRegExp = /(?:url(?:(?:\(\s*\"([^\"]+)\"\s*\))|(?:\(\s*\'([^\']+)\'\s*\))|(?:\(\s*([^)\s]+)\s*\))))|(?:\'([^\']+)\')|(?:\"([^\"]+)\")/gi;
   const styleRegExp = /\s*([^:]+):\s*([^;]+);?/g;
   const trimRightRegExp = /\s+$/;
-  const rgbRegExp = /rgb\s*\(\s*([0-9]+)\s*,\s*([0-9]+)\s*,\s*([0-9]+)\s*\)/gi; 
+  const rgbRegExp = /rgb\s*\(\s*([0-9]+)\s*,\s*([0-9]+)\s*,\s*([0-9]+)\s*\)/gi;
   const encodingLookup: Record<string, string> = {};
   let validStyles: Record<string, string[]> | undefined;
   let invalidStyles: Record<string, SchemaMap> | undefined;

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -42,7 +42,7 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
   const urlOrStrRegExp = /(?:url(?:(?:\(\s*\"([^\"]+)\"\s*\))|(?:\(\s*\'([^\']+)\'\s*\))|(?:\(\s*([^)\s]+)\s*\))))|(?:\'([^\']+)\')|(?:\"([^\"]+)\")/gi;
   const styleRegExp = /\s*([^:]+):\s*([^;]+);?/g;
   const trimRightRegExp = /\s+$/;
-  const rgbaRegExp = /rgba\s*\(\s*([0-9]+)\s*,\s*([0-9]+)\s*,\s*([0-9]+)\s*,\s*(0|1|0?\.\d+)\s*\)/i;
+  const rgbRegExp = /rgb\s*\(\s*([0-9]+)\s*,\s*([0-9]+)\s*,\s*([0-9]+)\s*\)/gi; 
   const encodingLookup: Record<string, string> = {};
   let validStyles: Record<string, string[]> | undefined;
   let invalidStyles: Record<string, SchemaMap> | undefined;
@@ -266,7 +266,7 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
             }
 
             // Convert RGB colors to HEX
-            if (!rgbaRegExp.test(value)) {
+            if (rgbRegExp.test(value)) {
               RgbaColour.fromString(value).each((rgba) => {
                 value = Transformations.rgbaToHexString(RgbaColour.toString(rgba)).toLowerCase();
               });

--- a/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
@@ -280,6 +280,10 @@ describe('browser.tinymce.core.html.StylesTest', () => {
     assertStyles(styles, 'border-color: transparent;', 'border-color: transparent;');
     assertStyles(styles, 'border: 1px solid transparent;', 'border: 1px solid transparent;');
     assertStyles(styles, 'background: transparent;', 'background: transparent;');
+    assertStyles(styles, 'outline: 1px solid transparent;', 'outline: 1px solid transparent;');
+    assertStyles(styles, 'box-shadow: 1px 1px 1px transparent;', 'box-shadow: 1px 1px 1px transparent;');
+    assertStyles(styles, 'text-shadow: 1px 1px 1px transparent;', 'text-shadow: 1px 1px 1px transparent;');
+    assertStyles(styles, 'text-decoration-color: transparent;', 'text-decoration-color: transparent;');
   });
 
   it('TINY-10916: transparent should not be converted to other format when using set/get Content API', () => {
@@ -289,7 +293,11 @@ describe('browser.tinymce.core.html.StylesTest', () => {
       '<p style="background-color: transparent;">bg colour transparent</p>',
       '<p style="border-color: transparent;">border colour transparent</p>',
       '<p style="border: 1px solid transparent;">border transparent</p>',
-      `<p style="background: transparent;">bg transparent</p>`
+      `<p style="background: transparent;">bg transparent</p>`,
+      '<p style="outline: 1px solid transparent;">outline transparent</p>',
+      '<p style="box-shadow: 1px 1px 1px transparent;">box-shadow transparent</p>',
+      '<p style="text-shadow: 1px 1px 1px transparent;">text-shadow transparent</p>',
+      '<p style="text-decoration-color: transparent;">text-decoration-color transparent</p>'
     ], (content) => {
       editor.setContent(content);
       const result = editor.getContent();

--- a/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
@@ -304,4 +304,10 @@ describe('browser.tinymce.core.html.StylesTest', () => {
       Assertions.assertEq('Should not convert transparent to other format', content, result);
     });
   });
+
+  it('TINY-10916: only non calculative new colour foramt should be handled', () => {
+    const styles = Styles();
+    assertStyles(styles, 'color: rgb(0 0 0)', 'color: #000000;');
+    assertStyles(styles, 'color: rgb(0 0 0 / 0)', 'color: rgb(0 0 0 / 0);');
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
@@ -1,10 +1,17 @@
+import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
+import Editor from 'tinymce/core/api/Editor';
 import Schema from 'tinymce/core/api/html/Schema';
 import Styles from 'tinymce/core/api/html/Styles';
 
 describe('browser.tinymce.core.html.StylesTest', () => {
+
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce'
+  }, []);
 
   const assertStyles = (styles: Styles, input: string, expected: string) => {
     assert.equal(styles.serialize(styles.parse(input)), expected);
@@ -265,8 +272,15 @@ describe('browser.tinymce.core.html.StylesTest', () => {
     assertStyles(styles, 'color: rgb(1, 2, 3, 0.5);', 'color: rgb(1, 2, 3, 0.5);');
   });
 
-  it('TINY-10916: transparent should be convert to black with 0 alpha', () => {
+  it('TINY-10916: transparent should not be converted to other format', () => {
     const styles = Styles();
-    assertStyles(styles, 'color: transparent;', 'color: #00000000;');
+    assertStyles(styles, 'color: transparent;', 'color: transparent;');
+  });
+
+  it('TINY-10916: transparent should not be converted to other format when using set/get Content API', () => {
+    const editor = hook.editor();
+    editor.setContent('<p style="color: transparent;">test</p>');
+    const content = editor.getContent();
+    Assertions.assertEq('Should not convert transparent to other format', '<p style="color: transparent;">test</p>', content);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
@@ -264,4 +264,9 @@ describe('browser.tinymce.core.html.StylesTest', () => {
     assertStyles(styles, 'color: rgba(1, 2, 3);', 'color: rgba(1, 2, 3);');
     assertStyles(styles, 'color: rgb(1, 2, 3, 0.5);', 'color: rgb(1, 2, 3, 0.5);');
   });
+
+  it('TINY-10916: transparent should be convert to black with 0 alpha', () => {
+    const styles = Styles();
+    assertStyles(styles, 'color: transparent;', 'color: #00000000;');
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
@@ -1,5 +1,6 @@
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -272,15 +273,27 @@ describe('browser.tinymce.core.html.StylesTest', () => {
     assertStyles(styles, 'color: rgb(1, 2, 3, 0.5);', 'color: rgb(1, 2, 3, 0.5);');
   });
 
-  it('TINY-10916: transparent should not be converted to other format', () => {
+  it('TINY-10916: transparent should not be converted to other formats', () => {
     const styles = Styles();
     assertStyles(styles, 'color: transparent;', 'color: transparent;');
+    assertStyles(styles, 'background-color: transparent;', 'background-color: transparent;');
+    assertStyles(styles, 'border-color: transparent;', 'border-color: transparent;');
+    assertStyles(styles, 'border: 1px solid transparent;', 'border: 1px solid transparent;');
+    assertStyles(styles, 'background: transparent;', 'background: transparent;');
   });
 
   it('TINY-10916: transparent should not be converted to other format when using set/get Content API', () => {
     const editor = hook.editor();
-    editor.setContent('<p style="color: transparent;">test</p>');
-    const content = editor.getContent();
-    Assertions.assertEq('Should not convert transparent to other format', '<p style="color: transparent;">test</p>', content);
+    Arr.each([
+      '<p style="color: transparent;">colour transparent</p>',
+      '<p style="background-color: transparent;">bg colour transparent</p>',
+      '<p style="border-color: transparent;">border colour transparent</p>',
+      '<p style="border: 1px solid transparent;">border transparent</p>',
+      `<p style="background: transparent;">bg transparent</p>`
+    ], (content) => {
+      editor.setContent(content);
+      const result = editor.getContent();
+      Assertions.assertEq('Should not convert transparent to other format', content, result);
+    });
   });
 });


### PR DESCRIPTION
Related Ticket: 
TINY-10916

Description of Changes:
- Added a seperate if statement to cover the edge case of transparent

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] <s>Docs ticket created (if applicable)</s>

GitHub issues (if applicable):
https://github.com/tinymce/tinymce/issues/9391