### PR TITLE
TINY-10981: Address issues with selectionEnabled

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,1 +1,1 @@
-primaryBranch=main
+primaryBranch=epic/EPIC-114

--- a/modules/tinymce/src/core/main/ts/api/commands/FormatCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/commands/FormatCommands.ts
@@ -8,6 +8,10 @@ import { ContentLanguage } from '../OptionTypes';
 
 const registerExecCommands = (editor: Editor): void => {
   const toggleFormat = (name: string, value?: FormatVars) => {
+    if (editor.mode.isReadOnly()) {
+      return;
+    }
+
     editor.formatter.toggle(name, value);
     editor.nodeChanged();
   };

--- a/modules/tinymce/src/core/main/ts/api/commands/LinkCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/commands/LinkCommands.ts
@@ -4,6 +4,10 @@ import Editor from '../Editor';
 
 export const registerCommands = (editor: Editor): void => {
   const applyLinkToSelection = (_command: string, _ui: boolean, value: string | { href: string }): void => {
+    if (editor.mode.isReadOnly()) {
+      return;
+    }
+
     const linkDetails = Type.isString(value) ? { href: value } : value;
     const anchor = editor.dom.getParent(editor.selection.getNode(), 'a');
 

--- a/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/Selection.ts
@@ -265,6 +265,10 @@ const EditorSelection = (dom: DOMUtils, win: Window, serializer: DomSerializer, 
    * @return {Boolean} Will be true if the selection is editable and false if it's not editable.
    */
   const isEditable = (): boolean => {
+    if (editor.mode.isReadOnly()) {
+      return false;
+    }
+
     const rng = getRng();
     const fakeSelectedElements = editor.getBody().querySelectorAll('[data-mce-selected="1"]');
 

--- a/modules/tinymce/src/core/main/ts/commands/IndentOutdent.ts
+++ b/modules/tinymce/src/core/main/ts/commands/IndentOutdent.ts
@@ -60,6 +60,10 @@ const getBlocksToIndent = (editor: Editor): SugarElement<HTMLElement>[] =>
   );
 
 const handle = (editor: Editor, command: string): void => {
+  if (editor.mode.isReadOnly()) {
+    return;
+  }
+
   const { dom } = editor;
   const indentation = Options.getIndentation(editor);
   const indentUnit = /[a-z%]+$/i.exec(indentation)?.[0] ?? 'px';

--- a/modules/tinymce/src/core/main/ts/keyboard/TableNavigation.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/TableNavigation.ts
@@ -133,6 +133,10 @@ const tabGo = (editor: Editor, isRoot: (e: SugarElement<Node>) => boolean, cell:
       return getCellFirstCursorPosition(cell);
     });
   }, (current) => {
+    if (editor.mode.isReadOnly()) {
+      return Optional.none();
+    }
+
     editor.execCommand('mceTableInsertRowAfter');
     // Move forward from the last cell so that we move into the first valid position in the new row
     return tabForward(editor, isRoot, current);

--- a/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertNewLine.ts
@@ -15,6 +15,10 @@ interface BreakType {
 }
 
 const insertBreak = (breakType: BreakType, editor: Editor, evt?: EditorEvent<KeyboardEvent>): void => {
+  if (editor.mode.isReadOnly()) {
+    return;
+  }
+
   if (!editor.selection.isCollapsed()) {
     // IMPORTANT: We want to use the editor execCommand here, so that our `delete` execCommand
     // overrides will be considered.
@@ -35,6 +39,10 @@ const insertBreak = (breakType: BreakType, editor: Editor, evt?: EditorEvent<Key
 };
 
 const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>): void => {
+  if (editor.mode.isReadOnly()) {
+    return;
+  }
+
   const br = () => insertBreak(InsertBr.linebreak, editor, evt);
   const block = () => insertBreak(InsertBlock.blockbreak, editor, evt);
 

--- a/modules/tinymce/src/core/main/ts/newline/NewBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewBlock.ts
@@ -14,6 +14,10 @@ const getTopParentBlock = (editor: Editor, node: Node, root: Element, container:
 };
 
 const insert = (editor: Editor, before: boolean): void => {
+  if (editor.mode.isReadOnly()) {
+    return;
+  }
+
   const dom = editor.dom;
   const rng = editor.selection.getRng();
   const node = before ? editor.selection.getStart() : editor.selection.getEnd();

--- a/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormattingCommandsTest.ts
@@ -1,554 +1,1103 @@
-import { context, describe, it } from '@ephox/bedrock-client';
+import { afterEach, context, describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.FormattingCommandsTest', () => {
-  const hook = TinyHooks.bddSetupLight<Editor>({
-    add_unload_trigger: false,
-    disable_nodechange: true,
-    indent: false,
-    entities: 'raw',
-    convert_urls: false,
-    valid_styles: {
-      '*': 'color,font-size,font-family,background-color,font-weight,font-style,text-decoration,' +
-        'float,margin,margin-top,margin-right,margin-bottom,margin-left,padding-left,text-align,display'
-    },
-    base_url: '/project/tinymce/js/tinymce'
-  }, []);
 
-  it('Justify - multiple block elements selected - queryCommandState', () => {
-    const editor = hook.editor();
-    editor.setContent(
-      '<div style="text-align: left;"><div id="a" style="text-align: right;">' +
-      'one</div><div id="b" style="text-align: right;">two</div></div>'
-    );
-    LegacyUnit.setSelection(editor, '#a', 0, '#b', 3);
-    assert.isFalse(editor.queryCommandState('JustifyLeft'));
-    assert.ok(editor.queryCommandState('JustifyRight'));
-  });
+  context('Design mode', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      add_unload_trigger: false,
+      disable_nodechange: true,
+      indent: false,
+      entities: 'raw',
+      convert_urls: false,
+      valid_styles: {
+        '*': 'color,font-size,font-family,background-color,font-weight,font-style,text-decoration,' +
+          'float,margin,margin-top,margin-right,margin-bottom,margin-left,padding-left,text-align,display'
+      },
+      base_url: '/project/tinymce/js/tinymce'
+    }, []);
 
-  it('Formatting commands (xhtmlTextStyles)', () => {
-    const editor = hook.editor();
-    editor.focus();
-    editor.setContent('test 123');
-    editor.execCommand('SelectAll');
-    editor.execCommand('Bold');
-    TinyAssertions.assertContent(editor, '<p><strong>test 123</strong></p>');
-
-    editor.setContent('test 123');
-    editor.execCommand('SelectAll');
-    editor.execCommand('Italic');
-    TinyAssertions.assertContent(editor, '<p><em>test 123</em></p>');
-
-    editor.setContent('test 123');
-    editor.execCommand('SelectAll');
-    editor.execCommand('Underline');
-    TinyAssertions.assertContent(editor, '<p><span style="text-decoration: underline;">test 123</span></p>');
-
-    editor.setContent('test 123');
-    editor.execCommand('SelectAll');
-    editor.execCommand('Strikethrough');
-    TinyAssertions.assertContent(editor, '<p><s>test 123</s></p>');
-
-    editor.setContent('test 123');
-    editor.execCommand('SelectAll');
-    editor.execCommand('FontName', false, 'Arial');
-    TinyAssertions.assertContent(editor, '<p><span style="font-family: Arial;">test 123</span></p>');
-
-    editor.setContent('test 123');
-    editor.execCommand('SelectAll');
-    editor.execCommand('FontName', false, 'Bauhaus 93');
-    TinyAssertions.assertContent(editor, `<p><span style="font-family: 'Bauhaus 93';">test 123</span></p>`);
-
-    editor.setContent('test 123');
-    editor.execCommand('SelectAll');
-    editor.execCommand('FontSize', false, '7');
-    TinyAssertions.assertContent(editor, '<p><span style="font-size: xx-large;">test 123</span></p>');
-
-    editor.setContent('test 123');
-    editor.execCommand('SelectAll');
-    editor.execCommand('FontSize', false, '7pt');
-    TinyAssertions.assertContent(editor, '<p><span style="font-size: 7pt;">test 123</span></p>');
-
-    editor.setContent('test 123');
-    editor.execCommand('SelectAll');
-    editor.execCommand('ForeColor', false, '#FF0000');
-    TinyAssertions.assertContent(editor, '<p><span style="color: #ff0000;">test 123</span></p>');
-
-    editor.setContent('test 123');
-    editor.execCommand('SelectAll');
-    editor.execCommand('HiliteColor', false, '#FF0000');
-    TinyAssertions.assertContent(editor, '<p><span style="background-color: #ff0000;">test 123</span></p>');
-
-    editor.setContent('test 123');
-    editor.execCommand('SelectAll');
-    editor.execCommand('BackColor', false, '#FF0000');
-    TinyAssertions.assertContent(editor, '<p><span style="background-color: #ff0000;">test 123</span></p>');
-
-    editor.setContent('<p><span style="text-decoration: underline;">test 123</span></p>');
-    TinyAssertions.assertContent(editor, '<p><span style="text-decoration: underline;">test 123</span></p>');
-
-    editor.setContent('<p><span style="text-decoration: line-through;">test 123</span></p>');
-    TinyAssertions.assertContent(editor, '<p><span style="text-decoration: line-through;">test 123</span></p>');
-
-    editor.setContent('<p><span style="font-family: Arial;">test 123</span></p>');
-    TinyAssertions.assertContent(editor, '<p><span style="font-family: Arial;">test 123</span></p>');
-
-    editor.setContent('<p><span style="font-size: xx-large;">test 123</span></p>');
-    TinyAssertions.assertContent(editor, '<p><span style="font-size: xx-large;">test 123</span></p>');
-
-    editor.setContent('<p><strike>test 123</strike></p>');
-    TinyAssertions.assertContent(editor, '<p><s>test 123</s></p>');
-
-    editor.setContent('<p><font face="Arial">test 123</font></p>');
-    TinyAssertions.assertContent(editor, '<p><span style="font-family: Arial;">test 123</span></p>');
-
-    editor.setContent('<p><font size="7">test 123</font></p>');
-    TinyAssertions.assertContent(editor, '<p><span style="font-size: 300%;">test 123</span></p>');
-
-    editor.setContent('<p><font face="Arial" size="7">test 123</font></p>');
-    TinyAssertions.assertContent(editor, '<p><span style="font-size: 300%; font-family: Arial;">test 123</span></p>');
-
-    editor.setContent('<font style="background-color: #ff0000" color="#ff0000">test</font><font face="Arial">test</font>');
-    TinyAssertions.assertContent(
-      editor,
-      '<p><span style="color: #ff0000; background-color: #ff0000;">test</span><span style="font-family: Arial;">test</span></p>'
-    );
-
-    editor.setContent('<p><font face="Arial" style="color: #ff0000">test 123</font></p>');
-    TinyAssertions.assertContent(editor, '<p><span style="color: #ff0000; font-family: Arial;">test 123</span></p>');
-  });
-
-  context('Formatting commands (alignInline)', () => {
-    it('TBA - p, JustifyLeft', () => {
+    it('Justify - multiple block elements selected - queryCommandState', () => {
       const editor = hook.editor();
-      editor.setContent('<p>test 123</p>');
+      editor.setContent(
+        '<div style="text-align: left;"><div id="a" style="text-align: right;">' +
+        'one</div><div id="b" style="text-align: right;">two</div></div>'
+      );
+      LegacyUnit.setSelection(editor, '#a', 0, '#b', 3);
+      assert.isFalse(editor.queryCommandState('JustifyLeft'));
+      assert.ok(editor.queryCommandState('JustifyRight'));
+    });
+
+    it('Formatting commands (xhtmlTextStyles)', () => {
+      const editor = hook.editor();
+      editor.focus();
+      editor.setContent('test 123');
       editor.execCommand('SelectAll');
-      editor.execCommand('JustifyLeft');
-      TinyAssertions.assertContent(editor, '<p style="text-align: left;">test 123</p>');
-      assert.isTrue(editor.queryCommandState('JustifyLeft'), 'should have JustifyLeft state true');
-    });
+      editor.execCommand('Bold');
+      TinyAssertions.assertContent(editor, '<p><strong>test 123</strong></p>');
 
-    it('TBA - p, JustifyCenter', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>test 123</p>');
+      editor.setContent('test 123');
       editor.execCommand('SelectAll');
-      editor.execCommand('JustifyCenter');
-      TinyAssertions.assertContent(editor, '<p style="text-align: center;">test 123</p>');
-      assert.isTrue(editor.queryCommandState('JustifyCenter'), 'should have JustifyCenter state true');
-    });
+      editor.execCommand('Italic');
+      TinyAssertions.assertContent(editor, '<p><em>test 123</em></p>');
 
-    it('TBA - p, JustifyRight', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>test 123</p>');
+      editor.setContent('test 123');
       editor.execCommand('SelectAll');
-      editor.execCommand('JustifyRight');
-      TinyAssertions.assertContent(editor, '<p style="text-align: right;">test 123</p>');
-      assert.isTrue(editor.queryCommandState('JustifyRight'), 'should have JustifyRight state true');
-    });
+      editor.execCommand('Underline');
+      TinyAssertions.assertContent(editor, '<p><span style="text-decoration: underline;">test 123</span></p>');
 
-    it('TBA - p, JustifyFull', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>test 123</p>');
+      editor.setContent('test 123');
       editor.execCommand('SelectAll');
-      editor.execCommand('JustifyFull');
-      TinyAssertions.assertContent(editor, '<p style="text-align: justify;">test 123</p>');
-      assert.isTrue(editor.queryCommandState('JustifyFull'), 'should have JustifyFull state true');
-    });
+      editor.execCommand('Strikethrough');
+      TinyAssertions.assertContent(editor, '<p><s>test 123</s></p>');
 
-    it('TINY-7715 - pre, JustifyLeft', () => {
-      const editor = hook.editor();
-      editor.setContent('<pre>test 123</pre>');
+      editor.setContent('test 123');
       editor.execCommand('SelectAll');
-      editor.execCommand('JustifyLeft');
-      TinyAssertions.assertContent(editor, '<pre style="text-align: left;">test 123</pre>');
-      assert.isTrue(editor.queryCommandState('JustifyLeft'), 'should have JustifyLeft state true');
-    });
+      editor.execCommand('FontName', false, 'Arial');
+      TinyAssertions.assertContent(editor, '<p><span style="font-family: Arial;">test 123</span></p>');
 
-    it('TINY-7715 - pre, JustifyCenter', () => {
-      const editor = hook.editor();
-      editor.setContent('<pre>test 123</pre>');
+      editor.setContent('test 123');
       editor.execCommand('SelectAll');
-      editor.execCommand('JustifyCenter');
-      TinyAssertions.assertContent(editor, '<pre style="text-align: center;">test 123</pre>');
-      assert.isTrue(editor.queryCommandState('JustifyCenter'), 'should have JustifyCenter state true');
-    });
+      editor.execCommand('FontName', false, 'Bauhaus 93');
+      TinyAssertions.assertContent(editor, `<p><span style="font-family: 'Bauhaus 93';">test 123</span></p>`);
 
-    it('TINY-7715 - pre, JustifyRight', () => {
-      const editor = hook.editor();
-      editor.setContent('<pre>test 123</pre>');
+      editor.setContent('test 123');
       editor.execCommand('SelectAll');
-      editor.execCommand('JustifyRight');
-      TinyAssertions.assertContent(editor, '<pre style="text-align: right;">test 123</pre>');
-      assert.isTrue(editor.queryCommandState('JustifyRight'), 'should have JustifyRight state true');
-    });
+      editor.execCommand('FontSize', false, '7');
+      TinyAssertions.assertContent(editor, '<p><span style="font-size: xx-large;">test 123</span></p>');
 
-    it('TINY-7715 - pre, JustifyFull', () => {
-      const editor = hook.editor();
-      editor.setContent('<pre>test 123</pre>');
+      editor.setContent('test 123');
       editor.execCommand('SelectAll');
-      editor.execCommand('JustifyFull');
-      TinyAssertions.assertContent(editor, '<pre style="text-align: justify;">test 123</pre>');
-      assert.isTrue(editor.queryCommandState('JustifyFull'), 'should have JustifyFull state true');
-    });
+      editor.execCommand('FontSize', false, '7pt');
+      TinyAssertions.assertContent(editor, '<p><span style="font-size: 7pt;">test 123</span></p>');
 
-    it('TBA - img, JustifyLeft', () => {
-      const editor = hook.editor();
-      editor.setContent('<img src="tinymce/ui/img/raster.gif" />');
-      editor.selection.select(editor.dom.select('img')[0]);
-      editor.execCommand('JustifyLeft');
-      TinyAssertions.assertContent(editor, '<p><img style="float: left;" src="tinymce/ui/img/raster.gif"></p>');
-    });
+      editor.setContent('test 123');
+      editor.execCommand('SelectAll');
+      editor.execCommand('ForeColor', false, '#FF0000');
+      TinyAssertions.assertContent(editor, '<p><span style="color: #ff0000;">test 123</span></p>');
 
-    it('TBA - img, JustifyCenter', () => {
-      const editor = hook.editor();
-      editor.setContent('<img src="tinymce/ui/img/raster.gif" />');
-      editor.selection.select(editor.dom.select('img')[0]);
-      editor.execCommand('JustifyCenter');
+      editor.setContent('test 123');
+      editor.execCommand('SelectAll');
+      editor.execCommand('HiliteColor', false, '#FF0000');
+      TinyAssertions.assertContent(editor, '<p><span style="background-color: #ff0000;">test 123</span></p>');
+
+      editor.setContent('test 123');
+      editor.execCommand('SelectAll');
+      editor.execCommand('BackColor', false, '#FF0000');
+      TinyAssertions.assertContent(editor, '<p><span style="background-color: #ff0000;">test 123</span></p>');
+
+      editor.setContent('<p><span style="text-decoration: underline;">test 123</span></p>');
+      TinyAssertions.assertContent(editor, '<p><span style="text-decoration: underline;">test 123</span></p>');
+
+      editor.setContent('<p><span style="text-decoration: line-through;">test 123</span></p>');
+      TinyAssertions.assertContent(editor, '<p><span style="text-decoration: line-through;">test 123</span></p>');
+
+      editor.setContent('<p><span style="font-family: Arial;">test 123</span></p>');
+      TinyAssertions.assertContent(editor, '<p><span style="font-family: Arial;">test 123</span></p>');
+
+      editor.setContent('<p><span style="font-size: xx-large;">test 123</span></p>');
+      TinyAssertions.assertContent(editor, '<p><span style="font-size: xx-large;">test 123</span></p>');
+
+      editor.setContent('<p><strike>test 123</strike></p>');
+      TinyAssertions.assertContent(editor, '<p><s>test 123</s></p>');
+
+      editor.setContent('<p><font face="Arial">test 123</font></p>');
+      TinyAssertions.assertContent(editor, '<p><span style="font-family: Arial;">test 123</span></p>');
+
+      editor.setContent('<p><font size="7">test 123</font></p>');
+      TinyAssertions.assertContent(editor, '<p><span style="font-size: 300%;">test 123</span></p>');
+
+      editor.setContent('<p><font face="Arial" size="7">test 123</font></p>');
+      TinyAssertions.assertContent(editor, '<p><span style="font-size: 300%; font-family: Arial;">test 123</span></p>');
+
+      editor.setContent('<font style="background-color: #ff0000" color="#ff0000">test</font><font face="Arial">test</font>');
       TinyAssertions.assertContent(
         editor,
-        '<p><img style="margin-right: auto; margin-left: auto; display: block;" src="tinymce/ui/img/raster.gif"></p>'
+        '<p><span style="color: #ff0000; background-color: #ff0000;">test</span><span style="font-family: Arial;">test</span></p>'
+      );
+
+      editor.setContent('<p><font face="Arial" style="color: #ff0000">test 123</font></p>');
+      TinyAssertions.assertContent(editor, '<p><span style="color: #ff0000; font-family: Arial;">test 123</span></p>');
+    });
+
+    context('Formatting commands (alignInline)', () => {
+      it('TBA - p, JustifyLeft', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>test 123</p>');
+        editor.execCommand('SelectAll');
+        editor.execCommand('JustifyLeft');
+        TinyAssertions.assertContent(editor, '<p style="text-align: left;">test 123</p>');
+        assert.isTrue(editor.queryCommandState('JustifyLeft'), 'should have JustifyLeft state true');
+      });
+
+      it('TBA - p, JustifyCenter', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>test 123</p>');
+        editor.execCommand('SelectAll');
+        editor.execCommand('JustifyCenter');
+        TinyAssertions.assertContent(editor, '<p style="text-align: center;">test 123</p>');
+        assert.isTrue(editor.queryCommandState('JustifyCenter'), 'should have JustifyCenter state true');
+      });
+
+      it('TBA - p, JustifyRight', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>test 123</p>');
+        editor.execCommand('SelectAll');
+        editor.execCommand('JustifyRight');
+        TinyAssertions.assertContent(editor, '<p style="text-align: right;">test 123</p>');
+        assert.isTrue(editor.queryCommandState('JustifyRight'), 'should have JustifyRight state true');
+      });
+
+      it('TBA - p, JustifyFull', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>test 123</p>');
+        editor.execCommand('SelectAll');
+        editor.execCommand('JustifyFull');
+        TinyAssertions.assertContent(editor, '<p style="text-align: justify;">test 123</p>');
+        assert.isTrue(editor.queryCommandState('JustifyFull'), 'should have JustifyFull state true');
+      });
+
+      it('TINY-7715 - pre, JustifyLeft', () => {
+        const editor = hook.editor();
+        editor.setContent('<pre>test 123</pre>');
+        editor.execCommand('SelectAll');
+        editor.execCommand('JustifyLeft');
+        TinyAssertions.assertContent(editor, '<pre style="text-align: left;">test 123</pre>');
+        assert.isTrue(editor.queryCommandState('JustifyLeft'), 'should have JustifyLeft state true');
+      });
+
+      it('TINY-7715 - pre, JustifyCenter', () => {
+        const editor = hook.editor();
+        editor.setContent('<pre>test 123</pre>');
+        editor.execCommand('SelectAll');
+        editor.execCommand('JustifyCenter');
+        TinyAssertions.assertContent(editor, '<pre style="text-align: center;">test 123</pre>');
+        assert.isTrue(editor.queryCommandState('JustifyCenter'), 'should have JustifyCenter state true');
+      });
+
+      it('TINY-7715 - pre, JustifyRight', () => {
+        const editor = hook.editor();
+        editor.setContent('<pre>test 123</pre>');
+        editor.execCommand('SelectAll');
+        editor.execCommand('JustifyRight');
+        TinyAssertions.assertContent(editor, '<pre style="text-align: right;">test 123</pre>');
+        assert.isTrue(editor.queryCommandState('JustifyRight'), 'should have JustifyRight state true');
+      });
+
+      it('TINY-7715 - pre, JustifyFull', () => {
+        const editor = hook.editor();
+        editor.setContent('<pre>test 123</pre>');
+        editor.execCommand('SelectAll');
+        editor.execCommand('JustifyFull');
+        TinyAssertions.assertContent(editor, '<pre style="text-align: justify;">test 123</pre>');
+        assert.isTrue(editor.queryCommandState('JustifyFull'), 'should have JustifyFull state true');
+      });
+
+      it('TBA - img, JustifyLeft', () => {
+        const editor = hook.editor();
+        editor.setContent('<img src="tinymce/ui/img/raster.gif" />');
+        editor.selection.select(editor.dom.select('img')[0]);
+        editor.execCommand('JustifyLeft');
+        TinyAssertions.assertContent(editor, '<p><img style="float: left;" src="tinymce/ui/img/raster.gif"></p>');
+      });
+
+      it('TBA - img, JustifyCenter', () => {
+        const editor = hook.editor();
+        editor.setContent('<img src="tinymce/ui/img/raster.gif" />');
+        editor.selection.select(editor.dom.select('img')[0]);
+        editor.execCommand('JustifyCenter');
+        TinyAssertions.assertContent(
+          editor,
+          '<p><img style="margin-right: auto; margin-left: auto; display: block;" src="tinymce/ui/img/raster.gif"></p>'
+        );
+      });
+
+      it('TBA - img, JustifyRight', () => {
+        const editor = hook.editor();
+        editor.setContent('<img src="tinymce/ui/img/raster.gif" />');
+        editor.selection.select(editor.dom.select('img')[0]);
+        editor.execCommand('JustifyRight');
+        TinyAssertions.assertContent(editor, '<p><img style="float: right;" src="tinymce/ui/img/raster.gif"></p>');
+      });
+    });
+
+    it('mceBlockQuote', () => {
+      const editor = hook.editor();
+      editor.focus();
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('mceBlockQuote');
+      assert.equal(editor.getContent().replace(/\s+/g, ''), '<blockquote><p>test123</p></blockquote>');
+
+      editor.setContent('<p>test 123</p><p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('mceBlockQuote');
+      assert.equal(editor.getContent().replace(/\s+/g, ''), '<blockquote><p>test123</p><p>test123</p></blockquote>');
+    });
+
+    it('FormatBlock', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('FormatBlock', false, 'h1');
+      TinyAssertions.assertContent(editor, '<h1>test 123</h1>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('FormatBlock', false, 'h2');
+      TinyAssertions.assertContent(editor, '<h2>test 123</h2>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('FormatBlock', false, 'h3');
+      TinyAssertions.assertContent(editor, '<h3>test 123</h3>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('FormatBlock', false, 'h4');
+      TinyAssertions.assertContent(editor, '<h4>test 123</h4>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('FormatBlock', false, 'h5');
+      TinyAssertions.assertContent(editor, '<h5>test 123</h5>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('FormatBlock', false, 'h6');
+      TinyAssertions.assertContent(editor, '<h6>test 123</h6>');
+
+      editor.execCommand('SelectAll');
+
+      try {
+        editor.execCommand('FormatBlock', false, 'div');
+      } catch (ex) {
+        // t.log('Failed: ' + ex.message);
+      }
+
+      TinyAssertions.assertContent(editor, '<div>test 123</div>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('FormatBlock', false, 'address');
+      TinyAssertions.assertContent(editor, '<address>test 123</address>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('FormatBlock', false, 'pre');
+      TinyAssertions.assertContent(editor, '<pre>test 123</pre>');
+    });
+
+    it('createLink', () => {
+      const editor = hook.editor();
+      editor.setContent('test 123');
+      editor.execCommand('SelectAll');
+      editor.execCommand('createLink', false, 'http://www.site.com');
+      TinyAssertions.assertContent(editor, '<p><a href="http://www.site.com">test 123</a></p>');
+    });
+
+    it('mceInsertLink (relative)', () => {
+      const editor = hook.editor();
+      editor.setContent('test 123');
+      editor.execCommand('SelectAll');
+      editor.execCommand('mceInsertLink', false, 'test');
+      TinyAssertions.assertContent(editor, '<p><a href="test">test 123</a></p>');
+    });
+
+    it('mceInsertLink (link absolute)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('mceInsertLink', false, 'http://www.site.com');
+      TinyAssertions.assertContent(editor, '<p><a href="http://www.site.com">test 123</a></p>');
+    });
+
+    it('mceInsertLink (link encoded)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('mceInsertLink', false, '"&<>');
+      TinyAssertions.assertContent(editor, '<p><a href="&quot;&amp;&lt;&gt;">test 123</a></p>');
+    });
+
+    it('mceInsertLink (link encoded and with class)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('mceInsertLink', false, { href: '"&<>', class: 'test' });
+      TinyAssertions.assertContent(editor, '<p><a class="test" href="&quot;&amp;&lt;&gt;">test 123</a></p>');
+    });
+
+    it('mceInsertLink (link with space)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('mceInsertLink', false, { href: 'foo bar' });
+      TinyAssertions.assertContent(editor, '<p><a href="foo%20bar">test 123</a></p>');
+    });
+
+    it('mceInsertLink (link floated img)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><img style="float: right;" src="about:blank" /></p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('mceInsertLink', false, 'link');
+      TinyAssertions.assertContent(editor, '<p><a href="link"><img style="float: right;" src="about:blank"></a></p>');
+    });
+
+    it('mceInsertLink (link adjacent text)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="#">a</a>b</p>');
+
+      const rng = editor.dom.createRng();
+      rng.setStart(editor.getBody().firstChild?.lastChild as Text, 0);
+      rng.setEnd(editor.getBody().firstChild?.lastChild as Text, 1);
+      editor.selection.setRng(rng);
+
+      editor.execCommand('mceInsertLink', false, 'link');
+      TinyAssertions.assertContent(editor, '<p><a href="#">a</a><a href="link">b</a></p>');
+    });
+
+    it('mceInsertLink (link text inside text)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="#"><em>abc</em></a></p>');
+      LegacyUnit.setSelection(editor, 'em', 1, 'em', 2);
+
+      editor.execCommand('mceInsertLink', false, 'link');
+      TinyAssertions.assertContent(editor, '<p><a href="link"><em>abc</em></a></p>');
+    });
+
+    it('mceInsertLink (link around existing links)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="#1">1</a><a href="#2">2</a></p>');
+      editor.execCommand('SelectAll');
+
+      editor.execCommand('mceInsertLink', false, 'link');
+      TinyAssertions.assertContent(editor, '<p><a href="link">12</a></p>');
+    });
+
+    it('mceInsertLink (link around existing links with different attrs)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a id="a" href="#1">1</a><a id="b" href="#2">2</a></p>');
+      editor.execCommand('SelectAll');
+
+      editor.execCommand('mceInsertLink', false, 'link');
+      TinyAssertions.assertContent(editor, '<p><a href="link">12</a></p>');
+    });
+
+    it('mceInsertLink (link around existing complex contents with links)', () => {
+      const editor = hook.editor();
+      editor.setContent(
+        '<p><span id="s1"><strong><a id="a" href="#1"><em>1</em></a></strong></span><span id="s2">' +
+        '<em><a id="b" href="#2"><strong>2</strong></a></em></span></p>'
+      );
+      editor.execCommand('SelectAll');
+
+      editor.execCommand('mceInsertLink', false, 'link');
+      TinyAssertions.assertContent(
+        editor,
+        '<p><a href="link"><span id="s1"><strong><em>1</em>' +
+        '</strong></span><span id="s2"><em><strong>2</strong></em></span></a></p>'
       );
     });
 
