### PR TITLE
TINY-10971: introduce optional label for property

### DIFF
--- a/.changes/unreleased/bridge-TINY-10971-2024-06-04.yaml
+++ b/.changes/unreleased/bridge-TINY-10971-2024-06-04.yaml
@@ -1,0 +1,7 @@
+project: bridge
+kind: Added
+body: Added `for` attribute to component schema and as an optinal parameter for label
+  component.
+time: 2024-06-04T18:15:54.417924+02:00
+custom:
+  Issue: TINY-10971

--- a/.changes/unreleased/tinymce-TINY-10971-2024-06-04.yaml
+++ b/.changes/unreleased/tinymce-TINY-10971-2024-06-04.yaml
@@ -1,7 +1,7 @@
 project: tinymce
 kind: Added
-body: Added optional `for` parameter for a label dialog component. It accepts a name
-  of a different component.
+body: Added `for` option to dialog label components to improve accessibility. The
+  value must be another component on the same dialog.
 time: 2024-06-04T18:18:38.295757+02:00
 custom:
   Issue: TINY-10971

--- a/.changes/unreleased/tinymce-TINY-10971-2024-06-04.yaml
+++ b/.changes/unreleased/tinymce-TINY-10971-2024-06-04.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Added
+body: Added optional `for` parameter for a label dialog component. It accepts a name
+  of a different component.
+time: 2024-06-04T18:18:38.295757+02:00
+custom:
+  Issue: TINY-10971

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
@@ -1,4 +1,5 @@
 import { FieldProcessor, FieldSchema } from '@ephox/boulder';
+import { Optional } from '@ephox/katamari';
 
 import * as ComponentSchema from '../../core/ComponentSchema';
 import { BodyComponent, BodyComponentSpec } from './BodyComponent';
