### PR TITLE
Properly shut down the editors created by the reset content test

### DIFF
--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/McEditor.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/McEditor.ts
@@ -13,6 +13,7 @@ const pFromElement = <T extends EditorType = EditorType>(element: SugarElement<E
     const nuSettings: Record<string, any> = {
       toolbar_mode: 'wrap',
       promotion: false,
+      license_key: 'gpl',
       ...settings
     };
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/loader/Loader.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/loader/Loader.ts
@@ -90,6 +90,7 @@ const setup = (callbacks: Callbacks, settings: Record<string, any>, elementOpt: 
 
     tinymce.init({
       promotion: false,
+      license_key: 'gpl',
       ...settings,
       ...targetSettings,
       setup: (editor: Editor) => {

--- a/modules/tinymce/src/core/test/ts/browser/EditorOptionsDebugTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorOptionsDebugTest.ts
@@ -13,7 +13,7 @@ describe('browser.tinymce.core.EditorOptionsDebugTest', () => {
       ...options,
       base_url: '/project/tinymce/js/tinymce',
     }, []);
-  const ignoredKeys = new Set([ 'promotion', 'toolbar', 'menubar', 'statusbar', 'base_url', 'selector', 'setup' ]);
+  const ignoredKeys = new Set([ 'license_key', 'promotion', 'toolbar', 'menubar', 'statusbar', 'base_url', 'selector', 'setup' ]);
   const assertDebugLog = (editor: Editor, expectedLog: unknown) => {
     const logs: unknown[] = [];
     const originalLog = console.log;

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorResetContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorResetContentTest.ts
@@ -62,6 +62,7 @@ describe('browser.tinymce.core.content.EditorResetContentTest', () => {
       editor.resetContent();
       assert.isFalse(hasXssOccurred, 'XSS should not have occurred');
       (editor.getWin() as any)[xssFnName] = null;
+      McEditor.remove(editor);
     };
 
     it('TINY-10236: Excluding data-mce-bogus="all" elements does not cause mXSS',
@@ -85,6 +86,7 @@ describe('browser.tinymce.core.content.EditorResetContentTest', () => {
       editor.setContent('<p>some</p><p>content</p>');
       editor.resetContent();
       TinyAssertions.assertRawContent(editor, '<p>test</p>');
+      McEditor.remove(editor);
     });
 
     it('TINY-10305: Should remove ZWNBSP from initial content as parameter', () => {
@@ -92,6 +94,7 @@ describe('browser.tinymce.core.content.EditorResetContentTest', () => {
       editor.setContent('<p>some</p><p>content</p>');
       editor.resetContent('<p>te\uFEFFst</p>');
       TinyAssertions.assertRawContent(editor, '<p>test</p>');
+      McEditor.remove(editor);
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/init/LicenseKeyValidationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/LicenseKeyValidationTest.ts
@@ -91,6 +91,7 @@ describe('browser.tinymce.core.init.LicenseKeyValidationTest', () => {
     after(afterHandler);
 
     TinyHooks.bddSetupLight<Editor>({
+      license_key: undefined,
       base_url: '/project/tinymce/js/tinymce'
     });
 


### PR DESCRIPTION
Related Ticket: n/a

Description of Changes:
* Suppress the license key warning in our own tests
* The reset content test created a bunch of editors but didn't shut them down, resulting in `textarea` elements left in the page that might impact subsequent tests.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
