### PR TITLE
TINY-11342: Added slider and size input to context forms

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11342-2024-10-14.yaml
+++ b/.changes/unreleased/tinymce-TINY-11342-2024-10-14.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: New `contextsliderform` and `contextsizeinput` context form types.
+time: 2024-10-14T13:41:04.0298+02:00
+custom:
+  Issue: TINY-11342

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/common/InputBase.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/common/InputBase.ts
@@ -11,6 +11,7 @@ import * as Fields from '../../data/Fields';
 import { InputDetail } from '../types/InputTypes';
 
 const schema: () => FieldProcessor[] = Fun.constant([
+  FieldSchema.defaultedString('type', 'text'),
   FieldSchema.option('data'),
   FieldSchema.defaulted('inputAttributes', { }),
   FieldSchema.defaulted('inputStyles', { }),
@@ -28,7 +29,11 @@ const focusBehaviours = (detail: InputDetail): Behaviour.AlloyBehaviourRecord =>
     onFocus: !detail.selectOnFocus ? Fun.noop : (component) => {
       const input = component.element;
       const value = Value.get(input);
-      input.dom.setSelectionRange(0, value.length);
+
+      // TODO: There are probably more types that can't handle setSelectionRange
+      if (detail.type !== 'range') {
+        input.dom.setSelectionRange(0, value.length);
+      }
     }
   })
 ]);
