### PR TITLE
TINY-10799: Color picker input field error tooltip.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10799-2024-06-13.yaml
+++ b/.changes/unreleased/tinymce-TINY-10799-2024-06-13.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Added
+body: Colorpicker number input fields now show an error tooltip and error icon when
+  invalid text has been entered.
+time: 2024-06-13T15:06:22.0468735+02:00
+custom:
+  Issue: TINY-10799

--- a/modules/acid/src/demo/ts/ephox/acid/demo/Demo.ts
+++ b/modules/acid/src/demo/ts/ephox/acid/demo/Demo.ts
@@ -1,5 +1,5 @@
 import { Channels, Debugging, Gui, GuiFactory } from '@ephox/alloy';
-import { Fun, Optional, Type } from '@ephox/katamari';
+import { Fun, Optional, Result, Type } from '@ephox/katamari';
 import { Class, DomEvent, Insert, SugarElement } from '@ephox/sugar';
 
 import { Untranslated } from 'ephox/acid/alien/I18n';
@@ -23,7 +23,7 @@ DomEvent.bind(SugarElement.fromDom(document), 'mouseup', (evt) => {
 const fakeTranslate = (key: Untranslated): string => {
   if (Type.isString(key)) {
     return Optional.from(strings[key]).getOrThunk(() => {
-    // eslint-disable-next-line no-console
+      // eslint-disable-next-line no-console
       console.error('Missing translation for ' + key);
       return key;
     });
@@ -32,7 +32,16 @@ const fakeTranslate = (key: Untranslated): string => {
   }
 };
 
-const colourPickerFactory = ColourPicker.makeFactory(fakeTranslate, Fun.identity);
+const colourPickerFactory = ColourPicker.makeFactory(fakeTranslate, Fun.identity, Fun.constant({
+  lazySink: (a) => Result.value(a),
+  tooltipDom: {
+    tag: 'div'
+  }
+}), Fun.constant({
+  dom: {
+    tag: 'div'
+  }
+}));
 
 const colourPicker = GuiFactory.build(colourPickerFactory.sketch({
   dom: {

--- a/modules/acid/src/main/ts/ephox/acid/gui/ColourPicker.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/ColourPicker.ts
@@ -1,5 +1,6 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Composing, Keying, Memento, RawDomSchema, SimulatedEvent, Sketcher, Slider
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Composing, Keying, Memento, RawDomSchema,
+  SimulatedEvent, Sketcher, Slider
 } from '@ephox/alloy';
 import { FieldSchema } from '@ephox/boulder';
 import { Arr, Cell, Fun } from '@ephox/katamari';
@@ -31,10 +32,12 @@ export interface ColourPickerSketcher extends Sketcher.SingleSketch<ColourPicker
 
 const makeFactory = (
   translate: (key: Untranslated) => string,
-  getClass: (key: string) => string
+  getClass: (key: string) => string,
+  tooltipConfig: RgbForm.RGBTooltipGetConfig,
+  makeIcon: RgbForm.RgbIconCreation
 ): ColourPickerSketcher => {
   const factory = (detail: ColourPickerDetail) => {
-    const rgbForm = RgbForm.rgbFormFactory(translate, getClass, detail.onValidHex, detail.onInvalidHex);
+    const rgbForm = RgbForm.rgbFormFactory(translate, getClass, detail.onValidHex, detail.onInvalidHex, tooltipConfig, makeIcon);
     const sbPalette = SaturationBrightnessPalette.paletteFactory(translate, getClass);
 
     const hueSliderToDegrees = (hue: number): number => (100 - hue) / 100 * 360;

--- a/modules/acid/src/main/ts/ephox/acid/gui/components/RgbForm.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/RgbForm.ts
@@ -1,6 +1,7 @@
 import {
   AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, EventFormat, Focusing, Form, FormField, FormTypes, GuiFactory, Input, Invalidating,
-  Memento, Representing, SimulatedEvent, Sketcher, SketchSpec, Tabstopping, UiSketcher
+  Memento, Representing, SimpleSpec, SimulatedEvent, Sketcher, SketchSpec,
+  Tabstopping, Tooltipping, TooltippingTypes, UiSketcher
 } from '@ephox/alloy';
 import { Cell, Fun, Future, Id, Merger, Optional, Result } from '@ephox/katamari';
 import { Css } from '@ephox/sugar';
@@ -28,6 +29,14 @@ type InputEvent = HexInputEvent | ColorInputEvent;
 
 const translatePrefix = 'colorcustom.rgb.';
 
+interface RGBTooltipSpec {
+  tooltipText: string;
+  onShow?: (comp: AlloyComponent, tooltip: AlloyComponent) => void;
+  onSetup?: (comp: AlloyComponent) => void;
+}
+
+export type RGBTooltipGetConfig = (spec: RGBTooltipSpec) => TooltippingTypes.TooltippingConfigSpec;
+
 // tslint:disable:no-empty-interface
 export interface RgbFormDetail extends Sketcher.SingleSketchDetail {
 }
@@ -40,13 +49,46 @@ export interface RgbFormSketcher extends Sketcher.SingleSketch<RgbFormSpec> {
   updateHex: (slider: AlloyComponent, colour: Hex) => void;
 }
 
+export type RgbIconCreation = (name: string, errId: Optional<string>, icon?: string, label?: string) => SimpleSpec;
+
+interface TooltipInteractionApi {
+  setEnabled: (enabled: boolean) => void;
+  immediatelyShow: () => void;
+  immediatelyHide: () => void;
+  isEnabled: () => boolean;
+}
+
+const unitiatedTooltipApi: TooltipInteractionApi = {
+  isEnabled: Fun.always,
+  setEnabled: Fun.noop,
+  immediatelyShow: Fun.noop,
+  immediatelyHide: Fun.noop,
+};
+
 const rgbFormFactory = (
   translate: (key: string) => string,
   getClass: (key: string) => string,
   onValidHexx: (component: AlloyComponent) => void,
-  onInvalidHexx: (component: AlloyComponent) => void
+  onInvalidHexx: (component: AlloyComponent) => void,
+  tooltipGetConfig: RGBTooltipGetConfig,
+  makeIcon: RgbIconCreation
 ): RgbFormSketcher => {
-  const invalidation = (label: string, isValid: (value: string) => boolean) => Invalidating.config({
+  const setTooltipEnabled = (enabled: boolean, tooltipApi: Cell<TooltipInteractionApi>) => {
+    const api = tooltipApi.get();
+    if (enabled === api.isEnabled()) {
+      return;
+    }
+
+    api.setEnabled(enabled);
+
+    if (enabled) {
+      api.immediatelyShow();
+    } else {
+      api.immediatelyHide();
+    }
+  };
+
+  const invalidation = (label: string, isValid: (value: string) => boolean, tooltipApi: Cell<TooltipInteractionApi>) => Invalidating.config({
     invalidClass: getClass('invalid'),
 
     notify: {
@@ -56,13 +98,14 @@ const rgbFormFactory = (
         });
       },
       onValid: (comp: AlloyComponent) => {
+        setTooltipEnabled(false, tooltipApi);
         AlloyTriggers.emitWith(comp, validInput, {
           type: label,
           value: Representing.getValue(comp)
         });
       },
-
       onInvalid: (comp: AlloyComponent) => {
+        setTooltipEnabled(true, tooltipApi);
         AlloyTriggers.emitWith(comp, invalidInput, {
           type: label,
           value: Representing.getValue(comp)
@@ -87,6 +130,7 @@ const rgbFormFactory = (
     description: string,
     data: string | number
   ) => {
+    const tooltipApi = Cell(unitiatedTooltipApi);
     const helptext = translate(translatePrefix + 'range');
 
     const pLabel = FormField.parts.label({
@@ -105,8 +149,45 @@ const rgbFormFactory = (
 
       // Have basic invalidating and tabstopping behaviour.
       inputBehaviours: Behaviour.derive([
-        invalidation(name, isValid),
-        Tabstopping.config({})
+        invalidation(name, isValid, tooltipApi),
+        Tabstopping.config({}),
+        Tooltipping.config({
+          ...tooltipGetConfig({
+            tooltipText: '',
+            onSetup: (comp: AlloyComponent) => {
+              tooltipApi.set(
+                {
+                  isEnabled: () => {
+                    return Tooltipping.isEnabled(comp);
+                  },
+                  setEnabled: (enabled: boolean) => {
+                    return Tooltipping.setEnabled(comp, enabled);
+                  },
+                  immediatelyShow: () => {
+                    return Tooltipping.immediateOpenClose(comp, true);
+                  },
+                  immediatelyHide: () => {
+                    return Tooltipping.immediateOpenClose(comp, false);
+                  },
+                }
+              );
+              Tooltipping.setEnabled(comp, false);
+            },
+            onShow: (component, _tooltip) => {
+              Tooltipping.setComponents(component, [
+                {
+                  dom: {
+                    tag: 'p',
+                    innerHtml: translate('colorcustom.rgb.invalid'),
+                    classes: [
+                      getClass('rgb-warning-note')
+                    ]
+                  }
+                }
+              ]);
+            },
+          })
+        })
       ]),
 
       // If it was invalid, and the value was set, run validation against it.
@@ -118,7 +199,23 @@ const rgbFormFactory = (
       }
     });
 
-    const comps = [ pLabel, pField ];
+    const errorId = Id.generate('aria-invalid');
+
+    const memInvalidIcon = Memento.record(
+      makeIcon('invalid', Optional.some(errorId), 'warning')
+    );
+
+    const memStatus = Memento.record({
+      dom: {
+        tag: 'div',
+        classes: [ getClass('invalid-icon') ]
+      },
+      components: [
+        memInvalidIcon.asSpec()
+      ]
+    });
+
+    const comps = [ pLabel, pField, memStatus.asSpec() ];
     const concats = name !== 'hex' ? [ FormField.parts['aria-descriptor']({
       text: helptext
     }) ] : [];
@@ -129,7 +226,10 @@ const rgbFormFactory = (
         tag: 'div',
         attributes: {
           role: 'presentation'
-        }
+        },
+        classes: [
+          getClass('rgb-container'),
+        ]
       },
       components
     };

--- a/modules/acid/src/main/ts/ephox/acid/gui/components/RgbForm.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/RgbForm.ts
@@ -58,7 +58,7 @@ interface TooltipInteractionApi {
   isEnabled: () => boolean;
 }
 
-const unitiatedTooltipApi: TooltipInteractionApi = {
+const uninitiatedTooltipApi: TooltipInteractionApi = {
   isEnabled: Fun.always,
   setEnabled: Fun.noop,
   immediatelyShow: Fun.noop,
@@ -130,7 +130,7 @@ const rgbFormFactory = (
     description: string,
     data: string | number
   ) => {
-    const tooltipApi = Cell(unitiatedTooltipApi);
+    const tooltipApi = Cell(uninitiatedTooltipApi);
     const helptext = translate(translatePrefix + 'range');
 
     const pLabel = FormField.parts.label({
@@ -178,11 +178,11 @@ const rgbFormFactory = (
                 {
                   dom: {
                     tag: 'p',
-                    innerHtml: translate('colorcustom.rgb.invalid'),
                     classes: [
                       getClass('rgb-warning-note')
                     ]
-                  }
+                  },
+                  components: [ GuiFactory.text(translate('colorcustom.rgb.invalid')) ]
                 }
               ]);
             },

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/ActiveTooltipping.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/ActiveTooltipping.ts
@@ -29,7 +29,7 @@ const events = (tooltipConfig: TooltippingConfig, state: TooltippingState): Allo
   };
 
   const show = (comp: AlloyComponent) => {
-    if (!state.isShowing()) {
+    if (!state.isShowing() && state.isEnabled()) {
       TooltippingApis.hideAllExclusive(comp, tooltipConfig, state);
       const sink = tooltipConfig.lazySink(comp).getOrDie();
       const popup = comp.getSystem().build({
@@ -161,6 +161,9 @@ const events = (tooltipConfig: TooltippingConfig, state: TooltippingState): Allo
 
   return AlloyEvents.derive(Arr.flatten([
     [
+      AlloyEvents.runOnInit((component) => {
+        tooltipConfig.onSetup(component);
+      }),
       AlloyEvents.run(ShowTooltipEvent, (comp) => {
         state.resetTimer(() => {
           show(comp);

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingApis.ts
@@ -1,14 +1,15 @@
 import { Replacing } from '../../api/behaviour/Replacing';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { AlloySpec } from '../../api/component/SpecTypes';
-import { ExclusivityChannel } from './TooltippingCommunication';
+import * as AlloyTriggers from '../../api/events/AlloyTriggers';
+import { ExclusivityChannel, ImmediateHideTooltipEvent, ImmediateShowTooltipEvent } from './TooltippingCommunication';
 import { TooltippingConfig, TooltippingState } from './TooltippingTypes';
 
 const hideAllExclusive = (component: AlloyComponent, _tConfig: TooltippingConfig, _tState: TooltippingState): void => {
   component.getSystem().broadcastOn([ ExclusivityChannel ], { });
 };
 
-const setComponents = (component: AlloyComponent, tConfig: TooltippingConfig, tState: TooltippingState, specs: AlloySpec[]): void => {
+const setComponents = (_component: AlloyComponent, _tConfig: TooltippingConfig, tState: TooltippingState, specs: AlloySpec[]): void => {
   tState.getTooltip().each((tooltip) => {
     if (tooltip.getSystem().isConnected()) {
       Replacing.set(tooltip, specs);
@@ -16,7 +17,19 @@ const setComponents = (component: AlloyComponent, tConfig: TooltippingConfig, tS
   });
 };
 
+const isEnabled = (_component: AlloyComponent, _tConfig: TooltippingConfig, tState: TooltippingState): boolean =>
+  tState.isEnabled();
+
+const setEnabled = (_component: AlloyComponent, _tConfig: TooltippingConfig, tState: TooltippingState, enabled: boolean): void =>
+  tState.setEnabled(enabled);
+
+const immediateOpenClose = (component: AlloyComponent, _tConfig: TooltippingConfig, _tState: TooltippingState, open: boolean): void =>
+  AlloyTriggers.emit(component, open ? ImmediateShowTooltipEvent : ImmediateHideTooltipEvent);
+
 export {
   hideAllExclusive,
-  setComponents
+  immediateOpenClose,
+  isEnabled,
+  setComponents,
+  setEnabled
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingSchema.ts
@@ -14,6 +14,7 @@ export default [
   FieldSchema.defaulted('tooltipComponents', []),
   FieldSchema.defaultedFunction('delayForShow', Fun.constant(300)),
   FieldSchema.defaultedFunction('delayForHide', Fun.constant(300)),
+  FieldSchema.defaultedFunction('onSetup', Fun.noop),
   FieldSchema.defaultedStringEnum('mode', 'normal', [ 'normal', 'follow-highlight', 'children-keyboard-focus', 'children-normal' ]),
   FieldSchema.defaulted('anchor', (comp: AlloyComponent): AnchorSpec => ({
     type: 'hotspot',

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingState.ts
@@ -1,10 +1,11 @@
-import { Fun, Singleton } from '@ephox/katamari';
+import { Cell, Fun, Singleton } from '@ephox/katamari';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { nuState } from '../common/BehaviourState';
 import { TooltippingState } from './TooltippingTypes';
 
 const init = (): TooltippingState => {
+  const enabled = Cell(true);
   const timer = Singleton.value<number>();
   const popup = Singleton.value<AlloyComponent>();
 
@@ -26,7 +27,9 @@ const init = (): TooltippingState => {
     clearTooltip: popup.clear,
     clearTimer,
     resetTimer,
-    readState
+    readState,
+    isEnabled: () => enabled.get(),
+    setEnabled: (setToEnabled) => enabled.set(setToEnabled)
   });
 
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingTypes.ts
@@ -10,6 +10,9 @@ import { BehaviourState } from '../common/BehaviourState';
 export interface TooltippingBehaviour extends AlloyBehaviour<TooltippingConfigSpec, TooltippingConfig> {
   hideAllExclusive: (comp: AlloyComponent) => void;
   setComponents: (comp: AlloyComponent, specs: AlloySpec[]) => void;
+  setEnabled: (comp: AlloyComponent, enabled: boolean) => void;
+  isEnabled: (comp: AlloyComponent) => boolean;
+  immediateOpenClose: (comp: AlloyComponent, open: boolean) => void;
 }
 
 export interface TooltippingConfig extends BehaviourConfigDetail {
@@ -20,6 +23,7 @@ export interface TooltippingConfig extends BehaviourConfigDetail {
   mode: 'normal' | 'follow-highlight' | 'children-keyboard-focus' | 'children-normal';
   delayForShow: () => number;
   delayForHide: () => number;
+  onSetup: (component: AlloyComponent) => void;
   anchor: (comp: AlloyComponent) => AnchorSpec;
   onShow: (comp: AlloyComponent, tooltip: AlloyComponent) => void;
   onHide: (comp: AlloyComponent, tooltip: AlloyComponent) => void;
@@ -36,6 +40,7 @@ export interface TooltippingConfigSpec extends BehaviourConfigSpec {
   anchor?: (comp: AlloyComponent) => AnchorSpec;
   onShow?: (comp: AlloyComponent, tooltip: AlloyComponent) => void;
   onHide?: (comp: AlloyComponent, tooltip: AlloyComponent) => void;
+  onSetup?: (component: AlloyComponent) => void;
 }
 
 export interface TooltippingState extends BehaviourState {
@@ -45,4 +50,6 @@ export interface TooltippingState extends BehaviourState {
   clearTimer: () => void;
   resetTimer: (f: () => void, delay: number) => void;
   isShowing: () => boolean;
+  isEnabled: () => boolean;
+  setEnabled: (enabled: boolean) => void;
 }

--- a/modules/alloy/src/main/ts/ephox/alloy/construct/CustomDefinition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/construct/CustomDefinition.ts
@@ -49,7 +49,7 @@ const schema = StructureSchema.objOf([
       // Note, not using constant behaviour names to avoid code size of unused behaviours
       [SystemEvents.execute()]: [ 'disabling', baseBehaviour, 'toggling', 'typeaheadevents' ],
       [SystemEvents.focus()]: [ baseBehaviour, 'focusing', 'keying' ],
-      [SystemEvents.systemInit()]: [ baseBehaviour, 'disabling', 'toggling', 'representing' ],
+      [SystemEvents.systemInit()]: [ baseBehaviour, 'disabling', 'toggling', 'representing', 'tooltipping' ],
       [NativeEvents.input()]: [ baseBehaviour, 'representing', 'streaming', 'invalidating' ],
       [SystemEvents.detachedFromDom()]: [ baseBehaviour, 'representing', 'item-events', 'toolbar-button-events', 'tooltipping' ],
       [NativeEvents.mousedown()]: [ 'focusing', baseBehaviour, 'item-type-events' ],
@@ -80,9 +80,9 @@ const toApis = <A>(info: CustomDetail<A>): A => info.apis;
 const toEvents = (info: CustomDetail<any>): AlloyEventRecord => info.events;
 
 export {
-  toInfo,
-  toDefinition,
-  toModification,
   toApis,
-  toEvents
+  toDefinition,
+  toEvents,
+  toInfo,
+  toModification
 };

--- a/modules/oxide/src/less/theme/components/color-picker/color-picker.less
+++ b/modules/oxide/src/less/theme/components/color-picker/color-picker.less
@@ -2,6 +2,15 @@
 // Color picker
 //
 
+//
+// Place your variables here
+//
+
+@color-picker-warning-frame-background-color: #faa;
+@color-picker-warning-frame-text-color: #f00;
+@color-picker-warning-frame-border-color: #f00;
+@color-picker-warning-frame-border: 1px solid @color-picker-warning-frame-border-color;
+
 .tox {
   .tox-hue-slider,
   .tox-rgb-form .tox-rgba-preview {
@@ -127,10 +136,10 @@
   }
 
   .tox-rgb-warning-note {
-    background-color: #fcc;
-    border: 1px solid #f00;
+    background-color: @color-picker-warning-frame-background-color;
+    border: @color-picker-warning-frame-border;
     border-radius: 3px;
-    color: #f00;
+    color: @color-picker-warning-frame-text-color;
     padding: 3px;
   }
 

--- a/modules/oxide/src/less/theme/components/color-picker/color-picker.less
+++ b/modules/oxide/src/less/theme/components/color-picker/color-picker.less
@@ -99,12 +99,43 @@
   }
 
   .tox-rgb-form input {
-    width: 6em;
+    min-width: 6em;
   }
 
   .tox-rgb-form input.tox-invalid {
     /* Need !important to override Chrome's focus styling unfortunately */
-    border: 1px solid red !important;
+    border: 1px solid @color-error-element-focus-color !important;
+    box-shadow: @color-error-element-focus;
+  }
+
+  .tox-rgb-container {
+    position: relative;
+  }
+
+  .tox-rgb-form .tox-invalid-icon {
+    align-content: center;
+    align-items: center;
+    display: none;
+    height: 100%;
+    position: absolute;
+    right: 0;
+    top: 0;
+
+    .tox-control-wrap__status-icon-invalid {
+      margin: 0;
+    }
+  }
+
+  .tox-rgb-warning-note {
+    background-color: #fcc;
+    border: 1px solid #f00;
+    border-radius: 3px;
+    color: #f00;
+    padding: 3px;
+  }
+
+  input.tox-invalid + .tox-invalid-icon {
+    display: flex;
   }
 
   .tox-rgb-form .tox-rgba-preview {

--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -16,6 +16,8 @@
 @color-tint: #006ce7;
 @color-white: #fff;
 @color-error: #c00;
+@color-error-element-focus-color: #f00;
+@color-error-element-focus: 0 0 0 1px @color-error-element-focus-color;
 @color-success: #78AB46;
 @font-stack: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
 

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/TooltipsBackstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/TooltipsBackstage.ts
@@ -1,8 +1,14 @@
 import { AlloyComponent, GuiFactory, SimpleSpec, TooltippingTypes } from '@ephox/alloy';
 import { Fun, Result } from '@ephox/katamari';
 
+interface TooltipConfigSpec {
+  readonly tooltipText: string;
+  readonly onShow?: (comp: AlloyComponent, tooltip: AlloyComponent) => void;
+  readonly onHide?: (comp: AlloyComponent, tooltip: AlloyComponent) => void;
+  readonly onSetup?: (comp: AlloyComponent) => void;
+}
 export interface TooltipsProvider {
-  readonly getConfig: (spec: { tooltipText: string; onShow?: (comp: AlloyComponent, tooltip: AlloyComponent) => void; onHide?: (comp: AlloyComponent, tooltip: AlloyComponent) => void }) => TooltippingTypes.TooltippingConfigSpec;
+  readonly getConfig: (spec: TooltipConfigSpec) => TooltippingTypes.TooltippingConfigSpec;
   readonly getComponents: (spec: { tooltipText: string }) => SimpleSpec[];
 }
 
@@ -31,7 +37,7 @@ export const TooltipsBackstage = (
     ];
   };
 
-  const getConfig = (spec: { tooltipText: string; onShow?: (comp: AlloyComponent, tooltip: AlloyComponent) => void; onHide?: (comp: AlloyComponent, tooltip: AlloyComponent) => void }) => {
+  const getConfig = (spec: TooltipConfigSpec) => {
     return {
       delayForShow: () => alreadyShowingTooltips() ? intervalDelay : tooltipDelay,
       delayForHide: Fun.constant(tooltipDelay),
@@ -53,7 +59,8 @@ export const TooltipsBackstage = (
         if (spec.onHide) {
           spec.onHide(comp, tooltip);
         }
-      }
+      },
+      onSetup: spec.onSetup,
     };
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
@@ -9,6 +9,7 @@ import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import { formActionEvent } from '../general/FormEvents';
+import * as Icons from '../icons/Icons';
 
 const english: Record<string, string> = {
   'colorcustom.rgb.red.label': 'R',
@@ -20,6 +21,7 @@ const english: Record<string, string> = {
   'colorcustom.rgb.hex.label': '#',
   'colorcustom.rgb.hex.description': 'Hex color code',
   'colorcustom.rgb.range': 'Range 0 to 255',
+  'colorcustom.rgb.invalid': 'Numbers only, 0 to 255',
   'aria.color.picker': 'Color Picker',
   'aria.input.invalid': 'Invalid input'
 };
@@ -36,8 +38,18 @@ type ColorPickerSpec = Omit<Dialog.ColorPicker, 'type'>;
 
 export const renderColorPicker = (_spec: ColorPickerSpec, providerBackstage: UiFactoryBackstageProviders, initialData: Optional<string>): SimpleSpec => {
   const getClass = (key: string) => 'tox-' + key;
+  const renderIcon = (name: string, errId: Optional<string>, icon: string = name, label: string = name): SimpleSpec =>
+    Icons.render(icon, {
+      tag: 'div',
+      classes: [ 'tox-icon', 'tox-control-wrap__status-icon-' + name ],
+      attributes: {
+        'title': providerBackstage.translate(label),
+        'aria-live': 'polite',
+        ...errId.fold(() => ({}), (id) => ({ id }))
+      }
+    }, providerBackstage.icons);
 
-  const colourPickerFactory = ColourPicker.makeFactory(translate(providerBackstage), getClass);
+  const colourPickerFactory = ColourPicker.makeFactory(translate(providerBackstage), getClass, providerBackstage.tooltips.getConfig, renderIcon);
 
   const onValidHex = (form: AlloyComponent) => {
     AlloyTriggers.emitWith(form, formActionEvent, { name: 'hex-valid', value: true });

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
@@ -16,7 +16,12 @@ export default {
   getOption: <T>(name: string): T | undefined => defaultOptions[name],
   tooltips: {
     getConfig: (): TooltippingTypes.TooltippingConfigSpec => {
-      return { } as any;
+      return {
+        lazySink: {},
+        tooltipDom: {
+          tag: 'div'
+        }
+      } as any;
     },
     getComponents: () => {
       return [] as any;


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-10799

Description of Changes:
Add an error tooltip and error icon when the text input is not valid.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
