### PR TITLE
TINY-11266: move comments styles to oxide and adjust to skins

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11266-2024-09-18.yaml
+++ b/.changes/unreleased/tinymce-TINY-11266-2024-09-18.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Added
-body: Added global `color-active` variable in oxide.
+body: Added global `color-active` LESS variable for use in editor skins.
 time: 2024-09-18T17:01:03.773568+02:00
 custom:
   Issue: TINY-11266

--- a/.changes/unreleased/tinymce-TINY-11266-2024-09-18.yaml
+++ b/.changes/unreleased/tinymce-TINY-11266-2024-09-18.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: Added global `color-active` variable in oxide.
+time: 2024-09-18T17:01:03.773568+02:00
+custom:
+  Issue: TINY-11266

--- a/modules/oxide/src/less/skins/ui/dark/skin.less
+++ b/modules/oxide/src/less/skins/ui/dark/skin.less
@@ -31,3 +31,6 @@
 }
 
 @edit-area-border-color: #FFFFFF;
+
+@color-selected-background: #3977ba;
+@color-selected-border: @color-tint;

--- a/modules/oxide/src/less/skins/ui/dark/skin.less
+++ b/modules/oxide/src/less/skins/ui/dark/skin.less
@@ -32,5 +32,4 @@
 
 @edit-area-border-color: #FFFFFF;
 
-@color-selected-background: #3977ba;
-@color-selected-border: @color-tint;
+@color-active: darken(desaturate(@color-tint, 20%), 5%);

--- a/modules/oxide/src/less/theme/components/comments/comment.less
+++ b/modules/oxide/src/less/theme/components/comments/comment.less
@@ -1,10 +1,9 @@
 //
 // Tiny Comments
 //
-@conversations-background-color: contrast(@background-color, darken(@background-color, 6%), lighten(@background-color, 5%));
 
-@comment-selected-background-color: @color-selected-background;
-@comment-selected-border-color: @color-selected-border;
+@comment-selected-background-color: lighten(@color-active, 30%); 
+@comment-selected-border-color: @color-active;
 
 @comment-background-color: contrast(@background-color, @background-color, lighten(@background-color, 5%));
 @comment-border-radius: @panel-border-radius;
@@ -30,7 +29,6 @@
     display: flex;
     flex-direction: column;
     position: relative;
-    background: @conversations-background-color;
     height: 100%;
 
     /* This is to give the sidebar a consistent width. Need a solution for this */

--- a/modules/oxide/src/less/theme/components/comments/comment.less
+++ b/modules/oxide/src/less/theme/components/comments/comment.less
@@ -136,6 +136,29 @@
     }
   }
 
+  .tox-comment__overlaytext {
+    bottom: 0;
+    flex-direction: column;
+    font-size: @font-size-sm;
+    left: 0;
+    padding: 1em;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: @z-index-comment-overlay-text;
+
+    p {
+      background-color: @comment-background-color;
+      box-shadow: 0 0 8px 8px @comment-background-color;
+      color: @comment-text-color;
+      text-align: center;
+    }
+
+    div:nth-of-type(2) {
+      font-size: .8em;
+    }
+  }
+
   .tox-comment__expander {
     padding-top: @pad-sm;
 
@@ -246,29 +269,6 @@
 
     > div {
       padding-bottom: @pad-md;
-    }
-  }
-
-  .tox-comment__overlaytext {
-    bottom: 0;
-    flex-direction: column;
-    font-size: @font-size-sm;
-    left: 0;
-    padding: 1em;
-    position: absolute;
-    right: 0;
-    top: 0;
-    z-index: @z-index-comment-overlay-text;
-
-    p {
-      background-color: @comment-background-color;
-      box-shadow: 0 0 8px 8px @comment-background-color;
-      color: @comment-text-color;
-      text-align: center;
-    }
-
-    div:nth-of-type(2) {
-      font-size: .8em;
     }
   }
 

--- a/modules/oxide/src/less/theme/components/comments/comment.less
+++ b/modules/oxide/src/less/theme/components/comments/comment.less
@@ -1,6 +1,10 @@
 //
 // Tiny Comments
 //
+@conversations-background-color: contrast(@background-color, darken(@background-color, 6%), lighten(@background-color, 5%));
+
+@comment-selected-background-color: @color-selected-background;
+@comment-selected-border-color: @color-selected-border;
 
 @comment-background-color: contrast(@background-color, @background-color, lighten(@background-color, 5%));
 @comment-border-radius: @panel-border-radius;
