### PR TITLE
TINY-10428: emit slider onChange event while using arrow keys 

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10428-2024-05-20.yaml
+++ b/.changes/unreleased/tinymce-TINY-10428-2024-05-20.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Improved
-body: 'Silver theme slider component emits onChange event now while using arrow keys '
+body: 'Silver theme slider component emits onChange event now while using arrow keys.'
 time: 2024-05-20T16:47:55.820758+02:00
 custom:
   Issue: TINY-10428

--- a/.changes/unreleased/tinymce-TINY-10428-2024-05-20.yaml
+++ b/.changes/unreleased/tinymce-TINY-10428-2024-05-20.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Improved
-body: 'Silver theme slider component emits onChange event now while using arrow keys.'
+body: 'Dialog slider components now emit an onChange event when using arrow keys.'
 time: 2024-05-20T16:47:55.820758+02:00
 custom:
   Issue: TINY-10428

--- a/.changes/unreleased/tinymce-TINY-10428-2024-05-20.yaml
+++ b/.changes/unreleased/tinymce-TINY-10428-2024-05-20.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Improved
+body: 'Silver theme slider component emits onChange event now while using arrow keys '
+time: 2024-05-20T16:47:55.820758+02:00
+custom:
+  Issue: TINY-10428

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Slider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Slider.ts
@@ -64,6 +64,9 @@ export const renderSlider = (spec: SliderSpec, providerBackstage: UiFactoryBacks
     ]),
     onChoose: (component, thumb, value) => {
       AlloyTriggers.emitWith(component, formChangeEvent, { name: spec.name, value } );
-    }
+    }, 
+    onChange: (component, thumb, value) => {
+      AlloyTriggers.emitWith(component, formChangeEvent, { name: spec.name, value } );
+    }, 
   });
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Slider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Slider.ts
@@ -64,9 +64,9 @@ export const renderSlider = (spec: SliderSpec, providerBackstage: UiFactoryBacks
     ]),
     onChoose: (component, thumb, value) => {
       AlloyTriggers.emitWith(component, formChangeEvent, { name: spec.name, value } );
-    }, 
+    },
     onChange: (component, thumb, value) => {
       AlloyTriggers.emitWith(component, formChangeEvent, { name: spec.name, value } );
-    }, 
+    },
   });
 };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogSliderApiTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogSliderApiTest.ts
