### PR TITLE
TINY-11294: Fixed CSS click through issue

### DIFF
--- a/modules/oxide/src/less/theme/components/comments/comment.less
+++ b/modules/oxide/src/less/theme/components/comments/comment.less
@@ -231,6 +231,7 @@
     display: flex;
     left: 0;
     opacity: .9;
+    pointer-events: none;
     position: absolute;
     right: 0;
     top: 0;


### PR DESCRIPTION
Related Ticket: TINY-11294

Description of Changes:
* Fixes an issue where the after element would block clicks on anything below it like the kebab menu

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
