### PR TITLE
TINY-11344: implement `contextForm.back` to restore the previous toolbar

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11344-2024-10-18.yaml
+++ b/.changes/unreleased/tinymce-TINY-11344-2024-10-18.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: '`ContextFormApi.hide` were removing a possible previous toolbar too'
+time: 2024-10-18T12:57:25.545660984+02:00
+custom:
+  Issue: TINY-11344

--- a/.changes/unreleased/tinymce-TINY-11344-2024-10-18.yaml
+++ b/.changes/unreleased/tinymce-TINY-11344-2024-10-18.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Added
-body: Add a new function`back` in `ContextFormApi` to go back to the previous toolbar
+body: New `back` function in `ContextFormApi` to go back to the previous toolbar.
 time: 2024-10-18T14:59:26.32197275+02:00
 custom:
   Issue: TINY-11344

--- a/.changes/unreleased/tinymce-TINY-11344-2024-10-18.yaml
+++ b/.changes/unreleased/tinymce-TINY-11344-2024-10-18.yaml
@@ -1,6 +1,6 @@
 project: tinymce
-kind: Fixed
-body: '`ContextFormApi.hide` were removing a possible previous toolbar too'
-time: 2024-10-18T12:57:25.545660984+02:00
+kind: Added
+body: Add a new function`back` in `ContextFormApi` to go back to the previous toolbar
+time: 2024-10-18T14:59:26.32197275+02:00
 custom:
   Issue: TINY-11344

--- a/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
@@ -68,6 +68,7 @@ export interface ContextFormInstanceApi<T> {
   setInputEnabled: (state: boolean) => void;
   isInputEnabled: () => boolean;
   hide: () => void;
+  back: () => void;
   getValue: () => T;
   setValue: (value: T) => void;
 }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
@@ -22,6 +22,14 @@ export const getFormApi = <T>(input: AlloyComponent): InlineContent.ContextFormI
         valueState.set(Representing.getValue(input));
       }
 
+      AlloyTriggers.emit(input, SystemEvents.sandboxClose());
+    },
+    back: () => {
+      // Before we hide snapshot the current value since accessing the value of a form field after it's been detached will throw an error
+      if (!valueState.isSet()) {
+        valueState.set(Representing.getValue(input));
+      }
+
       AlloyTriggers.emit(input, backSlideEvent);
       AlloyTriggers.emit(input, SystemEvents.sandboxClose());
     },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
@@ -2,7 +2,8 @@ import {
   AlloyComponent,
   AlloyTriggers,
   Disabling,
-  Representing
+  Representing,
+  SystemEvents
 } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Singleton } from '@ephox/katamari';
@@ -22,6 +23,7 @@ export const getFormApi = <T>(input: AlloyComponent): InlineContent.ContextFormI
       }
 
       AlloyTriggers.emit(input, backSlideEvent);
+      AlloyTriggers.emit(input, SystemEvents.sandboxClose());
     },
     getValue: () => {
       return valueState.get().getOrThunk(() => Representing.getValue(input));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
@@ -2,11 +2,12 @@ import {
   AlloyComponent,
   AlloyTriggers,
   Disabling,
-  Representing,
-  SystemEvents
+  Representing
 } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Singleton } from '@ephox/katamari';
+
+import { backSlideEvent } from './ContextUi';
 
 export const getFormApi = <T>(input: AlloyComponent): InlineContent.ContextFormInstanceApi<T> => {
   const valueState = Singleton.value<T>();
@@ -20,7 +21,7 @@ export const getFormApi = <T>(input: AlloyComponent): InlineContent.ContextFormI
         valueState.set(Representing.getValue(input));
       }
 
-      AlloyTriggers.emit(input, SystemEvents.sandboxClose());
+      AlloyTriggers.emit(input, backSlideEvent);
     },
     getValue: () => {
       return valueState.get().getOrThunk(() => Representing.getValue(input));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
@@ -48,6 +48,33 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
           }
         ]
       });
