### PR TITLE
TINY-11391: add tooltipping for group toolbar buttons

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11391-2024-10-28.yaml
+++ b/.changes/unreleased/tinymce-TINY-11391-2024-10-28.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Tooltip would not show for group toolbar button.
+time: 2024-10-28T16:13:31.620188+01:00
+custom:
+  Issue: TINY-11391

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -127,7 +127,8 @@ const renderCommonStructure = (
         'alloy.base.behaviour',
         commonButtonDisplayEvent
       ],
-      [SystemEvents.attachedToDom()]: [ commonButtonDisplayEvent, 'toolbar-group-button-events' ]
+      [SystemEvents.attachedToDom()]: [ commonButtonDisplayEvent, 'toolbar-group-button-events' ],
+      [SystemEvents.detachedFromDom()]: [ commonButtonDisplayEvent, 'toolbar-group-button-events', 'tooltipping' ]
     },
 
     buttonBehaviours: Behaviour.derive(
@@ -168,7 +169,14 @@ const renderFloatingToolbarButton = (spec: Toolbar.GroupToolbarButton, backstage
     AddEventsBehaviour.config('toolbar-group-button-events', [
       onControlAttached(specialisation, editorOffCell),
       onControlDetached(specialisation, editorOffCell)
-    ])
+    ]),
+    ...(spec.tooltip.map(
+      (t) => Tooltipping.config(
+        backstage.shared.providers.tooltips.getConfig({
+          tooltipText: backstage.shared.providers.translate(t),
+        })
+      )
+    )).toArray()
   ];
 
   return FloatingToolbarButton.sketch({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
@@ -149,7 +149,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
     pTestWithEditor({
       ...defaultToolbarGroupOptions,
     }, async () => {
-      const toolbarButton = await UiFinder.pWaitFor('Group toolbar button should exist', SugarBody.body(), 'button[data-mce-name="formatting"]')
+      const toolbarButton = await UiFinder.pWaitFor('Group toolbar button should exist', SugarBody.body(), 'button[data-mce-name="formatting"]');
       Mouse.mouseOver(toolbarButton);
       const tooltip = await UiFinder.pWaitFor('Tooltip should be visible after mouse over', SugarBody.body(), '.tox-silver-sink .tox-tooltip__body');
       assert.equal(TextContent.get(tooltip), 'Formatting');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, Mouse, StructAssert, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { SugarBody } from '@ephox/sugar';
+import { SelectorFilter, SugarBody, TextContent } from '@ephox/sugar';
 import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -145,4 +145,16 @@ describe('browser.tinymce.themes.silver.editor.buttons.GroupToolbarButtonTest', 
     });
   });
 
+  it('TINY-11391: Tooltip should show for toolbar group button', () =>
+    pTestWithEditor({
+      ...defaultToolbarGroupOptions,
+    }, async () => {
+      const toolbarButton = await UiFinder.pWaitFor('Group toolbar button should exist', SugarBody.body(), 'button[data-mce-name="formatting"]')
+      Mouse.mouseOver(toolbarButton);
+      const tooltip = await UiFinder.pWaitFor('Tooltip should be visible after mouse over', SugarBody.body(), '.tox-silver-sink .tox-tooltip__body');
+      assert.equal(TextContent.get(tooltip), 'Formatting');
+      assert.equal(SelectorFilter.all('.tox-silver-sink .tox-tooltip__body').length, 1);
+      return Promise.resolve();
+    })
+  );
 });


### PR DESCRIPTION
Related Ticket: TINY-11391

Description of Changes:
Add missing tooltipping for group toolbar buttons.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable): #9908