### PR TITLE
TINY-11619: fix input and size input css inside toolbar

### DIFF
--- a/modules/oxide/src/less/theme/components/button/button-icon.less
+++ b/modules/oxide/src/less/theme/components/button/button-icon.less
@@ -15,3 +15,12 @@
     }
   }
 }
+
+// TODO: remove me when the size input for toolbar is a separate component. Toolbar buttons should be styled by a toolbar-button.less but we use dialog size input so the classes don't match
+.tox-context-form__group {
+  .tox-button--icon,
+  .tox-button.tox-button--icon {
+    margin: @toolbar-button-margin;
+    padding: @toolbar-button-padding;
+  }
+}

--- a/modules/oxide/src/less/theme/components/form/textfield.less
+++ b/modules/oxide/src/less/theme/components/form/textfield.less
@@ -25,6 +25,8 @@
 @textfield-focus-box-shadow: 0 0 0 1px @color-tint;
 @textfield-focus-outline: none;
 
+@toolbar-textfield-height: @toolbar-button-height;
+
 .tox {
   .tox-textfield {
     appearance: none;
@@ -64,6 +66,8 @@
     margin-bottom: 3px;
     margin-top: 2px;
     max-width: 250px;
+    min-height: unset;
+    height: @toolbar-textfield-height;
   }
 
   .tox-toolbar-textfield[disabled] {

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
@@ -19,6 +19,8 @@
 @toolbar-button-text-color: contrast(@background-color, @color-white, @color-black);
 @toolbar-button-text-transform: none;
 @toolbar-button-width: 34px;
+@toolbar-button-margin: (@toolbar-button-spacing-y + 1px) @toolbar-button-spacing-x @toolbar-button-spacing-y 0;
+@toolbar-button-padding: 0;
 
 @toolbar-button-hover-background-color: contrast(@background-color, darken(@background-color, 6%), lighten(@background-color, 7%)); // Differentiating against the enabled color
 @toolbar-button-hover-border: @toolbar-button-border;
@@ -67,9 +69,9 @@
     font-weight: @toolbar-button-font-weight;
     height: @toolbar-button-height;
     justify-content: center;
-    margin: (@toolbar-button-spacing-y + 1px) @toolbar-button-spacing-x @toolbar-button-spacing-y 0;
+    margin: @toolbar-button-margin;
     outline: none;
-    padding: 0;
+    padding: @toolbar-button-padding;
     text-transform: @toolbar-button-text-transform;
     width: @toolbar-button-width;
 


### PR DESCRIPTION
Related Ticket: TINY-11619

Description of Changes:
Fix input and size input css inside toolbar for skin: 'small'

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced styling for icon buttons within context form groups for better visual differentiation.
	- Improved toolbar text field appearance to align with toolbar button height, ensuring consistent design.

- **Chores**
	- Introduced new variables for toolbar button margin and padding to streamline styling and improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->