### PR TITLE
Fix MediaResolver invalid after dimensions change

### DIFF
--- a/modules/tinymce/src/plugins/media/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/ui/Dialog.ts
@@ -210,7 +210,7 @@ const showDialog = (editor: Editor): void => {
         ? { ...dialogData, embed: '' }
         : dialogData;
 
-    const embed = dataToHtml(editor, data);
+    const embed = dataToHtml(editor, data.embed ? { ...data, source: HtmlToData.htmlToData(data.embed, editor.schema).source } : data);
     api.setData(wrap({
       ...data,
       embed


### PR DESCRIPTION
**GitHub issues:**
https://github.com/tinymce/tinymce/issues/9798

**Description of Changes:**

This is an issue of `Media` plugin, you can try following above issue page.
When convert rule settled using `media_url_resolver`, input source URL should be converted to other format.

Currently only the first time I input source URL the embed converted normally.
If I change dimensions, the embed src will become origin source URL.

Therefore I checked `modules\tinymce\src\plugins\media\main\ts\ui\Dialog.ts`
When `dimensions`, `altsource`, or `poster` `onChange`, it call function `handleUpdate`.

`handleUpdate` was only used here by these cases, so we modify it:
Change `data.source` from origin source to MediaResolver converted URL extract from `data.embed`.

In this way, converted URL in embed will not be replaced by origin source while wrapping new HTML. 
The problem will be solved. I've tested all scenes include dimensions and source change, all works well.

**Pre-checks:**
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

**Review:**
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)