@@ -1,4 +1,4 @@
-import { FocusTools, Keys, TestStore, Waiter } from '@ephox/agar';
+import { FocusTools, Keys, TestStore } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarDocument } from '@ephox/sugar';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogSliderApiTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogSliderApiTest.ts
@@ -51,7 +51,7 @@ describe('browser.tinymce.themes.silver.window.SilverDialogSliderApiTest', () =>
         await FocusTools.pTryOnSelector('Focus should be on slider rail', SugarDocument.getDocument(), '.tox-slider__rail');
         TinyUiActions.keydown(editor, Keys.left());
 
-       store.assertEq('Check if on change event is logged after using arrow key', [ 'logOnChangeEvent' ]);
+        store.assertEq('Check if on change event is logged after using arrow key', [ 'logOnChangeEvent' ]);
       });
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogSliderApiTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogSliderApiTest.ts
@@ -1,0 +1,58 @@
+import { FocusTools, Keys, TestStore, Waiter } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import { Dialog } from 'tinymce/core/api/ui/Ui';
+
+import * as DialogUtils from '../../module/DialogUtils';
+
+describe('browser.tinymce.themes.silver.window.SilverDialogSliderApiTest', () => {
+  const store = TestStore();
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce'
+  }, []);
+
+  const dialogSpec: Dialog.DialogSpec<{ sliderField: number }> = {
+    title: 'Silver Dialog Test Slider Api',
+    body: {
+      type: 'panel',
+      items: [
+        {
+          type: 'slider',
+          name: 'sliderField',
+          label: 'Slider label',
+          min: 0,
+          max: 100
+        }
+      ]
+    },
+    initialData: {
+      sliderField: 50
+    },
+    onChange: () => {
+      store.add('logOnChangeEvent');
+    }
+  };
+
+  Arr.each([
+    { label: 'Modal', params: { }},
+    { label: 'Inline', params: { inline: 'toolbar' as 'toolbar' }}
+  ], (test) => {
+    context(test.label, () => {
+      it('TINY-10428: dialog onChange handler should fire when using arrow key on slider', async () => {
+        store.clear();
+        const editor = hook.editor();
+        DialogUtils.open(editor, dialogSpec, test.params);
+        await TinyUiActions.pWaitForDialog(editor);
+
+        await FocusTools.pTryOnSelector('Focus should be on slider rail', SugarDocument.getDocument(), '.tox-slider__rail');
+        TinyUiActions.keydown(editor, Keys.left());
+
+        await Waiter.pTryUntil('', () => store.assertEq('Check if on change event is logged after using arrow key', [ 'logOnChangeEvent' ]));
+      });
+    });
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogSliderApiTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogSliderApiTest.ts
@@ -51,7 +51,7 @@ describe('browser.tinymce.themes.silver.window.SilverDialogSliderApiTest', () =>
         await FocusTools.pTryOnSelector('Focus should be on slider rail', SugarDocument.getDocument(), '.tox-slider__rail');
         TinyUiActions.keydown(editor, Keys.left());
 
-        await Waiter.pTryUntil('', () => store.assertEq('Check if on change event is logged after using arrow key', [ 'logOnChangeEvent' ]));
+       store.assertEq('Check if on change event is logged after using arrow key', [ 'logOnChangeEvent' ]);
       });
     });
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogSliderApiTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogSliderApiTest.ts
@@ -3,6 +3,7 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
@@ -14,6 +15,8 @@ describe('browser.tinymce.themes.silver.window.SilverDialogSliderApiTest', () =>
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce'
   }, []);
+
+  const initialSliderValue = 50;
 
   const dialogSpec: Dialog.DialogSpec<{ sliderField: number }> = {
     title: 'Silver Dialog Test Slider Api',
@@ -30,7 +33,7 @@ describe('browser.tinymce.themes.silver.window.SilverDialogSliderApiTest', () =>
       ]
     },
     initialData: {
-      sliderField: 50
+      sliderField: initialSliderValue
     },
     onChange: () => {
       store.add('logOnChangeEvent');
@@ -45,13 +48,21 @@ describe('browser.tinymce.themes.silver.window.SilverDialogSliderApiTest', () =>
       it('TINY-10428: dialog onChange handler should fire when using arrow key on slider', async () => {
         store.clear();
         const editor = hook.editor();
-        DialogUtils.open(editor, dialogSpec, test.params);
+        const dialogApi = DialogUtils.open(editor, dialogSpec, test.params);
         await TinyUiActions.pWaitForDialog(editor);
 
+        assert.deepEqual(dialogApi.getData(), { sliderField: initialSliderValue }, 'Check initial dialog data');
         await FocusTools.pTryOnSelector('Focus should be on slider rail', SugarDocument.getDocument(), '.tox-slider__rail');
+
         TinyUiActions.keydown(editor, Keys.left());
 
+        assert.deepEqual(dialogApi.getData(), { sliderField: initialSliderValue - 1 }, 'Check dialog data after left arrow key');
         store.assertEq('Check if on change event is logged after using arrow key', [ 'logOnChangeEvent' ]);
+
+        TinyUiActions.keydown(editor, Keys.right());
+
+        assert.deepEqual(dialogApi.getData(), { sliderField: initialSliderValue }, 'Check dialog data after right arrow key');
+        store.assertEq('Check if on change event is logged after using arrow key', [ 'logOnChangeEvent', 'logOnChangeEvent' ]);
       });
     });
   });


### PR DESCRIPTION
Related Ticket: TINY-10428

Description of Changes:
Silver theme slider component emits onChange event now while using arrow keys 

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
