### PR TITLE
TINY-11618: reset inherited styles for uploadcare placeholder

### DIFF
--- a/modules/oxide/src/less/theme/content/uploadcare/uploadcare.less
+++ b/modules/oxide/src/less/theme/content/uploadcare/uploadcare.less
@@ -43,6 +43,7 @@
 
 // UPLOADCARE PLACEHOLDER
 .tox-uploadcare-placeholder {
+  all: initial;
   display: inline-block;
   position: relative;
   width: @uploadcare-placeholder-initial-width;


### PR DESCRIPTION
Related Ticket: TINY-11618

Description of Changes:
Reset inherited styles for uploadcare placeholder by adding `all: initial;`

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced styling for the Uploadcare placeholder by adding a property to reset inheritable styles, improving its isolation from parent styles.
	- Maintained existing styles for the loading spinner and placeholder dimensions, ensuring consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->