### PR TITLE
TINY-11368: close dropdowns when dialog is dragged

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11368-2025-02-06.yaml
+++ b/.changes/unreleased/tinymce-TINY-11368-2025-02-06.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Improved
+body: Dialog menu dropdowns now close after dialog is dragged..
+time: 2025-02-06T15:30:03.907875+01:00
+custom:
+  Issue: TINY-11368

--- a/.changes/unreleased/tinymce-TINY-11368-2025-02-06.yaml
+++ b/.changes/unreleased/tinymce-TINY-11368-2025-02-06.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Improved
-body: Dialog menu dropdowns now close after dialog is dragged.
+body: Dialog menu dropdowns now close when a dialog is moved.
 time: 2025-02-06T15:30:03.907875+01:00
 custom:
   Issue: TINY-11368

--- a/.changes/unreleased/tinymce-TINY-11368-2025-02-06.yaml
+++ b/.changes/unreleased/tinymce-TINY-11368-2025-02-06.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Improved
-body: Dialog menu dropdowns now close after dialog is dragged..
+body: Dialog menu dropdowns now close after dialog is dragged.
 time: 2025-02-06T15:30:03.907875+01:00
 custom:
   Issue: TINY-11368

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
@@ -1,5 +1,5 @@
 import {
-  AlloySpec, AlloyTriggers, Behaviour, Button, Container, DomFactory, Dragging, Dropdown, GuiFactory, ModalDialog, Reflecting, SketchSpec, Tabstopping, Tooltipping
+  AlloySpec, AlloyTriggers, Behaviour, Button, Channels, Container, DomFactory, Dragging, GuiFactory, ModalDialog, Reflecting, SketchSpec, Tabstopping, Tooltipping
 } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { SelectorFind } from '@ephox/sugar';
@@ -7,7 +7,6 @@ import { SelectorFind } from '@ephox/sugar';
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { formCancelEvent } from '../general/FormEvents';
 import * as Icons from '../icons/Icons';
-import * as ButtonClasses from '../toolbar/button/ButtonClasses';
 import { titleChannel } from './DialogChannels';
 
 /* eslint-enable max-len */
@@ -99,10 +98,7 @@ const renderInlineHeader = (
         topAttr: 'data-drag-top'
       },
       onDrag: (comp, target) => {
-        const dropdownButtonSelector = '.' + ButtonClasses.ToolbarButtonClasses.MatchWidth;
-        SelectorFind.descendant(target, dropdownButtonSelector).each((dropdownElement) => {
-          comp.getSystem().getByDom(dropdownElement).each((dropdownComp) => Dropdown.close(dropdownComp));
-        });
+        comp.getSystem().broadcastOn([ Channels.dismissPopups() ], { target });
       }
     })
   ])

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
@@ -7,6 +7,7 @@ import { SelectorFind } from '@ephox/sugar';
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { formCancelEvent } from '../general/FormEvents';
 import * as Icons from '../icons/Icons';
+import * as ButtonClasses from '../toolbar/button/ButtonClasses';
 import { titleChannel } from './DialogChannels';
 
 /* eslint-enable max-len */
