### PR TITLE
TINY-11645: Migrate accessibility checker css to oxide

### DIFF
--- a/modules/oxide/src/less/theme/content-ui.less
+++ b/modules/oxide/src/less/theme/content-ui.less
@@ -28,3 +28,5 @@
 @import 'content/uploadcare/uploadcare';
 @import 'content/visualblocks/visualblocks';
 @import 'content/visualchars/visualchars';
+@import 'content/accessibility-checker/accessibility-checker';
+

--- a/modules/oxide/src/less/theme/content/accessibility-checker/accessibility-checker.less
+++ b/modules/oxide/src/less/theme/content/accessibility-checker/accessibility-checker.less
@@ -41,8 +41,8 @@
 }
 
 [data-ephox-foam-a11y-violation][data-ephox-foam-a11y-current-violation="warning"] {
-  outline-color: @accessibility-issue-warning-selection-color;
-  background-color: @accessibility-issue-warning-selection-background-color;
+  outline-color: @accessibility-issue-warn-selection-color;
+  background-color: @accessibility-issue-warn-selection-background-color;
 }
 
 [data-ephox-foam-a11y-violation][data-ephox-foam-a11y-current-violation="error"] {

--- a/modules/oxide/src/less/theme/content/accessibility-checker/accessibility-checker.less
+++ b/modules/oxide/src/less/theme/content/accessibility-checker/accessibility-checker.less
@@ -1,0 +1,51 @@
+//
+//
+// Accessibility checker
+@accessibility-overlay-opacity-90: 90%;
+@accessibility-overlay-opacity-60: 60%;
+
+@accessibility-issue-info-selection-color: if(@content-ui-darkmode = true, mix(@color-white, @color-tint, @accessibility-overlay-opacity-60), @color-tint);
+@accessibility-issue-info-selection-background-color: mix(@background-color, @color-tint, @accessibility-overlay-opacity-90);
+
+@accessibility-issue-warn-selection-color: if(@content-ui-darkmode = true, mix(@color-white, @color-warning, @accessibility-overlay-opacity-60), @color-warning);
+@accessibility-issue-warn-selection-background-color: mix(@background-color, @color-warning, @accessibility-overlay-opacity-90);
+
+@accessibility-issue-error-selection-color: if(@content-ui-darkmode = true, mix(@color-white, @color-error, @accessibility-overlay-opacity-60), @color-error);
+@accessibility-issue-error-selection-background-color: mix(@background-color, @color-error, @accessibility-overlay-opacity-90);
+
+[data-ephox-foam-a11y-violation] {
+  outline: 2px solid;
+  position: relative;
+}
+
+[data-ephox-foam-a11y-violation][data-ephox-foam-a11y-current-violation] {
+  outline-width: 4px;
+  transition: outline-width .1s ease-in-out, background-color .1s ease-in-out;
+}
+
+[data-ephox-foam-a11y-violation][data-ephox-foam-a11y-severity-info] {
+  outline-color: @accessibility-issue-info-selection-color;
+}
+
+[data-ephox-foam-a11y-violation][data-ephox-foam-a11y-severity-warn] {
+  outline-color: @accessibility-issue-warn-selection-color;
+}
+
+[data-ephox-foam-a11y-violation][data-ephox-foam-a11y-severity-error] {
+  outline-color: @accessibility-issue-error-selection-color;
+}
+
+[data-ephox-foam-a11y-violation][data-ephox-foam-a11y-current-violation="info"] {
+  outline-color: @accessibility-issue-info-selection-color;
+  background-color: @accessibility-issue-info-selection-background-color;
+}
+
+[data-ephox-foam-a11y-violation][data-ephox-foam-a11y-current-violation="warning"] {
+  outline-color: @accessibility-issue-warning-selection-color;
+  background-color: @accessibility-issue-warning-selection-background-color;
+}
+
+[data-ephox-foam-a11y-violation][data-ephox-foam-a11y-current-violation="error"] {
+  outline-color: @accessibility-issue-error-selection-color;
+  background-color: @accessibility-issue-error-selection-background-color;
+}


### PR DESCRIPTION
Related Ticket: 
TINY-11645

Description of Changes:
- Migrate accessibility checker css to oxide

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced accessibility checker styles to enhance visual representation of accessibility issues in the UI.
	- New styles adapt based on dark mode settings and provide clear differentiation for severity of violations (info, warning, error).
- **Improvements**
	- Added overlay opacity variables to improve accessibility-related UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->