### PR TITLE
TINY-10890: Fix menu part of split button to be wrongly disabled

### DIFF
--- a/modules/tinymce/src/core/main/ts/mode/Readonly.ts
+++ b/modules/tinymce/src/core/main/ts/mode/Readonly.ts
@@ -94,6 +94,10 @@ const toggleReadOnly = (editor: Editor, readOnlyMode: EditorReadOnlyType): void 
     if (Type.isBoolean(readOnlyMode) ? readOnlyMode : !readOnlyMode.selectionEnabled) {
       setContentEditable(body, false);
       switchOffContentEditableTrue(body);
+    } else {
+      if (editor.hasEditableRoot()) {
+        setContentEditable(body, true);
+      }
     }
   } else {
     unsetEditorReadonly(editor, body);

--- a/modules/tinymce/src/core/test/ts/browser/SelectionEnabledModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/SelectionEnabledModeTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Mouse, UiFinder, Clipboard, Waiter, Keys } from '@ephox/agar';
 import { afterEach, context, describe, it } from '@ephox/bedrock-client';
 import { Fun, Singleton } from '@ephox/katamari';
-import { Css, SelectorExists, SelectorFind, SugarElement, Traverse } from '@ephox/sugar';
+import { Attribute, Css, SelectorExists, SelectorFind, SugarElement, Traverse } from '@ephox/sugar';
 import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -499,6 +499,24 @@ describe('browser.tinymce.core.SelectionEnabledModeTest', () => {
 
       TinyContentActions.keystroke(editor, Keys.right());
       TinyAssertions.assertCursor(editor, [ 1, 1 ], 1);
+    });
+  });
+
+  context('contenteditable attribute editor body', () => {
+    it('TINY-10981: Checking content editable attribute of editor body', () => {
+      const editor = hook.editor();
+      const body = TinyDom.body(editor);
+      assert.equal(Attribute.get(body, 'contenteditable'), 'true');
+      setMode(editor, 'testmode');
+      assert.equal(Attribute.get(body, 'contenteditable'), 'true');
+      setMode(editor, 'readonly');
+      assert.equal(Attribute.get(body, 'contenteditable'), 'false');
+      setMode(editor, 'testmode');
+      assert.equal(Attribute.get(body, 'contenteditable'), 'true');
+      setMode(editor, 'readonly');
+      assert.equal(Attribute.get(body, 'contenteditable'), 'false');
+      setMode(editor, 'design');
+      assert.equal(Attribute.get(body, 'contenteditable'), 'true');
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/UiEnabledModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UiEnabledModeTest.ts
@@ -31,6 +31,9 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
     assert.equal(Attribute.get(menuButton, 'disabled'), 'disabled', 'Should be disabled');
   };
 
+  // Menu/Button part of split button
+  const assertMenuPartEnabled = (selector: string) => UiFinder.notExists(SugarBody.body(), `[data-mce-name="${selector}"] > span.tox-tbtn.tox-tbtn--select[aria-disabled="true"]`);
+
   const assertButtonEnabled = (selector: string) => UiFinder.notExists(SugarBody.body(), `[data-mce-name="${selector}"][aria-disabled="true"]`);
 
   const assertButtonDisabled = (selector: string) => UiFinder.exists(SugarBody.body(), `[data-mce-name="${selector}"][aria-disabled="true"]`);
@@ -249,7 +252,10 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
           },
         });
       },
-      assertButtonEnabled,
+      assertButtonEnabled: (selector: string) => {
+        assertMenuPartEnabled(selector);
+        assertButtonEnabled(selector);
+      },
       assertButtonDisabled
     },
     {
@@ -681,6 +687,27 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
         });
       });
 
