### PR TITLE
TINY-10955: Accidentally left a development .only on a test when merging in.

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
@@ -502,8 +502,7 @@ describe('browser.tinymce.core.EditorTest', () => {
     TinyAssertions.assertContent(editor, '<p><img src="data:image/gif;base64,R0"></p>');
   });
 
-  // eslint-disable-next-line mocha/no-exclusive-tests
-  it.only('TINY-10955: multiple comments will not cause unexpected newlines', () => {
+  it('TINY-10955: multiple comments will not cause unexpected newlines', () => {
     const editor = hook.editor();
     editor.setContent('<div>A</div><!--Comment1--><!--Comment2--><div>B</div>');
     TinyAssertions.assertRawContent(editor, '<div>A</div><!--Comment1--><!--Comment2--><div>B</div>');


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-10955

Description of Changes:
This is just removing that accidental .only

Pre-checks:
* ~~[x] Changelog entry added~~
* ~~[x] Tests have been added (if applicable)~~
* ~~[x] Branch prefixed with `feature/`, `hotfix/` or `spike/`~~

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
