### PR TITLE
TINY-11273: add zero width nobreak space to isWhitespace function

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11273-2024-09-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-11273-2024-09-24.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Autocompleter would not activate after font size change.
+body: Autocompleter would not activate after applying an inline format like font size in some cases.
 time: 2024-09-24T18:14:17.009975+02:00
 custom:
   Issue: TINY-11273

--- a/.changes/unreleased/tinymce-TINY-11273-2024-09-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-11273-2024-09-24.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Autocompleter would not activate after font size change.
+time: 2024-09-24T18:14:17.009975+02:00
+custom:
+  Issue: TINY-11273

--- a/modules/tinymce/src/core/main/ts/autocomplete/AutocompleteUtils.ts
+++ b/modules/tinymce/src/core/main/ts/autocomplete/AutocompleteUtils.ts
@@ -9,4 +9,4 @@ export const getText = (rng: Range): string =>
   Zwsp.trim(rng.toString().replace(/\u00A0/g, ' '));
 
 export const isWhitespace = (chr: string): boolean =>
-  chr !== '' && ' \u00a0\f\n\r\t\v'.indexOf(chr) !== -1;
+  chr !== '' && ' \u00a0\ufeff\f\n\r\t\v'.indexOf(chr) !== -1;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
@@ -767,9 +767,17 @@ describe('browser.tinymce.themes.silver.editor.autocomplete.AutocompleteTest', (
     assertion: (editor) => TinyAssertions.assertContent(editor, '<p>multi-bB</p>')
   }));
 
-  it('TINY-11273: Autocomplete should be triggered for content with formatting applied', async () => {
+  it('TINY-11273: Autocomplete should be triggered for content with font size formatting applied', async () => {
     const editor = hook.editor();
     editor.execCommand('FontSize', false, '36px');
+    TinyContentActions.type(editor, '+');
+    editor.dispatch('input');
+    await pWaitForAutocompleteToOpen();
+  });
+
+  it('TINY-11273: Autocomplete should be triggered for content with bold formatting applied', async () => {
+    const editor = hook.editor();
+    editor.execCommand('Bold');
     TinyContentActions.type(editor, '+');
     editor.dispatch('input');
     await pWaitForAutocompleteToOpen();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
@@ -766,4 +766,12 @@ describe('browser.tinymce.themes.silver.editor.autocomplete.AutocompleteTest', (
     },
     assertion: (editor) => TinyAssertions.assertContent(editor, '<p>multi-bB</p>')
   }));
+
+  it('TINY-11273: Autocomplete should be triggered for content with formatting applied.', async () => {
+    const editor = hook.editor();
+    editor.execCommand('FontSize', false, '36px');
+    TinyContentActions.type(editor, '+');
+    editor.dispatch('input');
+    await pWaitForAutocompleteToOpen();
+  });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
@@ -767,7 +767,7 @@ describe('browser.tinymce.themes.silver.editor.autocomplete.AutocompleteTest', (
     assertion: (editor) => TinyAssertions.assertContent(editor, '<p>multi-bB</p>')
   }));
 
-  it('TINY-11273: Autocomplete should be triggered for content with formatting applied.', async () => {
+  it('TINY-11273: Autocomplete should be triggered for content with formatting applied', async () => {
     const editor = hook.editor();
     editor.execCommand('FontSize', false, '36px');
     TinyContentActions.type(editor, '+');


### PR DESCRIPTION
Related Ticket: TINY-11273

Description of Changes:
When formatting is being applied a span with `zero width no-break space (ufeff)` is added to the editor. This character was not considered a whitespace and because of that the autocompleter was not triggering properly. To fix this bug I added the character to the `isWhitespace` function. 

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

- [x] Don't merge until we make the 7.4 RC

GitHub issues (if applicable):
