### PR TITLE
TINY-11520: Update version `6.8.*` as unsupported in `SECURITY.md`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ Tiny Technologies, Inc. supports the following community versions of TinyMCE:
 | Version | Supported                      |
 |---------| ------------------------------ |
 | 7.4.x   | &#10004;                       |
-| 6.8.x   | &#10004;                       |
+| 6.8.x   | &#10006;                       |
 | 5.10.x  | &#10006;                       |
 | Other   | &#10006;                       |
 


### PR DESCRIPTION
Related Ticket: [TINY-11520](https://ephocks.atlassian.net/browse/TINY-11520)

Description of Changes:
Mark version `6.8.*` in the `SECURITY.md` file as unsupported.

Pre-checks:
* ~[ ] Changelog entry added~
* ~[ ] Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* ~[ ] Docs ticket created (if applicable)~

GitHub issues (if applicable):
