### PR TITLE
TINY-11658: add focus style to `tox-toolbar-textfield`

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11658-2025-02-06.yaml
+++ b/.changes/unreleased/tinymce-TINY-11658-2025-02-06.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: '`tox-toolbar-textfield` didn''t have a focus style.'
+time: 2025-02-06T13:36:31.256957068+01:00
+custom:
+  Issue: TINY-11658

--- a/.changes/unreleased/tinymce-TINY-11658-2025-02-06.yaml
+++ b/.changes/unreleased/tinymce-TINY-11658-2025-02-06.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: '`tox-toolbar-textfield` didn''t have a focus style.'
+body: 'Toolbar text field was properly rendering focus.'
 time: 2025-02-06T13:36:31.256957068+01:00
 custom:
   Issue: TINY-11658

--- a/modules/oxide/src/less/theme/components/form/textfield.less
+++ b/modules/oxide/src/less/theme/components/form/textfield.less
@@ -50,13 +50,13 @@
     width: 100%;
   }
 
-  .tox-textfield[disabled] {
+  .tox-textfield[disabled], .tox-toolbar-textfield[disabled] {
     background-color: @textfield-disabled-background-color;
     color: @textfield-disabled-text-color;
     cursor: not-allowed;
   }
 
-  .tox-textfield:focus {
+  .tox-textfield:focus, .tox-toolbar-textfield:focus {
     background-color: @textfield-focus-background-color;
     border-color: @textfield-focus-border-color;
     box-shadow: @textfield-focus-box-shadow;
@@ -68,19 +68,6 @@
     min-height: unset;
     height: @toolbar-textfield-height;
     margin: @toolbar-textfield-margin;
-  }
-
-  .tox-toolbar-textfield[disabled] {
-    background-color: @textfield-disabled-background-color;
-    color: @textfield-disabled-text-color;
-    cursor: not-allowed;
-  }
-
-  .tox-toolbar-textfield:focus {
-    background-color: @textfield-focus-background-color;
-    border-color: @textfield-focus-border-color;
-    box-shadow: @textfield-focus-box-shadow;
-    outline: @textfield-focus-outline;
   }
 
   .tox-naked-btn {

--- a/modules/oxide/src/less/theme/components/form/textfield.less
+++ b/modules/oxide/src/less/theme/components/form/textfield.less
@@ -76,6 +76,13 @@
     cursor: not-allowed;
   }
 
+  .tox-toolbar-textfield:focus {
+    background-color: @textfield-focus-background-color;
+    border-color: @textfield-focus-border-color;
+    box-shadow: @textfield-focus-box-shadow;
+    outline: @textfield-focus-outline;
+  }
+
   .tox-naked-btn {
     background-color: transparent;
     border: 0;


### PR DESCRIPTION
Related Ticket: TINY-11658

Description of Changes:
added the focus style for `tox-toolbar-textfield`

I put the changelog in TinyMCE because I didn't see `oxide` in changie

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved a focus rendering issue for the toolbar text field, ensuring consistent visual feedback when active.
- **Style Updates**
  - Streamlined styling for the toolbar text field to align with standard text field behavior in both disabled and focused states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->