### PR TITLE
TINY-11428: Fixed issue with slider not returning numbers

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/ui/common/InputBase.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/common/InputBase.ts
@@ -18,6 +18,8 @@ const schema: () => FieldProcessor[] = Fun.constant([
   FieldSchema.defaulted('tag', 'input'),
   FieldSchema.defaulted('inputClasses', [ ]),
   Fields.onHandler('onSetValue'),
+  FieldSchema.defaultedFunction('fromInputValue', Fun.identity),
+  FieldSchema.defaultedFunction('toInputValue', Fun.identity),
   FieldSchema.defaulted('styles', { }),
   FieldSchema.defaulted('eventOrder', { }),
   SketchBehaviours.field('inputBehaviours', [ Representing, Focusing ]),
@@ -49,13 +51,13 @@ const behaviours = (detail: InputDetail): Behaviour.AlloyBehaviourRecord => ({
           // Propagating its Optional
           ...detail.data.map((data) => ({ initialValue: data } as { initialValue?: string })).getOr({ }),
           getValue: (input) => {
-            return Value.get(input.element);
+            return detail.fromInputValue(Value.get(input.element));
           },
           setValue: (input, data) => {
             const current = Value.get(input.element);
             // Only set it if it has changed ... otherwise the cursor goes to the end.
             if (current !== data) {
-              Value.set(input.element, data);
+              Value.set(input.element, detail.toInputValue(data));
             }
           }
         },

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/InputTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/InputTypes.ts
@@ -18,6 +18,8 @@ export interface InputDetail extends SingleSketchDetail {
   tag: string;
   data: Optional<string>;
   onSetValue: (comp: AlloyComponent, data: string) => void;
+  toInputValue: (value: any) => string;
+  fromInputValue: (value: string) => any;
   selectOnFocus: boolean;
   eventOrder: Record<string, string[]>;
 }
@@ -35,6 +37,8 @@ export interface InputSpec extends SingleSketchSpec {
   selectOnFocus?: boolean;
   eventOrder?: Record<string, string[]>;
   onSetValue?: (comp: AlloyComponent, data: string) => void;
+  toInputValue?: (value: any) => string;
+  fromInputValue?: (value: string) => any;
 }
 
 export interface InputSketcher extends SingleSketch<InputSpec> { }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
@@ -1,6 +1,6 @@
 import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Disabling, FormField, GuiFactory, Input, Keying, NativeEvents, SketchSpec } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
-import { Optional } from '@ephox/katamari';
+import { Optional, Strings } from '@ephox/katamari';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
@@ -26,6 +26,8 @@ export const renderContextFormSliderInput = (
       max: String(ctx.max())
     },
     data: ctx.initValue().toString(),
+    fromInputValue: (value: string) => Strings.toFloat(value).getOr(ctx.min()),
+    toInputValue: (value: number) => String(value),
     inputBehaviours: Behaviour.derive([
       Disabling.config({
         disabled: () => providers.checkUiComponentContext('mode:design').shouldDisable

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
@@ -23,7 +23,7 @@ describe('browser.tinymce.themes.silver.editor.ContextSliderFormTest', () => {
         min: Fun.constant(-100),
         max: Fun.constant(100),
         initValue: Fun.constant(37),
-        onInput: (formApi) => store.add(`input.${formApi.getValue()}`),
+        onInput: (formApi) => store.add(`input.${formApi.getValue()}(${typeof formApi.getValue()})`),
         commands: [
           {
             type: 'contextformbutton',
@@ -121,7 +121,7 @@ describe('browser.tinymce.themes.silver.editor.ContextSliderFormTest', () => {
     const input = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), '.tox-pop input').getOrDie();
     Value.set(input, '42');
     input.dom.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
-    store.assertEq('Input should trigger onInput', [ 'input.42' ]);
+    store.assertEq('Input should trigger onInput with the right value and type', [ 'input.42(number)' ]);
   });
 
   it('TINY-11342: Should have min/max attributes set', async () => {


### PR DESCRIPTION
Related Ticket: TINY-11428

Description of Changes:
* Fixes a type error where slider forms doesn't produce a number but a string

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
