### PR TITLE
TINY-11046: Switched from aws to lambdatest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,9 +202,11 @@ timestamps {
     // [ browser: 'edge', os: 'windows' ],
     // [ browser: 'firefox', os: 'macos' ],
     // Remote tests
-    [ browser: 'chrome', provider: 'aws', buckets: 2 ],
+    // [ browser: 'chrome', provider: 'aws', buckets: 2 ],
     // [ browser: 'edge', provider: 'aws', buckets: 2 ], // TINY-10540: Investigate Edge issues in AWS
-    [ browser: 'firefox', provider: 'aws', buckets: 2 ],
+    // [ browser: 'firefox', provider: 'aws', buckets: 2 ],
+    [ browser: 'chrome', provider: 'lambdatest', buckets: 1 ],
+    [ browser: 'firefox', provider: 'lambdatest', buckets: 1 ],
     [ browser: 'edge', provider: 'lambdatest', buckets: 1 ],
     [ browser: 'chrome', provider: 'lambdatest', os: 'macOS Sonoma', buckets: 1 ],
     [ browser: 'firefox', provider: 'lambdatest', os: 'macOS Sonoma', buckets: 1 ],


### PR DESCRIPTION
Related Ticket: TINY-11046

Description of Changes:
* Switches all tests to lambdatest since something is wrong with the aws device farm

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
