### PR TITLE
TINY-11093: Reduce code running on script load

### DIFF
--- a/.changes/unreleased/mcagar-TINY-11093-2024-07-10.yaml
+++ b/.changes/unreleased/mcagar-TINY-11093-2024-07-10.yaml
@@ -1,0 +1,6 @@
+project: mcagar
+kind: Removed
+body: Fallback code which was only required on browsers that are no longer supported.
+time: 2024-07-10T17:19:53.587054+10:00
+custom:
+  Issue: TINY-11093

--- a/.changes/unreleased/sugar-TINY-11093-2024-07-10.yaml
+++ b/.changes/unreleased/sugar-TINY-11093-2024-07-10.yaml
@@ -1,0 +1,6 @@
+project: sugar
+kind: Removed
+body: Fallback code which was only required on browsers that are no longer supported.
+time: 2024-07-10T17:19:53.587059+10:00
+custom:
+  Issue: TINY-11093

--- a/modules/agar/src/test/ts/browser/FocusToolsTest.ts
+++ b/modules/agar/src/test/ts/browser/FocusToolsTest.ts
@@ -1,5 +1,5 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { SugarElement, SugarShadowDom, Value } from '@ephox/sugar';
+import { SugarElement, Value } from '@ephox/sugar';
 
 import * as Assertions from 'ephox/agar/api/Assertions';
 import { Chain } from 'ephox/agar/api/Chain';
@@ -104,13 +104,13 @@ UnitTest.asynctest('FocusToolsTest', (success, failure) => {
       DomContainers.mTeardown
     ]),
 
-    SugarShadowDom.isSupported() ? Log.stepsAsStep('TINY-6360', 'Within ShadowRoot', [
+    Log.stepsAsStep('TINY-6360', 'Within ShadowRoot', [
       DomContainers.mSetupShadowRoot,
       Step.raw((state, next, die, logs) => {
         sTestFocusTools(state.shadowRoot, state.shadowRoot).runStep(state, next, die, logs);
       }),
       DomContainers.mTeardown
-    ]) : Step.pass
+    ])
   ], (_, _logs) => {
     success();
   }, failure);

