### PR TITLE
TINY-11488: Added new option to disable the editor

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11488-2024-11-11.yaml
+++ b/.changes/unreleased/tinymce-TINY-11488-2024-11-11.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Added
+body: New `disabled` option to restore the previous `readonly` mode behavior, allowing
+  the editor to be displayed in a disabled state.
+time: 2024-11-11T22:35:34.883095+08:00
+custom:
+  Issue: TINY-11488

--- a/modules/tinymce/src/core/demo/html/disabled_demo.html
+++ b/modules/tinymce/src/core/demo/html/disabled_demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Disabled demo Demo Page</title>
+  </head>
+
+  <body>
+  <h2>Disabled demo Page</h2>
+    <div id="ephox-ui">
+      <div class="tinymce">
+    <div>
+      <h1>Welcome to Your Project!</h1>
+      <p>This is a sample paragraph to showcase <strong>editable</strong> and <strong>non-editable</strong> elements in TinyMCE.</p>
+
+      <h2>About the Project</h2>
+      <p>
+        This project is a demonstration of how to use various elements within TinyMCE. You can add images, tables, and editable text.
+        TinyMCE is a robust WYSIWYG editor that allows for rich content editing and formatting.
+      </p>
+
+      <h2>Sample Table</h2>
+      <table border="1" cellpadding="10" cellspacing="0" style="width: 100%; margin: 10px 0;">
+        <thead>
+          <tr>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Row 1, Cell 1</td>
+            <td contenteditable="false">Row 1, Cell 2 (Non-Editable)</td>
+            <td>Row 1, Cell 3</td>
+          </tr>
+          <tr>
+            <td>Row 2, Cell 1</td>
+            <td>Row 2, Cell 2</td>
+            <td>Row 2, Cell 3</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Image Section</h2>
+      <p>Below is a sample image that can be resized and styled within TinyMCE.</p>
+      <img src="https://placehold.co/600x400" alt="Placeholder Image" style="display: block; margin: 10px auto; width: 600px;">
+
+      <h2>Conclusion</h2>
+      <p>Thank you for exploring this demo. You can <em>edit</em>, <strong>format</strong>, and <u>style</u> all the elements as needed!</p>
+    </div>
+      </div>
+    </div>
+
+    <script src="../../../../js/tinymce/tinymce.js"></script>
+    <script src="../../../../scratch/demos/core/demo.js"></script>
+    <script>demos.DisabledDemo();</script>
+
+  </body>
+</html>

--- a/modules/tinymce/src/core/demo/ts/demo/Demos.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/Demos.ts
@@ -2,6 +2,7 @@ import AnnotationsDemo from './AnnotationsDemo';
 import CommandsDemo from './CommandsDemo';
 import ContentEditableFalseDemo from './ContentEditableFalseDemo';
 import CustomThemeDemo from './CustomThemeDemo';
+import DisabledDemo from './DisabledDemo';
 import FixedToolbarContainerDemo from './FixedToolbarContainerDemo';
 import FullDemo from './FullDemo';
 import IframeDemo from './IframeDemo';
