### PR TITLE
TINY-11123: close dropdowns while resizing window

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11123-2024-08-26.yaml
+++ b/.changes/unreleased/tinymce-TINY-11123-2024-08-26.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Dropdowns would not adjust width after window resize.
+time: 2024-08-26T17:39:32.903555+02:00
+custom:
+  Issue: TINY-11123

--- a/.changes/unreleased/tinymce-TINY-11123-2024-08-26.yaml
+++ b/.changes/unreleased/tinymce-TINY-11123-2024-08-26.yaml
@@ -1,6 +1,6 @@
 project: tinymce
-kind: Fixed
-body: Dropdowns would not adjust width after window resize.
+kind: Improved
+body: Dropdowns would not close after window resize.
 time: 2024-08-26T17:39:32.903555+02:00
 custom:
   Issue: TINY-11123

--- a/.changes/unreleased/tinymce-TINY-11123-2024-08-26.yaml
+++ b/.changes/unreleased/tinymce-TINY-11123-2024-08-26.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Improved
-body: Dropdowns would not close after window resize.
+body: Dialog list dropdown menus now close when the browser window resizes.
 time: 2024-08-26T17:39:32.903555+02:00
 custom:
   Issue: TINY-11123

--- a/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
@@ -184,7 +184,7 @@ const matchWidth = (hotspot: AlloyComponent, container: AlloyComponent, useMinWi
   const menu = Composing.getCurrent(container).getOr(container);
   const buttonWidth = Width.get(hotspot.element);
   if (useMinWidth) {
-    Css.set(menu.element, 'min-width', buttonWidth + 'px');
+    Css.set(menu.element, 'min-width', `min(${buttonWidth}px, 100%)`);
   } else {
     Width.set(menu.element, buttonWidth);
   }

--- a/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
@@ -184,7 +184,7 @@ const matchWidth = (hotspot: AlloyComponent, container: AlloyComponent, useMinWi
   const menu = Composing.getCurrent(container).getOr(container);
   const buttonWidth = Width.get(hotspot.element);
   if (useMinWidth) {
-    Css.set(menu.element, 'min-width', `var(--dropdown-width)`);
+    Css.set(menu.element, 'min-width', buttonWidth + 'px');
   } else {
     Width.set(menu.element, buttonWidth);
   }

--- a/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dropdown/DropdownUtils.ts
@@ -184,7 +184,7 @@ const matchWidth = (hotspot: AlloyComponent, container: AlloyComponent, useMinWi
   const menu = Composing.getCurrent(container).getOr(container);
   const buttonWidth = Width.get(hotspot.element);
   if (useMinWidth) {
-    Css.set(menu.element, 'min-width', `min(${buttonWidth}px, 100%)`);
+    Css.set(menu.element, 'min-width', `var(--dropdown-width)`);
   } else {
     Width.set(menu.element, buttonWidth);
   }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
@@ -178,10 +178,10 @@ const renderCommonDropdown = <T>(
           onControlDetached(spec, editorOffCell)
         ]),
         AddEventsBehaviour.config(fixWidthBehaviourName, [
-          AlloyEvents.runOnAttached((comp, _se) => spec.listRole === 'listbox' ? document.documentElement.style.setProperty('--dropdown-width', `${comp.element.dom.offsetWidth}px`) : UiUtils.forceInitialSize(comp)),
+          AlloyEvents.runOnAttached((comp, _se) => spec.listRole === 'listbox' ? Fun.noop() : UiUtils.forceInitialSize(comp)),
         ]),
         AddEventsBehaviour.config('update-dropdown-width-variable', [
-          AlloyEvents.run(SystemEvents.windowResize(), (comp, _se) => document.documentElement.style.setProperty('--dropdown-width', `${comp.element.dom.offsetWidth}px`)),
+          AlloyEvents.run(SystemEvents.windowResize(), (comp, _se) => AlloyDropdown.close(comp)),
         ]),
         AddEventsBehaviour.config('menubutton-update-display-text', [
           // These handlers are just using Replacing to replace either the menu

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
@@ -178,7 +178,11 @@ const renderCommonDropdown = <T>(
           onControlDetached(spec, editorOffCell)
         ]),
         AddEventsBehaviour.config(fixWidthBehaviourName, [
-          AlloyEvents.runOnAttached((comp, _se) => spec.listRole === 'listbox' ? Fun.noop() : UiUtils.forceInitialSize(comp)),
+          AlloyEvents.runOnAttached((comp, _se) => {
+            if (spec.listRole !== 'listbox') {
+              UiUtils.forceInitialSize(comp);
+            }
+          }),
         ]),
         AddEventsBehaviour.config('update-dropdown-width-variable', [
           AlloyEvents.run(SystemEvents.windowResize(), (comp, _se) => AlloyDropdown.close(comp)),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
@@ -178,7 +178,10 @@ const renderCommonDropdown = <T>(
           onControlDetached(spec, editorOffCell)
         ]),
         AddEventsBehaviour.config(fixWidthBehaviourName, [
-          AlloyEvents.runOnAttached((comp, _se) => spec.listRole === 'listbox' ? Fun.noop : UiUtils.forceInitialSize(comp)),
+          AlloyEvents.runOnAttached((comp, _se) => spec.listRole === 'listbox' ? document.documentElement.style.setProperty('--dropdown-width', `${comp.element.dom.offsetWidth}px`) : UiUtils.forceInitialSize(comp)),
+        ]),
+        AddEventsBehaviour.config('update-dropdown-width-variable', [
+          AlloyEvents.run(SystemEvents.windowResize(), (comp, _se) => document.documentElement.style.setProperty('--dropdown-width', `${comp.element.dom.offsetWidth}px`)),
         ]),
         AddEventsBehaviour.config('menubutton-update-display-text', [
           // These handlers are just using Replacing to replace either the menu


### PR DESCRIPTION
Related Ticket: TINY-11123

Description of Changes:
Dropdown would not close or adjust its width while resizing the window. We decided to close the dropdown to solve that issue.

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
