### PR TITLE
TINY-11153: Only blur if the dialog has focus to start with.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11153-2024-10-03.yaml
+++ b/.changes/unreleased/tinymce-TINY-11153-2024-10-03.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Closing modal dialogs in inline mode, if more than one dialog, would lose focus
+  from the editor.
+time: 2024-10-03T05:39:21.982118585+02:00
+custom:
+  Issue: TINY-11153

--- a/.changes/unreleased/tinymce-TINY-11153-2024-10-03.yaml
+++ b/.changes/unreleased/tinymce-TINY-11153-2024-10-03.yaml
@@ -1,7 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Closing modal dialogs in inline mode, if more than one dialog, would lose focus
-  from the editor.
+body: Closing a nested modal dialog would lose focus from the editor.
 time: 2024-10-03T05:39:21.982118585+02:00
 custom:
   Issue: TINY-11153

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogEvents.ts
@@ -33,7 +33,9 @@ const initCommonEvents = <A, S extends EventSpec<A>>(fireApiEvent: FireApiFunc<A
   fireApiEvent<FormCloseEvent>(formCloseEvent, (_api: A, spec: S, _event, self) => {
     // TINY-9148: Safari scrolls down to the sink if the dialog is selected before removing,
     // so we should blur the currently active element beforehand.
-    Focus.active(SugarShadowDom.getRootNode(self.element)).fold(Fun.noop, Focus.blur);
+    if (Focus.hasFocus(self.element)) {
+      Focus.active(SugarShadowDom.getRootNode(self.element)).fold(Fun.noop, Focus.blur);
+    }
     extras.onClose();
     spec.onClose();
   }),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogEvents.ts
@@ -1,6 +1,6 @@
 import { AlloyComponent, AlloyEvents, AlloyTriggers, CustomEvent, Keying, NativeEvents, Reflecting, Representing } from '@ephox/alloy';
 import { Dialog, DialogManager } from '@ephox/bridge';
-import { Result, Fun } from '@ephox/katamari';
+import { Result } from '@ephox/katamari';
 import { Attribute, Compare, Focus, SugarElement, SugarShadowDom } from '@ephox/sugar';
 
 import {
@@ -34,7 +34,7 @@ const initCommonEvents = <A, S extends EventSpec<A>>(fireApiEvent: FireApiFunc<A
     // TINY-9148: Safari scrolls down to the sink if the dialog is selected before removing,
     // so we should blur the currently active element beforehand.
     if (Focus.hasFocus(self.element)) {
-      Focus.active(SugarShadowDom.getRootNode(self.element)).fold(Fun.noop, Focus.blur);
+      Focus.active(SugarShadowDom.getRootNode(self.element)).each(Focus.blur);
     }
     extras.onClose();
     spec.onClose();


### PR DESCRIPTION
Related Ticket: TINY-11153

Description of Changes:
We automatically blurred the ui when removing any modal dialog to prevent an issue with scrolling focus on safari if the focused dialog was removed. This fix will only blur the UI if the dialog has focus, preventing unneeded blurring and loss of UI in inline mode.
Manual test only, as the automated ones I made were highly unreliable and would succeed or fail randomly.

Pre-checks:
* [x] Changelog entry added
* ~~[ ] Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