@@ -21,6 +22,7 @@ window.demos = {
   CommandsDemo,
   ContentEditableFalseDemo,
   CustomThemeDemo,
+  DisabledDemo,
   IframeDemo,
   InlineDemo,
   FixedToolbarContainerDemo,

--- a/modules/tinymce/src/core/demo/ts/demo/DisabledDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/DisabledDemo.ts
@@ -1,0 +1,42 @@
+import { DomEvent, Html, Insert, SelectorFind, SugarBody, SugarElement, TextContent } from '@ephox/sugar';
+
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
+
+export default (): void => {
+  const container = SelectorFind.descendant(SugarBody.body(), '#ephox-ui').getOrDie();
+
+  const statusDiv = SugarElement.fromTag('p');
+  Insert.before(container, statusDiv);
+
+  const toggleModeBtn = SugarElement.fromTag('button');
+  Html.set(toggleModeBtn, 'Toggle readonly mode');
+  DomEvent.bind(toggleModeBtn, 'click', () => {
+    tinymce.activeEditor?.mode.set(tinymce.activeEditor.mode.get() === 'readonly' ? 'design' : 'readonly');
+    TextContent.set(statusDiv, `Mode: ${tinymce.activeEditor?.mode.get()}, Disabled: ${tinymce.activeEditor?.options.get('disabled')}`);
+  });
+  Insert.before(container, toggleModeBtn);
+
+  const toggleDisabledBtn = SugarElement.fromTag('button');
+  Html.set(toggleDisabledBtn, 'Toggle disabled mode');
+  DomEvent.bind(toggleDisabledBtn, 'click', () => {
+    tinymce.activeEditor?.options.set('disabled', !tinymce.activeEditor.options.get('disabled'));
+    TextContent.set(statusDiv, `Mode: ${tinymce.activeEditor?.mode.get()}, Disabled: ${tinymce.activeEditor?.options.get('disabled')}`);
+  });
+  Insert.before(container, toggleDisabledBtn);
+
+  tinymce.init({
+    skin_url: '../../../../js/tinymce/skins/ui/oxide',
+    selector: 'div.tinymce',
+    height: 1000,
+    plugins: 'accordion image table emoticons charmap codesample insertdatetime',
+    // eslint-disable-next-line max-len
+    toolbar: 'bold italic underline strikethrough subscript superscript accordion addtemplate inserttemplate| fontfamily fontsize fontsizeinput | numlist bullist checklist mergetags footnotes footnotesupdate| typography permanentpen formatpainter removeformat forecolor backcolor | blockquote nonbreaking hr pagebreak | casechange styles blocks lineheight | ltr rtl outdent indent | align alignleft aligncenter alignright alignjustify alignnone | h1 h2 h3 h4 h5 h6 h7 | copy cut paste pastetext selectall remove newdocument wordcount searchreplace | undo redo | save cancel restoredraft | fullscreen print preview export code help | template insertdatetime codesample emoticons charmap | anchor link unlink image media pageembed insertfile | visualblocks visualchars | table advtablerownumbering tableclass tablecellclass tablecellvalign tablecellborderwidth tablecellborderstyle tablecaption tablecellbackgroundcolor tablecellbordercolor tablerowheader tablecolheader',
+    setup: (ed) => {
+      ed.on('init', () => {
+        TextContent.set(statusDiv, `Mode: ${ed.mode.get()}, Disabled: ${ed.options.get('disabled')}`);
+      });
+    }
+  });
+};

--- a/modules/tinymce/src/core/main/ts/NodeChange.ts
+++ b/modules/tinymce/src/core/main/ts/NodeChange.ts
@@ -98,7 +98,7 @@ class NodeChange {
     let node: Element | undefined;
 
     // Fix for bug #1896577 it seems that this can not be fired while the editor is loading
-    if (editor.initialized && selection && !Options.shouldDisableNodeChange(editor)) {
+    if (editor.initialized && selection && !Options.shouldDisableNodeChange(editor) && !editor.disabled) {
       // Get start node
       const root = editor.getBody();
       node = selection.getStart(true) || root;

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -206,6 +206,7 @@ class Editor implements EditorObservable {
   public contentAreaContainer!: HTMLElement;
   public contentDocument!: Document;
   public contentWindow!: Window;
+  public disabled: boolean = false;
   public delegates: Record<string, EventUtilsCallback<any>> | undefined;
   public destroyed: boolean = false;
   public dom!: DOMUtils;

--- a/modules/tinymce/src/core/main/ts/api/EditorObservable.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorObservable.ts
@@ -1,6 +1,6 @@
 import { Obj } from '@ephox/katamari';
 
-import { isReadOnly, processReadonlyEvents } from '../mode/Readonly';
+import * as Disabled from '../mode/Disabled';
 import DOMUtils from './dom/DOMUtils';
 import { EventUtilsCallback } from './dom/EventUtils';
 import Editor from './Editor';
@@ -55,12 +55,12 @@ const getEventTarget = (editor: Editor, eventName: string): Node => {
   return editor.getBody();
 };
 
-const isListening = (editor: Editor) => !editor.hidden;
+const isListening = (editor: Editor) => !editor.hidden && !editor.disabled;
 const fireEvent = (editor: Editor, eventName: string, e: Event) => {
   if (isListening(editor)) {
     editor.dispatch(eventName, e);
-  } else if (isReadOnly(editor)) {
-    processReadonlyEvents(editor, e);
+  } else if (Disabled.isDisabled(editor)) {
+    Disabled.processDisabledEvents(editor, e);
   }
 };
 

--- a/modules/tinymce/src/core/main/ts/api/EventTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/EventTypes.ts
@@ -173,6 +173,10 @@ export interface OpenNotificationEvent {
   notification: NotificationApi;
 }
 
+export interface DisabledStateChangeEvent {
+  state: boolean;
+}
+
 export interface EditorEventMap extends Omit<NativeEventMap, 'blur' | 'focus'> {
   'activate': { relatedTarget: Editor | null };
   'deactivate': { relatedTarget: Editor };

--- a/modules/tinymce/src/core/main/ts/api/Events.ts
+++ b/modules/tinymce/src/core/main/ts/api/Events.ts
@@ -4,7 +4,7 @@ import { RangeLikeObject } from '../selection/RangeTypes';
 import Editor from './Editor';
 import {
   BeforeSetContentEvent, SetContentEvent, PastePlainTextToggleEvent, PastePostProcessEvent, PastePreProcessEvent, GetContentEvent, BeforeGetContentEvent,
-  PreProcessEvent, PostProcessEvent, EditableRootStateChangeEvent
+  PreProcessEvent, PostProcessEvent, EditableRootStateChangeEvent, DisabledStateChangeEvent
 } from './EventTypes';
 import { ParserArgs } from './html/DomParser';
 import { EditorEvent } from './util/EventDispatcher';
@@ -103,6 +103,9 @@ const firePastePlainTextToggle = (editor: Editor, state: boolean): EditorEvent<P
 const fireEditableRootStateChange = (editor: Editor, state: boolean): EditorEvent<EditableRootStateChangeEvent> =>
   editor.dispatch('EditableRootStateChange', { state });
 
+const fireDisabledStateChange = (editor: Editor, state: boolean): EditorEvent<DisabledStateChangeEvent> =>
+  editor.dispatch('DisabledStateChange', { state });
+
 export {
   firePreProcess,
   firePostProcess,
@@ -129,5 +132,6 @@ export {
   firePastePlainTextToggle,
   firePastePostProcess,
   firePastePreProcess,
-  fireEditableRootStateChange
+  fireEditableRootStateChange,
+  fireDisabledStateChange
 };

--- a/modules/tinymce/src/core/main/ts/api/Mode.ts
+++ b/modules/tinymce/src/core/main/ts/api/Mode.ts
@@ -1,7 +1,7 @@
 import { Cell, Fun } from '@ephox/katamari';
 
 import { registerMode, setMode } from '../mode/Mode';
-import { isReadOnly, registerReadOnlySelectionBlockers } from '../mode/Readonly';
+import { isReadOnly, registerReadOnlyInputBlockers } from '../mode/Readonly';
 import Editor from './Editor';
 
 /**
@@ -83,7 +83,7 @@ export const create = (editor: Editor): EditorMode => {
     }
   });
 
-  registerReadOnlySelectionBlockers(editor);
+  registerReadOnlyInputBlockers(editor);
 
   return {
     isReadOnly: () => isReadOnly(editor),

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -247,6 +247,7 @@ interface BaseEditorOptions {
   width?: number | string;
   xss_sanitization?: boolean;
   license_key?: string;
+  disabled?: boolean;
 
   // Internal settings (used by cloud or tests)
   disable_nodechange?: boolean;
@@ -353,4 +354,5 @@ export interface EditorOptions extends NormalizedEditorOptions {
   visual_table_class: string;
   width: number | string;
   xss_sanitization: boolean;
+  disabled: boolean;
 }

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -5,6 +5,7 @@ import * as Pattern from '../textpatterns/core/Pattern';
 import * as PatternTypes from '../textpatterns/core/PatternTypes';
 import DOMUtils from './dom/DOMUtils';
 import Editor from './Editor';
+import { fireDisabledStateChange } from './Events';
 import { EditorOptions } from './OptionTypes';
 import I18n from './util/I18n';
 import Tools from './util/Tools';
@@ -434,6 +435,20 @@ const register = (editor: Editor): void => {
 
   registerOption('disable_nodechange', {
     processor: 'boolean',
+    default: false
+  });
+
+  registerOption('disabled', {
+    processor: (value) => {
+      if (Type.isBoolean(value)) {
+        if (editor.disabled !== value) {
+          fireDisabledStateChange(editor, value);
+        }
+        return { valid: true, value };
+      }
+
+      return { valid: false, message: 'The value must be a boolean.' };
+    },
     default: false
   });
 
@@ -988,6 +1003,7 @@ const getSandboxIframesExclusions = (editor: Editor): string[] => editor.options
 const shouldConvertUnsafeEmbeds = option('convert_unsafe_embeds');
 const getLicenseKey = option('license_key');
 const getApiKey = option('api_key');
+const isDisabled = option('disabled');
 
 export {
   register,
@@ -1097,5 +1113,6 @@ export {
   getLicenseKey,
   getSandboxIframesExclusions,
   shouldConvertUnsafeEmbeds,
-  getApiKey
+  getApiKey,
+  isDisabled
 };

--- a/modules/tinymce/src/core/main/ts/init/Init.ts
+++ b/modules/tinymce/src/core/main/ts/init/Init.ts
@@ -160,7 +160,7 @@ const augmentEditorUiApi = (editor: Editor, api: Partial<EditorUiApi>) => {
     hide: Optional.from(api.hide).getOr(Fun.noop),
     isEnabled: Optional.from(api.isEnabled).getOr(Fun.always),
     setEnabled: (state) => {
-      const shouldSkip = state && editor.mode.get() === 'readonly';
+      const shouldSkip = state && (editor.mode.get() === 'readonly' || editor.disabled);
       if (!shouldSkip) {
         Optional.from(api.setEnabled).each((f) => f(state));
       }

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -27,6 +27,7 @@ import * as TouchEvents from '../events/TouchEvents';
 import * as ForceBlocks from '../ForceBlocks';
 import * as NonEditableFilter from '../html/NonEditableFilter';
 import * as KeyboardOverrides from '../keyboard/KeyboardOverrides';
+import * as Disabled from '../mode/Disabled';
 import { NodeChange } from '../NodeChange';
 import * as Paste from '../paste/Paste';
 import * as Rtc from '../Rtc';
@@ -253,6 +254,9 @@ const moveSelectionToFirstCaretPosition = (editor: Editor) => {
 
 const initEditor = (editor: Editor) => {
   editor.bindPendingEventDelegates();
+  if (editor.disabled) {
+    Disabled.toggleDisabled(editor, true);
+  }
   editor.initialized = true;
   Events.fireInit(editor);
   editor.focus(true);
@@ -263,6 +267,7 @@ const initEditor = (editor: Editor) => {
     initInstanceCallback.call(editor, editor);
   }
   autoFocus(editor);
+  Disabled.registerEventsAndFilters(editor);
 };
 
 const getStyleSheetLoader = (editor: Editor): StyleSheetLoader =>
@@ -420,9 +425,10 @@ const contentBodyLoaded = (editor: Editor): void => {
   // TODO: See if we actually need to disable/re-enable here
   (body as any).disabled = true;
   editor.readonly = Options.isReadOnly(editor);
+  editor.disabled = Options.isDisabled(editor);
   editor._editableRoot = Options.hasEditableRoot(editor);
 
-  if (editor.hasEditableRoot()) {
+  if (!editor.disabled && editor.hasEditableRoot()) {
     if (editor.inline && DOM.getStyle(body, 'position', true) === 'static') {
       body.style.position = 'relative';
     }

--- a/modules/tinymce/src/core/main/ts/mode/Disabled.ts
+++ b/modules/tinymce/src/core/main/ts/mode/Disabled.ts
@@ -1,0 +1,144 @@
+import { Arr, Optional, Strings } from '@ephox/katamari';
+import { Attribute, Compare, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
+
+import Editor from '../api/Editor';
+import VK from '../api/util/VK';
+import * as ModeUtils from '../util/ModeUtils';
+
+const isDisabled = (editor: Editor): boolean => editor.disabled;
+
+const internalContentEditableAttr = 'data-mce-contenteditable';
+
+const setContentEditable = (elm: SugarElement<HTMLElement>, state: boolean) => {
+  elm.dom.contentEditable = state ? 'true' : 'false';
+};
+
+const switchOffContentEditableTrue = (elm: SugarElement<Node>) => {
+  Arr.each(SelectorFilter.descendants<HTMLElement>(elm, '*[contenteditable="true"]'), (elm) => {
+    Attribute.set(elm, internalContentEditableAttr, 'true');
+    setContentEditable(elm, false);
+  });
+};
+
+const switchOnContentEditableTrue = (elm: SugarElement<Node>) => {
+  Arr.each(SelectorFilter.descendants<HTMLElement>(elm, `*[${internalContentEditableAttr}="true"]`), (elm) => {
+    Attribute.remove(elm, internalContentEditableAttr);
+    setContentEditable(elm, true);
+  });
+};
+
+const toggleDisabled = (editor: Editor, state: boolean): void => {
+  const body = SugarElement.fromDom(editor.getBody());
+
+  if (state) {
+    editor.disabled = true;
+    ModeUtils.disableEditor(editor);
+    setContentEditable(body, false);
+    switchOffContentEditableTrue(body);
+  } else {
+    editor.disabled = false;
+    switchOnContentEditableTrue(body);
+    ModeUtils.enableEditor(editor);
+  }
+};
+
+const registerDisabledContentFilters = (editor: Editor): void => {
+  if (editor.serializer) {
+    registerFilters(editor);
+  } else {
+    editor.on('PreInit', () => {
+      registerFilters(editor);
+    });
+  }
+};
+
+const registerFilters = (editor: Editor): void => {
+  editor.parser.addAttributeFilter('contenteditable', (nodes) => {
+    if (isDisabled(editor)) {
+      Arr.each(nodes, (node) => {
+        node.attr(internalContentEditableAttr, node.attr('contenteditable'));
+        node.attr('contenteditable', 'false');
+      });
+    }
+  });
+
+  editor.serializer.addAttributeFilter(internalContentEditableAttr, (nodes) => {
+    if (isDisabled(editor)) {
+      Arr.each(nodes, (node) => {
+        node.attr('contenteditable', node.attr(internalContentEditableAttr));
+      });
+    }
+  });
+
+  editor.serializer.addTempAttr(internalContentEditableAttr);
+};
+
+const isClickEvent = (e: Event): e is MouseEvent => e.type === 'click';
+
+const allowedEvents: ReadonlyArray<string> = [ 'copy' ];
+
+const isDisabledAllowedEvent = (e: Event) => Arr.contains(allowedEvents, e.type);
+
+const getAnchorHrefOpt = (editor: Editor, elm: SugarElement<Node>): Optional<string> => {
+  const isRoot = (elm: SugarElement<Node>) => Compare.eq(elm, SugarElement.fromDom(editor.getBody()));
+  return SelectorFind.closest<HTMLAnchorElement>(elm, 'a', isRoot).bind((a) => Attribute.getOpt(a, 'href'));
+};
+
+const processDisabledEvents = (editor: Editor, e: Event): void => {
+  /*
+    If an event is a click event on or within an anchor, and the CMD/CTRL key is
+    not held, then we want to prevent default behaviour and either:
+      a) scroll to the relevant bookmark
+      b) open the link using default browser behaviour
+  */
+  if (isClickEvent(e) && !VK.metaKeyPressed(e)) {
+    const elm = SugarElement.fromDom(e.target as Node);
+    getAnchorHrefOpt(editor, elm).each((href) => {
+      e.preventDefault();
+      if (/^#/.test(href)) {
+        const targetEl = editor.dom.select(`${href},[name="${Strings.removeLeading(href, '#')}"]`);
+        if (targetEl.length) {
+          editor.selection.scrollIntoView(targetEl[0], true);
+        }
+      } else {
+        window.open(href, '_blank', 'rel=noopener noreferrer,menubar=yes,toolbar=yes,location=yes,status=yes,resizable=yes,scrollbars=yes');
+      }
+    });
+  } else if (isDisabledAllowedEvent(e)) {
+    editor.dispatch(e.type, e);
+  }
+};
+
+const registerDisabledModeEventHandlers = (editor: Editor): void => {
+  editor.on('ShowCaret', (e) => {
+    if (isDisabled(editor)) {
+      e.preventDefault();
+    }
+  });
+
+  editor.on('ObjectSelected', (e) => {
+    if (isDisabled(editor)) {
+      e.preventDefault();
+    }
+  });
+
+  // Preprend to the handlers as this should be the first to fire
+  editor.on('DisabledStateChange', (e) => {
+    if (!e.isDefaultPrevented()) {
+      toggleDisabled(editor, e.state);
+    }
+  }, true);
+};
+
+const registerEventsAndFilters = (editor: Editor): void => {
+  registerDisabledContentFilters(editor);
+  registerDisabledModeEventHandlers(editor);
+};
+
+export {
+  isDisabled,
+  processDisabledEvents,
+  getAnchorHrefOpt,
+  toggleDisabled,
+  registerEventsAndFilters
+};

--- a/modules/tinymce/src/core/main/ts/mode/EditableRoot.ts
+++ b/modules/tinymce/src/core/main/ts/mode/EditableRoot.ts
@@ -5,8 +5,10 @@ export const setEditableRoot = (editor: Editor, state: boolean): void => {
   if (editor._editableRoot !== state) {
     editor._editableRoot = state;
 
-    editor.getBody().contentEditable = String(editor.hasEditableRoot());
-    editor.nodeChanged();
+    if (!editor.disabled) {
+      editor.getBody().contentEditable = String(editor.hasEditableRoot());
+      editor.nodeChanged();
+    }
 
     Events.fireEditableRootStateChange(editor, state);
   }

--- a/modules/tinymce/src/core/main/ts/mode/Mode.ts
+++ b/modules/tinymce/src/core/main/ts/mode/Mode.ts
@@ -28,7 +28,7 @@ const switchToMode = (editor: Editor, activeMode: Cell<string>, availableModes: 
 };
 
 const setMode = (editor: Editor, availableModes: Record<string, EditorModeApi>, activeMode: Cell<string>, mode: string): void => {
-  if (mode === activeMode.get()) {
+  if (mode === activeMode.get() || editor.disabled) {
     return;
   } else if (!Obj.has(availableModes, mode)) {
     throw new Error(`Editor mode '${mode}' is invalid`);

--- a/modules/tinymce/src/core/main/ts/mode/Readonly.ts
+++ b/modules/tinymce/src/core/main/ts/mode/Readonly.ts
@@ -1,125 +1,31 @@
-import { Arr, Optional, Strings, Type } from '@ephox/katamari';
-import { Attribute, Class, Compare, SelectorFind, SugarElement } from '@ephox/sugar';
+import { Type } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
-import VK from '../api/util/VK';
-import * as EditorFocus from '../focus/EditorFocus';
-
-// Not quite sugar Class.toggle, it's more of a Class.set
-const toggleClass = (elm: SugarElement<Element>, cls: string, state: boolean) => {
-  if (Class.has(elm, cls) && !state) {
-    Class.remove(elm, cls);
-  } else if (state) {
-    Class.add(elm, cls);
-  }
-};
-
-const setEditorCommandState = (editor: Editor, cmd: string, state: boolean) => {
-  try {
-    // execCommand needs a string for the value, so convert the boolean to a string
-    // See: https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#Parameters
-    editor.getDoc().execCommand(cmd, false, String(state));
-  } catch (ex) {
-    // Ignore
-  }
-};
+import * as ModeUtils from '../util/ModeUtils';
 
 const setContentEditable = (elm: SugarElement<HTMLElement>, state: boolean) => {
   elm.dom.contentEditable = state ? 'true' : 'false';
 };
 
-const removeFakeSelection = (editor: Editor) => {
-  Optional.from(editor.selection.getNode()).each((elm) => {
-    elm.removeAttribute('data-mce-selected');
-  });
-};
-
-const restoreFakeSelection = (editor: Editor) => {
-  editor.selection.setRng(editor.selection.getRng());
-};
-
-const setCommonEditorCommands = (editor: Editor, state: boolean): void => {
-  setEditorCommandState(editor, 'StyleWithCSS', state);
-  setEditorCommandState(editor, 'enableInlineTableEditing', state);
-  setEditorCommandState(editor, 'enableObjectResizing', state);
-};
-
-const setEditorReadonly = (editor: Editor) => {
-  editor.readonly = true;
-  editor.selection.controlSelection.hideResizeRect();
-  editor._selectionOverrides.hideFakeCaret();
-  removeFakeSelection(editor);
-};
-
-const unsetEditorReadonly = (editor: Editor, body: SugarElement<HTMLElement>) => {
-  editor.readonly = false;
-  if (editor.hasEditableRoot()) {
-    setContentEditable(body, true);
-  }
-  setCommonEditorCommands(editor, false);
-  if (EditorFocus.hasEditorOrUiFocus(editor)) {
-    editor.focus();
-  }
-  restoreFakeSelection(editor);
-  editor.nodeChanged();
-};
-
 const toggleReadOnly = (editor: Editor, state: boolean): void => {
   const body = SugarElement.fromDom(editor.getBody());
-  toggleClass(body, 'mce-content-readonly', state);
 
   if (state) {
-    setEditorReadonly(editor);
+    editor.readonly = true;
     if (editor.hasEditableRoot()) {
       setContentEditable(body, true);
     }
+    ModeUtils.disableEditor(editor);
   } else {
-    unsetEditorReadonly(editor, body);
+    editor.readonly = false;
+    ModeUtils.enableEditor(editor);
   }
 };
 
 const isReadOnly = (editor: Editor): boolean => editor.readonly;
 
-const isClickEvent = (e: Event): e is MouseEvent => e.type === 'click';
-
-const allowedEvents: ReadonlyArray<string> = [ 'copy' ];
-
-const isReadOnlyAllowedEvent = (e: Event) => Arr.contains(allowedEvents, e.type);
-
-/*
-* This function is exported for unit testing purposes only
-*/
-const getAnchorHrefOpt = (editor: Editor, elm: SugarElement<Node>): Optional<string> => {
-  const isRoot = (elm: SugarElement<Node>) => Compare.eq(elm, SugarElement.fromDom(editor.getBody()));
-  return SelectorFind.closest<HTMLAnchorElement>(elm, 'a', isRoot).bind((a) => Attribute.getOpt(a, 'href'));
-};
-
-const processReadonlyEvents = (editor: Editor, e: Event): void => {
-  /*
-    If an event is a click event on or within an anchor, and the CMD/CTRL key is
-    not held, then we want to prevent default behaviour and either:
-      a) scroll to the relevant bookmark
-      b) open the link using default browser behaviour
-  */
-  if (isClickEvent(e) && !VK.metaKeyPressed(e)) {
-    const elm = SugarElement.fromDom(e.target as Node);
-    getAnchorHrefOpt(editor, elm).each((href) => {
-      e.preventDefault();
-      if (/^#/.test(href)) {
-        const targetEl = editor.dom.select(`${href},[name="${Strings.removeLeading(href, '#')}"]`);
-        if (targetEl.length) {
-          editor.selection.scrollIntoView(targetEl[0], true);
-        }
-      } else {
-        window.open(href, '_blank', 'rel=noopener noreferrer,menubar=yes,toolbar=yes,location=yes,status=yes,resizable=yes,scrollbars=yes');
-      }
-    });
-  } else if (isReadOnlyAllowedEvent(e)) {
-    editor.dispatch(e.type, e);
-  }
-};
-
-const registerReadOnlySelectionBlockers = (editor: Editor): void => {
+const registerReadOnlyInputBlockers = (editor: Editor): void => {
   editor.on('beforeinput paste cut dragend dragover draggesture dragdrop drop drag', (e) => {
     if (isReadOnly(editor)) {
       e.preventDefault();
@@ -153,8 +59,6 @@ const registerReadOnlySelectionBlockers = (editor: Editor): void => {
 
 export {
   isReadOnly,
-  getAnchorHrefOpt,
   toggleReadOnly,
-  processReadonlyEvents,
-  registerReadOnlySelectionBlockers
+  registerReadOnlyInputBlockers
 };

--- a/modules/tinymce/src/core/main/ts/util/ModeUtils.ts
+++ b/modules/tinymce/src/core/main/ts/util/ModeUtils.ts
@@ -1,0 +1,72 @@
+import { Optional } from '@ephox/katamari';
+import { Class, SugarElement } from '@ephox/sugar';
+
+import Editor from '../api/Editor';
+import * as EditorFocus from '../focus/EditorFocus';
+
+const removeFakeSelection = (editor: Editor) => {
+  Optional.from(editor.selection.getNode()).each((elm) => {
+    elm.removeAttribute('data-mce-selected');
+  });
+};
+
+const setEditorCommandState = (editor: Editor, cmd: string, state: boolean) => {
+  try {
+    // execCommand needs a string for the value, so convert the boolean to a string
+    // See: https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#Parameters
+    editor.getDoc().execCommand(cmd, false, String(state));
+  } catch (ex) {
+    // Ignore
+  }
+};
+
+const setCommonEditorCommands = (editor: Editor, state: boolean): void => {
+  setEditorCommandState(editor, 'StyleWithCSS', state);
+  setEditorCommandState(editor, 'enableInlineTableEditing', state);
+  setEditorCommandState(editor, 'enableObjectResizing', state);
+};
+
+const setContentEditable = (elm: SugarElement<HTMLElement>, state: boolean) => {
+  elm.dom.contentEditable = state ? 'true' : 'false';
+};
+
+const restoreFakeSelection = (editor: Editor) => {
+  editor.selection.setRng(editor.selection.getRng());
+};
+
+// Not quite sugar Class.toggle, it's more of a Class.set
+const toggleClass = (elm: SugarElement<Element>, cls: string, state: boolean) => {
+  if (Class.has(elm, cls) && !state) {
+    Class.remove(elm, cls);
+  } else if (state) {
+    Class.add(elm, cls);
+  }
+};
+
+const disableEditor = (editor: Editor): void => {
+  const body = SugarElement.fromDom(editor.getBody());
+  toggleClass(body, 'mce-content-readonly', true);
+  editor.selection.controlSelection.hideResizeRect();
+  editor._selectionOverrides.hideFakeCaret();
+  removeFakeSelection(editor);
+};
+
+const enableEditor = (editor: Editor): void => {
+  const body = SugarElement.fromDom(editor.getBody());
+  toggleClass(body, 'mce-content-readonly', false);
+
+  if (editor.hasEditableRoot()) {
+    setContentEditable(body, true);
+  }
+  setCommonEditorCommands(editor, false);
+  if (EditorFocus.hasEditorOrUiFocus(editor)) {
+    editor.focus();
+  }
+  restoreFakeSelection(editor);
+  editor.nodeChanged();
+};
+
+export {
+  enableEditor,
+  disableEditor
+};

--- a/modules/tinymce/src/core/test/ts/browser/DisabledModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/DisabledModeTest.ts
@@ -1,0 +1,523 @@
+import { ApproxStructure, Mouse, UiFinder, Clipboard, TestStore } from '@ephox/agar';
+import { afterEach, Assert, context, describe, it } from '@ephox/bedrock-client';
+import { Arr, Optional, OptionalInstances } from '@ephox/katamari';
+import { Class, Css, Scroll, SelectorFind, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import * as Disabled from 'tinymce/core/mode/Disabled';
+import TablePlugin from 'tinymce/plugins/table/Plugin';
+
+const tOptional = OptionalInstances.tOptional;
+
+interface TestButtonDisabledState {
+  name: string;
+  disabledAttribute: 'aria-disabled' | 'disabled';
+}
+
+describe('browser.tinymce.core.DisabledModeTest', () => {
+  const settings = {
+    base_url: '/project/tinymce/js/tinymce',
+    toolbar: 'bold',
+    statusbar: false
+  };
+
+  context('Disabled mode', () => {
+    const hook = TinyHooks.bddSetup<Editor>({ ...settings, plugins: 'table' }, [ TablePlugin ]);
+
+    const assertNestedContentEditableTrueDisabled = (editor: Editor, state: boolean, offscreen: boolean) => {
+      TinyAssertions.assertContentStructure(editor,
+        ApproxStructure.build((s, str, _arr) => {
+          const attrs = state ? {
+            'contenteditable': str.is('false'),
+            'data-mce-contenteditable': str.is('true')
+          } : {
+            'contenteditable': str.is('true'),
+            'data-mce-contenteditable': str.none()
+          };
+
+          return s.element('body', {
+            children: [
+              s.element('div', {
+                attrs: {
+                  contenteditable: str.is('false')
+                },
+                children: [
+                  s.text(str.is('a')),
+                  s.element('span', {
+                    attrs,
+                  }),
+                  s.text(str.is('c'))
+                ]
+              }),
+              ...offscreen ? [ s.element('div', {}) ] : [] // Offscreen cef clone
+            ]
+          });
+        })
+      );
+    };
+
+    const assertFakeSelection = (editor: Editor, expectedState: boolean) => {
+      assert.equal(editor.selection.getNode().hasAttribute('data-mce-selected'), expectedState, 'Selected element should have expected state');
+    };
+
+    const assertResizeBars = (editor: Editor, expectedState: boolean) => {
+      SelectorFind.descendant(Traverse.documentElement(TinyDom.document(editor)), '.ephox-snooker-resizer-bar').fold(
+        () => {
+          assert.isFalse(expectedState, 'Was expecting to find resize bars');
+        },
+        (bar) => {
+          const actualDisplay = Css.get(bar, 'display');
+          const expectedDisplay = expectedState ? 'block' : 'none';
+          assert.equal(actualDisplay, expectedDisplay, 'Should be expected display state on resize bar');
+        }
+      );
+    };
+
+    const mouseOverTable = (editor: Editor) => {
+      const table = UiFinder.findIn(TinyDom.body(editor), 'table').getOrDie();
+      Mouse.mouseOver(table);
+    };
+
+    const assertToolbarDisabled = (expectedState: boolean) => {
+      const elm = UiFinder.findIn(SugarBody.body(), 'button[data-mce-name="bold"]').getOrDie();
+      assert.equal(Class.has(elm, 'tox-tbtn--disabled'), expectedState, 'Button should have expected disabled state');
+    };
+
+    const assertHrefOpt = (editor: Editor, selector: string, expectedHref: Optional<string>) => {
+      const elm = SugarElement.fromDom(editor.dom.select(selector)[0]);
+      const hrefOpt = Disabled.getAnchorHrefOpt(editor, elm);
+      Assert.eq('href options match', expectedHref, hrefOpt, tOptional());
+    };
+
+    it('TBA: Switching to disabled mode while having cef selection should remove fake selection', () => {
+      const editor = hook.editor();
+      editor.setContent('<div contenteditable="false">CEF</div>');
+      TinySelections.select(editor, 'div[contenteditable="false"]', []);
+      assertFakeSelection(editor, true);
+      editor.options.set('disabled', true);
+      assertFakeSelection(editor, false);
+      editor.options.set('disabled', false);
+      assertFakeSelection(editor, true);
+    });
+
+    it('TBA: Selecting cef element while in disabled mode should not add fake selection', () => {
+      const editor = hook.editor();
+      editor.setContent('<div contenteditable="false">CEF</div>');
+      TinySelections.select(editor, 'div[contenteditable="false"]', []);
+      assertFakeSelection(editor, true);
+      editor.options.set('disabled', true);
+      TinySelections.select(editor, 'div[contenteditable="false"]', []);
+      assertFakeSelection(editor, false);
+      editor.options.set('disabled', false);
+      TinySelections.select(editor, 'div[contenteditable="false"]', []);
+      assertFakeSelection(editor, true);
+    });
+
+    it('TBA: Setting caret before cef in editor while in disabled mode should not render fake caret', () => {
+      const editor = hook.editor();
+      editor.setContent('<div contenteditable="false">CEF</div>');
+      editor.options.set('disabled', true);
+      TinySelections.setCursor(editor, [], 0);
+      TinyAssertions.assertContentStructure(editor,
+        ApproxStructure.build((s, str, _arr) => {
+          return s.element('body', {
+            children: [
+              s.element('div', {
+                attrs: {
+                  contenteditable: str.is('false')
+                },
+                children: [
+                  s.text(str.is('CEF'))
+                ]
+              })
+            ]
+          });
+        })
+      );
+      editor.options.set('disabled', false);
+      TinyAssertions.assertContentStructure(editor,
+        ApproxStructure.build((s, str, arr) => {
+          return s.element('body', {
+            children: [
+              s.element('p', {
+                attrs: {
+                  'data-mce-caret': str.is('before'),
+                  'data-mce-bogus': str.is('all')
+                },
+                children: [
+                  s.element('br', {})
+                ]
+              }),
+              s.element('div', {
+                attrs: {
+                  contenteditable: str.is('false')
+                },
+                children: [
+                  s.text(str.is('CEF'))
+                ]
+              }),
+              s.element('div', {
+                attrs: {
+                  'data-mce-bogus': str.is('all')
+                },
+                classes: [ arr.has('mce-visual-caret'), arr.has('mce-visual-caret-before') ]
+              })
+            ]
+          });
+        })
+      );
+    });
+
+    it('TBA: Switching to disabled mode on content with nested contenteditable=true should toggle them to contenteditable=false', async () => {
+      const editor = hook.editor();
+      editor.setContent('<div contenteditable="false">a<span contenteditable="true">b</span>c</div>');
+      TinySelections.select(editor, 'div[contenteditable="false"]', []);
+      assertFakeSelection(editor, true);
+      editor.options.set('disabled', true);
+      assertNestedContentEditableTrueDisabled(editor, true, true);
+      TinyAssertions.assertContent(editor, '<div contenteditable="false">a<span contenteditable="true">b</span>c</div>');
+      assertFakeSelection(editor, false);
+      editor.options.set('disabled', false);
+      TinyAssertions.assertContent(editor, '<div contenteditable="false">a<span contenteditable="true">b</span>c</div>');
+      assertNestedContentEditableTrueDisabled(editor, false, true);
+    });
+
+    it('TBA: Setting contents with contenteditable=true should switch them to contenteditable=false while in disabled mode', () => {
+      const editor = hook.editor();
+      editor.options.set('disabled', true);
+      editor.setContent('<div contenteditable="false">a<span contenteditable="true">b</span>c</div>');
+      assertNestedContentEditableTrueDisabled(editor, true, false);
+      TinyAssertions.assertContent(editor, '<div contenteditable="false">a<span contenteditable="true">b</span>c</div>');
+      editor.options.set('disabled', false);
+      TinyAssertions.assertContent(editor, '<div contenteditable="false">a<span contenteditable="true">b</span>c</div>');
+      TinySelections.select(editor, 'div[contenteditable="false"]', []);
+      assertNestedContentEditableTrueDisabled(editor, false, true);
+      editor.setContent('<div contenteditable="false">a<span contenteditable="true">b</span>c</div>');
+      TinySelections.select(editor, 'div[contenteditable="false"]', []);
+      assertNestedContentEditableTrueDisabled(editor, false, true);
+    });
+
+    it('TBA: Resize bars for tables should be hidden while in disabled mode', async () => {
+      const editor = hook.editor();
+      editor.setContent('<table><tbody><tr><td>a</td></tr></tbody></table>');
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+      mouseOverTable(editor);
+      assertResizeBars(editor, true);
+      editor.options.set('disabled', true);
+      assertResizeBars(editor, false);
+      mouseOverTable(editor);
+      assertResizeBars(editor, false);
+      editor.options.set('disabled', false);
+      mouseOverTable(editor);
+      assertResizeBars(editor, true);
+    });
+
+    it('TBA: Context toolbar should be hidden in disabled mode', async () => {
+      const editor = hook.editor();
+      editor.focus();
+      editor.setContent('<table><tbody><tr><td>a</td></tr></tbody></table>');
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+      await UiFinder.pWaitFor('Waited for context toolbar', SugarBody.body(), '.tox-pop');
+      editor.options.set('disabled', true);
+      UiFinder.notExists(SugarBody.body(), '.tox-pop');
+      editor.options.set('disabled', false);
+      editor.setContent('<table><tbody><tr><td>a</td></tr></tbody></table>');
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
+      UiFinder.sWaitFor('Waited for context toolbar', SugarBody.body(), '.tox-pop');
+    });
+
+    it('TBA: Main toolbar should be disabled when switching to disabled mode', () => {
+      const editor = hook.editor();
+      assertToolbarDisabled(false);
+      editor.options.set('disabled', true);
+      assertToolbarDisabled(true);
+      editor.options.set('disabled', false);
+      assertToolbarDisabled(false);
+    });
+
+    it('TBA: Menus should close when switching to readonly mode', async () => {
+      const editor = hook.editor();
+      const fileMenu = UiFinder.findIn(SugarBody.body(), '.tox-mbtn:contains("File")').getOrDie();
+      Mouse.click(fileMenu);
+      await UiFinder.pWaitFor('Waited for menu', SugarBody.body(), '.tox-menu');
+      editor.options.set('disabled', true);
+      UiFinder.notExists(SugarBody.body(), '.tox-menu');
+      editor.options.set('disabled', false);
+    });
+
+    it('TINY-6248: getAnchorHrefOpt should return an Optional of the href of the closest anchor tag', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="https://tiny.cloud">external link</a></p>');
+      assertHrefOpt(editor, 'a', Optional.some('https://tiny.cloud'));
+      editor.setContent('<p><a>external link with no href</a></p>');
+      assertHrefOpt(editor, 'a', Optional.none());
+      editor.setContent('<p><a href="https://tiny.cloud"><img src="">nested image </img>inside anchor</a></p>');
+      assertHrefOpt(editor, 'img', Optional.some('https://tiny.cloud'));
+    });
+
+    it('TINY-6248: processReadonlyEvents should scroll to bookmark with id in disabled mode', () => {
+      const editor = hook.editor();
+      editor.resetContent();
+      editor.options.set('disabled', true);
+      editor.setContent('<p><a href="#someBookmark">internal bookmark</a></p><div style="padding-top: 2000px;"></div><p><a id="someBookmark"></a></p>');
+
+      const body = TinyDom.body(editor);
+      const doc = TinyDom.document(editor);
+      const yPos = Scroll.get(doc).top;
+      const anchor = UiFinder.findIn(body, 'a[href="#someBookmark"]').getOrDie();
+      Mouse.click(anchor);
+      const newPos = Scroll.get(doc).top;
+      assert.notEqual(newPos, yPos, 'assert yPos has changed i.e. has scrolled');
+      editor.options.set('disabled', false);
+    });
+
+    it('TINY-6800: Copy events should be dispatched even in disabled mode', () => {
+      const editor = hook.editor();
+      editor.options.set('disabled', true);
+
+      let copyEventCount = 0;
+      const copyHandler = () => copyEventCount++;
+      editor.on('copy', copyHandler);
+
+      Clipboard.copy(TinyDom.body(editor));
+      assert.equal(copyEventCount, 1, 'copy event should be fired');
+      editor.off('copy', copyHandler);
+      editor.options.set('disabled', false);
+    });
+
+    it('TINY-6248: processReadonlyEvents should scroll to bookmark with name in disabled mode', async () => {
+      const editor = hook.editor();
+      const body = TinyDom.body(editor);
+      const doc = TinyDom.document(editor);
+      editor.resetContent();
+      editor.options.set('disabled', true);
+      editor.setContent('<p><a href="#someBookmark">internal bookmark</a></p><div style="padding-top: 2000px;"></div><p><a name="someBookmark"></a></p>');
+
+      const yPos = Scroll.get(doc).top;
+      const anchor = UiFinder.findIn(body, 'a[href="#someBookmark"]').getOrDie();
+      Mouse.click(anchor);
+      const newPos = Scroll.get(doc).top;
+      assert.notEqual(newPos, yPos, 'assert yPos has changed i.e. has scrolled');
+      editor.options.set('disabled', false);
+    });
+
+    const assertBodyClass = (editor: Editor, cls: string, state: boolean) => {
+      assert.equal(Class.has(TinyDom.body(editor), cls), state, 'Should be the expected class state');
+    };
+
+    it('TINY-11488: Assert body class when editor is disabled', () => {
+      const editor = hook.editor();
+      editor.options.set('disabled', true);
+      assertBodyClass(editor, 'mce-content-readonly', true);
+
+      editor.options.set('disabled', false);
+      assertBodyClass(editor, 'mce-content-readonly', false);
+
+      editor.options.set('disabled', true);
+      assertBodyClass(editor, 'mce-content-readonly', true);
+    });
+  });
+
+  const assertContentEditableBody = (editor: Editor) => (shouldBeEditable: boolean) => {
+    assert.isTrue(editor.getBody().contentEditable === shouldBeEditable.toString(), 'Editor body contentEditable should be ' + shouldBeEditable);
+  };
+
+  const assertEditorContainerClass = (editor: Editor) => (shouldNotHaveClass: boolean) => {
+    const hasClass = Class.has(TinyDom.container(editor), 'tox-tinymce--disabled');
+    assert.equal(!hasClass, shouldNotHaveClass, 'Editor container should not have class: tox-tinymce--disabled');
+  };
+
+  const assertEditorState = (shouldBeEnabled: boolean) => (editor: Editor) => {
+    assert.equal(editor.disabled, !shouldBeEnabled, `Editor.disabled should be ${!shouldBeEnabled}`);
+    assertContentEditableBody(editor)(shouldBeEnabled);
+    assertEditorContainerClass(editor)(shouldBeEnabled);
+  };
+
+  const assertEditorDisabled = assertEditorState(false);
+  const assertEditorEnabled = assertEditorState(true);
+
+  context('Switching editor mode', () => {
+    const hook = TinyHooks.bddSetup<Editor>({ ...settings, disabled: true }, []);
+
+    afterEach(() => hook.editor().options.set('disabled', true));
+
+    // Basic checking of the UI and editor body contentEditable
+    it('TINY-11488: Should be able to switch from disabled mode to enabled mode', () => {
+      const editor = hook.editor();
+      assertEditorDisabled(editor);
+      editor.options.set('disabled', false);
+      assertEditorEnabled(editor);
+    });
+
+    it('TINY-11488: Should not allow switching modes when the editor is disabled', () => {
+      const editor = hook.editor();
+      assertEditorDisabled(editor);
+      editor.mode.set('readonly');
+      assertEditorDisabled(editor);
+      editor.options.set('disabled', false);
+      assertEditorEnabled(editor);
+      editor.mode.set('readonly');
+      assertEditorEnabled(editor);
+      editor.mode.set('design');
+    });
+
+    it('TINY-11488: UIs should still be disabled when switching to disable false in readonly mode', () => {
+      const editor = hook.editor();
+      editor.options.set('disabled', false);
+      editor.mode.set('readonly');
+      assertEditorEnabled(editor);
+      editor.options.set('disabled', true);
+      assertEditorDisabled(editor);
+      editor.options.set('disabled', false);
+      assertEditorEnabled(editor);
+    });
+  });
+
+  context('Default disabled: false', () => {
+    const hook = TinyHooks.bddSetup<Editor>({ ...settings, disabled: false }, []);
+
+    afterEach(() => hook.editor().options.set('disabled', true));
+
+    // Basic checking of the UI and editor body contentEditable
+    it('TINY-11488: Should be able to switch from disabled mode to enabled mode', () => {
+      const editor = hook.editor();
+      assertEditorEnabled(editor);
+      editor.options.set('disabled', true);
+      assertEditorDisabled(editor);
+      editor.options.set('disabled', false);
+      assertEditorEnabled(editor);
+    });
+  });
+
+  context('DisabledStateChange Event', () => {
+    const store = TestStore<boolean>();
+    const hook = TinyHooks.bddSetup<Editor>({
+      ...settings,
+      disabled: true,
+      setup: (ed: Editor) => {
+        ed.on('DisabledStateChange', (e) => store.add(e.state));
+      }
+    }, []);
+
+    afterEach(() => {
+      hook.editor().options.set('disabled', true);
+      store.clear();
+    });
+
+    it('TINY-11488: DisabledStateChange event should be dispatched when state changes', () => {
+      const editor = hook.editor();
+      store.assertEq('InitialState', [ ]);
+      editor.options.set('disabled', false);
+      store.assertEq('Disable state change event setting to false', [ false ]);
+
+      editor.options.set('disabled', false);
+      store.assertEq('Setting the same value should not dispatch DisabledStateChange', [ false ]);
+
+      editor.options.set('disabled', true);
+      store.assertEq('Disable state change event setting to true', [ false, true ]);
+    });
+  });
+
+  context('Toolbar button state with disable state and readonly mode/non editable root', () => {
+    const assertButtonState = (button: TestButtonDisabledState, shouldBeDisabled: boolean) => {
+      const { name, disabledAttribute } = button;
+      const attributeValue = disabledAttribute === 'disabled' ? 'disabled' : 'true';
+      const selector = `[data-mce-name="${name}"][${disabledAttribute}="${attributeValue}"]`;
+
+      if (shouldBeDisabled) {
+        UiFinder.exists(SugarBody.body(), selector);
+      } else {
+        UiFinder.notExists(SugarBody.body(), selector);
+      }
+    };
+
+    const assertButtonsStateDisabled = (buttons: TestButtonDisabledState[]) => {
+      Arr.each(buttons, (button) => assertButtonState(button, true));
+    };
+
+    const assertButtonsStateEnabled = (buttons: TestButtonDisabledState[]) => {
+      Arr.each(buttons, (button) => assertButtonState(button, false));
+    };
+
+    const toolbarButtons: TestButtonDisabledState[] = [
+      { name: 'bold', disabledAttribute: 'aria-disabled' },
+      { name: 'print', disabledAttribute: 'aria-disabled' },
+      { name: 'forecolor', disabledAttribute: 'aria-disabled' },
+      { name: 'searchreplace', disabledAttribute: 'aria-disabled' },
+    ];
+
+    const nativeDisabledToolbarButtons: TestButtonDisabledState[] = [
+      { name: 'lineheight', disabledAttribute: 'disabled' },
+      { name: 'fontfamily', disabledAttribute: 'disabled' },
+      { name: 'fontsize', disabledAttribute: 'disabled' },
+      { name: 'blocks', disabledAttribute: 'disabled' },
+      { name: 'styles', disabledAttribute: 'disabled' },
+    ];
+
+    const allButtons = [ ...toolbarButtons, ...nativeDisabledToolbarButtons ];
+
+    const excludeReadOnlyEnabledButton = Arr.filter(toolbarButtons, (btn) => btn.name !== 'print');
+    const excludeNonEditableRootButton = Arr.filter(toolbarButtons, (btn) => btn.name !== 'print' && btn.name !== 'searchreplace');
+
+    const hook = TinyHooks.bddSetup<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      disabled: true,
+      plugins: 'searchreplace',
+      toolbar: Arr.map(allButtons, (button) => button.name).join(' '),
+    }, []);
+
+    afterEach(() => hook.editor().options.set('disabled', true));
+
+    it('TINY-11488: Toolbar buttons should reflect the editor disabled state in readonly', () => {
+      const editor = hook.editor();
+      assertButtonsStateDisabled(allButtons);
+
+      editor.options.set('disabled', false);
+      assertButtonsStateEnabled(allButtons);
+
+      // Set the editor to readonly mode
+      editor.mode.set('readonly');
+      assertButtonsStateDisabled([ ...excludeReadOnlyEnabledButton, ...nativeDisabledToolbarButtons ]);
+      assertButtonState({ name: 'print', disabledAttribute: 'aria-disabled' }, false);
+
+      // Disable the editor again, all buttons should be disabled
+      editor.options.set('disabled', true);
+      assertButtonsStateDisabled(allButtons);
+
+      // Re-enable the editor; only 'print' should be enabled in readonly mode
+      editor.options.set('disabled', false);
+      assertButtonsStateDisabled([ ...excludeReadOnlyEnabledButton, ...nativeDisabledToolbarButtons ]);
+      assertButtonState({ name: 'print', disabledAttribute: 'aria-disabled' }, false);
+
+      // Switch back to design mode; all buttons should be enabled
+      editor.mode.set('design');
+      assertButtonsStateEnabled(allButtons);
+    });
+
+    it('TINY-11488: Toolbar buttons should reflect the editor disabled state in noneditable root', () => {
+      const editor = hook.editor();
+      assertButtonsStateDisabled(allButtons);
+
+      editor.options.set('disabled', false);
+      assertButtonsStateEnabled(allButtons);
+
+      // Set the editor to editableRoot false
+      editor.setEditableRoot(false);
+      assertButtonsStateDisabled([ ...excludeNonEditableRootButton, ...nativeDisabledToolbarButtons ]);
+      assertButtonsStateEnabled([{ name: 'print', disabledAttribute: 'aria-disabled' }, { name: 'searchreplace', disabledAttribute: 'aria-disabled' }]);
+
+      // Disable the editor again, all buttons should be disabled
+      editor.options.set('disabled', true);
+      assertButtonsStateDisabled(allButtons);
+
+      editor.options.set('disabled', false);
+      assertButtonsStateDisabled([ ...excludeNonEditableRootButton, ...nativeDisabledToolbarButtons ]);
+      assertButtonsStateEnabled([{ name: 'print', disabledAttribute: 'aria-disabled' }, { name: 'searchreplace', disabledAttribute: 'aria-disabled' }]);
+
+      editor.setEditableRoot(true);
+      assertButtonsStateEnabled(allButtons);
+    });
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/EditableRootTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditableRootTest.ts
@@ -5,8 +5,8 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.EditableRootTest', () => {
-  const assertContentEditableState = (editor: Editor, expectedState: boolean) => {
-    assert.equal(editor.getBody().isContentEditable, expectedState);
+  const assertContentEditableState = (editor: Editor, expectedState: boolean, message?: string) => {
+    assert.equal(editor.getBody().isContentEditable, expectedState, message);
   };
 
   const assertRootEditableState = (editor: Editor, expectedState: boolean) => {
@@ -91,6 +91,34 @@ describe('browser.tinymce.core.EditableRootTest', () => {
 
       assert.isTrue(editor.hasEditableRoot());
       assertContentEditableState(editor, true);
+    });
+
+    it('TINY-11488: Editor editable state should not be impacted by disabled mode toggling', () => {
+      const editor = hook.editor();
+
+      editor.options.set('disabled', true);
+      assert.isTrue(editor.hasEditableRoot(), 'Editable root should be present when disabled');
+      assertContentEditableState(editor, false, 'Content should not be editable when disabled');
+
+      editor.options.set('disabled', false);
+      assert.isTrue(editor.hasEditableRoot(), 'Editable root should remain when re-enabled');
+      assertContentEditableState(editor, true, 'Content should be editable when re-enabled');
+
+      editor.setEditableRoot(false);
+
+      editor.options.set('disabled', true);
+      assert.isFalse(editor.hasEditableRoot(), 'Editable root should not be present after disabling');
+      assertContentEditableState(editor, false, 'Content should not be editable when disabled with no editable root');
+
+      editor.options.set('disabled', false);
+      assert.isFalse(editor.hasEditableRoot(), 'Editable root should remain absent when re-enabled');
+      assertContentEditableState(editor, false, 'Content should not be editable when re-enabled with no editable root');
+
+      editor.options.set('disabled', true);
+      editor.setEditableRoot(true);
+
+      assert.isTrue(editor.hasEditableRoot(), 'Editable root should be restored');
+      assertContentEditableState(editor, false, 'Content should remain non-editable when disabled with editable root');
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
@@ -442,6 +442,33 @@ describe('browser.tinymce.core.EditorTest', () => {
     assert.equal(clickCount, 3, 'setMode');
   });
 
+  it('TINY-11488: Verifies click event behavior in disabled and enabled editor states', () => {
+    const editor = hook.editor();
+    let clickCount = 0;
+
+    const isDisabled = (selector: string) => {
+      const elm = UiFinder.findIn(SugarBody.body(), selector);
+      return elm.forall((elm) => Attribute.has(elm, 'disabled') || Class.has(elm, 'tox-tbtn--disabled'));
+    };
+
+    editor.on('click', () => {
+      clickCount++;
+    });
+
+    editor.dom.dispatch(editor.getBody(), 'click');
+    assert.equal(clickCount, 1, 'Click should be counted in enabled state');
+
+    editor.options.set('disabled', true);
+    assert.isTrue(isDisabled('.tox-editor-container button:last-of-type'), 'Button should be disabled in disabled mode');
+    editor.dom.dispatch(editor.getBody(), 'click');
+    assert.equal(clickCount, 1, 'Click should not be counted in disabled state');
+
+    editor.options.set('disabled', false);
+    editor.dom.dispatch(editor.getBody(), 'click');
+    assert.isFalse(isDisabled('.tox-editor-container button:last-of-type'), 'Button should remain enabled in enabled state');
+    assert.equal(clickCount, 2, 'Click should be counted in re-enabled state');
+  });
+
   it('TBA: translate', () => {
     const editor = hook.editor();
     EditorManager.addI18n('en', {

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
@@ -1,18 +1,14 @@
 import { ApproxStructure, Mouse, UiFinder, Clipboard } from '@ephox/agar';
-import { Assert, describe, it } from '@ephox/bedrock-client';
-import { Optional, OptionalInstances } from '@ephox/katamari';
+import { describe, it } from '@ephox/bedrock-client';
 import { PlatformDetection } from '@ephox/sand';
-import { Attribute, Class, Css, Scroll, SelectorFind, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
+import { Attribute, Class, Css, Scroll, SelectorFind, SugarBody, Traverse } from '@ephox/sugar';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
-import * as Readonly from 'tinymce/core/mode/Readonly';
 import AnchorPlugin from 'tinymce/plugins/anchor/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
-
-const tOptional = OptionalInstances.tOptional;
 
 describe('browser.tinymce.core.ReadOnlyModeTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
@@ -87,12 +83,6 @@ describe('browser.tinymce.core.ReadOnlyModeTest', () => {
     const elm = UiFinder.findIn(SugarBody.body(), '.tox-toolbar-overlord').getOrDie();
     assert.equal(Class.has(elm, 'tox-tbtn--disabled'), expectedState, 'Toolbar should have expected disabled state');
     assert.equal(Attribute.get(elm, 'aria-disabled'), expectedState.toString(), 'Toolbar should have expected disabled state');
-  };
-
-  const assertHrefOpt = (editor: Editor, selector: string, expectedHref: Optional<string>) => {
-    const elm = SugarElement.fromDom(editor.dom.select(selector)[0]);
-    const hrefOpt = Readonly.getAnchorHrefOpt(editor, elm);
-    Assert.eq('href options match', expectedHref, hrefOpt, tOptional());
   };
 
   it('TBA: Switching to readonly mode while having cef selection should remove fake selection', () => {
@@ -249,16 +239,6 @@ describe('browser.tinymce.core.ReadOnlyModeTest', () => {
     UiFinder.sWaitFor('Waited for menu', SugarBody.body(), '.tox-menu');
     setMode(editor, 'readonly');
     UiFinder.sNotExists(SugarBody.body(), '.tox-menu');
-  });
-
-  it('TINY-6248: getAnchorHrefOpt should return an Optional of the href of the closest anchor tag', () => {
-    const editor = hook.editor();
-    editor.setContent('<p><a href="https://tiny.cloud">external link</a></p>');
-    assertHrefOpt(editor, 'a', Optional.some('https://tiny.cloud'));
-    editor.setContent('<p><a>external link with no href</a></p>');
-    assertHrefOpt(editor, 'a', Optional.none());
-    editor.setContent('<p><a href="https://tiny.cloud"><img src="">nested image </img>inside anchor</a></p>');
-    assertHrefOpt(editor, 'img', Optional.some('https://tiny.cloud'));
   });
 
   const metaKey = PlatformDetection.detect().os.isMacOS() ? { metaKey: true } : { ctrlKey: true };

--- a/modules/tinymce/src/models/dom/main/ts/table/api/TableResizeHandler.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/TableResizeHandler.ts
@@ -209,28 +209,30 @@ export const TableResizeHandler = (editor: Editor): TableResizeHandler => {
     }
   });
 
-  editor.on('SwitchMode', () => {
+  const showResizeBars = () => {
     tableResize.on((resize) => {
-      if (editor.mode.isReadOnly()) {
-        resize.off();
-        resize.hideBars();
-      } else {
-        resize.on();
-        resize.showBars();
-      }
+      resize.on();
+      resize.showBars();
     });
+  };
+
+  const hideResizeBars = () => {
+    tableResize.on((resize) => {
+      resize.off();
+      resize.hideBars();
+    });
+  };
+
+  editor.on('DisabledStateChange', (e) => {
+    e.state ? hideResizeBars() : showResizeBars();
+  });
+
+  editor.on('SwitchMode', () => {
+    editor.mode.isReadOnly() ? hideResizeBars() : showResizeBars();
   });
 
   editor.on('dragstart dragend', (e) => {
-    tableResize.on((resize) => {
-      if (e.type === 'dragstart') {
-        resize.hideBars();
-        resize.off();
-      } else {
-        resize.on();
-        resize.showBars();
-      }
-    });
+    e.type === 'dragstart' ? hideResizeBars() : showResizeBars();
   });
 
   editor.on('remove', () => {

--- a/modules/tinymce/src/themes/silver/main/ts/UiState.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/UiState.ts
@@ -2,7 +2,7 @@ import { Behaviour, Channels, Disabling, Receiving } from '@ephox/alloy';
 import { Arr } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
-import { NodeChangeEvent, SwitchModeEvent } from 'tinymce/core/api/EventTypes';
+import { DisabledStateChangeEvent, NodeChangeEvent, SwitchModeEvent } from 'tinymce/core/api/EventTypes';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import * as Options from './api/Options';
@@ -10,33 +10,50 @@ import { ReadyUiReferences } from './modes/UiReferences';
 
 export const UiStateChannel = 'silver.uistate';
 
-const broadcastEvents = (uiRefs: ReadyUiReferences, data: string): void => {
+const messageSetDisabled = 'setDisabled';
+const messageSetEnabled = 'setEnabled';
+const messageInit = 'init';
+const messageSwitchMode = 'switchmode';
+const modeContextMessages = [ messageSwitchMode, messageInit ];
+
+const broadcastEvents = (uiRefs: ReadyUiReferences, messageType: string): void => {
   const outerContainer = uiRefs.mainUi.outerContainer;
-  const target = outerContainer.element;
   const motherships = [ uiRefs.mainUi.mothership, ...uiRefs.uiMotherships ];
 
-  if (data === 'setDisabled') {
+  if (messageType === messageSetDisabled) {
     Arr.each(motherships, (m) => {
-      m.broadcastOn([ Channels.dismissPopups() ], { target });
+      m.broadcastOn([ Channels.dismissPopups() ], { target: outerContainer.element });
     });
   }
 
   Arr.each(motherships, (m) => {
-    m.broadcastOn([ UiStateChannel ], data);
+    m.broadcastOn([ UiStateChannel ], messageType);
   });
 };
 
 const setupEventsForUi = (editor: Editor, uiRefs: ReadyUiReferences): void => {
-  editor.on('init SwitchMode', (e: EditorEvent<{} | SwitchModeEvent>) => {
-    broadcastEvents(uiRefs, e.type);
+  editor.on('init SwitchMode', (event: EditorEvent<{} | SwitchModeEvent>) => {
+    broadcastEvents(uiRefs, event.type);
+  });
+
+  editor.on('DisabledStateChange', (event: EditorEvent<DisabledStateChangeEvent>) => {
+    if (!event.isDefaultPrevented()) {
+      // When the event state indicates the editor is **enabled** (`event.state` is false),
+      // we send an 'init' message instead of 'setEnabled' because the editor might be in read-only mode.
+      // Sending 'setEnabled' would enable all the toolbar buttons, which is undesirable if the editor is read-only.
+      const messageType = event.state ? messageSetDisabled : messageInit;
+      broadcastEvents(uiRefs, messageType);
+
+      // After refreshing the state of the buttons, trigger a NodeChange event.
+      if (!event.state) {
+        editor.nodeChanged();
+      }
+    }
   });
 
   editor.on('NodeChange', (e: EditorEvent<NodeChangeEvent>) => {
-    if (!editor.ui.isEnabled()) {
-      broadcastEvents(uiRefs, 'setDisabled');
-    } else {
-      broadcastEvents(uiRefs, e.type);
-    }
+    const messageType = editor.ui.isEnabled() ? e.type : messageSetDisabled;
+    broadcastEvents(uiRefs, messageType);
   });
 
   if (Options.isReadOnly(editor)) {
@@ -47,18 +64,18 @@ const setupEventsForUi = (editor: Editor, uiRefs: ReadyUiReferences): void => {
 const toggleOnReceive = (getContext: () => { contextType: string; shouldDisable: boolean }): Behaviour.NamedConfiguredBehaviour<any, any> => Receiving.config({
   channels: {
     [UiStateChannel]: {
-      onReceive: (comp, buttonStateData: string) => {
-        if (buttonStateData === 'setDisabled' || buttonStateData === 'setEnabled') {
-          Disabling.set(comp, buttonStateData === 'setDisabled');
+      onReceive: (comp, messageType: string) => {
+        if (messageType === messageSetDisabled || messageType === messageSetEnabled) {
+          Disabling.set(comp, messageType === messageSetDisabled);
           return;
         }
 
-        const { contextType, shouldDisable: contextShouldDisable } = getContext();
-        if (contextType === 'mode' && !Arr.contains([ 'switchmode', 'init' ], buttonStateData)) {
+        const { contextType, shouldDisable } = getContext();
+        if (contextType === 'mode' && !Arr.contains(modeContextMessages, messageType)) {
           return;
         }
 
-        Disabling.set(comp, contextShouldDisable);
+        Disabling.set(comp, shouldDisable);
       }
     }
   }

--- a/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
@@ -295,6 +295,7 @@ const register = (editor: Editor): void => {
 };
 
 const isReadOnly = option('readonly');
+const isDisabled = option('disabled');
 const getHeightOption = option('height');
 const getWidthOption = option('width');
 const getMinWidthOption = wrapOptional(option('min_width'));
@@ -439,6 +440,7 @@ export {
   getSkinUrl,
   getSkinUrlOption,
   isReadOnly,
+  isDisabled,
   isSkinDisabled,
   getHeightOption,
   getWidthOption,

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -61,6 +61,12 @@ const init = (lazySinks: { popup: () => Result<AlloyComponent, string>; dialog: 
     getOption: editor.options.get,
     tooltips: TooltipsBackstage(lazySinks.dialog),
     checkUiComponentContext: (specContext: string) => {
+      if (editor.disabled) {
+        return {
+          contextType: 'disabled',
+          shouldDisable: true
+        };
+      }
       const [ key, value = '' ] = specContext.split(':');
       const contexts = editor.ui.registry.getAll().contexts;
       const enabledInContext = Obj.get(contexts, key)

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
@@ -274,8 +274,8 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
       }, 0);
     });
 
-    editor.on('SwitchMode', () => {
-      if (editor.mode.isReadOnly()) {
+    editor.on('SwitchMode DisabledStateChange', () => {
+      if (editor.mode.isReadOnly() || editor.disabled) {
         close();
       }
     });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -22,11 +22,11 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
   const getValueFromCurrentComp = (comp: Optional<AlloyComponent>): string =>
     comp.map((alloyComp) => Representing.getValue(alloyComp)).getOr('');
 
-  const onSetup = onSetupEvent(editor, 'NodeChange SwitchMode', (api: BespokeSelectApi) => {
+  const onSetup = onSetupEvent(editor, 'NodeChange SwitchMode DisabledStateChange', (api: BespokeSelectApi) => {
     const comp = api.getComponent();
     currentComp = Optional.some(comp);
     spec.updateInputValue(comp);
-    Disabling.set(comp, !editor.selection.isEditable());
+    Disabling.set(comp, !editor.selection.isEditable() || editor.disabled);
   });
 
   const getApi = (comp: AlloyComponent): BespokeSelectApi => ({ getComponent: Fun.constant(comp) });
@@ -75,8 +75,8 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
     const editorOffCellStepButton = Cell(Fun.noop);
     const translatedTooltip = backstage.shared.providers.translate(tooltip);
     const altExecuting = Id.generate('altExecuting');
-    const onSetup = onSetupEvent(editor, 'NodeChange SwitchMode', (api: BespokeSelectApi) => {
-      Disabling.set(api.getComponent(), !editor.selection.isEditable());
+    const onSetup = onSetupEvent(editor, 'NodeChange SwitchMode DisabledStateChange', (api: BespokeSelectApi) => {
+      Disabling.set(api.getComponent(), !editor.selection.isEditable() || editor.disabled);
     });
 
     const onClick = (comp: AlloyComponent) => {


### PR DESCRIPTION
Related Ticket: TINY-11488 & TINY-11490

Description of Changes:
* Reverted previous `readonly` mode to `disabled` option
* Added demo (feel free to try and compare)
* Added support for dynamically changing the option in runtime, `firing` a `DisabledStateChangeEvent` when the value of setting the option and `editor.disabled` is different
* Disabled the ability to switch mode, switch to non-editable root and enable UIs when the editor is disabled
* Restored some tests from the previous readonly mode to disabled mode.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
