### PR TITLE
TINY-11100: Fire input event during delete if one is not already fired.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11100-2024-08-05.yaml
+++ b/.changes/unreleased/tinymce-TINY-11100-2024-08-05.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Deleting a selection in a list element would sometimes prevent the `input` event
+  from firing
+time: 2024-08-05T05:07:18.131117218+02:00
+custom:
+  Issue: TINY-11100

--- a/.changes/unreleased/tinymce-TINY-11100-2024-08-05.yaml
+++ b/.changes/unreleased/tinymce-TINY-11100-2024-08-05.yaml
@@ -1,7 +1,7 @@
 project: tinymce
 kind: Fixed
 body: Deleting a selection in a list element would sometimes prevent the `input` event
-  from firing
+  from being dispatched.
 time: 2024-08-05T05:07:18.131117218+02:00
 custom:
   Issue: TINY-11100

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -274,14 +274,14 @@ const backspaceDeleteRange = (editor: Editor): boolean => {
   if (hasListSelection(editor)) {
     editor.undoManager.transact(() => {
       // Some delete actions may prevent the input event from being fired. If we do not detect it, we fire it ourselves.
-      let fireInput = true;
-      const inputHandler = () => fireInput = false;
+      let shouldFireInput = true;
+      const inputHandler = () => shouldFireInput = false;
 
       editor.on('input', inputHandler);
       editor.execCommand('Delete');
       editor.off('input', inputHandler);
 
-      if (fireInput) {
+      if (shouldFireInput) {
         editor.dispatch('input');
       }
 

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -273,7 +273,18 @@ const hasListSelection = (editor: Editor) => {
 const backspaceDeleteRange = (editor: Editor): boolean => {
   if (hasListSelection(editor)) {
     editor.undoManager.transact(() => {
+      // Some delete actions may prevent the input event from being fired. If we do not detect it, we fire it ourselves.
+      let fireInput = true;
+      const inputHandler = () => fireInput = false;
+
+      editor.on('input', inputHandler);
       editor.execCommand('Delete');
+      editor.off('input', inputHandler);
+
+      if (fireInput) {
+        editor.dispatch('input');
+      }
+
       NormalizeLists.normalizeLists(editor.dom, editor.getBody());
     });
 
@@ -312,6 +323,6 @@ const setup = (editor: Editor): void => {
 };
 
 export {
-  setup,
-  backspaceDelete
+  backspaceDelete,
+  setup
 };

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteTest.ts
@@ -61,6 +61,28 @@ describe('browser.tinymce.plugins.lists.BackspaceDeleteTest', () => {
     assert.equal(editor.selection.getNode().nodeName, 'LI');
   });
 
+  it('TINY-11100: Backspacing with a selection should cause an input event', () => {
+    const editor = hook.editor();
+    editor.setContent('<ul><li>ab</li></ul>');
+
+    editor.focus();
+    let inputEventCounter = 0;
+    const inputEventHandler = () => inputEventCounter++;
+
+    const li = editor.dom.select('li')[0].childNodes.item(0);
+    const rng = editor.dom.createRng();
+    rng.setStart(li, 0);
+    rng.setEnd(li, 1);
+    editor.selection.setRng(rng);
+
+    editor.on('input', inputEventHandler);
+    editor.plugins.lists.backspaceDelete();
+    editor.off('input', inputEventHandler);
+
+    assert.equal(inputEventCounter, 1);
+    TinyAssertions.assertContent(editor, '<ul><li>b</li></ul>');
+  });
+
   it('TBA: Backspace at end of single LI in UL with STRONG', () => {
     const editor = hook.editor();
     const content = '<ul><li><span>a</span><strong>b</strong></li></ul>';

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteTest.ts
@@ -69,11 +69,7 @@ describe('browser.tinymce.plugins.lists.BackspaceDeleteTest', () => {
     let inputEventCounter = 0;
     const inputEventHandler = () => inputEventCounter++;
 
-    const li = editor.dom.select('li')[0].childNodes.item(0);
-    const rng = editor.dom.createRng();
-    rng.setStart(li, 0);
-    rng.setEnd(li, 1);
-    editor.selection.setRng(rng);
+    TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
 
     editor.on('input', inputEventHandler);
     editor.plugins.lists.backspaceDelete();


### PR DESCRIPTION
Related Ticket: TINY-11100

Description of Changes:
The list plugin will fire an input event if none is fired by the delete command.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
