### PR TITLE
TINY-11137: dont apply toolbar offset while in fullscreen

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11137-2024-10-01.yaml
+++ b/.changes/unreleased/tinymce-TINY-11137-2024-10-01.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: The `toolbar-sticky-offset` would be applied after entering fullscreen mode.
+body: The `toolbar-sticky-offset` would still be applied after entering fullscreen mode.
 time: 2024-10-01T16:27:44.670057+02:00
 custom:
   Issue: TINY-11137

--- a/.changes/unreleased/tinymce-TINY-11137-2024-10-01.yaml
+++ b/.changes/unreleased/tinymce-TINY-11137-2024-10-01.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: The `toolbar-sticky-offset` would be applied after entering fullscreen mode.
+time: 2024-10-01T16:27:44.670057+02:00
+custom:
+  Issue: TINY-11137

--- a/modules/tinymce/src/themes/silver/main/ts/modes/ScrollingContext.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/ScrollingContext.ts
@@ -28,7 +28,7 @@ export const isScroller = (elem: SugarElement<Node> | any): boolean => {
   }
 };
 
-const isFullscreen = (editor: Editor): boolean =>
+export const isFullscreen = (editor: Editor): boolean =>
   editor.plugins.fullscreen && editor.plugins.fullscreen.isFullscreen();
 
 // NOTE: Calculating the list of scrolling ancestors each time this function is called might

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/StickyHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/StickyHeader.ts
@@ -53,7 +53,6 @@ const scrollFromBehindHeader = (e: ScrollIntoViewEvent, containerHeader: SugarEl
 };
 
 const isDockedMode = (header: AlloyComponent, mode: 'top' | 'bottom') => Arr.contains(Docking.getModes(header), mode);
-const isFullscreen = (editor: Editor) => editor.hasPlugin('fullscreen') && editor.plugins.fullscreen.isFullscreen();
 
 const updateIframeContentFlow = (header: AlloyComponent): void => {
   const getOccupiedHeight = (elm: SugarElement<HTMLElement>) => Height.getOuter(elm) +
@@ -275,7 +274,7 @@ const getBehaviours = (editor: Editor, sharedBackstage: UiFactoryBackstageShared
           () => {
             const boundsWithoutOffset = Boxes.win();
             const offset = Options.getStickyToolbarOffset(editor);
-            const top = boundsWithoutOffset.y + (isDockedMode(comp, 'top') && !isFullscreen(editor) ? offset : 0);
+            const top = boundsWithoutOffset.y + (isDockedMode(comp, 'top') && !ScrollingContext.isFullscreen(editor) ? offset : 0);
             const height = boundsWithoutOffset.height - (isDockedMode(comp, 'bottom') ? offset : 0);
             // No scrolling context, so just window
             return {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/StickyHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/StickyHeader.ts
@@ -53,6 +53,7 @@ const scrollFromBehindHeader = (e: ScrollIntoViewEvent, containerHeader: SugarEl
 };
 
 const isDockedMode = (header: AlloyComponent, mode: 'top' | 'bottom') => Arr.contains(Docking.getModes(header), mode);
+const isFullscreen = (editor: Editor) => editor.hasPlugin('fullscreen') && editor.plugins.fullscreen.isFullscreen();
 
 const updateIframeContentFlow = (header: AlloyComponent): void => {
   const getOccupiedHeight = (elm: SugarElement<HTMLElement>) => Height.getOuter(elm) +
@@ -274,7 +275,7 @@ const getBehaviours = (editor: Editor, sharedBackstage: UiFactoryBackstageShared
           () => {
             const boundsWithoutOffset = Boxes.win();
             const offset = Options.getStickyToolbarOffset(editor);
-            const top = boundsWithoutOffset.y + (isDockedMode(comp, 'top') ? offset : 0);
+            const top = boundsWithoutOffset.y + (isDockedMode(comp, 'top') && !isFullscreen(editor) ? offset : 0);
             const height = boundsWithoutOffset.height - (isDockedMode(comp, 'bottom') ? offset : 0);
             // No scrolling context, so just window
             return {


### PR DESCRIPTION
Related Ticket: TINY-11137

Description of Changes:
Added isFullscreen function to StickyHeader. Now, we don't apply offset if the editor is in fullscreen mode.

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
