### PR TITLE
TINY-11748: Added subtoolbar support

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11748-2025-02-18.yaml
+++ b/.changes/unreleased/tinymce-TINY-11748-2025-02-18.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: New subtoolbar support for context toolbars.
+time: 2025-02-18T09:03:17.435561+01:00
+custom:
+    Issue: TINY-11748

--- a/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextToolbar.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextToolbar.ts
@@ -12,7 +12,7 @@ export interface ToolbarGroupSpec {
 }
 
 export interface ContextToolbarLaunchButtonApi extends BaseToolbarButtonSpec<BaseToolbarButtonInstanceApi> {
-  type: 'contexttoolbarbutton';
+  type?: 'contexttoolbarbutton';
 }
 
 export interface ContextToolbarSpec extends ContextBarSpec {

--- a/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextToolbar.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/content/ContextToolbar.ts
@@ -2,6 +2,7 @@ import { FieldSchema, StructureSchema, ValueType } from '@ephox/boulder';
 import { Arr, Optional, Result, Type } from '@ephox/katamari';
 
 import * as ComponentSchema from '../../core/ComponentSchema';
+import { baseToolbarButtonFields, BaseToolbarButtonInstanceApi, BaseToolbarButtonSpec } from '../toolbar/ToolbarButton';
 import { ContextBar, contextBarFields, ContextBarSpec } from './ContextBar';
 
 export interface ToolbarGroupSpec {
@@ -10,8 +11,13 @@ export interface ToolbarGroupSpec {
   items: string[];
 }
 
+export interface ContextToolbarLaunchButtonApi extends BaseToolbarButtonSpec<BaseToolbarButtonInstanceApi> {
+  type: 'contexttoolbarbutton';
+}
+
 export interface ContextToolbarSpec extends ContextBarSpec {
   type?: 'contexttoolbar';
+  launch?: ContextToolbarLaunchButtonApi;
   items: string | ToolbarGroupSpec[];
 }
 
@@ -23,11 +29,17 @@ export interface ToolbarGroup {
 
 export interface ContextToolbar extends ContextBar {
   type: 'contexttoolbar';
+  launch: Optional<ContextToolbarLaunchButtonApi>;
   items: string | ToolbarGroup[];
 }
 
+const launchButtonFields = baseToolbarButtonFields.concat([
+  ComponentSchema.defaultedType('contexttoolbarbutton')
+]);
+
 const contextToolbarSchema = StructureSchema.objOf([
   ComponentSchema.defaultedType('contexttoolbar'),
+  FieldSchema.optionObjOf('launch', launchButtonFields),
   FieldSchema.requiredOf('items', StructureSchema.oneOf([
     ValueType.string,
     StructureSchema.arrOfObj([
@@ -46,6 +58,7 @@ const toolbarGroupBackToSpec = (toolbarGroup: ToolbarGroup): ToolbarGroupSpec =>
 
 export const contextToolbarToSpec = (contextToolbar: ContextToolbar): ContextToolbarSpec => ({
   ...contextToolbar,
+  launch: contextToolbar.launch.getOrUndefined(),
   items: Type.isString(contextToolbar.items) ? contextToolbar.items : Arr.map(contextToolbar.items, toolbarGroupBackToSpec)
 });
 

--- a/modules/tinymce/src/core/demo/ts/demo/ContextToolbarDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContextToolbarDemo.ts
@@ -29,7 +29,7 @@ export default (): void => {
             items: [ 'undo', 'redo' ]
           },
           {
-            items: [ 'undo', 'italic' ]
+            items: [ 'undo', 'italic', 'subbar1' ]
           }
         ],
         position: 'line',
@@ -41,6 +41,30 @@ export default (): void => {
         items: 'bold italic | undo redo',
         position: 'line',
         scope: 'editor'
+      });
+
+      ed.ui.registry.addContextToolbar('subbar1', {
+        launch: {
+          type: 'contexttoolbarbutton',
+          text: 'Subbar 1'
+        },
+        items: 'navigateback bold italic | undo redo | subbar2'
+      });
+
+      ed.ui.registry.addContextToolbar('subbar2', {
+        launch: {
+          type: 'contexttoolbarbutton',
+          text: 'Subbar 2'
+        },
+        items: 'navigateback bold italic | undo redo | subbar3'
+      });
+
+      ed.ui.registry.addContextToolbar('subbar3', {
+        launch: {
+          type: 'contexttoolbarbutton',
+          text: 'Subbar 3'
+        },
+        items: 'navigateback bold italic | undo redo'
       });
     }
   };

--- a/modules/tinymce/src/core/demo/ts/demo/ContextToolbarDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContextToolbarDemo.ts
@@ -44,26 +44,17 @@ export default (): void => {
       });
 
       ed.ui.registry.addContextToolbar('subbar1', {
-        launch: {
-          type: 'contexttoolbarbutton',
-          text: 'Subbar 1'
-        },
+        launch: { text: 'Subbar 1' },
         items: 'navigateback bold italic | undo redo | subbar2'
       });
 
       ed.ui.registry.addContextToolbar('subbar2', {
-        launch: {
-          type: 'contexttoolbarbutton',
-          text: 'Subbar 2'
-        },
+        launch: { text: 'Subbar 2' },
         items: 'navigateback bold italic | undo redo | subbar3'
       });
 
       ed.ui.registry.addContextToolbar('subbar3', {
-        launch: {
-          type: 'contexttoolbarbutton',
-          text: 'Subbar 3'
-        },
+        launch: { text: 'Subbar 3' },
         items: 'navigateback bold italic | undo redo'
       });
     }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
@@ -145,9 +145,9 @@ export const renderContextFormSizeInput = (
 
   const controlLifecycleHandlers = [
     onControlAttached({
+      onBeforeSetup: (comp) => SelectorFind.descendant<HTMLElement>(comp.element, 'input').each(Focus.focus),
       onSetup: ctx.onSetup,
-      getApi,
-      onBeforeSetup: (comp) => SelectorFind.descendant<HTMLElement>(comp.element, 'input').each(Focus.focus)
+      getApi
     }, editorOffCell),
     onContextFormControlDetached({ getApi }, editorOffCell, valueState),
   ];

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
@@ -144,7 +144,11 @@ export const renderContextFormSizeInput = (
   const editorOffCell = Cell(Fun.noop);
 
   const controlLifecycleHandlers = [
-    onControlAttached( { onSetup: ctx.onSetup, getApi }, editorOffCell),
+    onControlAttached({
+      onSetup: ctx.onSetup,
+      getApi,
+      onBeforeSetup: (comp) => SelectorFind.descendant<HTMLElement>(comp.element, 'input').each(Focus.focus)
+    }, editorOffCell),
     onContextFormControlDetached({ getApi }, editorOffCell, valueState),
   ];
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
@@ -144,21 +144,23 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
     ])
   });
 
-  const getScopes: () => ScopedToolbars = Thunk.cached(() => ToolbarScopes.categorise(registryContextToolbars, (toolbarApi) => {
+  const navigate = (toolbarApi: InlineContent.ContextForm | InlineContent.ContextToolbar) => {
     // ASSUMPTION: This should only ever show one context toolbar since it's used for context forms hence [toolbarApi]
     const alloySpec = buildToolbar([ toolbarApi ]);
     AlloyTriggers.emitWith(contextbar, forwardSlideEvent, {
       forwardContents: wrapInPopDialog(alloySpec)
     });
-  }));
+  };
+
+  const getScopes: () => ScopedToolbars = Thunk.cached(() => ToolbarScopes.categorise(registryContextToolbars, navigate));
 
   const buildContextToolbarGroups = (allButtons: Record<string, ContextToolbarButtonType>, ctx: InlineContent.ContextToolbarSpec) => {
-    return identifyButtons(editor, { buttons: allButtons, toolbar: ctx.items, allowToolbarGroups: false }, extras.backstage, Optional.some([ 'form:' ]));
+    return identifyButtons(editor, { buttons: allButtons, toolbar: ctx.items, allowToolbarGroups: false }, extras.backstage, Optional.some([ 'form:', 'toolbar:' ]));
   };
 
   const buildContextFormGroups = (ctx: InlineContent.ContextForm, providers: UiFactoryBackstageProviders) => ContextForm.buildInitGroups(ctx, providers);
 
-  const buildToolbar = (toolbars: Array<ContextType>): AlloySpec => {
+  const buildToolbar = (toolbars: ContextType[]): AlloySpec => {
     const { buttons } = editor.ui.registry.getAll();
     const scopes = getScopes();
     const allButtons: Record<string, ContextToolbarButtonType> = { ...buttons, ...scopes.formNavigators };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarScopes.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarScopes.ts
@@ -13,8 +13,10 @@ export interface ScopedToolbars {
   readonly formNavigators: Record<string, Toolbar.ToolbarButtonSpec | Toolbar.ToolbarToggleButtonSpec>; // this stays API due to toolbar applying bridge
 }
 
-const categorise = (contextToolbars: Record<string, ContextSpecType>, navigate: (destForm: InlineContent.ContextForm) => void): ScopedToolbars => {
-
+const categorise = (
+  contextToolbars: Record<string, ContextSpecType>,
+  navigate: (destForm: InlineContent.ContextForm | InlineContent.ContextToolbar) => void
+): ScopedToolbars => {
   // TODO: Use foldl/foldr and avoid as much mutation.
   const forms: Record<string, InlineContent.ContextForm> = { };
   const inNodeScope: Array<ContextType> = [ ];
@@ -47,6 +49,16 @@ const categorise = (contextToolbars: Record<string, ContextSpecType>, navigate: 
 
   const registerToolbar = (key: string, toolbarSpec: InlineContent.ContextToolbarSpec) => {
     InlineContent.createContextToolbar(toolbarSpec).each((contextToolbar) => {
+      if (contextToolbar.launch.isSome()) {
+        formNavigators['toolbar:' + key + ''] = {
+          ...toolbarSpec.launch,
+          type: 'button',
+          onAction: () => {
+            navigate(contextToolbar);
+          }
+        };
+      }
+
       if (toolbarSpec.scope === 'editor') {
         inEditorScope.push(contextToolbar);
       } else {
@@ -59,7 +71,7 @@ const categorise = (contextToolbars: Record<string, ContextSpecType>, navigate: 
   const keys = Obj.keys(contextToolbars);
   Arr.each(keys, (key) => {
     const toolbarApi = contextToolbars[key];
-    // TS wouldn't really let me do the ternary I wanted :(
+
     if (toolbarApi.type === 'contextform' || toolbarApi.type === 'contextsliderform' || toolbarApi.type === 'contextsizeinputform') {
       registerForm(key, toolbarApi);
     } else if (toolbarApi.type === 'contexttoolbar') {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -99,7 +99,7 @@ const renderContextToolbar = (spec: ContextToolbarSpec): SketchSpec => {
               Focus.active(SugarShadowDom.getRootNode(comp.element)).fold(
                 () => Focus.focus(f),
                 (active) => {
-                  // We need this extra check since if the focus is aleady on the iframe we don't want to call focus on on it again since that closes the context toolbar
+                  // We need this extra check since if the focus is aleady on the iframe we don't want to call focus on it again since that closes the context toolbar
                   if (!Compare.eq(active, f)) {
                     Focus.focus(f);
                   }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/NavigateBackBespokeButton.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/NavigateBackBespokeButton.ts
@@ -1,0 +1,29 @@
+import { AlloyEvents, AlloyTriggers, SketchSpec } from '@ephox/alloy';
+import { StructureSchema } from '@ephox/boulder';
+import { Toolbar } from '@ephox/bridge';
+import { Fun } from '@ephox/katamari';
+
+import Editor from 'tinymce/core/api/Editor';
+
+import { UiFactoryBackstage } from '../../backstage/Backstage';
+import * as ButtonEvents from '../toolbar/button/ButtonEvents';
+import * as ToolbarButtons from '../toolbar/button/ToolbarButtons';
+import * as ContextUi from './ContextUi';
+
+export const createNavigateBackButton = (editor: Editor, backstage: UiFactoryBackstage): SketchSpec => {
+  const bridged = StructureSchema.getOrDie(
+    Toolbar.createToolbarButton({
+      type: 'button',
+      icon: 'chevron-left',
+      tooltip: 'Back',
+      onAction: Fun.noop
+    })
+  );
+
+  return ToolbarButtons.renderToolbarButtonWith(bridged, backstage.shared.providers, [
+    AlloyEvents.run<ButtonEvents.InternalToolbarButtonExecuteEvent<unknown>>(ButtonEvents.internalToolbarButtonExecute, (comp) => {
+      AlloyTriggers.emit(comp, ContextUi.backSlideEvent);
+    })
+  ]);
+};
+

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -24,7 +24,7 @@ import { ToolbarButtonClasses, ViewButtonClasses } from '../toolbar/button/Butto
 import { formActionEvent, formCancelEvent, formSubmitEvent } from './FormEvents';
 
 type Behaviours = Behaviour.NamedConfiguredBehaviour<any, any, any>[];
-type AlloyButtonSpec = Parameters<typeof AlloyButton['sketch']>[0];
+export type AlloyButtonSpec = Parameters<typeof AlloyButton['sketch']>[0];
 
 type ButtonSpec = Omit<Dialog.Button, 'type'>;
 type FooterToggleButtonSpec = Omit<Dialog.DialogFooterToggleButton, 'type'>;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -24,7 +24,7 @@ import { ToolbarButtonClasses, ViewButtonClasses } from '../toolbar/button/Butto
 import { formActionEvent, formCancelEvent, formSubmitEvent } from './FormEvents';
 
 type Behaviours = Behaviour.NamedConfiguredBehaviour<any, any, any>[];
-export type AlloyButtonSpec = Parameters<typeof AlloyButton['sketch']>[0];
+type AlloyButtonSpec = Parameters<typeof AlloyButton['sketch']>[0];
 
 type ButtonSpec = Omit<Dialog.Button, 'type'>;
 type FooterToggleButtonSpec = Omit<Dialog.DialogFooterToggleButton, 'type'>;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
@@ -9,6 +9,7 @@ import { getToolbarMode, ToolbarGroupOption, ToolbarMode } from '../../api/Optio
 import { UiFactoryBackstage } from '../../backstage/Backstage';
 import { ToolbarConfig } from '../../Render';
 import { renderMenuButton } from '../button/MenuButton';
+import { createNavigateBackButton } from '../context/NavigateBackBespokeButton';
 import { createAlignButton } from '../core/complex/AlignBespoke';
 import { createBlocksButton } from '../core/complex/BlocksBespoke';
 import { createFontFamilyButton } from '../core/complex/FontFamilyBespoke';
@@ -121,7 +122,8 @@ const bespokeButtons: Record<string, (editor: Editor, backstage: UiFactoryBackst
   fontsizeinput: createFontSizeInputButton,
   fontfamily: createFontFamilyButton,
   blocks: createBlocksButton,
-  align: createAlignButton
+  align: createAlignButton,
+  navigateback: createNavigateBackButton
 };
 
 const removeUnusedDefaults = (buttons: RenderToolbarConfig['buttons']) => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPositionPriorityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPositionPriorityTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { InlineContent } from '@ephox/bridge';
-import { Arr, Fun } from '@ephox/katamari';
+import { Arr, Fun, Optional } from '@ephox/katamari';
 import { assert } from 'chai';
 
 import { ContextType } from 'tinymce/themes/silver/ui/context/ContextToolbar';
@@ -9,6 +9,7 @@ import { filterByPositionForAncestorNode, filterByPositionForStartNode } from 't
 describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLookupPositionPriorityTest', () => {
   const createToolbars = (positions: InlineContent.ContextPosition[]): ContextType[] => Arr.map(positions, (p) => ({
     type: 'contexttoolbar',
+    launch: Optional.none(),
     items: 'bold italic',
     predicate: Fun.always,
     position: p,

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
@@ -10,6 +10,7 @@ import { matchStartNode } from 'tinymce/themes/silver/ui/context/ContextToolbarL
 describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLookupPrioritisationTest', () => {
   const createToolbar = (items: string): InlineContent.ContextToolbar => ({
     type: 'contexttoolbar',
+    launch: Optional.none(),
     items,
     predicate: Fun.always,
     position: 'selection',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
@@ -68,9 +68,12 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
 
     const pNavigateBackByMouse = async (index: number) => {
       Mouse.clickOn(SugarBody.body(), '.tox-tbtn[aria-label="Back"]');
-      await pWaitForToolbarState(index);
 
-      if (index === 0) {
+      const indexAfter = index - 1;
+
+      await pWaitForToolbarState(indexAfter);
+
+      if (indexAfter === 1) {
         UiFinder.notExists(SugarBody.body(), '.tox-tbtn[aria-label="Back"]');
       }
 
@@ -87,33 +90,34 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
 
       Keyboard.activeKeystroke(SugarDocument.getDocument(), Keys.enter());
 
-      await pWaitForToolbarState(index + 1);
+      const indexAfter = index + 1;
+
+      await pWaitForToolbarState(indexAfter);
 
       FocusTools.isOnSelector(
-        `Should move focus to back button on toolbar ${index}`,
+        `Should move focus to back button on toolbar ${indexAfter}`,
         SugarDocument.getDocument(),
         '.tox-tbtn[aria-label="Back"]'
       );
     };
 
     const pNavigateBackByKeyboard = async (index: number) => {
-      if (index < 3) {
-        Keyboard.activeKeystroke(SugarDocument.getDocument(), Keys.left());
-        Keyboard.activeKeystroke(SugarDocument.getDocument(), Keys.left());
-      }
-
+      Keyboard.activeKeystroke(SugarDocument.getDocument(), Keys.left());
+      Keyboard.activeKeystroke(SugarDocument.getDocument(), Keys.left());
       Keyboard.activeKeystroke(SugarDocument.getDocument(), Keys.enter());
 
-      await pWaitForToolbarState(index);
+      const indexAfter = index - 1;
 
-      if (index === 0) {
+      await pWaitForToolbarState(indexAfter);
+
+      if (indexAfter === 1) {
         UiFinder.notExists(SugarBody.body(), '.tox-tbtn[aria-label="Back"]');
       }
 
       FocusTools.isOnSelector(
-        `Should retain focus to subtoolbar button ${index}`,
+        `Should retain focus to subtoolbar button ${indexAfter}`,
         SugarDocument.getDocument(),
-        `.tox-pop .tox-tbtn[data-mce-name="test-subtoolbar${index}"]`
+        `.tox-pop .tox-tbtn[data-mce-name="test-subtoolbar${indexAfter}"]`
       );
     };
 
@@ -129,7 +133,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
         await pNavigateDownInToolbarByMouse(i);
       }
 
-      for (let i = 3; i >= 1; i--) {
+      for (let i = 4; i >= 2; i--) {
         await pNavigateBackByMouse(i);
       }
     });
@@ -147,7 +151,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
         await pNavigateDownInToolbarByKeyboard(i);
       }
 
-      for (let i = 3; i >= 1; i--) {
+      for (let i = 4; i >= 2; i--) {
         await pNavigateBackByKeyboard(i);
       }
     });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
@@ -1,6 +1,6 @@
-import { TestStore, UiFinder, Waiter } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
-import { SugarBody } from '@ephox/sugar';
+import { FocusTools, Keyboard, Keys, Mouse, TestStore, UiFinder, Waiter } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -16,10 +16,19 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
       });
       ed.ui.registry.addContextToolbar('test-toolbar', {
         predicate: (node) => node.nodeName.toLowerCase() === 'a',
-        items: 'alpha'
+        items: 'alpha test-subtoolbar1'
       });
+
+      for (let i = 1; i < 4; i++) {
+        ed.ui.registry.addContextToolbar(`test-subtoolbar${i}`, {
+          launch: {
+            text: `Subtoolbar ${i}`
+          },
+          items: [ 'navigateback', 'alpha', 'test-subtoolbar' + (i + 1) ].join(' ')
+        });
+      }
     }
-  }, []);
+  }, [], true);
 
   it('TBA: Moving selection away from the context toolbar predicate should make it disappear', async () => {
     const editor = hook.editor();
@@ -37,5 +46,110 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
       'Wait for dialog to disappear after nodeChange',
       () => UiFinder.notExists(SugarBody.body(), '.tox-pop')
     );
+  });
+
+  context('subtoolbars', () => {
+    const pWaitForToolbarState = async (index: number) => {
+      if (index === 4) {
+        await UiFinder.pWaitFor(`Waiting for last toolbar`, SugarBody.body(), `.tox-pop .tox-tbtn[data-mce-name="alpha"]:last-child`);
+      } else {
+        await UiFinder.pWaitFor(`Waiting for toolbar${index}`, SugarBody.body(), `.tox-pop .tox-tbtn[data-mce-name="test-subtoolbar${index}"]`);
+      }
+
+      UiFinder.notExists(SugarBody.body(), `.tox-tbtn[data-mce-name="test-subtoolbar${index - 1}"]`);
+      UiFinder.notExists(SugarBody.body(), `.tox-tbtn[data-mce-name="test-subtoolbar${index + 1}"]`);
+    };
+
+    const pNavigateDownInToolbarByMouse = async (index: number) => {
+      Mouse.clickOn(SugarBody.body(), `.tox-tbtn[data-mce-name="test-subtoolbar${index}"]`);
+      await pWaitForToolbarState(index + 1);
+      FocusTools.isOnSelector('Should remain editor iframe', SugarDocument.getDocument(), 'iframe');
+    };
+
+    const pNavigateBackByMouse = async (index: number) => {
+      Mouse.clickOn(SugarBody.body(), '.tox-tbtn[aria-label="Back"]');
+      await pWaitForToolbarState(index);
+
+      if (index === 0) {
+        UiFinder.notExists(SugarBody.body(), '.tox-tbtn[aria-label="Back"]');
+      }
+
+      FocusTools.isOnSelector('Should remain editor iframe', SugarDocument.getDocument(), 'iframe');
+    };
+
+    const pNavigateDownInToolbarByKeyboard = async (index: number) => {
+      if (index === 1) {
+        Keyboard.activeKeystroke(SugarDocument.getDocument(), Keys.right());
+      } else {
+        Keyboard.activeKeystroke(SugarDocument.getDocument(), Keys.right());
+        Keyboard.activeKeystroke(SugarDocument.getDocument(), Keys.right());
+      }
+
+      Keyboard.activeKeystroke(SugarDocument.getDocument(), Keys.enter());
+
+      await pWaitForToolbarState(index + 1);
+
+      FocusTools.isOnSelector(
+        `Should move focus to back button on toolbar ${index}`,
+        SugarDocument.getDocument(),
+        '.tox-tbtn[aria-label="Back"]'
+      );
+    };
+
+    const pNavigateBackByKeyboard = async (index: number) => {
+      if (index < 3) {
+        Keyboard.activeKeystroke(SugarDocument.getDocument(), Keys.left());
+        Keyboard.activeKeystroke(SugarDocument.getDocument(), Keys.left());
+      }
+
+      Keyboard.activeKeystroke(SugarDocument.getDocument(), Keys.enter());
+
+      await pWaitForToolbarState(index);
+
+      if (index === 0) {
+        UiFinder.notExists(SugarBody.body(), '.tox-tbtn[aria-label="Back"]');
+      }
+
+      FocusTools.isOnSelector(
+        `Should retain focus to subtoolbar button ${index}`,
+        SugarDocument.getDocument(),
+        `.tox-pop .tox-tbtn[data-mce-name="test-subtoolbar${index}"]`
+      );
+    };
+
+    it('TINY-11748: Launch button should be able to navigate to a context toolbars and navigateback', async () => {
+      const editor = hook.editor();
+
+      editor.setContent('<p>One <a href="http://tiny.cloud">link</a> Two</p>');
+      TinySelections.setCursor(editor, [ 0, 1, 0 ], 'l'.length);
+
+      await UiFinder.pWaitFor('Waiting for toolbar', SugarBody.body(), '.tox-pop');
+
+      for (let i = 1; i < 4; i++) {
+        await pNavigateDownInToolbarByMouse(i);
+      }
+
+      for (let i = 3; i >= 1; i--) {
+        await pNavigateBackByMouse(i);
+      }
+    });
+
+    it('TINY-11748: Launch button should be able to navigate to a context toolbars and navigateback and retain toolbar focus', async () => {
+      const editor = hook.editor();
+
+      editor.setContent('<p>One <a href="http://tiny.cloud">link</a> Two</p>');
+      TinySelections.setCursor(editor, [ 0, 1, 0 ], 'l'.length);
+
+      await UiFinder.pWaitFor('Waiting for toolbar', SugarBody.body(), '.tox-pop');
+      FocusTools.setFocus(SugarDocument.getDocument(), '.tox-tbtn[data-mce-name="alpha"]');
+
+      for (let i = 1; i < 4; i++) {
+        await pNavigateDownInToolbarByKeyboard(i);
+      }
+
+      for (let i = 3; i >= 1; i--) {
+        await pNavigateBackByKeyboard(i);
+      }
+    });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-11748

Description of Changes:
* Adds a new launch property to context toolbars that can be used to launch sub toolbars

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Subtoolbar support has been added to context toolbars, enabling advanced multi-level editing options.
  - A new “Back” button is introduced for effortless navigation between toolbar levels.
  - Additional subtoolbar configurations now offer context-specific editing controls.
  - Improved focus management ensures input fields activate promptly, delivering a smoother editing experience.
  - Overall, these enhancements provide a more dynamic and user-friendly editor interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->