### PR TITLE
TINY-11437: Fixed bug with nodeChanged while having UI focus

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11437-2024-10-23.yaml
+++ b/.changes/unreleased/tinymce-TINY-11437-2024-10-23.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Image selection was removed when calling nodeChanged while having focus inside
+  the editor UI.
+time: 2024-10-23T12:43:58.517087+02:00
+custom:
+  Issue: TINY-11437

--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -3,6 +3,7 @@ import { SelectorFind, Selectors, SugarElement } from '@ephox/sugar';
 
 import * as NodeType from '../../dom/NodeType';
 import * as RangePoint from '../../dom/RangePoint';
+import * as EditorFocus from '../../focus/EditorFocus';
 import Editor from '../Editor';
 import Env from '../Env';
 import * as Events from '../Events';
@@ -441,7 +442,7 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
       img.removeAttribute(elementSelectionAttr);
     });
 
-    if (Type.isNonNullable(controlElm) && isChildOrEqual(controlElm, rootElement) && editor.hasFocus()) {
+    if (Type.isNonNullable(controlElm) && isChildOrEqual(controlElm, rootElement) && EditorFocus.hasEditorOrUiFocus(editor)) {
       disableGeckoResize();
       const startElm = selection.getStart(true);
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
@@ -1,8 +1,8 @@
-import { Assertions, Mouse, UiFinder, Waiter } from '@ephox/agar';
+import { Assertions, FocusTools, Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Arr, Cell, Obj, Strings } from '@ephox/katamari';
-import { Attribute, Css, Hierarchy, SugarElement } from '@ephox/sugar';
-import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { Attribute, Css, Hierarchy, SugarDocument, SugarElement } from '@ephox/sugar';
+import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -11,7 +11,7 @@ import Env from 'tinymce/core/api/Env';
 describe('browser.tinymce.core.dom.ControlSelectionTest', () => {
   const imgSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAGUlEQVR4nGK5aLGTATdgwiM3gqUBAQAA//8ukgHZvWHlnwAAAABJRU5ErkJggg==';
   const eventCounter = Cell<Record<string, number>>({});
-  const hook = TinyHooks.bddSetupLight<Editor>({
+  const hook = TinyHooks.bddSetup<Editor>({
     add_unload_trigger: false,
     base_url: '/project/tinymce/js/tinymce',
     content_style: 'body.mce-content-body  { margin: 0 }',
@@ -239,6 +239,17 @@ describe('browser.tinymce.core.dom.ControlSelectionTest', () => {
     TinyAssertions.assertContentPresence(editor, { 'details[data-mce-selected="1"]': 0 });
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
     TinyAssertions.assertContentPresence(editor, { 'details[data-mce-selected="1"]': 1 });
+  });
+
+  it('TINY-11437: Node change while editor UI has focus should not hide control selection', async () => {
+    const editor = hook.editor();
+
+    editor.setContent(`<p><img src="${imgSrc}" width="100" height="100"></p>`);
+    TinySelections.select(editor, 'img', []);
+    TinyContentActions.keystroke(editor, 121, { altKey: true });
+    await FocusTools.pTryOnSelector('Assert toolbar is focused', SugarDocument.getDocument(), 'div[role=toolbar] .tox-tbtn');
+    editor.nodeChanged();
+    TinyAssertions.assertContentPresence(editor, { 'img[data-mce-selected="1"]': 1 });
   });
 
   Arr.each([ 'nw', 'ne', 'se', 'sw' ], (origin) => {


### PR DESCRIPTION
Related Ticket: TINY-11437

Description of Changes:
* Control selection on images was removed when calling nodeChange while the editor UI was focused

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
