### PR TITLE
TINY-11470: Removed title attribute to prevent double tooltip.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11470-2024-11-01.yaml
+++ b/.changes/unreleased/tinymce-TINY-11470-2024-11-01.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Removed title attribute from tree elements as it already has a tooltip.
+time: 2024-11-01T19:31:17.273725209+01:00
+custom:
+    Issue: TINY-11470

--- a/.changes/unreleased/tinymce-TINY-11470-2024-11-01.yaml
+++ b/.changes/unreleased/tinymce-TINY-11470-2024-11-01.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Removed title attribute from tree elements as it already has a tooltip.
+body: Removed title attribute from dialog tree elements as they already have a tooltip.
 time: 2024-11-01T19:31:17.273725209+01:00
 custom:
     Issue: TINY-11470

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
@@ -97,11 +97,7 @@ const renderCustomStateIcon = (container: Dialog.Directory | Dialog.Leaf, compon
           )
         ]
       ),
-      [ 'tox-icon-custom-state' ],
-      container.customStateIconTooltip.fold(
-        () => ({}),
-        (tooltip) => ({ title: tooltip })
-      )
+      [ 'tox-icon-custom-state' ]
     ))
   );
 };


### PR DESCRIPTION
Related Ticket: TINY-11470

Description of Changes:
Previously we set the title, which the browser will show as a tooltip in addition to our own tooltip. Removing the title will stop this double-tooltip from appearing.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
