### PR TITLE
TINY-11488: Preserve disabled state during init

### DIFF
--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -254,9 +254,6 @@ const moveSelectionToFirstCaretPosition = (editor: Editor) => {
 
 const initEditor = (editor: Editor) => {
   editor.bindPendingEventDelegates();
-  if (Disabled.isDisabled(editor)) {
-    Disabled.toggleDisabled(editor, true);
-  }
   editor.initialized = true;
   Events.fireInit(editor);
   editor.focus(true);
@@ -267,6 +264,9 @@ const initEditor = (editor: Editor) => {
     initInstanceCallback.call(editor, editor);
   }
   autoFocus(editor);
+  if (Disabled.isDisabled(editor)) {
+    Disabled.toggleDisabled(editor, true);
+  }
 };
 
 const getStyleSheetLoader = (editor: Editor): StyleSheetLoader =>

--- a/modules/tinymce/src/core/test/ts/browser/DisabledModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/DisabledModeTest.ts
@@ -330,8 +330,8 @@ describe('browser.tinymce.core.DisabledModeTest', () => {
     assert.equal(!hasClass, shouldNotHaveClass, 'Editor container should not have class: tox-tinymce--disabled');
   };
 
+  // Basic checking of the UI and editor body contentEditable
   const assertEditorState = (shouldBeEnabled: boolean) => (editor: Editor) => {
-    // assert.equal(editor.disabled, !shouldBeEnabled, `Editor.disabled should be ${!shouldBeEnabled}`);
     assertContentEditableBody(editor)(shouldBeEnabled);
     assertEditorContainerClass(editor)(shouldBeEnabled);
   };
@@ -344,7 +344,6 @@ describe('browser.tinymce.core.DisabledModeTest', () => {
 
     afterEach(() => hook.editor().options.set('disabled', true));
 
-    // Basic checking of the UI and editor body contentEditable
     it('TINY-11488: Should be able to switch from disabled mode to enabled mode', async () => {
       const editor = hook.editor();
       await Waiter.pTryUntil('Wait for editor to be disabled', () => assertEditorDisabled(editor));
@@ -552,14 +551,17 @@ describe('browser.tinymce.core.DisabledModeTest', () => {
       const editor = hook.editor();
       assert.equal(hook.editor().mode.get(), 'readonly', 'Editor should be readonly');
       assert.isTrue(hook.editor().readonly, 'Editor should be readonly');
+      assertEditorDisabled(editor);
 
       editor.mode.set('design');
       assert.equal(hook.editor().mode.get(), 'readonly', 'Editor should still be in readonly');
       assert.isTrue(hook.editor().readonly, 'Editor should still be in readonly');
+      assertEditorDisabled(editor);
 
       editor.options.set('disabled', false);
       assert.equal(hook.editor().mode.get(), 'readonly', 'Editor should still be in readonly');
       assert.isTrue(hook.editor().readonly, 'Editor should still be in readonly');
+      await Waiter.pTryUntil('Wait for editor to be enabled', () => assertEditorEnabled(editor));
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-11488

Description of Changes:
* Previously when having both `readonly` and `disabled` options would overwrite the disabled state
* Added coverage to test the editor state when both option are set 

Pre-checks:
* [x] ~Changelog entry added~ 
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced behavior for toggling the editor's disabled state, ensuring correct UI responses.
	- Added new tests to verify the editor's disabled and readonly states.

- **Bug Fixes**
	- Improved assertions in tests to ensure the editor behaves as expected when changing states.

- **Documentation**
	- Added comments for clarity in the editor initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->