### PR TITLE
TINY-10590: Merge blocks now no longer relying on browser behavior for edgecase.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10590-2024-05-21.yaml
+++ b/.changes/unreleased/tinymce-TINY-10590-2024-05-21.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Text content would in some cases move unexpectedly when deleting a paragraph.
+time: 2024-05-21T08:45:35.803719938+02:00
+custom:
+  Issue: TINY-10590

--- a/.changes/unreleased/tinymce-TINY-10590-2024-05-21.yaml
+++ b/.changes/unreleased/tinymce-TINY-10590-2024-05-21.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Text content would in some cases move unexpectedly when deleting a paragraph.
+body: Text content could move unexpectedly when deleting a paragraph.
 time: 2024-05-21T08:45:35.803719938+02:00
 custom:
   Issue: TINY-10590

--- a/modules/tinymce/src/core/main/ts/delete/BlockBoundaryDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/BlockBoundaryDelete.ts
@@ -11,7 +11,7 @@ const backspaceDelete = (editor: Editor, forward: boolean): Optional<() => void>
   const position = BlockMergeBoundary.read(editor.schema, rootNode.dom, forward, editor.selection.getRng())
     .map((blockBoundary) =>
       () => {
-        MergeBlocks.mergeBlocks(rootNode, forward, blockBoundary.from.block, blockBoundary.to.block, editor.schema)
+        MergeBlocks.mergeBlocks(rootNode, forward, blockBoundary.from.block, blockBoundary.to.block, editor.schema, true)
           .each((pos) => {
             editor.selection.setRng(pos.toRange());
           });

--- a/modules/tinymce/src/core/main/ts/delete/BlockMergeBoundary.ts
+++ b/modules/tinymce/src/core/main/ts/delete/BlockMergeBoundary.ts
@@ -36,9 +36,6 @@ const getBlockPosition = (rootNode: HTMLElement, pos: CaretPosition): Optional<B
   return DeleteUtils.getParentBlock(rootElm, containerElm).map((block) => blockPosition(block, pos));
 };
 
-const isNotAncestorial = (blockBoundary: BlockBoundary) =>
-  !(Compare.contains(blockBoundary.to.block, blockBoundary.from.block) || Compare.contains(blockBoundary.from.block, blockBoundary.to.block));
-
 const isDifferentBlocks = (blockBoundary: BlockBoundary): boolean =>
   !Compare.eq(blockBoundary.from.block, blockBoundary.to.block);
 
@@ -84,7 +81,7 @@ const readFromRange = (schema: Schema, rootNode: HTMLElement, forward: boolean, 
   );
 
   return Optionals.lift2(fromBlockPos, toBlockPos, blockBoundary).filter((blockBoundary) =>
-    isDifferentBlocks(blockBoundary) && hasSameHost(rootNode, blockBoundary) && isEditable(blockBoundary) && hasValidBlocks(blockBoundary) && isNotAncestorial(blockBoundary));
+    isDifferentBlocks(blockBoundary) && hasSameHost(rootNode, blockBoundary) && isEditable(blockBoundary) && hasValidBlocks(blockBoundary));
 };
 
 const read = (schema: Schema, rootNode: HTMLElement, forward: boolean, rng: Range): Optional<BlockBoundary> =>

--- a/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
@@ -9,16 +9,36 @@ import * as Empty from '../dom/Empty';
 import * as PaddingBr from '../dom/PaddingBr';
 import * as Parents from '../dom/Parents';
 
