### PR TITLE
TINY-10971: add for attribute for label and id attribute for inputs

### DIFF
--- a/.changes/unreleased/bridge-TINY-10971-2024-05-24.yaml
+++ b/.changes/unreleased/bridge-TINY-10971-2024-05-24.yaml
@@ -1,0 +1,7 @@
+project: bridge
+kind: Added
+body: Added for and id attributes to component schema. Label component has an optional
+  for parameter. Input has an optional id parameter.
+time: 2024-05-24T12:05:29.521753+02:00
+custom:
+  Issue: TINY-10971

--- a/.changes/unreleased/bridge-TINY-10971-2024-05-24.yaml
+++ b/.changes/unreleased/bridge-TINY-10971-2024-05-24.yaml
@@ -1,7 +1,7 @@
 project: bridge
 kind: Added
 body: Added for and id attributes to component schema. Label component has an optional
-  for parameter. Input, Colorinput, Checkbox, SelectBox and Textarea have an optional id parameter.
+  for parameter. Input, Colorinput, SelectBox and Textarea have an optional id parameter.
 time: 2024-05-24T12:05:29.521753+02:00
 custom:
   Issue: TINY-10971

--- a/.changes/unreleased/bridge-TINY-10971-2024-05-24.yaml
+++ b/.changes/unreleased/bridge-TINY-10971-2024-05-24.yaml
@@ -1,7 +1,7 @@
 project: bridge
 kind: Added
 body: Added for and id attributes to component schema. Label component has an optional
-  for parameter. Input has an optional id parameter.
+  for parameter. Input, Colorinput, Checkbox, SelectBox and Textarea have an optional id parameter.
 time: 2024-05-24T12:05:29.521753+02:00
 custom:
   Issue: TINY-10971

--- a/.changes/unreleased/tinymce-TINY-10971-2024-05-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-10971-2024-05-24.yaml
@@ -1,5 +1,5 @@
 project: tinymce
 kind: Added
-body: Added support for setting custom `for` attributes on label dialog components and an custom `id` attributes on the Input, Colorinput, Checkbox, SelectBox and Textarea components.
+body: Added support for setting custom `for` attributes on label dialog components and an custom `id` attributes on the Input, Colorinput, SelectBox and Textarea components.
 custom:
   Issue: TINY-10971

--- a/.changes/unreleased/tinymce-TINY-10971-2024-05-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-10971-2024-05-24.yaml
@@ -1,6 +1,5 @@
 project: tinymce
 kind: Added
-body: Added a possibility to define for and id attributes. Label component has an optional
-  for spec parameter. Input, Colorinput, Checkbox, SelectBox and Textarea have an optional id spec parameter.
+body: Added support for setting custom `for` attributes on label dialog components and an custom `id` attributes on the Input, Colorinput, Checkbox, SelectBox and Textarea components.
 custom:
   Issue: TINY-10971

--- a/.changes/unreleased/tinymce-TINY-10971-2024-05-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-10971-2024-05-24.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Added
-body: Added a possibility to define for attribute for label and id attribute for input.
-time: 2024-05-24T12:06:21.264227+02:00
+body: Added a possibility to define for and id attributes. Label component has an optional
+  for spec parameter. Input, Colorinput, Checkbox, SelectBox and Textarea have an optional id spec parameter.
 custom:
   Issue: TINY-10971

--- a/.changes/unreleased/tinymce-TINY-10971-2024-05-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-10971-2024-05-24.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: Added a possibility to define for attribute for label and id attribute for input.
+time: 2024-05-24T12:06:21.264227+02:00
+custom:
+  Issue: TINY-10971

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Checkbox.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Checkbox.ts
@@ -1,5 +1,5 @@
-import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
-import { Optional, Result } from '@ephox/katamari';
+import { StructureSchema, ValueType } from '@ephox/boulder';
+import { Result } from '@ephox/katamari';
 
 import * as ComponentSchema from '../../core/ComponentSchema';
 import { FormComponent, formComponentFields, FormComponentSpec } from './FormComponent';
@@ -8,20 +8,17 @@ export interface CheckboxSpec extends FormComponentSpec {
   type: 'checkbox';
   label: string;
   enabled?: boolean;
-  id?: string;
 }
 
 export interface Checkbox extends FormComponent {
   type: 'checkbox';
   label: string;
   enabled: boolean;
-  id: Optional<string>;
 }
 
 const checkboxFields = formComponentFields.concat([
   ComponentSchema.label,
-  ComponentSchema.enabled,
-  FieldSchema.optionString('id'),
+  ComponentSchema.enabled
 ]);
 
 export const checkboxSchema = StructureSchema.objOf(checkboxFields);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Checkbox.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Checkbox.ts
