### PR TITLE
Remove the TinyComments hack from SelectedTextLinkTest

### DIFF
--- a/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/SelectedTextLinkTest.ts
@@ -12,14 +12,6 @@ describe('browser.tinymce.plugins.link.SelectedTextLinkTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'link',
     toolbar: '',
-    setup: (editor: Editor) => {
-      // Simulate comments being enabled
-      editor.on('GetContent', (e) => {
-        if (e.selection) {
-          e.content += '<!-- TinyComments -->';
-        }
-      });
-    },
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ]);
 


### PR DESCRIPTION
Description of Changes:

It's unclear to me what this comment was meant for, but it looks like it's supposed to trick the SUT into thinking that the TinyComments plugin is also active, so that the SUT would change its behavior accordingly. But the SUT does not check for the presence of TinyComments (anymore?), so this seems redundant. Additionally it's undesirable, because this HTML comment accidentally becomes the text of inserted links (rather than the URL being copied into the link text field).

Pre-checks:
* ~~Changelog entry added~~ (doesn't seem worth it when only changing test code)
* [x] Tests have been added (if applicable)
* ~~[ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`~~ (seems to match neither or those)

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable): #10143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
	- Revised internal testing routines for text selection and link manipulation to ensure more accurate behavior validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->