### PR TITLE
TINY-11313: apply opacity to color toolbar buttons in readonly mode

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11313-2024-10-01.yaml
+++ b/.changes/unreleased/tinymce-TINY-11313-2024-10-01.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Text and background color toolbar buttons would not be fully greyed out in readonly
+  mode.
+time: 2024-10-01T18:11:07.535161+02:00
+custom:
+  Issue: TINY-11313

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-split-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-split-button.less
@@ -3,7 +3,7 @@
 //
 
 @toolbar-split-button-chevron-touch-padding: 4px;
-@toolbar-split-color-preview-opacity: 0.6;
+@toolbar-split-color-preview-opacity: 0.3;
 
 .tox {
   .tox-split-button {
@@ -92,8 +92,8 @@
     }
   }
 
-  .tox-split-button.tox-tbtn--disabled svg #tox-icon-text-color__color,
-  .tox-split-button.tox-tbtn--disabled svg #tox-icon-highlight-bg-color__color {
+  .tox-split-button.tox-tbtn--disabled svg .tox-icon-text-color__color,
+  .tox-split-button.tox-tbtn--disabled svg .tox-icon-highlight-bg-color__color {
     opacity: @toolbar-split-color-preview-opacity;
   }
 }


### PR DESCRIPTION
Related Ticket: TINY-11313

Description of Changes:
Buttons like "Background Color" and "Text Color" were not fully greyed out in readonly mode.

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
