### PR TITLE
Revert "TINY-10590: Merge blocks now no longer relying on browser behavior for edgecase."

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10590-2024-05-21.yaml
+++ b/.changes/unreleased/tinymce-TINY-10590-2024-05-21.yaml
@@ -1,6 +1,0 @@
-project: tinymce
-kind: Fixed
-body: Text content could move unexpectedly when deleting a paragraph.
-time: 2024-05-21T08:45:35.803719938+02:00
-custom:
-  Issue: TINY-10590

--- a/modules/tinymce/src/core/main/ts/delete/BlockBoundaryDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/BlockBoundaryDelete.ts
@@ -11,7 +11,7 @@ const backspaceDelete = (editor: Editor, forward: boolean): Optional<() => void>
   const position = BlockMergeBoundary.read(editor.schema, rootNode.dom, forward, editor.selection.getRng())
     .map((blockBoundary) =>
       () => {
-        MergeBlocks.mergeBlocks(rootNode, forward, blockBoundary.from.block, blockBoundary.to.block, editor.schema, true)
+        MergeBlocks.mergeBlocks(rootNode, forward, blockBoundary.from.block, blockBoundary.to.block, editor.schema)
           .each((pos) => {
             editor.selection.setRng(pos.toRange());
           });

--- a/modules/tinymce/src/core/main/ts/delete/BlockMergeBoundary.ts
+++ b/modules/tinymce/src/core/main/ts/delete/BlockMergeBoundary.ts
@@ -36,6 +36,9 @@ const getBlockPosition = (rootNode: HTMLElement, pos: CaretPosition): Optional<B
   return DeleteUtils.getParentBlock(rootElm, containerElm).map((block) => blockPosition(block, pos));
 };
 
+const isNotAncestorial = (blockBoundary: BlockBoundary) =>
+  !(Compare.contains(blockBoundary.to.block, blockBoundary.from.block) || Compare.contains(blockBoundary.from.block, blockBoundary.to.block));
+
 const isDifferentBlocks = (blockBoundary: BlockBoundary): boolean =>
   !Compare.eq(blockBoundary.from.block, blockBoundary.to.block);
 
@@ -81,7 +84,7 @@ const readFromRange = (schema: Schema, rootNode: HTMLElement, forward: boolean, 
   );
 
   return Optionals.lift2(fromBlockPos, toBlockPos, blockBoundary).filter((blockBoundary) =>
-    isDifferentBlocks(blockBoundary) && hasSameHost(rootNode, blockBoundary) && isEditable(blockBoundary) && hasValidBlocks(blockBoundary));
+    isDifferentBlocks(blockBoundary) && hasSameHost(rootNode, blockBoundary) && isEditable(blockBoundary) && hasValidBlocks(blockBoundary) && isNotAncestorial(blockBoundary));
 };
 
 const read = (schema: Schema, rootNode: HTMLElement, forward: boolean, rng: Range): Optional<BlockBoundary> =>

--- a/modules/tinymce/src/core/test/ts/browser/delete/BlockMergeBoundaryTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/BlockMergeBoundaryTest.ts
@@ -72,6 +72,24 @@ describe('browser.tinymce.core.delete.BlockMergeBoundary', () => {
       const boundaryOpt = readBlockBoundary(true, [ 1, 0 ], 1);
       assertBlockBoundaryNone(boundaryOpt);
     });
+
+    it('TINY-10590: If the cursor is between an internal block and a text-node it should not count as a block boundary', () => {
+      setHtml('<div>A<p>B</p>C</div>');
+      const boundaryOpt = readBlockBoundary(false, [ 0 ], 2);
+      assertBlockBoundaryNone(boundaryOpt);
+    });
+
+    it('TINY-10590: If the cursor is in a text node and attempt to go outside of it, going backwards, it should not count as a boundary', () => {
+      setHtml('<div>A<p>B</p>C</div>');
+      const boundaryOpt = readBlockBoundary(false, [ 0, 1 ], 0);
+      assertBlockBoundaryNone(boundaryOpt);
+    });
+
+    it('TINY-10590: If the cursor is in a text node and attempt to go outside of it, going forwards, it should not count as a boundary', () => {
+      setHtml('<div>A<p>B</p>C</div>');
+      const boundaryOpt = readBlockBoundary(true, [ 0, 1 ], 1);
+      assertBlockBoundaryNone(boundaryOpt);
+    });
   });
 
   context('Some block boundaries', () => {

--- a/modules/tinymce/src/core/test/ts/browser/delete/MergeBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/MergeBlocksTest.ts
@@ -21,10 +21,10 @@ describe('browser.tinymce.core.delete.MergeBlocksTest', () => {
     Assertions.assertHtml('Should equal html', expectedHtml, viewBlock.get().innerHTML);
   };
 
-  const mergeBlocks = (forward: boolean, block1Path: number[], block2Path: number[], mergeNotDelete: boolean = false) => {
+  const mergeBlocks = (forward: boolean, block1Path: number[], block2Path: number[]) => {
     const block1 = Hierarchy.follow(SugarElement.fromDom(viewBlock.get()), block1Path).getOrDie() as SugarElement<Element>;
     const block2 = Hierarchy.follow(SugarElement.fromDom(viewBlock.get()), block2Path).getOrDie() as SugarElement<Element>;
-    return MergeBlocks.mergeBlocks(SugarElement.fromDom(viewBlock.get()), forward, block1, block2, baseSchema, mergeNotDelete);
+    return MergeBlocks.mergeBlocks(SugarElement.fromDom(viewBlock.get()), forward, block1, block2, baseSchema);
   };
 
   const assertPosition = (position: Optional<CaretPosition>, expectedPath: number[], expectedOffset: number) => {
@@ -238,20 +238,6 @@ describe('browser.tinymce.core.delete.MergeBlocksTest', () => {
       const pos = mergeBlocks(false, [ 1 ], [ 0 ]);
       assertPosition(pos, [ 0, 0 ], 1);
       assertHtml('<div>ab</div><div><h1>c</h1></div>');
-    });
-
-    it('TINY-10590: Merge children until we find a block backwards', () => {
-      setHtml('<div>A<p>B</p>C</div>');
-      const pos = mergeBlocks(false, [ 0, 1 ], [ 0 ], true);
-      assertHtml('<div><p>AB</p>C</div>');
-      assertPosition(pos, [ 0, 0, 1 ], 1);
-    });
-
-    it('TINY-10590: Merge children until we find a block forwards', () => {
-      setHtml('<div>A<p>B</p>C</div>');
-      const pos = mergeBlocks(true, [ 0, 1 ], [ 0 ], true);
-      assertHtml('<div>A<p>BC</p></div>');
-      assertPosition(pos, [ 0, 1, 0 ], 1);
     });
   });
 });


### PR DESCRIPTION
After an investigation, it was determined that the change in #9669 incorrectly modifies the DOM when pressing backspace on a `br`. The following image shows the result between before (left) and after (right) the change has been reverted. 

![Screenshot 2024-07-04 at 11 21 50 am](https://github.com/tinymce/tinymce/assets/97494111/d0606130-2ade-4ef2-a0dc-fe70bc4f248f)

