### PR TITLE
TINY-11368: close dropdowns on window scroll

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11368-2024-12-06.yaml
+++ b/.changes/unreleased/tinymce-TINY-11368-2024-12-06.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Improved
+body: Dialog listDropdowns now close when the window is scrolled.
+time: 2024-12-06T14:35:39.09459+01:00
+custom:
+  Issue: TINY-11368

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
@@ -185,8 +185,11 @@ const renderCommonDropdown = <T>(
             }
           }),
         ]),
-        AddEventsBehaviour.config('update-dropdown-width-variable', [
+        AddEventsBehaviour.config('close-on--window-resize', [
           AlloyEvents.run(SystemEvents.windowResize(), (comp, _se) => AlloyDropdown.close(comp)),
+        ]),
+        AddEventsBehaviour.config('close-on--window-scroll', [
+          AlloyEvents.run(SystemEvents.windowScroll(), (comp, _se) => AlloyDropdown.close(comp)),
         ]),
         AddEventsBehaviour.config('menubutton-update-display-text', [
           // These handlers are just using Replacing to replace either the menu


### PR DESCRIPTION
Related Ticket: TINY-11368

Description of Changes:
- the menu will not close if the scroll happen inside the editor 
- the menu will  now close if the scroll happen on the widow

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
