### PR TITLE
TINY-11875: Fix content css truncated when bundling, add validation to build step

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11875-2025-02-25.yaml
+++ b/.changes/unreleased/tinymce-TINY-11875-2025-02-25.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Skin UI content CSS was truncated when bundling, causing CSS styles to be missing.
+time: 2025-02-25T10:06:08.0508+08:00
+custom:
+    Issue: TINY-11875

--- a/modules/oxide/src/less/theme/content/comments/comments.less
+++ b/modules/oxide/src/less/theme/content/comments/comments.less
@@ -2,7 +2,7 @@
 // Comments
 //
 
-@document-comment-color: if(@content-ui-darkmode = true, mix(@color-active, @color-black, 20%), lighten(@color-active, 20%)); 
+@document-comment-color: if(@content-ui-darkmode = true, mix(@color-active, @color-black, 20%), lighten(@color-active, 20%));
 @document-comment-active-color: @color-active;
 @document-comment-background-color: @document-comment-color;
 @document-comment-active-background-color: if(@content-ui-darkmode = true, mix(@color-active, @color-black, 20%), @document-comment-active-color);
@@ -41,12 +41,10 @@
     border-radius: 3px;
     box-shadow: 0 0 0 2px @keyboard-focus-outline-color;
 
-    &:has(
-        img[data-mce-selected],
+    &:has(img[data-mce-selected],
         > audio[data-mce-selected],
         > video[data-mce-selected],
-        span.mce-preview-object[data-mce-selected]
-      ) {
+        span.mce-preview-object[data-mce-selected]) {
       box-shadow: none;
     }
   }

--- a/modules/oxide/tasks/js-skins.js
+++ b/modules/oxide/tasks/js-skins.js
@@ -20,7 +20,15 @@ module.exports = function (grunt) {
           grunt.log.error(err);
           return done(false);
         }
-        const content = `tinymce.Resource.add('${file.replace(/\.min.css$/, '.css')}', \`${data.split("\n")[0]}\`)`
+
+        const fileLines = data.split("\n");
+        // Check if the minified CSS file has more than 2 lines
+        // Line 1: The minified CSS content
+        // Line 2: The sourcemap comment, eg: (/*# sourceMappingURL=content.min.css.map */)
+        if (fileLines.length > 2) {
+          grunt.fail.fatal(`Failed to create JS resource for ${srcPath}. Expected minified CSS contains ${fileLines.length} lines instead of the expected 2 or fewer.`);
+        }
+        const content = `tinymce.Resource.add('${file.replace(/\.min.css$/, '.css')}', \`${fileLines[0]}\`)`
         grunt.file.write(destPath, content);
         processed++;
 


### PR DESCRIPTION
Related Ticket: TINY-11875

Description of Changes:
* Added validation step in `gruntfile` to ensure that the minified CSS satisfy the condition or else it will fail
* Fixed error in the `comments.less` file

<details><summary>Sample message when build step fails:</summary>
<p>
<pre>
Running "cssmin:target" (cssmin) task
>> 22 sourcemaps created.
>> 22 files created. 724 kB → 627 kB

Running "generateJsSkins" task
Fatal error: Failed to create JS resource for ./build/skins/ui/dark/content.inline.min.css. Expected minified CSS contains 4 lines instead of the expected 2 or fewer.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
ERROR: "oxide-ci" exited with 1.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
</pre>

No `ui/*/content.js` file is created
<pre>
 find . -name "*.js"
./Gruntfile.js
./tasks/js-skins.js
./tasks/less-task.js
./tasks/demos.js
./build/skins/content/default/content.js
./build/skins/content/document/content.js
./build/skins/content/writer/content.js
./build/skins/content/tinymce-5/content.js
./build/skins/content/tinymce-5-dark/content.js
./build/skins/content/dark/content.js
</pre>
</p>
</details> 

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
#10187 