### PR TITLE
TINY-11194: A CSS Calc function with a unitless number causes Sass compilation error

### DIFF
--- a/modules/oxide/src/less/theme/components/toolbar/toolbar.less
+++ b/modules/oxide/src/less/theme/components/toolbar/toolbar.less
@@ -44,8 +44,8 @@
   .tox-toolbar-overlord > .tox-toolbar,
   .tox-toolbar-overlord > .tox-toolbar__primary,
   .tox-toolbar-overlord > .tox-toolbar__overflow {
-    @_toolbar-row-separator-image-offset: 0;
-    @_toolbar-row-separator-downsize: 0;
+    @_toolbar-row-separator-image-offset: 0px;
+    @_toolbar-row-separator-downsize: 0px;
 
     background-position: @_toolbar-row-separator-image-position;
     background-size: @_toolbar-row-separator-image-size;


### PR DESCRIPTION
Related Ticket: 
TINY-11194

Description of Changes:
- Addressed the 0 with no unit issue

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