@@ -1,5 +1,5 @@
-import { StructureSchema, ValueType } from '@ephox/boulder';
-import { Result } from '@ephox/katamari';
+import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
+import { Optional, Result } from '@ephox/katamari';
 
 import * as ComponentSchema from '../../core/ComponentSchema';
 import { FormComponent, formComponentFields, FormComponentSpec } from './FormComponent';
@@ -8,17 +8,20 @@ export interface CheckboxSpec extends FormComponentSpec {
   type: 'checkbox';
   label: string;
   enabled?: boolean;
+  id?: string;
 }
 
 export interface Checkbox extends FormComponent {
   type: 'checkbox';
   label: string;
   enabled: boolean;
+  id: Optional<string>;
 }
 
 const checkboxFields = formComponentFields.concat([
   ComponentSchema.label,
-  ComponentSchema.enabled
+  ComponentSchema.enabled,
+  FieldSchema.optionString('id'),
 ]);
 
 export const checkboxSchema = StructureSchema.objOf(checkboxFields);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/ColorInput.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/ColorInput.ts
@@ -1,20 +1,23 @@
 import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
-import { Result } from '@ephox/katamari';
+import { Optional, Result } from '@ephox/katamari';
 
 import { FormComponentWithLabel, formComponentWithLabelFields, FormComponentWithLabelSpec } from './FormComponent';
 
 export interface ColorInputSpec extends FormComponentWithLabelSpec {
   type: 'colorinput';
   storageKey?: string;
+  id?: string;
 }
 
 export interface ColorInput extends FormComponentWithLabel {
   type: 'colorinput';
   storageKey: string;
+  id: Optional<string>;
 }
 
 const colorInputFields = formComponentWithLabelFields.concat([
-  FieldSchema.defaultedString('storageKey', 'default')
+  FieldSchema.defaultedString('storageKey', 'default'),
+  FieldSchema.optionString('id')
 ]);
 
 export const colorInputSchema = StructureSchema.objOf(colorInputFields);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Input.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Input.ts
@@ -10,6 +10,7 @@ export interface InputSpec extends FormComponentWithLabelSpec {
   placeholder?: string;
   maximized?: boolean;
   enabled?: boolean;
+  id?: string;
 }
 
 export interface Input extends FormComponentWithLabel {
@@ -18,11 +19,13 @@ export interface Input extends FormComponentWithLabel {
   placeholder: Optional<string>;
   maximized: boolean;
   enabled: boolean;
+  id: Optional<string>;
 }
 
 const inputFields = formComponentWithLabelFields.concat([
   FieldSchema.optionString('inputMode'),
   FieldSchema.optionString('placeholder'),
+  FieldSchema.optionString('id'),
   FieldSchema.defaultedBoolean('maximized', false),
   ComponentSchema.enabled
 ]);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
@@ -26,7 +26,6 @@ export const createLabelFields = (itemsField: FieldProcessor): FieldProcessor[] 
   ComponentSchema.type,
   ComponentSchema.label,
   ComponentSchema.optionalFor,
-  //items still required I guess??? it is called like that: createLabelFields(createItemsField('label'))
   itemsField,
   FieldSchema.defaultedStringEnum('align', 'start', [ 'start', 'center', 'end' ])
 ];

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
@@ -1,8 +1,8 @@
 import { FieldProcessor, FieldSchema } from '@ephox/boulder';
+import { Optional } from '@ephox/katamari';
 
 import * as ComponentSchema from '../../core/ComponentSchema';
 import { BodyComponent, BodyComponentSpec } from './BodyComponent';
-import { Optional } from '@ephox/katamari';
 
 type Alignment = 'start' | 'center' | 'end';
 

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
@@ -9,7 +9,7 @@ type Alignment = 'start' | 'center' | 'end';
 export interface LabelSpec {
   type: 'label';
   label: string;
-  items?: BodyComponentSpec[];
+  items: BodyComponentSpec[];
   align?: Alignment;
   for?: string;
 }

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
@@ -2,14 +2,16 @@ import { FieldProcessor, FieldSchema } from '@ephox/boulder';
 
 import * as ComponentSchema from '../../core/ComponentSchema';
 import { BodyComponent, BodyComponentSpec } from './BodyComponent';
