### PR TITLE
TINY-11494: add onSetup function to context forms

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11494-2024-11-07.yaml
+++ b/.changes/unreleased/tinymce-TINY-11494-2024-11-07.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Added
-body: Added onSetup function to the context forms.
+body: New `onSetup` function to the context forms.
 time: 2024-11-07T14:00:39.729004+01:00
 custom:
   Issue: TINY-11494

--- a/.changes/unreleased/tinymce-TINY-11494-2024-11-07.yaml
+++ b/.changes/unreleased/tinymce-TINY-11494-2024-11-07.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: Added onSetup function to the context forms.
+time: 2024-11-07T14:00:39.729004+01:00
+custom:
+  Issue: TINY-11494

--- a/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
@@ -167,7 +167,7 @@ const baseContextFormFields = [
     contextformtogglebutton: launchToggleButtonFields
   })),
   FieldSchema.defaultedFunction('onInput', Fun.noop),
-  FieldSchema.defaultedFunction('onSetup', () => Fun.noop)
+  FieldSchema.defaultedFunction('onSetup', Fun.noop)
 ];
 
 const contextFormFields = [

--- a/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
@@ -84,7 +84,7 @@ export interface BaseContextFormSpec<T> extends ContextBarSpec {
   launch?: ContextFormLaunchButtonApi | ContextFormLaunchToggleButtonSpec;
   commands: Array<ContextFormToggleButtonSpec<T> | ContextFormButtonSpec<T>>;
   onInput?: (api: ContextFormInstanceApi<T>) => void;
-  onSetup?: (api: ContextFormInstanceApi<T>) => void;
+  onSetup?: (api: ContextFormInstanceApi<T>) => (api: ContextFormInstanceApi<T>) => void;
 }
 
 export interface ContextInputFormSpec extends BaseContextFormSpec<string> {
@@ -111,7 +111,7 @@ export interface BaseContextForm<T> extends ContextBar {
   launch: Optional<ContextFormLaunchButton | ContextFormLaunchToggleButton>;
   commands: ContextFormCommand<T>[];
   onInput: (api: ContextFormInstanceApi<T>) => void;
-  onSetup: (api: ContextFormInstanceApi<T>) => void;
+  onSetup: (api: ContextFormInstanceApi<T>) => (api: ContextFormInstanceApi<T>) => void;
 }
 
 export interface ContextInputForm extends BaseContextForm<string> {
@@ -167,7 +167,7 @@ const baseContextFormFields = [
     contextformtogglebutton: launchToggleButtonFields
   })),
   FieldSchema.defaultedFunction('onInput', Fun.noop),
-  FieldSchema.defaultedFunction('onSetup', Fun.noop)
+  FieldSchema.defaultedFunction('onSetup', () => Fun.noop)
 ];
 
 const contextFormFields = [

--- a/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextForm.ts
@@ -84,6 +84,7 @@ export interface BaseContextFormSpec<T> extends ContextBarSpec {
   launch?: ContextFormLaunchButtonApi | ContextFormLaunchToggleButtonSpec;
   commands: Array<ContextFormToggleButtonSpec<T> | ContextFormButtonSpec<T>>;
   onInput?: (api: ContextFormInstanceApi<T>) => void;
+  onSetup?: (api: ContextFormInstanceApi<T>) => void;
 }
 
 export interface ContextInputFormSpec extends BaseContextFormSpec<string> {
@@ -110,6 +111,7 @@ export interface BaseContextForm<T> extends ContextBar {
   launch: Optional<ContextFormLaunchButton | ContextFormLaunchToggleButton>;
   commands: ContextFormCommand<T>[];
   onInput: (api: ContextFormInstanceApi<T>) => void;
+  onSetup: (api: ContextFormInstanceApi<T>) => void;
 }
 
 export interface ContextInputForm extends BaseContextForm<string> {
@@ -164,7 +166,8 @@ const baseContextFormFields = [
     contextformbutton: launchButtonFields,
     contextformtogglebutton: launchToggleButtonFields
   })),
-  FieldSchema.defaultedFunction('onInput', Fun.noop)
+  FieldSchema.defaultedFunction('onInput', Fun.noop),
+  FieldSchema.defaultedFunction('onSetup', Fun.noop)
 ];
 
 const contextFormFields = [

--- a/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
@@ -14,6 +14,13 @@ export default (): void => {
         text: 'Alt',
         tooltip: 'Alt'
       },
+      onSetup: (api) => {
+        console.log('setup context form');
+
+        return () => {
+          console.log('teardown context form', api.getValue());
+        };
+      },
       onInput: (api) => {
         console.log('text', api.getValue());
       },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
@@ -22,6 +22,7 @@ export const renderContextFormSizeInput = (
     width,
     height,
     onEnter: Optional.some(onEnter),
-    onInput: Optional.some((input) => ctx.onInput(ContextFormApi.getFormApi(input)))
+    onInput: Optional.some((input) => ctx.onInput(ContextFormApi.getFormApi(input))),
+    onSetup: Optional.some((input) => ctx.onSetup(ContextFormApi.getFormApi(input)))
   }, providersBackstage);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
