### PR TITLE
TINY-11166: Added new option to allow specific math annotation elements

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11166-2024-09-06.yaml
+++ b/.changes/unreleased/tinymce-TINY-11166-2024-09-06.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Added
+body: New option `allow_mathml_annotation_encodings` to opt-in to keep math annotations
+  with specific encodings.
+time: 2024-09-06T10:31:15.360045+02:00
+custom:
+  Issue: TINY-11166

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -547,6 +547,14 @@ const register = (editor: Editor): void => {
     default: false
   });
 
+  registerOption('allow_mathml_annotation_encodings', {
+    processor: (value) => {
+      const valid = Type.isArrayOf(value, Type.isString);
+      return valid ? { value: true, valid } : { valid: false, message: 'Must be an array of strings.' };
+    },
+    default: []
+  });
+
   registerOption('convert_fonts_to_spans', {
     processor: 'boolean',
     default: true,

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -56,6 +56,7 @@ export interface DomParserSettings {
   allow_html_in_named_anchor?: boolean;
   allow_script_urls?: boolean;
   allow_unsafe_link_target?: boolean;
+  allow_mathml_annotation_encodings?: string[];
   blob_cache?: BlobCache;
   convert_fonts_to_spans?: boolean;
   convert_unsafe_embeds?: boolean;

--- a/modules/tinymce/src/core/main/ts/html/Sanitization.ts
+++ b/modules/tinymce/src/core/main/ts/html/Sanitization.ts
@@ -203,32 +203,55 @@ const getPurifyConfig = (settings: DomParserSettings, mimeType: string): Config 
   return config;
 };
 
-const sanitizeNamespaceElement = (ele: Element) => {
+const sanitizeSvgElement = (ele: Element) => {
+  // xlink:href used to be the way to do links in SVG 1.x https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href
+  const xlinkAttrs = [ 'type', 'href', 'role', 'arcrole', 'title', 'show', 'actuate', 'label', 'from', 'to' ].map((name) => `xlink:${name}`);
+  const config: Config = {
+    IN_PLACE: true,
+    USE_PROFILES: {
+      html: true,
+      svg: true,
+      svgFilters: true
+    },
+    ALLOWED_ATTR: xlinkAttrs
+  };
+
+  createDompurify().sanitize(ele, config);
+
+};
+
+const sanitizeMathmlElement = (node: Element, settings: DomParserSettings) => {
+  const config: Config = {
+    IN_PLACE: true,
+    USE_PROFILES: {
+      mathMl: true
+    },
+  };
+
+  const purify = createDompurify();
+
+  purify.addHook('uponSanitizeElement', (node, evt) => {
+    const lcTagName = evt.tagName ?? node.nodeName.toLowerCase();
+    const allowedEncodings = settings.allow_mathml_annotation_encodings;
+
+    if (lcTagName === 'annotation' && Type.isArray(allowedEncodings) && allowedEncodings.length > 0) {
+      const encoding = node.getAttribute('encoding');
+      if (Type.isString(encoding) && Arr.contains(allowedEncodings, encoding)) {
+        evt.allowedTags[lcTagName] = true;
+      }
+    }
+  });
+
+  purify.sanitize(node, config);
+};
+
+const mkSanitizeNamespaceElement = (settings: DomParserSettings) => (ele: Element) => {
   const namespaceType = Namespace.toScopeType(ele);
 
   if (namespaceType === 'svg') {
-    // xlink:href used to be the way to do links in SVG 1.x https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href
-    const xlinkAttrs = [ 'type', 'href', 'role', 'arcrole', 'title', 'show', 'actuate', 'label', 'from', 'to' ].map((name) => `xlink:${name}`);
-    const config: Config = {
-      IN_PLACE: true,
-      USE_PROFILES: {
-        html: true,
-        svg: true,
-        svgFilters: true
-      },
-      ALLOWED_ATTR: xlinkAttrs
-    };
-
-    createDompurify().sanitize(ele, config);
+    sanitizeSvgElement(ele);
   } else if (namespaceType === 'math') {
-    const config: Config = {
-      IN_PLACE: true,
-      USE_PROFILES: {
-        mathMl: true
-      },
-    };
-
-    createDompurify().sanitize(ele, config);
+    sanitizeMathmlElement(ele, settings);
   } else {
     throw new Error('Not a namespace element');
   }
@@ -247,7 +270,7 @@ const getSanitizer = (settings: DomParserSettings, schema: Schema): Sanitizer =>
 
     return {
       sanitizeHtmlElement,
-      sanitizeNamespaceElement
+      sanitizeNamespaceElement: mkSanitizeNamespaceElement(settings)
     };
   } else {
     const sanitizeHtmlElement = (body: HTMLElement, _mimeType: MimeType) => {

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -73,6 +73,7 @@ const mkParserSettings = (editor: Editor): DomParserSettings => {
     allow_svg_data_urls: getOption('allow_svg_data_urls'),
     allow_html_in_named_anchor: getOption('allow_html_in_named_anchor'),
     allow_script_urls: getOption('allow_script_urls'),
+    allow_mathml_annotation_encodings: getOption('allow_mathml_annotation_encodings'),
     allow_unsafe_link_target: getOption('allow_unsafe_link_target'),
     convert_unsafe_embeds: getOption('convert_unsafe_embeds'),
     convert_fonts_to_spans: getOption('convert_fonts_to_spans'),

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1739,6 +1739,31 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
       assert.equal(serializedHtml, '<div><math> <mrow> </mrow> </math> <math> </math></div>');
     });
 
+    it('TINY-11166: Allow custom annotation mime types only annotation with encoding and no src attributes', () => {
+      const schema = Schema();
+      schema.addValidElements('math[*]');
+      const input = [
+        '<math><annotation encoding="application/x-tex">\\frac{1}{2}</annotation></math>',
+        '<math><annotation encoding="application/custom">custom</annotation></math>',
+        '<math><annotation encoding="application/custom" src="foo">custom with src</annotation></math>',
+        '<math><annotation encoding="wiris">{"version":"1.1","math":"&lt;math xmlns="http://www.w3.org/1998/Math/MathML"&gt;&lt;mfrac&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;/mfrac&gt;&lt;/math&gt;"}</annotation></math>',
+        '<math><annotation encoding="text/html">html</annotation></math>',
+        '<math><annotation encoding="text/svg">svg</annotation></math>',
+      ].join('');
+      const allowedAnnotationEncodings = [ 'application/x-tex', 'application/custom', 'wiris' ];
+      const domParser = DomParser({ forced_root_block: 'p', allow_mathml_annotation_encodings: allowedAnnotationEncodings }, schema);
+      const serializedHtml = HtmlSerializer({}, schema).serialize(domParser.parse(input));
+
+      const expected = [
+        '<math><annotation encoding="application/x-tex">\\frac{1}{2}</annotation></math>',
+        '<math><annotation encoding="application/custom">custom</annotation></math>',
+        '<math><annotation encoding="application/custom">custom with src</annotation></math>',
+        '<math><annotation encoding="wiris">{"version":"1.1","math":"&lt;math xmlns="http://www.w3.org/1998/Math/MathML"&gt;&lt;mfrac&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;/mfrac&gt;&lt;/math&gt;"}</annotation></math>',
+        '<math>html</math>',
+        '<math>svg</math>'
+      ].join('');
+      assert.equal(serializedHtml, expected);
+    });
   });
 
   context('Special elements', () => {


### PR DESCRIPTION
Related Ticket: TINY-11166

Description of Changes:
* Added new option to keep specific annotation encodings.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
