### PR TITLE
TINY-11768: Prevent duplicate title element

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11768-2025-02-03.yaml
+++ b/.changes/unreleased/tinymce-TINY-11768-2025-02-03.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Toolbar groups no longer display a title to prevent overlapping tooltips
+time: 2025-02-03T15:06:52.667595+01:00
+custom:
+    Issue: TINY-11768

--- a/.changes/unreleased/tinymce-TINY-11768-2025-02-03.yaml
+++ b/.changes/unreleased/tinymce-TINY-11768-2025-02-03.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Toolbar groups no longer display a title to prevent overlapping tooltips
+body: Toolbar groups had both a `title` attribute and a custom tooltip, causing overlapping tooltips
 time: 2025-02-03T15:06:52.667595+01:00
 custom:
     Issue: TINY-11768

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -49,10 +49,15 @@ export interface ToolbarGroup {
 }
 
 const renderToolbarGroupCommon = (toolbarGroup: ToolbarGroup) => {
-  const attributes = toolbarGroup.label.isNone() ? toolbarGroup.title.fold(() => ({}),
-    (title) => ({ attributes: { title }})) : toolbarGroup.label.fold(() => ({}),
-    (label) => ({ attributes: { 'aria-label': label }})
-  );
+  const attributes = toolbarGroup.label.isNone() ?
+    toolbarGroup.title.fold(
+      () => ({}),
+      (title) => ({ attributes: { 'aria-label': title }})
+    )
+    : toolbarGroup.label.fold(
+      () => ({}),
+      (label) => ({ attributes: { 'aria-label': label }})
+    );
 
   return {
     dom: {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
@@ -199,7 +199,7 @@ const identifyButtons = (editor: Editor, toolbarConfig: RenderToolbarConfig, bac
         lookupButton(editor, toolbarConfig.buttons, toolbarItem, toolbarConfig.allowToolbarGroups, backstage, prefixes).toArray();
     });
     return {
-      title: Optional.from(editor.translate(group.name)),
+      title: Optional.none(),
       label: Optionals.someIf(group.label !== undefined, editor.translate(group.label)),
       items
     };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
@@ -199,7 +199,7 @@ const identifyButtons = (editor: Editor, toolbarConfig: RenderToolbarConfig, bac
         lookupButton(editor, toolbarConfig.buttons, toolbarItem, toolbarConfig.allowToolbarGroups, backstage, prefixes).toArray();
     });
     return {
-      title: Optional.none(),
+      title: Optional.from(editor.translate(group.name)),
       label: Optionals.someIf(group.label !== undefined, editor.translate(group.label)),
       items
     };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/EditorToolbarOptionsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/EditorToolbarOptionsTest.ts
@@ -438,7 +438,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.EditorToolbarOptionsTest'
           s.element('div', {
             classes: [ arr.has('tox-toolbar__group') ],
             attrs: {
-              title: str.is('history')
+              'aria-label': str.is('history')
             },
             children: [
               s.element('button', {}),
@@ -448,7 +448,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.EditorToolbarOptionsTest'
           s.element('div', {
             classes: [ arr.has('tox-toolbar__group') ],
             attrs: {
-              title: str.is('formatting')
+              'aria-label': str.is('formatting')
             },
             children: [
               s.element('button', {}),

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarTest.ts
@@ -61,7 +61,7 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarTest', () => {
           s.element('div', {
             classes: [ arr.has('tox-toolbar__group') ],
             attrs: {
-              title: str.none()
+              'aria-label': str.none()
             },
             children: [
               s.element('span', {
@@ -78,7 +78,7 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarTest', () => {
           s.element('div', {
             classes: [ arr.has('tox-toolbar__group') ],
             attrs: {
-              title: str.is('group title')
+              'aria-label': str.is('group title')
             },
             children: [
               s.element('span', {
@@ -92,7 +92,7 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarTest', () => {
           s.element('div', {
             classes: [ arr.has('tox-toolbar__group') ],
             attrs: {
-              title: str.is('another group title')
+              'aria-label': str.is('another group title')
             },
             children: [
               s.element('span', {


### PR DESCRIPTION
Related Ticket: TINY-11768

Description of Changes:
Prevents the titles from showing. I'd honestly say we should remove the functionality entirely for the groups since I can't see it being very useful ( or at least change it to some aria-thing ), but for this I've just removed it from adding the titles earlier on to keep the change small.

Pre-checks:
* [x] Changelog entry added
* ~~[ ] Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue with toolbar groups displaying overlapping tooltips, ensuring a cleaner and more intuitive toolbar experience.
- **Accessibility Improvements**
  - Replaced `title` attributes with `aria-label` attributes for toolbar groups, enhancing accessibility for screen readers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->