### PR TITLE
TINY-11162: Undomanager.exta is optionally async

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11162-2024-09-18.yaml
+++ b/.changes/unreleased/tinymce-TINY-11162-2024-09-18.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Improved
+body: UndoManager.extra is made async if either callback returns a promise.
+time: 2024-09-18T15:33:19.318383083+02:00
+custom:
+  Issue: TINY-11162

--- a/modules/tinymce/src/core/main/ts/Rtc.ts
+++ b/modules/tinymce/src/core/main/ts/Rtc.ts
@@ -15,13 +15,8 @@ import * as ToggleFormat from './fmt/ToggleFormat';
 import { getSelectedContentInternal } from './selection/GetSelectionContentImpl';
 import { RangeLikeObject } from './selection/RangeTypes';
 import * as Operations from './undo/Operations';
-import { Index, Locks, UndoBookmark, UndoLevel, UndoManager } from './undo/UndoManagerTypes';
+import { Extra, Index, Locks, UndoBookmark, UndoLevel, UndoManager } from './undo/UndoManagerTypes';
 import { addVisualInternal } from './view/VisualAidsImpl';
-
-interface ExtraAPI {
-  (callback1: () => void, callback2: () => void): void;
-  (callback1: () => Promise<void> | void, callback2: () => Promise<void> | void): Promise<void> ;
-}
 
 /** API implemented by the RTC plugin */
 interface RtcRuntimeApi {
@@ -39,7 +34,7 @@ interface RtcRuntimeApi {
     reset: () => void;
     clear: () => void;
     ignore: (fn: () => void) => void;
-    extra: ExtraAPI;
+    extra: Extra;
   };
   formatter: {
     canApply: (format: string) => boolean;
@@ -75,7 +70,7 @@ interface RtcRuntimeApi {
 
 interface RTCExtra {
   (undoManager: UndoManager, locks: Locks, index: Index, callback1: () => void, callback2: () => void): void;
-  (undoManager: UndoManager, locks: Locks, index: Index, callback1: () => Promise<void> | void, callback2: () => Promise<void> | void): Promise<void> ;
+  (undoManager: UndoManager, locks: Locks, index: Index, callback1: () => Promise<void>, callback2: () => Promise<void>): Promise<void> ;
 }
 
 /** A copy of the TinyMCE api definitions that the plugin overrides  */

--- a/modules/tinymce/src/core/main/ts/api/UndoManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/UndoManager.ts
@@ -163,7 +163,7 @@ const UndoManager = (editor: Editor): UndoManager => {
      * @method extra
      * @param {Function} callback1 Function that does mutation but gets stored as a "hidden" extra undo level.
      * @param {Function} callback2 Function that does mutation but gets displayed to the user.
-     * @returns {void or Promise<void>}
+     * @returns {void or Promise<void>} Optionally returns a promise if either callback returned one.
      */
     extra
   };

--- a/modules/tinymce/src/core/main/ts/api/UndoManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/UndoManager.ts
@@ -5,7 +5,7 @@ import * as GetBookmark from '../bookmark/GetBookmark';
 import * as Rtc from '../Rtc';
 import * as Levels from '../undo/Levels';
 import { addKeyboardShortcuts, registerEvents } from '../undo/Setup';
-import { Index, Locks, UndoLevel, UndoManager } from '../undo/UndoManagerTypes';
+import { Extra, Index, Locks, UndoLevel, UndoManager } from '../undo/UndoManagerTypes';
 import Editor from './Editor';
 
 /**
@@ -17,6 +17,10 @@ const UndoManager = (editor: Editor): UndoManager => {
   const beforeBookmark = Singleton.value<Bookmark>();
   const locks: Locks = Cell(0);
   const index: Index = Cell(0);
+
+  const extra: Extra = (callback1: () => Promise<void> | void, callback2: () => Promise<void> | void) => {
+    return Rtc.extra(editor, undoManager, locks, index, callback1, callback2) as any;
+  };
 
   /* eslint consistent-this:0 */
   const undoManager = {
@@ -159,10 +163,9 @@ const UndoManager = (editor: Editor): UndoManager => {
      * @method extra
      * @param {Function} callback1 Function that does mutation but gets stored as a "hidden" extra undo level.
      * @param {Function} callback2 Function that does mutation but gets displayed to the user.
+     * @returns {void or Promise<void>}
      */
-    extra: (callback1: () => void, callback2: () => void) => {
-      Rtc.extra(editor, undoManager, index, callback1, callback2);
-    }
+    extra
   };
 
   if (!Rtc.isRtc(editor)) {

--- a/modules/tinymce/src/core/main/ts/undo/UndoManagerTypes.ts
+++ b/modules/tinymce/src/core/main/ts/undo/UndoManagerTypes.ts
@@ -26,6 +26,14 @@ export interface CompleteUndoLevel extends BaseUndoLevel {
 export type NewUndoLevel = CompleteUndoLevel | FragmentedUndoLevel;
 export type UndoLevel = NewUndoLevel & { bookmark: Bookmark };
 
+export interface Extra {
+  (callback1: () => void, callback2: () => void): void;
+  (callback1: () => Promise<void>, callback2: () => void): Promise<void>;
+  (callback1: () => void, callback2: () => Promise<void>): Promise<void>;
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  (callback1: () => Promise<void>, callback2: () => Promise<void>): Promise<void>;
+}
+
 export interface UndoManager {
   data: UndoLevel[];
   typing: boolean;
@@ -40,7 +48,7 @@ export interface UndoManager {
   hasRedo: () => boolean;
   transact: (callback: () => void) => UndoLevel | null;
   ignore: (callback: () => void) => void;
-  extra: (callback1: () => void, callback2: () => void) => void;
+  extra: Extra;
 }
 
 export type Index = Cell<number>;

--- a/modules/tinymce/src/core/main/ts/undo/UndoManagerTypes.ts
+++ b/modules/tinymce/src/core/main/ts/undo/UndoManagerTypes.ts
@@ -28,9 +28,6 @@ export type UndoLevel = NewUndoLevel & { bookmark: Bookmark };
 
 export interface Extra {
   (callback1: () => void, callback2: () => void): void;
-  (callback1: () => Promise<void>, callback2: () => void): Promise<void>;
-  (callback1: () => void, callback2: () => Promise<void>): Promise<void>;
-  // eslint-disable-next-line @typescript-eslint/unified-signatures
   (callback1: () => Promise<void>, callback2: () => Promise<void>): Promise<void>;
 }
 


### PR DESCRIPTION
Related Ticket: TINY-11162

Description of Changes:
Make UndoManager.extra to be optionally async, to allow us to work around issues where one or both of the steps is async, which may cause problems.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
