### PR TITLE
TINY-11053: Now handling whole html documents in the text area.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11053-2024-07-04.yaml
+++ b/.changes/unreleased/tinymce-TINY-11053-2024-07-04.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Improved
+body: When adding a full document the content of the head element is no longer added
+  to the body.
+time: 2024-07-04T17:12:09.757923664+02:00
+custom:
+  Issue: TINY-11053

--- a/.changes/unreleased/tinymce-TINY-11053-2024-07-04.yaml
+++ b/.changes/unreleased/tinymce-TINY-11053-2024-07-04.yaml
@@ -1,7 +1,6 @@
 project: tinymce
 kind: Improved
-body: When adding a full document the content of the head element is no longer added
-  to the body.
+body: When a full document was loaded as editor content the head elements were added to the body.
 time: 2024-07-04T17:12:09.757923664+02:00
 custom:
   Issue: TINY-11053

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -297,7 +297,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
       if (format === 'xhtml') {
         // If parsing XHTML then the content must contain the xmlns declaration, see https://www.w3.org/TR/xhtml1/normative.html#strict
         return `<html xmlns="http://www.w3.org/1999/xhtml"><head></head><body>${content}</body></html>`;
-      } else if (/^[\s]*<head/i.test(html) || /^[\s]*<html/i.test(html)) {
+      } else if (/^[\s]*<head/i.test(html) || /^[\s]*<html/i.test(html) || /^[\s]*<!DOCTYPE/i.test(html)) {
         return `<html>${content}</html>`;
       } else {
         return `<body>${content}</body>`;

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1756,6 +1756,11 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       expected: '<script>if (a < b) alert(1)</script>'
     }));
 
+    it('TINY-11053: HTML and head elements should be ignored.', () => testSpecialElement({
+      input: '<html><head><!--comment 1--></head><body><!--comment 2--><body></html>',
+      expected: '<!--comment 2-->'
+    }));
+
     it('TINY-11019: Should not entity encode text in style elements', () => testSpecialElement({
       input: '<style>b > i {}</style>',
       expected: '<style>b > i {}</style>'


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-11057

Description of Changes:
Previously whole html-blocks were put into a body-tag and merging the head and body before we could do anything about them.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
