### PR TITLE
TINY-11488: Prevent switching modes only when editor has been initialized

### DIFF
--- a/modules/tinymce/src/core/main/ts/mode/Mode.ts
+++ b/modules/tinymce/src/core/main/ts/mode/Mode.ts
@@ -29,7 +29,7 @@ const switchToMode = (editor: Editor, activeMode: Cell<string>, availableModes: 
 };
 
 const setMode = (editor: Editor, availableModes: Record<string, EditorModeApi>, activeMode: Cell<string>, mode: string): void => {
-  if (mode === activeMode.get() || Disabled.isDisabled(editor)) {
+  if (mode === activeMode.get() || (editor.initialized && Disabled.isDisabled(editor))) {
     return;
   } else if (!Obj.has(availableModes, mode)) {
     throw new Error(`Editor mode '${mode}' is invalid`);

--- a/modules/tinymce/src/core/test/ts/browser/DisabledModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/DisabledModeTest.ts
@@ -355,22 +355,6 @@ describe('browser.tinymce.core.DisabledModeTest', () => {
     it('TINY-11488: Should not allow switching modes when the editor is disabled', async () => {
       const editor = hook.editor();
       await Waiter.pTryUntil('Wait for editor to be disabled', () => assertEditorDisabled(editor));
-
-      editor.mode.set('readonly');
-      await Waiter.pTryUntil('Wait for editor to be disabled', () => assertEditorDisabled(editor));
-
-      editor.options.set('disabled', false);
-      await Waiter.pTryUntil('Wait for editor to be enabled', () => assertEditorEnabled(editor));
-
-      editor.mode.set('readonly');
-      await Waiter.pTryUntil('Wait for editor to be enabled', () => assertEditorEnabled(editor));
-
-      editor.mode.set('design');
-    });
-
-    it('TINY-11488: Checking editor property when switching modes', async () => {
-      const editor = hook.editor();
-      await Waiter.pTryUntil('Wait for editor to be disabled', () => assertEditorDisabled(editor));
       assert.equal(editor.mode.get(), 'design', 'Editor should still be in design mode');
       assert.isFalse(editor.readonly, 'Editor readonly property should not be true');
 

--- a/modules/tinymce/src/core/test/ts/browser/DisabledModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/DisabledModeTest.ts
@@ -355,12 +355,40 @@ describe('browser.tinymce.core.DisabledModeTest', () => {
     it('TINY-11488: Should not allow switching modes when the editor is disabled', async () => {
       const editor = hook.editor();
       await Waiter.pTryUntil('Wait for editor to be disabled', () => assertEditorDisabled(editor));
+
       editor.mode.set('readonly');
       await Waiter.pTryUntil('Wait for editor to be disabled', () => assertEditorDisabled(editor));
+
       editor.options.set('disabled', false);
       await Waiter.pTryUntil('Wait for editor to be enabled', () => assertEditorEnabled(editor));
+
       editor.mode.set('readonly');
       await Waiter.pTryUntil('Wait for editor to be enabled', () => assertEditorEnabled(editor));
+
+      editor.mode.set('design');
+    });
+
+    it('TINY-11488: Checking editor property when switching modes', async () => {
+      const editor = hook.editor();
+      await Waiter.pTryUntil('Wait for editor to be disabled', () => assertEditorDisabled(editor));
+      assert.equal(editor.mode.get(), 'design', 'Editor should still be in design mode');
+      assert.isFalse(editor.readonly, 'Editor readonly property should not be true');
+
+      editor.mode.set('readonly');
+      await Waiter.pTryUntil('Wait for editor to be disabled', () => assertEditorDisabled(editor));
+      assert.equal(editor.mode.get(), 'design', 'Editor should still be in design mode');
+      assert.isFalse(editor.readonly, 'Editor readonly property should not be true');
+
+      editor.options.set('disabled', false);
+      await Waiter.pTryUntil('Wait for editor to be enabled', () => assertEditorEnabled(editor));
+      assert.equal(editor.mode.get(), 'design', 'Editor should still be in design mode');
+      assert.isFalse(editor.readonly, 'Editor readonly property should not be true');
+
+      editor.mode.set('readonly');
+      await Waiter.pTryUntil('Wait for editor to be enabled', () => assertEditorEnabled(editor));
+      assert.equal(editor.mode.get(), 'readonly', 'Editor switch to readonly mode');
+      assert.isTrue(editor.readonly, 'Editor readonly property should be true');
+
       editor.mode.set('design');
     });
 
@@ -526,6 +554,28 @@ describe('browser.tinymce.core.DisabledModeTest', () => {
 
       editor.setEditableRoot(true);
       assertButtonsStateEnabled(allButtons);
+    });
+  });
+
+  context('With disabled and readonly option', () => {
+    const hook = TinyHooks.bddSetup<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      disabled: true,
+      readonly: true,
+    }, []);
+
+    it('TINY-11488: Should set to disabled and readonly when both option is set', async () => {
+      const editor = hook.editor();
+      assert.equal(hook.editor().mode.get(), 'readonly', 'Editor should be readonly');
+      assert.isTrue(hook.editor().readonly, 'Editor should be readonly');
+
+      editor.mode.set('design');
+      assert.equal(hook.editor().mode.get(), 'readonly', 'Editor should still be in readonly');
+      assert.isTrue(hook.editor().readonly, 'Editor should still be in readonly');
+
+      editor.options.set('disabled', false);
+      assert.equal(hook.editor().mode.get(), 'readonly', 'Editor should still be in readonly');
+      assert.isTrue(hook.editor().readonly, 'Editor should still be in readonly');
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-11488

Description of Changes:
* Fix when setting both `readonly` and `disabled` to true, the editor stays in design mode
* Should only prevent mode from being switched when the editor has been initialized

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved condition checks for editor mode transitions, ensuring the editor is initialized before evaluating disabled states.
- **Bug Fixes**
	- Enhanced handling of editor states to ensure correct behavior and UI responses during mode transitions.
- **Tests**
	- Added new test cases for verifying the editor's behavior in disabled and readonly modes, ensuring accurate state representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->