### PR TITLE
TINY-11890: fix behavior when a context form has `setInputEnabled(false)` on init

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11890-2025-02-26.yaml
+++ b/.changes/unreleased/tinymce-TINY-11890-2025-02-26.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Context forms used to disapear if their input were disabled on `onSetup`.
+time: 2025-02-26T15:59:43.211446802+01:00
+custom:
+    Issue: TINY-11890

--- a/.changes/unreleased/tinymce-TINY-11890-2025-02-26.yaml
+++ b/.changes/unreleased/tinymce-TINY-11890-2025-02-26.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Context forms used to disapear if their input were disabled on `onSetup`.
+body: Context forms used to disappear if their input were disabled on `onSetup`.
 time: 2025-02-26T15:59:43.211446802+01:00
 custom:
     Issue: TINY-11890

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
@@ -1,6 +1,7 @@
 import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Disabling, FormField, GuiFactory, Input, Keying, NativeEvents, SketchSpec } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Cell, Fun, Optional } from '@ephox/katamari';
+import { Attribute, PredicateFind, SelectorFind, SugarElement, SugarNode } from '@ephox/sugar';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
@@ -55,7 +56,18 @@ export const renderContextFormTextInput = (
       AddEventsBehaviour.config('input-events', [
         onControlAttached<InlineContent.ContextFormInstanceApi<string>>({
           onSetup: ctx.onSetup,
-          getApi: ContextFormApi.getFormApi,
+          getApi: (comp) => {
+            const closestFocussableOpt = SelectorFind.ancestor(comp.element, '.tox-toolbar').bind((toolbar) =>
+              PredicateFind.descendant(toolbar, (e) =>
+                SugarNode.isTag('button')(e) && Attribute.get(e, 'disabled') !== 'disabled'
+              )
+            ) as Optional<SugarElement<HTMLButtonElement>>;
+
+            return closestFocussableOpt.fold(
+              () => ContextFormApi.getFormApi(comp),
+              (closestFocussable) => ContextFormApi.getFormApi(comp, closestFocussable)
+            );
+          },
           onBeforeSetup: Keying.focusIn
         }, editorOffCell),
         onControlDetached({ getApi: ContextFormApi.getFormApi }, editorOffCell),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
@@ -1,7 +1,7 @@
 import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Disabling, FormField, GuiFactory, Input, Keying, NativeEvents, SketchSpec } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Cell, Fun, Optional } from '@ephox/katamari';
-import { Attribute, PredicateFind, SelectorFind, SugarElement, SugarNode } from '@ephox/sugar';
+import { SelectorFind } from '@ephox/sugar';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
@@ -58,10 +58,8 @@ export const renderContextFormTextInput = (
           onSetup: ctx.onSetup,
           getApi: (comp) => {
             const closestFocussableOpt = SelectorFind.ancestor(comp.element, '.tox-toolbar').bind((toolbar) =>
-              PredicateFind.descendant(toolbar, (e) =>
-                SugarNode.isTag('button')(e) && Attribute.get(e, 'disabled') !== 'disabled'
-              )
-            ) as Optional<SugarElement<HTMLButtonElement>>;
+              SelectorFind.descendant<HTMLButtonElement>(toolbar, 'button:enabled')
+            );
 
             return closestFocussableOpt.fold(
               () => ContextFormApi.getFormApi(comp),

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -148,6 +148,32 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
         predicate: Fun.never,
         items: 'form:test-form-focus-on-init',
       });
+
+      ed.ui.registry.addContextForm('test-form-disable-on-setup', {
+        launch: {
+          type: 'contextformtogglebutton',
+          icon: 'fake-icon-name',
+          tooltip: 'Focus on init',
+        },
+        onSetup: (api) => {
+          api.setInputEnabled(false);
+          return Fun.noop;
+        },
+        commands: [{
+          type: 'contextformbutton',
+          icon: 'fake-icon-name',
+          tooltip: 'A',
+          onAction: (formApi) => {
+            formApi.setInputEnabled(false);
+            return Fun.noop;
+          }
+        }]
+      });
+
+      ed.ui.registry.addContextToolbar('test-toolbar-disable-on-setup', {
+        predicate: Fun.never,
+        items: 'test-form-disable-on-setup',
+      });
     }
   }, [], true);
 
@@ -427,7 +453,20 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     assert.isTrue(Attribute.has(input, 'disabled'), 'the input sohuld be disabled');
   });
 
-  it('TINY-11665: it shound not be possible to navigate to the input field if this one is disabled', () => {
+  it('TINY-11890: It should be possible to open a context toolbar with an input disabled via onSetup', async () => {
+    const editor = hook.editor();
+    const doc = SugarDocument.getDocument();
+    editor.dispatch('test.updateButtonABC', { disable: true });
+
+    openToolbar(editor, 'test-toolbar-disable-on-setup');
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-name="test-form-disable-on-setup"]');
+
+    FocusTools.isOnSelector('Focus should stay on the "A" button', doc, '.tox-pop__dialog button[aria-label="A"]');
+    const input = await UiFinder.pWaitFor<HTMLInputElement>('getting the main input', doc, '[role="toolbar"] input');
+    assert.isTrue(Attribute.has(input, 'disabled'), 'the input sohuld be disabled');
+  });
+
+  it('TINY-11665: it shound not be possible to navigate to the input field if this one is disabled', async () => {
     const editor = hook.editor();
     const doc = SugarDocument.getDocument();
     openToolbar(editor, 'test-form');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -450,23 +450,22 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
 
     FocusTools.isOnSelector('Focus should stay on the "A" button', doc, '.tox-pop__dialog button[aria-label="A"]');
     const input = await UiFinder.pWaitFor<HTMLInputElement>('getting the main input', doc, '[role="toolbar"] input');
-    assert.isTrue(Attribute.has(input, 'disabled'), 'the input sohuld be disabled');
+    assert.isTrue(Attribute.has(input, 'disabled'), 'the input should be disabled');
   });
 
   it('TINY-11890: It should be possible to open a context toolbar with an input disabled via onSetup', async () => {
     const editor = hook.editor();
     const doc = SugarDocument.getDocument();
-    editor.dispatch('test.updateButtonABC', { disable: true });
 
     openToolbar(editor, 'test-toolbar-disable-on-setup');
     TinyUiActions.clickOnUi(editor, 'button[data-mce-name="test-form-disable-on-setup"]');
 
     FocusTools.isOnSelector('Focus should stay on the "A" button', doc, '.tox-pop__dialog button[aria-label="A"]');
     const input = await UiFinder.pWaitFor<HTMLInputElement>('getting the main input', doc, '[role="toolbar"] input');
-    assert.isTrue(Attribute.has(input, 'disabled'), 'the input sohuld be disabled');
+    assert.isTrue(Attribute.has(input, 'disabled'), 'the input should be disabled');
   });
 
-  it('TINY-11665: it shound not be possible to navigate to the input field if this one is disabled', async () => {
+  it('TINY-11665: it should not be possible to navigate to the input field if this one is disabled', async () => {
     const editor = hook.editor();
     const doc = SugarDocument.getDocument();
     openToolbar(editor, 'test-form');


### PR DESCRIPTION
Related Ticket: TINY-11890

Description of Changes:
now the selection is moved to the first not-disabled button that make the toolbar not disapear

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
