### PR TITLE
TINY-11110: Make some considerations for brs after tables

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11110-2024-08-12.yaml
+++ b/.changes/unreleased/tinymce-TINY-11110-2024-08-12.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Placing the cursor after a table with a br after it would misplace added newlines
+  before the table instead of after.
+time: 2024-08-12T11:29:50.268405782+02:00
+custom:
+  Issue: TINY-11110

--- a/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
@@ -36,8 +36,11 @@ const isEmptyAnchor = (dom: DOMUtils, elm: Node): boolean => {
   return elm && elm.nodeName === 'A' && dom.isEmpty(elm);
 };
 
-const containerAndSiblingName = (container: Node, nodeName: string) => {
+const containerAndPreviousSiblingName = (container: Node, nodeName: string) => {
   return container.nodeName === nodeName || (container.previousSibling && container.previousSibling.nodeName === nodeName);
+};
+const containerAndNextSiblingName = (container: Node, nodeName: string) => {
+  return container.nodeName === nodeName || (container.nextSibling && container.nextSibling.nodeName === nodeName);
 };
 
 // Returns true if the block can be split into two blocks or not
@@ -241,7 +244,10 @@ const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>): void => {
     }
 
     // Caret can be before/after a table or a hr
-    if (containerAndSiblingName(container, 'TABLE') || containerAndSiblingName(container, 'HR')) {
+    if (containerAndPreviousSiblingName(container, 'TABLE') || containerAndPreviousSiblingName(container, 'HR')) {
+      if (containerAndNextSiblingName(container, 'BR')) {
+        return !start;
+      }
       return (isAfterLastNodeInContainer && !start) || (!isAfterLastNodeInContainer && start);
     }
 
@@ -413,7 +419,7 @@ const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>): void => {
 
     newBlock = parentBlockParent.insertBefore(createNewBlock(), parentBlock);
 
-    const root = containerAndSiblingName(parentBlock, 'HR') || afterTable ? newBlock : prevBrOpt.getOr(parentBlock);
+    const root = containerAndPreviousSiblingName(parentBlock, 'HR') || afterTable ? newBlock : prevBrOpt.getOr(parentBlock);
     NewLineUtils.moveToCaretPosition(editor, root);
   } else {
     // Extract after fragment and insert it after the current block

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -187,6 +187,15 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
       TinyAssertions.assertCursor(editor, [ 1 ], 0);
     });
 
+    it('TINY-11110: Placed cursor after a table, before the br, and pressed enter', () => {
+      const editor = hook.editor();
+      editor.setContent('<div><table><tbody><tr><td><br></td></tr></tbody></table><br></div>');
+      setSelectionTo(editor, [ 0 ], 1);
+      insertNewline(editor, { });
+      TinyAssertions.assertContent(editor, '<div><table><tbody><tr><td>&nbsp;</td></tr></tbody></table></div><div>&nbsp;</div>');
+      TinyAssertions.assertCursor(editor, [ 1 ], 0);
+    });
+
     it('TINY-9813: Placed a cursor is placed after a table, with an editable afterwards', () => {
       const editor = hook.editor();
       editor.setContent('<table><tbody><tr><td><br></td></tr></tbody></table><div contenteditable="true">&nbsp;</div>');


### PR DESCRIPTION
Related Ticket: TINY-11110

Description of Changes:
When clicking on the new line after a table, which is the first element of its parent,  followed by a br-element the newline-insertion code accidentally mistook the cursor placement to be before the table, rather than after.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
