### PR TITLE
TINY-11478: Lock lts to node-20

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,6 +76,7 @@ def runTestPod(String cacheName, String name, String testname, String browser, S
         resourceLimitMemory: '4Gi',
         resourceLimitEphemeralStorage: '16Gi'
       ],
+      tag: '20',
       build: cacheName,
       useContainers: ['node', 'aws-cli']
     ) {
@@ -126,6 +127,7 @@ def runHeadlessPod(String cacheName, Boolean runAll) {
         resourceLimitMemory: '4Gi',
         resourceLimitEphemeralStorage: '16Gi'
       ],
+      tag: '20',
       seleniumOpts: [
         image: "selenium/standalone-chrome:127.0",
       ],
@@ -168,6 +170,7 @@ timestamps {
       resourceLimitMemory: '4Gi',
       resourceLimitEphemeralStorage: '16Gi'
     ],
+    tag: '20',
     build: cacheName
   ) {
     props = readProperties(file: 'build.properties')


### PR DESCRIPTION
Related Ticket: TINY-11478

Description of Changes:
* Lock `lts` version to `node:20` in CI environments

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
