### PR TITLE
TINY-11624: use toolbar button margins to calculate input margins

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11624-2024-12-20.yaml
+++ b/.changes/unreleased/tinymce-TINY-11624-2024-12-20.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Context toolbar inputs would have incorrect margins.
+time: 2024-12-20T17:40:15.824417+01:00
+custom:
+  Issue: TINY-11624

--- a/.changes/unreleased/tinymce-TINY-11624-2024-12-20.yaml
+++ b/.changes/unreleased/tinymce-TINY-11624-2024-12-20.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Context toolbar inputs would have incorrect margins.
+body: Context toolbar inputs had incorrect margins.
 time: 2024-12-20T17:40:15.824417+01:00
 custom:
   Issue: TINY-11624

--- a/modules/oxide/src/less/theme/components/form/textfield.less
+++ b/modules/oxide/src/less/theme/components/form/textfield.less
@@ -26,6 +26,7 @@
 @textfield-focus-outline: none;
 
 @toolbar-textfield-height: @toolbar-button-height;
+@toolbar-textfield-margin: @toolbar-button-spacing-y 0 (@toolbar-button-spacing-y + 1px) 0;
 
 .tox {
   .tox-textfield {
@@ -63,11 +64,10 @@
   }
 
   .tox-toolbar-textfield:extend(.tox .tox-textfield) {
-    margin-bottom: 3px;
-    margin-top: 2px;
     max-width: 250px;
     min-height: unset;
     height: @toolbar-textfield-height;
+    margin: @toolbar-textfield-margin;
   }
 
   .tox-toolbar-textfield[disabled] {


### PR DESCRIPTION
Related Ticket: TINY-11624

Description of Changes:
The incorrect input margins would break the layout in some skins. Now they are calculated based on toolbar button margins.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected margins for context toolbar inputs in TinyMCE.

- **New Features**
	- Introduced a new margin variable for toolbar text fields to enhance spacing consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->