### PR TITLE
TINY-11838: Update dompurify to 3.2.4

### DIFF
--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -33,6 +33,6 @@
     "@ephox/darwin": "^9.0.0",
     "@tinymce/oxide": "^3.0.0",
     "@tinymce/oxide-icons-default": "^3.0.0",
-    "dompurify": "3.1.7"
+    "dompurify": "3.2.4"
   }
 }

--- a/modules/tinymce/src/core/main/ts/html/Sanitization.ts
+++ b/modules/tinymce/src/core/main/ts/html/Sanitization.ts
@@ -240,16 +240,16 @@ const sanitizeMathmlElement = (node: Element, settings: DomParserSettings) => {
   };
 
   purify.addHook('uponSanitizeElement', (node, evt) => {
-    // We know the node is an element as we have
-    // passed an element to the purify.sanitize function below
-    const elm = node as Element;
-    const lcTagName = evt.tagName ?? elm.nodeName.toLowerCase();
+    const lcTagName = evt.tagName ?? node.nodeName.toLowerCase();
 
     if (hasAllowedEncodings && lcTagName === 'semantics') {
       evt.allowedTags[lcTagName] = true;
     }
 
     if (lcTagName === 'annotation') {
+      // We know the node is an element as we have
+      // passed an element to the purify.sanitize function below
+      const elm = node as Element;
       const keepElement = hasValidEncoding(elm);
       evt.allowedTags[lcTagName] = keepElement;
       if (!keepElement) {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@tinymce/eslint-plugin": "^2.4.0",
     "@tinymce/moxiedoc": "^0.3.0",
     "@types/chai": "^5.0.1",
-    "@types/dompurify": "3.0.5",
     "@types/prismjs": "^1.16.6",
     "chai": "^5.1.2",
     "chalk": "^4.1.0",

--- a/patches/dompurify+3.2.4.patch
+++ b/patches/dompurify+3.2.4.patch
@@ -1,38 +1,37 @@
 diff --git a/node_modules/dompurify/dist/purify.es.mjs b/node_modules/dompurify/dist/purify.es.mjs
-index 7a42ce6..3a0a69b 100644
+index 86186cf..9b57304 100644
 --- a/node_modules/dompurify/dist/purify.es.mjs
 +++ b/node_modules/dompurify/dist/purify.es.mjs
-@@ -1169,6 +1169,7 @@ function createDOMPurify() {
+@@ -1054,6 +1054,7 @@ function createDOMPurify() {
        } = attr;
        const lcName = transformCaseFunc(name);
        let value = name === 'value' ? attrValue : stringTrim(attrValue);
 +      const initValue = value;
- 
        /* Execute a hook if present */
        hookEvent.attrName = lcName;
-@@ -1184,10 +1185,10 @@ function createDOMPurify() {
+       hookEvent.attrValue = value;
+@@ -1080,9 +1081,9 @@ function createDOMPurify() {
+         continue;
        }
- 
        /* Remove attribute */
 -      _removeAttribute(name, currentNode);
- 
        /* Did the hooks approve of the attribute? */
        if (!hookEvent.keepAttr) {
 +        _removeAttribute(name, currentNode);
          continue;
        }
- 
-@@ -1207,6 +1208,7 @@ function createDOMPurify() {
+       /* Work around a security issue in jQuery 3.0 */
+@@ -1099,6 +1100,7 @@ function createDOMPurify() {
        /* Is `value` valid for this attribute? */
        const lcTag = transformCaseFunc(currentNode.nodeName);
        if (!_isValidAttribute(lcTag, lcName, value)) {
 +        _removeAttribute(name, currentNode);
          continue;
        }
- 
-@@ -1246,19 +1248,21 @@ function createDOMPurify() {
+       /* Handle attributes that require Trusted Types */
+@@ -1119,19 +1121,21 @@ function createDOMPurify() {
+         }
        }
- 
        /* Handle invalid data-* attribute set by try-catching it */
 -      try {
 -        if (namespaceURI) {
@@ -63,43 +62,42 @@ index 7a42ce6..3a0a69b 100644
 +        } catch (_) {}
 +      }
      }
- 
      /* Execute a hook if present */
+     _executeHooks(hooks.afterSanitizeAttributes, currentNode, null);
 diff --git a/node_modules/dompurify/dist/purify.js b/node_modules/dompurify/dist/purify.js
-index 5b07950..2a00fff 100644
+index a03f326..7bcc749 100644
 --- a/node_modules/dompurify/dist/purify.js
 +++ b/node_modules/dompurify/dist/purify.js
-@@ -1175,6 +1175,7 @@
+@@ -1060,6 +1060,7 @@
          } = attr;
          const lcName = transformCaseFunc(name);
          let value = name === 'value' ? attrValue : stringTrim(attrValue);
 +        const initValue = value;
- 
          /* Execute a hook if present */
          hookEvent.attrName = lcName;
-@@ -1190,10 +1191,10 @@
+         hookEvent.attrValue = value;
+@@ -1086,9 +1087,9 @@
+           continue;
          }
- 
          /* Remove attribute */
 -        _removeAttribute(name, currentNode);
- 
          /* Did the hooks approve of the attribute? */
          if (!hookEvent.keepAttr) {
 +          _removeAttribute(name, currentNode);
            continue;
          }
- 
-@@ -1213,6 +1214,7 @@
+         /* Work around a security issue in jQuery 3.0 */
+@@ -1105,6 +1106,7 @@
          /* Is `value` valid for this attribute? */
          const lcTag = transformCaseFunc(currentNode.nodeName);
          if (!_isValidAttribute(lcTag, lcName, value)) {
 +          _removeAttribute(name, currentNode);
            continue;
          }
- 
-@@ -1252,19 +1254,21 @@
+         /* Handle attributes that require Trusted Types */
+@@ -1125,19 +1127,21 @@
+           }
          }
- 
          /* Handle invalid data-* attribute set by try-catching it */
 -        try {
 -          if (namespaceURI) {
@@ -130,5 +128,5 @@ index 5b07950..2a00fff 100644
 +          } catch (_) {}
 +        }
        }
- 
        /* Execute a hook if present */
+       _executeHooks(hooks.afterSanitizeAttributes, currentNode, null);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2349,13 +2349,6 @@
   resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
   integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
-"@types/dompurify@3.0.5":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-3.0.5.tgz#02069a2fcb89a163bacf1a788f73cb415dd75cb7"
-  integrity sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==
-  dependencies:
-    "@types/trusted-types" "*"
-
 "@types/eslint-scope@^3.7.7":
   version "3.7.7"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"
@@ -2563,7 +2556,7 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
 
-"@types/trusted-types@*":
+"@types/trusted-types@^2.0.7":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
@@ -4726,10 +4719,12 @@ domhandler@^4.2.0, domhandler@^4.3.1:
   dependencies:
     domelementtype "^2.2.0"
 
-dompurify@3.1.7:
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.1.7.tgz#711a8c96479fb6ced93453732c160c3c72418a6a"
-  integrity sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==
+dompurify@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.4.tgz#af5a5a11407524431456cf18836c55d13441cd8e"
+  integrity sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 domutils@^2.8.0:
   version "2.8.0"


### PR DESCRIPTION
Related Ticket: TINY-11838

Description of Changes:
* A cherry pick of #10191 so we can include the dompurify update in the unscheduled 7.7.1 patch release

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* [X] Docs ticket created (if applicable)

GitHub issues (if applicable):
