### PR TITLE
TINY-11045: Update the styles of Revision History sidebar

### DIFF
--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -66,7 +66,7 @@
       background-color: @background-color;
       box-shadow: 0 4px 8px 0 rgba(34, 47, 62, .1);
       color: @revisionhistory-text-color;
-      font-size: 20px;
+      font-size: @font-size-lg;
       font-weight: 400;
       line-height: 28px;
       padding: @revisionhistory-gap;

--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -74,6 +74,7 @@
     .tox-revisionhistory__revisions {
       background-color: @revisionhistory-border-color;
       display: flex;
+      flex: 1;
       flex-direction: column;
       gap: @revisionhistory-gap;
       overflow-y: auto;

--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -3,8 +3,10 @@
 //
 @revisionhistory-gap: 12px;
 @revisionhistory-border-radius: 6px;
-@revisionhistory-background-color: contrast(@background-color, @background-color, lighten(@background-color, 5%));
-@revisionhistory-border-color: #f0f0f0;
+@revisionhistory-dark-mode: boolean(luma(@background-color) < 3);
+@revisionhistory-secondary-color: #f0f0f0;
+@revisionhistory-sidebar-background-color: if(@revisionhistory-dark-mode, #2b3b4e, @revisionhistory-secondary-color);   // Trial and error
+@revisionhistory-border-color: if(@revisionhistory-dark-mode, rgba(255, 255, 255, .15), @revisionhistory-secondary-color);
 @revisionhistory-text-color: @text-color;
 @revisionhistory-card-hover-background-color: @toolbar-button-hover-background-color;
 @revisionhistory-card-active-background-color: multiply(white, contrast(@background-color, fade(@color-tint, 35), fade(@color-tint, 65)));
@@ -13,7 +15,7 @@
 @revisionhistory-sidebar-minwidth: 248px;
 @revisionhistory-text-lineheight: 24px;
 @revisionhistory-padding: @revisionhistory-gap;
-@revisonhistory-box-shadow: none;
+@revisionhistory-box-shadow: none;
 
 .overflow-text() {
   overflow: hidden;
@@ -33,8 +35,7 @@
   }
 
   .tox-revisionhistory {
-    background-color: @revisionhistory-background-color;
-    border-radius: 4px;
+    background-color: @background-color;
     border-top: @revisionhistory-border;
     display: flex;
     flex: 1;
@@ -62,6 +63,7 @@
     width: 436px;
 
     .tox-revisionhistory__sidebar-title {
+      background-color: @background-color;
       box-shadow: 0 4px 8px 0 rgba(34, 47, 62, .1);
       color: @revisionhistory-text-color;
       font-size: 20px;
@@ -72,7 +74,7 @@
     }
 
     .tox-revisionhistory__revisions {
-      background-color: @revisionhistory-border-color;
+      background-color: @revisionhistory-sidebar-background-color;
       display: flex;
       flex: 1;
       flex-direction: column;
@@ -97,7 +99,7 @@
       }
 
       .tox-revisionhistory__card {
-        background-color: @revisionhistory-background-color;
+        background-color: @background-color;
         border: @revisionhistory-border;
         border-radius: @revisionhistory-border-radius;
         color: @revisionhistory-text-color;
@@ -108,7 +110,7 @@
 
         &:hover {
           background-color: @revisionhistory-card-hover-background-color;
-          box-shadow: @revisonhistory-box-shadow;
+          box-shadow: @revisionhistory-box-shadow;
           color: @revisionhistory-card-active-text-color;
         }
 
@@ -124,7 +126,7 @@
 
         &.tox-revisionhistory__card--selected {
           background-color: @revisionhistory-card-active-background-color;
-          box-shadow: @revisonhistory-box-shadow;
+          box-shadow: @revisionhistory-box-shadow;
           color: @revisionhistory-card-active-text-color;
         }
       }

--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -1,19 +1,18 @@
 //
 // Revision history
 //
-@revisionhistory-base-value: 12px;
+@revisionhistory-gap: 12px;
 @revisionhistory-border-radius: 6px;
 @revisionhistory-background-color: contrast(@background-color, @background-color, lighten(@background-color, 5%));
-@revisionhistory-border-color:  #f0f0f0;
+@revisionhistory-border-color: #f0f0f0;
 @revisionhistory-text-color: @text-color;
 @revisionhistory-card-hover-background-color: @toolbar-button-hover-background-color;
 @revisionhistory-card-active-background-color: multiply(white, contrast(@background-color, fade(@color-tint, 35), fade(@color-tint, 65)));
 @revisionhistory-card-active-text-color: @toolbar-button-active-text-color;
 @revisionhistory-border: 1px solid @revisionhistory-border-color;
-@revisionhistory-sidebar-title-font-size: @font-size-lg;
 @revisionhistory-sidebar-minwidth: 248px;
 @revisionhistory-text-lineheight: 24px;
-@revisionhistory-card-padding: @revisionhistory-base-value;
+@revisionhistory-padding: @revisionhistory-gap;
 @revisonhistory-box-shadow: none;
 
 .overflow-text() {
@@ -63,13 +62,12 @@
     width: 436px;
 
     .tox-revisionhistory__sidebar-title {
-      background-color: @revisionhistory-background-color;
       box-shadow: 0 4px 8px 0 rgba(34, 47, 62, .1);
       color: @revisionhistory-text-color;
       font-size: 20px;
       font-weight: 400;
       line-height: 28px;
-      padding: @revisionhistory-card-padding;
+      padding: @revisionhistory-gap;
       z-index: 1; // To get a shadow effect
     }
 
@@ -77,9 +75,9 @@
       background-color: @revisionhistory-border-color;
       display: flex;
       flex-direction: column;
-      gap: @revisionhistory-base-value;
+      gap: @revisionhistory-gap;
       overflow-y: auto;
-      padding: 10px @revisionhistory-card-padding;
+      padding: 10px @revisionhistory-gap;
 
       &:focus {
         height: 100%;
@@ -104,7 +102,7 @@
         color: @revisionhistory-text-color;
         cursor: pointer;
         font-size: @font-size-sm;
-        padding: @revisionhistory-card-padding;
+        padding: @revisionhistory-gap;
         width: 100%;
 
         &:hover {

--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -4,7 +4,7 @@
 @revisionhistory-gap: 12px;
 @revisionhistory-border-radius: 6px;
 @revisionhistory-dark-mode: boolean(luma(@background-color) < 3);
-@revisionhistory-secondary-color: #f0f0f0;
+@revisionhistory-secondary-color: contrast(@background-color, darken(@background-color, 6%), lighten(@background-color, 15%));
 @revisionhistory-sidebar-background-color: if(@revisionhistory-dark-mode, #2b3b4e, @revisionhistory-secondary-color);   // Trial and error
 @revisionhistory-border-color: if(@revisionhistory-dark-mode, rgba(255, 255, 255, .15), @revisionhistory-secondary-color);
 @revisionhistory-text-color: @text-color;
@@ -60,7 +60,7 @@
     flex-direction: column;
     height: 100%;
     min-width: @revisionhistory-sidebar-minwidth;
-    width: 436px;
+    width: 316px;
 
     .tox-revisionhistory__sidebar-title {
       background-color: @background-color;

--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -2,16 +2,16 @@
 // Revision history
 //
 @revisionhistory-base-value: 12px;
+@revisionhistory-border-radius: 6px;
 @revisionhistory-background-color: contrast(@background-color, @background-color, lighten(@background-color, 5%));
-@revisionhistory-border-color: @border-color;
+@revisionhistory-border-color:  #f0f0f0;
 @revisionhistory-text-color: @text-color;
 @revisionhistory-card-hover-background-color: @toolbar-button-hover-background-color;
 @revisionhistory-card-active-background-color: multiply(white, contrast(@background-color, fade(@color-tint, 35), fade(@color-tint, 65)));
 @revisionhistory-card-active-text-color: @toolbar-button-active-text-color;
 @revisionhistory-border: 1px solid @revisionhistory-border-color;
 @revisionhistory-sidebar-title-font-size: @font-size-lg;
-@revisionhistory-sidebar-title-height: 60px;
-@revisionhistory-sidebar-minwidth: 192px;
+@revisionhistory-sidebar-minwidth: 248px;
 @revisionhistory-text-lineheight: 24px;
 @revisionhistory-card-padding: @revisionhistory-base-value;
 @revisonhistory-box-shadow: none;
@@ -56,26 +56,30 @@
   }
 
   .tox-revisionhistory__sidebar {
-    border-left: @revisionhistory-border;
+    display: flex;
+    flex-direction: column;
     height: 100%;
-    max-width: 360px;
+    min-width: @revisionhistory-sidebar-minwidth;
+    width: 436px;
 
     .tox-revisionhistory__sidebar-title {
-      border-bottom: @revisionhistory-border;
+      background-color: @revisionhistory-background-color;
+      box-shadow: 0 4px 8px 0 rgba(34, 47, 62, .1);
       color: @revisionhistory-text-color;
-      font-size: @revisionhistory-sidebar-title-font-size;
+      font-size: 20px;
       font-weight: 400;
-      height: @revisionhistory-sidebar-title-height;
-      min-width: @revisionhistory-sidebar-minwidth;
-      padding: 16px;
+      line-height: 28px;
+      padding: @revisionhistory-card-padding;
+      z-index: 1; // To get a shadow effect
     }
 
     .tox-revisionhistory__revisions {
+      background-color: @revisionhistory-border-color;
+      display: flex;
       flex-direction: column;
-      max-height: calc(100% - @revisionhistory-sidebar-title-height);
-      min-width: @revisionhistory-sidebar-minwidth;
+      gap: @revisionhistory-base-value;
       overflow-y: auto;
-      padding: @revisionhistory-card-padding;
+      padding: 10px @revisionhistory-card-padding;
 
       &:focus {
         height: 100%;
@@ -94,12 +98,12 @@
       }
 
       .tox-revisionhistory__card {
+        background-color: @revisionhistory-background-color;
         border: @revisionhistory-border;
-        border-radius: 6px;
+        border-radius: @revisionhistory-border-radius;
         color: @revisionhistory-text-color;
         cursor: pointer;
         font-size: @font-size-sm;
-        margin-bottom: @revisionhistory-card-padding;
         padding: @revisionhistory-card-padding;
         width: 100%;
 
@@ -124,10 +128,6 @@
           box-shadow: @revisonhistory-box-shadow;
           color: @revisionhistory-card-active-text-color;
         }
-      }
-
-      .tox-revisionhistory__card > *:not(:last-child) {
-        margin-bottom: @revisionhistory-base-value;
       }
 
       .tox-revisionhistory__card-date {


### PR DESCRIPTION
Related Ticket: TINY-11045

Description of Changes:
* Updated the styling of revision sidebar according to the design
* Removed unused variables
* Added background and border colors for dark mode

**Attached pictures of revision history in normal and dark modes**:
![Screenshot 2024-07-15 at 3 33 44 pm](https://github.com/user-attachments/assets/924042c0-62b8-4493-9fd0-17e22d2dd1c0)
![Screenshot 2024-07-15 at 3 35 49 pm](https://github.com/user-attachments/assets/0b47f89c-83e0-46e1-a19b-57e091372234)



Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