@@ -13,7 +13,7 @@ export const renderContextFormSizeInput = (
 ): SketchSpec => {
   const { width, height } = ctx.initValue();
 
-  return SizeInput.renderSizeInput({
+  return SizeInput.renderSizeInput<InlineContent.ContextFormInstanceApi<InlineContent.SizeData>>({
     inDialog: false,
     label: ctx.label,
     enabled: true,
@@ -23,6 +23,7 @@ export const renderContextFormSizeInput = (
     height,
     onEnter: Optional.some(onEnter),
     onInput: Optional.some((input) => ctx.onInput(ContextFormApi.getFormApi(input))),
-    onSetup: Optional.some((input) => ctx.onSetup(ContextFormApi.getFormApi(input)))
+    onSetup: Optional.some(ctx.onSetup),
+    getApi: Optional.some(ContextFormApi.getFormApi<InlineContent.SizeData>)
   }, providersBackstage);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
@@ -49,6 +49,9 @@ export const renderContextFormSliderInput = (
         }
       }),
       AddEventsBehaviour.config('slider-events', [
+        AlloyEvents.runOnAttached((comp) => {
+          ctx.onSetup(ContextFormApi.getFormApi(comp));
+        }),
         AlloyEvents.run(NativeEvents.input(), (comp) => {
           ctx.onInput(ContextFormApi.getFormApi(comp));
         })

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
@@ -1,9 +1,10 @@
 import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Disabling, FormField, GuiFactory, Input, Keying, NativeEvents, SketchSpec } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
-import { Optional, Strings } from '@ephox/katamari';
+import { Cell, Fun, Optional, Strings } from '@ephox/katamari';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
+import { onControlAttached, onControlDetached } from '../controls/Controls';
 import * as ContextFormApi from './ContextFormApi';
 import * as ContextFormGroup from './ContextFormGroup';
 
@@ -12,6 +13,8 @@ export const renderContextFormSliderInput = (
   providers: UiFactoryBackstageProviders,
   onEnter: (input: AlloyComponent) => Optional<boolean>
 ): SketchSpec => {
+  const editorOffCell = Cell(Fun.noop);
+
   const pLabel = ctx.label.map((label) => FormField.parts.label({
     dom: { tag: 'label', classes: [ 'tox-label' ] },
     components: [ GuiFactory.text(label) ]
@@ -49,9 +52,8 @@ export const renderContextFormSliderInput = (
         }
       }),
       AddEventsBehaviour.config('slider-events', [
-        AlloyEvents.runOnAttached((comp) => {
-          ctx.onSetup(ContextFormApi.getFormApi(comp));
-        }),
+        onControlAttached<InlineContent.ContextFormInstanceApi<number>>({ onSetup: ctx.onSetup, getApi: ContextFormApi.getFormApi }, editorOffCell),
+        onControlDetached({ getApi: ContextFormApi.getFormApi }, editorOffCell),
         AlloyEvents.run(NativeEvents.input(), (comp) => {
           ctx.onInput(ContextFormApi.getFormApi(comp));
         })

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
@@ -1,9 +1,10 @@
 import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Disabling, FormField, GuiFactory, Input, Keying, NativeEvents, SketchSpec } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
-import { Optional } from '@ephox/katamari';
+import { Cell, Fun, Optional } from '@ephox/katamari';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
+import { onControlAttached, onControlDetached } from '../controls/Controls';
 import * as ContextFormApi from './ContextFormApi';
 import * as ContextFormGroup from './ContextFormGroup';
 
@@ -12,6 +13,8 @@ export const renderContextFormTextInput = (
   providers: UiFactoryBackstageProviders,
   onEnter: (input: AlloyComponent) => Optional<boolean>
 ): SketchSpec => {
+  const editorOffCell = Cell(Fun.noop);
+
   const pLabel = ctx.label.map((label) => FormField.parts.label({
     dom: { tag: 'label', classes: [ 'tox-label' ] },
     components: [ GuiFactory.text(label) ]
@@ -43,9 +46,8 @@ export const renderContextFormTextInput = (
         }
       }),
       AddEventsBehaviour.config('input-events', [
-        AlloyEvents.runOnAttached((comp) => {
-          ctx.onSetup(ContextFormApi.getFormApi(comp));
-        }),
+        onControlAttached<InlineContent.ContextFormInstanceApi<string>>({ onSetup: ctx.onSetup, getApi: ContextFormApi.getFormApi }, editorOffCell),
+        onControlDetached({ getApi: ContextFormApi.getFormApi }, editorOffCell),
         AlloyEvents.run(NativeEvents.input(), (comp) => {
           ctx.onInput(ContextFormApi.getFormApi(comp));
         })

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
@@ -43,6 +43,9 @@ export const renderContextFormTextInput = (
         }
       }),
       AddEventsBehaviour.config('input-events', [
+        AlloyEvents.runOnAttached((comp) => {
+          ctx.onSetup(ContextFormApi.getFormApi(comp));
+        }),
         AlloyEvents.run(NativeEvents.input(), (comp) => {
           ctx.onInput(ContextFormApi.getFormApi(comp));
         })

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
@@ -20,6 +20,7 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
     height: '',
     onEnter: Optional.none(),
     onInput: Optional.none(),
-    onSetup: Optional.none()
+    onSetup: Optional.none(),
+    getApi: Optional.none()
   }, providersBackstage);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
@@ -19,6 +19,7 @@ export const renderSizeInput = (spec: SizeInputSpec, providersBackstage: UiFacto
     width: '',
     height: '',
     onEnter: Optional.none(),
-    onInput: Optional.none()
+    onInput: Optional.none(),
+    onSetup: Optional.none()
   }, providersBackstage);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInput.ts
@@ -8,12 +8,13 @@ import {
   Keying,
   NativeEvents, Representing, SketchSpec, Tabstopping, Tooltipping
 } from '@ephox/alloy';
-import { Id, Optional, Unicode } from '@ephox/katamari';
+import { Cell, Fun, Id, Optional, Optionals, Unicode } from '@ephox/katamari';
 
 import { formChangeEvent, formInputEvent } from 'tinymce/themes/silver/ui/general/FormEvents';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
+import { onControlAttached, onControlDetached } from '../controls/Controls';
 import * as Icons from '../icons/Icons';
 import { formatSize, makeRatioConverter, noSizeConversion, parseSize, SizeConversion } from '../sizeinput/SizeInputModel';
 
@@ -21,7 +22,7 @@ interface RatioEvent extends CustomEvent {
   readonly isField1: boolean;
 }
 
-export interface SizeInputGenericSpec {
+export interface SizeInputGenericSpec<ApiType = never> {
   readonly inDialog: boolean;
   readonly label: Optional<string>;
   readonly enabled: boolean;
@@ -31,10 +32,11 @@ export interface SizeInputGenericSpec {
   readonly height: string;
   readonly onEnter: Optional<(input: AlloyComponent) => Optional<boolean>>;
   readonly onInput: Optional<(input: AlloyComponent) => void>;
-  readonly onSetup: Optional<(input: AlloyComponent) => void>;
+  readonly onSetup: Optional<(api: ApiType) => (api: ApiType) => void>;
+  readonly getApi: Optional<(input: AlloyComponent) => ApiType>;
 }
 
-export const renderSizeInput = (spec: SizeInputGenericSpec, providersBackstage: UiFactoryBackstageProviders): SketchSpec => {
+export const renderSizeInput = <ApiType = never>(spec: SizeInputGenericSpec<ApiType>, providersBackstage: UiFactoryBackstageProviders): SketchSpec => {
   let converter: SizeConversion = noSizeConversion;
 
   const ratioEvent = Id.generate('ratio-event');
@@ -119,6 +121,13 @@ export const renderSizeInput = (spec: SizeInputGenericSpec, providersBackstage: 
     formGroup([ AlloyFormField.parts.label(getLabel('Height')), getFieldPart(false) ])
   );
 
+  const editorOffCell = Cell(Fun.noop);
+
+  const controlLifecycleHandlers = Optionals.lift2(spec.onSetup, spec.getApi, (onSetup, getApi) => [
+    onControlAttached<ApiType>( { onSetup, getApi }, editorOffCell),
+    onControlDetached<ApiType>( { getApi }, editorOffCell)
+  ]).getOr([]);
+
   return AlloyFormCoupledInputs.sketch({
     dom: {
       tag: 'div',
@@ -183,9 +192,7 @@ export const renderSizeInput = (spec: SizeInputGenericSpec, providersBackstage: 
         AlloyEvents.run(formInputEvent, (component) => {
           spec.onInput.each((onInput) => onInput(component));
         }),
-        AlloyEvents.runOnAttached((component) => {
-          spec.onSetup.each((onSetup) => onSetup(component));
-        }),
+        ...controlLifecycleHandlers,
       ])
     ])
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizeinput/SizeInput.ts
@@ -31,6 +31,7 @@ export interface SizeInputGenericSpec {
   readonly height: string;
   readonly onEnter: Optional<(input: AlloyComponent) => Optional<boolean>>;
   readonly onInput: Optional<(input: AlloyComponent) => void>;
+  readonly onSetup: Optional<(input: AlloyComponent) => void>;
 }
 
 export const renderSizeInput = (spec: SizeInputGenericSpec, providersBackstage: UiFactoryBackstageProviders): SketchSpec => {
@@ -181,7 +182,10 @@ export const renderSizeInput = (spec: SizeInputGenericSpec, providersBackstage: 
         }),
         AlloyEvents.run(formInputEvent, (component) => {
           spec.onInput.each((onInput) => onInput(component));
-        })
+        }),
+        AlloyEvents.runOnAttached((component) => {
+          spec.onSetup.each((onSetup) => onSetup(component));
+        }),
       ])
     ])
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -33,6 +33,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
             };
           }
         },
+        onSetup: (_) => store.add('setup'),
         onInput: (formApi) => store.add(`input.${formApi.getValue()}`),
         predicate: (node) => node.nodeName.toLowerCase() === 'a',
         commands: [
@@ -186,7 +187,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     await FocusTools.pTryOnSelector('Focus should go back to input in context form', doc, 'input');
     FocusTools.setActiveValue(doc, 'Words');
     TinyUiActions.keydown(editor, Keys.enter());
-    store.assertEq('B should have fired because it is primary', [ 'B.Words' ]);
+    store.assertEq('B should have fired because it is primary', [ 'setup', 'B.Words' ]);
     hasDialog('Immediate context form should have an inner dialog class');
     TinyUiActions.keyup(editor, Keys.escape());
     // Check that the context popup still exists;
@@ -272,20 +273,30 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     await TinyUiActions.pWaitForUi(editor, '.tox-pop input:not(:disabled)');
   });
 
+  it('TINY-11494: Opening contex form should trigger onSetup', () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+    Waiter.pTryUntil(
+      'Toolbar should be opened',
+      () => UiFinder.exists(SugarBody.body(), '.tox-pop input')
+    );
+    store.assertEq('Opening contex slider form should trigger onSetup', [ 'setup' ]);
+  });
+
   it('TINY-11342: Input event should trigger onInput', () => {
     const editor = hook.editor();
     openToolbar(editor, 'test-form');
     const input = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), '.tox-pop input').getOrDie();
     Value.set(input, 'Hello');
     input.dom.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
