### PR TITLE
Hotfix/5127 Improve handling of captioned images where <img> is not direct descendent of <figure>

### DIFF
--- a/modules/tinymce/src/plugins/image/main/ts/core/ImageData.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/core/ImageData.ts
@@ -58,8 +58,11 @@ const getAttrib = (image: HTMLElement, name: string): string => {
   }
 };
 
+const getFigure = (image: HTMLElement): HTMLElement | null =>
+  DOM.getParent(image, 'figure');
+
 const hasCaption = (image: HTMLElement): boolean =>
-  image.parentNode !== null && image.parentNode.nodeName === 'FIGURE';
+  getFigure(image) !== null;
 
 const updateAttrib = (image: HTMLElement, name: string, value: string | null): void => {
   if (value === '' || value === null) {
@@ -69,19 +72,29 @@ const updateAttrib = (image: HTMLElement, name: string, value: string | null): v
   }
 };
 
+const getInlineContainer = (image: HTMLElement): HTMLElement => {
+  let container = image;
+  while (container.parentElement !== null && !DOM.isBlock(container.parentElement)) {
+    container = container.parentElement;
+  }
+  return container;
+};
+
 const wrapInFigure = (image: HTMLElement): void => {
   const figureElm = DOM.create('figure', { class: 'image' });
-  DOM.insertAfter(figureElm, image);
+  const imageElm = getInlineContainer(image);
+  DOM.insertAfter(figureElm, imageElm);
 
-  figureElm.appendChild(image);
+  figureElm.appendChild(imageElm);
   figureElm.appendChild(DOM.create('figcaption', { contentEditable: 'true' }, 'Caption'));
   figureElm.contentEditable = 'false';
 };
 
 const removeFigure = (image: HTMLElement): void => {
-  const figureElm = image.parentNode;
+  const figureElm = getFigure(image);
+  const imageElm = getInlineContainer(image);
   if (Type.isNonNullable(figureElm)) {
-    DOM.insertAfter(image, figureElm);
+    DOM.insertAfter(imageElm, figureElm);
     DOM.remove(figureElm);
   }
 };


### PR DESCRIPTION
Related Ticket: 
https://github.com/tinymce/tinymce/issues/5127

Description of Changes:
* Images can be given a caption by ticking a box in the image editor which wraps them in a `<figure>`. This works as long as the image is kept as a direct descendant of the `<figure>`, but things go awry if the path is changed e.g. if the image is made a link, so the path is now figure > a > img. The caption checkbox in the image editor is cleared, and ticking it adds a second caption to the image (for example).
* Similarly, adding a caption to an existing image with a link removes the `<img>` from the `<a>`, making the image link no longer work and leaving an empty `<a>` behind.
* This fix works by changing the way image and figure are selected.
  * Rather than directly access the `<figure>` from the `<img>` by accessing `image.parentNode`, a `getFigure(image)` function is used which will access any parent `<figure>` of the `<img>` (so `hasCaption(image)` now works if there's an `<a>` between the two).
  * Rather than directly manipulate the `<img>` when wrapping the element in a `<figure>` a `getInlineContainer(image)` function is used which searches for the topmost non-block-level element containing the `<img>` (e.g. its containing `<a>`) which means that that those elements are retained when the image is moved inside the containing figure (links no longer get lost and left behind as empty elements).

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
https://github.com/tinymce/tinymce/issues/5127