### PR TITLE
TINY-11178: Move creation of sidebars back to after `PostRender` event

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11178-2024-08-21.yaml
+++ b/.changes/unreleased/tinymce-TINY-11178-2024-08-21.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Sidebar could not be toggled until the skin was loaded.
+time: 2024-08-21T10:01:13.080247+10:00
+custom:
+  Issue: TINY-11178

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -107,16 +107,19 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
   Attachment.attachSystemAfter(eTargetNode, mainUi.mothership);
   attachUiMotherships(editor, uiRoot, uiRefs);
 
-  // TINY-10343: Using `SkinLoaded` instead of `PostRender` because if the skin loading takes too long you run in to rendering problems since things are measured before the CSS is being applied
-  editor.on('SkinLoaded', () => {
-    // Set the sidebar before the toolbar and menubar
-    // - each sidebar has an associated toggle toolbar button that needs to check the
-    //   sidebar that is set to determine its active state on setup
+  editor.on('PostRender', () => {
     OuterContainer.setSidebar(
       outerContainer,
       rawUiConfig.sidebar,
       Options.getSidebarShow(editor)
     );
+  });
+
+  // TINY-10343: Using `SkinLoaded` instead of `PostRender` because if the skin loading takes too long you run in to rendering problems since things are measured before the CSS is being applied
+  editor.on('SkinLoaded', () => {
+    // Set the sidebar before the toolbar and menubar
+    // - each sidebar has an associated toggle toolbar button that needs to check the
+    //   sidebar that is set to determine its active state on setup
 
     setToolbar(editor, uiRefs, rawUiConfig, backstage);
     lastToolbarWidth.set(editor.getWin().innerWidth);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
@@ -3,7 +3,7 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { McEditor } from '@ephox/mcagar';
 import { SugarBody, SugarElement, Traverse } from '@ephox/sugar';
-import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Sidebar } from 'tinymce/core/api/ui/Ui';


### PR DESCRIPTION
Related Ticket: TINY-11178

Description of Changes:
* Sidebar creation was moved to the `SkinLoaded` event, causing the `ToggleSidebar` command to not work in an `init` event listener.
* Moved it back to inside the `PostRender` event

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
