### PR TITLE
TINY-10127: Fix cursor would shift to the start of the editor body when focus was shifted to a noneditable cell of a table

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10127-2024-06-12.yaml
+++ b/.changes/unreleased/tinymce-TINY-10127-2024-06-12.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: 'Cursor would shift to the start of the editor body when focus was shifted to a noneditable cell of a table.'
+time: 2024-06-12T08:42:51.138159+08:00
+custom:
+  Issue: TINY-10127

--- a/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
@@ -35,9 +35,8 @@ export const MouseSelection = (bridge: WindowBridge, container: SugarElement<Nod
             const isNonEditableCell = ContentEditable.getRaw(singleCell) === 'false';
             const isCellClosestContentEditable = Optionals.is(ContentEditable.closest(event.target), singleCell, Compare.eq);
             if (isNonEditableCell && isCellClosestContentEditable) {
+              // Not selecting the contents or the node of the actual cell as shown below, keeping the selection on the offscreen element.
               annotations.selectRange(container, boxes, singleCell, singleCell);
-              // TODO: TINY-7874 This is purely a workaround until the offscreen selection issues are solved
-              bridge.selectContents(singleCell);
             }
           } else if (boxes.length > 1) {
             // Wait until we have more than one, otherwise you can't do text selection inside a cell.

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/FakeSelectionTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/FakeSelectionTest.ts
@@ -1,7 +1,7 @@
-import { Assertions, Keys } from '@ephox/agar';
-import { afterEach, context, describe, it } from '@ephox/bedrock-client';
-import { Arr } from '@ephox/katamari';
-import { Html, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
+import { Assertions, FocusTools, Keys, Mouse, UiFinder } from '@ephox/agar';
+import { after, afterEach, before, context, describe, it } from '@ephox/bedrock-client';
+import { Arr, Optional } from '@ephox/katamari';
+import { Attribute, Focus, Html, Insert, Remove, SelectorFilter, SelectorFind, SugarBody, SugarDocument, SugarElement, Traverse } from '@ephox/sugar';
 import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -252,6 +252,52 @@ describe('browser.tinymce.models.dom.table.FakeSelectionTest', () => {
       'td[contenteditable="false"][data-mce-selected="1"]': 0,
       'td[contenteditable="false"][data-mce-first-selected="1"]': 0,
       'td[contenteditable="false"][data-mce-last-selected="1"]': 0
+    });
+  });
+
+  context('Focusing on noneditable cell', () => {
+    before(() => {
+      const fakeButton = SugarElement.fromTag('button');
+      const body = SugarBody.body();
+      Attribute.set(fakeButton, 'id', 'button1');
+      Insert.append(fakeButton, SugarElement.fromText('Button 1'));
+      Insert.append(body, fakeButton);
+    });
+
+    after(() => SelectorFind.child(SugarBody.body(), '#button1').map(Remove.remove));
+
+    const pShiftFocusOutsideEditor = async (fakeButton: SugarElement<HTMLButtonElement>) => {
+      Mouse.mouseDown(fakeButton, { button: 0 });
+      Mouse.mouseUp(fakeButton, { button: 0 });
+      Focus.focus(fakeButton);
+      await FocusTools.pTryOnSelector('Wait for focus to be shifted out of the editor', SugarDocument.getDocument(), '#button1');
+    };
+
+    const pSelectCellAndAssertSelection = async (editor: Editor, cellSelection: [string, string]) => {
+      editor.focus();
+      selectCellsWithMouse(editor, cellSelection);
+      TinyAssertions.assertContentPresence(editor, {
+        'td[contenteditable="false"][data-mce-selected="1"][data-mce-first-selected="1"][data-mce-last-selected="1"]': 1
+
+      });
+      const actual = Optional.from(editor.selection.getSel()?.anchorNode).map(SugarElement.fromDom).bind(Traverse.parentElement).getOrDie();
+      const expected = UiFinder.findIn(TinyDom.body(editor), '.mce-offscreen-selection').getOrDie();
+
+      Assertions.assertDomEq('Parent of selection anchor node should be offscreen element', expected, actual);
+    };
+
+    it('TINY-10127: Selection should still be on the noneditable cell when focus is shifted elsewhere', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p>test</p><table><tbody><tr><td contenteditable="false">1</td><td>2</td></tr><tr><td contenteditable="false">3</td><td>4</td></tr></tbody></table>');
+
+      const fakeButton = UiFinder.findIn<HTMLButtonElement>(SugarBody.body(), '#button1').getOrDie();
+      await pShiftFocusOutsideEditor(fakeButton);
+      await pSelectCellAndAssertSelection(editor, [ '1', '1' ]);
+
+      await pShiftFocusOutsideEditor(fakeButton);
+      await pSelectCellAndAssertSelection(editor, [ '3', '3' ]);
+
+      await pSelectCellAndAssertSelection(editor, [ '1', '1' ]);
     });
   });
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/FakeSelectionTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/FakeSelectionTest.ts
@@ -264,12 +264,12 @@ describe('browser.tinymce.models.dom.table.FakeSelectionTest', () => {
       Insert.append(body, fakeButton);
     });
 
-    after(() => SelectorFind.child(SugarBody.body(), '#button1').map(Remove.remove));
+    after(() => SelectorFind.child(SugarBody.body(), '#button1').each(Remove.remove));
 
-    const pShiftFocusOutsideEditor = async (fakeButton: SugarElement<HTMLButtonElement>) => {
-      Mouse.mouseDown(fakeButton, { button: 0 });
-      Mouse.mouseUp(fakeButton, { button: 0 });
-      Focus.focus(fakeButton);
+    const pShiftFocusOutsideEditor = async (button: SugarElement<HTMLButtonElement>) => {
+      Mouse.mouseDown(button, { button: 0 });
+      Mouse.mouseUp(button, { button: 0 });
+      Focus.focus(button);
       await FocusTools.pTryOnSelector('Wait for focus to be shifted out of the editor', SugarDocument.getDocument(), '#button1');
     };
 
@@ -278,7 +278,6 @@ describe('browser.tinymce.models.dom.table.FakeSelectionTest', () => {
       selectCellsWithMouse(editor, cellSelection);
       TinyAssertions.assertContentPresence(editor, {
         'td[contenteditable="false"][data-mce-selected="1"][data-mce-first-selected="1"][data-mce-last-selected="1"]': 1
-
       });
       const actual = Optional.from(editor.selection.getSel()?.anchorNode).map(SugarElement.fromDom).bind(Traverse.parentElement).getOrDie();
       const expected = UiFinder.findIn(TinyDom.body(editor), '.mce-offscreen-selection').getOrDie();


### PR DESCRIPTION
Related Ticket: TINY-10127

Description of Changes:
* Keeping the selection on the offscreen element instead of selecting the content of the actual td cell
* Similar behaviour when selecting the non editable paragraph or other elements, preventing the cursor to be shifted when the editor is not focused, then focused by clicking on noneditable cell

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
