### PR TITLE
TINY-11432: Added more events for context toolbars

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/api/Events.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Events.ts
@@ -71,6 +71,14 @@ const fireToggleView = (editor: Editor): void => {
   editor.dispatch('ToggleView');
 };
 
+const fireContextToolbarClose = (editor: Editor): void => {
+  editor.dispatch('ContextToolbarClose');
+};
+
+const fireContextFormSlideBack = (editor: Editor): void => {
+  editor.dispatch('ContextFormSlideBack');
+};
+
 export {
   fireSkinLoaded,
   fireSkinLoadError,
@@ -88,5 +96,7 @@ export {
   fireBlocksTextUpdate,
   fireFontFamilyTextUpdate,
   fireToggleSidebar,
-  fireToggleView
+  fireToggleView,
+  fireContextToolbarClose,
+  fireContextFormSlideBack
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
@@ -9,6 +9,7 @@ import { Class, Compare, Css, Focus, SugarElement } from '@ephox/sugar';
 import Editor from 'tinymce/core/api/Editor';
 import Delay from 'tinymce/core/api/util/Delay';
 
+import * as Events from '../../api/Events';
 import { getToolbarMode, ToolbarMode } from '../../api/Options';
 import { UiFactoryBackstage, UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { renderToolbar } from '../toolbar/CommonToolbar';
@@ -54,7 +55,14 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
       sink,
       onEscape: () => {
         editor.focus();
+        Events.fireContextToolbarClose(editor);
         return Optional.some(true);
+      },
+      onHide: () => {
+        Events.fireContextToolbarClose(editor);
+      },
+      onBack: () => {
+        Events.fireContextFormSlideBack(editor);
       }
     })
   );


### PR DESCRIPTION
Related Ticket: TINY-11432

Description of Changes:
* Added events for context form slide back and context toolbar close

Pre-checks:
* [x] ~~Changelog entry added~~ Not sure we should document these
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
