### PR TITLE
TINY-10994: filter unsupported commands from text patterns

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10994-2024-06-17.yaml
+++ b/.changes/unreleased/tinymce-TINY-10994-2024-06-17.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: The pattern commans would execute even if command was not supported.
+time: 2024-06-17T16:06:10.078426+02:00
+custom:
+  Issue: TINY-10994

--- a/.changes/unreleased/tinymce-TINY-10994-2024-06-17.yaml
+++ b/.changes/unreleased/tinymce-TINY-10994-2024-06-17.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: The pattern commans would execute even if command was not supported.
+body: The pattern commands would execute even if the command was not enabled.
 time: 2024-06-17T16:06:10.078426+02:00
 custom:
   Issue: TINY-10994

--- a/modules/tinymce/src/core/main/ts/textpatterns/keyboard/Keyboard.ts
+++ b/modules/tinymce/src/core/main/ts/textpatterns/keyboard/Keyboard.ts
@@ -11,7 +11,13 @@ const setup = (editor: Editor): void => {
 
   // This is a thunk so that they reflect changes in the underlying options each time they are requested.
   const getPatternSet = () => Pattern.createPatternSet(
-    Options.getTextPatterns(editor),
+    Options.getTextPatterns(editor)
+      .filter((pattern) => {
+        if (pattern.type === 'inline-command' || pattern.type === 'block-command') {
+          return editor.queryCommandSupported(pattern.cmd);
+        }
+        return true;
+      }),
     Options.getTextPatternsLookup(editor)
   );
 

--- a/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsUnsupportedCmdTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/textpatterns/TextPatternsUnsupportedCmdTest.ts
@@ -1,0 +1,34 @@
+import { ApproxStructure } from '@ephox/agar';
+import { beforeEach, describe, it } from '@ephox/bedrock-client';
+import { Unicode } from '@ephox/katamari';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+import * as Utils from '../../module/test/TextPatternsUtils';
+
+describe('browser.tinymce.core.textpatterns.TextPatternsUnsupportedCmdTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    text_patterns: true,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ ]);
+
+  beforeEach(() => {
+    const editor = hook.editor();
+    editor.setContent('');
+  });
+
+  it('TINY-10994: Try applying list pattern from premium plugin and assert it does nothing', () => {
+    const editor = hook.editor();
+    Utils.setContentAndPressSpace(editor, '1.');
+    TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str) => {
+      return Utils.bodyStruct([
+        s.element('p', {
+          children: [
+            s.text(str.is(`1.${Unicode.nbsp}`), true)
+          ]
+        })
+      ]);
+    }));
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-10994

Description of Changes:
Text pattern commands do not execute now if the command is not available.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
