### PR TITLE
TINY-10955: Remove whitespaces between comment elements.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10955-2024-06-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-10955-2024-06-24.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Multiple comment html elements after each other would in some cases generate
+  unwanted elements.
+time: 2024-06-24T17:40:05.135911183+02:00
+custom:
+  Issue: TINY-10955

--- a/.changes/unreleased/tinymce-TINY-10955-2024-06-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-10955-2024-06-24.yaml
@@ -1,7 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Multiple comment html elements after each other would in some cases generate
-  unwanted elements.
+body: Sequential html comments would in some cases generate unwanted elements.
 time: 2024-06-24T17:40:05.135911183+02:00
 custom:
   Issue: TINY-10955

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -1,4 +1,5 @@
 import { Arr, Fun, Obj, Type } from '@ephox/katamari';
+import { NodeTypes } from '@ephox/sugar';
 
 import * as TransparentElements from '../../content/TransparentElements';
 import * as NodeType from '../../dom/NodeType';
@@ -212,7 +213,7 @@ const whitespaceCleaner = (root: AstNode, schema: Schema, settings: DomParserSet
 
         if (text.length === 0) {
           node.remove();
-        } else if (text === ' ' && node.prev && node.prev.type === 8 && node.next && node.next.type === 8) {
+        } else if (text === ' ' && node.prev && node.prev.type === NodeTypes.COMMENT && node.next && node.next.type === NodeTypes.COMMENT) {
           node.remove();
         } else {
           node.value = text;

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -212,6 +212,8 @@ const whitespaceCleaner = (root: AstNode, schema: Schema, settings: DomParserSet
 
         if (text.length === 0) {
           node.remove();
+        } else if (text === ' ' && node.prev && node.prev.type === 8 && node.next && node.next.type === 8) {
+          node.remove();
         } else {
           node.value = text;
         }

--- a/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
@@ -502,6 +502,17 @@ describe('browser.tinymce.core.EditorTest', () => {
     TinyAssertions.assertContent(editor, '<p><img src="data:image/gif;base64,R0"></p>');
   });
 
+  // eslint-disable-next-line mocha/no-exclusive-tests
+  it.only('TINY-10955: multiple comments will not cause unexpected newlines', () => {
+    const editor = hook.editor();
+    editor.setContent('<div>A</div><!--Comment1--><!--Comment2--><div>B</div>');
+    TinyAssertions.assertRawContent(editor, '<div>A</div><!--Comment1--><!--Comment2--><div>B</div>');
+    editor.setContent('<div>A</div> <!--Comment1--> <!--Comment2--> <div>B</div>');
+    TinyAssertions.assertRawContent(editor, '<div>A</div><!--Comment1--><!--Comment2--><div>B</div>');
+    editor.setContent('<div>A</div>\n<!--Comment1-->\n<!--Comment2-->\n<div>B</div>');
+    TinyAssertions.assertRawContent(editor, '<div>A</div><!--Comment1--><!--Comment2--><div>B</div>');
+  });
+
   context('hasPlugin', () => {
     const checkWithoutManager = (title: string, plugins: string, plugin: string, expected: boolean) => {
       const editor = hook.editor();


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-10955

Description of Changes:
To prevent element generation we just remove the whitespaces.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
