### PR TITLE
TINY-9548: Handle URL-encoded characters in base64 data decoding

### DIFF
--- a/.changes/unreleased/tinymce-TINY-9548-2024-11-08.yaml
+++ b/.changes/unreleased/tinymce-TINY-9548-2024-11-08.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Improved
+body: Base64 data was not being properly decoded due to unhandled URL-encoded characters.
+time: 2024-11-08T09:23:16.862556+10:00
+custom:
+  Issue: TINY-9548

--- a/.changes/unreleased/tinymce-TINY-9548-2024-11-08.yaml
+++ b/.changes/unreleased/tinymce-TINY-9548-2024-11-08.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Improved
-body: Base64 data was not being properly decoded due to unhandled URL-encoded characters.
+body: Base64 data was not properly decoded due to unhandled URL-encoded characters.
 time: 2024-11-08T09:23:16.862556+10:00
 custom:
   Issue: TINY-9548

--- a/modules/tinymce/src/core/main/ts/file/Conversions.ts
+++ b/modules/tinymce/src/core/main/ts/file/Conversions.ts
@@ -22,8 +22,7 @@ const blobUriToBlob = (url: string): Promise<Blob> =>
     }));
 
 const extractBase64Data = (data: string): string => {
-  const whitespaceRemovedData = data.replace(/\s+/g, '');
-  const matches = /([a-z0-9+\/=\s]+)/i.exec(whitespaceRemovedData);
+  const matches = /([a-z0-9+\/=\s]+)/i.exec(data);
   return matches ? matches[1] : '';
 };
 

--- a/modules/tinymce/src/core/main/ts/file/Conversions.ts
+++ b/modules/tinymce/src/core/main/ts/file/Conversions.ts
@@ -22,8 +22,17 @@ const blobUriToBlob = (url: string): Promise<Blob> =>
     }));
 
 const extractBase64Data = (data: string): string => {
-  const matches = /([a-z0-9+\/=\s]+)/i.exec(data);
+  const whitespaceRemovedData = data.replace(/\s+/g, '');
+  const matches = /([a-z0-9+\/=\s]+)/i.exec(whitespaceRemovedData);
   return matches ? matches[1] : '';
+};
+
+const decodeData = (data: string): string => {
+  try {
+    return decodeURIComponent(data);
+  } catch {
+    return data;
+  }
 };
 
 const parseDataUri = (uri: string): Optional<DataUriResult> => {
@@ -33,7 +42,8 @@ const parseDataUri = (uri: string): Optional<DataUriResult> => {
   const matches = /data:([^/]+\/[^;]+)(;.+)?/.exec(type);
   if (matches) {
     const base64Encoded = matches[2] === ';base64';
-    const extractedData = base64Encoded ? extractBase64Data(data) : decodeURIComponent(data);
+    const decodedData = decodeData(data);
+    const extractedData = base64Encoded ? extractBase64Data(decodedData) : decodedData;
     return Optional.some({
       type: matches[1],
       data: extractedData,

--- a/modules/tinymce/src/core/test/ts/browser/file/ConversionsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/file/ConversionsTest.ts
@@ -6,12 +6,10 @@ import * as Conversions from 'tinymce/core/file/Conversions';
 describe('browser.tinymce.core.file.ConversionsTest', () => {
   const invalidBlobUriSrc = 'blob:70BE8432-BA4D-4787-9AB9-86563351FBF7';
 
-  it('uriToBlob', () => {
-    return Conversions.uriToBlob('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D')
-      .then(Conversions.blobToDataUri)
-      .then((dataUri) => {
-        assert.equal(dataUri, 'data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==');
-      });
+  it('uriToBlob', async () => {
+    const blob = await Conversions.uriToBlob('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D');
+    const dataUri = await Conversions.blobToDataUri(blob);
+    assert.equal(dataUri, 'data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==');
   });
 
   it('uriToBlob with invalid src', () => {
@@ -21,5 +19,28 @@ describe('browser.tinymce.core.file.ConversionsTest', () => {
       assert.typeOf(error, 'object');
       assert.include(error.message, invalidBlobUriSrc);
     });
+  });
+
+  it('TINY-9548: should handle line feed carriage return characters in base64 data', async () => {
+    const lfcrCharacters = '%0D%0A';
+    const base64DataWithCrlf = `SGVsbG8sIFdvcmxkIQ${lfcrCharacters}==`;
+    const blob = await Conversions.uriToBlob(`data:text/plain;base64,${base64DataWithCrlf}`);
+    const dataUri = await Conversions.blobToDataUri(blob);
+    assert.equal(dataUri, 'data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==');
+  });
+
+  it('TINY-9548: should handle space characters in base64 data', async () => {
+    const spaceCharacters = '%20%20';
+    const base64DataWithSpaces = `SGVsbG8sIFdvcmxkIQ${spaceCharacters}==`;
+    const blob = await Conversions.uriToBlob(`data:text/plain;base64,${base64DataWithSpaces}`);
+    const dataUri = await Conversions.blobToDataUri(blob);
+    assert.equal(dataUri, 'data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==');
+  });
+
+  it('TINY-9548: should handle already decoded base64 data', async () => {
+    const alreadyDecodedData = 'SGVsbG8sIFdvcmxkIQ==';
+    const blob = await Conversions.uriToBlob(`data:text/plain;base64,${alreadyDecodedData}`);
+    const dataUri = await Conversions.blobToDataUri(blob);
+    assert.equal(dataUri, 'data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==');
   });
 });


### PR DESCRIPTION
Related Ticket: [TINY-9548](https://ephocks.atlassian.net/browse/TINY-9548)

Description of Changes:
Updated the way we are handling URL-encoded characters in base64 data by decoding them before processing.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* ~[x] Docs ticket created (if applicable)~

GitHub issues (if applicable): [#8400](https://github.com/tinymce/tinymce/issues/8400)


[TINY-9548]: https://ephocks.atlassian.net/browse/TINY-9548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