### PR TITLE
TINY-11558: Fix bundling for skin UI content CSS

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11558-2024-11-20.yaml
+++ b/.changes/unreleased/tinymce-TINY-11558-2024-11-20.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Fixed CSS bundling for skin UI content CSS.
+time: 2024-11-20T17:04:10.574250183+10:00
+custom:
+  Issue: TINY-11558

--- a/.changes/unreleased/tinymce-TINY-11558-2024-11-21.yaml
+++ b/.changes/unreleased/tinymce-TINY-11558-2024-11-21.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Fixed incorect resource keys for CSS bundling JS files.
+time: 2024-11-21T14:39:55.661765563+10:00
+custom:
+  Issue: TINY-11558

--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -396,7 +396,7 @@ module.exports = function (grunt) {
         options: {
           process: function (content) {
             return content.replace(
-              /'ui\/(.+)\/(.+\.css)'/,
+              /'ui\/([^\/]+)\/([^']+)'/,
               (_, p1, p2) => `'ui/${oxideUiSkinMap[p1] || p1}/${p2}'`
             );
           },

--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -393,6 +393,14 @@ module.exports = function (grunt) {
         ]
       },
       'ui-skins': {
+        options: {
+          process: function (content) {
+            return content.replace(
+              /'ui\/(.+)\/(.+\.css)'/,
+              (_, p1, p2) => `'ui/${oxideUiSkinMap[p1] || p1}/${p2}'`
+            );
+          },
+        },
         files: gruntUtils.flatMap(oxideUiSkinMap, function (name, mappedName) {
           return [
             {

--- a/modules/tinymce/src/core/demo/html/bundled_css_demo.html
+++ b/modules/tinymce/src/core/demo/html/bundled_css_demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Bundled CSS Demo Page</title>
+  </head>
+
+  <body>
+  <h2>Bundled CSS Demo Page</h2>
+    <div id="ephox-ui">
+      <textarea class="tinymce">
+        <p>Plain paragraph</p>
+        <p><a id="abc"></a></p>
+        <table style="border-collapse: collapse; width: 99.9851%;" border="1"><colgroup><col style="width: 50%;"><col style="width: 50%;"></colgroup>
+        <tbody>
+        <tr>
+        <td>a</td>
+        <td>b</td>
+        </tr>
+        <tr>
+        <td>c</td>
+        <td>d</td>
+        </tr>
+        </tbody>
+        </table>
+        <p><img src="https://www.w3schools.com/w3css/img_lights.jpg" alt="" width="600" height="400"></p>
+      </textarea>
+    </div>
+    <script src="../../../../js/tinymce/tinymce.js"></script>
+    <script src="../../../../js/tinymce/skins/ui/oxide/skin.js"></script>
+    <script src="../../../../js/tinymce/skins/content/default/content.js"></script>
+    <script src="../../../../js/tinymce/skins/ui/oxide/content.js"></script>
+    <script src="../../../../scratch/demos/core/demo.js"></script>
+    <script>demos.BundledCssDemo();</script>
+  </body>
+</html>

--- a/modules/tinymce/src/core/demo/html/bundled_css_demo.html
+++ b/modules/tinymce/src/core/demo/html/bundled_css_demo.html
@@ -29,6 +29,9 @@
     <script src="../../../../js/tinymce/skins/ui/oxide/skin.js"></script>
     <script src="../../../../js/tinymce/skins/content/default/content.js"></script>
     <script src="../../../../js/tinymce/skins/ui/oxide/content.js"></script>
+    <!-- <script src="../../../../js/tinymce/skins/ui/oxide-dark/skin.js"></script>
+    <script src="../../../../js/tinymce/skins/content/dark/content.js"></script>
+    <script src="../../../../js/tinymce/skins/ui/oxide-dark/content.js"></script> -->
     <script src="../../../../scratch/demos/core/demo.js"></script>
     <script>demos.BundledCssDemo();</script>
   </body>

--- a/modules/tinymce/src/core/demo/ts/demo/BundledCssDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/BundledCssDemo.ts
@@ -6,6 +6,7 @@ export default (): void => {
   tinymce.init({
     selector: 'textarea',
     plugins: [ 'code' ],
+    // Enable scripts in bundled_css_demo.html before uncommenting below lines
     // skin: 'oxide-dark',
     // content_css: 'dark'
   });

--- a/modules/tinymce/src/core/demo/ts/demo/BundledCssDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/BundledCssDemo.ts
@@ -1,0 +1,12 @@
+import { TinyMCE } from 'tinymce/core/api/PublicApi';
+
+declare let tinymce: TinyMCE;
+
+export default (): void => {
+  tinymce.init({
+    selector: 'textarea',
+    plugins: [ 'code' ],
+    // skin: 'oxide-dark',
+    // content_css: 'dark'
+  });
+};

--- a/modules/tinymce/src/core/demo/ts/demo/Demos.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/Demos.ts
@@ -1,4 +1,5 @@
 import AnnotationsDemo from './AnnotationsDemo';
+import BundledCssDemo from './BundledCssDemo';
 import CommandsDemo from './CommandsDemo';
 import ContentEditableFalseDemo from './ContentEditableFalseDemo';
 import ContextFormDemo from './ContextFormDemo';
@@ -37,5 +38,6 @@ window.demos = {
   ShadowDomInlineDemo,
   ReadOnlyDemo,
   ViewDemo,
-  ContextFormDemo
+  ContextFormDemo,
+  BundledCssDemo
 };

--- a/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
@@ -166,9 +166,10 @@ const StyleSheetLoader = (documentOrShadowRoot: Document | ShadowRoot, settings:
     // Start loading
     const styleElem = SugarElement.fromTag('style', doc.dom);
     Attribute.setAll(styleElem, {
-      rel: 'stylesheet',
-      type: 'text/css',
-      id: state.id
+      'rel': 'stylesheet',
+      'type': 'text/css',
+      'id': state.id,
+      'data-mce-key': key
     });
 
     styleElem.dom.innerHTML = css;

--- a/modules/tinymce/src/core/test/ts/browser/dom/BundledCssTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/BundledCssTest.ts
@@ -91,7 +91,7 @@ describe('browser.tinymce.core.dom.BundledCssTest', () => {
               for (const skin of [ 'oxide', 'oxide-dark', 'tinymce-5', 'tinymce-5-dark' ] as UiSkin[]) {
                 context('skin: ' + skin, () => {
                   context('no bundling', () => {
-                    it('TINY-11558: Load CSS styesheets as links', async () => {
+                    it('TINY-11558: Load CSS stylesheets as links', async () => {
                       const [ editor, cleanup ] = await pCreateEditor(
                         shadowdom,
                         {

--- a/modules/tinymce/src/core/test/ts/browser/dom/BundledCssTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/BundledCssTest.ts
@@ -1,0 +1,256 @@
+import { after, before, context, describe, it } from '@ephox/bedrock-client';
+import { Arr, Fun } from '@ephox/katamari';
+import { Insert, Remove, SelectorFilter, SugarBody, SugarElement, SugarHead, SugarShadowDom } from '@ephox/sugar';
+import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import { TinyMCE } from 'tinymce/core/api/Tinymce';
+
+declare const tinymce: TinyMCE;
+
+describe('browser.tinymce.core.dom.BundledCssTest', () => {
+  const baseUrl = '/project/tinymce/js/tinymce/';
+  const skinContentDir = (skin: 'default' | 'dark') => baseUrl + `skins/content/${skin}/`;
+  const skinUiDir = (skin: 'oxide' | 'oxide-dark') => baseUrl + `skins/ui/${skin}/`;
+
+  const skinContentCss = (skin: 'default' | 'dark', withSuffix: boolean) => skinContentDir(skin) + `content${withSuffix ? '.min' : ''}.css`;
+  const skinContentJs = (skin: 'default' | 'dark') => skinContentDir(skin) + `content.js`;
+
+  const skinUiCss = (skin: 'oxide' | 'oxide-dark', shadowDom: boolean, withSuffix: boolean) => skinUiDir(skin) + `skin${shadowDom ? '.shadowdom' : ''}${withSuffix ? '.min' : ''}.css`;
+  const skinUiJs = (skin: 'oxide' | 'oxide-dark', shadowDom: boolean) => skinUiDir(skin) + `skin${shadowDom ? '.shadowdom' : ''}.js`;
+
+  const skinUiContentCss = (skin: 'oxide' | 'oxide-dark', inline: boolean, withSuffix: boolean) => skinUiDir(skin) + `content${inline ? '.inline' : ''}${withSuffix ? '.min' : ''}.css`;
+  const skinUiContentJs = (skin: 'oxide' | 'oxide-dark', inline: boolean) => skinUiDir(skin) + `content${inline ? '.inline' : ''}.js`;
+
+  const styleTagsToKeys = (styleTags: SugarElement<HTMLStyleElement>[]) => {
+    return Arr.map(styleTags, (tag) => tag.dom.dataset.mceKey);
+  };
+
+  const linkTagsToKeys = (linkTags: SugarElement<HTMLLinkElement>[], basePath: string) => {
+    return Arr.map(linkTags, (tag) => tag.dom.href.replace(basePath, ''));
+  };
+
+  const getCssTags = (container: SugarElement<HTMLHeadElement | ShadowRoot>) => {
+    const style =
+      SelectorFilter.descendants<HTMLStyleElement>(
+        container,
+        'style'
+      );
+    const link =
+      SelectorFilter.descendants<HTMLLinkElement>(
+        container,
+        'link'
+      );
+
+    return {
+      style,
+      link
+    };
+  };
+
+  const getIframeCSSTags = (editor: Editor) =>
+    getCssTags(SugarShadowDom.getStyleContainer(SugarShadowDom.getRootNode(TinyDom.body(editor))));
+
+  const getCSSContainerTags = (editor: Editor) =>
+    getCssTags(SugarShadowDom.getStyleContainer(SugarShadowDom.getRootNode(TinyDom.targetElement(editor))));
+
+  const pCreateEditor = async (shadowDom: boolean, settings: Record<string, any>) => {
+    if (shadowDom) {
+      const shadowHost = SugarElement.fromTag('div', document);
+      Insert.append(SugarBody.body(), shadowHost);
+      const sr = SugarElement.fromDom(shadowHost.dom.attachShadow({ mode: 'open' }));
+      const editorDiv = SugarElement.fromTag('div', document);
+      Insert.append(sr, editorDiv);
+
+      const cleanup = () => {
+        Remove.remove(shadowHost);
+      };
+      const editor = await McEditor.pFromElement<Editor>(editorDiv, {
+        ...settings
+      });
+      return [ editor, cleanup ] as const;
+    } else {
+      const editor = await McEditor.pFromSettings<Editor>({
+        ...settings
+      });
+      const cleanup = Fun.noop;
+      return [ editor, cleanup ] as const;
+    }
+  };
+
+  for (const inline of [ false, true ]) {
+    context('inline: ' + inline, () => {
+      for (const shadowdom of [ false, true ]) {
+        context('shadowdom: ' + shadowdom, () => {
+          for (const contentCss of [ 'default', 'dark' ] as const) {
+            context('contentCSS: ' + contentCss, () => {
+              for (const skin of [ 'oxide', 'oxide-dark' ] as const) {
+                context('skin: ' + skin, () => {
+                  const oxideUiSkinMap: Record<string, string> = {
+                    'oxide-dark': 'dark',
+                    'oxide': 'default',
+                    'tinymce-5': 'tinymce-5',
+                    'tinymce-5-dark': 'tinymce-5-dark'
+                  };
+
+                  context('no bundling', () => {
+                    it('TINY-11558: Load CSS styesheets as links', async () => {
+                      const [ editor, cleanup ] = await pCreateEditor(
+                        shadowdom,
+                        {
+                          inline,
+                          skin,
+                          ...!inline ? { content_css: contentCss } : {},
+                          content_style: '',
+                          base_url: '/project/tinymce/js/tinymce'
+                        }
+                      );
+                      const hostUrl = `${editor.baseURI.protocol}://${editor.baseURI.authority}`;
+
+                      if (!inline) {
+                        const { style: iframeStyleTags, link: iframeLinkTags } = getIframeCSSTags(editor);
+                        assert.isEmpty(iframeStyleTags);
+                        assert.lengthOf(iframeLinkTags, 2);
+                        assert.includeMembers(
+                          linkTagsToKeys(iframeLinkTags, hostUrl),
+                          [
+                            skinContentCss(contentCss, false),
+                            skinUiContentCss(skin, inline, false),
+                          ]
+                        );
+                      }
+
+                      if (shadowdom) {
+                        const { style: pageStyleTags, link: pageLinkTags } = getCssTags(SugarHead.head());
+                        assert.isEmpty(pageStyleTags);
+                        assert.lengthOf(pageLinkTags, 2);
+                        assert.includeMembers(
+                          linkTagsToKeys(pageLinkTags, hostUrl),
+                          [
+                            skinUiCss(skin, true, false),
+                            '/css/bedrock.css'
+                          ]
+                        );
+                      }
+
+                      const { style: cssStyleTags, link: cssLinkTags } = getCSSContainerTags(editor);
+                      assert.isEmpty(cssStyleTags);
+                      assert.lengthOf(cssLinkTags, 1 + (inline ? 1 : 0) + (shadowdom ? 0 : 1));
+                      assert.includeMembers(
+                        linkTagsToKeys(cssLinkTags, hostUrl),
+                        [
+                          ...shadowdom ? [] : [ '/css/bedrock.css' ],
+                          ...inline ? [ skinUiContentCss(skin, inline, false) ] : [],
+                          skinUiCss(skin, false, false),
+                        ]
+                      );
+
+                      McEditor.remove(editor);
+                      cleanup();
+                    });
+                  });
+
+                  context('bundling', () => {
+                    const resourceKeys = [
+                      `content/${contentCss}/content.css`,
+                      `ui/${oxideUiSkinMap[skin]}/content.css`,
+                      `ui/${oxideUiSkinMap[skin]}/skin.css`,
+                      `ui/${oxideUiSkinMap[skin]}/skin.shadowdom.css`,
+                      `ui/${oxideUiSkinMap[skin]}/content.inline.css`,
+                    ];
+
+                    const jsScripts = [
+                      skinUiJs(skin, false),
+                      skinUiJs(skin, true),
+                      skinContentJs(contentCss),
+                      skinUiContentJs(skin, false),
+                      skinUiContentJs(skin, true),
+                    ];
+
+                    before(async () => {
+                      const scriptsLoaded = tinymce.ScriptLoader.loadScripts(jsScripts)
+                        .catch((errors) => {
+                          // eslint-disable-next-line no-console
+                          console.error(errors);
+                          assert.fail('Unable to load scripts');
+                        });
+                      await scriptsLoaded;
+
+                      for (const key of resourceKeys) {
+                        assert.isTrue(tinymce.Resource.has(key));
+                      }
+                    });
+
+                    after(() => {
+                      Arr.each(jsScripts, (url) => tinymce.ScriptLoader.remove(url));
+                      Arr.each(resourceKeys, tinymce.Resource.unload);
+                    });
+
+                    it('TINY-11558: Load CSS using JS files', async () => {
+                      const [ editor, cleanup ] = await pCreateEditor(
+                        shadowdom,
+                        {
+                          inline,
+                          skin,
+                          ...!inline ? { content_css: contentCss } : {},
+                          content_style: '',
+                        }
+                      );
+                      const hostUrl = `${editor.baseURI.protocol}://${editor.baseURI.authority}`;
+
+                      if (!inline) {
+                        const { style: iframeStyleTags, link: iframeLinkTags } = getIframeCSSTags(editor);
+                        assert.isEmpty(iframeLinkTags);
+                        assert.lengthOf(iframeStyleTags, 2);
+                        assert.includeMembers(
+                          styleTagsToKeys(iframeStyleTags),
+                          [
+                            contentCss,
+                            `ui/${oxideUiSkinMap[skin]}/content.css`
+                          ]
+                        );
+                      }
+
+                      if (shadowdom) {
+                        const { style: pageStyleTags, link: pageLinkTags } = getCssTags(SugarHead.head());
+                        assert.deepEqual(
+                          linkTagsToKeys(pageLinkTags, hostUrl),
+                          [ '/css/bedrock.css' ]
+                        );
+                        assert.lengthOf(pageStyleTags, 1);
+                        assert.includeMembers(
+                          styleTagsToKeys(pageStyleTags),
+                          [
+                            `ui/${oxideUiSkinMap[skin]}/skin.shadowdom.css`
+                          ]
+                        );
+                      }
+
+                      const { style: cssStyleTags, link: cssLinkTags } = getCSSContainerTags(editor);
+                      assert.deepEqual(
+                        linkTagsToKeys(cssLinkTags, hostUrl),
+                        shadowdom ? [] : [ '/css/bedrock.css' ]
+                      );
+                      assert.lengthOf(cssStyleTags, 1 + (inline ? 1 : 0));
+                      assert.includeMembers(
+                        styleTagsToKeys(cssStyleTags),
+                        [
+                          `ui/${oxideUiSkinMap[skin]}/skin.css`,
+                          ...inline ? [ `ui/${oxideUiSkinMap[skin]}/content.inline.css` ] : [],
+                        ]
+                      );
+
+                      McEditor.remove(editor);
+                      cleanup();
+                    });
+                  });
+                });
+              }
+            });
+          }
+        });
+      }
+    });
+  }
+});

--- a/modules/tinymce/src/core/test/ts/browser/dom/BundledCssTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/BundledCssTest.ts
@@ -10,6 +10,13 @@ import { TinyMCE } from 'tinymce/core/api/Tinymce';
 declare const tinymce: TinyMCE;
 
 describe('browser.tinymce.core.dom.BundledCssTest', () => {
+  const oxideUiSkinMap: Record<string, string> = {
+    'oxide-dark': 'dark',
+    'oxide': 'default',
+    'tinymce-5': 'tinymce-5',
+    'tinymce-5-dark': 'tinymce-5-dark'
+  };
+
   const baseUrl = '/project/tinymce/js/tinymce/';
   const skinContentDir = (skin: 'default' | 'dark') => baseUrl + `skins/content/${skin}/`;
   const skinUiDir = (skin: 'oxide' | 'oxide-dark') => baseUrl + `skins/ui/${skin}/`;
@@ -87,13 +94,6 @@ describe('browser.tinymce.core.dom.BundledCssTest', () => {
             context('contentCSS: ' + contentCss, () => {
               for (const skin of [ 'oxide', 'oxide-dark' ] as const) {
                 context('skin: ' + skin, () => {
-                  const oxideUiSkinMap: Record<string, string> = {
-                    'oxide-dark': 'dark',
-                    'oxide': 'default',
-                    'tinymce-5': 'tinymce-5',
-                    'tinymce-5-dark': 'tinymce-5-dark'
-                  };
-
                   context('no bundling', () => {
                     it('TINY-11558: Load CSS styesheets as links', async () => {
                       const [ editor, cleanup ] = await pCreateEditor(

--- a/modules/tinymce/src/core/test/ts/browser/dom/BundledCssTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/BundledCssTest.ts
@@ -9,26 +9,22 @@ import { TinyMCE } from 'tinymce/core/api/Tinymce';
 
 declare const tinymce: TinyMCE;
 
+type ContentSkin = 'default' | 'dark' | 'writer' | 'document' | 'tinymce-5' | 'tinymce-5-dark';
+type UiSkin = 'oxide' | 'oxide-dark' | 'tinymce-5' | 'tinymce-5-dark';
+
 describe('browser.tinymce.core.dom.BundledCssTest', () => {
-  const oxideUiSkinMap: Record<string, string> = {
-    'oxide-dark': 'dark',
-    'oxide': 'default',
-    'tinymce-5': 'tinymce-5',
-    'tinymce-5-dark': 'tinymce-5-dark'
-  };
-
   const baseUrl = '/project/tinymce/js/tinymce/';
-  const skinContentDir = (skin: 'default' | 'dark') => baseUrl + `skins/content/${skin}/`;
-  const skinUiDir = (skin: 'oxide' | 'oxide-dark') => baseUrl + `skins/ui/${skin}/`;
+  const skinContentDir = (skin: ContentSkin) => baseUrl + `skins/content/${skin}/`;
+  const skinUiDir = (skin: UiSkin) => baseUrl + `skins/ui/${skin}/`;
 
-  const skinContentCss = (skin: 'default' | 'dark', withSuffix: boolean) => skinContentDir(skin) + `content${withSuffix ? '.min' : ''}.css`;
-  const skinContentJs = (skin: 'default' | 'dark') => skinContentDir(skin) + `content.js`;
+  const skinContentCss = (skin: ContentSkin, withSuffix: boolean) => skinContentDir(skin) + `content${withSuffix ? '.min' : ''}.css`;
+  const skinContentJs = (skin: ContentSkin) => skinContentDir(skin) + `content.js`;
 
-  const skinUiCss = (skin: 'oxide' | 'oxide-dark', shadowDom: boolean, withSuffix: boolean) => skinUiDir(skin) + `skin${shadowDom ? '.shadowdom' : ''}${withSuffix ? '.min' : ''}.css`;
-  const skinUiJs = (skin: 'oxide' | 'oxide-dark', shadowDom: boolean) => skinUiDir(skin) + `skin${shadowDom ? '.shadowdom' : ''}.js`;
+  const skinUiCss = (skin: UiSkin, shadowDom: boolean, withSuffix: boolean) => skinUiDir(skin) + `skin${shadowDom ? '.shadowdom' : ''}${withSuffix ? '.min' : ''}.css`;
+  const skinUiJs = (skin: UiSkin, shadowDom: boolean) => skinUiDir(skin) + `skin${shadowDom ? '.shadowdom' : ''}.js`;
 
-  const skinUiContentCss = (skin: 'oxide' | 'oxide-dark', inline: boolean, withSuffix: boolean) => skinUiDir(skin) + `content${inline ? '.inline' : ''}${withSuffix ? '.min' : ''}.css`;
-  const skinUiContentJs = (skin: 'oxide' | 'oxide-dark', inline: boolean) => skinUiDir(skin) + `content${inline ? '.inline' : ''}.js`;
+  const skinUiContentCss = (skin: UiSkin, inline: boolean, withSuffix: boolean) => skinUiDir(skin) + `content${inline ? '.inline' : ''}${withSuffix ? '.min' : ''}.css`;
+  const skinUiContentJs = (skin: UiSkin, inline: boolean) => skinUiDir(skin) + `content${inline ? '.inline' : ''}.js`;
 
   const styleTagsToKeys = (styleTags: SugarElement<HTMLStyleElement>[]) => {
     return Arr.map(styleTags, (tag) => tag.dom.dataset.mceKey);
@@ -90,9 +86,9 @@ describe('browser.tinymce.core.dom.BundledCssTest', () => {
     context('inline: ' + inline, () => {
       for (const shadowdom of [ false, true ]) {
         context('shadowdom: ' + shadowdom, () => {
-          for (const contentCss of [ 'default', 'dark' ] as const) {
+          for (const contentCss of [ 'default', 'dark', 'document', 'writer' ] as ContentSkin[]) {
             context('contentCSS: ' + contentCss, () => {
-              for (const skin of [ 'oxide', 'oxide-dark' ] as const) {
+              for (const skin of [ 'oxide', 'oxide-dark', 'tinymce-5', 'tinymce-5-dark' ] as UiSkin[]) {
                 context('skin: ' + skin, () => {
                   context('no bundling', () => {
                     it('TINY-11558: Load CSS styesheets as links', async () => {
@@ -154,10 +150,10 @@ describe('browser.tinymce.core.dom.BundledCssTest', () => {
                   context('bundling', () => {
                     const resourceKeys = [
                       `content/${contentCss}/content.css`,
-                      `ui/${oxideUiSkinMap[skin]}/content.css`,
-                      `ui/${oxideUiSkinMap[skin]}/skin.css`,
-                      `ui/${oxideUiSkinMap[skin]}/skin.shadowdom.css`,
-                      `ui/${oxideUiSkinMap[skin]}/content.inline.css`,
+                      `ui/${skin}/content.css`,
+                      `ui/${skin}/skin.css`,
+                      `ui/${skin}/skin.shadowdom.css`,
+                      `ui/${skin}/content.inline.css`,
                     ];
 
                     const jsScripts = [
@@ -207,7 +203,7 @@ describe('browser.tinymce.core.dom.BundledCssTest', () => {
                           styleTagsToKeys(iframeStyleTags),
                           [
                             contentCss,
-                            `ui/${oxideUiSkinMap[skin]}/content.css`
+                            `ui/${skin}/content.css`
                           ]
                         );
                       }
@@ -222,7 +218,7 @@ describe('browser.tinymce.core.dom.BundledCssTest', () => {
                         assert.includeMembers(
                           styleTagsToKeys(pageStyleTags),
                           [
-                            `ui/${oxideUiSkinMap[skin]}/skin.shadowdom.css`
+                            `ui/${skin}/skin.shadowdom.css`
                           ]
                         );
                       }
@@ -236,8 +232,8 @@ describe('browser.tinymce.core.dom.BundledCssTest', () => {
                       assert.includeMembers(
                         styleTagsToKeys(cssStyleTags),
                         [
-                          `ui/${oxideUiSkinMap[skin]}/skin.css`,
-                          ...inline ? [ `ui/${oxideUiSkinMap[skin]}/content.inline.css` ] : [],
+                          `ui/${skin}/skin.css`,
+                          ...inline ? [ `ui/${skin}/content.inline.css` ] : [],
                         ]
                       );
 

--- a/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
@@ -332,6 +332,7 @@ const getSidebarShow = option('sidebar_show');
 const promotionEnabled = option('promotion');
 const useHelpAccessibility = option('help_accessibility');
 const getDefaultFontStack = option('default_font_stack');
+
 const getSkin = option<string | false>('skin');
 
 const isSkinDisabled = (editor: Editor): boolean =>

--- a/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
@@ -332,7 +332,7 @@ const getSidebarShow = option('sidebar_show');
 const promotionEnabled = option('promotion');
 const useHelpAccessibility = option('help_accessibility');
 const getDefaultFontStack = option('default_font_stack');
-const getSkin = option('skin');
+const getSkin = option<string | false>('skin');
 
 const isSkinDisabled = (editor: Editor): boolean =>
   editor.options.get('skin') === false;

--- a/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
@@ -332,6 +332,7 @@ const getSidebarShow = option('sidebar_show');
 const promotionEnabled = option('promotion');
 const useHelpAccessibility = option('help_accessibility');
 const getDefaultFontStack = option('default_font_stack');
+const getSkin = option('skin');
 
 const isSkinDisabled = (editor: Editor): boolean =>
   editor.options.get('skin') === false;
@@ -439,6 +440,7 @@ export {
   getSkinUrl,
   getSkinUrlOption,
   isReadOnly,
+  getSkin,
   isSkinDisabled,
   getHeightOption,
   getWidthOption,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/skin/Loader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/skin/Loader.ts
@@ -20,10 +20,8 @@ const getSkinResourceIdentifier = (editor: Editor): Optional<string> => {
   };
 
   const skin = Options.getSkin(editor);
-  if (skin === false) {
+  if (!skin) {
     return Optional.none();
-  } else if (skin === true || Type.isNullable(skin)) {
-    return Obj.get(oxideUiSkinMap, 'oxide');
   } else {
     return Obj.get(oxideUiSkinMap, skin).or(Optional.from(skin));
   }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/skin/Loader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/skin/Loader.ts
@@ -1,4 +1,4 @@
-import { Fun, Obj, Optional, Optionals, Type } from '@ephox/katamari';
+import { Fun, Optional, Optionals, Type } from '@ephox/katamari';
 import { SugarElement, SugarShadowDom } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
@@ -12,18 +12,12 @@ import * as Options from '../../api/Options';
 import * as SkinLoaded from './SkinLoaded';
 
 const getSkinResourceIdentifier = (editor: Editor): Optional<string> => {
-  const oxideUiSkinMap: Record<string, string> = {
-    'oxide-dark': 'dark',
-    'oxide': 'default',
-    'tinymce-5': 'tinymce-5',
-    'tinymce-5-dark': 'tinymce-5-dark'
-  };
-
   const skin = Options.getSkin(editor);
+  // Use falsy check to cover false, undefined/null and empty string
   if (!skin) {
     return Optional.none();
   } else {
-    return Obj.get(oxideUiSkinMap, skin).or(Optional.from(skin));
+    return Optional.from(skin);
   }
 };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ResourceLoadingCssTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ResourceLoadingCssTest.ts
@@ -27,10 +27,10 @@ describe('browser.tinymce.themes.silver.editor.ResourceLoadingCssTest', () => {
   });
 
   it('TINY-10378: A resource is added, and it is relevant to our skins', async () => {
-    tinymce.Resource.add('ui/default/skin.css', '* {background-color: red !important;}');
+    tinymce.Resource.add('ui/oxide/skin.css', '* {background-color: red !important;}');
     const editor = await pGetEditor();
     assert.equal(Css.get(TinyDom.container(editor), 'background-color'), 'rgb(255, 0, 0)');
-    tinymce.Resource.unload('ui/default/skin.css');
+    tinymce.Resource.unload('ui/oxide/skin.css');
     McEditor.remove(editor);
 
     // confidence check that subsequent editor aren't also red.


### PR DESCRIPTION
Related Ticket: TINY-11558

Description of Changes:
* Change Loader.ts to use `skin` option rather than the `skin_url` option for checking if a resource exists for bundling.
* Fix loading UI skin content CSS in iframe mode as it would have never correctly inserted it in the iframe

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [X] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a demo page for showcasing bundled CSS functionality in TinyMCE.
  - Added a new function to retrieve the skin option from the editor's settings.

- **Bug Fixes**
  - Fixed issues related to CSS bundling for skin UI content.
  - Corrected resource keys used for CSS bundling of JavaScript files.

- **Tests**
  - Added a comprehensive test suite for validating bundled CSS functionality within TinyMCE.
  - Updated tests to reflect changes in resource paths for CSS loading.

- **Chores**
  - Enhanced the handling of skin resources and loading processes in the TinyMCE editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->