### PR TITLE
TINY-11211: Add context for UI components

### DIFF
--- a/modules/bridge/src/main/ts/ephox/bridge/api/Registry.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/api/Registry.ts
@@ -32,6 +32,7 @@ export interface Registry {
   addAutocompleter: (name: string, spec: AutocompleterSpec) => void;
   addSidebar: (name: string, spec: SidebarSpec) => void;
   addView: (name: string, spec: ViewSpec) => void;
+  addContext: (name: string, func: (...args: any[]) => boolean) => void;
 
   getAll: () => {
     buttons: Record<string, ToolbarButtonSpec | GroupToolbarButtonSpec | ToolbarMenuButtonSpec | ToolbarSplitButtonSpec | ToolbarToggleButtonSpec>;
@@ -42,6 +43,7 @@ export interface Registry {
     icons: Record<string, string>;
     sidebars: Record<string, SidebarSpec>;
     views: Record<string, ViewSpec>;
+    contexts: Record<string, (...args: any[]) => boolean>;
   };
 }
 
@@ -52,12 +54,14 @@ export const create = (): Registry => {
   const icons: Record<string, string> = {};
   const contextMenus: Record<string, ContextMenuApi> = {};
   const contextToolbars: Record<string, ContextToolbarSpec | ContextFormSpec> = {};
+  const contexts: Record<string, (...args: any[]) => boolean> = {};
   const sidebars: Record<string, SidebarSpec> = {};
   const views: Record<string, ViewSpec> = {};
   const add = <T, S extends T>(collection: Record<string, T>, type: string) => (name: string, spec: S): void => {
     collection[name.toLowerCase()] = { ...spec, type };
   };
   const addIcon = (name: string, svgData: string) => icons[name.toLowerCase()] = svgData;
+  const addContext = (name: string, func: (...args: any[]) => boolean) => contexts[name.toLowerCase()] = func;
 
   return {
     addButton: add(buttons, 'button'),
@@ -75,6 +79,7 @@ export const create = (): Registry => {
     addSidebar: add(sidebars, 'sidebar'),
     addView: add(views, 'views'),
     addIcon,
+    addContext,
 
     getAll: () => ({
       buttons,
@@ -89,7 +94,8 @@ export const create = (): Registry => {
 
       contextToolbars,
       sidebars,
-      views
+      views,
+      contexts
     })
   };
 };

--- a/modules/bridge/src/main/ts/ephox/bridge/api/Registry.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/api/Registry.ts
@@ -32,7 +32,7 @@ export interface Registry {
   addAutocompleter: (name: string, spec: AutocompleterSpec) => void;
   addSidebar: (name: string, spec: SidebarSpec) => void;
   addView: (name: string, spec: ViewSpec) => void;
-  addContext: (name: string, pred: (...args: any[]) => boolean) => void;
+  addContext: (name: string, pred: (args: string) => boolean) => void;
 
   getAll: () => {
     buttons: Record<string, ToolbarButtonSpec | GroupToolbarButtonSpec | ToolbarMenuButtonSpec | ToolbarSplitButtonSpec | ToolbarToggleButtonSpec>;
@@ -43,7 +43,7 @@ export interface Registry {
     icons: Record<string, string>;
     sidebars: Record<string, SidebarSpec>;
     views: Record<string, ViewSpec>;
-    contexts: Record<string, (...args: any[]) => boolean>;
+    contexts: Record<string, (args: string) => boolean>;
   };
 }
 
@@ -54,14 +54,14 @@ export const create = (): Registry => {
   const icons: Record<string, string> = {};
   const contextMenus: Record<string, ContextMenuApi> = {};
   const contextToolbars: Record<string, ContextToolbarSpec | ContextFormSpec> = {};
-  const contexts: Record<string, (...args: any[]) => boolean> = {};
+  const contexts: Record<string, (args: string) => boolean> = {};
   const sidebars: Record<string, SidebarSpec> = {};
   const views: Record<string, ViewSpec> = {};
   const add = <T, S extends T>(collection: Record<string, T>, type: string) => (name: string, spec: S): void => {
     collection[name.toLowerCase()] = { ...spec, type };
   };
   const addIcon = (name: string, svgData: string) => icons[name.toLowerCase()] = svgData;
-  const addContext = (name: string, pred: (...args: any[]) => boolean) => contexts[name.toLowerCase()] = pred;
+  const addContext = (name: string, pred: (args: string) => boolean) => contexts[name.toLowerCase()] = pred;
 
   return {
     addButton: add(buttons, 'button'),

--- a/modules/bridge/src/main/ts/ephox/bridge/api/Registry.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/api/Registry.ts
@@ -32,7 +32,7 @@ export interface Registry {
   addAutocompleter: (name: string, spec: AutocompleterSpec) => void;
   addSidebar: (name: string, spec: SidebarSpec) => void;
   addView: (name: string, spec: ViewSpec) => void;
-  addContext: (name: string, func: (...args: any[]) => boolean) => void;
+  addContext: (name: string, pred: (...args: any[]) => boolean) => void;
 
   getAll: () => {
     buttons: Record<string, ToolbarButtonSpec | GroupToolbarButtonSpec | ToolbarMenuButtonSpec | ToolbarSplitButtonSpec | ToolbarToggleButtonSpec>;
@@ -61,7 +61,7 @@ export const create = (): Registry => {
     collection[name.toLowerCase()] = { ...spec, type };
   };
   const addIcon = (name: string, svgData: string) => icons[name.toLowerCase()] = svgData;
-  const addContext = (name: string, func: (...args: any[]) => boolean) => contexts[name.toLowerCase()] = func;
+  const addContext = (name: string, pred: (...args: any[]) => boolean) => contexts[name.toLowerCase()] = pred;
 
   return {
     addButton: add(buttons, 'button'),

--- a/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarButton.ts
@@ -1,4 +1,4 @@
-import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
+import { FieldSchema, StructureSchema } from '@ephox/boulder';
 import { Optional, Result } from '@ephox/katamari';
 
 import * as ComponentSchema from '../../core/ComponentSchema';

--- a/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarButton.ts
@@ -1,4 +1,4 @@
-import { StructureSchema } from '@ephox/boulder';
+import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
 import { Optional, Result } from '@ephox/katamari';
 
 import * as ComponentSchema from '../../core/ComponentSchema';
@@ -9,6 +9,7 @@ export interface BaseToolbarButtonSpec<I extends BaseToolbarButtonInstanceApi> {
   icon?: string;
   text?: string;
   onSetup?: (api: I) => (api: I) => void;
+  context?: string;
 }
 
 export interface BaseToolbarButtonInstanceApi {
@@ -35,6 +36,7 @@ export interface BaseToolbarButton<I extends BaseToolbarButtonInstanceApi> {
   icon: Optional<string>;
   text: Optional<string>;
   onSetup: (api: I) => (api: I) => void;
+  context: string;
 }
 
 export interface ToolbarButton extends BaseToolbarButton<ToolbarButtonInstanceApi> {
@@ -48,7 +50,8 @@ export const baseToolbarButtonFields = [
   ComponentSchema.optionalTooltip,
   ComponentSchema.optionalIcon,
   ComponentSchema.optionalText,
-  ComponentSchema.onSetup
+  ComponentSchema.onSetup,
+  FieldSchema.defaultedOf('context', 'mode:design', ValueType.string)
 ];
 
 export const toolbarButtonSchema = StructureSchema.objOf([

--- a/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarButton.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/toolbar/ToolbarButton.ts
@@ -51,7 +51,7 @@ export const baseToolbarButtonFields = [
   ComponentSchema.optionalIcon,
   ComponentSchema.optionalText,
   ComponentSchema.onSetup,
-  FieldSchema.defaultedOf('context', 'mode:design', ValueType.string)
+  FieldSchema.defaultedString('context', 'mode:design')
 ];
 
 export const toolbarButtonSchema = StructureSchema.objOf([

--- a/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
+++ b/modules/tinymce/src/core/main/ts/api/ui/Registry.ts
@@ -240,6 +240,8 @@ const registry = (): Registry.Registry => {
      */
     addView: bridge.addView,
 
+    addContext: bridge.addContext,
+
     /* note getAll is an internal method and may not be supported in future revisions */
     getAll: bridge.getAll
   };

--- a/modules/tinymce/src/themes/silver/main/ts/ButtonState.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ButtonState.ts
@@ -15,20 +15,12 @@ const broadcastEvents = (uiRefs: ReadyUiReferences): void => {
 };
 
 const setupEventsForButton = (editor: Editor, uiRefs: ReadyUiReferences): void => {
-  editor.on('init', () => {
-    broadcastEvents(uiRefs);
-  });
-
-  editor.on('SwitchMode', () => {
-    broadcastEvents(uiRefs);
-  });
-
-  editor.on('NodeChange', () => {
+  editor.on('init SwitchMode NodeChange', () => {
     broadcastEvents(uiRefs);
   });
 };
 
-const toggleButtonStateOnReceive = (shouldDisable: () => boolean): Behaviour.NamedConfiguredBehaviour<any, any> => Receiving.config({
+const toggleOnReceive = (shouldDisable: () => boolean): Behaviour.NamedConfiguredBehaviour<any, any> => Receiving.config({
   channels: {
     [ButtonStateChannel]: {
       onReceive: (comp) => {
@@ -40,5 +32,5 @@ const toggleButtonStateOnReceive = (shouldDisable: () => boolean): Behaviour.Nam
 
 export {
   setupEventsForButton,
-  toggleButtonStateOnReceive
+  toggleOnReceive
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ButtonState.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ButtonState.ts
@@ -2,29 +2,38 @@ import { Behaviour, Disabling, Receiving } from '@ephox/alloy';
 import { Arr } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
+import { NodeChangeEvent, SwitchModeEvent } from 'tinymce/core/api/EventTypes';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import { ReadyUiReferences } from './modes/UiReferences';
 
 export const ButtonStateChannel = 'silver.buttonstate';
 
-const broadcastEvents = (uiRefs: ReadyUiReferences): void => {
+const broadcastEvents = (uiRefs: ReadyUiReferences, eventType: string): void => {
   const motherships = [ uiRefs.mainUi.mothership, ...uiRefs.uiMotherships ];
   Arr.each(motherships, (m) => {
-    m.broadcastOn([ ButtonStateChannel ], '');
+    m.broadcastOn([ ButtonStateChannel ], eventType);
   });
 };
 
 const setupEventsForButton = (editor: Editor, uiRefs: ReadyUiReferences): void => {
-  editor.on('init SwitchMode NodeChange', () => {
-    broadcastEvents(uiRefs);
+  editor.on('init SwitchMode NodeChange', (e: EditorEvent<{} | NodeChangeEvent | SwitchModeEvent>) => {
+    broadcastEvents(uiRefs, e.type);
   });
 };
 
-const toggleOnReceive = (shouldDisable: () => boolean): Behaviour.NamedConfiguredBehaviour<any, any> => Receiving.config({
+const toggleOnReceive = (getContext: () => { contextType: string; shouldDisable: boolean }): Behaviour.NamedConfiguredBehaviour<any, any> => Receiving.config({
   channels: {
     [ButtonStateChannel]: {
-      onReceive: (comp) => {
-        Disabling.set(comp, shouldDisable());
+      onReceive: (comp, eventType: string) => {
+        const { contextType, shouldDisable } = getContext();
+        if (contextType === 'mode') {
+          if (Arr.contains([ 'switchmode' ], eventType)) {
+            Disabling.set(comp, shouldDisable);
+          }
+        } else {
+          Disabling.set(comp, shouldDisable);
+        }
       }
     }
   }

--- a/modules/tinymce/src/themes/silver/main/ts/ButtonState.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ButtonState.ts
@@ -1,0 +1,44 @@
+import { Behaviour, Disabling, Receiving } from '@ephox/alloy';
+import { Arr } from '@ephox/katamari';
+
+import Editor from 'tinymce/core/api/Editor';
+
+import { ReadyUiReferences } from './modes/UiReferences';
+
+export const ButtonStateChannel = 'silver.buttonstate';
+
+const broadcastEvents = (uiRefs: ReadyUiReferences): void => {
+  const motherships = [ uiRefs.mainUi.mothership, ...uiRefs.uiMotherships ];
+  Arr.each(motherships, (m) => {
+    m.broadcastOn([ ButtonStateChannel ], '');
+  });
+};
+
+const setupEventsForButton = (editor: Editor, uiRefs: ReadyUiReferences): void => {
+  editor.on('init', () => {
+    broadcastEvents(uiRefs);
+  });
+
+  editor.on('SwitchMode', () => {
+    broadcastEvents(uiRefs);
+  });
+
+  editor.on('NodeChange', () => {
+    broadcastEvents(uiRefs);
+  });
+};
+
+const receivingConfigConditional = (shouldDisable: () => boolean): Behaviour.NamedConfiguredBehaviour<any, any> => Receiving.config({
+  channels: {
+    [ButtonStateChannel]: {
+      onReceive: (comp) => {
+        Disabling.set(comp, !shouldDisable());
+      }
+    }
+  }
+});
+
+export {
+  setupEventsForButton,
+  receivingConfigConditional
+};

--- a/modules/tinymce/src/themes/silver/main/ts/ButtonState.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ButtonState.ts
@@ -28,11 +28,11 @@ const setupEventsForButton = (editor: Editor, uiRefs: ReadyUiReferences): void =
   });
 };
 
-const receivingConfigConditional = (shouldDisable: () => boolean): Behaviour.NamedConfiguredBehaviour<any, any> => Receiving.config({
+const toggleButtonStateOnReceive = (shouldDisable: () => boolean): Behaviour.NamedConfiguredBehaviour<any, any> => Receiving.config({
   channels: {
     [ButtonStateChannel]: {
       onReceive: (comp) => {
-        Disabling.set(comp, !shouldDisable());
+        Disabling.set(comp, shouldDisable());
       }
     }
   }
@@ -40,5 +40,5 @@ const receivingConfigConditional = (shouldDisable: () => boolean): Behaviour.Nam
 
 export {
   setupEventsForButton,
-  receivingConfigConditional
+  toggleButtonStateOnReceive
 };

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -68,8 +68,8 @@ const init = (lazySinks: { popup: () => Result<AlloyComponent, string>; dialog: 
       return Obj.get(contexts, key)
         .fold(
           // Fallback to 'mode:design' if key is not found
-          () => Obj.get(contexts, 'mode').map((pred) => pred(editor, 'design')).getOr(false),
-          (pred) => pred(...[ editor, value ])
+          () => Obj.get(contexts, 'mode').map((pred) => pred('design')).getOr(false),
+          (pred) => pred(value)
         );
     }
   };

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -61,24 +61,16 @@ const init = (lazySinks: { popup: () => Result<AlloyComponent, string>; dialog: 
     getOption: editor.options.get,
     tooltips: TooltipsBackstage(lazySinks.dialog),
     checkButtonContext: (specContext: string) => {
-      const resolveContext = () => {
-        if (Strings.contains(specContext, ':')) {
-          return specContext.split(':');
-        } else {
-          return [ specContext ];
-        }
-      };
+      const resolveContext = () => Strings.contains(specContext, ':') ? specContext.split(':') : [ specContext ];
 
       const [ key, value ] = resolveContext();
-
-      return Obj.get(editor.ui.registry.getAll().contexts, key)
-        .fold(() => {
+      const contexts = editor.ui.registry.getAll().contexts;
+      return Obj.get(contexts, key)
+        .fold(
           // Fallback to 'mode:design' if key is not found
-          return Obj.get(editor.ui.registry.getAll().contexts, 'mode').map((pred) => pred(editor, 'design')).getOr(false);
-        },
-        (pred) => {
-          return pred(...[ editor, value ]);
-        });
+          () => Obj.get(contexts, 'mode').map((pred) => pred(editor, 'design')).getOr(false),
+          (pred) => pred(...[ editor, value ])
+        );
     }
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -23,7 +23,7 @@ export interface UiFactoryBackstageProviders {
   readonly isDisabled: () => boolean;
   readonly getOption: Editor['options']['get'];
   readonly tooltips: TooltipsProvider;
-  readonly checkButtonContext: (specContext: string) => boolean;
+  readonly checkButtonContext: (specContext: string) => { contextType: string; shouldDisable: boolean };
 }
 
 export interface UiFactoryBackstageShared {
@@ -65,12 +65,16 @@ const init = (lazySinks: { popup: () => Result<AlloyComponent, string>; dialog: 
 
       const [ key, value ] = resolveContext();
       const contexts = editor.ui.registry.getAll().contexts;
-      return Obj.get(contexts, key)
+      const enabledInContext = Obj.get(contexts, key)
         .fold(
           // Fallback to 'mode:design' if key is not found
           () => Obj.get(contexts, 'mode').map((pred) => pred('design')).getOr(false),
           (pred) => pred(value)
         );
+      return {
+        contextType: key,
+        shouldDisable: !enabledInContext
+      };
     }
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -10,6 +10,7 @@ import { EditorUiApi } from 'tinymce/core/api/ui/Ui';
 import * as Events from '../api/Events';
 import * as Options from '../api/Options';
 import { UiFactoryBackstage } from '../backstage/Backstage';
+import * as ButtonState from '../ButtonState';
 import * as ReadOnly from '../ReadOnly';
 import { ModeRenderInfo, RenderArgs, RenderUiConfig } from '../Render';
 import OuterContainer from '../ui/general/OuterContainer';
@@ -151,6 +152,7 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
   }
 
   ReadOnly.setupReadonlyModeSwitch(editor, uiRefs);
+  ButtonState.setupEventsForButton(editor, uiRefs);
 
   editor.addCommand('ToggleSidebar', (_ui: boolean, value: string) => {
     OuterContainer.toggleSidebar(outerContainer, value);

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -9,6 +9,7 @@ import { EditorUiApi } from 'tinymce/core/api/ui/Ui';
 import * as Events from '../api/Events';
 import * as Options from '../api/Options';
 import { UiFactoryBackstage } from '../backstage/Backstage';
+import * as ButtonState from '../ButtonState';
 import * as ReadOnly from '../ReadOnly';
 import { ModeRenderInfo, RenderArgs, RenderUiConfig } from '../Render';
 import OuterContainer from '../ui/general/OuterContainer';
@@ -198,6 +199,7 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
   });
 
   ReadOnly.setupReadonlyModeSwitch(editor, uiRefs);
+  ButtonState.setupEventsForButton(editor, uiRefs);
 
   const api: Partial<EditorUiApi> = {
     show: render,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/Context.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/Context.ts
@@ -1,0 +1,27 @@
+import { Fun } from '@ephox/katamari';
+
+import Editor from 'tinymce/core/api/Editor';
+
+const register = (editor: Editor): void => {
+  editor.ui.registry.addContext('editable', (editor: Editor) => {
+    return editor.selection.isEditable();
+  });
+
+  editor.ui.registry.addContext('mode', (editor: Editor, mode: string) => {
+    return editor.mode.get() === mode;
+  });
+
+  editor.ui.registry.addContext('any', Fun.always);
+
+  editor.ui.registry.addContext('formatting', (editor: Editor, format: string) => {
+    return editor.formatter.canApply(format);
+  });
+
+  editor.ui.registry.addContext('insert', (editor: Editor, child: string) => {
+    return editor.schema.isValidChild(editor.selection.getNode().tagName, child);
+  });
+};
+
+export {
+  register
+};

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/Context.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/Context.ts
@@ -3,21 +3,21 @@ import { Fun } from '@ephox/katamari';
 import Editor from 'tinymce/core/api/Editor';
 
 const register = (editor: Editor): void => {
-  editor.ui.registry.addContext('editable', (editor: Editor) => {
+  editor.ui.registry.addContext('editable', () => {
     return editor.selection.isEditable();
   });
 
-  editor.ui.registry.addContext('mode', (editor: Editor, mode: string) => {
+  editor.ui.registry.addContext('mode', (mode: string) => {
     return editor.mode.get() === mode;
   });
 
   editor.ui.registry.addContext('any', Fun.always);
 
-  editor.ui.registry.addContext('formatting', (editor: Editor, format: string) => {
+  editor.ui.registry.addContext('formatting', (format: string) => {
     return editor.formatter.canApply(format);
   });
 
-  editor.ui.registry.addContext('insert', (editor: Editor, child: string) => {
+  editor.ui.registry.addContext('insert', (child: string) => {
     return editor.schema.isValidChild(editor.selection.getNode().tagName, child);
   });
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/FormatControls.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/FormatControls.ts
@@ -5,6 +5,7 @@ import * as AlignmentButtons from './AlignmentButtons';
 import * as ChoiceControls from './ChoiceControls';
 import * as ColorSwatch from './color/ColorSwatch';
 import * as ComplexControls from './ComplexControls';
+import * as Context from './Context';
 import * as IndentOutdent from './IndentOutdent';
 import * as PasteControls from './PasteControls';
 import * as SimpleControls from './SimpleControls';
@@ -21,6 +22,7 @@ const setup = (editor: Editor, backstage: UiFactoryBackstage): void => {
   IndentOutdent.register(editor);
   ChoiceControls.register(editor);
   PasteControls.register(editor);
+  Context.register(editor);
 };
 
 export {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -6,7 +6,7 @@ import {
   Unselecting
 } from '@ephox/alloy';
 import { Toolbar } from '@ephox/bridge';
-import { Arr, Cell, Fun, Future, Id, Merger, Optional, Strings, Type } from '@ephox/katamari';
+import { Arr, Cell, Fun, Future, Id, Merger, Optional, Type } from '@ephox/katamari';
 import { Attribute, EventArgs, SelectorFind } from '@ephox/sugar';
 
 import { ToolbarGroupOption } from '../../../api/Options';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -222,9 +222,8 @@ const renderCommonToolbarButton = <T>(spec: GeneralToolbarButton<T>, specialisat
           DisablingConfigs.toolbarButton(() => {
             return !spec.enabled || !providersBackstage.checkButtonContext(spec.context);
           }),
-          // ReadOnly.receivingConfig(),
-          ButtonState.receivingConfigConditional(() => {
-            return providersBackstage.checkButtonContext(spec.context);
+          ButtonState.toggleButtonStateOnReceive(() => {
+            return !providersBackstage.checkButtonContext(spec.context) || !spec.enabled;
           })
         ].concat(specialisation.toolbarButtonBehaviours)
       ),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -6,7 +6,7 @@ import {
   Unselecting
 } from '@ephox/alloy';
 import { Toolbar } from '@ephox/bridge';
-import { Arr, Cell, Fun, Future, Id, Merger, Optional, Type } from '@ephox/katamari';
+import { Arr, Cell, Fun, Future, Id, Merger, Optional, Strings, Type } from '@ephox/katamari';
 import { Attribute, EventArgs, SelectorFind } from '@ephox/sugar';
 
 import { ToolbarGroupOption } from '../../../api/Options';
@@ -220,7 +220,12 @@ const renderCommonToolbarButton = <T>(spec: GeneralToolbarButton<T>, specialisat
           )).toArray(),
           // Enable toolbar buttons by default
           DisablingConfigs.toolbarButton(() => !spec.enabled || !providersBackstage.checkButtonContext(spec.context)),
-          ButtonState.toggleOnReceive(() => !spec.enabled || !providersBackstage.checkButtonContext(spec.context)),
+          ButtonState.toggleOnReceive(() => {
+            return {
+              contextType: Strings.contains(spec.context, ':') ? spec.context.split(':')[0] : spec.context,
+              shouldDisable: !providersBackstage.checkButtonContext(spec.context)
+            };
+          }),
         ].concat(specialisation.toolbarButtonBehaviours)
       ),
       // Here we add the commonButtonDisplayEvent behaviour from the structure so we can listen

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -219,13 +219,8 @@ const renderCommonToolbarButton = <T>(spec: GeneralToolbarButton<T>, specialisat
             )
           )).toArray(),
           // Enable toolbar buttons by default
-          DisablingConfigs.toolbarButton(() => !spec.enabled || !providersBackstage.checkButtonContext(spec.context)),
-          ButtonState.toggleOnReceive(() => {
-            return {
-              contextType: Strings.contains(spec.context, ':') ? spec.context.split(':')[0] : spec.context,
-              shouldDisable: !providersBackstage.checkButtonContext(spec.context)
-            };
-          }),
+          DisablingConfigs.toolbarButton(() => !spec.enabled || providersBackstage.checkButtonContext(spec.context).shouldDisable),
+          ButtonState.toggleOnReceive(() => providersBackstage.checkButtonContext(spec.context))
         ].concat(specialisation.toolbarButtonBehaviours)
       ),
       // Here we add the commonButtonDisplayEvent behaviour from the structure so we can listen

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -219,12 +219,8 @@ const renderCommonToolbarButton = <T>(spec: GeneralToolbarButton<T>, specialisat
             )
           )).toArray(),
           // Enable toolbar buttons by default
-          DisablingConfigs.toolbarButton(() => {
-            return !spec.enabled || !providersBackstage.checkButtonContext(spec.context);
-          }),
-          ButtonState.toggleButtonStateOnReceive(() => {
-            return !providersBackstage.checkButtonContext(spec.context) || !spec.enabled;
-          })
+          DisablingConfigs.toolbarButton(() => !spec.enabled || !providersBackstage.checkButtonContext(spec.context)),
+          ButtonState.toggleOnReceive(() => !spec.enabled || !providersBackstage.checkButtonContext(spec.context)),
         ].concat(specialisation.toolbarButtonBehaviours)
       ),
       // Here we add the commonButtonDisplayEvent behaviour from the structure so we can listen

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -11,6 +11,7 @@ import { Attribute, EventArgs, SelectorFind } from '@ephox/sugar';
 
 import { ToolbarGroupOption } from '../../../api/Options';
 import { UiFactoryBackstage, UiFactoryBackstageProviders, UiFactoryBackstageShared } from '../../../backstage/Backstage';
+import * as ButtonState from '../../../ButtonState';
 import * as ReadOnly from '../../../ReadOnly';
 import * as ConvertShortcut from '../../../ui/alien/ConvertShortcut';
 import { DisablingConfigs } from '../../alien/DisablingConfigs';
@@ -49,6 +50,7 @@ interface GeneralToolbarButton<T> {
   readonly shortcut: Optional<string>;
   readonly onAction: (api: T) => void;
   readonly enabled: boolean;
+  readonly context: string;
 }
 
 interface ChoiceFetcher {
@@ -217,8 +219,13 @@ const renderCommonToolbarButton = <T>(spec: GeneralToolbarButton<T>, specialisat
             )
           )).toArray(),
           // Enable toolbar buttons by default
-          DisablingConfigs.toolbarButton(() => !spec.enabled || providersBackstage.isDisabled()),
-          ReadOnly.receivingConfig()
+          DisablingConfigs.toolbarButton(() => {
+            return !spec.enabled || !providersBackstage.checkButtonContext(spec.context);
+          }),
+          // ReadOnly.receivingConfig(),
+          ButtonState.receivingConfigConditional(() => {
+            return providersBackstage.checkButtonContext(spec.context);
+          })
         ].concat(specialisation.toolbarButtonBehaviours)
       ),
       // Here we add the commonButtonDisplayEvent behaviour from the structure so we can listen

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
@@ -30,7 +30,8 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLook
       tooltip: Optional.none(),
       icon: Optional.none(),
       text: Optional.none(),
-      onSetup: () => Fun.noop
+      onSetup: () => Fun.noop,
+      context: 'any'
     }],
     predicate: Fun.always,
     position: 'selection',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
@@ -267,7 +267,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           }
         }, [], true);
 
-        it(`TINY-11211: Toolbar ${scenario.label} should be enabled in uiEnabled mode`, async () => {
+        it(`TINY-11211: Toolbar ${scenario.label} should only be enabled in readonly mode`, async () => {
           const editor = hook.editor();
           scenario.assertButtonDisabled('t3');
           editor.mode.set('readonly');
@@ -448,7 +448,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           }
         }, [], true);
 
-        it(`TINY-11211: Toolbar ${scenario.label} should be enabled in uiEnabled mode`, async () => {
+        it(`TINY-11211: Toolbar ${scenario.label} should always be disabled`, async () => {
           const editor = hook.editor();
           editor.mode.set('design');
           scenario.assertButtonDisabled('t8');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
@@ -66,7 +66,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
       buttonSetupDoesntMatch: (ed: Editor) => makeButton(ed, { name: 't9', text: 't9', context: 'doesntmatch' }),
       buttonSetupModeDesign2: (ed: Editor) => makeButton(ed, { name: 't10', text: 't10', context: 'mode:design' }),
       buttonSetupInsertSpan: (ed: Editor) => makeButton(ed, { name: 't11', text: 't11', context: 'insert:span' }),
-      buttonSetupAnyEnabledFalse: (ed: Editor) => makeButton(ed, { name: 't12', text: 't12', context: 'any', enabled: false }),
+      buttonSetupAnyEnabledFalse: (ed: Editor) => makeButton(ed, { name: 't12', text: 't12', context: 'mode:design', enabled: false }),
       assertButtonEnabled,
       assertButtonDisabled
     },
@@ -86,7 +86,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
       buttonSetupDoesntMatch: (ed: Editor) => makeToggleButton(ed, { name: 't9', text: 't9', context: 'doesntmatch' }),
       buttonSetupModeDesign2: (ed: Editor) => makeToggleButton(ed, { name: 't10', text: 't10', context: 'mode:design' }),
       buttonSetupInsertSpan: (ed: Editor) => makeToggleButton(ed, { name: 't11', text: 't11', context: 'insert:span' }),
-      buttonSetupAnyEnabledFalse: (ed: Editor) => makeToggleButton(ed, { name: 't12', text: 't12', context: 'any', enabled: false }),
+      buttonSetupAnyEnabledFalse: (ed: Editor) => makeToggleButton(ed, { name: 't12', text: 't12', context: 'mode:design', enabled: false }),
       assertButtonEnabled,
       assertButtonDisabled
     }
@@ -132,7 +132,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
         });
       });
 
-      context('Toolbar button spec with context: any, switching modes in editor setup ', () => {
+      context('Toolbar button spec with context: any, switching modes in editor setup', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
           toolbar: 't1',
@@ -255,7 +255,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
         });
       });
 
-      context('Toolbar button spec with context: mode:readonly, switching modes in editor setup ', () => {
+      context('Toolbar button spec with context: mode:readonly, switching modes in editor setup', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
           toolbar: 't3',
@@ -451,7 +451,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
         it(`TINY-11211: Toolbar ${scenario.label} should be enabled in uiEnabled mode`, async () => {
           const editor = hook.editor();
           editor.mode.set('design');
-          scenario.assertButtonEnabled('t8');
+          scenario.assertButtonDisabled('t8');
 
           editor.mode.set('testmode');
           scenario.assertButtonDisabled('t8');
@@ -577,7 +577,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           scenario.assertButtonDisabled('t12');
 
           editor.mode.set('design');
-          scenario.assertButtonDisabled('t12');
+          scenario.assertButtonEnabled('t12');
         });
       });
     });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
@@ -59,7 +59,10 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
       buttonSetupFormattingBold: (ed: Editor) => makeButton(ed, { name: 't5', text: 't5', context: 'formatting:bold' }),
       buttonSetupNodeChangeSetEnabledFalse: (ed: Editor) => makeButton(ed, { name: 't6', text: 't6', context: 'mode:design', onSetup: (api) => setupNodeChangeHandler(ed, () => api.setEnabled(false)) }),
       buttonSetupNodeChangeSetEnabledTrue: (ed: Editor) => makeButton(ed, { name: 't7', text: 't7', context: 'mode:readonly', onSetup: (api) => setupNodeChangeHandler(ed, () => api.setEnabled(true)) }),
-      buttonSetupSetEnabledFalse: (ed: Editor) => makeButton(ed, { name: 't8', text: 't8', context: 'mode:design', onSetup: (api) => () => api.setEnabled(false) }),
+      buttonSetupSetEnabledFalse: (ed: Editor) => makeButton(ed, { name: 't8', text: 't8', context: 'mode:design', onSetup: (api) => {
+        api.setEnabled(false);
+        return Fun.noop;
+      } }),
       buttonSetupDoesntMatch: (ed: Editor) => makeButton(ed, { name: 't9', text: 't9', context: 'doesntmatch' }),
       buttonSetupModeDesign2: (ed: Editor) => makeButton(ed, { name: 't10', text: 't10', context: 'mode:design' }),
       buttonSetupInsertSpan: (ed: Editor) => makeButton(ed, { name: 't11', text: 't11', context: 'insert:span' }),
@@ -76,7 +79,10 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
       buttonSetupFormattingBold: (ed: Editor) => makeToggleButton(ed, { name: 't5', text: 't5', context: 'formatting:bold' }),
       buttonSetupNodeChangeSetEnabledFalse: (ed: Editor) => makeToggleButton(ed, { name: 't6', text: 't6', context: 'mode:design', onSetup: (api) => setupNodeChangeHandler(ed, () => api.setEnabled(false)) }),
       buttonSetupNodeChangeSetEnabledTrue: (ed: Editor) => makeToggleButton(ed, { name: 't7', text: 't7', context: 'mode:readonly', onSetup: (api) => setupNodeChangeHandler(ed, () => api.setEnabled(true)) }),
-      buttonSetupSetEnabledFalse: (ed: Editor) => makeToggleButton(ed, { name: 't8', text: 't8', context: 'mode:design', onSetup: (api) => () => api.setEnabled(false) }),
+      buttonSetupSetEnabledFalse: (ed: Editor) => makeToggleButton(ed, { name: 't8', text: 't8', context: 'mode:design', onSetup: (api) => {
+        api.setEnabled(false);
+        return Fun.noop;
+      } }),
       buttonSetupDoesntMatch: (ed: Editor) => makeToggleButton(ed, { name: 't9', text: 't9', context: 'doesntmatch' }),
       buttonSetupModeDesign2: (ed: Editor) => makeToggleButton(ed, { name: 't10', text: 't10', context: 'mode:design' }),
       buttonSetupInsertSpan: (ed: Editor) => makeToggleButton(ed, { name: 't11', text: 't11', context: 'insert:span' }),
@@ -158,7 +164,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           }
         }, [], true);
 
-        it(`TINY-11211: Toolbar ${scenario.label} should not be enabled in design mode only`, async () => {
+        it(`TINY-11211: Toolbar ${scenario.label} should only be enabled in design mode`, async () => {
           const editor = hook.editor();
           editor.mode.set('design');
           scenario.assertButtonEnabled('t2');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
@@ -2,7 +2,7 @@ import { UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -130,6 +130,15 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           text: 'Test Menu Item 11',
           context: 'insert:span',
           onAction: Fun.noop,
+        });
+      },
+      buttonSetupTwelve: (ed: Editor) => {
+        ed.ui.registry.addButton('t12', {
+          icon: 'italic',
+          text: 'Test Menu Item 12',
+          context: 'any',
+          onAction: Fun.noop,
+          enabled: false
         });
       },
       assertButtonEnabled,
@@ -596,6 +605,33 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           editor.setContent('<img src="https://picsum.photos/200/300"/>');
           editor.selection.select(editor.dom.select('img')[0]);
           await Waiter.pTryUntil('Wait until toolbar button is disabled', () => scenario.assertButtonDisabled('t11'));
+        });
+      });
+
+      context('Toolbar button spec enabled: false', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't12',
+          statusbar: false,
+          setup: (ed: Editor) => {
+            registerMode(ed);
+            scenario.buttonSetupTwelve(ed);
+          }
+        }, [], true);
+
+        it(`TINY-11211: Toolbar ${scenario.label} should be stay disabled when enabled: false`, async () => {
+          const editor = hook.editor();
+          editor.mode.set('design');
+          scenario.assertButtonDisabled('t12');
+
+          editor.mode.set('readonly');
+          scenario.assertButtonDisabled('t12');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t12');
+
+          editor.mode.set('design');
+          scenario.assertButtonDisabled('t12');
         });
       });
     });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
@@ -1,0 +1,603 @@
+import { UiFinder, Waiter } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr, Fun } from '@ephox/katamari';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest', () => {
+  const registerMode = (ed: Editor) => {
+    ed.mode.register('testmode', {
+      activate: Fun.noop,
+      deactivate: Fun.noop,
+      editorReadOnly: {
+        selectionEnabled: true
+      }
+    });
+  };
+
+  const assertButtonEnabled = (selector: string) => UiFinder.notExists(SugarBody.body(), `[data-mce-name="${selector}"][aria-disabled="true"]`);
+
+  const assertButtonDisabled = (selector: string) => UiFinder.exists(SugarBody.body(), `[data-mce-name="${selector}"][aria-disabled="true"]`);
+
+  const setupButtonsScenario = [
+    {
+      label: 'Normal toolbar button',
+      buttonSetupOne: (ed: Editor) => {
+        ed.ui.registry.addButton('t1', {
+          icon: 'italic',
+          text: 'Test Menu Item 1',
+          onAction: Fun.noop,
+          context: 'any'
+        });
+      },
+      buttonSetupTwo: (ed: Editor) => {
+        ed.ui.registry.addButton('t2', {
+          icon: 'italic',
+          text: 'Test Menu Item 2',
+          onAction: Fun.noop,
+          context: 'mode:design'
+        });
+      },
+      buttonSetupThree: (ed: Editor) => {
+        ed.ui.registry.addButton('t3', {
+          icon: 'italic',
+          text: 'Test Menu Item 3',
+          context: 'mode:readonly',
+          onAction: Fun.noop,
+        });
+      },
+      buttonSetupFour: (ed: Editor) => {
+        ed.ui.registry.addButton('t4', {
+          icon: 'italic',
+          text: 'Test Menu Item 4',
+          onAction: Fun.noop,
+          context: 'editable',
+        });
+      },
+      buttonSetupFive: (ed: Editor) => {
+        ed.ui.registry.addButton('t5', {
+          icon: 'italic',
+          text: 'Test Menu Item 5',
+          context: 'formatting:bold',
+          onAction: Fun.noop,
+        });
+      },
+      buttonSetupSix: (ed: Editor) => {
+        ed.ui.registry.addButton('t6', {
+          icon: 'italic',
+          text: 'Test Menu Item 6',
+          context: 'mode:design',
+          onAction: Fun.noop,
+          onSetup: (api) => {
+            const handler = () => api.setEnabled(false);
+            ed.on('NodeChange', handler);
+            handler();
+            return () => ed.off('NodeChange', handler);
+          }
+        });
+      },
+      buttonSetupSeven: (ed: Editor) => {
+        ed.ui.registry.addButton('t7', {
+          icon: 'italic',
+          text: 'Test Menu Item 7',
+          context: 'mode:readonly',
+          onAction: Fun.noop,
+          onSetup: (api) => {
+            const handler = () => api.setEnabled(true);
+            ed.on('NodeChange', handler);
+            handler();
+            return () => ed.off('NodeChange', handler);
+          }
+        });
+      },
+      buttonSetupEight: (ed: Editor) => {
+        ed.ui.registry.addButton('t8', {
+          icon: 'italic',
+          text: 'Test Menu Item 8',
+          context: 'mode:design',
+          onAction: Fun.noop,
+          onSetup: (api) => {
+            api.setEnabled(false);
+            return Fun.noop;
+          }
+        });
+      },
+      buttonSetupNine: (ed: Editor) => {
+        ed.ui.registry.addButton('t9', {
+          icon: 'italic',
+          text: 'Test Menu Item 9',
+          context: 'doesntmatch',
+          onAction: Fun.noop,
+          onSetup: (api) => {
+            api.setEnabled(false);
+            return Fun.noop;
+          }
+        });
+      },
+      buttonSetupTen: (ed: Editor) => {
+        ed.ui.registry.addButton('t10', {
+          icon: 'italic',
+          text: 'Test Menu Item 10',
+          context: 'mode:design',
+          onAction: Fun.noop,
+        });
+      },
+      buttonSetupEleven: (ed: Editor) => {
+        ed.ui.registry.addButton('t11', {
+          icon: 'italic',
+          text: 'Test Menu Item 11',
+          context: 'insert:span',
+          onAction: Fun.noop,
+        });
+      },
+      assertButtonEnabled,
+      assertButtonDisabled
+    },
+  ];
+
+  Arr.each(setupButtonsScenario, (scenario) => {
+    context(scenario.label, () => {
+      context('Toolbar button spec with context: any', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't1',
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupOne(ed);
+          }
+        }, [], true);
+
+        it(`TINY-11211: Toolbar ${scenario.label} should be enabled in all modes`, async () => {
+          const editor = hook.editor();
+          scenario.assertButtonEnabled('t1');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonEnabled('t1');
+
+          editor.mode.set('readonly');
+          scenario.assertButtonEnabled('t1');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonEnabled('t1');
+
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t1');
+        });
+
+        it(`TINY-11211: Toolbar ${scenario.label} should be enabled in noneditable selection`, async () => {
+          const editor = hook.editor();
+          editor.setContent('<p>a</p>');
+          scenario.assertButtonEnabled('t1');
+
+          editor.setEditableRoot(false);
+          scenario.assertButtonEnabled('t1');
+        });
+      });
+
+      context('Toolbar button spec with context: any, switching modes in editor setup ', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't1',
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupOne(ed);
+            ed.mode.set('testmode');
+          }
+        }, [], true);
+
+        it(`TINY-11211: Toolbar ${scenario.label} should be enabled in all modes`, async () => {
+          const editor = hook.editor();
+          scenario.assertButtonEnabled('t1');
+
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t1');
+        });
+      });
+
+      context('Toolbar button spec with context mode:design', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't2',
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupTwo(ed);
+          }
+        }, [], true);
+
+        it(`TINY-11211: Toolbar ${scenario.label} should not be enabled in design mode only`, async () => {
+          const editor = hook.editor();
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t2');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t2');
+
+          editor.mode.set('readonly');
+          scenario.assertButtonDisabled('t2');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t2');
+
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t2');
+        });
+
+        it(`TINY-11211: Toolbar ${scenario.label} should be enabled in noneditable selection`, async () => {
+          const editor = hook.editor();
+          editor.setContent('<p>a</p>');
+          scenario.assertButtonEnabled('t2');
+
+          editor.setEditableRoot(false);
+          scenario.assertButtonEnabled('t2');
+        });
+      });
+
+      context('Toolbar button spec with context: mode:design, switching modes in editor setup ', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't2',
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupTwo(ed);
+            ed.mode.set('testmode');
+          }
+        }, [], true);
+
+        it(`TINY-11211: Toolbar ${scenario.label} should be enabled in design mode only`, async () => {
+          const editor = hook.editor();
+          scenario.assertButtonDisabled('t2');
+
+          editor.mode.set('readonly');
+          scenario.assertButtonDisabled('t2');
+
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t2');
+        });
+      });
+
+      context('Toolbar button spec with context: mode:readonly', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't3',
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupThree(ed);
+          }
+        }, [], true);
+
+        it(`TINY-11211: Toolbar ${scenario.label} should be enabled in readonly mode`, async () => {
+          const editor = hook.editor();
+          editor.mode.set('design');
+          scenario.assertButtonDisabled('t3');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t3');
+
+          editor.mode.set('readonly');
+          scenario.assertButtonEnabled('t3');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t3');
+
+          editor.mode.set('design');
+          scenario.assertButtonDisabled('t3');
+        });
+
+        it(`TINY-11211: Toolbar ${scenario.label} should be enabled in noneditable selection`, async () => {
+          const editor = hook.editor();
+          editor.setContent('<p>a</p>');
+          scenario.assertButtonDisabled('t3');
+
+          editor.setEditableRoot(false);
+          scenario.assertButtonDisabled('t3');
+        });
+      });
+
+      context('Toolbar button spec with context: mode:readonly, switching modes in editor setup ', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't3',
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupThree(ed);
+            ed.mode.set('testmode');
+          }
+        }, [], true);
+
+        it(`TINY-11211: Toolbar ${scenario.label} should be enabled in uiEnabled mode`, async () => {
+          const editor = hook.editor();
+          scenario.assertButtonDisabled('t3');
+          editor.mode.set('readonly');
+          scenario.assertButtonEnabled('t3');
+          editor.mode.set('design');
+          scenario.assertButtonDisabled('t3');
+        });
+      });
+
+      context('Toolbar button spec with context: editable', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't4',
+          statusbar: false,
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupFour(ed);
+          }
+        }, [], true);
+
+        it(`TINY-11211: Toolbar ${scenario.label} should be enabled when selection is editable`, async () => {
+          const editor = hook.editor();
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t4');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t4');
+
+          editor.mode.set('readonly');
+          scenario.assertButtonDisabled('t4');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t4');
+
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t4');
+        });
+
+        it(`TINY-11211: Toolbar ${scenario.label} should be disabled in non-editable root`, async () => {
+          const editor = hook.editor();
+          editor.setEditableRoot(false);
+          editor.mode.set('design');
+          scenario.assertButtonDisabled('t4');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t4');
+
+          editor.mode.set('readonly');
+          scenario.assertButtonDisabled('t4');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t4');
+
+          editor.setEditableRoot(true);
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t4');
+        });
+      });
+
+      context('Toolbar button spec with context: formatting:bold', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't5',
+          statusbar: false,
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupFive(ed);
+          }
+        }, [], true);
+
+        it(`TINY-11211: Toolbar ${scenario.label} should be enabled when formatter can be applied`, async () => {
+          const editor = hook.editor();
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t5');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t5');
+
+          editor.mode.set('readonly');
+          scenario.assertButtonDisabled('t5');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t5');
+
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t5');
+        });
+
+        it(`TINY-11211: Toolbar ${scenario.label} should not be enabled when formatter cannot be applied`, () => {
+          const editor = hook.editor();
+          editor.setContent('<p>test</p>');
+          scenario.assertButtonEnabled('t5');
+          editor.setEditableRoot(false);
+          scenario.assertButtonDisabled('t5');
+          editor.setEditableRoot(true);
+          scenario.assertButtonEnabled('t5');
+        });
+      });
+
+      context('Toolbar button spec with context: mode:design and onSetup buttonApi setEnabled(false)', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't6',
+          statusbar: false,
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupSix(ed);
+          }
+        }, [], true);
+
+        it(`TINY-11211: Toolbar ${scenario.label} buttonApi.setEnabled should overwrite the context`, async () => {
+          const editor = hook.editor();
+          editor.mode.set('design');
+          scenario.assertButtonDisabled('t6');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t6');
+
+          editor.mode.set('readonly');
+          scenario.assertButtonDisabled('t6');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t6');
+
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t6');
+          // Since the onSetup for this button is listening for the NodeChange event, manually dispatching a nodeChanged to trigger a state change
+          editor.nodeChanged();
+          scenario.assertButtonDisabled('t6');
+        });
+      });
+
+      context('Toolbar button spec with context: mode:readonly and onSetup buttonApi setEnabled(true)', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't7',
+          statusbar: false,
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupSeven(ed);
+          }
+        }, [], true);
+
+        it(`TINY-11211: Toolbar ${scenario.label} buttonApi.setEnabled should overwrite the context`, async () => {
+          const editor = hook.editor();
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t7');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t7');
+
+          editor.mode.set('readonly');
+          scenario.assertButtonEnabled('t7');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t7');
+
+          editor.mode.set('design');
+          scenario.assertButtonDisabled('t7');
+          editor.nodeChanged();
+          scenario.assertButtonEnabled('t7');
+        });
+      });
+
+      context('Toolbar button spec with context: mode:design and onSetup buttonApi setEnabled(false), without NodeChange', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't8',
+          statusbar: false,
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupEight(ed);
+          }
+        }, [], true);
+
+        it(`TINY-11211: Toolbar ${scenario.label} should be enabled in uiEnabled mode`, async () => {
+          const editor = hook.editor();
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t8');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t8');
+
+          editor.mode.set('readonly');
+          scenario.assertButtonDisabled('t8');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t8');
+
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t8');
+        });
+      });
+
+      context('Toolbar button spec with context: doesntmatch, should fallback to default mode:design', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't9',
+          statusbar: false,
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupNine(ed);
+          }
+        }, [], true);
+
+        it(`TINY-11211: Toolbar ${scenario.label} should fall back to mode:design`, async () => {
+          const editor = hook.editor();
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t9');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t9');
+
+          editor.mode.set('readonly');
+          scenario.assertButtonDisabled('t9');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t9');
+
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t9');
+        });
+      });
+
+      context('Toolbar button spec with context mode:design, readonly: true editor option', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't10',
+          statusbar: false,
+          readonly: true,
+          setup: (ed: Editor) => {
+            registerMode(ed);
+
+            scenario.buttonSetupTen(ed);
+          }
+        }, [], true);
+
+        it(`TINY-11211: Toolbar ${scenario.label} should be disabled initially`, async () => {
+          const editor = hook.editor();
+          scenario.assertButtonDisabled('t10');
+
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t10');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t10');
+
+          editor.mode.set('readonly');
+          scenario.assertButtonDisabled('t10');
+
+          editor.mode.set('testmode');
+          scenario.assertButtonDisabled('t10');
+
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t10');
+        });
+      });
+
+      context('Toolbar button spec with context insert:tr', () => {
+        const hook = TinyHooks.bddSetup<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          toolbar: 't11',
+          statusbar: false,
+          setup: (ed: Editor) => {
+            registerMode(ed);
+            scenario.buttonSetupEleven(ed);
+          }
+        }, [], true);
+
+        it(`TINY-11211: Toolbar ${scenario.label} should be disabled initially`, async () => {
+          const editor = hook.editor();
+          editor.mode.set('design');
+          scenario.assertButtonEnabled('t11');
+
+          editor.setContent('<img src="https://picsum.photos/200/300"/>');
+          editor.selection.select(editor.dom.select('img')[0]);
+          await Waiter.pTryUntil('Wait until toolbar button is disabled', () => scenario.assertButtonDisabled('t11'));
+        });
+      });
+    });
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
@@ -27,6 +27,17 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
     return () => ed.off('NodeChange', handler);
   };
 
