### PR TITLE
TINY-11446: Fixed issue with input in form elements

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11446-2024-12-17.yaml
+++ b/.changes/unreleased/tinymce-TINY-11446-2024-12-17.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Text input was prevented in form elements in the contents of the editor.
+time: 2024-12-17T09:12:40.242178+01:00
+custom:
+  Issue: TINY-11446

--- a/modules/tinymce/src/core/main/ts/keyboard/PreventNoneditableInput.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/PreventNoneditableInput.ts
@@ -3,11 +3,22 @@ import { Arr } from '@ephox/katamari';
 import Editor from '../api/Editor';
 import * as EditableRange from '../selection/EditableRange';
 
+const isValidContainer = (root: Element, container: Node) => root === container || root.contains(container);
+
+const isInEditableRange = (editor: Editor, range: StaticRange) => {
+  // If the range is not in the body then it's in a shadow root and we should allow that more details in: TINY-11446
+  if (!isValidContainer(editor.getBody(), range.startContainer) || !isValidContainer(editor.getBody(), range.endContainer)) {
+    return true;
+  }
+
+  return EditableRange.isEditableRange(editor.dom, range);
+};
+
 export const setup = (editor: Editor): void => {
   editor.on('beforeinput', (e) => {
     // Normally input is blocked on non-editable elements that have contenteditable="false" however we are also treating
     // SVG elements as non-editable and deleting inside or into is possible in some browsers so we need to detect that and prevent that.
-    if (!editor.selection.isEditable() || Arr.exists(e.getTargetRanges(), (rng) => !EditableRange.isEditableRange(editor.dom, rng))) {
+    if (!editor.selection.isEditable() || Arr.exists(e.getTargetRanges(), (rng) => !isInEditableRange(editor, rng))) {
       e.preventDefault();
     }
   });


### PR DESCRIPTION
Related Ticket: TINY-11446

Description of Changes:
* Checks if the `getTargetRanges` return ranges that have startContainer or endContainer not being in the body element.
* Didn't add at test since it pretty hard to simulate a internal browser shadowRoot element in theory we could try to use webdriver to type in a textbox inside a iframe but since we can barely type using webdriver in a regular textarea without flaking I opted to not do that.

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
