### PR TITLE
TINY-11729: Comment card jumps when editing large comment in Chrome

### DIFF
--- a/modules/oxide/src/less/theme/components/comments/comment.less
+++ b/modules/oxide/src/less/theme/components/comments/comment.less
@@ -308,7 +308,7 @@
     padding: 12px;
     scroll-behavior: smooth;
 
-    &:has(textarea:focus-within) {
+    &:has(textarea:focus) {
       scroll-behavior: auto;
     }
   }

--- a/modules/oxide/src/less/theme/components/comments/comment.less
+++ b/modules/oxide/src/less/theme/components/comments/comment.less
@@ -307,6 +307,10 @@
     overflow: auto;
     padding: 12px;
     scroll-behavior: smooth;
+
+    &:has(textarea:focus-within) {
+      scroll-behavior: auto;
+    }
   }
 
   /* Animation for deleting a comment */


### PR DESCRIPTION
Related Ticket: TINY-11729

Problem:
* Chrome triggers the smooth scrolling animation when resizing the edit textarea. Unlike Safari and Firefox.

Description of Changes:
* Removed smooth scrolling behaviour when editing a comment.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
	- Updated scrolling behavior in the comment section when a textarea is focused, ensuring more immediate user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->