### PR TITLE
TINY-11377: Converted `isEmpty` to an assertion function, improving cases with optional object properties

### DIFF
--- a/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
@@ -107,7 +107,7 @@ export const has = <T extends {}, K extends keyof T>(obj: T, key: K): boolean =>
 export const hasNonNullableKey = <T extends {}, K extends keyof T>(obj: T, key: K): obj is T & Record<K, NonNullable<T[K]>> =>
   has(obj, key) && obj[key] !== undefined && obj[key] !== null;
 
-export const isEmpty = (r: Record<any, any>): boolean => {
+export const isEmpty = (r: Record<any, any>): r is {} => {
   for (const x in r) {
     if (hasOwnProperty.call(r, x)) {
       return false;

--- a/modules/katamari/src/test/ts/atomic/api/obj/ObjIsEmptyTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/obj/ObjIsEmptyTest.ts
@@ -4,7 +4,7 @@ import fc from 'fast-check';
 
 import * as Obj from 'ephox/katamari/api/Obj';
 
-const makePossiblyEmptyValue = (): { hasKey: boolean } | {} => ({ hasKey: true });
+const makePossiblyEmptyValue = (isEmpty: boolean): { hasKey: boolean } | {} => isEmpty ? {} : { hasKey: true };
 
 describe('atomic.katamari.api.obj.ObjIsEmptyTest', () => {
   it('unit tests', () => {
@@ -23,11 +23,24 @@ describe('atomic.katamari.api.obj.ObjIsEmptyTest', () => {
     ));
   });
 
-  it('helps TypeScript understand the empty type', () => {
-    const maybeEmpty = makePossiblyEmptyValue();
+  it('helps TypeScript understand the non-empty type', () => {
+    const maybeEmpty = makePossiblyEmptyValue(false);
     if (!Obj.isEmpty(maybeEmpty)) {
-      const _emptyType: { hasKey: boolean } = maybeEmpty;
-      assert.isTrue(_emptyType.hasKey);
+      const emptyType: { hasKey: boolean } = maybeEmpty;
+      assert.isTrue(emptyType.hasKey);
+    } else {
+      assert.fail('Expected non-empty object');
+    }
+  });
+
+  /* The compiler won't complain about this case even if the value is non-empty, but just for completeness */
+  it('helps TypeScript understand the empty type', () => {
+    const maybeEmpty = makePossiblyEmptyValue(true);
+    if (Obj.isEmpty(maybeEmpty)) {
+      const emptyType: {} = maybeEmpty;
+      assert.deepStrictEqual(emptyType, {});
+    } else {
+      assert.fail('Expected empty object');
     }
   });
 });

--- a/modules/katamari/src/test/ts/atomic/api/obj/ObjIsEmptyTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/obj/ObjIsEmptyTest.ts
@@ -4,6 +4,8 @@ import fc from 'fast-check';
 
 import * as Obj from 'ephox/katamari/api/Obj';
 
+const makePossiblyEmptyValue = (): { hasKey: boolean } | {} => ({ hasKey: true });
+
 describe('atomic.katamari.api.obj.ObjIsEmptyTest', () => {
   it('unit tests', () => {
     assert.isTrue(Obj.isEmpty({}));
@@ -19,5 +21,13 @@ describe('atomic.katamari.api.obj.ObjIsEmptyTest', () => {
         assert.isFalse(Obj.isEmpty(o));
       }
     ));
+  });
+
+  it('helps TypeScript understand the empty type', () => {
+    const maybeEmpty = makePossiblyEmptyValue();
+    if (!Obj.isEmpty(maybeEmpty)) {
+      const _emptyType: { hasKey: boolean } = maybeEmpty;
+      assert.isTrue(_emptyType.hasKey);
+    }
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-11377

Description of Changes:
* Not actually related to the ticket, something I came across while working on it. The code in the test won't compile without the assertion return type and it's a pattern I was trying to use.

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [x] ~Docs ticket created (if applicable)~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new function to create potentially empty objects for testing.
  
- **Bug Fixes**
  - Enhanced type safety of the `isEmpty` function, ensuring accurate type inference for empty objects.

- **Tests**
  - Expanded the test suite for `isEmpty` with additional cases to validate TypeScript's understanding of empty object types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->