### PR TITLE
TINY-11304: Fixed expand to word not working inside inline editable hosts

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11304-2025-01-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-11304-2025-01-24.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Expanding selection to word didn't work inside inline editable host elements.
+body: Expanding selection to word didn't work inside inline editing host elements.
 time: 2025-01-24T15:07:19.167621+01:00
 custom:
   Issue: TINY-11304

--- a/.changes/unreleased/tinymce-TINY-11304-2025-01-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-11304-2025-01-24.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Expanding selection to word didn't work inside inline editable host elements.
+time: 2025-01-24T15:07:19.167621+01:00
+custom:
+  Issue: TINY-11304

--- a/modules/tinymce/src/core/main/ts/api/dom/RangeUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/RangeUtils.ts
@@ -72,7 +72,7 @@ const RangeUtils = (dom: DOMUtils): RangeUtils => {
    */
   const expand = (rng: Range, options: { type: 'word' } = { type: 'word' }): Range => {
     if (options.type === 'word') {
-      const rangeLike = ExpandRange.expandRng(dom, rng, [{ inline: 'span' }]);
+      const rangeLike = ExpandRange.expandRng(dom, rng, [{ inline: 'span' }], { includeTrailingSpace: false, expandToBlock: false });
       const newRange = dom.createRng();
       newRange.setStart(rangeLike.startContainer, rangeLike.startOffset);
       newRange.setEnd(rangeLike.endContainer, rangeLike.endOffset);

--- a/modules/tinymce/src/core/main/ts/dom/NodeType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/NodeType.ts
@@ -102,6 +102,7 @@ const isBr = matchNodeName<HTMLBRElement>('br');
 const isImg = matchNodeName<HTMLImageElement>('img');
 const isContentEditableTrue = hasContentEditableState('true');
 const isContentEditableFalse = hasContentEditableState('false');
+const isEditableHost = (node: Node): node is HTMLElement => isHTMLElement(node) && node.isContentEditable && Type.isNonNullable(node.parentElement) && !node.parentElement.isContentEditable;
 
 const isTableCell = matchNodeNames<HTMLTableCellElement>([ 'td', 'th' ]);
 const isTableCellOrCaption = matchNodeNames<HTMLTableCellElement>([ 'td', 'th', 'caption' ]);
@@ -124,6 +125,7 @@ export {
   isImg,
   isContentEditableTrue,
   isContentEditableFalse,
+  isEditableHost,
   isMedia,
   isTableCell,
   isTableCellOrCaption,

--- a/modules/tinymce/src/core/main/ts/dom/NodeType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/NodeType.ts
@@ -102,7 +102,7 @@ const isBr = matchNodeName<HTMLBRElement>('br');
 const isImg = matchNodeName<HTMLImageElement>('img');
 const isContentEditableTrue = hasContentEditableState('true');
 const isContentEditableFalse = hasContentEditableState('false');
-const isEditableHost = (node: Node): node is HTMLElement => isHTMLElement(node) && node.isContentEditable && Type.isNonNullable(node.parentElement) && !node.parentElement.isContentEditable;
+const isEditingHost = (node: Node): node is HTMLElement => isHTMLElement(node) && node.isContentEditable && Type.isNonNullable(node.parentElement) && !node.parentElement.isContentEditable;
 
 const isTableCell = matchNodeNames<HTMLTableCellElement>([ 'td', 'th' ]);
 const isTableCellOrCaption = matchNodeNames<HTMLTableCellElement>([ 'td', 'th', 'caption' ]);
@@ -125,7 +125,7 @@ export {
   isImg,
   isContentEditableTrue,
   isContentEditableFalse,
-  isEditableHost,
+  isEditingHost,
   isMedia,
   isTableCell,
   isTableCellOrCaption,

--- a/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/CaretFormat.ts
@@ -307,7 +307,7 @@ const removeCaretFormat = (editor: Editor, name: string, vars?: FormatVars, simi
     rng.collapse(true);
 
     // Expand the range to the closest word and split it at those points
-    let expandedRng = ExpandRange.expandRng(dom, rng, formatList, true);
+    let expandedRng = ExpandRange.expandRng(dom, rng, formatList, { includeTrailingSpace: true });
     expandedRng = SplitRange.split(expandedRng);
 
     // TODO: Figure out how on earth this works, as it shouldn't since remove format

--- a/modules/tinymce/src/core/main/ts/fmt/ExpandRange.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ExpandRange.ts
@@ -74,7 +74,7 @@ const findWordEndPoint = (
   includeTrailingSpaces: boolean
 ) => {
   let lastTextNode: Text;
-  const closestRoot = dom.getParent(container, (node) => NodeType.isEditableHost(node) || dom.isBlock(node));
+  const closestRoot = dom.getParent(container, (node) => NodeType.isEditingHost(node) || dom.isBlock(node));
   const rootNode = Type.isNonNullable(closestRoot) ? closestRoot : body;
 
   const walk = (container: Node, offset: number, pred: (start: boolean, node: Text, offset: number) => number) => {
@@ -206,7 +206,7 @@ const findParentContainer = (
   }
 
   while (parent) {
-    if (NodeType.isEditableHost(parent)) {
+    if (NodeType.isEditingHost(parent)) {
       return container;
     }
 
@@ -240,7 +240,7 @@ const isSelfOrParentBookmark = (container: Node) => isBookmarkNode(container.par
 
 const expandRng = (dom: DOMUtils, rng: Range, formatList: Format[], expandOptions: ExpandOptions = {}): RangeLikeObject => {
   const { includeTrailingSpace = false, expandToBlock = true } = expandOptions;
-  const editableHost = dom.getParent(rng.commonAncestorContainer, (node) => NodeType.isEditableHost(node)) as HTMLElement;
+  const editableHost = dom.getParent(rng.commonAncestorContainer, (node) => NodeType.isEditingHost(node)) as HTMLElement;
   const root = Type.isNonNullable(editableHost) ? editableHost : dom.getRoot();
   let { startContainer, startOffset, endContainer, endOffset } = rng;
   const format = formatList[0];

--- a/modules/tinymce/src/core/main/ts/fmt/ExpandRange.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ExpandRange.ts
@@ -12,6 +12,11 @@ import * as FormatUtils from './FormatUtils';
 
 type Sibling = 'previousSibling' | 'nextSibling';
 
+export interface ExpandOptions {
+  readonly includeTrailingSpace?: boolean;
+  readonly expandToBlock?: boolean;
+}
+
 const isBookmarkNode = Bookmarks.isBookmarkNode;
 const getParents = FormatUtils.getParents;
 const isWhiteSpaceNode = FormatUtils.isWhiteSpaceNode;
@@ -69,7 +74,8 @@ const findWordEndPoint = (
   includeTrailingSpaces: boolean
 ) => {
   let lastTextNode: Text;
-  const rootNode = dom.getParent(container, dom.isBlock) || body;
+  const closestRoot = dom.getParent(container, (node) => NodeType.isEditableHost(node) || dom.isBlock(node));
+  const rootNode = Type.isNonNullable(closestRoot) ? closestRoot : body;
 
   const walk = (container: Node, offset: number, pred: (start: boolean, node: Text, offset: number) => number) => {
     const textSeeker = TextSeeker(dom);
@@ -185,10 +191,10 @@ const findParentContainer = (
   formatList: Format[],
   container: Node,
   offset: number,
-  start: boolean
+  start: boolean,
+  expandToBlock: boolean
 ) => {
   let parent: Node | null = container;
-
   const siblingName = start ? 'previousSibling' : 'nextSibling';
   const root = dom.getRoot();
 
@@ -200,9 +206,13 @@ const findParentContainer = (
   }
 
   while (parent) {
+    if (NodeType.isEditableHost(parent)) {
+      return container;
+    }
+
     // Stop expanding on block elements
     if (!formatList[0].block_expand && dom.isBlock(parent)) {
-      return parent;
+      return expandToBlock ? parent : container;
     }
 
     // Walk left/right
@@ -228,7 +238,10 @@ const findParentContainer = (
 
 const isSelfOrParentBookmark = (container: Node) => isBookmarkNode(container.parentNode) || isBookmarkNode(container);
 
-const expandRng = (dom: DOMUtils, rng: Range, formatList: Format[], includeTrailingSpace: boolean = false): RangeLikeObject => {
+const expandRng = (dom: DOMUtils, rng: Range, formatList: Format[], expandOptions: ExpandOptions = {}): RangeLikeObject => {
+  const { includeTrailingSpace = false, expandToBlock = true } = expandOptions;
+  const editableHost = dom.getParent(rng.commonAncestorContainer, (node) => NodeType.isEditableHost(node)) as HTMLElement;
+  const root = Type.isNonNullable(editableHost) ? editableHost : dom.getRoot();
   let { startContainer, startOffset, endContainer, endOffset } = rng;
   const format = formatList[0];
 
@@ -283,7 +296,7 @@ const expandRng = (dom: DOMUtils, rng: Range, formatList: Format[], includeTrail
     // Expand left to closest word boundary
     const startPoint = findWordEndPoint(
       dom,
-      dom.getRoot(),
+      root,
       startContainer,
       startOffset,
       true,
@@ -295,7 +308,7 @@ const expandRng = (dom: DOMUtils, rng: Range, formatList: Format[], includeTrail
     });
 
     // Expand right to closest word boundary
-    const endPoint = findWordEndPoint(dom, dom.getRoot(), endContainer, endOffset, false, includeTrailingSpace);
+    const endPoint = findWordEndPoint(dom, root, endContainer, endOffset, false, includeTrailingSpace);
     endPoint.each(({ container, offset }) => {
       endContainer = container;
       endOffset = offset;
@@ -308,11 +321,11 @@ const expandRng = (dom: DOMUtils, rng: Range, formatList: Format[], includeTrail
   // Move start point up the tree
   if (FormatUtils.isInlineFormat(format) || format.block_expand) {
     if (!FormatUtils.isInlineFormat(format) || (!NodeType.isText(startContainer) || startOffset === 0)) {
-      startContainer = findParentContainer(dom, formatList, startContainer, startOffset, true);
+      startContainer = findParentContainer(dom, formatList, startContainer, startOffset, true, expandToBlock);
     }
 
     if (!FormatUtils.isInlineFormat(format) || (!NodeType.isText(endContainer) || endOffset === endContainer.data.length)) {
-      endContainer = findParentContainer(dom, formatList, endContainer, endOffset, false);
+      endContainer = findParentContainer(dom, formatList, endContainer, endOffset, false, expandToBlock);
     }
   }
 
@@ -332,14 +345,14 @@ const expandRng = (dom: DOMUtils, rng: Range, formatList: Format[], includeTrail
     // Non block element then try to expand up the leaf
     if (FormatUtils.isBlockFormat(format)) {
       if (!dom.isBlock(startContainer)) {
-        startContainer = findParentContainer(dom, formatList, startContainer, startOffset, true);
+        startContainer = findParentContainer(dom, formatList, startContainer, startOffset, true, expandToBlock);
         if (NodeType.isText(startContainer)) {
           startOffset = 0;
         }
       }
 
       if (!dom.isBlock(endContainer)) {
-        endContainer = findParentContainer(dom, formatList, endContainer, endOffset, false);
+        endContainer = findParentContainer(dom, formatList, endContainer, endOffset, false, expandToBlock);
         if (NodeType.isText(endContainer)) {
           endOffset = endContainer.data.length;
         }

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -537,7 +537,7 @@ const removeFormatInternal = (ed: Editor, name: string, vars?: FormatVars, node?
     let startContainer: Node;
     let endContainer: Node;
 
-    let expandedRng = ExpandRange.expandRng(dom, rng, formatList, rng.collapsed);
+    let expandedRng = ExpandRange.expandRng(dom, rng, formatList, { includeTrailingSpace: rng.collapsed });
 
     if (format.split) {
       // Split text nodes

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotateBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotateBlocksTest.ts
@@ -708,7 +708,7 @@ describe('browser.tinymce.core.annotate.AnnotateBlocksTest', () => {
               `<figure class="image" contenteditable="false" ${expectedBlockAnnotationAttrs(1)}>${imageHtml}<figcaption><span ${expectedSpanAnnotationAttrs(2)}>Caption</span></figcaption></figure>`,
               '<p>After</p>'
             ],
-            selectionPath([ 1 ], 1, [ 1 ], 2),
+            selectionPath([ 1, 1 ], 0, [ 1, 1 ], 1),
             { span: 1, block: 1 }
           );
         });

--- a/modules/tinymce/src/core/test/ts/browser/api/dom/RangeExpandTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/api/dom/RangeExpandTest.ts
@@ -1,6 +1,8 @@
+import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinySelections, TinyHooks } from '@ephox/wrap-mcagar';
+import { Hierarchy, SugarElement } from '@ephox/sugar';
+import { TinySelections, TinyHooks, TinyDom } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import RangeUtils from 'tinymce/core/api/dom/RangeUtils';
@@ -30,17 +32,23 @@ describe('browser.tinymce.core.api.dom.RangeExpandTest', () => {
     assert.equal(range1.endOffset, range2.endOffset, 'Mismatching end offset');
   };
 
+  const assertRange = (editor: Editor, rng: Range, startPath: number[], startOffset: number, endPath: number[], endOffset: number) => {
+    const startContainer = Hierarchy.follow(TinyDom.body(editor), startPath).getOrDie();
+    const endContainer = Hierarchy.follow(TinyDom.body(editor), endPath).getOrDie();
+
+    Assertions.assertDomEq('Should be expected start container', startContainer, SugarElement.fromDom(rng.startContainer));
+    assert.equal(rng.startOffset, startOffset, 'Should be expected start offset');
+    Assertions.assertDomEq('Should be expected end container', endContainer, SugarElement.fromDom(rng.endContainer));
+    assert.equal(rng.endOffset, endOffset, 'Should be expected end offset');
+  };
+
   it('TINY-9001: The content is empty', () => {
     const editor = hook.editor();
     editor.setContent('');
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 0);
     const startRange = editor.selection.getRng();
-    const endRange = RangeUtils(editor.dom).expand(startRange);
-    const body = editor.getBody();
-    const expectedRange = editor.dom.createRng();
-    expectedRange.setStart(body, 0);
-    expectedRange.setEnd(body, 1);
-    compareRanges(expectedRange, endRange);
+    const expandedRange = RangeUtils(editor.dom).expand(startRange);
+    assertRange(editor, expandedRange, [ 0 ], 0, [ 0 ], 1);
   });
 
   it('TINY-9001: The cursor is in between two spaces', () => {

--- a/modules/tinymce/src/core/test/ts/browser/dom/NodeTypeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/NodeTypeTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { SugarElement } from '@ephox/sugar';
+import { Insert, Remove, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import * as NodeType from 'tinymce/core/dom/NodeType';
@@ -119,5 +119,17 @@ describe('browser.tinymce.core.dom.NodeTypeTest', () => {
     assert.isFalse(NodeType.isTable(SugarElement.fromHtml('<div></div>').dom));
     assert.isFalse(NodeType.isTable(document.createTextNode('test')));
     assert.isFalse(NodeType.isTable(null));
+  });
+
+  it('isEditableHost', () => {
+    const div = SugarElement.fromHtml('<div contenteditable="false"><span contenteditable="true"><b></b></span></div>');
+
+    Insert.append(SugarBody.body(), div);
+
+    assert.isTrue(NodeType.isEditableHost(SelectorFind.descendant(div, 'span').getOrDie().dom), 'Inner span be editable host');
+    assert.isFalse(NodeType.isEditableHost(SelectorFind.descendant(div, 'b').getOrDie().dom), 'Inner b be not a editable host');
+    assert.isFalse(NodeType.isEditableHost(div.dom), 'Non-editable div be not a editable host');
+
+    Remove.remove(div);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/NodeTypeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/NodeTypeTest.ts
@@ -121,14 +121,14 @@ describe('browser.tinymce.core.dom.NodeTypeTest', () => {
     assert.isFalse(NodeType.isTable(null));
   });
 
-  it('isEditableHost', () => {
+  it('isEditingHost', () => {
     const div = SugarElement.fromHtml('<div contenteditable="false"><span contenteditable="true"><b></b></span></div>');
 
     Insert.append(SugarBody.body(), div);
 
-    assert.isTrue(NodeType.isEditableHost(SelectorFind.descendant(div, 'span').getOrDie().dom), 'Inner span be editable host');
-    assert.isFalse(NodeType.isEditableHost(SelectorFind.descendant(div, 'b').getOrDie().dom), 'Inner b be not a editable host');
-    assert.isFalse(NodeType.isEditableHost(div.dom), 'Non-editable div be not a editable host');
+    assert.isTrue(NodeType.isEditingHost(SelectorFind.descendant(div, 'span').getOrDie().dom), 'Inner span be editable host');
+    assert.isFalse(NodeType.isEditingHost(SelectorFind.descendant(div, 'b').getOrDie().dom), 'Inner b be not a editable host');
+    assert.isFalse(NodeType.isEditingHost(div.dom), 'Non-editable div be not a editable host');
 
     Remove.remove(div);
   });

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
@@ -1216,6 +1216,14 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     TinyAssertions.assertSelection(editor, [ 0, 0 ], 2, [ 0, 0 ], 6);
   });
 
+  it('TINY-11304: Expanding a word expands does not expand beyond closest editing host', () => {
+    const editor = hook.editor();
+    editor.setContent('<div contenteditable="false">a<span contenteditable="true">bc</span>d</div>');
+    TinySelections.setCursor(editor, [ 1, 1, 0 ], 1); // Shifted because of fake caret
+    editor.selection.expand({ type: 'word' });
+    TinyAssertions.assertSelection(editor, [ 0, 1, 0 ], 0, [ 0, 1, 0 ], 2);
+  });
+
   it('TINY-9259: Should be able to get selection range on hidden editors', () => {
     const editor = hook.editor();
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
@@ -1216,7 +1216,7 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
     TinyAssertions.assertSelection(editor, [ 0, 0 ], 2, [ 0, 0 ], 6);
   });
 
-  it('TINY-11304: Expanding a word expands does not expand beyond closest editing host', () => {
+  it('TINY-11304: Expanding a word does not expand beyond closest editing host', () => {
     const editor = hook.editor();
     editor.setContent('<div contenteditable="false">a<span contenteditable="true">bc</span>d</div>');
     TinySelections.setCursor(editor, [ 1, 1, 0 ], 1); // Shifted because of fake caret

--- a/modules/tinymce/src/core/test/ts/browser/fmt/ExpandRangeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/ExpandRangeTest.ts
@@ -19,7 +19,7 @@ describe('browser.tinymce.core.fmt.ExpandRangeTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   }, [], true);
 
-  const expandRng = (editor: Editor, startPath: number[], startOffset: number, endPath: number[], endOffset: number, format: Format[], excludeTrailingSpaces: boolean = false) => {
+  const expandRng = (editor: Editor, startPath: number[], startOffset: number, endPath: number[], endOffset: number, format: Format[], expandOpts: ExpandRange.ExpandOptions = {}) => {
     const startContainer = Hierarchy.follow(TinyDom.body(editor), startPath).getOrDie();
     const endContainer = Hierarchy.follow(TinyDom.body(editor), endPath).getOrDie();
 
@@ -27,7 +27,7 @@ describe('browser.tinymce.core.fmt.ExpandRangeTest', () => {
     rng.setStart(startContainer.dom, startOffset);
     rng.setEnd(endContainer.dom, endOffset);
 
-    return ExpandRange.expandRng(editor.dom, rng, format, excludeTrailingSpaces);
+    return ExpandRange.expandRng(editor.dom, rng, format, expandOpts);
   };
 
   const assertRange = (editor: Editor, rng: RangeLikeObject, startPath: number[], startOffset: number, endPath: number[], endOffset: number) => {
@@ -41,129 +41,150 @@ describe('browser.tinymce.core.fmt.ExpandRangeTest', () => {
   };
 
   context('TBA: Expand inline format words', () => {
+    it('In middle of first word in paragraph includeTrailingSpace: true, expandToBlock: true', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>ab cd</p>');
+      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 1, inlineFormat, { includeTrailingSpace: true, expandToBlock: true });
+      assertRange(editor, rng, [ ], 0, [ 0, 0 ], 3);
+    });
+
+    it('In middle of first word in paragraph includeTrailingSpace: true, expandToBlock: false', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>ab cd</p>');
+      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 1, inlineFormat, { includeTrailingSpace: true, expandToBlock: false });
+      assertRange(editor, rng, [ 0, 0 ], 0, [ 0, 0 ], 3);
+    });
+
+    it('In middle of first word in paragraph includeTrailingSpace: false, expandToBlock: false', () => {
+      const editor = hook.editor();
+      editor.setContent('<p>ab cd</p>');
+      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 1, inlineFormat, { includeTrailingSpace: false, expandToBlock: false });
+      assertRange(editor, rng, [ 0, 0 ], 0, [ 0, 0 ], 2);
+    });
+
     it('TBA: In middle of single word in paragraph', () => {
       const editor = hook.editor();
       editor.setContent('<p>ab</p>');
-      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 1, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 1, inlineFormat);
       assertRange(editor, rng, [], 0, [], 1);
     });
 
     it('TBA: In middle of single word in paragraph with paragraph siblings', () => {
       const editor = hook.editor();
       editor.setContent('<p>a</p><p>bc</p><p>de</p>');
-      const rng = expandRng(editor, [ 1, 0 ], 1, [ 1, 0 ], 1, inlineFormat, false);
+      const rng = expandRng(editor, [ 1, 0 ], 1, [ 1, 0 ], 1, inlineFormat);
       assertRange(editor, rng, [], 1, [], 2);
     });
 
     it('TBA: In middle of single word wrapped in b', () => {
       const editor = hook.editor();
       editor.setContent('<p><b>ab</b></p>');
-      const rng = expandRng(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1, inlineFormat);
       assertRange(editor, rng, [], 0, [], 1);
     });
 
     it('TBA: In middle of first word', () => {
       const editor = hook.editor();
       editor.setContent('<p>ab cd</p>');
-      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 1, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 1, inlineFormat, { includeTrailingSpace: false });
       assertRange(editor, rng, [], 0, [ 0, 0 ], 2);
     });
 
     it('TBA: In middle of last word', () => {
       const editor = hook.editor();
       editor.setContent('<p>ab cd</p>');
-      const rng = expandRng(editor, [ 0, 0 ], 4, [ 0, 0 ], 4, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 0 ], 4, [ 0, 0 ], 4, inlineFormat, { includeTrailingSpace: false });
       assertRange(editor, rng, [ 0, 0 ], 3, [], 1);
     });
 
     it('TBA: In middle of middle word', () => {
       const editor = hook.editor();
       editor.setContent('<p>ab cd ef</p>');
-      const rng = expandRng(editor, [ 0, 0 ], 4, [ 0, 0 ], 4, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 0 ], 4, [ 0, 0 ], 4, inlineFormat, { includeTrailingSpace: false });
       assertRange(editor, rng, [ 0, 0 ], 3, [ 0, 0 ], 5);
     });
 
     it('TBA: In middle of word with bold siblings expand to sibling spaces', () => {
       const editor = hook.editor();
       editor.setContent('<p><b>ab </b>cd<b> ef</b></p>');
-      const rng = expandRng(editor, [ 0, 1 ], 1, [ 0, 1 ], 1, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 1 ], 1, [ 0, 1 ], 1, inlineFormat, { includeTrailingSpace: false });
       assertRange(editor, rng, [ 0, 0, 0 ], 3, [ 0, 2, 0 ], 0);
     });
 
     it('TBA: In middle of word with block sibling and inline sibling expand to sibling space to the right', () => {
       const editor = hook.editor();
       editor.setContent('<div><p>ab </p>cd<b> ef</b></div>');
-      const rng = expandRng(editor, [ 0, 1 ], 1, [ 0, 1 ], 1, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 1 ], 1, [ 0, 1 ], 1, inlineFormat, { includeTrailingSpace: false });
       assertRange(editor, rng, [ 0, 1 ], 0, [ 0, 2, 0 ], 0);
     });
 
     it('TBA: In middle of word with block sibling and inline sibling expand to sibling space to the left', () => {
       const editor = hook.editor();
       editor.setContent('<div><b>ab </b>cd<p> ef</p></div>');
-      const rng = expandRng(editor, [ 0, 1 ], 1, [ 0, 1 ], 1, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 1 ], 1, [ 0, 1 ], 1, inlineFormat, { includeTrailingSpace: false });
       assertRange(editor, rng, [ 0, 0, 0 ], 3, [ 0, 1 ], 2);
     });
 
     it('TBA: In middle of middle word separated by nbsp characters', () => {
       const editor = hook.editor();
       editor.setContent('<p>ab\u00a0cd\u00a0ef</p>');
-      const rng = expandRng(editor, [ 0, 0 ], 4, [ 0, 0 ], 4, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 0 ], 4, [ 0, 0 ], 4, inlineFormat, { includeTrailingSpace: false });
       assertRange(editor, rng, [ 0, 0 ], 3, [ 0, 0 ], 5);
     });
 
     it('TBA: In empty paragraph', () => {
       const editor = hook.editor();
       editor.setContent('<p><br></p>');
-      const rng = expandRng(editor, [ 0 ], 0, [ 0 ], 0, inlineFormat, false);
+      const rng = expandRng(editor, [ 0 ], 0, [ 0 ], 0, inlineFormat);
       assertRange(editor, rng, [], 0, [], 1);
     });
 
     it('TBA: Fully selected word', () => {
       const editor = hook.editor();
       editor.setContent('<p>ab</p>');
-      const rng = expandRng(editor, [ 0, 0 ], 0, [ 0, 0 ], 2, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 0 ], 0, [ 0, 0 ], 2, inlineFormat);
       assertRange(editor, rng, [], 0, [], 1);
     });
 
     it('TBA: Partially selected word', () => {
       const editor = hook.editor();
       editor.setContent('<p>abc</p>');
-      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 2, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 2, inlineFormat);
       assertRange(editor, rng, [ 0, 0 ], 1, [ 0, 0 ], 2);
     });
 
     it('TBA: Whole word selected wrapped in multiple inlines', () => {
       const editor = hook.editor();
       editor.setContent('<p><b><i>c</i></b></p>');
-      const rng = expandRng(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 1, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0 ], 1, inlineFormat);
       assertRange(editor, rng, [], 0, [], 1);
     });
 
     it('TBA: Whole word inside td', () => {
       const editor = hook.editor();
       editor.setContent('<table><tbody><tr><td>a</td></tr></tbody></table>');
-      const rng = expandRng(editor, [ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 1, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 1, inlineFormat);
       assertRange(editor, rng, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
     });
 
     it('TBA: In middle of single word in paragraph (index based)', () => {
       const editor = hook.editor();
       editor.setContent('<p>ab</p>');
-      const rng = expandRng(editor, [ 0 ], 0, [ 0 ], 1, inlineFormat, false);
+      const rng = expandRng(editor, [ 0 ], 0, [ 0 ], 1, inlineFormat);
       assertRange(editor, rng, [], 0, [], 1);
     });
 
     it('TBA: In middle of single word wrapped in bold in paragraph (index based)', () => {
       const editor = hook.editor();
       editor.setContent('<p><b>ab</b></p>');
-      const rng = expandRng(editor, [ 0 ], 0, [ 0 ], 1, inlineFormat, false);
+      const rng = expandRng(editor, [ 0 ], 0, [ 0 ], 1, inlineFormat);
       assertRange(editor, rng, [], 0, [], 1);
     });
 
     it('TBA: In middle of word inside bookmark then exclude bookmark', () => {
       const editor = hook.editor();
       editor.setContent('<p><span data-mce-type="bookmark">ab cd ef</span></p>');
-      const rng = expandRng(editor, [ 0, 0, 0 ], 3, [ 0, 0, 0 ], 5, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 0, 0 ], 3, [ 0, 0, 0 ], 5, inlineFormat);
       assertRange(editor, rng, [], 0, [], 1);
     });
   });
@@ -172,35 +193,35 @@ describe('browser.tinymce.core.fmt.ExpandRangeTest', () => {
     it('TBA: In middle of single word in paragraph', () => {
       const editor = hook.editor();
       editor.setContent('<p>ab</p>');
-      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 1, inlineFormat, true);
+      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 1, inlineFormat);
       assertRange(editor, rng, [], 0, [], 1);
     });
 
     it('TINY-6268: Does not extend over space before', () => {
       const editor = hook.editor();
       TinyApis(editor).setRawContent('<p>ab<u> <span data-mce-type="bookmark">' + ZWSP + '</span>cd</u></p>');
-      const rng = expandRng(editor, [ 0, 1, 2 ], 0, [ 0, 1, 2 ], 2, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 1, 2 ], 0, [ 0, 1, 2 ], 2, inlineFormat);
       assertRange(editor, rng, [ 0, 1, 2 ], 0, [], 1);
     });
 
     it('TINY-6268: Does not extend over space after', () => {
       const editor = hook.editor();
       TinyApis(editor).setRawContent('<p><u>ab<span data-mce-type="bookmark">' + ZWSP + '</span> </u>cd</p>');
-      const rng = expandRng(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2, inlineFormat);
       assertRange(editor, rng, [], 0, [ 0, 0, 0 ], 2);
     });
 
     it('TINY-6268: Does extend over collapsible space at start of block', () => {
       const editor = hook.editor();
       TinyApis(editor).setRawContent('<p><u> <span data-mce-type="bookmark">' + ZWSP + '</span>ab</u></p>');
-      const rng = expandRng(editor, [ 0, 0, 2 ], 0, [ 0, 0, 2 ], 2, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 0, 2 ], 0, [ 0, 0, 2 ], 2, inlineFormat);
       assertRange(editor, rng, [], 0, [], 1);
     });
 
     it('TINY-6268: Does extend over collapsible space at end of block', () => {
       const editor = hook.editor();
       TinyApis(editor).setRawContent('<p><u>ab<span data-mce-type="bookmark">' + ZWSP + '</span> </u></p>');
-      const rng = expandRng(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2, inlineFormat, false);
+      const rng = expandRng(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2, inlineFormat);
       assertRange(editor, rng, [], 0, [], 1);
     });
   });
@@ -209,21 +230,21 @@ describe('browser.tinymce.core.fmt.ExpandRangeTest', () => {
     it('TBA: In middle word', () => {
       const editor = hook.editor();
       editor.setContent('<p>ab cd ef</p>');
-      const rng = expandRng(editor, [ 0, 0 ], 4, [ 0, 0 ], 4, blockFormat, false);
+      const rng = expandRng(editor, [ 0, 0 ], 4, [ 0, 0 ], 4, blockFormat);
       assertRange(editor, rng, [], 0, [], 1);
     });
 
     it('TBA: In middle bold word', () => {
       const editor = hook.editor();
       editor.setContent('<p>ab <b>cd</b> ef</p>');
-      const rng = expandRng(editor, [ 0, 1, 0 ], 1, [ 0, 1, 0 ], 1, blockFormat, false);
+      const rng = expandRng(editor, [ 0, 1, 0 ], 1, [ 0, 1, 0 ], 1, blockFormat);
       assertRange(editor, rng, [], 0, [], 1);
     });
 
     it('TBA: Whole word inside td', () => {
       const editor = hook.editor();
       editor.setContent('<table><tbody><tr><td>a</td></tr></tbody></table>');
-      const rng = expandRng(editor, [ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 1, blockFormat, false);
+      const rng = expandRng(editor, [ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 1, blockFormat);
       assertRange(editor, rng, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 1);
     });
 
@@ -231,7 +252,7 @@ describe('browser.tinymce.core.fmt.ExpandRangeTest', () => {
       const editor = hook.editor();
       // eslint-disable-next-line max-len
       editor.setContent(`<details class="mce-accordion" open="open"><summary class="mce-accordion-summary">Accordion summary 1</summary><div class="mce-accordion-body"><p>Accordion body1</p><details class="mce-accordion" open="open"><summary class="mce-accordion-summary">Accordion summary1.1</summary><div class="mce-accordion-body"><p>Accordion body 1.1</p></div></details></div></details>`);
-      const rng = expandRng(editor, [ 0, 1, 1, 0, 0 ], 2, [ 0, 1, 1, 0, 0 ], 2, [{ block: 'h1', deep: true, remove: 'all', split: true }], false);
+      const rng = expandRng(editor, [ 0, 1, 1, 0, 0 ], 2, [ 0, 1, 1, 0, 0 ], 2, [{ block: 'h1', deep: true, remove: 'all', split: true }]);
       assertRange(editor, rng, [ 0, 1, 1 ], 0, [ 0, 1, 1, 0, 0 ], 20);
     });
 
@@ -239,12 +260,12 @@ describe('browser.tinymce.core.fmt.ExpandRangeTest', () => {
       const editor = hook.editor();
       editor.setContent(`<details class="mce-accordion" open="open"><summary>Accordion summary</summary><p>Accordion body</p></details>`);
       // caret before space character
-      const rng1 = expandRng(editor, [ 0, 0, 0 ], 9, [ 0, 0, 0 ], 9, [{ block: 'h4', deep: true, remove: 'all', split: true }], false);
+      const rng1 = expandRng(editor, [ 0, 0, 0 ], 9, [ 0, 0, 0 ], 9, [{ block: 'h4', deep: true, remove: 'all', split: true }]);
       // assertRange(editor, rng1, [ 0, 0, 0 ], 0, [ 0 ], 1 );
       assertRange(editor, rng1, [ 0 ], 0, [ 0, 0, 0 ], 17 );
 
       // caret after space character
-      const rng2 = expandRng(editor, [ 0, 0, 0 ], 10, [ 0, 0, 0 ], 10, [{ block: 'h4', deep: true, remove: 'all', split: true }], false);
+      const rng2 = expandRng(editor, [ 0, 0, 0 ], 10, [ 0, 0, 0 ], 10, [{ block: 'h4', deep: true, remove: 'all', split: true }]);
       assertRange(editor, rng2, [ 0, 0, 0 ], 0, [ 0 ], 1 );
     });
   });
@@ -253,42 +274,42 @@ describe('browser.tinymce.core.fmt.ExpandRangeTest', () => {
     it('TBA: Do not expand over element if selector does not match', () => {
       const editor = hook.editor();
       editor.setContent('<p>ab</p>');
-      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 1, selectorFormat, false);
+      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 1, selectorFormat);
       assertRange(editor, rng, [ 0, 0 ], 0, [ 0, 0 ], 2);
     });
 
     it('TBA: Do not expand outside of element if selector does not match - from bookmark at middle', () => {
       const editor = hook.editor();
       editor.setContent('<p>a<span data-mce-type="bookmark">&#65279;</span>b</p>');
-      const rng = expandRng(editor, [ 0, 1, 0 ], 0, [ 0, 1, 0 ], 0, selectorFormat, false);
+      const rng = expandRng(editor, [ 0, 1, 0 ], 0, [ 0, 1, 0 ], 0, selectorFormat);
       assertRange(editor, rng, [ 0, 0 ], 0, [ 0, 2 ], 1);
     });
 
     it('TBA: Do not expand outside of element if selector does not match - from bookmark at start', () => {
       const editor = hook.editor();
       editor.setContent('<p><span data-mce-type="bookmark">&#65279;</span>ab</p>');
-      const rng = expandRng(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0, selectorFormat, false);
+      const rng = expandRng(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 0, selectorFormat);
       assertRange(editor, rng, [ 0 ], 0, [ 0, 1 ], 2);
     });
 
     it('TBA: Do not expand outside of element if selector does not match - from bookmark at end', () => {
       const editor = hook.editor();
       editor.setContent('<p>ab<span data-mce-type="bookmark">&#65279;</span></p>');
-      const rng = expandRng(editor, [ 0, 1, 0 ], 0, [ 0, 1, 0 ], 0, selectorFormat, false);
+      const rng = expandRng(editor, [ 0, 1, 0 ], 0, [ 0, 1, 0 ], 0, selectorFormat);
       assertRange(editor, rng, [ 0, 0 ], 0, [ 0 ], 2);
     });
 
     it('TBA: Expand since selector matches', () => {
       const editor = hook.editor();
       editor.setContent('<div>ab</div>');
-      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 1, selectorFormat, false);
+      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 1, selectorFormat);
       assertRange(editor, rng, [], 0, [], 1);
     });
 
     it('TBA: Expand since selector matches non collapsed', () => {
       const editor = hook.editor();
       editor.setContent('<div>ab</div>');
-      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 2, selectorFormat, false);
+      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 2, selectorFormat);
       assertRange(editor, rng, [], 0, [], 1);
     });
   });
@@ -297,15 +318,38 @@ describe('browser.tinymce.core.fmt.ExpandRangeTest', () => {
     it('TBA: Expand since selector matches collapsed on collapsed format', () => {
       const editor = hook.editor();
       editor.setContent('<div>ab</div>');
-      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 1, selectorFormatCollapsed, false);
+      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 1, selectorFormatCollapsed);
       assertRange(editor, rng, [], 0, [], 1);
     });
 
     it('TBA: Expand since selector matches non collapsed on collapsed format', () => {
       const editor = hook.editor();
       editor.setContent('<div>ab</div>');
-      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 2, selectorFormatCollapsed, false);
+      const rng = expandRng(editor, [ 0, 0 ], 1, [ 0, 0 ], 2, selectorFormatCollapsed);
       assertRange(editor, rng, [ 0, 0 ], 1, [ 0, 0 ], 2);
+    });
+  });
+
+  context('Expand range inside editable hosts inside non-editable parents', () => {
+    it('TINY-11304: Expanding range inside inner editable host div should expand to word but not beyond editable host boundary', () => {
+      const editor = hook.editor();
+      editor.setContent('<div contenteditable="false">a<div contenteditable="true">bc</div>d</div>');
+      const rng = expandRng(editor, [ 1, 1, 0 ], 1, [ 1, 1, 0 ], 1, inlineFormat); // Shifted because of fake caret
+      assertRange(editor, rng, [ 1, 1, 0 ], 0, [ 1, 1, 0 ], 2);
+    });
+
+    it('TINY-11304: Expanding range inside inner editable host span should expand to word but not beyond editable host boundary', () => {
+      const editor = hook.editor();
+      editor.setContent('<div contenteditable="false">a<span contenteditable="true">bc</span>d</div>');
+      const rng = expandRng(editor, [ 1, 1, 0 ], 1, [ 1, 1, 0 ], 1, inlineFormat); // Shifted because of fake caret
+      assertRange(editor, rng, [ 1, 1, 0 ], 0, [ 1, 1, 0 ], 2);
+    });
+
+    it('TINY-11304: Expanding range inside inner block inside editable host div should expand to word but not beyond inner block boundary', () => {
+      const editor = hook.editor();
+      editor.setContent('<div contenteditable="false"><div contenteditable="true">a<div>bc</div>d</div></div>');
+      const rng = expandRng(editor, [ 1, 0, 1, 0 ], 1, [ 1, 0, 1, 0 ], 1, inlineFormat, { expandToBlock: false }); // Shifted because of fake caret
+      assertRange(editor, rng, [ 1, 0, 1, 0 ], 0, [ 1, 0, 1, 0 ], 2);
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
@@ -345,7 +345,7 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
                 },
                 {
                   select: () => TinySelections.setCursor(editor, [ 0, 1, 1, 0, 0 ], 1),
-                  expectedHtml: `<p><${format.html}>first</${format.tag}> ${noneditableBeforeHtml}<span contenteditable="true">editable</span>${noneditableAfterHtml} <${format.html}>third</${format.tag}></p>`,
+                  expectedHtml: `<p><${format.html}>first </${format.tag}>${noneditableBeforeHtml}<span contenteditable="true">editable</span>${noneditableAfterHtml}<${format.html}> third</${format.tag}></p>`,
                   pAssertAfter: pAssertToolbar(false)
                 },
               ]);


### PR DESCRIPTION
Related Ticket: TINY-11304

Description of Changes:
* Fixes an issue where the expand to word code would try to find the start/end of word wouldn't be scoped to the closest editing host element.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue with expanding word selection inside inline editing host elements.
  - Improved range expansion behavior to respect editing host boundaries.

- **New Features**
  - Added `isEditingHost` function to detect content editable elements.
  - Enhanced range expansion options with more granular control.

- **Tests**
  - Added new test cases for selection and range expansion scenarios.
  - Improved test coverage for nested editable and non-editable elements.
  - Added assertions for the new `assertRange` function in range expansion tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->