+import { Optional } from '@ephox/katamari';
 
 type Alignment = 'start' | 'center' | 'end';
 
 export interface LabelSpec {
   type: 'label';
   label: string;
-  items: BodyComponentSpec[];
+  items?: BodyComponentSpec[];
   align?: Alignment;
+  for?: string;
 }
 
 export interface Label {
@@ -17,11 +19,14 @@ export interface Label {
   label: string;
   items: BodyComponent[];
   align: Alignment;
+  for: Optional<string>;
 }
 
 export const createLabelFields = (itemsField: FieldProcessor): FieldProcessor[] => [
   ComponentSchema.type,
   ComponentSchema.label,
+  ComponentSchema.optionalFor,
+  //items still required I guess??? it is called like that: createLabelFields(createItemsField('label'))
   itemsField,
   FieldSchema.defaultedStringEnum('align', 'start', [ 'start', 'center', 'end' ])
 ];

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/SelectBox.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/SelectBox.ts
@@ -1,5 +1,5 @@
 import { FieldProcessor, FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
-import { Result } from '@ephox/katamari';
+import { Optional, Result } from '@ephox/katamari';
 
 import * as ComponentSchema from '../../core/ComponentSchema';
 import { FormComponentWithLabel, formComponentWithLabelFields, FormComponentWithLabelSpec } from './FormComponent';
@@ -14,6 +14,7 @@ export interface SelectBoxSpec extends FormComponentWithLabelSpec {
   items: SelectBoxItemSpec[];
   size?: number;
   enabled?: boolean;
+  id?: string;
 }
 
 export interface SelectBoxItem {
@@ -26,6 +27,7 @@ export interface SelectBox extends FormComponentWithLabel {
   items: SelectBoxItem[];
   size: number;
   enabled: boolean;
+  id: Optional<string>;
 }
 
 const selectBoxFields: FieldProcessor[] = formComponentWithLabelFields.concat([
@@ -34,6 +36,7 @@ const selectBoxFields: FieldProcessor[] = formComponentWithLabelFields.concat([
     ComponentSchema.value
   ]),
   FieldSchema.defaultedNumber('size', 1),
+  FieldSchema.optionString('string'),
   ComponentSchema.enabled
 ]);
 

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/SelectBox.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/SelectBox.ts
@@ -36,7 +36,7 @@ const selectBoxFields: FieldProcessor[] = formComponentWithLabelFields.concat([
     ComponentSchema.value
   ]),
   FieldSchema.defaultedNumber('size', 1),
-  FieldSchema.optionString('string'),
+  FieldSchema.optionString('id'),
   ComponentSchema.enabled
 ]);
 

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Textarea.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Textarea.ts
@@ -9,6 +9,7 @@ export interface TextAreaSpec extends FormComponentWithLabelSpec {
   placeholder?: string;
   maximized?: boolean;
   enabled?: boolean;
+  id?: string;
 }
 
 export interface TextArea extends FormComponentWithLabel {
@@ -16,11 +17,13 @@ export interface TextArea extends FormComponentWithLabel {
   maximized: boolean;
   placeholder: Optional<string>;
   enabled: boolean;
+  id: Optional<string>;
 }
 
 const textAreaFields = formComponentWithLabelFields.concat([
   FieldSchema.optionString('placeholder'),
   FieldSchema.defaultedBoolean('maximized', false),
+  FieldSchema.optionString('id'),
   ComponentSchema.enabled
 ]);
 

--- a/modules/bridge/src/main/ts/ephox/bridge/core/ComponentSchema.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/core/ComponentSchema.ts
@@ -21,6 +21,8 @@ export const optionalTooltip = FieldSchema.optionString('tooltip');
 export const optionalLabel = FieldSchema.optionString('label');
 export const optionalShortcut = FieldSchema.optionString('shortcut');
 export const optionalSelect = FieldSchema.optionFunction('select');
+export const optionalFor = FieldSchema.optionString('for');
+export const optionalID = FieldSchema.optionString('id');
 
 export const active = FieldSchema.defaultedBoolean('active', false);
 export const borderless = FieldSchema.defaultedBoolean('borderless', false);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorInput.ts
@@ -39,9 +39,12 @@ export const renderColorInput = (
   colorInputBackstage: UiFactoryBackstageForColorInput,
   initialData: Optional<string>
 ): SimpleSpec => {
+  const idAttr = spec.id.fold(Fun.constant({}), (id) => ({ id }));
+
   const pField = FormField.parts.field({
     factory: Input,
     inputClasses: [ 'tox-textfield' ],
+    inputAttributes: { ...idAttr },
     data: initialData,
 
     onSetValue: (c: AlloyComponent) => Invalidating.run(c).get(Fun.noop),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Label.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Label.ts
@@ -1,6 +1,6 @@
 import { AlloySpec, Behaviour, GuiFactory, Keying, Replacing, SimpleSpec } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Fun, Optional } from '@ephox/katamari';
 
 import { UiFactoryBackstageShared } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
@@ -13,10 +13,15 @@ export const renderLabel = (spec: LabelSpec, backstageShared: UiFactoryBackstage
   const centerClass = spec.align === 'center' ? [ `${baseClass}--center` ] : [];
   const endClass = spec.align === 'end' ? [ `${baseClass}--end` ] : [];
 
+  const forAttr = spec.for.fold(Fun.constant({}), (forAttr) => ({ for: forAttr }) );
+
   const label: AlloySpec = {
     dom: {
       tag: 'label',
-      classes: [ baseClass, ...centerClass, ...endClass ]
+      classes: [ baseClass, ...centerClass, ...endClass ],
+      attributes: {
+        ...forAttr,
+      },
     },
     components: [
       GuiFactory.text(backstageShared.providers.translate(spec.label))

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SelectBox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SelectBox.ts
@@ -3,7 +3,7 @@ import {
   NativeEvents, SimpleSpec, SketchSpec, Tabstopping
 } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Fun, Optional } from '@ephox/katamari';
 
 import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 import { renderLabel } from 'tinymce/themes/silver/ui/alien/FieldLabeller';
@@ -23,12 +23,15 @@ export const renderSelectBox = (spec: SelectBoxSpec, providersBackstage: UiFacto
   // DUPE with TextField.
   const pLabel = spec.label.map((label) => renderLabel(label, providersBackstage));
 
+  const idAttr = spec.id.fold(Fun.constant({}), (id) => ({ id }));
+
   const pField = AlloyFormField.parts.field({
     // TODO: Alloy should not allow dom changing of an HTML select!
     dom: { },
     ...initialData.map((data) => ({ data })).getOr({}),
     selectAttributes: {
-      size: spec.size
+      size: spec.size,
+      ...idAttr
     },
     options: translatedOptions,
     factory: AlloyHtmlSelect,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
@@ -28,6 +28,7 @@ export interface TextField {
   }>;
   readonly maximized: boolean;
   readonly data: Optional<string>;
+  readonly id: Optional<string>;
 }
 
 type InputSpec = Omit<Dialog.Input, 'type'>;
@@ -78,10 +79,12 @@ const renderTextField = (spec: TextField, providersBackstage: UiFactoryBackstage
 
   const placeholder = spec.placeholder.fold( Fun.constant({}), (p) => ({ placeholder: providersBackstage.translate(p) }));
   const inputMode = spec.inputMode.fold(Fun.constant({}), (mode) => ({ inputmode: mode }));
+  const id = spec.id.fold(Fun.constant({}), (id) => ({ id }));
 
   const inputAttributes = {
     ...placeholder,
-    ...inputMode
+    ...inputMode,
+    ...id
   };
 
   const pField = AlloyFormField.parts.field({
@@ -129,6 +132,7 @@ const renderTextField = (spec: TextField, providersBackstage: UiFactoryBackstage
 
 const renderInput = (spec: InputSpec, providersBackstage: UiFactoryBackstageProviders, initialData: Optional<string>): SketchSpec => renderTextField({
   name: spec.name,
+  id: spec.id,
   multiline: false,
   label: spec.label,
   inputMode: spec.inputMode,
@@ -143,6 +147,7 @@ const renderInput = (spec: InputSpec, providersBackstage: UiFactoryBackstageProv
 
 const renderTextarea = (spec: TextAreaSpec, providersBackstage: UiFactoryBackstageProviders, initialData: Optional<string>): SketchSpec => renderTextField({
   name: spec.name,
+  id: Optional.none(), //should text area also have an id? 
   multiline: true,
   label: spec.label,
   inputMode: Optional.none(), // type attribute is not valid for textareas

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
@@ -147,7 +147,7 @@ const renderInput = (spec: InputSpec, providersBackstage: UiFactoryBackstageProv
 
 const renderTextarea = (spec: TextAreaSpec, providersBackstage: UiFactoryBackstageProviders, initialData: Optional<string>): SketchSpec => renderTextField({
   name: spec.name,
-  id: Optional.none(), //should text area also have an id? 
+  id: Optional.none(), // I would consider adding id for textarea and other components (for now it is only added in the input component)
   multiline: true,
   label: spec.label,
   inputMode: Optional.none(), // type attribute is not valid for textareas

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
@@ -147,7 +147,7 @@ const renderInput = (spec: InputSpec, providersBackstage: UiFactoryBackstageProv
 
 const renderTextarea = (spec: TextAreaSpec, providersBackstage: UiFactoryBackstageProviders, initialData: Optional<string>): SketchSpec => renderTextField({
   name: spec.name,
-  id: Optional.none(), // I would consider adding id for textarea and other components (for now it is only added in the input component)
+  id: spec.id,
   multiline: true,
   label: spec.label,
   inputMode: Optional.none(), // type attribute is not valid for textareas

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
@@ -21,16 +21,13 @@ export const renderCheckbox = (spec: CheckboxSpec, providerBackstage: UiFactoryB
     return Optional.some(true);
   };
 
-  const idAttr = spec.id.fold(Fun.constant({}), (id) => ({ id }));
-
   const pField = AlloyFormField.parts.field({
     factory: { sketch: Fun.identity },
     dom: {
       tag: 'input',
       classes: [ 'tox-checkbox__input' ],
       attributes: {
-        type: 'checkbox',
-        ...idAttr
+        type: 'checkbox'
       }
     },
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
@@ -21,13 +21,16 @@ export const renderCheckbox = (spec: CheckboxSpec, providerBackstage: UiFactoryB
     return Optional.some(true);
   };
 
+  const idAttr = spec.id.fold(Fun.constant({}), (id) => ({ id }));
+
   const pField = AlloyFormField.parts.field({
     factory: { sketch: Fun.identity },
     dom: {
       tag: 'input',
       classes: [ 'tox-checkbox__input' ],
       attributes: {
-        type: 'checkbox'
+        type: 'checkbox',
+        ...idAttr
       }
     },
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageSinkTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageSinkTest.ts
@@ -73,7 +73,8 @@ describe('browser.tinymce.themes.silver.editor.backstage.BackstageSinkTest', () 
       type: 'colorinput',
       label: Optional.some('color'),
       storageKey: 'test_storage_key',
-      name: 'color'
+      name: 'color',
+      id: Optional.none()
     });
 
     const colorInputComp = GuiFactory.build(colorInputSpec);

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/BasicCheckboxTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/BasicCheckboxTest.ts
@@ -21,8 +21,7 @@ describe('headless.tinymce.themes.silver.components.checkbox.Checkbox component 
     renderCheckbox({
       label: 'TestCheckbox',
       name: 'test-check-box',
-      enabled: true,
-      id: Optional.none()
+      enabled: true
     }, providers, Optional.none())
   ));
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/BasicCheckboxTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/BasicCheckboxTest.ts
@@ -22,6 +22,7 @@ describe('headless.tinymce.themes.silver.components.checkbox.Checkbox component 
       label: 'TestCheckbox',
       name: 'test-check-box',
       enabled: true,
+      id: Optional.none()
     }, providers, Optional.none())
   ));
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/CheckboxFormChangeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/CheckboxFormChangeTest.ts
@@ -17,8 +17,7 @@ describe('headless.tinymce.themes.silver.components.checkbox.CheckboxFormChangeT
       renderCheckbox({
         label: 'TestCheckbox',
         name: 'test-check-box',
-        enabled: true,
-        id: Optional.none()
+        enabled: true
       }, TestProviders, Optional.none())
     ],
     behaviours: Behaviour.derive([

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/CheckboxFormChangeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/CheckboxFormChangeTest.ts
@@ -18,6 +18,7 @@ describe('headless.tinymce.themes.silver.components.checkbox.CheckboxFormChangeT
         label: 'TestCheckbox',
         name: 'test-check-box',
         enabled: true,
+        id: Optional.none()
       }, TestProviders, Optional.none())
     ],
     behaviours: Behaviour.derive([

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/colorinput/ColorInputCustomIDTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/colorinput/ColorInputCustomIDTest.ts
@@ -1,0 +1,65 @@
+import { ApproxStructure, Assertions } from '@ephox/agar';
+import { Container, GuiFactory, TestHelpers } from '@ephox/alloy';
+import { describe, it } from '@ephox/bedrock-client';
+import { Fun, Optional } from '@ephox/katamari';
+
+import { renderColorInput } from 'tinymce/themes/silver/ui/dialog/ColorInput';
+
+import * as TestExtras from '../../../module/TestExtras';
+
+describe('headless.tinymce.themes.silver.components.colorinput.ColorInputCustomIDTest', () => {
+  const extrasHook = TestExtras.bddSetup();
+
+  const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(
+    Container.sketch({
+      dom: {
+        classes: [ 'colorinput-container' ]
+      },
+      components: [
+        renderColorInput({
+          name: 'alpha',
+          storageKey: 'test',
+          // Note: in order for out custom id to not be overritten the label must not be set
+          label: Optional.none(),
+          id: Optional.some('test-color-input-id')
+        }, extrasHook.access().extras.backstages.popup.shared, {
+          colorPicker: (_callback, _value) => {},
+          hasCustomColors: Fun.always,
+          getColors: () => [
+            { type: 'choiceitem', text: 'Turquoise', value: '#18BC9B' },
+            { type: 'choiceitem', text: 'Green', value: '#2FCC71' },
+            { type: 'choiceitem', text: 'Blue', value: '#3598DB' },
+            { type: 'choiceitem', text: 'Purple', value: '#9B59B6' },
+            { type: 'choiceitem', text: 'Navy Blue', value: '#34495E' }
+          ],
+          getColorCols: Fun.constant(3)
+        }, Optional.none())
+      ]
+    })
+  ));
+
+  it('TINY-10971: Check if custom id is rendered', () => {
+    Assertions.assertStructure(
+      'Input should have custom id attribute',
+      ApproxStructure.build((s, str, _arr) => s.element('div', {
+        children: [
+          s.element('div', {
+            children: [
+              s.element('div', {
+                children: [
+                  s.element('input', {
+                    attrs: {
+                      id: str.is('test-color-input-id')
+                    }
+                  }),
+                  s.element('span', {})
+                ]
+              })
+            ]
+          })
+        ]
+      })),
+      hook.component().element
+    );
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/colorinput/ColorInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/colorinput/ColorInputTest.ts
@@ -24,7 +24,8 @@ describe('headless.tinymce.themes.silver.components.colorinput.ColorInputTest', 
         renderColorInput({
           name: 'alpha',
           storageKey: 'test',
-          label: Optional.some('test-color-input')
+          label: Optional.some('test-color-input'),
+          id: Optional.none()
         }, extrasHook.access().extras.backstages.popup.shared, {
           colorPicker: (_callback, _value) => {},
           hasCustomColors: Fun.always,

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/input/InputCustomIDTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/input/InputCustomIDTest.ts
@@ -1,0 +1,42 @@
+import { ApproxStructure, Assertions } from '@ephox/agar';
+import { GuiFactory, TestHelpers } from '@ephox/alloy';
+import { describe, it } from '@ephox/bedrock-client';
+import { Optional } from '@ephox/katamari';
+
+import { renderInput } from 'tinymce/themes/silver/ui/dialog/TextField';
+
+import TestProviders from '../../../module/TestProviders';
+
+describe('headless.tinymce.themes.silver.components.input.InputCustomIDTest', () => {
+  const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(
+    renderInput({
+      name: 'input',
+      // Note: in order for out custom id to not be overritten the label must not be set
+      label: Optional.none(),
+      inputMode: Optional.none(),
+      placeholder: Optional.none(),
+      maximized: false,
+      enabled: true,
+      id: Optional.some('input-id-test')
+    }, TestProviders, Optional.none())
+  ));
+
+  it('TINY-10971: Check if custom id is rendered', () => {
+    Assertions.assertStructure(
+      'Input should have custom id attribute',
+      ApproxStructure.build((s, str, arr) => s.element('div', {
+        classes: [ arr.has('tox-form__group') ],
+        children: [
+          s.element('input', {
+            classes: [ arr.has('tox-textfield') ],
+            attrs: {
+              'data-alloy-tabstop': str.is('true'),
+              'id': str.is('input-id-test')
+            }
+          })
+        ]
+      })),
+      hook.component().element
+    );
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/input/InputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/input/InputTest.ts
@@ -19,6 +19,7 @@ describe('headless.tinymce.themes.silver.components.input.InputTest', () => {
       placeholder: Optional.none(),
       maximized: false,
       enabled: true,
+      id: Optional.none()
     }, TestProviders, Optional.none())
   ));
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/label/LabelForTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/label/LabelForTest.ts
@@ -1,0 +1,63 @@
+import { ApproxStructure, Assertions } from '@ephox/agar';
+import { GuiFactory, Memento, TestHelpers } from '@ephox/alloy';
+import { describe, it } from '@ephox/bedrock-client';
+import { Fun, Optional } from '@ephox/katamari';
+
+import { UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
+import { renderLabel } from 'tinymce/themes/silver/ui/dialog/Label';
+
+import TestProviders from '../../../module/TestProviders';
+
+describe('headless.tinymce.themes.silver.components.label.LabelForTest', () => {
+  const sharedBackstage = {
+    providers: TestProviders,
+    interpreter: Fun.identity as any
+  } as UiFactoryBackstageShared;
+
+  const items = [
+    {
+      dom: {
+        tag: 'div',
+        classes: [ 'tox-checkbox' ]
+      }
+    } as any
+  ];
+
+  const labelFor = Memento.record(renderLabel({
+    label: 'This label has a for attribute',
+    items,
+    align: 'end',
+    for: Optional.some('IDofSomeElement')
+  }, sharedBackstage));
+
+  const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build({
+    dom: { tag: 'div' },
+    components: [ labelFor.asSpec() ]
+  }));
+
+  it('TINY-10971: label should be rendered with for attribute', () => {
+    const labelForComponent = labelFor.get(hook.component());
+    Assertions.assertStructure(
+      'Label should have for attribute',
+      ApproxStructure.build((s, str, arr) => s.element('div', {
+        classes: [ arr.has('tox-form__group') ],
+        children: [
+          s.element('label', {
+            classes: [ arr.has('tox-label') ],
+            attrs: {
+              for: str.is('IDofSomeElement')
+            },
+            children: [
+              s.text(str.is('This label has a for attribute'))
+            ]
+          }),
+          s.element('div', {
+            classes: [ arr.has('tox-checkbox') ]
+          })
+        ]
+      })),
+      labelForComponent.element
+    );
+  });
+
+});

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/label/LabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/label/LabelTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
 import { AlloyComponent, GuiFactory, Memento, TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
-import { Fun } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 
 import { UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
 import { renderLabel } from 'tinymce/themes/silver/ui/dialog/Label';
@@ -26,25 +26,29 @@ describe('headless.tinymce.themes.silver.components.label.LabelTest', () => {
   const memBasicLabel = Memento.record(renderLabel({
     label: 'Group of Options',
     items,
-    align: 'start'
+    align: 'start',
+    for: Optional.none()
   }, sharedBackstage));
 
   const memHtmlLabel = Memento.record(renderLabel({
     label: 'Some <html> like content',
     items,
-    align: 'start'
+    align: 'start',
+    for: Optional.none()
   }, sharedBackstage));
 
   const memCenterLabel = Memento.record(renderLabel({
     label: 'Group of Options',
     items,
-    align: 'center'
+    align: 'center',
+    for: Optional.none()
   }, sharedBackstage));
 
   const memEndLabel = Memento.record(renderLabel({
     label: 'Group of Options',
     items,
-    align: 'end'
+    align: 'end',
+    for: Optional.none()
   }, sharedBackstage));
 
   const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build({

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/selectbox/SelectboxCustomIDTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/selectbox/SelectboxCustomIDTest.ts
@@ -1,0 +1,68 @@
+import { ApproxStructure, Assertions } from '@ephox/agar';
+import { GuiFactory, TestHelpers } from '@ephox/alloy';
+import { describe, it } from '@ephox/bedrock-client';
+import { Optional } from '@ephox/katamari';
+
+import { renderSelectBox } from 'tinymce/themes/silver/ui/dialog/SelectBox';
+
+import TestProviders from '../../../module/TestProviders';
+
+describe('headless.tinymce.themes.silver.components.selectbox.SelectboxCustomIDTest', () => {
+  const providers = {
+    ...TestProviders,
+    icons: (): Record<string, string> => ({
+      'chevron-down': '<svg></svg>' // details don't matter, just needs an SVG for the test
+    })
+  };
+
+  const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(
+    renderSelectBox({
+      name: 'selector',
+      size: 1,
+      // Note: in order for out custom id to not be overritten the label must not be set
+      label: Optional.none(),
+      enabled: true,
+      items: [
+        { value: 'one', text: 'One' },
+        { value: 'two', text: 'Two' },
+        { value: 'three', text: 'Three' }
+      ],
+      id: Optional.some('selectbox-custom-id')
+    }, providers, Optional.none())
+  ));
+
+  it('TINY-10971: Check if custom id is rendered', () => {
+    Assertions.assertStructure(
+      'Selectbox should have custom id attribute',
+      ApproxStructure.build((s, str, arr) => s.element('div', {
+        classes: [ arr.has('tox-form__group') ],
+        children: [
+          s.element('div', {
+            classes: [ arr.has('tox-selectfield') ],
+            children: [
+              s.element('select', {
+                value: str.is('one'),
+                attrs: {
+                  size: str.is('1'),
+                  id: str.is('selectbox-custom-id')
+                },
+                children: [
+                  s.element('option', { value: str.is('one'), html: str.is('One') }),
+                  s.element('option', { value: str.is('two'), html: str.is('Two') }),
+                  s.element('option', { value: str.is('three'), html: str.is('Three') })
+                ]
+              }),
+              s.element('div', {
+                classes: [ arr.has('tox-selectfield__icon-js') ],
+                children: [
+                  s.element('svg', {})
+                ]
+              })
+            ]
+          })
+        ]
+      })),
+      hook.component().element
+    );
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/selectbox/SelectboxTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/selectbox/SelectboxTest.ts
@@ -28,7 +28,8 @@ describe('headless.tinymce.themes.silver.components.selectbox.SelectboxTest', ()
         { value: 'one', text: 'One' },
         { value: 'two', text: 'Two' },
         { value: 'three', text: 'Three' }
-      ]
+      ],
+      id: Optional.none()
     }, providers, Optional.none())
   ));
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/selectbox/SelectboxWithSizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/selectbox/SelectboxWithSizeTest.ts
@@ -22,7 +22,8 @@ describe('headless.tinymce.themes.silver.components.selectbox.SelectboxWithSizeT
         { value: 'three', text: 'Three' },
         { value: 'four', text: 'Four' },
         { value: 'five', text: 'Five' }
-      ]
+      ],
+      id: Optional.none()
     }, TestProviders, Optional.none())
   ));
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/textarea/TextareaCustomIDTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/textarea/TextareaCustomIDTest.ts
@@ -1,0 +1,46 @@
+import { ApproxStructure, Assertions } from '@ephox/agar';
+import { GuiFactory, TestHelpers } from '@ephox/alloy';
+import { describe, it } from '@ephox/bedrock-client';
+import { Optional } from '@ephox/katamari';
+
+import { renderTextarea } from 'tinymce/themes/silver/ui/dialog/TextField';
+
+import TestProviders from '../../../module/TestProviders';
+
+describe('headless.tinymce.themes.silver.components.textarea.TextareaCustomIDTest', () => {
+  const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build(
+    renderTextarea({
+      name: 'textarea',
+      // Note: in order for out custom id to not be overritten the label must not be set
+      label: Optional.none(),
+      placeholder: Optional.none(),
+      maximized: false,
+      enabled: true,
+      id: Optional.some('textarea-custom-id')
+    }, TestProviders, Optional.none())
+  ));
+
+  it('TINY-10971: Check if custom id is rendered', () => {
+    Assertions.assertStructure(
+      'Textarea should have custom id attribute',
+      ApproxStructure.build((s, str, arr) => s.element('div', {
+        classes: [ arr.has('tox-form__group') ],
+        children: [
+          s.element('div', {
+            classes: [ arr.has('tox-textarea-wrap') ],
+            children: [
+              s.element('textarea', {
+                classes: [ arr.has('tox-textarea') ],
+                attrs: {
+                  'data-alloy-tabstop': str.is('true'),
+                  'id': str.is('textarea-custom-id')
+                }
+              })
+            ]
+          })
+        ]
+      })),
+      hook.component().element
+    );
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/textarea/TextareaTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/textarea/TextareaTest.ts
@@ -16,7 +16,8 @@ describe('headless.tinymce.themes.silver.components.textarea.TextareaTest', () =
       label: Optional.some('LabelA'),
       placeholder: Optional.none(),
       maximized: false,
-      enabled: true
+      enabled: true,
+      id: Optional.none()
     }, TestProviders, Optional.none())
   ));
 


### PR DESCRIPTION
Related Ticket: TINY-10971

Description of Changes:
It is now possible to define for attribute for label and id attribute for input

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