@@ -21,13 +25,36 @@
 @z-index-comment-busy-spinner: 20;
 
 .tox {
-  .tox-comment-thread {
-    background: @comment-background-color;
-    position: relative;
 
-    > *:not(:first-child) {
-      margin-top: @pad-sm;
-    }
+  .tox-conversations {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    background: @conversations-background-color;
+    height: 100%;
+
+    /* This is to give the sidebar a consistent width. Need a solution for this */
+    min-width: 300px;
+    max-width: 300px;
+    width: 300px;
+  }
+
+  .tox-conversations__header {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    box-shadow: 0px 4px 8px 0px rgba(34, 47, 62, 0.1);
+    padding: 8px 12px;
+    background: @background-color;
+  }
+
+  .tox-conversations__title {
+    font-size: 20px;
+    font-weight: 400;
+    padding: 8px 0 8px 0;
+    color: @comment-text-color;
+  
+    line-height: 28px;
   }
 
   .tox-comment {
@@ -37,6 +64,32 @@
     box-shadow: @comment-box-shadow;
     padding: @comment-padding;
     position: relative;
+
+    &.tox-comment--selected {
+      background-color: @comment-selected-background-color;
+      border: 1px solid @comment-selected-border-color;
+      box-shadow: 0px 4px 8px 0px rgba(34, 47, 62, 0.10);
+    
+      &:focus {
+        border: 1px solid @keyboard-focus-outline-color;
+      }
+    
+      .tox-comment__single {
+        margin-bottom: 12px;
+    
+        &:focus {
+          border: 1px solid @keyboard-focus-outline-color; 
+          border-radius: 6px;
+          margin-left: -8px;
+          margin-right: -8px;
+          padding-left: 7px;
+          padding-right: 7px;
+          padding-top: 2px;
+          margin-top: -3px;
+          margin-bottom: 11px;
+        }
+      }
+    }
   }
 
   .tox-comment__header {
@@ -61,6 +114,22 @@
     margin-top: @pad-sm;
     position: relative;
     text-transform: @comment-text-transform;
+    transition: max-height 0.5s cubic-bezier(0, 1, 0, 1);
+    white-space: pre-wrap;
+
+    &.tox-comment__body--expanded {
+      max-height: 100em;
+      transition: max-height 1.0s ease-in-out;
+    }
+
+    /* We remove the transitions when wanting to measure and jump straight to collapsed or expanded */
+    &.tox-comment__body--pending {
+      transition: max-height 0s;
+    }
+
+    p {
+      margin: 0;
+    }
 
     textarea {
       resize: none;
@@ -76,16 +145,39 @@
       color: @comment-text-color-muted;
       font-size: @font-size-sm;
       font-style: normal;
-    }
-  }
 
-  .tox-comment__body p {
-    margin: 0;
+      /* Need a focus highlight on the show more/less button */
+      &:focus {
+        font-weight: bold;
+      }
+    }
   }
 
   .tox-comment__buttonspacing {
     padding-top: @pad-md;
     text-align: center;
+  }
+
+  .tox-tbtn.tox-comment__mention-btn {
+    display: flex;
+    width: 34px;
+    height: 34px;
+    padding: 5px;
+    justify-content: center;
+    align-items: center;
+    margin: 0;
+    background-color: transparent;
+  }
+
+  .tox-comment-thread {
+    background: @comment-background-color;
+    position: relative;
+    border-radius: 6px;
+    background-color: transparent;
+
+    > *:not(:first-child) {
+      margin-top: @pad-sm;
+    }
   }
 
   .tox-comment-thread__overlay::after {
@@ -200,6 +292,47 @@
     flex-direction: column;
     flex-shrink: 1;
     overflow: auto;
+    padding: 12px;
+    scroll-behavior: smooth;
+  }
+
+  /* Animation for deleting a comment */
+  .tox-comment--disappearing {
+    transition: opacity 0.5s ease;
+  }
+
+  /* A comment fades to 0 when it is being deleted, then is removed */
+  .tox-comment[data-transitioning-destination="deleting"] {
+    opacity: 0.0;
+  }
+
+  //should this be in comments? Or will we use this in some different places?
+  .tox-skeleton {
+    .tox-skeleton__line {
+      height: 16px;
+      width: 100%;
+      background: linear-gradient(to right, rgba(240, 240, 240, 0.5) 8%, rgba(240, 240, 240, 0.7) 18%, rgba(240, 240, 240, 0.5) 33%);
+      animation: wave 2s infinite ease-out;
+    }
+
+    .tox-skeleton__circle {
+      height: 36px;
+      width: 36px;
+      margin-right: 8px;
+      border-radius: 100%;
+      background: linear-gradient(to right, rgba(240, 240, 240, 0.5) 8%, rgba(240, 240, 240, 0.7) 18%, rgba(240, 240, 240, 0.5) 33%);
+      animation: wave 2s infinite ease-out;
+    }
+
+    @keyframes wave {
+      0% {
+        background-position: -268px 0;
+      }
+      100% {
+        background-position: 268px 0;
+      }
+    }
+
   }
 }
 //end tox

--- a/modules/oxide/src/less/theme/components/comments/comment.less
+++ b/modules/oxide/src/less/theme/components/comments/comment.less
@@ -136,6 +136,18 @@
     }
   }
 