+  const makeToggleButton = (ed: Editor, spec: { name: string; text: string; context: string; onSetup?: (api: any) => (api: any) => void; enabled?: boolean }) => {
+    ed.ui.registry.addToggleButton(spec.name, {
+      icon: 'italic',
+      text: spec.text,
+      onAction: Fun.noop,
+      onSetup: spec.onSetup,
+      context: spec.context,
+      enabled: spec.enabled
+    });
+  };
+
   const makeButton = (ed: Editor, spec: { name: string; text: string; context: string; onSetup?: (api: any) => (api: any) => void; enabled?: boolean }) => {
     ed.ui.registry.addButton(spec.name, {
       icon: 'italic',
@@ -56,6 +67,23 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
       assertButtonEnabled,
       assertButtonDisabled
     },
+    {
+      label: 'Toggle toolbar button',
+      buttonSetupAny: (ed: Editor) => makeToggleButton(ed, { name: 't1', text: 't1', context: 'any' }),
+      buttonSetupModeDesign: (ed: Editor) => makeToggleButton(ed, { name: 't2', text: 't2', context: 'mode:design' }),
+      buttonSetupModeReadonly: (ed: Editor) => makeToggleButton(ed, { name: 't3', text: 't3', context: 'mode:readonly' }),
+      buttonSetupEditable: (ed: Editor) => makeToggleButton(ed, { name: 't4', text: 't4', context: 'editable' }),
+      buttonSetupFormattingBold: (ed: Editor) => makeToggleButton(ed, { name: 't5', text: 't5', context: 'formatting:bold' }),
+      buttonSetupNodeChangeSetEnabledFalse: (ed: Editor) => makeToggleButton(ed, { name: 't6', text: 't6', context: 'mode:design', onSetup: (api) => setupNodeChangeHandler(ed, () => api.setEnabled(false)) }),
+      buttonSetupNodeChangeSetEnabledTrue: (ed: Editor) => makeToggleButton(ed, { name: 't7', text: 't7', context: 'mode:readonly', onSetup: (api) => setupNodeChangeHandler(ed, () => api.setEnabled(true)) }),
+      buttonSetupSetEnabledFalse: (ed: Editor) => makeToggleButton(ed, { name: 't8', text: 't8', context: 'mode:design', onSetup: (api) => () => api.setEnabled(false) }),
+      buttonSetupDoesntMatch: (ed: Editor) => makeToggleButton(ed, { name: 't9', text: 't9', context: 'doesntmatch' }),
+      buttonSetupModeDesign2: (ed: Editor) => makeToggleButton(ed, { name: 't10', text: 't10', context: 'mode:design' }),
+      buttonSetupInsertSpan: (ed: Editor) => makeToggleButton(ed, { name: 't11', text: 't11', context: 'insert:span' }),
+      buttonSetupAnyEnabledFalse: (ed: Editor) => makeToggleButton(ed, { name: 't12', text: 't12', context: 'any', enabled: false }),
+      assertButtonEnabled,
+      assertButtonDisabled
+    }
   ];
 
   Arr.each(setupButtonsScenario, (scenario) => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
@@ -21,126 +21,38 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
 
   const assertButtonDisabled = (selector: string) => UiFinder.exists(SugarBody.body(), `[data-mce-name="${selector}"][aria-disabled="true"]`);
 
+  const setupNodeChangeHandler = (ed: Editor, handler: () => void) => {
+    ed.on('NodeChange', handler);
+    handler();
+    return () => ed.off('NodeChange', handler);
+  };
+
+  const makeButton = (ed: Editor, spec: { name: string; text: string; context: string; onSetup?: (api: any) => (api: any) => void; enabled?: boolean }) => {
+    ed.ui.registry.addButton(spec.name, {
+      icon: 'italic',
+      text: spec.text,
+      onAction: Fun.noop,
+      onSetup: spec.onSetup,
+      context: spec.context,
+      enabled: spec.enabled
+    });
+  };
+
   const setupButtonsScenario = [
     {
       label: 'Normal toolbar button',
-      buttonSetupOne: (ed: Editor) => {
-        ed.ui.registry.addButton('t1', {
-          icon: 'italic',
-          text: 'Test Menu Item 1',
-          onAction: Fun.noop,
-          context: 'any'
-        });
-      },
-      buttonSetupTwo: (ed: Editor) => {
-        ed.ui.registry.addButton('t2', {
-          icon: 'italic',
-          text: 'Test Menu Item 2',
-          onAction: Fun.noop,
-          context: 'mode:design'
-        });
-      },
-      buttonSetupThree: (ed: Editor) => {
-        ed.ui.registry.addButton('t3', {
-          icon: 'italic',
-          text: 'Test Menu Item 3',
-          context: 'mode:readonly',
-          onAction: Fun.noop,
-        });
-      },
-      buttonSetupFour: (ed: Editor) => {
-        ed.ui.registry.addButton('t4', {
-          icon: 'italic',
-          text: 'Test Menu Item 4',
-          onAction: Fun.noop,
-          context: 'editable',
-        });
-      },
-      buttonSetupFive: (ed: Editor) => {
-        ed.ui.registry.addButton('t5', {
-          icon: 'italic',
-          text: 'Test Menu Item 5',
-          context: 'formatting:bold',
-          onAction: Fun.noop,
-        });
-      },
-      buttonSetupSix: (ed: Editor) => {
-        ed.ui.registry.addButton('t6', {
-          icon: 'italic',
-          text: 'Test Menu Item 6',
-          context: 'mode:design',
-          onAction: Fun.noop,
-          onSetup: (api) => {
-            const handler = () => api.setEnabled(false);
-            ed.on('NodeChange', handler);
-            handler();
-            return () => ed.off('NodeChange', handler);
-          }
-        });
-      },
-      buttonSetupSeven: (ed: Editor) => {
-        ed.ui.registry.addButton('t7', {
-          icon: 'italic',
-          text: 'Test Menu Item 7',
-          context: 'mode:readonly',
-          onAction: Fun.noop,
-          onSetup: (api) => {
-            const handler = () => api.setEnabled(true);
-            ed.on('NodeChange', handler);
-            handler();
-            return () => ed.off('NodeChange', handler);
-          }
-        });
-      },
-      buttonSetupEight: (ed: Editor) => {
-        ed.ui.registry.addButton('t8', {
-          icon: 'italic',
-          text: 'Test Menu Item 8',
-          context: 'mode:design',
-          onAction: Fun.noop,
-          onSetup: (api) => {
-            api.setEnabled(false);
-            return Fun.noop;
-          }
-        });
-      },
-      buttonSetupNine: (ed: Editor) => {
-        ed.ui.registry.addButton('t9', {
-          icon: 'italic',
-          text: 'Test Menu Item 9',
-          context: 'doesntmatch',
-          onAction: Fun.noop,
-          onSetup: (api) => {
-            api.setEnabled(false);
-            return Fun.noop;
-          }
-        });
-      },
-      buttonSetupTen: (ed: Editor) => {
-        ed.ui.registry.addButton('t10', {
-          icon: 'italic',
-          text: 'Test Menu Item 10',
-          context: 'mode:design',
-          onAction: Fun.noop,
-        });
-      },
-      buttonSetupEleven: (ed: Editor) => {
-        ed.ui.registry.addButton('t11', {
-          icon: 'italic',
-          text: 'Test Menu Item 11',
-          context: 'insert:span',
-          onAction: Fun.noop,
-        });
-      },
-      buttonSetupTwelve: (ed: Editor) => {
-        ed.ui.registry.addButton('t12', {
-          icon: 'italic',
-          text: 'Test Menu Item 12',
-          context: 'any',
-          onAction: Fun.noop,
-          enabled: false
-        });
-      },
+      buttonSetupAny: (ed: Editor) => makeButton(ed, { name: 't1', text: 't1', context: 'any' }),
+      buttonSetupModeDesign: (ed: Editor) => makeButton(ed, { name: 't2', text: 't2', context: 'mode:design' }),
+      buttonSetupModeReadonly: (ed: Editor) => makeButton(ed, { name: 't3', text: 't3', context: 'mode:readonly' }),
+      buttonSetupEditable: (ed: Editor) => makeButton(ed, { name: 't4', text: 't4', context: 'editable' }),
+      buttonSetupFormattingBold: (ed: Editor) => makeButton(ed, { name: 't5', text: 't5', context: 'formatting:bold' }),
+      buttonSetupNodeChangeSetEnabledFalse: (ed: Editor) => makeButton(ed, { name: 't6', text: 't6', context: 'mode:design', onSetup: (api) => setupNodeChangeHandler(ed, () => api.setEnabled(false)) }),
+      buttonSetupNodeChangeSetEnabledTrue: (ed: Editor) => makeButton(ed, { name: 't7', text: 't7', context: 'mode:readonly', onSetup: (api) => setupNodeChangeHandler(ed, () => api.setEnabled(true)) }),
+      buttonSetupSetEnabledFalse: (ed: Editor) => makeButton(ed, { name: 't8', text: 't8', context: 'mode:design', onSetup: (api) => () => api.setEnabled(false) }),
+      buttonSetupDoesntMatch: (ed: Editor) => makeButton(ed, { name: 't9', text: 't9', context: 'doesntmatch' }),
+      buttonSetupModeDesign2: (ed: Editor) => makeButton(ed, { name: 't10', text: 't10', context: 'mode:design' }),
+      buttonSetupInsertSpan: (ed: Editor) => makeButton(ed, { name: 't11', text: 't11', context: 'insert:span' }),
+      buttonSetupAnyEnabledFalse: (ed: Editor) => makeButton(ed, { name: 't12', text: 't12', context: 'any', enabled: false }),
       assertButtonEnabled,
       assertButtonDisabled
     },
@@ -155,7 +67,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           setup: (ed: Editor) => {
             registerMode(ed);
 
-            scenario.buttonSetupOne(ed);
+            scenario.buttonSetupAny(ed);
           }
         }, [], true);
 
@@ -193,7 +105,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           setup: (ed: Editor) => {
             registerMode(ed);
 
-            scenario.buttonSetupOne(ed);
+            scenario.buttonSetupAny(ed);
             ed.mode.set('testmode');
           }
         }, [], true);
