### PR TITLE
TINY-11166: Fixed issue with editor config option

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -550,7 +550,7 @@ const register = (editor: Editor): void => {
   registerOption('allow_mathml_annotation_encodings', {
     processor: (value) => {
       const valid = Type.isArrayOf(value, Type.isString);
-      return valid ? { value: true, valid } : { valid: false, message: 'Must be an array of strings.' };
+      return valid ? { value, valid } : { valid: false, message: 'Must be an array of strings.' };
     },
     default: []
   });

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -720,4 +720,47 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
       TinyAssertions.assertContent(editor, '<noscript>&amp;lt;/noscript&amp;&gt;</noscript>');
     });
   });
+
+  context('math elements', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      custom_elements: 'math',
+      allow_mathml_annotation_encodings: [
+        'application/x-tex',
+        'application/custom',
+        'wiris'
+      ]
+    }, []);
+
+    it('TINY-11166: allow_mathml_annotation_encodings should retain the specified annotation elements', () => {
+      const editor = hook.editor();
+
+      const input = [
+        '<div>',
+        '<math><annotation encoding="application/x-tex">\\frac{1}{2}</annotation></math>',
+        '<math><annotation encoding="application/custom">custom</annotation></math>',
+        '<math><annotation encoding="application/custom" src="foo">custom with src</annotation></math>',
+        '<math><annotation encoding="wiris">{"version":"1.1","math":"&lt;math xmlns="http://www.w3.org/1998/Math/MathML"&gt;&lt;mfrac&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;/mfrac&gt;&lt;/math&gt;"}</annotation></math>',
+        '<math><annotation encoding="text/html">html</annotation></math>',
+        '<math><annotation encoding="text/svg">svg</annotation></math>',
+        '</div>'
+      ].join('');
+
+      editor.setContent(input);
+
+      const expected = [
+        '<div>',
+        '<math><annotation encoding="application/x-tex">\\frac{1}{2}</annotation></math>',
+        '<math><annotation encoding="application/custom">custom</annotation></math>',
+        '<math><annotation encoding="application/custom">custom with src</annotation></math>',
+        '<math><annotation encoding="wiris">{"version":"1.1","math":"&lt;math xmlns="http://www.w3.org/1998/Math/MathML"&gt;&lt;mfrac&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;/mfrac&gt;&lt;/math&gt;"}</annotation></math>',
+        '<math>html</math>',
+        '<math>svg</math>',
+        '</div>'
+      ].join('');
+
+      TinyAssertions.assertContent(editor, expected);
+    });
+  });
+
 });


### PR DESCRIPTION
Related Ticket: TINY-11166

Description of Changes:
* Follow up to TINY-11166 since I messed up the option it would return `true` instead of the expected value.
* Added a proper integration test than just the unit test I had for DomParser this would have been caught if I had done that in the first place.

Pre-checks:
* [x] ~~Changelog entry added~~ not needed since it already has a changelog item.
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
