### PR TITLE
TINY-11707: Add option link_attributes_postprocess that allows overriding attributes of inserted link through link plugin dialog

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11707-2025-01-07.yaml
+++ b/.changes/unreleased/tinymce-TINY-11707-2025-01-07.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Added
+body: '`link_attributes_postprocess` option that allows overriding attributes of a
+  link that would be inserted through the link dialog.'
+time: 2025-01-07T20:12:31.813482+01:00
+custom:
+  Issue: TINY-11707

--- a/modules/tinymce/src/plugins/link/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/link/demo/ts/demo/Demo.ts
@@ -15,6 +15,9 @@ tinymce.init({
   menu: {
     custom: { title: 'Custom', items: 'link unlink openlink' }
   },
+  // link_attributes_postprocess: (attrs: any) => {
+  // attrs.rel += ' noreferrer';
+  // },
   height: 600,
   setup: (ed) => {
     ed.on('init', () => {

--- a/modules/tinymce/src/plugins/link/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/api/Options.ts
@@ -82,6 +82,10 @@ const register = (editor: Editor): void => {
     processor: 'boolean',
     default: false
   });
+
+  registerOption('link_attributes_postprocess', {
+    processor: 'function',
+  });
 };
 
 const assumeExternalTargets = option<AssumeExternalTargets>('link_assume_external_targets');
@@ -95,6 +99,7 @@ const getLinkClassList = option<UserListItem[]>('link_class_list');
 const shouldShowLinkTitle = option<boolean>('link_title');
 const allowUnsafeLinkTarget = option<boolean>('allow_unsafe_link_target');
 const useQuickLink = option<boolean>('link_quicklink');
+const attributesPostProcess = option<Function>('link_attributes_postprocess');
 
 export {
   register,
@@ -108,5 +113,6 @@ export {
   shouldShowLinkTitle,
   allowUnsafeLinkTarget,
   useQuickLink,
-  getDefaultLinkProtocol
+  getDefaultLinkProtocol,
+  attributesPostProcess
 };

--- a/modules/tinymce/src/plugins/link/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/api/Options.ts
@@ -99,7 +99,7 @@ const getLinkClassList = option<UserListItem[]>('link_class_list');
 const shouldShowLinkTitle = option<boolean>('link_title');
 const allowUnsafeLinkTarget = option<boolean>('allow_unsafe_link_target');
 const useQuickLink = option<boolean>('link_quicklink');
-const attributesPostProcess = option<Function>('link_attributes_postprocess');
+const attributesPostProcess = option<(attributes: Record<string, string | null | undefined>) => void>('link_attributes_postprocess');
 
 export {
   register,

--- a/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
@@ -33,8 +33,8 @@ const getLinkAttrs = (data: LinkDialogOutput): LinkAttrs => {
 
 const handleExternalTargets = (href: string, assumeExternalTargets: AssumeExternalTargets): string => {
   if ((assumeExternalTargets === AssumeExternalTargets.ALWAYS_HTTP
-        || assumeExternalTargets === AssumeExternalTargets.ALWAYS_HTTPS)
-      && !Utils.hasProtocol(href)) {
+    || assumeExternalTargets === AssumeExternalTargets.ALWAYS_HTTPS)
+    && !Utils.hasProtocol(href)) {
     return assumeExternalTargets + '://' + href;
   }
   return href;
@@ -90,6 +90,10 @@ const linkDomMutation = (editor: Editor, attachState: AttachState, data: LinkDia
   const selectedElm = editor.selection.getNode();
   const anchorElm = Utils.getAnchorElement(editor, selectedElm);
   const linkAttrs = applyLinkOverrides(editor, getLinkAttrs(data));
+  const attributesPostProcess = Options.attributesPostProcess(editor);
+  if (Type.isNonNullable(attributesPostProcess)) {
+    attributesPostProcess(linkAttrs);
+  }
 
   editor.undoManager.transact(() => {
     if (data.href === attachState.href) {

--- a/modules/tinymce/src/plugins/link/test/ts/browser/AttributesPostprocessTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/AttributesPostprocessTest.ts
@@ -9,7 +9,7 @@ import Plugin from 'tinymce/plugins/link/Plugin';
 
 import { TestLinkUi } from '../module/TestLinkUi';
 
-describe('browser.tinymce.plugins.link.AttributesPostprocess', () => {
+describe('browser.tinymce.plugins.link.AttributesPostprocessTest', () => {
   const newRel = 'noopener noreferrer';
   const newHref = 'https://www.google.com';
   const attrsOverride = (attrs: any) => {

--- a/modules/tinymce/src/plugins/link/test/ts/browser/AttributesPostprocessTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/AttributesPostprocessTest.ts
@@ -1,0 +1,64 @@
+import { ApproxStructure, FocusTools, Waiter } from '@ephox/agar';
+import { describe, it, before, after } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
+import { SugarDocument } from '@ephox/sugar';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import Plugin from 'tinymce/plugins/link/Plugin';
+
+import { TestLinkUi } from '../module/TestLinkUi';
+
+describe('browser.tinymce.plugins.link.AttributesPostprocess', () => {
+  const newRel = Fun.constant('noopener noreferrer');
+  const attrsOverride = (attrs: any) => {
+    attrs.rel = newRel();
+  };
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    plugins: 'link',
+    toolbar: 'link',
+    link_attributes_postprocess: attrsOverride,
+    base_url: '/project/tinymce/js/tinymce'
+  }, [ Plugin ]);
+
+  before(() => {
+    TestLinkUi.clearHistory();
+  });
+
+  after(() => {
+    TestLinkUi.clearHistory();
+  });
+
+  it('TINY-11707: The link_attributes_postprocess can be used to override link attributes', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>Something</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], ''.length, [ 0, 0 ], 'Something'.length);
+    await TestLinkUi.pOpenLinkDialog(editor);
+
+    FocusTools.setActiveValue(SugarDocument.getDocument(), 'http://www.tiny.cloud');
+    TestLinkUi.assertDialogContents({
+      href: 'http://www.tiny.cloud',
+      text: 'Something',
+      title: '',
+      target: ''
+    });
+    await TestLinkUi.pClickSave(editor);
+    await Waiter.pTryUntil('Waiting for content to have correct structure', () => {
+      TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s, str, _arr) => {
+        return s.element('body', {
+          children: [
+            s.element('p', {
+              children: [
+                s.element('a', {
+                  attrs: {
+                    rel: str.is(newRel())
+                  }
+                })
+              ]
+            })
+          ]
+        });
+      }));
+    });
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-11707

Description of Changes:
* Adds option link_attributes_postprocess that allows overriding attributes of inserted link through link plugin dialog

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `link_attributes_postprocess` option for TinyMCE.
  - Allows users to override link attributes when inserting links through the link dialog.

- **Documentation**
  - Added documentation for the new link attributes post-processing feature.

- **Tests**
  - Created a comprehensive test suite to verify the functionality of link attributes post-processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->