### PR TITLE
Fix placeholder not disappearing when typing special chars

### DIFF
--- a/modules/tinymce/src/core/main/ts/content/Placeholder.ts
+++ b/modules/tinymce/src/core/main/ts/content/Placeholder.ts
@@ -17,7 +17,7 @@ const nonTypingKeycodes = [
   // page up/down, insert
   33, 34, 45,
   // alt, shift, ctrl
-  16, 17, 18,
+  16, 17,
   // meta/windows key
   91, 92, 93,
   // direction
@@ -40,8 +40,8 @@ const isDeleteEvent = (e: EditorEvent<KeyboardEvent>): boolean => {
 const isNonTypingKeyboardEvent = (e: EditorEvent<unknown>): boolean => {
   if (isKeyboardEvent(e)) {
     const keyCode = e.keyCode;
-    // Ctrl/Meta/Alt key pressed, F1-12 or non typing keycode
-    return !isDeleteEvent(e) && (VK.metaKeyPressed(e) || e.altKey || keyCode >= 112 && keyCode <= 123 || Arr.contains(nonTypingKeycodes, keyCode));
+    // Ctrl/Meta key pressed, F1-12 or non typing keycode
+    return !isDeleteEvent(e) && (VK.metaKeyPressed(e) || keyCode >= 112 && keyCode <= 123 || Arr.contains(nonTypingKeycodes, keyCode));
   } else {
     return false;
   }
@@ -75,10 +75,6 @@ const setup = (editor: Editor): void => {
   const placeholder = Options.getPlaceholder(editor) ?? '';
 
   const updatePlaceholder = (e: EditorEvent<unknown>, initial?: boolean) => {
-    if (isNonTypingKeyboardEvent(e)) {
-      return;
-    }
-
     // Check to see if we should show the placeholder
     const body = editor.getBody();
     const showPlaceholder = isTypingKeyboardEvent(e) ? false : isVisuallyEmpty(dom, body, rootBlock);

--- a/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts
@@ -131,4 +131,15 @@ describe('webdriver.tinymce.core.content.PlaceholderTest', () => {
     await pAssertPlaceholderNotExists(editor);
     assertCount(1);
   });
+
+  it('TINY-XXXX: Check placeholder hides when typing special characters with Alt key', async () => {
+    const editor = hook.editor();
+    setContent(editor, '<p></p>');
+    await pAssertPlaceholderExists(editor);
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.combo({ alt: true }, '@') ]);
+    await pAssertPlaceholderNotExists(editor);
+    await RealKeys.pSendKeysOn('iframe => body => p', [ RealKeys.backspace() ]);
+    await pAssertPlaceholderExists(editor);
+    assertCount(2);
+  });
 });


### PR DESCRIPTION
Fixes #9873

Fix the placeholder not disappearing when typing special characters on an Italian keyboard layout.

* Update `isNonTypingKeyboardEvent` function in `modules/tinymce/src/core/main/ts/content/Placeholder.ts` to treat events with `Alt` key pressed as typing events.
* Remove the check for non-typing events in the `updatePlaceholder` function in `modules/tinymce/src/core/main/ts/content/Placeholder.ts` to always update the placeholder.
* Add a test case in `modules/tinymce/src/core/test/ts/webdriver/content/PlaceholderTest.ts` to check that the placeholder disappears when typing special characters with the `Alt` key.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tinymce/tinymce/pull/9985?shareId=9217b320-51a4-48b5-9017-dab476ff8aed).