### PR TITLE
TINY-10891: Add tooltips to element path

### DIFF
--- a/.changes/unreleased/alloy-TINY-10891-2024-05-30.yaml
+++ b/.changes/unreleased/alloy-TINY-10891-2024-05-30.yaml
@@ -1,0 +1,6 @@
+project: alloy
+kind: Added
+body: Exposed the `AriaDescribe` module in the API.
+time: 2024-05-30T22:25:13.432892+08:00
+custom:
+  Issue: TINY-10891

--- a/.changes/unreleased/alloy-TINY-10891-2024-05-30_2.yaml
+++ b/.changes/unreleased/alloy-TINY-10891-2024-05-30_2.yaml
@@ -1,0 +1,6 @@
+project: alloy
+kind: Added
+body: New `remove` API to the `AriaDescribe` module.
+time: 2024-05-30T22:25:13.432892+08:00
+custom:
+  Issue: TINY-10891

--- a/.changes/unreleased/tinymce-TINY-10891-2024-05-30.yaml
+++ b/.changes/unreleased/tinymce-TINY-10891-2024-05-30.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Improved
+body: Accessibility for element path buttons, added tooltip to describe the button and removed incorrect `aria-level` attribute.
+time: 2024-05-30T22:37:58.698242+08:00
+custom:
+  Issue: TINY-10891

--- a/modules/alloy/src/main/ts/ephox/alloy/api/Main.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/Main.ts
@@ -1,6 +1,7 @@
 import * as Boxes from '../alien/Boxes';
 import * as EventRoot from '../alien/EventRoot';
 import * as OffsetOrigin from '../alien/OffsetOrigin';
+import * as AriaDescribe from '../aria/AriaDescribe';
 import * as AriaVoice from '../aria/AriaVoice';
 import { BehaviourState } from '../behaviour/common/BehaviourState';
 import * as DockingTypes from '../behaviour/docking/DockingTypes';
