### PR TITLE
TINY-11596: fix focus outline for image annotations

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11596-2024-12-03.yaml
+++ b/.changes/unreleased/tinymce-TINY-11596-2024-12-03.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Improved
+body: Improved visual indication of a keyboard focus for a comment annotation when
+  there is an image inside.
+time: 2024-12-03T16:05:49.139224+01:00
+custom:
+  Issue: TINY-11596

--- a/modules/oxide/src/less/theme/content/comments/comments.less
+++ b/modules/oxide/src/less/theme/content/comments/comments.less
@@ -27,17 +27,6 @@
     }
   }
 
-  span.tox-comment[data-mce-annotation-active="true"] {
-    & img,
-    & > audio,
-    & > video,
-    & span.mce-preview-object {
-      &:not([data-mce-selected]) {
-        outline: @document-comment-outline-width solid @document-comment-active-outline-color;
-      }
-    }
-  }
-
   span.tox-comment:not([data-mce-selected]) {
     background-color: @document-comment-background-color;
     outline: none;
@@ -52,21 +41,29 @@
     border-radius: 3px;
     box-shadow: 0 0 0 2px @keyboard-focus-outline-color;
 
-    & img,
-    & > audio,
-    & > video,
-    & span.mce-preview-object {
-      &:not([data-mce-selected]) {
-        box-shadow: 0 0 0 5px @keyboard-focus-outline-color;
-      }
-    }
-
-    &:has(
-      img[data-mce-selected], 
-      > audio[data-mce-selected],
-      > video[data-mce-selected],
-      span.mce-preview-object[data-mce-selected]) {
+    &
+      :has(
+        img[data-mce-selected],
+        > audio[data-mce-selected],
+        > video[data-mce-selected],
+        span.mce-preview-object[data-mce-selected]
+      ) {
       box-shadow: none;
     }
+  }
+
+  span.tox-comment[data-mce-selected] img:not([data-mce-selected]),
+  span.tox-comment[data-mce-selected] > audio:not([data-mce-selected]),
+  span.tox-comment[data-mce-selected] > video:not([data-mce-selected]),
+  span.tox-comment[data-mce-selected] span.mce-preview-object:not([data-mce-selected]) {
+    box-shadow: 0 0 0 5px @keyboard-focus-outline-color;
+  }
+
+  span.tox-comment[data-mce-annotation-active="true"] img:not([data-mce-selected]),
+  span.tox-comment[data-mce-annotation-active="true"] > audio:not([data-mce-selected]),
+  span.tox-comment[data-mce-annotation-active="true"] > video:not([data-mce-selected]),
+  span.tox-comment[data-mce-annotation-active="true"] span.mce-preview-object:not([data-mce-selected]) {
+    outline: @document-comment-outline-width solid
+    @document-comment-active-outline-color;
   }
 }

--- a/modules/oxide/src/less/theme/content/comments/comments.less
+++ b/modules/oxide/src/less/theme/content/comments/comments.less
@@ -51,5 +51,22 @@
     background-color: @document-comment-active-background-color;
     border-radius: 3px;
     box-shadow: 0 0 0 2px @keyboard-focus-outline-color;
+
+    & img,
+    & > audio,
+    & > video,
+    & span.mce-preview-object {
+      &:not([data-mce-selected]) {
+        box-shadow: 0 0 0 5px @keyboard-focus-outline-color;
+      }
+    }
+
+    &:has(
+      img[data-mce-selected], 
+      > audio[data-mce-selected],
+      > video[data-mce-selected],
+      span.mce-preview-object[data-mce-selected]) {
+      box-shadow: none;
+    }
   }
 }


### PR DESCRIPTION
Related Ticket: TINY-11596

Description of Changes:
Fix focus outline for image annotations.

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved visual indication of keyboard focus for comment annotations containing images.
	- Enhanced styling for comment elements to better represent selected and non-selected states.

- **Bug Fixes**
	- Addressed visibility issues for media elements in comments, providing clearer feedback on selection states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->