-    store.assertEq('Input should trigger onInput', [ 'input.Hello' ]);
+    store.assertEq('Input should trigger onInput', [ 'setup', 'input.Hello' ]);
   });
 
   it('TINY-11342: Should be able to get value after the context form has been hidden', async () => {
     const editor = hook.editor();
     openToolbar(editor, 'test-form');
     TinyUiActions.clickOnUi(editor, 'button[aria-label="D"]');
-    store.assertEq('D should have fired', [ 'D.before-hide', 'D.after-hide' ]);
+    store.assertEq('D should have fired', [ 'setup', 'D.before-hide', 'D.after-hide' ]);
   });
 
   it('TINY-11432: Should trigger ContextFormSlideBack on escape key in context form', async () => {
@@ -302,7 +313,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     TinyUiActions.keystroke(editor, Keys.escape());
     await FocusTools.pTryOnSelector('Focus should now be back on button in context toolbar', doc, '.tox-pop button');
 
-    store.assertEq('Should have triggered ContextFormSlideBack', [ 'contextformslideback' ]);
+    store.assertEq('Should have triggered ContextFormSlideBack', [ 'setup', 'contextformslideback' ]);
 
     editor.off('ContextFormSlideBack', collectEvent);
   });
@@ -321,7 +332,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     TinyUiActions.clickOnUi(editor, 'button[aria-label="F"]');
     await FocusTools.pTryOnSelector('Focus should now be back on button in context toolbar', doc, '.tox-pop button');
 
