### PR TITLE
TINY-11082: place the caret after the table when pasting 

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11082-2024-07-30.yaml
+++ b/.changes/unreleased/tinymce-TINY-11082-2024-07-30.yaml
@@ -1,7 +1,6 @@
 project: tinymce
 kind: Improved
-body: Caret would be placed inside the last cell of the pasted table. Now is placed
-  after the table.
+body: Pasting a table now places the cursor after the table instead of into the last cell.
 time: 2024-07-30T13:39:58.930774+02:00
 custom:
   Issue: TINY-11082

--- a/.changes/unreleased/tinymce-TINY-11082-2024-07-30.yaml
+++ b/.changes/unreleased/tinymce-TINY-11082-2024-07-30.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Improved
+body: Caret would be placed inside the last cell of the pasted table. Now is placed
+  after the table.
+time: 2024-07-30T13:39:58.930774+02:00
+custom:
+  Issue: TINY-11082

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -314,6 +314,9 @@ export const insertHtmlAtCaret = (editor: Editor, value: string, details: Insert
     const marker = node;
 
     for (node = node.prev; node; node = node.walk(true)) {
+      if (node.name === 'table') {
+        break;
+      }
       if (node.type === 3 || !dom.isBlock(node.name)) {
         if (node.parent && editor.schema.isValidChild(node.parent.name, 'span')) {
           node.parent.insert(marker, node, node.name === 'br');

--- a/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentCommandTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentCommandTest.ts
@@ -117,7 +117,7 @@ describe('browser.tinymce.core.content.insert.InsertContentCommandTest', () => {
     editor.setContent('<h1>abc</h1><p>def</p>');
     LegacyUnit.setSelection(editor, 'h1', 3);
     editor.execCommand('mceInsertContent', false, '<table><tr><td></td></tr></table>');
-    assert.equal(editor.selection.getNode().nodeName, 'TD');
+    assert.equal(editor.selection.getNode().nodeName, 'P');
     TinyAssertions.assertContent(editor, '<h1>abc</h1><table><tbody><tr><td>\u00a0</td></tr></tbody></table><p>def</p>');
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentTest.ts
@@ -604,7 +604,7 @@ describe('browser.tinymce.core.content.insert.InsertContentTest', () => {
             '</td>' +
           '</tr>' +
         '</tbody>' +
-      '</table>' + 
+      '</table>' +
       `<p>${String.fromCharCode(160)}</p>` // UTF-16 char code '160' is NO-BREAK SPACE (U+00A0)
     );
   });

--- a/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentTest.ts
@@ -1,4 +1,5 @@
 import { context, describe, it } from '@ephox/bedrock-client';
+import { Unicode } from '@ephox/katamari';
 import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -605,7 +606,7 @@ describe('browser.tinymce.core.content.insert.InsertContentTest', () => {
           '</tr>' +
         '</tbody>' +
       '</table>' +
-      `<p>${String.fromCharCode(160)}</p>` // UTF-16 char code '160' is NO-BREAK SPACE (U+00A0)
+      `<p>${Unicode.nbsp}</p>`
     );
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentTest.ts
@@ -604,7 +604,8 @@ describe('browser.tinymce.core.content.insert.InsertContentTest', () => {
             '</td>' +
           '</tr>' +
         '</tbody>' +
-      '</table>'
+      '</table>' + 
+      `<p>${String.fromCharCode(160)}</p>` // UTF-16 char code '160' is NO-BREAK SPACE (U+00A0)
     );
   });
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/ResizeTableTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/ResizeTableTest.ts
@@ -128,6 +128,10 @@ describe('browser.tinymce.models.dom.table.ResizeTableTest', () => {
     const unbindEvents = bindResizeEvents(editor);
 
     const table = insert(editor);
+
+    // After TINY-11082 caret is placed after the table when pasting/inserting. For the purpose of this tests we need to place it back inside to show the resize handles
+    editor.selection.setCursorLocation(editor.dom.select('td:last-of-type')[0], 0);
+
     const tableWidthBefore = TableTestUtils.getWidthData(editor, table.dom);
     const tableHeightBefore = TableTestUtils.getHeightData(editor, table.dom);
     const colWidthsBefore = getColWidths(editor, table);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ClipboardTest.ts
@@ -789,6 +789,6 @@ describe('browser.tinymce.plugins.table.ClipboardTest', () => {
     assert.equal(dataTransfer.getData('text/html'), '<!-- x-tinymce/html -->' + expectedTable);
     TinySelections.setCursor(editor, [ 1, 0 ], 0);
     Clipboard.pasteItems(TinyDom.body(editor), Arr.mapToObject(dataTransfer.types, (type) => dataTransfer.getData(type)));
-    TinyAssertions.assertContent(editor, inputTable + expectedTable);
+    TinyAssertions.assertContent(editor, inputTable + expectedTable + '<p>&nbsp;</p>');
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableRemoveTrailingBrTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableRemoveTrailingBrTest.ts
@@ -27,6 +27,7 @@ describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
       '</tr>',
       '</tbody>',
       '</table>',
+      '<p>&nbsp;</p>'
     ].join('\n');
 
     it('TBA: serialised content should have nbsp\'s in table cells', async () => {
@@ -56,7 +57,8 @@ describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
       editor.setContent('');
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
       TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0 ], 0);
-      TinyAssertions.assertContentPresence(editor, { 'br': 4, 'br:not([data-mce-bogus])': 4 });
+      // Four brs for the table plus one after the table
+      TinyAssertions.assertContentPresence(editor, { 'br': 5, 'br:not([data-mce-bogus])': 4 });
     });
 
     it('TINY-9860: should have correct number of non-bogus brs for nested table', async () => {
@@ -64,8 +66,8 @@ describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
       editor.setContent('');
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
-      // Three brs for the outer table and four brs for the inner table
-      TinyAssertions.assertContentPresence(editor, { 'br': 7, 'br:not([data-mce-bogus])': 7 });
+      // Three brs for the outer table and four brs for the inner table plus one after the table
+      TinyAssertions.assertContentPresence(editor, { 'br': 8, 'br:not([data-mce-bogus])': 7 });
     });
   });
 
@@ -84,6 +86,7 @@ describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
       '</tr>',
       '</tbody>',
       '</table>',
+      '<p>&nbsp;</p>'
     ].join('\n');
 
     it('TBA: serialised content should have br\'s in table cells', async () => {
@@ -113,7 +116,8 @@ describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
       editor.setContent('');
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
       TinyAssertions.assertCursor(editor, [ 0, 1, 0, 0 ], 0);
-      TinyAssertions.assertContentPresence(editor, { 'br': 4, 'br:not([data-mce-bogus])': 4 });
+      // Four brs for the table plus one after the table
+      TinyAssertions.assertContentPresence(editor, { 'br': 5, 'br:not([data-mce-bogus])': 4 });
     });
 
     it('TINY-9860: should have correct number of non-bogus brs for nested table', async () => {
@@ -121,8 +125,8 @@ describe('browser.tinymce.plugins.table.TableRemoveTrailingBrTest', () => {
       editor.setContent('');
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
       await TableTestUtils.pInsertTableViaGrid(editor, 2, 2);
-      // Three brs for the outer table and four brs for the inner table
-      TinyAssertions.assertContentPresence(editor, { 'br': 7, 'br:not([data-mce-bogus])': 7 });
+      // Three brs for the outer table and four brs for the inner table plus one after the table
+      TinyAssertions.assertContentPresence(editor, { 'br': 8, 'br:not([data-mce-bogus])': 7 });
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-11082

Description of Changes:
Caret would be placed inside the last cell of the pasted table. Now is placed after the table.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable) <---- adjusted existing tests
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