@@ -131,6 +132,7 @@ type Bounds = Boxes.Bounds;
 // Type Def Exports
 export {
   AriaVoice,
+  AriaDescribe,
   AddEventsBehaviour,
   Behaviour,
   AllowBubbling,

--- a/modules/alloy/src/main/ts/ephox/alloy/aria/AriaDescribe.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/aria/AriaDescribe.ts
@@ -1,13 +1,13 @@
-import { Fun, Id, Optional } from '@ephox/katamari';
+import { Id, Optional } from '@ephox/katamari';
 import { Attribute, SugarElement } from '@ephox/sugar';
 
 const describedBy = (describedElement: SugarElement<Element>, describeElement: SugarElement<Element>): void => {
   const describeId = Optional.from(Attribute.get(describedElement, 'id'))
-    .fold(() => {
+    .getOrThunk(() => {
       const id = Id.generate('aria');
       Attribute.set(describeElement, 'id', id);
       return id;
-    }, Fun.identity);
+    });
 
   Attribute.set(describedElement, 'aria-describedby', describeId);
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/aria/AriaDescribe.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/aria/AriaDescribe.ts
@@ -4,7 +4,7 @@ import { Attribute, SugarElement } from '@ephox/sugar';
 const describedBy = (describedElement: SugarElement<Element>, describeElement: SugarElement<Element>): void => {
   const describeId = Optional.from(Attribute.get(describedElement, 'id'))
     .fold(() => {
-      const id = Id.generate('dialog-describe');
+      const id = Id.generate('aria');
       Attribute.set(describeElement, 'id', id);
       return id;
     }, Fun.identity);
@@ -12,6 +12,11 @@ const describedBy = (describedElement: SugarElement<Element>, describeElement: S
   Attribute.set(describedElement, 'aria-describedby', describeId);
 };
 
+const remove = (describedElement: SugarElement<Element>): void => {
+  Attribute.remove(describedElement, 'aria-describedby');
+};
+
 export {
-  describedBy
+  describedBy,
+  remove
 };

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/TooltipsBackstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/TooltipsBackstage.ts
@@ -2,7 +2,7 @@ import { AlloyComponent, GuiFactory, SimpleSpec, TooltippingTypes } from '@ephox
 import { Fun, Result } from '@ephox/katamari';
 
 export interface TooltipsProvider {
-  readonly getConfig: (spec: { tooltipText: string; onShow?: (comp: AlloyComponent, tooltip: AlloyComponent) => void }) => TooltippingTypes.TooltippingConfigSpec;
+  readonly getConfig: (spec: { tooltipText: string; onShow?: (comp: AlloyComponent, tooltip: AlloyComponent) => void; onHide?: (comp: AlloyComponent, tooltip: AlloyComponent) => void }) => TooltippingTypes.TooltippingConfigSpec;
   readonly getComponents: (spec: { tooltipText: string }) => SimpleSpec[];
 }
 
@@ -31,7 +31,7 @@ export const TooltipsBackstage = (
     ];
   };
 
-  const getConfig = (spec: { tooltipText: string; onShow?: (comp: AlloyComponent, tooltip: AlloyComponent) => void }) => {
+  const getConfig = (spec: { tooltipText: string; onShow?: (comp: AlloyComponent, tooltip: AlloyComponent) => void; onHide?: (comp: AlloyComponent, tooltip: AlloyComponent) => void }) => {
     return {
       delayForShow: () => alreadyShowingTooltips() ? intervalDelay : tooltipDelay,
       delayForHide: Fun.constant(tooltipDelay),
@@ -48,8 +48,11 @@ export const TooltipsBackstage = (
           spec.onShow(comp, tooltip);
         }
       },
-      onHide: () => {
+      onHide: (comp: AlloyComponent, tooltip: AlloyComponent) => {
         numActiveTooltips--;
+        if (spec.onHide) {
+          spec.onHide(comp, tooltip);
+        }
       }
     };
   };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ElementPath.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ElementPath.ts
@@ -23,8 +23,8 @@ const isHidden = (elm: Element): boolean =>
 const renderElementPath = (editor: Editor, settings: ElementPathSettings, providersBackstage: UiFactoryBackstageProviders): SimpleSpec => {
   const delimiter = settings.delimiter ?? '\u203A';
 
-  const renderElement = (name: string, element: Node, index: number): AlloySpec => {
-    return Button.sketch({
+  const renderElement = (name: string, element: Node, index: number): AlloySpec =>
+    Button.sketch({
       dom: {
         tag: 'div',
         classes: [ 'tox-statusbar__path-item' ],
@@ -56,7 +56,6 @@ const renderElementPath = (editor: Editor, settings: ElementPathSettings, provid
         ReadOnly.receivingConfig()
       ])
     });
-  };
 
   const renderDivider = (): AlloySpec => ({
     dom: {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ElementPath.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ElementPath.ts
@@ -1,4 +1,4 @@
-import { AddEventsBehaviour, AlloyEvents, AlloySpec, Behaviour, Button, Disabling, GuiFactory, Keying, Replacing, SimpleSpec, Tabstopping } from '@ephox/alloy';
+import { AddEventsBehaviour, AlloyEvents, AlloySpec, AriaDescribe, Behaviour, Button, Disabling, GuiFactory, Keying, Replacing, SimpleSpec, Tabstopping, Tooltipping } from '@ephox/alloy';
 import { Arr } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -23,28 +23,40 @@ const isHidden = (elm: Element): boolean =>
 const renderElementPath = (editor: Editor, settings: ElementPathSettings, providersBackstage: UiFactoryBackstageProviders): SimpleSpec => {
   const delimiter = settings.delimiter ?? '\u203A';
 
-  const renderElement = (name: string, element: Node, index: number): AlloySpec => Button.sketch({
-    dom: {
-      tag: 'div',
-      classes: [ 'tox-statusbar__path-item' ],
-      attributes: {
-        'data-index': index,
-        'aria-level': index + 1
-      }
-    },
-    components: [
-      GuiFactory.text(name)
-    ],
-    action: (_btn) => {
-      editor.focus();
-      editor.selection.select(element);
-      editor.nodeChanged();
-    },
-    buttonBehaviours: Behaviour.derive([
-      DisablingConfigs.button(providersBackstage.isDisabled),
-      ReadOnly.receivingConfig()
-    ])
-  });
+  const renderElement = (name: string, element: Node, index: number): AlloySpec => {
+    return Button.sketch({
+      dom: {
+        tag: 'div',
+        classes: [ 'tox-statusbar__path-item' ],
+        attributes: {
+          'data-index': index,
+        }
+      },
+      components: [
+        GuiFactory.text(name)
+      ],
+      action: (_btn) => {
+        editor.focus();
+        editor.selection.select(element);
+        editor.nodeChanged();
+      },
+      buttonBehaviours: Behaviour.derive([
+        Tooltipping.config({
+          ...providersBackstage.tooltips.getConfig({
+            tooltipText: providersBackstage.translate([ 'Select the {0} element', element.nodeName.toLowerCase() ]),
+            onShow: (comp, tooltip) => {
+              AriaDescribe.describedBy(comp.element, tooltip.element);
+            },
+            onHide: (comp) => {
+              AriaDescribe.remove(comp.element);
+            }
+          }),
+        }),
+        DisablingConfigs.button(providersBackstage.isDisabled),
+        ReadOnly.receivingConfig()
+      ])
+    });
+  };
 
   const renderDivider = (): AlloySpec => ({
     dom: {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/ElementPathTooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/ElementPathTooltipTest.ts
@@ -1,0 +1,222 @@
+import { FocusTools, RealKeys, RealMouse, UiFinder } from '@ephox/agar';
+import { Assert, before, context, describe, it } from '@ephox/bedrock-client';
+import { Arr, Type } from '@ephox/katamari';
+import { PlatformDetection } from '@ephox/sand';
+import { Attribute, SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import I18n from 'tinymce/core/api/util/I18n';
+
+import * as TooltipUtils from '../../../module/TooltipUtils';
+
+interface ElementPathTranslationScenario {
+  readonly label: string;
+  readonly expectedString: (elementName: string) => string;
+  readonly setup: () => void;
+}
+
+interface ElementPathTagScenario {
+  readonly content: string;
+  readonly expectedTag: string;
+  readonly cursor?: [number, number];
+  readonly selection?: [number[], number, number[], number];
+}
+
+describe('browser.tinymce.themes.silver.editor.ElementPathTooltipTest', () => {
+  const doc = SugarDocument.getDocument();
+  const browser = PlatformDetection.detect().browser;
+  const hook = TinyHooks.bddSetup<Editor>({
+    base_url: '/project/tinymce/js/tinymce'
+  });
+
+  Arr.each([
+    { label: 'no translations', expectedString: (elementName: string) => `Select the ${elementName} element`, setup: () => I18n.setCode('en') },
+    { label: 'translations', expectedString: (elementName: string) => `Zort the ${elementName} frum`,
+      setup: () => {
+        I18n.add('test', { 'Select the {0} element': 'Zort the {0} frum' });
+        I18n.setCode('test');
+      }
+    }], (scenario: ElementPathTranslationScenario) => {
+    context(scenario.label, () => {
+      before(() => scenario.setup());
+
+      it(`TINY-10891: Should show only single tooltip when navigating between elememt path with keyboard`, async () => {
+        const editor = hook.editor();
+        editor.focus();
+        editor.setContent(`
+        <table style="border-collapse: collapse; width: 100%;" border="1"><colgroup><col style="width: 24.9816%;"><col style="width: 24.9816%;"><col style="width: 24.9816%;"><col style="width: 24.9816%;"></colgroup>
+          <tbody>
+          <tr>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          </tr>
+          </tbody>
+          </table>
+        `);
+        const buttonSelector = '.tox-statusbar__path-item:contains(td)';
+        TinySelections.setCursor(editor, [ 0, 1, 0, 0 ], 0);
+
+        await TooltipUtils.pAssertTooltip(editor, async () => {
+          TinyContentActions.keystroke(editor, 122, { alt: true });
+          await FocusTools.pTryOnSelector('Assert element path is focused', doc, 'div[role=navigation] .tox-statusbar__path-item');
+          await RealKeys.pSendKeysOn('div[role=navigation] .tox-statusbar__path-item', [ RealKeys.text('arrowright') ]);
+          return Promise.resolve();
+        }, scenario.expectedString('tbody'));
+
+        await TooltipUtils.pAssertTooltip(editor, async () => {
+          await RealKeys.pSendKeysOn('.tox-statusbar__path-item=tbody', [ RealKeys.text('arrowright') ]);
+          await FocusTools.pTryOnSelector('Assert element path is focused', doc, '.tox-statusbar__path-item:contains(tr)');
+          return Promise.resolve();
+        }, scenario.expectedString('tr'));
+
+        await TooltipUtils.pAssertTooltip(editor, async () => {
+          await RealKeys.pSendKeysOn('.tox-statusbar__path-item=tr', [ RealKeys.text('arrowright') ]);
+          await FocusTools.pTryOnSelector('Assert element path is focused', doc, '.tox-statusbar__path-item:contains(td)');
+          return Promise.resolve();
+        }, scenario.expectedString('td'));
+
+        await TooltipUtils.pAssertTooltip(editor, async () => {
+          await RealKeys.pSendKeysOn('.tox-statusbar__path-item=td', [ RealKeys.text('arrowleft') ]);
+          await FocusTools.pTryOnSelector('Assert element path is focused', doc, '.tox-statusbar__path-item:contains(tr)');
+          return Promise.resolve();
+        }, scenario.expectedString('tr'));
+
+        await TooltipUtils.pAssertTooltip(editor, async () => {
+          await RealKeys.pSendKeysOn('.tox-statusbar__path-item=tr', [ RealKeys.text('arrowleft') ]);
+          await FocusTools.pTryOnSelector('Assert element path is focused', doc, '.tox-statusbar__path-item:contains(tbody)');
+          return Promise.resolve();
+        }, scenario.expectedString('tbody'));
+
+        await TooltipUtils.pAssertTooltip(editor, async () => {
+          await RealKeys.pSendKeysOn('.tox-statusbar__path-item=tbody', [ RealKeys.text('arrowleft') ]);
+          await FocusTools.pTryOnSelector('Assert element path is focused', doc, '.tox-statusbar__path-item:contains(table)');
+          return Promise.resolve();
+        }, scenario.expectedString('table'));
+
+        await TooltipUtils.pCloseTooltip(editor, buttonSelector);
+      });
+
+      (browser.isSafari() ? it.skip : it)(`TINY-10891: Should show only single tooltip when navigating between elememt path with mouse`, async () => {
+        const editor = hook.editor();
+        editor.focus();
+        editor.setContent(`
+        <table style="border-collapse: collapse; width: 100%;" border="1"><colgroup><col style="width: 24.9816%;"><col style="width: 24.9816%;"><col style="width: 24.9816%;"><col style="width: 24.9816%;"></colgroup>
+          <tbody>
+          <tr>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          </tr>
+          </tbody>
+          </table>
+        `);
+        TinySelections.setCursor(editor, [ 0, 1, 0, 0 ], 0);
+
+        await TooltipUtils.pAssertTooltip(editor, async () => {
+          await RealMouse.pMoveToOn('.tox-statusbar__path-item=tbody');
+          await UiFinder.pWaitFor('Waiting for label to be changed', SugarBody.body(), `.tox-silver-sink .tox-tooltip__body:contains(${scenario.expectedString('tbody')})`);
+          return Promise.resolve();
+        }, scenario.expectedString('tbody'));
+
+        await TooltipUtils.pAssertTooltip(editor, async () => {
+          await RealMouse.pMoveToOn('.tox-statusbar__path-item=table');
+          await UiFinder.pWaitFor('Waiting for label to be changed', SugarBody.body(), `.tox-silver-sink .tox-tooltip__body:contains(${scenario.expectedString('table')})`);
+          return Promise.resolve();
+        }, scenario.expectedString('table'));
+
+        await TooltipUtils.pAssertTooltip(editor, async () => {
+          await RealMouse.pMoveToOn('.tox-statusbar__path-item=tr');
+          await UiFinder.pWaitFor('Waiting for label to be changed', SugarBody.body(), `.tox-silver-sink .tox-tooltip__body:contains(${scenario.expectedString('tr')})`);
+          return Promise.resolve();
+        }, scenario.expectedString('tr'));
+
+        await TooltipUtils.pAssertTooltip(editor, async () => {
+          await RealMouse.pMoveToOn('.tox-statusbar__path-item=td');
+          await UiFinder.pWaitFor('Waiting for label to be changed', SugarBody.body(), `.tox-silver-sink .tox-tooltip__body:contains(${scenario.expectedString('td')})`);
+          return Promise.resolve();
+        }, scenario.expectedString('td'));
+
+        await RealMouse.pMoveToOn('iframe => body');
+      });
+
+      it(`TINY-10891: Should have correct aria-describedby id when tooltip is shown`, async () => {
+        const editor = hook.editor();
+        editor.focus();
+        editor.setContent(`
+        <table style="border-collapse: collapse; width: 100%;" border="1"><colgroup><col style="width: 24.9816%;"><col style="width: 24.9816%;"><col style="width: 24.9816%;"><col style="width: 24.9816%;"></colgroup>
+          <tbody>
+          <tr>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          </tr>
+          </tbody>
+          </table>
+        `);
+        TinySelections.setCursor(editor, [ 0, 1, 0, 0 ], 0);
+
+        await TooltipUtils.pAssertTooltip(editor, async () => {
+          TinyContentActions.keystroke(editor, 122, { alt: true });
+          await FocusTools.pTryOnSelector('Assert element path is focused', doc, 'div[role=navigation] .tox-statusbar__path-item');
+          await RealKeys.pSendKeysOn('.tox-statusbar__path-item=table', [ RealKeys.text('arrowright') ]);
+          await FocusTools.pTryOnSelector('Assert element path is focused', doc, '.tox-statusbar__path-item:contains(tbody)');
+          return Promise.resolve();
+        }, scenario.expectedString('tbody'));
+
+        const tooltip = UiFinder.findIn<HTMLElement>(SugarDocument.getDocument(), '.tox-silver-sink .tox-tooltip').getOrDie();
+        const elementPath = UiFinder.findIn<HTMLElement>(SugarDocument.getDocument(), `.tox-statusbar__path-item:contains(tbody)`).getOrDie();
+
+        Assert.eq('Element path aria-describedby matches the tooltip id', Attribute.get(tooltip, 'id'), Attribute.get(elementPath, 'aria-describedby'));
+
+        await TooltipUtils.pAssertTooltip(editor, async () => {
+          await RealKeys.pSendKeysOn('.tox-statusbar__path-item=tbody', [ RealKeys.text('arrowright') ]);
+          await FocusTools.pTryOnSelector('Assert element path is focused', doc, '.tox-statusbar__path-item:contains(tr)');
+          return Promise.resolve();
+        }, scenario.expectedString('tr'));
+
+        const tooltip2 = UiFinder.findIn<HTMLElement>(SugarDocument.getDocument(), '.tox-silver-sink .tox-tooltip').getOrDie();
+        const tbodyElementPath = UiFinder.findIn<HTMLElement>(SugarDocument.getDocument(), '.tox-statusbar__path-item:contains(tbody)').getOrDie();
+        const trElementPath = UiFinder.findIn<HTMLElement>(SugarDocument.getDocument(), '.tox-statusbar__path-item:contains(tr)').getOrDie();
+
+        Assert.eq('Element path aria-describedby matches the tooltip id 2', Attribute.get(tooltip2, 'id'), Attribute.get(trElementPath, 'aria-describedby'));
+        Assert.eq('Element path should not contain aria-describedby attribute after tooltip is removed ', undefined, Attribute.get(tbodyElementPath, 'aria-describedby'));
+
+        await RealMouse.pMoveToOn('iframe => body');
+      });
+
+      Arr.each([
+        { content: '<p><strong>Test</strong></p>', cursor: [ 0, 0 ], expectedTag: 'strong' },
+        { content: '<p><img src="test"/></p>', selection: [[ 0 ], 0, [ 0 ], 1 ], expectedTag: 'img' },
+        { content: '<ul><li>Test</li></ul>', cursor: [ 0, 0 ], expectedTag: 'li' },
+        { content: '<p><span style="text-decoration: underline;">test</span></p>', cursor: [ 0, 0 ], expectedTag: 'span' },
+        { content: '<p><a href="https://google.com">https://google.com</a></p>', cursor: [ 0, 0 ], expectedTag: 'a' },
+        { content: '<p><iframe src="https://www.youtube.com/embed/b3XFjWInBog" width="560" height="314" allowfullscreen="allowfullscreen"></iframe></p>', selection: [[ 0 ], 0, [ 0 ], 1 ], expectedTag: 'iframe' },
+      ], (tagScenario: ElementPathTagScenario) => {
+        it(`TINY-10891: Tooltip should show correct tag name for ${tagScenario.expectedTag} element`, async () => {
+          const editor = hook.editor();
+          editor.setContent(tagScenario.content);
+
+          if (Type.isNonNullable(tagScenario.selection)) {
+            const [ startPath, soffset, finishPath, foffset ] = tagScenario.selection;
+            TinySelections.setSelection(editor, startPath, soffset, finishPath, foffset);
+          } else if (Type.isNonNullable(tagScenario.cursor)) {
+            TinySelections.setCursor(editor, tagScenario.cursor, 0);
+          }
+
+          await TooltipUtils.pAssertTooltip(editor, async () => {
+            TinyContentActions.keystroke(editor, 122, { alt: true });
+            await FocusTools.pTryOnSelector('Assert element path is focused', doc, 'div[role=navigation] .tox-statusbar__path-item');
+            await RealKeys.pSendKeysOn('div[role=navigation] .tox-statusbar__path-item', [ RealKeys.text('arrowright') ]);
+            return Promise.resolve();
+          }, scenario.expectedString(tagScenario.expectedTag));
+          await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.text('escape') ]);
+        });
+      });
+    });
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
@@ -15,11 +15,11 @@ describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {
     s.element('div', {
       classes: [ arr.has('tox-statusbar__path') ],
       children: [
-        s.element('div', { children: [ s.text(str.is('p')) ] }),
+        s.element('div', { children: [ s.text(str.is('p')) ], attrs: { 'aria-level': str.none() }}),
         s.element('div', { children: [ s.text(str.is(' › ')) ] }),
-        s.element('div', { children: [ s.text(str.is('strong')) ] }),
+        s.element('div', { children: [ s.text(str.is('strong')) ], attrs: { 'aria-level': str.none() }}),
         s.element('div', { children: [ s.text(str.is(' › ')) ] }),
-        s.element('div', { children: [ s.text(str.is('em')) ] })
+        s.element('div', { children: [ s.text(str.is('em')) ], attrs: { 'aria-level': str.none() }})
       ]
     });
 

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/tooltip/ElementPathTooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/tooltip/ElementPathTooltipTest.ts
@@ -8,7 +8,7 @@ import { TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcaga
 import Editor from 'tinymce/core/api/Editor';
 import I18n from 'tinymce/core/api/util/I18n';
 
-import * as TooltipUtils from '../../../module/TooltipUtils';
+import * as TooltipUtils from '../../module/TooltipUtils';
 
 interface ElementPathTranslationScenario {
   readonly label: string;


### PR DESCRIPTION
Related Ticket: TINY-10891

Description of Changes:
* Add tooltips to element path, in the previous version, the label of the button is being announced but there's no additional description to describe what does the button do
* On mouse hover and keyboard focus, tooltip with label `Select the X element` will be shown, and when using screen reader this will also be announced
* Removal of incorrect `aria-level`
* Exposed `AriaDescribe` and added a `remove` function in that API

Pre-checks:
* [x] Changelog entry added
* [ x Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
