### PR TITLE
TINY-11115: Changed hex input field validation error text.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11115-2024-07-23.yaml
+++ b/.changes/unreleased/tinymce-TINY-11115-2024-07-23.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Colorpicker's hex-based input field showed the wrong validation error message
+time: 2024-07-23T10:42:15.090890687+02:00
+custom:
+  Issue: TINY-11115

--- a/modules/acid/src/main/ts/ephox/acid/gui/components/RgbForm.ts
+++ b/modules/acid/src/main/ts/ephox/acid/gui/components/RgbForm.ts
@@ -182,7 +182,7 @@ const rgbFormFactory = (
                       getClass('rgb-warning-note')
                     ]
                   },
-                  components: [ GuiFactory.text(translate('colorcustom.rgb.invalid')) ]
+                  components: [ GuiFactory.text(translate(name === 'hex' ? 'colorcustom.rgb.invalidHex' : 'colorcustom.rgb.invalid')) ]
                 }
               ]);
             },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
@@ -22,6 +22,7 @@ const english: Record<string, string> = {
   'colorcustom.rgb.hex.description': 'Hex color code',
   'colorcustom.rgb.range': 'Range 0 to 255',
   'colorcustom.rgb.invalid': 'Numbers only, 0 to 255',
+  'colorcustom.rgb.invalidHex': 'Hexadecimal only, 000000 to FFFFFF',
   'aria.color.picker': 'Color Picker',
   'aria.input.invalid': 'Invalid input'
 };


### PR DESCRIPTION
Related Ticket: TINY-11115

Description of Changes:
Wrong text, 

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
