### PR TITLE
TINY-11670: triggering caption now remove `float` from the image

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11670-2025-01-20.yaml
+++ b/.changes/unreleased/tinymce-TINY-11670-2025-01-20.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Image caption preserved the `float` style of the image causing a bad allignment
+  of the caption.
+time: 2025-01-20T14:49:52.937631196+01:00
+custom:
+  Issue: TINY-11670

--- a/.changes/unreleased/tinymce-TINY-11670-2025-01-20.yaml
+++ b/.changes/unreleased/tinymce-TINY-11670-2025-01-20.yaml
@@ -1,7 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Image caption preserved the `float` style of the image causing a bad allignment
-  of the caption.
+body: The `float` property was not properly removed on the image when converting a image into a captioned image.
 time: 2025-01-20T14:49:52.937631196+01:00
 custom:
   Issue: TINY-11670

--- a/modules/tinymce/src/plugins/image/main/ts/core/ImageSelection.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/core/ImageSelection.ts
@@ -98,6 +98,7 @@ const writeImageDataToSelection = (editor: Editor, data: ImageData) => {
     syncSrcAttr(editor, image);
 
     if (isFigure(image.parentNode)) {
+      editor.dom.setStyle(image, 'float', '');
       const figure = image.parentNode;
       splitTextBlock(editor, figure);
       editor.selection.select(image.parentNode);

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -79,5 +79,20 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
 
     TinyUiActions.submitDialog(editor);
     assertCleanHtml('Checking output', editor, '<figure class="image"><img style="border: 2px solid red;" src="https://www.google.com/logos/google.jpg" width="200" height="200"><figcaption>Caption</figcaption></figure>');
+    editor.options.set('image_caption', false);
+  });
+
+  it('TINY-11670: floating images should not lose the float if is not putted in a caption', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><img src="https://www.google.com/logos/google.jpg" style="border: 2px solid red; float: left" width="200" height="200"/></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    editor.execCommand('mceImage');
+    await TinyUiActions.pWaitForDialog(editor);
+    setInputValue(generalTabSelectors.height, '300');
+    setInputValue(generalTabSelectors.width, '300');
+    assertInputValue(generalTabSelectors.height, '300');
+    assertInputValue(generalTabSelectors.width, '300');
+    TinyUiActions.submitDialog(editor);
+    assertCleanHtml('Checking output', editor, '<p><img style="border: 2px solid red; float: left;" src="https://www.google.com/logos/google.jpg" width="300" height="300"></p>');
   });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -65,7 +65,7 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     assertCleanHtml('Checking output', editor, '<p><img src="https://www.google.com/logos/google.jpg" alt="" width="200"></p>');
   });
 
-  it('TINY-11670: floating images should lose the float if putted in a caption', async () => {
+  it('TINY-11670: floating images should lose the float if put in a caption', async () => {
     const editor = hook.editor();
     editor.options.set('image_caption', true);
     editor.setContent('<p><img src="https://www.google.com/logos/google.jpg" style="border: 2px solid red; float: left" width="200" height="200"/></p>');
@@ -80,7 +80,7 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     editor.options.set('image_caption', false);
   });
 
-  it('TINY-11670: floating images should not lose the float if is not putted in a caption', async () => {
+  it('TINY-11670: floating images should not lose the float if is not put in a caption', async () => {
     const editor = hook.editor();
     editor.setContent('<p><img src="https://www.google.com/logos/google.jpg" style="border: 2px solid red; float: left" width="200" height="200"/></p>');
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -71,8 +71,6 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     editor.setContent('<p><img src="https://www.google.com/logos/google.jpg" style="border: 2px solid red; float: left" width="200" height="200"/></p>');
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
     editor.execCommand('mceImage');
-    await TinyUiActions.pWaitForDialog(editor);
-
     const dialog = await TinyUiActions.pWaitForDialog(editor);
     Mouse.clickOn(dialog, generalTabSelectors.caption);
     assertInputValue(generalTabSelectors.caption, 'on');

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -64,4 +64,20 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     TinyUiActions.submitDialog(editor);
     assertCleanHtml('Checking output', editor, '<p><img src="https://www.google.com/logos/google.jpg" alt="" width="200"></p>');
   });
+
+  it('TINY-11670: floating images should lose the float if putted in a caption', async () => {
+    const editor = hook.editor();
+    editor.options.set('image_caption', true);
+    editor.setContent('<p><img src="https://www.google.com/logos/google.jpg" style="border: 2px solid red; float: left" width="200" height="200"/></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    editor.execCommand('mceImage');
+    await TinyUiActions.pWaitForDialog(editor);
+
+    const dialog = await TinyUiActions.pWaitForDialog(editor);
+    Mouse.clickOn(dialog, generalTabSelectors.caption);
+    assertInputValue(generalTabSelectors.caption, 'on');
+
+    TinyUiActions.submitDialog(editor);
+    assertCleanHtml('Checking output', editor, '<figure class="image"><img style="border: 2px solid red;" src="https://www.google.com/logos/google.jpg" width="200" height="200"><figcaption>Caption</figcaption></figure>');
+  });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -77,7 +77,7 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
 
     TinyUiActions.submitDialog(editor);
     assertCleanHtml('Checking output', editor, '<figure class="image"><img style="border: 2px solid red;" src="https://www.google.com/logos/google.jpg" width="200" height="200"><figcaption>Caption</figcaption></figure>');
-    editor.options.set('image_caption', false);
+    editor.options.unset('image_caption');
   });
 
   it('TINY-11670: floating images should not lose the float if is not put in a caption', async () => {

--- a/modules/tinymce/src/plugins/image/test/ts/browser/api/CommandsTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/api/CommandsTest.ts
@@ -154,4 +154,15 @@ describe('browser.tinymce.plugins.image.api.CommandsTest', () => {
     });
     TinyAssertions.assertContent(editor, '<p><img alt="alt1"></p>');
   });
+
+  it('TINY-11670: floating images should lose the float if putted in a caption', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><img style="border: 2px solid red; float: right" /></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    updateImage(editor, {
+      src: 'javascript:alert(1)',
+      caption: true
+    });
+    TinyAssertions.assertContent(editor, '<figure class="image"><img style="border: 2px solid red;"><figcaption>Caption</figcaption></figure>');
+  });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/api/CommandsTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/api/CommandsTest.ts
@@ -155,7 +155,7 @@ describe('browser.tinymce.plugins.image.api.CommandsTest', () => {
     TinyAssertions.assertContent(editor, '<p><img alt="alt1"></p>');
   });
 
-  it('TINY-11670: floating images should lose the float if putted in a caption', async () => {
+  it('TINY-11670: floating images should lose the float if put in a caption', async () => {
     const editor = hook.editor();
     editor.setContent('<p><img style="border: 2px solid red; float: right" /></p>');
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);


### PR DESCRIPTION
Related Ticket: TINY-11670

Description of Changes:
to avoid a bad visualization of the caption when the image as some `float`, now caption also remove the `float` from the image

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with image captions incorrectly preserving the float style of images, causing misalignment.
	- Ensured that floating images lose their float style when placed inside a caption.

- **Tests**
	- Added new test cases to verify image caption and float style behavior.
	- Confirmed correct handling of floating images in different scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->