### PR TITLE
TINY-11665: now `tox-toolbar__group` are not focusable

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11665-2025-01-29.yaml
+++ b/.changes/unreleased/tinymce-TINY-11665-2025-01-29.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Now groups with all elments disabled are not more focusable.
+body: It was possible to tab to toolbar groups that had all of it's children disabled.
 time: 2025-01-29T14:26:59.278610468+01:00
 custom:
   Issue: TINY-11665

--- a/.changes/unreleased/tinymce-TINY-11665-2025-01-29.yaml
+++ b/.changes/unreleased/tinymce-TINY-11665-2025-01-29.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Now groups with all elments disabled are not more focusable.
+time: 2025-01-29T14:26:59.278610468+01:00
+custom:
+  Issue: TINY-11665

--- a/.changes/unreleased/tinymce-TINY-11665-2025-01-29.yaml
+++ b/.changes/unreleased/tinymce-TINY-11665-2025-01-29.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: It was possible to tab to toolbar groups that had all of it's children disabled.
+body: It was possible to tab to a toolbar group that had all children disabled.
 time: 2025-01-29T14:26:59.278610468+01:00
 custom:
   Issue: TINY-11665

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
@@ -7,17 +7,22 @@ import {
 } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Singleton } from '@ephox/katamari';
+import { Focus } from '@ephox/sugar';
 
 import * as ContextToolbarFocus from './ContextToolbarFocus';
 import { backSlideEvent } from './ContextUi';
 
