### PR TITLE
TINY-11019 & TINY-11022: Bring security fixes for issues with noscript encoding and noneditable_regexp option to `release/6`

### DIFF
--- a/modules/tinymce/CHANGELOG.md
+++ b/modules/tinymce/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 6.8.4 - 2024-06-19
+
+### Fixed
+- HTML entities that were double decoded in `noscript` elements caused an XSS vulnerability. #TINY-11019
+- It was possible to inject XSS HTML that was not matching the regexp when using the `noneditable_regexp` option. #TINY-11022
+
 ## 6.8.3 - 2024-02-08
 
 ### Changed

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce",
-  "version": "6.8.3",
+  "version": "6.8.4",
   "private": true,
   "repository": {
     "type": "git",

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -92,7 +92,7 @@ const transferChildren = (parent: AstNode, nativeParent: Node, specialElements: 
   const parentName = parent.name;
   // Exclude the special elements where the content is RCDATA as their content needs to be parsed instead of being left as plain text
   // See: https://html.spec.whatwg.org/multipage/parsing.html#parsing-html-fragments
-  const isSpecial = parentName in specialElements && parentName !== 'title' && parentName !== 'textarea';
+  const isSpecial = parentName in specialElements && parentName !== 'title' && parentName !== 'textarea' && parentName !== 'noscript';
 
   const childNodes = nativeParent.childNodes;
   for (let ni = 0, nl = childNodes.length; ni < nl; ni++) {

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
@@ -2,7 +2,6 @@ import { Arr, Optional } from '@ephox/katamari';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import DomParser from '../api/html/DomParser';
-import Entities from '../api/html/Entities';
 import AstNode from '../api/html/Node';
 import * as Zwsp from '../text/Zwsp';
 import { DomSerializerSettings } from './DomSerializerImpl';
@@ -79,17 +78,6 @@ const register = (htmlParser: DomParser, settings: DomSerializerSettings, dom: D
         } else {
           node.remove();
         }
-      }
-    }
-  });
-
-  htmlParser.addNodeFilter('noscript', (nodes) => {
-    let i = nodes.length;
-    while (i--) {
-      const node = nodes[i].firstChild;
-
-      if (node) {
-        node.value = Entities.decode(node.value ?? '');
       }
     }
   });

--- a/modules/tinymce/src/core/main/ts/html/NonEditableFilter.ts
+++ b/modules/tinymce/src/core/main/ts/html/NonEditableFilter.ts
@@ -1,3 +1,5 @@
+import { Arr } from '@ephox/katamari';
+
 import Editor from '../api/Editor';
 import { SetContentEvent } from '../api/EventTypes';
 import AstNode from '../api/html/Node';
@@ -52,6 +54,13 @@ const convertRegExpsToNonEditable = (editor: Editor, nonEditableRegExps: RegExp[
   e.content = content;
 };
 
+const isValidContent = (nonEditableRegExps: RegExp[], content: string) => {
+  return Arr.forall(nonEditableRegExps, (re) => {
+    const matches = content.match(re);
+    return matches !== null && matches[0].length === content.length;
+  });
+};
+
 const setup = (editor: Editor): void => {
   const contentEditableAttrName = 'contenteditable';
 
@@ -91,11 +100,16 @@ const setup = (editor: Editor): void => {
         continue;
       }
 
-      if (nonEditableRegExps.length > 0 && node.attr('data-mce-content')) {
-        node.name = '#text';
-        node.type = 3;
-        node.raw = true;
-        node.value = node.attr('data-mce-content');
+      const content = node.attr('data-mce-content');
+      if (nonEditableRegExps.length > 0 && content) {
+        if (isValidContent(nonEditableRegExps, content)) {
+          node.name = '#text';
+          node.type = 3;
+          node.raw = true;
+          node.value = content;
+        } else {
+          node.remove();
+        }
       } else {
         node.attr(contentEditableAttrName, null);
       }

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -1,3 +1,4 @@
+import { Waiter } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
@@ -673,6 +674,38 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
       const editor = hook.editor();
       editor.setContent('<svg width="100" height="100"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><script>alert(1)</script></circle></svg>');
       TinyAssertions.assertContent(editor, '<svg width="100" height="100"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"><script>alert(1)</script></circle></svg>');
+    });
+  });
+
+  context('Special elements', () => {
+    const hook = TinyHooks.bddSetup<Editor>({
+      base_url: '/project/tinymce/js/tinymce'
+    }, []);
+
+    it('TINY-11019: Should not be possible to run scripts inside noscript elements', async () => {
+      const editor = hook.editor();
+      let state = false;
+      const editorWinGlobal = editor.getWin() as unknown as any;
+
+      editorWinGlobal.xss = () => {
+        state = true;
+      };
+
+      editor.setContent('<noscript>&lt;/noscript&gt;&lt;style onload=xss()&gt;&lt;/style&gt;</noscript>');
+
+      await Waiter.pWait(1);
+
+      delete editorWinGlobal.xss;
+
+      assert.isFalse(state, 'xss function should not have been called');
+      TinyAssertions.assertContent(editor, '<noscript>&lt;/noscript&gt;&lt;style onload=xss()&gt;&lt;/style&gt;</noscript>');
+    });
+
+    it('TINY-11019: Should not double decode noscript contents', () => {
+      const editor = hook.editor();
+
+      editor.setContent('<noscript>&amp;lt;/noscript&amp;&gt;</noscript>');
+      TinyAssertions.assertContent(editor, '<noscript>&amp;lt;/noscript&amp;&gt;</noscript>');
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1729,4 +1729,49 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       assert.equal(serializedHtml, '<div><svg> <circle> </circle> </svg> <svg> <circle> </circle> </svg></div>');
     });
   });
