### PR TITLE
TINY-11131: Added custom state to tree structure

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11131-2024-07-31.yaml
+++ b/.changes/unreleased/tinymce-TINY-11131-2024-07-31.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Added
-body: Tree component now allows the addition of a custom icon
+body: Tree component now allows the addition of a custom icon.
 time: 2024-07-31T10:02:00.266569402+02:00
 custom:
   Issue: TINY-11131

--- a/.changes/unreleased/tinymce-TINY-11131-2024-07-31.yaml
+++ b/.changes/unreleased/tinymce-TINY-11131-2024-07-31.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: Tree component now allows the addition of a custom icon
+time: 2024-07-31T10:02:00.266569402+02:00
+custom:
+  Issue: TINY-11131

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Tree.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Tree.ts
@@ -32,23 +32,20 @@ export interface Tree {
   defaultSelectedId: Optional<Id>;
 }
 
-interface SpecialTreeState {
-  icon: string;
-  tooltip: string;
-}
-
 interface BaseTreeItemSpec {
   title: string;
   id: Id;
   menu?: ToolbarMenuButtonSpec;
-  specialState?: SpecialTreeState;
+  customStateIcon?: string;
+  customStateIconTooltip?: string;
 }
 
 interface BaseTreeItem {
   title: string;
   id: string;
   menu: Optional<ToolbarMenuButton>;
-  specialState: Optional<SpecialTreeState>;
+  customStateIcon: Optional<string>;
+  customStateIconTooltip: Optional<string>;
 }
 
 export interface DirectorySpec extends BaseTreeItemSpec {
@@ -78,10 +75,8 @@ const baseTreeItemFields = [
   ComponentSchema.title,
   FieldSchema.requiredString('id'),
   FieldSchema.optionOf('menu', MenuButtonSchema),
-  FieldSchema.optionObjOf('specialState', [
-    FieldSchema.requiredString('icon'),
-    FieldSchema.requiredString('tooltip'),
-  ]),
+  FieldSchema.optionString('customStateIcon'),
+  FieldSchema.optionString('customStateIconTooltip'),
 ];
 
 const treeItemLeafFields = baseTreeItemFields;

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Tree.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Tree.ts
@@ -1,7 +1,7 @@
 import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
 import { Optional, Result } from '@ephox/katamari';
 
-import { ToolbarMenuButtonSpec, ToolbarMenuButton } from '../../api/Toolbar';
+import { ToolbarMenuButton, ToolbarMenuButtonSpec } from '../../api/Toolbar';
 import * as ComponentSchema from '../../core/ComponentSchema';
 import { MenuButtonSchema } from '../toolbar/ToolbarMenuButton';
 
@@ -32,16 +32,23 @@ export interface Tree {
   defaultSelectedId: Optional<Id>;
 }
 
+interface SpecialTreeState {
+  icon: string;
+  tooltip: string;
+}
+
 interface BaseTreeItemSpec {
   title: string;
   id: Id;
   menu?: ToolbarMenuButtonSpec;
+  specialState?: SpecialTreeState;
 }
 
 interface BaseTreeItem {
   title: string;
   id: string;
   menu: Optional<ToolbarMenuButton>;
+  specialState: Optional<SpecialTreeState>;
 }
 
 export interface DirectorySpec extends BaseTreeItemSpec {
@@ -71,6 +78,10 @@ const baseTreeItemFields = [
   ComponentSchema.title,
   FieldSchema.requiredString('id'),
   FieldSchema.optionOf('menu', MenuButtonSchema),
+  FieldSchema.optionObjOf('specialState', [
+    FieldSchema.requiredString('icon'),
+    FieldSchema.requiredString('tooltip'),
+  ]),
 ];
 
 const treeItemLeafFields = baseTreeItemFields;

--- a/modules/oxide/src/less/theme/components/tree/tree-button.less
+++ b/modules/oxide/src/less/theme/components/tree/tree-button.less
@@ -276,7 +276,7 @@
     }
   }
 
-  .tox-icon-special-state {
+  .tox-icon-custom-state {
     flex-grow: 1;
     display: flex;
     justify-content: flex-end;

--- a/modules/oxide/src/less/theme/components/tree/tree-button.less
+++ b/modules/oxide/src/less/theme/components/tree/tree-button.less
@@ -276,6 +276,12 @@
     }
   }
 
