### PR TITLE
TINY-11024: Fix test failures for CopyAndPasteTest.ts

### DIFF
--- a/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
@@ -70,7 +70,12 @@ const pWaitForAndAssertInputEvents = async (beforeinputEvent: SingletonEvent<Inp
   const assertInputEvent = (): void =>
     inputEvent.on((e) => {
       assert.equal(e.inputType, 'insertFromPaste', 'beforeinput event type should be "insertFromPaste"');
-      assert.isNull(e.data, 'input event data should be null');
+      // TINY-11373: Chromium >= 129, e.data is no longer null when pasting plain text
+      if (isNative && browser.isChromium() && browser.version.major >= 129) {
+        assert.isNotNull(e.data, 'input event data should not be null');
+      } else {
+        assert.isNull(e.data, 'input event data should be null');
+      }
       const dataTransfer = e.dataTransfer;
       if (isNative && (browser.isFirefox() || browser.isSafari())) {
         assert.equal(dataTransfer?.getData('text/html'), expectedBeforeinputDataTransferHtml, 'input event dataTransfer should contain expected html data');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
@@ -957,6 +957,8 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
 
       it('TINY-11211: Menu item should always be disabled', async () => {
         const editor = hook.editor();
+        // Wait for NodeChange to be processed
+        await Waiter.pWait(0);
         await pClickToolbarAndWait(editor, 't11');
         assertButtonDisabled('test');
         await pCloseMenu(editor);


### PR DESCRIPTION
Related Ticket: TINY-11024

Description of Changes:
* Fix test failure in CopyAndPasteTest.ts: e.data for input insertFromPaste with plain text is no longer null

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
