### PR TITLE
TINY-11596: fix double border for selected annotated image

### DIFF
--- a/modules/oxide/src/less/theme/content/comments/comments.less
+++ b/modules/oxide/src/less/theme/content/comments/comments.less
@@ -41,8 +41,7 @@
     border-radius: 3px;
     box-shadow: 0 0 0 2px @keyboard-focus-outline-color;
 
-    &
-      :has(
+    &:has(
         img[data-mce-selected],
         > audio[data-mce-selected],
         > video[data-mce-selected],


### PR DESCRIPTION
Related Ticket: TINY-11596

Description of Changes:
Follow up to TINY-11596. Because of wrong formatting the styles were never applied. Addressing the bug raised in comment: https://ephocks.atlassian.net/browse/TINY-11596?focusedCommentId=143953

Pre-checks:
* [x] ~~Changelog entry added~~ (changelog was added in the original TINY-11596 PR)
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Refined CSS selector syntax for comment styling
	- Simplified selector structure in comment-related styles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->