### PR TITLE
TINY-11617: decouple slider styles from button

### DIFF
--- a/modules/oxide/src/less/theme/components/slider/slider.less
+++ b/modules/oxide/src/less/theme/components/slider/slider.less
@@ -16,12 +16,12 @@
 // TODO: Remove the duplication of these values with the old sliders
 @slider-width: 130px;
 
-@slider-thumb-background-color: @button-background-color;
-@slider-thumb-background-color-disabled: @button-disabled-text-color;
-@slider-thumb-background-color-hover: @button-hover-background-color;
-@slider-thumb-background-color-active: @button-active-background-color;
-@slider-thumb-background-color-focus: @button-focus-background-color;
-@slider-thumb-focus-outline: @button-focus-outline;
+@slider-thumb-background-color: @color-tint;
+@slider-thumb-background-color-disabled: fade(contrast(@slider-thumb-background-color, @color-black, @color-white), 50%);
+@slider-thumb-background-color-hover: darken(@slider-thumb-background-color, 5%);
+@slider-thumb-background-color-active: darken(@slider-thumb-background-color, 10%);
+@slider-thumb-background-color-focus: darken(@slider-thumb-background-color, 5%);
+@slider-thumb-focus-outline: inset 0 0 0 1px @color-white, 0 0 0 2px @color-tint;
 
 @slider-thumb-border-radius: @slider-thumb-width;
 @slider-thumb-width: 16px;


### PR DESCRIPTION
Related Ticket: TINY-11617

Description of Changes:
The styles are calculated the same way but it happens separately for the slider. It fixes the bug of a transparent slider thumb for material skins (as button background color is set to transparent there)

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated styling for the slider component, enhancing the appearance and consistency of the slider thumb across various states (normal, disabled, hover, active, focus).
	- Improved focus visibility with new inset shadow outlines for the slider thumb.

- **Bug Fixes**
	- Removed redundant code, streamlining the styling approach for the slider component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->