### PR TITLE
TINY-11714: Fixed issue with replacing empty CEF block elements

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11714-2024-12-19.yaml
+++ b/.changes/unreleased/tinymce-TINY-11714-2024-12-19.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: The `insertContent` API was not replacing selected non-editable elements correctly.
+time: 2024-12-19T09:19:26.33408+01:00
+custom:
+  Issue: TINY-11714

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -58,16 +58,22 @@ const isTableCellContentSelected = (dom: DOMUtils, rng: Range, cell: Node | null
   }
 };
 
+const isEditableEmptyBlock = (dom: DOMUtils, node: Node): boolean => {
+  if (dom.isBlock(node) && dom.isEditable(node)) {
+    const childNodes = node.childNodes;
+    return (childNodes.length === 1 && NodeType.isBr(childNodes[0])) || childNodes.length === 0;
+  } else {
+    return false;
+  }
+};
+
 const validInsertion = (editor: Editor, value: string, parentNode: Element): void => {
   // Should never insert content into bogus elements, since these can
   // be resize handles or similar
   if (parentNode.getAttribute('data-mce-bogus') === 'all') {
     parentNode.parentNode?.insertBefore(editor.dom.createFragment(value), parentNode);
   } else {
-    // Check if parent is empty or only has one BR element then set the innerHTML of that parent
-    const node = parentNode.firstChild;
-    const node2 = parentNode.lastChild;
-    if (!node || (node === node2 && node.nodeName === 'BR')) {
+    if (isEditableEmptyBlock(editor.dom, parentNode)) {
       editor.dom.setHTML(parentNode, value);
     } else {
       editor.selection.setContent(value, { no_events: true });

--- a/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentTest.ts
@@ -667,6 +667,24 @@ describe('browser.tinymce.core.content.insert.InsertContentTest', () => {
     TinyAssertions.assertRawContent(editor, '<p>foo</p><p>X<span></span>baz</p>');
   });
 
+  it('TINY-11714: Should be able to replace CEF block', () => {
+    const editor = hook.editor();
+    editor.setContent('<div><div contenteditable="false">CEF</div></div>');
+    TinySelections.setSelection(editor, [ 0 ], 1, [ 0 ], 2); // Shifted since fake caret paragraph is before CEF
+    editor.insertContent('X');
+    TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+    TinyAssertions.assertContent(editor, '<div>X</div>');
+  });
+
+  it('TINY-11714: Should be able to replace CEF inline', () => {
+    const editor = hook.editor();
+    editor.setContent('<div><span contenteditable="false">CEF</span></div>');
+    TinySelections.setSelection(editor, [ 0 ], 1, [ 0 ], 2); // Shifted since fake caret paragraph is before CEF
+    editor.insertContent('X');
+    TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
+    TinyAssertions.assertContent(editor, '<div>X</div>');
+  });
+
   context('Transparent blocks', () => {
     it('TINY-9172: Insert block anchor in regular block', () => {
       const editor = hook.editor();


### PR DESCRIPTION
Related Ticket: TINY-11714

Description of Changes:
* Fixed issue with replacing non-editable elements with the `insertContent` API

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue with the `insertContent` API, ensuring it correctly replaces selected non-editable elements.

- **Tests**
  - Added new test cases to verify the functionality of replacing contenteditable elements within the TinyMCE editor, enhancing test coverage for this feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->