### PR TITLE
TINY-11368: revert close dropdowns on window scroll (#10037)

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11368-2024-12-06.yaml
+++ b/.changes/unreleased/tinymce-TINY-11368-2024-12-06.yaml
@@ -1,6 +1,0 @@
-project: tinymce
-kind: Improved
-body: Dialog menu dropdowns now close when the window is scrolled.
-time: 2024-12-06T14:35:39.09459+01:00
-custom:
-  Issue: TINY-11368

--- a/modules/tinymce/src/themes/silver/main/ts/ui/button/MenuButton.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/button/MenuButton.ts
@@ -1,4 +1,4 @@
-import { AlloyComponent, AlloyTriggers, Behaviour, Disabling, MementoRecord, SketchSpec, Tabstopping } from '@ephox/alloy';
+import { AlloyComponent, AlloyTriggers, Disabling, MementoRecord, SketchSpec, Tabstopping } from '@ephox/alloy';
 import { Dialog, Menu, Toolbar } from '@ephox/bridge';
 import { Arr, Cell, Optional } from '@ephox/katamari';
 import { Attribute, Class, Focus } from '@ephox/sugar';
@@ -12,16 +12,7 @@ import * as NestedMenus from '../menus/menu/NestedMenus';
 import { getSearchPattern } from '../menus/menu/searchable/SearchableMenu';
 import { ToolbarButtonClasses } from '../toolbar/button/ButtonClasses';
 
-type MenuButtonSpec = Omit<Toolbar.ToolbarMenuButton, 'type'>;
-
-interface MenuButtonConfig {
-  prefix: string;
-  backstage: UiFactoryBackstage;
-  role?: Optional<string>;
-  tabstopping?: boolean;
-  btnName?: string;
-  additionalBehaviours?: Behaviour.NamedConfiguredBehaviour<any, any, any>[];
-}
+export type MenuButtonSpec = Omit<Toolbar.ToolbarMenuButton, 'type'>;
 
 type FetchCallback = (success: (items: Menu.NestedMenuItemContents[]) => void) => void;
 
@@ -59,14 +50,7 @@ const getMenuButtonApi = (component: AlloyComponent): Toolbar.ToolbarMenuButtonI
   })
 });
 
