### PR TITLE
TINY-11797: Fix infinite loop while tabbing inside table

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11797-2025-02-07.yaml
+++ b/.changes/unreleased/tinymce-TINY-11797-2025-02-07.yaml
@@ -1,7 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Pressing tab in the last cell of noneditable table used to lead to infinite
-  loop.
+body: Exception when pressing tab in the last cell of a non-editable table.
 time: 2025-02-07T15:43:51.409042+01:00
 custom:
   Issue: TINY-11797

--- a/.changes/unreleased/tinymce-TINY-11797-2025-02-07.yaml
+++ b/.changes/unreleased/tinymce-TINY-11797-2025-02-07.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Pressing tab in the last cell of noneditable table used to lead to infinite
+  loop.
+time: 2025-02-07T15:43:51.409042+01:00
+custom:
+  Issue: TINY-11797

--- a/modules/tinymce/src/core/main/ts/keyboard/TableNavigation.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/TableNavigation.ts
@@ -1,6 +1,6 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
 import { CellLocation, CellNavigation, TableLookup } from '@ephox/snooker';
-import { Compare, ContentEditable, CursorPosition, Insert, PredicateExists, PredicateFind, SimSelection, SugarElement, SugarNode, Traverse, WindowSelection } from '@ephox/sugar';
+import { Compare, ContentEditable, CursorPosition, Insert, PredicateExists, PredicateFind, SimSelection, SugarElement, SugarNode, WindowSelection } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import * as CaretFinder from '../caret/CaretFinder';
@@ -15,7 +15,6 @@ import { findClosestPositionInAboveCell, findClosestPositionInBelowCell } from '
 import * as NodeType from '../dom/NodeType';
 import * as ForceBlocks from '../ForceBlocks';
 import * as NavigationUtils from './NavigationUtils';
-import { isEditable } from '@ephox/sugar/src/main/ts/ephox/sugar/api/properties/ContentEditable';
 
 type PositionsUntilFn = (scope: HTMLElement, start: CaretPosition) => LineInfo;
 
