### PR TITLE
TINY-10384: Make sure cursor moves to next line when around a <br>, <img>, or <table>

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10384-2024-05-21.yaml
+++ b/.changes/unreleased/tinymce-TINY-10384-2024-05-21.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Fixed cases where adding a newline around a br, table or img would not move the cursor to a new line.
+time: 2024-05-21T03:42:28.925827998+10:00
+custom:
+  Issue: TINY-10384

--- a/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
@@ -1,4 +1,4 @@
-import { Arr, Optional, Optionals, Type } from '@ephox/katamari';
+import { Arr, Optional, Type } from '@ephox/katamari';
 import { ContentEditable, Insert, PredicateFilter, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
@@ -400,14 +400,6 @@ const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>): void => {
       NewLineUtils.emptyBlock(parentBlock);
     }
     NewLineUtils.setForcedBlockAttrs(editor, newBlock);
-    // if (isBefore && node) {
-    //   // Keep selection before the fake caret candidate
-    //   showCaret(-1, editor, node as HTMLElement, true, false).each((newRng) => {
-    //     moveToRange(editor, newRng);
-    //   });
-    // } else {
-    //   NewLineUtils.moveToCaretPosition(editor, newBlock);
-    // }
     NewLineUtils.moveToCaretPosition(editor, newBlock);
   } else if (isCaretAtStartOrEndOfBlock(false)) {
     // Caret is moved to the new block in the insertNewBlockAfter fn

--- a/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
@@ -424,9 +424,7 @@ const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>): void => {
 
     newBlock = parentBlockParent.insertBefore(createNewBlock(), parentBlock);
 
-    const root = Optionals.someIf(containerAndSiblingName(parentBlock, 'HR') || afterTable, newBlock)
-      .or(prevBrOpt)
-      .getOr(parentBlock);
+    const root = containerAndSiblingName(parentBlock, 'HR') || afterTable ? newBlock : prevBrOpt.getOr(parentBlock);
     NewLineUtils.moveToCaretPosition(editor, root);
   } else {
     // Extract after fragment and insert it after the current block

--- a/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
@@ -390,11 +390,8 @@ const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>): void => {
     );
     editor.selection.setCursorLocation(newBlock, 0);
   } else if (CaretContainer.isCaretContainerBlock(parentBlock)) {
-    // TODO: NOTE: Added logic to make sure pressing enter is consistent between browsers
-    // As an example a fake caret is used before/after tables on FIrefox but not on Chrome so different behaviour could occur
-    // TODO: Create Jira to improve this
-    // const isBefore = parentBlock.getAttribute('data-mce-caret') === 'before';
-    // const node = isBefore ? parentBlock.nextElementSibling : parentBlock.previousElementSibling;
+    // TODO: TINY-10384 NOTE: Added logic to make sure pressing enter is consistent between browsers.
+    // As an example a fake caret is used before/after tables on Firefox but not on Chrome. So different behaviour could occur
     newBlock = CaretContainer.showCaretContainerBlock(parentBlock) as Element;
     if (dom.isEmpty(parentBlock)) {
       NewLineUtils.emptyBlock(parentBlock);

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyHrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyHrTest.ts
@@ -25,7 +25,8 @@ describe('browser.tinymce.core.keyboard.EnterKeyHrTest', () => {
     TinySelections.setCursor(editor, [], 1);
     TinyContentActions.keystroke(editor, Keys.enter());
     TinyAssertions.assertContent(editor, '<hr><p>&nbsp;</p><p>a</p>');
-    TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
+    // TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
+    TinyAssertions.assertSelection(editor, [ 2, 0 ], 0, [ 2, 0 ], 0);
   });
 
   it('Enter before HR in the middle of content', () => {
@@ -43,7 +44,8 @@ describe('browser.tinymce.core.keyboard.EnterKeyHrTest', () => {
     TinySelections.setCursor(editor, [], 2);
     TinyContentActions.keystroke(editor, Keys.enter());
     TinyAssertions.assertContent(editor, '<p>a</p><hr><p>&nbsp;</p><p>b</p>');
-    TinyAssertions.assertSelection(editor, [ 2 ], 0, [ 2 ], 0);
+    // TinyAssertions.assertSelection(editor, [ 2 ], 0, [ 2 ], 0);
+    TinyAssertions.assertSelection(editor, [ 3, 0 ], 0, [ 3, 0 ], 0);
   });
 
   it('Enter before HR in the end of content', () => {

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyHrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyHrTest.ts
@@ -25,7 +25,6 @@ describe('browser.tinymce.core.keyboard.EnterKeyHrTest', () => {
     TinySelections.setCursor(editor, [], 1);
     TinyContentActions.keystroke(editor, Keys.enter());
     TinyAssertions.assertContent(editor, '<hr><p>&nbsp;</p><p>a</p>');
-    // TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
     TinyAssertions.assertSelection(editor, [ 2, 0 ], 0, [ 2, 0 ], 0);
   });
 
@@ -44,7 +43,6 @@ describe('browser.tinymce.core.keyboard.EnterKeyHrTest', () => {
     TinySelections.setCursor(editor, [], 2);
     TinyContentActions.keystroke(editor, Keys.enter());
     TinyAssertions.assertContent(editor, '<p>a</p><hr><p>&nbsp;</p><p>b</p>');
-    // TinyAssertions.assertSelection(editor, [ 2 ], 0, [ 2 ], 0);
     TinyAssertions.assertSelection(editor, [ 3, 0 ], 0, [ 3, 0 ], 0);
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/newline/NewlineAroundBrTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/NewlineAroundBrTest.ts
@@ -1,0 +1,186 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import * as InsertNewLine from 'tinymce/core/newline/InsertNewLine';
+
+describe('browser.tinymce.core.newline.NewlineAroundBrTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce'
+  }, [], true);
+
+  const insertNewline = (editor: Editor, args: Partial<EditorEvent<KeyboardEvent>> = {}) => {
+    InsertNewLine.insert(editor, args as EditorEvent<KeyboardEvent>);
+  };
+
+  type CursorPos = [path: number[], offset: number];
+  const assertNewLine = (editor: Editor, startContent: string, startCursor: CursorPos, expectedContent: string, expectedCursor: CursorPos) => {
+    editor.setContent(startContent);
+    TinySelections.setCursor(editor, ...startCursor);
+    insertNewline(editor);
+    TinyAssertions.assertContent(editor, expectedContent);
+    TinyAssertions.assertCursor(editor, ...expectedCursor);
+  };
+
+  it('TINY-10384: Insert newline at |<p><br>text</p>', () => {
+    assertNewLine(
+      hook.editor(),
+      '<p><br>text</p>',
+      [[], 0 ],
+      '<p>&nbsp;</p>\n<p><br>text</p>',
+      [[ 1 ], 0 ]
+    );
+  });
+
+  it('TINY-10384: Insert newline at <p>|<br>text</p>', () => {
+    assertNewLine(
+      hook.editor(),
+      '<p><br>text</p>',
+      [[ 0 ], 0 ],
+      '<p>&nbsp;</p>\n<p><br>text</p>',
+      [[ 1 ], 0 ]
+    );
+  });
+
+  it('TINY-10384: Insert newline at <p><br>|text</p>', () => {
+    assertNewLine(
+      hook.editor(),
+      '<p><br>text</p>',
+      [[ 0, 0 ], 0 ],
+      '<p>&nbsp;</p>\n<p><br>text</p>',
+      [[ 1 ], 0 ]
+    );
+  });
+
+  it('TINY-10384: Insert newline at <p><br>text|</p>', () => {
+    assertNewLine(
+      hook.editor(),
+      '<p><br>text</p>',
+      [[ 0, 1 ], 'text'.length ],
+      '<p><br>text</p>\n<p>&nbsp;</p>',
+      [[ 1 ], 0 ]
+    );
+  });
+
+  it('TINY-10384: Insert newline at |<div><br>text</div>', () => {
+    assertNewLine(
+      hook.editor(),
+      '<div><br>text</div>',
+      [[], 0 ],
+      '<div>&nbsp;</div>\n<div><br>text</div>',
+      [[ 1 ], 0 ]
+    );
+  });
+
+  it('TINY-10384: Insert newline at <div>|<br>text</div>', () => {
+    assertNewLine(
+      hook.editor(),
+      '<div><br>text</div>',
+      [[ 0 ], 0 ],
+      '<div>&nbsp;</div>\n<div><br>text</div>',
+      [[ 1 ], 0 ]
+    );
+  });
+
+  it('TINY-10384: Insert newline at <div><br>|text</div>', () => {
+    assertNewLine(
+      hook.editor(),
+      '<div><br>text</div>',
+      [[ 0, 0 ], 0 ],
+      '<div>&nbsp;</div>\n<div><br>text</div>',
+      [[ 1 ], 0 ]
+    );
+  });
+
+  it('TINY-10384: Insert newline at <div><br>text|</div>', () => {
+    assertNewLine(
+      hook.editor(),
+      '<div><br>text</div>',
+      [[ 0, 1 ],
+        'text'.length ],
+      '<div><br>text</div>\n<div>&nbsp;</div>',
+      [[ 1 ], 0 ]
+    );
+  });
+
+  it('TINY-10384: Insert newline at |<p><img>text</p>', () => {
+    assertNewLine(
+      hook.editor(),
+      '<p><img>text</p>',
+      [[], 0 ],
+      '<p>&nbsp;</p>\n<p><img>text</p>',
+      [[ 1 ], 0 ]
+    );
+  });
+
+  it('TINY-10384: Insert newline at <p>|<img>text</p>', () => {
+    assertNewLine(
+      hook.editor(),
+      '<p><img>text</p>',
+      [[ 0 ], 0 ],
+      '<p>&nbsp;</p>\n<p><img>text</p>',
+      [[ 1 ], 0 ]
+    );
+  });
+
+  it('TINY-10384: Insert newline at <p><img>|text</p>', () => {
+    assertNewLine(
+      hook.editor(),
+      '<p><img>text</p>',
+      [[ 0, 0 ], 0 ],
+      '<p>&nbsp;</p>\n<p><img>text</p>',
+      [[ 1 ], 0 ]
+    );
+  });
+
+  it('TINY-10384: Insert newline at <p><img>text|</p>', () => {
+    assertNewLine(
+      hook.editor(),
+      '<p><img>text</p>',
+      [[ 0, 1 ], 'text'.length ],
+      '<p><img>text</p>\n<p>&nbsp;</p>',
+      [[ 1 ], 0 ]
+    );
+  });
+
+  it('TINY-10384: Insert newline at <p>|before<br>after</p>', () => {
+    assertNewLine(
+      hook.editor(),
+      '<p>before<br>after</p>',
+      [[ 0, 0 ], 0 ],
+      '<p>&nbsp;</p>\n<p>before<br>after</p>',
+      [[ 1, 0 ], 0 ]
+    );
+  });
+
+  it('TINY-10384: Insert newline at <p>before|<br>after</p>', () => {
+    assertNewLine(
+      hook.editor(),
+      '<p>before<br>after</p>',
+      [[ 0, 0 ], 'before'.length ],
+      '<p>before</p>\n<p><br>after</p>',
+      [[ 1 ], 0 ]
+    );
+  });
+
+  it('TINY-10384: Insert newline at <p>before<br>|after</p>', () => {
+    assertNewLine(
+      hook.editor(),
+      '<p>before<br>after</p>',
+      [[ 0, 2 ], 0 ],
+      '<p>before</p>\n<p>after</p>',
+      [[ 1, 0 ], 0 ]
+    );
+  });
+
+  it('TINY-10384: Insert newline at <p>before<br>after|</p>', () => {
+    assertNewLine(
+      hook.editor(),
+      '<p>before<br>after</p>',
+      [[ 0, 2 ], 'after'.length ],
+      '<p>before<br>after</p>\n<p>&nbsp;</p>',
+      [[ 1 ], 0 ]
+    );
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-10384

Description of Changes:
- Added a check before the cursor is potentially moved by the `insertBefore` function, to make sure it moves to the next line.
- Added _NewlineAroundBrTest.ts_ and modified existing _EnterKeyHrTest.ts_

Pre-checks:
* [x] Changelog entry added
* [-] Tests have been added (if applicable)
* [-] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
