### PR TITLE
TINY-11763: fix jumping cursor on delete within list

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11763-2025-02-19.yaml
+++ b/.changes/unreleased/tinymce-TINY-11763-2025-02-19.yaml
@@ -1,7 +1,6 @@
 project: tinymce
 kind: Fixed
 body: Deleting an empty block within <li> would move cursor at the end of the <li>.
-  Deleting an empty block that is between two lists would throw an error when all of the elements were nested inside the same <li>.
 time: 2025-02-19T22:32:09.312262+01:00
 custom:
   Issue: TINY-11763

--- a/.changes/unreleased/tinymce-TINY-11763-2025-02-19.yaml
+++ b/.changes/unreleased/tinymce-TINY-11763-2025-02-19.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Deleting an empty block within <li> would move cursor at the end of the <li>.
+  Deleting an empty block that is between two lists would throw an error when all of the elements were nested inside the same <li>.
+time: 2025-02-19T22:32:09.312262+01:00
+custom:
+  Issue: TINY-11763

--- a/.changes/unreleased/tinymce-TINY-11763-2025-02-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-11763-2025-02-24.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Deleting an empty block that is between two lists would throw an error when
+  all of the elements were nested inside the same <li>.
+time: 2025-02-24T09:28:23.00493+01:00
+custom:
+  Issue: TINY-11763

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteFromBlockIntoLiTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/BackspaceDeleteFromBlockIntoLiTest.ts
@@ -144,4 +144,82 @@ describe('browser.tinymce.plugins.lists.BackspaceDeleteFromBlockIntoLiTest', () 
     TinyContentActions.keystroke(editor, Keys.delete());
     TinyAssertions.assertContent(editor, '<ol><li>aaa</li><li>ccc</li></ol>');
   });
+
+  it('TINY-11763: backspace from empty div into same li', () => {
+    const editor = hook.editor();
+    editor.setContent('<ul>' +
+        '<li>' +
+          '<div>' +
+            '<strong>One</strong>' +
+            '<div><br></div>' +
+          '</div>' +
+          '<div><strong>Two</strong></div>' +
+        '</li>' +
+      '</ul>');
+    TinySelections.setCursor(editor, [ 0, 0, 0, 1 ], 0);
+    TinyContentActions.keystroke(editor, Keys.backspace());
+
+    TinyAssertions.assertContent(editor, '<ul>' +
+      '<li>' +
+        '<div>' +
+          '<strong>One</strong>' +
+        '</div>' +
+        '<div><strong>Two</strong></div>' +
+      '</li>' +
+    '</ul>');
+    TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0, 0 ], 'One'.length);
+  });
+
+  it('TINY-11763: delete from empty div into same li', () => {
+    const editor = hook.editor();
+    editor.setContent('<ul>' +
+        '<li>' +
+          '<div>' +
+            '<strong>One</strong>' +
+            '<div><br></div>' +
+          '</div>' +
+          '<div><strong>Two</strong></div>' +
+        '</li>' +
+      '</ul>');
+    TinySelections.setCursor(editor, [ 0, 0, 0, 1 ], 0);
+    TinyContentActions.keystroke(editor, Keys.delete());
+
+    TinyAssertions.assertContent(editor, '<ul>' +
+      '<li>' +
+        '<div>' +
+          '<strong>One</strong>' +
+        '</div>' +
+        '<div><strong>Two</strong></div>' +
+      '</li>' +
+    '</ul>');
+    TinyAssertions.assertCursor(editor, [ 0, 0, 1, 0, 0 ], 0);
+  });
+
+  it('TINY-11763: backspace from empty div into nested li', () => {
+    const editor = hook.editor();
+    editor.setContent('<ul>' +
+      '<li>' +
+        '<div>' +
+          '<div><strong>One</strong></div>' +
+          '<ol><li>One</li></ol>' +
+          '<div><br></div>' +
+          '<ol><li>Two</li></ol>' +
+        '</div>' +
+      '</li>' +
+    '</ul>');
+    TinySelections.setCursor(editor, [ 0, 0, 0, 2 ], 0);
+    TinyContentActions.keystroke(editor, Keys.backspace());
+
+    TinyAssertions.assertContent(editor, '<ul>' +
+      '<li>' +
+        '<div>' +
+          '<div><strong>One</strong></div>' +
+          '<ol>' +
+            '<li>One</li>' +
+            '<li>Two</li>' +
+          '</ol>' +
+        '</div>' +
+      '</li>' +
+    '</ul>');
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-11763

Description of Changes:
* Deleting an empty block within `<li>` would move cursor at the end of the `<li>`.
* Deleting an empty block that is between two lists would throw an error when all of the elements were nested inside the same `<li>`.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes and Improvements**
	- Corrected cursor movement when deleting empty blocks within list items.
	- Resolved errors during deletions between nested list structures, enhancing editor robustness.
- **Tests**
	- Added test cases to verify backspace and delete behaviors with empty `<div>` elements in list items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->