### PR TITLE
TINY-11749: Use pull-through cache images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,9 +3,6 @@
 
 standardProperties()
 
-String ciAccountId = "103651136441"
-String ciRegistry = "${ciAccountId}.dkr.ecr.us-east-2.amazonaws.com"
-
 def runBedrockTest(String name, String command, Boolean runAll, int retry = 0, int timeout = 0) {
   def bedrockCmd = command + (runAll ? " --ignore-lerna-changed=true" : "")
   echo "Running Bedrock cmd: ${command}"
@@ -108,6 +105,7 @@ def runTestPod(String cacheName, String name, String testname, String browser, S
 }
 
 def runSeleniumPod(String cacheName, String name, String browser, String version, Closure body) {
+  String ciRegistry = devPods.getHubRegistry()
   Map node = [
           name: 'node',
           image: "public.ecr.aws/docker/library/node:20",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,6 @@ def runTestPod(String cacheName, String name, String testname, String browser, S
 }
 
 def runSeleniumPod(String cacheName, String name, String browser, String version, Closure body) {
-  String ciRegistry = devPods.getHubRegistry()
   Map node = [
           name: 'node',
           image: "public.ecr.aws/docker/library/node:20",
@@ -120,7 +119,7 @@ def runSeleniumPod(String cacheName, String name, String browser, String version
         ]
   Map selenium = [
           name: "selenium",
-          image: "${ciRegistry}/docker-hub/selenium/standalone-${browser}:${version}",
+          image: tinyAws.getPullThroughCacheImage("selenium/standalone-${browser}", version),
           livenessProbe: [
             execArgs: "curl --fail --silent --output /dev/null http://localhost:4444/wd/hub/status",
             initialDelaySeconds: 30,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -234,9 +234,9 @@ timestamps {
   def macFirefox = [ browser: 'firefox', provider: 'lambdatest', os: 'macOS Sequoia', buckets: 1 ]
   def macSafari = [ browser: 'safari', provider: 'lambdatest', os: 'macOS Sequoia', buckets: 1 ]
 
-  def seleniumFirefox = [ browser: 'firefox', provider: 'selenium', buckets: 2 ]
-  def seleniumChrome = [ browser: 'chrome', provider: 'selenium', version: '127.0', buckets: 2 ]
-  def seleniumChromium = [ browser: 'edge', provider: 'selenium', buckets: 1 ]
+  def seleniumFirefox = [ browser: 'firefox', provider: 'selenium', buckets: 1 ]
+  def seleniumChrome = [ browser: 'chrome', provider: 'selenium', version: '127.0', buckets: 1 ]
+  def seleniumEdge = [ browser: 'edge', provider: 'selenium', buckets: 1 ]
 
   def branchBuildPlatforms = [
     winChrome,
@@ -251,8 +251,7 @@ timestamps {
   ];
 
   def buildingPrimary = env.BRANCH_NAME == props.primaryBranch
-  // def platforms = buildingPrimary ? primaryBuildPlatforms : branchBuildPlatforms
-  def platforms = [ seleniumFirefox, seleniumChrome ]
+  def platforms = buildingPrimary ? primaryBuildPlatforms : branchBuildPlatforms
 
   def processes = [:]
   def runAllTests = buildingPrimary

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,9 @@
 
 standardProperties()
 
+String ciAccountId = "103651136441"
+String ciRegistry = "${ciAccountId}.dkr.ecr.us-east-2.amazonaws.com"
+
 def runBedrockTest(String name, String command, Boolean runAll, int retry = 0, int timeout = 0) {
   def bedrockCmd = command + (runAll ? " --ignore-lerna-changed=true" : "")
   echo "Running Bedrock cmd: ${command}"
@@ -119,7 +122,7 @@ def runSeleniumPod(String cacheName, String name, String browser, String version
         ]
   Map selenium = [
           name: "selenium",
-          image: "selenium/standalone-${browser}:${version}",
+          image: "${ciRegistry}/docker-hub/selenium/standalone-${browser}:${version}",
           livenessProbe: [
             execArgs: "curl --fail --silent --output /dev/null http://localhost:4444/wd/hub/status",
             initialDelaySeconds: 30,
@@ -234,8 +237,8 @@ timestamps {
   def macFirefox = [ browser: 'firefox', provider: 'lambdatest', os: 'macOS Sequoia', buckets: 1 ]
   def macSafari = [ browser: 'safari', provider: 'lambdatest', os: 'macOS Sequoia', buckets: 1 ]
 
-  def seleniumFirefox = [ browser: 'firefox', provider: 'selenium', buckets: 1 ]
-  def seleniumChrome = [ browser: 'chrome', provider: 'selenium', version: '127.0', buckets: 1 ]
+  def seleniumFirefox = [ browser: 'firefox', provider: 'selenium', buckets: 2 ]
+  def seleniumChrome = [ browser: 'chrome', provider: 'selenium', version: '127.0', buckets: 2 ]
   def seleniumChromium = [ browser: 'edge', provider: 'selenium', buckets: 1 ]
 
   def branchBuildPlatforms = [
@@ -251,7 +254,8 @@ timestamps {
   ];
 
   def buildingPrimary = env.BRANCH_NAME == props.primaryBranch
-  def platforms = buildingPrimary ? primaryBuildPlatforms : branchBuildPlatforms
+  // def platforms = buildingPrimary ? primaryBuildPlatforms : branchBuildPlatforms
+  def platforms = [ seleniumFirefox, seleniumChrome ]
 
   def processes = [:]
   def runAllTests = buildingPrimary


### PR DESCRIPTION
Related Ticket: TINY-11749

Description of Changes:
* Replace container images with pull-through cache images

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the testing infrastructure with dynamic image retrieval for improved efficiency.
- **Refactor**
	- Updated naming conventions to better reflect the intended browser for testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->