-    store.assertEq('Should have triggered ContextFormSlideBack', [ 'contextformslideback' ]);
+    store.assertEq('Should have triggered ContextFormSlideBack', [ 'setup', 'contextformslideback' ]);
 
     editor.off('ContextFormSlideBack', collectEvent);
   });
@@ -339,7 +350,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     await FocusTools.pTryOnSelector('Focus should now be on input in context form', doc, 'input');
     TinyUiActions.clickOnUi(editor, 'button[aria-label="D"]');
 
-    store.assertEq('Should have triggered ContextToolbarClose', [ 'contexttoolbarclose', 'D.before-hide', 'D.after-hide' ]);
+    store.assertEq('Should have triggered ContextToolbarClose', [ 'setup', 'contexttoolbarclose', 'D.before-hide', 'D.after-hide' ]);
 
     editor.off('ContextToolbarClose', collectEvent);
   });
@@ -361,7 +372,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     TinyContentActions.trueClick(editor);
 
     await Waiter.pTryUntil('Watied to context toolbar to close', () => {
-      store.assertEq('Should have triggered ContextToolbarClose', [ 'contexttoolbarclose' ]);
+      store.assertEq('Should have triggered ContextToolbarClose', [ 'setup', 'contexttoolbarclose' ]);
     });
 
     editor.off('ContextToolbarClose', collectEvent);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -35,7 +35,9 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
         },
         onSetup: (_) => {
           store.add('setup');
-          return Fun.noop;
+          return () => {
+            store.add('teardown');
+          };
         },
         onInput: (formApi) => store.add(`input.${formApi.getValue()}`),
         predicate: (node) => node.nodeName.toLowerCase() === 'a',
