### PR TITLE
TINY-11077: add table row to a block like list

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11077-2024-07-26.yaml
+++ b/.changes/unreleased/tinymce-TINY-11077-2024-07-26.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Caret would unexpectedly go to a not editable table row above when user pressed enter.
+time: 2024-07-26T15:41:05.828102+02:00
+custom:
+  Issue: TINY-11077

--- a/modules/tinymce/src/core/main/ts/caret/CaretUtils.ts
+++ b/modules/tinymce/src/core/main/ts/caret/CaretUtils.ts
@@ -12,7 +12,7 @@ import { isFakeCaretTarget } from './FakeCaret';
 const isContentEditableTrue = NodeType.isContentEditableTrue;
 const isContentEditableFalse = NodeType.isContentEditableFalse;
 const isMedia = NodeType.isMedia;
-const isBlockLike = NodeType.matchStyleValues('display', 'block table table-cell table-caption list-item');
+const isBlockLike = NodeType.matchStyleValues('display', 'block table table-cell table-row table-caption list-item');
 const isCaretContainer = CaretContainer.isCaretContainer;
 const isCaretContainerBlock = CaretContainer.isCaretContainerBlock;
 const isElement = NodeType.isElement;

--- a/modules/tinymce/src/core/test/ts/browser/caret/TableRowNonEditable.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/TableRowNonEditable.ts
@@ -1,0 +1,45 @@
+import { Keys } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.TableRowNonEditable', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({ base_url: '/project/tinymce/js/tinymce' }, [ ]);
+
+  it('TINY-11077: Row with contenteditable="false" above should not shift selection while pressing enter.', async () => {
+    const editor = hook.editor();
+    editor.setContent(`
+        <p>This is the table with noneditable row</p>
+        <table>
+            <tbody>
+                <tr contenteditable="false">
+                    <td>&nbsp;</td>
+                </tr>
+                <tr>
+                    <td>Text <br>String</td>
+                </tr>
+            </tbody>
+        </table>`);
+
+    TinySelections.setCursor(editor, [ 1, 0, 1, 0 ], 1);
+
+    TinyContentActions.keydown(editor, Keys.enter());
+
+    TinyAssertions.assertCursor(editor, [ 1, 0, 1, 0, 1 ], 0);
+    TinyAssertions.assertContent(editor, `<p>This is the table with noneditable row</p>
+<table>
+<tbody>
+<tr contenteditable="false">
+<td>&nbsp;</td>
+</tr>
+<tr>
+<td>
+<p>Text</p>
+<p><br>String</p>
+</td>
+</tr>
+</tbody>
+</table>`);
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-11077

Description of Changes:
Fixed an issue with caret going unexpectedly to a not editable table row above when user pressed enter.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
