### PR TITLE
TINY-11837: Fixed Safari test issues

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterRemoveTest.ts
@@ -1,5 +1,4 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { PlatformDetection } from '@ephox/sand';
 import { LegacyUnit, TinyApis, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -9,8 +8,6 @@ import { ZWSP } from 'tinymce/core/text/Zwsp';
 import * as KeyUtils from '../module/test/KeyUtils';
 
 describe('browser.tinymce.core.FormatterRemoveTest', () => {
-  const browser = PlatformDetection.detect().browser;
-
   const hook = TinyHooks.bddSetupLight<Editor>({
     indent: false,
     extended_valid_elements: 'b[style],i,span[style|contenteditable|class]',
@@ -375,14 +372,7 @@ describe('browser.tinymce.core.FormatterRemoveTest', () => {
     editor.setContent(initialContent);
     LegacyUnit.setSelection(editor, 'p:nth-child(2) b', 0, 'p:last-of-type b', 3);
     editor.formatter.remove('format');
-    if (browser.isSafari()) {
-      // Safari 17 will not select the non-editable content
-      // Selection only covers editable "def" and removes format correctly
-      const expectedContent = '<p>abc</p><p>def</p><p contenteditable="false"><b>ghj</b></p>';
-      TinyAssertions.assertContent(editor, expectedContent);
-    } else {
-      TinyAssertions.assertContent(editor, initialContent);
-    }
+    TinyAssertions.assertContent(editor, initialContent);
   });
 
   it('contentEditable: true inside contentEditable: false', () => {

--- a/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/SelectionTest.ts
@@ -1,5 +1,4 @@
 import { context, describe, it } from '@ephox/bedrock-client';
-import { PlatformDetection } from '@ephox/sand';
 import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -11,9 +10,6 @@ import * as CaretContainer from 'tinymce/core/caret/CaretContainer';
 import * as Zwsp from 'tinymce/core/text/Zwsp';
 
 describe('browser.tinymce.core.dom.SelectionTest', () => {
-  const platform = PlatformDetection.detect();
-  const isSafari = platform.browser.isSafari();
-
   const hook = TinyHooks.bddSetupLight<Editor>({
     add_unload_trigger: false,
     entities: 'raw',
@@ -1380,8 +1376,7 @@ describe('browser.tinymce.core.dom.SelectionTest', () => {
       soffset: 1,
       fpath: [ 1, 0 ],
       foffset: 1,
-      // TINY-10639: Safari does not allow selection over non-editable content
-      expected: isSafari
+      expected: false
     }));
 
     it('TINY-9477: isEditable on selected noneditable table cells should be true since parent is editable', testIsEditableSelection({


### PR DESCRIPTION
Related Ticket: TINY-11837

Description of Changes:
* This fixes some tests that are broken on latest Safari

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Streamlined test cases by removing browser-specific conditions to ensure consistent validation of content formatting and selection behavior across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->