### PR TITLE
TINY-11661: Not specifying a notification type fallback to 'info'

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11661-2024-12-23.yaml
+++ b/.changes/unreleased/tinymce-TINY-11661-2024-12-23.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Improved
-body: Not specifying a notification type (or specifying incorrect one) now defaults to 'info'
+body: Not specifying a notification type (or specifying incorrect one) now defaults to 'info'.
 time: 2024-12-23T16:24:11.121022+01:00
 custom:
   Issue: TINY-11661

--- a/.changes/unreleased/tinymce-TINY-11661-2024-12-23.yaml
+++ b/.changes/unreleased/tinymce-TINY-11661-2024-12-23.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Improved
+body: Not specifying a notification type (or specifying incorrect one) now defaults to 'info'
+time: 2024-12-23T16:24:11.121022+01:00
+custom:
+  Issue: TINY-11661

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Notification.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Notification.ts
@@ -30,7 +30,7 @@ export interface NotificationSketchSpec extends Sketcher.SingleSketchSpec {
 // tslint:disable-next-line:no-empty-interface
 export interface NotificationSketchDetail extends Sketcher.SingleSketchDetail {
   readonly text: string;
-  readonly level: Optional<'info' | 'warn' | 'warning' | 'error' | 'success'>;
+  readonly level: 'info' | 'warn' | 'warning' | 'error' | 'success';
   readonly icon: Optional<string>;
   readonly onAction: Function;
   readonly progress: boolean;
@@ -136,8 +136,8 @@ const factory: UiSketcher.SingleSketchFactory<NotificationSketchDetail, Notifica
 
   const iconChoices = Arr.flatten([
     detail.icon.toArray(),
-    detail.level.toArray(),
-    detail.level.bind((level) => Optional.from(notificationIconMap[level])).toArray()
+    [ detail.level ],
+    Optional.from(notificationIconMap[detail.level]).toArray()
   ]);
 
   const memButton = Memento.record(Button.sketch({
@@ -191,9 +191,7 @@ const factory: UiSketcher.SingleSketchFactory<NotificationSketchDetail, Notifica
         'role': 'alert',
         'aria-labelledby': notificationTextId
       },
-      classes: detail.level.map((level) => [ 'tox-notification', 'tox-notification--in', `tox-notification--${level}` ]).getOr(
-        [ 'tox-notification', 'tox-notification--in' ]
-      )
+      classes: [ 'tox-notification', 'tox-notification--in', `tox-notification--${detail.level}` ],
     },
     behaviours: Behaviour.derive([
       Tabstopping.config({ }),
@@ -217,7 +215,7 @@ export const Notification: NotificationSketcher = Sketcher.single({
   name: 'Notification',
   factory,
   configFields: [
-    FieldSchema.option('level'),
+    FieldSchema.defaultedStringEnum('level', 'info', [ 'success', 'error', 'warning', 'warn', 'info' ]),
     FieldSchema.required('progress'),
     FieldSchema.option('icon'),
     FieldSchema.required('onAction'),

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
@@ -317,6 +317,18 @@ describe('browser.tinymce.themes.silver.editor.NotificationManagerImplTest', () 
 
       notification.close();
     });
+
+    it('TINY-11661: Not specifying a type should fallback to \'info\'', () => {
+      const editor = hook.editor();
+      const notification = editor.notificationManager.open({ text: 'My test notification' });
+      assertStructure('Check notification structure', notification, 'info', 'My test notification');
+    });
+
+    it('TINY-11661: Specifying unsupported type should fallback to \'info\'', () => {
+      const editor = hook.editor();
+      const notification = editor.notificationManager.open({ text: 'My test notification', type: 'madeuptype' as 'info' | 'warning' | 'error' | 'success' });
+      assertStructure('Check notification structure', notification, 'info', 'My test notification');
+    });
   });
 
   context('Bottom toolbar positioning', () => {


### PR DESCRIPTION
Related Ticket: TINY-11661

Description of Changes:
* Not specifying a notification type fallback to 'info'

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a changelog entry detailing improvements to notification types, defaulting to 'info' when no valid type is specified.

- **Bug Fixes**
  - Enhanced notification manager to ensure it defaults to 'info' when an unsupported notification type is provided.

- **Tests**
  - Introduced new test cases to verify default behavior of notifications when types are unspecified or unsupported.

- **Refactor**
  - Updated the `NotificationSketchDetail` interface to enforce non-optional notification levels and improved type safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->