### PR TITLE
TINY-10904: now polaris manage acronyms correctly

### DIFF
--- a/.changes/unreleased/polaris-TINY-10904-2024-05-22.yaml
+++ b/.changes/unreleased/polaris-TINY-10904-2024-05-22.yaml
@@ -1,0 +1,6 @@
+project: polaris
+kind: Fixed
+body: Acronyms where not managed correctly.
+time: 2024-05-22T16:02:02.052181985+02:00
+custom:
+  Issue: TINY-10904

--- a/.changes/unreleased/polaris-TINY-10904-2024-05-22.yaml
+++ b/.changes/unreleased/polaris-TINY-10904-2024-05-22.yaml
@@ -1,6 +1,6 @@
 project: polaris
 kind: Fixed
-body: Acronyms where not managed correctly.
+body: Acronyms were not managed correctly.
 time: 2024-05-22T16:02:02.052181985+02:00
 custom:
   Issue: TINY-10904

--- a/modules/polaris/src/main/ts/ephox/polaris/words/Words.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/words/Words.ts
@@ -51,7 +51,6 @@ const findWordsWithIndices = <T>(chars: Word<T>, sChars: string[], characterMap:
     word.push(chars[i]);
 
     // If there's a word boundary between the current character and the next character,
-    // (and this boundary doesn't depend from a dot at the end of an acronym)
     // append the current word to the words array and start building a new word.
     if (isWordBoundary(characterMap, i)) {
       const ch = sChars[i];

--- a/modules/polaris/src/main/ts/ephox/polaris/words/Words.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/words/Words.ts
@@ -107,9 +107,6 @@ const findWordsWithIndices = <T>(chars: Word<T>, sChars: string[], characterMap:
           start: startOfWord,
           end: endOfWord
         });
-        couldBeAnAcronym.prev = undefined;
-        couldBeAnAcronym.check = undefined;
-        couldBeAnAcronym.isTheLast = false;
       }
 
       word = [];

--- a/modules/polaris/src/main/ts/ephox/polaris/words/Words.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/words/Words.ts
@@ -38,6 +38,8 @@ export interface WordsWithIndices<T> {
   readonly indices: WordIndex[];
 }
 
+const isAnAcronym = (str: string) => new RegExp(/^(?:[A-Z]\.)+$/gm).test(str);
+
 const findWordsWithIndices = <T>(chars: Word<T>, sChars: string[], characterMap: CharacterMap, options: WordOptions): WordsWithIndices<T> => {
   const words: Word<T>[] = [];
   const indices: WordIndex[] = [];
@@ -51,12 +53,13 @@ const findWordsWithIndices = <T>(chars: Word<T>, sChars: string[], characterMap:
     word.push(chars[i]);
 
     // If there's a word boundary between the current character and the next character,
+    // (and this boundary doesn't depend from a dot at the end of an acronym)
     // append the current word to the words array and start building a new word.
-    if (isWordBoundary(characterMap, i)) {
+    if (isWordBoundary(characterMap, i) && !isAnAcronym(word.join('') + sChars[i + 1])) {
       const ch = sChars[i];
       if (
         (options.includeWhitespace || !WHITESPACE.test(ch)) &&
-        (options.includePunctuation || !PUNCTUATION.test(ch))
+        (options.includePunctuation || !PUNCTUATION.test(ch) || isAnAcronym(word.join('')))
       ) {
         const startOfWord = i - word.length + 1;
         const endOfWord = i + 1;

--- a/modules/polaris/src/main/ts/ephox/polaris/words/Words.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/words/Words.ts
@@ -55,8 +55,6 @@ const findWordsWithIndices = <T>(chars: Word<T>, sChars: string[], characterMap:
       isInAcronym = true;
     }
 
-    const onWordBoundary = isWordBoundary(characterMap, i);
-
     const dotAfterLetter: boolean = isInAcronym && sChars[i] === '.' && i > 0 && characterMap[i - 1] === ci.ALETTER;
     const letterAfterDot: boolean = isInAcronym && ((characterMap[i] === ci.ALETTER && i > 0 && sChars[i - 1] === '.') || word.length === 1);
     const isTheLastLeter: boolean = isInAcronym && letterAfterDot && (i + 1) <= sChars.length && sChars[i + 1] !== '.';
@@ -65,7 +63,7 @@ const findWordsWithIndices = <T>(chars: Word<T>, sChars: string[], characterMap:
     // If there's a word boundary between the current character and the next character,
     // (and this boundary doesn't depend from a dot at the end of an acronym)
     // append the current word to the words array and start building a new word.
-    if (onWordBoundary && (!isInAcronym || dotAfterLetter || isTheLastLeter)) {
+    if (isWordBoundary(characterMap, i) && (!isInAcronym || dotAfterLetter || isTheLastLeter)) {
       const ch = sChars[i];
       if (
         (options.includeWhitespace || !WHITESPACE.test(ch)) &&

--- a/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
+++ b/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
@@ -129,8 +129,10 @@ describe('atomic.robin.words.IdentifyTest', () => {
       WordScope('abc', none, some(' ')),
       WordScope('U.S.A.', some(' '), some('.')),
       WordScope('E.U.', some(' '), some(' ')),
+      WordScope('u.s.a', some(' '), some('.')),
       WordScope('something', some(' '), some(' ')),
+      WordScope('H.', some(' '), some(' ')),
       WordScope('else', some(' '), none)
-    ], 'abc U.S.A.. E.U. something else');
+    ], 'abc U.S.A.. E.U. u.s.a.. something H. else');
   });
 });

--- a/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
+++ b/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
@@ -123,4 +123,14 @@ describe('atomic.robin.words.IdentifyTest', () => {
       'Really I’d hope that was enough for you, but I\u2019ll throw');
 
   });
+
+  it('TINY-10904: acronyms should be managed correctly', () => {
+    check([
+      WordScope('abc', none, some(' ')),
+      WordScope('U.S.A.', some(' '), some('.')),
+      WordScope('E.U.', some(' '), some(' ')),
+      WordScope('something', some(' '), some(' ')),
+      WordScope('else', some(' '), none)
+    ], 'abc U.S.A.. E.U. something else');
+  });
 });

