### PR TITLE
TINY-10807: Use role="combobox" for flat ListBox components

### DIFF
--- a/.changes/unreleased/alloy-TINY-10806-2024-04-19.yaml
+++ b/.changes/unreleased/alloy-TINY-10806-2024-04-19.yaml
@@ -1,6 +1,6 @@
 project: alloy
 kind: Added
-body: Added a new boolean `menuRole` property to `MenuSpec`, which affects the rendering
+body: Added a new boolean `showMenuRole` property to `MenuSpec`, which affects the rendering
   of the `role` attribute on the menu component.
 time: 2024-04-19T14:34:23.744021+03:00
 custom:

--- a/.changes/unreleased/tinymce-TINY-10807-2024-05-23.yaml
+++ b/.changes/unreleased/tinymce-TINY-10807-2024-05-23.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Corrected the `role` attribute on listbox dialog components to `combobox` when
+  there are no nested menu items.
+time: 2024-05-23T12:52:53.428286+03:00
+custom:
+  Issue: TINY-10807

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/Dropdown.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/Dropdown.ts
@@ -181,7 +181,7 @@ const factory: CompositeSketchFactory<DropdownDetail, DropdownSpec> = (detail, c
 
     domModification: {
       attributes: {
-        'aria-haspopup': 'true',
+        'aria-haspopup': detail.listRole.getOr('true'),
         ...detail.role.fold(() => ({}), (role) => ({ role })),
         ...detail.dom.tag === 'button' ? { type: lookupAttr('type').getOr('button') } : {}
       }

--- a/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
@@ -67,50 +67,58 @@ const openF = (
   const getLazySink = getSink(component, detail);
 
   // TODO: Make this potentially a single menu also
-  return futureData.map((tdata) => tdata.bind((data) => Optional.from(TieredMenu.sketch({
+  return futureData.map((tdata) => tdata.bind((data) => {
+    const primaryMenu = data.menus[data.primary];
+    Optional.from(primaryMenu).each((menu) => {
+      detail.listRole.each((listRole) => {
+        menu.role = listRole;
+      });
+    });
+    return Optional.from(TieredMenu.sketch({
     // Externals are configured by the "menu" part. It's called external because it isn't contained
     // within the DOM descendants of the dropdown. You can configure things like `fakeFocus` here.
-    ...externals.menu(),
+      ...externals.menu(),
 
-    uid: Tagger.generate(''),
-    data,
+      uid: Tagger.generate(''),
+      data,
 
-    highlightOnOpen,
+      highlightOnOpen,
 
-    onOpenMenu: (tmenu, menu) => {
-      const sink = getLazySink().getOrDie();
-      Positioning.position(sink, menu, { anchor });
-      Sandboxing.decloak(sandbox);
-    },
+      onOpenMenu: (tmenu, menu) => {
+        const sink = getLazySink().getOrDie();
+        Positioning.position(sink, menu, { anchor });
+        Sandboxing.decloak(sandbox);
+      },
 
-    onOpenSubmenu: (tmenu, item, submenu) => {
-      const sink = getLazySink().getOrDie();
-      Positioning.position(sink, submenu, {
-        anchor: {
-          type: 'submenu',
-          item
-        }
-      });
-      Sandboxing.decloak(sandbox);
-    },
-
-    onRepositionMenu: (tmenu, primaryMenu, submenuTriggers) => {
-      const sink = getLazySink().getOrDie();
-      Positioning.position(sink, primaryMenu, { anchor });
-      Arr.each(submenuTriggers, (st) => {
-        Positioning.position(sink, st.triggeredMenu, {
-          anchor: { type: 'submenu', item: st.triggeringItem }
+      onOpenSubmenu: (tmenu, item, submenu) => {
+        const sink = getLazySink().getOrDie();
+        Positioning.position(sink, submenu, {
+          anchor: {
+            type: 'submenu',
+            item
+          }
         });
-      });
-    },
+        Sandboxing.decloak(sandbox);
+      },
 
-    onEscape: () => {
+      onRepositionMenu: (tmenu, primaryMenu, submenuTriggers) => {
+        const sink = getLazySink().getOrDie();
+        Positioning.position(sink, primaryMenu, { anchor });
+        Arr.each(submenuTriggers, (st) => {
+          Positioning.position(sink, st.triggeredMenu, {
+            anchor: { type: 'submenu', item: st.triggeringItem }
+          });
+        });
+      },
+
+      onEscape: () => {
       // Focus the triggering component after escaping the menu
-      Focusing.focus(component);
-      Sandboxing.close(sandbox);
-      return Optional.some(true);
-    }
-  }))));
+        Focusing.focus(component);
+        Sandboxing.close(sandbox);
+        return Optional.some(true);
+      }
+    }));
+  }));
 };
 
 // onOpenSync is because some operations need to be applied immediately, not wrapped in a future
@@ -245,7 +253,6 @@ const makeSandbox = (
       // TODO: Add aria-selected attribute
       attributes: {
         id: ariaControls.id,
-        role: 'listbox'
       }
     },
     behaviours: SketchBehaviours.augment(

--- a/modules/alloy/src/main/ts/ephox/alloy/menu/build/ItemType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/menu/build/ItemType.ts
@@ -1,5 +1,5 @@
 import { FieldProcessor, FieldSchema } from '@ephox/boulder';
-import { Obj, Type } from '@ephox/katamari';
+import { Fun, Obj, Type } from '@ephox/katamari';
 
 import * as AddEventsBehaviour from '../../api/behaviour/AddEventsBehaviour';
 import { Focusing } from '../../api/behaviour/Focusing';
@@ -19,10 +19,13 @@ import * as ItemEvents from '../util/ItemEvents';
 
 type ItemRole = 'menuitem' | 'menuitemcheckbox' | 'menuitemradio';
 
-const getItemRole = (detail: NormalItemDetail): ItemRole =>
-  detail.toggling
-    .map((toggling) => toggling.exclusive ? 'menuitemradio' : 'menuitemcheckbox')
-    .getOr('menuitem');
+const getItemRole = (detail: NormalItemDetail): ItemRole | string =>
+  detail.role.fold(
+    () => detail.toggling
+      .map((toggling) => toggling.exclusive ? 'menuitemradio' : 'menuitemcheckbox')
+      .getOr('menuitem'),
+    Fun.identity
+  );
 
 const getTogglingSpec = (tConfig: Partial<ItemTogglingConfigSpec>): TogglingConfigSpec => ({
   aria: {
@@ -98,6 +101,7 @@ const schema: FieldProcessor[] = [
   FieldSchema.defaulted('hasSubmenu', false),
 
   FieldSchema.option('toggling'),
+  FieldSchema.option('role'),
 
   // Maybe this needs to have fewer behaviours
   SketchBehaviours.field('itemBehaviours', [ Toggling, Focusing, Keying, Representing ]),

--- a/modules/alloy/src/main/ts/ephox/alloy/menu/build/ItemType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/menu/build/ItemType.ts
@@ -27,9 +27,9 @@ const getItemRole = (detail: NormalItemDetail): ItemRole | string =>
     Fun.identity
   );
 
-const getTogglingSpec = (tConfig: Partial<ItemTogglingConfigSpec>): TogglingConfigSpec => ({
+const getTogglingSpec = (tConfig: Partial<ItemTogglingConfigSpec>, isOption: boolean): TogglingConfigSpec => ({
   aria: {
-    mode: 'checked'
+    mode: isOption ? 'selected' : 'checked'
   },
   // Filter out the additional properties that are not in Toggling Behaviour's configuration (e.g. exclusive)
   ...Obj.filter(tConfig, (_value, name) => name !== 'exclusive'),
@@ -58,7 +58,7 @@ const builder = (detail: NormalItemDetail): AlloySpec => ({
     detail.itemBehaviours,
     [
       // Investigate, is the Toggling.revoke still necessary here?
-      detail.toggling.fold(Toggling.revoke, (tConfig) => Toggling.config(getTogglingSpec(tConfig))),
+      detail.toggling.fold(Toggling.revoke, (tConfig) => Toggling.config(getTogglingSpec(tConfig, detail.role.exists((role) => role === 'option')))),
       Focusing.config({
         ignore: detail.ignoreFocus,
         // Rationale: because nothing is focusable, when you click

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/DropdownSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/DropdownSchema.ts
@@ -27,7 +27,8 @@ const schema = Fun.constant([
   FieldSchema.option('lazySink'),
   FieldSchema.defaulted('matchWidth', false),
   FieldSchema.defaulted('useMinWidth', false),
-  FieldSchema.option('role')
+  FieldSchema.option('role'),
+  FieldSchema.option('listRole'),
 ].concat(
   SketcherFields.sandboxFields()
 ));

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/MenuSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/MenuSchema.ts
@@ -86,6 +86,7 @@ const parts: () => PartType.PartTypeAdt[] = Fun.constant([
 ]);
 
 const schema = Fun.constant([
+  FieldSchema.optionString('role'),
   FieldSchema.required('value'),
   FieldSchema.required('items'),
   FieldSchema.required('dom'),
@@ -125,7 +126,7 @@ const schema = Fun.constant([
   FieldSchema.defaulted('focusManager', FocusManagers.dom()),
   Fields.onHandler('onHighlight'),
   Fields.onHandler('onDehighlight'),
-  FieldSchema.defaulted('menuRole', true),
+  FieldSchema.defaulted('showMenuRole', true),
 ]);
 
 const name = Fun.constant('menu');

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/SplitDropdownSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/SplitDropdownSchema.ts
@@ -34,7 +34,8 @@ const schema = Fun.constant([
   FieldSchema.defaulted('matchWidth', false),
   FieldSchema.defaulted('useMinWidth', false),
   FieldSchema.defaulted('eventOrder', {}),
-  FieldSchema.option('role')
+  FieldSchema.option('role'),
+  FieldSchema.option('listRole')
 ].concat(
   SketcherFields.sandboxFields()
 ));

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/TypeaheadSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/TypeaheadSchema.ts
@@ -51,6 +51,7 @@ const schema = Fun.constant([
   FieldSchema.defaulted('dismissOnBlur', true),
   Fields.markers([ 'openClass' ]),
   FieldSchema.option('initialData'),
+  FieldSchema.option('listRole'),
 
   SketchBehaviours.field('typeaheadBehaviours', [
     Focusing, Representing, Streaming, Keying, Toggling, Coupling

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/single/MenuSpec.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/single/MenuSpec.ts
@@ -88,10 +88,10 @@ const make: CompositeSketchFactory<MenuDetail, MenuSpec> = (detail, components, 
   components,
   eventOrder: detail.eventOrder,
 
-  ...detail.menuRole ? {
+  ...detail.showMenuRole ? {
     domModification: {
       attributes: {
-        role: 'menu'
+        role: detail.role.getOr('menu')
       }
     }
   } : {}

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/DropdownTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/DropdownTypes.ts
@@ -16,6 +16,7 @@ export interface CommonDropdownDetail<F> extends CompositeSketchDetail, HasLayou
   components: AlloySpec[ ];
 
   role: Optional<string>;
+  listRole: Optional<string>;
   eventOrder: Record<string, string[]>;
   fetch: (comp: AlloyComponent) => Future<Optional<F>>;
   onOpen: (anchor: AnchorSpec, comp: AlloyComponent, menu: AlloyComponent) => void;

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/ItemTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/ItemTypes.ts
@@ -79,6 +79,7 @@ export interface NormalItemDetail extends ItemDetail {
   eventOrder: Record<string, string[]>;
   builder: <NormalItemInfo>(buildInfo: NormalItemInfo) => AlloySpec;
   hasSubmenu: boolean;
+  role: Optional<string>;
 }
 
 export interface ItemDetail {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/MenuTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/MenuTypes.ts
@@ -76,7 +76,8 @@ export interface MenuDetail extends CompositeSketchDetail {
 
   focusManager: FocusManager;
   eventOrder: Record<string, string[]>;
-  menuRole: boolean;
+  showMenuRole: boolean;
+  role: Optional<string>;
 }
 
 export interface MenuSpec extends CompositeSketchSpec {
@@ -100,7 +101,8 @@ export interface MenuSpec extends CompositeSketchSpec {
   onHighlight?: (comp: AlloyComponent, target: AlloyComponent) => void;
   onDehighlight?: (comp: AlloyComponent, target: AlloyComponent) => void;
   eventOrder?: Record<string, string[]>;
-  menuRole?: boolean;
+  showMenuRole?: boolean;
+  role?: string;
 }
 
 export interface MenuSketcher extends CompositeSketch<MenuSpec> { }

--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/CommonMenuItem.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/CommonMenuItem.ts
@@ -20,6 +20,7 @@ export interface CommonMenuItem {
   enabled: boolean;
   text: Optional<string>;
   value: string;
+  role: Optional<string>;
   meta: Record<string, any>;
   shortcut: Optional<string>;
 }
@@ -27,6 +28,7 @@ export interface CommonMenuItem {
 export const commonMenuItemFields: FieldProcessor[] = [
   ComponentSchema.enabled,
   ComponentSchema.optionalText,
+  ComponentSchema.optionalRole,
   ComponentSchema.optionalShortcut,
   ComponentSchema.generatedValue('menuitem'),
   ComponentSchema.defaultedMeta

--- a/modules/bridge/src/main/ts/ephox/bridge/core/ComponentSchema.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/core/ComponentSchema.ts
@@ -16,6 +16,7 @@ export const onSetup = FieldSchema.defaultedFunction('onSetup', () => Fun.noop);
 
 export const optionalName = FieldSchema.optionString('name');
 export const optionalText = FieldSchema.optionString('text');
+export const optionalRole = FieldSchema.optionString('role');
 export const optionalIcon = FieldSchema.optionString('icon');
 export const optionalTooltip = FieldSchema.optionString('tooltip');
 export const optionalLabel = FieldSchema.optionString('label');

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
@@ -248,7 +248,7 @@ const openPropsDialog = async (editor: Editor, dialogCommand: `mceTable${'' | 'C
 
 const selectListBoxValue = async (editor: Editor, section: string, title: string): Promise<void> => {
   TinyUiActions.clickOnUi(editor, `button[aria-label="${section}"].tox-listbox--select`);
-  await TinyUiActions.pWaitForUi(editor, 'div[role="menu"].tox-menu.tox-collection--list');
+  await TinyUiActions.pWaitForUi(editor, 'div[role="listbox"].tox-menu.tox-collection--list');
   TinyUiActions.clickOnUi(editor, `div[aria-label="${title}"].tox-collection__item`);
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ListBox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ListBox.ts
@@ -75,16 +75,17 @@ export const renderListBox = (spec: ListBoxSpec, backstage: UiFactoryBackstage, 
         ariaLabel: spec.label,
         fetch: (comp, callback) => {
           const items = fetchItems(comp, spec.name, spec.items, Representing.getValue(comp), hasNestedItems);
-          const built = NestedMenus.build(
-            items,
-            ItemResponse.CLOSE_ON_EXECUTE,
-            backstage,
-            {
-              isHorizontalMenu: false,
-              search: Optional.none()
-            }
+          callback(
+            NestedMenus.build(
+              items,
+              ItemResponse.CLOSE_ON_EXECUTE,
+              backstage,
+              {
+                isHorizontalMenu: false,
+                search: Optional.none()
+              }
+            )
           );
-          callback(built);
         },
         onSetup: Fun.constant(Fun.noop),
         getApi: Fun.constant({ }),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ListBox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ListBox.ts
@@ -20,17 +20,18 @@ const isSingleListItem = (item: Dialog.ListBoxItemSpec): item is Dialog.ListBoxS
 
 const dataAttribute = 'data-value';
 
-const fetchItems = (dropdownComp: AlloyComponent, name: string, items: Dialog.ListBoxItemSpec[], selectedValue: string): Array<BridgeMenu.ToggleMenuItemSpec | BridgeMenu.NestedMenuItemSpec> =>
+const fetchItems = (dropdownComp: AlloyComponent, name: string, items: Dialog.ListBoxItemSpec[], selectedValue: string, hasNestedItems: boolean): Array<BridgeMenu.ToggleMenuItemSpec | BridgeMenu.NestedMenuItemSpec> =>
   Arr.map(items, (item) => {
     if (!isSingleListItem(item)) {
       return {
         type: 'nestedmenuitem',
         text: item.text,
-        getSubmenuItems: () => fetchItems(dropdownComp, name, item.items, selectedValue)
+        getSubmenuItems: () => fetchItems(dropdownComp, name, item.items, selectedValue, hasNestedItems)
       };
     } else {
       return {
         type: 'togglemenuitem',
+        ...(hasNestedItems ? {} : { role: 'option' }),
         text: item.text,
         value: item.value,
         active: item.value === selectedValue,
@@ -53,6 +54,7 @@ const findItemByValue = (items: Dialog.ListBoxItemSpec[], value: string): Option
   });
 
 export const renderListBox = (spec: ListBoxSpec, backstage: UiFactoryBackstage, initialData: Optional<string>): SketchSpec => {
+  const hasNestedItems = Arr.exists(spec.items, (item) => !isSingleListItem(item));
   const providersBackstage = backstage.shared.providers;
   const initialItem = initialData
     .bind((value) => findItemByValue(spec.items, value))
@@ -68,21 +70,21 @@ export const renderListBox = (spec: ListBoxSpec, backstage: UiFactoryBackstage, 
         text: initialItem.map((item) => item.text),
         icon: Optional.none(),
         tooltip: Optional.none(),
-        role: Optional.none(),
+        role: Optionals.someIf(!hasNestedItems, 'combobox'),
+        ...(hasNestedItems ? {} : { listRole: 'listbox' }),
         ariaLabel: spec.label,
         fetch: (comp, callback) => {
-          const items = fetchItems(comp, spec.name, spec.items, Representing.getValue(comp));
-          callback(
-            NestedMenus.build(
-              items,
-              ItemResponse.CLOSE_ON_EXECUTE,
-              backstage,
-              {
-                isHorizontalMenu: false,
-                search: Optional.none()
-              }
-            )
+          const items = fetchItems(comp, spec.name, spec.items, Representing.getValue(comp), hasNestedItems);
+          const built = NestedMenus.build(
+            items,
+            ItemResponse.CLOSE_ON_EXECUTE,
+            backstage,
+            {
+              isHorizontalMenu: false,
+              search: Optional.none()
+            }
           );
+          callback(built);
         },
         onSetup: Fun.constant(Fun.noop),
         getApi: Fun.constant({ }),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
@@ -38,6 +38,7 @@ export interface CommonDropdownSpec<T> {
   readonly disabled?: boolean;
   readonly tooltip: Optional<string>;
   readonly role: Optional<string>;
+  readonly listRole?: string;
   readonly fetch: (comp: AlloyComponent, callback: (tdata: Optional<TieredData>) => void) => void;
   readonly onSetup: (itemApi: T) => OnDestroy<T>;
   readonly getApi: (comp: AlloyComponent) => T;
@@ -105,6 +106,7 @@ const renderCommonDropdown = <T>(
   };
 
   const role = spec.role.fold(() => ({}), (role) => ({ role }));
+  const listRole = Optional.from(spec.listRole).map((listRole) => ({ listRole })).getOr({});
 
   const ariaLabelAttribute = spec.ariaLabel.fold(
     () => ({}),
@@ -129,6 +131,7 @@ const renderCommonDropdown = <T>(
     AlloyDropdown.sketch({
       ...spec.uid ? { uid: spec.uid } : {},
       ...role,
+      ...listRole,
       dom: {
         tag: 'button',
         classes: [ prefix, `${prefix}--select` ].concat(Arr.map(spec.classes, (c) => `${prefix}--${c}`)),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
@@ -245,16 +245,19 @@ const renderCommonDropdown = <T>(
           // When the menu is "searchable", use fakeFocus so that keyboard
           // focus stays in the search field
           fakeFocus: spec.searchable,
-          onHighlightItem: updateAriaOnHighlight,
-          onCollapseMenu: (tmenuComp, itemCompCausingCollapse, nowActiveMenuComp) => {
-            // We want to update ARIA on collapsing as well, because it isn't changing
-            // the highlights. So what we need to do is get the right parameters to
-            // pass to updateAriaOnHighlight
-            Highlighting.getHighlighted(nowActiveMenuComp).each((itemComp) => {
-              updateAriaOnHighlight(tmenuComp, nowActiveMenuComp, itemComp);
-            });
-          },
-          onDehighlightItem: updateAriaOnDehighlight
+          // We don't want to update the  `aria-selected` on highlight or dehighlight for the `listbox` role because that is used to indicate the selected item
+          ...(spec.listRole === 'listbox' ? {} : {
+            onHighlightItem: updateAriaOnHighlight,
+            onCollapseMenu: (tmenuComp, itemCompCausingCollapse, nowActiveMenuComp) => {
+              // We want to update ARIA on collapsing as well, because it isn't changing
+              // the highlights. So what we need to do is get the right parameters to
+              // pass to updateAriaOnHighlight
+              Highlighting.getHighlighted(nowActiveMenuComp).each((itemComp) => {
+                updateAriaOnHighlight(tmenuComp, nowActiveMenuComp, itemComp);
+              });
+            },
+            onDehighlightItem: updateAriaOnDehighlight
+          })
         }
       },
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
@@ -33,7 +33,7 @@ export const renderColorSwatchItem = (spec: Menu.ColorSwatchMenuItem, backstage:
     markers: MenuParts.markers(presets),
     movement: deriveMenuMovement(columns, presets),
     // TINY-10806: Avoid duplication of ARIA role="menu" in the accessibility tree for Color Swatch menu item.
-    menuRole: false
+    showMenuRole: false
   };
 
   return {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ToggleMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ToggleMenuItem.ts
@@ -54,7 +54,8 @@ const renderToggleMenuItem = (
         toggleClass: ItemClasses.tickedClass,
         toggleOnExecute: false,
         selected: spec.active
-      }
+      },
+      role: spec.role.getOrUndefined()
     }
   );
 };

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/listbox/ListBoxAriaTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/listbox/ListBoxAriaTest.ts
@@ -1,0 +1,93 @@
+import { ApproxStructure, Assertions, Mouse, UiFinder } from '@ephox/agar';
+import { GuiFactory, Representing, TestHelpers } from '@ephox/alloy';
+import { describe, it } from '@ephox/bedrock-client';
+import { Optional } from '@ephox/katamari';
+
+import { renderListBox } from 'tinymce/themes/silver/ui/dialog/ListBox';
+
+import * as TestExtras from '../../../module/TestExtras';
+
+describe('headless.tinymce.themes.silver.components.listbox.ListBoxAriaTest', () => {
+  const extrasHook = TestExtras.bddSetup();
+
+  const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(
+    renderListBox({
+      name: 'selector',
+      label: Optional.some('selector'),
+      enabled: true,
+      items: [
+        { value: 'one', text: 'One' },
+        { value: 'two', text: 'Two' },
+        { value: 'three', text: 'Three' },
+      ]
+    }, extrasHook.access().extras.backstages.popup, Optional.none())
+  ));
+
+  it('Check basic structure', () => {
+    Assertions.assertStructure(
+      'Checking initial structure',
+      ApproxStructure.build((s, str, arr) => s.element('div', {
+        children: [
+          s.element('label', {
+            classes: [ arr.has('tox-label') ]
+          }),
+          s.element('div', {
+            children: [
+              s.element('button', {
+                attrs: {
+                  role: str.is('combobox'),
+                },
+              })
+            ]
+          })
+        ]
+      })),
+      hook.component().element
+    );
+  });
+
+  it('Open menu and check children structure', async () => {
+    const component = hook.component();
+    const gui = hook.gui();
+    const sink = extrasHook.access().getPopupSink();
+    Representing.setValue(component, 'three');
+
+    Mouse.clickOn(gui.element, '.tox-listbox');
+    await UiFinder.pWaitFor('Waiting for menu to appear', sink, '.tox-menu .tox-collection__item');
+
+    const menu = UiFinder.findIn(sink, '.tox-menu').getOrDie();
+    Assertions.assertStructure(
+      'Checking for aria attributes on menu and items',
+      ApproxStructure.build((s, str) => s.element('div', {
+        attrs: {
+          role: str.is('listbox'),
+        },
+        children: [
+          s.element('div', {
+            children: [
+              s.element('div', {
+                attrs: {
+                  'aria-checked': str.is('false'),
+                  'role': str.is('option'),
+                },
+              }),
+              s.element('div', {
+                attrs: {
+                  'aria-checked': str.is('false'),
+                  'role': str.is('option'),
+                },
+              }),
+              s.element('div', {
+                attrs: {
+                  'aria-checked': str.is('true'),
+                  'role': str.is('option'),
+                },
+              }),
+            ]
+          })
+        ]
+      })),
+      menu
+    );
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/listbox/ListBoxAriaTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/listbox/ListBoxAriaTest.ts
@@ -35,7 +35,8 @@ describe('headless.tinymce.themes.silver.components.listbox.ListBoxAriaTest', ()
             children: [
               s.element('button', {
                 attrs: {
-                  role: str.is('combobox'),
+                  'role': str.is('combobox'),
+                  'aria-haspopup': str.is('listbox'),
                 },
               })
             ]
@@ -67,19 +68,19 @@ describe('headless.tinymce.themes.silver.components.listbox.ListBoxAriaTest', ()
             children: [
               s.element('div', {
                 attrs: {
-                  'aria-checked': str.is('false'),
+                  'aria-selected': str.is('false'),
                   'role': str.is('option'),
                 },
               }),
               s.element('div', {
                 attrs: {
-                  'aria-checked': str.is('false'),
+                  'aria-selected': str.is('false'),
                   'role': str.is('option'),
                 },
               }),
               s.element('div', {
                 attrs: {
-                  'aria-checked': str.is('true'),
+                  'aria-selected': str.is('true'),
                   'role': str.is('option'),
                 },
               }),


### PR DESCRIPTION
Related Ticket: TINY-10807

Description of Changes:
* Added `role` and `listRole` fields in schemas where needed to pass necessary role values for ListBox components. So for a ListBox without nested menu items, the menu button should have `role="combobox"`, the list of items should have `listRole="listbox" `(instead of `"menu"`) and items should have `role="option"` (instead of `"menuitem"`)
* rename the `menuRole` field to `showMenuRole` since it is confusing to have `menuRole` and `role` fields

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
