### PR TITLE
Revert Update accessibility checker styles for dark mode

### DIFF
--- a/modules/oxide/src/less/theme/content/accessibility-checker/accessibility-checker.less
+++ b/modules/oxide/src/less/theme/content/accessibility-checker/accessibility-checker.less
@@ -5,13 +5,13 @@
 @accessibility-overlay-opacity-60: 60%;
 
 @accessibility-issue-info-selection-color: if(@content-ui-darkmode = true, mix(@color-white, @color-tint, @accessibility-overlay-opacity-60), @color-tint);
-@accessibility-issue-info-selection-background-color: if(@content-ui-darkmode = true, mix(@color-black, @color-tint, @accessibility-overlay-opacity-90), mix(@background-color, @color-tint, @accessibility-overlay-opacity-90));
+@accessibility-issue-info-selection-background-color: mix(@background-color, @color-tint, @accessibility-overlay-opacity-90);
 
 @accessibility-issue-warn-selection-color: if(@content-ui-darkmode = true, mix(@color-white, @color-warning, @accessibility-overlay-opacity-60), @color-warning);
-@accessibility-issue-warn-selection-background-color: if(@content-ui-darkmode = true, mix(@color-black, @color-warning, @accessibility-overlay-opacity-90), mix(@background-color, @color-warning, @accessibility-overlay-opacity-90));
+@accessibility-issue-warn-selection-background-color: mix(@background-color, @color-warning, @accessibility-overlay-opacity-90);
 
 @accessibility-issue-error-selection-color: if(@content-ui-darkmode = true, mix(@color-white, @color-error, @accessibility-overlay-opacity-60), @color-error);
-@accessibility-issue-error-selection-background-color: if(@content-ui-darkmode = true, mix(@color-black, @color-error, @accessibility-overlay-opacity-90), mix(@background-color, @color-error, @accessibility-overlay-opacity-90));
+@accessibility-issue-error-selection-background-color: mix(@background-color, @color-error, @accessibility-overlay-opacity-90);
 
 [data-ephox-foam-a11y-violation] {
   outline: 2px solid;


### PR DESCRIPTION
Related Ticket: 
TINY-11652

Description of Changes:
This reverts commit 3bfbda75dd7ceb63e166f04e2564b5f5b3e32324.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified background color calculations for accessibility issue states
	- Removed dark mode conditional logic for background color assignments
	- Streamlined color selection for info, warning, and error states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->