### PR TITLE
TINY-10638: remove prevent default for mousedown from button

### DIFF
--- a/.changes/unreleased/tinymce-TINY-10638-2024-07-12.yaml
+++ b/.changes/unreleased/tinymce-TINY-10638-2024-07-12.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Prevent default mousedown on button was causing misplaced focus bugs.
+body: Prevent default mousedown on toolbar buttons was causing misplaced focus bugs.
 time: 2024-07-12T13:54:15.834489+02:00
 custom:
   Issue: TINY-10638

--- a/.changes/unreleased/tinymce-TINY-10638-2024-07-12.yaml
+++ b/.changes/unreleased/tinymce-TINY-10638-2024-07-12.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Prevent default mousedown on button was causing misplaced focus bugs.
+time: 2024-07-12T13:54:15.834489+02:00
+custom:
+  Issue: TINY-10638

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -59,8 +59,7 @@ export const renderCommonSpec = (
         )
       ).toArray(),
       AddEventsBehaviour.config('button press', [
-        AlloyEvents.preventDefault('click'),
-        AlloyEvents.preventDefault('mousedown')
+        AlloyEvents.preventDefault('click')
       ])
     ].concat(extraBehaviours)),
     eventOrder: {


### PR DESCRIPTION
Related Ticket: TINY-10638

Description of Changes:
Removed prevent default for mousedown in Button as it was causing bugs.

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