@@ -98,7 +99,8 @@ const renderInlineHeader = (
         topAttr: 'data-drag-top'
       },
       onDrag: (comp, target) => {
-        SelectorFind.descendant(target, '.tox-tbtn--select').each((dropdownElement) => {
+        const dropdownButtonSelector = '.' + ButtonClasses.ToolbarButtonClasses.MatchWidth;
+        SelectorFind.descendant(target, dropdownButtonSelector).each((dropdownElement) => {
           comp.getSystem().getByDom(dropdownElement).each((dropdownComp) => Dropdown.close(dropdownComp));
         });
       }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
@@ -1,5 +1,5 @@
 import {
-  AlloySpec, AlloyTriggers, Behaviour, Button, Container, DomFactory, Dragging, GuiFactory, ModalDialog, Reflecting, SketchSpec, Tabstopping, Tooltipping
+  AlloySpec, AlloyTriggers, Behaviour, Button, Container, DomFactory, Dragging, Dropdown, GuiFactory, ModalDialog, Reflecting, SketchSpec, Tabstopping, Tooltipping
 } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { SelectorFind } from '@ephox/sugar';
@@ -96,6 +96,11 @@ const renderInlineHeader = (
         getSnapPoints: () => [],
         leftAttr: 'data-drag-left',
         topAttr: 'data-drag-top'
+      },
+      onDrag: (comp, target) => {
+        SelectorFind.descendant(target, '.tox-tbtn--select').each((dropdownElement) => {
+          comp.getSystem().getByDom(dropdownElement).each((dropdownComp) => Dropdown.close(dropdownComp));
+        });
       }
     })
   ])

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogDraggedTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogDraggedTest.ts
@@ -60,7 +60,7 @@ describe('browser.tinymce.themes.silver.editor.SilverDialogDraggedTest', () => {
     return menuButton;
   };
 
-  it('', async () => {
+  it('TINY-11368: should close menu when dialog is dragged', async () => {
     hook.editor();
     const dialog = UiFinder.findIn(SugarBody.body(), '[role="dialog"]').getOrDie();
     const menuButton = openMenuButton(dialog);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogDraggedTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogDraggedTest.ts
@@ -1,0 +1,75 @@
+import { Mouse, UiFinder, Waiter } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import * as ButtonClasses from 'tinymce/themes/silver/ui/toolbar/button/ButtonClasses';
+
+describe('browser.tinymce.themes.silver.editor.SilverDialogDraggedTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    setup: (ed: Editor) => {
+      ed.on('init', () => {
+        ed.windowManager.open( {
+          title: 'Silver Test Modal Dialog',
+          body: {
+            type: 'panel',
+            items: []
+          },
+          buttons: [
+            {
+              type: 'menu',
+              name: 'menuButton',
+              icon: 'preferences',
+              tooltip: 'Dialog Menu Button',
+              items: [
+                {
+                  type: 'togglemenuitem',
+                  name: 'option1',
+                }, {
+                  type: 'togglemenuitem',
+                  name: 'option2',
+                }
+              ]
+            },
+          ],
+          initialData: {
+            option1: true,
+            option2: false,
+          },
+        }, { inline: 'toolbar' });
+      });
+    }
+  }, []);
+
+  const dragDialog = (dx: number, dy: number) => {
+    const draghandle = UiFinder.findIn(SugarBody.body(), '.tox-dialog__draghandle').getOrDie();
+    Mouse.mouseDown(draghandle);
+    Mouse.mouseMoveTo(draghandle, dx, dy);
+    Mouse.mouseUp(draghandle);
+  };
+
+  const openMenuButton = (container: SugarElement): SugarElement => {
+    const menuButtonSelector = '.' + ButtonClasses.ToolbarButtonClasses.MatchWidth;
+    const menuButton = UiFinder.findIn(container, menuButtonSelector).getOrDie();
+    Mouse.click(menuButton);
+    assert.equal(menuButton.dom.getAttribute('aria-expanded'), 'true');
+
+    return menuButton;
+  };
+
+  it('', async () => {
+    hook.editor();
+    const dialog = UiFinder.findIn(SugarBody.body(), '[role="dialog"]').getOrDie();
+    const menuButton = openMenuButton(dialog);
+
+    dragDialog(10, 10);
+
+    await Waiter.pTryUntil(
+      'Waiting for menu to close after dialog was dragged',
+      () => assert.equal(menuButton.dom.getAttribute('aria-expanded'), 'false')
+    );
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogDraggedTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogDraggedTest.ts
@@ -44,11 +44,17 @@ describe('browser.tinymce.themes.silver.editor.SilverDialogDraggedTest', () => {
     }
   }, []);
 
-  const dragDialog = (dx: number, dy: number) => {
+  const dragDialog = async (dx: number, dy: number) => {
     const draghandle = UiFinder.findIn(SugarBody.body(), '.tox-dialog__draghandle').getOrDie();
+
     Mouse.mouseDown(draghandle);
-    Mouse.mouseMoveTo(draghandle, dx, dy);
-    Mouse.mouseUp(draghandle);
+    await Waiter.pWaitBetweenUserActions();
+
+    const blocker = UiFinder.findIn(SugarBody.body(), '.blocker').getOrDie();
+    Mouse.mouseMove(blocker);
+    Mouse.mouseMoveTo(blocker, dx, dy);
+    Mouse.mouseUp(blocker);
+    Mouse.mouseMoveTo(SugarBody.body(), 0, 0);
   };
 
   const openMenuButton = (container: SugarElement): SugarElement => {
@@ -65,7 +71,7 @@ describe('browser.tinymce.themes.silver.editor.SilverDialogDraggedTest', () => {
     const dialog = UiFinder.findIn(SugarBody.body(), '[role="dialog"]').getOrDie();
     const menuButton = openMenuButton(dialog);
 
-    dragDialog(10, 10);
+    await dragDialog(10, 10);
 
     await Waiter.pTryUntil(
       'Waiting for menu to close after dialog was dragged',


### PR DESCRIPTION
Related Ticket: TINY-11368

Description of Changes:
Fixing issue from this comment: https://ephocks.atlassian.net/browse/TINY-11368?focusedCommentId=144328
Dropdowns now close after dialog is dragged.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced dialog interactions: dialog menu dropdowns now automatically close when a dialog is dragged, ensuring a smoother and more intuitive user experience.

- **Tests**
  - Introduced automated tests for dialog functionality to verify the behavior of menu buttons during drag-and-drop operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->