### PR TITLE
TINY-11714: Fixed test so it properly tests the insert change

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentTest.ts
@@ -678,11 +678,12 @@ describe('browser.tinymce.core.content.insert.InsertContentTest', () => {
 
   it('TINY-11714: Should be able to replace CEF inline', () => {
     const editor = hook.editor();
-    editor.setContent('<div><span contenteditable="false">CEF</span></div>');
-    TinySelections.setSelection(editor, [ 0 ], 1, [ 0 ], 2); // Shifted since fake caret paragraph is before CEF
+    editor.schema.addCustomElements('~custom-inline');
+    editor.setContent('<p><custom-inline contenteditable="false"></custom-inline></p>');
+    TinySelections.select(editor, 'p custom-inline', []);
     editor.insertContent('X');
     TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
-    TinyAssertions.assertContent(editor, '<div>X</div>');
+    TinyAssertions.assertContent(editor, '<p>X</p>');
   });
 
   context('Transparent blocks', () => {


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Follow up PR the previous one didn't properly test the issue the replaced element can't have any children and we need to alter the schema to allow a element of that type.

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test case for content insertion with custom inline elements
	- Modified test to use a custom inline element instead of a span
	- Adjusted content assertion to reflect new element structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->