+  .tox-icon-special-state {
+    flex-grow: 1;
+    display: flex;
+    justify-content: flex-end;
+  }
+
   .tox-tree--directory__children {
     overflow: hidden;
     padding-left: 16px;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
@@ -1,5 +1,23 @@
 import {
-  Behaviour, Button as AlloyButton, Tabstopping, GuiFactory, SimpleSpec, Toggling, Replacing, Keying, AddEventsBehaviour, AlloyEvents, NativeEvents, AlloyComponent, CustomEvent, Receiving, Focusing, Sliding, AlloyTriggers, EventFormat
+  AddEventsBehaviour,
+  Button as AlloyButton,
+  AlloyComponent,
+  AlloyEvents,
+  AlloyTriggers,
+  Behaviour,
+  CustomEvent,
+  EventFormat,
+  Focusing,
+  GuiFactory,
+  Keying,
+  NativeEvents,
+  Receiving,
+  Replacing,
+  SimpleSpec,
+  Sliding,
+  Tabstopping,
+  Toggling,
+  Tooltipping
 } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Cell, Fun, Id, Optional } from '@ephox/katamari';
@@ -53,7 +71,7 @@ interface RenderDirectoryChildrenProps extends RenderItemProps {
   selectedId: Optional<string>;
 }
 
