### PR TITLE
TINY-11618: prevent text decoration styles to be inherited

### DIFF
--- a/modules/oxide/src/less/theme/content/uploadcare/uploadcare.less
+++ b/modules/oxide/src/less/theme/content/uploadcare/uploadcare.less
@@ -43,7 +43,7 @@
 
 // UPLOADCARE PLACEHOLDER
 .tox-uploadcare-placeholder {
-  all: initial;
+  all: initial; // prevents inheritable styles to leak into the shadow DOM
   display: inline-block;
   position: relative;
   width: @uploadcare-placeholder-initial-width;
@@ -56,7 +56,8 @@
   --tox-uploadcare-placeholder--content-border: @uploadcare-placeholder-border;
   --tox-uploadcare-placeholder--content-font-family: @uploadcare-placeholder-font-family;
   --tox-uploadcare-placeholder--content-height: 100%;
-  --tox-uploadcare-placeholder--content-display: flex;
+  --tox-uploadcare-placeholder--content-width: 100%;
+  --tox-uploadcare-placeholder--content-display: inline-flex; // needs to be inline so the line decoration styles are not inherited https://www.w3.org/TR/css-text-decor-3/#line-decoration
   --tox-uploadcare-placeholder--content-align-items: center;
   --tox-uploadcare-placeholder--content-justify-content: center;
   --tox-uploadcare-placeholder--content-gap: 8px;


### PR DESCRIPTION
Related Ticket: TINY-11618

Description of Changes:
Prevent text decoration styles to be inherited inside the placeholder shadow DOM.

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced styling and layout behavior for the Uploadcare placeholder and loading elements.
- **Bug Fixes**
	- Adjusted the display property to prevent inheritance of line decoration styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->