### PR TITLE
TINY-11500: When validating, also remove invalid attribute names

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11500-2024-12-09.yaml
+++ b/.changes/unreleased/tinymce-TINY-11500-2024-12-09.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Attribute names with invalid characters were not properly filtered out.
+time: 2024-12-09T17:29:29.84038+01:00
+custom:
+    Issue: TINY-11500

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Replication.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Replication.ts
@@ -1,3 +1,5 @@
+import { Arr, Obj } from '@ephox/katamari';
+
 import { HTMLElementFullTagNameMap } from '../../alien/DomTypes';
 import { SugarElement } from '../node/SugarElement';
 import * as Attribute from '../properties/Attribute';
@@ -5,6 +7,11 @@ import * as Traverse from '../search/Traverse';
 import * as Insert from './Insert';
 import * as InsertAll from './InsertAll';
 import * as Remove from './Remove';
+
+// eslint-disable-next-line max-len
+const startAttributeCharacterLayout = '[A-Za-z:_]|[\u{C0}-\u{D6}]|[\u{D8}-\u{F6}]|[\u{F8}-\u{2FF}]|[\u{370}-\u{37D}]|[\u{37F}-\u{1FFF}]|[\u{200C}-\u{200D}]|[\u{2070}-\u{218F}]|[\u{2C00}-\u{2FEF}]|[\u{3001}-\u{D7FF}]|[\u{F900}-\u{FDCF}]|[\u{FDF0}-\u{FFFD}]';// |[\u{10000}-\u{EFFFF}]';
+const followingAttributeCharacterLayout = startAttributeCharacterLayout + '|"-"|"."|[0-9]|\u{B7}|[\u{0300}-\u{036F}]|[\u{203F}-\u{2040}]';
+const attributeNameRegex = RegExp(`^(${startAttributeCharacterLayout})(${followingAttributeCharacterLayout})*$`);
 
 const clone = <E extends Node> (original: SugarElement<E>, isDeep: boolean): SugarElement<E> =>
   SugarElement.fromDom(original.dom.cloneNode(isDeep) as E);
@@ -22,6 +29,11 @@ const shallowAs = <K extends keyof HTMLElementFullTagNameMap> (original: SugarEl
   const nu = SugarElement.fromTag(tag);
 
   const attributes = Attribute.clone(original);
+  Arr.each(Obj.keys(attributes), (key) => {
+    if (!attributeNameRegex.test(key)) {
+      delete attributes[key];
+    }
+  });
   Attribute.setAll(nu, attributes);
 
   return nu;

--- a/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
@@ -6,8 +6,8 @@ import { getSanitizer, MimeType } from 'tinymce/core/html/Sanitization';
 
 describe('browser.tinymce.core.html.SanitizationTest', () => {
   context('Sanitize html', () => {
-    const testHtmlSanitizer = (testCase: { input: string; expected: string; mimeType: MimeType; sanitize?: boolean }) => {
-      const sanitizer = getSanitizer({ sanitize: testCase.sanitize ?? true }, Schema());
+    const testHtmlSanitizer = (testCase: { input: string; expected: string; mimeType: MimeType; sanitize?: boolean; validate?: boolean }) => {
+      const sanitizer = getSanitizer({ sanitize: testCase.sanitize ?? true, validate: testCase.validate }, Schema());
 
       const body = document.createElement('body');
       body.innerHTML = testCase.input;
@@ -20,6 +20,13 @@ describe('browser.tinymce.core.html.SanitizationTest', () => {
       input: '<iframe src="x"><script>alert(1)</script></iframe><iframe src="javascript:alert(1)"></iframe>',
       expected: '<iframe></iframe>',
       mimeType: 'text/html'
+    }));
+
+    it('TINY-11500: Sanitize with invalid attribute name in content', () => testHtmlSanitizer({
+      input: '<i gothic",="" sans-serif;"="">test</i>',
+      expected: '<em>test</em>',
+      mimeType: 'text/html',
+      validate: true,
     }));
 
     it('Disabled sanitization of iframe HTML', () => testHtmlSanitizer({


### PR DESCRIPTION
Related Ticket: TINY-11500

Description of Changes:
A regex-check on attribute names to ensure that they are valid. The entirety of the valid regexes could not be added due to javascript regex being limited to four-digit hex ( Remaining still in a comment if this can be updated in the future ).
Running some efficiency tests suggests that this regex-check has a minor impact on speed even larger files with a lot of attributes.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