@@ -214,7 +126,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           setup: (ed: Editor) => {
             registerMode(ed);
 
-            scenario.buttonSetupTwo(ed);
+            scenario.buttonSetupModeDesign(ed);
           }
         }, [], true);
 
@@ -253,7 +165,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           setup: (ed: Editor) => {
             registerMode(ed);
 
-            scenario.buttonSetupTwo(ed);
+            scenario.buttonSetupModeDesign(ed);
             ed.mode.set('testmode');
           }
         }, [], true);
@@ -277,7 +189,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           setup: (ed: Editor) => {
             registerMode(ed);
 
-            scenario.buttonSetupThree(ed);
+            scenario.buttonSetupModeReadonly(ed);
           }
         }, [], true);
 
@@ -316,7 +228,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           setup: (ed: Editor) => {
             registerMode(ed);
 
-            scenario.buttonSetupThree(ed);
+            scenario.buttonSetupModeReadonly(ed);
             ed.mode.set('testmode');
           }
         }, [], true);
@@ -339,7 +251,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           setup: (ed: Editor) => {
             registerMode(ed);
 
-            scenario.buttonSetupFour(ed);
+            scenario.buttonSetupEditable(ed);
           }
         }, [], true);
 
@@ -390,7 +302,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           setup: (ed: Editor) => {
             registerMode(ed);
 
-            scenario.buttonSetupFive(ed);
+            scenario.buttonSetupFormattingBold(ed);
           }
         }, [], true);
 
