### PR TITLE
TINY-11108: Height setting is more examined.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11108-2025-01-28.yaml
+++ b/.changes/unreleased/tinymce-TINY-11108-2025-01-28.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Setting editor height to pt/em values would ignore min/max height settings.
+time: 2025-01-28T12:11:04.210024+01:00
+custom:
+    Issue: TINY-11108

--- a/.changes/unreleased/tinymce-TINY-11108-2025-01-28.yaml
+++ b/.changes/unreleased/tinymce-TINY-11108-2025-01-28.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Setting editor height to pt/em values would ignore min/max height settings.
+body: Setting editor height to a `pt` or `em` value was ignoring min/max height settings.
 time: 2025-01-28T12:11:04.210024+01:00
 custom:
     Issue: TINY-11108

--- a/modules/tinymce/src/core/test/ts/browser/EditorSizeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorSizeTest.ts
@@ -1,0 +1,76 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Height } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.EditorSizeTest', () => {
+  context('Minimum Size Enforcement', () => {
+    context('Unitless wrapper', () => {
+      const hook = TinyHooks.bddSetup<Editor>({
+        selector: 'textarea',
+        height: 10,
+        min_height: 500,
+        base_url: '/project/tinymce/js/tinymce'
+      }, []);
+      it('TINY-11108: unitless', () => {
+        const editor = hook.editor();
+        assert.equal(Height.get(TinyDom.container(editor)), 500);
+      });
+    });
+
+    context('em Wrapper', () => {
+      const hook = TinyHooks.bddSetup<Editor>({
+        selector: 'textarea',
+        height: '10em',
+        min_height: 500,
+        base_url: '/project/tinymce/js/tinymce'
+      }, []);
+      it('TINY-11108: using em units', () => {
+        const editor = hook.editor();
+        assert.equal(Height.get(TinyDom.container(editor)), 500);
+      });
+    });
+
+    context('pt Wrapper', () => {
+      const hook = TinyHooks.bddSetup<Editor>({
+        selector: 'textarea',
+        height: '10pt',
+        min_height: 500,
+        base_url: '/project/tinymce/js/tinymce'
+      }, []);
+      it('TINY-11108: using pt units', () => {
+        const editor = hook.editor();
+        assert.equal(Height.get(TinyDom.container(editor)), 500);
+      });
+    });
+
+    context('px Wrapper', () => {
+      const hook = TinyHooks.bddSetup<Editor>({
+        selector: 'textarea',
+        height: '10px',
+        min_height: 500,
+        base_url: '/project/tinymce/js/tinymce'
+      }, []);
+      it('TINY-11108: using px units', () => {
+        const editor = hook.editor();
+        assert.equal(Height.get(TinyDom.container(editor)), 500);
+      });
+    });
+
+    context('percentage wrapper', () => {
+      const hook = TinyHooks.bddSetup<Editor>({
+        selector: 'textarea',
+        height: '10%',
+        min_height: 500,
+        base_url: '/project/tinymce/js/tinymce'
+      }, []);
+      it('TINY-11108: using % units', () => {
+        const editor = hook.editor();
+        // % not really supported, so we do this.
+        assert.isTrue(Height.get(TinyDom.container(editor)) < 200);
+      });
+    });
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/EditorSizeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorSizeTest.ts
@@ -14,6 +14,7 @@ describe('browser.tinymce.core.EditorSizeTest', () => {
         min_height: 500,
         base_url: '/project/tinymce/js/tinymce'
       }, []);
+
       it('TINY-11108: unitless', () => {
         const editor = hook.editor();
         assert.equal(Height.get(TinyDom.container(editor)), 500);
@@ -27,6 +28,7 @@ describe('browser.tinymce.core.EditorSizeTest', () => {
         min_height: 500,
         base_url: '/project/tinymce/js/tinymce'
       }, []);
+
       it('TINY-11108: using em units', () => {
         const editor = hook.editor();
         assert.equal(Height.get(TinyDom.container(editor)), 500);
@@ -40,6 +42,7 @@ describe('browser.tinymce.core.EditorSizeTest', () => {
         min_height: 500,
         base_url: '/project/tinymce/js/tinymce'
       }, []);
+
       it('TINY-11108: using pt units', () => {
         const editor = hook.editor();
         assert.equal(Height.get(TinyDom.container(editor)), 500);
@@ -53,6 +56,7 @@ describe('browser.tinymce.core.EditorSizeTest', () => {
         min_height: 500,
         base_url: '/project/tinymce/js/tinymce'
       }, []);
+
       it('TINY-11108: using px units', () => {
         const editor = hook.editor();
         assert.equal(Height.get(TinyDom.container(editor)), 500);
@@ -66,6 +70,7 @@ describe('browser.tinymce.core.EditorSizeTest', () => {
         min_height: 500,
         base_url: '/project/tinymce/js/tinymce'
       }, []);
+
       it('TINY-11108: using % units', () => {
         const editor = hook.editor();
         // % not really supported, so we do this.

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizing/EditorSize.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizing/EditorSize.ts
@@ -1,39 +1,13 @@
 import { Optional } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 
 import * as Options from '../../api/Options';
 import * as Utils from './Utils';
 
-const convertValueToPx = (editor: Editor, value: number | string): Optional<number> => {
-  if (typeof value === 'number') {
-    return Optional.from(value);
-  }
-
-  return Utils.parseToInt(value.trim()).orThunk(() => {
-    const splitValue = /^([0-9.]+)(pt|em|px)$/.exec(value);
-
-    if (splitValue) {
-      const type = splitValue[2];
-      const parsed = Number.parseFloat(splitValue[1]);
-
-      if (Number.isNaN(parsed) || parsed < 0) {
-        return Optional.none();
-      } else if (type === 'em') {
-        return Optional.from(parsed * Number.parseFloat(window.getComputedStyle(editor.targetElm).fontSize));
-      } else if (type === 'pt') {
-        return Optional.from(parsed * (72 / 96));
-      } else if (type === 'px') {
-        return Optional.from(parsed);
-      }
-    }
-
-    return Optional.none();
-  });
-};
-
 export const getHeight = (editor: Editor): Optional<number> => {
-  const baseHeight = convertValueToPx(editor, Options.getHeightOption(editor));
+  const baseHeight = Utils.convertValueToPx(SugarElement.fromDom(editor.targetElm), Options.getHeightOption(editor));
   const minHeight = Options.getMinHeightOption(editor);
   const maxHeight = Options.getMaxHeightOption(editor);
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizing/EditorSize.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizing/EditorSize.ts
@@ -17,12 +17,14 @@ const convertValueToPx = (editor: Editor, value: number | string): Optional<numb
       const type = splitValue[2];
       const parsed = Number.parseFloat(splitValue[1]);
 
-      if (type === 'em') {
+      if (Number.isNaN(parsed) || parsed < 0) {
+        return Optional.none();
+      } else if (type === 'em') {
         return Optional.from(parsed * Number.parseFloat(window.getComputedStyle(editor.targetElm).fontSize));
       } else if (type === 'pt') {
         return Optional.from(parsed * (72 / 96));
       } else if (type === 'px') {
-        Optional.from(parsed);
+        return Optional.from(parsed);
       }
     }
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizing/Utils.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizing/Utils.ts
@@ -1,4 +1,5 @@
 import { Optional, Type } from '@ephox/katamari';
+import { SugarElement } from '@ephox/sugar';
 
 const parseToInt = (val: string | number): Optional<number> => {
   // if size is a number or '_px', will return the number
@@ -17,8 +18,36 @@ const calcCappedSize = (size: number, minSize: Optional<number>, maxSize: Option
   return minOverride.or(maxOverride).getOr(size);
 };
 
+const convertValueToPx = (element: SugarElement<Element>, value: number | string): Optional<number> => {
+  if (typeof value === 'number') {
+    return Optional.from(value);
+  }
+
+  return parseToInt(value.trim()).orThunk(() => {
+    const splitValue = /^([0-9.]+)(pt|em|px)$/.exec(value);
+
+    if (splitValue) {
+      const type = splitValue[2];
+      const parsed = Number.parseFloat(splitValue[1]);
+
+      if (Number.isNaN(parsed) || parsed < 0) {
+        return Optional.none();
+      } else if (type === 'em') {
+        return Optional.from(parsed * Number.parseFloat(window.getComputedStyle(element.dom).fontSize));
+      } else if (type === 'pt') {
+        return Optional.from(parsed * (72 / 96));
+      } else if (type === 'px') {
+        return Optional.from(parsed);
+      }
+    }
+
+    return Optional.none();
+  });
+};
+
 export {
   calcCappedSize,
+  convertValueToPx,
   parseToInt,
   numToPx
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizing/Utils.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizing/Utils.ts
@@ -23,26 +23,24 @@ const convertValueToPx = (element: SugarElement<Element>, value: number | string
     return Optional.from(value);
   }
 
-  return parseToInt(value.trim()).orThunk(() => {
-    const splitValue = /^([0-9.]+)(pt|em|px)$/.exec(value);
+  const splitValue = /^([0-9.]+)(pt|em|px)$/.exec(value.trim());
 
-    if (splitValue) {
-      const type = splitValue[2];
-      const parsed = Number.parseFloat(splitValue[1]);
+  if (splitValue) {
+    const type = splitValue[2];
+    const parsed = Number.parseFloat(splitValue[1]);
 
-      if (Number.isNaN(parsed) || parsed < 0) {
-        return Optional.none();
-      } else if (type === 'em') {
-        return Optional.from(parsed * Number.parseFloat(window.getComputedStyle(element.dom).fontSize));
-      } else if (type === 'pt') {
-        return Optional.from(parsed * (72 / 96));
-      } else if (type === 'px') {
-        return Optional.from(parsed);
-      }
+    if (Number.isNaN(parsed) || parsed < 0) {
+      return Optional.none();
+    } else if (type === 'em') {
+      return Optional.from(parsed * Number.parseFloat(window.getComputedStyle(element.dom).fontSize));
+    } else if (type === 'pt') {
+      return Optional.from(parsed * (72 / 96));
+    } else if (type === 'px') {
+      return Optional.from(parsed);
     }
+  }
 
-    return Optional.none();
-  });
+  return Optional.none();
 };
 
 export {


### PR DESCRIPTION
Related Ticket: TINY-11108

Description of Changes:
Attempt to convert strings into px number if possible.
Converting % seemed a bit too unreliable to me to be added here due to position-styling. This covers pt/em/px, but we can easily add any other units if needed.
Placed the code in the same file since I didn't know if we had any suitable library for it, but happy to move it if we have a better choice.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Bug Fixes**
	- Resolved an issue with editor height settings where pt/em values were incorrectly ignoring minimum and maximum height constraints.

- **Tests**
	- Added comprehensive test suite to validate editor size enforcement across different unit types (px, em, pt, percentage).

- **New Features**
	- Introduced a new function to enhance height value conversion, allowing for more flexible handling of various measurement units.

This update improves TinyMCE's height configuration reliability by ensuring consistent sizing behavior across multiple measurement units.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->