@@ -63,7 +68,7 @@ const behaviours = (detail: InputDetail): Behaviour.AlloyBehaviourRecord => ({
 const dom = (detail: InputDetail): RawDomSchema => ({
   tag: detail.tag,
   attributes: {
-    type: 'text',
+    type: detail.type,
     ...detail.inputAttributes
   },
   styles: detail.inputStyles,

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/FormCoupledInputsSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/FormCoupledInputsSchema.ts
@@ -25,7 +25,8 @@ const schema = Fun.constant([
   Fields.onStrictHandler('onLockedChange'),
   Fields.markers([ 'lockClass' ]),
   FieldSchema.defaulted('locked', false),
-  SketchBehaviours.field('coupledFieldBehaviours', [ Composing, Representing ])
+  SketchBehaviours.field('coupledFieldBehaviours', [ Composing, Representing ]),
+  FieldSchema.defaultedFunction('onInput', Fun.noop)
 ]);
 
 const getField = (comp: AlloyComponent, detail: FormCoupledInputsDetail, partName: string) => AlloyParts.getPart(comp, detail, partName).bind(Composing.getCurrent);
@@ -44,6 +45,8 @@ const coupledPart = (selfName: string, otherName: string) => PartType.required<F
                 if (Toggling.isOn(lock)) {
                   detail.onLockedChange(me, other, lock);
                 }
+
+                detail.onInput(me);
               });
             });
           })

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/FormCoupledInputsTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/FormCoupledInputsTypes.ts
@@ -18,6 +18,7 @@ export interface FormCoupledInputsDetail extends CompositeSketchDetail {
   markers: {
     lockClass: string;
   };
+  onInput: (comp: AlloyComponent) => void;
 }
 
 export interface FormCoupledInputsSpec extends CompositeSketchSpec {
@@ -32,6 +33,7 @@ export interface FormCoupledInputsSpec extends CompositeSketchSpec {
   markers: {
     lockClass: string;
   };
+  onInput?: (comp: AlloyComponent) => void;
 }
 
 export interface FormCoupledInputsApis {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/InputTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/InputTypes.ts
@@ -8,6 +8,7 @@ import { SingleSketch, SingleSketchDetail, SingleSketchSpec } from '../../api/ui
 
 // The V is because this is shared with Typeahead.
 export interface InputDetail extends SingleSketchDetail {
+  type: string;
   uid: string;
   dom: RawDomSchema;
   inputBehaviours: SketchBehaviours;
@@ -22,6 +23,7 @@ export interface InputDetail extends SingleSketchDetail {
 }
 
 export interface InputSpec extends SingleSketchSpec {
+  type?: string;
   uid?: string;
   tag?: string;
   inputClasses?: string[];

--- a/modules/alloy/src/test/ts/browser/ui/coupled/FormCoupledInputsTest.ts
+++ b/modules/alloy/src/test/ts/browser/ui/coupled/FormCoupledInputsTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, Chain, Mouse, UiControls, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { Result } from '@ephox/katamari';
-import { Class } from '@ephox/sugar';
+import { Attribute, Class } from '@ephox/sugar';
 
 import * as AddEventsBehaviour from 'ephox/alloy/api/behaviour/AddEventsBehaviour';
 import * as Behaviour from 'ephox/alloy/api/behaviour/Behaviour';
@@ -23,6 +23,7 @@ interface MakeConfig {
   field1Name?: string;
   field2Name?: string;
   coupledFieldBehaviours?: Behaviour.AlloyBehaviourRecord;
+  onInput?: (comp: AlloyComponent) => void;
 }
 
 UnitTest.asynctest('FormCoupledInputsTest', (success, failure) => {
@@ -73,7 +74,8 @@ UnitTest.asynctest('FormCoupledInputsTest', (success, failure) => {
     locked: config.locked,
     field1Name: config.field1Name,
     field2Name: config.field2Name,
-    coupledFieldBehaviours: config.coupledFieldBehaviours
+    coupledFieldBehaviours: config.coupledFieldBehaviours,
+    onInput: config.onInput
   });
 
   GuiSetup.setup((store, _doc, _body) => GuiFactory.build(
@@ -82,7 +84,7 @@ UnitTest.asynctest('FormCoupledInputsTest', (success, failure) => {
         tag: 'div'
       },
       components: [
-        make({ className: 'default' }),
+        make({ className: 'default', onInput: (comp) => store.add(`input:${Attribute.get(comp.element, 'class')}`) }),
         make({ className: 'start-locked', locked: true }),
         make({ className: 'renamed-fields', field1Name: 'width', field2Name: 'height' }),
         make({
@@ -202,6 +204,32 @@ UnitTest.asynctest('FormCoupledInputsTest', (success, failure) => {
           ])
       ]);
 
+    const sTestOnInput = (selector: string) =>
+      Chain.asStep(component.element, [
+        Chain.fromParent(
+          UiFinder.cFindIn(selector),
+          [
+            Chain.fromChains([
+              UiFinder.cFindIn('.field1 input'),
+              Chain.binder((elem) => component.getSystem().getByDom(elem)),
+              Chain.op((input) => AlloyTriggers.emit(input, NativeEvents.input())),
+              Chain.op(() => {
+                store.assertEq('input', [ 'input:field1' ]);
+              })
+            ]),
+            Chain.fromChains([
+              store.cClear,
+              UiFinder.cFindIn('.field2 input'),
+              Chain.binder((elem) => component.getSystem().getByDom(elem)),
+              Chain.op((input) => AlloyTriggers.emit(input, NativeEvents.input())),
+              Chain.op(() => {
+                store.assertEq('input', [ 'input:field2' ]);
+              })
+            ])
+          ]
+        )
+      ]);
+
     return [
       sTestStructure('.default', false),
       sTestStructure('.start-locked', true),
@@ -219,10 +247,12 @@ UnitTest.asynctest('FormCoupledInputsTest', (success, failure) => {
       sTestCopying('.start-locked', '.field2 input', { field1: '', field2: 'dfgh' }, { field1: '', field2: 'dfgh' }),
       sTestCopying('.default', '.field1 input', { field1: 'asdf', field2: '' }, { field1: 'asdf', field2: 'asdf' }),
       sTestCopying('.default', '.field2 input', { field1: '', field2: 'lkjh' }, { field1: 'lkjh', field2: 'lkjh' }),
-      store.sAssertEq('click', []),
+      store.sClear,
       Mouse.sClickOn(component.element, '.behaviour-tester'),
       store.sAssertEq('click', [ 'click' ]),
-      sTestApi()
+      sTestApi(),
+      store.sClear,
+      sTestOnInput('.default')
     ];
   }, success, failure);
 });

--- a/modules/bridge/src/main/ts/ephox/bridge/api/InlineContent.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/api/InlineContent.ts
@@ -5,7 +5,8 @@ import {
 import { ContextPosition, ContextScope } from '../components/content/ContextBar';
 import {
   ContextForm, ContextInputForm, ContextSliderForm, ContextSizeInputForm, ContextFormButton, ContextFormButtonInstanceApi, ContextFormButtonSpec, ContextFormInstanceApi, ContextFormSpec,
-  ContextInputFormSpec, ContextSliderFormSpec, ContextSizeInputFormSpec, ContextFormToggleButton, ContextFormToggleButtonInstanceApi, ContextFormToggleButtonSpec, ContextFormCommand, createContextForm
+  ContextInputFormSpec, ContextSliderFormSpec, ContextSizeInputFormSpec, ContextFormToggleButton, ContextFormToggleButtonInstanceApi, ContextFormToggleButtonSpec,
+  SizeData, ContextFormCommand, createContextForm
 } from '../components/content/ContextForm';
 import { ContextToolbar, ContextToolbarSpec, createContextToolbar, contextToolbarToSpec, ToolbarGroup } from '../components/content/ContextToolbar';
 
@@ -38,6 +39,7 @@ export {
   ContextFormToggleButton,
   ContextFormToggleButtonSpec,
   ContextFormToggleButtonInstanceApi,
+  SizeData,
   ContextFormCommand,
   createContextForm,
 

--- a/modules/bridge/src/main/ts/ephox/bridge/api/InlineContent.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/api/InlineContent.ts
@@ -5,7 +5,7 @@ import {
 import { ContextPosition, ContextScope } from '../components/content/ContextBar';
 import {
   ContextForm, ContextInputForm, ContextSliderForm, ContextSizeInputForm, ContextFormButton, ContextFormButtonInstanceApi, ContextFormButtonSpec, ContextFormInstanceApi, ContextFormSpec,
-  ContextInputFormSpec, ContextSliderFormSpec, ContextSizeInputFormSpec, ContextFormToggleButton, ContextFormToggleButtonInstanceApi, ContextFormToggleButtonSpec, createContextForm
+  ContextInputFormSpec, ContextSliderFormSpec, ContextSizeInputFormSpec, ContextFormToggleButton, ContextFormToggleButtonInstanceApi, ContextFormToggleButtonSpec, ContextFormCommand, createContextForm
 } from '../components/content/ContextForm';
 import { ContextToolbar, ContextToolbarSpec, createContextToolbar, contextToolbarToSpec, ToolbarGroup } from '../components/content/ContextToolbar';
 
@@ -38,6 +38,7 @@ export {
   ContextFormToggleButton,
   ContextFormToggleButtonSpec,
   ContextFormToggleButtonInstanceApi,
+  ContextFormCommand,
   createContextForm,
 
   ContextToolbar,

--- a/modules/bridge/src/main/ts/ephox/bridge/api/InlineContent.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/api/InlineContent.ts
@@ -4,7 +4,7 @@ import {
 } from '../components/content/Autocompleter';
 import { ContextPosition, ContextScope } from '../components/content/ContextBar';
 import {
-  ContextForm, ContextInputForm, ContextSliderForm, ContextSizeInputForm, ContextFormButton, ContextFormButtonInstanceApi, ContextFormButtonSpec, ContextFormInstanceApi, ContextFormSpec,
+  BaseContextForm, ContextForm, ContextInputForm, ContextSliderForm, ContextSizeInputForm, ContextFormButton, ContextFormButtonInstanceApi, ContextFormButtonSpec, ContextFormInstanceApi, ContextFormSpec,
   ContextInputFormSpec, ContextSliderFormSpec, ContextSizeInputFormSpec, ContextFormToggleButton, ContextFormToggleButtonInstanceApi, ContextFormToggleButtonSpec,
   SizeData, ContextFormCommand, createContextForm
 } from '../components/content/ContextForm';
@@ -25,6 +25,7 @@ export {
   ContextScope,
 
   ContextFormInstanceApi,
+  BaseContextForm,
   ContextForm,
   ContextInputForm,
   ContextSliderForm,

--- a/modules/bridge/src/main/ts/ephox/bridge/api/InlineContent.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/api/InlineContent.ts
@@ -4,8 +4,8 @@ import {
 } from '../components/content/Autocompleter';
 import { ContextPosition, ContextScope } from '../components/content/ContextBar';
 import {
-  ContextForm, ContextFormButton, ContextFormButtonInstanceApi, ContextFormButtonSpec, ContextFormInstanceApi, ContextFormSpec,
-  ContextFormToggleButton, ContextFormToggleButtonInstanceApi, ContextFormToggleButtonSpec, createContextForm
+  ContextForm, ContextInputForm, ContextSliderForm, ContextSizeInputForm, ContextFormButton, ContextFormButtonInstanceApi, ContextFormButtonSpec, ContextFormInstanceApi, ContextFormSpec,
+  ContextInputFormSpec, ContextSliderFormSpec, ContextSizeInputFormSpec, ContextFormToggleButton, ContextFormToggleButtonInstanceApi, ContextFormToggleButtonSpec, createContextForm
 } from '../components/content/ContextForm';
 import { ContextToolbar, ContextToolbarSpec, createContextToolbar, contextToolbarToSpec, ToolbarGroup } from '../components/content/ContextToolbar';
 
@@ -25,7 +25,13 @@ export {
 
   ContextFormInstanceApi,
   ContextForm,
+  ContextInputForm,
+  ContextSliderForm,
+  ContextSizeInputForm,
   ContextFormSpec,
+  ContextInputFormSpec,
+  ContextSliderFormSpec,
+  ContextSizeInputFormSpec,
   ContextFormButton,
   ContextFormButtonSpec,
   ContextFormButtonInstanceApi,

--- a/modules/bridge/src/main/ts/ephox/bridge/api/Registry.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/api/Registry.ts
@@ -60,6 +60,9 @@ export const create = (): Registry => {
   const add = <T, S extends T>(collection: Record<string, T>, type: string) => (name: string, spec: S): void => {
     collection[name.toLowerCase()] = { ...spec, type };
   };
+  const addDefaulted = <T, S extends T>(collection: Record<string, T>, type: string) => (name: string, spec: S): void => {
+    collection[name.toLowerCase()] = { type, ...spec };
+  };
   const addIcon = (name: string, svgData: string) => icons[name.toLowerCase()] = svgData;
   const addContext = (name: string, pred: (args: string) => boolean) => contexts[name.toLowerCase()] = pred;
 
@@ -75,7 +78,7 @@ export const create = (): Registry => {
     addAutocompleter: add(popups, 'autocompleter'),
     addContextMenu: add(contextMenus, 'contextmenu'),
     addContextToolbar: add(contextToolbars, 'contexttoolbar'),
-    addContextForm: add(contextToolbars, 'contextform'),
+    addContextForm: addDefaulted(contextToolbars, 'contextform'),
     addSidebar: add(sidebars, 'sidebar'),
     addView: add(views, 'views'),
     addIcon,

--- a/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
@@ -66,6 +66,7 @@ export interface ContextFormToggleButton<T> extends BaseToolbarToggleButton<Cont
 
 export interface ContextFormInstanceApi<T> {
   setInputEnabled: (state: boolean) => void;
+  isInputEnabled: () => boolean;
   hide: () => void;
   getValue: () => T;
   setValue: (value: T) => void;

--- a/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
@@ -34,52 +34,90 @@ export interface ContextFormToggleButtonInstanceApi extends BaseToolbarToggleBut
 
 }
 
-export interface ContextFormButtonSpec extends BaseToolbarButtonSpec<ContextFormButtonInstanceApi> {
+export interface ContextFormButtonSpec<T> extends BaseToolbarButtonSpec<ContextFormButtonInstanceApi> {
   type?: 'contextformbutton';
   primary?: boolean;
-  onAction: (formApi: ContextFormInstanceApi, api: ContextFormButtonInstanceApi) => void;
+  onAction: (formApi: ContextFormInstanceApi<T>, api: ContextFormButtonInstanceApi) => void;
 }
 
-export interface ContextFormToggleButtonSpec extends BaseToolbarToggleButtonSpec<ContextFormToggleButtonInstanceApi> {
+export interface ContextFormToggleButtonSpec<T> extends BaseToolbarToggleButtonSpec<ContextFormToggleButtonInstanceApi> {
   type?: 'contextformtogglebutton';
-  onAction: (formApi: ContextFormInstanceApi, buttonApi: ContextFormToggleButtonInstanceApi) => void;
+  onAction: (formApi: ContextFormInstanceApi<T>, buttonApi: ContextFormToggleButtonInstanceApi) => void;
   primary?: boolean;
 }
 
-export interface ContextFormButton extends BaseToolbarButton<ContextFormButtonInstanceApi> {
+export interface ContextFormButton<T> extends BaseToolbarButton<ContextFormButtonInstanceApi> {
   type?: 'contextformbutton';
   primary?: boolean;
-  onAction: (formApi: ContextFormInstanceApi, buttonApi: ContextFormButtonInstanceApi) => void;
-  original: ContextFormButtonSpec;
+  onAction: (formApi: ContextFormInstanceApi<T>, buttonApi: ContextFormButtonInstanceApi) => void;
+  original: ContextFormButtonSpec<T>;
 }
 
-export interface ContextFormToggleButton extends BaseToolbarToggleButton<ContextFormToggleButtonInstanceApi> {
+export interface ContextFormToggleButton<T> extends BaseToolbarToggleButton<ContextFormToggleButtonInstanceApi> {
   type?: 'contextformtogglebutton';
   primary?: boolean;
-  onAction: (formApi: ContextFormInstanceApi, buttonApi: ContextFormToggleButtonInstanceApi) => void;
-  original: ContextFormToggleButtonSpec;
+  onAction: (formApi: ContextFormInstanceApi<T>, buttonApi: ContextFormToggleButtonInstanceApi) => void;
+  original: ContextFormToggleButtonSpec<T>;
 }
 
-export interface ContextFormInstanceApi {
+export interface ContextFormInstanceApi<T> {
   hide: () => void;
-  getValue: () => string; // Maybe we need to support other data types?
+  getValue: () => T;
+  setValue: (value: T) => void;
 }
 
-export interface ContextFormSpec extends ContextBarSpec {
-  type?: 'contextform';
-  initValue?: () => string;
+export interface SizeData {
+  width: string;
+  height: string;
+}
+
+export interface BaseContextFormSpec<T> extends ContextBarSpec {
+  initValue?: () => T;
   label?: string;
   launch?: ContextFormLaunchButtonApi | ContextFormLaunchToggleButtonSpec;
-  commands: Array<ContextFormToggleButtonSpec | ContextFormButtonSpec>;
+  commands: Array<ContextFormToggleButtonSpec<T> | ContextFormButtonSpec<T>>;
+  onInput?: (api: ContextFormInstanceApi<T>) => void;
 }
 
-export interface ContextForm extends ContextBar {
-  type: 'contextform';
-  initValue: () => string;
+export interface ContextInputFormSpec extends BaseContextFormSpec<string> {
+  type?: 'contextform';
+}
+
+export interface ContextSliderFormSpec extends BaseContextFormSpec<number> {
+  type: 'contextsliderform';
+  min?: () => number;
+  max?: () => number;
+}
+
+export interface ContextSizeInputFormSpec extends BaseContextFormSpec<SizeData> {
+  type: 'contextsizeinputform';
+}
+
+export type ContextFormSpec = ContextInputFormSpec | ContextSliderFormSpec | ContextSizeInputFormSpec;
+
+export interface BaseContextForm<T> extends ContextBar {
+  initValue: () => T;
   label: Optional<string>;
   launch: Optional<ContextFormLaunchButton | ContextFormLaunchToggleButton>;
-  commands: Array<ContextFormToggleButton | ContextFormButton>;
+  commands: Array<ContextFormToggleButton<T> | ContextFormButton<T>>;
+  onInput: (api: ContextFormInstanceApi<T>) => void;
 }
+
+export interface ContextInputForm extends BaseContextForm<string> {
+  type: 'contextform';
+}
+
+export interface ContextSliderForm extends BaseContextForm<number> {
+  type: 'contextsliderform';
+  min: () => number;
+  max: () => number;
+}
+
+export interface ContextSizeInputForm extends BaseContextForm<SizeData> {
+  type: 'contextsizeinputform';
+}
+
+export type ContextForm = ContextInputForm | ContextSliderForm | ContextSizeInputForm;
 
 const contextButtonFields = baseToolbarButtonFields.concat([
   ComponentSchema.defaultedType('contextformbutton'),
@@ -108,16 +146,47 @@ const toggleOrNormal = StructureSchema.choose('type', {
   contextformtogglebutton: contextToggleButtonFields
 });
 
-const contextFormSchema = StructureSchema.objOf([
-  ComponentSchema.defaultedType('contextform'),
-  FieldSchema.defaultedFunction('initValue', Fun.constant('')),
+const baseContextFormFields = [
   ComponentSchema.optionalLabel,
   FieldSchema.requiredArrayOf('commands', toggleOrNormal),
   FieldSchema.optionOf('launch', StructureSchema.choose('type', {
     contextformbutton: launchButtonFields,
     contextformtogglebutton: launchToggleButtonFields
-  }))
-].concat(contextBarFields));
+  })),
+  FieldSchema.defaultedFunction('onInput', Fun.noop)
+];
+
+const contextFormFields = [
+  ...contextBarFields,
+  ...baseContextFormFields,
+  FieldSchema.requiredStringEnum('type', [ 'contextform' ]),
+  FieldSchema.defaultedFunction('initValue', Fun.constant('')),
+];
+
+const contextSliderFormFields = [
+  ...contextBarFields,
+  ...baseContextFormFields,
+  FieldSchema.requiredStringEnum('type', [ 'contextsliderform' ]),
+  FieldSchema.defaultedFunction('initValue', Fun.constant(0)),
+  FieldSchema.defaultedFunction('min', Fun.constant(0)),
+  FieldSchema.defaultedFunction('max', Fun.constant(100))
+];
+
+const contextSizeInputFormFields = [
+  ...contextBarFields,
+  ...baseContextFormFields,
+  FieldSchema.requiredStringEnum('type', [ 'contextsizeinputform' ]),
+  FieldSchema.defaultedFunction('initValue', Fun.constant({ width: '', height: '' }))
+];
+
+export const contextFormSchema = StructureSchema.choose(
+  'type',
+  {
+    contextform: contextFormFields,
+    contextsliderform: contextSliderFormFields,
+    contextsizeinputform: contextSizeInputFormFields
+  }
+);
 
 export const createContextForm = (spec: ContextFormSpec): Result<ContextForm, StructureSchema.SchemaError<any>> =>
   StructureSchema.asRaw<ContextForm>('ContextForm', contextFormSchema, spec);

--- a/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
@@ -65,6 +65,7 @@ export interface ContextFormToggleButton<T> extends BaseToolbarToggleButton<Cont
 }
 
 export interface ContextFormInstanceApi<T> {
+  setInputEnabled: (state: boolean) => void;
   hide: () => void;
   getValue: () => T;
   setValue: (value: T) => void;

--- a/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
@@ -37,18 +37,21 @@ export interface ContextFormToggleButtonInstanceApi extends BaseToolbarToggleBut
 export interface ContextFormButtonSpec<T> extends BaseToolbarButtonSpec<ContextFormButtonInstanceApi> {
   type?: 'contextformbutton';
   primary?: boolean;
+  align?: 'start' | 'end';
   onAction: (formApi: ContextFormInstanceApi<T>, api: ContextFormButtonInstanceApi) => void;
 }
 
 export interface ContextFormToggleButtonSpec<T> extends BaseToolbarToggleButtonSpec<ContextFormToggleButtonInstanceApi> {
   type?: 'contextformtogglebutton';
-  onAction: (formApi: ContextFormInstanceApi<T>, buttonApi: ContextFormToggleButtonInstanceApi) => void;
   primary?: boolean;
+  align?: 'start' | 'end';
+  onAction: (formApi: ContextFormInstanceApi<T>, buttonApi: ContextFormToggleButtonInstanceApi) => void;
 }
 
 export interface ContextFormButton<T> extends BaseToolbarButton<ContextFormButtonInstanceApi> {
   type?: 'contextformbutton';
   primary?: boolean;
+  align?: 'start' | 'end';
   onAction: (formApi: ContextFormInstanceApi<T>, buttonApi: ContextFormButtonInstanceApi) => void;
   original: ContextFormButtonSpec<T>;
 }
@@ -56,6 +59,7 @@ export interface ContextFormButton<T> extends BaseToolbarButton<ContextFormButto
 export interface ContextFormToggleButton<T> extends BaseToolbarToggleButton<ContextFormToggleButtonInstanceApi> {
   type?: 'contextformtogglebutton';
   primary?: boolean;
+  align?: 'start' | 'end';
   onAction: (formApi: ContextFormInstanceApi<T>, buttonApi: ContextFormToggleButtonInstanceApi) => void;
   original: ContextFormToggleButtonSpec<T>;
 }
@@ -95,11 +99,13 @@ export interface ContextSizeInputFormSpec extends BaseContextFormSpec<SizeData> 
 
 export type ContextFormSpec = ContextInputFormSpec | ContextSliderFormSpec | ContextSizeInputFormSpec;
 
+export type ContextFormCommand<T> = ContextFormButton<T> | ContextFormToggleButton<T>;
+
 export interface BaseContextForm<T> extends ContextBar {
   initValue: () => T;
   label: Optional<string>;
   launch: Optional<ContextFormLaunchButton | ContextFormLaunchToggleButton>;
-  commands: Array<ContextFormToggleButton<T> | ContextFormButton<T>>;
+  commands: ContextFormCommand<T>[];
   onInput: (api: ContextFormInstanceApi<T>) => void;
 }
 
@@ -121,6 +127,7 @@ export type ContextForm = ContextInputForm | ContextSliderForm | ContextSizeInpu
 
 const contextButtonFields = baseToolbarButtonFields.concat([
   ComponentSchema.defaultedType('contextformbutton'),
+  FieldSchema.defaultedString('align', 'end'),
   ComponentSchema.primary,
   ComponentSchema.onAction,
   FieldSchema.customField('original', Fun.identity)
@@ -128,6 +135,7 @@ const contextButtonFields = baseToolbarButtonFields.concat([
 
 const contextToggleButtonFields = baseToolbarToggleButtonFields.concat([
   ComponentSchema.defaultedType('contextformbutton'),
+  FieldSchema.defaultedString('align', 'end'),
   ComponentSchema.primary,
   ComponentSchema.onAction,
   FieldSchema.customField('original', Fun.identity)

--- a/modules/oxide/src/less/theme/components/form/textfield.less
+++ b/modules/oxide/src/less/theme/components/form/textfield.less
@@ -89,7 +89,7 @@
     }
   }
 
-  .tox-textfield--context-form {
+  .tox-textfield-size {
     width: 80px;
   }
 }

--- a/modules/oxide/src/less/theme/components/form/textfield.less
+++ b/modules/oxide/src/less/theme/components/form/textfield.less
@@ -61,7 +61,6 @@
   }
 
   .tox-toolbar-textfield:extend(.tox .tox-textfield) {
-    border-width: 0;
     margin-bottom: 3px;
     margin-top: 2px;
     max-width: 250px;
@@ -82,6 +81,10 @@
       display: block;
       fill: @text-color;
     }
+  }
+
+  .tox-textfield--context-form {
+    width: 80px;
   }
 }
 

--- a/modules/oxide/src/less/theme/components/form/textfield.less
+++ b/modules/oxide/src/less/theme/components/form/textfield.less
@@ -66,6 +66,12 @@
     max-width: 250px;
   }
 
+  .tox-toolbar-textfield[disabled] {
+    background-color: @textfield-disabled-background-color;
+    color: @textfield-disabled-text-color;
+    cursor: not-allowed;
+  }
+
   .tox-naked-btn {
     background-color: transparent;
     border: 0;

--- a/modules/oxide/src/less/theme/components/slider/slider.less
+++ b/modules/oxide/src/less/theme/components/slider/slider.less
@@ -13,6 +13,19 @@
 @slider-rail-border: 1px solid @border-color;
 @slider-rail-height: 10px;
 
+// TODO: Remove the duplication of these values with the old sliders
+@slider-width: 130px;
+@slider-thumb-background-color: @button-background-color;
+@slider-thumb-border-radius: @slider-thumb-width;
+@slider-thumb-width: 13px;
+@slider-thumb-height: 13px;
+@slider-thumb-middle: 4px;
+
+@slider-track-background-color: @border-color;
+@slider-track-border-radius: @slider-thumb-width;
+@slider-track-border: none;
+@slider-track-height: 2px;
+
 .tox {
   .tox-slider {
     align-items: center;
@@ -57,5 +70,48 @@
 
   .tox-form__controls-h-stack > .tox-slider + .tox-form__group {
     margin-inline-start: @pad-xl;
+  }
+
+  // Toolbar specific slider
+  .tox-toolbar-slider {
+    align-items: center;
+    display: inline-flex;
+    height: @slider-thumb-height;
+  }
+
+  .tox-toolbar-slider__input {
+    appearance: none;
+    background: @slider-track-background-color;
+    border-radius: @slider-thumb-height;
+    width: @slider-width;
+    height: @slider-track-height;
+  }
+
+  .tox-toolbar-slider__input::-webkit-slider-runnable-track {
+    background-color: transparent;
+    height: @slider-thumb-height;
+  }
+
+  .tox-toolbar-slider__input::-moz-range-track {
+    background-color: transparent;
+    height: @slider-thumb-height;
+  }
+
+  .tox-toolbar-slider__input::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    background-color: @slider-thumb-background-color;
+    border-radius: @slider-thumb-height;
+    border: none;
+    height: @slider-thumb-height;
+    width: @slider-thumb-width;
+  }
+
+  .tox-toolbar-slider__input::-moz-range-thumb {
+    appearance: none;
+    background-color: @slider-thumb-background-color;
+    border-radius: @slider-thumb-height;
+    border: none;
+    height: @slider-thumb-height;
+    width: @slider-thumb-width;
   }
 }

--- a/modules/oxide/src/less/theme/components/toolbar/toolbar.less
+++ b/modules/oxide/src/less/theme/components/toolbar/toolbar.less
@@ -149,3 +149,9 @@
     padding: @pad-xs 0;
   }
 }
+
+// Context form group
+.tox-context-form__group {
+  display: flex;
+  align-items: center;
+}

--- a/modules/tinymce/src/core/demo/html/context_form_demo.html
+++ b/modules/tinymce/src/core/demo/html/context_form_demo.html
@@ -1,0 +1,51 @@
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>TinyMCE context form Demo Page</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+
+<body>
+  <main>
+    <h1>Tinymce context form Demo Page</h1>
+    <div id="ephox-ui">
+      <textarea>
+        <p>
+          <img src="https://www.google.com/logos/google.jpg">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed augue velit. Sed viverra aliquet fringilla. Duis quis turpis rutrum, auctor
+          <img src="https://www.google.com/logos/google.jpg" style="float: right">
+          diam vitae,
+          pellentesque arcu. Pellentesque vel ipsum a urna condimentum tincidunt ut bibendum metus. Ut eu ipsum faucibus sapien tempor ullamcorper. Donec
+          tempor
+          fermentum posuere. Suspendisse vel vestibulum nisl, a auctor nisi. Phasellus in aliquam ex, nec vulputate orci. Fusce non pharetra magna. Sed id
+          felis et
+          magna ultricies dapibus. Nunc varius ipsum at nunc lobortis viverra. Nulla neque sem, tincidunt nec tempus et, tempus sagittis nisl. Vivamus
+          dolor ligula,
+          euismod at rhoncus sed, consequat eget nibh. Nam massa dui, dictum sit amet erat at, mollis sodales orci. Vestibulum sodales dictum felis, sed
+          vulputate
+          turpis condimentum sed.
+        </p>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed augue velit. Sed viverra aliquet fringilla. Duis quis turpis rutrum, auctor
+          diam vitae,
+          pellentesque arcu. Pellentesque vel ipsum a urna condimentum tincidunt ut bibendum metus. Ut eu ipsum faucibus sapien tempor ullamcorper. Donec
+          tempor
+          fermentum posuere. Suspendisse vel vestibulum nisl, a auctor nisi. Phasellus in aliquam ex, nec vulputate orci. Fusce non pharetra magna. Sed id
+          felis et
+          magna ultricies dapibus. Nunc varius ipsum at nunc lobortis viverra. Nulla neque sem, tincidunt nec tempus et, tempus sagittis nisl. Vivamus
+          dolor ligula,
+          euismod at rhoncus sed, consequat eget nibh. Nam massa dui, dictum sit amet erat at, mollis sodales orci. Vestibulum sodales dictum felis, sed
+          vulputate
+          turpis condimentum sed.
+        </p></textarea>
+    </div>
+    <div class="tinymce">Inline demo</div>
+    <script src="../../../../js/tinymce/tinymce.js"></script>
+    <script src="../../../../scratch/demos/core/demo.js"></script>
+    <script>demos.ContextFormDemo();</script>
+  </main>
+</body>
+
+</html>

--- a/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
@@ -181,7 +181,7 @@ export default (): void => {
     // rtl_ui: true,
     add_unload_trigger: false,
     autosave_ask_before_unload: false,
-    toolbar: 'foo undo redo sidebar1 fontsizeinput | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | align lineheight fontsize fontfamily blocks styles insertfile | styles | ' +
+    toolbar: 'undo redo sidebar1 fontsizeinput | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | align lineheight fontsize fontfamily blocks styles insertfile | styles | ' +
     'bullist numlist outdent indent | link image | print preview media | forecolor backcolor emoticons table codesample code language | ltr rtl',
     contextmenu: 'link linkchecker image table lists configurepermanentpen',
     toolbar_mode: 'floating',

--- a/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
@@ -1,0 +1,185 @@
+/* eslint-disable no-console */
+import { Fun, Merger } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
+
+import { Editor, RawEditorOptions, TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
+
+export default (): void => {
+  const registerUi = (editor: Editor) => {
+    editor.ui.registry.addContextForm('text', {
+      type: 'contextform',
+      launch: {
+        type: 'contextformbutton',
+        text: 'Alt',
+        tooltip: 'Alt'
+      },
+      onInput: (api) => {
+        console.log('text', api.getValue());
+      },
+      label: 'Alt',
+      commands: [
+        {
+          type: 'contextformtogglebutton',
+          // align: 'start',
+          text: 'Decorative',
+          onAction: (_formApi, _buttonApi) => {
+            // formApi.setInputEnabled(buttonApi.isActive());
+          }
+        }
+      ]
+    });
+
+    editor.ui.registry.addContextForm('size', {
+      type: 'contextsizeinputform',
+      launch: {
+        type: 'contextformbutton',
+        text: 'Size',
+        tooltip: 'Size'
+      },
+      initValue: () => ({ width: '400', height: '300' }),
+      onInput: (api) => {
+        console.log('size', api.getValue());
+      },
+      label: 'Size',
+      commands: [
+        // {
+        //   type: 'contextbackbutton',
+        //   // align: 'start',
+        //   icon: 'back'
+        // },
+        {
+          type: 'contextformbutton',
+          // align: 'end',
+          text: 'Reset',
+          onAction: (formApi) => {
+            formApi.setValue({ width: '400', height: '300' });
+          }
+        }
+      ]
+    });
+
+    editor.ui.registry.addContextForm('slider', {
+      type: 'contextsliderform',
+      launch: {
+        type: 'contextformbutton',
+        text: 'Brightness',
+        tooltip: 'Brightness'
+      },
+      min: Fun.constant(-100),
+      max: Fun.constant(100),
+      initValue: Fun.constant(0),
+      onInput: (api) => {
+        console.log('onInput', api.getValue());
+      },
+      label: 'Brightness',
+      commands: [
+        // {
+        //   type: 'contextbackbutton',
+        //   align: 'start',
+        //   icon: 'back'
+        // },
+        {
+          type: 'contextformbutton',
+          // align: 'end',
+          primary: true,
+          text: 'Apply',
+          onAction: (formApi) => {
+            formApi.hide();
+            editor.focus();
+          }
+        },
+        {
+          type: 'contextformbutton',
+          // align: 'end',
+          text: 'Reset',
+          onAction: (formApi) => {
+            formApi.setValue(50);
+          }
+        }
+      ]
+    });
+
+    editor.ui.registry.addContextToolbar('contexttoolbar1', {
+      predicate: (node) => node.nodeName === 'IMG',
+      items: 'text slider size',
+      position: 'node',
+      scope: 'node'
+    });
+  };
+
+  const settings: RawEditorOptions = {
+    skin_url: '../../../../js/tinymce/skins/ui/oxide',
+    content_css: '../../../../js/tinymce/skins/content/default/content.css',
+    content_langs: [
+      { title: 'English (US)', code: 'en_us' },
+      { title: 'Spanish', code: 'es' },
+      { title: 'English (US Medical)', code: 'en_us', customCode: 'en_us_medical' }
+    ],
+    images_upload_url: 'd',
+    selector: 'textarea',
+    // rtl_ui: true,
+    link_list: [
+      { title: 'My page 1', value: 'http://www.tinymce.com' },
+      { title: 'My page 2', value: 'http://www.moxiecode.com' }
+    ],
+    image_list: [
+      { title: 'My page 1', value: 'http://www.tinymce.com' },
+      { title: 'My page 2', value: 'http://www.moxiecode.com' }
+    ],
+    image_class_list: [
+      { title: 'None', value: '' },
+      { title: 'Some class', value: 'class-name' }
+    ],
+    importcss_append: true,
+    // init_content_sync: true,
+    height: 400,
+    image_advtab: true,
+    file_picker_callback: (callback, _value, meta) => {
+      if (meta.fieldname === 'poster') {
+        callback('test.mp4', { altsource: 'blah.ogg', width: '400px', poster: 'testing.jpg', embed: '<p>test</p>' });
+        return;
+      }
+      // Provide file and text for the link dialog
+      if (meta.filetype === 'file') {
+        callback('https://www.google.com/logos/google.jpg', { text: 'My text', title: 'blah' });
+      }
+
+      // Provide image and alt text for the image dialog
+      if (meta.filetype === 'image') {
+        // tslint:disable-next-line: no-debugger
+        callback('https://www.google.com/logos/google.jpg', { alt: 'My alt text', style: 'border: 10px solid black;' });
+      }
+
+      // Provide alternative source and posted for the media dialog
+      if (meta.filetype === 'media') {
+        callback('movie.mp4', { embed: '<p>test</p>' });
+      }
+    },
+    image_caption: true,
+    theme: 'silver',
+    setup: (editor) => {
+      registerUi(editor);
+    },
+    plugins: [
+      'autosave', 'advlist', 'autolink', 'link', 'image', 'lists', 'charmap', 'preview', 'anchor', 'pagebreak',
+      'searchreplace', 'wordcount', 'visualblocks', 'visualchars', 'code', 'fullscreen', 'insertdatetime', 'media', 'nonbreaking',
+      'save', 'table', 'directionality', 'emoticons', 'importcss', 'codesample', 'help', 'accordion'
+    ],
+    // rtl_ui: true,
+    add_unload_trigger: false,
+    autosave_ask_before_unload: false,
+    toolbar: 'foo undo redo sidebar1 fontsizeinput | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | align lineheight fontsize fontfamily blocks styles insertfile | styles | ' +
+    'bullist numlist outdent indent | link image | print preview media | forecolor backcolor emoticons table codesample code language | ltr rtl',
+    contextmenu: 'link linkchecker image table lists configurepermanentpen',
+    toolbar_mode: 'floating',
+    emoticons_database_url: '/src/plugins/emoticons/main/js/emojis.js',
+    resize_img_proportional: true,
+    format_empty_lines: true
+  };
+
+  tinymce.init(settings);
+  tinymce.init(Merger.deepMerge(settings, { inline: true, selector: 'div.tinymce' }));
+};
+

--- a/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
@@ -31,9 +31,9 @@ export default (): void => {
           type: 'contextformtogglebutton',
           align: 'start',
           text: 'Decorative',
-          onAction: (_formApi, buttonApi) => {
+          onAction: (formApi, buttonApi) => {
             buttonApi.setActive(!buttonApi.isActive());
-            // formApi.setInputEnabled(buttonApi.isActive());
+            formApi.setInputEnabled(!buttonApi.isActive());
           }
         }
       ]

--- a/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
@@ -33,7 +33,7 @@ export default (): void => {
           text: 'Decorative',
           onAction: (formApi, buttonApi) => {
             buttonApi.setActive(!buttonApi.isActive());
-            formApi.setInputEnabled(!buttonApi.isActive());
+            formApi.setInputEnabled(!formApi.isInputEnabled());
           }
         }
       ]

--- a/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import { Fun, Merger } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
 
 import { Editor, RawEditorOptions, TinyMCE } from 'tinymce/core/api/PublicApi';
 
@@ -21,10 +20,19 @@ export default (): void => {
       label: 'Alt',
       commands: [
         {
+          type: 'contextformbutton',
+          align: 'start',
+          icon: 'chevron-left',
+          onAction: (formApi) => {
+            formApi.hide();
+          }
+        },
+        {
           type: 'contextformtogglebutton',
-          // align: 'start',
+          align: 'start',
           text: 'Decorative',
-          onAction: (_formApi, _buttonApi) => {
+          onAction: (_formApi, buttonApi) => {
+            buttonApi.setActive(!buttonApi.isActive());
             // formApi.setInputEnabled(buttonApi.isActive());
           }
         }
@@ -44,14 +52,16 @@ export default (): void => {
       },
       label: 'Size',
       commands: [
-        // {
-        //   type: 'contextbackbutton',
-        //   // align: 'start',
-        //   icon: 'back'
-        // },
         {
           type: 'contextformbutton',
-          // align: 'end',
+          align: 'start',
+          icon: 'chevron-left',
+          onAction: (formApi) => {
+            formApi.hide();
+          }
+        },
+        {
+          type: 'contextformbutton',
           text: 'Reset',
           onAction: (formApi) => {
             formApi.setValue({ width: '400', height: '300' });
@@ -75,14 +85,16 @@ export default (): void => {
       },
       label: 'Brightness',
       commands: [
-        // {
-        //   type: 'contextbackbutton',
-        //   align: 'start',
-        //   icon: 'back'
-        // },
         {
           type: 'contextformbutton',
-          // align: 'end',
+          align: 'start',
+          icon: 'chevron-left',
+          onAction: (formApi) => {
+            formApi.hide();
+          }
+        },
+        {
+          type: 'contextformbutton',
           primary: true,
           text: 'Apply',
           onAction: (formApi) => {
@@ -92,7 +104,6 @@ export default (): void => {
         },
         {
           type: 'contextformbutton',
-          // align: 'end',
           text: 'Reset',
           onAction: (formApi) => {
             formApi.setValue(50);

--- a/modules/tinymce/src/core/demo/ts/demo/Demos.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/Demos.ts
@@ -1,6 +1,7 @@
 import AnnotationsDemo from './AnnotationsDemo';
 import CommandsDemo from './CommandsDemo';
 import ContentEditableFalseDemo from './ContentEditableFalseDemo';
+import ContextFormDemo from './ContextFormDemo';
 import ContextToolbarDemo from './ContextToolbarDemo';
 import CustomThemeDemo from './CustomThemeDemo';
 import FixedToolbarContainerDemo from './FixedToolbarContainerDemo';
@@ -35,5 +36,6 @@ window.demos = {
   ShadowDomDemo,
   ShadowDomInlineDemo,
   ReadOnlyDemo,
-  ViewDemo
+  ViewDemo,
+  ContextFormDemo
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextForm.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextForm.ts
@@ -28,7 +28,7 @@ const buildInitGroups = (ctx: InlineContent.ContextForm, providers: UiFactoryBac
 
   const memInput = Memento.record(renderInput(ctx, providers, onEnter));
   // TODO: This any cast is needed since it somehow always picks the first type Type<string> from Type<string> | Type<number> | Type<SizeData>
-  const commandParts = Arr.partition(ctx.commands, (command: InlineContent.ContextFormCommand<any>) => command.align as string === 'start');
+  const commandParts = Arr.partition(ctx.commands, (command: InlineContent.ContextFormCommand<any>) => command.align === 'start');
   const startCommands = generate(memInput, commandParts.pass, providers);
   const endCommands = generate(memInput, commandParts.fail, providers);
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextForm.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextForm.ts
@@ -1,53 +1,32 @@
-import { AlloySpec, AlloyTriggers, Behaviour, Disabling, Input, Keying, Memento, SketchSpec } from '@ephox/alloy';
+import { AlloyComponent, AlloySpec, AlloyTriggers, Memento, SketchSpec } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Id, Optional } from '@ephox/katamari';
 
 import { ToolbarMode } from '../../api/Options';
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
-import * as UiState from '../../UiState';
 import { renderToolbar, ToolbarGroup } from '../toolbar/CommonToolbar';
 import { generate } from './ContextFormButtons';
+import * as ContextFormSizeInput from './ContextFormSizeInput';
+import * as ContextFormSlider from './ContextFormSlider';
+import * as ContextFormTextInput from './ContextFormTextInput';
+
+const renderInput = (ctx: InlineContent.ContextForm, providers: UiFactoryBackstageProviders, onEnter: (input: AlloyComponent) => Optional<boolean>) => {
+  switch (ctx.type) {
+    case 'contextform': return ContextFormTextInput.renderContextFormTextInput(ctx, providers, onEnter);
+    case 'contextsliderform': return ContextFormSlider.renderContextFormSliderInput(ctx, providers, onEnter);
+    case 'contextsizeinputform': return ContextFormSizeInput.renderContextFormSizeInput(ctx, providers, onEnter);
+  }
+};
 
 const buildInitGroups = (ctx: InlineContent.ContextForm, providers: UiFactoryBackstageProviders): ToolbarGroup[] => {
-  // Cannot use the FormField.sketch, because the DOM structure doesn't have a wrapping group
-  const inputAttributes = ctx.label.fold(
-    () => ({ }),
-    (label) => ({ 'aria-label': label })
-  );
+  const onEnter = (input: AlloyComponent) => {
+    return commands.findPrimary(input).map((primary) => {
+      AlloyTriggers.emitExecute(primary);
+      return true;
+    });
+  };
 
-  const memInput = Memento.record(
-    Input.sketch({
-      inputClasses: [ 'tox-toolbar-textfield', 'tox-toolbar-nav-js' ],
-      data: ctx.initValue(),
-      inputAttributes,
-      selectOnFocus: true,
-      inputBehaviours: Behaviour.derive([
-        Disabling.config({
-          disabled: () => providers.checkUiComponentContext('mode:design').shouldDisable
-        }),
-        UiState.toggleOnReceive(() => providers.checkUiComponentContext('mode:design')),
-        Keying.config({
-          mode: 'special',
-          onEnter: (input) => commands.findPrimary(input).map((primary) => {
-            AlloyTriggers.emitExecute(primary);
-            return true;
-          }),
-          // These two lines need to be tested. They are about left and right bypassing
-          // any keyboard handling, and allowing left and right to be processed by the input
-          // Maybe this should go in an alloy sketch for Input?
-          onLeft: (comp, se) => {
-            se.cut();
-            return Optional.none();
-          },
-          onRight: (comp, se) => {
-            se.cut();
-            return Optional.none();
-          }
-        })
-      ])
-    })
-  );
-
+  const memInput = Memento.record(renderInput(ctx, providers, onEnter));
   const commands = generate(memInput, ctx.commands, providers);
 
   return [

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
@@ -6,12 +6,31 @@ import {
   SystemEvents
 } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
+import { Singleton } from '@ephox/katamari';
 
-export const getFormApi = <T>(input: AlloyComponent): InlineContent.ContextFormInstanceApi<T> => ({
-  setInputEnabled: (state: boolean) => Disabling.set(input, !state),
-  isInputEnabled: () => !Disabling.isDisabled(input),
-  hide: () => AlloyTriggers.emit(input, SystemEvents.sandboxClose()),
-  getValue: () => Representing.getValue(input),
-  setValue: (value) => Representing.setValue(input, value)
-});
+export const getFormApi = <T>(input: AlloyComponent): InlineContent.ContextFormInstanceApi<T> => {
+  const valueState = Singleton.value<T>();
 
+  return ({
+    setInputEnabled: (state: boolean) => Disabling.set(input, !state),
+    isInputEnabled: () => !Disabling.isDisabled(input),
+    hide: () => {
+      // Before we hide snapshot the current value since accessing the value of a form field after it's been detached will throw an error
+      if (!valueState.isSet()) {
+        valueState.set(Representing.getValue(input));
+      }
+
+      AlloyTriggers.emit(input, SystemEvents.sandboxClose());
+    },
+    getValue: () => {
+      return valueState.get().getOrThunk(() => Representing.getValue(input));
+    },
+    setValue: (value) => {
+      if (valueState.isSet()) {
+        valueState.set(value);
+      } else {
+        Representing.setValue(input, value);
+      }
+    }
+  });
+};

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
@@ -1,12 +1,14 @@
 import {
   AlloyComponent,
   AlloyTriggers,
+  Disabling,
   Representing,
   SystemEvents
 } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 
 export const getFormApi = (input: AlloyComponent): InlineContent.ContextFormInstanceApi<any> => ({
+  setInputEnabled: (state: boolean) => Disabling.set(input, !state),
   hide: () => AlloyTriggers.emit(input, SystemEvents.sandboxClose()),
   getValue: () => Representing.getValue(input),
   setValue: (value) => Representing.setValue(input, value)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
@@ -1,0 +1,14 @@
+import {
+  AlloyComponent,
+  AlloyTriggers,
+  Representing,
+  SystemEvents
+} from '@ephox/alloy';
+import { InlineContent } from '@ephox/bridge';
+
+export const getFormApi = (input: AlloyComponent): InlineContent.ContextFormInstanceApi<any> => ({
+  hide: () => AlloyTriggers.emit(input, SystemEvents.sandboxClose()),
+  getValue: () => Representing.getValue(input),
+  setValue: (value) => Representing.setValue(input, value)
+});
+

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
@@ -7,8 +7,9 @@ import {
 } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 
-export const getFormApi = (input: AlloyComponent): InlineContent.ContextFormInstanceApi<any> => ({
+export const getFormApi = <T>(input: AlloyComponent): InlineContent.ContextFormInstanceApi<T> => ({
   setInputEnabled: (state: boolean) => Disabling.set(input, !state),
+  isInputEnabled: () => !Disabling.isDisabled(input),
   hide: () => AlloyTriggers.emit(input, SystemEvents.sandboxClose()),
   getValue: () => Representing.getValue(input),
   setValue: (value) => Representing.setValue(input, value)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
@@ -20,7 +20,7 @@ interface ContextFormButtonRegistry {
 const runOnExecute = <T, U>(memInput: MementoRecord, original: { onAction: (formApi: InlineContent.ContextFormInstanceApi<U>, buttonApi: T) => void }) =>
   AlloyEvents.run<InternalToolbarButtonExecuteEvent<T>>(internalToolbarButtonExecute, (comp, se) => {
     const input = memInput.get(comp);
-    const formApi = getFormApi(input);
+    const formApi = getFormApi<U>(input);
     original.onAction(formApi, se.event.buttonApi);
   });
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
@@ -17,14 +17,14 @@ interface ContextFormButtonRegistry {
   readonly findPrimary: (compInSystem: AlloyComponent) => Optional<AlloyComponent>;
 }
 
-const runOnExecute = <T>(memInput: MementoRecord, original: { onAction: (formApi: InlineContent.ContextFormInstanceApi<any>, buttonApi: T) => void }) =>
+const runOnExecute = <T, U>(memInput: MementoRecord, original: { onAction: (formApi: InlineContent.ContextFormInstanceApi<U>, buttonApi: T) => void }) =>
   AlloyEvents.run<InternalToolbarButtonExecuteEvent<T>>(internalToolbarButtonExecute, (comp, se) => {
     const input = memInput.get(comp);
     const formApi = getFormApi(input);
     original.onAction(formApi, se.event.buttonApi);
   });
 
-const renderContextButton = (memInput: MementoRecord, button: InlineContent.ContextFormButton<any>, providers: UiFactoryBackstageProviders) => {
+const renderContextButton = <T>(memInput: MementoRecord, button: InlineContent.ContextFormButton<T>, providers: UiFactoryBackstageProviders) => {
   const { primary, ...rest } = button.original;
   const bridged = StructureSchema.getOrDie(
     Toolbar.createToolbarButton({
@@ -35,11 +35,11 @@ const renderContextButton = (memInput: MementoRecord, button: InlineContent.Cont
   );
 
   return renderToolbarButtonWith(bridged, providers, [
-    runOnExecute<Toolbar.ToolbarButtonInstanceApi>(memInput, button)
+    runOnExecute<Toolbar.ToolbarButtonInstanceApi, T>(memInput, button)
   ]);
 };
 
-const renderContextToggleButton = (memInput: MementoRecord, button: InlineContent.ContextFormToggleButton<any>, providers: UiFactoryBackstageProviders) => {
+const renderContextToggleButton = <T>(memInput: MementoRecord, button: InlineContent.ContextFormToggleButton<T>, providers: UiFactoryBackstageProviders) => {
   const { primary, ...rest } = button.original;
   const bridged = StructureSchema.getOrDie(
     Toolbar.createToggleButton({
@@ -50,14 +50,14 @@ const renderContextToggleButton = (memInput: MementoRecord, button: InlineConten
   );
 
   return renderToolbarToggleButtonWith(bridged, providers, [
-    runOnExecute<InlineContent.ContextFormToggleButtonInstanceApi>(memInput, button)
+    runOnExecute<InlineContent.ContextFormToggleButtonInstanceApi, T>(memInput, button)
   ]);
 };
 
-const isToggleButton = (button: InlineContent.ContextFormCommand<any>): button is InlineContent.ContextFormToggleButton<any> =>
+const isToggleButton = <T>(button: InlineContent.ContextFormCommand<T>): button is InlineContent.ContextFormToggleButton<T> =>
   button.type === 'contextformtogglebutton';
 
-const generateOne = (memInput: MementoRecord, button: InlineContent.ContextFormCommand<any>, providersBackstage: UiFactoryBackstageProviders) => {
+const generateOne = <T>(memInput: MementoRecord, button: InlineContent.ContextFormCommand<T>, providersBackstage: UiFactoryBackstageProviders) => {
   if (isToggleButton(button)) {
     return renderContextToggleButton(memInput, button, providersBackstage);
   } else {
@@ -65,7 +65,7 @@ const generateOne = (memInput: MementoRecord, button: InlineContent.ContextFormC
   }
 };
 
-const generate = (memInput: MementoRecord, buttons: InlineContent.ContextFormCommand<any>[], providersBackstage: UiFactoryBackstageProviders): ContextFormButtonRegistry => {
+const generate = <T>(memInput: MementoRecord, buttons: InlineContent.ContextFormCommand<T>[], providersBackstage: UiFactoryBackstageProviders): ContextFormButtonRegistry => {
 
   const mementos = Arr.map(buttons, (button) => Memento.record(
     generateOne(memInput, button, providersBackstage)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
@@ -1,5 +1,7 @@
 import {
-  AlloyComponent, AlloyEvents, AlloyTriggers, Disabling, Memento, MementoRecord, Representing, SimpleOrSketchSpec, SystemEvents
+  AlloyComponent, AlloyEvents,
+  Disabling, Memento, MementoRecord,
+  SimpleOrSketchSpec
 } from '@ephox/alloy';
 import { StructureSchema } from '@ephox/boulder';
 import { InlineContent, Toolbar } from '@ephox/bridge';
@@ -8,29 +10,23 @@ import { Arr, Fun, Optional } from '@ephox/katamari';
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { internalToolbarButtonExecute, InternalToolbarButtonExecuteEvent } from '../toolbar/button/ButtonEvents';
 import { renderToolbarButtonWith, renderToolbarToggleButtonWith } from '../toolbar/button/ToolbarButtons';
+import { getFormApi } from './ContextFormApi';
 
-type ContextFormButton = InlineContent.ContextFormToggleButton | InlineContent.ContextFormButton;
+type ContextFormButton = InlineContent.ContextFormToggleButton<any> | InlineContent.ContextFormButton<any>;
 
 interface ContextFormButtonRegistry {
   readonly asSpecs: () => SimpleOrSketchSpec[];
   readonly findPrimary: (compInSystem: AlloyComponent) => Optional<AlloyComponent>;
 }
 
-// Can probably generalise.
-
-const getFormApi = (input: AlloyComponent): InlineContent.ContextFormInstanceApi => ({
-  hide: () => AlloyTriggers.emit(input, SystemEvents.sandboxClose()),
-  getValue: () => Representing.getValue(input)
-});
-
-const runOnExecute = <T>(memInput: MementoRecord, original: { onAction: (formApi: InlineContent.ContextFormInstanceApi, buttonApi: T) => void }) =>
+const runOnExecute = <T>(memInput: MementoRecord, original: { onAction: (formApi: InlineContent.ContextFormInstanceApi<any>, buttonApi: T) => void }) =>
   AlloyEvents.run<InternalToolbarButtonExecuteEvent<T>>(internalToolbarButtonExecute, (comp, se) => {
     const input = memInput.get(comp);
     const formApi = getFormApi(input);
     original.onAction(formApi, se.event.buttonApi);
   });
 
-const renderContextButton = (memInput: MementoRecord, button: InlineContent.ContextFormButton, providers: UiFactoryBackstageProviders) => {
+const renderContextButton = (memInput: MementoRecord, button: InlineContent.ContextFormButton<any>, providers: UiFactoryBackstageProviders) => {
   const { primary, ...rest } = button.original;
   const bridged = StructureSchema.getOrDie(
     Toolbar.createToolbarButton({
@@ -45,7 +41,7 @@ const renderContextButton = (memInput: MementoRecord, button: InlineContent.Cont
   ]);
 };
 
-const renderContextToggleButton = (memInput: MementoRecord, button: InlineContent.ContextFormToggleButton, providers: UiFactoryBackstageProviders) => {
+const renderContextToggleButton = (memInput: MementoRecord, button: InlineContent.ContextFormToggleButton<any>, providers: UiFactoryBackstageProviders) => {
   const { primary, ...rest } = button.original;
   const bridged = StructureSchema.getOrDie(
     Toolbar.createToggleButton({
@@ -60,7 +56,7 @@ const renderContextToggleButton = (memInput: MementoRecord, button: InlineConten
   ]);
 };
 
-const isToggleButton = (button: ContextFormButton): button is InlineContent.ContextFormToggleButton =>
+const isToggleButton = (button: ContextFormButton): button is InlineContent.ContextFormToggleButton<any> =>
   button.type === 'contextformtogglebutton';
 
 const generateOne = (memInput: MementoRecord, button: ContextFormButton, providersBackstage: UiFactoryBackstageProviders) => {
@@ -96,3 +92,4 @@ const generate = (memInput: MementoRecord, buttons: ContextFormButton[], provide
 export {
   generate
 };
+

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
@@ -12,8 +12,6 @@ import { internalToolbarButtonExecute, InternalToolbarButtonExecuteEvent } from 
 import { renderToolbarButtonWith, renderToolbarToggleButtonWith } from '../toolbar/button/ToolbarButtons';
 import { getFormApi } from './ContextFormApi';
 
-type ContextFormButton = InlineContent.ContextFormToggleButton<any> | InlineContent.ContextFormButton<any>;
-
 interface ContextFormButtonRegistry {
   readonly asSpecs: () => SimpleOrSketchSpec[];
   readonly findPrimary: (compInSystem: AlloyComponent) => Optional<AlloyComponent>;
@@ -56,10 +54,10 @@ const renderContextToggleButton = (memInput: MementoRecord, button: InlineConten
   ]);
 };
 
-const isToggleButton = (button: ContextFormButton): button is InlineContent.ContextFormToggleButton<any> =>
+const isToggleButton = (button: InlineContent.ContextFormCommand<any>): button is InlineContent.ContextFormToggleButton<any> =>
   button.type === 'contextformtogglebutton';
 
-const generateOne = (memInput: MementoRecord, button: ContextFormButton, providersBackstage: UiFactoryBackstageProviders) => {
+const generateOne = (memInput: MementoRecord, button: InlineContent.ContextFormCommand<any>, providersBackstage: UiFactoryBackstageProviders) => {
   if (isToggleButton(button)) {
     return renderContextToggleButton(memInput, button, providersBackstage);
   } else {
@@ -67,7 +65,7 @@ const generateOne = (memInput: MementoRecord, button: ContextFormButton, provide
   }
 };
 
-const generate = (memInput: MementoRecord, buttons: ContextFormButton[], providersBackstage: UiFactoryBackstageProviders): ContextFormButtonRegistry => {
+const generate = (memInput: MementoRecord, buttons: InlineContent.ContextFormCommand<any>[], providersBackstage: UiFactoryBackstageProviders): ContextFormButtonRegistry => {
 
   const mementos = Arr.map(buttons, (button) => Memento.record(
     generateOne(memInput, button, providersBackstage)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormFocus.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormFocus.ts
@@ -1,0 +1,15 @@
+import {
+  AlloyComponent,
+  InlineView,
+  Keying
+} from '@ephox/alloy';
+import { Focus, SelectorFind } from '@ephox/sugar';
+
+export const focusInputIn = (contextbar: AlloyComponent): void => {
+  InlineView.getContent(contextbar).each((comp) => {
+    SelectorFind.descendant<HTMLInputElement>(comp.element, 'input').fold(
+      () => Keying.focusIn(comp),
+      Focus.focus
+    );
+  });
+};

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormGroup.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormGroup.ts
@@ -1,0 +1,11 @@
+import { AlloySpec, FormField, SketchSpec } from '@ephox/alloy';
+import { Optional } from '@ephox/katamari';
+
+export const createContextFormFieldFromParts = (pLabel: Optional<AlloySpec>, pField: AlloySpec): SketchSpec => FormField.sketch({
+  dom: {
+    tag: 'div',
+    classes: [ 'tox-context-form__group' ]
+  },
+  components: [ ...pLabel.toArray(), pField ]
+});
+

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormGroup.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormGroup.ts
@@ -1,11 +1,36 @@
-import { AlloySpec, FormField, SketchSpec } from '@ephox/alloy';
+import { AlloySpec, Behaviour, Disabling, FormField, SketchSpec } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
+import { Focus, SelectorFind } from '@ephox/sugar';
 
-export const createContextFormFieldFromParts = (pLabel: Optional<AlloySpec>, pField: AlloySpec): SketchSpec => FormField.sketch({
+import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+
+export const createContextFormFieldFromParts = (
+  pLabel: Optional<AlloySpec>,
+  pField: AlloySpec,
+  providers: UiFactoryBackstageProviders
+): SketchSpec => FormField.sketch({
   dom: {
     tag: 'div',
     classes: [ 'tox-context-form__group' ]
   },
-  components: [ ...pLabel.toArray(), pField ]
+  components: [ ...pLabel.toArray(), pField ],
+  fieldBehaviours: Behaviour.derive([
+    Disabling.config({
+      disabled: () => providers.checkUiComponentContext('mode:design').shouldDisable,
+      onDisabled: (comp) => {
+        // TODO: Is this really the best way to move focus out of the input when it gets disabled
+        Focus.search(comp.element).each((focus) => {
+          SelectorFind.ancestor<HTMLElement>(focus, '[tabindex="-1"]').each((parent) => {
+            Focus.focus(parent);
+          });
+        });
+
+        FormField.getField(comp).each(Disabling.disable);
+      },
+      onEnabled: (comp) => {
+        FormField.getField(comp).each(Disabling.enable);
+      }
+    }),
+  ])
 });
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
@@ -1,6 +1,7 @@
 import { AlloyComponent, SketchSpec } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Optional } from '@ephox/katamari';
+import { Focus } from '@ephox/sugar';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as SizeInput from '../sizeinput/SizeInput';
@@ -22,6 +23,7 @@ export const renderContextFormSizeInput = (
     width,
     height,
     onEnter: Optional.some(onEnter),
-    onInput: Optional.some((input) => ctx.onInput(ContextFormApi.getFormApi(input)))
+    onInput: Optional.some((input) => ctx.onInput(ContextFormApi.getFormApi(input))),
+    onAttachField1: (comp) => Focus.focus(comp.element),
   }, providersBackstage);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
@@ -1,7 +1,6 @@
 import { AlloyComponent, SketchSpec } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Optional } from '@ephox/katamari';
-import { Focus } from '@ephox/sugar';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as SizeInput from '../sizeinput/SizeInput';
@@ -23,7 +22,6 @@ export const renderContextFormSizeInput = (
     width,
     height,
     onEnter: Optional.some(onEnter),
-    onInput: Optional.some((input) => ctx.onInput(ContextFormApi.getFormApi(input))),
-    onAttachField1: (comp) => Focus.focus(comp.element),
+    onInput: Optional.some((input) => ctx.onInput(ContextFormApi.getFormApi(input)))
   }, providersBackstage);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
@@ -1,0 +1,27 @@
+import { AlloyComponent, SketchSpec } from '@ephox/alloy';
+import { InlineContent } from '@ephox/bridge';
+import { Optional } from '@ephox/katamari';
+
+import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import * as SizeInput from '../sizeinput/SizeInput';
+import * as ContextFormApi from './ContextFormApi';
+
+export const renderContextFormSizeInput = (
+  ctx: InlineContent.ContextSizeInputForm,
+  providersBackstage: UiFactoryBackstageProviders,
+  onEnter: (input: AlloyComponent) => Optional<boolean>
+): SketchSpec => {
+  const { width, height } = ctx.initValue();
+
+  return SizeInput.renderSizeInput({
+    inDialog: false,
+    label: ctx.label,
+    enabled: true,
+    context: Optional.none(),
+    name: Optional.none(),
+    width,
+    height,
+    onEnter: Optional.some(onEnter),
+    onInput: Optional.some((input) => ctx.onInput(ContextFormApi.getFormApi(input)))
+  }, providersBackstage);
+};

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
@@ -1,7 +1,6 @@
 import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Disabling, FormField, GuiFactory, Input, Keying, NativeEvents, SketchSpec } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Optional } from '@ephox/katamari';
-import { Focus } from '@ephox/sugar';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
@@ -50,8 +49,7 @@ export const renderContextFormSliderInput = (
       AddEventsBehaviour.config('slider-events', [
         AlloyEvents.run(NativeEvents.input(), (comp) => {
           ctx.onInput(ContextFormApi.getFormApi(comp));
-        }),
-        AlloyEvents.runOnAttached((comp) => Focus.focus(comp.element))
+        })
       ])
     ])
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
@@ -54,6 +54,6 @@ export const renderContextFormSliderInput = (
     ])
   });
 
-  return ContextFormGroup.createContextFormFieldFromParts(pLabel, pField);
+  return ContextFormGroup.createContextFormFieldFromParts(pLabel, pField, providers);
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
@@ -1,0 +1,59 @@
+import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Disabling, FormField, GuiFactory, Input, Keying, NativeEvents, SketchSpec } from '@ephox/alloy';
+import { InlineContent } from '@ephox/bridge';
+import { Optional } from '@ephox/katamari';
+
+import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import * as UiState from '../../UiState';
+import * as ContextFormApi from './ContextFormApi';
+import * as ContextFormGroup from './ContextFormGroup';
+
+export const renderContextFormSliderInput = (
+  ctx: InlineContent.ContextSliderForm,
+  providers: UiFactoryBackstageProviders,
+  onEnter: (input: AlloyComponent) => Optional<boolean>
+): SketchSpec => {
+  const pLabel = ctx.label.map((label) => FormField.parts.label({
+    dom: { tag: 'label', classes: [ 'tox-label' ] },
+    components: [ GuiFactory.text(label) ]
+  }));
+
+  const pField = FormField.parts.field({
+    factory: Input,
+    type: 'range',
+    inputClasses: [ 'tox-toolbar-slider__input' ],
+    inputAttributes: {
+      min: String(ctx.min()),
+      max: String(ctx.max())
+    },
+    data: ctx.initValue().toString(),
+    inputBehaviours: Behaviour.derive([
+      Disabling.config({
+        disabled: () => providers.checkUiComponentContext('mode:design').shouldDisable
+      }),
+      UiState.toggleOnReceive(() => providers.checkUiComponentContext('mode:design')),
+      Keying.config({
+        mode: 'special',
+        onEnter,
+        // These two lines need to be tested. They are about left and right bypassing
+        // any keyboard handling, and allowing left and right to be processed by the input
+        // Maybe this should go in an alloy sketch for Input?
+        onLeft: (comp, se) => {
+          se.cut();
+          return Optional.none();
+        },
+        onRight: (comp, se) => {
+          se.cut();
+          return Optional.none();
+        }
+      }),
+      AddEventsBehaviour.config('slider-events', [
+        AlloyEvents.run(NativeEvents.input(), (comp) => {
+          ctx.onInput(ContextFormApi.getFormApi(comp));
+        })
+      ])
+    ])
+  });
+
+  return ContextFormGroup.createContextFormFieldFromParts(pLabel, pField);
+};
+

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
@@ -1,6 +1,7 @@
 import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Disabling, FormField, GuiFactory, Input, Keying, NativeEvents, SketchSpec } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Optional } from '@ephox/katamari';
+import { Focus } from '@ephox/sugar';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
@@ -49,7 +50,8 @@ export const renderContextFormSliderInput = (
       AddEventsBehaviour.config('slider-events', [
         AlloyEvents.run(NativeEvents.input(), (comp) => {
           ctx.onInput(ContextFormApi.getFormApi(comp));
-        })
+        }),
+        AlloyEvents.runOnAttached((comp) => Focus.focus(comp.element))
       ])
     ])
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
@@ -1,0 +1,54 @@
+import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Disabling, FormField, GuiFactory, Input, Keying, NativeEvents, SketchSpec } from '@ephox/alloy';
+import { InlineContent } from '@ephox/bridge';
+import { Optional } from '@ephox/katamari';
+
+import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import * as UiState from '../../UiState';
+import * as ContextFormApi from './ContextFormApi';
+import * as ContextFormGroup from './ContextFormGroup';
+
+export const renderContextFormTextInput = (
+  ctx: InlineContent.ContextInputForm,
+  providers: UiFactoryBackstageProviders,
+  onEnter: (input: AlloyComponent) => Optional<boolean>
+): SketchSpec => {
+  const pLabel = ctx.label.map((label) => FormField.parts.label({
+    dom: { tag: 'label', classes: [ 'tox-label' ] },
+    components: [ GuiFactory.text(label) ]
+  }));
+
+  const pField = FormField.parts.field({
+    factory: Input,
+    inputClasses: [ 'tox-toolbar-textfield', 'tox-toolbar-nav-js' ],
+    data: ctx.initValue(),
+    selectOnFocus: true,
+    inputBehaviours: Behaviour.derive([
+      Disabling.config({
+        disabled: () => providers.checkUiComponentContext('mode:design').shouldDisable
+      }),
+      UiState.toggleOnReceive(() => providers.checkUiComponentContext('mode:design')),
+      Keying.config({
+        mode: 'special',
+        onEnter,
+        // These two lines need to be tested. They are about left and right bypassing
+        // any keyboard handling, and allowing left and right to be processed by the input
+        // Maybe this should go in an alloy sketch for Input?
+        onLeft: (comp, se) => {
+          se.cut();
+          return Optional.none();
+        },
+        onRight: (comp, se) => {
+          se.cut();
+          return Optional.none();
+        }
+      }),
+      AddEventsBehaviour.config('input-events', [
+        AlloyEvents.run(NativeEvents.input(), (comp) => {
+          ctx.onInput(ContextFormApi.getFormApi(comp));
+        })
+      ])
+    ])
+  });
+
+  return ContextFormGroup.createContextFormFieldFromParts(pLabel, pField);
+};

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
@@ -50,5 +50,5 @@ export const renderContextFormTextInput = (
     ])
   });
 
-  return ContextFormGroup.createContextFormFieldFromParts(pLabel, pField);
+  return ContextFormGroup.createContextFormFieldFromParts(pLabel, pField, providers);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
@@ -1,6 +1,7 @@
 import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Disabling, FormField, GuiFactory, Input, Keying, NativeEvents, SketchSpec } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Optional } from '@ephox/katamari';
+import { Focus } from '@ephox/sugar';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
@@ -45,7 +46,8 @@ export const renderContextFormTextInput = (
       AddEventsBehaviour.config('input-events', [
         AlloyEvents.run(NativeEvents.input(), (comp) => {
           ctx.onInput(ContextFormApi.getFormApi(comp));
-        })
+        }),
+        AlloyEvents.runOnAttached((comp) => Focus.focus(comp.element))
       ])
     ])
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
@@ -1,7 +1,6 @@
 import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Disabling, FormField, GuiFactory, Input, Keying, NativeEvents, SketchSpec } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Optional } from '@ephox/katamari';
-import { Focus } from '@ephox/sugar';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
@@ -46,8 +45,7 @@ export const renderContextFormTextInput = (
       AddEventsBehaviour.config('input-events', [
         AlloyEvents.run(NativeEvents.input(), (comp) => {
           ctx.onInput(ContextFormApi.getFormApi(comp));
-        }),
-        AlloyEvents.runOnAttached((comp) => Focus.focus(comp.element))
+        })
       ])
     ])
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
@@ -15,6 +15,7 @@ import { renderToolbar } from '../toolbar/CommonToolbar';
 import { identifyButtons } from '../toolbar/Integration';
 import { hideContextToolbarEvent, showContextToolbarEvent } from './ContextEditorEvents';
 import { ContextForm } from './ContextForm';
+import * as ContextFormFocus from './ContextFormFocus';
 import * as ContextToolbarAnchor from './ContextToolbarAnchor';
 import * as ContextToolbarBounds from './ContextToolbarBounds';
 import * as ToolbarLookup from './ContextToolbarLookup';
@@ -262,8 +263,7 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
       Obj.get(scopes.lookupTable, e.toolbarKey).each((ctx) => {
         // ASSUMPTION: this is only used to open one specific toolbar at a time, hence [ctx]
         launchContext([ ctx ], Optionals.someIf(e.target !== editor, e.target));
-        // Forms launched via this way get immediate focus
-        InlineView.getContent(contextbar).each(Keying.focusIn);
+        ContextFormFocus.focusInputIn(contextbar);
       });
     });
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
@@ -15,9 +15,9 @@ import { renderToolbar } from '../toolbar/CommonToolbar';
 import { identifyButtons } from '../toolbar/Integration';
 import { hideContextToolbarEvent, showContextToolbarEvent } from './ContextEditorEvents';
 import { ContextForm } from './ContextForm';
-import * as ContextFormFocus from './ContextFormFocus';
 import * as ContextToolbarAnchor from './ContextToolbarAnchor';
 import * as ContextToolbarBounds from './ContextToolbarBounds';
+import * as ContextToolbarFocus from './ContextToolbarFocus';
 import * as ToolbarLookup from './ContextToolbarLookup';
 import * as ToolbarScopes from './ContextToolbarScopes';
 import { forwardSlideEvent, renderContextToolbar } from './ContextUi';
@@ -263,7 +263,7 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
       Obj.get(scopes.lookupTable, e.toolbarKey).each((ctx) => {
         // ASSUMPTION: this is only used to open one specific toolbar at a time, hence [ctx]
         launchContext([ ctx ], Optionals.someIf(e.target !== editor, e.target));
-        ContextFormFocus.focusInputIn(contextbar);
+        ContextToolbarFocus.focusIn(contextbar);
       });
     });
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarFocus.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarFocus.ts
@@ -5,9 +5,11 @@ import {
 } from '@ephox/alloy';
 import { Focus, SelectorFind } from '@ephox/sugar';
 
-export const focusInputIn = (contextbar: AlloyComponent): void => {
+const contextFormInputSelector = '.tox-toolbar-slider__input,.tox-toolbar-textfield';
+
+export const focusIn = (contextbar: AlloyComponent): void => {
   InlineView.getContent(contextbar).each((comp) => {
-    SelectorFind.descendant<HTMLInputElement>(comp.element, 'input').fold(
+    SelectorFind.descendant<HTMLInputElement>(comp.element, contextFormInputSelector).fold(
       () => Keying.focusIn(comp),
       Focus.focus
     );

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarScopes.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarScopes.ts
@@ -60,7 +60,7 @@ const categorise = (contextToolbars: Record<string, ContextSpecType>, navigate: 
   Arr.each(keys, (key) => {
     const toolbarApi = contextToolbars[key];
     // TS wouldn't really let me do the ternary I wanted :(
-    if (toolbarApi.type === 'contextform') {
+    if (toolbarApi.type === 'contextform' || toolbarApi.type === 'contextsliderform' || toolbarApi.type === 'contextsizeinputform') {
       registerForm(key, toolbarApi);
     } else if (toolbarApi.type === 'contexttoolbar') {
       registerToolbar(key, toolbarApi);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -61,15 +61,9 @@ const renderContextToolbar = (spec: { onEscape: () => Optional<boolean>; sink: A
           Class.add(elem, resizingClass);
           const newWidth = Width.get(elem);
           Css.set(elem, 'width', currentWidth + 'px');
-          InlineView.getContent(comp).each((newContents) => {
-            se.event.focus.bind((f) => {
-              Focus.focus(f);
-              return Focus.search(elem);
-            }).orThunk(() => {
-              Keying.focusIn(newContents);
-              return Focus.active(SugarShadowDom.getRootNode(elem));
-            });
-          });
+
+          se.event.focus.each(Focus.focus);
+
           setTimeout(() => {
             Css.set(comp.element, 'width', newWidth + 'px');
           }, 0);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -55,11 +55,24 @@ const renderContextToolbar = (spec: { onEscape: () => Optional<boolean>; sink: A
           const elem = comp.element;
           // If it was partially through a slide, clear that and measure afresh
           Css.remove(elem, 'width');
+
           const currentWidth = Width.get(elem);
+
+          // Remove these so that we can property measure the width of the context form content
+          Css.remove(elem, 'left');
+          Css.remove(elem, 'right');
+          Css.remove(elem, 'max-width');
 
           InlineView.setContent(comp, se.event.contents);
           Class.add(elem, resizingClass);
+
           const newWidth = Width.get(elem);
+
+          // Reposition without transition to avoid it from being animated from previous position
+          Css.set(elem, 'transition', 'none');
+          InlineView.reposition(comp);
+          Css.remove(elem, 'transition');
+
           Css.set(elem, 'width', currentWidth + 'px');
 
           se.event.focus.each(Focus.focus);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -79,7 +79,13 @@ const renderContextToolbar = (spec: { onEscape: () => Optional<boolean>; sink: A
 
           se.event.focus.fold(
             () => ContextToolbarFocus.focusIn(comp),
-            Focus.focus
+            (f) => {
+              Focus.focus(f);
+
+              if (Focus.search(elem).isNone()) {
+                ContextToolbarFocus.focusIn(comp);
+              }
+            }
           );
 
           setTimeout(() => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -5,7 +5,7 @@ import {
 import { Arr, Cell, Id, Optional, Result } from '@ephox/katamari';
 import { Class, Css, EventArgs, Focus, SugarElement, SugarShadowDom, Width } from '@ephox/sugar';
 
-import * as ContextFormFocus from './ContextFormFocus';
+import * as ContextToolbarFocus from './ContextToolbarFocus';
 
 const forwardSlideEvent = Id.generate('forward-slide');
 export interface ForwardSlideEvent extends CustomEvent {
@@ -78,7 +78,7 @@ const renderContextToolbar = (spec: { onEscape: () => Optional<boolean>; sink: A
           Css.set(elem, 'width', currentWidth + 'px');
 
           se.event.focus.fold(
-            () => ContextFormFocus.focusInputIn(comp),
+            () => ContextToolbarFocus.focusIn(comp),
             Focus.focus
           );
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -5,6 +5,8 @@ import {
 import { Arr, Cell, Id, Optional, Result } from '@ephox/katamari';
 import { Class, Css, EventArgs, Focus, SugarElement, SugarShadowDom, Width } from '@ephox/sugar';
 
+import * as ContextFormFocus from './ContextFormFocus';
+
 const forwardSlideEvent = Id.generate('forward-slide');
 export interface ForwardSlideEvent extends CustomEvent {
   readonly forwardContents: AlloySpec;
@@ -75,7 +77,10 @@ const renderContextToolbar = (spec: { onEscape: () => Optional<boolean>; sink: A
 
           Css.set(elem, 'width', currentWidth + 'px');
 
-          se.event.focus.each(Focus.focus);
+          se.event.focus.fold(
+            () => ContextFormFocus.focusInputIn(comp),
+            Focus.focus
+          );
 
           setTimeout(() => {
             Css.set(comp.element, 'width', newWidth + 'px');

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
@@ -2,7 +2,7 @@ import {
   SketchSpec
 } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Fun, Optional } from '@ephox/katamari';
+import { Optional } from '@ephox/katamari';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as SizeInput from '../sizeinput/SizeInput';
@@ -19,7 +19,6 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
     width: '',
     height: '',
     onEnter: Optional.none(),
-    onInput: Optional.none(),
-    onAttachField1: Fun.noop
+    onInput: Optional.none()
   }, providersBackstage);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
@@ -2,7 +2,7 @@ import {
   SketchSpec
 } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Optional } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as SizeInput from '../sizeinput/SizeInput';
@@ -19,6 +19,7 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
     width: '',
     height: '',
     onEnter: Optional.none(),
-    onInput: Optional.none()
+    onInput: Optional.none(),
+    onAttachField1: Fun.noop
   }, providersBackstage);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
@@ -1,169 +1,24 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, AlloyTriggers, Behaviour, CustomEvent, Disabling,
-  FormCoupledInputs as AlloyFormCoupledInputs,
-  FormField as AlloyFormField, GuiFactory, Input as AlloyInput, NativeEvents, Representing, SketchSpec, Tabstopping, Tooltipping
+  SketchSpec
 } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
-import { Id, Unicode } from '@ephox/katamari';
-
-import { formChangeEvent } from 'tinymce/themes/silver/ui/general/FormEvents';
+import { Optional } from '@ephox/katamari';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
-import * as UiState from '../../UiState';
-import * as Icons from '../icons/Icons';
-import { formatSize, makeRatioConverter, noSizeConversion, parseSize, SizeConversion } from '../sizeinput/SizeInputModel';
-
-interface RatioEvent extends CustomEvent {
-  readonly isField1: boolean;
-}
+import * as SizeInput from '../sizeinput/SizeInput';
 
 type SizeInputSpec = Omit<Dialog.SizeInput, 'type'>;
 
 export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFactoryBackstageProviders): SketchSpec => {
-  let converter: SizeConversion = noSizeConversion;
-
-  const ratioEvent = Id.generate('ratio-event');
-
-  const makeIcon = (iconName: string) =>
-    Icons.render(iconName, { tag: 'span', classes: [ 'tox-icon', 'tox-lock-icon__' + iconName ] }, providersBackstage.icons);
-
-  const label = spec.label.getOr('Constrain proportions');
-  const translatedLabel = providersBackstage.translate(label);
-  const pLock = AlloyFormCoupledInputs.parts.lock({
-    dom: {
-      tag: 'button',
-      classes: [ 'tox-lock', 'tox-button', 'tox-button--naked', 'tox-button--icon' ],
-      attributes: {
-        'aria-label': translatedLabel,
-        'data-mce-name': label
-      }
-    },
-    components: [
-      makeIcon('lock'),
-      makeIcon('unlock')
-    ],
-    buttonBehaviours: Behaviour.derive([
-      Disabling.config({
-        disabled: () => !spec.enabled || providersBackstage.checkUiComponentContext(spec.context).shouldDisable
-      }),
-      UiState.toggleOnReceive(() => providersBackstage.checkUiComponentContext(spec.context)),
-      Tabstopping.config({}),
-      Tooltipping.config(
-        providersBackstage.tooltips.getConfig({
-          tooltipText: translatedLabel
-        })
-      )
-    ])
-  });
-
-  const formGroup = (components: AlloySpec[]) => ({
-    dom: {
-      tag: 'div',
-      classes: [ 'tox-form__group' ]
-    },
-    components
-  });
-
-  const getFieldPart = (isField1: boolean) => AlloyFormField.parts.field({
-    factory: AlloyInput,
-    inputClasses: [ 'tox-textfield' ],
-    inputBehaviours: Behaviour.derive([
-      Disabling.config({
-        disabled: () => !spec.enabled || providersBackstage.checkUiComponentContext(spec.context).shouldDisable
-      }),
-      UiState.toggleOnReceive(() => providersBackstage.checkUiComponentContext(spec.context)),
-      Tabstopping.config({}),
-      AddEventsBehaviour.config('size-input-events', [
-        AlloyEvents.run(NativeEvents.focusin(), (component, _simulatedEvent) => {
-          AlloyTriggers.emitWith(component, ratioEvent, { isField1 });
-        }),
-        AlloyEvents.run(NativeEvents.change(), (component, _simulatedEvent) => {
-          AlloyTriggers.emitWith(component, formChangeEvent, { name: spec.name });
-        })
-      ])
-    ]),
-    selectOnFocus: false
-  });
-
-  const getLabel = (label: string) => ({
-    dom: {
-      tag: 'label',
-      classes: [ 'tox-label' ]
-    },
-    components: [
-      GuiFactory.text(providersBackstage.translate(label))
-    ]
-  });
-
-  const widthField = AlloyFormCoupledInputs.parts.field1(
-    formGroup([ AlloyFormField.parts.label(getLabel('Width')), getFieldPart(true) ])
-  );
-
-  const heightField = AlloyFormCoupledInputs.parts.field2(
-    formGroup([ AlloyFormField.parts.label(getLabel('Height')), getFieldPart(false) ])
-  );
-
-  return AlloyFormCoupledInputs.sketch({
-    dom: {
-      tag: 'div',
-      classes: [ 'tox-form__group' ]
-    },
-    components: [
-      {
-        dom: {
-          tag: 'div',
-          classes: [ 'tox-form__controls-h-stack' ]
-        },
-        components: [
-          // NOTE: Form coupled inputs to the FormField.sketch themselves.
-          widthField,
-          heightField,
-          formGroup([
-            getLabel(Unicode.nbsp),
-            pLock
-          ])
-        ]
-      }
-    ],
-    field1Name: 'width',
-    field2Name: 'height',
-    locked: true,
-
-    markers: {
-      lockClass: 'tox-locked'
-    },
-    onLockedChange: (current: AlloyComponent, other: AlloyComponent, _lock: AlloyComponent) => {
-      parseSize(Representing.getValue(current)).each((size) => {
-        converter(size).each((newSize) => {
-          Representing.setValue(other, formatSize(newSize));
-        });
-      });
-    },
-    coupledFieldBehaviours: Behaviour.derive([
-      Disabling.config({
-        disabled: () => !spec.enabled || providersBackstage.checkUiComponentContext(spec.context).shouldDisable,
-        onDisabled: (comp) => {
-          AlloyFormCoupledInputs.getField1(comp).bind(AlloyFormField.getField).each(Disabling.disable);
-          AlloyFormCoupledInputs.getField2(comp).bind(AlloyFormField.getField).each(Disabling.disable);
-          AlloyFormCoupledInputs.getLock(comp).each(Disabling.disable);
-        },
-        onEnabled: (comp) => {
-          AlloyFormCoupledInputs.getField1(comp).bind(AlloyFormField.getField).each(Disabling.enable);
-          AlloyFormCoupledInputs.getField2(comp).bind(AlloyFormField.getField).each(Disabling.enable);
-          AlloyFormCoupledInputs.getLock(comp).each(Disabling.enable);
-        }
-      }),
-      UiState.toggleOnReceive(() => providersBackstage.checkUiComponentContext('mode:design')),
-      AddEventsBehaviour.config('size-input-events2', [
-        AlloyEvents.run<RatioEvent>(ratioEvent, (component, simulatedEvent) => {
-          const isField1 = simulatedEvent.event.isField1;
-          const optCurrent = isField1 ? AlloyFormCoupledInputs.getField1(component) : AlloyFormCoupledInputs.getField2(component);
-          const optOther = isField1 ? AlloyFormCoupledInputs.getField2(component) : AlloyFormCoupledInputs.getField1(component);
-          const value1 = optCurrent.map<string>(Representing.getValue).getOr('');
-          const value2 = optOther.map<string>(Representing.getValue).getOr('');
-          converter = makeRatioConverter(value1, value2);
-        })
-      ])
-    ])
-  });
+  return SizeInput.renderSizeInput({
+    inDialog: true,
+    label: spec.label,
+    enabled: spec.enabled,
+    context: Optional.some(spec.context),
+    name: Optional.some(spec.name),
+    width: '',
+    height: '',
+    onEnter: Optional.none(),
+    onInput: Optional.none()
+  }, providersBackstage);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/FormEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/FormEvents.ts
@@ -41,6 +41,7 @@ export interface FormTabChangeEvent extends CustomEvent {
 }
 
 const formChangeEvent = Id.generate('form-component-change');
+const formInputEvent = Id.generate('form-component-input');
 const formCloseEvent = Id.generate('form-close');
 const formCancelEvent = Id.generate('form-cancel');
 const formActionEvent = Id.generate('form-action');
@@ -52,6 +53,7 @@ const formResizeEvent = Id.generate('form-resize');
 
 export {
   formChangeEvent,
+  formInputEvent,
   formActionEvent,
   formSubmitEvent,
   formCloseEvent,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInput.ts
@@ -1,0 +1,191 @@
+import {
+  AddEventsBehaviour, AlloyComponent, AlloyEvents,
+  FormCoupledInputs as AlloyFormCoupledInputs,
+  FormField as AlloyFormField,
+  Input as AlloyInput,
+  AlloySpec, AlloyTriggers, Behaviour, CustomEvent, Disabling,
+  GuiFactory,
+  Keying,
+  NativeEvents, Representing, SketchSpec, Tabstopping, Tooltipping
+} from '@ephox/alloy';
+import { Id, Optional, Unicode } from '@ephox/katamari';
+
+import { formChangeEvent, formInputEvent } from 'tinymce/themes/silver/ui/general/FormEvents';
+
+import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import * as UiState from '../../UiState';
+import * as Icons from '../icons/Icons';
+import { formatSize, makeRatioConverter, noSizeConversion, parseSize, SizeConversion } from '../sizeinput/SizeInputModel';
+
+interface RatioEvent extends CustomEvent {
+  readonly isField1: boolean;
+}
+
+export interface SizeInputGenericSpec {
+  readonly inDialog: boolean;
+  readonly label: Optional<string>;
+  readonly enabled: boolean;
+  readonly context: Optional<string>;
+  readonly name: Optional<string>;
+  readonly width: string;
+  readonly height: string;
+  readonly onEnter: Optional<(input: AlloyComponent) => Optional<boolean>>;
+  readonly onInput: Optional<(input: AlloyComponent) => void>;
+}
+
+export const renderSizeInput = (spec: SizeInputGenericSpec, providersBackstage: UiFactoryBackstageProviders): SketchSpec => {
+  let converter: SizeConversion = noSizeConversion;
+
+  const ratioEvent = Id.generate('ratio-event');
+
+  const makeIcon = (iconName: string) =>
+    Icons.render(iconName, { tag: 'span', classes: [ 'tox-icon', 'tox-lock-icon__' + iconName ] }, providersBackstage.icons);
+
+  const disabled = () => !spec.enabled || spec.context.exists((context) => providersBackstage.checkUiComponentContext(context).shouldDisable);
+  const toggleOnReceive = spec.context.map((context) => UiState.toggleOnReceive(() => providersBackstage.checkUiComponentContext(context)));
+
+  const label = spec.label.getOr('Constrain proportions');
+  const translatedLabel = providersBackstage.translate(label);
+  const pLock = AlloyFormCoupledInputs.parts.lock({
+    dom: {
+      tag: 'button',
+      classes: [ 'tox-lock', 'tox-button', 'tox-button--naked', 'tox-button--icon' ],
+      attributes: {
+        'aria-label': translatedLabel,
+        'data-mce-name': label
+      }
+    },
+    components: [
+      makeIcon('lock'),
+      makeIcon('unlock')
+    ],
+    buttonBehaviours: Behaviour.derive([
+      Disabling.config({ disabled }),
+      ...toggleOnReceive.toArray(),
+      Tabstopping.config({}),
+      Tooltipping.config(
+        providersBackstage.tooltips.getConfig({
+          tooltipText: translatedLabel
+        })
+      )
+    ])
+  });
+
+  const formGroup = (components: AlloySpec[]) => ({
+    dom: {
+      tag: 'div',
+      classes: [ spec.inDialog ? 'tox-form__group' : 'tox-context-form__group' ]
+    },
+    components
+  });
+
+  const getFieldPart = (isField1: boolean) => AlloyFormField.parts.field({
+    factory: AlloyInput,
+    inputClasses: spec.inDialog ? [ 'tox-textfield' ] : [ 'tox-textfield', 'tox-textfield--context-form' ],
+    data: isField1 ? spec.width : spec.height,
+    inputBehaviours: Behaviour.derive([
+      Disabling.config({ disabled }),
+      ...toggleOnReceive.toArray(),
+      Tabstopping.config({}),
+      AddEventsBehaviour.config('size-input-events', [
+        AlloyEvents.run(NativeEvents.focusin(), (component, _simulatedEvent) => {
+          AlloyTriggers.emitWith(component, ratioEvent, { isField1 });
+        }),
+        AlloyEvents.run(NativeEvents.change(), (component, _simulatedEvent) => {
+          AlloyTriggers.emitWith(component, formChangeEvent, { name: spec.name });
+        }),
+        AlloyEvents.run(NativeEvents.input(), (component, _simulatedEvent) => {
+          AlloyTriggers.emitWith(component, formInputEvent, { name: spec.name });
+        })
+      ]),
+      ...spec.onEnter.map((onEnter) => Keying.config({ mode: 'special', onEnter })).toArray()
+    ]),
+    selectOnFocus: false
+  });
+
+  const getLabel = (label: string) => ({
+    dom: {
+      tag: 'label',
+      classes: [ 'tox-label' ]
+    },
+    components: [
+      GuiFactory.text(providersBackstage.translate(label))
+    ]
+  });
+
+  const widthField = AlloyFormCoupledInputs.parts.field1(
+    formGroup([ AlloyFormField.parts.label(getLabel('Width')), getFieldPart(true) ])
+  );
+
+  const heightField = AlloyFormCoupledInputs.parts.field2(
+    formGroup([ AlloyFormField.parts.label(getLabel('Height')), getFieldPart(false) ])
+  );
+
+  return AlloyFormCoupledInputs.sketch({
+    dom: {
+      tag: 'div',
+      classes: [ spec.inDialog ? 'tox-form__group' : 'tox-context-form__group' ]
+    },
+    components: [
+      {
+        dom: {
+          tag: 'div',
+          classes: [ 'tox-form__controls-h-stack' ]
+        },
+        components: [
+          // NOTE: Form coupled inputs to the FormField.sketch themselves.
+          widthField,
+          heightField,
+          formGroup([
+            getLabel(Unicode.nbsp),
+            pLock
+          ])
+        ]
+      }
+    ],
+    field1Name: 'width',
+    field2Name: 'height',
+    locked: true,
+
+    markers: {
+      lockClass: 'tox-locked'
+    },
+    onLockedChange: (current: AlloyComponent, other: AlloyComponent, _lock: AlloyComponent) => {
+      parseSize(Representing.getValue(current)).each((size) => {
+        converter(size).each((newSize) => {
+          Representing.setValue(other, formatSize(newSize));
+        });
+      });
+    },
+    coupledFieldBehaviours: Behaviour.derive([
+      Disabling.config({
+        disabled,
+        onDisabled: (comp) => {
+          AlloyFormCoupledInputs.getField1(comp).bind(AlloyFormField.getField).each(Disabling.disable);
+          AlloyFormCoupledInputs.getField2(comp).bind(AlloyFormField.getField).each(Disabling.disable);
+          AlloyFormCoupledInputs.getLock(comp).each(Disabling.disable);
+        },
+        onEnabled: (comp) => {
+          AlloyFormCoupledInputs.getField1(comp).bind(AlloyFormField.getField).each(Disabling.enable);
+          AlloyFormCoupledInputs.getField2(comp).bind(AlloyFormField.getField).each(Disabling.enable);
+          AlloyFormCoupledInputs.getLock(comp).each(Disabling.enable);
+        }
+      }),
+      UiState.toggleOnReceive(() => providersBackstage.checkUiComponentContext('mode:design')),
+      AddEventsBehaviour.config('size-input-events', [
+        AlloyEvents.run<RatioEvent>(ratioEvent, (component, simulatedEvent) => {
+          const isField1 = simulatedEvent.event.isField1;
+          const optCurrent = isField1 ? AlloyFormCoupledInputs.getField1(component) : AlloyFormCoupledInputs.getField2(component);
+          const optOther = isField1 ? AlloyFormCoupledInputs.getField2(component) : AlloyFormCoupledInputs.getField1(component);
+          const value1 = optCurrent.map<string>(Representing.getValue).getOr('');
+          const value2 = optOther.map<string>(Representing.getValue).getOr('');
+          converter = makeRatioConverter(value1, value2);
+        }),
+        AlloyEvents.run<RatioEvent>(formInputEvent, (component) => {
+          spec.onInput.each((onInput) => onInput(component));
+        })
+      ])
+    ])
+  });
+};
+

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInput.ts
@@ -93,9 +93,6 @@ export const renderSizeInput = (spec: SizeInputGenericSpec, providersBackstage: 
         }),
         AlloyEvents.run(NativeEvents.change(), (component, _simulatedEvent) => {
           AlloyTriggers.emitWith(component, formChangeEvent, { name: spec.name });
-        }),
-        AlloyEvents.run(NativeEvents.input(), (component, _simulatedEvent) => {
-          AlloyTriggers.emitWith(component, formInputEvent, { name: spec.name });
         })
       ]),
       ...spec.onEnter.map((onEnter) => Keying.config({ mode: 'special', onEnter })).toArray()
@@ -157,6 +154,9 @@ export const renderSizeInput = (spec: SizeInputGenericSpec, providersBackstage: 
         });
       });
     },
+    onInput: (current) => {
+      AlloyTriggers.emitWith(current, formInputEvent, { name: spec.name });
+    },
     coupledFieldBehaviours: Behaviour.derive([
       Disabling.config({
         disabled,
@@ -181,7 +181,7 @@ export const renderSizeInput = (spec: SizeInputGenericSpec, providersBackstage: 
           const value2 = optOther.map<string>(Representing.getValue).getOr('');
           converter = makeRatioConverter(value1, value2);
         }),
-        AlloyEvents.run<RatioEvent>(formInputEvent, (component) => {
+        AlloyEvents.run(formInputEvent, (component) => {
           spec.onInput.each((onInput) => onInput(component));
         })
       ])

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInput.ts
@@ -81,7 +81,7 @@ export const renderSizeInput = (spec: SizeInputGenericSpec, providersBackstage: 
 
   const getFieldPart = (isField1: boolean) => AlloyFormField.parts.field({
     factory: AlloyInput,
-    inputClasses: spec.inDialog ? [ 'tox-textfield' ] : [ 'tox-textfield', 'tox-textfield--context-form' ],
+    inputClasses: spec.inDialog ? [ 'tox-textfield' ] : [ 'tox-textfield', 'tox-toolbar-textfield', 'tox-textfield-size' ],
     data: isField1 ? spec.width : spec.height,
     inputBehaviours: Behaviour.derive([
       Disabling.config({ disabled }),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInput.ts
@@ -93,7 +93,7 @@ export const renderSizeInput = (spec: SizeInputGenericSpec, providersBackstage: 
           AlloyTriggers.emitWith(component, ratioEvent, { isField1 });
         }),
         AlloyEvents.run(NativeEvents.change(), (component, _simulatedEvent) => {
-          AlloyTriggers.emitWith(component, formChangeEvent, { name: spec.name });
+          spec.name.each((name) => AlloyTriggers.emitWith(component, formChangeEvent, { name }));
         }),
         AlloyEvents.runOnAttached((component) => {
           if (isField1) {
@@ -160,9 +160,7 @@ export const renderSizeInput = (spec: SizeInputGenericSpec, providersBackstage: 
         });
       });
     },
-    onInput: (current) => {
-      AlloyTriggers.emitWith(current, formInputEvent, { name: spec.name });
-    },
+    onInput: (current) => AlloyTriggers.emit(current, formInputEvent),
     coupledFieldBehaviours: Behaviour.derive([
       Disabling.config({
         disabled,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInput.ts
@@ -31,7 +31,6 @@ export interface SizeInputGenericSpec {
   readonly height: string;
   readonly onEnter: Optional<(input: AlloyComponent) => Optional<boolean>>;
   readonly onInput: Optional<(input: AlloyComponent) => void>;
-  readonly onAttachField1: (comp: AlloyComponent) => void;
 }
 
 export const renderSizeInput = (spec: SizeInputGenericSpec, providersBackstage: UiFactoryBackstageProviders): SketchSpec => {
@@ -94,12 +93,7 @@ export const renderSizeInput = (spec: SizeInputGenericSpec, providersBackstage: 
         }),
         AlloyEvents.run(NativeEvents.change(), (component, _simulatedEvent) => {
           spec.name.each((name) => AlloyTriggers.emitWith(component, formChangeEvent, { name }));
-        }),
-        AlloyEvents.runOnAttached((component) => {
-          if (isField1) {
-            spec.onAttachField1(component);
-          }
-        }),
+        })
       ]),
       ...spec.onEnter.map((onEnter) => Keying.config({ mode: 'special', onEnter })).toArray()
     ]),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInput.ts
@@ -31,6 +31,7 @@ export interface SizeInputGenericSpec {
   readonly height: string;
   readonly onEnter: Optional<(input: AlloyComponent) => Optional<boolean>>;
   readonly onInput: Optional<(input: AlloyComponent) => void>;
+  readonly onAttachField1: (comp: AlloyComponent) => void;
 }
 
 export const renderSizeInput = (spec: SizeInputGenericSpec, providersBackstage: UiFactoryBackstageProviders): SketchSpec => {
@@ -93,7 +94,12 @@ export const renderSizeInput = (spec: SizeInputGenericSpec, providersBackstage: 
         }),
         AlloyEvents.run(NativeEvents.change(), (component, _simulatedEvent) => {
           AlloyTriggers.emitWith(component, formChangeEvent, { name: spec.name });
-        })
+        }),
+        AlloyEvents.runOnAttached((component) => {
+          if (isField1) {
+            spec.onAttachField1(component);
+          }
+        }),
       ]),
       ...spec.onEnter.map((onEnter) => Keying.config({ mode: 'special', onEnter })).toArray()
     ]),

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -81,6 +81,14 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
               };
             },
             onAction: (formApi, _buttonApi) => store.adder('C.' + formApi.getValue())()
+          },
+          {
+            type: 'contextformbutton',
+            icon: 'fake-icon-name',
+            tooltip: 'D',
+            onAction: (formApi, _buttonApi) => {
+              formApi.setInputEnabled(!formApi.isInputEnabled());
+            }
           }
         ]
       });
@@ -222,7 +230,17 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     checkLastButtonGroup('Checking buttons have right state', (s, str, arr) => [
       s.element('button', { classes: [ arr.has('tox-tbtn--disabled') ], attrs: { 'aria-disabled': str.is('true') }}),
       s.element('button', { classes: [ arr.not('tox-tbtn--disabled') ] }),
-      s.element('button', { attrs: { 'aria-pressed': str.is('true') }})
+      s.element('button', { attrs: { 'aria-pressed': str.is('true') }}),
+      s.element('button', { classes: [ arr.not('tox-tbtn--disabled') ] })
     ]);
+  });
+
+  it('TINY-11342: Should enable/disable input when calling setInputEnabled and read the state using isInputEnabled', async () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+    TinyUiActions.clickOnUi(editor, 'button[aria-label="D"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop input:disabled');
+    TinyUiActions.clickOnUi(editor, 'button[aria-label="D"]');
+    await TinyUiActions.pWaitForUi(editor, '.tox-pop input:not(:disabled)');
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -1,5 +1,5 @@
 import { ApproxStructure, Assertions, FocusTools, Keys, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Fun, Obj } from '@ephox/katamari';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
@@ -100,6 +100,17 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     }
   }, [], true);
 
+  afterEach(async () => {
+    const editor = hook.editor();
+
+    store.clear();
+    editor.focus();
+
+    // Simulate clicking elsewhere in the editor
+    clickAway(editor);
+    await pAssertNoPopDialog();
+  });
+
   const openToolbar = (editor: Editor, toolbarKey: string) => {
     editor.dispatch('contexttoolbar-show', {
       toolbarKey
@@ -160,9 +171,6 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     // Check that the context popup still exists;
     UiFinder.exists(SugarBody.body(), '.tox-pop');
     await Waiter.pTryUntil('Check that the editor still has focus', () => editor.hasFocus());
-    // Simulate clicking elsewhere in the editor
-    clickAway(editor);
-    await pAssertNoPopDialog();
   });
 
   it('TBA: Launch a context form from a context toolbar', async () => {
@@ -181,12 +189,9 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     // Check that the context popup still exists;
     UiFinder.exists(SugarBody.body(), '.tox-pop');
     await Waiter.pTryUntil('Check that the editor still has focus', () => editor.hasFocus());
-    // Simulate clicking elsewhere in the editor
-    clickAway(editor);
-    await pAssertNoPopDialog();
   });
 
-  it('TBA: Launching context form does not work if the context toolbar launcher is disabled', () => {
+  it('TBA: Launching context form does not work if the context toolbar launcher is disabled', async () => {
     const editor = hook.editor();
     openToolbar(editor, 'test-toolbar');
     editor.dispatch('test.updateButtonABC', { disable: true });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -87,9 +87,21 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
             icon: 'fake-icon-name',
             tooltip: 'D',
             onAction: (formApi, _buttonApi) => {
+              formApi.setValue('before-hide');
+              formApi.hide();
+              store.add('D.' + formApi.getValue());
+              formApi.setValue('after-hide');
+              store.add('D.' + formApi.getValue());
+            }
+          },
+          {
+            type: 'contextformbutton',
+            icon: 'fake-icon-name',
+            tooltip: 'E',
+            onAction: (formApi, _buttonApi) => {
               formApi.setInputEnabled(!formApi.isInputEnabled());
             }
-          }
+          },
         ]
       });
 
@@ -236,6 +248,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
       s.element('button', { classes: [ arr.has('tox-tbtn--disabled') ], attrs: { 'aria-disabled': str.is('true') }}),
       s.element('button', { classes: [ arr.not('tox-tbtn--disabled') ] }),
       s.element('button', { attrs: { 'aria-pressed': str.is('true') }}),
+      s.element('button', { classes: [ arr.not('tox-tbtn--disabled') ] }),
       s.element('button', { classes: [ arr.not('tox-tbtn--disabled') ] })
     ]);
   });
@@ -243,9 +256,9 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
   it('TINY-11342: Should enable/disable input when calling setInputEnabled and read the state using isInputEnabled', async () => {
     const editor = hook.editor();
     openToolbar(editor, 'test-form');
-    TinyUiActions.clickOnUi(editor, 'button[aria-label="D"]');
+    TinyUiActions.clickOnUi(editor, 'button[aria-label="E"]');
     await TinyUiActions.pWaitForUi(editor, '.tox-pop input:disabled');
-    TinyUiActions.clickOnUi(editor, 'button[aria-label="D"]');
+    TinyUiActions.clickOnUi(editor, 'button[aria-label="E"]');
     await TinyUiActions.pWaitForUi(editor, '.tox-pop input:not(:disabled)');
   });
 
@@ -256,5 +269,12 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     Value.set(input, 'Hello');
     input.dom.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
     store.assertEq('Input should trigger onInput', [ 'input.Hello' ]);
+  });
+
+  it('TINY-11342: Should be able to get value after the context form has been hidden', async () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+    TinyUiActions.clickOnUi(editor, 'button[aria-label="D"]');
+    store.assertEq('D should have fired', [ 'D.before-hide', 'D.after-hide' ]);
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -191,7 +191,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     await Waiter.pTryUntil('Check that the editor still has focus', () => editor.hasFocus());
   });
 
-  it('TBA: Launching context form does not work if the context toolbar launcher is disabled', async () => {
+  it('TBA: Launching context form does not work if the context toolbar launcher is disabled', () => {
     const editor = hook.editor();
     openToolbar(editor, 'test-toolbar');
     editor.dispatch('test.updateButtonABC', { disable: true });
@@ -249,7 +249,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     await TinyUiActions.pWaitForUi(editor, '.tox-pop input:not(:disabled)');
   });
 
-  it('TINY-11342: Input event should trigger onInput', async () => {
+  it('TINY-11342: Input event should trigger onInput', () => {
     const editor = hook.editor();
     openToolbar(editor, 'test-form');
     const input = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), '.tox-pop input').getOrDie();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, FocusTools, Keys, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Fun, Obj } from '@ephox/katamari';
-import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { SugarBody, SugarDocument, Value } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -32,7 +32,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
             };
           }
         },
-
+        onInput: (formApi) => store.add(`input.${formApi.getValue()}`),
         predicate: (node) => node.nodeName.toLowerCase() === 'a',
         commands: [
           {
@@ -247,5 +247,14 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     await TinyUiActions.pWaitForUi(editor, '.tox-pop input:disabled');
     TinyUiActions.clickOnUi(editor, 'button[aria-label="D"]');
     await TinyUiActions.pWaitForUi(editor, '.tox-pop input:not(:disabled)');
+  });
+
+  it('TINY-11342: Input event should trigger onInput', async () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+    const input = UiFinder.findIn<HTMLInputElement>(SugarDocument.getDocument(), '.tox-pop input').getOrDie();
+    Value.set(input, 'Hello');
+    input.dom.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
+    store.assertEq('Input should trigger onInput', [ 'input.Hello' ]);
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -252,7 +252,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
   it('TINY-11342: Input event should trigger onInput', async () => {
     const editor = hook.editor();
     openToolbar(editor, 'test-form');
-    const input = UiFinder.findIn<HTMLInputElement>(SugarDocument.getDocument(), '.tox-pop input').getOrDie();
+    const input = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), '.tox-pop input').getOrDie();
     Value.set(input, 'Hello');
     input.dom.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
     store.assertEq('Input should trigger onInput', [ 'input.Hello' ]);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
@@ -1,0 +1,153 @@
+import { ApproxStructure, Assertions, FocusTools, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
+import { afterEach, describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
+import { SugarBody, SugarDocument, Value } from '@ephox/sugar';
+import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => {
+  const store = TestStore();
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    setup: (ed: Editor) => {
+      ed.ui.registry.addContextToolbar('test-toolbar', {
+        items: 'test-form',
+        position: 'node',
+        scope: 'node',
+        predicate: (node) => node.nodeName.toLowerCase() === 'a',
+      });
+
+      ed.ui.registry.addContextForm('test-form', {
+        type: 'contextsizeinputform',
+        launch: {
+          type: 'contextformtogglebutton',
+          icon: 'fake-icon-name',
+          tooltip: 'ABC'
+        },
+        initValue: Fun.constant({ width: '100', height: '200' }),
+        onInput: (formApi) => store.add(`input.${JSON.stringify(formApi.getValue())}`),
+        commands: [
+          {
+            type: 'contextformbutton',
+            icon: 'fake-icon-name',
+            tooltip: 'A',
+            align: 'start',
+            onAction: (formApi, _buttonApi) => {
+              formApi.setValue({ width: '200', height: '400' });
+            }
+          },
+          {
+            type: 'contextformbutton',
+            icon: 'fake-icon-name',
+            align: 'end',
+            tooltip: 'B',
+            primary: true,
+            onAction: (formApi, _buttonApi) => store.add('B.' + formApi.getValue())
+          }
+        ]
+      });
+    }
+  }, [], true);
+
+  afterEach(async () => {
+    const editor = hook.editor();
+
+    store.clear();
+    editor.focus();
+
+    // Simulate clicking elsewhere in the editor
+    clickAway(editor);
+    await pAssertNoPopDialog();
+  });
+
+  const openToolbar = (editor: Editor, toolbarKey: string) => {
+    editor.dispatch('contexttoolbar-show', {
+      toolbarKey
+    });
+  };
+
+  const checkFirstButtonGroup = (label: string, children: ApproxStructure.Builder<StructAssert[]>) => {
+    const group = UiFinder.findIn(SugarBody.body(), '.tox-pop .tox-toolbar__group:first').getOrDie();
+    Assertions.assertStructure(
+      label,
+      ApproxStructure.build((s, str, arr) => s.element('div', {
+        children: children(s, str, arr)
+      })),
+      group
+    );
+  };
+
+  const checkLastButtonGroup = (label: string, children: ApproxStructure.Builder<StructAssert[]>) => {
+    const group = UiFinder.findIn(SugarBody.body(), '.tox-pop .tox-toolbar__group:last').getOrDie();
+    Assertions.assertStructure(
+      label,
+      ApproxStructure.build((s, str, arr) => s.element('div', {
+        children: children(s, str, arr)
+      })),
+      group
+    );
+  };
+
+  const clickAway = (editor: Editor) => {
+    // <a> tags make the context bar appear so click away from an a tag. We have no content so it's probably fine.
+    editor.nodeChanged();
+  };
+
+  const pAssertNoPopDialog = () => Waiter.pTryUntil(
+    'Pop dialog should disappear (soon)',
+    () => UiFinder.notExists(SugarBody.body(), '.tox-pop')
+  );
+
+  it('TINY-11342: Should be buttons before and after the input and the input should have focus', async () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+    checkFirstButtonGroup('Checking buttons have right state', (s, str) => [
+      s.element('button', { attrs: { 'aria-label': str.is('A') }}),
+    ]);
+    checkLastButtonGroup('Checking buttons have right state', (s, str) => [
+      s.element('button', { attrs: { 'aria-label': str.is('B') }}),
+    ]);
+    await FocusTools.pTryOnSelector('Focus should now be on input in context form', SugarDocument.getDocument(), 'input');
+  });
+
+  it('TINY-11342: Input should have initial value', async () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+    const inputW = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), '.tox-pop .tox-context-form__group:nth-child(1) input').getOrDie();
+    const inputH = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), '.tox-pop .tox-context-form__group:nth-child(2) input').getOrDie();
+    assert.strictEqual(Value.get(inputW), '100', 'Should be initial width value');
+    assert.strictEqual(Value.get(inputH), '200', 'Should be initial height value');
+  });
+
+  it('TINY-11342: Input should trigger onInput and constrain the proportions', async () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+    const inputW = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), '.tox-pop .tox-context-form__group:nth-child(1) input').getOrDie();
+    Value.set(inputW, '200');
+    inputW.dom.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
+    inputW.dom.dispatchEvent(new Event('change', { bubbles: true, cancelable: true }));
+    store.assertEq('Input should trigger onInput', [ 'input.{"width":"200","height":"400"}' ]);
+  });
+
+  it('TINY-11342: Clicking `A` button should update the values', async () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+    TinyUiActions.clickOnUi(editor, '.tox-pop button[aria-label="A"]');
+    const inputW = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), '.tox-pop .tox-context-form__group:nth-child(1) input').getOrDie();
+    const inputH = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), '.tox-pop .tox-context-form__group:nth-child(2) input').getOrDie();
+    assert.strictEqual(Value.get(inputW), '200', 'Should be updated width value');
+    assert.strictEqual(Value.get(inputH), '400', 'Should be updated height value');
+  });
+
+  it('TINY-11342: When the context form is opened on the right side and does not fit the popup should be repositioned', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p style="float: right"><a href="#" style="padding-right: 100px">link</a></p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    await UiFinder.pWaitFor('Waiting for context toolbar to appear', SugarBody.body(), '.tox-pop[data-alloy-placement="south"]');
+    TinyUiActions.clickOnUi(editor, '.tox-pop button[aria-label="ABC"]');
+    await UiFinder.pWaitFor('Waiting for context toolbar to appear', SugarBody.body(), '.tox-pop[data-alloy-placement="southwest"] input');
+  });
+});
+

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
@@ -1,0 +1,143 @@
+import { ApproxStructure, Assertions, FocusTools, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
+import { afterEach, describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
+import { Attribute, SugarBody, SugarDocument, Value } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.ContextSliderFormTest', () => {
+  const store = TestStore();
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    setup: (ed: Editor) => {
+      ed.ui.registry.addContextForm('test-form', {
+        type: 'contextsliderform',
+        launch: {
+          type: 'contextformtogglebutton',
+          icon: 'fake-icon-name',
+          tooltip: 'ABC'
+        },
+        predicate: (node) => node.nodeName.toLowerCase() === 'a',
+        min: Fun.constant(-100),
+        max: Fun.constant(100),
+        initValue: Fun.constant(37),
+        onInput: (formApi) => store.add(`input.${formApi.getValue()}`),
+        commands: [
+          {
+            type: 'contextformbutton',
+            icon: 'fake-icon-name',
+            tooltip: 'A',
+            align: 'start',
+            onAction: (formApi, _buttonApi) => {
+              formApi.setValue(100);
+            }
+          },
+          {
+            type: 'contextformbutton',
+            icon: 'fake-icon-name',
+            align: 'end',
+            tooltip: 'B',
+            primary: true,
+            onAction: (formApi, _buttonApi) => store.add('B.' + formApi.getValue())
+          }
+        ]
+      });
+    }
+  }, [], true);
+
+  afterEach(async () => {
+    const editor = hook.editor();
+
+    store.clear();
+    editor.focus();
+
+    // Simulate clicking elsewhere in the editor
+    clickAway(editor);
+    await pAssertNoPopDialog();
+  });
+
+  const openToolbar = (editor: Editor, toolbarKey: string) => {
+    editor.dispatch('contexttoolbar-show', {
+      toolbarKey
+    });
+  };
+
+  const checkFirstButtonGroup = (label: string, children: ApproxStructure.Builder<StructAssert[]>) => {
+    const group = UiFinder.findIn(SugarBody.body(), '.tox-pop .tox-toolbar__group:first').getOrDie();
+    Assertions.assertStructure(
+      label,
+      ApproxStructure.build((s, str, arr) => s.element('div', {
+        children: children(s, str, arr)
+      })),
+      group
+    );
+  };
+
+  const checkLastButtonGroup = (label: string, children: ApproxStructure.Builder<StructAssert[]>) => {
+    const group = UiFinder.findIn(SugarBody.body(), '.tox-pop .tox-toolbar__group:last').getOrDie();
+    Assertions.assertStructure(
+      label,
+      ApproxStructure.build((s, str, arr) => s.element('div', {
+        children: children(s, str, arr)
+      })),
+      group
+    );
+  };
+
+  const clickAway = (editor: Editor) => {
+    // <a> tags make the context bar appear so click away from an a tag. We have no content so it's probably fine.
+    editor.nodeChanged();
+  };
+
+  const pAssertNoPopDialog = () => Waiter.pTryUntil(
+    'Pop dialog should disappear (soon)',
+    () => UiFinder.notExists(SugarBody.body(), '.tox-pop')
+  );
+
+  it('TINY-11342: Should be buttons before and after the input and the input should have focus', async () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+    checkFirstButtonGroup('Checking buttons have right state', (s, str) => [
+      s.element('button', { attrs: { 'aria-label': str.is('A') }}),
+    ]);
+    checkLastButtonGroup('Checking buttons have right state', (s, str) => [
+      s.element('button', { attrs: { 'aria-label': str.is('B') }}),
+    ]);
+    await FocusTools.pTryOnSelector('Focus should now be on input in context form', SugarDocument.getDocument(), 'input');
+  });
+
+  it('TINY-11342: Input should have initial value', async () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+    const input = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), '.tox-pop input').getOrDie();
+    assert.strictEqual(Value.get(input), '37', 'Should be initial value');
+  });
+
+  it('TINY-11342: Input should trigger onInput', async () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+    const input = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), '.tox-pop input').getOrDie();
+    Value.set(input, '42');
+    input.dom.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
+    store.assertEq('Input should trigger onInput', [ 'input.42' ]);
+  });
+
+  it('TINY-11342: Should have min/max attributes set', async () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+    const input = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), '.tox-pop input').getOrDie();
+    Assertions.assertEq('Should have min attribute set', '-100', Attribute.get(input, 'min'));
+    Assertions.assertEq('Should have max attribute set', '100', Attribute.get(input, 'max'));
+  });
+
+  it('TINY-11342: Clicking `A` button should update the value', async () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+    TinyUiActions.clickOnUi(editor, '.tox-pop button[aria-label="A"]');
+    const input = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), '.tox-pop input').getOrDie();
+    assert.strictEqual(Value.get(input), '100', 'Should be updated slider value');
+  });
+});
+

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
@@ -21,6 +21,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLook
     initValue: Fun.constant('test'),
     label: Optional.none(),
     launch: Optional.none(),
+    onInput: Fun.noop,
     commands: [{
       onAction: Fun.noop,
       original: {


### PR DESCRIPTION
Related Ticket: TINY-11342

Description of Changes:
* Adds new `contextsliderform` uses a native slider see ticket for details why
* Adds new `contextsizeinputform`
* Adds new APIs to disable the input and get the input disabled state
* Adds support for adding buttons in front of the input as well as after the input in context forms similar to dialog buttons that have a `align` property
* Adds support for `type=range` input to alloy so that we can use native sliders
* Made a common size input module that both dialog and context toolbar uses

Note:
* This is not fully working in terms of a11y since all context forms are rendered inside a toolbar I don't think that is what what we should be doing since that breaks keyboard navigation if you try to tab between the size input form fields. But this is a stop gap PR so that we can move forward we can circle back and fix a11y later. Logged in TINY-11394

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