-const getChildrenUntilBlockBoundary = (block: SugarElement<Element>, schema: Schema): SugarElement<Node>[] => {
-  const children = Traverse.children(block);
-  return Arr.findIndex(children, (el) => schema.isBlock(SugarNode.name(el))).fold(
-    Fun.constant(children),
-    (index) => children.slice(0, index)
+const getChildrenFromNestedUntilBlockBoundary = (block: SugarElement<Element>, schema: Schema, forwardDelete: boolean): SugarElement<Node>[] => {
+  const allSiblingsInDirection = forwardDelete ? Traverse.prevSiblings(block).reverse() : Traverse.nextSiblings(block);
+  const siblingsToMergeIn = Arr.findIndex(allSiblingsInDirection, (element) => schema.isBlock(SugarNode.name(element))).fold(
+    Fun.constant(allSiblingsInDirection),
+    (index) => allSiblingsInDirection.slice(0, index)
   );
+
+  if (forwardDelete) {
+    return siblingsToMergeIn.reverse();
+  }
+
+  return siblingsToMergeIn;
 };
 
-const extractChildren = (block: SugarElement<Element>, schema: Schema): SugarElement<Node>[] => {
-  const children = getChildrenUntilBlockBoundary(block, schema);
+const getChildrenUntilBlockBoundary = (toBlock: SugarElement<Element>, fromBlock: SugarElement<Element>, schema: Schema, forwardDelete: boolean, extractsiblingsIfNested: boolean): SugarElement<Node>[] => {
+  if (extractsiblingsIfNested && Compare.contains(toBlock, fromBlock)) {
+    return getChildrenFromNestedUntilBlockBoundary(fromBlock, schema, forwardDelete);
+  } else if (extractsiblingsIfNested && Compare.contains(fromBlock, toBlock)) {
+    return getChildrenFromNestedUntilBlockBoundary(toBlock, schema, forwardDelete);
+  } else {
+    const children = Traverse.children(fromBlock);
+    return Arr.findIndex(children, (el) => schema.isBlock(SugarNode.name(el))).fold(
+      Fun.constant(children),
+      (index) => children.slice(0, index)
+    );
+  }
+};
+
+const extractChildren = (toBlock: SugarElement<Element>, fromBlock: SugarElement<Element>, schema: Schema, forwardDelete: boolean, extractsiblingsIfNested: boolean): SugarElement<Node>[] => {
+  const children = getChildrenUntilBlockBoundary(toBlock, fromBlock, schema, forwardDelete, extractsiblingsIfNested);
   Arr.each(children, Remove.remove);
   return children;
 };
@@ -36,6 +56,7 @@ const nestedBlockMerge = (
   fromBlock: SugarElement<Element>,
   toBlock: SugarElement<Element>,
   schema: Schema,
+  forward: boolean,
   insertionPoint: SugarElement<Node>
 ): Optional<CaretPosition> => {
   if (Empty.isEmpty(schema, toBlock)) {
@@ -48,7 +69,7 @@ const nestedBlockMerge = (
   }
 
   const position = CaretFinder.prevPosition(toBlock.dom, CaretPosition.before(insertionPoint.dom));
-  Arr.each(extractChildren(fromBlock, schema), (child) => {
+  Arr.each(extractChildren(toBlock, fromBlock, schema, forward, false), (child) => {
     Insert.before(insertionPoint, child);
   });
   removeEmptyRoot(schema, rootNode, fromBlock);
@@ -57,7 +78,7 @@ const nestedBlockMerge = (
 
 const isInline = (schema: Schema, node: SugarElement<Node>): node is SugarElement<HTMLElement> => schema.isInline(SugarNode.name(node));
 
-const sidelongBlockMerge = (rootNode: SugarElement<Node>, fromBlock: SugarElement<Element>, toBlock: SugarElement<Element>, schema: Schema): Optional<CaretPosition> => {
+const sidelongBlockMerge = (rootNode: SugarElement<Node>, fromBlock: SugarElement<Element>, toBlock: SugarElement<Element>, schema: Schema, forwardDelete: boolean): Optional<CaretPosition> => {
   if (Empty.isEmpty(schema, toBlock)) {
     if (Empty.isEmpty(schema, fromBlock)) {
       const getInlineToBlockDescendants = (el: SugarElement<Element>) => {
@@ -87,8 +108,12 @@ const sidelongBlockMerge = (rootNode: SugarElement<Node>, fromBlock: SugarElemen
   }
 
   const position = CaretFinder.lastPositionIn(toBlock.dom);
-  Arr.each(extractChildren(fromBlock, schema), (child) => {
-    Insert.append(toBlock, child);
+  Arr.each(extractChildren(toBlock, fromBlock, schema, forwardDelete, true), (child) => {
+    if (forwardDelete && Compare.contains(fromBlock, toBlock)) {
+      Insert.prepend(toBlock, child);
+    } else {
+      Insert.append(toBlock, child);
+    }
   });
   removeEmptyRoot(schema, rootNode, fromBlock);
   return position;
@@ -110,18 +135,27 @@ const trimBr = (first: boolean, block: SugarElement<Element>) => {
     .each(Remove.remove);
 };
 
-const mergeBlockInto = (rootNode: SugarElement<Node>, fromBlock: SugarElement<Element>, toBlock: SugarElement<Element>, schema: Schema): Optional<CaretPosition> => {
+const mergeBlockInto = (rootNode: SugarElement<Node>, fromBlock: SugarElement<Element>, toBlock: SugarElement<Element>, schema: Schema, forward: boolean): Optional<CaretPosition> => {
   trimBr(true, fromBlock);
   trimBr(false, toBlock);
 
   return getInsertionPoint(fromBlock, toBlock).fold(
-    Fun.curry(sidelongBlockMerge, rootNode, fromBlock, toBlock, schema),
-    Fun.curry(nestedBlockMerge, rootNode, fromBlock, toBlock, schema)
+    Fun.curry(sidelongBlockMerge, rootNode, fromBlock, toBlock, schema, forward),
+    Fun.curry(nestedBlockMerge, rootNode, fromBlock, toBlock, schema, forward)
   );
 };
 
-const mergeBlocks = (rootNode: SugarElement<Node>, forward: boolean, block1: SugarElement<Element>, block2: SugarElement<Element>, schema: Schema): Optional<CaretPosition> =>
-  forward ? mergeBlockInto(rootNode, block2, block1, schema) : mergeBlockInto(rootNode, block1, block2, schema);
+const mergeBlocks = (rootNode: SugarElement<Node>, forward: boolean, block1: SugarElement<Element>, block2: SugarElement<Element>, schema: Schema, mergeNotDelete: boolean = false): Optional<CaretPosition> => {
+  if (mergeNotDelete) {
+    if (Compare.contains(block2, block1)) {
+      return mergeBlockInto(rootNode, block2, block1, schema, !forward);
+    } else if (Compare.contains(block1, block2)) {
+      return mergeBlockInto(rootNode, block1, block2, schema, forward);
+    }
+  }
+
+  return forward ? mergeBlockInto(rootNode, block2, block1, schema, forward) : mergeBlockInto(rootNode, block1, block2, schema, !forward);
+};
 
 export {
   mergeBlocks

--- a/modules/tinymce/src/core/test/ts/browser/delete/BlockMergeBoundaryTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/BlockMergeBoundaryTest.ts
@@ -72,24 +72,6 @@ describe('browser.tinymce.core.delete.BlockMergeBoundary', () => {
       const boundaryOpt = readBlockBoundary(true, [ 1, 0 ], 1);
       assertBlockBoundaryNone(boundaryOpt);
     });
-
-    it('TINY-10590: If the cursor is between an internal block and a text-node it should not count as a block boundary', () => {
-      setHtml('<div>A<p>B</p>C</div>');
-      const boundaryOpt = readBlockBoundary(false, [ 0 ], 2);
-      assertBlockBoundaryNone(boundaryOpt);
-    });
-
-    it('TINY-10590: If the cursor is in a text node and attempt to go outside of it, going backwards, it should not count as a boundary', () => {
-      setHtml('<div>A<p>B</p>C</div>');
-      const boundaryOpt = readBlockBoundary(false, [ 0, 1 ], 0);
-      assertBlockBoundaryNone(boundaryOpt);
-    });
-
-    it('TINY-10590: If the cursor is in a text node and attempt to go outside of it, going forwards, it should not count as a boundary', () => {
-      setHtml('<div>A<p>B</p>C</div>');
-      const boundaryOpt = readBlockBoundary(true, [ 0, 1 ], 1);
-      assertBlockBoundaryNone(boundaryOpt);
-    });
   });
 
   context('Some block boundaries', () => {

--- a/modules/tinymce/src/core/test/ts/browser/delete/MergeBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/MergeBlocksTest.ts
@@ -21,10 +21,10 @@ describe('browser.tinymce.core.delete.MergeBlocksTest', () => {
     Assertions.assertHtml('Should equal html', expectedHtml, viewBlock.get().innerHTML);
   };
 
-  const mergeBlocks = (forward: boolean, block1Path: number[], block2Path: number[]) => {
+  const mergeBlocks = (forward: boolean, block1Path: number[], block2Path: number[], mergeNotDelete: boolean = false) => {
     const block1 = Hierarchy.follow(SugarElement.fromDom(viewBlock.get()), block1Path).getOrDie() as SugarElement<Element>;
     const block2 = Hierarchy.follow(SugarElement.fromDom(viewBlock.get()), block2Path).getOrDie() as SugarElement<Element>;
-    return MergeBlocks.mergeBlocks(SugarElement.fromDom(viewBlock.get()), forward, block1, block2, baseSchema);
+    return MergeBlocks.mergeBlocks(SugarElement.fromDom(viewBlock.get()), forward, block1, block2, baseSchema, mergeNotDelete);
   };
 
   const assertPosition = (position: Optional<CaretPosition>, expectedPath: number[], expectedOffset: number) => {
@@ -238,6 +238,20 @@ describe('browser.tinymce.core.delete.MergeBlocksTest', () => {
       const pos = mergeBlocks(false, [ 1 ], [ 0 ]);
       assertPosition(pos, [ 0, 0 ], 1);
       assertHtml('<div>ab</div><div><h1>c</h1></div>');
+    });
+
+    it('TINY-10590: Merge children until we find a block backwards', () => {
+      setHtml('<div>A<p>B</p>C</div>');
+      const pos = mergeBlocks(false, [ 0, 1 ], [ 0 ], true);
+      assertHtml('<div><p>AB</p>C</div>');
+      assertPosition(pos, [ 0, 0, 1 ], 1);
+    });
+
+    it('TINY-10590: Merge children until we find a block forwards', () => {
+      setHtml('<div>A<p>B</p>C</div>');
+      const pos = mergeBlocks(true, [ 0, 1 ], [ 0 ], true);
+      assertHtml('<div>A<p>BC</p></div>');
+      assertPosition(pos, [ 0, 1, 0 ], 1);
     });
   });
 });


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-10590

Description of Changes:
Merge block would not always consider nested elements correctly.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
