### PR TITLE
TINY-11390: Avoid `samp` being registered as block format

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11390-2024-10-30.yaml
+++ b/.changes/unreleased/tinymce-TINY-11390-2024-10-30.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Avoid `samp` from being registered as a `block` format.
+body: The `samp` format was being applied as a `block` level format, instead of an `inline` format.
 time: 2024-10-30T08:34:13.33087+10:00
 custom:
   Issue: TINY-11390

--- a/.changes/unreleased/tinymce-TINY-11390-2024-10-30.yaml
+++ b/.changes/unreleased/tinymce-TINY-11390-2024-10-30.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Avoid `samp` from being registered as a `block` format.
+time: 2024-10-30T08:34:13.33087+10:00
+custom:
+  Issue: TINY-11390

--- a/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
@@ -214,6 +214,7 @@ const get = (editor: Editor): Formats => {
     subscript: { inline: 'sub' },
     superscript: { inline: 'sup' },
     code: { inline: 'code' },
+    samp: { inline: 'samp' },
 
     link: {
       inline: 'a', selector: 'a', remove: 'all', split: true, deep: true,
@@ -252,7 +253,7 @@ const get = (editor: Editor): Formats => {
     ]
   };
 
-  Tools.each('p h1 h2 h3 h4 h5 h6 div address pre dt dd samp'.split(/\s/), (name) => {
+  Tools.each('p h1 h2 h3 h4 h5 h6 div address pre dt dd'.split(/\s/), (name) => {
     formats[name] = { block: name, remove: 'all' };
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/fmt/DefaultFormatsWithSchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/DefaultFormatsWithSchemaTest.ts
@@ -35,6 +35,14 @@ describe('browser.tinymce.core.fmt.DefaultFormatsWithSchemaTest', () => {
       editor.setContent('<p><strike>Test</strike></p>');
       TinyAssertions.assertContent(editor, '<p><s>Test</s></p>');
     });
+
+    it('TINY-11390: should only wrap selected text in <samp> tags when applying "Sample" format', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>one two three</p>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 4, [ 0, 0 ], 7);
+      editor.formatter.apply('samp');
+      TinyAssertions.assertContent(editor, '<p>one <samp>two</samp> three</p>');
+    });
   });
 
   context(`schema version: html5-strict`, () => {
@@ -51,6 +59,14 @@ describe('browser.tinymce.core.fmt.DefaultFormatsWithSchemaTest', () => {
       TinyAssertions.assertContent(editor, '<p><s>Test</s></p>');
       toggleInlineStyle(editor, 'Strikethrough');
       editor.setContent('<p>Test</p>');
+    });
+
+    it('TINY-11390: should only wrap selected text in <samp> tags when applying "Sample" format', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>one two three</p>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 4, [ 0, 0 ], 7);
+      editor.formatter.apply('samp');
+      TinyAssertions.assertContent(editor, '<p>one <samp>two</samp> three</p>');
     });
   });
 
@@ -74,6 +90,14 @@ describe('browser.tinymce.core.fmt.DefaultFormatsWithSchemaTest', () => {
       const editor = hook.editor();
       editor.setContent('<p><strike>Test</strike></p>');
       TinyAssertions.assertContent(editor, '<p><span style="text-decoration: line-through;">Test</span></p>');
+    });
+
+    it('TINY-11390: should only wrap the selected text in <samp> tags when applying "Sample" format', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>one two three</p>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 4, [ 0, 0 ], 7);
+      editor.formatter.apply('samp');
+      TinyAssertions.assertContent(editor, '<p>one <samp>two</samp> three</p>');
     });
   });
 });


### PR DESCRIPTION
Related Ticket: [TINY-11390](https://ephocks.atlassian.net/browse/TINY-11390)

Description of Changes:
Removed `samp` from the list of elements being registered in `block` format as well as explicitly defining it as `inline`.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* ~[x] Docs ticket created (if applicable)~

GitHub issues (if applicable): [#7577
](https://github.com/tinymce/tinymce/issues/7577)

[TINY-11390]: https://ephocks.atlassian.net/browse/TINY-11390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