### PR TITLE
TINY-11395: Fix inability to type '{' character on German keyboard layouts

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11395-2024-10-17.yaml
+++ b/.changes/unreleased/tinymce-TINY-11395-2024-10-17.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Fixed inability to type '{' character on German keyboard layouts.
+time: 2024-10-17T12:00:38.34871+11:00
+custom:
+  Issue: TINY-11395

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -156,7 +156,7 @@ const NotificationManager = (editor: Editor): NotificationManager => {
     });
 
     editor.on('keydown', (e) => {
-      if ((e.altKey) && e.key.toLowerCase() === 'f12') {
+      if (e.altKey && e.key.toLowerCase() === 'f12') {
         e.preventDefault();
         getTopNotification()
           .map((notificationApi) => SugarElement.fromDom(notificationApi.getEl()))

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -156,7 +156,9 @@ const NotificationManager = (editor: Editor): NotificationManager => {
     });
 
     editor.on('keydown', (e) => {
-      if (e.altKey && e.key.toLowerCase() === 'f12') {
+      // TODO: Remove this once we remove the use of keycodes
+      const isF12 = e.key?.toLowerCase() === 'f12' || e.keyCode === 123;
+      if (e.altKey && isF12) {
         e.preventDefault();
         getTopNotification()
           .map((notificationApi) => SugarElement.fromDom(notificationApi.getEl()))

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -156,7 +156,7 @@ const NotificationManager = (editor: Editor): NotificationManager => {
     });
 
     editor.on('keydown', (e) => {
-      if ((e.altKey || e.metaKey) && e.key.toLowerCase() === 'f12') {
+      if ((e.altKey) && e.key.toLowerCase() === 'f12') {
         e.preventDefault();
         getTopNotification()
           .map((notificationApi) => SugarElement.fromDom(notificationApi.getEl()))

--- a/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/NotificationManager.ts
@@ -155,10 +155,14 @@ const NotificationManager = (editor: Editor): NotificationManager => {
       });
     });
 
-    editor.addShortcut('alt+F12', 'Focus to notification', () =>
-      getTopNotification()
-        .map((notificationApi) => SugarElement.fromDom(notificationApi.getEl()))
-        .each((elm) => Focus.focus(elm)));
+    editor.on('keydown', (e) => {
+      if ((e.altKey || e.metaKey) && e.key.toLowerCase() === 'f12') {
+        e.preventDefault();
+        getTopNotification()
+          .map((notificationApi) => SugarElement.fromDom(notificationApi.getEl()))
+          .each((elm) => Focus.focus(elm));
+      }
+    });
   };
 
   registerEvents(editor);

--- a/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
@@ -2,7 +2,7 @@ import { FocusTools } from '@ephox/agar';
 import { afterEach, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { Focus, Insert, Remove, SugarElement, SugarShadowDom } from '@ephox/sugar';
-import { LegacyUnit, TinyContentActions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';

--- a/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/NotificationManagerTest.ts
@@ -151,7 +151,12 @@ describe('browser.tinymce.core.NotificationManagerTest', () => {
 
         const hasFocus = (node: Node) => Focus.search(SugarElement.fromDom(node)).isSome();
 
-        TinyContentActions.keystroke(editor, 123, { alt: true });
+        editor.getBody().dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'F12',
+          altKey: true,
+          bubbles: true
+        }));
+
         await FocusTools.pTryOnSelector('Assert focus should be on notification 1', root, '.tox-notification');
         assert.isTrue(hasFocus(n1.getEl()), 'Focus should be on notification 1');
 


### PR DESCRIPTION
Related Ticket: 
TINY-11395

Description of Changes:
- Changed the keyboard shortcut to a custom keyboard handler

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
