### PR TITLE
TINY-11482: fix tab navigation for `ContextFormSlider`

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11482-2024-12-05.yaml
+++ b/.changes/unreleased/tinymce-TINY-11482-2024-12-05.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: tab navigation for ContextFormSlider.
+body: Keyboard navigation for context form sliders.
 time: 2024-12-05T09:26:33.096250912+01:00
 custom:
   Issue: TINY-11482

--- a/.changes/unreleased/tinymce-TINY-11482-2024-12-05.yaml
+++ b/.changes/unreleased/tinymce-TINY-11482-2024-12-05.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: tab navigation for ContextFormSlider.
+time: 2024-12-05T09:26:33.096250912+01:00
+custom:
+  Issue: TINY-11482

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
@@ -23,7 +23,7 @@ export const renderContextFormSliderInput = (
   const pField = FormField.parts.field({
     factory: Input,
     type: 'range',
-    inputClasses: [ 'tox-toolbar-slider__input' ],
+    inputClasses: [ 'tox-toolbar-slider__input', 'tox-toolbar-nav-js' ],
     inputAttributes: {
       min: String(ctx.min()),
       max: String(ctx.max())

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
@@ -1,4 +1,4 @@
-import { ApproxStructure, Assertions, FocusTools, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
+import { ApproxStructure, Assertions, FocusTools, Keys, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { Attribute, SugarBody, SugarDocument, Value } from '@ephox/sugar';
@@ -152,6 +152,25 @@ describe('browser.tinymce.themes.silver.editor.ContextSliderFormTest', () => {
     TinyUiActions.clickOnUi(editor, '.tox-pop button[aria-label="A"]');
     const input = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), '.tox-pop input').getOrDie();
     assert.strictEqual(Value.get(input), '100', 'Should be updated slider value');
+  });
+
+  it('TINY-11482: should navigate correctly via keyboard', async () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+
+    const buttonASelector = '.tox-pop button[aria-label="A"]';
+    const sliderSelector = '.tox-pop input';
+    const buttonBSelector = '.tox-pop button[aria-label="B"]';
+
+    FocusTools.setFocus(SugarDocument.getDocument(), buttonASelector);
+    await FocusTools.pTryOnSelector('Focus should be on the A button', SugarDocument.getDocument(), buttonASelector);
+    TinyUiActions.keystroke(editor, Keys.tab());
+
+    await FocusTools.pTryOnSelector('Focus should be on the slider', SugarDocument.getDocument(), sliderSelector);
+    TinyUiActions.keystroke(editor, Keys.tab());
+
+    await FocusTools.pTryOnSelector('Focus should be on the B button', SugarDocument.getDocument(), buttonBSelector);
+    TinyUiActions.keystroke(editor, Keys.tab());
   });
 });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
@@ -170,7 +170,15 @@ describe('browser.tinymce.themes.silver.editor.ContextSliderFormTest', () => {
     TinyUiActions.keystroke(editor, Keys.tab());
 
     await FocusTools.pTryOnSelector('Focus should be on the B button', SugarDocument.getDocument(), buttonBSelector);
-    TinyUiActions.keystroke(editor, Keys.tab());
+
+    // Reverse tab navigation
+    await FocusTools.pTryOnSelector('Focus should stay on B button', SugarDocument.getDocument(), buttonBSelector);
+    TinyUiActions.keystroke(editor, Keys.tab(), { shiftKey: true });
+
+    await FocusTools.pTryOnSelector('Focus should be back on slider', SugarDocument.getDocument(), sliderSelector);
+    TinyUiActions.keystroke(editor, Keys.tab(), { shiftKey: true });
+
+    await FocusTools.pTryOnSelector('Focus should be back on A button', SugarDocument.getDocument(), buttonASelector);
   });
 });
 


### PR DESCRIPTION
Related Ticket: TINY-11482

Description of Changes:
fix tab navigation for `ContextFormSlider`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new entry in the changelog addressing keyboard navigation for the ContextFormSlider component.

- **Bug Fixes**
  - Improved keyboard navigation functionality for the ContextFormSlider, enhancing user experience.

- **Tests**
  - Introduced a new test case to verify keyboard navigation within the context slider form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->