### PR TITLE
TINY-10974: fix tests for new Firefox version (126)

### DIFF
--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
@@ -13,6 +13,7 @@ import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 import * as TestExtras from '../../module/TestExtras';
 
 describe('webdriver.tinymce.themes.silver.dialogs.IFrameDialogTest', () => {
+  // TINY-10974: this can be removed with all relatives if in this file when all the CI Firefoxs are updated to version 126
   const isFirefoxBelove126 = PlatformDetection.detect().browser.isFirefox() && PlatformDetection.detect().browser.version.major < 126;
   const extrasHook = TestExtras.bddSetup();
   let windowManager: WindowManagerImpl;

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
@@ -13,7 +13,7 @@ import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 import * as TestExtras from '../../module/TestExtras';
 
 describe('webdriver.tinymce.themes.silver.dialogs.IFrameDialogTest', () => {
-  const isFirefox = PlatformDetection.detect().browser.isFirefox();
+  const isFirefoxBelove126 = PlatformDetection.detect().browser.isFirefox() && PlatformDetection.detect().browser.version.major < 126;
   const extrasHook = TestExtras.bddSetup();
   let windowManager: WindowManagerImpl;
   before(() => {
@@ -84,7 +84,7 @@ describe('webdriver.tinymce.themes.silver.dialogs.IFrameDialogTest', () => {
     await pWaitUntilIframeLoaded();
     const input = await FocusTools.pTryOnSelector('focus should be on the input initially', SugarDocument.getDocument(), 'input');
 
-    if (isFirefox) {
+    if (isFirefoxBelove126) {
       // Firefox doesn't allow escaping the iframe when using shift+tab if it's body hasn't been interacted with? Focusing alone didn't work
       // TODO: TINY-2308 - Investigate how to fix this, as it means tabbing can get stuck in the iframe on Firefox
       await RealMouse.pClickOn('iframe => body');
@@ -105,7 +105,7 @@ describe('webdriver.tinymce.themes.silver.dialogs.IFrameDialogTest', () => {
 
     // Firefox when shift+tabbing it will cause the iframe to be focused twice
     // so we need to do an extra shift+tab
-    if (isFirefox) {
+    if (isFirefoxBelove126) {
       await FocusTools.pTryOnSelector('focus should be on the iframe', SugarDocument.getDocument(), 'iframe');
       await pPressTab('iframe', true);
     }
@@ -127,7 +127,7 @@ describe('webdriver.tinymce.themes.silver.dialogs.IFrameDialogTest', () => {
 
     const input = await FocusTools.pTryOnSelector('focus should be on the input initially', SugarDocument.getDocument(), 'input');
 
-    if (isFirefox) {
+    if (isFirefoxBelove126) {
       // Firefox doesn't allow escaping the iframe when using shift+tab if it's body hasn't been interacted with? Focusing alone didn't work
       // TODO: TINY-2308 - Investigate how to fix this, as it means tabbing can get stuck in the iframe on Firefox
       await RealMouse.pClickOn('iframe => body');
@@ -148,7 +148,7 @@ describe('webdriver.tinymce.themes.silver.dialogs.IFrameDialogTest', () => {
     await pPressTab('iframe => body', true);
     // Firefox when shift+tabbing it will cause the iframe to be focused twice
     // so we need to do an extra shift+tab
-    if (isFirefox) {
+    if (isFirefoxBelove126) {
       await FocusTools.pTryOnSelector('focus should be on the iframe', SugarDocument.getDocument(), 'iframe');
       await assertContainerBorderFocus(true);
       await pPressTab('iframe', true);

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
@@ -14,7 +14,7 @@ import * as TestExtras from '../../module/TestExtras';
 
 describe('webdriver.tinymce.themes.silver.dialogs.IFrameDialogTest', () => {
   // TINY-10974: this can be removed with all relatives if in this file when all the CI Firefoxs are updated to version 126
-  const isFirefoxBelove126 = PlatformDetection.detect().browser.isFirefox() && PlatformDetection.detect().browser.version.major < 126;
+  const isFirefoxBelow126 = PlatformDetection.detect().browser.isFirefox() && PlatformDetection.detect().browser.version.major < 126;
   const extrasHook = TestExtras.bddSetup();
   let windowManager: WindowManagerImpl;
   before(() => {
@@ -85,7 +85,7 @@ describe('webdriver.tinymce.themes.silver.dialogs.IFrameDialogTest', () => {
     await pWaitUntilIframeLoaded();
     const input = await FocusTools.pTryOnSelector('focus should be on the input initially', SugarDocument.getDocument(), 'input');
 
-    if (isFirefoxBelove126) {
+    if (isFirefoxBelow126) {
       // Firefox doesn't allow escaping the iframe when using shift+tab if it's body hasn't been interacted with? Focusing alone didn't work
       // TODO: TINY-2308 - Investigate how to fix this, as it means tabbing can get stuck in the iframe on Firefox
       await RealMouse.pClickOn('iframe => body');
@@ -106,7 +106,7 @@ describe('webdriver.tinymce.themes.silver.dialogs.IFrameDialogTest', () => {
 
     // Firefox when shift+tabbing it will cause the iframe to be focused twice
     // so we need to do an extra shift+tab
-    if (isFirefoxBelove126) {
+    if (isFirefoxBelow126) {
       await FocusTools.pTryOnSelector('focus should be on the iframe', SugarDocument.getDocument(), 'iframe');
       await pPressTab('iframe', true);
     }
@@ -128,7 +128,7 @@ describe('webdriver.tinymce.themes.silver.dialogs.IFrameDialogTest', () => {
 
     const input = await FocusTools.pTryOnSelector('focus should be on the input initially', SugarDocument.getDocument(), 'input');
 
-    if (isFirefoxBelove126) {
+    if (isFirefoxBelow126) {
       // Firefox doesn't allow escaping the iframe when using shift+tab if it's body hasn't been interacted with? Focusing alone didn't work
       // TODO: TINY-2308 - Investigate how to fix this, as it means tabbing can get stuck in the iframe on Firefox
       await RealMouse.pClickOn('iframe => body');
@@ -149,7 +149,7 @@ describe('webdriver.tinymce.themes.silver.dialogs.IFrameDialogTest', () => {
     await pPressTab('iframe => body', true);
     // Firefox when shift+tabbing it will cause the iframe to be focused twice
     // so we need to do an extra shift+tab
-    if (isFirefoxBelove126) {
+    if (isFirefoxBelow126) {
       await FocusTools.pTryOnSelector('focus should be on the iframe', SugarDocument.getDocument(), 'iframe');
       await assertContainerBorderFocus(true);
       await pPressTab('iframe', true);


### PR DESCRIPTION
Related Ticket: TINY-10974

Description of Changes:
Version 126 of Firefox fix [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1884870) so some special behaviors for Firefox in `IFrameDialogTest.ts` are no more needed if the version of Firefox is 126 or superior

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] ~Milestone set~
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
