### PR TITLE
TINY-11659: override keying for context toolbar

### DIFF
--- a/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
@@ -64,7 +64,7 @@ export default (): void => {
           align: 'start',
           icon: 'chevron-left',
           onAction: (formApi) => {
-            formApi.hide();
+            formApi.back();
           }
         },
         {
@@ -97,7 +97,7 @@ export default (): void => {
           align: 'start',
           icon: 'chevron-left',
           onAction: (formApi) => {
-            formApi.hide();
+            formApi.back();
           }
         },
         {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextForm.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextForm.ts
@@ -31,18 +31,8 @@ const buildInitGroup = <T>(
     {
       title: Optional.none(),
       label: Optional.none(),
-      items: startCommands.asSpecs() as AlloySpec[]
+      items: [ ...startCommands.asSpecs() as AlloySpec[], memInput.asSpec(), ...endCommands.asSpecs() as AlloySpec[] ]
     },
-    {
-      title: Optional.none(),
-      label: Optional.none(),
-      items: [ memInput.asSpec() ]
-    },
-    {
-      title: Optional.none(),
-      label: Optional.none(),
-      items: endCommands.asSpecs() as AlloySpec[]
-    }
   ], (group) => group.items.length > 0);
 };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
@@ -177,7 +177,12 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
       initGroups,
       onEscape: Optional.none,
       cyclicKeying: true,
-      providers: sharedBackstage.providers
+      providers: sharedBackstage.providers,
+      overrideKeying: {
+        mode: 'menu',
+        selector: 'button, input, .tox-toolbar__group',
+        moveOnTab: true
+      }
     });
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -7,7 +7,7 @@ import {
   Behaviour, Boxes,
   Focusing,
   GuiFactory,
-  Keying, SketchSpec,
+  Keying, KeyingConfigSpec, SketchSpec,
   Tabstopping
 } from '@ephox/alloy';
 import { Arr, Optional, Result } from '@ephox/katamari';
@@ -35,6 +35,8 @@ export interface ToolbarSpec {
   readonly initGroups: ToolbarGroup[];
   readonly attributes?: Record<string, string>;
   readonly providers: UiFactoryBackstageProviders;
+
+  readonly overrideKeying?: KeyingConfigSpec;
 }
 
 export interface MoreDrawerToolbarSpec extends ToolbarSpec {
@@ -111,7 +113,7 @@ const getToolbarBehaviours = (toolbarSpec: ToolbarSpec, modeName: 'cyclic' | 'ac
   return Behaviour.derive([
     DisablingConfigs.toolbarButton(() => toolbarSpec.providers.checkUiComponentContext('any').shouldDisable),
     UiState.toggleOnReceive(() => toolbarSpec.providers.checkUiComponentContext('any')),
-    Keying.config({
+    Keying.config(toolbarSpec.overrideKeying ?? {
       // Tabs between groups
       mode: modeName,
       onEscape: toolbarSpec.onEscape,


### PR DESCRIPTION
Related Ticket: TINY-11659

Description of Changes:
* Consolidated toolbar context form groups into a single group with all items
* Added custom keying configuration for context toolbars to improve navigation
* Implemented menu-style navigation for buttons, inputs, and toolbar groups with tab support

TODO: 
* [ ] Figure out typing and passing the overrideKeying. The cyclicKeying and onEscape props still need to be passed but then are not used because of the override, so it needs a bit of cleaning. 

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated context forms now offer a dedicated "back" navigation action for more intuitive user interactions.
	- Streamlined toolbar groups by consolidating control items for a cleaner interface.
	- Enhanced keyboard navigation in toolbars, including improved tab behavior for better accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->