### PR TITLE
TINY-11559: Fixed focus onSetup issue

### DIFF
--- a/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
@@ -31,7 +31,7 @@ export default (): void => {
           align: 'start',
           icon: 'chevron-left',
           onAction: (formApi) => {
-            formApi.hide();
+            formApi.back();
           }
         },
         {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
@@ -8,13 +8,20 @@ import {
 import { InlineContent } from '@ephox/bridge';
 import { Singleton } from '@ephox/katamari';
 
+import * as ContextToolbarFocus from './ContextToolbarFocus';
 import { backSlideEvent } from './ContextUi';
 
 export const getFormApi = <T>(input: AlloyComponent): InlineContent.ContextFormInstanceApi<T> => {
   const valueState = Singleton.value<T>();
 
   return ({
-    setInputEnabled: (state: boolean) => Disabling.set(input, !state),
+    setInputEnabled: (state: boolean) => {
+      if (!state) {
+        ContextToolbarFocus.focusParent(input);
+      }
+
+      Disabling.set(input, !state);
+    },
     isInputEnabled: () => !Disabling.isDisabled(input),
     hide: () => {
       // Before we hide snapshot the current value since accessing the value of a form field after it's been detached will throw an error

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
@@ -38,7 +38,6 @@ export const getFormApi = <T>(input: AlloyComponent): InlineContent.ContextFormI
       }
 
       AlloyTriggers.emit(input, backSlideEvent);
-      AlloyTriggers.emit(input, SystemEvents.sandboxClose());
     },
     getValue: () => {
       return valueState.get().getOrThunk(() => Representing.getValue(input));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormGroup.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormGroup.ts
@@ -1,8 +1,8 @@
 import { AlloySpec, Behaviour, Disabling, FormField, SketchSpec } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
-import { Focus, SelectorFind } from '@ephox/sugar';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import * as ContextToolbarFocus from './ContextToolbarFocus';
 
 export const createContextFormFieldFromParts = (
   pLabel: Optional<AlloySpec>,
@@ -18,13 +18,7 @@ export const createContextFormFieldFromParts = (
     Disabling.config({
       disabled: () => providers.checkUiComponentContext('mode:design').shouldDisable,
       onDisabled: (comp) => {
-        // TODO: Is this really the best way to move focus out of the input when it gets disabled #TINY-11527
-        Focus.search(comp.element).each((focus) => {
-          SelectorFind.ancestor<HTMLElement>(focus, '[tabindex="-1"]').each((parent) => {
-            Focus.focus(parent);
-          });
-        });
-
+        ContextToolbarFocus.focusParent(comp);
         FormField.getField(comp).each(Disabling.disable);
       },
       onEnabled: (comp) => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
@@ -52,7 +52,11 @@ export const renderContextFormSliderInput = (
         }
       }),
       AddEventsBehaviour.config('slider-events', [
-        onControlAttached<InlineContent.ContextFormInstanceApi<number>>({ onSetup: ctx.onSetup, getApi: ContextFormApi.getFormApi }, editorOffCell),
+        onControlAttached<InlineContent.ContextFormInstanceApi<number>>({
+          onSetup: ctx.onSetup,
+          getApi: ContextFormApi.getFormApi,
+          onBeforeSetup: Keying.focusIn
+        }, editorOffCell),
         onControlDetached({ getApi: ContextFormApi.getFormApi }, editorOffCell),
         AlloyEvents.run(NativeEvents.input(), (comp) => {
           ctx.onInput(ContextFormApi.getFormApi(comp));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
@@ -53,7 +53,11 @@ export const renderContextFormTextInput = (
         }
       }),
       AddEventsBehaviour.config('input-events', [
-        onControlAttached<InlineContent.ContextFormInstanceApi<string>>({ onSetup: ctx.onSetup, getApi: ContextFormApi.getFormApi }, editorOffCell),
+        onControlAttached<InlineContent.ContextFormInstanceApi<string>>({
+          onSetup: ctx.onSetup,
+          getApi: ContextFormApi.getFormApi,
+          onBeforeSetup: Keying.focusIn
+        }, editorOffCell),
         onControlDetached({ getApi: ContextFormApi.getFormApi }, editorOffCell),
         AlloyEvents.run(NativeEvents.input(), (comp) => {
           ctx.onInput(ContextFormApi.getFormApi(comp));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarFocus.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarFocus.ts
@@ -15,3 +15,12 @@ export const focusIn = (contextbar: AlloyComponent): void => {
     );
   });
 };
+
+// TODO: Is this really the best way to move focus out of the input when it gets disabled #TINY-11527
+export const focusParent = (comp: AlloyComponent): void =>
+  Focus.search(comp.element).each((focus) => {
+    SelectorFind.ancestor<HTMLElement>(focus, '[tabindex="-1"]').each((parent) => {
+      Focus.focus(parent);
+    });
+  });
+

--- a/modules/tinymce/src/themes/silver/main/ts/ui/controls/Controls.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/controls/Controls.ts
@@ -9,6 +9,7 @@ export type OnDestroy<T> = (controlApi: T) => void;
 
 export interface OnControlAttachedType<T> extends GetApiType<T> {
   readonly onSetup: (controlApi: T) => OnDestroy<T> | void;
+  readonly onBeforeSetup?: (comp: AlloyComponent) => void;
 }
 
 const runWithApi = <T>(info: GetApiType<T>, comp: AlloyComponent): (f: OnDestroy<T>) => void => {
@@ -25,6 +26,10 @@ const runWithApi = <T>(info: GetApiType<T>, comp: AlloyComponent): (f: OnDestroy
 // the cell and the onAttachedHandler, but that would provide too much complexity.
 const onControlAttached = <T>(info: OnControlAttachedType<T>, editorOffCell: Cell<OnDestroy<T>>): AlloyEvents.AlloyEventKeyAndHandler<EventFormat> =>
   AlloyEvents.runOnAttached((comp) => {
+    if (Type.isFunction(info.onBeforeSetup)) {
+      info.onBeforeSetup(comp);
+    }
+
     const run = runWithApi(info, comp);
     run((api) => {
       const onDestroy = info.onSetup(api);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -123,7 +123,25 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
 
       ed.ui.registry.addContextToolbar('test-toolbar', {
         predicate: Fun.never,
-        items: 'form:test-form'
+        items: 'form:test-form',
+      });
+
+      ed.ui.registry.addContextForm('test-form-focus-on-init', {
+        launch: {
+          type: 'contextformtogglebutton',
+          icon: 'fake-icon-name',
+          tooltip: 'Focus on init',
+        },
+        onSetup: (formApi) => {
+          formApi.setInputEnabled(false);
+          return Fun.noop;
+        },
+        commands: [ ]
+      });
+
+      ed.ui.registry.addContextToolbar('test-toolbar-focus-on-init', {
+        predicate: Fun.never,
+        items: 'form:test-form-focus-on-init',
       });
     }
   }, [], true);
@@ -389,5 +407,14 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     const editor = hook.editor();
     openToolbar(editor, 'test-form');
     UiFinder.exists(SugarBody.body(), '.tox-pop input[placeholder="This is a placeholder"]');
+  });
+
+  it('TINY-11559: Focus should be on toolbar when onSetup disables the main input', () => {
+    const editor = hook.editor();
+    const doc = SugarDocument.getDocument();
+
+    openToolbar(editor, 'test-toolbar-focus-on-init');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-name="form:test-form-focus-on-init"]');
+    FocusTools.isOnSelector('Focus should be on toolbar', doc, '[role="toolbar"]');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-11559

Description of Changes:
* Calling `setInputEnabled` in the `onSetup` would move the the focus to the `document.body` so now it instead it moves the focus to the parent toolbar.
* Focus needs to be set before we call `onSetup` and since we can only have one handler for the `onControlAttached` a new optional handler was added to the generic `onControlAttached`.

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new context form and toolbar that focuses on initialization.
	- Added functionality to manage focus behavior when input fields are disabled.

- **Enhancements**
	- Streamlined focus handling during input component disabling.
	- Added pre-setup logic capability for better control initialization.

- **Bug Fixes**
	- Improved focus management to ensure correct behavior when inputs are disabled during setup.

- **Tests**
	- Expanded test suite to verify focus behavior in new context forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->