--- a/modules/alloy/src/main/ts/ephox/alloy/api/testhelpers/GuiSetup.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/testhelpers/GuiSetup.ts
@@ -167,9 +167,6 @@ const setupInShadowRoot = <T = string>(
   success: () => void,
   failure: (err: any, logs?: TestLogs) => void
 ): void => {
-  if (!SugarShadowDom.isSupported()) {
-    return success();
-  }
   const sh = SugarElement.fromTag('div');
   Insert.append(SugarBody.body(), sh);
   const sr = SugarElement.fromDom(sh.dom.attachShadow({ mode: 'open' }));
@@ -191,7 +188,7 @@ const bddSetupInShadowRoot = <T = string>(
       root: sr,
       teardown: () => Remove.remove(sh)
     };
-  }, createComponent, createGui, () => !SugarShadowDom.isSupported());
+  }, createComponent, createGui);
 };
 
 const setupInBodyAndShadowRoot = <T = string>(

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyHooks.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyHooks.ts
@@ -1,6 +1,6 @@
 import { after, afterEach, before } from '@ephox/bedrock-client';
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Insert, Remove, SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 
 import { Editor as EditorType } from '../../alien/EditorTypes';
 import * as Loader from '../../loader/Loader';
@@ -99,11 +99,7 @@ const bddSetupInShadowRoot = <T extends EditorType = EditorType>(settings: Recor
   let editorDiv: Optional<SugarElement<HTMLElement>>;
   let teardown: () => void = Fun.noop;
 
-  before(function () {
-    if (!SugarShadowDom.isSupported()) {
-      this.skip();
-    }
-
+  before(() => {
     const shadowHost = SugarElement.fromTag('div', document);
 
     Insert.append(SugarBody.body(), shadowHost);

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyLoader.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyLoader.ts
@@ -1,6 +1,6 @@
 import { TestLogs } from '@ephox/agar';
 import { Optional } from '@ephox/katamari';
-import { Insert, Remove, SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 
 import * as Loader from '../../loader/Loader';
 import { setupTinymceBaseUrl } from '../../loader/Urls';
@@ -54,10 +54,6 @@ const setupInShadowRoot = (
   success: Loader.SuccessCallback,
   failure: Loader.FailureCallback
 ): void => {
-  if (!SugarShadowDom.isSupported()) {
-    return success();
-  }
-
   const shadowHost: SugarElement<HTMLElement> = SugarElement.fromTag('div', document);
 
   Insert.append(SugarBody.body(), shadowHost);
@@ -84,14 +80,10 @@ const setupInBodyAndShadowRoot = (callback: Loader.RunCallback, settings: Record
     callback,
     settings,
     (v, logs1) => {
-      if (SugarShadowDom.isSupported()) {
-        setupInShadowRoot((e, _sr, s, f) => callback(e, s, f), settings, (v2, logs2) => {
-          const logs = TestLogs.concat(TestLogs.getOrInit(logs1), TestLogs.getOrInit(logs2));
-          success(v2, logs);
-        }, failure);
-      } else {
-        success(v, logs1);
-      }
+      setupInShadowRoot((e, _sr, s, f) => callback(e, s, f), settings, (v2, logs2) => {
+        const logs = TestLogs.concat(TestLogs.getOrInit(logs1), TestLogs.getOrInit(logs2));
+        success(v2, logs);
+      }, failure);
     },
     failure
   );

--- a/modules/mcagar/src/test/ts/browser/api/TinyLoaderTest.ts
+++ b/modules/mcagar/src/test/ts/browser/api/TinyLoaderTest.ts
@@ -1,6 +1,5 @@
 import { Assertions, Logger, Pipeline, Step, TestLogs } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { SugarShadowDom } from '@ephox/sugar';
 
 import { Editor } from 'ephox/mcagar/alien/EditorTypes';
 import * as TinyLoader from 'ephox/mcagar/api/pipeline/TinyLoader';
@@ -49,14 +48,8 @@ UnitTest.asynctest('TinyLoader.setupInBodyAndShadowRoot passes logs through', (s
     base_url: '/project/tinymce/js/tinymce'
   }, (v, logs) => {
     try {
-      if (SugarShadowDom.isSupported()) {
-        Assert.eq('Value should come from second call', 'call2', v);
-        Assert.eq('Logs should be concatenated', TestLogs.addLogEntry(TestLogs.single('log1'), 'log2'), logs);
-      } else {
-        // if the browser isn't supported, the "shadow dom" test won't be run, so we only get logs from the "body" test
-        Assert.eq('Value should come from first call', 'call1', v);
-        Assert.eq('Logs should just be from the first call', TestLogs.single('log1'), logs);
-      }
+      Assert.eq('Value should come from second call', 'call2', v);
+      Assert.eq('Logs should be concatenated', TestLogs.addLogEntry(TestLogs.single('log1'), 'log2'), logs);
       success();
     } catch (e: any) {
       failure(e);

--- a/modules/sand/src/main/ts/ephox/sand/api/PlatformDetection.ts
+++ b/modules/sand/src/main/ts/ephox/sand/api/PlatformDetection.ts
@@ -14,7 +14,7 @@ const mediaMatch = (query: string) => window.matchMedia(query).matches;
 // IMPORTANT: Must be in a thunk, otherwise rollup thinks calling this immediately
 // causes side effects and won't tree shake this away
 // Note: navigator.userAgentData is not part of the native typescript types yet
-let platform = Thunk.cached(() => PlatformDetection.detect(navigator.userAgent, Optional.from(((navigator as any).userAgentData)), mediaMatch));
+let platform = Thunk.cached(() => PlatformDetection.detect(window.navigator.userAgent, Optional.from(((window.navigator as any).userAgentData)), mediaMatch));
 
 export const detect = (): PlatformDetection => platform();
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/Viewable.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/Viewable.ts
@@ -10,14 +10,7 @@ import * as Visibility from '../view/Visibility';
  *
  * It's a bit harder to manage, though, because visibility is a one-shot listener.
  */
-
-const poll = (element: SugarElement<HTMLElement>, f: () => void): () => void => {
-  const poller = setInterval(f, 500);
-
-  return () => clearInterval(poller);
-};
-
-const mutate = (element: SugarElement<HTMLElement>, f: () => void): () => void => {
+const observe = (element: SugarElement<HTMLElement>, f: () => void): () => void => {
   const observer: MutationObserver = new window.MutationObserver(f);
 
   const unbindMutate = () => observer.disconnect();
@@ -28,9 +21,6 @@ const mutate = (element: SugarElement<HTMLElement>, f: () => void): () => void =
 
   return unbindMutate;
 };
-
-// IE11 and above, not using numerosity so we can poll on IE10
-const wait = window.MutationObserver !== undefined && window.MutationObserver !== null ? mutate : poll;
 
 const onShow = (element: SugarElement<HTMLElement>, f: () => void): () => void => {
   if (Visibility.isVisible(element)) {
@@ -45,7 +35,7 @@ const onShow = (element: SugarElement<HTMLElement>, f: () => void): () => void =
       }
     }, 100);
 
-    const unbind = wait(element, throttler.throttle);
+    const unbind = observe(element, throttler.throttle);
 
     return unbind;
   }

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarShadowDom.ts
@@ -1,4 +1,4 @@
-import { Arr, Fun, Optional, Type } from '@ephox/katamari';
+import { Arr, Optional, Type } from '@ephox/katamari';
 
 import { HTMLElementFullTagNameMap } from '../../alien/DomTypes';
 import * as Traverse from '../search/Traverse';
@@ -17,23 +17,8 @@ export type RootNode = SugarElement<Document | ShadowRoot>;
 export const isShadowRoot = (dos: SugarElement<Node>): dos is SugarElement<ShadowRoot> =>
   SugarNode.isDocumentFragment(dos) && Type.isNonNullable((dos.dom as ShadowRoot).host);
 
-/* eslint-disable @tinymce/no-implicit-dom-globals, @typescript-eslint/unbound-method */
-const supported: boolean =
-  Type.isFunction(Element.prototype.attachShadow) &&
-  Type.isFunction(Node.prototype.getRootNode);
-/* eslint-enable */
-
-/**
- * Does the browser support shadow DOM?
- *
- * NOTE: Node.getRootNode() and Element.attachShadow don't exist on IE11 and pre-Chromium Edge.
- */
-export const isSupported = Fun.constant(supported);
-
-export const getRootNode: (e: SugarElement<Node>) => RootNode =
-  supported
-    ? (e) => SugarElement.fromDom((e.dom as any).getRootNode())
-    : Traverse.documentOrOwner;
+export const getRootNode: (e: SugarElement<Node>) => RootNode = (e) =>
+  SugarElement.fromDom(e.dom.getRootNode()) as RootNode;
 
 /** Create an element, using the actual document. */
 export const createElement: {
@@ -76,7 +61,7 @@ export const getShadowHost = (e: SugarElement<ShadowRoot>): SugarElement<Element
  * See: https://developers.google.com/web/fundamentals/web-components/shadowdom#events
  */
 export const getOriginalEventTarget = (event: Event): Optional<EventTarget> => {
-  if (isSupported() && Type.isNonNullable(event.target)) {
+  if (Type.isNonNullable(event.target)) {
     const el = SugarElement.fromDom(event.target as Node);
     if (SugarNode.isElement(el) && isOpenShadowHost(el)) {
       // When target element is inside Shadow DOM we need to take first element from composedPath

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/Platform.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/Platform.ts
@@ -6,9 +6,8 @@ interface ChoiceOption<T> {
   value: () => T;
 }
 
-const platform = PlatformDetection.detect();
-const isTouch: () => boolean = platform.deviceType.isTouch;
-const isAndroid: () => boolean = platform.deviceType.isAndroid;
+const isTouch: () => boolean = () => PlatformDetection.detect().deviceType.isTouch();
+const isAndroid: () => boolean = () => PlatformDetection.detect().deviceType.isAndroid();
 
 // TODO: Work out what these values are supposed to be.
 const MINIMUM_LARGE_WIDTH = 620;

--- a/modules/sugar/src/test/ts/browser/BodyTest.ts
+++ b/modules/sugar/src/test/ts/browser/BodyTest.ts
@@ -4,7 +4,6 @@ import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
 import * as SugarBody from 'ephox/sugar/api/node/SugarBody';
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
-import * as SugarShadowDom from 'ephox/sugar/api/node/SugarShadowDom';
 import * as SelectorFind from 'ephox/sugar/api/search/SelectorFind';
 import { withShadowElement } from 'ephox/sugar/test/WithHelpers';
 
@@ -35,41 +34,39 @@ UnitTest.test('Body.inBody - elements in body', () => {
   Remove.remove(div);
 });
 
-if (SugarShadowDom.isSupported()) {
-  UnitTest.test('Body.inBody - shadow root', () => {
-    withShadowElement((sr) => {
-      Assert.eq('should be inBody', true, SugarBody.inBody(sr));
-    });
+UnitTest.test('Body.inBody - shadow root', () => {
+  withShadowElement((sr) => {
+    Assert.eq('should be inBody', true, SugarBody.inBody(sr));
   });
+});
 
-  UnitTest.test('Body.inBody - element in shadow root', () => {
-    withShadowElement((sr) => {
-      Assert.eq('should be inBody', true, SugarBody.inBody(sr));
-    });
+UnitTest.test('Body.inBody - element in shadow root', () => {
+  withShadowElement((sr) => {
+    Assert.eq('should be inBody', true, SugarBody.inBody(sr));
   });
+});
 
-  UnitTest.test('Body.inBody - element in nested shadow root', () => {
-    const div1 = document.createElement('div');
-    document.body.appendChild(div1);
+UnitTest.test('Body.inBody - element in nested shadow root', () => {
+  const div1 = document.createElement('div');
+  document.body.appendChild(div1);
 
-    const sr1 = div1.attachShadow({ mode: 'open' });
-    const div2 = document.createElement('div');
-    sr1.appendChild(div2);
+  const sr1 = div1.attachShadow({ mode: 'open' });
+  const div2 = document.createElement('div');
+  sr1.appendChild(div2);
 
-    const sr2 = div2.attachShadow({ mode: 'open' });
-    const div3 = document.createElement('div');
-    sr2.appendChild(div3);
+  const sr2 = div2.attachShadow({ mode: 'open' });
+  const div3 = document.createElement('div');
+  sr2.appendChild(div3);
 
-    const div4 = document.createElement('div');
-    div3.appendChild(div4);
+  const div4 = document.createElement('div');
+  div3.appendChild(div4);
 
-    Assert.eq('div1 should be inBody', true, SugarBody.inBody(SugarElement.fromDom(div1)));
-    Assert.eq('div2 should be inBody', true, SugarBody.inBody(SugarElement.fromDom(div2)));
-    Assert.eq('div3 should be inBody', true, SugarBody.inBody(SugarElement.fromDom(div3)));
-    Assert.eq('div4 should be inBody', true, SugarBody.inBody(SugarElement.fromDom(div4)));
+  Assert.eq('div1 should be inBody', true, SugarBody.inBody(SugarElement.fromDom(div1)));
+  Assert.eq('div2 should be inBody', true, SugarBody.inBody(SugarElement.fromDom(div2)));
+  Assert.eq('div3 should be inBody', true, SugarBody.inBody(SugarElement.fromDom(div3)));
+  Assert.eq('div4 should be inBody', true, SugarBody.inBody(SugarElement.fromDom(div4)));
 
-    Assert.eq('sr1 should be inBody', true, SugarBody.inBody(SugarElement.fromDom(sr1)));
-    Assert.eq('sr2 should be inBody', true, SugarBody.inBody(SugarElement.fromDom(sr2)));
-    document.body.removeChild(div1);
-  });
-}
+  Assert.eq('sr1 should be inBody', true, SugarBody.inBody(SugarElement.fromDom(sr1)));
+  Assert.eq('sr2 should be inBody', true, SugarBody.inBody(SugarElement.fromDom(sr2)));
+  document.body.removeChild(div1);
+});

--- a/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
+++ b/modules/sugar/src/test/ts/browser/ShadowDomTest.ts
@@ -21,18 +21,16 @@ import { setupShadowRoot, withIframe, withNormalElement, withShadowElement, with
 type RootNode = SugarShadowDom.RootNode;
 
 UnitTest.test('ShadowDom - SelectorFind.descendant', () => {
-  if (SugarShadowDom.isSupported()) {
-    fc.assert(fc.property(htmlBlockTagName(), htmlInlineTagName(), fc.hexaString(), (block, inline, text) => {
-      withShadowElement((ss) => {
-        const id = 'theid';
-        const inner = SugarElement.fromHtml(`<${block}><p>hello<${inline} id="${id}">${text}</${inline}></p></${block}>`);
-        Insert.append(ss, inner);
+  fc.assert(fc.property(htmlBlockTagName(), htmlInlineTagName(), fc.hexaString(), (block, inline, text) => {
+    withShadowElement((ss) => {
+      const id = 'theid';
+      const inner = SugarElement.fromHtml(`<${block}><p>hello<${inline} id="${id}">${text}</${inline}></p></${block}>`);
+      Insert.append(ss, inner);
 
-        const frog: SugarElement<Element> = SelectorFind.descendant(ss, `#${id}`).getOrDie('Element not found');
-        Assert.eq('textcontent', text, frog.dom.textContent);
-      });
-    }));
-  }
+      const frog: SugarElement<Element> = SelectorFind.descendant(ss, `#${id}`).getOrDie('Element not found');
+      Assert.eq('textcontent', text, frog.dom.textContent);
+    });
+  }));
 });
 
 const shouldBeShadowRoot = (n: RootNode) => {
@@ -96,11 +94,6 @@ UnitTest.test('isDocument in iframe', () => {
   withIframe((div, iframe, cw) => {
     shouldBeDocument(SugarElement.fromDom(cw.document));
   });
-});
-
-UnitTest.test('isSupported platform test', () => {
-  // as of TinyMCE 6 all browsers support it
-  Assert.eq('This browser should support root node', true, SugarShadowDom.isSupported());
 });
 
 UnitTest.test('stylecontainer is shadow root for shadow root', () => {
@@ -171,17 +164,10 @@ const checkOriginalEventTarget = (mode: 'open' | 'closed', success: UnitTest.Suc
 };
 
 UnitTest.asynctest('getOriginalEventTarget on a closed shadow root', (success, failure) => {
-  if (!SugarShadowDom.isSupported()) {
-    return success();
-  }
-
   checkOriginalEventTarget('closed', success, failure);
 });
 
 UnitTest.asynctest('getOriginalEventTarget on an open shadow root', (success, failure) => {
-  if (!SugarShadowDom.isSupported()) {
-    return success();
-  }
   checkOriginalEventTarget('open', success, failure);
 });
 
@@ -199,12 +185,10 @@ UnitTest.test('isOpenShadowHost on closed shadow host', () => {
   });
 });
 
-if (SugarShadowDom.isSupported()) {
-  UnitTest.test('withShadowElement gives us open and closed roots', () => {
-    const roots: Array<SugarElement<ShadowRoot>> = [];
-    withShadowElement((sr) => {
-      roots.push(sr);
-    });
-    Assert.eq('open then closed', [ 'open', 'closed' ], Arr.map(roots, (r) => (r.dom as any).mode ));
+UnitTest.test('withShadowElement gives us open and closed roots', () => {
+  const roots: Array<SugarElement<ShadowRoot>> = [];
+  withShadowElement((sr) => {
+    roots.push(sr);
   });
-}
+  Assert.eq('open then closed', [ 'open', 'closed' ], Arr.map(roots, (r) => (r.dom as any).mode ));
+});

--- a/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
+++ b/modules/sugar/src/test/ts/module/ephox/sugar/test/WithHelpers.ts
@@ -2,7 +2,6 @@ import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
 import * as SugarBody from 'ephox/sugar/api/node/SugarBody';
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
-import * as SugarShadowDom from 'ephox/sugar/api/node/SugarShadowDom';
 import * as Attribute from 'ephox/sugar/api/properties/Attribute';
 
 export const withNormalElement = (f: (d: SugarElement<Element>) => void): void => {
@@ -27,11 +26,9 @@ export const setupShadowRoot = (mode: 'open' | 'closed'): { shadowRoot: SugarEle
 };
 
 export const withShadowElementInMode = (mode: 'open' | 'closed', f: (sr: SugarElement<ShadowRoot>, innerDiv: SugarElement<HTMLElement>, shadowHost: SugarElement<HTMLElement>) => void): void => {
-  if (SugarShadowDom.isSupported()) {
-    const { shadowRoot, innerDiv, shadowHost } = setupShadowRoot(mode);
-    f(shadowRoot, innerDiv, shadowHost);
-    Remove.remove(shadowHost);
-  }
+  const { shadowRoot, innerDiv, shadowHost } = setupShadowRoot(mode);
+  f(shadowRoot, innerDiv, shadowHost);
+  Remove.remove(shadowHost);
 };
 
 export const withShadowElement = (f: (shadowRoot: SugarElement<ShadowRoot>, innerDiv: SugarElement<HTMLElement>, shadowHost: SugarElement<HTMLElement>) => void): void => {

--- a/modules/tinymce/src/core/main/ts/api/Env.ts
+++ b/modules/tinymce/src/core/main/ts/api/Env.ts
@@ -9,7 +9,7 @@ import { PlatformDetection } from '@ephox/sand';
  * @static
  */
 
-const userAgent = navigator.userAgent;
+const userAgent = window.navigator.userAgent;
 const platform = PlatformDetection.detect();
 const browser = platform.browser;
 const os = platform.os;

--- a/modules/tinymce/src/core/test/ts/browser/dom/StyleSheetLoaderRegistryTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/StyleSheetLoaderRegistryTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { SugarDocument, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { SugarDocument, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import StyleSheetLoader from 'tinymce/core/api/dom/StyleSheetLoader';
@@ -13,11 +13,7 @@ describe('browser.tinymce.core.dom.StyleSheetLoaderRegistry', () => {
     assert.strictEqual(ssl2, ssl1, 'Should be the same');
   });
 
-  it('same element gets same instance (ShadowRoot)', function () {
-    if (!SugarShadowDom.isSupported()) {
-      this.skip();
-    }
-
+  it('same element gets same instance (ShadowRoot)', () => {
     const div = document.createElement('div');
     const sr = div.attachShadow({ mode: 'open' });
     const innerDiv = document.createElement('div');

--- a/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/ShadowDomEditorTest.ts
@@ -1,19 +1,13 @@
 import { UiFinder } from '@ephox/agar';
-import { before, context, describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Strings } from '@ephox/katamari';
-import { Insert, Remove, SelectorFilter, SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { Insert, Remove, SelectorFilter, SugarBody, SugarElement } from '@ephox/sugar';
 import { McEditor, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.init.ShadowDomEditorTest', () => {
-  before(function () {
-    if (!SugarShadowDom.isSupported()) {
-      this.skip();
-    }
-  });
-
   const isSkin = (ss: StyleSheet) => ss.href !== null && Strings.contains(ss.href, 'skin.css');
   const isShadowDomSkin = (ss: StyleSheet) => ss.href !== null && Strings.contains(ss.href, 'skin.shadowdom.css');
 


### PR DESCRIPTION
Related Ticket: TINY-11093

Description of Changes:
* Remove IE11 and Edge Legacy poll fallback for mutation observer.
* Remove IE11 and Edge Legacy shadow DOM fallback.
* Avoid caching `PlatformDetection.detect()` as it's already cached.
* Remove on-load feature detection of caret position, it doesn't cost much to do at runtime and this simplifies the code.

This should have no user-facing impact. The bulk of the changes are unwinding test code that handled the case where ShadowDom was unavailable; I simply set the value to `true` and let my IDE refactoring remove the dead code.

Pre-checks:
* [] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~