--- a/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
+++ b/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
@@ -126,6 +126,14 @@ describe('atomic.robin.words.IdentifyTest', () => {
 
   it('TINY-10904: acronyms should be managed correctly', () => {
     check([
+      WordScope('U.S.A.', none, none),
+    ], 'U.S.A.');
+
+    check([
+      WordScope('U.S.A', none, none),
+    ], 'U.S.A');
+
+    check([
       WordScope('abc', none, some(' ')),
       WordScope('U.S.A.', some(' '), some('.')),
       WordScope('E.U.', some(' '), some(' ')),

--- a/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
+++ b/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
@@ -129,10 +129,13 @@ describe('atomic.robin.words.IdentifyTest', () => {
       WordScope('abc', none, some(' ')),
       WordScope('U.S.A.', some(' '), some('.')),
       WordScope('E.U.', some(' '), some(' ')),
-      WordScope('u.s.a', some(' '), some('.')),
+      WordScope('u.s.a.', some(' '), some('.')),
       WordScope('something', some(' '), some(' ')),
       WordScope('H.', some(' '), some(' ')),
-      WordScope('else', some(' '), none)
-    ], 'abc U.S.A.. E.U. u.s.a.. something H. else');
+      WordScope('else', some(' '), some(' ')),
+      WordScope('U.S', some(' '), some(' ')),
+      WordScope('abc', some(' '), some(' ')),
+      WordScope('E.U', some(' '), none)
+    ], 'abc U.S.A.. E.U. u.s.a.. something H. else U.S abc E.U');
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
@@ -3,7 +3,7 @@ import { TestHelpers } from '@ephox/alloy';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { SelectorFind, SugarDocument } from '@ephox/sugar';
+import { Focus, SelectorFind, SugarDocument } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import { Dialog } from 'tinymce/core/api/ui/Ui';

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
@@ -3,7 +3,7 @@ import { TestHelpers } from '@ephox/alloy';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { Focus, SelectorFind, SugarDocument } from '@ephox/sugar';
+import { SelectorFind, SugarDocument } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import { Dialog } from 'tinymce/core/api/ui/Ui';


### PR DESCRIPTION
Related Ticket: TINY-10904

Description of Changes:
to manage correctly the acronyms when we get the words via polaris, I changed the check inside `findWordsWithIndices` instead of inside `isWordBoundary`.

This is because `isWordBoundary` is based on single "characters" so to avoid performance and readability issues I create an external check that is triggered only at the end of a word and on dots at the end of the word or after it.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
