### PR TITLE
TINY-11326: Disable restore last draft button in readonly mode

### DIFF
--- a/modules/tinymce/src/plugins/autosave/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/autosave/main/ts/ui/Buttons.ts
@@ -7,8 +7,9 @@ interface Api {
 }
 
 const makeSetupHandler = (editor: Editor) => (api: Api) => {
-  api.setEnabled(Storage.hasDraft(editor));
-  const editorEventCallback = () => api.setEnabled(Storage.hasDraft(editor));
+  const shouldEnable = () => Storage.hasDraft(editor) && !editor.mode.isReadOnly();
+  api.setEnabled(shouldEnable());
+  const editorEventCallback = () => api.setEnabled(shouldEnable());
   editor.on('StoreDraft RestoreDraft RemoveDraft', editorEventCallback);
   return () => editor.off('StoreDraft RestoreDraft RemoveDraft', editorEventCallback);
 };


### PR DESCRIPTION
Related Ticket: TINY-11326

Description of Changes:
* Follow up PR for ticket TINY-11264
* Disabling the `Restore last draft `button which was enabled in readonly mode

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