-const renderLabel = (text: string ): SimpleSpec => ({
+const renderLabel = (text: string): SimpleSpec => ({
   dom: {
     tag: 'span',
     classes: [ 'tox-tree__label' ],
@@ -65,6 +83,21 @@ const renderLabel = (text: string ): SimpleSpec => ({
     GuiFactory.text(text)
   ],
 });
+
+const renderSpecialStateIcon = (container: Dialog.Directory | Dialog.Leaf, components: SimpleSpec[], backstage: UiFactoryBackstage): void => {
+  container.specialState.each((icon) =>
+    components.push(renderIcon(
+      icon.icon, backstage.shared.providers.icons, [
+        Tooltipping.config(
+          backstage.shared.providers.tooltips.getConfig({
+            tooltipText: icon.tooltip
+          })
+        )
+      ],
+      [ 'tox-icon-special-state' ]
+    ))
+  );
+};
 
 const leafLabelEventsId = Id.generate('leaf-label-event-id');
 
@@ -78,6 +111,7 @@ const renderLeafLabel = ({
 }: RenderLeafLabelProps): SimpleSpec => {
   const internalMenuButton = leaf.menu.map((btn) => renderMenuButton(btn, 'tox-mbtn', backstage, Optional.none(), visible));
   const components = [ renderLabel(leaf.title) ];
+  renderSpecialStateIcon(leaf, components, backstage);
   internalMenuButton.each((btn) => components.push(btn));
 
   return AlloyButton.sketch({
@@ -147,13 +181,13 @@ const renderLeafLabel = ({
   });
 };
 
-const renderIcon = (iconName: string, iconsProvider: Icons.IconProvider, behaviours: Array<Behaviour.NamedConfiguredBehaviour<any, any, any>>): SimpleSpec =>
+const renderIcon = (iconName: string, iconsProvider: Icons.IconProvider, behaviours: Array<Behaviour.NamedConfiguredBehaviour<any, any, any>>, extraClasses?: string[]): SimpleSpec =>
   Icons.render(iconName, {
     tag: 'span',
     classes: [
       'tox-tree__icon-wrap',
       'tox-icon',
-    ],
+    ].concat(extraClasses || []),
     behaviours
   }, iconsProvider);
 
@@ -181,6 +215,7 @@ const renderDirectoryLabel = ({
     },
     renderLabel(directory.title)
   ];
+  renderSpecialStateIcon(directory, components, backstage);
   internalMenuButton.each((btn) => {
     components.push(btn);
   });
@@ -196,7 +231,7 @@ const renderDirectoryLabel = ({
   return AlloyButton.sketch({
     dom: {
       tag: 'div',
-      classes: [ 'tox-tree--directory__label', 'tox-trbtn' ].concat( visible ? [ 'tox-tree--directory__label--visible' ] : [] ),
+      classes: [ 'tox-tree--directory__label', 'tox-trbtn' ].concat(visible ? [ 'tox-tree--directory__label--visible' ] : []),
     },
     components,
     action: toggleExpandChildren,
@@ -212,11 +247,11 @@ const renderDirectoryLabel = ({
         AlloyEvents.run<EventArgs<KeyboardEvent>>(NativeEvents.keydown(), (comp, se) => {
           const isRightArrowKey = se.event.raw.code === 'ArrowRight';
           const isLeftArrowKey = se.event.raw.code === 'ArrowLeft';
-          if (isRightArrowKey && noChildren ) {
+          if (isRightArrowKey && noChildren) {
             se.stop();
           }
-          if (isRightArrowKey || isLeftArrowKey ) {
-            SelectorFind.ancestor( comp.element, '.tox-tree--directory').each((directoryEle) => {
+          if (isRightArrowKey || isLeftArrowKey) {
+            SelectorFind.ancestor(comp.element, '.tox-tree--directory').each((directoryEle) => {
               comp.getSystem().getByDom(directoryEle).each((directoryComp) => {
                 if (!Toggling.isOn(directoryComp) && isRightArrowKey || Toggling.isOn(directoryComp) && isLeftArrowKey) {
                   toggleExpandChildren(comp);
@@ -311,14 +346,14 @@ const renderDirectory = ({
         }),
         AlloyEvents.run<ToggleExpandTreeNodeEventArgs>('expand-tree-node', (_cmp, se) => {
           const { expanded, node } = se.event;
-          expandedIdsCell.set( expanded ?
+          expandedIdsCell.set(expanded ?
             [ ...expandedIdsCell.get(), node ] :
             expandedIdsCell.get().filter((id) => id !== node)
           );
         }),
       ]),
       Toggling.config({
-        ...( directory.children.length > 0 ? {
+        ...(directory.children.length > 0 ? {
           aria: {
             mode: 'expanded',
           },
@@ -378,7 +413,7 @@ const renderTree = (
       AddEventsBehaviour.config(treeEventsId, [
         AlloyEvents.run<ToggleExpandTreeNodeEventArgs>('expand-tree-node', (_cmp, se) => {
           const { expanded, node } = se.event;
-          expandedIds.set( expanded ?
+          expandedIds.set(expanded ?
             [ ...expandedIds.get(), node ] :
             expandedIds.get().filter((id) => id !== node)
           );

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
@@ -84,17 +84,20 @@ const renderLabel = (text: string): SimpleSpec => ({
   ],
 });
 
-const renderSpecialStateIcon = (container: Dialog.Directory | Dialog.Leaf, components: SimpleSpec[], backstage: UiFactoryBackstage): void => {
-  container.specialState.each((icon) =>
+const renderCustomStateIcon = (container: Dialog.Directory | Dialog.Leaf, components: SimpleSpec[], backstage: UiFactoryBackstage): void => {
+  container.customStateIcon.each((icon) =>
     components.push(renderIcon(
-      icon.icon, backstage.shared.providers.icons, [
-        Tooltipping.config(
-          backstage.shared.providers.tooltips.getConfig({
-            tooltipText: icon.tooltip
-          })
-        )
-      ],
-      [ 'tox-icon-special-state' ]
+      icon, backstage.shared.providers.icons, container.customStateIconTooltip.fold(
+        () => [],
+        (tooltip) => [
+          Tooltipping.config(
+            backstage.shared.providers.tooltips.getConfig({
+              tooltipText: tooltip
+            })
+          )
+        ]
+      ),
+      [ 'tox-icon-custom-state' ]
     ))
   );
 };
@@ -111,7 +114,7 @@ const renderLeafLabel = ({
 }: RenderLeafLabelProps): SimpleSpec => {
   const internalMenuButton = leaf.menu.map((btn) => renderMenuButton(btn, 'tox-mbtn', backstage, Optional.none(), visible));
   const components = [ renderLabel(leaf.title) ];
-  renderSpecialStateIcon(leaf, components, backstage);
+  renderCustomStateIcon(leaf, components, backstage);
   internalMenuButton.each((btn) => components.push(btn));
 
   return AlloyButton.sketch({
@@ -215,7 +218,7 @@ const renderDirectoryLabel = ({
     },
     renderLabel(directory.title)
   ];
-  renderSpecialStateIcon(directory, components, backstage);
+  renderCustomStateIcon(directory, components, backstage);
   internalMenuButton.each((btn) => {
     components.push(btn);
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
@@ -97,7 +97,11 @@ const renderCustomStateIcon = (container: Dialog.Directory | Dialog.Leaf, compon
           )
         ]
       ),
-      [ 'tox-icon-custom-state' ]
+      [ 'tox-icon-custom-state' ],
+      container.customStateIconTooltip.fold(
+        () => ({}),
+        (tooltip) => ({ title: tooltip })
+      )
     ))
   );
 };
@@ -184,14 +188,15 @@ const renderLeafLabel = ({
   });
 };
 
-const renderIcon = (iconName: string, iconsProvider: Icons.IconProvider, behaviours: Array<Behaviour.NamedConfiguredBehaviour<any, any, any>>, extraClasses?: string[]): SimpleSpec =>
+const renderIcon = (iconName: string, iconsProvider: Icons.IconProvider, behaviours: Array<Behaviour.NamedConfiguredBehaviour<any, any, any>>, extraClasses?: string[], extraAttributes?: Record<string, string>): SimpleSpec =>
   Icons.render(iconName, {
     tag: 'span',
     classes: [
       'tox-tree__icon-wrap',
       'tox-icon',
     ].concat(extraClasses || []),
-    behaviours
+    behaviours,
+    attributes: extraAttributes
   }, iconsProvider);
 
 const renderIconFromPack = (iconName: string, iconsProvider: Icons.IconProvider): SimpleSpec =>

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
@@ -75,19 +75,15 @@ describe('headless.tinymce.themes.silver.tree.TreeTest', () => {
         type: 'directory',
         id: 'dir2',
         title: 'Dir2',
-        specialState: {
-          icon: 'color-swatch',
-          tooltip: 'Test Tooltip 1'
-        },
+        customStateIcon: 'color-swatch',
+        customStateIconTooltip: 'Test Tooltip 1',
         children: [
           {
             type: 'leaf',
             title: 'File 3',
             id: '3',
-            specialState: {
-              icon: 'color-swatch',
-              tooltip: 'Test Tooltip 1'
-            },
+            customStateIcon: 'color-swatch',
+            customStateIconTooltip: 'Test Tooltip 2',
           },
         ]
       },
@@ -141,8 +137,8 @@ describe('headless.tinymce.themes.silver.tree.TreeTest', () => {
 
   it('TINY-11131: Check that custom icon is correct', () => {
     const element = SugarElement.fromDom(getTreeItem('.tox-tree__label[aria-label="Dir2"').element.dom.parentElement);
-    SelectorFind.child(element, '.tox-icon-special-state').getOrDie();
-    SelectorFind.child(SelectorFind.sibling(element, '.tox-tree--directory__children').getOrDie(), '.tox-icon-special-state');
+    SelectorFind.child(element, '.tox-icon-custom-state').getOrDie();
+    SelectorFind.child(SelectorFind.sibling(element, '.tox-tree--directory__children').getOrDie(), '.tox-icon-custom-state');
   });
 
   it('TINY-9614: Basic tree interactions', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
@@ -3,7 +3,7 @@ import { AlloyComponent, AlloyTriggers, GuiFactory, NativeEvents, TestHelpers } 
 import { describe, it } from '@ephox/bedrock-client';
 import { StructureSchema } from '@ephox/boulder';
 import { Dialog } from '@ephox/bridge';
-import { Class, SelectorFind, SugarBody, SugarDocument } from '@ephox/sugar';
+import { Class, SelectorFind, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import { renderTree } from 'tinymce/themes/silver/ui/dialog/Tree';
@@ -71,6 +71,26 @@ describe('headless.tinymce.themes.silver.tree.TreeTest', () => {
         title: 'File 6',
         id: '6',
       },
+      {
+        type: 'directory',
+        id: 'dir2',
+        title: 'Dir2',
+        specialState: {
+          icon: 'color-swatch',
+          tooltip: 'Test Tooltip 1'
+        },
+        children: [
+          {
+            type: 'leaf',
+            title: 'File 3',
+            id: '3',
+            specialState: {
+              icon: 'color-swatch',
+              tooltip: 'Test Tooltip 1'
+            },
+          },
+        ]
+      },
     ];
 
     const treeSpec = StructureSchema.getOrDie(Dialog.createTree({
@@ -117,6 +137,12 @@ describe('headless.tinymce.themes.silver.tree.TreeTest', () => {
     const file3Element = SelectorFind.child(dirChildren.element, '.tox-tree--leaf__label').getOrDie();
     const file3 = dirChildren.getSystem().getByDom(file3Element).getOrDie();
     assertLeafSelectedState('File 3', true, file3);
+  });
+
+  it('TINY-11131: Check that custom icon is correct', () => {
+    const element = SugarElement.fromDom(getTreeItem('.tox-tree__label[aria-label="Dir2"').element.dom.parentElement);
+    SelectorFind.child(element, '.tox-icon-special-state').getOrDie();
+    SelectorFind.child(SelectorFind.sibling(element, '.tox-tree--directory__children').getOrDie(), '.tox-icon-special-state');
   });
 
   it('TINY-9614: Basic tree interactions', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
@@ -139,6 +139,8 @@ describe('headless.tinymce.themes.silver.tree.TreeTest', () => {
     const element = SugarElement.fromDom(getTreeItem('.tox-tree__label[aria-label="Dir2"').element.dom.parentElement);
     SelectorFind.child(element, '.tox-icon-custom-state').getOrDie();
     SelectorFind.child(SelectorFind.sibling(element, '.tox-tree--directory__children').getOrDie(), '.tox-icon-custom-state');
+    const element2 = SugarElement.fromDom(getTreeItem('.tox-tree__label[aria-label="Dir"').element.dom.parentElement);
+    assert.isNull(SelectorFind.descendant(element2, '.tox-icon-custom-state').getOrNull());
   });
 
   it('TINY-9614: Basic tree interactions', async () => {


### PR DESCRIPTION
Related Ticket: TINY-11131

Description of Changes:
To display some sort of locked/readonly icon for locked/readonly templates and categories we needed to add the ability to add these.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