@@ -431,7 +343,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           setup: (ed: Editor) => {
             registerMode(ed);
 
-            scenario.buttonSetupSix(ed);
+            scenario.buttonSetupNodeChangeSetEnabledFalse(ed);
           }
         }, [], true);
 
@@ -465,7 +377,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           setup: (ed: Editor) => {
             registerMode(ed);
 
-            scenario.buttonSetupSeven(ed);
+            scenario.buttonSetupNodeChangeSetEnabledTrue(ed);
           }
         }, [], true);
 
@@ -498,7 +410,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           setup: (ed: Editor) => {
             registerMode(ed);
 
-            scenario.buttonSetupEight(ed);
+            scenario.buttonSetupSetEnabledFalse(ed);
           }
         }, [], true);
 
@@ -529,7 +441,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           setup: (ed: Editor) => {
             registerMode(ed);
 
-            scenario.buttonSetupNine(ed);
+            scenario.buttonSetupDoesntMatch(ed);
           }
         }, [], true);
 
@@ -561,7 +473,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           setup: (ed: Editor) => {
             registerMode(ed);
 
-            scenario.buttonSetupTen(ed);
+            scenario.buttonSetupModeDesign2(ed);
           }
         }, [], true);
 
@@ -593,7 +505,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           statusbar: false,
           setup: (ed: Editor) => {
             registerMode(ed);
-            scenario.buttonSetupEleven(ed);
+            scenario.buttonSetupInsertSpan(ed);
           }
         }, [], true);
 