@@ -128,12 +130,13 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
   afterEach(async () => {
     const editor = hook.editor();
 
-    store.clear();
     editor.focus();
 
     // Simulate clicking elsewhere in the editor
     clickAway(editor);
     await pAssertNoPopDialog();
+
+    store.clear();
   });
 
   const openToolbar = (editor: Editor, toolbarKey: string) => {
@@ -299,7 +302,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     const editor = hook.editor();
     openToolbar(editor, 'test-form');
     TinyUiActions.clickOnUi(editor, 'button[aria-label="D"]');
-    store.assertEq('D should have fired', [ 'setup', 'D.before-hide', 'D.after-hide' ]);
+    store.assertEq('D should have fired', [ 'setup', 'teardown', 'D.before-hide', 'D.after-hide' ]);
   });
 
   it('TINY-11432: Should trigger ContextFormSlideBack on escape key in context form', async () => {
@@ -316,7 +319,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     TinyUiActions.keystroke(editor, Keys.escape());
     await FocusTools.pTryOnSelector('Focus should now be back on button in context toolbar', doc, '.tox-pop button');
 
-    store.assertEq('Should have triggered ContextFormSlideBack', [ 'setup', 'contextformslideback' ]);
+    store.assertEq('Should have triggered ContextFormSlideBack', [ 'setup', 'contextformslideback', 'teardown' ]);
 
     editor.off('ContextFormSlideBack', collectEvent);
   });
@@ -335,7 +338,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     TinyUiActions.clickOnUi(editor, 'button[aria-label="F"]');
     await FocusTools.pTryOnSelector('Focus should now be back on button in context toolbar', doc, '.tox-pop button');
 
