### PR TITLE
TINY-11843: Make docs team owner of changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,5 +8,5 @@
 /modules/katamari/ @tinymce/tinymce-reviewers @tinymce/integrations-team
 
 # Changelogs should include docs team
-/.changes/ @tinymce/tinymce-reviewers @tinymce/documentation-team
+/.changes/tinymce/ @tinymce/tinymce-reviewers @tinymce/documentation-team
 **/CHANGELOG.md @tinymce/tinymce-reviewers @tinymce/documentation-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,7 @@
 
 # Katamari changes should include the integrations team as well
 /modules/katamari/ @tinymce/tinymce-reviewers @tinymce/integrations-team
+
+# Changelogs should include docs team
+/.changes/ @tinymce/tinymce-reviewers @tinymce/documentation-team
+**/CHANGELOG.md @tinymce/tinymce-reviewers @tinymce/documentation-team


### PR DESCRIPTION
Related Ticket: TINY-11843

Description of Changes:
* Make docs team owner of changes

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced internal oversight to ensure our changelog documentation maintains a consistent and high-quality standard for clearer future release information.
  - Added the documentation team as code owners for changelogs in the `/changes/tinymce/` directory and for all `CHANGELOG.md` files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->