### PR TITLE
TINY-10961: Long translations of the bottom helptext would overflow poorly.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10961-2024-06-18.yaml
+++ b/.changes/unreleased/tinymce-TINY-10961-2024-06-18.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Long translations of the bottom help text would cause minor graphical issues.
+time: 2024-06-18T13:47:57.814089221+02:00
+custom:
+  Issue: TINY-10961

--- a/modules/oxide/src/less/theme/components/statusbar/statusbar.less
+++ b/modules/oxide/src/less/theme/components/statusbar/statusbar.less
@@ -7,6 +7,7 @@
 @statusbar-font-size: @font-size-sm;
 @statusbar-font-weight: @font-weight-normal;
 @statusbar-height: 25px;
+@statusbar-text-height: 16px;
 @statusbar-padding-x: @pad-sm;
 @statusbar-separator-color: @tinymce-separator-color;
 @statusbar-text-color: contrast(@statusbar-background-color, @text-color-muted, fade(@color-white, 75));
@@ -53,9 +54,12 @@
   }
 
   .tox-statusbar__text-container {
+    align-items: flex-start;
     display: flex;
     flex: 1 1 auto;
+    height: @statusbar-text-height;
     justify-content: space-between;
+    overflow: hidden;
 
     @media @breakpoint-gt-sm {
       &.tox-statusbar__text-container-3-cols > .tox-statusbar__help-text,


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-10961

Description of Changes:
Minor css changes for improved design.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