-    store.assertEq('Should have triggered ContextFormSlideBack', [ 'setup', 'contextformslideback' ]);
+    store.assertEq('Should have triggered ContextFormSlideBack', [ 'setup', 'contextformslideback', 'teardown' ]);
 
     editor.off('ContextFormSlideBack', collectEvent);
   });
@@ -353,7 +356,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     await FocusTools.pTryOnSelector('Focus should now be on input in context form', doc, 'input');
     TinyUiActions.clickOnUi(editor, 'button[aria-label="D"]');
 
-    store.assertEq('Should have triggered ContextToolbarClose', [ 'setup', 'contexttoolbarclose', 'D.before-hide', 'D.after-hide' ]);
+    store.assertEq('Should have triggered ContextToolbarClose', [ 'setup', 'teardown', 'contexttoolbarclose', 'D.before-hide', 'D.after-hide' ]);
 
     editor.off('ContextToolbarClose', collectEvent);
   });
@@ -375,7 +378,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     TinyContentActions.trueClick(editor);
 
     await Waiter.pTryUntil('Watied to context toolbar to close', () => {
-      store.assertEq('Should have triggered ContextToolbarClose', [ 'setup', 'contexttoolbarclose' ]);
+      store.assertEq('Should have triggered ContextToolbarClose', [ 'setup', 'teardown', 'contexttoolbarclose' ]);
     });
 
     editor.off('ContextToolbarClose', collectEvent);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -33,7 +33,10 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
             };
           }
         },
-        onSetup: (_) => store.add('setup'),
+        onSetup: (_) => {
+          store.add('setup');
+          return Fun.noop;
+        },
         onInput: (formApi) => store.add(`input.${formApi.getValue()}`),
         predicate: (node) => node.nodeName.toLowerCase() === 'a',
         commands: [
@@ -273,7 +276,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     await TinyUiActions.pWaitForUi(editor, '.tox-pop input:not(:disabled)');
   });
 
