### PR TITLE
TINY-9915: remove scroll on mouseover of collection dialog elements

### DIFF
--- a/.changes/unreleased/tinymce-TINY-9915-2024-07-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-9915-2024-07-24.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Removed jumpy scroll when hovering on partially visible collection element.
+time: 2024-07-24T15:36:51.584528+02:00
+custom:
+  Issue: TINY-9915

--- a/.changes/unreleased/tinymce-TINY-9915-2024-07-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-9915-2024-07-24.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Removed jumpy scroll when hovering on partially visible collection element.
+body: Mouse hover on partially visible dialog collection elements no longer scrolls.
 time: 2024-07-24T15:36:51.584528+02:00
 custom:
   Issue: TINY-9915

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -77,6 +77,7 @@
     overflow-x: hidden;
     overflow-y: auto;
     padding: 0;
+    scroll-behavior: smooth;
   }
 
   .tox-collection--list .tox-collection__group {

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -77,7 +77,6 @@
     overflow-x: hidden;
     overflow-y: auto;
     padding: 0;
-    scroll-behavior: smooth;
   }
 
   .tox-collection--list .tox-collection__group {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Collection.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Collection.ts
@@ -83,7 +83,7 @@ export const renderCollection = (
 
   const collectionEvents = [
     AlloyEvents.run<EventArgs>(NativeEvents.mouseover(), runOnItem((comp, se, tgt) => {
-      Focus.focus(tgt);
+      Focus.focus(tgt, true);
     })),
     AlloyEvents.run<EventArgs>(NativeEvents.click(), onClick),
     AlloyEvents.run<EventArgs>(SystemEvents.tap(), onClick),
@@ -146,7 +146,7 @@ export const renderCollection = (
                   Tooltipping.setComponents(comp, providersBackstage.tooltips.getComponents( { tooltipText: text }));
                 });
               });
-            },
+            }
           }),
           mode: 'children-keyboard-focus',
           anchor: (comp: AlloyComponent) => ({


### PR DESCRIPTION
Related Ticket: TINY-9915

Description of Changes:
Removed jumpy scroll when hovering on partially visible collection element. 

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