-    it('TBA - img, JustifyRight', () => {
+    it('mceInsertLink (link text inside link)', () => {
       const editor = hook.editor();
-      editor.setContent('<img src="tinymce/ui/img/raster.gif" />');
-      editor.selection.select(editor.dom.select('img')[0]);
-      editor.execCommand('JustifyRight');
-      TinyAssertions.assertContent(editor, '<p><img style="float: right;" src="tinymce/ui/img/raster.gif"></p>');
+      editor.setContent('<p><a href="#">test</a></p>');
+      LegacyUnit.setSelection(editor, 'p', 0, 'p', 1);
+      editor.execCommand('SelectAll');
+
+      editor.execCommand('mceInsertLink', false, 'link');
+      TinyAssertions.assertContent(editor, '<p><a href="link">test</a></p>');
     });
-  });
 
-  it('mceBlockQuote', () => {
-    const editor = hook.editor();
-    editor.focus();
-    editor.setContent('<p>test 123</p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('mceBlockQuote');
-    assert.equal(editor.getContent().replace(/\s+/g, ''), '<blockquote><p>test123</p></blockquote>');
+    it('mceInsertLink bug #7331', () => {
+      const editor = hook.editor();
+      editor.setContent('<table><tbody><tr><td>A</td></tr><tr><td>B</td></tr></tbody></table>');
+      const rng = editor.dom.createRng();
+      rng.setStart(editor.dom.select('td')[1].firstChild as Text, 0);
+      rng.setEnd(editor.getBody(), 1);
+      editor.selection.setRng(rng);
+      editor.execCommand('mceInsertLink', false, { href: 'x' });
+      TinyAssertions.assertContent(editor, '<table><tbody><tr><td>A</td></tr><tr><td><a href=\"x\">B</a></td></tr></tbody></table>');
+    });
 
-    editor.setContent('<p>test 123</p><p>test 123</p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('mceBlockQuote');
-    assert.equal(editor.getContent().replace(/\s+/g, ''), '<blockquote><p>test123</p><p>test123</p></blockquote>');
-  });
-
-  it('FormatBlock', () => {
-    const editor = hook.editor();
-    editor.setContent('<p>test 123</p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('FormatBlock', false, 'h1');
-    TinyAssertions.assertContent(editor, '<h1>test 123</h1>');
-
-    editor.execCommand('SelectAll');
-    editor.execCommand('FormatBlock', false, 'h2');
-    TinyAssertions.assertContent(editor, '<h2>test 123</h2>');
-
-    editor.execCommand('SelectAll');
-    editor.execCommand('FormatBlock', false, 'h3');
-    TinyAssertions.assertContent(editor, '<h3>test 123</h3>');
-
-    editor.execCommand('SelectAll');
-    editor.execCommand('FormatBlock', false, 'h4');
-    TinyAssertions.assertContent(editor, '<h4>test 123</h4>');
-
-    editor.execCommand('SelectAll');
-    editor.execCommand('FormatBlock', false, 'h5');
-    TinyAssertions.assertContent(editor, '<h5>test 123</h5>');
-
-    editor.execCommand('SelectAll');
-    editor.execCommand('FormatBlock', false, 'h6');
-    TinyAssertions.assertContent(editor, '<h6>test 123</h6>');
-
-    editor.execCommand('SelectAll');
-
-    try {
-      editor.execCommand('FormatBlock', false, 'div');
-    } catch (ex) {
-      // t.log('Failed: ' + ex.message);
-    }
-
-    TinyAssertions.assertContent(editor, '<div>test 123</div>');
-
-    editor.execCommand('SelectAll');
-    editor.execCommand('FormatBlock', false, 'address');
-    TinyAssertions.assertContent(editor, '<address>test 123</address>');
-
-    editor.execCommand('SelectAll');
-    editor.execCommand('FormatBlock', false, 'pre');
-    TinyAssertions.assertContent(editor, '<pre>test 123</pre>');
-  });
-
-  it('createLink', () => {
-    const editor = hook.editor();
-    editor.setContent('test 123');
-    editor.execCommand('SelectAll');
-    editor.execCommand('createLink', false, 'http://www.site.com');
-    TinyAssertions.assertContent(editor, '<p><a href="http://www.site.com">test 123</a></p>');
-  });
-
-  it('mceInsertLink (relative)', () => {
-    const editor = hook.editor();
-    editor.setContent('test 123');
-    editor.execCommand('SelectAll');
-    editor.execCommand('mceInsertLink', false, 'test');
-    TinyAssertions.assertContent(editor, '<p><a href="test">test 123</a></p>');
-  });
-
-  it('mceInsertLink (link absolute)', () => {
-    const editor = hook.editor();
-    editor.setContent('<p>test 123</p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('mceInsertLink', false, 'http://www.site.com');
-    TinyAssertions.assertContent(editor, '<p><a href="http://www.site.com">test 123</a></p>');
-  });
-
-  it('mceInsertLink (link encoded)', () => {
-    const editor = hook.editor();
-    editor.setContent('<p>test 123</p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('mceInsertLink', false, '"&<>');
-    TinyAssertions.assertContent(editor, '<p><a href="&quot;&amp;&lt;&gt;">test 123</a></p>');
-  });
-
-  it('mceInsertLink (link encoded and with class)', () => {
-    const editor = hook.editor();
-    editor.setContent('<p>test 123</p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('mceInsertLink', false, { href: '"&<>', class: 'test' });
-    TinyAssertions.assertContent(editor, '<p><a class="test" href="&quot;&amp;&lt;&gt;">test 123</a></p>');
-  });
-
-  it('mceInsertLink (link with space)', () => {
-    const editor = hook.editor();
-    editor.setContent('<p>test 123</p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('mceInsertLink', false, { href: 'foo bar' });
-    TinyAssertions.assertContent(editor, '<p><a href="foo%20bar">test 123</a></p>');
-  });
-
-  it('mceInsertLink (link floated img)', () => {
-    const editor = hook.editor();
-    editor.setContent('<p><img style="float: right;" src="about:blank" /></p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('mceInsertLink', false, 'link');
-    TinyAssertions.assertContent(editor, '<p><a href="link"><img style="float: right;" src="about:blank"></a></p>');
-  });
-
-  it('mceInsertLink (link adjacent text)', () => {
-    const editor = hook.editor();
-    editor.setContent('<p><a href="#">a</a>b</p>');
-
-    const rng = editor.dom.createRng();
-    rng.setStart(editor.getBody().firstChild?.lastChild as Text, 0);
-    rng.setEnd(editor.getBody().firstChild?.lastChild as Text, 1);
-    editor.selection.setRng(rng);
-
-    editor.execCommand('mceInsertLink', false, 'link');
-    TinyAssertions.assertContent(editor, '<p><a href="#">a</a><a href="link">b</a></p>');
-  });
-
-  it('mceInsertLink (link text inside text)', () => {
-    const editor = hook.editor();
-    editor.setContent('<p><a href="#"><em>abc</em></a></p>');
-    LegacyUnit.setSelection(editor, 'em', 1, 'em', 2);
-
-    editor.execCommand('mceInsertLink', false, 'link');
-    TinyAssertions.assertContent(editor, '<p><a href="link"><em>abc</em></a></p>');
-  });
-
-  it('mceInsertLink (link around existing links)', () => {
-    const editor = hook.editor();
-    editor.setContent('<p><a href="#1">1</a><a href="#2">2</a></p>');
-    editor.execCommand('SelectAll');
-
-    editor.execCommand('mceInsertLink', false, 'link');
-    TinyAssertions.assertContent(editor, '<p><a href="link">12</a></p>');
-  });
-
-  it('mceInsertLink (link around existing links with different attrs)', () => {
-    const editor = hook.editor();
-    editor.setContent('<p><a id="a" href="#1">1</a><a id="b" href="#2">2</a></p>');
-    editor.execCommand('SelectAll');
-
-    editor.execCommand('mceInsertLink', false, 'link');
-    TinyAssertions.assertContent(editor, '<p><a href="link">12</a></p>');
-  });
-
-  it('mceInsertLink (link around existing complex contents with links)', () => {
-    const editor = hook.editor();
-    editor.setContent(
-      '<p><span id="s1"><strong><a id="a" href="#1"><em>1</em></a></strong></span><span id="s2">' +
-      '<em><a id="b" href="#2"><strong>2</strong></a></em></span></p>'
-    );
-    editor.execCommand('SelectAll');
-
-    editor.execCommand('mceInsertLink', false, 'link');
-    TinyAssertions.assertContent(
-      editor,
-      '<p><a href="link"><span id="s1"><strong><em>1</em>' +
-      '</strong></span><span id="s2"><em><strong>2</strong></em></span></a></p>'
-    );
-  });
-
-  it('mceInsertLink (link text inside link)', () => {
-    const editor = hook.editor();
-    editor.setContent('<p><a href="#">test</a></p>');
-    LegacyUnit.setSelection(editor, 'p', 0, 'p', 1);
-    editor.execCommand('SelectAll');
-
-    editor.execCommand('mceInsertLink', false, 'link');
-    TinyAssertions.assertContent(editor, '<p><a href="link">test</a></p>');
-  });
-
-  it('mceInsertLink bug #7331', () => {
-    const editor = hook.editor();
-    editor.setContent('<table><tbody><tr><td>A</td></tr><tr><td>B</td></tr></tbody></table>');
-    const rng = editor.dom.createRng();
-    rng.setStart(editor.dom.select('td')[1].firstChild as Text, 0);
-    rng.setEnd(editor.getBody(), 1);
-    editor.selection.setRng(rng);
-    editor.execCommand('mceInsertLink', false, { href: 'x' });
-    TinyAssertions.assertContent(editor, '<table><tbody><tr><td>A</td></tr><tr><td><a href=\"x\">B</a></td></tr></tbody></table>');
-  });
-
-  it('unlink', () => {
-    const editor = hook.editor();
-    editor.setContent('<p><a href="test">test</a> <a href="test">123</a></p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('unlink');
-    TinyAssertions.assertContent(editor, '<p>test 123</p>');
-  });
-
-  it('unlink - unselected a[href] with childNodes', () => {
-    const editor = hook.editor();
-    editor.setContent('<p><a href="test"><strong><em>test</em></strong></a></p>');
-    LegacyUnit.setSelection(editor, 'em', 0);
-    editor.execCommand('unlink');
-    TinyAssertions.assertContent(editor, '<p><strong><em>test</em></strong></p>');
-  });
-
-  it('TINY-9172: unlink block links', () => {
-    const editor = hook.editor();
-    editor.setContent('<a href="test">test</a><div><a href="#"><p>test</p></a></div>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('unlink');
-    TinyAssertions.assertContent(editor, '<p>test</p><div><p>test</p></div>');
-  });
-
-  it('TINY-9739: Removing link should be a noop for noneditable selections', () => {
-    TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
-      editor.setContent('<p><a href="#">tiny</a></p>');
-      TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 3);
+    it('unlink', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="test">test</a> <a href="test">123</a></p>');
+      editor.execCommand('SelectAll');
       editor.execCommand('unlink');
-      TinyAssertions.assertContent(editor, '<p><a href="#">tiny</a></p>');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+    });
+
+    it('unlink - unselected a[href] with childNodes', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="test"><strong><em>test</em></strong></a></p>');
+      LegacyUnit.setSelection(editor, 'em', 0);
+      editor.execCommand('unlink');
+      TinyAssertions.assertContent(editor, '<p><strong><em>test</em></strong></p>');
+    });
+
+    it('TINY-9172: unlink block links', () => {
+      const editor = hook.editor();
+      editor.setContent('<a href="test">test</a><div><a href="#"><p>test</p></a></div>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('unlink');
+      TinyAssertions.assertContent(editor, '<p>test</p><div><p>test</p></div>');
+    });
+
+    it('TINY-9739: Removing link should be a noop for noneditable selections', () => {
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        editor.setContent('<p><a href="#">tiny</a></p>');
+        TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 3);
+        editor.execCommand('unlink');
+        TinyAssertions.assertContent(editor, '<p><a href="#">tiny</a></p>');
+      });
+    });
+
+    it('subscript/superscript', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('subscript');
+      TinyAssertions.assertContent(editor, '<p><sub>test 123</sub></p>');
+
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('superscript');
+      TinyAssertions.assertContent(editor, '<p><sup>test 123</sup></p>');
+
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('subscript');
+      editor.execCommand('subscript');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('superscript');
+      editor.execCommand('superscript');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+    });
+
+    it('indent/outdent', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('Indent');
+      TinyAssertions.assertContent(editor, '<p style="padding-left: 40px;">test 123</p>');
+
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('Indent');
+      editor.execCommand('Indent');
+      TinyAssertions.assertContent(editor, '<p style="padding-left: 80px;">test 123</p>');
+
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('Indent');
+      editor.execCommand('Indent');
+      editor.execCommand('Outdent');
+      TinyAssertions.assertContent(editor, '<p style="padding-left: 40px;">test 123</p>');
+
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('Outdent');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+    });
+
+    it('indent/outdent table always uses margin', () => {
+      const editor = hook.editor();
+      editor.setContent('<table><tbody><tr><td>test</td></tr></tbody></table>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('Indent');
+      TinyAssertions.assertContent(editor, '<table style="margin-left: 40px;"><tbody><tr><td>test</td></tr></tbody></table>');
+
+      editor.setContent('<table><tbody><tr><td>test</td></tr></tbody></table>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('Indent');
+      editor.execCommand('Indent');
+      TinyAssertions.assertContent(editor, '<table style="margin-left: 80px;"><tbody><tr><td>test</td></tr></tbody></table>');
+
+      editor.setContent('<table><tbody><tr><td>test</td></tr></tbody></table>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('Indent');
+      editor.execCommand('Indent');
+      editor.execCommand('Outdent');
+      TinyAssertions.assertContent(editor, '<table style="margin-left: 40px;"><tbody><tr><td>test</td></tr></tbody></table>');
+
+      editor.setContent('<table><tbody><tr><td>test</td></tr></tbody></table>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('Outdent');
+      TinyAssertions.assertContent(editor, '<table><tbody><tr><td>test</td></tr></tbody></table>');
+    });
+
+    it('RemoveFormat', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><em>test</em> <strong>123</strong> <a href="123">123</a> 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('RemoveFormat');
+      TinyAssertions.assertContent(editor, '<p>test 123 <a href="123">123</a> 123</p>');
+
+      editor.setContent('<p><em><em>test</em> <strong>123</strong> <a href="123">123</a> 123</em></p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('RemoveFormat');
+      TinyAssertions.assertContent(editor, '<p>test 123 <a href="123">123</a> 123</p>');
+
+      editor.setContent('<p><em>test<span id="x">test <strong>123</strong></span><a href="123">123</a> 123</em></p>');
+      editor.selection.select(editor.dom.get('x') as HTMLSpanElement);
+      editor.execCommand('RemoveFormat');
+      TinyAssertions.assertContent(editor, '<p><em>test</em><span id="x">test 123</span><em><a href="123">123</a> 123</em></p>');
+
+      editor.setContent(
+        '<p><dfn>dfn tag </dfn> <code>code tag </code> <samp>samp tag</samp> ' +
+        '<kbd> kbd tag</kbd> <var> var tag</var> <cite> cite tag</cite> <mark> mark tag</mark> <q> q tag</q> ' +
+        '<strike>strike tag</strike> <s>s tag</s> <small>small tag</small></p>'
+      );
+      editor.execCommand('SelectAll');
+      editor.execCommand('RemoveFormat');
+      TinyAssertions.assertContent(editor, '<p>dfn tag code tag samp tag kbd tag var tag cite tag mark tag q tag strike tag s tag small tag</p>');
     });
   });
 
-  it('subscript/superscript', () => {
-    const editor = hook.editor();
-    editor.setContent('<p>test 123</p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('subscript');
-    TinyAssertions.assertContent(editor, '<p><sub>test 123</sub></p>');
+  context('TINY-10981: readonly selectionEnabled mode', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      add_unload_trigger: false,
+      disable_nodechange: true,
+      indent: false,
+      entities: 'raw',
+      convert_urls: false,
+      valid_styles: {
+        '*': 'color,font-size,font-family,background-color,font-weight,font-style,text-decoration,' +
+          'float,margin,margin-top,margin-right,margin-bottom,margin-left,padding-left,text-align,display'
+      },
+      base_url: '/project/tinymce/js/tinymce',
+      setup: (editor: Editor) => {
+        editor.mode.register('testmode', {
+          activate: Fun.noop,
+          deactivate: Fun.noop,
+          editorReadOnly: {
+            uiEnabled: true,
+            selectionEnabled: true
+          }
+        });
+      }
+    }, []);
 
-    editor.setContent('<p>test 123</p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('superscript');
-    TinyAssertions.assertContent(editor, '<p><sup>test 123</sup></p>');
+    afterEach(() => hook.editor().mode.set('design'));
 
-    editor.setContent('<p>test 123</p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('subscript');
-    editor.execCommand('subscript');
-    TinyAssertions.assertContent(editor, '<p>test 123</p>');
+    it('Formatting commands (xhtmlTextStyles)', () => {
+      const editor = hook.editor();
+      editor.setContent('test 123');
+      editor.mode.set('testmode');
+      editor.focus();
+      editor.execCommand('SelectAll');
+      editor.execCommand('Bold');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
 
-    editor.setContent('<p>test 123</p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('superscript');
-    editor.execCommand('superscript');
-    TinyAssertions.assertContent(editor, '<p>test 123</p>');
-  });
+      editor.execCommand('SelectAll');
+      editor.execCommand('Italic');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
 
-  it('indent/outdent', () => {
-    const editor = hook.editor();
-    editor.setContent('<p>test 123</p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('Indent');
-    TinyAssertions.assertContent(editor, '<p style="padding-left: 40px;">test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('Underline');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
 
-    editor.setContent('<p>test 123</p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('Indent');
-    editor.execCommand('Indent');
-    TinyAssertions.assertContent(editor, '<p style="padding-left: 80px;">test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('Strikethrough');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
 
-    editor.setContent('<p>test 123</p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('Indent');
-    editor.execCommand('Indent');
-    editor.execCommand('Outdent');
-    TinyAssertions.assertContent(editor, '<p style="padding-left: 40px;">test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('FontName', false, 'Arial');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
 
-    editor.setContent('<p>test 123</p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('Outdent');
-    TinyAssertions.assertContent(editor, '<p>test 123</p>');
-  });
+      editor.setContent('test 123');
+      editor.execCommand('SelectAll');
+      editor.execCommand('FontName', false, 'Bauhaus 93');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
 
-  it('indent/outdent table always uses margin', () => {
-    const editor = hook.editor();
-    editor.setContent('<table><tbody><tr><td>test</td></tr></tbody></table>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('Indent');
-    TinyAssertions.assertContent(editor, '<table style="margin-left: 40px;"><tbody><tr><td>test</td></tr></tbody></table>');
+      editor.setContent('test 123');
+      editor.execCommand('SelectAll');
+      editor.execCommand('FontSize', false, '7');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
 
-    editor.setContent('<table><tbody><tr><td>test</td></tr></tbody></table>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('Indent');
-    editor.execCommand('Indent');
-    TinyAssertions.assertContent(editor, '<table style="margin-left: 80px;"><tbody><tr><td>test</td></tr></tbody></table>');
+      editor.setContent('test 123');
+      editor.execCommand('SelectAll');
+      editor.execCommand('FontSize', false, '7pt');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
 
-    editor.setContent('<table><tbody><tr><td>test</td></tr></tbody></table>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('Indent');
-    editor.execCommand('Indent');
-    editor.execCommand('Outdent');
-    TinyAssertions.assertContent(editor, '<table style="margin-left: 40px;"><tbody><tr><td>test</td></tr></tbody></table>');
+      editor.setContent('test 123');
+      editor.execCommand('SelectAll');
+      editor.execCommand('ForeColor', false, '#FF0000');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
 
-    editor.setContent('<table><tbody><tr><td>test</td></tr></tbody></table>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('Outdent');
-    TinyAssertions.assertContent(editor, '<table><tbody><tr><td>test</td></tr></tbody></table>');
-  });
+      editor.setContent('test 123');
+      editor.execCommand('SelectAll');
+      editor.execCommand('HiliteColor', false, '#FF0000');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
 
-  it('RemoveFormat', () => {
-    const editor = hook.editor();
-    editor.setContent('<p><em>test</em> <strong>123</strong> <a href="123">123</a> 123</p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('RemoveFormat');
-    TinyAssertions.assertContent(editor, '<p>test 123 <a href="123">123</a> 123</p>');
+      editor.setContent('test 123');
+      editor.execCommand('SelectAll');
+      editor.execCommand('BackColor', false, '#FF0000');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+    });
 
-    editor.setContent('<p><em><em>test</em> <strong>123</strong> <a href="123">123</a> 123</em></p>');
-    editor.execCommand('SelectAll');
-    editor.execCommand('RemoveFormat');
-    TinyAssertions.assertContent(editor, '<p>test 123 <a href="123">123</a> 123</p>');
+    context('Formatting commands (alignInline)', () => {
+      it('TBA - p, JustifyLeft', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>test 123</p>');
+        editor.mode.set('testmode');
+        editor.execCommand('SelectAll');
+        editor.execCommand('JustifyLeft');
+        TinyAssertions.assertContent(editor, '<p>test 123</p>');
+        assert.isFalse(editor.queryCommandState('JustifyLeft'), 'should have JustifyLeft state false');
+      });
 
-    editor.setContent('<p><em>test<span id="x">test <strong>123</strong></span><a href="123">123</a> 123</em></p>');
-    editor.selection.select(editor.dom.get('x') as HTMLSpanElement);
-    editor.execCommand('RemoveFormat');
-    TinyAssertions.assertContent(editor, '<p><em>test</em><span id="x">test 123</span><em><a href="123">123</a> 123</em></p>');
+      it('TBA - p, JustifyCenter', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>test 123</p>');
+        editor.mode.set('testmode');
+        editor.execCommand('SelectAll');
+        editor.execCommand('JustifyCenter');
+        TinyAssertions.assertContent(editor, '<p>test 123</p>');
+        assert.isFalse(editor.queryCommandState('JustifyCenter'), 'should have JustifyCenter state false');
+      });
 
-    editor.setContent(
-      '<p><dfn>dfn tag </dfn> <code>code tag </code> <samp>samp tag</samp> ' +
-      '<kbd> kbd tag</kbd> <var> var tag</var> <cite> cite tag</cite> <mark> mark tag</mark> <q> q tag</q> ' +
-      '<strike>strike tag</strike> <s>s tag</s> <small>small tag</small></p>'
-    );
-    editor.execCommand('SelectAll');
-    editor.execCommand('RemoveFormat');
-    TinyAssertions.assertContent(editor, '<p>dfn tag code tag samp tag kbd tag var tag cite tag mark tag q tag strike tag s tag small tag</p>');
+      it('TBA - p, JustifyRight', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>test 123</p>');
+        editor.mode.set('testmode');
+        editor.execCommand('SelectAll');
+        editor.execCommand('JustifyRight');
+        TinyAssertions.assertContent(editor, '<p>test 123</p>');
+        assert.isFalse(editor.queryCommandState('JustifyRight'), 'should have JustifyRight state false');
+      });
+
+      it('TBA - p, JustifyFull', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>test 123</p>');
+        editor.mode.set('testmode');
+        editor.execCommand('SelectAll');
+        editor.execCommand('JustifyFull');
+        TinyAssertions.assertContent(editor, '<p>test 123</p>');
+        assert.isFalse(editor.queryCommandState('JustifyFull'), 'should have JustifyFull state false');
+      });
+
+      it('TINY-7715 - pre, JustifyLeft', () => {
+        const editor = hook.editor();
+        editor.setContent('<pre>test 123</pre>');
+        editor.mode.set('testmode');
+        editor.execCommand('SelectAll');
+        editor.execCommand('JustifyLeft');
+        TinyAssertions.assertContent(editor, '<pre>test 123</pre>');
+        assert.isFalse(editor.queryCommandState('JustifyLeft'), 'should have JustifyLeft state false');
+      });
+
+      it('TINY-7715 - pre, JustifyCenter', () => {
+        const editor = hook.editor();
+        editor.setContent('<pre>test 123</pre>');
+        editor.mode.set('testmode');
+        editor.execCommand('SelectAll');
+        editor.execCommand('JustifyCenter');
+        TinyAssertions.assertContent(editor, '<pre>test 123</pre>');
+        assert.isFalse(editor.queryCommandState('JustifyCenter'), 'should have JustifyCenter state false');
+      });
+
+      it('TINY-7715 - pre, JustifyRight', () => {
+        const editor = hook.editor();
+        editor.setContent('<pre>test 123</pre>');
+        editor.mode.set('testmode');
+        editor.execCommand('SelectAll');
+        editor.execCommand('JustifyRight');
+        TinyAssertions.assertContent(editor, '<pre>test 123</pre>');
+        assert.isFalse(editor.queryCommandState('JustifyRight'), 'should have JustifyRight state false');
+      });
+
+      it('TINY-7715 - pre, JustifyFull', () => {
+        const editor = hook.editor();
+        editor.setContent('<pre>test 123</pre>');
+        editor.mode.set('testmode');
+        editor.execCommand('SelectAll');
+        editor.execCommand('JustifyFull');
+        TinyAssertions.assertContent(editor, '<pre>test 123</pre>');
+        assert.isFalse(editor.queryCommandState('JustifyFull'), 'should have JustifyFull state false');
+      });
+
+      it('TBA - img, JustifyLeft', () => {
+        const editor = hook.editor();
+        editor.setContent('<img src="tinymce/ui/img/raster.gif" />');
+        editor.mode.set('testmode');
+        editor.selection.select(editor.dom.select('img')[0]);
+        editor.execCommand('JustifyLeft');
+        TinyAssertions.assertContent(editor, '<p><img src="tinymce/ui/img/raster.gif"></p>');
+      });
+
+      it('TBA - img, JustifyCenter', () => {
+        const editor = hook.editor();
+        editor.setContent('<img src="tinymce/ui/img/raster.gif" />');
+        editor.mode.set('testmode');
+        editor.selection.select(editor.dom.select('img')[0]);
+        editor.execCommand('JustifyCenter');
+        TinyAssertions.assertContent(editor, '<p><img src="tinymce/ui/img/raster.gif"></p>');
+      });
+
+      it('TBA - img, JustifyRight', () => {
+        const editor = hook.editor();
+        editor.setContent('<img src="tinymce/ui/img/raster.gif" />');
+        editor.mode.set('testmode');
+        editor.selection.select(editor.dom.select('img')[0]);
+        editor.execCommand('JustifyRight');
+        TinyAssertions.assertContent(editor, '<p><img src="tinymce/ui/img/raster.gif"></p>');
+      });
+    });
+
+    it('mceBlockQuote', () => {
+      const editor = hook.editor();
+      editor.focus();
+      editor.setContent('<p>test 123</p>');
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+      editor.execCommand('mceBlockQuote');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+
+      editor.mode.set('design');
+      editor.setContent('<p>test 123</p><p>test 123</p>');
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+      editor.execCommand('mceBlockQuote');
+      TinyAssertions.assertContent(editor, '<p>test 123</p><p>test 123</p>');
+    });
+
+    it('FormatBlock', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>test 123</p>');
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+      editor.execCommand('FormatBlock', false, 'h1');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('FormatBlock', false, 'h2');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('FormatBlock', false, 'h3');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('FormatBlock', false, 'h4');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('FormatBlock', false, 'h5');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('FormatBlock', false, 'h6');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+
+      editor.execCommand('SelectAll');
+
+      try {
+        editor.execCommand('FormatBlock', false, 'div');
+      } catch (ex) {
+        // t.log('Failed: ' + ex.message);
+      }
+
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('FormatBlock', false, 'address');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('FormatBlock', false, 'pre');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+    });
+
+    it('createLink', () => {
+      const editor = hook.editor();
+      editor.setContent('test 123');
+      editor.execCommand('SelectAll');
+      editor.execCommand('createLink', false, 'http://www.site.com');
+      TinyAssertions.assertContent(editor, '<p><a href="http://www.site.com">test 123</a></p>');
+    });
+
+    it('mceInsertLink (relative)', () => {
+      const editor = hook.editor();
+      editor.setContent('test 123');
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+      editor.execCommand('mceInsertLink', false, 'test');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+    });
+
+    it('mceInsertLink (link absolute)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>test 123</p>');
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+      editor.execCommand('mceInsertLink', false, 'http://www.site.com');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+    });
+
+    it('mceInsertLink (link encoded)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>test 123</p>');
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+      editor.execCommand('mceInsertLink', false, '"&<>');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+    });
+
+    it('mceInsertLink (link encoded and with class)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>test 123</p>');
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+      editor.execCommand('mceInsertLink', false, { href: '"&<>', class: 'test' });
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+    });
+
+    it('mceInsertLink (link with space)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>test 123</p>');
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+      editor.execCommand('mceInsertLink', false, { href: 'foo bar' });
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+    });
+
+    it('mceInsertLink (link floated img)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><img style="float: right;" src="about:blank" /></p>');
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+      editor.execCommand('mceInsertLink', false, 'link');
+      TinyAssertions.assertContent(editor, '<p><img style="float: right;" src="about:blank"></p>');
+    });
+
+    it('mceInsertLink (link adjacent text)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="#">a</a>b</p>');
+      editor.mode.set('testmode');
+
+      const rng = editor.dom.createRng();
+      rng.setStart(editor.getBody().firstChild?.lastChild as Text, 0);
+      rng.setEnd(editor.getBody().firstChild?.lastChild as Text, 1);
+      editor.selection.setRng(rng);
+
+      editor.execCommand('mceInsertLink', false, 'link');
+      TinyAssertions.assertContent(editor, '<p><a href="#">a</a>b</p>');
+    });
+
+    it('mceInsertLink (link text inside text)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="#"><em>abc</em></a></p>');
+      editor.mode.set('testmode');
+      LegacyUnit.setSelection(editor, 'em', 1, 'em', 2);
+
+      editor.execCommand('mceInsertLink', false, 'link');
+      TinyAssertions.assertContent(editor, '<p><a href="#"><em>abc</em></a></p>');
+    });
+
+    it('mceInsertLink (link around existing links)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="#1">1</a><a href="#2">2</a></p>');
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+
+      editor.execCommand('mceInsertLink', false, 'link');
+      TinyAssertions.assertContent(editor, '<p><a href="#1">1</a><a href="#2">2</a></p>');
+    });
+
+    it('mceInsertLink (link around existing links with different attrs)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a id="a" href="#1">1</a><a id="b" href="#2">2</a></p>');
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+
+      editor.execCommand('mceInsertLink', false, 'link');
+      TinyAssertions.assertContent(editor, '<p><a id="a" href="#1">1</a><a id="b" href="#2">2</a></p>');
+    });
+
+    it('mceInsertLink (link around existing complex contents with links)', () => {
+      const editor = hook.editor();
+      editor.setContent(
+        '<p><span id="s1"><strong><a id="a" href="#1"><em>1</em></a></strong></span><span id="s2">' +
+        '<em><a id="b" href="#2"><strong>2</strong></a></em></span></p>'
+      );
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+
+      editor.execCommand('mceInsertLink', false, 'link');
+      TinyAssertions.assertContent(
+        editor,
+        '<p><span id="s1"><strong><a id="a" href="#1"><em>1</em></a></strong></span><span id="s2">' +
+        '<em><a id="b" href="#2"><strong>2</strong></a></em></span></p>'
+      );
+    });
+
+    it('mceInsertLink (link text inside link)', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="#">test</a></p>');
+      editor.mode.set('testmode');
+      LegacyUnit.setSelection(editor, 'p', 0, 'p', 1);
+      editor.execCommand('SelectAll');
+
+      editor.execCommand('mceInsertLink', false, 'link');
+      TinyAssertions.assertContent(editor, '<p><a href="#">test</a></p>');
+    });
+
+    it('mceInsertLink bug #7331', () => {
+      const editor = hook.editor();
+      editor.setContent('<table><tbody><tr><td>A</td></tr><tr><td>B</td></tr></tbody></table>');
+      editor.mode.set('testmode');
+      const rng = editor.dom.createRng();
+      rng.setStart(editor.dom.select('td')[1].firstChild as Text, 0);
+      rng.setEnd(editor.getBody(), 1);
+      editor.selection.setRng(rng);
+      editor.execCommand('mceInsertLink', false, { href: 'x' });
+      TinyAssertions.assertContent(editor, '<table><tbody><tr><td>A</td></tr><tr><td>B</td></tr></tbody></table>');
+    });
+
+    it('unlink', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="test">test</a> <a href="test">123</a></p>');
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+      editor.execCommand('unlink');
+      TinyAssertions.assertContent(editor, '<p><a href="test">test</a> <a href="test">123</a></p>');
+    });
+
+    it('unlink - unselected a[href] with childNodes', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="test"><strong><em>test</em></strong></a></p>');
+      editor.mode.set('testmode');
+      LegacyUnit.setSelection(editor, 'em', 0);
+      editor.execCommand('unlink');
+      TinyAssertions.assertContent(editor, '<p><a href="test"><strong><em>test</em></strong></a></p>');
+    });
+
+    it('TINY-9172: unlink block links', () => {
+      const editor = hook.editor();
+      editor.setContent('<a href="test">test</a><div><a href="#"><p>test</p></a></div>');
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+      editor.execCommand('unlink');
+      TinyAssertions.assertContent(editor, '<p><a href="test">test</a></p><div><a href="#"><p>test</p></a></div>');
+    });
+
+    it('TINY-9739: Removing link should be a noop for noneditable selections', () => {
+      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+        editor.setContent('<p><a href="#">tiny</a></p>');
+        TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 3);
+        editor.execCommand('unlink');
+        TinyAssertions.assertContent(editor, '<p><a href="#">tiny</a></p>');
+      });
+    });
+
+    it('subscript/superscript', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>test 123</p>');
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+      editor.execCommand('subscript');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('superscript');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('subscript');
+      editor.execCommand('subscript');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('superscript');
+      editor.execCommand('superscript');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+    });
+
+    it('indent/outdent', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>test 123</p>');
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+      editor.execCommand('Indent');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('Indent');
+      editor.execCommand('Indent');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('Indent');
+      editor.execCommand('Indent');
+      editor.execCommand('Outdent');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+
+      editor.setContent('<p>test 123</p>');
+      editor.execCommand('SelectAll');
+      editor.execCommand('Outdent');
+      TinyAssertions.assertContent(editor, '<p>test 123</p>');
+    });
+
+    it('indent/outdent table always uses margin', () => {
+      const editor = hook.editor();
+      editor.setContent('<table><tbody><tr><td>test</td></tr></tbody></table>');
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+      editor.execCommand('Indent');
+      TinyAssertions.assertContent(editor, '<table><tbody><tr><td>test</td></tr></tbody></table>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('Indent');
+      editor.execCommand('Indent');
+      TinyAssertions.assertContent(editor, '<table><tbody><tr><td>test</td></tr></tbody></table>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('Indent');
+      editor.execCommand('Indent');
+      editor.execCommand('Outdent');
+      TinyAssertions.assertContent(editor, '<table><tbody><tr><td>test</td></tr></tbody></table>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('Outdent');
+      TinyAssertions.assertContent(editor, '<table><tbody><tr><td>test</td></tr></tbody></table>');
+    });
+
+    it('RemoveFormat', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><em>test</em> <strong>123</strong> <a href="123">123</a> 123</p>');
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+      editor.execCommand('RemoveFormat');
+      TinyAssertions.assertContent(editor, '<p><em>test</em> <strong>123</strong> <a href="123">123</a> 123</p>');
+
+      editor.execCommand('SelectAll');
+      editor.execCommand('RemoveFormat');
+      TinyAssertions.assertContent(editor, '<p><em>test</em> <strong>123</strong> <a href="123">123</a> 123</p>');
+
+      editor.selection.select(editor.dom.get('x') as HTMLSpanElement);
+      editor.execCommand('RemoveFormat');
+      TinyAssertions.assertContent(editor, '<p><em>test</em> <strong>123</strong> <a href="123">123</a> 123</p>');
+
+      editor.mode.set('design');
+      editor.setContent(
+        '<p><dfn>dfn tag </dfn> <code>code tag </code> <samp>samp tag</samp> ' +
+        '<kbd> kbd tag</kbd> <var> var tag</var> <cite> cite tag</cite> <mark> mark tag</mark> <q> q tag</q> ' +
+        '<strike>strike tag</strike> <s>s tag</s> <small>small tag</small></p>'
+      );
+      editor.mode.set('testmode');
+      editor.execCommand('SelectAll');
+      editor.execCommand('RemoveFormat');
+      TinyAssertions.assertContent(editor,
+        '<p><dfn>dfn tag </dfn> <code>code tag </code> <samp>samp tag</samp> ' +
+        '<kbd> kbd tag</kbd> <var> var tag</var> <cite> cite tag</cite> <mark> mark tag</mark> <q> q tag</q> ' +
+        '<s>strike tag</s> <s>s tag</s> <small>small tag</small></p>'
+      );
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/api/commands/NewBlockCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/api/commands/NewBlockCommandsTest.ts
@@ -1,4 +1,5 @@
-import { context, describe, it } from '@ephox/bedrock-client';
+import { afterEach, context, describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -6,244 +7,514 @@ import Editor from 'tinymce/core/api/Editor';
 describe('browser.tinymce.core.api.commands.NewBlockCommandsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
-    indent: false
+    indent: false,
+    setup: (editor: Editor) => {
+      editor.mode.register('testmode', {
+        activate: Fun.noop,
+        deactivate: Fun.noop,
+        editorReadOnly: {
+          uiEnabled: true,
+          selectionEnabled: true
+        }
+      });
+    },
   }, [], true);
 
-  context('InsertNewBlockBefore command', () => {
-    it('TINY-10022: empty editor', () => {
-      const editor = hook.editor();
-      editor.execCommand('InsertNewBlockBefore');
-      TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>&nbsp;</p>');
-      TinyAssertions.assertCursor(editor, [ 0 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<p>X</p><p>&nbsp;</p>');
-    });
-
-    it('TINY-10022: should insert empty block after paragrpaph with text', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>AAA</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 2);
-      editor.execCommand('InsertNewBlockBefore');
-      TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>AAA</p>');
-      TinyAssertions.assertCursor(editor, [ 0 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<p>X</p><p>AAA</p>');
-    });
-
-    it('TINY-10022: should insert empty block before paragraph with inline elements', () => {
-      const editor = hook.editor();
-      editor.setContent('<p><em>AAA</em></p>');
-      TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
-      editor.execCommand('InsertNewBlockBefore');
-      TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p><em>AAA</em></p>');
-      TinyAssertions.assertCursor(editor, [ 0 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<p>X</p><p><em>AAA</em></p>');
-    });
-
-    it('TINY-10022: should insert empty block before blockquote', () => {
-      const editor = hook.editor();
-      editor.setContent('<blockquote><p>AAA</p></blockquote>');
-      TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
-      editor.execCommand('InsertNewBlockBefore');
-      TinyAssertions.assertContent(editor, '<p>&nbsp;</p><blockquote><p>AAA</p></blockquote>');
-      TinyAssertions.assertCursor(editor, [ 0 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<p>X</p><blockquote><p>AAA</p></blockquote>');
-    });
-
-    it('TINY-10022: should insert new empty block between two paragraphs', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>AAA</p><p>BBB</p>');
-      TinySelections.setCursor(editor, [ 1, 0 ], 2);
-      editor.execCommand('InsertNewBlockBefore');
-      TinyAssertions.assertContent(editor, '<p>AAA</p><p>&nbsp;</p><p>BBB</p>');
-      TinyAssertions.assertCursor(editor, [ 1 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<p>AAA</p><p>X</p><p>BBB</p>');
-    });
-
-    it('TINY-10022: should insert new empty block between two blockquotes', () => {
-      const editor = hook.editor();
-      editor.setContent('<blockquote><p>AAA</p></blockquote><blockquote><p>BBB</p></blockquote>');
-      TinySelections.setCursor(editor, [ 1, 0, 0 ], 2);
-      editor.execCommand('InsertNewBlockBefore');
-      TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>&nbsp;</p><blockquote><p>BBB</p></blockquote>');
-      TinyAssertions.assertCursor(editor, [ 1 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>X</p><blockquote><p>BBB</p></blockquote>');
-    });
-
-    it('TINY-10022: insert new empty block within CET root', () => {
-      const editor = hook.editor();
-      editor.setContent('<div contenteditable="true"><p>AAA</p><p>BBB</p></div>');
-      TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
-      editor.execCommand('InsertNewBlockBefore');
-      TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>&nbsp;</p><p>AAA</p><p>BBB</p></div>');
-      TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>X</p><p>AAA</p><p>BBB</p></div>');
-    });
-
-    it('TINY-10022: insert new empty block before start container of ranged selection', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>AAA</p><p>BBB</p>');
-      TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 1, 0 ], 2);
-      editor.execCommand('InsertNewBlockBefore');
-      TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>AAA</p><p>BBB</p>');
-      TinyAssertions.assertCursor(editor, [ 0 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<p>X</p><p>AAA</p><p>BBB</p>');
-    });
-
-    it('TINY-10022: insert new empty block before noneditable block', () => {
-      const editor = hook.editor();
-      editor.setContent('<p contenteditable="false">AAA</p><p>BBB</p>');
-      TinySelections.select(editor, '[contenteditable]', []);
-      editor.execCommand('InsertNewBlockBefore');
-      TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p contenteditable="false">AAA</p><p>BBB</p>');
-      TinyAssertions.assertCursor(editor, [ 0 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<p>X</p><p contenteditable="false">AAA</p><p>BBB</p>');
-    });
-
-    it('TINY-10022: should not split editing host in noneditable root', () => {
-      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
-        const initialContent = '<p contenteditable="true">ab</p>';
-        editor.setContent(initialContent);
-        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+  context('Design mode', () => {
+    context('InsertNewBlockBefore command', () => {
+      it('TINY-10022: empty editor', () => {
+        const editor = hook.editor();
         editor.execCommand('InsertNewBlockBefore');
-        TinyAssertions.assertContent(editor, initialContent);
+        TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>&nbsp;</p>');
+        TinyAssertions.assertCursor(editor, [ 0 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p>X</p><p>&nbsp;</p>');
+      });
+
+      it('TINY-10022: should insert empty block after paragrpaph with text', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>AAA</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>AAA</p>');
+        TinyAssertions.assertCursor(editor, [ 0 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p>X</p><p>AAA</p>');
+      });
+
+      it('TINY-10022: should insert empty block before paragraph with inline elements', () => {
+        const editor = hook.editor();
+        editor.setContent('<p><em>AAA</em></p>');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p><em>AAA</em></p>');
+        TinyAssertions.assertCursor(editor, [ 0 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p>X</p><p><em>AAA</em></p>');
+      });
+
+      it('TINY-10022: should insert empty block before blockquote', () => {
+        const editor = hook.editor();
+        editor.setContent('<blockquote><p>AAA</p></blockquote>');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, '<p>&nbsp;</p><blockquote><p>AAA</p></blockquote>');
+        TinyAssertions.assertCursor(editor, [ 0 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p>X</p><blockquote><p>AAA</p></blockquote>');
+      });
+
+      it('TINY-10022: should insert new empty block between two paragraphs', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>AAA</p><p>BBB</p>');
+        TinySelections.setCursor(editor, [ 1, 0 ], 2);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, '<p>AAA</p><p>&nbsp;</p><p>BBB</p>');
+        TinyAssertions.assertCursor(editor, [ 1 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p>AAA</p><p>X</p><p>BBB</p>');
+      });
+
+      it('TINY-10022: should insert new empty block between two blockquotes', () => {
+        const editor = hook.editor();
+        editor.setContent('<blockquote><p>AAA</p></blockquote><blockquote><p>BBB</p></blockquote>');
+        TinySelections.setCursor(editor, [ 1, 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>&nbsp;</p><blockquote><p>BBB</p></blockquote>');
+        TinyAssertions.assertCursor(editor, [ 1 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>X</p><blockquote><p>BBB</p></blockquote>');
+      });
+
+      it('TINY-10022: insert new empty block within CET root', () => {
+        const editor = hook.editor();
+        editor.setContent('<div contenteditable="true"><p>AAA</p><p>BBB</p></div>');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>&nbsp;</p><p>AAA</p><p>BBB</p></div>');
+        TinyAssertions.assertCursor(editor, [ 0, 0 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>X</p><p>AAA</p><p>BBB</p></div>');
+      });
+
+      it('TINY-10022: insert new empty block before start container of ranged selection', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>AAA</p><p>BBB</p>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 1, 0 ], 2);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>AAA</p><p>BBB</p>');
+        TinyAssertions.assertCursor(editor, [ 0 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p>X</p><p>AAA</p><p>BBB</p>');
+      });
+
+      it('TINY-10022: insert new empty block before noneditable block', () => {
+        const editor = hook.editor();
+        editor.setContent('<p contenteditable="false">AAA</p><p>BBB</p>');
+        TinySelections.select(editor, '[contenteditable]', []);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p contenteditable="false">AAA</p><p>BBB</p>');
+        TinyAssertions.assertCursor(editor, [ 0 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p>X</p><p contenteditable="false">AAA</p><p>BBB</p>');
+      });
+
+      it('TINY-10022: should not split editing host in noneditable root', () => {
+        TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+          const initialContent = '<p contenteditable="true">ab</p>';
+          editor.setContent(initialContent);
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          editor.execCommand('InsertNewBlockBefore');
+          TinyAssertions.assertContent(editor, initialContent);
+        });
+      });
+
+      it('TINY-10022: should not insert new block in in noneditable root', () => {
+        TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+          const initialContent = '<p>ab</p>';
+          editor.setContent(initialContent);
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          editor.execCommand('InsertNewBlockBefore');
+          TinyAssertions.assertContent(editor, initialContent);
+        });
       });
     });
 
-    it('TINY-10022: should not insert new block in in noneditable root', () => {
-      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
-        const initialContent = '<p>ab</p>';
-        editor.setContent(initialContent);
-        TinySelections.setCursor(editor, [ 0, 0 ], 1);
-        editor.execCommand('InsertNewBlockBefore');
-        TinyAssertions.assertContent(editor, initialContent);
+    context('InsertNewBlockAfter command', () => {
+      it('TINY-10022: empty editor', () => {
+        const editor = hook.editor();
+        editor.resetContent();
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>&nbsp;</p>');
+        TinyAssertions.assertCursor(editor, [ 1 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>X</p>');
+      });
+
+      it('TINY-10022: should insert empty block after paragrpaph with text', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>AAA</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, '<p>AAA</p><p>&nbsp;</p>');
+        TinyAssertions.assertCursor(editor, [ 1 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p>AAA</p><p>X</p>');
+      });
+
+      it('TINY-10022: should insert empty block after paragraph with inline elements', () => {
+        const editor = hook.editor();
+        editor.setContent('<p><em>AAA</em></p>');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, '<p><em>AAA</em></p><p>&nbsp;</p>');
+        TinyAssertions.assertCursor(editor, [ 1 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p><em>AAA</em></p><p>X</p>');
+      });
+
+      it('TINY-10022: should insert empty block after blockquote', () => {
+        const editor = hook.editor();
+        editor.setContent('<blockquote><p>AAA</p></blockquote>');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>&nbsp;</p>');
+        TinyAssertions.assertCursor(editor, [ 1 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>X</p>');
+      });
+
+      it('TINY-10022: should insert new empty block between two paragraphs', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>AAA</p><p>BBB</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, '<p>AAA</p><p>&nbsp;</p><p>BBB</p>');
+        TinyAssertions.assertCursor(editor, [ 1 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p>AAA</p><p>X</p><p>BBB</p>');
+      });
+
+      it('TINY-10022: should insert new empty block between two blockquotes', () => {
+        const editor = hook.editor();
+        editor.setContent('<blockquote><p>AAA</p></blockquote><blockquote><p>BBB</p></blockquote>');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>&nbsp;</p><blockquote><p>BBB</p></blockquote>');
+        TinyAssertions.assertCursor(editor, [ 1 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>X</p><blockquote><p>BBB</p></blockquote>');
+      });
+
+      it('TINY-10022: insert new empty block within CET root', () => {
+        const editor = hook.editor();
+        editor.setContent('<div contenteditable="true"><p>AAA</p><p>BBB</p></div>');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>AAA</p><p>&nbsp;</p><p>BBB</p></div>');
+        TinyAssertions.assertCursor(editor, [ 0, 1 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>AAA</p><p>X</p><p>BBB</p></div>');
+      });
+
+      it('TINY-10022: insert new empty block after end container of ranged selection', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>AAA</p><p>BBB</p>');
+        TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 1, 0 ], 2);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, '<p>AAA</p><p>BBB</p><p>&nbsp;</p>');
+        TinyAssertions.assertCursor(editor, [ 2 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p>AAA</p><p>BBB</p><p>X</p>');
+      });
+
+      it('TINY-10022: insert new empty block after noneditable block', () => {
+        const editor = hook.editor();
+        editor.setContent('<p contenteditable="false">AAA</p><p>BBB</p>');
+        TinySelections.select(editor, '[contenteditable]', []);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, '<p contenteditable="false">AAA</p><p>&nbsp;</p><p>BBB</p>');
+        TinyAssertions.assertCursor(editor, [ 1 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p contenteditable="false">AAA</p><p>X</p><p>BBB</p>');
+      });
+
+      it('TINY-10022: should not split editing host in noneditable root', () => {
+        TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+          const initialContent = '<p contenteditable="true">ab</p>';
+          editor.setContent(initialContent);
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          editor.execCommand('InsertNewBlockAfter');
+          TinyAssertions.assertContent(editor, initialContent);
+        });
+      });
+
+      it('TINY-10022: should not insert new block in in noneditable root', () => {
+        TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+          const initialContent = '<p>ab</p>';
+          editor.setContent(initialContent);
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          editor.execCommand('InsertNewBlockAfter');
+          TinyAssertions.assertContent(editor, initialContent);
+        });
       });
     });
   });
 
-  context('InsertNewBlockAfter command', () => {
-    it('TINY-10022: empty editor', () => {
-      const editor = hook.editor();
-      editor.resetContent();
-      editor.execCommand('InsertNewBlockAfter');
-      TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>&nbsp;</p>');
-      TinyAssertions.assertCursor(editor, [ 1 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>X</p>');
-    });
+  context('TINY-10981: readonly selectionEnabled mode', () => {
+    afterEach(() => hook.editor().mode.set('design'));
 
-    it('TINY-10022: should insert empty block after paragrpaph with text', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>AAA</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 2);
-      editor.execCommand('InsertNewBlockAfter');
-      TinyAssertions.assertContent(editor, '<p>AAA</p><p>&nbsp;</p>');
-      TinyAssertions.assertCursor(editor, [ 1 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<p>AAA</p><p>X</p>');
-    });
+    context('InsertNewBlockBefore command', () => {
+      it('TINY-10022: empty editor', () => {
+        const editor = hook.editor();
+        editor.resetContent();
+        editor.mode.set('testmode');
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, '');
+        TinyAssertions.assertCursor(editor, [ 0 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '');
+      });
 
-    it('TINY-10022: should insert empty block after paragraph with inline elements', () => {
-      const editor = hook.editor();
-      editor.setContent('<p><em>AAA</em></p>');
-      TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
-      editor.execCommand('InsertNewBlockAfter');
-      TinyAssertions.assertContent(editor, '<p><em>AAA</em></p><p>&nbsp;</p>');
-      TinyAssertions.assertCursor(editor, [ 1 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<p><em>AAA</em></p><p>X</p>');
-    });
+      it('TINY-10022: should insert empty block after paragrpaph with text', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>AAA</p>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, '<p>AAA</p>');
+        TinyAssertions.assertCursor(editor, [ 0, 0 ], 2);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p>AAA</p>');
+      });
 
-    it('TINY-10022: should insert empty block after blockquote', () => {
-      const editor = hook.editor();
-      editor.setContent('<blockquote><p>AAA</p></blockquote>');
-      TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
-      editor.execCommand('InsertNewBlockAfter');
-      TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>&nbsp;</p>');
-      TinyAssertions.assertCursor(editor, [ 1 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>X</p>');
-    });
+      it('TINY-10022: should insert empty block before paragraph with inline elements', () => {
+        const editor = hook.editor();
+        editor.setContent('<p><em>AAA</em></p>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, '<p><em>AAA</em></p>');
+        TinyAssertions.assertCursor(editor, [ 0, 0, 0 ], 2);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p><em>AAA</em></p>');
+      });
 
-    it('TINY-10022: should insert new empty block between two paragraphs', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>AAA</p><p>BBB</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 2);
-      editor.execCommand('InsertNewBlockAfter');
-      TinyAssertions.assertContent(editor, '<p>AAA</p><p>&nbsp;</p><p>BBB</p>');
-      TinyAssertions.assertCursor(editor, [ 1 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<p>AAA</p><p>X</p><p>BBB</p>');
-    });
+      it('TINY-10022: should insert empty block before blockquote', () => {
+        const editor = hook.editor();
+        editor.setContent('<blockquote><p>AAA</p></blockquote>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote>');
+        TinyAssertions.assertCursor(editor, [ 0, 0, 0 ], 2);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote>');
+      });
 
-    it('TINY-10022: should insert new empty block between two blockquotes', () => {
-      const editor = hook.editor();
-      editor.setContent('<blockquote><p>AAA</p></blockquote><blockquote><p>BBB</p></blockquote>');
-      TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
-      editor.execCommand('InsertNewBlockAfter');
-      TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>&nbsp;</p><blockquote><p>BBB</p></blockquote>');
-      TinyAssertions.assertCursor(editor, [ 1 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><p>X</p><blockquote><p>BBB</p></blockquote>');
-    });
+      it('TINY-10022: should insert new empty block between two paragraphs', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>AAA</p><p>BBB</p>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 1, 0 ], 2);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, '<p>AAA</p><p>BBB</p>');
+        TinyAssertions.assertCursor(editor, [ 1, 0 ], 2);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p>AAA</p><p>BBB</p>');
+      });
 
-    it('TINY-10022: insert new empty block within CET root', () => {
-      const editor = hook.editor();
-      editor.setContent('<div contenteditable="true"><p>AAA</p><p>BBB</p></div>');
-      TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
-      editor.execCommand('InsertNewBlockAfter');
-      TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>AAA</p><p>&nbsp;</p><p>BBB</p></div>');
-      TinyAssertions.assertCursor(editor, [ 0, 1 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>AAA</p><p>X</p><p>BBB</p></div>');
-    });
+      it('TINY-10022: should insert new empty block between two blockquotes', () => {
+        const editor = hook.editor();
+        editor.setContent('<blockquote><p>AAA</p></blockquote><blockquote><p>BBB</p></blockquote>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 1, 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><blockquote><p>BBB</p></blockquote>');
+        TinyAssertions.assertCursor(editor, [ 1, 0, 0 ], 2);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><blockquote><p>BBB</p></blockquote>');
+      });
 
-    it('TINY-10022: insert new empty block after end container of ranged selection', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>AAA</p><p>BBB</p>');
-      TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 1, 0 ], 2);
-      editor.execCommand('InsertNewBlockAfter');
-      TinyAssertions.assertContent(editor, '<p>AAA</p><p>BBB</p><p>&nbsp;</p>');
-      TinyAssertions.assertCursor(editor, [ 2 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<p>AAA</p><p>BBB</p><p>X</p>');
-    });
+      it('TINY-10022: insert new empty block within CET root', () => {
+        const editor = hook.editor();
+        editor.setContent('<div contenteditable="true"><p>AAA</p><p>BBB</p></div>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>AAA</p><p>BBB</p></div>');
+        TinyAssertions.assertCursor(editor, [ 0, 0, 0 ], 2);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>AAA</p><p>BBB</p></div>');
+      });
 
-    it('TINY-10022: insert new empty block after noneditable block', () => {
-      const editor = hook.editor();
-      editor.setContent('<p contenteditable="false">AAA</p><p>BBB</p>');
-      TinySelections.select(editor, '[contenteditable]', []);
-      editor.execCommand('InsertNewBlockAfter');
-      TinyAssertions.assertContent(editor, '<p contenteditable="false">AAA</p><p>&nbsp;</p><p>BBB</p>');
-      TinyAssertions.assertCursor(editor, [ 1 ], 0);
-      editor.insertContent('X');
-      TinyAssertions.assertContent(editor, '<p contenteditable="false">AAA</p><p>X</p><p>BBB</p>');
-    });
+      it('TINY-10022: insert new empty block before start container of ranged selection', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>AAA</p><p>BBB</p>');
+        editor.mode.set('testmode');
+        TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 1, 0 ], 2);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, '<p>AAA</p><p>BBB</p>');
+        TinyAssertions.assertSelection(editor, [ 0, 0 ], 2, [ 1, 0 ], 2);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p>AAA</p><p>BBB</p>');
+      });
 
-    it('TINY-10022: should not split editing host in noneditable root', () => {
-      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
-        const initialContent = '<p contenteditable="true">ab</p>';
-        editor.setContent(initialContent);
-        TinySelections.setCursor(editor, [ 0, 0 ], 1);
-        editor.execCommand('InsertNewBlockAfter');
-        TinyAssertions.assertContent(editor, initialContent);
+      it('TINY-10022: insert new empty block before noneditable block', () => {
+        const editor = hook.editor();
+        editor.setContent('<p contenteditable="false">AAA</p><p>BBB</p>');
+        editor.mode.set('testmode');
+        TinySelections.select(editor, '[contenteditable]', []);
+        editor.execCommand('InsertNewBlockBefore');
+        TinyAssertions.assertContent(editor, '<p contenteditable="false">AAA</p><p>BBB</p>');
+      });
+
+      it('TINY-10022: should not split editing host in noneditable root', () => {
+        TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+          const initialContent = '<p contenteditable="true">ab</p>';
+          editor.setContent(initialContent);
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          editor.execCommand('InsertNewBlockBefore');
+          TinyAssertions.assertContent(editor, initialContent);
+        });
+      });
+
+      it('TINY-10022: should not insert new block in in noneditable root', () => {
+        TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+          const initialContent = '<p>ab</p>';
+          editor.setContent(initialContent);
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          editor.execCommand('InsertNewBlockBefore');
+          TinyAssertions.assertContent(editor, initialContent);
+        });
       });
     });
 
-    it('TINY-10022: should not insert new block in in noneditable root', () => {
-      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
-        const initialContent = '<p>ab</p>';
-        editor.setContent(initialContent);
-        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    context('InsertNewBlockAfter command', () => {
+      it('TINY-10022: empty editor', () => {
+        const editor = hook.editor();
+        editor.resetContent();
+        editor.mode.set('testmode');
         editor.execCommand('InsertNewBlockAfter');
-        TinyAssertions.assertContent(editor, initialContent);
+        TinyAssertions.assertContent(editor, '');
+        TinyAssertions.assertCursor(editor, [ 0 ], 0);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '');
+      });
+
+      it('TINY-10022: should insert empty block after paragrpaph with text', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>AAA</p>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, '<p>AAA</p>');
+        TinyAssertions.assertCursor(editor, [ 0, 0 ], 2);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p>AAA</p>');
+      });
+
+      it('TINY-10022: should insert empty block after paragraph with inline elements', () => {
+        const editor = hook.editor();
+        editor.setContent('<p><em>AAA</em></p>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, '<p><em>AAA</em></p>');
+        TinyAssertions.assertCursor(editor, [ 0, 0, 0 ], 2);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p><em>AAA</em></p>');
+      });
+
+      it('TINY-10022: should insert empty block after blockquote', () => {
+        const editor = hook.editor();
+        editor.setContent('<blockquote><p>AAA</p></blockquote>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote>');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote>');
+      });
+
+      it('TINY-10022: should insert new empty block between two paragraphs', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>AAA</p><p>BBB</p>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, '<p>AAA</p><p>BBB</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 2);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p>AAA</p><p>BBB</p>');
+      });
+
+      it('TINY-10022: should insert new empty block between two blockquotes', () => {
+        const editor = hook.editor();
+        editor.setContent('<blockquote><p>AAA</p></blockquote><blockquote><p>BBB</p></blockquote>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><blockquote><p>BBB</p></blockquote>');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<blockquote><p>AAA</p></blockquote><blockquote><p>BBB</p></blockquote>');
+      });
+
+      it('TINY-10022: insert new empty block within CET root', () => {
+        const editor = hook.editor();
+        editor.setContent('<div contenteditable="true"><p>AAA</p><p>BBB</p></div>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>AAA</p><p>BBB</p></div>');
+        TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>AAA</p><p>BBB</p></div>');
+      });
+
+      it('TINY-10022: insert new empty block after end container of ranged selection', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>AAA</p><p>BBB</p>');
+        editor.mode.set('testmode');
+        TinySelections.setSelection(editor, [ 0, 0 ], 2, [ 1, 0 ], 2);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, '<p>AAA</p><p>BBB</p>');
+        TinyAssertions.assertSelection(editor, [ 0, 0 ], 2, [ 1, 0 ], 2);
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p>AAA</p><p>BBB</p>');
+      });
+
+      it('TINY-10022: insert new empty block after noneditable block', () => {
+        const editor = hook.editor();
+        editor.setContent('<p contenteditable="false">AAA</p><p>BBB</p>');
+        editor.mode.set('testmode');
+        TinySelections.select(editor, '[contenteditable]', []);
+        editor.execCommand('InsertNewBlockAfter');
+        TinyAssertions.assertContent(editor, '<p contenteditable="false">AAA</p><p>BBB</p>');
+        editor.insertContent('X');
+        TinyAssertions.assertContent(editor, '<p contenteditable="false">AAA</p><p>BBB</p>');
+      });
+
+      it('TINY-10022: should not split editing host in noneditable root', () => {
+        TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+          const initialContent = '<p contenteditable="true">ab</p>';
+          editor.setContent(initialContent);
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          editor.execCommand('InsertNewBlockAfter');
+          TinyAssertions.assertContent(editor, initialContent);
+        });
+      });
+
+      it('TINY-10022: should not insert new block in in noneditable root', () => {
+        TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+          const initialContent = '<p>ab</p>';
+          editor.setContent(initialContent);
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          editor.execCommand('InsertNewBlockAfter');
+          TinyAssertions.assertContent(editor, initialContent);
+        });
       });
     });
   });

--- a/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/InsertNewLineTest.ts
@@ -1,6 +1,6 @@
 import { ApproxStructure, Cursors } from '@ephox/agar';
-import { after, before, context, describe, it } from '@ephox/bedrock-client';
-import { Arr, Type } from '@ephox/katamari';
+import { after, afterEach, before, context, describe, it } from '@ephox/bedrock-client';
+import { Arr, Fun, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
@@ -13,7 +13,17 @@ import * as InsertNewLine from 'tinymce/core/newline/InsertNewLine';
 describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
-    base_url: '/project/tinymce/js/tinymce'
+    base_url: '/project/tinymce/js/tinymce',
+    setup: (editor: Editor) => {
+      editor.mode.register('testmode', {
+        activate: Fun.noop,
+        deactivate: Fun.noop,
+        editorReadOnly: {
+          uiEnabled: true,
+          selectionEnabled: true
+        }
+      });
+    }
   }, [], true);
 
   const bookmarkSpan = '<span data-mce-type="bookmark" id="mce_2_start" data-mce-style="overflow:hidden;line-height:0px" style="overflow:hidden;line-height:0px"></span>';
@@ -53,800 +63,1594 @@ describe('browser.tinymce.core.newline.InsertNewLineTest', () => {
     }
   };
 
-  context('Enter in paragraph', () => {
-    it('Insert block before', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>ab</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 0);
-      insertNewline(editor, { });
-      TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>ab</p>');
-      TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
-    });
+  context('design mode', () => {
+    context('Enter in paragraph', () => {
+      it('Insert block before', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 0);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>ab</p>');
+        TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
+      });
 
-    it('Split block in the middle', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>ab</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      insertNewline(editor, { });
-      TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
-      TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
-    });
-
-    it('Insert block after', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>ab</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 2);
-      insertNewline(editor, { });
-      TinyAssertions.assertContent(editor, '<p>ab</p><p>&nbsp;</p>');
-      TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
-    });
-
-    it('Insert block after bookmark', () => {
-      const editor = hook.editor();
-      editor.setContent(`<p>${bookmarkSpan}<br data-mce-bogus="1"></p>`, { format: 'raw' });
-      TinySelections.setCursor(editor, [ 0 ], 1);
-      insertNewline(editor, { });
-      TinyAssertions.assertContentStructure(editor,
-        ApproxStructure.build((s, str) => s.element('body', {
-          children: [
-            s.element('p', {
-              children: [
-                ApproxStructure.fromHtml(bookmarkSpan),
-                s.element('br', {
-                  attrs: {
-                    'data-mce-bogus': str.is('1')
-                  }
-                })
-              ]
-            }),
-            s.element('p', {
-              children: [
-                s.element('br', {
-                  attrs: {
-                    'data-mce-bogus': str.is('1')
-                  }
-                })
-              ]
-            })
-          ]
-        }))
-      );
-      TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
-    });
-  });
-
-  context('CEF', () => {
-    it('TINY-9098: insert newline on inline CEF element should do nothing', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>before<span contenteditable="false">x</span>after</p>');
-      TinySelections.select(editor, 'span', []);
-      insertNewline(editor, { });
-      editor.nodeChanged();
-      TinyAssertions.assertContent(editor, '<p>before<span contenteditable="false">x</span>after</p>');
-    });
-
-    it('TINY-9194: restore selection from the bookmark and insert newline after inline CEF element', () => {
-      const editor = hook.editor();
-      editor.setContent('<p><span contenteditable="false">a</span></p>');
-      // actual content <p>&#xFEFF;<span contenteditable="false">a</span></p>
-      TinySelections.setCursor(editor, [ 0 ], 2);
-      // actual content <p><span contenteditable="false">a</span>&#xFEFF;</p>
-      TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
-      const bookmark = editor.selection.getBookmark();
-      editor.selection.moveToBookmark(bookmark);
-      // actual content <p><span contenteditable="false">a</span></p>
-      TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
-      insertNewline(editor, { });
-      TinyAssertions.assertContent(editor, '<p><span contenteditable="false">a</span></p><p>&nbsp;</p>');
-      TinyAssertions.assertCursor(editor, [ 1 ], 0);
-    });
-
-    it('TINY-9461: should not split editing host in noneditable root', () => {
-      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
-        const initialContent = '<p contenteditable="true">ab</p>';
-        editor.setContent(initialContent);
+      it('Split block in the middle', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
         TinySelections.setCursor(editor, [ 0, 0 ], 1);
-        insertNewline(editor, { });
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
+        TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
+      });
+
+      it('Insert block after', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 2);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<p>ab</p><p>&nbsp;</p>');
+        TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
+      });
+
+      it('Insert block after bookmark', () => {
+        const editor = hook.editor();
+        editor.setContent(`<p>${bookmarkSpan}<br data-mce-bogus="1"></p>`, { format: 'raw' });
+        TinySelections.setCursor(editor, [ 0 ], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContentStructure(editor,
+          ApproxStructure.build((s, str) => s.element('body', {
+            children: [
+              s.element('p', {
+                children: [
+                  ApproxStructure.fromHtml(bookmarkSpan),
+                  s.element('br', {
+                    attrs: {
+                      'data-mce-bogus': str.is('1')
+                    }
+                  })
+                ]
+              }),
+              s.element('p', {
+                children: [
+                  s.element('br', {
+                    attrs: {
+                      'data-mce-bogus': str.is('1')
+                    }
+                  })
+                ]
+              })
+            ]
+          }))
+        );
+        TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
+      });
+    });
+
+    context('CEF', () => {
+      it('TINY-9098: insert newline on inline CEF element should do nothing', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>before<span contenteditable="false">x</span>after</p>');
+        TinySelections.select(editor, 'span', []);
+        insertNewline(editor, {});
+        editor.nodeChanged();
+        TinyAssertions.assertContent(editor, '<p>before<span contenteditable="false">x</span>after</p>');
+      });
+
+      it('TINY-9194: restore selection from the bookmark and insert newline after inline CEF element', () => {
+        const editor = hook.editor();
+        editor.setContent('<p><span contenteditable="false">a</span></p>');
+        // actual content <p>&#xFEFF;<span contenteditable="false">a</span></p>
+        TinySelections.setCursor(editor, [ 0 ], 2);
+        // actual content <p><span contenteditable="false">a</span>&#xFEFF;</p>
+        TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        const bookmark = editor.selection.getBookmark();
+        editor.selection.moveToBookmark(bookmark);
+        // actual content <p><span contenteditable="false">a</span></p>
+        TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<p><span contenteditable="false">a</span></p><p>&nbsp;</p>');
+        TinyAssertions.assertCursor(editor, [ 1 ], 0);
+      });
+
+      it('TINY-9461: should not split editing host in noneditable root', () => {
+        TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+          const initialContent = '<p contenteditable="true">ab</p>';
+          editor.setContent(initialContent);
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, initialContent);
+        });
+      });
+
+      it('TINY-9461: should wrap div contents in paragraph and split inner paragraph in a div editing host inside a noneditable root', () => {
+        TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+          editor.setContent('<div contenteditable="true">ab</div>');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>a</p><p>b</p></div>');
+        });
+      });
+
+      it('TINY-9461: should not split editing host', () => {
+        const editor = hook.editor();
+        const initialContent = '<div contenteditable="false"><p contenteditable="true">ab</p></div>';
+        editor.setContent(initialContent);
+        TinySelections.setCursor(editor, [ 1, 0, 0 ], 1);
+        insertNewline(editor, {});
         TinyAssertions.assertContent(editor, initialContent);
       });
-    });
 
-    it('TINY-9461: should wrap div contents in paragraph and split inner paragraph in a div editing host inside a noneditable root', () => {
-      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
-        editor.setContent('<div contenteditable="true">ab</div>');
-        TinySelections.setCursor(editor, [ 0, 0 ], 1);
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<div contenteditable="true"><p>a</p><p>b</p></div>');
+      it('TINY-9461: should wrap div contents in paragraph and split inner paragraph in a div editing host', () => {
+        TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
+          editor.setContent('<div contenteditable="false"><div contenteditable="true">ab</div></div>');
+          TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<div contenteditable="false"><div contenteditable="true"><p>a</p><p>b</p></div></div>');
+        });
       });
-    });
 
-    it('TINY-9461: should not split editing host', () => {
-      const editor = hook.editor();
-      const initialContent = '<div contenteditable="false"><p contenteditable="true">ab</p></div>';
-      editor.setContent(initialContent);
-      TinySelections.setCursor(editor, [ 1, 0, 0 ], 1);
-      insertNewline(editor, { });
-      TinyAssertions.assertContent(editor, initialContent);
-    });
-
-    it('TINY-9461: should wrap div contents in paragraph and split inner paragraph in a div editing host', () => {
-      TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
-        editor.setContent('<div contenteditable="false"><div contenteditable="true">ab</div></div>');
-        TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<div contenteditable="false"><div contenteditable="true"><p>a</p><p>b</p></div></div>');
-      });
-    });
-
-    it('TINY-9813: Placed a cursor is placed after a table, with a noneditable afterwards', () => {
-      const editor = hook.editor();
-      editor.setContent('<table><tbody><tr><td><br></td></tr></tbody></table><div contenteditable="false"></div>');
-      setSelectionTo(editor, [], 1);
-      insertNewline(editor, { });
-      TinyAssertions.assertContent(editor, '<table><tbody><tr><td>&nbsp;</td></tr></tbody></table><p>&nbsp;</p><div contenteditable="false">&nbsp;</div>');
-      TinyAssertions.assertCursor(editor, [ 1 ], 0);
-    });
-
-    it('TINY-9813: Placed a cursor is placed after a table, with an editable afterwards', () => {
-      const editor = hook.editor();
-      editor.setContent('<table><tbody><tr><td><br></td></tr></tbody></table><div contenteditable="true">&nbsp;</div>');
-      setSelectionTo(editor, [], 1);
-      insertNewline(editor, { });
-      TinyAssertions.assertContent(editor, '<table><tbody><tr><td>&nbsp;</td></tr></tbody></table><div contenteditable="true">&nbsp;</div><div contenteditable="true">&nbsp;</div>');
-      TinyAssertions.assertCursor(editor, [ 1 ], 0);
-    });
-
-    it('TINY-9813: Placed a cursor is placed after a table, with nothing', () => {
-      const editor = hook.editor();
-      editor.setContent('<table><tbody><tr><td><br></td></tr></tbody></table>');
-      setSelectionTo(editor, [], 1);
-      insertNewline(editor, { });
-      TinyAssertions.assertContent(editor, '<table><tbody><tr><td>&nbsp;</td></tr></tbody></table><p>&nbsp;</p>');
-      TinyAssertions.assertCursor(editor, [ 1 ], 0);
-    });
-
-    it('TINY-9813: Placed a cursor is placed after a table, with a noneditable afterwards, wrapped in div', () => {
-      const editor = hook.editor();
-      editor.setContent('<div><table><tbody><tr><td><br></td></tr></tbody></table><div contenteditable="false"></div></div>');
-      setSelectionTo(editor, [ 0 ], 1);
-      insertNewline(editor, { });
-      TinyAssertions.assertContent(editor, '<div><table><tbody><tr><td>&nbsp;</td></tr></tbody></table><p>&nbsp;</p><div contenteditable="false">&nbsp;</div></div>');
-      TinyAssertions.assertCursor(editor, [ 0, 1 ], 0);
-    });
-  });
-
-  context('br_newline_selector', () => {
-    before(() => {
-      hook.editor().options.set('br_newline_selector', 'p,div.test');
-    });
-
-    after(() => {
-      hook.editor().options.unset('br_newline_selector');
-    });
-
-    it('Insert newline where br is forced (paragraph)', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>ab</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      insertNewline(editor, { });
-      editor.nodeChanged();
-      TinyAssertions.assertContent(editor, '<p>a<br>b</p>');
-    });
-
-    it('Insert newline where br is forced (div)', () => {
-      const editor = hook.editor();
-      editor.setContent('<div class="test">ab</div>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      insertNewline(editor, { });
-      editor.nodeChanged();
-      TinyAssertions.assertContent(editor, '<div class="test">a<br>b</div>');
-    });
-
-    it('Insert newline where br is not forced', () => {
-      const editor = hook.editor();
-      editor.setContent('<div>ab</div>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      insertNewline(editor, { });
-      editor.nodeChanged();
-      TinyAssertions.assertContent(editor, '<div>a</div><div>b</div>');
-    });
-  });
-
-  context('no_newline_selector', () => {
-    before(() => {
-      hook.editor().options.set('no_newline_selector', 'p,div.test');
-    });
-
-    after(() => {
-      hook.editor().options.unset('no_newline_selector');
-    });
-
-    it('Insert newline where newline is blocked (paragraph)', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>ab</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      insertNewline(editor, { });
-      editor.nodeChanged();
-      TinyAssertions.assertContent(editor, '<p>ab</p>');
-    });
-
-    it('Insert newline where newline is blocked (div)', () => {
-      const editor = hook.editor();
-      editor.setContent('<div class="test">ab</div>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      insertNewline(editor, { });
-      editor.nodeChanged();
-      TinyAssertions.assertContent(editor, '<div class="test">ab</div>');
-    });
-
-    it('Insert newline where newline is not blocked', () => {
-      const editor = hook.editor();
-      editor.setContent('<div>ab</div>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      insertNewline(editor, { });
-      editor.nodeChanged();
-      TinyAssertions.assertContent(editor, '<div>a</div><div>b</div>');
-    });
-  });
-
-  it('Insert newline before image in link', () => {
-    const editor = hook.editor();
-    editor.setContent('<p><a href="#">a<img src="about:blank" /></a></p>');
-    TinySelections.setCursor(editor, [ 0, 0 ], 1);
-    insertNewline(editor, { });
-    TinyAssertions.assertContent(editor, '<p><a href="#">a</a></p><p><a href="#"><img src="about:blank"></a></p>');
-    TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
-  });
-
-  context('end_container_on_empty_block', () => {
-    context('With the default value', () => {
-      it('TINY-6559: Press Enter in blockquote', () => {
+      it('TINY-9813: Placed a cursor is placed after a table, with a noneditable afterwards', () => {
         const editor = hook.editor();
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p><p>&nbsp;</p></blockquote>');
-        TinyAssertions.assertSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
+        editor.setContent('<table><tbody><tr><td><br></td></tr></tbody></table><div contenteditable="false"></div>');
+        setSelectionTo(editor, [], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<table><tbody><tr><td>&nbsp;</td></tr></tbody></table><p>&nbsp;</p><div contenteditable="false">&nbsp;</div>');
+        TinyAssertions.assertCursor(editor, [ 1 ], 0);
       });
 
-      it('TINY-6559: Press Shift+Enter in blockquote', () => {
+      it('TINY-9813: Placed a cursor is placed after a table, with an editable afterwards', () => {
         const editor = hook.editor();
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { shiftKey: true });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2<br><br></p></blockquote>');
-        TinyAssertions.assertSelection(editor, [ 0, 1 ], 2, [ 0, 1 ], 2);
+        editor.setContent('<table><tbody><tr><td><br></td></tr></tbody></table><div contenteditable="true">&nbsp;</div>');
+        setSelectionTo(editor, [], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<table><tbody><tr><td>&nbsp;</td></tr></tbody></table><div contenteditable="true">&nbsp;</div><div contenteditable="true">&nbsp;</div>');
+        TinyAssertions.assertCursor(editor, [ 1 ], 0);
       });
 
-      it('TINY-6559: Press Enter twice in blockquote', () => {
+      it('TINY-9813: Placed a cursor is placed after a table, with nothing', () => {
         const editor = hook.editor();
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote><p>&nbsp;</p>');
-        TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
+        editor.setContent('<table><tbody><tr><td><br></td></tr></tbody></table>');
+        setSelectionTo(editor, [], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<table><tbody><tr><td>&nbsp;</td></tr></tbody></table><p>&nbsp;</p>');
+        TinyAssertions.assertCursor(editor, [ 1 ], 0);
       });
 
-      it('TINY-6559: Press Enter twice in blockquote while between two lines', () => {
+      it('TINY-9813: Placed a cursor is placed after a table, with a noneditable afterwards, wrapped in div', () => {
         const editor = hook.editor();
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 0 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p></blockquote><p>&nbsp;</p><blockquote><p>Line 2</p></blockquote>');
-        TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
-      });
-
-      it('TINY-6559: Press Enter twice in a div', () => {
-        const editor = hook.editor();
-        editor.setContent('<div><p>Line 1</p><p>Line 2</p></div>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<div><p>Line 1</p><p>Line 2</p><p>&nbsp;</p><p>&nbsp;</p></div>');
-        TinyAssertions.assertSelection(editor, [ 0, 3 ], 0, [ 0, 3 ], 0);
-      });
-
-      it('TINY-6559: Press Enter twice in a section', () => {
-        const editor = hook.editor();
-        editor.setContent('<section><p>Line 1</p><p>Line 2</p></section>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<section><p>Line 1</p><p>Line 2</p><p>&nbsp;</p><p>&nbsp;</p></section>');
-        TinyAssertions.assertSelection(editor, [ 0, 3 ], 0, [ 0, 3 ], 0);
+        editor.setContent('<div><table><tbody><tr><td><br></td></tr></tbody></table><div contenteditable="false"></div></div>');
+        setSelectionTo(editor, [ 0 ], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<div><table><tbody><tr><td>&nbsp;</td></tr></tbody></table><p>&nbsp;</p><div contenteditable="false">&nbsp;</div></div>');
+        TinyAssertions.assertCursor(editor, [ 0, 1 ], 0);
       });
     });
 
-    context('Is set to "div"', () => {
-      it('TINY-6559: Press Enter in blockquote', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', 'div');
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p><p>&nbsp;</p></blockquote>');
-        TinyAssertions.assertSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
-      });
-
-      it('TINY-6559: Press Shift+Enter in blockquote', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', 'div');
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { shiftKey: true });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2<br><br></p></blockquote>');
-        TinyAssertions.assertSelection(editor, [ 0, 1 ], 2, [ 0, 1 ], 2);
-      });
-
-      it('TINY-6559: Press Enter twice in blockquote', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', 'div');
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p><p>&nbsp;</p><p>&nbsp;</p></blockquote>');
-        TinyAssertions.assertSelection(editor, [ 0, 3 ], 0, [ 0, 3 ], 0);
-      });
-
-      it('TINY-6559: Press Enter twice in blockquote while between two lines', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', 'div');
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 0 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>&nbsp;</p><p>&nbsp;</p><p>Line 2</p></blockquote>');
-        TinyAssertions.assertSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
-      });
-
-      it('TINY-6559: Press Enter twice in a div', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', 'div');
-        editor.setContent('<div><p>Line 1</p><p>Line 2</p></div>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<div><p>Line 1</p><p>Line 2</p></div><p>&nbsp;</p>');
-        TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
-      });
-
-      it('TINY-6559: Press Enter twice in a section', () => {
-        const editor = hook.editor();
-        editor.setContent('<section><p>Line 1</p><p>Line 2</p></section>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<section><p>Line 1</p><p>Line 2</p><p>&nbsp;</p><p>&nbsp;</p></section>');
-        TinyAssertions.assertSelection(editor, [ 0, 3 ], 0, [ 0, 3 ], 0);
-      });
-    });
-
-    context('Is set to "div,blockquote"', () => {
-      it('TINY-6559: Press Enter in blockquote', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', 'div,blockquote');
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p><p>&nbsp;</p></blockquote>');
-        TinyAssertions.assertSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
-      });
-
-      it('TINY-6559: Press Shift+Enter in blockquote', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', 'div,blockquote');
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { shiftKey: true });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2<br><br></p></blockquote>');
-        TinyAssertions.assertSelection(editor, [ 0, 1 ], 2, [ 0, 1 ], 2);
-      });
-
-      it('TINY-6559: Press Enter twice in blockquote', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', 'div,blockquote');
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote><p>&nbsp;</p>');
-        TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
-      });
-
-      it('TINY-6559: Press Enter twice in blockquote while between two lines', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', 'div,blockquote');
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 0 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p></blockquote><p>&nbsp;</p><blockquote><p>Line 2</p></blockquote>');
-        TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
-      });
-
-      it('TINY-6559: Press Enter twice in a div', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', 'div,blockquote');
-        editor.setContent('<div><p>Line 1</p><p>Line 2</p></div>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<div><p>Line 1</p><p>Line 2</p></div><p>&nbsp;</p>');
-        TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
-      });
-
-      it('TINY-6559: Press Enter twice in a section', () => {
-        const editor = hook.editor();
-        editor.setContent('<section><p>Line 1</p><p>Line 2</p></section>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<section><p>Line 1</p><p>Line 2</p><p>&nbsp;</p><p>&nbsp;</p></section>');
-        TinyAssertions.assertSelection(editor, [ 0, 3 ], 0, [ 0, 3 ], 0);
-      });
-    });
-
-    context('Is set to true', () => {
-      it('TINY-6559: Press Enter in blockquote', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', true);
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p><p>&nbsp;</p></blockquote>');
-        TinyAssertions.assertSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
-      });
-
-      it('TINY-6559: Press Shift+Enter in blockquote', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', true);
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { shiftKey: true });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2<br><br></p></blockquote>');
-        TinyAssertions.assertSelection(editor, [ 0, 1 ], 2, [ 0, 1 ], 2);
-      });
-
-      it('TINY-6559: Press Enter twice in blockquote', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', true);
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote><p>&nbsp;</p>');
-        TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
-      });
-
-      it('TINY-6559: Press Enter twice in blockquote while between two lines', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', true);
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 0 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p></blockquote><p>&nbsp;</p><blockquote><p>Line 2</p></blockquote>');
-        TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
-      });
-
-      it('TINY-6559: Press Enter twice in a div', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', true);
-        editor.setContent('<div><p>Line 1</p><p>Line 2</p></div>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<div><p>Line 1</p><p>Line 2</p></div><p>&nbsp;</p>');
-        TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
-      });
-
-      it('TINY-6559: Press Enter twice in a section', () => {
-        const editor = hook.editor();
-        editor.setContent('<section><p>Line 1</p><p>Line 2</p></section>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<section><p>Line 1</p><p>Line 2</p></section><p>&nbsp;</p>');
-        TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
-      });
-    });
-
-    context('Is set to false', () => {
-      it('TINY-6559: Press Enter in blockquote', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', false);
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p><p>&nbsp;</p></blockquote>');
-        TinyAssertions.assertSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
-      });
-
-      it('TINY-6559: Press Shift+Enter in blockquote', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', false);
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { shiftKey: true });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2<br><br></p></blockquote>');
-        TinyAssertions.assertSelection(editor, [ 0, 1 ], 2, [ 0, 1 ], 2);
-      });
-
-      it('TINY-6559: Press Enter twice in blockquote', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', false);
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p><p>&nbsp;</p><p>&nbsp;</p></blockquote>');
-        TinyAssertions.assertSelection(editor, [ 0, 3 ], 0, [ 0, 3 ], 0);
-      });
-
-      it('TINY-6559: Press Enter twice in blockquote while between two lines', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', false);
-        editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
-        TinySelections.setCursor(editor, [ 0, 0 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>&nbsp;</p><p>&nbsp;</p><p>Line 2</p></blockquote>');
-        TinyAssertions.assertSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
-      });
-
-      it('TINY-6559: Press Enter twice in a div', () => {
-        const editor = hook.editor();
-        editor.options.set('end_container_on_empty_block', false);
-        editor.setContent('<div><p>Line 1</p><p>Line 2</p></div>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<div><p>Line 1</p><p>Line 2</p><p>&nbsp;</p><p>&nbsp;</p></div>');
-        TinyAssertions.assertSelection(editor, [ 0, 3 ], 0, [ 0, 3 ], 0);
-      });
-
-      it('TINY-6559: Press Enter twice in a section', () => {
-        const editor = hook.editor();
-        editor.setContent('<section><p>Line 1</p><p>Line 2</p></section>');
-        TinySelections.setCursor(editor, [ 0, 1 ], 1);
-        insertNewline(editor, { });
-        insertNewline(editor, { });
-        TinyAssertions.assertContent(editor, '<section><p>Line 1</p><p>Line 2</p><p>&nbsp;</p><p>&nbsp;</p></section>');
-        TinyAssertions.assertSelection(editor, [ 0, 3 ], 0, [ 0, 3 ], 0);
-      });
-    });
-  });
-
-  context('TINY-8458: newline_behavior "block"', () => {
-    before(() => {
-      hook.editor().options.set('newline_behavior', 'block');
-    });
-
-    after(() => {
-      hook.editor().options.unset('newline_behavior');
-    });
-
-    it('Split block in the middle', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>ab</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      insertNewline(editor, { });
-      TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
-      TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
-    });
-
-    it('Split block in the middle with shift+enter', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>ab</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      insertNewline(editor, { shiftKey: true });
-      TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
-      TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
-    });
-
-    context('ignores br_newline_selector', () => {
+    context('br_newline_selector', () => {
       before(() => {
-        hook.editor().options.set('br_newline_selector', 'p');
+        hook.editor().options.set('br_newline_selector', 'p,div.test');
       });
 
       after(() => {
         hook.editor().options.unset('br_newline_selector');
       });
 
-      it('Insert newline where br is forced', () => {
+      it('Insert newline where br is forced (paragraph)', () => {
         const editor = hook.editor();
         editor.setContent('<p>ab</p>');
         TinySelections.setCursor(editor, [ 0, 0 ], 1);
-        insertNewline(editor, { });
+        insertNewline(editor, {});
         editor.nodeChanged();
-        TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
-      });
-    });
-
-    context('does not ignore no_newline_selector', () => {
-      before(() => {
-        hook.editor().options.set('no_newline_selector', 'p');
+        TinyAssertions.assertContent(editor, '<p>a<br>b</p>');
       });
 
-      after(() => {
-        hook.editor().options.unset('no_newline_selector');
-      });
-
-      it('Insert newline where newline is blocked', () => {
+      it('Insert newline where br is forced (div)', () => {
         const editor = hook.editor();
-        editor.setContent('<p>ab</p>');
+        editor.setContent('<div class="test">ab</div>');
         TinySelections.setCursor(editor, [ 0, 0 ], 1);
-        insertNewline(editor, { });
+        insertNewline(editor, {});
         editor.nodeChanged();
-        TinyAssertions.assertContent(editor, '<p>ab</p>');
-      });
-    });
-  });
-
-  context('TINY-8458: newline_behavior "linebreak"', () => {
-    before(() => {
-      hook.editor().options.set('newline_behavior', 'linebreak');
-    });
-
-    after(() => {
-      hook.editor().options.unset('newline_behavior');
-    });
-
-    it('Split block in the middle', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>ab</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      insertNewline(editor, { });
-      TinyAssertions.assertContent(editor, '<p>a<br>b</p>');
-      TinyAssertions.assertSelection(editor, [ 0 ], 2, [ 0 ], 2);
-    });
-
-    it('Split block in the middle with shift+enter', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>ab</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      insertNewline(editor, { shiftKey: true });
-      TinyAssertions.assertContent(editor, '<p>a<br>b</p>');
-      TinyAssertions.assertSelection(editor, [ 0 ], 2, [ 0 ], 2);
-    });
-
-    context('ignores br_newline_selector', () => {
-      before(() => {
-        hook.editor().options.set('br_newline_selector', 'p');
-      });
-
-      after(() => {
-        hook.editor().options.unset('br_newline_selector');
+        TinyAssertions.assertContent(editor, '<div class="test">a<br>b</div>');
       });
 
       it('Insert newline where br is not forced', () => {
         const editor = hook.editor();
         editor.setContent('<div>ab</div>');
         TinySelections.setCursor(editor, [ 0, 0 ], 1);
-        insertNewline(editor, { });
+        insertNewline(editor, {});
         editor.nodeChanged();
-        TinyAssertions.assertContent(editor, '<div>a<br>b</div>');
+        TinyAssertions.assertContent(editor, '<div>a</div><div>b</div>');
       });
     });
 
-    context('does not ignore no_newline_selector', () => {
+    context('no_newline_selector', () => {
       before(() => {
-        hook.editor().options.set('no_newline_selector', 'p');
+        hook.editor().options.set('no_newline_selector', 'p,div.test');
       });
 
       after(() => {
         hook.editor().options.unset('no_newline_selector');
       });
 
-      it('Insert newline where newline is blocked', () => {
+      it('Insert newline where newline is blocked (paragraph)', () => {
         const editor = hook.editor();
         editor.setContent('<p>ab</p>');
         TinySelections.setCursor(editor, [ 0, 0 ], 1);
-        insertNewline(editor, { });
+        insertNewline(editor, {});
         editor.nodeChanged();
         TinyAssertions.assertContent(editor, '<p>ab</p>');
+      });
+
+      it('Insert newline where newline is blocked (div)', () => {
+        const editor = hook.editor();
+        editor.setContent('<div class="test">ab</div>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, {});
+        editor.nodeChanged();
+        TinyAssertions.assertContent(editor, '<div class="test">ab</div>');
+      });
+
+      it('Insert newline where newline is not blocked', () => {
+        const editor = hook.editor();
+        editor.setContent('<div>ab</div>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, {});
+        editor.nodeChanged();
+        TinyAssertions.assertContent(editor, '<div>a</div><div>b</div>');
+      });
+    });
+
+    it('Insert newline before image in link', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="#">a<img src="about:blank" /></a></p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      insertNewline(editor, {});
+      TinyAssertions.assertContent(editor, '<p><a href="#">a</a></p><p><a href="#"><img src="about:blank"></a></p>');
+      TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
+    });
+
+    context('end_container_on_empty_block', () => {
+      context('With the default value', () => {
+        it('TINY-6559: Press Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p><p>&nbsp;</p></blockquote>');
+          TinyAssertions.assertSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
+        });
+
+        it('TINY-6559: Press Shift+Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, { shiftKey: true });
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2<br><br></p></blockquote>');
+          TinyAssertions.assertSelection(editor, [ 0, 1 ], 2, [ 0, 1 ], 2);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote', () => {
+          const editor = hook.editor();
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote><p>&nbsp;</p>');
+          TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote while between two lines', () => {
+          const editor = hook.editor();
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p></blockquote><p>&nbsp;</p><blockquote><p>Line 2</p></blockquote>');
+          TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
+        });
+
+        it('TINY-6559: Press Enter twice in a div', () => {
+          const editor = hook.editor();
+          editor.setContent('<div><p>Line 1</p><p>Line 2</p></div>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<div><p>Line 1</p><p>Line 2</p><p>&nbsp;</p><p>&nbsp;</p></div>');
+          TinyAssertions.assertSelection(editor, [ 0, 3 ], 0, [ 0, 3 ], 0);
+        });
+
+        it('TINY-6559: Press Enter twice in a section', () => {
+          const editor = hook.editor();
+          editor.setContent('<section><p>Line 1</p><p>Line 2</p></section>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<section><p>Line 1</p><p>Line 2</p><p>&nbsp;</p><p>&nbsp;</p></section>');
+          TinyAssertions.assertSelection(editor, [ 0, 3 ], 0, [ 0, 3 ], 0);
+        });
+      });
+
+      context('Is set to "div"', () => {
+        it('TINY-6559: Press Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div');
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p><p>&nbsp;</p></blockquote>');
+          TinyAssertions.assertSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
+        });
+
+        it('TINY-6559: Press Shift+Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div');
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, { shiftKey: true });
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2<br><br></p></blockquote>');
+          TinyAssertions.assertSelection(editor, [ 0, 1 ], 2, [ 0, 1 ], 2);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div');
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p><p>&nbsp;</p><p>&nbsp;</p></blockquote>');
+          TinyAssertions.assertSelection(editor, [ 0, 3 ], 0, [ 0, 3 ], 0);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote while between two lines', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div');
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>&nbsp;</p><p>&nbsp;</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
+        });
+
+        it('TINY-6559: Press Enter twice in a div', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div');
+          editor.setContent('<div><p>Line 1</p><p>Line 2</p></div>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<div><p>Line 1</p><p>Line 2</p></div><p>&nbsp;</p>');
+          TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
+        });
+
+        it('TINY-6559: Press Enter twice in a section', () => {
+          const editor = hook.editor();
+          editor.setContent('<section><p>Line 1</p><p>Line 2</p></section>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<section><p>Line 1</p><p>Line 2</p><p>&nbsp;</p><p>&nbsp;</p></section>');
+          TinyAssertions.assertSelection(editor, [ 0, 3 ], 0, [ 0, 3 ], 0);
+        });
+      });
+
+      context('Is set to "div,blockquote"', () => {
+        it('TINY-6559: Press Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div,blockquote');
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p><p>&nbsp;</p></blockquote>');
+          TinyAssertions.assertSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
+        });
+
+        it('TINY-6559: Press Shift+Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div,blockquote');
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, { shiftKey: true });
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2<br><br></p></blockquote>');
+          TinyAssertions.assertSelection(editor, [ 0, 1 ], 2, [ 0, 1 ], 2);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div,blockquote');
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote><p>&nbsp;</p>');
+          TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote while between two lines', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div,blockquote');
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p></blockquote><p>&nbsp;</p><blockquote><p>Line 2</p></blockquote>');
+          TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
+        });
+
+        it('TINY-6559: Press Enter twice in a div', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div,blockquote');
+          editor.setContent('<div><p>Line 1</p><p>Line 2</p></div>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<div><p>Line 1</p><p>Line 2</p></div><p>&nbsp;</p>');
+          TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
+        });
+
+        it('TINY-6559: Press Enter twice in a section', () => {
+          const editor = hook.editor();
+          editor.setContent('<section><p>Line 1</p><p>Line 2</p></section>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<section><p>Line 1</p><p>Line 2</p><p>&nbsp;</p><p>&nbsp;</p></section>');
+          TinyAssertions.assertSelection(editor, [ 0, 3 ], 0, [ 0, 3 ], 0);
+        });
+      });
+
+      context('Is set to true', () => {
+        it('TINY-6559: Press Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', true);
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p><p>&nbsp;</p></blockquote>');
+          TinyAssertions.assertSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
+        });
+
+        it('TINY-6559: Press Shift+Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', true);
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, { shiftKey: true });
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2<br><br></p></blockquote>');
+          TinyAssertions.assertSelection(editor, [ 0, 1 ], 2, [ 0, 1 ], 2);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', true);
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote><p>&nbsp;</p>');
+          TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote while between two lines', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', true);
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p></blockquote><p>&nbsp;</p><blockquote><p>Line 2</p></blockquote>');
+          TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
+        });
+
+        it('TINY-6559: Press Enter twice in a div', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', true);
+          editor.setContent('<div><p>Line 1</p><p>Line 2</p></div>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<div><p>Line 1</p><p>Line 2</p></div><p>&nbsp;</p>');
+          TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
+        });
+
+        it('TINY-6559: Press Enter twice in a section', () => {
+          const editor = hook.editor();
+          editor.setContent('<section><p>Line 1</p><p>Line 2</p></section>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<section><p>Line 1</p><p>Line 2</p></section><p>&nbsp;</p>');
+          TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
+        });
+      });
+
+      context('Is set to false', () => {
+        it('TINY-6559: Press Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', false);
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p><p>&nbsp;</p></blockquote>');
+          TinyAssertions.assertSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
+        });
+
+        it('TINY-6559: Press Shift+Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', false);
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, { shiftKey: true });
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2<br><br></p></blockquote>');
+          TinyAssertions.assertSelection(editor, [ 0, 1 ], 2, [ 0, 1 ], 2);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', false);
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p><p>&nbsp;</p><p>&nbsp;</p></blockquote>');
+          TinyAssertions.assertSelection(editor, [ 0, 3 ], 0, [ 0, 3 ], 0);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote while between two lines', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', false);
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>&nbsp;</p><p>&nbsp;</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertSelection(editor, [ 0, 2 ], 0, [ 0, 2 ], 0);
+        });
+
+        it('TINY-6559: Press Enter twice in a div', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', false);
+          editor.setContent('<div><p>Line 1</p><p>Line 2</p></div>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<div><p>Line 1</p><p>Line 2</p><p>&nbsp;</p><p>&nbsp;</p></div>');
+          TinyAssertions.assertSelection(editor, [ 0, 3 ], 0, [ 0, 3 ], 0);
+        });
+
+        it('TINY-6559: Press Enter twice in a section', () => {
+          const editor = hook.editor();
+          editor.setContent('<section><p>Line 1</p><p>Line 2</p></section>');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<section><p>Line 1</p><p>Line 2</p><p>&nbsp;</p><p>&nbsp;</p></section>');
+          TinyAssertions.assertSelection(editor, [ 0, 3 ], 0, [ 0, 3 ], 0);
+        });
+      });
+    });
+
+    context('TINY-8458: newline_behavior "block"', () => {
+      before(() => {
+        hook.editor().options.set('newline_behavior', 'block');
+      });
+
+      after(() => {
+        hook.editor().options.unset('newline_behavior');
+      });
+
+      it('Split block in the middle', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
+        TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
+      });
+
+      it('Split block in the middle with shift+enter', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, { shiftKey: true });
+        TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
+        TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
+      });
+
+      context('ignores br_newline_selector', () => {
+        before(() => {
+          hook.editor().options.set('br_newline_selector', 'p');
+        });
+
+        after(() => {
+          hook.editor().options.unset('br_newline_selector');
+        });
+
+        it('Insert newline where br is forced', () => {
+          const editor = hook.editor();
+          editor.setContent('<p>ab</p>');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          editor.nodeChanged();
+          TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
+        });
+      });
+
+      context('does not ignore no_newline_selector', () => {
+        before(() => {
+          hook.editor().options.set('no_newline_selector', 'p');
+        });
+
+        after(() => {
+          hook.editor().options.unset('no_newline_selector');
+        });
+
+        it('Insert newline where newline is blocked', () => {
+          const editor = hook.editor();
+          editor.setContent('<p>ab</p>');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          editor.nodeChanged();
+          TinyAssertions.assertContent(editor, '<p>ab</p>');
+        });
+      });
+    });
+
+    context('TINY-8458: newline_behavior "linebreak"', () => {
+      before(() => {
+        hook.editor().options.set('newline_behavior', 'linebreak');
+      });
+
+      after(() => {
+        hook.editor().options.unset('newline_behavior');
+      });
+
+      it('Split block in the middle', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<p>a<br>b</p>');
+        TinyAssertions.assertSelection(editor, [ 0 ], 2, [ 0 ], 2);
+      });
+
+      it('Split block in the middle with shift+enter', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, { shiftKey: true });
+        TinyAssertions.assertContent(editor, '<p>a<br>b</p>');
+        TinyAssertions.assertSelection(editor, [ 0 ], 2, [ 0 ], 2);
+      });
+
+      context('ignores br_newline_selector', () => {
+        before(() => {
+          hook.editor().options.set('br_newline_selector', 'p');
+        });
+
+        after(() => {
+          hook.editor().options.unset('br_newline_selector');
+        });
+
+        it('Insert newline where br is not forced', () => {
+          const editor = hook.editor();
+          editor.setContent('<div>ab</div>');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          editor.nodeChanged();
+          TinyAssertions.assertContent(editor, '<div>a<br>b</div>');
+        });
+      });
+
+      context('does not ignore no_newline_selector', () => {
+        before(() => {
+          hook.editor().options.set('no_newline_selector', 'p');
+        });
+
+        after(() => {
+          hook.editor().options.unset('no_newline_selector');
+        });
+
+        it('Insert newline where newline is blocked', () => {
+          const editor = hook.editor();
+          editor.setContent('<p>ab</p>');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          editor.nodeChanged();
+          TinyAssertions.assertContent(editor, '<p>ab</p>');
+        });
+      });
+    });
+
+    context('TINY-8458: newline_behavior "invert"', () => {
+      before(() => {
+        hook.editor().options.set('newline_behavior', 'invert');
+      });
+
+      after(() => {
+        hook.editor().options.unset('newline_behavior');
+      });
+
+      it('Split block in the middle', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<p>a<br>b</p>');
+        TinyAssertions.assertSelection(editor, [ 0 ], 2, [ 0 ], 2);
+      });
+
+      it('Split block in the middle with shift+enter', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, { shiftKey: true });
+        TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
+        TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
+      });
+
+      context('inverts br_newline_selector', () => {
+        before(() => {
+          hook.editor().options.set('br_newline_selector', 'p');
+        });
+
+        after(() => {
+          hook.editor().options.unset('br_newline_selector');
+        });
+
+        it('Insert newline where br is forced', () => {
+          const editor = hook.editor();
+          editor.setContent('<p>ab</p>');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          editor.nodeChanged();
+          TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
+        });
+
+        it('Insert newline where br is not forced', () => {
+          const editor = hook.editor();
+          editor.setContent('<div>ab</div>');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          editor.nodeChanged();
+          TinyAssertions.assertContent(editor, '<div>a<br>b</div>');
+        });
+      });
+
+      context('does not ignore no_newline_selector', () => {
+        before(() => {
+          hook.editor().options.set('no_newline_selector', 'p');
+        });
+
+        after(() => {
+          hook.editor().options.unset('no_newline_selector');
+        });
+
+        it('Insert newline where newline is blocked', () => {
+          const editor = hook.editor();
+          editor.setContent('<p>ab</p>');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          editor.nodeChanged();
+          TinyAssertions.assertContent(editor, '<p>ab</p>');
+        });
+      });
+    });
+
+    it('TINY-9794: Press Enter in a blockquote and then add format and then press Enter again should exit from the blockquote', () => {
+      const editor = hook.editor();
+      editor.setContent('<blockquote><p>A</p></blockquote>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      insertNewline(editor, {});
+      CaretFormat.applyCaretFormat(editor, 'bold');
+      insertNewline(editor, {});
+      TinyAssertions.assertContent(editor, '<blockquote><p>A</p></blockquote><p>&nbsp;</p>');
+      TinyAssertions.assertCursor(editor, [ 1, 0, 0, 0 ], 0);
+    });
+
+    it('TINY-10560: Press Enter after a `selection.setContent` should create a new line and not throw errors', () => {
+      const editor = hook.editor();
+      Arr.each([ 'pre', 'h1', 'div', 'p' ], (tagName) => {
+        editor.setContent('abc');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
+
+        editor.selection.setContent(`<${tagName}>hello</${tagName}>`);
+        assert.doesNotThrow(() => {
+          insertNewline(editor, {});
+        });
       });
     });
   });
 