@@ -153,11 +152,11 @@ const tabForward = (editor: Editor, isRoot: (e: SugarElement<Node>) => boolean, 
 const tabBackward = (editor: Editor, isRoot: (e: SugarElement<Node>) => boolean, cell: SugarElement<HTMLTableCellElement>) =>
   tabGo(editor, isRoot, CellNavigation.prev(cell, isCellEditable));
 
-const isCellEditable = (cell: SugarElement<HTMLTableCellElement>) => 
-  isEditable(cell) || PredicateExists.descendant(cell, isEditableHTMLElement)
+const isCellEditable = (cell: SugarElement<HTMLTableCellElement>) =>
+  ContentEditable.isEditable(cell) || PredicateExists.descendant(cell, isEditableHTMLElement);
 
 const isEditableHTMLElement = (node: SugarElement<Node>) =>
-  SugarNode.isHTMLElement(node) && isEditable(node)
+  SugarNode.isHTMLElement(node) && ContentEditable.isEditable(node);
 
 const handleTab = (editor: Editor, forward: boolean): boolean => {
   const rootElements = [ 'table', 'li', 'dl' ];

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/KeyboardCellNavigationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/KeyboardCellNavigationTest.ts
@@ -85,4 +85,26 @@ describe('browser.tinymce.core.table.KeyboardCellNavigationTest', () => {
     TinyContentActions.keydown(editor, Keys.tab(), { shiftKey: true });
     TinyAssertions.assertCursor(editor, [ 0, 0, 0, 1, 0 ], 0);
   });
+
+  it('TINY-11797: Tabbing forwards in cef table should include cef cells with editable content', () => {
+    const editor = hook.editor();
+    editor.setContent('<table contenteditable="false"><tbody><tr><td contenteditable="true">cell 1</td><td><div contenteditable="true">cell 2</div></td></tr></tbody></table>');
+    TinyAssertions.assertContentPresence(editor, { tr: 1, td: 2, div: 1 });
+    TinySelections.setCursor(editor, [0, 0, 0, 0, 0], 0);
+    TinyContentActions.keystroke(editor, Keys.tab());
+
+    // Assert cursor is inside contenteditable div
+    TinyAssertions.assertCursor(editor, [0, 0, 0, 1, 0, 0], 0);
+  });
+
+  it('TINY-11797: Tabbing backwards in cef table should include cef cells with editable content', () => {
+    const editor = hook.editor();
+    editor.setContent('<table contenteditable="false"><tbody><tr><td><div contenteditable="true">cell 1</div></td><td contenteditable="true">cell 2</td></tr></tbody></table>');
+    TinyAssertions.assertContentPresence(editor, { tr: 1, td: 2, div: 1 });
+    TinySelections.setCursor(editor, [0, 0, 0, 1, 0], 0);
+    TinyContentActions.keystroke(editor, Keys.tab(), { shift: true });
+
+    // Assert cursor is inside contenteditable div
+    TinyAssertions.assertCursor(editor, [0, 0, 0, 0, 0, 0], 0);
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/KeyboardCellNavigationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/KeyboardCellNavigationTest.ts
@@ -90,21 +90,21 @@ describe('browser.tinymce.core.table.KeyboardCellNavigationTest', () => {
     const editor = hook.editor();
     editor.setContent('<table contenteditable="false"><tbody><tr><td contenteditable="true">cell 1</td><td><div contenteditable="true">cell 2</div></td></tr></tbody></table>');
     TinyAssertions.assertContentPresence(editor, { tr: 1, td: 2, div: 1 });
-    TinySelections.setCursor(editor, [0, 0, 0, 0, 0], 0);
+    TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
     TinyContentActions.keystroke(editor, Keys.tab());
 
     // Assert cursor is inside contenteditable div
-    TinyAssertions.assertCursor(editor, [0, 0, 0, 1, 0, 0], 0);
+    TinyAssertions.assertCursor(editor, [ 0, 0, 0, 1, 0, 0 ], 0);
   });
 
   it('TINY-11797: Tabbing backwards in cef table should include cef cells with editable content', () => {
     const editor = hook.editor();
     editor.setContent('<table contenteditable="false"><tbody><tr><td><div contenteditable="true">cell 1</div></td><td contenteditable="true">cell 2</td></tr></tbody></table>');
     TinyAssertions.assertContentPresence(editor, { tr: 1, td: 2, div: 1 });
-    TinySelections.setCursor(editor, [0, 0, 0, 1, 0], 0);
+    TinySelections.setCursor(editor, [ 0, 0, 0, 1, 0 ], 0);
     TinyContentActions.keystroke(editor, Keys.tab(), { shift: true });
 
     // Assert cursor is inside contenteditable div
-    TinyAssertions.assertCursor(editor, [0, 0, 0, 0, 0, 0], 0);
+    TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0, 0, 0 ], 0);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/TableTabKeyNavigationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/TableTabKeyNavigationTest.ts
@@ -118,7 +118,7 @@ describe('browser.tinymce.core.keyboard.TableTabKeyNavigationTest', () => {
       TinyAssertions.assertContentPresence(editor, { tr: 1, td: 1 });
       TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
       TinyContentActions.keystroke(editor, Keys.tab());
-      
+
       TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
       TinyAssertions.assertContentPresence(editor, { tr: 1, td: 1 });
       assert.isEmpty(events);

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/TableTabKeyNavigationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/TableTabKeyNavigationTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { afterEach, context, describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, McEditor, TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -116,13 +116,13 @@ describe('browser.tinymce.core.keyboard.TableTabKeyNavigationTest', () => {
       editor.on('TableModified', logEvent);
       editor.setContent('<table contenteditable="false"><tbody><tr><td contenteditable="true">cell 1</td></tr></tbody></table>');
       TinyAssertions.assertContentPresence(editor, { tr: 1, td: 1 });
-      TinySelections.setCursor(editor, [0, 0, 0, 0, 0], 0);
+      TinySelections.setCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
       TinyContentActions.keystroke(editor, Keys.tab());
       
-      TinyAssertions.assertCursor(editor, [0, 0, 0, 0, 0], 0);
+      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
       TinyAssertions.assertContentPresence(editor, { tr: 1, td: 1 });
       assert.isEmpty(events);
-      
+
       editor.off('TableModified', logEvent);
     });
 

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/TableTabKeyNavigationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/TableTabKeyNavigationTest.ts
@@ -1,6 +1,6 @@
 import { Keys } from '@ephox/agar';
 import { afterEach, context, describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { LegacyUnit, McEditor, TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -109,6 +109,21 @@ describe('browser.tinymce.core.keyboard.TableTabKeyNavigationTest', () => {
       // Creates a new cell + row and moves to it
       TinyAssertions.assertContentPresence(editor, { tr: 3, td: 3 });
       TinyAssertions.assertSelection(editor, [ 0, 0, 2, 0 ], 0, [ 0, 0, 2, 0 ], 0);
+    });
+
+    it('TINY-11797: Tabbing in the last cell does not create a new row, when table is not editable', async () => {
+      const editor = hook.editor();
+      editor.on('TableModified', logEvent);
+      editor.setContent('<table contenteditable="false"><tbody><tr><td contenteditable="true">cell 1</td></tr></tbody></table>');
+      TinyAssertions.assertContentPresence(editor, { tr: 1, td: 1 });
+      TinySelections.setCursor(editor, [0, 0, 0, 0, 0], 0);
+      TinyContentActions.keystroke(editor, Keys.tab());
+      
+      TinyAssertions.assertCursor(editor, [0, 0, 0, 0, 0], 0);
+      TinyAssertions.assertContentPresence(editor, { tr: 1, td: 1 });
+      assert.isEmpty(events);
+      
+      editor.off('TableModified', logEvent);
     });
 
     it('TINY-6638: Shift+Tab does nothing on first cell', () => {


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-11797

Description of Changes:
* If you press tab in the last cell of a non-editable table **do nothing.** Previously it tried to insert a new row and move selection to that row which resulted in infinite loop.
* If you press tab in editable cell, and the next cell is cef, but has editable descendant, then move cursor to that descendant.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
https://github.com/tinymce/tinymce/issues/10133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**  
  - Enhanced table navigation improves the editing experience by ensuring focus only shifts to editable cells.  

- **Bug Fixes**  
  - Prevented unintended row creation in non-editable tables during tab navigation.
  - Resolved an exception when pressing the tab key in the last cell of a non-editable table.  

- **Tests**  
  - Added new test cases to verify tabbing behavior in contenteditable tables.  
  - Introduced a test case to ensure no new row is created when tabbing in the last cell of a non-editable table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->