### PR TITLE
TINY-11672: Remove open help dialog aria label when help plugin is not enabled

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11672-2025-01-07.yaml
+++ b/.changes/unreleased/tinymce-TINY-11672-2025-01-07.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Iframe aria text used to suggest to open help dialog when help plugin was not
+body: Iframe aria text used to suggest to open help dialog even when the help plugin was not
   enabled.
 time: 2025-01-07T16:15:55.983669+01:00
 custom:

--- a/.changes/unreleased/tinymce-TINY-11672-2025-01-07.yaml
+++ b/.changes/unreleased/tinymce-TINY-11672-2025-01-07.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Iframe aria text used to suggest to open help dialog when help plugin was not
+  enabled.
+time: 2025-01-07T16:15:55.983669+01:00
+custom:
+  Issue: TINY-11672

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -510,7 +510,7 @@ const register = (editor: Editor): void => {
 
   registerOption('iframe_aria_text', {
     processor: 'string',
-    default: 'Rich Text Area. Press ALT-0 for help.'
+    default: editor.hasPlugin('help') ? 'Rich Text Area. Press ALT-0 for help.' : 'Rich Text Area'
   });
 
   registerOption('setup', {

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -510,7 +510,7 @@ const register = (editor: Editor): void => {
 
   registerOption('iframe_aria_text', {
     processor: 'string',
-    default: editor.hasPlugin('help') ? 'Rich Text Area. Press ALT-0 for help.' : 'Rich Text Area'
+    default: 'Rich Text Area'.concat(editor.hasPlugin('help') ? '. Press ALT-0 for help.' : '')
   });
 
   registerOption('setup', {

--- a/modules/tinymce/src/core/test/ts/browser/init/InitIframeAriaTextTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitIframeAriaTextTest.ts
@@ -9,7 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 describe('browser.tinymce.core.init.InitIframeAriaTextTest', () => {
   const defaultIframeTitle = 'Rich Text Area';
   const defaultIframeAriaText = 'Rich Text Area';
-  const defaultIframeAriaTextWithHelpPlugin = 'Rich Text Area. Press ALT-0 for help.';
+  const defaultIframeAriaTextWithHelpPlugin = defaultIframeAriaText.concat('. Press ALT-0 for help.');
   const customIframeAriaText = 'Cupidatat magna aliquip.';
   const isFirefox = PlatformDetection.detect().browser.isFirefox();
 

--- a/modules/tinymce/src/core/test/ts/browser/init/InitIframeAriaTextTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitIframeAriaTextTest.ts
@@ -7,30 +7,44 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.init.InitIframeAriaTextTest', () => {
-  const defaultIframeTitle = 'Rich Text Area. Press ALT-0 for help.';
-  const customIframeTitle = 'Cupidatat magna aliquip.';
+  const defaultIframeTitle = 'Rich Text Area';
+  const defaultIframeAriaText = 'Rich Text Area';
+  const defaultIframeAriaTextWithHelpPlugin = 'Rich Text Area. Press ALT-0 for help.';
+  const customIframeAriaText = 'Cupidatat magna aliquip.';
   const isFirefox = PlatformDetection.detect().browser.isFirefox();
 
-  it('TINY-1264: Should use the default iframe title when iframe_aria_text is not set', async () => {
+  it('TINY-1264: Should use the default iframe aria text when iframe_aria_text is not set', async () => {
     const editor = await McEditor.pFromSettings<Editor>({
       base_url: '/project/tinymce/js/tinymce'
     });
     const iframe = SugarElement.fromDom(editor.iframeElement as HTMLIFrameElement);
     const iframeBody = TinyDom.body(editor);
-    assert.equal(Attribute.get(iframe, 'title'), isFirefox ? defaultIframeTitle : 'Rich Text Area');
-    assert.equal(Attribute.get(iframeBody, 'aria-label'), defaultIframeTitle);
+    assert.equal(Attribute.get(iframe, 'title'), defaultIframeTitle);
+    assert.equal(Attribute.get(iframeBody, 'aria-label'), defaultIframeAriaText);
     McEditor.remove(editor);
   });
 
-  it('TINY-1264: Should use iframe_aria_text as the iframe title', async () => {
+  it('TINY-11672: Should add the help shortcut to default iframe aria text when help plugin is enabled', async () => {
     const editor = await McEditor.pFromSettings<Editor>({
       base_url: '/project/tinymce/js/tinymce',
-      iframe_aria_text: customIframeTitle
+      plugins: 'help',
     });
     const iframe = SugarElement.fromDom(editor.iframeElement as HTMLIFrameElement);
     const iframeBody = TinyDom.body(editor);
-    assert.equal(Attribute.get(iframe, 'title'), isFirefox ? customIframeTitle : 'Rich Text Area');
-    assert.equal(Attribute.get(iframeBody, 'aria-label'), customIframeTitle);
+    assert.equal(Attribute.get(iframe, 'title'), isFirefox ? defaultIframeAriaTextWithHelpPlugin : defaultIframeTitle);
+    assert.equal(Attribute.get(iframeBody, 'aria-label'), defaultIframeAriaTextWithHelpPlugin);
+    McEditor.remove(editor);
+  });
+
+  it('TINY-1264: Should use iframe_aria_text as the iframe aria text', async () => {
+    const editor = await McEditor.pFromSettings<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      iframe_aria_text: customIframeAriaText
+    });
+    const iframe = SugarElement.fromDom(editor.iframeElement as HTMLIFrameElement);
+    const iframeBody = TinyDom.body(editor);
+    assert.equal(Attribute.get(iframe, 'title'), isFirefox ? customIframeAriaText : defaultIframeTitle);
+    assert.equal(Attribute.get(iframeBody, 'aria-label'), customIframeAriaText);
     McEditor.remove(editor);
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-11672

Description of Changes:
* Remove open help dialog aria label when help plugin is not enabled

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved iframe accessibility text to only suggest help dialog when the help plugin is enabled.
  - Prevented misleading aria text for editors without the help plugin.

- **Documentation**
  - Updated default iframe aria text to be more context-aware.

- **Tests**
  - Enhanced test cases to verify correct iframe aria text behavior under different plugin configurations, including new assertions for custom aria text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->