### PR TITLE
TINY-11090: Update stylings of focused, hovered and selected revisions

### DIFF
--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -8,7 +8,6 @@
 @revisionhistory-sidebar-background-color: if(@revisionhistory-dark-mode, #2b3b4e, @revisionhistory-secondary-color);   // Trial and error
 @revisionhistory-border-color: if(@revisionhistory-dark-mode, rgba(255, 255, 255, .15), @revisionhistory-secondary-color);
 @revisionhistory-text-color: @text-color;
-@revisionhistory-card-hover-background-color: @toolbar-button-hover-background-color;
 @revisionhistory-card-active-background-color: if(@revisionhistory-dark-mode, #62430b, #fff5cc);
 @revisionhistory-border: 1px solid @revisionhistory-border-color;
 @revisionhistory-border-color--selected: if(@revisionhistory-dark-mode, #cea215, #e3b82a);
@@ -141,7 +140,15 @@
         }
       }
 
+      .tox-revisionhistory__card-header {
+        align-items: center;
+        display: flex;
+        gap: @revisionhistory-gap;
+        margin-bottom: @revisionhistory-gap;
+      }
+
       .tox-revisionhistory__card-date {
+        flex: 1;
         font-size: 16px;
         line-height: @revisionhistory-text-lineheight;
       }
@@ -172,6 +179,11 @@
         font-size: 16px;
         line-height: @revisionhistory-text-lineheight;
         padding: 5px 5.5px;
+      }
+
+      .tox-revisionhistory__card-icon-elected {
+        color: @revisionhistory-text-color;
+        height: 24px;
       }
     }
   }

--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -99,7 +99,7 @@
       }
 
       .tox-revisionhistory__card {
-        background-color: @background-color;
+        background-color: @revisionhistory-background-color;
         border: @revisionhistory-border;
         border-radius: @revisionhistory-border-radius;
         color: @revisionhistory-text-color;

--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -99,7 +99,7 @@
       }
 
       .tox-revisionhistory__card {
-        background-color: @revisionhistory-background-color;
+        background-color: @background-color;
         border: @revisionhistory-border;
         border-radius: @revisionhistory-border-radius;
         color: @revisionhistory-text-color;

--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -9,10 +9,10 @@
 @revisionhistory-border-color: if(@revisionhistory-dark-mode, rgba(255, 255, 255, .15), @revisionhistory-secondary-color);
 @revisionhistory-text-color: @text-color;
 @revisionhistory-card-hover-background-color: @toolbar-button-hover-background-color;
-@revisionhistory-card-active-background-color: #fff5cc;
+@revisionhistory-card-active-background-color: if(@revisionhistory-dark-mode, #62430b, #fff5cc);
 @revisionhistory-border: 1px solid @revisionhistory-border-color;
-@revisionhistory-border-color--selected: #e3b82a;
-@revisionhistory-border-color--focused: #006ce7;
+@revisionhistory-border-color--selected: if(@revisionhistory-dark-mode, #cea215, #e3b82a);
+@revisionhistory-border-color--focused: if(@revisionhistory-dark-mode, #285ec7, #006ce7);
 @revisionhistory-box-shadow: 0 4px 8px 0 rgba(34, 47, 62, .1);
 @revisionhistory-sidebar-minwidth: 248px;
 @revisionhistory-text-lineheight: 24px;

--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -9,19 +9,26 @@
 @revisionhistory-border-color: if(@revisionhistory-dark-mode, rgba(255, 255, 255, .15), @revisionhistory-secondary-color);
 @revisionhistory-text-color: @text-color;
 @revisionhistory-card-hover-background-color: @toolbar-button-hover-background-color;
-@revisionhistory-card-active-background-color: multiply(white, contrast(@background-color, fade(@color-tint, 35), fade(@color-tint, 65)));
-@revisionhistory-card-active-text-color: @toolbar-button-active-text-color;
+@revisionhistory-card-active-background-color: #fff5cc;
 @revisionhistory-border: 1px solid @revisionhistory-border-color;
+@revisionhistory-border-color--selected: #e3b82a;
+@revisionhistory-border-color--focused: #006ce7;
+@revisionhistory-box-shadow: 0 4px 8px 0 rgba(34, 47, 62, .1);
 @revisionhistory-sidebar-minwidth: 248px;
 @revisionhistory-text-lineheight: 24px;
-@revisionhistory-padding: @revisionhistory-gap;
-@revisionhistory-box-shadow: none;
 
 .overflow-text() {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 };
+
+.revisionhistory-focus-outline-mixin(@border-color: ~'') {
+  .keyboard-focus-outline-mixin(@border-color);
+
+  border-radius: @revisionhistory-border-radius;
+  box-shadow: 0 0 0 2px @border-color;
+}
 
 .tox {
   .tox-revisionhistory__pane {
@@ -64,7 +71,7 @@
 
     .tox-revisionhistory__sidebar-title {
       background-color: @background-color;
-      box-shadow: 0 4px 8px 0 rgba(34, 47, 62, .1);
+      box-shadow: @revisionhistory-box-shadow;
       color: @revisionhistory-text-color;
       font-size: @font-size-lg;
       font-weight: 400;
@@ -109,25 +116,28 @@
         width: 100%;
 
         &:hover {
-          background-color: @revisionhistory-card-hover-background-color;
           box-shadow: @revisionhistory-box-shadow;
-          color: @revisionhistory-card-active-text-color;
         }
 
         &:focus {
           position: relative;   // Override static which prevents z-index to have any effect
-          z-index: 1; // Ensure focus outline is on top of other buttons
+          z-index: 1; // Ensure focus outline is on the top of other buttons
 
           &::after {
-            border-radius: @control-border-radius !important;
-            .keyboard-focus-outline-mixin();
+            .revisionhistory-focus-outline-mixin(@revisionhistory-border-color--focused);
+
+            box-shadow: 0 0 0 2px @revisionhistory-border-color--focused !important; // Override box-shadow set by tox-revisionhistory__card-selected when card is both selected and focused
           }
         }
 
         &.tox-revisionhistory__card--selected {
           background-color: @revisionhistory-card-active-background-color;
           box-shadow: @revisionhistory-box-shadow;
-          color: @revisionhistory-card-active-text-color;
+          position: relative;
+
+          &::after {
+            .revisionhistory-focus-outline-mixin(@revisionhistory-border-color--selected);
+          }
         }
       }
 

--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -181,7 +181,7 @@
         padding: 5px 5.5px;
       }
 
-      .tox-revisionhistory__card-icon-elected {
+      .tox-revisionhistory__card-check-icon {
         color: @revisionhistory-text-color;
         height: 24px;
       }


### PR DESCRIPTION
Related Ticket: TINY-11090

Description of Changes:
* Updated the stylings of focused, hovered and selected revisions as per design
* Added a class for revision card check icon

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
