### PR TITLE
TINY-11842: Added footnote as an annotatable element

### DIFF
--- a/modules/tinymce/src/core/main/ts/annotate/AnnotationContext.ts
+++ b/modules/tinymce/src/core/main/ts/annotate/AnnotationContext.ts
@@ -30,13 +30,15 @@ const validBlocks = [
   'div.tiny-pageembed',
   // Tableofcontents plugin
   'div.mce-toc',
-  'div[data-mce-toc]'
+  'div[data-mce-toc]',
+  // Footnootes plugin
+  'div.mce-footnotes'
 ];
 
 const isZeroWidth = (elem: SugarElement<Node>): boolean =>
   SugarNode.isText(elem) && SugarText.get(elem) === ZWSP;
 
-const context = (editor: Editor, elem: SugarElement<Node>, wrapName: string, nodeName: string): ChildContext => Traverse.parent(elem).fold(
+const context = (editor: Editor, elem: SugarElement<Node>, wrapName: string, nodeName: string): ChildContext => Traverse.parentElement(elem).fold(
   () => ChildContext.Skipping,
 
   (parent) => {

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotateBlocksTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotateBlocksTest.ts
@@ -224,6 +224,12 @@ describe('browser.tinymce.core.annotate.AnnotateBlocksTest', () => {
     '<iframe src="about:blank" width="350px" height="260px" scrolling="no"></iframe>' +
     '</div>'
   );
+  const footnoteHtml = (withAnnotation: boolean) => (
+    `<div class="mce-footnotes" contenteditable="false"${withAnnotation ? ' ' + expectedBlockAnnotationAttrs() : ''}>` +
+    '<hr><ol><li id="footnotes_entry_72291395111727305907324"><a class="mce-footnotes-backlink" href="#footnote_72291395111727305907324">^&nbsp;</a>' +
+    '<span class="mce-footnotes-note" contenteditable="true">This is a footnote</span></li></ol>' +
+    '</div>'
+  );
 
   Arr.each([
     { label: 'Normal mode', before: () => hook.editor().mode.set('design'), after: Fun.noop, mode: 'normal' },
@@ -410,6 +416,16 @@ describe('browser.tinymce.core.annotate.AnnotateBlocksTest', () => {
           html: pageEmbedHtml(false),
           expectedDirectHtml: pageEmbedHtml(true),
           expectedRangeHtml: pageEmbedHtml(true),
+          expectedDirectSelection: selectionPath([], 1, [], 2),
+          blockType: 'root'
+        },
+        {
+          label: 'footnote',
+          name: 'div',
+          annotationSelector: 'div',
+          html: footnoteHtml(false),
+          expectedDirectHtml: footnoteHtml(true),
+          expectedRangeHtml: footnoteHtml(true),
           expectedDirectSelection: selectionPath([], 1, [], 2),
           blockType: 'root'
         },


### PR DESCRIPTION
Related Ticket: TINY-11842

Description of Changes:
* Added support for adding annotations to footnotes

Pre-checks:
* [x] ~~Changelog entry added~~ Skipping changelog here and adding a separate PR to add that to the comments plugin
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the annotation functionality to recognize and properly handle footnotes, offering an improved editing experience.

- **Tests**
  - Expanded test coverage to ensure the updated footnotes functionality is reliably validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->