### PR TITLE
fix(styles): change cursor for resize options #10189

### DIFF
--- a/modules/oxide/src/less/theme/components/statusbar/statusbar.less
+++ b/modules/oxide/src/less/theme/components/statusbar/statusbar.less
@@ -151,10 +151,17 @@
     }
   }
 
+  .tox-statusbar__resize-cursor-default {
+    cursor: ns-resize;
+  }
+
+  .tox-statusbar__resize-cursor-both {
+    cursor: nwse-resize;
+  }
+
   .tox-statusbar__resize-handle {
     align-items: flex-end;
     align-self: stretch;
-    cursor: nwse-resize;
     display: flex;
     flex: 0 0 auto;
     justify-content: flex-end;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
@@ -36,10 +36,10 @@ export const renderResizeHandler = (editor: Editor, providersBackstage: UiFactor
   const resizeLabel = resizeType === ResizeTypes.Both
     ? 'Press the arrow keys to resize the editor.'
     : 'Press the Up and Down arrow keys to resize the editor.';
-
+  const cursorClass = resizeType === ResizeTypes.Both ? 'tox-statusbar__resize-cursor-both' : 'tox-statusbar__resize-cursor-default'
   return Optional.some(Icons.render('resize-handle', {
     tag: 'div',
-    classes: [ 'tox-statusbar__resize-handle' ],
+    classes: [ 'tox-statusbar__resize-handle', cursorClass ],
     attributes: {
       'aria-label': providersBackstage.translate(resizeLabel),
       'data-mce-name': 'resize-handle'


### PR DESCRIPTION
Related Ticket: 
closes #10189

Description of Changes:
Removed `cursor` style from ` .tox-statusbar__resize-handle` class
Added two new classes, one for `both` resize option, second one, if we just have resize turned on, and it works only for vertical cases
Made a check, which class should be added, based on `resizeType`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable): #10189


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the status bar's resizing experience by providing distinct cursor styles for different resizing actions, offering clearer visual feedback.

- **Style**
  - Updated the visual design of cursor indicators to differentiate between vertical and combined resizing interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->