+
+      ed.ui.registry.addContextToolbar('test-toolbar-with-close', {
+        items: 'test-form-with-close undo',
+        position: 'node',
+        scope: 'node',
+        predicate: (node) => node.nodeName.toLowerCase() === 'div',
+      });
+
+      ed.ui.registry.addContextForm('test-form-with-close', {
+        type: 'contextsizeinputform',
+        launch: {
+          type: 'contextformtogglebutton',
+          icon: 'fake-icon-name',
+          tooltip: 'ABC'
+        },
+        initValue: Fun.constant({ width: '100', height: '200' }),
+        onInput: (formApi) => store.add(`input.${JSON.stringify(formApi.getValue())}`),
+        commands: [
+          {
+            type: 'contextformbutton',
+            icon: 'fake-icon-name',
+            tooltip: 'Back',
+            align: 'start',
+            onAction: (formApi, _buttonApi) => formApi.hide()
+          }
+        ]
+      });
     }
   }, [], true);
 
@@ -148,6 +175,16 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
     await UiFinder.pWaitFor('Waiting for context toolbar to appear', SugarBody.body(), '.tox-pop[data-alloy-placement="south"]');
     TinyUiActions.clickOnUi(editor, '.tox-pop button[aria-label="ABC"]');
     await UiFinder.pWaitFor('Waiting for context toolbar to appear', SugarBody.body(), '.tox-pop[data-alloy-placement="southwest"] input');
+  });
+
+  it('TINY-11344: pressing `back` it should show the previous toolbar', async () => {
+    const editor = hook.editor();
+    editor.setContent('<div>some div</div>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    await UiFinder.pWaitFor('Waiting for context toolbar to appear', SugarBody.body(), '.tox-pop[data-alloy-placement="south"]');
+    TinyUiActions.clickOnUi(editor, '.tox-pop button[aria-label="ABC"]');
+    TinyUiActions.clickOnUi(editor, '.tox-pop button[aria-label="Back"]');
+    await UiFinder.pWaitFor('Waiting for context toolbar to previous toolbar to apper', SugarBody.body(), '.tox-pop button[aria-label="Undo"]');
   });
 });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
@@ -71,7 +71,7 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
             icon: 'fake-icon-name',
             tooltip: 'Back',
             align: 'start',
-            onAction: (formApi, _buttonApi) => formApi.hide()
+            onAction: (formApi) => formApi.back()
           }
         ]
       });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
@@ -49,14 +49,14 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
         ]
       });
 
-      ed.ui.registry.addContextToolbar('test-toolbar-with-close', {
-        items: 'test-form-with-close undo',
+      ed.ui.registry.addContextToolbar('test-toolbar-with-back', {
+        items: 'test-form-with-back undo',
         position: 'node',
         scope: 'node',
         predicate: (node) => node.nodeName.toLowerCase() === 'div',
       });
 
-      ed.ui.registry.addContextForm('test-form-with-close', {
+      ed.ui.registry.addContextForm('test-form-with-back', {
         type: 'contextsizeinputform',
         launch: {
           type: 'contextformtogglebutton',
@@ -177,14 +177,14 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
     await UiFinder.pWaitFor('Waiting for context toolbar to appear', SugarBody.body(), '.tox-pop[data-alloy-placement="southwest"] input');
   });
 
-  it('TINY-11344: pressing `back` it should show the previous toolbar', async () => {
+  it('TINY-11344: pressing `back` should show the previous toolbar', async () => {
     const editor = hook.editor();
     editor.setContent('<div>some div</div>');
     TinySelections.setCursor(editor, [ 0, 0 ], 1);
     await UiFinder.pWaitFor('Waiting for context toolbar to appear', SugarBody.body(), '.tox-pop[data-alloy-placement="south"]');
     TinyUiActions.clickOnUi(editor, '.tox-pop button[aria-label="ABC"]');
     TinyUiActions.clickOnUi(editor, '.tox-pop button[aria-label="Back"]');
-    await UiFinder.pWaitFor('Waiting for context toolbar to previous toolbar to apper', SugarBody.body(), '.tox-pop button[aria-label="Undo"]');
+    await UiFinder.pWaitFor('Waiting for context toolbar to previous toolbar to appear', SugarBody.body(), '.tox-pop button[aria-label="Undo"]');
   });
 });
 


### PR DESCRIPTION
Related Ticket: TINY-11344

Description of Changes:
implemented `contextForm.back` to restore the previous toolbar, to go back to the previous toolbar when we press back in the toolbar I added a function `contextForm.back` that use the event `backSlideEvent`.
since when we go in the context form we use [forwardSlideEvent](https://github.com/tinymce/tinymce/blob/main/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts#L139) so to go to the previous toolbar we need `backSlideEvent`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