-  context('TINY-8458: newline_behavior "invert"', () => {
-    before(() => {
-      hook.editor().options.set('newline_behavior', 'invert');
+  context('TINY-10981: readonly selectionEnabled mode', () => {
+    afterEach(() => hook.editor().mode.set('design'));
+    context('Enter in paragraph', () => {
+      it('Insert block before', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0 ], 0);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<p>ab</p>');
+      });
+
+      it('Split block in the middle', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<p>ab</p>');
+      });
+
+      it('Insert block after', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0 ], 2);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<p>ab</p>');
+      });
+
+      it('Insert block after bookmark', () => {
+        const editor = hook.editor();
+        editor.setContent(`<p>${bookmarkSpan}<br data-mce-bogus="1"></p>`, { format: 'raw' });
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0 ], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContentStructure(editor,
+          ApproxStructure.build((s, str) => s.element('body', {
+            children: [
+              s.element('p', {
+                children: [
+                  ApproxStructure.fromHtml(bookmarkSpan),
+                  s.element('br', {
+                    attrs: {
+                      'data-mce-bogus': str.is('1')
+                    }
+                  })
+                ]
+              }),
+            ]
+          }))
+        );
+      });
     });
 
-    after(() => {
-      hook.editor().options.unset('newline_behavior');
+    context('CEF', () => {
+      it('TINY-9098: insert newline on inline CEF element should do nothing', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>before<span contenteditable="false">x</span>after</p>');
+        editor.mode.set('testmode');
+        TinySelections.select(editor, 'span', []);
+        insertNewline(editor, {});
+        editor.nodeChanged();
+        TinyAssertions.assertContent(editor, '<p>before<span contenteditable="false">x</span>after</p>');
+      });
+
+      it('TINY-9813: Placed a cursor is placed after a table, with a noneditable afterwards', () => {
+        const editor = hook.editor();
+        editor.setContent('<table><tbody><tr><td><br></td></tr></tbody></table><div contenteditable="false"></div>');
+        editor.mode.set('testmode');
+        setSelectionTo(editor, [], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<table><tbody><tr><td>&nbsp;</td></tr></tbody></table><div contenteditable="false">&nbsp;</div>');
+      });
+
+      it('TINY-9813: Placed a cursor is placed after a table, with an editable afterwards', () => {
+        const editor = hook.editor();
+        editor.setContent('<table><tbody><tr><td><br></td></tr></tbody></table><div contenteditable="true">&nbsp;</div>');
+        editor.mode.set('testmode');
+        setSelectionTo(editor, [], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<table><tbody><tr><td>&nbsp;</td></tr></tbody></table><div contenteditable="true">&nbsp;</div>');
+      });
+
+      it('TINY-9813: Placed a cursor is placed after a table, with nothing', () => {
+        const editor = hook.editor();
+        editor.setContent('<table><tbody><tr><td><br></td></tr></tbody></table>');
+        editor.mode.set('testmode');
+        setSelectionTo(editor, [], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<table><tbody><tr><td>&nbsp;</td></tr></tbody></table>');
+      });
+
+      it('TINY-9813: Placed a cursor is placed after a table, with a noneditable afterwards, wrapped in div', () => {
+        const editor = hook.editor();
+        editor.setContent('<div><table><tbody><tr><td><br></td></tr></tbody></table><div contenteditable="false"></div></div>');
+        editor.mode.set('testmode');
+        setSelectionTo(editor, [ 0 ], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<div><table><tbody><tr><td>&nbsp;</td></tr></tbody></table><div contenteditable="false">&nbsp;</div></div>');
+      });
     });
 
-    it('Split block in the middle', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>ab</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      insertNewline(editor, { });
-      TinyAssertions.assertContent(editor, '<p>a<br>b</p>');
-      TinyAssertions.assertSelection(editor, [ 0 ], 2, [ 0 ], 2);
-    });
-
-    it('Split block in the middle with shift+enter', () => {
-      const editor = hook.editor();
-      editor.setContent('<p>ab</p>');
-      TinySelections.setCursor(editor, [ 0, 0 ], 1);
-      insertNewline(editor, { shiftKey: true });
-      TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
-      TinyAssertions.assertSelection(editor, [ 1, 0 ], 0, [ 1, 0 ], 0);
-    });
-
-    context('inverts br_newline_selector', () => {
+    context('br_newline_selector', () => {
       before(() => {
-        hook.editor().options.set('br_newline_selector', 'p');
+        hook.editor().options.set('br_newline_selector', 'p,div.test');
       });
 
       after(() => {
         hook.editor().options.unset('br_newline_selector');
       });
 
-      it('Insert newline where br is forced', () => {
+      it('Insert newline where br is forced (paragraph)', () => {
         const editor = hook.editor();
         editor.setContent('<p>ab</p>');
+        editor.mode.set('testmode');
         TinySelections.setCursor(editor, [ 0, 0 ], 1);
-        insertNewline(editor, { });
+        insertNewline(editor, {});
         editor.nodeChanged();
-        TinyAssertions.assertContent(editor, '<p>a</p><p>b</p>');
+        TinyAssertions.assertContent(editor, '<p>ab</p>');
+      });
+
+      it('Insert newline where br is forced (div)', () => {
+        const editor = hook.editor();
+        editor.setContent('<div class="test">ab</div>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, {});
+        editor.nodeChanged();
+        TinyAssertions.assertContent(editor, '<div class="test">ab</div>');
       });
 
       it('Insert newline where br is not forced', () => {
         const editor = hook.editor();
         editor.setContent('<div>ab</div>');
+        editor.mode.set('testmode');
         TinySelections.setCursor(editor, [ 0, 0 ], 1);
-        insertNewline(editor, { });
+        insertNewline(editor, {});
         editor.nodeChanged();
-        TinyAssertions.assertContent(editor, '<div>a<br>b</div>');
+        TinyAssertions.assertContent(editor, '<div>ab</div>');
       });
     });
 
-    context('does not ignore no_newline_selector', () => {
+    context('no_newline_selector', () => {
       before(() => {
-        hook.editor().options.set('no_newline_selector', 'p');
+        hook.editor().options.set('no_newline_selector', 'p,div.test');
       });
 
       after(() => {
         hook.editor().options.unset('no_newline_selector');
       });
 
-      it('Insert newline where newline is blocked', () => {
+      it('Insert newline where newline is blocked (paragraph)', () => {
         const editor = hook.editor();
         editor.setContent('<p>ab</p>');
+        editor.mode.set('testmode');
         TinySelections.setCursor(editor, [ 0, 0 ], 1);
-        insertNewline(editor, { });
+        insertNewline(editor, {});
         editor.nodeChanged();
         TinyAssertions.assertContent(editor, '<p>ab</p>');
       });
+
+      it('Insert newline where newline is blocked (div)', () => {
+        const editor = hook.editor();
+        editor.setContent('<div class="test">ab</div>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, {});
+        editor.nodeChanged();
+        TinyAssertions.assertContent(editor, '<div class="test">ab</div>');
+      });
+
+      it('Insert newline where newline is not blocked', () => {
+        const editor = hook.editor();
+        editor.setContent('<div>ab</div>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, {});
+        editor.nodeChanged();
+        TinyAssertions.assertContent(editor, '<div>ab</div>');
+      });
     });
-  });
 
-  it('TINY-9794: Press Enter in a blockquote and then add format and then press Enter again should exit from the blockquote', () => {
-    const editor = hook.editor();
-    editor.setContent('<blockquote><p>A</p></blockquote>');
-    TinySelections.setCursor(editor, [ 0, 0 ], 1);
-    insertNewline(editor, { });
-    CaretFormat.applyCaretFormat(editor, 'bold');
-    insertNewline(editor, { });
-    TinyAssertions.assertContent(editor, '<blockquote><p>A</p></blockquote><p>&nbsp;</p>');
-    TinyAssertions.assertCursor(editor, [ 1, 0, 0, 0 ], 0);
-  });
+    it('Insert newline before image in link', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="#">a<img src="about:blank" /></a></p>');
+      editor.mode.set('testmode');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      insertNewline(editor, {});
+      TinyAssertions.assertContent(editor, '<p><a href="#">a<img src="about:blank"></a></p>');
+      TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+    });
 
-  it('TINY-10560: Press Enter after a `selection.setContent` should create a new line and not throw errors', () => {
-    const editor = hook.editor();
-    Arr.each([ 'pre', 'h1', 'div', 'p' ], (tagName) => {
-      editor.setContent('abc');
-      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
+    context('end_container_on_empty_block', () => {
+      context('With the default value', () => {
+        it('TINY-6559: Press Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
 
-      editor.selection.setContent(`<${tagName}>hello</${tagName}>`);
-      assert.doesNotThrow(() => {
-        insertNewline(editor, { });
+        it('TINY-6559: Press Shift+Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, { shiftKey: true });
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote', () => {
+          const editor = hook.editor();
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote while between two lines', () => {
+          const editor = hook.editor();
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in a div', () => {
+          const editor = hook.editor();
+          editor.setContent('<div><p>Line 1</p><p>Line 2</p></div>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<div><p>Line 1</p><p>Line 2</p></div>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in a section', () => {
+          const editor = hook.editor();
+          editor.setContent('<section><p>Line 1</p><p>Line 2</p></section>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<section><p>Line 1</p><p>Line 2</p></section>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+      });
+
+      context('Is set to "div"', () => {
+        it('TINY-6559: Press Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div');
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Shift+Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div');
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, { shiftKey: true });
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div');
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote while between two lines', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div');
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in a div', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div');
+          editor.setContent('<div><p>Line 1</p><p>Line 2</p></div>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<div><p>Line 1</p><p>Line 2</p></div>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in a section', () => {
+          const editor = hook.editor();
+          editor.setContent('<section><p>Line 1</p><p>Line 2</p></section>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<section><p>Line 1</p><p>Line 2</p></section>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+      });
+
+      context('Is set to "div,blockquote"', () => {
+        it('TINY-6559: Press Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div,blockquote');
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Shift+Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div,blockquote');
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, { shiftKey: true });
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div,blockquote');
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote while between two lines', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div,blockquote');
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in a div', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', 'div,blockquote');
+          editor.setContent('<div><p>Line 1</p><p>Line 2</p></div>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<div><p>Line 1</p><p>Line 2</p></div>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in a section', () => {
+          const editor = hook.editor();
+          editor.setContent('<section><p>Line 1</p><p>Line 2</p></section>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<section><p>Line 1</p><p>Line 2</p></section>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+      });
+
+      context('Is set to true', () => {
+        it('TINY-6559: Press Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', true);
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Shift+Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', true);
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, { shiftKey: true });
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', true);
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote while between two lines', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', true);
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in a div', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', true);
+          editor.setContent('<div><p>Line 1</p><p>Line 2</p></div>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<div><p>Line 1</p><p>Line 2</p></div>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in a section', () => {
+          const editor = hook.editor();
+          editor.setContent('<section><p>Line 1</p><p>Line 2</p></section>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<section><p>Line 1</p><p>Line 2</p></section>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+      });
+
+      context('Is set to false', () => {
+        it('TINY-6559: Press Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', false);
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Shift+Enter in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', false);
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, { shiftKey: true });
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', false);
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in blockquote while between two lines', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', false);
+          editor.setContent('<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<blockquote><p>Line 1</p><p>Line 2</p></blockquote>');
+          TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in a div', () => {
+          const editor = hook.editor();
+          editor.options.set('end_container_on_empty_block', false);
+          editor.setContent('<div><p>Line 1</p><p>Line 2</p></div>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<div><p>Line 1</p><p>Line 2</p></div>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+
+        it('TINY-6559: Press Enter twice in a section', () => {
+          const editor = hook.editor();
+          editor.setContent('<section><p>Line 1</p><p>Line 2</p></section>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 1 ], 1);
+          insertNewline(editor, {});
+          insertNewline(editor, {});
+          TinyAssertions.assertContent(editor, '<section><p>Line 1</p><p>Line 2</p></section>');
+          TinyAssertions.assertCursor(editor, [ 0, 1 ], 1);
+        });
+      });
+    });
+
+    context('TINY-8458: newline_behavior "block"', () => {
+      before(() => {
+        hook.editor().options.set('newline_behavior', 'block');
+      });
+
+      after(() => {
+        hook.editor().options.unset('newline_behavior');
+      });
+
+      it('Split block in the middle', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<p>ab</p>');
+        TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+      });
+
+      it('Split block in the middle with shift+enter', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, { shiftKey: true });
+        TinyAssertions.assertContent(editor, '<p>ab</p>');
+        TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+      });
+
+      context('ignores br_newline_selector', () => {
+        before(() => {
+          hook.editor().options.set('br_newline_selector', 'p');
+        });
+
+        after(() => {
+          hook.editor().options.unset('br_newline_selector');
+        });
+
+        it('Insert newline where br is forced', () => {
+          const editor = hook.editor();
+          editor.setContent('<p>ab</p>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          editor.nodeChanged();
+          TinyAssertions.assertContent(editor, '<p>ab</p>');
+        });
+      });
+
+      context('does not ignore no_newline_selector', () => {
+        before(() => {
+          hook.editor().options.set('no_newline_selector', 'p');
+        });
+
+        after(() => {
+          hook.editor().options.unset('no_newline_selector');
+        });
+
+        it('Insert newline where newline is blocked', () => {
+          const editor = hook.editor();
+          editor.setContent('<p>ab</p>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          editor.nodeChanged();
+          TinyAssertions.assertContent(editor, '<p>ab</p>');
+        });
+      });
+    });
+
+    context('TINY-8458: newline_behavior "linebreak"', () => {
+      before(() => {
+        hook.editor().options.set('newline_behavior', 'linebreak');
+      });
+
+      after(() => {
+        hook.editor().options.unset('newline_behavior');
+      });
+
+      it('Split block in the middle', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<p>ab</p>');
+        TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+      });
+
+      it('Split block in the middle with shift+enter', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, { shiftKey: true });
+        TinyAssertions.assertContent(editor, '<p>ab</p>');
+        TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+      });
+
+      context('ignores br_newline_selector', () => {
+        before(() => {
+          hook.editor().options.set('br_newline_selector', 'p');
+        });
+
+        after(() => {
+          hook.editor().options.unset('br_newline_selector');
+        });
+
+        it('Insert newline where br is not forced', () => {
+          const editor = hook.editor();
+          editor.setContent('<div>ab</div>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          editor.nodeChanged();
+          TinyAssertions.assertContent(editor, '<div>ab</div>');
+        });
+      });
+
+      context('does not ignore no_newline_selector', () => {
+        before(() => {
+          hook.editor().options.set('no_newline_selector', 'p');
+        });
+
+        after(() => {
+          hook.editor().options.unset('no_newline_selector');
+        });
+
+        it('Insert newline where newline is blocked', () => {
+          const editor = hook.editor();
+          editor.setContent('<p>ab</p>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          editor.nodeChanged();
+          TinyAssertions.assertContent(editor, '<p>ab</p>');
+        });
+      });
+    });
+
+    context('TINY-8458: newline_behavior "invert"', () => {
+      before(() => {
+        hook.editor().options.set('newline_behavior', 'invert');
+      });
+
+      after(() => {
+        hook.editor().options.unset('newline_behavior');
+      });
+
+      it('Split block in the middle', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, {});
+        TinyAssertions.assertContent(editor, '<p>ab</p>');
+        TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+      });
+
+      it('Split block in the middle with shift+enter', () => {
+        const editor = hook.editor();
+        editor.setContent('<p>ab</p>');
+        editor.mode.set('testmode');
+        TinySelections.setCursor(editor, [ 0, 0 ], 1);
+        insertNewline(editor, { shiftKey: true });
+        TinyAssertions.assertContent(editor, '<p>ab</p>');
+        TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+      });
+
+      context('inverts br_newline_selector', () => {
+        before(() => {
+          hook.editor().options.set('br_newline_selector', 'p');
+        });
+
+        after(() => {
+          hook.editor().options.unset('br_newline_selector');
+        });
+
+        it('Insert newline where br is forced', () => {
+          const editor = hook.editor();
+          editor.setContent('<p>ab</p>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          editor.nodeChanged();
+          TinyAssertions.assertContent(editor, '<p>ab</p>');
+        });
+
+        it('Insert newline where br is not forced', () => {
+          const editor = hook.editor();
+          editor.setContent('<div>ab</div>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          editor.nodeChanged();
+          TinyAssertions.assertContent(editor, '<div>ab</div>');
+        });
+      });
+
+      context('does not ignore no_newline_selector', () => {
+        before(() => {
+          hook.editor().options.set('no_newline_selector', 'p');
+        });
+
+        after(() => {
+          hook.editor().options.unset('no_newline_selector');
+        });
+
+        it('Insert newline where newline is blocked', () => {
+          const editor = hook.editor();
+          editor.setContent('<p>ab</p>');
+          editor.mode.set('testmode');
+          TinySelections.setCursor(editor, [ 0, 0 ], 1);
+          insertNewline(editor, {});
+          editor.nodeChanged();
+          TinyAssertions.assertContent(editor, '<p>ab</p>');
+        });
+      });
+    });
+
+    it('TINY-9794: Press Enter in a blockquote and then add format and then press Enter again should exit from the blockquote', () => {
+      const editor = hook.editor();
+      editor.setContent('<blockquote><p>A</p></blockquote>');
+      editor.mode.set('testmode');
+      editor.mode.set('testmode');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      insertNewline(editor, {});
+      CaretFormat.applyCaretFormat(editor, 'bold');
+      insertNewline(editor, {});
+      TinyAssertions.assertContent(editor, '<blockquote><p>A</p></blockquote>');
+    });
+
+    it('TINY-10560: Press Enter after a `selection.setContent` should create a new line and not throw errors', () => {
+      const editor = hook.editor();
+      Arr.each([ 'pre', 'h1', 'div', 'p' ], (tagName) => {
+        editor.setContent('abc');
+        editor.mode.set('testmode');
+        TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
+
+        editor.selection.setContent(`<${tagName}>hello</${tagName}>`);
+        assert.doesNotThrow(() => {
+          insertNewline(editor, {});
+        });
       });
     });
   });

--- a/modules/tinymce/src/models/dom/main/ts/table/api/TableResizeHandler.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/TableResizeHandler.ts
@@ -131,7 +131,11 @@ export const TableResizeHandler = (editor: Editor): TableResizeHandler => {
     if (Options.hasTableObjectResizing(editor) && Options.hasTableResizeBars(editor)) {
       const resizing = lazyResizingBehaviour();
       const sz = TableResize.create(rawWire, resizing, lazySizing);
-      sz.on();
+
+      if (!editor.mode.isReadOnly()) {
+        sz.on();
+      }
+
       sz.events.startDrag.bind((_event) => {
         selectionRng.set(editor.selection.getRng());
       });
@@ -162,7 +166,7 @@ export const TableResizeHandler = (editor: Editor): TableResizeHandler => {
   // If we're updating the table width via the old mechanic, we need to update the constituent cells' widths/heights too.
   editor.on('ObjectResizeStart', (e) => {
     const targetElm = e.target;
-    if (isTable(targetElm)) {
+    if (isTable(targetElm) && !editor.mode.isReadOnly()) {
       const table = SugarElement.fromDom(targetElm);
 
       // Add a class based on the resizing mode
@@ -208,8 +212,10 @@ export const TableResizeHandler = (editor: Editor): TableResizeHandler => {
   editor.on('SwitchMode', () => {
     tableResize.on((resize) => {
       if (editor.mode.isReadOnly()) {
+        resize.off();
         resize.hideBars();
       } else {
+        resize.on();
         resize.showBars();
       }
     });

--- a/modules/tinymce/src/plugins/accordion/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/accordion/main/ts/core/Actions.ts
@@ -60,17 +60,20 @@ const toggleAccordion = (editor: Editor, state?: boolean): void => {
 };
 
 const removeAccordion = (editor: Editor): void => {
-  Utils.getSelectedDetails(editor).each((details) => {
-    const { nextSibling } = details;
-    if (nextSibling) {
-      editor.selection.select(nextSibling, true);
-      editor.selection.collapse(true);
-    } else {
-      Utils.insertAndSelectParagraphAfter(editor, details);
-    }
+  if (!editor.mode.isReadOnly()) {
+    Utils.getSelectedDetails(editor)
+      .each((details) => {
+        const { nextSibling } = details;
+        if (nextSibling) {
+          editor.selection.select(nextSibling, true);
+          editor.selection.collapse(true);
+        } else {
+          Utils.insertAndSelectParagraphAfter(editor, details);
+        }
 
-    details.remove();
-  });
+        details.remove();
+      });
+  }
 };
 
 const toggleAllAccordions = (editor: Editor, state?: boolean): void => {

--- a/modules/tinymce/src/plugins/autolink/main/ts/core/Keys.ts
+++ b/modules/tinymce/src/plugins/autolink/main/ts/core/Keys.ts
@@ -17,7 +17,7 @@ const parseCurrentLine = (editor: Editor, offset: number): ParseResult | null =>
   const { dom, selection } = editor;
 
   // Never create a link when we are inside a link
-  if (dom.getParent(selection.getNode(), 'a[href]') !== null) {
+  if (dom.getParent(selection.getNode(), 'a[href]') !== null || editor.mode.isReadOnly()) {
     return null;
   }
 

--- a/modules/tinymce/src/plugins/lists/main/ts/core/Util.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Util.ts
@@ -19,12 +19,12 @@ const isWithinNonEditable = (editor: Editor, element: Element | null): boolean =
 
 const selectionIsWithinNonEditableList = (editor: Editor): boolean => {
   const parentList = Selection.getParentList(editor);
-  return isWithinNonEditable(editor, parentList);
+  return isWithinNonEditable(editor, parentList) || editor.mode.isReadOnly();
 };
 
 const isWithinNonEditableList = (editor: Editor, element: Element | null): boolean => {
   const parentList = editor.dom.getParent(element, 'ol,ul,dl');
-  return isWithinNonEditable(editor, parentList);
+  return isWithinNonEditable(editor, parentList) || editor.mode.isReadOnly();
 };
 
 const setNodeChangeHandler = (editor: Editor, nodeChangeHandler: (e: NodeChangeEvent) => void): () => void => {


### PR DESCRIPTION
Related Ticket: TINY-10981

Description of Changes:
* Follow up ticket to address issues such as:
  * Formatter still working with keyboard shortcuts
  * Tabbing to indent list
  * Tabbing to create new row when selection is at the last cell of a table
  * Various commands that still work, example: `InsertNewBlockBefore`, `InsertLineBreak`
  * Added readonly check to `selection.isEditable`
* They should be blocked anyway in readonly mode, but since the cursor cannot be placed in the editor with full readonly mode (`contenteditable="false"`) so they weren't.

Pre-checks:
* [x] ~Changelog entry added~ Will be addressed in EPIC-114
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):