### PR TITLE
TINY-11083: add `Type.isPromiseLike` to `Katamari`

### DIFF
--- a/.changes/unreleased/katamari-TINY-11083-2024-07-11.yaml
+++ b/.changes/unreleased/katamari-TINY-11083-2024-07-11.yaml
@@ -1,0 +1,7 @@
+project: katamari
+kind: Added
+body: Added new `Type.isPromiseLike` API to check if a function has a promise like
+  shape.
+time: 2024-07-11T10:18:07.025355594+02:00
+custom:
+  Issue: TINY-11083

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Type.ts
@@ -83,3 +83,8 @@ export const isArrayOf = <E>(value: any, pred: (x: any) => x is E): value is Arr
   }
   return false;
 };
+
+export const isPromiseLike = (x: any): x is Promise<unknown> =>
+  isObject(x)
+  && isFunction(x.then)
+  && isFunction(x.catch);

--- a/modules/katamari/src/test/ts/atomic/api/type/TypeTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/type/TypeTest.ts
@@ -31,6 +31,7 @@ const checkIsObject = check(Type.isObject, 'isObject');
 const checkIsArray = check(Type.isArray, 'isArray');
 const checkIsFunction = check(Type.isFunction, 'isFunction');
 const checkIsNumber = check(Type.isNumber, 'isNumber');
+const checkIsPromiseLike = check(Type.isPromiseLike, 'isPromiseLike');
 
 describe('atomic.katamari.api.struct.TypeTest', () => {
   it('isNull', () => {
@@ -129,6 +130,21 @@ describe('atomic.katamari.api.struct.TypeTest', () => {
     checkIsFunction(true, noop);
     checkIsFunction(false, [ 1, 3, 4, 5 ]);
     checkIsFunction(false, 1);
+  });
+
+  it('isPromiseLike', () => {
+    checkIsPromiseLike(false, null);
+    checkIsPromiseLike(false, undefined);
+    checkIsPromiseLike(false, true);
+    checkIsPromiseLike(false, false);
+    checkIsPromiseLike(false, 'ball');
+    checkIsPromiseLike(false, {});
+    checkIsPromiseLike(false, objectString);
+    checkIsPromiseLike(false, []);
+    checkIsPromiseLike(false, noop);
+    checkIsPromiseLike(false, [ 1, 3, 4, 5 ]);
+    checkIsPromiseLike(false, 1);
+    checkIsPromiseLike(true, new Promise(noop));
   });
 
   it('isNumber', () => {

--- a/modules/katamari/src/test/ts/atomic/api/type/TypeTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/type/TypeTest.ts
@@ -145,6 +145,9 @@ describe('atomic.katamari.api.struct.TypeTest', () => {
     checkIsPromiseLike(false, [ 1, 3, 4, 5 ]);
     checkIsPromiseLike(false, 1);
     checkIsPromiseLike(true, new Promise(noop));
+    checkIsPromiseLike(false, { then: noop });
+    checkIsPromiseLike(false, { catch: noop });
+    checkIsPromiseLike(true, { then: noop, catch: noop });
   });
 
   it('isNumber', () => {


### PR DESCRIPTION
Related Ticket: TINY-11083

Description of Changes:
as title says: add `Type.isPromiseLike` to `Katamari`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
