### PR TITLE
TINY-11510:  Adjust font size in the Comment input field

### DIFF
--- a/modules/oxide/src/less/theme/components/comments/comment.less
+++ b/modules/oxide/src/less/theme/components/comments/comment.less
@@ -145,6 +145,7 @@
       resize: none;
       white-space: normal;
       width: 100%;
+      font-size: @comment-font-size;
     }
   }
 


### PR DESCRIPTION
Related Ticket: TINY-11510

Description of Changes:
* Adjust font size in the Comment input field to match the comment body font size

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
