### PR TITLE
TINY-11085: CET-marked elements outside of a CEF-element would not always gain focus as expected.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11043-2024-07-12.yaml
+++ b/.changes/unreleased/tinymce-TINY-11043-2024-07-12.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Attempting to use focus commands on an editor where the cursor had last been
+  in certain contentEditable="true" elements would fail.
+time: 2024-07-12T14:33:10.01268867+02:00
+custom:
+  Issue: TINY-11085

--- a/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
+++ b/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
@@ -14,6 +14,9 @@ import * as FocusController from './FocusController';
 const getContentEditableHost = (editor: Editor, node: Node): HTMLElement | null =>
   editor.dom.getParent(node, (node): node is HTMLElement => editor.dom.getContentEditable(node) === 'true');
 
+const hasContentEditableFalseParent = (editor: Editor, node: Node): boolean =>
+  editor.dom.getParent(node, (node): node is HTMLElement => editor.dom.getContentEditable(node) === 'false') !== null;
+
 const getCollapsedNode = (rng: Range): Optional<SugarElement<Node>> =>
   rng.collapsed ? Optional.from(RangeNodes.getNode(rng.startContainer, rng.startOffset)).map(SugarElement.fromDom) : Optional.none();
 
@@ -95,6 +98,10 @@ const focusEditor = (editor: Editor) => {
   // Move focus to contentEditable=true child if needed
   const contentEditableHost = getContentEditableHost(editor, selection.getNode());
   if (contentEditableHost && editor.dom.isChildOf(contentEditableHost, body)) {
+    if (!hasContentEditableFalseParent(editor, contentEditableHost)) {
+      focusBody(body);
+    }
+
     focusBody(contentEditableHost);
     if (!editor.hasEditableRoot()) {
       restoreBookmark(editor);

--- a/modules/tinymce/src/core/test/ts/browser/focus/EditorFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/EditorFocusTest.ts
@@ -1,6 +1,6 @@
 import { Assertions } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { Focus, Hierarchy, SugarBody, SugarNode } from '@ephox/sugar';
+import { Focus, Hierarchy, Insert, Remove, SugarBody, SugarElement, SugarNode } from '@ephox/sugar';
 import { McEditor, TinyAssertions, TinyDom, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -8,7 +8,6 @@ import Editor from 'tinymce/core/api/Editor';
 import * as EditorFocus from 'tinymce/core/focus/EditorFocus';
 
 describe('browser.tinymce.core.focus.EditorFocusTest', () => {
-
   const pCreateInlineEditor = (html: string) => McEditor.pFromHtml<Editor>(html, {
     menubar: false,
     inline: true,
@@ -66,6 +65,23 @@ describe('browser.tinymce.core.focus.EditorFocusTest', () => {
       selectBody();
       focusEditor(editor);
       TinyAssertions.assertSelection(editor, [ 1, 1, 0, 0, 0, 0 ], 0, [ 1, 1, 0, 0, 0, 0 ], 0);
+      McEditor.remove(editor);
+    });
+
+    it('TINY-11085: Focus should return to the editor even if focus is in CET div', async () => {
+      const editor = await pCreateEditor('<div class="tinymce-editor"><div contentEditable="true">A</div></div>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 0);
+      const button: SugarElement<HTMLElement> = SugarElement.fromHtml('<button id="justForFocus">Text</button>');
+      Insert.append(SugarBody.body(), button);
+
+      Focus.focus(button);
+      assert.isTrue(Focus.hasFocus(button), 'Focus should be on the button');
+      assert.isFalse(EditorFocus.hasFocus(editor), 'Editor should not have focus');
+      focusEditor(editor);
+      assert.isFalse(Focus.hasFocus(button), 'Button should have lost focus');
+      assert.isTrue(EditorFocus.hasFocus(editor), 'Editor should have lost focus');
+
+      Remove.remove(button);
       McEditor.remove(editor);
     });
   });


### PR DESCRIPTION
Related Ticket: TINY-11085

Description of Changes:
Giving focus to a CET which was not placed inside a CEF would cause some issues if we didn't also focus on the body first.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
