### PR TITLE
TINY-10127: Correct the merge branch for CI

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,1 +1,1 @@
-primaryBranch=main
+primaryBranch=release/7


### PR DESCRIPTION
Related Ticket: TINY-10127

Descriptions:
- In some cases, when a branch is branched off `main` and target for `release/7`, the CI fails because of merge conflicts


GitHub issues (if applicable):