-export const getFormApi = <T>(input: AlloyComponent): InlineContent.ContextFormInstanceApi<T> => {
+export const getFormApi = <T>(input: AlloyComponent, focusfallbackComp?: AlloyComponent): InlineContent.ContextFormInstanceApi<T> => {
   const valueState = Singleton.value<T>();
 
   return ({
     setInputEnabled: (state: boolean) => {
       if (!state) {
-        ContextToolbarFocus.focusParent(input);
+        if (focusfallbackComp) {
+          Focus.focus(focusfallbackComp.element);
+        } else {
+          ContextToolbarFocus.focusParent(input);
+        }
       }
 
       Disabling.set(input, !state);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
@@ -9,7 +9,6 @@ import { InlineContent } from '@ephox/bridge';
 import { Singleton } from '@ephox/katamari';
 import { Focus } from '@ephox/sugar';
 
-import * as ContextToolbarFocus from './ContextToolbarFocus';
 import { backSlideEvent } from './ContextUi';
 
 export const getFormApi = <T>(input: AlloyComponent, focusfallbackComp?: AlloyComponent): InlineContent.ContextFormInstanceApi<T> => {
@@ -17,12 +16,8 @@ export const getFormApi = <T>(input: AlloyComponent, focusfallbackComp?: AlloyCo
 
   return ({
     setInputEnabled: (state: boolean) => {
-      if (!state) {
-        if (focusfallbackComp) {
-          Focus.focus(focusfallbackComp.element);
-        } else {
-          ContextToolbarFocus.focusParent(input);
-        }
+      if (!state && focusfallbackComp) {
+        Focus.focus(focusfallbackComp.element);
       }
 
       Disabling.set(input, !state);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
@@ -7,17 +7,17 @@ import {
 } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Singleton } from '@ephox/katamari';
-import { Focus } from '@ephox/sugar';
+import { Focus, SugarElement } from '@ephox/sugar';
 
 import { backSlideEvent } from './ContextUi';
 
-export const getFormApi = <T>(input: AlloyComponent, focusfallbackComp?: AlloyComponent): InlineContent.ContextFormInstanceApi<T> => {
+export const getFormApi = <T>(input: AlloyComponent, focusfallbackElement?: SugarElement<HTMLElement>): InlineContent.ContextFormInstanceApi<T> => {
   const valueState = Singleton.value<T>();
 
   return ({
     setInputEnabled: (state: boolean) => {
-      if (!state && focusfallbackComp) {
-        Focus.focus(focusfallbackComp.element);
+      if (!state && focusfallbackElement) {
+        Focus.focus(focusfallbackElement);
       }
 
       Disabling.set(input, !state);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
@@ -20,7 +20,7 @@ interface ContextFormButtonRegistry {
 const runOnExecute = <T, U>(memInput: MementoRecord, original: { onAction: (formApi: InlineContent.ContextFormInstanceApi<U>, buttonApi: T) => void }) =>
   AlloyEvents.run<InternalToolbarButtonExecuteEvent<T>>(internalToolbarButtonExecute, (comp, se) => {
     const input = memInput.get(comp);
-    const formApi = getFormApi<U>(input);
+    const formApi = getFormApi<U>(input, comp);
     original.onAction(formApi, se.event.buttonApi);
   });
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
@@ -20,7 +20,7 @@ interface ContextFormButtonRegistry {
 const runOnExecute = <T, U>(memInput: MementoRecord, original: { onAction: (formApi: InlineContent.ContextFormInstanceApi<U>, buttonApi: T) => void }) =>
   AlloyEvents.run<InternalToolbarButtonExecuteEvent<T>>(internalToolbarButtonExecute, (comp, se) => {
     const input = memInput.get(comp);
-    const formApi = getFormApi<U>(input, comp);
+    const formApi = getFormApi<U>(input, comp.element);
     original.onAction(formApi, se.event.buttonApi);
   });
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -4,7 +4,8 @@ import {
   SplitFloatingToolbar as AlloySplitFloatingToolbar,
   SplitSlidingToolbar as AlloySplitSlidingToolbar,
   Toolbar as AlloyToolbar, ToolbarGroup as AlloyToolbarGroup,
-  Behaviour, Boxes, Focusing,
+  Behaviour, Boxes,
+  Focusing,
   GuiFactory,
   Keying, SketchSpec,
   Tabstopping
@@ -86,7 +87,9 @@ const renderToolbarGroupCommon = (toolbarGroup: ToolbarGroup) => {
     },
     tgroupBehaviours: Behaviour.derive([
       Tabstopping.config({}),
-      Focusing.config({})
+      Focusing.config({
+        ignore: true
+      })
     ])
   };
 };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -133,11 +133,15 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
           icon: 'fake-icon-name',
           tooltip: 'Focus on init',
         },
-        onSetup: (formApi) => {
-          formApi.setInputEnabled(false);
-          return Fun.noop;
-        },
-        commands: [ ]
+        commands: [{
+          type: 'contextformbutton',
+          icon: 'fake-icon-name',
+          tooltip: 'A',
+          onAction: (formApi) => {
+            formApi.setInputEnabled(false);
+            return Fun.noop;
+          }
+        }]
       });
 
       ed.ui.registry.addContextToolbar('test-toolbar-focus-on-init', {
@@ -416,6 +420,9 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
 
     openToolbar(editor, 'test-toolbar-focus-on-init');
     TinyUiActions.clickOnUi(editor, 'button[data-mce-name="form:test-form-focus-on-init"]');
+    TinyUiActions.clickOnUi(editor, 'button[aria-label="A"]');
+
+    FocusTools.isOnSelector('Focus should stay on the "A" button', doc, '.tox-pop__dialog button[aria-label="A"]');
     const input = await UiFinder.pWaitFor<HTMLInputElement>('getting the main input', doc, '[role="toolbar"] input');
     assert.isTrue(Attribute.has(input, 'disabled'), 'the input sohuld be disabled');
   });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -144,46 +144,6 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
         predicate: Fun.never,
         items: 'form:test-form-focus-on-init',
       });
-
-      ed.ui.registry.addContextForm('text', {
-        type: 'contextform',
-        launch: {
-          type: 'contextformbutton',
-          text: 'Alt',
-          tooltip: 'Alt'
-        },
-        onSetup: Fun.constant,
-        onInput: Fun.noop,
-        label: 'Alt',
-        commands: [
-          {
-            type: 'contextformbutton',
-            align: 'start',
-            tooltip: 'Back',
-            icon: 'chevron-left',
-            onAction: (formApi) => {
-              formApi.back();
-            }
-          },
-          {
-            type: 'contextformtogglebutton',
-            align: 'start',
-            text: 'Decorative',
-            tooltip: 'Decorative',
-            onAction: (formApi, buttonApi) => {
-              buttonApi.setActive(!buttonApi.isActive());
-              formApi.setInputEnabled(!formApi.isInputEnabled());
-            }
-          }
-        ]
-      });
-
-      ed.ui.registry.addContextToolbar('contexttoolbar1', {
-        predicate: (node) => node.nodeName === 'IMG',
-        items: 'text',
-        position: 'node',
-        scope: 'node'
-      });
     }
   }, [], true);
 
@@ -460,24 +420,20 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     assert.isTrue(Attribute.has(input, 'disabled'), 'the input sohuld be disabled');
   });
 
-  it('TINY-11665: it shound not be possible to navigate to the input field if this one is disabled', async () => {
+  it('TINY-11665: it shound not be possible to navigate to the input field if this one is disabled', () => {
     const editor = hook.editor();
     const doc = SugarDocument.getDocument();
-    editor.setContent('<img>');
-
-    TinySelections.select(editor, 'img', []);
-
-    await TinyUiActions.pTriggerContextMenu(editor, 'img', '.tox-silver-sink [role="toolbar"]');
-    TinyUiActions.clickOnUi(editor, 'button[aria-label="Alt"]');
+    openToolbar(editor, 'test-form');
 
     FocusTools.isOnSelector('Focus should be initial on the input', doc, '.tox-pop__dialog input');
+    TinyUiActions.clickOnUi(editor, 'button[aria-label="E"]');
+    FocusTools.isOnSelector('Focus should be moved on the "E" button after click', doc, '.tox-pop__dialog button[aria-label="E"]');
     Keyboard.activeKeydown(doc, Keys.tab());
-    FocusTools.isOnSelector('Focus should be moved on the back button', doc, '.tox-pop__dialog button[aria-label="Back"]');
+    FocusTools.isOnSelector('Focus should stay on the "E" button', doc, '.tox-pop__dialog button[aria-label="E"]');
 
-    TinyUiActions.clickOnUi(editor, 'button[aria-label="Decorative"]');
-    FocusTools.isOnSelector('Focus should on the the button after click', doc, '.tox-pop__dialog button[aria-label="Decorative"]');
-
+    TinyUiActions.clickOnUi(editor, 'button[aria-label="E"]');
+    FocusTools.isOnSelector('Focus should on the the button after click', doc, '.tox-pop__dialog button[aria-label="E"]');
     Keyboard.activeKeydown(doc, Keys.tab());
-    FocusTools.isOnSelector('Focus should stay on decorative button since the input is disable', doc, '.tox-pop__dialog button[aria-label="Decorative"]');
+    FocusTools.isOnSelector('Focus should go on the input now that it is enable', doc, '.tox-pop__dialog input');
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -1,8 +1,9 @@
 import { ApproxStructure, Assertions, FocusTools, Keyboard, Keys, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Fun, Obj } from '@ephox/katamari';
-import { SugarBody, SugarDocument, Value } from '@ephox/sugar';
+import { Attribute, SugarBody, SugarDocument, Value } from '@ephox/sugar';
 import { TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
@@ -449,14 +450,14 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     UiFinder.exists(SugarBody.body(), '.tox-pop input[placeholder="This is a placeholder"]');
   });
 
-  // TODO: fix and re-enable it or replace/remove it
-  it.skip('TINY-11559: Focus should be on toolbar when onSetup disables the main input', () => {
+  it('TINY-11559: It should be possible to disable the main input via onSetup', async () => {
     const editor = hook.editor();
     const doc = SugarDocument.getDocument();
 
     openToolbar(editor, 'test-toolbar-focus-on-init');
     TinyUiActions.clickOnUi(editor, 'button[data-mce-name="form:test-form-focus-on-init"]');
-    FocusTools.isOnSelector('Focus should be on toolbar', doc, '[role="toolbar"]');
+    const input = await UiFinder.pWaitFor<HTMLInputElement>('getting the main input', doc, '[role="toolbar"] input');
+    assert.isTrue(Attribute.has(input, 'disabled'), 'the input sohuld be disabled');
   });
 
   it('TINY-11665: it shound not be possible to navigate to the input field if this one is disabled', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -409,7 +409,8 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     UiFinder.exists(SugarBody.body(), '.tox-pop input[placeholder="This is a placeholder"]');
   });
 
-  it('TINY-11559: Focus should be on toolbar when onSetup disables the main input', () => {
+  // TODO: fix and re-enable it or replace/remove it
+  it.skip('TINY-11559: Focus should be on toolbar when onSetup disables the main input', () => {
     const editor = hook.editor();
     const doc = SugarDocument.getDocument();
 


### PR DESCRIPTION
Related Ticket: TINY-11665

Description of Changes:
having `tox-toolbar__group` focusable also man that it could be possible to focus even if the elements contained in that `tox-toolbar__group` aren't focusable creating a situation where the focus is on a container that should not be really focusable.

Also to avoid that is some case when the input is disable the fallback goes on the empty container I had to implement the possibility to have a different fallback element

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where groups with all elements disabled were still focusable.

- **New Features**
	- Enhanced focus handling for disabled input fields, allowing for alternative components to be focused.
	- Improved configuration for focus management within toolbar groups.

- **Tests**
	- Added new test case to verify that navigation to a disabled input field is not possible.
	- Updated existing test scenarios to ensure proper functionality of context forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->