### PR TITLE
TINY-11446: Escape shadowdom trapping the cursor

### DIFF
--- a/modules/tinymce/src/core/main/ts/keyboard/PreventNoneditableInput.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/PreventNoneditableInput.ts
@@ -1,4 +1,5 @@
-import { Arr } from '@ephox/katamari';
+import { Arr, Fun } from '@ephox/katamari';
+import { ContentEditable, SugarElement, SugarNode, SugarShadowDom } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import * as EditableRange from '../selection/EditableRange';
@@ -7,8 +8,35 @@ export const setup = (editor: Editor): void => {
   editor.on('beforeinput', (e) => {
     // Normally input is blocked on non-editable elements that have contenteditable="false" however we are also treating
     // SVG elements as non-editable and deleting inside or into is possible in some browsers so we need to detect that and prevent that.
-    if (!editor.selection.isEditable() || Arr.exists(e.getTargetRanges(), (rng) => !EditableRange.isEditableRange(editor.dom, rng))) {
+    if (!editor.selection.isEditable() || Arr.exists(e.getTargetRanges(), (range) => !isInEditableRange(range))) {
       e.preventDefault();
     }
   });
+
+  const isInEditableRange = (range: StaticRange) => {
+    if (EditableRange.isEditableRange(editor.dom, range)) {
+      return true;
+    }
+
+    if (isInEditableHost(range.startContainer)) {
+      return true;
+    }
+
+    if (!range.collapsed) {
+      return isInEditableHost(range.endContainer);
+    }
+
+    return false;
+  };
 };
+
+const isInEditableHost = (node: Node) => {
+  const sugar = SugarElement.fromDom(node);
+  return SugarShadowDom.isInShadowRoot(sugar) && isInEditable(sugar);
+};
+
+const isInEditable = (node: SugarElement<Node>) =>
+  SugarShadowDom.getShadowRoot(node).map(SugarShadowDom.getShadowHost).fold(
+    Fun.never,
+    (value) => SugarNode.isHTMLElement(value) && !ContentEditable.isEditable(value)
+  );


### PR DESCRIPTION
Related Ticket: TINY-11446

Description of Changes:
If we are not in something editable, check if we are in a shadowdom. If we are, climb out of it and check again.

Was not able to get the cursor placed in the shadowdom during tests, so none included.

Pre-checks:
* [ ] Changelog entry added
* ~~[ ] Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
