### PR TITLE
TINY-11194: A CSS Calc function with a unitless number causes Sass compilation error

### DIFF
--- a/modules/oxide/src/less/theme/components/toolbar/toolbar.less
+++ b/modules/oxide/src/less/theme/components/toolbar/toolbar.less
@@ -7,7 +7,7 @@
 @toolbar-padding-x: @pad-sm;
 @toolbar-row-separator-color: @tinymce-separator-color;
 @toolbar-row-separator-padding: @toolbar-group-padding-x;
-@toolbar-separator-distance: 0;
+@toolbar-separator-distance: 0px;
 @toolbar-separator-color: transparent;
 
 // private variables


### PR DESCRIPTION
Related Ticket: 
TINY-11194

Description of Changes:
- Added the pixel unit to a css value

Pre-checks:
* [x] <s>Changelog entry added</s>
* [x] <s>Tests have been added (if applicable)</s>
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] <s> Docs ticket created (if applicable)</s>

GitHub issues (if applicable):
