### PR TITLE
Added missing dependency (chalk)

### DIFF
--- a/modules/oxide/tasks/demos.js
+++ b/modules/oxide/tasks/demos.js
@@ -3,6 +3,7 @@ const path = require('path');
 const connect = require('connect');
 const liveReload = require('connect-livereload');
 const serveStatic = require('serve-static');
+const chalk = require("chalk");
 
 module.exports = function (grunt) {
   grunt.registerTask('buildDemos', function() {


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* I've tried to follow the skins tutorial (https://www.tiny.cloud/docs/tinymce/latest/creating-a-skin/) but couldn't run it because `yarn oxide-start` and `yarn oxide-build` are throwing errors. Added chalk to fix the issue.

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added color library to improve console output readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->