### PR TITLE
TINY-11551: Upgrade Typescript to v5.7

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/Behaviour.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/Behaviour.ts
@@ -102,7 +102,7 @@ const doCreate = <
     ...wrappedExtra,
     ...wrappedApis,
     revoke: Fun.curry(revokeBehaviour, name),
-    config: (spec) => {
+    config: (spec: C) => {
       const prepared = StructureSchema.asRawOrDie(name + '-config', configSchema, spec);
 
       return {

--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -73,7 +73,7 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
   const rootDocument = document;
   const rootElement = editor.getBody();
   let selectedElm: HTMLElement, selectedElmGhost: HTMLElement, resizeHelper: HTMLElement, selectedHandle: SelectedResizeHandle, resizeBackdrop: HTMLElement;
-  let startX: number, startY: number, selectedElmX: number, selectedElmY: number, startW: number, startH: number, ratio: number, resizeStarted: boolean;
+  let startX: number, startY: number, startW: number, startH: number, ratio: number, resizeStarted: boolean;
   let width: number;
   let height: number;
   let startScrollWidth: number;
@@ -223,15 +223,17 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
 
     resizeHelper.innerHTML = width + ' &times; ' + height;
 
-    // Update ghost X position if needed
-    if (selectedHandle[2] < 0 && selectedElmGhost.clientWidth <= width) {
-      dom.setStyle(selectedElmGhost, 'left', selectedElmX + (startW - width));
-    }
+    /* TODO: TINY-11702 dom.setStyle() has no effect because the value is NaN
+      // Update ghost X position if needed
+      if (selectedHandle[2] < 0 && selectedElmGhost.clientWidth <= width) {
+        dom.setStyle(selectedElmGhost, 'left', selectedElmX + (startW - width));
+      }
 
-    // Update ghost Y position if needed
-    if (selectedHandle[3] < 0 && selectedElmGhost.clientHeight <= height) {
-      dom.setStyle(selectedElmGhost, 'top', selectedElmY + (startH - height));
-    }
+      // Update ghost Y position if needed
+      if (selectedHandle[3] < 0 && selectedElmGhost.clientHeight <= height) {
+        dom.setStyle(selectedElmGhost, 'top', selectedElmY + (startH - height));
+      }
+    */
 
     // Calculate how must overflow we got
     deltaX = rootElement.scrollWidth - startScrollWidth;

--- a/modules/tinymce/src/core/main/ts/events/DragEvents.ts
+++ b/modules/tinymce/src/core/main/ts/events/DragEvents.ts
@@ -17,7 +17,7 @@ const makeDndEventFromMouseEvent = (type: DragEventType, mouseEvent: EditorEvent
 const makeDndEvent = (type: DragEventType, target: Element, dataTransfer: DataTransfer): DragEvent => {
   const fail = Fun.die('Function not supported on simulated event.');
 
-  const event: DragEvent = {
+  const event = {
     // Event
     bubbles: true,
     cancelBubble: false,
@@ -47,6 +47,8 @@ const makeDndEvent = (type: DragEventType, target: Element, dataTransfer: DataTr
     clientX: 0,
     clientY: 0,
     ctrlKey: false,
+    layerX: 0,
+    layerY: 0,
     metaKey: false,
     movementX: 0,
     movementY: 0,

--- a/modules/tinymce/src/core/test/ts/browser/caret/CaretUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/CaretUtilsTest.ts
@@ -42,18 +42,12 @@ describe('browser.tinymce.core.CaretUtilTest', () => {
 
   it('isForwards', () => {
     assert.isTrue(CaretUtils.isForwards(1));
-    assert.isTrue(CaretUtils.isForwards(10 as any));
-    assert.isFalse(CaretUtils.isForwards(0 as any));
     assert.isFalse(CaretUtils.isForwards(-1));
-    assert.isFalse(CaretUtils.isForwards(-10 as any));
   });
 
   it('isBackwards', () => {
     assert.isFalse(CaretUtils.isBackwards(1));
-    assert.isFalse(CaretUtils.isBackwards(10 as any));
-    assert.isFalse(CaretUtils.isBackwards(0 as any));
     assert.isTrue(CaretUtils.isBackwards(-1));
-    assert.isTrue(CaretUtils.isBackwards(-10 as any));
   });
 
   it('findNode', () => {

--- a/modules/tinymce/src/core/test/ts/browser/caret/CaretUtilsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/CaretUtilsTest.ts
@@ -42,18 +42,18 @@ describe('browser.tinymce.core.CaretUtilTest', () => {
 
   it('isForwards', () => {
     assert.isTrue(CaretUtils.isForwards(1));
-    assert.isTrue(CaretUtils.isForwards(10));
-    assert.isFalse(CaretUtils.isForwards(0));
+    assert.isTrue(CaretUtils.isForwards(10 as any));
+    assert.isFalse(CaretUtils.isForwards(0 as any));
     assert.isFalse(CaretUtils.isForwards(-1));
-    assert.isFalse(CaretUtils.isForwards(-10));
+    assert.isFalse(CaretUtils.isForwards(-10 as any));
   });
 
   it('isBackwards', () => {
     assert.isFalse(CaretUtils.isBackwards(1));
-    assert.isFalse(CaretUtils.isBackwards(10));
-    assert.isFalse(CaretUtils.isBackwards(0));
+    assert.isFalse(CaretUtils.isBackwards(10 as any));
+    assert.isFalse(CaretUtils.isBackwards(0 as any));
     assert.isTrue(CaretUtils.isBackwards(-1));
-    assert.isTrue(CaretUtils.isBackwards(-10));
+    assert.isTrue(CaretUtils.isBackwards(-10 as any));
   });
 
   it('findNode', () => {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "tsconfig-paths-webpack-plugin": "^4.0.1",
     "tslib": "^2.0.0",
     "twemoji": "^14.0.2",
-    "typescript": "^4.8.3",
+    "typescript": "^5.7.2",
     "webpack": "^5.74.0",
     "webpack-cli": "^5.1.1",
     "webpack-dev-server": "^4.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5816,7 +5816,7 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-func-name@^2.0.0:
+get-func-name@^2.0.1, get-func-name@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.2.tgz#0d7cf20cd13fda808669ffa88f4ffc7a3943fc41"
   integrity sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==
@@ -11536,10 +11536,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
-typescript@^4.8.3, typescript@^4.9.5:
+typescript@^4.9.5:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+typescript@^5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
+  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Upgraded Typescript to v5.7.2
* Commented out ineffective code in `ControlSelection.ts`
* Added `layerX` and `layerY` properties to drag event but defaulted them to 0 as [they are not standard properties](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/layerX)  


Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced type safety in configuration handling for behavior creation.
	- Improved drag-and-drop event handling with additional mouse position properties.

- **Bug Fixes**
	- Adjusted ghost element positioning logic during resizing to address potential issues.

- **Tests**
	- Updated assertions in caret movement tests to improve type handling.

- **Chores**
	- Updated TypeScript version in development dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->