### PR TITLE
TINY-11019 & TINY-11022: Bring security fixes for issues with noscript encoding and noneditable_regexp option to `release/7`

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11019-2024-06-11.yaml
+++ b/.changes/unreleased/tinymce-TINY-11019-2024-06-11.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: HTML entities that were double decoded in `noscript` elements caused an XSS vulnerability.
+time: 2024-06-11T14:05:19.634277+02:00
+custom:
+  Issue: TINY-11019

--- a/.changes/unreleased/tinymce-TINY-11022-2024-06-12.yaml
+++ b/.changes/unreleased/tinymce-TINY-11022-2024-06-12.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: It was possible to inject XSS HTML that was not matching the regexp when using the `noneditable_regexp` option.
+time: 2024-06-12T07:27:17.817625+02:00
+custom:
+  Issue: TINY-11022

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -90,7 +90,7 @@ const transferChildren = (parent: AstNode, nativeParent: Node, specialElements: 
   const parentName = parent.name;
   // Exclude the special elements where the content is RCDATA as their content needs to be parsed instead of being left as plain text
   // See: https://html.spec.whatwg.org/multipage/parsing.html#parsing-html-fragments
-  const isSpecial = parentName in specialElements && parentName !== 'title' && parentName !== 'textarea';
+  const isSpecial = parentName in specialElements && parentName !== 'title' && parentName !== 'textarea' && parentName !== 'noscript';
 
   const childNodes = nativeParent.childNodes;
   for (let ni = 0, nl = childNodes.length; ni < nl; ni++) {

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
@@ -2,7 +2,6 @@ import { Arr, Optional } from '@ephox/katamari';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import DomParser from '../api/html/DomParser';
-import Entities from '../api/html/Entities';
 import AstNode from '../api/html/Node';
 import * as Zwsp from '../text/Zwsp';
 import { DomSerializerSettings } from './DomSerializerImpl';
@@ -79,17 +78,6 @@ const register = (htmlParser: DomParser, settings: DomSerializerSettings, dom: D
         } else {
           node.remove();
         }
-      }
-    }
-  });
-
-  htmlParser.addNodeFilter('noscript', (nodes) => {
-    let i = nodes.length;
-    while (i--) {
-      const node = nodes[i].firstChild;
-
-      if (node) {
-        node.value = Entities.decode(node.value ?? '');
       }
     }
   });

--- a/modules/tinymce/src/core/main/ts/html/NonEditableFilter.ts
+++ b/modules/tinymce/src/core/main/ts/html/NonEditableFilter.ts
@@ -1,3 +1,5 @@
+import { Arr } from '@ephox/katamari';
+
 import Editor from '../api/Editor';
 import { SetContentEvent } from '../api/EventTypes';
 import AstNode from '../api/html/Node';
@@ -52,6 +54,13 @@ const convertRegExpsToNonEditable = (editor: Editor, nonEditableRegExps: RegExp[
   e.content = content;
 };
 
+const isValidContent = (nonEditableRegExps: RegExp[], content: string) => {
+  return Arr.forall(nonEditableRegExps, (re) => {
+    const matches = content.match(re);
+    return matches !== null && matches[0].length === content.length;
+  });
+};
+
 const setup = (editor: Editor): void => {
   const contentEditableAttrName = 'contenteditable';
 
@@ -91,11 +100,16 @@ const setup = (editor: Editor): void => {
         continue;
       }
 
-      if (nonEditableRegExps.length > 0 && node.attr('data-mce-content')) {
-        node.name = '#text';
-        node.type = 3;
-        node.raw = true;
-        node.value = node.attr('data-mce-content');
+      const content = node.attr('data-mce-content');
+      if (nonEditableRegExps.length > 0 && content) {
+        if (isValidContent(nonEditableRegExps, content)) {
+          node.name = '#text';
+          node.type = 3;
+          node.raw = true;
+          node.value = content;
+        } else {
+          node.remove();
+        }
       } else {
         node.attr(contentEditableAttrName, null);
       }

--- a/modules/tinymce/src/core/test/ts/browser/html/NonEditableFilterTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/NonEditableFilterTest.ts
@@ -1,4 +1,4 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -38,5 +38,23 @@ describe('browser.tinymce.core.html.NonEditableFilterTest', () => {
     const editor = hook.editor();
     editor.setContent('<span contenteditable="false">{test1}</span>');
     assert.lengthOf(editor.dom.select('span'), 1);
+  });
+
+  context('Noneditable content injection', () => {
+    const testNoneditableContentInjection = (testCase: { input: string; expected: string }) => {
+      const editor = hook.editor();
+      editor.setContent(testCase.input);
+      TinyAssertions.assertContent(editor, testCase.expected);
+    };
+
+    it('TINY-11022: noneditable elements should not be allowed to include content that does not match the pattern', () => testNoneditableContentInjection({
+      input: '<p>foo<span class="mceNonEditable" data-mce-content="<b>baz</b>" contenteditable="false">something</span>bar</p>',
+      expected: '<p>foobar</p>'
+    }));
+
+    it('TINY-11022: noneditable elements should not be allowed to include content that just partially matches the pattern', () => testNoneditableContentInjection({
+      input: '<p>foo<span class="mceNonEditable" data-mce-content="{test1}<b>baz</b>" contenteditable="false">something</span>bar</p>',
+      expected: '<p>foobar</p>'
+    }));
   });
 });


### PR DESCRIPTION
Related Ticket:  TINY-11019 & TINY-11022

Description of Changes:
* Bring [the security fixes ](https://github.com/tinymce/tinymce-security-patches/pull/16) for issues with noscript encoding and noneditable_regexp option to `release/7`

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/`, `hotfix/` or `spike/`~

Review:
* [x] ~Milestone set~
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
