### PR TITLE
TINY- 11720: Move utils to devPods

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,21 +67,20 @@ def runBrowserTests(String name, String browser, String platform, String bucket,
 
 def runTestPod(String cacheName, String name, String testname, String browser, String provider, String platform, String version, String bucket, String buckets, Boolean runAll) {
   return {
-    devPods.nodeConsumer(
-      nodeOpts: [
-        resourceRequestCpu: '2',
-        resourceRequestMemory: '4Gi',
-        resourceRequestEphemeralStorage: '16Gi',
-        resourceLimitCpu: '7',
-        resourceLimitMemory: '4Gi',
-        resourceLimitEphemeralStorage: '16Gi'
-      ],
-      tag: '20',
-      build: cacheName,
-      useContainers: ['node', 'aws-cli']
-    ) {
-
-      stage("${name}") {
+    stage("${name}") {
+      devPods.nodeConsumer(
+        nodeOpts: [
+          resourceRequestCpu: '2',
+          resourceRequestMemory: '4Gi',
+          resourceRequestEphemeralStorage: '16Gi',
+          resourceLimitCpu: '7',
+          resourceLimitMemory: '4Gi',
+          resourceLimitEphemeralStorage: '16Gi'
+        ],
+        tag: '20',
+        build: cacheName,
+        useContainers: ['node', 'aws-cli']
+      ) {
         grunt('list-changed-browser')
         bedrockRemoteTools.withRemoteCreds(provider) {
           int retry = 0
@@ -159,17 +158,17 @@ def runHeadlessPod(String cacheName, Boolean runAll) {
           resourceLimitEphemeralStorage: '1Gi'
         ]
   return {
-    devPods.customConsumer(
-      containers: [
-        node,
-        selenium,
-        aws
-      ],
-      base: 'node',
-      build: cacheName
-    ) {
-      container('node') {
-        stage("Headless-chrome") {
+    stage("Headless-chrome") {
+      devPods.customConsumer(
+        containers: [
+          node,
+          selenium,
+          aws
+        ],
+        base: 'node',
+        build: cacheName
+      ) {
+        container('node') {
           yarnInstall()
           grunt('list-changed-headless')
           runHeadlessTests(runAll)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ def runRemoteTests(String name, String browser, String provider, String platform
   def browserVersion = version != null ? " --browserVersion=${version}" : ""
   def bedrockCommand =
   "yarn browser-test" +
-    " --chunk=400" +
+    " --chunk=1000" +
     " --bedrock-browser=" + browser +
     " --remote=" + provider +
     " --bucket=" + bucket +
@@ -48,7 +48,7 @@ def runRemoteTests(String name, String browser, String provider, String platform
 def runBrowserTests(String name, String browser, String platform, String bucket, String buckets, Boolean runAll) {
   def bedrockCommand =
     "yarn grunt browser-auto" +
-      " --chunk=400" +
+      " --chunk=1000" +
       " --bedrock-os=" + platform +
       " --bedrock-browser=" + browser +
       " --bucket=" + bucket +

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,12 +163,28 @@ def runHeadlessPod(String cacheName, Boolean runAll) {
         ]
       ],
       base: 'node',
-      build: cacheName
+      build: cacheName,
+      cacheStep: {
+        stage('headless-cache-step') {
+          tinyAws.withAWSEngineeringCICredentials(role) {
+            sh "aws s3 cp ${cache}/${buildName}.tar.gz ${tar}"
+          }
+        }
+      },
+      environment: {
+        stage('headless-env') {
+          container('node') {
+            sh "tar -zxf ${tar}"
+          }
+        }
+      }
     ) {
-      stage("Headless-chrome") {
-        yarnInstall()
-        grunt('list-changed-headless')
-        runHeadlessTests(runAll)
+      container('node') {
+        stage("Headless-chrome") {
+          yarnInstall()
+          grunt('list-changed-headless')
+          runHeadlessTests(runAll)
+        }
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -223,19 +223,16 @@ timestamps {
       yarnInstall()
     }
 
-    stage("Validate changelog") {
-      // we use a changelog to run changie
+    stage('Build') {
+      // verify no errors in changelog merge
       exec("yarn changie-merge")
-    }
-
-    stage('Type check') {
       withEnv(["NODE_OPTIONS=--max-old-space-size=1936"]) {
+        // type check and build TinyMCE
         exec("yarn ci-all-seq")
-      }
-    }
 
-    stage('Moxiedoc check') {
-      exec("yarn tinymce-grunt shell:moxiedoc")
+        // validate documentation generator
+        exec("yarn tinymce-grunt shell:moxiedoc")
+      }
     }
   }
 


### PR DESCRIPTION
Related Ticket: TINY-11720

Description of Changes:
* Use devPods instead of bedrockRemoteTools to have better control of stages

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Transitioned pod management to a new library for improved functionality.
	- Updated cleanup process to utilize new pod management functions.
	- Enhanced configuration for the selenium container with health checks.
	- Increased chunk size for test execution commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->