### PR TITLE
TINY-11828: fix Firefox tests

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/delete/InlineFormatDeleteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/delete/InlineFormatDeleteTest.ts
@@ -401,60 +401,39 @@ describe('browser.tinymce.core.delete.InlineFormatDelete', () => {
           return s.element('body', {
             children: [
               s.element('p', {
-                // firefox retains formats by default, so no new caret created
-                children: browser.isFirefox()
-                  ? [
-                    s.element('strong', {
-                      children: [
-                        s.element('em', {
-                          children: [
-                            s.element('span', {
-                              attrs: {
-                                style: str.is('text-decoration: underline;')
-                              },
-                              children: [
-                                s.element('br', {})
-                              ]
-                            })
-                          ]
-                        })
-                      ]
-                    })
-                  ]
-                  : [
-                    s.element('span', {
-                      attrs: {
-                        'id': str.is('_mce_caret'),
-                        'data-mce-bogus': str.is('1'),
-                        'data-mce-type': str.is('format-caret')
-                      },
-                      children: [
-                        s.element('strong', {
-                          children: [
-                            s.element('em', {
-                              children: [
-                                s.element('span', {
-                                  attrs: {
-                                    style: str.is('text-decoration: underline;')
-                                  },
-                                  children: [
-                                    s.text(str.is(Zwsp.ZWSP))
-                                  ]
-                                })
-                              ]
-                            })
-                          ]
-                        })
-                      ]
-                    })
-                  ]
+                children: [
+                  s.element('span', {
+                    attrs: {
+                      'id': str.is('_mce_caret'),
+                      'data-mce-bogus': str.is('1'),
+                      'data-mce-type': str.is('format-caret')
+                    },
+                    children: [
+                      s.element('strong', {
+                        children: [
+                          s.element('em', {
+                            children: [
+                              s.element('span', {
+                                attrs: {
+                                  style: str.is('text-decoration: underline;')
+                                },
+                                children: [
+                                  s.text(str.is(Zwsp.ZWSP))
+                                ]
+                              })
+                            ]
+                          })
+                        ]
+                      })
+                    ]
+                  })
+                ]
               })
             ]
           });
         })
       );