+
+  context('Special elements', () => {
+    const schema = Schema({ extended_valid_elements: 'script,noembed,xmp', valid_children: '+body[style]' });
+
+    const testSpecialElement = (testCase: { input: string; expected: string }) => {
+      const fragment = DomParser({ forced_root_block: 'p', sanitize: false }, schema).parse(testCase.input);
+      const serializedHtml = HtmlSerializer({}, schema).serialize(fragment);
+
+      assert.equal(serializedHtml, testCase.expected);
+    };
+
+    it('TINY-11019: Should not entity encode text in script elements', () => testSpecialElement({
+      input: '<script>if (a < b) alert(1)</script>',
+      expected: '<script>if (a < b) alert(1)</script>'
+    }));
+
+    it('TINY-11019: Should not entity encode text in style elements', () => testSpecialElement({
+      input: '<style>b > i {}</style>',
+      expected: '<style>b > i {}</style>'
+    }));
+
+    it('TINY-11019: Should not entity decode text inside textarea elements', () => testSpecialElement({
+      input: '<div><textarea>&lt;&gt;&amp;</textarea></div>',
+      expected: '<div><textarea>&lt;&gt;&amp;</textarea></div>'
+    }));
+
+    it('TINY-11019: Should not entity encode text inside textarea elements', () => testSpecialElement({
+      input: '<div><textarea><b>test</b></textarea></div>',
+      expected: '<div><textarea>&lt;b&gt;test&lt;/b&gt;</textarea></div>'
+    }));
+
+    const excluded = [ 'script', 'style', 'title', 'plaintext', 'textarea' ];
+    const specialElements = Arr.filter(Obj.keys(schema.getSpecialElements()), (name) => !Arr.contains(excluded, name));
+    Arr.each(specialElements, (elementName) => {
+      it(`TINY-11019: Should not entity decode text inside ${elementName} elements`, () => testSpecialElement({
+        input: `<div><${elementName}>&lt;&gt;&amp;</${elementName}></div>`,
+        expected: `<div><${elementName}>&lt;&gt;&amp;</${elementName}></div>`
+      }));
+
+      it(`TINY-11019: Should not entity encode elements inside ${elementName} elements`, () => testSpecialElement({
+        input: `<div><${elementName}><em>test</em></${elementName}></div>`,
+        expected: `<div><${elementName}><em>test</em></${elementName}></div>`
+      }));
+    });
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/NonEditableFilterTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/NonEditableFilterTest.ts
@@ -1,4 +1,4 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -38,5 +38,23 @@ describe('browser.tinymce.core.html.NonEditableFilterTest', () => {
     const editor = hook.editor();
     editor.setContent('<span contenteditable="false">{test1}</span>');
     assert.lengthOf(editor.dom.select('span'), 1);
+  });
+
+  context('Noneditable content injection', () => {
+    const testNoneditableContentInjection = (testCase: { input: string; expected: string }) => {
+      const editor = hook.editor();
+      editor.setContent(testCase.input);
+      TinyAssertions.assertContent(editor, testCase.expected);
+    };
+
+    it('TINY-11022: noneditable elements should not be allowed to include content that does not match the pattern', () => testNoneditableContentInjection({
+      input: '<p>foo<span class="mceNonEditable" data-mce-content="<b>baz</b>" contenteditable="false">something</span>bar</p>',
+      expected: '<p>foobar</p>'
+    }));
+
+    it('TINY-11022: noneditable elements should not be allowed to include content that just partially matches the pattern', () => testNoneditableContentInjection({
+      input: '<p>foo<span class="mceNonEditable" data-mce-content="{test1}<b>baz</b>" contenteditable="false">something</span>bar</p>',
+      expected: '<p>foobar</p>'
+    }));
   });
 });


### PR DESCRIPTION
Related Ticket:  TINY-11019 & TINY-11022

Description of Changes:
* Bring [the security fixes](https://github.com/tinymce/tinymce-security-patches/pull/15/commits/9d6c86fccb69786a7ffb3ae83e82e17993a60879) for noscript encoding and noneditable_regexp option to `release/6`

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] ~Branch prefixed with `feature/`, `hotfix/` or `spike/`~

Review:
* [x] ~Milestone set~
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
