### PR TITLE
TINY-11329: properly align focus outline on save + clean some fixed values

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11329-2025-02-10.yaml
+++ b/.changes/unreleased/tinymce-TINY-11329-2025-02-10.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Improved
+body: Focus outline was misaligned with comment card border on saving an edit.
+time: 2025-02-10T16:04:44.938101+01:00
+custom:
+  Issue: TINY-11329

--- a/modules/oxide/src/less/theme/components/comments/comment.less
+++ b/modules/oxide/src/less/theme/components/comments/comment.less
@@ -8,14 +8,16 @@
 @comment-background-color: @background-color;
 @comment-border-color: @comment-background-color;
 @comment-border-radius: @panel-border-radius;
-@comment-border: 1px solid @comment-border-color;
+@comment-border-width: 1px;
+@comment-border: @comment-border-width solid @comment-border-color;
 @comment-box-shadow: 0 4px 8px 0 fade(@color-black, 10%);
 //TODO: Same as menu. Make a common helper variable?
 @comment-font-size: @font-size-md;
 @comment-font-style: normal;
 @comment-font-weight: @font-weight-normal;
 @comment-line-height: @line-height-base;
-@comment-padding: @pad-sm @pad-sm @pad-md @pad-sm;
+@comment-padding: @pad-sm;
+@comment-padding-bottom: @pad-md;
 @comment-text-color: @text-color;
 @comment-text-transform: initial;
 @comment-text-color-muted: @text-color-muted;
@@ -24,6 +26,7 @@
 @z-index-comment-overlay-text: 10;
 @z-index-comment-busy-spinner: 20;
 
+@single-comment-margin-bottom: 12px;
 .tox {
 
   .tox-conversations {
@@ -42,16 +45,16 @@
     align-items: center;
     display: flex;
     justify-content: space-between;
-    box-shadow: 0px 4px 8px 0px rgba(34, 47, 62, 0.1);
-    padding: 8px 12px;
+    box-shadow: @comment-box-shadow;
+    padding: @pad-sm 12px;
     background: @background-color;
     z-index: 1;
   }
 
   .tox-conversations__title {
-    font-size: 20px;
+    font-size: @font-size-lg;
     font-weight: 400;
-    padding: 8px 0 8px 0;
+    padding: @pad-sm 0 @pad-sm 0;
     color: @comment-text-color;
     line-height: 28px;
   }
@@ -61,6 +64,7 @@
     border: @comment-border;
     border-radius: @comment-border-radius;
     padding: @comment-padding;
+    padding-bottom: @comment-padding-bottom;
     position: relative;
 
     &:hover {
@@ -69,8 +73,8 @@
 
     &.tox-comment--selected {
       background-color: @comment-selected-background-color;
-      border: 1px solid @comment-selected-border-color;
-      box-shadow: 0px 4px 8px 0px rgba(34, 47, 62, 0.10);
+      border: @comment-border-width solid @comment-selected-border-color;
+      box-shadow: @comment-box-shadow;
 
       &:focus {
         border: 2px solid @keyboard-focus-outline-color;
@@ -82,7 +86,7 @@
       }
 
       .tox-comment__single {
-        margin-bottom: 12px;
+        margin-bottom: @single-comment-margin-bottom;
 
         &:focus {
           position: relative;
@@ -96,8 +100,12 @@
             bottom: -9px;
             left: -9px;
             right: -9px;
-            border-radius: 6px;
+            border-radius: @comment-border-radius;
             border: 2px solid @keyboard-focus-outline-color;
+          }
+
+          &:last-of-type:has(textarea):after {
+            bottom: calc((@single-comment-margin-bottom + @comment-padding-bottom + @comment-border-width) * -1);
           }
         }
       }
@@ -220,7 +228,7 @@
   .tox-comment-thread {
     background: @comment-background-color;
     position: relative;
-    border-radius: 6px;
+    border-radius: @comment-border-radius;
     background-color: transparent;
 
     > *:not(:first-child) {
@@ -335,7 +343,7 @@
     .tox-skeleton__circle {
       height: 36px;
       width: 36px;
-      margin-right: 8px;
+      margin-right: @pad-sm;
       border-radius: 100%;
       background: linear-gradient(to right, rgba(240, 240, 240, 0.5) 8%, rgba(240, 240, 240, 0.7) 18%, rgba(240, 240, 240, 0.5) 33%);
       animation: wave 2s infinite ease-out;


### PR DESCRIPTION
Related Ticket: TINY-11329

Description of Changes:
* Fixed misaligned focus outline for last/single comment in thread when saving edits
* Removed some of fixed values from styles

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced focus outline alignment ensures the comment card border and focus indicators now sync up during edit saving for a smoother interaction.

- **Style**
  - Refined comment styling with updated borders, consistent margins, and adjusted padding.
  - Improved visual consistency with revised box shadows and typography adjustments for comment headers and titles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->