-      const selPath = browser.isFirefox() ? [ 0, 0, 0, 0 ] : [ 0, 0, 0, 0, 0, 0 ];
-      TinyAssertions.assertCursor(editor, selPath, 0);
+      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0, 0, 0 ], 0);
     };
 
     it('Backspace entire selection of block containing a single text format element', () => {
@@ -774,42 +753,30 @@ describe('browser.tinymce.core.delete.InlineFormatDelete', () => {
           return s.element('body', {
             children: [
               s.element('p', {
-                // firefox retains formats by default, so no new caret created
-                children: browser.isFirefox()
-                  ? [
-                    s.element('span', {
-                      attrs: {
-                        style: str.is('text-decoration: underline;')
-                      },
-                      children: [
-                        s.element('br', {})
-                      ]
-                    })
-                  ] : [
-                    s.element('span', {
-                      attrs: {
-                        'id': str.is('_mce_caret'),
-                        'data-mce-bogus': str.is('1'),
-                        'data-mce-type': str.is('format-caret')
-                      },
-                      children: [
-                        s.element('span', {
-                          attrs: {
-                            style: str.is('text-decoration: underline;')
-                          },
-                          children: [
-                            s.text(str.is(Zwsp.ZWSP))
-                          ]
-                        })
-                      ]
-                    })
-                  ]
+                children: [
+                  s.element('span', {
+                    attrs: {
+                      'id': str.is('_mce_caret'),
+                      'data-mce-bogus': str.is('1'),
+                      'data-mce-type': str.is('format-caret')
+                    },
+                    children: [
+                      s.element('span', {
+                        attrs: {
+                          style: str.is('text-decoration: underline;')
+                        },
+                        children: [
+                          s.text(str.is(Zwsp.ZWSP))
+                        ]
+                      })
+                    ]
+                  })
+                ]
               })
             ]
           });
         }));
-      const selPath = browser.isFirefox() ? [ 0, 0 ] : [ 0, 0, 0, 0 ];
-      TinyAssertions.assertCursor(editor, selPath, 0);
+      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0 ], 0);
     });
 
     it('Backspace selection starting at start of and ending after the end of format element containing non-text child', () => {
@@ -860,44 +827,31 @@ describe('browser.tinymce.core.delete.InlineFormatDelete', () => {
           return s.element('body', {
             children: [
               s.element('p', {
-                // firefox retains formats by default, so no new caret created
-                children: browser.isFirefox()
-                  ? [
-                    s.element('span', {
-                      attrs: {
-                        style: str.is('text-decoration: underline;')
-                      },
-                      children: [
-                        s.element('br', {})
-                      ]
-                    })
-                  ]
-                  : [
-                    s.element('span', {
-                      attrs: {
-                        'id': str.is('_mce_caret'),
-                        'data-mce-bogus': str.is('1'),
-                        'data-mce-type': str.is('format-caret')
-                      },
-                      children: [
-                        s.element('span', {
-                          attrs: {
-                            style: str.is('text-decoration: underline;')
-                          },
-                          children: [
-                            s.text(str.is(Zwsp.ZWSP))
-                          ]
-                        })
-                      ]
-                    })
-                  ]
+                children: [
+                  s.element('span', {
+                    attrs: {
+                      'id': str.is('_mce_caret'),
+                      'data-mce-bogus': str.is('1'),
+                      'data-mce-type': str.is('format-caret')
+                    },
+                    children: [
+                      s.element('span', {
+                        attrs: {
+                          style: str.is('text-decoration: underline;')
+                        },
+                        children: [
+                          s.text(str.is(Zwsp.ZWSP))
+                        ]
+                      })
+                    ]
+                  })
+                ]
               })
             ]
           });
         })
       );
-      const selPath = browser.isFirefox() ? [ 0, 0 ] : [ 0, 0, 0, 0 ];
-      TinyAssertions.assertCursor(editor, selPath, 0);
+      TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0 ], 0);
     });
 
     it('Backspace partial selection from start to middle of text format element should do nothing', () => {

--- a/modules/tinymce/src/core/test/ts/webdriver/delete/InlineFormatRetentionTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/delete/InlineFormatRetentionTest.ts
@@ -23,10 +23,9 @@ describe('webdriver.tinymce.core.delete.InlineFormatRetentionTest', () => {
     editor.setContent('<p><span style="text-decoration: underline;">abc</span></p><p>&nbsp;</p>');
     TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 3);
     await doNativeBackspace();
-    // firefox natively preserves formats for block deletion
-    TinyAssertions.assertContent(editor, browser.isFirefox() ? '<p><span style="text-decoration: underline;">&nbsp;</span></p><p>&nbsp;</p>' : '<p>&nbsp;</p><p>&nbsp;</p>');
+    TinyAssertions.assertContent(editor, '<p>&nbsp;</p><p>&nbsp;</p>');
     await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.text('d') ]);
-    TinyAssertions.assertContent(editor, browser.isFirefox() ? '<p><span style="text-decoration: underline;">d<br></span></p><p>&nbsp;</p>' : '<p><span style="text-decoration: underline;">d</span></p><p>&nbsp;</p>');
+    TinyAssertions.assertContent(editor, '<p><span style="text-decoration: underline;">d</span></p><p>&nbsp;</p>');
   });
 
   it('TINY-9302: Backspace partial selection of underlined text within block then typing will not produce unexpected formats', async () => {


### PR DESCRIPTION
Related Ticket: TINY-11828

Description of Changes:
it seems that Firefox aligned some behavior to the other browser

Pre-checks:
* [ ] ~Changelog entry added~
* [ ] ~Tests have been added (if applicable)~
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