@@ -10,6 +11,7 @@ export interface LabelSpec {
   label: string;
   items: BodyComponentSpec[];
   align?: Alignment;
+  for?: string;
 }
 
 export interface Label {
@@ -17,11 +19,13 @@ export interface Label {
   label: string;
   items: BodyComponent[];
   align: Alignment;
+  for: Optional<string>;
 }
 
 export const createLabelFields = (itemsField: FieldProcessor): FieldProcessor[] => [
   ComponentSchema.type,
   ComponentSchema.label,
   itemsField,
-  FieldSchema.defaultedStringEnum('align', 'start', [ 'start', 'center', 'end' ])
+  FieldSchema.defaultedStringEnum('align', 'start', [ 'start', 'center', 'end' ]),
+  FieldSchema.optionString('for')
 ];

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Dialog.ts
@@ -105,6 +105,12 @@ const open = (editor: Editor, currentSearchState: Cell<Actions.SearchState>): vo
         type: 'bar',
         items: [
           {
+            type: 'label',
+            label: 'Hello',
+            for: 'replacetext',
+            items: []
+          },
+          {
             type: 'input',
             name: 'findtext',
             placeholder: 'Find',

--- a/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/searchreplace/main/ts/ui/Dialog.ts
@@ -105,12 +105,6 @@ const open = (editor: Editor, currentSearchState: Cell<Actions.SearchState>): vo
         type: 'bar',
         items: [
           {
-            type: 'label',
-            label: 'Hello',
-            for: 'replacetext',
-            items: []
-          },
-          {
             type: 'input',
             name: 'findtext',
             placeholder: 'Find',

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -1,6 +1,6 @@
 import { AlloyComponent, AlloySpec } from '@ephox/alloy';
 import { Dialog, Menu } from '@ephox/bridge';
-import { Cell, Result } from '@ephox/katamari';
+import { Cell, Optional, Result } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import I18n, { TranslatedString, Untranslated } from 'tinymce/core/api/util/I18n';
@@ -82,11 +82,14 @@ const init = (lazySinks: { popup: () => Result<AlloyComponent, string>; dialog: 
     setContextMenuState
   };
 
+  // TODO: Investigate this
+  const getCompByName = (_name: string) => Optional.none();
+
   const popupBackstage: UiFactoryBackstage = {
     ...commonBackstage,
     shared: {
       ...commonBackstage.shared,
-      interpreter: (s) => UiFactory.interpretWithoutForm(s, {}, popupBackstage),
+      interpreter: (s) => UiFactory.interpretWithoutForm(s, {}, popupBackstage, getCompByName),
       getSink: lazySinks.popup
     }
   };
@@ -95,7 +98,7 @@ const init = (lazySinks: { popup: () => Result<AlloyComponent, string>; dialog: 
     ...commonBackstage,
     shared: {
       ...commonBackstage.shared,
-      interpreter: (s) => UiFactory.interpretWithoutForm(s, {}, dialogBackstage),
+      interpreter: (s) => UiFactory.interpretWithoutForm(s, {}, dialogBackstage, getCompByName),
       getSink: lazySinks.dialog
     }
   };

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -82,7 +82,6 @@ const init = (lazySinks: { popup: () => Result<AlloyComponent, string>; dialog: 
     setContextMenuState
   };
 
-  // TODO: Investigate this
   const getCompByName = (_name: string) => Optional.none();
 
   const popupBackstage: UiFactoryBackstage = {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/BodyPanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/BodyPanel.ts
@@ -1,4 +1,4 @@
-import { AddEventsBehaviour, AlloyEvents, Behaviour, Form as AlloyForm, Keying, Memento, NativeEvents, SimpleSpec } from '@ephox/alloy';
+import { AddEventsBehaviour, AlloyEvents, Behaviour, Form as AlloyForm, Keying, Memento, NativeEvents, SimpleSpec, AlloyComponent } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Arr, Fun, Optional } from '@ephox/katamari';
 
@@ -12,7 +12,7 @@ import { dialogFocusShiftedChannel } from '../window/DialogChannels';
 
 export type BodyPanelSpec = Omit<Dialog.Panel, 'type'>;
 
-const renderBodyPanel = (spec: BodyPanelSpec, dialogData: Dialog.DialogData, backstage: UiFactoryBackstage): SimpleSpec => {
+const renderBodyPanel = (spec: BodyPanelSpec, dialogData: Dialog.DialogData, backstage: UiFactoryBackstage, getCompByName: (name: string) => Optional<AlloyComponent>): SimpleSpec => {
   const memForm = Memento.record(
     AlloyForm.sketch((parts) => ({
       dom: {
@@ -21,7 +21,7 @@ const renderBodyPanel = (spec: BodyPanelSpec, dialogData: Dialog.DialogData, bac
       },
       // All of the items passed through the form need to be put through the interpreter
       // with their form part preserved.
-      components: Arr.map(spec.items, (item) => interpretInForm(parts, item, dialogData, backstage))
+      components: Arr.map(spec.items, (item) => interpretInForm(parts, item, dialogData, backstage, getCompByName))
     }))
   );
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Label.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Label.ts
@@ -45,7 +45,7 @@ export const renderLabel = (spec: LabelSpec, backstageShared: UiFactoryBackstage
           spec.for.each((name) => {
             getCompByName(name).each((target) => {
               label.getOpt(comp).each((labelComp) => {
-                const id = Attribute.get(labelComp.element, 'id') ?? Id.generate('foo');
+                const id = Attribute.get(target.element, 'id') ?? Id.generate('form-field');
                 Attribute.set(target.element, 'id', id);
                 Attribute.set(labelComp.element, 'for', id);
               });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Label.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Label.ts
@@ -1,6 +1,7 @@
-import { AlloySpec, Behaviour, GuiFactory, Keying, Replacing, SimpleSpec } from '@ephox/alloy';
+import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, GuiFactory, Keying, Memento, Replacing, SimpleSpec } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Id, Optional } from '@ephox/katamari';
+import { Attribute } from '@ephox/sugar';
 
 import { UiFactoryBackstageShared } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
@@ -8,12 +9,11 @@ import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 
 type LabelSpec = Omit<Dialog.Label, 'type'>;
 
-export const renderLabel = (spec: LabelSpec, backstageShared: UiFactoryBackstageShared): SimpleSpec => {
+export const renderLabel = (spec: LabelSpec, backstageShared: UiFactoryBackstageShared, getCompByName: (name: string) => Optional<AlloyComponent>): SimpleSpec => {
   const baseClass = 'tox-label';
   const centerClass = spec.align === 'center' ? [ `${baseClass}--center` ] : [];
   const endClass = spec.align === 'end' ? [ `${baseClass}--end` ] : [];
-
-  const label: AlloySpec = {
+  const label = Memento.record({
     dom: {
       tag: 'label',
       classes: [ baseClass, ...centerClass, ...endClass ]
@@ -21,7 +21,7 @@ export const renderLabel = (spec: LabelSpec, backstageShared: UiFactoryBackstage
     components: [
       GuiFactory.text(backstageShared.providers.translate(spec.label))
     ]
-  };
+  });
 
   const comps = Arr.map(spec.items, backstageShared.interpreter);
   return {
@@ -30,7 +30,7 @@ export const renderLabel = (spec: LabelSpec, backstageShared: UiFactoryBackstage
       classes: [ 'tox-form__group' ]
     },
     components: [
-      label,
+      label.asSpec(),
       ...comps
     ],
     behaviours: Behaviour.derive([
@@ -39,7 +39,20 @@ export const renderLabel = (spec: LabelSpec, backstageShared: UiFactoryBackstage
       RepresentingConfigs.domHtml(Optional.none()),
       Keying.config({
         mode: 'acyclic'
-      })
+      }),
+      AddEventsBehaviour.config('label', [
+        AlloyEvents.runOnAttached((comp) => {
+          spec.for.each((name) => {
+            getCompByName(name).each((target) => {
+              label.getOpt(comp).each((labelComp) => {
+                const id = Attribute.get(labelComp.element, 'id') ?? Id.generate('foo');
+                Attribute.set(target.element, 'id', id);
+                Attribute.set(labelComp.element, 'for', id);
+              });
+            });
+          });
+        })
+      ]),
     ])
   };
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TabPanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TabPanel.ts
@@ -22,7 +22,7 @@ export type TabData = Record<string, any>;
 
 type TabPanelSpec = Omit<Dialog.TabPanel, 'type'>;
 
-export const renderTabPanel = (spec: TabPanelSpec, dialogData: Dialog.DialogData, backstage: UiFactoryBackstage): SketchSpec => {
+export const renderTabPanel = (spec: TabPanelSpec, dialogData: Dialog.DialogData, backstage: UiFactoryBackstage, getCompByName: (name: string) => Optional<AlloyComponent>): SketchSpec => {
   const storedValue = Cell<TabData>({ });
 
   const updateDataWithForm = (form: AlloyComponent): void => {
@@ -58,7 +58,7 @@ export const renderTabPanel = (spec: TabPanelSpec, dialogData: Dialog.DialogData
               tag: 'div',
               classes: [ 'tox-form' ]
             },
-            components: Arr.map(tab.items, (item) => interpretInForm(parts, item, dialogData, backstage)),
+            components: Arr.map(tab.items, (item) => interpretInForm(parts, item, dialogData, backstage, getCompByName)),
             formBehaviours: Behaviour.derive([
               Keying.config({
                 mode: 'acyclic',

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
@@ -1,4 +1,4 @@
-import { AlloyComponent, Composing, Form, ModalDialog, Reflecting } from '@ephox/alloy';
+import { AlloyComponent, Composing, ModalDialog, Reflecting } from '@ephox/alloy';
 import { Dialog, DialogManager } from '@ephox/bridge';
 import { Cell, Fun, Id, Optional, Optionals } from '@ephox/katamari';
 
@@ -7,30 +7,13 @@ import { dialogChannel } from './DialogChannels';
 import { renderModalBody } from './SilverDialogBody';
 import * as SilverDialogCommon from './SilverDialogCommon';
 import * as SilverDialogEvents from './SilverDialogEvents';
-import { FooterState, renderModalFooter } from './SilverDialogFooter';
-import { DialogAccess, getDialogApi } from './SilverDialogInstanceApi';
+import { renderModalFooter } from './SilverDialogFooter';
+import * as SilverDialogInstanceApi from './SilverDialogInstanceApi';
 
 interface RenderedDialog<T extends Dialog.DialogData> {
   readonly dialog: AlloyComponent;
   readonly instanceApi: Dialog.DialogInstanceApi<T>;
 }
-
-const getCompByNameFromAccess = (access: DialogAccess, name: string): Optional<AlloyComponent> => {
-  // TODO: Add API to alloy to find the inner most component of a Composing chain.
-  const root = access.getRoot();
-  // This is just to avoid throwing errors if the dialog closes before this. We should take it out
-  // while developing (probably), and put it back in for the real thing.
-  if (root.getSystem().isConnected()) {
-    const form = Composing.getCurrent(access.getFormWrapper()).getOr(access.getFormWrapper());
-    return Form.getField(form, name).orThunk(() => {
-      const footer = access.getFooter();
-      const footerState: Optional<FooterState> = footer.bind((f) => Reflecting.getState(f).get());
-      return footerState.bind((f) => f.lookupByName(name));
-    });
-  } else {
-    return Optional.none();
-  }
-};
 
 const renderDialog = <T extends Dialog.DialogData>(dialogInit: DialogManager.DialogInit<T>, extra: SilverDialogCommon.WindowExtra<T>, backstage: UiFactoryBackstage): RenderedDialog<T> => {
   const dialogId = Id.generate('dialog');
@@ -39,7 +22,7 @@ const renderDialog = <T extends Dialog.DialogData>(dialogInit: DialogManager.Dia
 
   const dialogSize = Cell<Dialog.DialogSize>(internalDialog.size);
 
-  const getCompByName = (name: string) => getCompByNameFromAccess(modalAccess, name);
+  const getCompByName = (name: string) => SilverDialogInstanceApi.getCompByName(modalAccess, name);
 
   const dialogSizeClasses = SilverDialogCommon.getDialogSizeClass(dialogSize.get()).toArray();
 
@@ -87,7 +70,7 @@ const renderDialog = <T extends Dialog.DialogData>(dialogInit: DialogManager.Dia
 
   const dialog: AlloyComponent = SilverDialogCommon.renderModalDialog(spec, dialogEvents, backstage);
 
-  const modalAccess = ((): DialogAccess => {
+  const modalAccess = ((): SilverDialogInstanceApi.DialogAccess => {
     const getForm = (): AlloyComponent => {
       const outerForm = ModalDialog.getBody(dialog);
       return Composing.getCurrent(outerForm).getOr(outerForm);
@@ -108,7 +91,7 @@ const renderDialog = <T extends Dialog.DialogData>(dialogInit: DialogManager.Dia
   })();
 
   // TODO: Get the validator from the dialog state.
-  const instanceApi = getDialogApi<T>(modalAccess, extra.redial, objOfCells);
+  const instanceApi = SilverDialogInstanceApi.getDialogApi<T>(modalAccess, extra.redial, objOfCells);
 
   return {
     dialog,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogBody.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogBody.ts
@@ -17,19 +17,19 @@ interface WindowBodySpec {
 
 // ariaAttrs is being passed through to silver inline dialog
 // from the WindowManager as a property of 'params'
-const renderBody = (spec: WindowBodySpec, dialogId: string, contentId: Optional<string>, backstage: UiFactoryBackstage, ariaAttrs: boolean): SimpleSpec => {
+const renderBody = (spec: WindowBodySpec, dialogId: string, contentId: Optional<string>, backstage: UiFactoryBackstage, ariaAttrs: boolean, getCompByName: (name: string) => Optional<AlloyComponent>): SimpleSpec => {
   const renderComponents = (incoming: WindowBodySpec) => {
     const body = incoming.body;
     switch (body.type) {
       case 'tabpanel': {
         return [
-          renderTabPanel(body, incoming.initialData, backstage)
+          renderTabPanel(body, incoming.initialData, backstage, getCompByName)
         ];
       }
 
       default: {
         return [
-          renderBodyPanel(body, incoming.initialData, backstage)
+          renderBodyPanel(body, incoming.initialData, backstage, getCompByName)
         ];
       }
     }
@@ -65,11 +65,11 @@ const renderBody = (spec: WindowBodySpec, dialogId: string, contentId: Optional<
   };
 };
 
-const renderInlineBody = (spec: WindowBodySpec, dialogId: string, contentId: string, backstage: UiFactoryBackstage, ariaAttrs: boolean): SimpleSpec =>
-  renderBody(spec, dialogId, Optional.some(contentId), backstage, ariaAttrs);
+const renderInlineBody = (spec: WindowBodySpec, dialogId: string, contentId: string, backstage: UiFactoryBackstage, ariaAttrs: boolean, getCompByName: (name: string) => Optional<AlloyComponent>): SimpleSpec =>
+  renderBody(spec, dialogId, Optional.some(contentId), backstage, ariaAttrs, getCompByName);
 
-const renderModalBody = (spec: WindowBodySpec, dialogId: string, backstage: UiFactoryBackstage): AlloyParts.ConfiguredPart => {
-  const bodySpec = renderBody(spec, dialogId, Optional.none(), backstage, false);
+const renderModalBody = (spec: WindowBodySpec, dialogId: string, backstage: UiFactoryBackstage, getCompByName: (name: string) => Optional<AlloyComponent>): AlloyParts.ConfiguredPart => {
+  const bodySpec = renderBody(spec, dialogId, Optional.none(), backstage, false, getCompByName);
   return ModalDialog.parts.body(bodySpec);
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogInstanceApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogInstanceApi.ts
@@ -164,5 +164,6 @@ const getDialogApi = <T extends Dialog.DialogData>(
 };
 
 export {
-  getDialogApi
+  getDialogApi,
+  getCompByName
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -1,6 +1,6 @@
 // DUPE with SilverDialog. Cleaning up.
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Blocking, Composing, Focusing, GuiFactory, Keying, Memento, NativeEvents,
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Blocking, Composing, Focusing, Form, GuiFactory, Keying, Memento, NativeEvents,
   Receiving, Reflecting, Replacing, SystemEvents
 } from '@ephox/alloy';
 import { Dialog, DialogManager } from '@ephox/bridge';
@@ -25,6 +25,23 @@ interface RenderedDialog<T extends Dialog.DialogData> {
   readonly instanceApi: Dialog.DialogInstanceApi<T>;
 }
 
+const getCompByNameFromAccess = (access: SilverDialogInstanceApi.DialogAccess, name: string): Optional<AlloyComponent> => {
+  // TODO: Add API to alloy to find the inner most component of a Composing chain.
+  const root = access.getRoot();
+  // This is just to avoid throwing errors if the dialog closes before this. We should take it out
+  // while developing (probably), and put it back in for the real thing.
+  if (root.getSystem().isConnected()) {
+    const form = Composing.getCurrent(access.getFormWrapper()).getOr(access.getFormWrapper());
+    return Form.getField(form, name).orThunk(() => {
+      const footer = access.getFooter();
+      const footerState: Optional<SilverDialogFooter.FooterState> = footer.bind((f) => Reflecting.getState(f).get());
+      return footerState.bind((f) => f.lookupByName(name));
+    });
+  } else {
+    return Optional.none();
+  }
+};
+
 const renderInlineDialog = <T extends Dialog.DialogData>(
   dialogInit: DialogManager.DialogInit<T>,
   extra: SilverDialogCommon.WindowExtra<T>,
@@ -36,6 +53,8 @@ const renderInlineDialog = <T extends Dialog.DialogData>(
   const dialogLabelId = Id.generate('dialog-label');
   const dialogContentId = Id.generate('dialog-content');
   const internalDialog = dialogInit.internalDialog;
+
+  const getCompByName = (name: string) => getCompByNameFromAccess(modalAccess, name);
 
   const dialogSize = Cell<Dialog.DialogSize>(internalDialog.size);
 
@@ -61,7 +80,7 @@ const renderInlineDialog = <T extends Dialog.DialogData>(
     SilverDialogBody.renderInlineBody({
       body: internalDialog.body,
       initialData: internalDialog.initialData,
-    }, dialogId, dialogContentId, backstage, ariaAttrs)
+    }, dialogId, dialogContentId, backstage, ariaAttrs, getCompByName)
   );
 
   const storagedMenuButtons = SilverDialogCommon.mapMenuButtons(internalDialog.buttons);
@@ -165,7 +184,7 @@ const renderInlineDialog = <T extends Dialog.DialogData>(
   };
 
   // TODO: Clean up the dupe between this (InlineDialog) and SilverDialog
-  const instanceApi = SilverDialogInstanceApi.getDialogApi<T>({
+  const modalAccess: SilverDialogInstanceApi.DialogAccess = {
     getId: Fun.constant(dialogId),
     getRoot: Fun.constant(dialog),
     getFooter: () => optMemFooter.map((memFooter) => memFooter.get(dialog)),
@@ -175,7 +194,8 @@ const renderInlineDialog = <T extends Dialog.DialogData>(
       return Composing.getCurrent(body).getOr(body);
     },
     toggleFullscreen
-  }, extra.redial, objOfCells);
+  };
+  const instanceApi = SilverDialogInstanceApi.getDialogApi<T>(modalAccess, extra.redial, objOfCells);
 
   return {
     dialog,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -1,6 +1,6 @@
 // DUPE with SilverDialog. Cleaning up.
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Blocking, Composing, Focusing, Form, GuiFactory, Keying, Memento, NativeEvents,
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Blocking, Composing, Focusing, GuiFactory, Keying, Memento, NativeEvents,
   Receiving, Reflecting, Replacing, SystemEvents
 } from '@ephox/alloy';
 import { Dialog, DialogManager } from '@ephox/bridge';
@@ -25,23 +25,6 @@ interface RenderedDialog<T extends Dialog.DialogData> {
   readonly instanceApi: Dialog.DialogInstanceApi<T>;
 }
 
-const getCompByNameFromAccess = (access: SilverDialogInstanceApi.DialogAccess, name: string): Optional<AlloyComponent> => {
-  // TODO: Add API to alloy to find the inner most component of a Composing chain.
-  const root = access.getRoot();
-  // This is just to avoid throwing errors if the dialog closes before this. We should take it out
-  // while developing (probably), and put it back in for the real thing.
-  if (root.getSystem().isConnected()) {
-    const form = Composing.getCurrent(access.getFormWrapper()).getOr(access.getFormWrapper());
-    return Form.getField(form, name).orThunk(() => {
-      const footer = access.getFooter();
-      const footerState: Optional<SilverDialogFooter.FooterState> = footer.bind((f) => Reflecting.getState(f).get());
-      return footerState.bind((f) => f.lookupByName(name));
-    });
-  } else {
-    return Optional.none();
-  }
-};
-
 const renderInlineDialog = <T extends Dialog.DialogData>(
   dialogInit: DialogManager.DialogInit<T>,
   extra: SilverDialogCommon.WindowExtra<T>,
@@ -54,7 +37,7 @@ const renderInlineDialog = <T extends Dialog.DialogData>(
   const dialogContentId = Id.generate('dialog-content');
   const internalDialog = dialogInit.internalDialog;
 
-  const getCompByName = (name: string) => getCompByNameFromAccess(modalAccess, name);
+  const getCompByName = (name: string) => SilverDialogInstanceApi.getCompByName(modalAccess, name);
 
   const dialogSize = Cell<Dialog.DialogSize>(internalDialog.size);
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/label/LabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/label/LabelTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
 import { AlloyComponent, GuiFactory, Memento, TestHelpers } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
-import { Fun } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 
 import { UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
 import { renderLabel } from 'tinymce/themes/silver/ui/dialog/Label';
@@ -23,29 +23,35 @@ describe('headless.tinymce.themes.silver.components.label.LabelTest', () => {
     } as any
   ];
 
+  const getCompByName = (_name: string) => Optional.none();
+
   const memBasicLabel = Memento.record(renderLabel({
     label: 'Group of Options',
     items,
-    align: 'start'
-  }, sharedBackstage));
+    align: 'start',
+    for: Optional.none()
+  }, sharedBackstage, getCompByName));
 
   const memHtmlLabel = Memento.record(renderLabel({
     label: 'Some <html> like content',
     items,
-    align: 'start'
-  }, sharedBackstage));
+    align: 'start',
+    for: Optional.none()
+  }, sharedBackstage, getCompByName));
 
   const memCenterLabel = Memento.record(renderLabel({
     label: 'Group of Options',
     items,
-    align: 'center'
-  }, sharedBackstage));
+    align: 'center',
+    for: Optional.none()
+  }, sharedBackstage, getCompByName));
 
   const memEndLabel = Memento.record(renderLabel({
     label: 'Group of Options',
     items,
-    align: 'end'
-  }, sharedBackstage));
+    align: 'end',
+    for: Optional.none()
+  }, sharedBackstage, getCompByName));
 
   const hook = TestHelpers.GuiSetup.bddSetup((_store, _doc, _body) => GuiFactory.build({
     dom: { tag: 'div' },

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogForLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogForLabelTest.ts
@@ -43,30 +43,30 @@ describe('headless.tinymce.themes.silver.window.SilverDialogForLabelTest', () =>
       ApproxStructure.build((s, str, arr) => s.element('div', {
         classes: [ arr.has('tox-form') ],
         children: [
-            s.element('div', {
+          s.element('div', {
+            classes: [ arr.has('tox-form__group') ],
+            children: [
+              s.element('label', {
+                attrs: {
+                  for: str.startsWith('form-field'),
+                },
+                children: [
+                  s.text(str.is('This is a label'))
+                ]
+              }),
+              s.element('div', {
                 classes: [ arr.has('tox-form__group') ],
                 children: [
-                    s.element('label', {
-                      attrs: {
-                        for: str.startsWith('form-field'),
-                      },
-                      children: [
-                        s.text(str.is('This is a label'))
-                      ]
-                    }),
-                    s.element('div', {
-                      classes: [ arr.has('tox-form__group') ],
-                      children: [
-                        s.element('input', {
-                          classes: [ arr.has('tox-textfield') ],
-                          attrs: {
-                            id: str.startsWith('form-field')
-                          }
-                        })
-                      ]
-                    })
-                  ]
-            })
+                  s.element('input', {
+                    classes: [ arr.has('tox-textfield') ],
+                    attrs: {
+                      id: str.startsWith('form-field')
+                    }
+                  })
+                ]
+              })
+            ]
+          })
         ]
       })),
       UiFinder.findIn(SugarBody.body(), '.tox-form').getOrDie()

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogForLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogForLabelTest.ts
@@ -1,0 +1,75 @@
+import { ApproxStructure, Assertions, UiFinder } from '@ephox/agar';
+import { before, describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
+import { SugarBody } from '@ephox/sugar';
+
+import { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
+import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
+
+import * as TestExtras from '../../module/TestExtras';
+
+describe('headless.tinymce.themes.silver.window.SilverDialogForLabelTest', () => {
+  const extrasHook = TestExtras.bddSetup();
+  let windowManager: WindowManagerImpl;
+  before(() => {
+    windowManager = WindowManager.setup(extrasHook.access().extras);
+  });
+
+  const openDialog = () => {
+    windowManager.open({
+      title: 'Silver Dialog Label For Test',
+      body: {
+        type: 'panel',
+        items: [
+          {
+            type: 'label',
+            label: 'This is a label',
+            for: 'input-name',
+            items: [
+              {
+                type: 'input',
+                name: 'input-name',
+              }
+            ]
+          }
+        ]
+      }
+    }, {}, Fun.noop);
+  };
+
+  it('TINY-10971: Label for property should be rendered with the id of provided element.', async () => {
+    openDialog();
+    Assertions.assertStructure('Check label for and input id attributes',
+      ApproxStructure.build((s, str, arr) => s.element('div', {
+        classes: [ arr.has('tox-form') ],
+        children: [
+            s.element('div', {
+                classes: [ arr.has('tox-form__group') ],
+                children: [
+                    s.element('label', {
+                      attrs: {
+                        for: str.startsWith('foo'),
+                      },
+                      children: [
+                        s.text(str.is('This is a label'))
+                      ]
+                    }),
+                    s.element('div', {
+                      classes: [ arr.has('tox-form__group') ],
+                      children: [
+                        s.element('input', {
+                          classes: [ arr.has('tox-textfield') ],
+                          attrs: {
+                            id: str.startsWith('foo')
+                          }
+                        })
+                      ]
+                    })
+                  ]
+            })
+        ]
+      })),
+      UiFinder.findIn(SugarBody.body(), '.tox-form').getOrDie()
+    );
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogForLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogForLabelTest.ts
@@ -48,7 +48,7 @@ describe('headless.tinymce.themes.silver.window.SilverDialogForLabelTest', () =>
                 children: [
                     s.element('label', {
                       attrs: {
-                        for: str.startsWith('foo'),
+                        for: str.startsWith('form-field'),
                       },
                       children: [
                         s.text(str.is('This is a label'))
@@ -60,7 +60,7 @@ describe('headless.tinymce.themes.silver.window.SilverDialogForLabelTest', () =>
                         s.element('input', {
                           classes: [ arr.has('tox-textfield') ],
                           attrs: {
-                            id: str.startsWith('foo')
+                            id: str.startsWith('form-field')
                           }
                         })
                       ]


### PR DESCRIPTION
Related Ticket: TINY-10971

Description of Changes:
It is now possible to define for attribute in a label component. It accepts the name of a different element.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
