### PR TITLE
TINY-11079: Fix styling of revision card when not displaying author

### DIFF
--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -110,7 +110,10 @@
         border-radius: @revisionhistory-border-radius;
         color: @revisionhistory-text-color;
         cursor: pointer;
+        display: flex;
+        flex-direction: column;
         font-size: @font-size-sm;
+        gap: @revisionhistory-gap;
         padding: @revisionhistory-gap;
         width: 100%;
 

--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -143,13 +143,6 @@
         }
       }
 
-      .tox-revisionhistory__card-header {
-        align-items: center;
-        display: flex;
-        gap: @revisionhistory-gap;
-        margin-bottom: @revisionhistory-gap;
-      }
-
       .tox-revisionhistory__card-date {
         display: flex;
         gap: @revisionhistory-gap;

--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -151,7 +151,12 @@
       }
 
       .tox-revisionhistory__card-date {
-        flex: 1;
+        display: flex;
+        gap: @revisionhistory-gap;
+        justify-content: space-between;
+      }
+
+      .tox-revisionhistory__card-date-label {
         font-size: 16px;
         line-height: @revisionhistory-text-lineheight;
       }
@@ -160,6 +165,7 @@
         font-size: 12px;
         font-weight: 600;
         line-height: @revisionhistory-text-lineheight;
+        padding: 0;
       }
 
       .tox-revisionhistory__card-author {


### PR DESCRIPTION
Related Ticket:  TINY-11079

Description of Changes:
* Removed extra padding under revision card date
* Fixed label and date being rendered on the same line
* Removed an unused class

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
