### PR TITLE
TINY-11762: more-button should no longer trap tab-movement.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11762-2025-02-03.yaml
+++ b/.changes/unreleased/tinymce-TINY-11762-2025-02-03.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Keyboard navigation would get stuck on 'more' toolbar button.
+time: 2025-02-03T14:57:27.798833+01:00
+custom:
+    Issue: TINY-11762

--- a/.changes/unreleased/tinymce-TINY-11762-2025-02-03.yaml
+++ b/.changes/unreleased/tinymce-TINY-11762-2025-02-03.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Keyboard navigation would get stuck on 'more' toolbar button.
+body: Keyboard navigation would get stuck on the 'more' toolbar button.
 time: 2025-02-03T14:57:27.798833+01:00
 custom:
     Issue: TINY-11762

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/TabbingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/TabbingTypes.ts
@@ -84,7 +84,7 @@ const create = (cyclicField: FieldProcessor): KeyingType.KeyingType<TabbingConfi
     // 2. Find the index of that tabstop
     // 3. Cycle the tabstop
     // 4. Fire alloy focus on the resultant tabstop
-    const tabstops = SelectorFilter.descendants<HTMLElement>(component.element, tabbingConfig.selector);
+    const tabstops = Arr.filter(SelectorFilter.descendants<HTMLElement>(component.element, tabbingConfig.selector), (element) => isVisible(tabbingConfig, element));
     return findCurrent(component, tabbingConfig).bind((tabstop) => {
       // focused component
       const optStopIndex = Arr.findIndex(tabstops, Fun.curry(Compare.eq, tabstop));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -107,6 +107,7 @@ const getToolbarBehaviours = (toolbarSpec: ToolbarSpec, modeName: 'cyclic' | 'ac
       // Tabs between groups
       mode: modeName,
       onEscape: toolbarSpec.onEscape,
+      visibilitySelector: '.tox-toolbar__overflow',
       selector: '.tox-toolbar__group'
     }),
     AddEventsBehaviour.config('toolbar-events', [ onAttached ])

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/TabStoppingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/TabStoppingTest.ts
@@ -5,7 +5,7 @@ import { TinyContentActions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar
 
 import Editor from 'tinymce/core/api/Editor';
 
-describe('webdriver.tinymce.themes.silver.editor.TabStoppingTest', () => {
+describe('browser.tinymce.themes.silver.editor.TabStoppingTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     width: 400,

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/TabStoppingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/TabStoppingTest.ts
@@ -1,0 +1,33 @@
+import { FocusTools, Keys } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarDocument } from '@ephox/sugar';
+import { TinyContentActions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('webdriver.tinymce.themes.silver.editor.TabStoppingTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    width: 400,
+    toolbar_mode: 'sliding',
+    toolbar: 'bold italic | underline strikethrough fontsizeinput | alignleft aligncenter alignright alignjustify | align lineheight fontsize fontfamily blocks styles insertfile | styles | ' +
+    'bullist numlist outdent indent | link image | print preview media | forecolor backcolor emoticons table codesample code language | ltr rtl'
+  }, []);
+
+  const focusToolbar = (editor: Editor) =>
+    TinyContentActions.keydown(editor, 121, { altKey: true });
+  const pressTab = (editor: Editor) =>
+    TinyUiActions.keydown(editor, Keys.tab());
+  const pAssertFocused = (name: string, selector: string) =>
+    FocusTools.pTryOnSelector(name, SugarDocument.getDocument(), selector);
+
+  it('TINY-11762: More-button does not trap the focus when in sliding mode', async () => {
+    const editor = hook.editor();
+    focusToolbar(editor);
+    pressTab(editor);
+    pressTab(editor);
+    await pAssertFocused('More-button is focused', '.tox-tbtn[aria-label="Reveal or hide additional toolbar items"]');
+    pressTab(editor);
+    await pAssertFocused('Breadcrumb-element is focused', '.tox-statusbar__path-item');
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-11762

Description of Changes:
Elements hidden by the toolbar still existed in the dom structure and caused issues when attempting to tab. 

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue causing keyboard navigation to become unresponsive when interacting with the overflow toolbar.
	- Enhanced tabbing behavior to include only visible interactive elements, improving overall navigation experience.

- **Tests**
	- Introduced automated tests to verify correct focus management during toolbar navigation, specifically for the "More-button" in sliding mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->