### PR TITLE
TINY-10980: Fix issues with `uiEnabled` mode

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,1 +1,1 @@
-primaryBranch=main
+primaryBranch=epic/EPIC-114

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableApis.ts
@@ -41,7 +41,7 @@ const ariaEnable = (component: AlloyComponent): void => {
   Attribute.set(component.element, 'aria-disabled', 'false');
 };
 
-const disable = (component: AlloyComponent, disableConfig: DisableConfig, disableState: DisableState, storeState: boolean): void => {
+const disable = (component: AlloyComponent, disableConfig: DisableConfig, disableState: DisableState, storeState: boolean = false): void => {
   disableConfig.disableClass.each((disableClass) => {
     Class.add(component.element, disableClass);
   });
@@ -53,7 +53,7 @@ const disable = (component: AlloyComponent, disableConfig: DisableConfig, disabl
   disableConfig.onDisabled(component);
 };
 
-const enable = (component: AlloyComponent, disableConfig: DisableConfig, disableState: DisableState, storeState: boolean): void => {
+const enable = (component: AlloyComponent, disableConfig: DisableConfig, disableState: DisableState, storeState: boolean = false): void => {
   disableConfig.disableClass.each((disableClass) => {
     Class.remove(component.element, disableClass);
   });
@@ -68,9 +68,14 @@ const enable = (component: AlloyComponent, disableConfig: DisableConfig, disable
 const isDisabled = (component: AlloyComponent, disableConfig: DisableConfig): boolean =>
   hasNative(component, disableConfig) ? nativeIsDisabled(component) : ariaIsDisabled(component);
 
-const set = (component: AlloyComponent, disableConfig: DisableConfig, disableState: DisableState, disabled: boolean, storeState: boolean = false): void => {
+const set = (component: AlloyComponent, disableConfig: DisableConfig, disableState: DisableState, disabled: boolean): void => {
   const f = disabled ? disable : enable;
-  f(component, disableConfig, disableState, storeState);
+  f(component, disableConfig, disableState);
+};
+
+const setAndStoreState = (component: AlloyComponent, disableConfig: DisableConfig, disableState: DisableState, disabled: boolean): void => {
+  const f = disabled ? disable : enable;
+  f(component, disableConfig, disableState, true);
 };
 
 const getLastDisabledState = (_: AlloyComponent, __: DisableConfig, disableState: DisableState): boolean =>
@@ -82,5 +87,6 @@ export {
   isDisabled,
   onLoad,
   set,
+  setAndStoreState,
   getLastDisabledState
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableApis.ts
@@ -1,4 +1,4 @@
-import { Arr } from '@ephox/katamari';
+import { Arr, Optional } from '@ephox/katamari';
 import { Attribute, Class, SugarNode } from '@ephox/sugar';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
@@ -78,7 +78,7 @@ const setAndStoreState = (component: AlloyComponent, disableConfig: DisableConfi
   f(component, disableConfig, disableState, true);
 };
 
-const getLastDisabledState = (_: AlloyComponent, __: DisableConfig, disableState: DisableState): boolean | undefined =>
+const getLastDisabledState = (_: AlloyComponent, __: DisableConfig, disableState: DisableState): Optional<boolean> =>
   disableState.getLastDisabledState();
 
 export {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableApis.ts
@@ -78,7 +78,7 @@ const setAndStoreState = (component: AlloyComponent, disableConfig: DisableConfi
   f(component, disableConfig, disableState, true);
 };
 
-const getLastDisabledState = (_: AlloyComponent, __: DisableConfig, disableState: DisableState): boolean =>
+const getLastDisabledState = (_: AlloyComponent, __: DisableConfig, disableState: DisableState): boolean | undefined =>
   disableState.getLastDisabledState();
 
 export {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableState.ts
@@ -1,10 +1,10 @@
-import { Cell } from '@ephox/katamari';
+import { Singleton } from '@ephox/katamari';
 
 import { nuState } from '../common/BehaviourState';
 import { DisableState } from './DisableTypes';
 
 const init = (): DisableState => {
-  const lastDisabledState = Cell<boolean | undefined>(undefined);
+  const lastDisabledState = Singleton.value<boolean>();
 
   const readState = () => 'last disabled state:' + lastDisabledState.get();
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableState.ts
@@ -4,12 +4,12 @@ import { nuState } from '../common/BehaviourState';
 import { DisableState } from './DisableTypes';
 
 const init = (): DisableState => {
-  const lastDisabledState = Cell(false);
+  const lastDisabledState = Cell<boolean | undefined>(undefined);
 
   const readState = () => 'last disabled state:' + lastDisabledState.get();
 
   return nuState({
-    getLastDisabledState: () => lastDisabledState.get() === true,
+    getLastDisabledState: () => lastDisabledState.get(),
     setLastDisabledState: lastDisabledState.set,
     readState
   });

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableTypes.ts
@@ -12,7 +12,7 @@ export interface DisableBehaviour extends Behaviour.AlloyBehaviour<DisableConfig
   onLoad: (component: AlloyComponent) => void;
   set: (component: AlloyComponent, disabled: boolean) => void;
   setAndStoreState: (component: AlloyComponent, disabled: boolean) => void;
-  getLastDisabledState: (component: AlloyComponent) => boolean;
+  getLastDisabledState: (component: AlloyComponent) => Optional<boolean>;
 }
 
 export interface DisableConfig extends Behaviour.BehaviourConfigDetail {
@@ -32,6 +32,6 @@ export interface DisableConfigSpec extends Behaviour.BehaviourConfigSpec {
 }
 
 export interface DisableState extends BehaviourState {
-  getLastDisabledState: () => boolean | undefined;
+  getLastDisabledState: () => Optional<boolean>;
   setLastDisabledState: (state: boolean) => void;
 }

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableTypes.ts
@@ -32,6 +32,6 @@ export interface DisableConfigSpec extends Behaviour.BehaviourConfigSpec {
 }
 
 export interface DisableState extends BehaviourState {
-  getLastDisabledState: () => boolean;
+  getLastDisabledState: () => boolean | undefined;
   setLastDisabledState: (state: boolean) => void;
 }

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableTypes.ts
@@ -10,7 +10,8 @@ export interface DisableBehaviour extends Behaviour.AlloyBehaviour<DisableConfig
   disable: (component: AlloyComponent) => void;
   isDisabled: (component: AlloyComponent) => boolean;
   onLoad: (component: AlloyComponent) => void;
-  set: (component: AlloyComponent, disabled: boolean, storeState?: boolean) => void;
+  set: (component: AlloyComponent, disabled: boolean) => void;
+  setAndStoreState: (component: AlloyComponent, disabled: boolean) => void;
   getLastDisabledState: (component: AlloyComponent) => boolean;
 }
 

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/DialogFooterButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/DialogFooterButton.ts
@@ -1,4 +1,4 @@
-import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
+import { FieldSchema, StructureSchema } from '@ephox/boulder';
 import { Optional, Result } from '@ephox/katamari';
 
 import * as ComponentSchema from '../../core/ComponentSchema';
@@ -16,7 +16,7 @@ interface BaseDialogFooterButtonSpec {
   enabled?: boolean;
   icon?: string;
   buttonType?: 'primary' | 'secondary';
-  allowedModes?: string[];
+  allowedInReadonlyUiMode?: boolean;
 }
 
 export interface DialogFooterNormalButtonSpec extends BaseDialogFooterButtonSpec {
@@ -50,7 +50,7 @@ interface BaseDialogFooterButton {
   enabled: boolean;
   icon: Optional<string>;
   buttonType: Optional<'primary' | 'secondary'>;
-  allowedModes: string[];
+  allowedInReadonlyUiMode: boolean;
 }
 
 export interface DialogFooterNormalButton extends BaseDialogFooterButton {
@@ -84,7 +84,7 @@ const baseFooterButtonFields = [
   ComponentSchema.enabled,
   // this should be defaulted to `secondary` but the implementation needs to manage the deprecation
   FieldSchema.optionStringEnum('buttonType', [ 'primary', 'secondary' ]),
-  FieldSchema.defaultedArrayOf('allowedModes', [ 'design' ], ValueType.string)
+  FieldSchema.defaultedBoolean('allowedInReadonlyUiMode', false)
 ];
 
 export const dialogFooterButtonFields = [

--- a/modules/bridge/src/main/ts/ephox/bridge/components/menu/CommonMenuItem.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/menu/CommonMenuItem.ts
@@ -1,4 +1,4 @@
-import { FieldProcessor, FieldSchema, ValueType } from '@ephox/boulder';
+import { FieldProcessor, FieldSchema } from '@ephox/boulder';
 import { Optional } from '@ephox/katamari';
 
 import * as ComponentSchema from '../../core/ComponentSchema';
@@ -9,7 +9,7 @@ export interface CommonMenuItemSpec {
   value?: string;
   meta?: Record<string, any>;
   shortcut?: string;
-  allowedModes?: string[];
+  allowedInReadonlyUiMode?: boolean;
 }
 
 export interface CommonMenuItemInstanceApi {
@@ -24,7 +24,7 @@ export interface CommonMenuItem {
   role: Optional<string>;
   meta: Record<string, any>;
   shortcut: Optional<string>;
-  allowedModes: string[];
+  allowedInReadonlyUiMode: boolean;
 }
 
 export const commonMenuItemFields: FieldProcessor[] = [
@@ -34,5 +34,5 @@ export const commonMenuItemFields: FieldProcessor[] = [
   ComponentSchema.optionalShortcut,
   ComponentSchema.generatedValue('menuitem'),
   ComponentSchema.defaultedMeta,
-  FieldSchema.defaultedArrayOf('allowedModes', [ 'design' ], ValueType.string)
+  FieldSchema.defaultedBoolean('allowedInReadonlyUiMode', false)
 ];

--- a/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarButton.ts
@@ -1,4 +1,4 @@
-import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
+import { FieldSchema, StructureSchema } from '@ephox/boulder';
 import { Optional, Result } from '@ephox/katamari';
 
 import * as ComponentSchema from '../../core/ComponentSchema';
@@ -9,7 +9,7 @@ export interface BaseToolbarButtonSpec<I extends BaseToolbarButtonInstanceApi> {
   icon?: string;
   text?: string;
   onSetup?: (api: I) => (api: I) => void;
-  allowedModes?: string[];
+  allowedInReadonlyUiMode?: boolean;
 }
 
 export interface BaseToolbarButtonInstanceApi {
@@ -36,7 +36,7 @@ export interface BaseToolbarButton<I extends BaseToolbarButtonInstanceApi> {
   icon: Optional<string>;
   text: Optional<string>;
   onSetup: (api: I) => (api: I) => void;
-  allowedModes: string[];
+  allowedInReadonlyUiMode: boolean;
 }
 
 export interface ToolbarButton extends BaseToolbarButton<ToolbarButtonInstanceApi> {
@@ -51,7 +51,7 @@ export const baseToolbarButtonFields = [
   ComponentSchema.optionalIcon,
   ComponentSchema.optionalText,
   ComponentSchema.onSetup,
-  FieldSchema.defaultedArrayOf('allowedModes', [ 'design' ], ValueType.string)
+  FieldSchema.defaultedBoolean('allowedInReadonlyUiMode', false)
 ];
 
 export const toolbarButtonSchema = StructureSchema.objOf([

--- a/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarSplitButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarSplitButton.ts
@@ -1,4 +1,4 @@
-import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
+import { FieldSchema, StructureSchema } from '@ephox/boulder';
 import { Optional, Result } from '@ephox/katamari';
 
 import { ChoiceMenuItemSpec, SeparatorMenuItemSpec } from '../../api/Menu';
@@ -25,7 +25,7 @@ export interface ToolbarSplitButtonSpec {
   onSetup?: (api: ToolbarSplitButtonInstanceApi) => (api: ToolbarSplitButtonInstanceApi) => void;
   onAction: (api: ToolbarSplitButtonInstanceApi) => void;
   onItemAction: (api: ToolbarSplitButtonInstanceApi, value: string) => void;
-  allowedModes?: string[];
+  allowedInReadonlyUiMode?: boolean;
 }
 
 export interface ToolbarSplitButton {
@@ -40,7 +40,7 @@ export interface ToolbarSplitButton {
   onSetup: (api: ToolbarSplitButtonInstanceApi) => (api: ToolbarSplitButtonInstanceApi) => void;
   onAction: (api: ToolbarSplitButtonInstanceApi) => void;
   onItemAction: (api: ToolbarSplitButtonInstanceApi, value: string) => void;
-  allowedModes: string[];
+  allowedInReadonlyUiMode: boolean;
 }
 
 export interface ToolbarSplitButtonInstanceApi {
@@ -67,7 +67,7 @@ export const splitButtonSchema = StructureSchema.objOf([
   ComponentSchema.defaultedColumns(1),
   ComponentSchema.onAction,
   ComponentSchema.onItemAction,
-  FieldSchema.defaultedArrayOf('allowedModes', [ 'design' ], ValueType.string)
+  FieldSchema.defaultedBoolean('allowedInReadonlyUiMode', false)
 ]);
 
 export const isSplitButtonButton = (spec: any): spec is ToolbarSplitButton => spec.type === 'splitbutton';

--- a/modules/bridge/src/main/ts/ephox/bridge/components/view/ViewButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/view/ViewButton.ts
@@ -19,6 +19,7 @@ interface BaseButtonSpec<Api extends ViewButtonApi> {
   buttonType?: 'primary' | 'secondary';
   borderless?: boolean;
   onAction: (api: Api) => void;
+  allowedInReadonlyUiMode?: boolean;
 }
 
 export interface ViewNormalButtonSpec extends BaseButtonSpec<ViewButtonApi> {
@@ -46,6 +47,7 @@ interface BaseButton<Api extends ViewButtonApi> {
   buttonType: 'primary' | 'secondary';
   borderless: boolean;
   onAction: (api: Api) => void;
+  allowedInReadonlyUiMode: boolean;
 }
 
 export interface ViewNormalButton extends Omit<BaseButton<ViewButtonApi>, 'text'> {
@@ -72,7 +74,8 @@ const baseButtonFields = [
   FieldSchema.optionString('tooltip'),
   FieldSchema.defaultedStringEnum('buttonType', 'secondary', [ 'primary', 'secondary' ]),
   FieldSchema.defaultedBoolean('borderless', false),
-  FieldSchema.requiredFunction('onAction')
+  FieldSchema.requiredFunction('onAction'),
+  FieldSchema.defaultedBoolean('allowedInReadonlyUiMode', false)
 ];
 
 const normalButtonFields = [

--- a/modules/bridge/src/main/ts/ephox/bridge/core/MenuButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/core/MenuButton.ts
@@ -20,7 +20,7 @@ export interface BaseMenuButtonSpec {
   // as an additional argument to fetch.
   fetch: (success: SuccessCallback, fetchContext: MenuButtonFetchContext, api: BaseMenuButtonInstanceApi) => void;
   onSetup?: (api: BaseMenuButtonInstanceApi) => (api: BaseMenuButtonInstanceApi) => void;
-  allowedModes?: string[];
+  allowedInReadonlyUiMode?: boolean;
 }
 
 export interface BaseMenuButton {
@@ -30,7 +30,7 @@ export interface BaseMenuButton {
   search: Optional<{ placeholder: Optional<string> }>;
   fetch: (success: SuccessCallback, fetchContext: MenuButtonFetchContext, api: BaseMenuButtonInstanceApi) => void;
   onSetup: (api: BaseMenuButtonInstanceApi) => (api: BaseMenuButtonInstanceApi) => void;
-  allowedModes: string[];
+  allowedInReadonlyUiMode: boolean;
 }
 
 export interface BaseMenuButtonInstanceApi {
@@ -46,7 +46,7 @@ export const baseMenuButtonFields = [
   FieldSchema.optionString('text'),
   FieldSchema.optionString('tooltip'),
   FieldSchema.optionString('icon'),
-  FieldSchema.defaultedArrayOf('allowedModes', [ 'design' ], ValueType.string),
+  FieldSchema.defaultedBoolean('allowedInReadonlyUiMode', false),
 
   FieldSchema.defaultedOf(
     'search',

--- a/modules/tinymce/src/core/demo/ts/demo/UiSelectionEnabledModeDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/UiSelectionEnabledModeDemo.ts
@@ -30,7 +30,7 @@ export default (): void => {
           ed.on('SwitchMode', toggleActive);
           return () => ed.off('SwitchMode', toggleActive);
         },
-        allowedModes: [ 'design', 'readonly' ]
+        allowedInReadonlyUiMode: true
       };
       ed.ui.registry.addToggleMenuItem(mode, toggleSpec);
       ed.ui.registry.addToggleButton(mode, toggleSpec);

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeMenuToolbarButtonsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeMenuToolbarButtonsTest.ts
@@ -559,7 +559,7 @@ describe('browser.tinymce.core.ReadonlyModeMenuToolbarButtonsTest', () => {
         TinyUiActions.keystroke(editor, Keys.escape());
       });
 
-      it('TINY-10980: Menu item should be enabled since setEnabled(true) in onSetup callback and toolbar spec allowedModes: [ design, readonly ]', async () => {
+      it('TINY-10980: Menu item should be enabled since setEnabled(true) in onSetup callback and toolbar spec allowedInReadonlyUiMode: true', async () => {
         const editor = hook.editor();
         editor.mode.set('design');
         TinyUiActions.clickOnMenu(editor, '.tox-mbtn:contains("test")');
@@ -575,7 +575,7 @@ describe('browser.tinymce.core.ReadonlyModeMenuToolbarButtonsTest', () => {
         TinyUiActions.keystroke(editor, Keys.escape());
       });
 
-      it('TINY-10980: Menu item should be disabled since setEnabled(false) in onSetup callback and toolbar spec allowedModes: [ design, readonly ]', async () => {
+      it('TINY-10980: Menu item should be disabled since setEnabled(false) in onSetup callback and toolbar spec allowedInReadonlyUiMode: true', async () => {
         const editor = hook.editor();
         editor.mode.set('design');
         TinyUiActions.clickOnMenu(editor, '.tox-mbtn:contains("test")');
@@ -595,7 +595,7 @@ describe('browser.tinymce.core.ReadonlyModeMenuToolbarButtonsTest', () => {
 
   Arr.each(setupButtonsScenario, (scenario) => {
     context(scenario.label, () => {
-      context('onSetup callback and toolbar button spec allowedModes: [ readonly ] not present', () => {
+      context('onSetup callback and toolbar button spec allowedInReadonlyUiMode not present', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
           toolbar: 't1',
@@ -638,7 +638,7 @@ describe('browser.tinymce.core.ReadonlyModeMenuToolbarButtonsTest', () => {
         });
       });
 
-      context('onSetup callback with setEnabled(true) and toolbar button allowedModes: [ design, readonly ]', () => {
+      context('onSetup callback with setEnabled(true) and toolbar button allowedInReadonlyUiMode: true', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
           toolbar: 't3',
@@ -660,7 +660,7 @@ describe('browser.tinymce.core.ReadonlyModeMenuToolbarButtonsTest', () => {
         });
       });
 
-      context('onSetup callback with setEnabled(false) and toolbar button allowedModes: [ design, readonly ]', () => {
+      context('onSetup callback with setEnabled(false) and toolbar button allowedInReadonlyUiMode: true', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
           toolbar: 't4',
@@ -683,7 +683,7 @@ describe('browser.tinymce.core.ReadonlyModeMenuToolbarButtonsTest', () => {
         });
       });
 
-      context('onSetup callback not present and toolbar button allowedModes: [ design, readonly ]', () => {
+      context('onSetup callback not present and toolbar button allowedInReadonlyUiMode: true', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
           toolbar: 't5',
@@ -782,7 +782,7 @@ describe('browser.tinymce.core.ReadonlyModeMenuToolbarButtonsTest', () => {
 
     Arr.each(setupButtonsScenario, (scenario) => {
       context(scenario.label, () => {
-        context('onSetup callback and toolbar button spec allowedModes: [ readonly ] not present', () => {
+        context('onSetup callback and toolbar button spec allowedInReadonlyUiMode not present', () => {
           const hook = TinyHooks.bddSetup<Editor>({
             base_url: '/project/tinymce/js/tinymce',
             toolbar: Arr.range(50, Fun.constant('t1')).join(' | '),
@@ -868,7 +868,7 @@ describe('browser.tinymce.core.ReadonlyModeMenuToolbarButtonsTest', () => {
           });
         });
 
-        context('onSetup callback with setEnabled(true) and toolbar button allowedModes: [ design, readonly ]', () => {
+        context('onSetup callback with setEnabled(true) and toolbar button allowedInReadonlyUiMode: true', () => {
           const hook = TinyHooks.bddSetup<Editor>({
             base_url: '/project/tinymce/js/tinymce',
             toolbar: Arr.range(50, Fun.constant('t3')).join(' | '),
@@ -911,7 +911,7 @@ describe('browser.tinymce.core.ReadonlyModeMenuToolbarButtonsTest', () => {
           });
         });
 
-        context('onSetup callback with setEnabled(false) and toolbar button allowedModes: [ design, readonly ]', () => {
+        context('onSetup callback with setEnabled(false) and toolbar button allowedInReadonlyUiMode: true', () => {
           const hook = TinyHooks.bddSetup<Editor>({
             base_url: '/project/tinymce/js/tinymce',
             toolbar: Arr.range(50, Fun.constant('t4')).join(' | '),
@@ -954,7 +954,7 @@ describe('browser.tinymce.core.ReadonlyModeMenuToolbarButtonsTest', () => {
           });
         });
 
-        context('onSetup callback not present and toolbar button allowedModes: [ design, readonly ]', () => {
+        context('onSetup callback not present and toolbar button allowedInReadonlyUiMode: true', () => {
           const hook = TinyHooks.bddSetup<Editor>({
             base_url: '/project/tinymce/js/tinymce',
             toolbar: Arr.range(50, Fun.constant('t5')).join(' | '),
@@ -1214,6 +1214,102 @@ describe('browser.tinymce.core.ReadonlyModeMenuToolbarButtonsTest', () => {
 
       TinyUiActions.clickOnUi(editor, '[data-mce-name="Submit"]');
       store.assertEq('Clicking on submit should call onSubmit', [ 'onSubmit' ]);
+    });
+  });
+
+  context('View Buttons', () => {
+    const hook = TinyHooks.bddSetup<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      toolbar: 't1 t2 t3 t4',
+      setup: (ed: Editor) => {
+        ed.ui.registry.addView('myview1', {
+          buttons: [
+            {
+              type: 'group',
+              buttons: [
+                {
+                  type: 'togglebutton',
+                  icon: 'info',
+                  text: 'Test 1',
+                  allowedInReadonlyUiMode: true,
+                  onAction: Fun.noop
+                },
+                {
+                  type: 'togglebutton',
+                  text: 'iconAndText',
+                  icon: 'copy',
+                  borderless: true,
+                  onAction: Fun.noop
+                }
+              ]
+            },
+            {
+              type: 'togglebutton',
+              icon: 'info',
+              onAction: Fun.noop
+            },
+            {
+              type: 'group',
+              buttons: [
+                {
+                  type: 'button',
+                  text: 'Cancel',
+                  onAction: Fun.noop,
+                  buttonType: 'secondary',
+                  allowedInReadonlyUiMode: true
+                },
+                {
+                  type: 'button',
+                  text: 'Save Code',
+                  onAction: Fun.noop,
+                  buttonType: 'primary'
+                }
+              ]
+            }
+          ],
+          onShow: (api: any) => {
+            api.getContainer().innerHTML = '<button>myview1</button>';
+            api.getContainer().querySelector('button')?.focus();
+          },
+          onHide: Fun.noop
+        });
+      }
+    });
+
+    const assertButtonNativelyEnabled = (selector: string) => UiFinder.exists(SugarBody.body(), `[aria-label="${selector}"]:not([disabled="disabled"])`);
+
+    const assertButtonNativelyDisabled = (selector: string) => UiFinder.exists(SugarBody.body(), `[aria-label="${selector}"][disabled="disabled"]`);
+
+    it('TINY-10980: View buttons should be enabled in uiEnabled mode', () => {
+      const editor = hook.editor();
+      editor.execCommand('ToggleView', false, 'myview1');
+      assertButtonNativelyEnabled('Test 1');
+      assertButtonNativelyEnabled('iconAndText');
+      assertButtonNativelyEnabled('Cancel');
+      assertButtonNativelyEnabled('Save Code');
+
+      editor.mode.set('readonly');
+      assertButtonNativelyDisabled('Test 1');
+      assertButtonNativelyDisabled('iconAndText');
+      assertButtonNativelyDisabled('Cancel');
+      assertButtonNativelyDisabled('Save Code');
+      editor.execCommand('ToggleView', false, 'myview1');
+
+      editor.execCommand('ToggleView', false, 'myview1');
+      assertButtonNativelyDisabled('Test 1');
+      assertButtonNativelyDisabled('iconAndText');
+      assertButtonNativelyDisabled('Cancel');
+      assertButtonNativelyDisabled('Save Code');
+      editor.execCommand('ToggleView', false, 'myview1');
+
+      editor.mode.set('design');
+      editor.execCommand('ToggleView', false, 'myview1');
+      assertButtonNativelyEnabled('Test 1');
+      assertButtonNativelyEnabled('iconAndText');
+      assertButtonNativelyEnabled('Cancel');
+      assertButtonNativelyEnabled('Save Code');
+
+      editor.execCommand('ToggleView', false, 'myview1');
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeMenuToolbarButtonsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeMenuToolbarButtonsTest.ts
@@ -1,5 +1,5 @@
-import { Keys, UiFinder } from '@ephox/agar';
-import { context, describe, it } from '@ephox/bedrock-client';
+import { Keys, TestStore, UiFinder } from '@ephox/agar';
+import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { Attribute, SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
@@ -7,8 +7,9 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { ToolbarMode } from 'tinymce/core/api/OptionTypes';
+import { Dialog } from 'tinymce/core/api/ui/Ui';
 
-describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
+describe('browser.tinymce.core.ReadonlyModeMenuToolbarButtonsTest', () => {
   const assertMenuEnabled = (menu: string) => {
     const menuButton = UiFinder.findIn(SugarBody.body(), `.tox-mbtn:contains("${menu}")`).getOrDie();
     assert.equal(Attribute.get(menuButton, 'disabled'), undefined, 'Should not be disabled');
@@ -19,9 +20,12 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
     assert.equal(Attribute.get(menuButton, 'disabled'), 'disabled', 'Should be disabled');
   };
 
+  // Menu/Button part of split button
+  const assertMenuPartEnabled = (selector: string) => UiFinder.notExists(SugarBody.body(), `[data-mce-name="${selector}"] > span.tox-tbtn.tox-tbtn--select[aria-disabled="true"]`);
+
   const assertButtonEnabled = (selector: string) => UiFinder.notExists(SugarBody.body(), `[data-mce-name="${selector}"][aria-disabled="true"]`);
 
-  const assertButtonDisabled = (selector: string) => UiFinder.notExists(SugarBody.body(), `[data-mce-name="${selector}"]:not([aria-disabled="true"])`);
+  const assertButtonDisabled = (selector: string) => UiFinder.exists(SugarBody.body(), `[data-mce-name="${selector}"][aria-disabled="true"]`);
 
   const assertOverflowButtonDisabled = () => UiFinder.exists(SugarBody.body(), '[data-mce-name="overflow-button"][disabled="disabled"]');
 
@@ -54,7 +58,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         ed.ui.registry.addButton('t3', {
           icon: 'italic',
           text: 'Test Menu Item 3',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
           onSetup: (api) => {
             api.setEnabled(true);
@@ -66,7 +70,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         ed.ui.registry.addButton('t4', {
           icon: 'italic',
           text: 'Test Menu Item 4',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
           onSetup: (api) => {
             api.setEnabled(false);
@@ -78,7 +82,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         ed.ui.registry.addButton('t5', {
           icon: 'italic',
           text: 'Test Menu Item 5',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
         });
       },
@@ -109,7 +113,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         ed.ui.registry.addToggleButton('t3', {
           icon: 'italic',
           text: 'Test Menu Item 3',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
           onSetup: (api) => {
             api.setEnabled(true);
@@ -121,7 +125,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         ed.ui.registry.addToggleButton('t4', {
           icon: 'italic',
           text: 'Test Menu Item 4',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
           onSetup: (api) => {
             api.setEnabled(false);
@@ -133,7 +137,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         ed.ui.registry.addToggleButton('t5', {
           icon: 'italic',
           text: 'Test Menu Item 5',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
         });
       },
@@ -182,7 +186,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         ed.ui.registry.addSplitButton('t3', {
           icon: 'italic',
           text: 'Test Menu Item 3',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
           onItemAction: Fun.noop,
           fetch: (success) => {
@@ -203,7 +207,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         ed.ui.registry.addSplitButton('t4', {
           icon: 'italic',
           text: 'Test Menu Item 4',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
           onSetup: (api) => {
             api.setEnabled(false);
@@ -224,7 +228,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         ed.ui.registry.addSplitButton('t5', {
           icon: 'italic',
           text: 'Test Menu Item 5',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
           onItemAction: Fun.noop,
           fetch: (success) => {
@@ -237,7 +241,10 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
           },
         });
       },
-      assertButtonEnabled,
+      assertButtonEnabled: (selector: string) => {
+        assertMenuPartEnabled(selector);
+        assertButtonEnabled(selector);
+      },
       assertButtonDisabled
     },
     {
@@ -278,7 +285,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         ed.ui.registry.addMenuButton('t3', {
           icon: 'italic',
           text: 'Test Menu Item 3',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           fetch: (success) => {
             success([
               {
@@ -297,7 +304,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         ed.ui.registry.addMenuButton('t4', {
           icon: 'italic',
           text: 'Test Menu Item 4',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onSetup: (api) => {
             api.setEnabled(false);
             return Fun.noop;
@@ -316,7 +323,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         ed.ui.registry.addMenuButton('t5', {
           icon: 'italic',
           text: 'Test Menu Item 5',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           fetch: (success) => {
             success([
               {
@@ -387,7 +394,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
             api.setEnabled(true);
             return Fun.noop;
           },
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           shortcut: 'Meta+M',
           onAction: Fun.noop
         });
@@ -399,7 +406,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
             api.setEnabled(false);
             return Fun.noop;
           },
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           shortcut: 'Meta+M',
           onAction: Fun.noop
         });
@@ -437,7 +444,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
             return Fun.noop;
           },
           shortcut: 'Meta+M',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           getSubmenuItems: Fun.constant('test'),
         });
 
@@ -449,7 +456,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
             return Fun.noop;
           },
           shortcut: 'Meta+M',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           getSubmenuItems: Fun.constant('test'),
         });
       },
@@ -484,7 +491,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
             api.setEnabled(true);
             return Fun.noop;
           },
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           shortcut: 'Meta+M',
           onAction: Fun.noop
         });
@@ -492,7 +499,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         ed.ui.registry.addToggleMenuItem('x4', {
           icon: 'italic',
           text: 'Test Menu Item 4',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onSetup: (api) => {
             api.setEnabled(false);
             return Fun.noop;
@@ -588,7 +595,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
 
   Arr.each(setupButtonsScenario, (scenario) => {
     context(scenario.label, () => {
-      context('onSetup callback and toolbar button spec allowedModes not present', () => {
+      context('onSetup callback and toolbar button spec allowedModes: [ readonly ] not present', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
           toolbar: 't1',
@@ -626,7 +633,6 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
 
           editor.mode.set('readonly');
           scenario.assertButtonDisabled('t2');
-
           editor.mode.set('design');
           scenario.assertButtonEnabled('t2');
         });
@@ -695,7 +701,6 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
           editor.mode.set('readonly');
           scenario.assertButtonDisabled('t5');
 
-          // Switching mode when the overflow toolbar is opened, the onSetup callback is not executed hence all buttons are enabled
           editor.mode.set('design');
           scenario.assertButtonEnabled('t5');
         });
@@ -735,7 +740,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
   context('Floating overflow toolbar button', () => {
     const hook = TinyHooks.bddSetup<Editor>({
       base_url: '/project/tinymce/js/tinymce',
-      toolbar: Arr.range(50, Fun.constant('t1')).join(' | ' ),
+      toolbar: Arr.range(50, Fun.constant('t1')).join(' | '),
       width: 1105,
       statusbar: false,
       setup: (ed: Editor) => {
@@ -777,12 +782,12 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
 
     Arr.each(setupButtonsScenario, (scenario) => {
       context(scenario.label, () => {
-        context('onSetup callback and toolbar button spec allowedModes not present', () => {
+        context('onSetup callback and toolbar button spec allowedModes: [ readonly ] not present', () => {
           const hook = TinyHooks.bddSetup<Editor>({
             base_url: '/project/tinymce/js/tinymce',
-            toolbar: Arr.range(50, Fun.constant('t1')).join(' | ' ),
-            width: 1105,
+            toolbar: Arr.range(50, Fun.constant('t1')).join(' | '),
             statusbar: false,
+            width: 1105,
             toolbar_mode: 'floating',
             setup: (ed: Editor) => {
               scenario.buttonSetupOne(ed);
@@ -823,7 +828,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         context('onSetup callback with setEnabled(true) and toolbar button readonly: false', () => {
           const hook = TinyHooks.bddSetup<Editor>({
             base_url: '/project/tinymce/js/tinymce',
-            toolbar: Arr.range(30, Fun.constant('t2')).join(' | ' ),
+            toolbar: Arr.range(30, Fun.constant('t2')).join(' | '),
             width: 1105,
             toolbar_mode: 'floating',
             statusbar: false,
@@ -866,7 +871,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         context('onSetup callback with setEnabled(true) and toolbar button allowedModes: [ design, readonly ]', () => {
           const hook = TinyHooks.bddSetup<Editor>({
             base_url: '/project/tinymce/js/tinymce',
-            toolbar: Arr.range(50, Fun.constant('t3')).join(' | ' ),
+            toolbar: Arr.range(50, Fun.constant('t3')).join(' | '),
             width: 1105,
             toolbar_mode: 'floating',
             statusbar: false,
@@ -909,7 +914,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         context('onSetup callback with setEnabled(false) and toolbar button allowedModes: [ design, readonly ]', () => {
           const hook = TinyHooks.bddSetup<Editor>({
             base_url: '/project/tinymce/js/tinymce',
-            toolbar: Arr.range(50, Fun.constant('t4')).join(' | ' ),
+            toolbar: Arr.range(50, Fun.constant('t4')).join(' | '),
             width: 1105,
             toolbar_mode: 'floating',
             statusbar: false,
@@ -952,9 +957,9 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         context('onSetup callback not present and toolbar button allowedModes: [ design, readonly ]', () => {
           const hook = TinyHooks.bddSetup<Editor>({
             base_url: '/project/tinymce/js/tinymce',
-            toolbar: Arr.range(50, Fun.constant('t5')).join(' | ' ),
-            width: 1105,
+            toolbar: Arr.range(50, Fun.constant('t5')).join(' | '),
             toolbar_mode: 'floating',
+            width: 1105,
             statusbar: false,
             setup: (ed: Editor) => {
               scenario.buttonSetupFive(ed);
@@ -1004,7 +1009,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
       context(scenario.label, () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
-          toolbar: Arr.range(50, Fun.constant(scenario.selector)).join(' | ' ),
+          toolbar: Arr.range(50, Fun.constant(scenario.selector)).join(' | '),
           width: 1105,
         }, [], true);
 
@@ -1043,7 +1048,7 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
     context('Fontsizeinput', () => {
       const hook = TinyHooks.bddSetup<Editor>({
         base_url: '/project/tinymce/js/tinymce',
-        toolbar: Arr.range(50, Fun.constant('fontsizeinput')).join(' | ' ),
+        toolbar: Arr.range(50, Fun.constant('fontsizeinput')).join(' | '),
         width: 1105,
       }, [], true);
 
@@ -1082,6 +1087,133 @@ describe('browser.tinymce.core.ReadOnlyMenuToolbarButtonsTest', () => {
         assertFontSizeInputEnabled();
         closeOverflowToolbar(editor);
       });
+    });
+  });
+
+  context('Dialog footer buttons', () => {
+    const store = TestStore();
+
+    const hook = TinyHooks.bddSetup<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      toolbar: 't1 t2 t3 t4',
+      setup: (ed: Editor) => {
+        const getDialogSpec = (allowedInReadonlyUiMode: boolean = false): Dialog.DialogSpec<{}> => {
+          return {
+            title: 'Test',
+            body: {
+              type: 'panel',
+              items: [
+                {
+                  type: 'htmlpanel',
+                  html: '<div><p>Test</p></div>'
+                }
+              ]
+            },
+            buttons: [
+              {
+                type: 'cancel',
+                text: 'Cancel',
+                allowedInReadonlyUiMode
+              },
+              {
+                type: 'submit',
+                text: 'Submit',
+                buttonType: 'primary',
+                allowedInReadonlyUiMode
+              }
+            ],
+            onSubmit: (api: Dialog.DialogInstanceApi<{}>) => {
+              store.add('onSubmit');
+              api.close();
+            }
+          };
+        };
+
+        ed.ui.registry.addButton('t1', {
+          icon: 'italic',
+          text: 'Test Menu Item 1',
+          allowedInReadonlyUiMode: true,
+          onAction: () => {
+            ed.windowManager.open(getDialogSpec());
+          }
+        });
+
+        ed.ui.registry.addButton('t2', {
+          icon: 'italic',
+          text: 'Test Menu Item 1',
+          allowedInReadonlyUiMode: true,
+          onAction: () => {
+            ed.windowManager.open(getDialogSpec(true));
+          }
+        });
+
+        ed.ui.registry.addButton('t3', {
+          icon: 'italic',
+          text: 'Test Menu Item 1',
+          allowedInReadonlyUiMode: true,
+          onAction: () => {
+            ed.windowManager.open({
+              title: 'Test',
+              body: {
+                type: 'panel',
+                items: [
+                  {
+                    type: 'htmlpanel',
+                    html: '<div><p>Test</p></div>'
+                  }
+                ]
+              },
+              buttons: [
+                {
+                  type: 'cancel',
+                  text: 'Cancel',
+                },
+                {
+                  type: 'submit',
+                  text: 'Submit',
+                  buttonType: 'primary',
+                }
+              ],
+              onSubmit: (api: Dialog.DialogInstanceApi<{}>) => {
+                store.add('onSubmit');
+                api.close();
+              }
+            });
+          }
+        });
+      }
+    }, [], true);
+
+    beforeEach(() => store.clear());
+
+    it('TINY-10980: Dialog footer buttons should be enabled in uiEnabled mode', async () => {
+      const editor = hook.editor();
+
+      TinyUiActions.clickOnToolbar(editor, '[data-mce-name="t1"]');
+      await TinyUiActions.pWaitForDialog(editor);
+      assertButtonNativelyEnabled('Cancel');
+      assertButtonNativelyEnabled('Submit');
+      TinyUiActions.closeDialog(editor);
+
+      TinyUiActions.clickOnToolbar(editor, '[data-mce-name="t3"]');
+      await TinyUiActions.pWaitForDialog(editor);
+      assertButtonNativelyEnabled('Cancel');
+      assertButtonNativelyEnabled('Submit');
+      TinyUiActions.closeDialog(editor);
+
+      TinyUiActions.clickOnToolbar(editor, '[data-mce-name="t2"]');
+      await TinyUiActions.pWaitForDialog(editor);
+      assertButtonNativelyEnabled('Cancel');
+      assertButtonNativelyEnabled('Submit');
+      TinyUiActions.closeDialog(editor);
+
+      TinyUiActions.clickOnToolbar(editor, '[data-mce-name="t2"]');
+      await TinyUiActions.pWaitForDialog(editor);
+      assertButtonNativelyEnabled('Cancel');
+      assertButtonNativelyEnabled('Submit');
+
+      TinyUiActions.clickOnUi(editor, '[data-mce-name="Submit"]');
+      store.assertEq('Clicking on submit should call onSubmit', [ 'onSubmit' ]);
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/UiEnabledModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UiEnabledModeTest.ts
@@ -601,7 +601,7 @@ describe('browser.tinymce.core.UiEnabledModeTest', () => {
         TinyUiActions.keystroke(editor, Keys.escape());
       });
 
-      it('TINY-10980: Menu item should be enabled since setEnabled(true) in onSetup callback and toolbar spec allowedModes: [ design, readonly ]', async () => {
+      it('TINY-10980: Menu item should be enabled since setEnabled(true) in onSetup callback and toolbar spec allowedInReadonlyUiMode: true', async () => {
         const editor = hook.editor();
         editor.mode.set('design');
         TinyUiActions.clickOnMenu(editor, '.tox-mbtn:contains("test")');
@@ -627,7 +627,7 @@ describe('browser.tinymce.core.UiEnabledModeTest', () => {
         TinyUiActions.keystroke(editor, Keys.escape());
       });
 
-      it('TINY-10980: Menu item should be disabled since setEnabled(false) in onSetup callback and toolbar spec allowedModes: [ design, readonly ]', async () => {
+      it('TINY-10980: Menu item should be disabled since setEnabled(false) in onSetup callback and toolbar spec allowedInReadonlyUiMode: true', async () => {
         const editor = hook.editor();
         editor.mode.set('design');
         TinyUiActions.clickOnMenu(editor, '.tox-mbtn:contains("test")');
@@ -657,7 +657,7 @@ describe('browser.tinymce.core.UiEnabledModeTest', () => {
 
   Arr.each(setupButtonsScenario, (scenario) => {
     context(scenario.label, () => {
-      context('onSetup callback and toolbar button spec allowedModes: [ readonly ] not present', () => {
+      context('onSetup callback and toolbar button spec allowedInReadonlyUiMode not present', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
           toolbar: 't1',
@@ -687,7 +687,7 @@ describe('browser.tinymce.core.UiEnabledModeTest', () => {
         });
       });
 
-      context('onSetup callback and toolbar button spec allowedModes: [ readonly ] not present, switch to mode onSetup', () => {
+      context('onSetup callback and toolbar button spec allowedInReadonlyUiMode not present, switch to mode onSetup', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
           toolbar: 't1',
@@ -759,7 +759,7 @@ describe('browser.tinymce.core.UiEnabledModeTest', () => {
         });
       });
 
-      context('onSetup callback with setEnabled(true) and toolbar button allowedModes: [ design, readonly ]', () => {
+      context('onSetup callback with setEnabled(true) and toolbar button allowedInReadonlyUiMode: true', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
           toolbar: 't3',
@@ -789,7 +789,7 @@ describe('browser.tinymce.core.UiEnabledModeTest', () => {
         });
       });
 
-      context('onSetup callback with setEnabled(true) and toolbar button allowedModes: [ design, readonly ], switch to mode onSetup ', () => {
+      context('onSetup callback with setEnabled(true) and toolbar button allowedInReadonlyUiMode: true, switch to mode onSetup ', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
           toolbar: 't3',
@@ -809,7 +809,7 @@ describe('browser.tinymce.core.UiEnabledModeTest', () => {
         });
       });
 
-      context('onSetup callback with setEnabled(false) and toolbar button allowedModes: [ design, readonly ]', () => {
+      context('onSetup callback with setEnabled(false) and toolbar button allowedInReadonlyUiMode: true', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
           toolbar: 't4',
@@ -840,7 +840,7 @@ describe('browser.tinymce.core.UiEnabledModeTest', () => {
         });
       });
 
-      context('onSetup callback with setEnabled(false) and toolbar button allowedModes: [ design, readonly ], switch to mode onSetup', () => {
+      context('onSetup callback with setEnabled(false) and toolbar button allowedInReadonlyUiMode: true, switch to mode onSetup', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
           toolbar: 't4',
@@ -861,7 +861,7 @@ describe('browser.tinymce.core.UiEnabledModeTest', () => {
         });
       });
 
-      context('onSetup callback not present and toolbar button allowedModes: [ design, readonly ]', () => {
+      context('onSetup callback not present and toolbar button allowedInReadonlyUiMode: true', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
           toolbar: 't5',
@@ -893,7 +893,7 @@ describe('browser.tinymce.core.UiEnabledModeTest', () => {
         });
       });
 
-      context('onSetup callback not present and toolbar button allowedModes: [ design, readonly ], switch to mode onSetup', () => {
+      context('onSetup callback not present and toolbar button allowedInReadonlyUiMode: true, switch to mode onSetup', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
           toolbar: 't5',
@@ -1007,7 +1007,7 @@ describe('browser.tinymce.core.UiEnabledModeTest', () => {
 
     Arr.each(setupButtonsScenario, (scenario) => {
       context(scenario.label, () => {
-        context('onSetup callback and toolbar button spec allowedModes: [ readonly ] not present', () => {
+        context('onSetup callback and toolbar button spec allowedInReadonlyUiMode not present', () => {
           const hook = TinyHooks.bddSetup<Editor>({
             base_url: '/project/tinymce/js/tinymce',
             toolbar: Arr.range(50, Fun.constant('t1')).join(' | '),
@@ -1129,7 +1129,7 @@ describe('browser.tinymce.core.UiEnabledModeTest', () => {
           });
         });
 
-        context('onSetup callback with setEnabled(true) and toolbar button allowedModes: [ design, readonly ]', () => {
+        context('onSetup callback with setEnabled(true) and toolbar button allowedInReadonlyUiMode: true', () => {
           const hook = TinyHooks.bddSetup<Editor>({
             base_url: '/project/tinymce/js/tinymce',
             toolbar: Arr.range(50, Fun.constant('t3')).join(' | '),
@@ -1190,7 +1190,7 @@ describe('browser.tinymce.core.UiEnabledModeTest', () => {
           });
         });
 
-        context('onSetup callback with setEnabled(false) and toolbar button allowedModes: [ design, readonly ]', () => {
+        context('onSetup callback with setEnabled(false) and toolbar button allowedInReadonlyUiMode: true', () => {
           const hook = TinyHooks.bddSetup<Editor>({
             base_url: '/project/tinymce/js/tinymce',
             toolbar: Arr.range(50, Fun.constant('t4')).join(' | '),
@@ -1251,7 +1251,7 @@ describe('browser.tinymce.core.UiEnabledModeTest', () => {
           });
         });
 
-        context('onSetup callback not present and toolbar button allowedModes: [ design, readonly ]', () => {
+        context('onSetup callback not present and toolbar button allowedInReadonlyUiMode: true', () => {
           const hook = TinyHooks.bddSetup<Editor>({
             base_url: '/project/tinymce/js/tinymce',
             toolbar: Arr.range(50, Fun.constant('t5')).join(' | '),
@@ -1593,6 +1593,110 @@ describe('browser.tinymce.core.UiEnabledModeTest', () => {
       store.assertEq('Clicking on submit should call onSubmit', [ 'onSubmit' ]);
 
       editor.mode.set('design');
+    });
+  });
+
+  context('View Buttons', () => {
+    const hook = TinyHooks.bddSetup<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      toolbar: 't1 t2 t3 t4',
+      setup: (ed: Editor) => {
+        registerMode(ed);
+        ed.ui.registry.addView('myview1', {
+          buttons: [
+            {
+              type: 'group',
+              buttons: [
+                {
+                  type: 'togglebutton',
+                  icon: 'info',
+                  text: 'Test 1',
+                  allowedInReadonlyUiMode: true,
+                  onAction: Fun.noop
+                },
+                {
+                  type: 'togglebutton',
+                  text: 'iconAndText',
+                  icon: 'copy',
+                  borderless: true,
+                  onAction: Fun.noop
+                }
+              ]
+            },
+            {
+              type: 'togglebutton',
+              icon: 'info',
+              onAction: Fun.noop
+            },
+            {
+              type: 'group',
+              buttons: [
+                {
+                  type: 'button',
+                  text: 'Cancel',
+                  onAction: Fun.noop,
+                  buttonType: 'secondary',
+                  allowedInReadonlyUiMode: true
+                },
+                {
+                  type: 'button',
+                  text: 'Save Code',
+                  onAction: Fun.noop,
+                  buttonType: 'primary'
+                }
+              ]
+            }
+          ],
+          onShow: (api: any) => {
+            api.getContainer().innerHTML = '<button>myview1</button>';
+            api.getContainer().querySelector('button')?.focus();
+          },
+          onHide: Fun.noop
+        });
+      }
+    });
+
+    const assertButtonNativelyEnabled = (selector: string) => UiFinder.exists(SugarBody.body(), `[aria-label="${selector}"]:not([disabled="disabled"])`);
+
+    const assertButtonNativelyDisabled = (selector: string) => UiFinder.exists(SugarBody.body(), `[aria-label="${selector}"][disabled="disabled"]`);
+
+    it('TINY-10980: View buttons should be enabled in uiEnabled mode', () => {
+      const editor = hook.editor();
+      editor.execCommand('ToggleView', false, 'myview1');
+      assertButtonNativelyEnabled('Test 1');
+      assertButtonNativelyEnabled('iconAndText');
+      assertButtonNativelyEnabled('Cancel');
+      assertButtonNativelyEnabled('Save Code');
+
+      editor.mode.set('testmode');
+      assertButtonNativelyEnabled('Test 1');
+      assertButtonNativelyDisabled('iconAndText');
+      assertButtonNativelyEnabled('Cancel');
+      assertButtonNativelyDisabled('Save Code');
+
+      editor.mode.set('readonly');
+      assertButtonNativelyDisabled('Test 1');
+      assertButtonNativelyDisabled('iconAndText');
+      assertButtonNativelyDisabled('Cancel');
+      assertButtonNativelyDisabled('Save Code');
+      editor.mode.set('testmode');
+      editor.execCommand('ToggleView', false, 'myview1');
+
+      editor.execCommand('ToggleView', false, 'myview1');
+      assertButtonNativelyEnabled('Test 1');
+      assertButtonNativelyDisabled('iconAndText');
+      assertButtonNativelyEnabled('Cancel');
+      assertButtonNativelyDisabled('Save Code');
+      editor.execCommand('ToggleView', false, 'myview1');
+
+      editor.mode.set('design');
+      editor.execCommand('ToggleView', false, 'myview1');
+      assertButtonNativelyEnabled('Test 1');
+      assertButtonNativelyEnabled('iconAndText');
+      assertButtonNativelyEnabled('Cancel');
+      assertButtonNativelyEnabled('Save Code');
+
+      editor.execCommand('ToggleView', false, 'myview1');
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/UiEnabledModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/UiEnabledModeTest.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 import { ToolbarMode } from 'tinymce/core/api/OptionTypes';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
 
-describe('browser.tinymce.core.UiEnabledModesTest', () => {
+describe('browser.tinymce.core.UiEnabledModeTest', () => {
   const registerMode = (ed: Editor) => {
     ed.mode.register('testmode', {
       activate: Fun.noop,
@@ -69,7 +69,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
         ed.ui.registry.addButton('t3', {
           icon: 'italic',
           text: 'Test Menu Item 3',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
           onSetup: (api) => {
             api.setEnabled(true);
@@ -81,7 +81,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
         ed.ui.registry.addButton('t4', {
           icon: 'italic',
           text: 'Test Menu Item 4',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
           onSetup: (api) => {
             api.setEnabled(false);
@@ -93,7 +93,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
         ed.ui.registry.addButton('t5', {
           icon: 'italic',
           text: 'Test Menu Item 5',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
         });
       },
@@ -124,7 +124,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
         ed.ui.registry.addToggleButton('t3', {
           icon: 'italic',
           text: 'Test Menu Item 3',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
           onSetup: (api) => {
             api.setEnabled(true);
@@ -136,7 +136,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
         ed.ui.registry.addToggleButton('t4', {
           icon: 'italic',
           text: 'Test Menu Item 4',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
           onSetup: (api) => {
             api.setEnabled(false);
@@ -148,7 +148,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
         ed.ui.registry.addToggleButton('t5', {
           icon: 'italic',
           text: 'Test Menu Item 5',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
         });
       },
@@ -197,7 +197,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
         ed.ui.registry.addSplitButton('t3', {
           icon: 'italic',
           text: 'Test Menu Item 3',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
           onItemAction: Fun.noop,
           fetch: (success) => {
@@ -218,7 +218,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
         ed.ui.registry.addSplitButton('t4', {
           icon: 'italic',
           text: 'Test Menu Item 4',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
           onSetup: (api) => {
             api.setEnabled(false);
@@ -239,7 +239,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
         ed.ui.registry.addSplitButton('t5', {
           icon: 'italic',
           text: 'Test Menu Item 5',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: Fun.noop,
           onItemAction: Fun.noop,
           fetch: (success) => {
@@ -296,7 +296,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
         ed.ui.registry.addMenuButton('t3', {
           icon: 'italic',
           text: 'Test Menu Item 3',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           fetch: (success) => {
             success([
               {
@@ -315,7 +315,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
         ed.ui.registry.addMenuButton('t4', {
           icon: 'italic',
           text: 'Test Menu Item 4',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onSetup: (api) => {
             api.setEnabled(false);
             return Fun.noop;
@@ -334,7 +334,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
         ed.ui.registry.addMenuButton('t5', {
           icon: 'italic',
           text: 'Test Menu Item 5',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           fetch: (success) => {
             success([
               {
@@ -414,7 +414,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
             api.setEnabled(true);
             return Fun.noop;
           },
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           shortcut: 'Meta+M',
           onAction: Fun.noop
         });
@@ -426,7 +426,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
             api.setEnabled(false);
             return Fun.noop;
           },
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           shortcut: 'Meta+M',
           onAction: Fun.noop
         });
@@ -464,7 +464,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
             return Fun.noop;
           },
           shortcut: 'Meta+M',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           getSubmenuItems: Fun.constant('test'),
         });
 
@@ -476,7 +476,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
             return Fun.noop;
           },
           shortcut: 'Meta+M',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           getSubmenuItems: Fun.constant('test'),
         });
       },
@@ -511,7 +511,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
             api.setEnabled(true);
             return Fun.noop;
           },
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           shortcut: 'Meta+M',
           onAction: Fun.noop
         });
@@ -519,7 +519,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
         ed.ui.registry.addToggleMenuItem('x4', {
           icon: 'italic',
           text: 'Test Menu Item 4',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onSetup: (api) => {
             api.setEnabled(false);
             return Fun.noop;
@@ -1457,7 +1457,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
       setup: (ed: Editor) => {
         registerMode(ed);
 
-        const getDialogSpec = (allowedModes: string[] = [ 'design' ]): Dialog.DialogSpec<{}> => {
+        const getDialogSpec = (allowedInReadonlyUiMode: boolean = false): Dialog.DialogSpec<{}> => {
           return {
             title: 'Test',
             body: {
@@ -1473,13 +1473,13 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
               {
                 type: 'cancel',
                 text: 'Cancel',
-                allowedModes
+                allowedInReadonlyUiMode
               },
               {
                 type: 'submit',
                 text: 'Submit',
                 buttonType: 'primary',
-                allowedModes
+                allowedInReadonlyUiMode
               }
             ],
             onSubmit: (api: Dialog.DialogInstanceApi<{}>) => {
@@ -1492,7 +1492,7 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
         ed.ui.registry.addButton('t1', {
           icon: 'italic',
           text: 'Test Menu Item 1',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: () => {
             ed.windowManager.open(getDialogSpec());
           }
@@ -1501,9 +1501,44 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
         ed.ui.registry.addButton('t2', {
           icon: 'italic',
           text: 'Test Menu Item 1',
-          allowedModes: [ 'design', 'readonly' ],
+          allowedInReadonlyUiMode: true,
           onAction: () => {
-            ed.windowManager.open(getDialogSpec([ 'design', 'readonly' ]));
+            ed.windowManager.open(getDialogSpec(true));
+          }
+        });
+
+        ed.ui.registry.addButton('t3', {
+          icon: 'italic',
+          text: 'Test Menu Item 1',
+          allowedInReadonlyUiMode: true,
+          onAction: () => {
+            ed.windowManager.open({
+              title: 'Test',
+              body: {
+                type: 'panel',
+                items: [
+                  {
+                    type: 'htmlpanel',
+                    html: '<div><p>Test</p></div>'
+                  }
+                ]
+              },
+              buttons: [
+                {
+                  type: 'cancel',
+                  text: 'Cancel',
+                },
+                {
+                  type: 'submit',
+                  text: 'Submit',
+                  buttonType: 'primary',
+                }
+              ],
+              onSubmit: (api: Dialog.DialogInstanceApi<{}>) => {
+                store.add('onSubmit');
+                api.close();
+              }
+            });
           }
         });
       }
@@ -1522,6 +1557,20 @@ describe('browser.tinymce.core.UiEnabledModesTest', () => {
 
       editor.mode.set('testmode');
       TinyUiActions.clickOnToolbar(editor, '[data-mce-name="t1"]');
+      await TinyUiActions.pWaitForDialog(editor);
+      assertButtonNativelyDisabled('Cancel');
+      assertButtonNativelyDisabled('Submit');
+      TinyUiActions.closeDialog(editor);
+
+      editor.mode.set('design');
+      TinyUiActions.clickOnToolbar(editor, '[data-mce-name="t3"]');
+      await TinyUiActions.pWaitForDialog(editor);
+      assertButtonNativelyEnabled('Cancel');
+      assertButtonNativelyEnabled('Submit');
+      TinyUiActions.closeDialog(editor);
+
+      editor.mode.set('testmode');
+      TinyUiActions.clickOnToolbar(editor, '[data-mce-name="t3"]');
       await TinyUiActions.pWaitForDialog(editor);
       assertButtonNativelyDisabled('Cancel');
       assertButtonNativelyDisabled('Submit');

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -1,6 +1,6 @@
 import { AlloyComponent, AlloySpec } from '@ephox/alloy';
 import { Dialog, Menu } from '@ephox/bridge';
-import { Arr, Cell, Optional, Result } from '@ephox/katamari';
+import { Cell, Optional, Result } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 import I18n, { TranslatedString, Untranslated } from 'tinymce/core/api/util/I18n';
@@ -21,7 +21,7 @@ export interface UiFactoryBackstageProviders {
   readonly menuItems: () => Record<string, Menu.MenuItemSpec | Menu.NestedMenuItemSpec | Menu.ToggleMenuItemSpec>;
   readonly translate: (text: Untranslated) => TranslatedString;
   readonly isDisabled: () => boolean;
-  readonly isButtonAllowedInCurrentMode: (buttonsAllowedModes?: string[]) => boolean;
+  readonly isButtonAllowedInCurrentMode: (allowedInReadonlyUiMode?: boolean) => boolean;
   readonly getOption: Editor['options']['get'];
   readonly tooltips: TooltipsProvider;
 }
@@ -58,11 +58,11 @@ const init = (lazySinks: { popup: () => Result<AlloyComponent, string>; dialog: 
     menuItems: () => editor.ui.registry.getAll().menuItems,
     translate: I18n.translate,
     isDisabled: () => editor.mode.isReadOnly() || !editor.ui.isEnabled(),
-    isButtonAllowedInCurrentMode: (buttonsAllowedModes: string[] = []) => {
+    isButtonAllowedInCurrentMode: (allowedInReadonlyUiMode: boolean = false) => {
       if (!editor.mode.isReadOnly()) {
-        return Arr.contains(buttonsAllowedModes, 'design') && editor.ui.isEnabled();
+        return editor.ui.isEnabled();
       } else if (editor.mode.isUiEnabled()) {
-        return Arr.contains(buttonsAllowedModes, 'readonly');
+        return allowedInReadonlyUiMode;
       }
       return false;
     },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/alien/DisablingConfigs.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/alien/DisablingConfigs.ts
@@ -1,25 +1,41 @@
-import { Disabling } from '@ephox/alloy';
+import { AlloyComponent, Disabling } from '@ephox/alloy';
 
 type DisablingBehaviour = ReturnType<typeof Disabling['config']>;
 
-const item = (disabled: () => boolean): DisablingBehaviour => Disabling.config({
-  disabled,
+const item = (config: {
+  disabled: () => boolean;
+  onEnabled?: (comp: AlloyComponent) => void;
+  onDisabled?: (comp: AlloyComponent) => void;
+}): DisablingBehaviour => Disabling.config({
+  ...config,
   disableClass: 'tox-collection__item--state-disabled'
 });
 
-const button = (disabled: () => boolean): DisablingBehaviour => Disabling.config({
-  disabled
+const button = (config: {
+  disabled: () => boolean;
+  onEnabled?: (comp: AlloyComponent) => void;
+  onDisabled?: (comp: AlloyComponent) => void;
+}): DisablingBehaviour => Disabling.config({
+  ...config
 });
 
-const splitButton = (disabled: () => boolean): DisablingBehaviour => Disabling.config({
-  disabled,
-  disableClass: 'tox-tbtn--disabled'
-});
-
-const toolbarButton = (disabled: () => boolean): DisablingBehaviour => Disabling.config({
-  disabled,
+const splitButton = (config: {
+  disabled: () => boolean;
+  onEnabled?: (comp: AlloyComponent) => void;
+  onDisabled?: (comp: AlloyComponent) => void;
+}): DisablingBehaviour => Disabling.config({
   disableClass: 'tox-tbtn--disabled',
-  useNative: false
+  ...config
+});
+
+const toolbarButton = (config: {
+  disabled: () => boolean;
+  onEnabled?: (comp: AlloyComponent) => void;
+  onDisabled?: (comp: AlloyComponent) => void;
+}): DisablingBehaviour => Disabling.config({
+  disableClass: 'tox-tbtn--disabled',
+  useNative: false,
+  ...config
 });
 
 export const DisablingConfigs = {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/button/MenuButton.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/button/MenuButton.ts
@@ -105,14 +105,14 @@ const renderMenuButton = (spec: MenuButtonSpec, prefix: string, backstage: UiFac
           }
         },
         onEnabled: (component) => {
-          if (prefix === ToolbarButtonClasses.Button && (Disabling.getLastDisabledState(component) === true || !backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode))) {
-            Disabling.set(component, true);
-          }
+          Disabling.getLastDisabledState(component)
+            .filter((disabled) => prefix === ToolbarButtonClasses.Button && (disabled || !backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)))
+            .each(() => Disabling.set(component, true));
         },
-        onDisabled: (comp) => {
-          if (prefix === ToolbarButtonClasses.Button && Disabling.getLastDisabledState(comp) === false && backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
-            Disabling.set(comp, false);
-          }
+        onDisabled: (component) => {
+          Disabling.getLastDisabledState(component)
+            .filter((disabled) => prefix === ToolbarButtonClasses.Button && !disabled && backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode))
+            .each(() => Disabling.set(component, false));
         }
       }),
       ReadOnly.receivingConfigConditional((comp) => {
@@ -120,7 +120,7 @@ const renderMenuButton = (spec: MenuButtonSpec, prefix: string, backstage: UiFac
           case MenuButtonClasses.Button:
             return !backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
           case ToolbarButtonClasses.Button:
-            return Disabling.getLastDisabledState(comp) === true || !backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
+            return Disabling.getLastDisabledState(comp).getOr(false) || !backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
           default:
             return true;
         }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/button/MenuButton.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/button/MenuButton.ts
@@ -24,12 +24,10 @@ interface StoredMenuButton extends Omit<Dialog.DialogFooterMenuButton, 'items'> 
   readonly items: StoredMenuItem[];
 }
 
-const getMenuButtonApi = (spec: MenuButtonSpec, backstage: UiFactoryBackstage) => (component: AlloyComponent): Toolbar.ToolbarMenuButtonInstanceApi => ({
+const getMenuButtonApi = (component: AlloyComponent): Toolbar.ToolbarMenuButtonInstanceApi => ({
   isEnabled: () => !Disabling.isDisabled(component),
   setEnabled: (state: boolean) => {
-    if (backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedModes)) {
-      Disabling.set(component, !state, true);
-    }
+    Disabling.setAndStoreState(component, !state);
   },
   setActive: (state: boolean) => {
     // Note: We can't use the toggling behaviour here, as the dropdown for the menu also relies on it.
@@ -84,18 +82,18 @@ const renderMenuButton = (spec: MenuButtonSpec, prefix: string, backstage: UiFac
           );
         },
         fetchContext,
-        getMenuButtonApi(spec, backstage)(dropdownComp)
+        getMenuButtonApi(dropdownComp)
       );
     },
     onSetup: spec.onSetup,
-    getApi: getMenuButtonApi(spec, backstage),
+    getApi: getMenuButtonApi,
     columns: 1,
     presets: 'normal',
     classes: [],
     dropdownBehaviours: [
       ...(tabstopping ? [ Tabstopping.config({ }) ] : [])
     ],
-    allowedModes: spec.allowedModes
+    allowedInReadonlyUiMode: spec.allowedInReadonlyUiMode
   },
   prefix,
   backstage.shared,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -234,8 +234,7 @@ const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec:
             }
           }),
         })
-      ],
-      allowedModes: [ 'design' ]
+      ]
     },
     ToolbarButtonClasses.Button,
     backstage.shared,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -7,6 +7,8 @@ import { Menu } from 'tinymce/core/api/ui/Ui';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 
+import * as ReadOnly from '../../../ReadOnly';
+import { DisablingConfigs } from '../../alien/DisablingConfigs';
 import { renderCommonDropdown } from '../../dropdown/CommonDropdown';
 import ItemResponse from '../../menus/item/ItemResponse';
 import * as NestedMenus from '../../menus/menu/NestedMenus';
@@ -221,6 +223,8 @@ const createSelectButton = (editor: Editor, backstage: UiFactoryBackstage, spec:
       presets: 'normal',
       classes: spec.icon.isSome() ? [] : [ 'bespoke' ],
       dropdownBehaviours: [
+        DisablingConfigs.button({ disabled: () => backstage.shared.providers.isDisabled() }),
+        ReadOnly.receivingConfig(),
         Tooltipping.config({
           ...backstage.shared.providers.tooltips.getConfig({
             tooltipText: backstage.shared.providers.translate(spec.tooltip),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/AlertDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/AlertDialog.ts
@@ -29,7 +29,7 @@ export const setup = (backstage: UiFactoryBackstage): AlertDialogApi => {
         align: 'end',
         enabled: true,
         icon: Optional.none(),
-        allowedModes: [ 'design', 'readonly' ]
+        allowedInReadonlyUiMode: true,
       }, 'cancel', backstage)
     );
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ConfirmDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ConfirmDialog.ts
@@ -29,7 +29,7 @@ export const setup = (backstage: UiFactoryBackstage): ConfirmDialogApi => {
         align: 'end',
         enabled: true,
         icon: Optional.none(),
-        allowedModes: [ 'design', 'readonly' ]
+        allowedInReadonlyUiMode: true,
       }, 'submit', backstage)
     );
 
@@ -41,7 +41,7 @@ export const setup = (backstage: UiFactoryBackstage): ConfirmDialogApi => {
       align: 'end',
       enabled: true,
       icon: Optional.none(),
-      allowedModes: [ 'design', 'readonly' ]
+      allowedInReadonlyUiMode: true,
     }, 'cancel', backstage);
 
     const titleSpec = Dialogs.pUntitled();

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
@@ -136,7 +136,7 @@ export const renderDropZone = (spec: DropZoneSpec, providersBackstage: UiFactory
             },
             buttonBehaviours: Behaviour.derive([
               Tabstopping.config({ }),
-              DisablingConfigs.button(providersBackstage.isDisabled),
+              DisablingConfigs.button({ disabled: providersBackstage.isDisabled }),
               ReadOnly.receivingConfig()
             ])
           })

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ListBox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ListBox.ts
@@ -7,6 +7,8 @@ import { Arr, Fun, Obj, Optional, Optionals } from '@ephox/katamari';
 import { Attribute } from '@ephox/sugar';
 
 import { UiFactoryBackstage } from '../../backstage/Backstage';
+import * as ReadOnly from '../../ReadOnly';
+import { DisablingConfigs } from '../alien/DisablingConfigs';
 import { renderLabel } from '../alien/FieldLabeller';
 import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import { renderCommonDropdown, updateMenuText } from '../dropdown/CommonDropdown';
@@ -93,6 +95,8 @@ export const renderListBox = (spec: ListBoxSpec, backstage: UiFactoryBackstage, 
         presets: 'normal',
         classes: [],
         dropdownBehaviours: [
+          DisablingConfigs.button({ disabled: () => backstage.shared.providers.isDisabled() }),
+          ReadOnly.receivingConfig(),
           Tabstopping.config({}),
           RepresentingConfigs.withComp(
             initialItem.map((item) => item.value),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ListBox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ListBox.ts
@@ -107,7 +107,6 @@ export const renderListBox = (spec: ListBoxSpec, backstage: UiFactoryBackstage, 
             }
           )
         ],
-        allowedModes: [ 'design' ]
       },
       'tox-listbox',
       backstage.shared)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
@@ -1,5 +1,5 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, CustomEvent, Disabling, Dropdown as AlloyDropdown, Focusing, GuiFactory, Highlighting,
+  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, CustomEvent, Dropdown as AlloyDropdown, Focusing, GuiFactory, Highlighting,
   Keying, MaxHeight, Memento, NativeEvents, Replacing, Representing, SimulatedEvent, SketchSpec, SystemEvents, TieredData, Tooltipping, Unselecting
 } from '@ephox/alloy';
 import { Toolbar } from '@ephox/bridge';
@@ -9,8 +9,6 @@ import { EventArgs, SugarElement } from '@ephox/sugar';
 import { toolbarButtonEventOrder } from 'tinymce/themes/silver/ui/toolbar/button/ButtonEvents';
 
 import { UiFactoryBackstageShared } from '../../backstage/Backstage';
-import * as ReadOnly from '../../ReadOnly';
-import { DisablingConfigs } from '../alien/DisablingConfigs';
 import * as UiUtils from '../alien/UiUtils';
 import { renderLabel, renderReplaceableIconFromPack } from '../button/ButtonSlices';
 import { onControlAttached, onControlDetached, OnDestroy } from '../controls/Controls';
@@ -19,7 +17,6 @@ import { componentRenderPipeline } from '../menus/item/build/CommonMenuItem';
 import * as MenuParts from '../menus/menu/MenuParts';
 import { focusSearchField, handleRedirectToMenuItem, handleRefetchTrigger, updateAriaOnDehighlight, updateAriaOnHighlight } from '../menus/menu/searchable/SearchableMenu';
 import { RedirectMenuItemInteractionEvent, redirectMenuItemInteractionEvent, RefetchTriggerEvent, refetchTriggerEvent } from '../menus/menu/searchable/SearchableMenuEvents';
-import { ToolbarButtonClasses, MenuButtonClasses } from '../toolbar/button/ButtonClasses';
 
 export const updateMenuText = Id.generate('update-menu-text');
 export const updateMenuIcon = Id.generate('update-menu-icon');
@@ -160,30 +157,6 @@ const renderCommonDropdown = <T>(
 
       dropdownBehaviours: Behaviour.derive([
         ...spec.dropdownBehaviours,
-        DisablingConfigs.button({
-          disabled: () => {
-            if (prefix === MenuButtonClasses.Button) {
-              return !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
-            }
-            return spec.disabled || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
-          },
-          onEnabled: (component) => {
-            if (prefix === ToolbarButtonClasses.Button && (Disabling.getLastDisabledState(component) || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode))) {
-              Disabling.set(component, true);
-            }
-          },
-          onDisabled: (comp) => {
-            if (prefix === ToolbarButtonClasses.Button && !Disabling.getLastDisabledState(comp) && sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
-              Disabling.set(comp, false);
-            }
-          }
-        }),
-        ReadOnly.receivingConfigConditional((comp) => {
-          if (prefix === MenuButtonClasses.Button) {
-            return !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
-          }
-          return Disabling.getLastDisabledState(comp) || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
-        }),
         // INVESTIGATE (TINY-9012): There was a old comment here about something not quite working, and that
         // we can still get the button focused. It was probably related to Unselecting.
         Unselecting.config({}),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -293,14 +293,14 @@ export const renderFooterButton = (spec: FooterButtonSpec, buttonType: string, b
         DisablingConfigs.button({
           disabled: () => !spec.enabled || !backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode),
           onEnabled: (component) => {
-            if (Disabling.getLastDisabledState(component) === true || !backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
-              Disabling.set(component, true);
-            }
+            Disabling.getLastDisabledState(component)
+              .filter((disabled) => disabled || !backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode))
+              .each(() => Disabling.set(component, true));
           },
           onDisabled: (component) => {
-            if (Disabling.getLastDisabledState(component) === false && backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
-              Disabling.set(component, false);
-            }
+            Disabling.getLastDisabledState(component)
+              .filter((disabled) => !disabled && backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode))
+              .each(() => Disabling.set(component, false));
           }
         }),
         ReadOnly.receivingConfigConditional(() => !backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -293,12 +293,12 @@ export const renderFooterButton = (spec: FooterButtonSpec, buttonType: string, b
         DisablingConfigs.button({
           disabled: () => !spec.enabled || !backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode),
           onEnabled: (component) => {
-            if (Disabling.getLastDisabledState(component) || !backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
+            if (Disabling.getLastDisabledState(component) === true || !backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
               Disabling.set(component, true);
             }
           },
           onDisabled: (component) => {
-            if (!Disabling.getLastDisabledState(component) && backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
+            if (Disabling.getLastDisabledState(component) === false && backstage.shared.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
               Disabling.set(component, false);
             }
           }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/PanelButton.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/PanelButton.ts
@@ -31,7 +31,7 @@ export const renderPanelButton = (spec: SwatchPanelButtonSpec, sharedBackstage: 
   toggleClass: 'mce-active',
 
   dropdownBehaviours: Behaviour.derive([
-    DisablingConfigs.button(sharedBackstage.providers.isDisabled),
+    DisablingConfigs.button({ disabled: sharedBackstage.providers.isDisabled }),
     ReadOnly.receivingConfig(),
     Unselecting.config({}),
     Tabstopping.config({})

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/AutocompleteMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/AutocompleteMenuItem.ts
@@ -99,7 +99,6 @@ const renderAutocompleteItem = (
   const tooltipString = spec.text.filter((text) => !useText && text !== '');
   return renderCommonItem({
     data: buildData(spec),
-    allowedModes: [ 'design' ],
     enabled: spec.enabled,
     getApi: Fun.constant({}),
     onAction: (_api) => onItemValueHandler(spec.value, spec.meta),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CardMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CardMenuItem.ts
@@ -73,7 +73,6 @@ export const renderCardMenuItem = (
   };
 
   return renderCommonItem({
-    allowedModes: spec.allowedModes,
     data: buildData({ text: Optional.none(), ...spec }),
     enabled: spec.enabled,
     getApi,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ChoiceItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ChoiceItem.ts
@@ -55,7 +55,7 @@ const renderChoiceItem = (
 
   return Merger.deepMerge(
     renderCommonItem({
-      allowedModes: spec.allowedModes,
+      allowedInReadonlyUiMode: spec.allowedInReadonlyUiMode,
       data: buildData(spec),
       enabled: spec.enabled,
       getApi,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CommonMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CommonMenuItem.ts
@@ -60,12 +60,12 @@ const renderCommonItem = <T>(spec: CommonMenuItemSpec<T>, structure: ItemStructu
             return !spec.enabled || !providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
           },
           onEnabled: (component) => {
-            if (Disabling.getLastDisabledState(component) || !providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
+            if (Disabling.getLastDisabledState(component) === true || !providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
               Disabling.set(component, true);
             }
           },
           onDisabled: (component) => {
-            if (!Disabling.getLastDisabledState(component) && providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
+            if (Disabling.getLastDisabledState(component) === false && providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
               Disabling.set(component, false);
             }
           }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CommonMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CommonMenuItem.ts
@@ -60,14 +60,14 @@ const renderCommonItem = <T>(spec: CommonMenuItemSpec<T>, structure: ItemStructu
             return !spec.enabled || !providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
           },
           onEnabled: (component) => {
-            if (Disabling.getLastDisabledState(component) === true || !providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
-              Disabling.set(component, true);
-            }
+            Disabling.getLastDisabledState(component)
+              .filter((disabled) => disabled || !providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode))
+              .each(() => Disabling.set(component, true));
           },
           onDisabled: (component) => {
-            if (Disabling.getLastDisabledState(component) === false && providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
-              Disabling.set(component, false);
-            }
+            Disabling.getLastDisabledState(component)
+              .filter((disabled) => !disabled && providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode))
+              .each(() => Disabling.set(component, false));
           }
         }),
         ReadOnly.receivingConfig(),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/NestedMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/NestedMenuItem.ts
@@ -16,9 +16,7 @@ const renderNestedItem = (spec: Menu.NestedMenuItem, itemResponse: ItemResponse,
   const getApi = (component: AlloyComponent): Menu.NestedMenuItemInstanceApi => ({
     isEnabled: () => !Disabling.isDisabled(component),
     setEnabled: (state: boolean) => {
-      if (providersBackstage.isButtonAllowedInCurrentMode(spec.allowedModes)) {
-        Disabling.set(component, !state);
-      }
+      Disabling.setAndStoreState(component, !state);
     },
     setIconFill: (id, value) => {
       SelectorFind.descendant(component.element, `svg path[class="${id}"], rect[class="${id}"]`).each((underlinePath) => {
@@ -42,7 +40,7 @@ const renderNestedItem = (spec: Menu.NestedMenuItem, itemResponse: ItemResponse,
     shortcutContent: spec.shortcut
   }, providersBackstage, renderIcons);
   return renderCommonItem({
-    allowedModes: spec.allowedModes,
+    allowedInReadonlyUiMode: spec.allowedInReadonlyUiMode,
     data: buildData(spec),
     getApi,
     enabled: spec.enabled,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/NormalMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/NormalMenuItem.ts
@@ -13,8 +13,8 @@ const renderNormalItem = (spec: Menu.MenuItem, itemResponse: ItemResponse, provi
   const getApi = (component: AlloyComponent): Menu.MenuItemInstanceApi => ({
     isEnabled: () => !Disabling.isDisabled(component),
     setEnabled: (state: boolean) => {
-      if (providersBackstage.isButtonAllowedInCurrentMode(spec.allowedModes)) {
-        Disabling.set(component, !state);
+      if (providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
+        Disabling.setAndStoreState(component, !state);
       }
     }
   });
@@ -33,7 +33,7 @@ const renderNormalItem = (spec: Menu.MenuItem, itemResponse: ItemResponse, provi
   return renderCommonItem({
     data: buildData(spec),
     getApi,
-    allowedModes: spec.allowedModes,
+    allowedInReadonlyUiMode: spec.allowedInReadonlyUiMode,
     enabled: spec.enabled,
     onAction: spec.onAction,
     onSetup: spec.onSetup,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ToggleMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ToggleMenuItem.ts
@@ -23,9 +23,7 @@ const renderToggleMenuItem = (
     isActive: () => Toggling.isOn(component),
     isEnabled: () => !Disabling.isDisabled(component),
     setEnabled: (state: boolean) => {
-      if (providersBackstage.isButtonAllowedInCurrentMode(spec.allowedModes)) {
-        Disabling.set(component, !state);
-      }
+      Disabling.setAndStoreState(component, !state);
     }
   });
 
@@ -45,7 +43,7 @@ const renderToggleMenuItem = (
 
   return Merger.deepMerge(
     renderCommonItem({
-      allowedModes: spec.allowedModes,
+      allowedInReadonlyUiMode: spec.allowedInReadonlyUiMode,
       data: buildData(spec),
       enabled: spec.enabled,
       getApi,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/SilverMenubar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/SilverMenubar.ts
@@ -50,7 +50,7 @@ const factory: UiSketcher.SingleSketchFactory<SilverMenubarDetail, SilverMenubar
         fetch: (callback) => {
           callback(m.getItems());
         },
-        allowedModes: [ 'design', 'readonly' ]
+        allowedInReadonlyUiMode: true
       };
 
       // Convert to an internal bridge spec

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
@@ -44,7 +44,7 @@ const setup = (editor: Editor): void => {
           editor.off('ToggleSidebar', handleToggle);
         };
       },
-      allowedModes: [ 'design', 'readonly' ]
+      allowedInReadonlyUiMode: true
     });
   });
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ElementPath.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ElementPath.ts
@@ -52,7 +52,7 @@ const renderElementPath = (editor: Editor, settings: ElementPathSettings, provid
             }
           }),
         }),
-        DisablingConfigs.button(providersBackstage.isDisabled),
+        DisablingConfigs.button({ disabled: providersBackstage.isDisabled }),
         ReadOnly.receivingConfig()
       ])
     });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/WordCount.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/WordCount.ts
@@ -31,7 +31,7 @@ export const renderWordCount = (editor: Editor, providersBackstage: UiFactoryBac
     },
     components: [ ],
     buttonBehaviours: Behaviour.derive([
-      DisablingConfigs.button(providersBackstage.isDisabled),
+      DisablingConfigs.button({ disabled: providersBackstage.isDisabled }),
       ReadOnly.receivingConfig(),
       Tabstopping.config({ }),
       Replacing.config({ }),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -81,9 +81,11 @@ const getToolbarBehaviours = (toolbarSpec: ToolbarSpec, modeName: 'cyclic' | 'ac
   });
 
   return Behaviour.derive([
-    DisablingConfigs.toolbarButton(toolbarSpec.providers.isDisabled),
+    DisablingConfigs.toolbarButton({
+      disabled: toolbarSpec.providers.isDisabled
+    }),
     ReadOnly.receivingConfigConditional(() => {
-      return !toolbarSpec.providers.isButtonAllowedInCurrentMode([ 'design', 'readonly' ]);
+      return !toolbarSpec.providers.isButtonAllowedInCurrentMode(true);
     }),
     Keying.config({
       // Tabs between groups
@@ -118,10 +120,13 @@ const renderMoreToolbarCommon = (toolbarSpec: MoreDrawerToolbarSpec) => {
         primary: false,
         buttonType: Optional.none(),
         borderless: false,
-        allowedModes: [ 'design', 'readonly' ],
+        allowedInReadonlyUiMode: true
       }, Optional.none(), toolbarSpec.providers, [
+        DisablingConfigs.button({
+          disabled: toolbarSpec.providers.isDisabled
+        }),
         ReadOnly.receivingConfigConditional(() => {
-          return toolbarSpec.providers.isDisabled() && !toolbarSpec.providers.isButtonAllowedInCurrentMode([ 'design', 'readonly' ]);
+          return toolbarSpec.providers.isDisabled() && !toolbarSpec.providers.isButtonAllowedInCurrentMode(true);
         })
       ], 'overflow-button')
     },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -139,14 +139,14 @@ const renderCommonStructure = (
         DisablingConfigs.toolbarButton({
           disabled: () => !providersBackstage.isButtonAllowedInCurrentMode(allowedInReadonlyUiMode) || providersBackstage.isDisabled(),
           onEnabled: (component) => {
-            if (Disabling.getLastDisabledState(component) === true || !providersBackstage.isButtonAllowedInCurrentMode(allowedInReadonlyUiMode)) {
-              Disabling.set(component, true);
-            }
+            Disabling.getLastDisabledState(component)
+              .filter((disabled) => disabled || !providersBackstage.isButtonAllowedInCurrentMode(allowedInReadonlyUiMode))
+              .each(() => Disabling.set(component, true));
           },
           onDisabled: (component) => {
-            if (Disabling.getLastDisabledState(component) === false && providersBackstage.isButtonAllowedInCurrentMode(allowedInReadonlyUiMode)) {
-              Disabling.set(component, false);
-            }
+            Disabling.getLastDisabledState(component)
+              .filter((disabled) => !disabled && !providersBackstage.isButtonAllowedInCurrentMode(allowedInReadonlyUiMode))
+              .each(() => Disabling.set(component, false));
           }
         }),
         ReadOnly.receivingConfigConditional(() => {
@@ -242,17 +242,18 @@ const renderCommonToolbarButton = <T>(spec: GeneralToolbarButton<T>, specialisat
               return !spec.enabled || !providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
             },
             onEnabled: (component) => {
-              if (Disabling.getLastDisabledState(component) === true || !providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
-                Disabling.set(component, true);
-              }
-            }, onDisabled: (comp) => {
-              if (Disabling.getLastDisabledState(comp) === false && providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
-                Disabling.set(comp, false);
-              }
+              Disabling.getLastDisabledState(component)
+                .filter((disabled) => disabled || !providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode))
+                .each(() => Disabling.set(component, true));
+            },
+            onDisabled: (component) => {
+              Disabling.getLastDisabledState(component)
+                .filter((disabled) => !disabled && providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode))
+                .each(() => Disabling.set(component, false));
             }
           }),
           ReadOnly.receivingConfigConditional((comp: AlloyComponent) => {
-            return Disabling.getLastDisabledState(comp) === true || !providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
+            return Disabling.getLastDisabledState(comp).getOr(false) || !providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
           })
         ].concat(specialisation.toolbarButtonBehaviours)
       ),
@@ -402,18 +403,18 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
           return !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
         },
         onEnabled: (component) => {
-          if (Disabling.getLastDisabledState(component) === true || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
-            Disabling.set(component, true);
-          }
+          Disabling.getLastDisabledState(component)
+            .filter((disabled) => disabled || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode))
+            .each(() => Disabling.set(component, true));
         },
         onDisabled: (component) => {
-          if (Disabling.getLastDisabledState(component) === false && sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
-            Disabling.set(component, false);
-          }
+          Disabling.getLastDisabledState(component)
+            .filter((disabled) => !disabled && sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode))
+            .each(() => Disabling.set(component, false));
         }
       }),
       ReadOnly.receivingConfigConditional((comp: AlloyComponent) => {
-        return Disabling.getLastDisabledState(comp) === true || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
+        return Disabling.getLastDisabledState(comp).getOr(false) || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
       }),
       AddEventsBehaviour.config('split-dropdown-events', [
         AlloyEvents.runOnAttached((comp, _se) => UiUtils.forceInitialSize(comp)),
@@ -464,18 +465,18 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
               return !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
             },
             onEnabled: (component) => {
-              if (Disabling.getLastDisabledState(component) === true || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
-                Disabling.set(component, true);
-              }
+              Disabling.getLastDisabledState(component)
+                .filter((disabled) => disabled || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode))
+                .each(() => Disabling.set(component, true));
             },
             onDisabled: (component) => {
-              if (Disabling.getLastDisabledState(component) === false && sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
-                Disabling.set(component, false);
-              }
+              Disabling.getLastDisabledState(component)
+                .filter((disabled) => !disabled && sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode))
+                .each(() => Disabling.set(component, false));
             }
           }),
           ReadOnly.receivingConfigConditional((comp: AlloyComponent) => {
-            return Disabling.getLastDisabledState(comp) === true || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
+            return Disabling.getLastDisabledState(comp).getOr(false) || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
           })
         ]), sharedBackstage.providers, undefined, spec.allowedInReadonlyUiMode)
       ),
@@ -492,7 +493,7 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
             }
           }),
           ReadOnly.receivingConfigConditional((comp: AlloyComponent) => {
-            return Disabling.getLastDisabledState(comp) === true || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
+            return Disabling.getLastDisabledState(comp).getOr(false) || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
           }),
           Icons.addFocusableBehaviour()
         ])

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -139,12 +139,12 @@ const renderCommonStructure = (
         DisablingConfigs.toolbarButton({
           disabled: () => !providersBackstage.isButtonAllowedInCurrentMode(allowedInReadonlyUiMode) || providersBackstage.isDisabled(),
           onEnabled: (component) => {
-            if (Disabling.getLastDisabledState(component) || !providersBackstage.isButtonAllowedInCurrentMode(allowedInReadonlyUiMode)) {
+            if (Disabling.getLastDisabledState(component) === true || !providersBackstage.isButtonAllowedInCurrentMode(allowedInReadonlyUiMode)) {
               Disabling.set(component, true);
             }
           },
           onDisabled: (component) => {
-            if (!Disabling.getLastDisabledState(component) && providersBackstage.isButtonAllowedInCurrentMode(allowedInReadonlyUiMode)) {
+            if (Disabling.getLastDisabledState(component) === false && providersBackstage.isButtonAllowedInCurrentMode(allowedInReadonlyUiMode)) {
               Disabling.set(component, false);
             }
           }
@@ -242,17 +242,17 @@ const renderCommonToolbarButton = <T>(spec: GeneralToolbarButton<T>, specialisat
               return !spec.enabled || !providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
             },
             onEnabled: (component) => {
-              if (Disabling.getLastDisabledState(component) || !providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
+              if (Disabling.getLastDisabledState(component) === true || !providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
                 Disabling.set(component, true);
               }
             }, onDisabled: (comp) => {
-              if (!Disabling.getLastDisabledState(comp) && providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
+              if (Disabling.getLastDisabledState(comp) === false && providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
                 Disabling.set(comp, false);
               }
             }
           }),
           ReadOnly.receivingConfigConditional((comp: AlloyComponent) => {
-            return Disabling.getLastDisabledState(comp) || !providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
+            return Disabling.getLastDisabledState(comp) === true || !providersBackstage.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
           })
         ].concat(specialisation.toolbarButtonBehaviours)
       ),
@@ -402,18 +402,18 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
           return !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
         },
         onEnabled: (component) => {
-          if (Disabling.getLastDisabledState(component) || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
+          if (Disabling.getLastDisabledState(component) === true || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
             Disabling.set(component, true);
           }
         },
         onDisabled: (component) => {
-          if (!Disabling.getLastDisabledState(component) && sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
+          if (Disabling.getLastDisabledState(component) === false && sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
             Disabling.set(component, false);
           }
         }
       }),
       ReadOnly.receivingConfigConditional((comp: AlloyComponent) => {
-        return Disabling.getLastDisabledState(comp) || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
+        return Disabling.getLastDisabledState(comp) === true || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
       }),
       AddEventsBehaviour.config('split-dropdown-events', [
         AlloyEvents.runOnAttached((comp, _se) => UiUtils.forceInitialSize(comp)),
@@ -464,18 +464,18 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
               return !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
             },
             onEnabled: (component) => {
-              if (Disabling.getLastDisabledState(component) || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
+              if (Disabling.getLastDisabledState(component) === true || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
                 Disabling.set(component, true);
               }
             },
             onDisabled: (component) => {
-              if (!Disabling.getLastDisabledState(component) && sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
+              if (Disabling.getLastDisabledState(component) === false && sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)) {
                 Disabling.set(component, false);
               }
             }
           }),
           ReadOnly.receivingConfigConditional((comp: AlloyComponent) => {
-            return Disabling.getLastDisabledState(comp) || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
+            return Disabling.getLastDisabledState(comp) === true || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
           })
         ]), sharedBackstage.providers, undefined, spec.allowedInReadonlyUiMode)
       ),
@@ -492,7 +492,7 @@ const renderSplitButton = (spec: Toolbar.ToolbarSplitButton, sharedBackstage: Ui
             }
           }),
           ReadOnly.receivingConfigConditional((comp: AlloyComponent) => {
-            return Disabling.getLastDisabledState(comp) || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
+            return Disabling.getLastDisabledState(comp) === true || !sharedBackstage.providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
           }),
           Icons.addFocusableBehaviour()
         ])

--- a/modules/tinymce/src/themes/silver/main/ts/ui/view/ViewButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/view/ViewButtons.ts
@@ -3,6 +3,8 @@ import { Optional } from '@ephox/katamari';
 import { Attribute, Class } from '@ephox/sugar';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import * as ReadOnly from '../../ReadOnly';
+import { DisablingConfigs } from '../alien/DisablingConfigs';
 import { renderReplaceableIconFromPack } from '../button/ButtonSlices';
 import { calculateClassesFromButtonType, IconButtonWrapper, renderCommonSpec } from '../general/Button';
 import { componentRenderPipeline } from '../menus/item/build/CommonMenuItem';
@@ -81,7 +83,14 @@ export const renderButton = (spec: ViewButtonWithoutGroup, providers: UiFactoryB
       .concat(...spec.type === 'togglebutton' && spec.active ? [ ViewButtonClasses.Ticked ] : []),
     attributes: ariaLabelAttributes
   };
-  const extraBehaviours: Behaviours = [];
+  const extraBehaviours: Behaviours = [
+    DisablingConfigs.button({
+      disabled: () => !providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode)
+    }),
+    ReadOnly.receivingConfigConditional(() => {
+      return !providers.isButtonAllowedInCurrentMode(spec.allowedInReadonlyUiMode);
+    })
+  ];
 
   const iconButtonSpec = renderCommonSpec(buttonSpec, Optional.some(action), extraBehaviours, dom, components, spec.tooltip, providers);
   return AlloyButton.sketch(iconButtonSpec);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/view/ViewButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/view/ViewButtons.ts
@@ -57,7 +57,6 @@ export const renderButton = (spec: ViewButtonWithoutGroup, providers: UiFactoryB
     icon: spec.icon,
     enabled: true,
     borderless: spec.borderless,
-    allowedModes: [ 'design' ]
   };
 
   const buttonTypeClasses = calculateClassesFromButtonType(spec.buttonType ?? 'secondary');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
@@ -27,7 +27,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLook
         onAction: Fun.noop
       },
       enabled: true,
-      allowedModes: [ 'design' ],
+      allowedInReadonlyUiMode: false,
       tooltip: Optional.none(),
       icon: Optional.none(),
       text: Optional.none(),

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/dialogbutton/DialogFooterButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/dialogbutton/DialogFooterButtonTest.ts
@@ -20,7 +20,7 @@ describe('headless.tinymce.themes.silver.components.dialogbutton.DialogFooterBut
         icon: Optional.none(),
         tooltip: Optional.some('Submit'),
         buttonType: Optional.some('primary'),
-        allowedModes: [ 'design' ]
+        allowedInReadonlyUiMode: false
       }, 'submit', backstage)
     ));
 
@@ -46,7 +46,7 @@ describe('headless.tinymce.themes.silver.components.dialogbutton.DialogFooterBut
         buttonType: Optional.some('secondary'),
         icon: Optional.none(),
         align: 'end',
-        allowedModes: [ 'design' ]
+        allowedInReadonlyUiMode: false
       }, 'cancel', backstage)
     ));
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonPlaceholderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonPlaceholderTest.ts
@@ -34,7 +34,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonPlaceholder
     (store, _doc, _body) => GuiFactory.build(
       renderMenuButton(
         {
-          allowedModes: [ 'design' ],
+          allowedInReadonlyUiMode: false,
           text: Optional.some('MailMerge'),
           icon: Optional.none(),
           tooltip: Optional.none(),

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonTest.ts
@@ -30,7 +30,7 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
     (store, _doc, _body) => GuiFactory.build(
       renderMenuButton(
         {
-          allowedModes: [ 'design' ],
+          allowedInReadonlyUiMode: false,
           text: Optional.some('MailMerge'),
           icon: Optional.none(),
           tooltip: Optional.none(),

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
@@ -29,7 +29,7 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
         },
         components: [
           renderToolbarButton({
-            allowedModes: [ 'design' ],
+            allowedInReadonlyUiMode: false,
             type: 'button',
             shortcut: Optional.none(),
             enabled: true,
@@ -55,7 +55,7 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
         },
         components: [
           renderToolbarToggleButton({
-            allowedModes: [ 'design' ],
+            allowedInReadonlyUiMode: false,
             type: 'togglebutton',
             shortcut: Optional.none(),
             enabled: true,
@@ -83,7 +83,7 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
         },
         components: [
           renderSplitButton({
-            allowedModes: [ 'design' ],
+            allowedInReadonlyUiMode: false,
             type: 'splitbutton',
             tooltip: Optional.some('tooltip'),
             icon: Optional.none(),
@@ -124,7 +124,7 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
         },
         components: [
           renderMenuButton({
-            allowedModes: [ 'design' ],
+            allowedInReadonlyUiMode: false,
             tooltip: Optional.some('tooltip'),
             icon: Optional.none(),
             text: Optional.some('button4'),

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogEventTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogEventTest.ts
@@ -42,7 +42,7 @@ describe('headless.tinymce.themes.silver.window.SilverDialogEventTest', () => {
           buttonType: Optional.some('secondary'),
           enabled: true,
           icon: Optional.none(),
-          allowedModes: [ 'design', 'readonly ' ]
+          allowedInReadonlyUiMode: false
         },
         {
           type: 'submit',
@@ -53,7 +53,7 @@ describe('headless.tinymce.themes.silver.window.SilverDialogEventTest', () => {
           buttonType: Optional.some('primary'),
           enabled: true,
           icon: Optional.none(),
-          allowedModes: [ 'design', 'readonly ' ]
+          allowedInReadonlyUiMode: false
         }
       ],
       initialData: {},

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/toolbar/SearchableMenuTypingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/toolbar/SearchableMenuTypingTest.ts
@@ -102,7 +102,7 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
     (store, _doc, _body) => GuiFactory.build(
       renderMenuButton(
         {
-          allowedModes: [ 'design' ],
+          allowedInReadonlyUiMode: false,
           text: Optional.some('MailMerge'),
           icon: Optional.none(),
           tooltip: Optional.none(),


### PR DESCRIPTION
Related Ticket: TINY-10980

Description of Changes:
* Renamed from `allowedModes` that takes a `string[]` to `allowedinReadonlyUiMode` bool
* Instead of checking of the mode and allowing the API to set the button to be enabled/disabled, now uses `onEnabled` or `onDisabled` to make sure that the buttons are in the correct state.
* Configuration that could change the button state:
  *  `DisablingConfigs` - on load, checks if there's enabled/disabled property for the button, or the buttons has `allowedinReadonlyUiMode` property
  * `buttonAPI` - if the `onSetup` button API is used, then will store the state. Example of this is used is: when `setEnabled(false)` is set to button, when switching to `uiEnabled` mode, even though the button has  `allowedinReadonlyUiMode`, we will still want it to be disabled, even after switching back to design, it should still use the store state.
  * `ReadOnly.receivingConfigConditional` - this is used to listen for mode switches, and to enable/disable the buttons as appropriately.
* Fixes this issue when the button is set to disabled with (`enabled: false` or `setEnabled(false)`), the button gets re-enabled. https://fiddle.tiny.cloud/u3YZQU1LS7/1
* Split out `Disabling.config` from modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts 

Pre-checks:
* [x] ~Changelog entry added~ will be added in epic/EPIC-114
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