+  .tox-comment__loading-text {
+    align-items: center;
+    color: @comment-text-color;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+
+    > div {
+      padding-bottom: @pad-md;
+    }
+  }
+
   .tox-comment__overlaytext {
     bottom: 0;
     flex-direction: column;
@@ -258,18 +270,6 @@
     text-align: center;
     top: 0;
     z-index: @z-index-comment-overlay;
-  }
-
-  .tox-comment__loading-text {
-    align-items: center;
-    color: @comment-text-color;
-    display: flex;
-    flex-direction: column;
-    position: relative;
-
-    > div {
-      padding-bottom: @pad-md;
-    }
   }
 
   .tox-comment__busy-spinner {

--- a/modules/oxide/src/less/theme/components/comments/comment.less
+++ b/modules/oxide/src/less/theme/components/comments/comment.less
@@ -69,7 +69,12 @@
       box-shadow: 0px 4px 8px 0px rgba(34, 47, 62, 0.10);
     
       &:focus {
-        border: 1px solid @keyboard-focus-outline-color;
+        border: 2px solid @keyboard-focus-outline-color;
+        margin: -1px;
+    
+        &:not(:first-child) {
+          margin-top: 7px;
+        }
       }
     
       .tox-comment__single {
@@ -330,7 +335,27 @@
         background-position: 268px 0;
       }
     }
+  }
 
+  .tox-ring-loader {
+    width: 10px;
+    height: 10px;
+    border: 1px solid #FFF;
+    border-bottom-color: transparent;
+    border-radius: 50%;
+    display: inline-block;
+    box-sizing: border-box;
+    animation: rotation 1s linear infinite;
+  }
+
+  @keyframes rotation {
+    0% {
+      transform: rotate(0deg);
+    }
+
+    100% {
+      transform: rotate(360deg);
+    }
   }
 }
 //end tox

--- a/modules/oxide/src/less/theme/components/sidebar/sidebar.less
+++ b/modules/oxide/src/less/theme/components/sidebar/sidebar.less
@@ -2,7 +2,7 @@
 // Sidebar
 //
 
-@sidebar-background-color: @background-color;
+@sidebar-background-color: contrast(@background-color, darken(@background-color, 6%), lighten(@background-color, 10%));
 
 .tox {
   .tox-sidebar-wrap {

--- a/modules/oxide/src/less/theme/content/comments/comments.less
+++ b/modules/oxide/src/less/theme/content/comments/comments.less
@@ -2,8 +2,8 @@
 // Comments
 //
 
-@document-comment-color: #ffe89d;
-@document-comment-active-color: #fed635;
+@document-comment-color: lighten(@color-active, 20%); 
+@document-comment-active-color: @color-active;
 @document-comment-background-color: @document-comment-color;
 @document-comment-active-background-color: @document-comment-active-color;
 @document-comment-outline-color: @document-comment-color;

--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -19,8 +19,7 @@
 @color-error-element-focus-color: #f00;
 @color-error-element-focus: 0 0 0 1px @color-error-element-focus-color;
 @color-success: #78AB46;
-@color-selected-background: #FFF5CC;
-@color-selected-border: #E3B82A;
+@color-active: #ffcf30;
 
 @font-stack: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
 

--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -19,6 +19,9 @@
 @color-error-element-focus-color: #f00;
 @color-error-element-focus: 0 0 0 1px @color-error-element-focus-color;
 @color-success: #78AB46;
+@color-selected-background: #FFF5CC;
+@color-selected-border: #E3B82A;
+
 @font-stack: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
 
 // Content;

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationStylingTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationStylingTest.ts
@@ -56,20 +56,20 @@ describe('browser.tinymce.core.annotate.AnnotationStylingTest', () => {
   };
 
   const commentOutline: Outline = {
-    color: 'rgb(255, 232, 157)', // #ffe89d
+    color: 'rgb(255, 231, 150)', // #ffe796
     width: '3px',
     style: 'solid'
   };
 
   const commentActiveOutline: Outline = {
-    color: 'rgb(254, 214, 53)', // #fed635
+    color: 'rgb(255, 207, 48)', // #ffcf30
     width: '3px',
     style: 'solid'
   };
 
   const noBackgroundColor = 'rgba(0, 0, 0, 0)';
-  const commentBackgroundColor = 'rgb(255, 232, 157)'; // #ffe89d
-  const commentActiveBackgroundColor = 'rgb(254, 214, 53)'; // #fed635
+  const commentBackgroundColor = 'rgb(255, 231, 150)'; // #ffe796
+  const commentActiveBackgroundColor = 'rgb(255, 207, 48)'; // #ffcf30
   const inlineBoundaryBackgroundColor = 'rgb(180, 215, 255)'; // #b4d7ff
   const commentActiveBoxShadow = 'rgb(0, 108, 231) 0px 0px 0px 2px';
 


### PR DESCRIPTION
Related Ticket: TINY-11266

Description of Changes:
Moved all styles from comments to oxide and adjusted them to dark mode. Added `@color-active` to global variables as a way to configure selected comment colors.

Default and dark mode after changes: 

![Screenshot 2024-09-18 at 17 02 24](https://github.com/user-attachments/assets/22bd7127-663b-4110-a5bc-a24e013875e1)
![Screenshot 2024-09-18 at 17 03 21](https://github.com/user-attachments/assets/bd80c948-d33b-4294-92db-c98b98f956ab)


Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