-  it('TINY-11494: Opening contex form should trigger onSetup', () => {
+  it('TINY-11494: Opening context form should trigger onSetup', () => {
     const editor = hook.editor();
     openToolbar(editor, 'test-form');
     Waiter.pTryUntil(

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -279,10 +279,10 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     await TinyUiActions.pWaitForUi(editor, '.tox-pop input:not(:disabled)');
   });
 
-  it('TINY-11494: Opening context form should trigger onSetup', () => {
+  it('TINY-11494: Opening context form should trigger onSetup', async () => {
     const editor = hook.editor();
     openToolbar(editor, 'test-form');
-    Waiter.pTryUntil(
+    await Waiter.pTryUntil(
       'Toolbar should be opened',
       () => UiFinder.exists(SugarBody.body(), '.tox-pop input')
     );

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
@@ -27,6 +27,7 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
           tooltip: 'ABC'
         },
         initValue: Fun.constant({ width: '100', height: '200' }),
+        onSetup: (_) => store.add('setup'),
         onInput: (formApi) => store.add(`input.${JSON.stringify(formApi.getValue())}`),
         commands: [
           {
@@ -155,7 +156,17 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
     Value.set(inputW, '200');
     inputW.dom.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
     inputW.dom.dispatchEvent(new Event('change', { bubbles: true, cancelable: true }));
-    store.assertEq('Input should trigger onInput', [ 'input.{"width":"200","height":"400"}' ]);
+    store.assertEq('Input should trigger onInput', [ 'setup', 'input.{"width":"200","height":"400"}' ]);
+  });
+
+  it('TINY-11494: Opening contex size input form should trigger onSetup', async () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+    Waiter.pTryUntil(
+      'Toolbar should be opened',
+      () => UiFinder.exists(SugarBody.body(), '.tox-pop .tox-context-form__group')
+    );
+    store.assertEq('Opening contex size input form should trigger onSetup', [ 'setup' ]);
   });
 
   it('TINY-11342: Clicking `A` button should update the values', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
@@ -165,7 +165,7 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
   it('TINY-11494: Opening context size input form should trigger onSetup', async () => {
     const editor = hook.editor();
     openToolbar(editor, 'test-form');
-    Waiter.pTryUntil(
+    await Waiter.pTryUntil(
       'Toolbar should be opened',
       () => UiFinder.exists(SugarBody.body(), '.tox-pop .tox-context-form__group')
     );

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
@@ -27,7 +27,10 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
           tooltip: 'ABC'
         },
         initValue: Fun.constant({ width: '100', height: '200' }),
-        onSetup: (_) => store.add('setup'),
+        onSetup: (_) => {
+          store.add('setup');
+          return Fun.noop;
+        },
         onInput: (formApi) => store.add(`input.${JSON.stringify(formApi.getValue())}`),
         commands: [
           {
@@ -159,7 +162,7 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
     store.assertEq('Input should trigger onInput', [ 'setup', 'input.{"width":"200","height":"400"}' ]);
   });
 
-  it('TINY-11494: Opening contex size input form should trigger onSetup', async () => {
+  it('TINY-11494: Opening context size input form should trigger onSetup', async () => {
     const editor = hook.editor();
     openToolbar(editor, 'test-form');
     Waiter.pTryUntil(

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
@@ -23,6 +23,7 @@ describe('browser.tinymce.themes.silver.editor.ContextSliderFormTest', () => {
         min: Fun.constant(-100),
         max: Fun.constant(100),
         initValue: Fun.constant(37),
+        onSetup: (_) => store.add('setup'),
         onInput: (formApi) => store.add(`input.${formApi.getValue()}(${typeof formApi.getValue()})`),
         commands: [
           {
@@ -121,7 +122,17 @@ describe('browser.tinymce.themes.silver.editor.ContextSliderFormTest', () => {
     const input = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), '.tox-pop input').getOrDie();
     Value.set(input, '42');
     input.dom.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
-    store.assertEq('Input should trigger onInput with the right value and type', [ 'input.42(number)' ]);
+    store.assertEq('Input should trigger onInput with the right value and type', [ 'setup', 'input.42(number)' ]);
+  });
+
+  it('TINY-11494: Opening contex slider form should trigger onSetup', async () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+    Waiter.pTryUntil(
+      'Toolbar should be opened',
+      () => UiFinder.exists(SugarBody.body(), '.tox-pop input')
+    );
+    store.assertEq('Opening contex slider form should trigger onSetup', [ 'setup' ]);
   });
 
   it('TINY-11342: Should have min/max attributes set', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
@@ -131,7 +131,7 @@ describe('browser.tinymce.themes.silver.editor.ContextSliderFormTest', () => {
   it('TINY-11494: Opening context slider form should trigger onSetup', async () => {
     const editor = hook.editor();
     openToolbar(editor, 'test-form');
-    Waiter.pTryUntil(
+    await Waiter.pTryUntil(
       'Toolbar should be opened',
       () => UiFinder.exists(SugarBody.body(), '.tox-pop input')
     );

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
@@ -23,7 +23,10 @@ describe('browser.tinymce.themes.silver.editor.ContextSliderFormTest', () => {
         min: Fun.constant(-100),
         max: Fun.constant(100),
         initValue: Fun.constant(37),
-        onSetup: (_) => store.add('setup'),
+        onSetup: (_) => {
+          store.add('setup');
+          return Fun.noop;
+        },
         onInput: (formApi) => store.add(`input.${formApi.getValue()}(${typeof formApi.getValue()})`),
         commands: [
           {
@@ -125,7 +128,7 @@ describe('browser.tinymce.themes.silver.editor.ContextSliderFormTest', () => {
     store.assertEq('Input should trigger onInput with the right value and type', [ 'setup', 'input.42(number)' ]);
   });
 
-  it('TINY-11494: Opening contex slider form should trigger onSetup', async () => {
+  it('TINY-11494: Opening context slider form should trigger onSetup', async () => {
     const editor = hook.editor();
     openToolbar(editor, 'test-form');
     Waiter.pTryUntil(

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
@@ -22,6 +22,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLook
     label: Optional.none(),
     launch: Optional.none(),
     onInput: Fun.noop,
+    onSetup: Fun.noop,
     commands: [{
       onAction: Fun.noop,
       original: {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
@@ -22,7 +22,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLook
     label: Optional.none(),
     launch: Optional.none(),
     onInput: Fun.noop,
-    onSetup: Fun.noop,
+    onSetup: () => Fun.noop,
     commands: [{
       onAction: Fun.noop,
       original: {


### PR DESCRIPTION
Related Ticket: TINY-11494

Description of Changes:
Added onSetup function to the context forms.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
