### PR TITLE
TINY-11733: Add style overwrite for warning message

### DIFF
--- a/modules/oxide/src/less/theme/components/accessibility-checker/accessibility-checker.less
+++ b/modules/oxide/src/less/theme/components/accessibility-checker/accessibility-checker.less
@@ -214,6 +214,10 @@
     margin-top: 0;
     // Inherits other styles from dialog body content heading
   }
+
+  .tox-form__group .tox-form__group--error{
+    color: @accessibility-issue-error-heading-text-color;
+  }
 }
 
 .tox:not([dir=rtl]) {

--- a/modules/oxide/src/less/theme/components/accessibility-checker/accessibility-checker.less
+++ b/modules/oxide/src/less/theme/components/accessibility-checker/accessibility-checker.less
@@ -86,6 +86,10 @@
 
   .accessibility-issue__repair {
     margin-top: @pad-sm;
+
+    .tox-form__group .tox-form__group--error{
+      color: @accessibility-issue-error-heading-text-color;
+    }
   }
 
   // Wrap all states with `tox-dialog__body-content` class for css specificity of primarily the H2 colors
@@ -215,9 +219,7 @@
     // Inherits other styles from dialog body content heading
   }
 
-  .tox-form__group .tox-form__group--error{
-    color: @accessibility-issue-error-heading-text-color;
-  }
+
 }
 
 .tox:not([dir=rtl]) {

--- a/modules/oxide/src/less/theme/components/accessibility-checker/accessibility-checker.less
+++ b/modules/oxide/src/less/theme/components/accessibility-checker/accessibility-checker.less
@@ -87,7 +87,7 @@
   .accessibility-issue__repair {
     margin-top: @pad-sm;
 
-    .tox-form__group .tox-form__group--error{
+    .tox-form__group .tox-form__group--error {
       color: @accessibility-issue-error-heading-text-color;
     }
   }

--- a/modules/oxide/src/less/theme/components/accessibility-checker/accessibility-checker.less
+++ b/modules/oxide/src/less/theme/components/accessibility-checker/accessibility-checker.less
@@ -218,8 +218,6 @@
     margin-top: 0;
     // Inherits other styles from dialog body content heading
   }
-
-
 }
 
 .tox:not([dir=rtl]) {


### PR DESCRIPTION
Related Ticket: 
TINY-11733

Description of Changes:
- Add style overwrite for warning message

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
	- Enhanced accessibility checker error state styling
	- Improved visual distinction for error messages in the accessibility component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->