-const renderMenuButton = (spec: MenuButtonSpec, {
-  prefix,
-  backstage,
-  btnName,
-  role = Optional.none(),
-  tabstopping = true,
-  additionalBehaviours = []
-}: MenuButtonConfig): SketchSpec => {
+const renderMenuButton = (spec: MenuButtonSpec, prefix: string, backstage: UiFactoryBackstage, role: Optional<string>, tabstopping = true, btnName?: string): SketchSpec => {
   return renderCommonDropdown({
     text: spec.text,
     icon: spec.icon,
@@ -105,8 +89,7 @@ const renderMenuButton = (spec: MenuButtonSpec, {
     presets: 'normal',
     classes: [],
     dropdownBehaviours: [
-      ...(tabstopping ? [ Tabstopping.config({ }) ] : []),
-      ...additionalBehaviours
+      ...(tabstopping ? [ Tabstopping.config({ }) ] : [])
     ],
     context: spec.context
   },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
@@ -112,7 +112,7 @@ const renderLeafLabel = ({
   selectedId,
   backstage
 }: RenderLeafLabelProps): SimpleSpec => {
-  const internalMenuButton = leaf.menu.map((btn) => renderMenuButton(btn, { prefix: 'tox-mbtn', backstage, tabstopping: visible }));
+  const internalMenuButton = leaf.menu.map((btn) => renderMenuButton(btn, 'tox-mbtn', backstage, Optional.none(), visible));
   const components = [ renderLabel(leaf.title) ];
   renderCustomStateIcon(leaf, components, backstage);
   internalMenuButton.each((btn) => components.push(btn));
@@ -206,7 +206,7 @@ const renderDirectoryLabel = ({
   noChildren,
   backstage
 }: RenderDirectoryLabelProps): SimpleSpec => {
-  const internalMenuButton = directory.menu.map((btn) => renderMenuButton(btn, { prefix: 'tox-mbtn', backstage }));
+  const internalMenuButton = directory.menu.map((btn) => renderMenuButton(btn, 'tox-mbtn', backstage, Optional.none()));
   const components: SimpleSpec[] = [
     {
       dom: {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
@@ -185,7 +185,7 @@ const renderCommonDropdown = <T>(
             }
           }),
         ]),
-        AddEventsBehaviour.config('close-on--window-resize', [
+        AddEventsBehaviour.config('update-dropdown-width-variable', [
           AlloyEvents.run(SystemEvents.windowResize(), (comp, _se) => AlloyDropdown.close(comp)),
         ]),
         AddEventsBehaviour.config('menubutton-update-display-text', [

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -4,9 +4,8 @@ import {
   AlloyComponent, AlloyEvents,
   FormField as AlloyFormField,
   AlloySpec, AlloyTriggers, Behaviour,
-  Dropdown,
   GuiFactory, Memento,
-  RawDomSchema, Replacing, SimpleOrSketchSpec, SketchSpec, SystemEvents, Tabstopping, Tooltipping
+  RawDomSchema, Replacing, SimpleOrSketchSpec, SketchSpec, Tabstopping, Tooltipping
 } from '@ephox/alloy';
 import { Dialog, Toolbar } from '@ephox/bridge';
 import { Fun, Merger, Optional, Type } from '@ephox/katamari';
@@ -278,19 +277,7 @@ export const renderFooterButton = (spec: FooterButtonSpec, buttonType: string, b
       fetch: getFetch(menuButtonSpec.items, getButton, backstage)
     };
 
-    const memButton = Memento.record(renderMenuButton(fixedSpec, {
-      prefix: ToolbarButtonClasses.Button,
-      backstage,
-      tabstopping: true,
-      btnName: spec.text.or(spec.tooltip).getOrUndefined(),
-      additionalBehaviours: [
-        AddEventsBehaviour.config('close-on--window-scroll', [
-          AlloyEvents.run(SystemEvents.windowScroll(), (comp, _se) => {
-            Dropdown.close(comp);
-          }),
-        ]),
-      ]
-    }));
+    const memButton = Memento.record(renderMenuButton(fixedSpec, ToolbarButtonClasses.Button, backstage, Optional.none(), true, spec.text.or(spec.tooltip).getOrUndefined()));
 
     return memButton.asSpec();
   } else if (isNormalFooterButtonSpec(spec, buttonType)) {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/SilverMenubar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/SilverMenubar.ts
@@ -56,12 +56,12 @@ const factory: UiSketcher.SingleSketchFactory<SilverMenubarDetail, SilverMenubar
       // Convert to an internal bridge spec
       const internal = Toolbar.createMenuButton(buttonSpec).mapError((errInfo) => StructureSchema.formatError(errInfo)).getOrDie();
 
-      return renderMenuButton(internal, {
-        prefix: MenuButtonClasses.Button,
-        backstage: spec.backstage,
+      return renderMenuButton(internal,
+        MenuButtonClasses.Button,
+        spec.backstage,
         // https://www.w3.org/TR/wai-aria-practices/examples/menubar/menubar-2/menubar-2.html
-        role: Optional.some('menuitem')
-      });
+        Optional.some('menuitem')
+      );
     });
 
     Replacing.set(comp, newMenus);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
@@ -74,7 +74,7 @@ const types: Record<string, BridgeRenderFn<any>> = {
 
   menubutton: renderFromBridge(
     Toolbar.createMenuButton,
-    (s, backstage, _, btnName) => renderMenuButton(s, { prefix: ToolbarButtonClasses.Button, backstage, tabstopping: false, btnName })
+    (s, backstage, _, btnName) => renderMenuButton(s, ToolbarButtonClasses.Button, backstage, Optional.none(), false, btnName)
   ),
 
   splitbutton: renderFromBridge(

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonPlaceholderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonPlaceholderTest.ts
@@ -45,10 +45,9 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonPlaceholder
             collapseSearchResults: true
           }, store)
         },
-        {
-          prefix: 'prefix',
-          backstage: helpers.access().extras.backstages.popup
-        }
+        'prefix',
+        helpers.access().extras.backstages.popup,
+        Optional.none()
       )
     )
   );

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonTest.ts
@@ -41,10 +41,9 @@ describe('headless.tinymce.themes.silver.toolbar.SearchableMenuButtonTest', () =
             collapseSearchResults: true
           }, store)
         },
-        {
-          prefix: 'prefix',
-          backstage: extrasHook.access().extras.backstages.popup
-        }
+        'prefix',
+        extrasHook.access().extras.backstages.popup,
+        Optional.none()
       )
     )
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
@@ -144,7 +144,7 @@ describe('headless.tinymce.themes.silver.toolbar.ToolbarButtonsTest', () => {
               store.adder('onSetup.4')();
               return Fun.noop;
             }
-          }, { prefix: 'tox-mbtn', backstage: extrasHook.access().extras.backstages.popup })
+          }, 'tox-mbtn', extrasHook.access().extras.backstages.popup, Optional.none())
         ]
       }
     ]

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/toolbar/SearchableMenuTypingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/toolbar/SearchableMenuTypingTest.ts
@@ -115,10 +115,9 @@ describe('webdriver.tinymce.themes.silver.toolbar.SearchableMenuTypingTest', () 
             collapseSearchResults: false
           }, store)
         },
-        {
-          prefix: 'prefix',
-          backstage: extrasHook.access().extras.backstages.popup
-        }
+        'prefix',
+        extrasHook.access().extras.backstages.popup,
+        Optional.none()
       )
     )
   );


### PR DESCRIPTION
This reverts commit 5f4049f3045f4a8cf751a3dbb68a017738e119d6.

Related Ticket: TINY-11368

Description of Changes:
Reverting changes because of the bug reported here: https://ephocks.atlassian.net/browse/TINY-11368?focusedCommentId=144793

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
