### PR TITLE
TINY-11781: fix using context form api after component detached

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11781-2025-02-13.yaml
+++ b/.changes/unreleased/tinymce-TINY-11781-2025-02-13.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Exception was thrown when trying to use context form API after component was detached.
+time: 2025-02-13T11:14:01.865459+01:00
+custom:
+  Issue: TINY-11781

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
@@ -11,9 +11,7 @@ import { Focus, SugarElement } from '@ephox/sugar';
 
 import { backSlideEvent } from './ContextUi';
 
-export const getFormApi = <T>(input: AlloyComponent, focusfallbackElement?: SugarElement<HTMLElement>): InlineContent.ContextFormInstanceApi<T> => {
-  const valueState = Singleton.value<T>();
-
+export const getFormApi = <T>(input: AlloyComponent, valueState: Singleton.Value<T>, focusfallbackElement?: SugarElement<HTMLElement>): InlineContent.ContextFormInstanceApi<T> => {
   return ({
     setInputEnabled: (state: boolean) => {
       if (!state && focusfallbackElement) {
@@ -24,29 +22,19 @@ export const getFormApi = <T>(input: AlloyComponent, focusfallbackElement?: Suga
     },
     isInputEnabled: () => !Disabling.isDisabled(input),
     hide: () => {
-      // Before we hide snapshot the current value since accessing the value of a form field after it's been detached will throw an error
-      if (!valueState.isSet()) {
-        valueState.set(Representing.getValue(input));
-      }
-
       AlloyTriggers.emit(input, SystemEvents.sandboxClose());
     },
     back: () => {
-      // Before we hide snapshot the current value since accessing the value of a form field after it's been detached will throw an error
-      if (!valueState.isSet()) {
-        valueState.set(Representing.getValue(input));
-      }
-
       AlloyTriggers.emit(input, backSlideEvent);
     },
     getValue: () => {
       return valueState.get().getOrThunk(() => Representing.getValue(input));
     },
     setValue: (value) => {
-      if (valueState.isSet()) {
-        valueState.set(value);
-      } else {
+      if (input.getSystem().isConnected()) {
         Representing.setValue(input, value);
+      } else {
+        valueState.set(value);
       }
     }
   });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
@@ -5,7 +5,7 @@ import {
 } from '@ephox/alloy';
 import { StructureSchema } from '@ephox/boulder';
 import { InlineContent, Toolbar } from '@ephox/bridge';
-import { Arr, Fun, Optional } from '@ephox/katamari';
+import { Arr, Fun, Optional, Singleton } from '@ephox/katamari';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { internalToolbarButtonExecute, InternalToolbarButtonExecuteEvent } from '../toolbar/button/ButtonEvents';
@@ -17,14 +17,14 @@ interface ContextFormButtonRegistry {
   readonly findPrimary: (compInSystem: AlloyComponent) => Optional<AlloyComponent>;
 }
 
-const runOnExecute = <T, U>(memInput: MementoRecord, original: { onAction: (formApi: InlineContent.ContextFormInstanceApi<U>, buttonApi: T) => void }) =>
+const runOnExecute = <T, U>(memInput: MementoRecord, original: { onAction: (formApi: InlineContent.ContextFormInstanceApi<U>, buttonApi: T) => void }, valueState: Singleton.Value<U>) =>
   AlloyEvents.run<InternalToolbarButtonExecuteEvent<T>>(internalToolbarButtonExecute, (comp, se) => {
     const input = memInput.get(comp);
-    const formApi = getFormApi<U>(input, comp.element);
+    const formApi = getFormApi<U>(input, valueState, comp.element);
     original.onAction(formApi, se.event.buttonApi);
   });
 
-const renderContextButton = <T>(memInput: MementoRecord, button: InlineContent.ContextFormButton<T>, providers: UiFactoryBackstageProviders) => {
+const renderContextButton = <T>(memInput: MementoRecord, button: InlineContent.ContextFormButton<T>, providers: UiFactoryBackstageProviders, valueState: Singleton.Value<T>) => {
   const { primary, ...rest } = button.original;
   const bridged = StructureSchema.getOrDie(
     Toolbar.createToolbarButton({
@@ -35,11 +35,11 @@ const renderContextButton = <T>(memInput: MementoRecord, button: InlineContent.C
   );
 
   return renderToolbarButtonWith(bridged, providers, [
-    runOnExecute<Toolbar.ToolbarButtonInstanceApi, T>(memInput, button)
+    runOnExecute<Toolbar.ToolbarButtonInstanceApi, T>(memInput, button, valueState)
   ]);
 };
 
-const renderContextToggleButton = <T>(memInput: MementoRecord, button: InlineContent.ContextFormToggleButton<T>, providers: UiFactoryBackstageProviders) => {
+const renderContextToggleButton = <T>(memInput: MementoRecord, button: InlineContent.ContextFormToggleButton<T>, providers: UiFactoryBackstageProviders, valueState: Singleton.Value<T>) => {
   const { primary, ...rest } = button.original;
   const bridged = StructureSchema.getOrDie(
     Toolbar.createToggleButton({
@@ -50,25 +50,25 @@ const renderContextToggleButton = <T>(memInput: MementoRecord, button: InlineCon
   );
 
   return renderToolbarToggleButtonWith(bridged, providers, [
-    runOnExecute<InlineContent.ContextFormToggleButtonInstanceApi, T>(memInput, button)
+    runOnExecute<InlineContent.ContextFormToggleButtonInstanceApi, T>(memInput, button, valueState)
   ]);
 };
 
 const isToggleButton = <T>(button: InlineContent.ContextFormCommand<T>): button is InlineContent.ContextFormToggleButton<T> =>
   button.type === 'contextformtogglebutton';
 
-const generateOne = <T>(memInput: MementoRecord, button: InlineContent.ContextFormCommand<T>, providersBackstage: UiFactoryBackstageProviders) => {
+const generateOne = <T>(memInput: MementoRecord, button: InlineContent.ContextFormCommand<T>, providersBackstage: UiFactoryBackstageProviders, valueState: Singleton.Value<T>) => {
   if (isToggleButton(button)) {
-    return renderContextToggleButton(memInput, button, providersBackstage);
+    return renderContextToggleButton(memInput, button, providersBackstage, valueState);
   } else {
-    return renderContextButton(memInput, button, providersBackstage);
+    return renderContextButton(memInput, button, providersBackstage, valueState);
   }
 };
 
-const generate = <T>(memInput: MementoRecord, buttons: InlineContent.ContextFormCommand<T>[], providersBackstage: UiFactoryBackstageProviders): ContextFormButtonRegistry => {
+const generate = <T>(memInput: MementoRecord, buttons: InlineContent.ContextFormCommand<T>[], providersBackstage: UiFactoryBackstageProviders, valueState: Singleton.Value<T>): ContextFormButtonRegistry => {
 
   const mementos = Arr.map(buttons, (button) => Memento.record(
-    generateOne(memInput, button, providersBackstage)
+    generateOne(memInput, button, providersBackstage, valueState)
   ));
 
   const asSpecs = () => Arr.map(mementos, (mem) => mem.asSpec());

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
@@ -208,7 +208,7 @@ export const renderContextFormSizeInput = (
           const value2 = optOther.map<string>(Representing.getValue).getOr('');
           converter = makeRatioConverter(value1, value2);
         }),
-        AlloyEvents.run(formInputEvent, (input) => ctx.onInput(ContextFormApi.getFormApi(input, valueState))),
+        AlloyEvents.run(formInputEvent, (input) => ctx.onInput(getApi(input))),
         ...controlLifecycleHandlers,
       ])
     ])

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
@@ -11,14 +11,14 @@ import {
   NativeEvents, Representing, SketchSpec, Tabstopping, Tooltipping
 } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
-import { Cell, Fun, Id, Optional, Unicode } from '@ephox/katamari';
+import { Cell, Fun, Id, Optional, Singleton, Unicode } from '@ephox/katamari';
 import { Focus, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import { formInputEvent } from 'tinymce/themes/silver/ui/general/FormEvents';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
-import { onControlAttached, onControlDetached } from '../controls/Controls';
+import { onContextFormControlDetached, onControlAttached } from '../controls/Controls';
 import * as Icons from '../icons/Icons';
 import { formatSize, makeRatioConverter, noSizeConversion, parseSize, SizeConversion } from '../sizeinput/SizeInputModel';
 import * as ContextFormApi from './ContextFormApi';
@@ -28,13 +28,14 @@ interface RatioEvent extends CustomEvent {
 export const renderContextFormSizeInput = (
   ctx: InlineContent.ContextSizeInputForm,
   providersBackstage: UiFactoryBackstageProviders,
-  onEnter: (input: AlloyComponent) => Optional<boolean>
+  onEnter: (input: AlloyComponent) => Optional<boolean>,
+  valueState: Singleton.Value<InlineContent.SizeData>
 ): SketchSpec => {
   const { width, height } = ctx.initValue();
   let converter: SizeConversion = noSizeConversion;
   const enabled = true;
   const ratioEvent = Id.generate('ratio-event');
-  const getApi = ContextFormApi.getFormApi<InlineContent.SizeData>;
+  const getApi = (comp: AlloyComponent) => ContextFormApi.getFormApi<InlineContent.SizeData>(comp, valueState);
 
   const makeIcon = (iconName: string) =>
     Icons.render(iconName, { tag: 'span', classes: [ 'tox-icon', 'tox-lock-icon__' + iconName ] }, providersBackstage.icons);
@@ -144,7 +145,7 @@ export const renderContextFormSizeInput = (
 
   const controlLifecycleHandlers = [
     onControlAttached( { onSetup: ctx.onSetup, getApi }, editorOffCell),
-    onControlDetached( { getApi }, editorOffCell)
+    onContextFormControlDetached({ getApi }, editorOffCell, valueState),
   ];
 
   return AlloyFormCoupledInputs.sketch({
@@ -207,7 +208,7 @@ export const renderContextFormSizeInput = (
           const value2 = optOther.map<string>(Representing.getValue).getOr('');
           converter = makeRatioConverter(value1, value2);
         }),
-        AlloyEvents.run(formInputEvent, (input) => ctx.onInput(ContextFormApi.getFormApi(input))),
+        AlloyEvents.run(formInputEvent, (input) => ctx.onInput(ContextFormApi.getFormApi(input, valueState))),
         ...controlLifecycleHandlers,
       ])
     ])

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
@@ -1,19 +1,21 @@
 import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Disabling, FormField, GuiFactory, Input, Keying, NativeEvents, SketchSpec } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
-import { Cell, Fun, Optional, Strings } from '@ephox/katamari';
+import { Cell, Fun, Optional, Singleton, Strings } from '@ephox/katamari';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
-import { onControlAttached, onControlDetached } from '../controls/Controls';
+import { onContextFormControlDetached, onControlAttached } from '../controls/Controls';
 import * as ContextFormApi from './ContextFormApi';
 import * as ContextFormGroup from './ContextFormGroup';
 
 export const renderContextFormSliderInput = (
   ctx: InlineContent.ContextSliderForm,
   providers: UiFactoryBackstageProviders,
-  onEnter: (input: AlloyComponent) => Optional<boolean>
+  onEnter: (input: AlloyComponent) => Optional<boolean>,
+  valueState: Singleton.Value<number>
 ): SketchSpec => {
   const editorOffCell = Cell(Fun.noop);
+  const getApi = (comp: AlloyComponent) => ContextFormApi.getFormApi<number>(comp, valueState);
 
   const pLabel = ctx.label.map((label) => FormField.parts.label({
     dom: { tag: 'label', classes: [ 'tox-label' ] },
@@ -54,12 +56,12 @@ export const renderContextFormSliderInput = (
       AddEventsBehaviour.config('slider-events', [
         onControlAttached<InlineContent.ContextFormInstanceApi<number>>({
           onSetup: ctx.onSetup,
-          getApi: ContextFormApi.getFormApi,
+          getApi,
           onBeforeSetup: Keying.focusIn
         }, editorOffCell),
-        onControlDetached({ getApi: ContextFormApi.getFormApi }, editorOffCell),
+        onContextFormControlDetached({ getApi }, editorOffCell, valueState),
         AlloyEvents.run(NativeEvents.input(), (comp) => {
-          ctx.onInput(ContextFormApi.getFormApi(comp));
+          ctx.onInput(getApi(comp));
         })
       ])
     ])

--- a/modules/tinymce/src/themes/silver/main/ts/ui/controls/Controls.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/controls/Controls.ts
@@ -1,5 +1,5 @@
-import { AlloyComponent, AlloyEvents, EventFormat } from '@ephox/alloy';
-import { Cell, Type } from '@ephox/katamari';
+import { AlloyComponent, AlloyEvents, EventFormat, Representing } from '@ephox/alloy';
+import { Cell, Singleton, Type } from '@ephox/katamari';
 
 export interface GetApiType<T> {
   readonly getApi: (comp: AlloyComponent) => T;
@@ -42,4 +42,10 @@ const onControlAttached = <T>(info: OnControlAttachedType<T>, editorOffCell: Cel
 const onControlDetached = <T>(getApi: GetApiType<T>, editorOffCell: Cell<OnDestroy<T>>): AlloyEvents.AlloyEventKeyAndHandler<EventFormat> =>
   AlloyEvents.runOnDetached((comp) => runWithApi(getApi, comp)(editorOffCell.get()));
 
-export { runWithApi, onControlAttached, onControlDetached };
+const onContextFormControlDetached = <T>(getApi: GetApiType<T>, editorOffCell: Cell<OnDestroy<T>>, valueState: Singleton.Value<T>): AlloyEvents.AlloyEventKeyAndHandler<EventFormat> =>
+  AlloyEvents.runOnDetached((comp) => {
+    valueState.set(Representing.getValue(comp));
+    return runWithApi(getApi, comp)(editorOffCell.get());
+  });
+
+export { runWithApi, onControlAttached, onControlDetached, onContextFormControlDetached };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -371,8 +371,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     const editor = hook.editor();
     openToolbar(editor, 'test-form');
     TinyUiActions.clickOnUi(editor, 'button[aria-label="D"]');
-
-    store.assertEq('Should have triggered ContextToolbarClose', [ 'setup', 'teardown', 'D.before-hide', 'D.after-hide' ]);
+    store.assertEq('D should have fired', [ 'setup', 'teardown', 'D.before-hide', 'D.after-hide' ]);
   });
 
   it('TINY-11781: Should be able to get value after component has been detached', async () => {
@@ -383,7 +382,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
     TinyContentActions.trueClick(editor);
 
-    await Waiter.pTryUntil('Watied to context form to close', () => {
+    await Waiter.pTryUntil('Waited to context form to close', () => {
       store.assertEq('Should be able to get value', [ 'setup', 'teardown', '300x300' ]);
     });
   });
@@ -396,7 +395,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
     TinyContentActions.trueClick(editor);
 
-    await Waiter.pTryUntil('Watied to context form to close', () => {
+    await Waiter.pTryUntil('Waited to context form to close', () => {
       store.assertEq('Should be able to set value', [ 'setup', 'teardown', '500x500' ]);
     });
   });
@@ -473,7 +472,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     TinySelections.setCursor(editor, [ 0, 0 ], 0);
     TinyContentActions.trueClick(editor);
 
-    await Waiter.pTryUntil('Watied to context toolbar to close', () => {
+    await Waiter.pTryUntil('Waited to context toolbar to close', () => {
       store.assertEq('Should have triggered ContextToolbarClose', [ 'setup', 'teardown', 'contexttoolbarclose' ]);
     });
 


### PR DESCRIPTION
Related Ticket: TINY-11781

Description of Changes:
* Exceptions were raised if you call setValue on the context from API after the toolbar has been detached from the DOM. 

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an exception that occurred when using context forms after a component was detached.

- **New Features**
  - Enhanced state consistency in context form components including text, slider, and size inputs for smoother interactions.
  - Introduced new context forms in the editor’s UI that manage values correctly after detachment events.
  - Added new test cases to verify functionality of the context forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->