### PR TITLE
Preserve border dashed style from inline table styles

### DIFF
--- a/modules/oxide/src/less/skins/content/dark/content.less
+++ b/modules/oxide/src/less/skins/content/dark/content.less
@@ -26,23 +26,32 @@ table:not([cellpadding]) td {
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-width"]) th,
-table[border]:not([border="0"]):not([style*="border-width"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-width"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-width"])) td {
   border-width: 1px;
 }
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-style"]) th,
-table[border]:not([border="0"]):not([style*="border-style"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-style"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-style"])) td {
   border-style: solid;
 }
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-color"]) th,
-table[border]:not([border="0"]):not([style*="border-color"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-color"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-color"])) td {
   border-color: #6d737b;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: dashed"]) td,
+table[border]:where([style*="border-style: dashed"]) th,
+table[border]:where([style*=" dashed "]) td,
+table[border]:where([style*=" dashed "]) th {
+   border-style: dashed;
 }
 
 figure {

--- a/modules/oxide/src/less/skins/content/default/content.less
+++ b/modules/oxide/src/less/skins/content/default/content.less
@@ -20,23 +20,113 @@ table:not([cellpadding]) td {
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-width"]) th,
-table[border]:not([border="0"]):not([style*="border-width"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-width"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-width"])) td {
   border-width: 1px;
 }
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-style"]) th,
-table[border]:not([border="0"]):not([style*="border-style"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-style"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-style"])) td {
   border-style: solid;
 }
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-color"]) th,
-table[border]:not([border="0"]):not([style*="border-color"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-color"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-color"])) td {
   border-color: #ccc;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: none"]) td,
+table[border]:where([style*="border-style: none"]) th,
+table[border]:where([style*=" none "]) td,
+table[border]:where([style*=" none "]) th {
+   border-style: none;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: solid"]) td,
+table[border]:where([style*="border-style: solid"]) th,
+table[border]:where([style*=" solid "]) td,
+table[border]:where([style*=" solid "]) th {
+   border-style: solid;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: dotted"]) td,
+table[border]:where([style*="border-style: dotted"]) th,
+table[border]:where([style*=" dotted "]) td,
+table[border]:where([style*=" dotted "]) th {
+   border-style: dotted;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: dashed"]) td,
+table[border]:where([style*="border-style: dashed"]) th,
+table[border]:where([style*=" dashed "]) td,
+table[border]:where([style*=" dashed "]) th {
+   border-style: dashed;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: double"]) td,
+table[border]:where([style*="border-style: double"]) th,
+table[border]:where([style*=" double "]) td,
+table[border]:where([style*=" double "]) th {
+   border-style: double;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: groove"]) td,
+table[border]:where([style*="border-style: groove"]) th,
+table[border]:where([style*=" groove "]) td,
+table[border]:where([style*=" groove "]) th {
+   border-style: groove;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: ridge"]) td,
+table[border]:where([style*="border-style: ridge"]) th,
+table[border]:where([style*=" ridge "]) td,
+table[border]:where([style*=" ridge "]) th {
+   border-style: ridge;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: inset"]) td,
+table[border]:where([style*="border-style: inset"]) th,
+table[border]:where([style*=" inset "]) td,
+table[border]:where([style*=" inset "]) th {
+   border-style: inset;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: outset"]) td,
+table[border]:where([style*="border-style: outset"]) th,
+table[border]:where([style*=" outset "]) td,
+table[border]:where([style*=" outset "]) th {
+   border-style: outset;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: hidden"]) td,
+table[border]:where([style*="border-style: hidden"]) th,
+table[border]:where([style*=" hidden "]) td,
+table[border]:where([style*=" hidden "]) th {
+   border-style: hidden;
 }
 
 figure {

--- a/modules/oxide/src/less/skins/content/document/content.less
+++ b/modules/oxide/src/less/skins/content/document/content.less
@@ -37,23 +37,113 @@ table:not([cellpadding]) td {
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-width"]) th,
-table[border]:not([border="0"]):not([style*="border-width"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-width"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-width"])) td {
   border-width: 1px;
 }
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-style"]) th,
-table[border]:not([border="0"]):not([style*="border-style"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-style"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-style"])) td {
   border-style: solid;
 }
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-color"]) th,
-table[border]:not([border="0"]):not([style*="border-color"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-color"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-color"])) td {
   border-color: #ccc;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: none"]) td,
+table[border]:where([style*="border-style: none"]) th,
+table[border]:where([style*=" none "]) td,
+table[border]:where([style*=" none "]) th {
+   border-style: none;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: solid"]) td,
+table[border]:where([style*="border-style: solid"]) th,
+table[border]:where([style*=" solid "]) td,
+table[border]:where([style*=" solid "]) th {
+   border-style: solid;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: dotted"]) td,
+table[border]:where([style*="border-style: dotted"]) th,
+table[border]:where([style*=" dotted "]) td,
+table[border]:where([style*=" dotted "]) th {
+   border-style: dotted;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: dashed"]) td,
+table[border]:where([style*="border-style: dashed"]) th,
+table[border]:where([style*=" dashed "]) td,
+table[border]:where([style*=" dashed "]) th {
+   border-style: dashed;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: double"]) td,
+table[border]:where([style*="border-style: double"]) th,
+table[border]:where([style*=" double "]) td,
+table[border]:where([style*=" double "]) th {
+   border-style: double;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: groove"]) td,
+table[border]:where([style*="border-style: groove"]) th,
+table[border]:where([style*=" groove "]) td,
+table[border]:where([style*=" groove "]) th {
+   border-style: groove;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: ridge"]) td,
+table[border]:where([style*="border-style: ridge"]) th,
+table[border]:where([style*=" ridge "]) td,
+table[border]:where([style*=" ridge "]) th {
+   border-style: ridge;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: inset"]) td,
+table[border]:where([style*="border-style: inset"]) th,
+table[border]:where([style*=" inset "]) td,
+table[border]:where([style*=" inset "]) th {
+   border-style: inset;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: outset"]) td,
+table[border]:where([style*="border-style: outset"]) th,
+table[border]:where([style*=" outset "]) td,
+table[border]:where([style*=" outset "]) th {
+   border-style: outset;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: hidden"]) td,
+table[border]:where([style*="border-style: hidden"]) th,
+table[border]:where([style*=" hidden "]) td,
+table[border]:where([style*=" hidden "]) th {
+   border-style: hidden;
 }
 
 figure figcaption {

--- a/modules/oxide/src/less/skins/content/tinymce-5-dark/content.less
+++ b/modules/oxide/src/less/skins/content/tinymce-5-dark/content.less
@@ -26,23 +26,113 @@ table:not([cellpadding]) td {
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-width"]) th,
-table[border]:not([border="0"]):not([style*="border-width"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-width"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-width"])) td {
   border-width: 1px;
 }
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-style"]) th,
-table[border]:not([border="0"]):not([style*="border-style"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-style"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-style"])) td {
   border-style: solid;
 }
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-color"]) th,
-table[border]:not([border="0"]):not([style*="border-color"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-color"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-color"])) td {
   border-color: #6d737b;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: none"]) td,
+table[border]:where([style*="border-style: none"]) th,
+table[border]:where([style*=" none "]) td,
+table[border]:where([style*=" none "]) th {
+   border-style: none;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: solid"]) td,
+table[border]:where([style*="border-style: solid"]) th,
+table[border]:where([style*=" solid "]) td,
+table[border]:where([style*=" solid "]) th {
+   border-style: solid;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: dotted"]) td,
+table[border]:where([style*="border-style: dotted"]) th,
+table[border]:where([style*=" dotted "]) td,
+table[border]:where([style*=" dotted "]) th {
+   border-style: dotted;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: dashed"]) td,
+table[border]:where([style*="border-style: dashed"]) th,
+table[border]:where([style*=" dashed "]) td,
+table[border]:where([style*=" dashed "]) th {
+   border-style: dashed;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: double"]) td,
+table[border]:where([style*="border-style: double"]) th,
+table[border]:where([style*=" double "]) td,
+table[border]:where([style*=" double "]) th {
+   border-style: double;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: groove"]) td,
+table[border]:where([style*="border-style: groove"]) th,
+table[border]:where([style*=" groove "]) td,
+table[border]:where([style*=" groove "]) th {
+   border-style: groove;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: ridge"]) td,
+table[border]:where([style*="border-style: ridge"]) th,
+table[border]:where([style*=" ridge "]) td,
+table[border]:where([style*=" ridge "]) th {
+   border-style: ridge;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: inset"]) td,
+table[border]:where([style*="border-style: inset"]) th,
+table[border]:where([style*=" inset "]) td,
+table[border]:where([style*=" inset "]) th {
+   border-style: inset;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: outset"]) td,
+table[border]:where([style*="border-style: outset"]) th,
+table[border]:where([style*=" outset "]) td,
+table[border]:where([style*=" outset "]) th {
+   border-style: outset;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: hidden"]) td,
+table[border]:where([style*="border-style: hidden"]) th,
+table[border]:where([style*=" hidden "]) td,
+table[border]:where([style*=" hidden "]) th {
+   border-style: hidden;
 }
 
 figure {

--- a/modules/oxide/src/less/skins/content/tinymce-5/content.less
+++ b/modules/oxide/src/less/skins/content/tinymce-5/content.less
@@ -20,23 +20,113 @@ table:not([cellpadding]) td {
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-width"]) th,
-table[border]:not([border="0"]):not([style*="border-width"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-width"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-width"])) td {
   border-width: 1px;
 }
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-style"]) th,
-table[border]:not([border="0"]):not([style*="border-style"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-style"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-style"])) td {
   border-style: solid;
 }
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-color"]) th,
-table[border]:not([border="0"]):not([style*="border-color"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-color"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-color"])) td {
   border-color: #ccc;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: none"]) td,
+table[border]:where([style*="border-style: none"]) th,
+table[border]:where([style*=" none "]) td,
+table[border]:where([style*=" none "]) th {
+   border-style: none;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: solid"]) td,
+table[border]:where([style*="border-style: solid"]) th,
+table[border]:where([style*=" solid "]) td,
+table[border]:where([style*=" solid "]) th {
+   border-style: solid;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: dotted"]) td,
+table[border]:where([style*="border-style: dotted"]) th,
+table[border]:where([style*=" dotted "]) td,
+table[border]:where([style*=" dotted "]) th {
+   border-style: dotted;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: dashed"]) td,
+table[border]:where([style*="border-style: dashed"]) th,
+table[border]:where([style*=" dashed "]) td,
+table[border]:where([style*=" dashed "]) th {
+   border-style: dashed;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: double"]) td,
+table[border]:where([style*="border-style: double"]) th,
+table[border]:where([style*=" double "]) td,
+table[border]:where([style*=" double "]) th {
+   border-style: double;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: groove"]) td,
+table[border]:where([style*="border-style: groove"]) th,
+table[border]:where([style*=" groove "]) td,
+table[border]:where([style*=" groove "]) th {
+   border-style: groove;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: ridge"]) td,
+table[border]:where([style*="border-style: ridge"]) th,
+table[border]:where([style*=" ridge "]) td,
+table[border]:where([style*=" ridge "]) th {
+   border-style: ridge;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: inset"]) td,
+table[border]:where([style*="border-style: inset"]) th,
+table[border]:where([style*=" inset "]) td,
+table[border]:where([style*=" inset "]) th {
+   border-style: inset;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: outset"]) td,
+table[border]:where([style*="border-style: outset"]) th,
+table[border]:where([style*=" outset "]) td,
+table[border]:where([style*=" outset "]) th {
+   border-style: outset;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: hidden"]) td,
+table[border]:where([style*="border-style: hidden"]) th,
+table[border]:where([style*=" hidden "]) td,
+table[border]:where([style*=" hidden "]) th {
+   border-style: hidden;
 }
 
 figure {

--- a/modules/oxide/src/less/skins/content/writer/content.less
+++ b/modules/oxide/src/less/skins/content/writer/content.less
@@ -21,23 +21,113 @@ table:not([cellpadding]) td {
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-width"]) th,
-table[border]:not([border="0"]):not([style*="border-width"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-width"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-width"])) td {
   border-width: 1px;
 }
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-style"]) th,
-table[border]:not([border="0"]):not([style*="border-style"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-style"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-style"])) td {
   border-style: solid;
 }
 
 /* Set default table styles if a table has a positive border attribute
    and no inline css */
-table[border]:not([border="0"]):not([style*="border-color"]) th,
-table[border]:not([border="0"]):not([style*="border-color"]) td {
+table[border]:where(:not([border="0"]):not([style*="border-color"])) th,
+table[border]:where(:not([border="0"]):not([style*="border-color"])) td {
   border-color: #ccc;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: dashed"]) td,
+table[border]:where([style*="border-style: dashed"]) th,
+table[border]:where([style*=" dashed "]) td,
+table[border]:where([style*=" dashed "]) th {
+   border-style: dashed;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: none"]) td,
+table[border]:where([style*="border-style: none"]) th,
+table[border]:where([style*=" none "]) td,
+table[border]:where([style*=" none "]) th {
+   border-style: none;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: solid"]) td,
+table[border]:where([style*="border-style: solid"]) th,
+table[border]:where([style*=" solid "]) td,
+table[border]:where([style*=" solid "]) th {
+   border-style: solid;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: dotted"]) td,
+table[border]:where([style*="border-style: dotted"]) th,
+table[border]:where([style*=" dotted "]) td,
+table[border]:where([style*=" dotted "]) th {
+   border-style: dotted;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: double"]) td,
+table[border]:where([style*="border-style: double"]) th,
+table[border]:where([style*=" double "]) td,
+table[border]:where([style*=" double "]) th {
+   border-style: double;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: groove"]) td,
+table[border]:where([style*="border-style: groove"]) th,
+table[border]:where([style*=" groove "]) td,
+table[border]:where([style*=" groove "]) th {
+   border-style: groove;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: ridge"]) td,
+table[border]:where([style*="border-style: ridge"]) th,
+table[border]:where([style*=" ridge "]) td,
+table[border]:where([style*=" ridge "]) th {
+   border-style: ridge;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: inset"]) td,
+table[border]:where([style*="border-style: inset"]) th,
+table[border]:where([style*=" inset "]) td,
+table[border]:where([style*=" inset "]) th {
+   border-style: inset;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: outset"]) td,
+table[border]:where([style*="border-style: outset"]) th,
+table[border]:where([style*=" outset "]) td,
+table[border]:where([style*=" outset "]) th {
+   border-style: outset;
+}
+
+/* Set default table styles if a table has a positive border attribute
+   and no inline css */
+table[border]:where([style*="border-style: hidden"]) td,
+table[border]:where([style*="border-style: hidden"]) th,
+table[border]:where([style*=" hidden "]) td,
+table[border]:where([style*=" hidden "]) th {
+   border-style: hidden;
 }
 
 figure {


### PR DESCRIPTION
remove specificity of :not selectors for border styling

Related Ticket: 

Description of Changes:
* Configuring styles for the table borders are not being picked up by inner cells (td and th) because the css rules are dismissing the inheritance of the border styles.

![Description of Image](https://raw.githubusercontent.com/Mauricio9999/tinymce/refs/heads/main/output.gif)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Refined table styling for enhanced visual consistency.
	- Expanded border styling options to support various styles (dashed, solid, dotted, double, groove, ridge, inset, outset, hidden) based on applied attributes.
	- Improved CSS selector specificity by replacing `:not()` with `:where()` for better clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->