### PR TITLE
TINY-11258 TINY-11277: Remove shadow by default on comment cards

### DIFF
--- a/modules/oxide/src/less/theme/components/comments/comment.less
+++ b/modules/oxide/src/less/theme/components/comments/comment.less
@@ -51,7 +51,6 @@
     font-weight: 400;
     padding: 8px 0 8px 0;
     color: @comment-text-color;
-
     line-height: 28px;
   }
 

--- a/modules/oxide/src/less/theme/components/comments/comment.less
+++ b/modules/oxide/src/less/theme/components/comments/comment.less
@@ -34,9 +34,11 @@
     background: @comment-background-color;
     border: @comment-border;
     border-radius: @comment-border-radius;
-    box-shadow: @comment-box-shadow;
     padding: @comment-padding;
     position: relative;
+    &:hover {
+      box-shadow: @comment-box-shadow;
+    }
   }
 
   .tox-comment__header {

--- a/modules/oxide/src/less/theme/components/comments/comment.less
+++ b/modules/oxide/src/less/theme/components/comments/comment.less
@@ -61,6 +61,7 @@
     border-radius: @comment-border-radius;
     padding: @comment-padding;
     position: relative;
+
     &:hover {
       box-shadow: @comment-box-shadow;
     }


### PR DESCRIPTION
Related Ticket: TINY-11258 TINY-11277

Description of Changes:
* Remove shadow by default on comment cards
* apply shadow on hover instead

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