@@ -615,7 +527,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
           statusbar: false,
           setup: (ed: Editor) => {
             registerMode(ed);
-            scenario.buttonSetupTwelve(ed);
+            scenario.buttonSetupAnyEnabledFalse(ed);
           }
         }, [], true);
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
@@ -29,6 +29,7 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
         },
         components: [
           renderToolbarButton({
+            context: 'any',
             type: 'button',
             shortcut: Optional.none(),
             enabled: true,
@@ -54,6 +55,7 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
         },
         components: [
           renderToolbarToggleButton({
+            context: 'any',
             type: 'togglebutton',
             shortcut: Optional.none(),
             enabled: true,

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogEventTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogEventTest.ts
@@ -95,7 +95,7 @@ describe('headless.tinymce.themes.silver.window.SilverDialogEventTest', () => {
         shared: {
           getSink: () => Result.value(sink),
           providers: {
-            checkButtonContext: Fun.always,
+            checkButtonContext: Fun.constant({ contextType: 'any', shouldDisable: false }),
             icons: () => ({}),
             menuItems: () => ({}),
             translate: I18n.translate,

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogEventTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogEventTest.ts
@@ -95,6 +95,7 @@ describe('headless.tinymce.themes.silver.window.SilverDialogEventTest', () => {
         shared: {
           getSink: () => Result.value(sink),
           providers: {
+            checkButtonContext: Fun.always,
             icons: () => ({}),
             menuItems: () => ({}),
             translate: I18n.translate,

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
@@ -14,7 +14,7 @@ export default {
   translate: I18n.translate,
   isDisabled: Fun.never,
   getOption: <T>(name: string): T | undefined => defaultOptions[name],
-  checkButtonContext: Fun.always,
+  checkButtonContext: Fun.constant({ contextType: 'any', shouldDisable: false }),
   tooltips: {
     getConfig: (): TooltippingTypes.TooltippingConfigSpec => {
       return {

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
@@ -14,6 +14,7 @@ export default {
   translate: I18n.translate,
   isDisabled: Fun.never,
   getOption: <T>(name: string): T | undefined => defaultOptions[name],
+  checkButtonContext: Fun.always,
   tooltips: {
     getConfig: (): TooltippingTypes.TooltippingConfigSpec => {
       return {


### PR DESCRIPTION
Related Ticket:  TINY-11211

Description of Changes:
* First phase, adding the base for `addContext` to the registry and using them in the backstage.
* Added the `context` spec to the Toolbar buttons for now, will be expanding to other type of buttons in the upcoming PRs.

Pre-checks:
* [x] ~Changelog entry added~ Will be consolidated into epic/EPIC-114
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