+      context('onSetup callback and toolbar button spec allowedModes: [ readonly ] not present, switch to mode onSetup', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't1',
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupOne(ed);
+            ed.mode.set('testmode');
+          }
+        }, [], true);
+
+        it(`TINY-10980: Toolbar ${scenario.label} should be disabled in uiEnabled mode`, async () => {
+          const editor = hook.editor();
+          scenario.assertButtonDisabled('t1');
+
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t1');
+        });
+      });
+
       context('onSetup callback with setEnabled(true) and toolbar button readonly: false', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
@@ -704,6 +731,27 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
           scenario.assertButtonDisabled('t2');
 
           editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t2');
+
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t2');
+        });
+      });
+
+      context('onSetup callback with setEnabled(true) and toolbar button readonly: false, switch to mode onSetup', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't2',
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupTwo(ed);
+            ed.mode.set('testmode');
+          }
+        }, [], true);
+
+        it(`TINY-10980: Toolbar ${scenario.label} should not be enabled in uiEnabled mode`, async () => {
+          const editor = hook.editor();
           scenario.assertButtonDisabled('t2');
 
           editor.mode.set('design');
@@ -741,6 +789,26 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
         });
       });
 
+      context('onSetup callback with setEnabled(true) and toolbar button allowedModes: [ design, readonly ], switch to mode onSetup ', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't3',
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupThree(ed);
+            ed.mode.set('testmode');
+          }
+        }, [], true);
+
+        it(`TINY-10980: Toolbar ${scenario.label} should be enabled in uiEnabled mode`, async () => {
+          const editor = hook.editor();
+          scenario.assertButtonEnabled('t3');
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t3');
+        });
+      });
+
       context('onSetup callback with setEnabled(false) and toolbar button allowedModes: [ design, readonly ]', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
@@ -767,6 +835,27 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
           editor.mode.set('testmode');
           scenario.assertButtonDisabled('t4');
 
+          editor.mode.set('design');
+          scenario.assertButtonDisabled('t4');
+        });
+      });
+
+      context('onSetup callback with setEnabled(false) and toolbar button allowedModes: [ design, readonly ], switch to mode onSetup', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't4',
+          statusbar: false,
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupFour(ed);
+            ed.mode.set('testmode');
+          }
+        }, [], true);
+
+        it(`TINY-10980: Toolbar ${scenario.label} should be disabled in uiEnabled mode`, async () => {
+          const editor = hook.editor();
+          scenario.assertButtonDisabled('t4');
           editor.mode.set('design');
           scenario.assertButtonDisabled('t4');
         });
@@ -799,6 +888,27 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
           scenario.assertButtonEnabled('t5');
 
           // Switching mode when the overflow toolbar is opened, the onSetup callback is not executed hence all buttons are enabled
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t5');
+        });
+      });
+
+      context('onSetup callback not present and toolbar button allowedModes: [ design, readonly ], switch to mode onSetup', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't5',
+          statusbar: false,
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupFive(ed);
+            ed.mode.set('testmode');
+          }
+        }, [], true);
+
+        it(`TINY-10980: Toolbar ${scenario.label} should be enabled in uiEnabled mode`, async () => {
+          const editor = hook.editor();
+          scenario.assertButtonEnabled('t5');
           editor.mode.set('design');
           scenario.assertButtonEnabled('t5');
         });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -434,7 +434,13 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
     components: [
       AlloySplitDropdown.parts.button(
         renderCommonStructure(spec.icon, spec.text, Optional.none(), Optional.some([
-          Toggling.config({ toggleClass: ToolbarButtonClasses.Ticked, toggleOnExecute: false })
+          Toggling.config({ toggleClass: ToolbarButtonClasses.Ticked, toggleOnExecute: false }),
+          DisablingConfigs.toolbarButton(() => {
+            return !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedModes);
+          }),
+          ReadOnly.receivingConfigConditional((comp: AlloyComponent) => {
+            return Disabling.getLastDisabledState(comp) || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedModes);
+          })
         ]), sharedBackstage.providers, undefined, spec.allowedModes)
       ),
       AlloySplitDropdown.parts.arrow({


### PR DESCRIPTION
Related Ticket: TINY-10890

Description of Changes:
* Follow up PR, the button part of a split button was incorrectly disabled.
* Tests have been added, but only asserting the menu part of button and only when it's enabled, when it's disabled the whole div (button) structure gets disabled but the menu part and the arrow are missing those attributes (but they are still disabled) 
* Missed out re-enabling `contenteditable="true"` when switching from readonly -> selectionEnabled mode.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
