### PR TITLE
TINY-11257: fix resize handle placing

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11257-2024-09-16.yaml
+++ b/.changes/unreleased/tinymce-TINY-11257-2024-09-16.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Resize handle would be incorrectly located when no other components were added
+  to status bar.
+time: 2024-09-16T17:08:32.128063+02:00
+custom:
+  Issue: TINY-11257

--- a/.changes/unreleased/tinymce-TINY-11257-2024-09-16.yaml
+++ b/.changes/unreleased/tinymce-TINY-11257-2024-09-16.yaml
@@ -1,7 +1,7 @@
 project: tinymce
 kind: Fixed
-body: Resize handle would be incorrectly located when no other components were added
-  to status bar.
+body: The editor resize handle was incorrectly rendered when all components were
+  removed from the status bar.
 time: 2024-09-16T17:08:32.128063+02:00
 custom:
   Issue: TINY-11257

--- a/modules/oxide/src/less/theme/components/statusbar/statusbar.less
+++ b/modules/oxide/src/less/theme/components/statusbar/statusbar.less
@@ -190,6 +190,10 @@
       }
     }
   }
+
+  .tox-statusbar__resize-handle:only-child {
+    flex: 1;
+  }
 }
 
 .tox:not([dir=rtl]) {

--- a/modules/oxide/src/less/theme/components/statusbar/statusbar.less
+++ b/modules/oxide/src/less/theme/components/statusbar/statusbar.less
@@ -192,7 +192,7 @@
   }
 
   .tox-statusbar__resize-handle:only-child {
-    flex: 1;
+    margin-left: auto;
   }
 }
 


### PR DESCRIPTION
Related Ticket: TINY-11257

Description of Changes:
Resize handle would be incorrectly located in the right corner when no other components were added to status bar.

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
