### PR TITLE
TINY-11822: remove Sizzle

### DIFF
--- a/.changes/unreleased/agar-TINY-11822-2025-03-04.yaml
+++ b/.changes/unreleased/agar-TINY-11822-2025-03-04.yaml
@@ -1,0 +1,6 @@
+project: agar
+kind: Changed
+body: Sizzle has been removed from dependencies.
+time: 2025-03-04T14:40:05.337778+01:00
+custom:
+  Issue: TINY-11822

--- a/.changes/unreleased/agar-TINY-11822-2025-03-04.yaml
+++ b/.changes/unreleased/agar-TINY-11822-2025-03-04.yaml
@@ -1,6 +1,6 @@
 project: agar
 kind: Changed
-body: Sizzle has been removed from dependencies.
+body: Sizzle has been replaced with a custom engine for `:contains` matching. Note this only works at the end of selectors.
 time: 2025-03-04T14:40:05.337778+01:00
 custom:
   Issue: TINY-11822

--- a/modules/agar/package.json
+++ b/modules/agar/package.json
@@ -30,9 +30,7 @@
     "@ephox/jax": "^8.0.0",
     "@ephox/sand": "^7.0.0",
     "@ephox/sugar": "^10.0.0",
-    "@types/sizzle": "^2.3.3",
-    "fast-check": "^2.0.0",
-    "sizzle": "^2.3.4"
+    "fast-check": "^2.0.0"
   },
   "devDependencies": {
     "@ephox/katamari-assertions": "^5.0.0"

--- a/modules/agar/src/main/ts/ephox/agar/alien/SelectorEngine.ts
+++ b/modules/agar/src/main/ts/ephox/agar/alien/SelectorEngine.ts
@@ -1,5 +1,4 @@
 import { Arr, Obj, Optional } from '@ephox/katamari';
-import { NodeTypes } from '@ephox/sugar';
 import * as Sizzle from 'sizzle';
 
 const sizzleEnabled = false;
@@ -41,17 +40,8 @@ const unwrapFromQuotes = (pattern: string) => {
   return matchedGroups.content ?? pattern;
 };
 
-const hasText = (element: Node, text: string) => {
-  if (element.nodeType === NodeTypes.TEXT) {
-    return element.textContent.includes(text);
-  }
-  for (const child of Array.from(element.childNodes)) {
-    if (hasText(child, text)) {
-      return true;
-    }
-  }
-  return false;
-};
+const hasText = (element: Node, text: string) =>
+  element.textContent.includes(text);
 
 const matchesSelector = (element: Element, selector: string): boolean => {
   if (sizzleEnabled) {

--- a/modules/agar/src/main/ts/ephox/agar/alien/SelectorEngine.ts
+++ b/modules/agar/src/main/ts/ephox/agar/alien/SelectorEngine.ts
@@ -1,4 +1,4 @@
-import { Arr, Obj, Optional } from '@ephox/katamari';
+import { Arr, Obj, Optional, Strings } from '@ephox/katamari';
 import * as Sizzle from 'sizzle';
 
 const sizzleEnabled = false;
@@ -41,7 +41,7 @@ const unwrapFromQuotes = (pattern: string) => {
 };
 
 const hasText = (element: Node, text: string) =>
-  element.textContent.includes(text);
+  Strings.contains(element.textContent, text);
 
 const matchesSelector = (element: Element, selector: string): boolean => {
   if (sizzleEnabled) {

--- a/modules/agar/src/main/ts/ephox/agar/alien/SelectorEngine.ts
+++ b/modules/agar/src/main/ts/ephox/agar/alien/SelectorEngine.ts
@@ -1,22 +1,16 @@
 import { Arr, Obj, Optional, Strings } from '@ephox/katamari';
-import * as Sizzle from 'sizzle';
 
-const sizzleEnabled = false;
 type LookupContext = Element | Document | DocumentFragment;
 interface DecodedContainsSelector {
   baseSelector: string;
   text: string;
 }
 
-const selectAll = (selector: string, context: LookupContext): Element[] => {
-  if (sizzleEnabled) {
-    return Sizzle(selector, context);
-  }
-  return decodeContains(selector).fold(
+const selectAll = (selector: string, context: LookupContext): Element[] =>
+  decodeContains(selector).fold(
     () => queryAll(context, selector),
     (decodedContainsSelector) => queryAllWithContains(context, decodedContainsSelector)
   );
-};
 
 const decodeContains = (selector: string): Optional<DecodedContainsSelector> => {
   const regexp = /(?<baseSelector>.*):contains\((?<text>.*)\)$/;
@@ -43,15 +37,11 @@ const queryAllWithContains = (element: LookupContext, { baseSelector, text }: De
 const hasText = (element: Node, text: string) =>
   Strings.contains(element.textContent, text);
 
-const matchesSelector = (element: Element, selector: string): boolean => {
-  if (sizzleEnabled) {
-    return Sizzle.matchesSelector(element, selector);
-  }
-  return decodeContains(selector).fold(
+const matchesSelector = (element: Element, selector: string): boolean =>
+  decodeContains(selector).fold(
     () => matches(selector, element),
     (decodedContainsSelector) => matchesWithContains(decodedContainsSelector, element)
   );
-};
 
 const matches = (selector: string, element: Element) => element.matches(selector);
 

--- a/modules/agar/src/main/ts/ephox/agar/alien/SelectorEngine.ts
+++ b/modules/agar/src/main/ts/ephox/agar/alien/SelectorEngine.ts
@@ -6,6 +6,11 @@ interface DecodedContainsSelector {
   text: string;
 }
 
+const CONTAINS_REGEXP = /(?<baseSelector>.*):contains\((?<text>.*?)\)(?<remainings>.*)/;
+const CONTAINS_REGEXP_SINGLE_QUOTE = /(?<baseSelector>.*):contains\('(?<text>.*?)'\)(?<remainings>.*)/;
+const CONTAINS_REGEXP_DOUBLE_QUOTE = /(?<baseSelector>.*):contains\("(?<text>.*?)"\)(?<remainings>.*)/;
+const CONTAINS_REGEXPS = [ CONTAINS_REGEXP_DOUBLE_QUOTE, CONTAINS_REGEXP_SINGLE_QUOTE, CONTAINS_REGEXP ];
+
 const selectAll = (selector: string, context: LookupContext): Element[] =>
   decodeContains(selector)
     .fold(
@@ -19,20 +24,22 @@ const selectAll = (selector: string, context: LookupContext): Element[] =>
     );
 
 const decodeContains = (selector: string): Result<Optional<DecodedContainsSelector>, string> => {
-  const regexp = /(?<baseSelector>.*):contains\((?<text>.*?)\)(?<remainings>.*)/;
-  const matchedGroups = regexp.exec(selector)?.groups ?? {};
-  if (!Obj.has(matchedGroups, 'baseSelector') || !Obj.has(matchedGroups, 'text')) {
-    return Result.value(Optional.none());
-  }
-  if (Obj.has(matchedGroups, 'remainings') && Strings.trim(matchedGroups.remainings) !== '') {
-    return Result.error(`Invalid selector '${selector}'. ':contains' in only supported at the end of the selector`);
-  }
-  return Result.value(Optional.some({ baseSelector: matchedGroups.baseSelector, text: unwrapFromQuotes(matchedGroups.text) }));
-};
-
-const unwrapFromQuotes = (pattern: string) => {
-  const regexp = /^(?<quote>["'])(?<content>.*)\k<quote>$/;
-  return regexp.exec(pattern)?.groups?.content ?? pattern;
+  const selectorGroups = Arr.findMap(CONTAINS_REGEXPS, (regexp) => {
+    const matchedGroups = regexp.exec(selector)?.groups ?? {};
+    if (Obj.has(matchedGroups, 'baseSelector') && Obj.has(matchedGroups, 'text')) {
+      return Optional.from(matchedGroups);
+    }
+    return Optional.none();
+  });
+  return selectorGroups.fold(
+    () => Result.value(Optional.none()),
+    ({ baseSelector, text, remainings }) => {
+      if (remainings !== undefined && Strings.trim(remainings) !== '') {
+        return Result.error(`Invalid selector '${selector}'. ':contains' is only supported as the last pseudo-class.`);
+      }
+      return Result.value(Optional.some({ baseSelector, text }));
+    }
+  );
 };
 
 const queryAll = (element: LookupContext, selector: string) => Array.from(element.querySelectorAll(selector));

--- a/modules/agar/src/main/ts/ephox/agar/alien/SelectorEngine.ts
+++ b/modules/agar/src/main/ts/ephox/agar/alien/SelectorEngine.ts
@@ -12,15 +12,10 @@ const CONTAINS_REGEXP_DOUBLE_QUOTE = /(?<baseSelector>.*):contains\("(?<text>.*?
 const CONTAINS_REGEXPS = [ CONTAINS_REGEXP_DOUBLE_QUOTE, CONTAINS_REGEXP_SINGLE_QUOTE, CONTAINS_REGEXP ];
 
 const selectAll = (selector: string, context: LookupContext): Element[] =>
-  decodeContains(selector)
+  decodeContains(selector).getOrDie()
     .fold(
-      (deocdeError) => {
-        throw new Error(deocdeError);
-      },
-      (result) => result.fold(
-        () => queryAll(context, selector),
-        (decodedContainsSelector) => queryAllWithContains(context, decodedContainsSelector)
-      )
+      () => queryAll(context, selector),
+      (decodedContainsSelector) => queryAllWithContains(context, decodedContainsSelector)
     );
 
 const decodeContains = (selector: string): Result<Optional<DecodedContainsSelector>, string> => {
@@ -53,15 +48,10 @@ const hasText = (element: Node, text: string) =>
   Strings.contains(element.textContent, text);
 
 const matchesSelector = (element: Element, selector: string): boolean =>
-  decodeContains(selector)
+  decodeContains(selector).getOrDie()
     .fold(
-      (deocdeError) => {
-        throw new Error(deocdeError);
-      },
-      (result) => result.fold(
-        () => matches(selector, element),
-        (decodedContainsSelector) => matchesWithContains(decodedContainsSelector, element)
-      )
+      () => matches(selector, element),
+      (decodedContainsSelector) => matchesWithContains(decodedContainsSelector, element)
     );
 
 const matches = (selector: string, element: Element) => element.matches(selector);

--- a/modules/agar/src/main/ts/ephox/agar/alien/SelectorEngine.ts
+++ b/modules/agar/src/main/ts/ephox/agar/alien/SelectorEngine.ts
@@ -2,13 +2,13 @@ import { Arr, Obj, Optional, Strings } from '@ephox/katamari';
 import * as Sizzle from 'sizzle';
 
 const sizzleEnabled = false;
-type SizzleContext = Element | Document | DocumentFragment;
+type LookupContext = Element | Document | DocumentFragment;
 interface DecodedContainsSelector {
   baseSelector: string;
   text: string;
 }
 
-const selectAll = (selector: string, context: SizzleContext): Element[] => {
+const selectAll = (selector: string, context: LookupContext): Element[] => {
   if (sizzleEnabled) {
     return Sizzle(selector, context);
   }
@@ -17,13 +17,6 @@ const selectAll = (selector: string, context: SizzleContext): Element[] => {
     (decodedContainsSelector) => queryAllWithContains(context, decodedContainsSelector)
   );
 };
-
-const queryAllWithContains = (element: SizzleContext, { baseSelector, text }: DecodedContainsSelector) => {
-  const baseSelectorMatch = queryAll(element, baseSelector);
-  return Arr.filter(baseSelectorMatch, (e) => hasText(e, text));
-};
-
-const queryAll = (element: SizzleContext, selector: string) => Array.from(element.querySelectorAll(selector));
 
 const decodeContains = (selector: string): Optional<DecodedContainsSelector> => {
   const regexp = /(?<baseSelector>.*):contains\((?<text>.*)\)$/;
@@ -38,6 +31,13 @@ const unwrapFromQuotes = (pattern: string) => {
   const regexp = /^(?<quote>["'])(?<content>.*)\k<quote>$/;
   const matchedGroups = regexp.exec(pattern)?.groups ?? {};
   return matchedGroups.content ?? pattern;
+};
+
+const queryAll = (element: LookupContext, selector: string) => Array.from(element.querySelectorAll(selector));
+
+const queryAllWithContains = (element: LookupContext, { baseSelector, text }: DecodedContainsSelector) => {
+  const baseSelectorMatch = queryAll(element, baseSelector);
+  return Arr.filter(baseSelectorMatch, (e) => hasText(e, text));
 };
 
 const hasText = (element: Node, text: string) =>

--- a/modules/agar/src/main/ts/ephox/agar/alien/SelectorEngine.ts
+++ b/modules/agar/src/main/ts/ephox/agar/alien/SelectorEngine.ts
@@ -1,0 +1,66 @@
+import { Arr, Obj, Optional } from '@ephox/katamari';
+import { NodeTypes } from '@ephox/sugar';
+import * as Sizzle from 'sizzle';
+
+const sizzleEnabled = false;
+type SizzleContext = Element | Document | DocumentFragment;
+interface DecodedContainsSelector {
+  baseSelector: string;
+  text: string;
+}
+
+const selectAll = (selector: string, context: SizzleContext): Element[] => {
+  return sizzleEnabled ? Sizzle(selector, context) : selectAllInternal(selector, context);
+};
+
+const selectAllInternal = (selector: string, context: SizzleContext): Element[] =>
+  decodeContains(selector).fold(
+    () => queryAll(context, selector),
+    (decodedContainsSelector) => queryAllWithContains(context, decodedContainsSelector)
+  );
+
+const queryAllWithContains = (element: SizzleContext, { baseSelector, text }: DecodedContainsSelector) => {
+  const baseSelectorMatch = queryAll(element, baseSelector);
+  return Arr.filter(baseSelectorMatch, (e) => hasText(e, text));
+};
+
+const queryAll = (element: SizzleContext, selector: string) => Array.from(element.querySelectorAll(selector));
+
+const decodeContains = (selector: string): Optional<DecodedContainsSelector> => {
+  const regexp = /(?<baseSelector>.*):contains\((?<text>.*)\)$/;
+  const matchedGroups = regexp.exec(selector)?.groups ?? {};
+  if (!Obj.has(matchedGroups, 'baseSelector') || !Obj.has(matchedGroups, 'text')) {
+    return Optional.none();
+  }
+  return Optional.some({ baseSelector: matchedGroups.baseSelector, text: unwrapFromQuotes(matchedGroups.text) });
+};
+
+const unwrapFromQuotes = (pattern: string) => {
+  const regexp = /^(?<quote>["'])(?<content>.*)\k<quote>$/;
+  const matchedGroups = regexp.exec(pattern)?.groups ?? {};
+  return matchedGroups.content ?? pattern;
+};
+
+const hasText = (element: Node, text: string) => {
+  if (element.nodeType === NodeTypes.TEXT) {
+    return element.textContent.includes(text);
+  }
+  for (const child of Array.from(element.childNodes)) {
+    if (hasText(child, text)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const matchesSelector = (element: Element, selector: string): boolean => {
+  const root = element.getRootNode();
+  /* TODO: remove this cast */
+  const matches = selectAllInternal(selector, root as Document);
+  return Arr.exists(matches, (e) => e === element);
+};
+
+export {
+  selectAll,
+  matchesSelector
+};

--- a/modules/agar/src/main/ts/ephox/agar/alien/SelectorEngine.ts
+++ b/modules/agar/src/main/ts/ephox/agar/alien/SelectorEngine.ts
@@ -23,8 +23,7 @@ const decodeContains = (selector: string): Optional<DecodedContainsSelector> => 
 
 const unwrapFromQuotes = (pattern: string) => {
   const regexp = /^(?<quote>["'])(?<content>.*)\k<quote>$/;
-  const matchedGroups = regexp.exec(pattern)?.groups ?? {};
-  return matchedGroups.content ?? pattern;
+  return regexp.exec(pattern)?.groups?.content ?? pattern;
 };
 
 const queryAll = (element: LookupContext, selector: string) => Array.from(element.querySelectorAll(selector));

--- a/modules/agar/src/main/ts/ephox/agar/alien/SizzleFind.ts
+++ b/modules/agar/src/main/ts/ephox/agar/alien/SizzleFind.ts
@@ -2,6 +2,8 @@ import { Arr, Optional } from '@ephox/katamari';
 import { SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 import * as Sizzle from 'sizzle';
 
+import * as SelectorEngine from './SelectorEngine';
+
 type SizzleContext = Element | Document | DocumentFragment;
 
 const toOptionEl = <T extends Element>(output: T[]): Optional<SugarElement<T>> =>
@@ -9,7 +11,7 @@ const toOptionEl = <T extends Element>(output: T[]): Optional<SugarElement<T>> =
 
 /* Petrie makes extensive use of :visible, :has() and :contains() which are sizzle extensions */
 const descendant = <T extends Element>(sugarElement: SugarElement<SizzleContext>, selector: string): Optional<SugarElement<T>> => {
-  const siz = Sizzle(selector, sugarElement.dom) as T[];
+  const siz = SelectorEngine.selectAll(selector, sugarElement.dom) as T[];
   return toOptionEl(siz);
 };
 
@@ -18,7 +20,7 @@ const toArrayEl = <T extends Node | Window>(elements: T[]): SugarElement<T>[] =>
 
 /* Petrie makes extensive use of :visible, :has() and :contains() which are sizzle extensions */
 const descendants = <T extends Element>(sugarElement: SugarElement<SizzleContext>, selector: string): SugarElement<T>[] =>
-  toArrayEl(Sizzle(selector, sugarElement.dom) as T[]);
+  toArrayEl(SelectorEngine.selectAll(selector, sugarElement.dom) as T[]);
 
 const matches = <T extends Element>(sugarElement: SugarElement<Node>, selector: string): sugarElement is SugarElement<T> =>
   SugarNode.isElement(sugarElement) && Sizzle.matchesSelector(sugarElement.dom, selector);

--- a/modules/agar/src/main/ts/ephox/agar/alien/SizzleFind.ts
+++ b/modules/agar/src/main/ts/ephox/agar/alien/SizzleFind.ts
@@ -8,7 +8,6 @@ type SizzleContext = Element | Document | DocumentFragment;
 const toOptionEl = <T extends Element>(output: T[]): Optional<SugarElement<T>> =>
   output.length === 0 ? Optional.none() : Optional.from(output[0]).map(SugarElement.fromDom);
 
-/* Petrie makes extensive use of :visible, :has() and :contains() which are sizzle extensions */
 const descendant = <T extends Element>(sugarElement: SugarElement<SizzleContext>, selector: string): Optional<SugarElement<T>> => {
   const siz = SelectorEngine.selectAll(selector, sugarElement.dom) as T[];
   return toOptionEl(siz);
@@ -17,7 +16,6 @@ const descendant = <T extends Element>(sugarElement: SugarElement<SizzleContext>
 const toArrayEl = <T extends Node | Window>(elements: T[]): SugarElement<T>[] =>
   Arr.map(elements, SugarElement.fromDom);
 
-/* Petrie makes extensive use of :visible, :has() and :contains() which are sizzle extensions */
 const descendants = <T extends Element>(sugarElement: SugarElement<SizzleContext>, selector: string): SugarElement<T>[] =>
   toArrayEl(SelectorEngine.selectAll(selector, sugarElement.dom) as T[]);
 

--- a/modules/agar/src/main/ts/ephox/agar/alien/SizzleFind.ts
+++ b/modules/agar/src/main/ts/ephox/agar/alien/SizzleFind.ts
@@ -1,6 +1,5 @@
 import { Arr, Optional } from '@ephox/katamari';
 import { SugarElement, SugarNode, Traverse } from '@ephox/sugar';
-import * as Sizzle from 'sizzle';
 
 import * as SelectorEngine from './SelectorEngine';
 
@@ -23,7 +22,7 @@ const descendants = <T extends Element>(sugarElement: SugarElement<SizzleContext
   toArrayEl(SelectorEngine.selectAll(selector, sugarElement.dom) as T[]);
 
 const matches = <T extends Element>(sugarElement: SugarElement<Node>, selector: string): sugarElement is SugarElement<T> =>
-  SugarNode.isElement(sugarElement) && Sizzle.matchesSelector(sugarElement.dom, selector);
+  SugarNode.isElement(sugarElement) && SelectorEngine.matchesSelector(sugarElement.dom, selector);
 
 const child = <T extends Element>(sugarElement: SugarElement<Node>, selector: string): Optional<SugarElement<T>> => {
   const children = Traverse.children(sugarElement);

--- a/modules/agar/src/main/ts/ephox/agar/api/FocusTools.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/FocusTools.ts
@@ -52,6 +52,16 @@ const isOnSelector = (label: string, doc: SugarElement<Document | ShadowRoot>, s
   }).getOrDie();
 };
 
+/* TODO: add tests */
+const isOnByLabel = (errorLabel: string, doc: SugarElement<Document | ShadowRoot>, label: string): SugarElement<HTMLElement> => {
+  const element = UiFinder.findTargetByLabel(doc, label).getOrDie();
+  return getFocused(doc).bind((active) => {
+    return Compare.eq(element, active) ? Result.value(active) : Result.error(
+      errorLabel + '\nExpected focus: ' + Truncate.getHtml(element) + '\nActual focus: ' + Truncate.getHtml(active)
+    );
+  }).getOrDie();
+};
+
 const cGetFocused: Chain<SugarElement<Document | ShadowRoot>, SugarElement<HTMLElement>> =
   Chain.binder(getFocused);
 
@@ -92,8 +102,9 @@ const sTryOnSelector = <T>(label: string, doc: SugarElement<Document | ShadowRoo
 const pTryOnSelector = (label: string, doc: SugarElement<Document | ShadowRoot>, selector: string): Promise<SugarElement<HTMLElement>> =>
   Waiter.pTryUntil(label + '. Focus did not match: ' + selector, () => isOnSelector(label, doc, selector));
 
-const pTryOn = (label: string, element: SugarElement<Node>): Promise<SugarElement<HTMLElement>> =>
-  Waiter.pTryUntil(label + '. Focus did not match', () => isOn(label, element));
+/* TODO: add tests */
+const pTryOnByLabel = (errorLabel: string, doc: SugarElement<Document | ShadowRoot>, label: string): Promise<SugarElement<HTMLElement>> =>
+  Waiter.pTryUntil(errorLabel + '. Focus did not match label: ' + label, () => isOnByLabel(errorLabel, doc, label));
 
 const cSetFocus = <T extends Node, U extends HTMLElement>(label: string, selector: string): Chain<SugarElement<T>, SugarElement<U>> =>
   // Input: container
@@ -130,9 +141,10 @@ export {
   getFocused,
   isOn,
   isOnSelector,
+  isOnByLabel,
 
   pTryOnSelector,
-  pTryOn,
+  pTryOnByLabel,
 
   sSetActiveValue,
   sSetFocus,

--- a/modules/agar/src/main/ts/ephox/agar/api/FocusTools.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/FocusTools.ts
@@ -52,7 +52,6 @@ const isOnSelector = (label: string, doc: SugarElement<Document | ShadowRoot>, s
   }).getOrDie();
 };
 
-/* TODO: add tests */
 const isOnByLabel = (errorLabel: string, doc: SugarElement<Document | ShadowRoot>, label: string): SugarElement<HTMLElement> => {
   const element = UiFinder.findTargetByLabel(doc, label).getOrDie();
   return getFocused(doc).bind((active) => {
@@ -102,7 +101,6 @@ const sTryOnSelector = <T>(label: string, doc: SugarElement<Document | ShadowRoo
 const pTryOnSelector = (label: string, doc: SugarElement<Document | ShadowRoot>, selector: string): Promise<SugarElement<HTMLElement>> =>
   Waiter.pTryUntil(label + '. Focus did not match: ' + selector, () => isOnSelector(label, doc, selector));
 
-/* TODO: add tests */
 const pTryOnByLabel = (errorLabel: string, doc: SugarElement<Document | ShadowRoot>, label: string): Promise<SugarElement<HTMLElement>> =>
   Waiter.pTryUntil(errorLabel + '. Focus did not match label: ' + label, () => isOnByLabel(errorLabel, doc, label));
 

--- a/modules/agar/src/main/ts/ephox/agar/api/FocusTools.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/FocusTools.ts
@@ -92,6 +92,9 @@ const sTryOnSelector = <T>(label: string, doc: SugarElement<Document | ShadowRoo
 const pTryOnSelector = (label: string, doc: SugarElement<Document | ShadowRoot>, selector: string): Promise<SugarElement<HTMLElement>> =>
   Waiter.pTryUntil(label + '. Focus did not match: ' + selector, () => isOnSelector(label, doc, selector));
 
+const pTryOn = (label: string, element: SugarElement<Node>): Promise<SugarElement<HTMLElement>> =>
+  Waiter.pTryUntil(label + '. Focus did not match', () => isOn(label, element));
+
 const cSetFocus = <T extends Node, U extends HTMLElement>(label: string, selector: string): Chain<SugarElement<T>, SugarElement<U>> =>
   // Input: container
   Chain.control(
@@ -129,6 +132,7 @@ export {
   isOnSelector,
 
   pTryOnSelector,
+  pTryOn,
 
   sSetActiveValue,
   sSetFocus,

--- a/modules/agar/src/main/ts/ephox/agar/api/Mouse.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Mouse.ts
@@ -78,7 +78,6 @@ const sTriggerOn = <T, U extends Element>(container: SugarElement<Node>, selecto
 const clickOn = <T extends HTMLElement>(container: SugarElement<Node>, selector: string): SugarElement<T> =>
   triggerOn<T>(container, selector, Clicks.trigger);
 
-/* TODO: add tests */
 const clickByLabel = <T extends HTMLElement>(container: SugarElement<Node>, label: string): SugarElement<T> =>
   triggerByLabel<T>(container, label, Clicks.trigger);
 

--- a/modules/agar/src/main/ts/ephox/agar/api/Mouse.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Mouse.ts
@@ -65,12 +65,22 @@ const triggerOn = <T extends Element>(container: SugarElement<Node>, selector: s
   return ele;
 };
 
+const triggerByLabel = <T extends Element>(container: SugarElement<Node>, label: string, action: (ele: SugarElement<T>) => void): SugarElement<T> => {
+  const ele = UiFinder.findTargetByLabel<T>(container, label).getOrDie();
+  action(ele);
+  return ele;
+};
+
 // Work with selectors
 const sTriggerOn = <T, U extends Element>(container: SugarElement<Node>, selector: string, action: (ele: SugarElement<U>) => void) =>
   Step.sync<T>(() => triggerOn(container, selector, action));
 
 const clickOn = <T extends HTMLElement>(container: SugarElement<Node>, selector: string): SugarElement<T> =>
   triggerOn<T>(container, selector, Clicks.trigger);
+
+/* TODO: add tests */
+const clickByLabel = <T extends HTMLElement>(container: SugarElement<Node>, label: string): SugarElement<T> =>
+  triggerByLabel<T>(container, label, Clicks.trigger);
 
 const dblclickOn = <T extends HTMLElement>(container: SugarElement<Node>, selector: string): SugarElement<T> =>
   triggerOn<T>(container, selector, Clicks.dblclick({ }));
@@ -175,6 +185,7 @@ export {
   mouseOut,
 
   clickOn,
+  clickByLabel,
   dblclickOn,
   contextMenuOn,
   hoverOn,

--- a/modules/agar/src/main/ts/ephox/agar/api/UiFinder.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/UiFinder.ts
@@ -8,6 +8,7 @@ import { Step } from './Step';
 
 const findIn = UiSearcher.findIn;
 const findAllIn = UiSearcher.findAllIn;
+const findTargetByLabel = UiSearcher.findTargetByLabel;
 
 const exists = (container: SugarElement<Node>, selector: string): void => {
   findIn(container, selector).fold(
@@ -111,6 +112,7 @@ const pWaitForState = <T extends Element>(message: string, container: SugarEleme
 export {
   findIn,
   findAllIn,
+  findTargetByLabel,
   exists,
   notExists,
 

--- a/modules/agar/src/main/ts/ephox/agar/assertions/ApproxStructures.ts
+++ b/modules/agar/src/main/ts/ephox/agar/assertions/ApproxStructures.ts
@@ -1,6 +1,6 @@
 import { Assert, TestLabel } from '@ephox/bedrock-client';
 import { Arr, Fun, Obj, Optional } from '@ephox/katamari';
-import { Attribute, Classes, Css, Html, SugarElement, SugarNode, SugarText, TextContent, Traverse, Truncate, Value } from '@ephox/sugar';
+import { Attribute, Classes, Css, Html, SugarElement, SugarNode, SugarText, Traverse, Truncate, Value } from '@ephox/sugar';
 
 import * as ApproxComparisons from './ApproxComparisons';
 
@@ -43,7 +43,6 @@ export interface ElementFields {
   styles?: Record<string, StringAssert>;
   html?: StringAssert;
   value?: StringAssert;
-  textContent?: StringAssert;
   children?: StructAssert[];
   exactAttrs?: Record<string, StringAssert>;
   exactClasses?: string[];
@@ -110,7 +109,6 @@ const element = (tag: string, fields: ElementFields): StructAssert => {
       const attrs = fields.attrs ?? {};
       const classes = fields.classes ?? [];
       const styles = fields.styles ?? {};
-      const optTextContent = Optional.from(fields.textContent);
       const optHtml = Optional.from(fields.html);
       const optValue = Optional.from(fields.value);
       const optChildren = Optional.from(fields.children);
@@ -135,7 +133,6 @@ const element = (tag: string, fields: ElementFields): StructAssert => {
 
       assertHtml(optHtml, actual);
       assertValue(optValue, actual);
-      assertTextContent(optTextContent, actual);
       assertChildren(optChildren, actual);
     } else {
       Assert.eq('Incorrect node type for: ' + Truncate.getHtml(actual), 1, SugarNode.type(actual));
@@ -341,18 +338,6 @@ const assertValue = (expectedValue: Optional<StringAssert>, actual: SugarElement
     v.strAssert(
       () => 'Checking value of ' + Truncate.getHtml(actual),
       Value.get(actual as SugarElement<any>)
-    );
-  });
-};
-
-const assertTextContent = (expectedValue: Optional<StringAssert>, actual: SugarElement<HTMLElement>) => {
-  expectedValue.each((v) => {
-    if (v.strAssert === undefined) {
-      throw new Error(JSON.stringify(v) + ' is not a *string assertion*.\nSpecified in *expected* value of ' + TextContent.get(actual));
-    }
-    v.strAssert(
-      () => 'Checking value of ' + TextContent.get(actual),
-      TextContent.get(actual)
     );
   });
 };

--- a/modules/agar/src/main/ts/ephox/agar/assertions/ApproxStructures.ts
+++ b/modules/agar/src/main/ts/ephox/agar/assertions/ApproxStructures.ts
@@ -1,6 +1,6 @@
 import { Assert, TestLabel } from '@ephox/bedrock-client';
 import { Arr, Fun, Obj, Optional } from '@ephox/katamari';
-import { Attribute, Classes, Css, Html, SugarElement, SugarNode, SugarText, Traverse, Truncate, Value } from '@ephox/sugar';
+import { Attribute, Classes, Css, Html, SugarElement, SugarNode, SugarText, TextContent, Traverse, Truncate, Value } from '@ephox/sugar';
 
 import * as ApproxComparisons from './ApproxComparisons';
 
@@ -43,6 +43,7 @@ export interface ElementFields {
   styles?: Record<string, StringAssert>;
   html?: StringAssert;
   value?: StringAssert;
+  textContent?: StringAssert;
   children?: StructAssert[];
   exactAttrs?: Record<string, StringAssert>;
   exactClasses?: string[];
@@ -109,6 +110,7 @@ const element = (tag: string, fields: ElementFields): StructAssert => {
       const attrs = fields.attrs ?? {};
       const classes = fields.classes ?? [];
       const styles = fields.styles ?? {};
+      const optTextContent = Optional.from(fields.textContent);
       const optHtml = Optional.from(fields.html);
       const optValue = Optional.from(fields.value);
       const optChildren = Optional.from(fields.children);
@@ -133,6 +135,7 @@ const element = (tag: string, fields: ElementFields): StructAssert => {
 
       assertHtml(optHtml, actual);
       assertValue(optValue, actual);
+      assertTextContent(optTextContent, actual);
       assertChildren(optChildren, actual);
     } else {
       Assert.eq('Incorrect node type for: ' + Truncate.getHtml(actual), 1, SugarNode.type(actual));
@@ -338,6 +341,18 @@ const assertValue = (expectedValue: Optional<StringAssert>, actual: SugarElement
     v.strAssert(
       () => 'Checking value of ' + Truncate.getHtml(actual),
       Value.get(actual as SugarElement<any>)
+    );
+  });
+};
+
+const assertTextContent = (expectedValue: Optional<StringAssert>, actual: SugarElement<HTMLElement>) => {
+  expectedValue.each((v) => {
+    if (v.strAssert === undefined) {
+      throw new Error(JSON.stringify(v) + ' is not a *string assertion*.\nSpecified in *expected* value of ' + TextContent.get(actual));
+    }
+    v.strAssert(
+      () => 'Checking value of ' + TextContent.get(actual),
+      TextContent.get(actual)
     );
   });
 };

--- a/modules/agar/src/main/ts/ephox/agar/find/UiSearcher.ts
+++ b/modules/agar/src/main/ts/ephox/agar/find/UiSearcher.ts
@@ -1,6 +1,6 @@
 import { TestLabel } from '@ephox/bedrock-client';
 import { Adt, Arr, Optional, Result } from '@ephox/katamari';
-import { Attribute, SugarElement, Truncate } from '@ephox/sugar';
+import { Attribute, SugarElement, TextContent, Truncate } from '@ephox/sugar';
 
 import * as SizzleFind from '../alien/SizzleFind';
 
@@ -74,7 +74,7 @@ const findAllIn = <T extends Element>(container: SugarElement<Node>, selector: s
   selectAll(container, selector);
 
 const findTargetByLabel = <T extends Element>(container: SugarElement<Node>, labelText: string): Result<SugarElement<T>, TestLabel> => {
-  const label = Arr.find(selectAll(container, 'label'), (e) => e.dom.textContent === labelText);
+  const label = Arr.find(selectAll(container, 'label'), (e) => TextContent.get(e) === labelText);
   const targetByLabelOptional = label
     .bind((label) => {
       const forAttribute = Optional.from(Attribute.get(label, 'for'));

--- a/modules/agar/src/main/ts/ephox/agar/find/UiSearcher.ts
+++ b/modules/agar/src/main/ts/ephox/agar/find/UiSearcher.ts
@@ -4,6 +4,7 @@ import { SugarElement, Truncate } from '@ephox/sugar';
 
 import * as SizzleFind from '../alien/SizzleFind';
 
+/* TODO: what is this ADT */
 interface TargetAdt {
   fold: <T> (
     self: (element: SugarElement<Node>, selector: string) => T,

--- a/modules/agar/src/main/ts/ephox/agar/find/UiSearcher.ts
+++ b/modules/agar/src/main/ts/ephox/agar/find/UiSearcher.ts
@@ -1,5 +1,5 @@
 import { TestLabel } from '@ephox/bedrock-client';
-import { Adt, Optional, Result } from '@ephox/katamari';
+import { Adt, Arr, Optional, Result } from '@ephox/katamari';
 import { Attribute, SugarElement, Truncate } from '@ephox/sugar';
 
 import * as SizzleFind from '../alien/SizzleFind';
@@ -74,7 +74,8 @@ const findAllIn = <T extends Element>(container: SugarElement<Node>, selector: s
   selectAll(container, selector);
 
 const findTargetByLabel = <T extends Element>(container: SugarElement<Node>, labelText: string): Result<SugarElement<T>, TestLabel> => {
-  const targetByLabelOptional = select(container, `label:contains(${labelText})`)
+  const label = Arr.find(selectAll(container, 'label'), (e) => e.dom.textContent === labelText);
+  const targetByLabelOptional = label
     .bind((label) => {
       const forAttribute = Optional.from(Attribute.get(label, 'for'));
       return forAttribute.fold(

--- a/modules/agar/src/main/ts/ephox/agar/find/UiSearcher.ts
+++ b/modules/agar/src/main/ts/ephox/agar/find/UiSearcher.ts
@@ -4,7 +4,6 @@ import { Attribute, SugarElement, Truncate } from '@ephox/sugar';
 
 import * as SizzleFind from '../alien/SizzleFind';
 
-/* TODO: what is this ADT */
 interface TargetAdt {
   fold: <T> (
     self: (element: SugarElement<Node>, selector: string) => T,

--- a/modules/agar/src/main/ts/ephox/agar/find/UiSearcher.ts
+++ b/modules/agar/src/main/ts/ephox/agar/find/UiSearcher.ts
@@ -1,6 +1,6 @@
 import { TestLabel } from '@ephox/bedrock-client';
 import { Adt, Optional, Result } from '@ephox/katamari';
-import { SugarElement, Truncate } from '@ephox/sugar';
+import { Attribute, SugarElement, Truncate } from '@ephox/sugar';
 
 import * as SizzleFind from '../alien/SizzleFind';
 
@@ -74,8 +74,24 @@ const findIn = <T extends Element>(container: SugarElement<Node>, selector: stri
 const findAllIn = <T extends Element>(container: SugarElement<Node>, selector: string): Array<SugarElement<T>> =>
   selectAll(container, selector);
 
+const findTargetByLabel = <T extends Element>(container: SugarElement<Node>, labelText: string): Result<SugarElement<T>, TestLabel> => {
+  const targetByLabelOptional = select(container, `label:contains(${labelText})`)
+    .bind((label) => {
+      const forAttribute = Optional.from(Attribute.get(label, 'for'));
+      return forAttribute.fold(
+        () => select<T>(label, 'button,input,meter,output,progress,select,textarea'),
+        (inputId) => select<T>(container, `#${inputId}`)
+      );
+    });
+  return toResult(
+    () => 'Could not find target by label: ' + labelText + ' in ' + Truncate.getHtml(container),
+    targetByLabelOptional
+  );
+};
+
 export {
   select,
   findIn,
-  findAllIn
+  findAllIn,
+  findTargetByLabel
 };

--- a/modules/agar/src/test/ts/browser/SelectorEngineTest.ts
+++ b/modules/agar/src/test/ts/browser/SelectorEngineTest.ts
@@ -1,6 +1,7 @@
 import { afterEach, Assert, beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Testable } from '@ephox/dispute';
 import { Insert, Remove, SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
 
 import * as SelectorEngine from 'ephox/agar/alien/SelectorEngine';
 
@@ -22,7 +23,7 @@ describe('SelectorEngineTest', () => {
       '<div>' +
         '<div class="myDiv"></div>' +
         '<div id="myDiv"></div>' +
-        '<textarea></textarea' +
+        '<textarea></textarea>' +
       '</div>'
     );
     Insert.append(container, content);
@@ -38,7 +39,7 @@ describe('SelectorEngineTest', () => {
       '<div>' +
         '<div class="myDiv"></div>' +
         '<div id="myDiv"></div>' +
-        '<textarea></textarea' +
+        '<textarea></textarea>' +
       '</div>'
     );
     Insert.append(container, content);
@@ -54,7 +55,7 @@ describe('SelectorEngineTest', () => {
       '<div>' +
         '<div class="myDiv"></div>' +
         '<div id="myDiv"></div>' +
-        '<textarea></textarea' +
+        '<textarea></textarea>' +
       '</div>'
     );
     Insert.append(container, content);
@@ -168,14 +169,20 @@ describe('SelectorEngineTest', () => {
     Assert.eq(':contains("This is the only paragraph here") p returned', p, matches[0], Testable.tStrict);
   });
 
-  it('selectAll should throw error when :contains is not at the end', () => {
-    Assert.throws('selectAll should throw error when :contains is not at the end',
-      () => SelectorEngine.selectAll('label:contains(Foo) + input', container.dom));
-  });
+  const assertThrowsContainsAtTheEnd = (selector: string) => {
+    assert.throws(
+      () => SelectorEngine.selectAll(selector, container.dom),
+      `Invalid selector '${selector}'. ':contains' in only supported at the end of the selector`
+    );
+    assert.throws(
+      () => SelectorEngine.matchesSelector(container.dom, selector),
+      `Invalid selector '${selector}'. ':contains' in only supported at the end of the selector`
+    );
+  };
 
-  it('matchesSelector should throw error when :contains is not at the end', () => {
-    Assert.throws('matchesSelector should throw error when :contains is not at the end',
-      () => SelectorEngine.matchesSelector(container.dom, 'label:contains(Foo) + input'));
+  it('Should throw :contains has to be at the end', () => {
+    assertThrowsContainsAtTheEnd('label:contains(Foo) + input');
+    assertThrowsContainsAtTheEnd('.tox-tbtn.tox-tbtn--select:has(.tox-tbtn__select-label:contains(test))');
   });
 
   it('matchesSelector should match', () => {

--- a/modules/agar/src/test/ts/browser/SelectorEngineTest.ts
+++ b/modules/agar/src/test/ts/browser/SelectorEngineTest.ts
@@ -150,6 +150,23 @@ describe('SelectorEngineTest', () => {
     Assert.eq(':contains(Tiny) third li returned', liList[2], matches[2]);
   });
 
+  it(':contains should include text divided between elements', () => {
+    const content = SugarElement.fromHtml(
+      '<p>' +
+        'This is the only p' +
+        '<span>ar</span>' +
+        'agraph ' +
+        '<em>here</em>' +
+      '</p>'
+    );
+    Insert.append(container, content);
+    const p = container.dom.querySelector('p');
+
+    const matches = SelectorEngine.selectAll('p:contains("This is the only paragraph here")', container.dom);
+    Assert.eq(':contains("This is the only paragraph here") one element in array', 1, matches.length);
+    Assert.eq(':contains("This is the only paragraph here") p returned', p, matches[0]);
+  });
+
   /*
   TODO: maybe I should test how to escape " and ' inside "" and ''
   it(':contains should look for quotes', () => {

--- a/modules/agar/src/test/ts/browser/SelectorEngineTest.ts
+++ b/modules/agar/src/test/ts/browser/SelectorEngineTest.ts
@@ -167,6 +167,16 @@ describe('SelectorEngineTest', () => {
     Assert.eq(':contains("This is the only paragraph here") p returned', p, matches[0]);
   });
 
+  it('selectAll should throw error when :contains is not at the end', () => {
+    Assert.throws('selectAll should throw error when :contains is not at the end',
+      () => SelectorEngine.selectAll('label:contains(Foo) + input', container.dom));
+  });
+
+  it('matchesSelector should throw error when :contains is not at the end', () => {
+    Assert.throws('matchesSelector should throw error when :contains is not at the end',
+      () => SelectorEngine.matchesSelector(container.dom, 'label:contains(Foo) + input'));
+  });
+
   /*
   TODO: maybe I should test how to escape " and ' inside "" and ''
   it(':contains should look for quotes', () => {

--- a/modules/agar/src/test/ts/browser/SelectorEngineTest.ts
+++ b/modules/agar/src/test/ts/browser/SelectorEngineTest.ts
@@ -1,4 +1,5 @@
 import { afterEach, Assert, beforeEach, describe, it } from '@ephox/bedrock-client';
+import { Testable } from '@ephox/dispute';
 import { Insert, Remove, SugarElement } from '@ephox/sugar';
 
 import * as SelectorEngine from 'ephox/agar/alien/SelectorEngine';
@@ -29,7 +30,7 @@ describe('SelectorEngineTest', () => {
 
     const matches = SelectorEngine.selectAll('#myDiv', container.dom);
     Assert.eq('one element in array', 1, matches.length);
-    Assert.eq('div#myDiv returned', divWithId, matches[0]);
+    Assert.eq('div#myDiv returned', divWithId, matches[0], Testable.tStrict);
   });
 
   it('Should find element by class', async () => {
@@ -45,7 +46,7 @@ describe('SelectorEngineTest', () => {
 
     const matches = SelectorEngine.selectAll('.myDiv', container.dom);
     Assert.eq('one element in array', 1, matches.length);
-    Assert.eq('div.myDiv returned', divWithClass, matches[0]);
+    Assert.eq('div.myDiv returned', divWithClass, matches[0], Testable.tStrict);
   });
 
   it('Should find element by tag', async () => {
@@ -61,7 +62,7 @@ describe('SelectorEngineTest', () => {
 
     const matches = SelectorEngine.selectAll('textarea', container.dom);
     Assert.eq('one element in array', 1, matches.length);
-    Assert.eq('textarea returned', textarea, matches[0]);
+    Assert.eq('textarea returned', textarea, matches[0], Testable.tStrict);
   });
 
   it('Should find element by contains', () => {
@@ -77,15 +78,15 @@ describe('SelectorEngineTest', () => {
 
     let matches = SelectorEngine.selectAll('li:contains(Two)', container.dom);
     Assert.eq(':contains(Two) one element in array', 1, matches.length);
-    Assert.eq(':contains(Two) second li returned', secondLi, matches[0]);
+    Assert.eq(':contains(Two) second li returned', secondLi, matches[0], Testable.tStrict);
 
     matches = SelectorEngine.selectAll('li:contains(\'Two\')', container.dom);
     Assert.eq(':contains(\'Two\') one element in array', 1, matches.length);
-    Assert.eq(':contains(\'Two\') second li returned', secondLi, matches[0]);
+    Assert.eq(':contains(\'Two\') second li returned', secondLi, matches[0], Testable.tStrict);
 
     matches = SelectorEngine.selectAll('li:contains("Two")', container.dom);
     Assert.eq(':contains("Two") one element in array', 1, matches.length);
-    Assert.eq(':contains("Two") second li returned', secondLi, matches[0]);
+    Assert.eq(':contains("Two") second li returned', secondLi, matches[0], Testable.tStrict);
   });
 
   it(':contains should be case sensitive', () => {
@@ -109,7 +110,7 @@ describe('SelectorEngineTest', () => {
 
     const matches = SelectorEngine.selectAll('li:contains(This is a sentence)', container.dom);
     Assert.eq(':contains(This is a sentence) one element in array', 1, matches.length);
-    Assert.eq(':contains(This is a sentence) li returned', li, matches[0]);
+    Assert.eq(':contains(This is a sentence) li returned', li, matches[0], Testable.tStrict);
   });
 
   it(':contains should look in descendants', () => {
@@ -129,7 +130,7 @@ describe('SelectorEngineTest', () => {
 
     const matches = SelectorEngine.selectAll('ol:contains(Tiny)', container.dom);
     Assert.eq(':contains(Tiny) one element in array', 1, matches.length);
-    Assert.eq(':contains(Tiny) li returned', ol, matches[0]);
+    Assert.eq(':contains(Tiny) li returned', ol, matches[0], Testable.tStrict);
   });
 
   it(':contains should include partial match', () => {
@@ -145,9 +146,9 @@ describe('SelectorEngineTest', () => {
 
     const matches = SelectorEngine.selectAll('li:contains(Tiny)', container.dom);
     Assert.eq(':contains(Tiny) three elements in array', 3, matches.length);
-    Assert.eq(':contains(Tiny) first li returned', liList[0], matches[0]);
-    Assert.eq(':contains(Tiny) second li returned', liList[1], matches[1]);
-    Assert.eq(':contains(Tiny) third li returned', liList[2], matches[2]);
+    Assert.eq(':contains(Tiny) first li returned', liList[0], matches[0], Testable.tStrict);
+    Assert.eq(':contains(Tiny) second li returned', liList[1], matches[1], Testable.tStrict);
+    Assert.eq(':contains(Tiny) third li returned', liList[2], matches[2], Testable.tStrict);
   });
 
   it(':contains should include text divided between elements', () => {
@@ -164,7 +165,7 @@ describe('SelectorEngineTest', () => {
 
     const matches = SelectorEngine.selectAll('p:contains("This is the only paragraph here")', container.dom);
     Assert.eq(':contains("This is the only paragraph here") one element in array', 1, matches.length);
-    Assert.eq(':contains("This is the only paragraph here") p returned', p, matches[0]);
+    Assert.eq(':contains("This is the only paragraph here") p returned', p, matches[0], Testable.tStrict);
   });
 
   it('selectAll should throw error when :contains is not at the end', () => {

--- a/modules/agar/src/test/ts/browser/SelectorEngineTest.ts
+++ b/modules/agar/src/test/ts/browser/SelectorEngineTest.ts
@@ -166,7 +166,6 @@ describe('SelectorEngineTest', () => {
   */
 
   /* TODO: how about :contains() meaning empty string */
-
   it('matchesSelector should match', () => {
     const content = SugarElement.fromHtml(
       '<div id="home-content">' +
@@ -193,5 +192,21 @@ describe('SelectorEngineTest', () => {
     const p = container.dom.querySelector('p');
 
     Assert.eq('matchesSelector should not match', false, SelectorEngine.matchesSelector(p, 'main > section > p'));
+  });
+
+  it('matchesSelector should match with contains', () => {
+    const content = SugarElement.fromHtml(
+      '<div id="home-content">' +
+        '<section>' +
+          '<p>One</p>' +
+          '<p>Two</p>' +
+          '<p>Three</p>' +
+        '</section>' +
+      '</div>'
+    );
+    Insert.append(container, content);
+    const p = Array.from(container.dom.querySelectorAll('p'))[1];
+
+    Assert.eq('matchesSelector should match with contains', true, SelectorEngine.matchesSelector(p, 'p:contains(Two)'));
   });
 });

--- a/modules/agar/src/test/ts/browser/SelectorEngineTest.ts
+++ b/modules/agar/src/test/ts/browser/SelectorEngineTest.ts
@@ -1,0 +1,197 @@
+import { afterEach, Assert, beforeEach, describe, it } from '@ephox/bedrock-client';
+import { Insert, Remove, SugarElement } from '@ephox/sugar';
+
+import * as SelectorEngine from 'ephox/agar/alien/SelectorEngine';
+
+describe('SelectorEngineTest', () => {
+  const body = SugarElement.fromDom(document.body);
+  let container: SugarElement<HTMLElement>;
+
+  beforeEach(() => {
+    container = SugarElement.fromHtml<HTMLElement>('<div class="container"></div>');
+    Insert.append(body, container);
+  });
+
+  afterEach(() => {
+    Remove.remove(container);
+  });
+
+  it('Should find element by id', async () => {
+    const content = SugarElement.fromHtml(
+      '<div>' +
+        '<div class="myDiv"></div>' +
+        '<div id="myDiv"></div>' +
+        '<textarea></textarea' +
+      '</div>'
+    );
+    Insert.append(container, content);
+    const divWithId = container.dom.querySelector('#myDiv');
+
+    const matches = SelectorEngine.selectAll('#myDiv', container.dom);
+    Assert.eq('one element in array', 1, matches.length);
+    Assert.eq('div#myDiv returned', divWithId, matches[0]);
+  });
+
+  it('Should find element by class', async () => {
+    const content = SugarElement.fromHtml(
+      '<div>' +
+        '<div class="myDiv"></div>' +
+        '<div id="myDiv"></div>' +
+        '<textarea></textarea' +
+      '</div>'
+    );
+    Insert.append(container, content);
+    const divWithClass = container.dom.querySelector('.myDiv');
+
+    const matches = SelectorEngine.selectAll('.myDiv', container.dom);
+    Assert.eq('one element in array', 1, matches.length);
+    Assert.eq('div.myDiv returned', divWithClass, matches[0]);
+  });
+
+  it('Should find element by tag', async () => {
+    const content = SugarElement.fromHtml(
+      '<div>' +
+        '<div class="myDiv"></div>' +
+        '<div id="myDiv"></div>' +
+        '<textarea></textarea' +
+      '</div>'
+    );
+    Insert.append(container, content);
+    const textarea = container.dom.querySelector('textarea');
+
+    const matches = SelectorEngine.selectAll('textarea', container.dom);
+    Assert.eq('one element in array', 1, matches.length);
+    Assert.eq('textarea returned', textarea, matches[0]);
+  });
+
+  it('Should find element by contains', () => {
+    const content = SugarElement.fromHtml(
+      '<ul>' +
+        '<li>One</li>' +
+        '<li>Two</li>' +
+        '<li>Three</li>' +
+      '</ul>'
+    );
+    Insert.append(container, content);
+    const secondLi = container.dom.querySelector('ul').children[1];
+
+    let matches = SelectorEngine.selectAll('li:contains(Two)', container.dom);
+    Assert.eq(':contains(Two) one element in array', 1, matches.length);
+    Assert.eq(':contains(Two) second li returned', secondLi, matches[0]);
+
+    matches = SelectorEngine.selectAll('li:contains(\'Two\')', container.dom);
+    Assert.eq(':contains(\'Two\') one element in array', 1, matches.length);
+    Assert.eq(':contains(\'Two\') second li returned', secondLi, matches[0]);
+
+    matches = SelectorEngine.selectAll('li:contains("Two")', container.dom);
+    Assert.eq(':contains("Two") one element in array', 1, matches.length);
+    Assert.eq(':contains("Two") second li returned', secondLi, matches[0]);
+  });
+
+  it(':contains should be case sensitive', () => {
+    const content = SugarElement.fromHtml(
+      '<ul>' +
+        '<li>One</li>' +
+        '<li>Two</li>' +
+        '<li>Three</li>' +
+      '</ul>'
+    );
+    Insert.append(container, content);
+
+    const matches = SelectorEngine.selectAll('li:contains(two)', container.dom);
+    Assert.eq(':contains(two) should return empty array', 0, matches.length);
+  });
+
+  it(':contains should handle text with space', () => {
+    const content = SugarElement.fromHtml('<ul><li>This is a sentence</li></ul>');
+    Insert.append(container, content);
+    const li = container.dom.querySelector('li');
+
+    const matches = SelectorEngine.selectAll('li:contains(This is a sentence)', container.dom);
+    Assert.eq(':contains(This is a sentence) one element in array', 1, matches.length);
+    Assert.eq(':contains(This is a sentence) li returned', li, matches[0]);
+  });
+
+  it(':contains should look in descendants', () => {
+    const content = SugarElement.fromHtml(
+      '<ol>' +
+        '<li>Some text</li>' +
+        '<li>' +
+          '<ul>' +
+            '<li>Some text</li>' +
+            '<li><div id="tinyDiv">Tiny</div></li>' +
+          '</ul>' +
+        '</li>' +
+      '</ol>'
+    );
+    Insert.append(container, content);
+    const ol = container.dom.querySelector('ol');
+
+    const matches = SelectorEngine.selectAll('ol:contains(Tiny)', container.dom);
+    Assert.eq(':contains(Tiny) one element in array', 1, matches.length);
+    Assert.eq(':contains(Tiny) li returned', ol, matches[0]);
+  });
+
+  it(':contains should include partial match', () => {
+    const content = SugarElement.fromHtml(
+      '<ol>' +
+        '<li>Tiny and couple of other words<li>' +
+        '<li>TinyMCE</li>' +
+        '<li>Tiny</li>' +
+      '</ol>'
+    );
+    Insert.append(container, content);
+    const liList = container.dom.querySelectorAll('li');
+
+    const matches = SelectorEngine.selectAll('li:contains(Tiny)', container.dom);
+    Assert.eq(':contains(Tiny) three elements in array', 3, matches.length);
+    Assert.eq(':contains(Tiny) first li returned', liList[0], matches[0]);
+    Assert.eq(':contains(Tiny) second li returned', liList[1], matches[1]);
+    Assert.eq(':contains(Tiny) third li returned', liList[2], matches[2]);
+  });
+
+  /*
+  TODO: maybe I should test how to escape " and ' inside "" and ''
+  it(':contains should look for quotes', () => {
+    const content = SugarElement.fromHtml(
+      '<div>' +
+        '<div>That\'s interesting</div>' +
+        '<div id="quote">"To be or not to be"</div>' +
+        '<div>To be or not to be</div>' +
+      '</div>'
+    );
+    Insert.append(container, content);
+    const quote = document.querySelector('#quote');
+  });
+  */
+
+  /* TODO: how about :contains() meaning empty string */
+
+  it('matchesSelector should match', () => {
+    const content = SugarElement.fromHtml(
+      '<div id="home-content">' +
+        '<section>' +
+          '<p>This is my paragraph</p>' +
+        '</section>' +
+      '</div>'
+    );
+    Insert.append(container, content);
+    const p = container.dom.querySelector('p');
+
+    Assert.eq('matchesSelector should match', true, SelectorEngine.matchesSelector(p, '#home-content > section > p'));
+  });
+
+  it('matchesSelector should not match', () => {
+    const content = SugarElement.fromHtml(
+      '<div id="home-content">' +
+        '<section>' +
+          '<p>This is my paragraph</p>' +
+        '</section>' +
+      '</div>'
+    );
+    Insert.append(container, content);
+    const p = container.dom.querySelector('p');
+
+    Assert.eq('matchesSelector should not match', false, SelectorEngine.matchesSelector(p, 'main > section > p'));
+  });
+});

--- a/modules/agar/src/test/ts/browser/SelectorEngineTest.ts
+++ b/modules/agar/src/test/ts/browser/SelectorEngineTest.ts
@@ -114,6 +114,16 @@ describe('SelectorEngineTest', () => {
     Assert.eq(':contains(This is a sentence) li returned', li, matches[0], Testable.tStrict);
   });
 
+  it(':contains should handle text with parenthesis', () => {
+    const content = SugarElement.fromHtml('<ul><li>English (United States)</li></ul>');
+    Insert.append(container, content);
+    const li = container.dom.querySelector('li');
+
+    const matches = SelectorEngine.selectAll('li:contains("English (United States)")', container.dom);
+    Assert.eq(':contains(English (United States)) one element in array', 1, matches.length);
+    Assert.eq(':contains(English (United States)) li returned', li, matches[0], Testable.tStrict);
+  });
+
   it(':contains should look in descendants', () => {
     const content = SugarElement.fromHtml(
       '<ol>' +
@@ -172,11 +182,11 @@ describe('SelectorEngineTest', () => {
   const assertThrowsContainsAtTheEnd = (selector: string) => {
     assert.throws(
       () => SelectorEngine.selectAll(selector, container.dom),
-      `Invalid selector '${selector}'. ':contains' in only supported at the end of the selector`
+      `Invalid selector '${selector}'. ':contains' is only supported as the last pseudo-class.`
     );
     assert.throws(
       () => SelectorEngine.matchesSelector(container.dom, selector),
-      `Invalid selector '${selector}'. ':contains' in only supported at the end of the selector`
+      `Invalid selector '${selector}'. ':contains' is only supported as the last pseudo-class.`
     );
   };
 

--- a/modules/agar/src/test/ts/browser/SelectorEngineTest.ts
+++ b/modules/agar/src/test/ts/browser/SelectorEngineTest.ts
@@ -136,7 +136,7 @@ describe('SelectorEngineTest', () => {
   it(':contains should include partial match', () => {
     const content = SugarElement.fromHtml(
       '<ol>' +
-        '<li>Tiny and couple of other words<li>' +
+        '<li>Tiny and couple of other words</li>' +
         '<li>TinyMCE</li>' +
         '<li>Tiny</li>' +
       '</ol>'
@@ -178,22 +178,6 @@ describe('SelectorEngineTest', () => {
       () => SelectorEngine.matchesSelector(container.dom, 'label:contains(Foo) + input'));
   });
 
-  /*
-  TODO: maybe I should test how to escape " and ' inside "" and ''
-  it(':contains should look for quotes', () => {
-    const content = SugarElement.fromHtml(
-      '<div>' +
-        '<div>That\'s interesting</div>' +
-        '<div id="quote">"To be or not to be"</div>' +
-        '<div>To be or not to be</div>' +
-      '</div>'
-    );
-    Insert.append(container, content);
-    const quote = document.querySelector('#quote');
-  });
-  */
-
-  /* TODO: how about :contains() meaning empty string */
   it('matchesSelector should match', () => {
     const content = SugarElement.fromHtml(
       '<div id="home-content">' +

--- a/modules/agar/src/test/ts/browser/UiFinderTest.ts
+++ b/modules/agar/src/test/ts/browser/UiFinderTest.ts
@@ -1,4 +1,5 @@
 import { afterEach, Assert, beforeEach, describe, it, UnitTest } from '@ephox/bedrock-client';
+import { Testable } from '@ephox/dispute';
 import { Class, Css, Hierarchy, Html, Insert, Remove, SugarElement, SugarNode } from '@ephox/sugar';
 
 import * as Assertions from 'ephox/agar/api/Assertions';
@@ -129,7 +130,7 @@ describe('UiFinderTest', () => {
     Insert.append(container, content);
     const input = container.dom.querySelector('#input-width');
 
-    Assert.eq('Should find target by label', input, UiFinder.findTargetByLabel(container, 'Width').getOrDie().dom);
+    Assert.eq('Should find target by label', input, UiFinder.findTargetByLabel(container, 'Width').getOrDie().dom, Testable.tStrict);
   });
 
   it('Should find input target by label when input inside label', async () => {
@@ -142,7 +143,7 @@ describe('UiFinderTest', () => {
     Insert.append(container, content);
     const input = container.dom.querySelector('#has-border');
 
-    Assert.eq('Should find input inside label', input, UiFinder.findTargetByLabel(container, 'Has Border').getOrDie().dom);
+    Assert.eq('Should find input inside label', input, UiFinder.findTargetByLabel(container, 'Has Border').getOrDie().dom, Testable.tStrict);
   });
 
   it('Should find textarea target by label when textarea inside label', async () => {
@@ -155,6 +156,23 @@ describe('UiFinderTest', () => {
     Insert.append(container, content);
     const input = container.dom.querySelector('#description');
 
-    Assert.eq('Should find textarea inside label', input, UiFinder.findTargetByLabel(container, 'Description').getOrDie().dom);
+    Assert.eq('Should find textarea inside label', input, UiFinder.findTargetByLabel(container, 'Description').getOrDie().dom, Testable.tStrict);
+  });
+
+  it('Should match full label', async () => {
+    const content = SugarElement.fromHtml(
+      '<div>' +
+        '<label for="sort-by">Sort by</label>' +
+        '<input id="sort-by"></input>' +
+        '<label for="sort">Sort</label>' +
+        '<input id="sort"></input>' +
+      '</div>'
+    );
+    Insert.append(container, content);
+    const sortByInput = container.dom.querySelector('#sort-by');
+    const sortInput = container.dom.querySelector('#sort');
+
+    Assert.eq('Should find sortBy', sortByInput, UiFinder.findTargetByLabel(container, 'Sort by').getOrDie().dom, Testable.tStrict);
+    Assert.eq('Should find sort', sortInput, UiFinder.findTargetByLabel(container, 'Sort').getOrDie().dom, Testable.tStrict);
   });
 });

--- a/modules/agar/src/test/ts/browser/UiFinderTest.ts
+++ b/modules/agar/src/test/ts/browser/UiFinderTest.ts
@@ -1,4 +1,4 @@
-import { UnitTest } from '@ephox/bedrock-client';
+import { afterEach, Assert, beforeEach, describe, it, UnitTest } from '@ephox/bedrock-client';
 import { Class, Css, Hierarchy, Html, Insert, Remove, SugarElement, SugarNode } from '@ephox/sugar';
 
 import * as Assertions from 'ephox/agar/api/Assertions';
@@ -104,4 +104,57 @@ UnitTest.asynctest('UiFinderTest', (success, failure) => {
     teardown();
     success();
   }, failure);
+});
+
+describe('UiFinderTest', () => {
+  const body = SugarElement.fromDom(document.body);
+  let container: SugarElement<HTMLElement>;
+
+  beforeEach(() => {
+    container = SugarElement.fromHtml<HTMLElement>('<div class="container"></div>');
+    Insert.append(body, container);
+  });
+
+  afterEach(() => {
+    Remove.remove(container);
+  });
+
+  it('Should find target by label', async () => {
+    const content = SugarElement.fromHtml(
+      '<div>' +
+        '<label for="input-width">Width</label>' +
+        '<input type="number" id="input-width"></input>' +
+      '</div>'
+    );
+    Insert.append(container, content);
+    const input = container.dom.querySelector('#input-width');
+
+    Assert.eq('Should find target by label', input, UiFinder.findTargetByLabel(container, 'Width').getOrDie().dom);
+  });
+
+  it('Should find input target by label when input inside label', async () => {
+    const content = SugarElement.fromHtml(
+      '<label>' +
+        'Has Border' +
+        '<input type="checkbox" id="has-border"></input>' +
+      '</label>'
+    );
+    Insert.append(container, content);
+    const input = container.dom.querySelector('#has-border');
+
+    Assert.eq('Should find input inside label', input, UiFinder.findTargetByLabel(container, 'Has Border').getOrDie().dom);
+  });
+
+  it('Should find textarea target by label when textarea inside label', async () => {
+    const content = SugarElement.fromHtml(
+      '<label>' +
+        'Description' +
+        '<textarea id="description"></textarea>' +
+      '</label>'
+    );
+    Insert.append(container, content);
+    const input = container.dom.querySelector('#description');
+
+    Assert.eq('Should find textarea inside label', input, UiFinder.findTargetByLabel(container, 'Description').getOrDie().dom);
+  });
 });

--- a/modules/alloy/src/test/ts/browser/api/ForeignGuiTest.ts
+++ b/modules/alloy/src/test/ts/browser/api/ForeignGuiTest.ts
@@ -91,7 +91,7 @@ UnitTest.asynctest('Browser Test: api.ForeignGuiTest', (success, failure) => {
     sAssertChildHasNoUid('First child should have no uid', 0),
     sAssertChildHasRandomUid('Div should have a uid', 3),
 
-    Mouse.sClickOn(root, 'span.clicker:first'),
+    Mouse.sClickOn(root, 'span.clicker:first-child'),
 
     Assertions.sAssertStructure(
       'Checking structure after the first span is clicked',

--- a/modules/alloy/src/test/ts/browser/api/events/AlloyTriggersRetargetTest.ts
+++ b/modules/alloy/src/test/ts/browser/api/events/AlloyTriggersRetargetTest.ts
@@ -78,7 +78,7 @@ UnitTest.asynctest('AlloyTriggersRetargetTest', (success, failure) => {
     (_doc, _body, _gui, component, store) => [
       Logger.t(
         'Trigger a click on the original recipient',
-        Chain.isolate(component, Chain.fromChains([
+        Chain.isolate(component.element, Chain.fromChains([
           UiFinder.cFindIn('.original-recipient'),
           Mouse.cClickWith({ })
         ]))

--- a/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
@@ -172,7 +172,7 @@ describe('browser.tinymce.core.dom.ControlSelectionTest', () => {
     TinySelections.select(editor, 'span.mce-object-video', []);
     await pWaitForDragHandles(editorBody, '#mceResizeHandlenw');
     TinyAssertions.assertContentPresence(editor, {
-      'span[data-mce-selected=1] video': 1,
+      'span[data-mce-selected="1"] video': 1,
       'span[data-mce-selected] audio': 0
     });
 
@@ -182,7 +182,7 @@ describe('browser.tinymce.core.dom.ControlSelectionTest', () => {
     await Waiter.pTryUntil('Wait for resize handles to disappear', () => UiFinder.notExists(editorBody, '#mceResizeHandlenw'));
     TinyAssertions.assertContentPresence(editor, {
       'span[data-mce-selected] video': 0,
-      'span[data-mce-selected=3] audio': 1
+      'span[data-mce-selected="3"] audio': 1
     });
 
     const videoPreviewSpan = editor.dom.select('span')[0];
@@ -190,7 +190,7 @@ describe('browser.tinymce.core.dom.ControlSelectionTest', () => {
     TinySelections.select(editor, 'span.mce-object-video', []);
     await pWaitForDragHandles(editorBody, '#mceResizeHandlenw');
     TinyAssertions.assertContentPresence(editor, {
-      'span[data-mce-selected=2] video': 1,
+      'span[data-mce-selected="2"] video': 1,
       'span[data-mce-selected] audio': 0
     });
   });

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyCeFalseTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyCeFalseTest.ts
@@ -78,7 +78,7 @@ describe('browser.tinymce.core.keyboard.EnterKeyCeFalseTest', () => {
   it('TINY-9101: Pressing Enter on a cE=false block should do nothing', () => {
     const editor = hook.editor();
     editor.setContent('<p>First</p><p contenteditable="false">Second</p><p>Third</p>');
-    TinySelections.select(editor, 'p:eq(1)', [ ]);
+    TinySelections.select(editor, 'p:nth-child(2)', [ ]);
     pressEnter(editor);
     TinyAssertions.assertContent(editor, '<p>First</p><p contenteditable="false">Second</p><p>Third</p>');
     assert.equal(editor.selection.getNode().nodeName, 'P');

--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapSearchTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapSearchTest.ts
@@ -36,7 +36,7 @@ describe('browser.tinymce.plugins.charmap.SearchTest', () => {
     await Waiter.pTryUntil(
       'Wait until Euro is the first choice (search should filter)',
       () => {
-        const item = UiFinder.findIn(body, '.tox-collection__item:first').getOrDie();
+        const item = UiFinder.findIn(body, '.tox-collection__item:first-child').getOrDie();
         const value = Attribute.get(item, 'data-collection-item-value');
         assert.equal(value, '€', 'Search should show euro');
       }

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmojiAppendTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmojiAppendTest.ts
@@ -57,7 +57,7 @@ describe('browser.tinymce.plugins.emoticons.EmojiAppendTest', () => {
     await Waiter.pTryUntil(
       'Wait until clock is the first choice (search should filter)',
       () => {
-        const item = UiFinder.findIn(SugarBody.body(), '.tox-collection__item:first').getOrDie();
+        const item = UiFinder.findIn(SugarBody.body(), '.tox-collection__item:first-child').getOrDie();
         const value = Attribute.get(item, 'data-collection-item-value');
         assert.equal(value, '⏲', 'Search should show custom clock');
       }

--- a/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmojiSearchTest.ts
+++ b/modules/tinymce/src/plugins/emoticons/test/ts/browser/EmojiSearchTest.ts
@@ -35,7 +35,7 @@ describe('browser.tinymce.plugins.emoticons.EmojiSearchTest', () => {
     await Waiter.pTryUntil(
       'Wait until rainbow is the first choice (search should filter)',
       () => {
-        const item = UiFinder.findIn(SugarBody.body(), '.tox-collection__item:first').getOrDie();
+        const item = UiFinder.findIn(SugarBody.body(), '.tox-collection__item:first-child').getOrDie();
         const value = Attribute.get(item, 'data-collection-item-value');
         assert.equal(value, '🌈', 'Search should show rainbow');
       }

--- a/modules/tinymce/src/plugins/help/test/ts/module/Selectors.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/module/Selectors.ts
@@ -3,8 +3,8 @@ export const selectors = {
   toolbarHelpButton: 'button',
   pluginsTab: '[role="tab"]:contains(Plugins)',
   pluginsTabLists: {
-    installed: '[role=document] div:eq(0) ul',
-    available: '[role=document] div:eq(1) ul',
+    installed: '[role=document] div:nth-child(1) ul',
+    available: '[role=document] div:nth-child(2) ul',
     readMoreClass: 'tox-help__more-link'
   }
 };

--- a/modules/tinymce/src/plugins/image/test/ts/browser/A11yImageTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/A11yImageTest.ts
@@ -1,13 +1,13 @@
-import { Cursors, UiFinder } from '@ephox/agar';
+import { Cursors, Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { Attribute, SugarBody, Value } from '@ephox/sugar';
+import { Attribute, SugarBody, SugarElement, Value } from '@ephox/sugar';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
 
-import { fillActiveDialog, generalTabSelectors, ImageDialogData } from '../module/Helpers';
+import { fillActiveDialog, generalTabLabels, ImageDialogData } from '../module/Helpers';
 
 describe('browser.tinymce.plugins.image.A11yImageTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -39,7 +39,8 @@ describe('browser.tinymce.plugins.image.A11yImageTest', () => {
   const pTestUiStateDisabled = async (editor: Editor) => {
     editor.execCommand('mceImage');
     await TinyUiActions.pWaitForDialog(editor);
-    UiFinder.exists(SugarBody.body(), generalTabSelectors.alt + ':disabled');
+    UiFinder.findTargetByLabel(SugarBody.body(), generalTabLabels.alt)
+      .exists((e) => Attribute.has(e, 'disabled') && Attribute.get(e, 'disabled') === 'disabled');
     TinyUiActions.submitDialog(editor);
     UiFinder.notExists(SugarBody.body(), 'div[role="dialog"]');
   };
@@ -47,21 +48,24 @@ describe('browser.tinymce.plugins.image.A11yImageTest', () => {
   const pTestUiStateEnabled = async (editor: Editor, alt: string) => {
     editor.execCommand('mceImage');
     await TinyUiActions.pWaitForDialog(editor);
-    const altElem = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), generalTabSelectors.alt).getOrDie();
+    const altElem = UiFinder.findTargetByLabel<HTMLInputElement>(SugarBody.body(), generalTabLabels.alt).getOrDie();
     const value = Value.get(altElem);
     assert.equal(value, alt, 'Assert input value');
     TinyUiActions.submitDialog(editor);
     UiFinder.notExists(SugarBody.body(), 'div[role="dialog"]');
   };
 
+  const pWaitForInputState = async (waiterLabel: string, labelText: string, predicate: (input: SugarElement<Element>) => boolean) =>
+    await Waiter.pTryUntilPredicate(waiterLabel, () => UiFinder.findTargetByLabel(SugarBody.body(), labelText).exists(predicate));
+
   it('TBA: Check the decorative checkbox toggles the alt text input', async () => {
     const editor = hook.editor();
     await pInitAndOpenDialog(editor, '', { element: [ 0 ], offset: 0 });
-    await UiFinder.pWaitForState('Check alt text input is enabled', SugarBody.body(), generalTabSelectors.alt, (e) => !Attribute.has(e, 'disabled'));
-    TinyUiActions.clickOnUi(editor, generalTabSelectors.decorative);
-    await UiFinder.pWaitForState('Check alt text input is disabled', SugarBody.body(), generalTabSelectors.alt, (e) => Attribute.has(e, 'disabled') && Attribute.get(e, 'disabled') === 'disabled');
-    TinyUiActions.clickOnUi(editor, generalTabSelectors.decorative);
-    await UiFinder.pWaitForState('Check alt text input is enabled', SugarBody.body(), generalTabSelectors.alt, (e) => !Attribute.has(e, 'disabled'));
+    await pWaitForInputState('Check alt text input is enabled', generalTabLabels.alt, (e) => !Attribute.has(e, 'disabled'));
+    Mouse.click(UiFinder.findTargetByLabel(SugarBody.body(), generalTabLabels.decorative).getOrDie());
+    await pWaitForInputState('Check alt text input is disabled', generalTabLabels.alt, (e) => Attribute.has(e, 'disabled') && Attribute.get(e, 'disabled') === 'disabled');
+    Mouse.click(UiFinder.findTargetByLabel(SugarBody.body(), generalTabLabels.decorative).getOrDie());
+    await pWaitForInputState('Check alt text input is enabled', generalTabLabels.alt, (e) => !Attribute.has(e, 'disabled'));
     TinyUiActions.submitDialog(editor);
     UiFinder.notExists(SugarBody.body(), 'div[role="dialog"]');
   });
@@ -78,7 +82,7 @@ describe('browser.tinymce.plugins.image.A11yImageTest', () => {
       },
       '<p><img src="src" alt="alt"></p>'
     );
-    await pTestUiStateEnabled(editor, 'alt');
+    // await pTestUiStateEnabled(editor, 'alt');
   });
 
   it('FOAM-11: Decorative image', async () => {

--- a/modules/tinymce/src/plugins/image/test/ts/browser/A11yImageTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/A11yImageTest.ts
@@ -62,9 +62,9 @@ describe('browser.tinymce.plugins.image.A11yImageTest', () => {
     const editor = hook.editor();
     await pInitAndOpenDialog(editor, '', { element: [ 0 ], offset: 0 });
     await pWaitForInputState('Check alt text input is enabled', generalTabLabels.alt, (e) => !Attribute.has(e, 'disabled'));
-    Mouse.click(UiFinder.findTargetByLabel(SugarBody.body(), generalTabLabels.decorative).getOrDie());
+    Mouse.clickByLabel(SugarBody.body(), generalTabLabels.decorative);
     await pWaitForInputState('Check alt text input is disabled', generalTabLabels.alt, (e) => Attribute.has(e, 'disabled') && Attribute.get(e, 'disabled') === 'disabled');
-    Mouse.click(UiFinder.findTargetByLabel(SugarBody.body(), generalTabLabels.decorative).getOrDie());
+    Mouse.clickByLabel(SugarBody.body(), generalTabLabels.decorative);
     await pWaitForInputState('Check alt text input is enabled', generalTabLabels.alt, (e) => !Attribute.has(e, 'disabled'));
     TinyUiActions.submitDialog(editor);
     UiFinder.notExists(SugarBody.body(), 'div[role="dialog"]');

--- a/modules/tinymce/src/plugins/image/test/ts/browser/A11yImageTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/A11yImageTest.ts
@@ -82,7 +82,7 @@ describe('browser.tinymce.plugins.image.A11yImageTest', () => {
       },
       '<p><img src="src" alt="alt"></p>'
     );
-    // await pTestUiStateEnabled(editor, 'alt');
+    await pTestUiStateEnabled(editor, 'alt');
   });
 
   it('FOAM-11: Decorative image', async () => {

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DecorativeImageDialogTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DecorativeImageDialogTest.ts
@@ -6,7 +6,7 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
 
-import { assertCleanHtml, assertInputCheckbox, assertInputValue, fillActiveDialog, generalTabSelectors } from '../module/Helpers';
+import { assertCleanHtml, assertInputCheckbox, assertInputValue, fillActiveDialog, generalTabLabels } from '../module/Helpers';
 
 describe('browser.tinymce.plugins.image.DecorativeImageDialogTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -49,8 +49,8 @@ describe('browser.tinymce.plugins.image.DecorativeImageDialogTest', () => {
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
     editor.execCommand('mceImage');
     await TinyUiActions.pWaitForDialog(editor);
-    assertInputValue(generalTabSelectors.src, '#1');
-    assertInputValue(generalTabSelectors.alt, 'alt1');
+    assertInputValue(generalTabLabels.src, '#1');
+    assertInputValue(generalTabLabels.alt, 'alt1');
     fillActiveDialog({
       src: {
         value: 'src'
@@ -67,9 +67,9 @@ describe('browser.tinymce.plugins.image.DecorativeImageDialogTest', () => {
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
     editor.execCommand('mceImage');
     await TinyUiActions.pWaitForDialog(editor);
-    assertInputValue(generalTabSelectors.src, '#1');
-    assertInputValue(generalTabSelectors.alt, 'alt1');
-    assertInputCheckbox(generalTabSelectors.decorative, false);
+    assertInputValue(generalTabLabels.src, '#1');
+    assertInputValue(generalTabLabels.alt, 'alt1');
+    assertInputCheckbox(generalTabLabels.decorative, false);
     fillActiveDialog({
       decorative: true
     });
@@ -83,9 +83,9 @@ describe('browser.tinymce.plugins.image.DecorativeImageDialogTest', () => {
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
     editor.execCommand('mceImage');
     await TinyUiActions.pWaitForDialog(editor);
-    assertInputValue(generalTabSelectors.src, '#1');
-    assertInputValue(generalTabSelectors.alt, '');
-    assertInputCheckbox(generalTabSelectors.decorative, true);
+    assertInputValue(generalTabLabels.src, '#1');
+    assertInputValue(generalTabLabels.alt, '');
+    assertInputCheckbox(generalTabLabels.decorative, true);
     fillActiveDialog({
       decorative: false
     });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -72,7 +72,7 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
     editor.execCommand('mceImage');
     const dialog = await TinyUiActions.pWaitForDialog(editor);
-    Mouse.click(UiFinder.findTargetByLabel(dialog, generalTabLabels.caption).getOrDie());
+    Mouse.clickByLabel(dialog, generalTabLabels.caption);
     assertInputValue(generalTabLabels.caption, 'on');
 
     TinyUiActions.submitDialog(editor);

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -1,4 +1,4 @@
-import { Mouse, UiFinder, Waiter } from '@ephox/agar';
+import { Mouse, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -1,4 +1,4 @@
-import { Mouse, Waiter } from '@ephox/agar';
+import { Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
@@ -6,7 +6,7 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
 
-import { assertCleanHtml, assertInputValue, fakeEvent, fillActiveDialog, generalTabSelectors, setInputValue } from '../module/Helpers';
+import { assertCleanHtml, assertInputValue, fakeEvent, fillActiveDialog, generalTabLabels, setInputValue } from '../module/Helpers';
 
 describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -26,8 +26,8 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
     editor.execCommand('mceImage');
     await TinyUiActions.pWaitForDialog(editor);
-    assertInputValue(generalTabSelectors.src, '#1');
-    assertInputValue(generalTabSelectors.title, 'title');
+    assertInputValue(generalTabLabels.src, '#1');
+    assertInputValue(generalTabLabels.title, 'title');
     fillActiveDialog({
       src: { value: '#2' },
       title: ''
@@ -42,14 +42,14 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
     editor.execCommand('mceImage');
     await TinyUiActions.pWaitForDialog(editor);
-    assertInputValue(generalTabSelectors.src, 'https://www.google.com/logos/google.jpg');
-    assertInputValue(generalTabSelectors.height, '200');
-    assertInputValue(generalTabSelectors.width, '200');
+    assertInputValue(generalTabLabels.src, 'https://www.google.com/logos/google.jpg');
+    assertInputValue(generalTabLabels.height, '200');
+    assertInputValue(generalTabLabels.width, '200');
 
-    const input = setInputValue(generalTabSelectors.src, '');
+    const input = setInputValue(generalTabLabels.src, '');
     fakeEvent(input, 'change');
-    assertInputValue(generalTabSelectors.height, '');
-    assertInputValue(generalTabSelectors.width, '');
+    assertInputValue(generalTabLabels.height, '');
+    assertInputValue(generalTabLabels.width, '');
     TinyUiActions.submitDialog(editor);
     assertCleanHtml('Checking output', editor, '');
   });
@@ -60,7 +60,7 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     editor.execCommand('mceImage');
     await TinyUiActions.pWaitForDialog(editor);
     Mouse.clickOn(SugarBody.body(), 'button[data-mce-name="Browse files"]');
-    await Waiter.pTryUntil('Wait for width to be populated', () => assertInputValue(generalTabSelectors.width, '200'));
+    await Waiter.pTryUntil('Wait for width to be populated', () => assertInputValue(generalTabLabels.width, '200'));
     TinyUiActions.submitDialog(editor);
     assertCleanHtml('Checking output', editor, '<p><img src="https://www.google.com/logos/google.jpg" alt="" width="200"></p>');
   });
@@ -72,8 +72,8 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
     editor.execCommand('mceImage');
     const dialog = await TinyUiActions.pWaitForDialog(editor);
-    Mouse.clickOn(dialog, generalTabSelectors.caption);
-    assertInputValue(generalTabSelectors.caption, 'on');
+    Mouse.click(UiFinder.findTargetByLabel(dialog, generalTabLabels.caption).getOrDie());
+    assertInputValue(generalTabLabels.caption, 'on');
 
     TinyUiActions.submitDialog(editor);
     assertCleanHtml('Checking output', editor, '<figure class="image"><img style="border: 2px solid red;" src="https://www.google.com/logos/google.jpg" width="200" height="200"><figcaption>Caption</figcaption></figure>');
@@ -86,10 +86,10 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
     editor.execCommand('mceImage');
     await TinyUiActions.pWaitForDialog(editor);
-    setInputValue(generalTabSelectors.height, '300');
-    setInputValue(generalTabSelectors.width, '300');
-    assertInputValue(generalTabSelectors.height, '300');
-    assertInputValue(generalTabSelectors.width, '300');
+    setInputValue(generalTabLabels.height, '300');
+    setInputValue(generalTabLabels.width, '300');
+    assertInputValue(generalTabLabels.height, '300');
+    assertInputValue(generalTabLabels.width, '300');
     TinyUiActions.submitDialog(editor);
     assertCleanHtml('Checking output', editor, '<p><img style="border: 2px solid red; float: left;" src="https://www.google.com/logos/google.jpg" width="300" height="300"></p>');
   });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/FigureDeleteTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/FigureDeleteTest.ts
@@ -32,7 +32,7 @@ describe('browser.tinymce.plugins.image.FigureDeleteTest', () => {
     TinySelections.setSelection(editor, [], 1, [], 2);
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Insert/edit image"]');
     const dialog = await TinyUiActions.pWaitForDialog(editor);
-    Mouse.click(UiFinder.findTargetByLabel(dialog, 'Show caption').getOrDie());
+    Mouse.clickByLabel(dialog, 'Show caption');
     TinyUiActions.submitDialog(editor);
     TinyAssertions.assertContentPresence(editor, { img: 1, figure: 0, figcaption: 0 });
   });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/FigureDeleteTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/FigureDeleteTest.ts
@@ -6,7 +6,6 @@ import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
 
 import { generalTabLabels, setInputValue } from '../module/Helpers';
-import { SugarBody } from '@ephox/sugar';
 
 describe('browser.tinymce.plugins.image.FigureDeleteTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/plugins/image/test/ts/browser/FigureDeleteTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/FigureDeleteTest.ts
@@ -1,4 +1,4 @@
-import { Mouse, UiFinder } from '@ephox/agar';
+import { Mouse } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 

--- a/modules/tinymce/src/plugins/image/test/ts/browser/FigureDeleteTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/FigureDeleteTest.ts
@@ -1,11 +1,12 @@
-import { Mouse } from '@ephox/agar';
+import { Mouse, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
 
-import { generalTabSelectors, setInputValue } from '../module/Helpers';
+import { generalTabLabels, setInputValue } from '../module/Helpers';
+import { SugarBody } from '@ephox/sugar';
 
 describe('browser.tinymce.plugins.image.FigureDeleteTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -21,7 +22,7 @@ describe('browser.tinymce.plugins.image.FigureDeleteTest', () => {
     TinySelections.setSelection(editor, [], 1, [], 2);
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Insert/edit image"]');
     await TinyUiActions.pWaitForDialog(editor);
-    setInputValue(generalTabSelectors.src, '');
+    setInputValue(generalTabLabels.src, '');
     TinyUiActions.submitDialog(editor);
     TinyAssertions.assertContent(editor, '');
   });
@@ -32,7 +33,7 @@ describe('browser.tinymce.plugins.image.FigureDeleteTest', () => {
     TinySelections.setSelection(editor, [], 1, [], 2);
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Insert/edit image"]');
     const dialog = await TinyUiActions.pWaitForDialog(editor);
-    Mouse.clickOn(dialog, 'label:contains("Show caption") input[type="checkbox"]');
+    Mouse.click(UiFinder.findTargetByLabel(dialog, 'Show caption').getOrDie());
     TinyUiActions.submitDialog(editor);
     TinyAssertions.assertContentPresence(editor, { img: 1, figure: 0, figcaption: 0 });
   });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImageListTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImageListTest.ts
@@ -4,7 +4,7 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
 
-import { assertInputValue, generalTabSelectors, pSetListBoxItem, pWaitForDialogMeasurements, setInputValue } from '../module/Helpers';
+import { assertInputValue, generalTabLabels, pSetListBoxItem, pWaitForDialogMeasurements, setInputValue } from '../module/Helpers';
 
 describe('browser.tinymce.plugins.image.ImageListTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -21,11 +21,11 @@ describe('browser.tinymce.plugins.image.ImageListTest', () => {
     ]);
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Insert/edit image"]');
     await TinyUiActions.pWaitForDialog(editor);
-    await pSetListBoxItem(generalTabSelectors.images, 'Dog');
+    await pSetListBoxItem(generalTabLabels.images, 'Dog');
     await pWaitForDialogMeasurements('mydog.jpg');
-    assertInputValue(generalTabSelectors.src, 'mydog.jpg');
-    setInputValue(generalTabSelectors.src, 'mycat.jpg');
+    assertInputValue(generalTabLabels.src, 'mydog.jpg');
+    setInputValue(generalTabLabels.src, 'mycat.jpg');
     await pWaitForDialogMeasurements('mycat.jpg');
-    assertInputValue(generalTabSelectors.src, 'mycat.jpg');
+    assertInputValue(generalTabLabels.src, 'mycat.jpg');
   });
 });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImagePluginTest.ts
@@ -5,7 +5,7 @@ import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
 
-import { advancedTabSelectors, assertInputValue, fillActiveDialog, ImageDialogData } from '../module/Helpers';
+import { advancedTabLabels, assertInputValue, fillActiveDialog, ImageDialogData } from '../module/Helpers';
 
 describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -131,8 +131,8 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
       hook.editor(),
       'margin-left: 15px; margin-right: 15px;',
       () => {
-        assertInputValue(advancedTabSelectors.vspace, '');
-        assertInputValue(advancedTabSelectors.hspace, '15');
+        assertInputValue(advancedTabLabels.vspace, '');
+        assertInputValue(advancedTabLabels.hspace, '15');
       }
     )
   );
@@ -142,8 +142,8 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
       hook.editor(),
       'margin-top: 15px; margin-bottom: 15px;',
       () => {
-        assertInputValue(advancedTabSelectors.vspace, '15');
-        assertInputValue(advancedTabSelectors.hspace, '');
+        assertInputValue(advancedTabLabels.vspace, '15');
+        assertInputValue(advancedTabLabels.hspace, '');
       }
     )
   );
@@ -153,8 +153,8 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
       hook.editor(),
       'margin: 5px;',
       () => {
-        assertInputValue(advancedTabSelectors.vspace, '5');
-        assertInputValue(advancedTabSelectors.hspace, '5');
+        assertInputValue(advancedTabLabels.vspace, '5');
+        assertInputValue(advancedTabLabels.hspace, '5');
       }
     )
   );
@@ -164,8 +164,8 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
       hook.editor(),
       'margin: 5px 10px;',
       () => {
-        assertInputValue(advancedTabSelectors.vspace, '5');
-        assertInputValue(advancedTabSelectors.hspace, '10');
+        assertInputValue(advancedTabLabels.vspace, '5');
+        assertInputValue(advancedTabLabels.hspace, '10');
       }
     )
   );
@@ -175,8 +175,8 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
       hook.editor(),
       'margin: 5px 10px 15px;',
       () => {
-        assertInputValue(advancedTabSelectors.vspace, '');
-        assertInputValue(advancedTabSelectors.hspace, '10');
+        assertInputValue(advancedTabLabels.vspace, '');
+        assertInputValue(advancedTabLabels.hspace, '10');
       }
     )
   );
@@ -186,8 +186,8 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
       hook.editor(),
       'margin: 5px 10px 15px 20px;',
       () => {
-        assertInputValue(advancedTabSelectors.vspace, '');
-        assertInputValue(advancedTabSelectors.hspace, '');
+        assertInputValue(advancedTabLabels.vspace, '');
+        assertInputValue(advancedTabLabels.hspace, '');
       }
     )
   );
@@ -197,8 +197,8 @@ describe('browser.tinymce.plugins.image.ImagePluginTest', () => {
       hook.editor(),
       'margin: 5px 10px 15px 20px; margin-top: 15px;',
       () => {
-        assertInputValue(advancedTabSelectors.vspace, '15');
-        assertInputValue(advancedTabSelectors.hspace, '');
+        assertInputValue(advancedTabLabels.vspace, '15');
+        assertInputValue(advancedTabLabels.hspace, '');
       }
     )
   );

--- a/modules/tinymce/src/plugins/image/test/ts/browser/ImageResizeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/ImageResizeTest.ts
@@ -5,7 +5,7 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
 
-import { assertCleanHtml, assertInputValue, generalTabSelectors, setInputValue } from '../module/Helpers';
+import { assertCleanHtml, assertInputValue, generalTabLabels, setInputValue } from '../module/Helpers';
 
 // TODO TINY-10480: Investigate flaky tests
 describe.skip('browser.tinymce.plugins.image.ImageResizeTest', () => {
@@ -25,9 +25,9 @@ describe.skip('browser.tinymce.plugins.image.ImageResizeTest', () => {
     TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Insert/edit image"]');
     const dialog = await TinyUiActions.pWaitForDialog(editor);
     Mouse.clickOn(dialog, 'button.tox-browse-url');
-    await Waiter.pTryUntil('did not find width input with value 1', () => assertInputValue(generalTabSelectors.width, '1'));
-    setInputValue(generalTabSelectors.height, '5');
-    await Waiter.pTryUntil('did not find width input with value 5', () => assertInputValue(generalTabSelectors.width, '5'));
+    await Waiter.pTryUntil('did not find width input with value 1', () => assertInputValue(generalTabLabels.width, '1'));
+    setInputValue(generalTabLabels.height, '5');
+    await Waiter.pTryUntil('did not find width input with value 5', () => assertInputValue(generalTabLabels.width, '5'));
     TinyUiActions.submitDialog(editor);
     assertCleanHtml('Checking output', editor, '<p><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" width="5" height="5"></p>');
   });

--- a/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/UploadTabTest.ts
@@ -52,12 +52,12 @@ describe('browser.tinymce.plugins.image.UploadTabTest', () => {
   };
 
   const pAssertSrcTextValue = (expectedValue: string) => Waiter.pTryUntil('Waited for input to change to expected value', () => {
-    const input = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), 'label.tox-label:contains("Source") + div > div > input.tox-textfield').getOrDie();
+    const input = UiFinder.findTargetByLabel<HTMLInputElement>(SugarBody.body(), 'Source').getOrDie();
     assert.equal(Value.get(input), expectedValue, 'Assert field source value ');
   }, 10, 7000);
 
   const pAssertSrcTextValueStartsWith = (expectedValue: string) => Waiter.pTryUntil('Waited for input to change to start with expected value', () => {
-    const input = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), 'label.tox-label:contains("Source") + div > div > input.tox-textfield').getOrDie();
+    const input = UiFinder.findTargetByLabel<HTMLInputElement>(SugarBody.body(), 'Source').getOrDie();
     assert.isTrue(Strings.startsWith(Value.get(input), expectedValue), 'Assert field source value');
   }, 10, 7000);
 

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DefaultEmptyTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/DefaultEmptyTest.ts
@@ -4,7 +4,7 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
 
-import { assertCleanHtml, assertInputValue, fillActiveDialog, generalTabSelectors } from '../../module/Helpers';
+import { assertCleanHtml, assertInputValue, fillActiveDialog, generalTabLabels } from '../../module/Helpers';
 
 describe('browser.tinymce.plugins.image.plugin.DefaultEmptyTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
@@ -18,10 +18,10 @@ describe('browser.tinymce.plugins.image.plugin.DefaultEmptyTest', () => {
     editor.execCommand('mceImage');
     await TinyUiActions.pWaitForDialog(editor);
 
-    assertInputValue(generalTabSelectors.src, '');
-    assertInputValue(generalTabSelectors.alt, '');
-    assertInputValue(generalTabSelectors.height, '');
-    assertInputValue(generalTabSelectors.width, '');
+    assertInputValue(generalTabLabels.src, '');
+    assertInputValue(generalTabLabels.alt, '');
+    assertInputValue(generalTabLabels.height, '');
+    assertInputValue(generalTabLabels.width, '');
 
     fillActiveDialog({
       src: {

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependAbsoluteTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependAbsoluteTest.ts
@@ -6,7 +6,7 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
 
-import { assertCleanHtml, fakeEvent, fillActiveDialog, generalTabSelectors, pWaitForDialogMeasurements } from '../../module/Helpers';
+import { assertCleanHtml, fakeEvent, fillActiveDialog, generalTabLabels, pWaitForDialogMeasurements } from '../../module/Helpers';
 
 describe('browser.tinymce.plugins.image.plugin.PrependAbsoluteTest', () => {
   const prependUrl = 'http://localhost/images/';
@@ -28,7 +28,7 @@ describe('browser.tinymce.plugins.image.plugin.PrependAbsoluteTest', () => {
       },
       alt: 'alt'
     });
-    const srcElem = UiFinder.findIn(SugarBody.body(), generalTabSelectors.src).getOrDie();
+    const srcElem = UiFinder.findTargetByLabel(SugarBody.body(), generalTabLabels.src).getOrDie();
     fakeEvent(srcElem, 'change');
     TinyUiActions.submitDialog(editor);
     assertCleanHtml('Checking output', editor, '<p><img src="' + prependUrl + 'src" alt="alt"></p>');

--- a/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependRelativeTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/plugin/PrependRelativeTest.ts
@@ -6,7 +6,7 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/image/Plugin';
 
-import { assertCleanHtml, fakeEvent, fillActiveDialog, generalTabSelectors, pWaitForDialogMeasurements } from '../../module/Helpers';
+import { assertCleanHtml, fakeEvent, fillActiveDialog, generalTabLabels, pWaitForDialogMeasurements } from '../../module/Helpers';
 
 describe('browser.tinymce.plugins.image.plugin.PrependRelativeTest', () => {
   const prependUrl = 'testing/images/';
@@ -28,7 +28,7 @@ describe('browser.tinymce.plugins.image.plugin.PrependRelativeTest', () => {
       },
       alt: 'alt'
     });
-    const srcElem = UiFinder.findIn(SugarBody.body(), generalTabSelectors.src).getOrDie();
+    const srcElem = UiFinder.findTargetByLabel(SugarBody.body(), generalTabLabels.src).getOrDie();
     fakeEvent(srcElem, 'change');
     TinyUiActions.submitDialog(editor);
     assertCleanHtml('Checking output', editor, '<p><img src="' + prependUrl + 'src" alt="alt"></p>');

--- a/modules/tinymce/src/plugins/image/test/ts/module/Helpers.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/module/Helpers.ts
@@ -24,23 +24,23 @@ export interface ImageDialogData {
   borderstyle: string;
 }
 
-export const generalTabSelectors = {
-  src: 'label.tox-label:contains("Source") + div.tox-form__controls-h-stack div.tox-control-wrap input.tox-textfield',
-  title: 'label.tox-label:contains("Image title") + input.tox-textfield',
-  alt: 'label.tox-label:contains("Alternative description") + input.tox-textfield',
-  width: 'div.tox-form__controls-h-stack div label:contains("Width") + input.tox-textfield',
-  height: 'div.tox-form__controls-h-stack div label:contains("Height") + input.tox-textfield',
-  caption: 'label.tox-label:contains("Caption") + label input.tox-checkbox__input',
-  class: 'label.tox-label:contains("Class") + div.tox-listboxfield > .tox-listbox',
-  images: 'label.tox-label:contains("Image list") + div.tox-listboxfield > .tox-listbox',
-  decorative: 'label.tox-label:contains("Accessibility") + label.tox-checkbox>input'
+export const generalTabLabels = {
+  src: 'Source',
+  title: 'Image title',
+  alt: 'Alternative description',
+  width: 'Width',
+  height: 'Height',
+  caption: 'Show caption',
+  class: 'Class',
+  images: 'Image list',
+  decorative: 'Image is decorative'
 };
 
-export const advancedTabSelectors = {
-  border: 'label.tox-label:contains("Border width") + input.tox-textfield',
-  hspace: 'label.tox-label:contains("Horizontal space") + input.tox-textfield',
-  vspace: 'label.tox-label:contains("Vertical space") + input.tox-textfield',
-  borderstyle: 'label.tox-label:contains("Border style") + div.tox-listboxfield > .tox-listbox'
+export const advancedTabLabels = {
+  border: 'Border width',
+  hspace: 'Horizontal space',
+  vspace: 'Vertical space',
+  borderstyle: 'Border style'
 };
 
 const isObjWithValue = (value: ImageDialogData[keyof ImageDialogData]): value is { value: string } =>
@@ -51,8 +51,8 @@ const gotoAdvancedTab = (): void => {
   Mouse.click(tab);
 };
 
-const setFieldValue = (selector: string, value: string | boolean): SugarElement<HTMLElement> => {
-  const element = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), selector).getOrDie();
+const setFieldValue = (labelText: string, value: string | boolean): SugarElement<HTMLElement> => {
+  const element = UiFinder.findTargetByLabel<HTMLInputElement>(SugarBody.body(), labelText).getOrDie();
   Focus.focus(element);
   if (element.dom.type === 'checkbox' && Type.isBoolean(value)) {
     Checked.set(element, value);
@@ -64,22 +64,22 @@ const setFieldValue = (selector: string, value: string | boolean): SugarElement<
   return element;
 };
 
-const setTabFieldValues = (data: Partial<ImageDialogData>, tabSelectors: Record<string, string>): void => {
-  Obj.each(tabSelectors, (value, key) => {
+const setTabFieldValues = (data: Partial<ImageDialogData>, tabLabels: Record<string, string>): void => {
+  Obj.each(tabLabels, (value, key) => {
     Obj.get(data, key as keyof Omit<ImageDialogData, 'dimensions'>)
       .orThunk(() => Obj.has(data, 'dimensions') ? Obj.get(data.dimensions as Record<string, string>, key) : Optional.none())
       .each((obj) => {
         const newValue = isObjWithValue(obj) ? obj.value : obj;
-        setFieldValue(tabSelectors[key], newValue);
+        setFieldValue(tabLabels[key], newValue);
       });
   });
 };
 
 const fillActiveDialog = (data: Partial<ImageDialogData>, hasAdvanced = false): void => {
-  setTabFieldValues(data, generalTabSelectors);
+  setTabFieldValues(data, generalTabLabels);
   if (hasAdvanced) {
     gotoAdvancedTab();
-    setTabFieldValues(data, advancedTabSelectors);
+    setTabFieldValues(data, advancedTabLabels);
   }
 };
 
@@ -89,14 +89,14 @@ const fakeEvent = (elm: SugarElement<Node>, name: string): void => {
   elm.dom.dispatchEvent(evt);
 };
 
-const setInputValue = (selector: string, value: string): SugarElement<HTMLElement> => {
-  const field = setFieldValue(selector, value);
+const setInputValue = (labelText: string, value: string): SugarElement<HTMLElement> => {
+  const field = setFieldValue(labelText, value);
   fakeEvent(field, 'input');
   return field;
 };
 
-const setSelectValue = (selector: string, value: string): SugarElement<HTMLElement> => {
-  const field = setFieldValue(selector, value);
+const setSelectValue = (labelText: string, value: string): SugarElement<HTMLElement> => {
+  const field = setFieldValue(labelText, value);
   fakeEvent(field, 'change');
   return field;
 };
@@ -107,20 +107,20 @@ const cleanHtml = (html: string): string =>
 const assertCleanHtml = (label: string, editor: Editor, expected: string): void =>
   Assertions.assertHtml(label, expected, cleanHtml(editor.getContent()));
 
-const assertInputValue = (selector: string, expected: string): void => {
-  const element = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), selector).getOrDie();
+const assertInputValue = (labelText: string, expected: string): void => {
+  const element = UiFinder.findTargetByLabel<HTMLInputElement>(SugarBody.body(), labelText).getOrDie();
   const value = Value.get(element);
   assert.equal(value, expected, `input value should be ${expected}`);
 };
 
-const assertInputCheckbox = (selector: string, expectedState: boolean): void => {
-  const element = UiFinder.findIn<HTMLInputElement>(SugarBody.body(), selector).getOrDie();
+const assertInputCheckbox = (labelText: string, expectedState: boolean): void => {
+  const element = UiFinder.findTargetByLabel<HTMLInputElement>(SugarBody.body(), labelText).getOrDie();
   const value = Checked.get(element);
   assert.equal(value, expectedState, `input value should be ${expectedState}`);
 };
 
-const pSetListBoxItem = async (selector: string, itemText: string): Promise<void> => {
-  const listBox = UiFinder.findIn(SugarBody.body(), selector).getOrDie();
+const pSetListBoxItem = async (labelText: string, itemText: string): Promise<void> => {
+  const listBox = UiFinder.findTargetByLabel(SugarBody.body(), labelText).getOrDie();
   Mouse.click(listBox);
   await UiFinder.pWaitForVisible('Wait for list to open', SugarBody.body(), '.tox-menu.tox-collection--list');
   const item = UiFinder.findIn(SugarBody.body(), '.tox-collection__item-label:contains(' + itemText + ')').getOrDie();

--- a/modules/tinymce/src/plugins/insertdatetime/test/ts/browser/InsertDatetimeSanityTest.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/test/ts/browser/InsertDatetimeSanityTest.ts
@@ -18,7 +18,7 @@ describe('browser.tinymce.plugins.insertdatetime.InsertDatetimeSanityTest', () =
     const editor = hook.editor();
     TinyUiActions.clickOnToolbar(editor, '[aria-haspopup="true"]');
     await TinyUiActions.pWaitForUi(editor, '[role="menu"]');
-    TinyUiActions.clickOnUi(editor, '[role="menu"] [role="menuitemradio"]:first');
+    TinyUiActions.clickOnUi(editor, '[role="menu"] [role="menuitemradio"]:first-child');
 
     TinyAssertions.assertContentStructure(editor, ApproxStructure.build((s) => {
       return s.element('body', {
@@ -37,7 +37,7 @@ describe('browser.tinymce.plugins.insertdatetime.InsertDatetimeSanityTest', () =
     const editor = hook.editor();
     TinyUiActions.clickOnToolbar(editor, '[aria-haspopup="true"]');
     await TinyUiActions.pWaitForUi(editor, '[role="menu"]');
-    TinyUiActions.clickOnUi(editor, '[role="menu"] [role="menuitemradio"]:first');
+    TinyUiActions.clickOnUi(editor, '[role="menu"] [role="menuitemradio"]:first-child');
 
     editor.mode.set('readonly');
     const content = editor.getContent();

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DialogFlowTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DialogFlowTest.ts
@@ -69,7 +69,7 @@ describe('browser.tinymce.plugins.link.DialogFlowTest', () => {
     editor.setContent('<p><a name="anchor1"></a>Our Anchor1</p><p><a name="anchor2"></a>Our Anchor2</p>');
 
     await TestLinkUi.pOpenLinkDialog(editor);
-    await TestLinkUi.pSetListBoxItem(editor, 'Anchor', 'anchor2');
+    await TestLinkUi.pSetListBoxItem(editor, 'Anchors', 'anchor2');
     TestLinkUi.assertDialogContents({
       href: '#anchor2',
       text: 'anchor2',
@@ -78,7 +78,7 @@ describe('browser.tinymce.plugins.link.DialogFlowTest', () => {
       target: ''
     });
 
-    await TestLinkUi.pSetListBoxItem(editor, 'Anchor', 'anchor1');
+    await TestLinkUi.pSetListBoxItem(editor, 'Anchors', 'anchor1');
     TestLinkUi.assertDialogContents({
       href: '#anchor1',
       text: 'anchor1',
@@ -89,7 +89,7 @@ describe('browser.tinymce.plugins.link.DialogFlowTest', () => {
 
     // Change the text ...so text won't change, but href will still
     await TestLinkUi.pSetInputFieldValue(editor, 'Text to display', 'Other text');
-    await TestLinkUi.pSetListBoxItem(editor, 'Anchor', 'anchor2');
+    await TestLinkUi.pSetListBoxItem(editor, 'Anchors', 'anchor2');
     TestLinkUi.assertDialogContents({
       href: '#anchor2',
       text: 'Other text',

--- a/modules/tinymce/src/plugins/link/test/ts/browser/DialogFlowTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/DialogFlowTest.ts
@@ -25,13 +25,13 @@ describe('browser.tinymce.plugins.link.DialogFlowTest', () => {
   });
 
   const pAssertInputValue = async (editor: Editor, expected: string, group: string) => {
-    const input = await TestLinkUi.pFindInDialog<HTMLInputElement>(editor, 'label:contains("' + group + '") + input');
+    const input = await TestLinkUi.pFindTargetByLabelInDialog<HTMLInputElement>(editor, group);
     const value = UiControls.getValue(input);
     assert.equal(value, expected, 'Checking input value');
   };
 
   const pAssertUrlStructure = async (editor: Editor, expected: ApproxStructure.Builder<StructAssert>) => {
-    const input = await TestLinkUi.pFindInDialog(editor, 'label:contains("URL") + .tox-form__controls-h-stack input');
+    const input = await TestLinkUi.pFindTargetByLabelInDialog(editor, 'URL');
     Assertions.assertStructure(
       'Checking content of url input',
       ApproxStructure.build(expected),

--- a/modules/tinymce/src/plugins/link/test/ts/browser/LinkContextMenuTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/LinkContextMenuTest.ts
@@ -45,6 +45,6 @@ describe('browser.tinymce.plugins.link.LinkContextMenuTest', () => {
     TinySelections.select(editor, 'a', []);
     await TinyUiActions.pTriggerContextMenu(editor, 'a[href="http://tiny.cloud"]', '.tox-silver-sink [role="menuitem"]');
     await pTestContextMenuItems(editor);
-    await pAssertFocusOnItem('Open link', '.tox-collection__item:contains("Open link"):not([aria-disabled="true"])');
+    await pAssertFocusOnItem('Open link', '.tox-collection__item:not([aria-disabled="true"]):contains("Open link")');
   });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/OpenLinkContextMenuTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/OpenLinkContextMenuTest.ts
@@ -99,7 +99,7 @@ describe('browser.tinymce.plugins.link.OpenLinkContextMenuTest', () => {
     await TinyUiActions.pTriggerContextMenu(editor, 'img', '.tox-silver-sink [role="menuitem"]');
     TinyUiActions.keydown(editor, Keys.down());
     TinyUiActions.keydown(editor, Keys.down());
-    await pAssertFocusOnItem('Open link', '.tox-collection__item:contains("Open link"):not([aria-disabled="true"])');
+    await pAssertFocusOnItem('Open link', '.tox-collection__item:not([aria-disabled="true"]):contains("Open link")');
     TinyUiActions.keydown(editor, Keys.enter());
     store.assertEq('Should open the targeted link', [
       'https://www.exampleimage.com/'

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
@@ -1,6 +1,6 @@
 import { FocusTools, Keys, Mouse, UiControls, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { SugarBody, SugarDocument, Value } from '@ephox/sugar';
+import { SugarBody, SugarDocument, SugarElement, Value } from '@ephox/sugar';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -23,7 +23,7 @@ describe('browser.tinymce.plugins.lists.ListPropertiesTest', () => {
   }, [ Plugin ], true);
 
   const contentMenuSelector = '.tox-tinymce-aux .tox-menu .tox-collection__item:contains("List properties...")';
-  const inputSelector = 'label:contains(Start list at number) + input.tox-textfield';
+  const getInputSelector = (doc: SugarElement<Document | ShadowRoot>) => UiFinder.findTargetByLabel(doc, 'Start list at number').getOrDie();
 
   const openContextMenu = async (editor: Editor, selector: string) => {
     Mouse.contextMenuOn(TinyDom.body(editor), selector);
@@ -38,7 +38,7 @@ describe('browser.tinymce.plugins.lists.ListPropertiesTest', () => {
 
   const updateDialog = (editor: Editor, currentValue: string, newValue: string) => {
     const doc = SugarDocument.getDocument();
-    FocusTools.isOnSelector('Check focus is on the input field', doc, inputSelector);
+    FocusTools.isOn('Check focus is on the input field', getInputSelector(doc));
     const input = FocusTools.getFocused<HTMLInputElement>(doc).getOrDie();
     assert.equal(Value.get(input), currentValue, 'Initial input value matches');
     UiControls.setValue(input, newValue);
@@ -130,7 +130,7 @@ describe('browser.tinymce.plugins.lists.ListPropertiesTest', () => {
     editor.setContent('<ol><li>Item 1</li><li>Item 2</li></ol>');
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);
     TinyUiActions.clickOnMenu(editor, '.tox-mbtn:contains("Custom")');
-    await TinyUiActions.pWaitForUi(editor, '.tox-collection__item:contains("List properties"):not(.tox-collection__item--state-disabled)');
+    await TinyUiActions.pWaitForUi(editor, '.tox-collection__item:not(.tox-collection__item--state-disabled):contains("List properties")');
     TinyUiActions.clickOnMenu(editor, '.tox-mbtn:contains("Custom")');
   });
 

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
@@ -1,6 +1,6 @@
 import { FocusTools, Keys, Mouse, UiControls, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { SugarBody, SugarDocument, SugarElement, Value } from '@ephox/sugar';
+import { SugarBody, SugarDocument, Value } from '@ephox/sugar';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 

--- a/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
+++ b/modules/tinymce/src/plugins/lists/test/ts/browser/ListPropertiesTest.ts
@@ -23,7 +23,6 @@ describe('browser.tinymce.plugins.lists.ListPropertiesTest', () => {
   }, [ Plugin ], true);
 
   const contentMenuSelector = '.tox-tinymce-aux .tox-menu .tox-collection__item:contains("List properties...")';
-  const getInputSelector = (doc: SugarElement<Document | ShadowRoot>) => UiFinder.findTargetByLabel(doc, 'Start list at number').getOrDie();
 
   const openContextMenu = async (editor: Editor, selector: string) => {
     Mouse.contextMenuOn(TinyDom.body(editor), selector);
@@ -38,7 +37,7 @@ describe('browser.tinymce.plugins.lists.ListPropertiesTest', () => {
 
   const updateDialog = (editor: Editor, currentValue: string, newValue: string) => {
     const doc = SugarDocument.getDocument();
-    FocusTools.isOn('Check focus is on the input field', getInputSelector(doc));
+    FocusTools.isOnByLabel('Check focus is on the input field', doc, 'Start list at number');
     const input = FocusTools.getFocused<HTMLInputElement>(doc).getOrDie();
     assert.equal(Value.get(input), currentValue, 'Initial input value matches');
     UiControls.setValue(input, newValue);

--- a/modules/tinymce/src/plugins/media/test/ts/browser/DimensionsFalseEmbedTest.ts
+++ b/modules/tinymce/src/plugins/media/test/ts/browser/DimensionsFalseEmbedTest.ts
@@ -47,9 +47,9 @@ describe('browser.tinymce.plugins.media.DimensionsFalseEmbedTest', () => {
   it('TBA: Open dialog, assert dimensions fields are not present while media_dimensions is false', async () => {
     const editor = hook.editor();
     const dialog = await Utils.pOpenDialog(editor);
-    UiFinder.exists(dialog, Utils.selectors.source);
-    UiFinder.notExists(dialog, Utils.selectors.width);
-    UiFinder.notExists(dialog, Utils.selectors.height);
+    UiFinder.exists(dialog, Utils.selectors.sourceLabel);
+    UiFinder.notExists(dialog, Utils.selectors.widthLabel);
+    UiFinder.notExists(dialog, Utils.selectors.heightLabel);
     TinyUiActions.submitDialog(editor);
     await Waiter.pTryUntil(
       'Wait for dialog to close',

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/UndoReplaceSpanTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/UndoReplaceSpanTest.ts
@@ -26,7 +26,7 @@ describe('browser.tinymce.plugins.searchreplace.UndoReplaceSpanTest', () => {
     await Utils.pSetFieldValue(editor, findInputSelector, 'cats');
     await Utils.pSetFieldValue(editor, replaceWithInputSelector, 'dogs');
     Utils.clickFind(editor);
-    await UiFinder.pWaitFor('wait for button to be enabled', SugarBody.body(), 'button[disabled!="disabled"]:contains("Replace")');
+    await UiFinder.pWaitFor('wait for button to be enabled', SugarBody.body(), 'button:not([disabled="disabled"]):contains("Replace")');
     Utils.clickReplace(editor);
     Utils.clickClose(editor);
     editor.undoManager.undo();

--- a/modules/tinymce/src/plugins/searchreplace/test/ts/browser/UndoReplaceSpanTest.ts
+++ b/modules/tinymce/src/plugins/searchreplace/test/ts/browser/UndoReplaceSpanTest.ts
@@ -26,7 +26,7 @@ describe('browser.tinymce.plugins.searchreplace.UndoReplaceSpanTest', () => {
     await Utils.pSetFieldValue(editor, findInputSelector, 'cats');
     await Utils.pSetFieldValue(editor, replaceWithInputSelector, 'dogs');
     Utils.clickFind(editor);
-    await UiFinder.pWaitFor('wait for button to be enabled', SugarBody.body(), 'button:not([disabled="disabled"]):contains("Replace")');
+    await UiFinder.pWaitFor('wait for button to be enabled', SugarBody.body(), 'button:enabled:contains("Replace")');
     Utils.clickReplace(editor);
     Utils.clickClose(editor);
     editor.undoManager.undo();

--- a/modules/tinymce/src/plugins/table/test/ts/browser/AlignedCellRowStyleChangeTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/AlignedCellRowStyleChangeTest.ts
@@ -38,7 +38,7 @@ describe('browser.tinymce.plugins.table.AlignedCellRowStyleChangeTest', () => {
     editor.execCommand('mceTableRowProps');
     await TinyUiActions.pWaitForDialog(editor);
     TableTestUtils.gotoAdvancedTab();
-    TableTestUtils.setInputValue('label.tox-label:contains(Background color) + div>input.tox-textfield', 'red');
+    TableTestUtils.setInputValue('Background color', 'red');
     await TableTestUtils.pClickDialogButton(editor, true);
     TableTestUtils.assertTableStructure(editor, ApproxStructure.build((s, str, _arr) => s.element('table', {
       children: [

--- a/modules/tinymce/src/plugins/table/test/ts/browser/TableCellPropsStyleTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/TableCellPropsStyleTest.ts
@@ -25,7 +25,7 @@ describe('browser.tinymce.plugins.table.TableCellPropsStyleTest', () => {
     TinySelections.setSelection(editor, [ 0, 0, 0, 1, 0 ], 1, [ 0, 0, 0, 1, 0 ], 1);
     editor.execCommand('mceTableCellProps');
     TableTestUtils.gotoAdvancedTab();
-    TableTestUtils.setInputValue('label.tox-label:contains(Background color) + div>input.tox-textfield', 'red');
+    TableTestUtils.setInputValue('Background color', 'red');
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor,
       '<table style="border-collapse: collapse;" border="1"><tbody><tr><td style="background-color: red;">a</td><td style="background-color: red;">b</td></tr></tbody></table>'

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableAppearanceOptionsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableAppearanceOptionsTest.ts
@@ -27,7 +27,7 @@ describe('browser.tinymce.plugins.table.TableAppearanceTest', () => {
       {
         'label:contains("Cell spacing")': 0,
         'label:contains("Cell padding")': 0,
-        'label:contains("Border") + input': 0,
+        'label:contains("Border")': 0,
         'label:contains("Caption")': 0
       },
       dialog
@@ -47,7 +47,7 @@ describe('browser.tinymce.plugins.table.TableAppearanceTest', () => {
       {
         'label:contains("Cell spacing")': 1,
         'label:contains("Cell padding")': 1,
-        'label:contains("Border") + input': 1,
+        'label:contains("Border")': 1,
         'label:contains("Caption")': 1
       },
       dialog

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
@@ -30,11 +30,11 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
   }, [ Plugin ], true);
 
   const generalSelectors = {
-    width: 'label.tox-label:contains(Width) + input.tox-textfield',
-    celltype: 'label.tox-label:contains(Cell type) + div.tox-listboxfield > .tox-listbox',
-    scope: 'label.tox-label:contains(Scope) + div.tox-listboxfield > .tox-listbox',
-    halign: 'label.tox-label:contains(Horizontal align) + div.tox-listboxfield > .tox-listbox',
-    valign: 'label.tox-label:contains(Vertical align) + div.tox-listboxfield > .tox-listbox'
+    width: 'Width',
+    celltype: 'Cell type',
+    scope: 'Scope',
+    halign: 'Horizontal align',
+    valign: 'Vertical align'
   };
 
   let events: string[] = [];

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
@@ -29,7 +29,7 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
     }
   }, [ Plugin ], true);
 
-  const generalSelectors = {
+  const generalLabels = {
     width: 'Width',
     celltype: 'Cell type',
     scope: 'Scope',
@@ -110,7 +110,7 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
     editor.setContent(baseHtml);
     TinySelections.select(editor, 'td', [ 0 ]);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(baseData, false, generalSelectors);
+    TableTestUtils.assertDialogValues(baseData, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
     assertEventsOrder([]);
   });
@@ -122,14 +122,14 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
     editor.setContent(baseHtml);
     TinySelections.select(editor, 'td', [ 0 ]);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(baseData, false, generalSelectors);
+    TableTestUtils.assertDialogValues(baseData, false, generalLabels);
     TableTestUtils.setDialogValues({
       width: '100',
       celltype: 'td',
       scope: '',
       halign: '',
       valign: ''
-    }, false, generalSelectors);
+    }, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, '<table><tbody><tr><td style="width: 100px;">a</td><td>b</td></tr></tbody></table>');
     assertEventsOrder();
@@ -156,7 +156,7 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
     editor.setContent(complexHtml);
     TinySelections.select(editor, 'th', [ 0 ]);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(complexData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(complexData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
     assertEventsOrder([]);
   });
@@ -183,7 +183,7 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
     editor.setContent('<table><tr><td>X</td></tr></table>');
     TinySelections.select(editor, 'td', [ 0 ]);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.setDialogValues(advData, true, generalSelectors);
+    TableTestUtils.setDialogValues(advData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, advHtml);
     assertEventsOrder([ 'newcell', 'tablemodified' ]);
@@ -226,8 +226,8 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
     editor.setContent(initialHtml);
     TinySelections.select(editor, 'td:nth-child(2)', [ 0 ]);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(baseAdvData, true, generalSelectors);
-    TableTestUtils.setDialogValues(newData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(baseAdvData, true, generalLabels);
+    TableTestUtils.setDialogValues(newData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, newHtml);
     assertEventsOrder();
@@ -282,8 +282,8 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
     editor.setContent(initialHtml);
     TinySelections.select(editor, 'td:nth-child(2)', [ 0 ]);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(initialDialogValues, true, generalSelectors);
-    TableTestUtils.setDialogValues(newData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(initialDialogValues, true, generalLabels);
+    TableTestUtils.setDialogValues(newData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, newHtml);
     assertEventsOrder();
@@ -343,8 +343,8 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
     editor.setContent(initialHtml);
     TinySelections.select(editor, 'td:nth-child(2)', [ 0 ]);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(initialDialogValues, true, generalSelectors);
-    TableTestUtils.setDialogValues(newData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(initialDialogValues, true, generalLabels);
+    TableTestUtils.setDialogValues(newData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, newHtml);
     assertEventsOrder();
@@ -385,8 +385,8 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
     editor.setContent(advHtml);
     TinySelections.select(editor, 'th', [ 0 ]);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(advData, true, generalSelectors);
-    TableTestUtils.setDialogValues(emptyData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(advData, true, generalLabels);
+    TableTestUtils.setDialogValues(emptyData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, emptyTable);
     assertEventsOrder([ 'tablemodified' ]);
@@ -414,7 +414,7 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
     editor.setContent(advHtml);
     TinySelections.select(editor, 'th', [ 0 ]);
     editor.execCommand('mceTableCellProps');
-    TableTestUtils.assertDialogValues(advData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(advData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
     assertEventsOrder([]);
   });
@@ -441,20 +441,20 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
     editor.setContent(baseHtml);
     TinySelections.select(editor, 'td', [ 0 ]);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(baseAdvData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(baseAdvData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
     assertEventsOrder([]);
     clearEvents();
     TinyAssertions.assertContent(editor, noSelectBaseHtml);
 
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(baseAdvData, true, generalSelectors);
-    TableTestUtils.setDialogValues(advData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(baseAdvData, true, generalLabels);
+    TableTestUtils.setDialogValues(advData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, advHtml);
 
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(advData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(advData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
     assertEventsOrder([ 'newcell', 'tablemodified' ]);
     assertTableModifiedEvent({ structure: true, style: true });
@@ -507,7 +507,7 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
       scope: 'row',
       halign: '',
       valign: ''
-    }, false, generalSelectors);
+    }, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, expectedhtml);
     assertEventsOrder([ 'tablemodified' ]);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogKeyboardNavTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogKeyboardNavTest.ts
@@ -1,7 +1,6 @@
-import { FocusTools, Keys, UiFinder } from '@ephox/agar';
+import { FocusTools, Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { Fun } from '@ephox/katamari';
-import { SugarDocument, SugarElement } from '@ephox/sugar';
+import { SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -22,13 +21,17 @@ describe('browser.tinymce.plugins.table.TableDialogKeyboardNavTest', () => {
   const pressTabKey = (editor: Editor) => TinyUiActions.keydown(editor, Keys.tab());
 
   // Assert focus is on the expected form element
-  const pAssertFocusOnItem = (label: string, selectorOrElement: string | SugarElement<Node>) => {
-    if (typeof selectorOrElement === 'string') {
-      return FocusTools.pTryOnSelector(`Focus should be on: ${label}`, SugarDocument.getDocument(), selectorOrElement);
-    }
-    return FocusTools.pTryOn(`Focus should be on: ${label}`, selectorOrElement);
-  };
-  const findTargetByLabel = Fun.curry(UiFinder.findTargetByLabel, SugarDocument.getDocument());
+  const pAssertFocusOnItem = (label: string, selector: string) => FocusTools.pTryOnSelector(
+    `Focus should be on: ${label}`,
+    SugarDocument.getDocument(),
+    selector
+  );
+
+  const pAssertFocusOnItemByLabel = (label: string) => FocusTools.pTryOnByLabel(
+    `Focus should be on input with label: ${label}`,
+    SugarDocument.getDocument(),
+    label
+  );
 
   it('TBA: Open dialog, test the tab key navigation cycles through all focusable fields in General and Advanced tabs', async () => {
     const editor = hook.editor();
@@ -42,19 +45,19 @@ describe('browser.tinymce.plugins.table.TableDialogKeyboardNavTest', () => {
     // Keyboard nav within the General tab
     await pAssertFocusOnItem('General Tab', '.tox-dialog__body-nav-item:contains("General")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('Width', findTargetByLabel('Width').getOrDie());
+    await pAssertFocusOnItemByLabel('Width');
     pressTabKey(editor);
-    await pAssertFocusOnItem('Height', findTargetByLabel('Height').getOrDie());
+    await pAssertFocusOnItemByLabel('Height');
     pressTabKey(editor);
-    await pAssertFocusOnItem('Cell spacing', findTargetByLabel('Cell spacing').getOrDie());
+    await pAssertFocusOnItemByLabel('Cell spacing');
     pressTabKey(editor);
-    await pAssertFocusOnItem('Cell padding', findTargetByLabel('Cell padding').getOrDie());
+    await pAssertFocusOnItemByLabel('Cell padding');
     pressTabKey(editor);
-    await pAssertFocusOnItem('Border width', findTargetByLabel('Border width').getOrDie());
+    await pAssertFocusOnItemByLabel('Border width');
     pressTabKey(editor);
     await pAssertFocusOnItem('Caption', 'input[type="checkbox"]');
     pressTabKey(editor);
-    await pAssertFocusOnItem('Alignment', findTargetByLabel('Alignment').getOrDie());
+    await pAssertFocusOnItemByLabel('Alignment');
     pressTabKey(editor);
     await pAssertFocusOnItem('Cancel', '.tox-button:contains("Cancel")');
     pressTabKey(editor);
@@ -70,7 +73,7 @@ describe('browser.tinymce.plugins.table.TableDialogKeyboardNavTest', () => {
     // Keyboard nav within the Advanced tab
     await pAssertFocusOnItem('Advanced Tab', '.tox-dialog__body-nav-item:contains("Advanced")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('Border style', findTargetByLabel('Border style').getOrDie());
+    await pAssertFocusOnItemByLabel('Border style');
     pressTabKey(editor);
     await pAssertFocusOnItem('Border color', '.tox-form div:nth-child(2) input');
     pressTabKey(editor);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogKeyboardNavTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogKeyboardNavTest.ts
@@ -1,6 +1,7 @@
-import { FocusTools, Keys } from '@ephox/agar';
+import { FocusTools, Keys, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { SugarDocument } from '@ephox/sugar';
+import { Fun } from '@ephox/katamari';
+import { SugarDocument, SugarElement } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -21,11 +22,13 @@ describe('browser.tinymce.plugins.table.TableDialogKeyboardNavTest', () => {
   const pressTabKey = (editor: Editor) => TinyUiActions.keydown(editor, Keys.tab());
 
   // Assert focus is on the expected form element
-  const pAssertFocusOnItem = (label: string, selector: string) => FocusTools.pTryOnSelector(
-    `Focus should be on: ${label}`,
-    SugarDocument.getDocument(),
-    selector
-  );
+  const pAssertFocusOnItem = (label: string, selectorOrElement: string | SugarElement<Node>) => {
+    if (typeof selectorOrElement === 'string') {
+      return FocusTools.pTryOnSelector(`Focus should be on: ${label}`, SugarDocument.getDocument(), selectorOrElement);
+    }
+    return FocusTools.pTryOn(`Focus should be on: ${label}`, selectorOrElement);
+  };
+  const findTargetByLabel = Fun.curry(UiFinder.findTargetByLabel, SugarDocument.getDocument());
 
   it('TBA: Open dialog, test the tab key navigation cycles through all focusable fields in General and Advanced tabs', async () => {
     const editor = hook.editor();
@@ -39,19 +42,19 @@ describe('browser.tinymce.plugins.table.TableDialogKeyboardNavTest', () => {
     // Keyboard nav within the General tab
     await pAssertFocusOnItem('General Tab', '.tox-dialog__body-nav-item:contains("General")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('Width', 'label:contains("Width") + input');
+    await pAssertFocusOnItem('Width', findTargetByLabel('Width').getOrDie());
     pressTabKey(editor);
-    await pAssertFocusOnItem('Height', 'label:contains("Height") + input');
+    await pAssertFocusOnItem('Height', findTargetByLabel('Height').getOrDie());
     pressTabKey(editor);
-    await pAssertFocusOnItem('Cell spacing', 'label:contains("Cell spacing") + input');
+    await pAssertFocusOnItem('Cell spacing', findTargetByLabel('Cell spacing').getOrDie());
     pressTabKey(editor);
-    await pAssertFocusOnItem('Cell padding', 'label:contains("Cell padding") + input');
+    await pAssertFocusOnItem('Cell padding', findTargetByLabel('Cell padding').getOrDie());
     pressTabKey(editor);
-    await pAssertFocusOnItem('Border width', 'label:contains("Border width") + input');
+    await pAssertFocusOnItem('Border width', findTargetByLabel('Border width').getOrDie());
     pressTabKey(editor);
     await pAssertFocusOnItem('Caption', 'input[type="checkbox"]');
     pressTabKey(editor);
-    await pAssertFocusOnItem('Alignment', 'label:contains("Alignment") + .tox-listboxfield > .tox-listbox');
+    await pAssertFocusOnItem('Alignment', findTargetByLabel('Alignment').getOrDie());
     pressTabKey(editor);
     await pAssertFocusOnItem('Cancel', '.tox-button:contains("Cancel")');
     pressTabKey(editor);
@@ -67,7 +70,7 @@ describe('browser.tinymce.plugins.table.TableDialogKeyboardNavTest', () => {
     // Keyboard nav within the Advanced tab
     await pAssertFocusOnItem('Advanced Tab', '.tox-dialog__body-nav-item:contains("Advanced")');
     pressTabKey(editor);
-    await pAssertFocusOnItem('Border style', 'label:contains("Border style") + .tox-listboxfield > .tox-listbox');
+    await pAssertFocusOnItem('Border style', findTargetByLabel('Border style').getOrDie());
     pressTabKey(editor);
     await pAssertFocusOnItem('Border color', '.tox-form div:nth-child(2) input');
     pressTabKey(editor);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogStyleWithCssTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogStyleWithCssTest.ts
@@ -23,9 +23,9 @@ interface TableSpec {
 
 describe('browser.tinymce.plugins.table.ui.TableCellDialogStyleWithCssTest', () => {
   const generalSelectors = {
-    cellspacing: 'label.tox-label:contains(Cell spacing) + input.tox-textfield',
-    cellpadding: 'label.tox-label:contains(Cell padding) + input.tox-textfield',
-    borderwidth: 'label.tox-label:contains(Border width) + input.tox-textfield',
+    cellspacing: 'Cell spacing',
+    cellpadding: 'Cell padding',
+    borderwidth: 'Border width',
   } as const;
   type GeneralData = Partial<Record<keyof typeof generalSelectors, string>>;
 

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogStyleWithCssTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogStyleWithCssTest.ts
@@ -22,15 +22,15 @@ interface TableSpec {
 }
 
 describe('browser.tinymce.plugins.table.ui.TableCellDialogStyleWithCssTest', () => {
-  const generalSelectors = {
+  const generalLabels = {
     cellspacing: 'Cell spacing',
     cellpadding: 'Cell padding',
     borderwidth: 'Border width',
   } as const;
-  type GeneralData = Partial<Record<keyof typeof generalSelectors, string>>;
+  type GeneralData = Partial<Record<keyof typeof generalLabels, string>>;
 
-  const setDialogValues = (data: GeneralData) => TableTestUtils.setDialogValues(data, false, generalSelectors);
-  const assertDialogValues = (data: GeneralData) => TableTestUtils.assertDialogValues(data, false, generalSelectors);
+  const setDialogValues = (data: GeneralData) => TableTestUtils.setDialogValues(data, false, generalLabels);
+  const assertDialogValues = (data: GeneralData) => TableTestUtils.assertDialogValues(data, false, generalLabels);
 
   const initializeTable = (editor: Editor, table: TableSpec) => {
     const { cellPaddingAttr, cellPaddingStyle, cellSpacingAttr, cellSpacingStyle, cellBorderWidthStyle, borderAttr } = table;

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogTest.ts
@@ -28,7 +28,7 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     statusbar: false
   }, [ Plugin ], true);
 
-  const generalSelectors = {
+  const generalLabels = {
     width: 'Width',
     height: 'Height',
     cellspacing: 'Cell spacing',
@@ -59,11 +59,11 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     setTable(editor);
     setCursor(editor);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(emptyStandardData, false, generalSelectors);
+    TableTestUtils.assertDialogValues(emptyStandardData, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TableTestUtils.assertElementStructure(editor, 'table', htmlEmptyTable);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(emptyStandardData, false, generalSelectors);
+    TableTestUtils.assertDialogValues(emptyStandardData, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
   });
 
@@ -117,12 +117,12 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     setTable(editor);
     setCursor(editor);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(emptyStandardData, false, generalSelectors);
-    TableTestUtils.setDialogValues(fullStandardData, false, generalSelectors);
+    TableTestUtils.assertDialogValues(emptyStandardData, false, generalLabels);
+    TableTestUtils.setDialogValues(fullStandardData, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TableTestUtils.assertApproxElementStructure(editor, 'table', htmlFilledEmptyTable);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(fullStandardData, false, generalSelectors);
+    TableTestUtils.assertDialogValues(fullStandardData, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
   });
 
@@ -146,12 +146,12 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     setTable(editor);
     setCursor(editor);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(emptyAllOffData, false, generalSelectors);
-    TableTestUtils.setDialogValues(fullAllOffData, false, generalSelectors);
+    TableTestUtils.assertDialogValues(emptyAllOffData, false, generalLabels);
+    TableTestUtils.setDialogValues(fullAllOffData, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TableTestUtils.assertElementStructure(editor, 'table', htmlFilledAllOffTable);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(fullAllOffData, false, generalSelectors);
+    TableTestUtils.assertDialogValues(fullAllOffData, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
     editor.options.unset('table_appearance_options');
   });
@@ -226,13 +226,13 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     setTable(editor);
     setCursor(editor);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(emptyAllOnData, true, generalSelectors);
-    TableTestUtils.setDialogValues(fullAllOnData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(emptyAllOnData, true, generalLabels);
+    TableTestUtils.setDialogValues(fullAllOnData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TableTestUtils.assertApproxElementStructure(editor, 'table', htmlFilledAllOnTable);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(fullAllOnData, true, generalSelectors);
-    TableTestUtils.setDialogValues(emptyAllOnData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(fullAllOnData, true, generalLabels);
+    TableTestUtils.setDialogValues(emptyAllOnData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TableTestUtils.assertElementStructure(editor, 'table', htmlEmptyTable);
 
@@ -268,7 +268,7 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     editor.setContent(baseHtml);
     setCursor(editor);
     editor.execCommand('mceTableProps');
-    TableTestUtils.assertDialogValues(baseData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(baseData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
 
     editor.options.unset('table_advtab');
@@ -326,18 +326,18 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     editor.setContent(baseHtml);
     setCursor(editor);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(baseData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(baseData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
     TinyAssertions.assertContent(editor, baseHtml);
 
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(baseData, true, generalSelectors);
-    TableTestUtils.setDialogValues(newData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(baseData, true, generalLabels);
+    TableTestUtils.setDialogValues(newData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, newHtml);
 
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(newData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(newData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
 
     editor.options.unset('table_class_list');
@@ -365,12 +365,12 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     editor.setContent(floatTableHtml);
     setCursor(editor);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(initialData, false, generalSelectors);
-    TableTestUtils.setDialogValues(newData, false, generalSelectors);
+    TableTestUtils.assertDialogValues(initialData, false, generalLabels);
+    TableTestUtils.setDialogValues(newData, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TableTestUtils.assertElementStructure(editor, 'table', marginTableHtml);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(newData, false, generalSelectors);
+    TableTestUtils.assertDialogValues(newData, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
     editor.options.unset('table_appearance_options');
   });
@@ -390,12 +390,12 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     editor.setContent('<table style="border-collapse: collapse;" border="1px" width="60%"><tbody><tr><td>&nbsp;</td></tr></tbody></table>');
     setCursor(editor);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(getExpectedData(1), false, generalSelectors);
-    TableTestUtils.setDialogValues({ border: '2px' }, false, generalSelectors);
+    TableTestUtils.assertDialogValues(getExpectedData(1), false, generalLabels);
+    TableTestUtils.setDialogValues({ border: '2px' }, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, '<table style="width: 60%; border-width: 2px; border-collapse: collapse;" border="1" width="60%"><tbody><tr><td style="border-width: 2px;">&nbsp;</td></tr></tbody></table>');
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(getExpectedData(2), false, generalSelectors);
+    TableTestUtils.assertDialogValues(getExpectedData(2), false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
   });
 
@@ -414,12 +414,12 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     editor.setContent('<table style="border-collapse: collapse;" border="1px"><tbody><tr><td>&nbsp;</td></tr></tbody></table>');
     setCursor(editor);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(getExpectedData(1, ''), false, generalSelectors);
-    TableTestUtils.setDialogValues({ border: '2px' }, false, generalSelectors);
+    TableTestUtils.assertDialogValues(getExpectedData(1, ''), false, generalLabels);
+    TableTestUtils.setDialogValues({ border: '2px' }, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, '<table style="border-width: 2px; border-collapse: collapse;" border="1"><tbody><tr><td style="border-width: 2px;">&nbsp;</td></tr></tbody></table>');
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(getExpectedData(2, ''), false, generalSelectors);
+    TableTestUtils.assertDialogValues(getExpectedData(2, ''), false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
   });
 
@@ -442,13 +442,13 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     TinyAssertions.assertContent(editor, inputHtml);
     setCursor(editor);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(getExpectedData(1, ''), false, generalSelectors);
-    TableTestUtils.setDialogValues({ border: '3px' }, false, generalSelectors);
+    TableTestUtils.assertDialogValues(getExpectedData(1, ''), false, generalLabels);
+    TableTestUtils.setDialogValues({ border: '3px' }, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     // shorthand form is retained
     TinyAssertions.assertContent(editor, '<table style="border: 3px dotted rgb(255, 0, 0); border-collapse: collapse;" border="1"><tbody><tr><td style="border-width: 3px;">&nbsp;</td></tr></tbody></table>');
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(getExpectedData(3, ''), false, generalSelectors);
+    TableTestUtils.assertDialogValues(getExpectedData(3, ''), false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
   });
 
@@ -515,8 +515,8 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
       editor.setContent(baseHtml);
       setCursor(editor);
       editor.execCommand('mceTableProps');
-      TableTestUtils.assertDialogValues(baseData, true, generalSelectors);
-      TableTestUtils.setDialogValues({ ...baseData, ...newData }, true, generalSelectors);
+      TableTestUtils.assertDialogValues(baseData, true, generalLabels);
+      TableTestUtils.setDialogValues({ ...baseData, ...newData }, true, generalLabels);
       await TableTestUtils.pClickDialogButton(editor, true);
       TinyAssertions.assertContent(editor, expectedHtml);
     };

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogTest.ts
@@ -29,14 +29,14 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
   }, [ Plugin ], true);
 
   const generalSelectors = {
-    width: 'label.tox-label:contains(Width) + input.tox-textfield',
-    height: 'label.tox-label:contains(Height) + input.tox-textfield',
-    cellspacing: 'label.tox-label:contains(Cell spacing) + input.tox-textfield',
-    cellpadding: 'label.tox-label:contains(Cell padding) + input.tox-textfield',
-    border: 'label.tox-label:contains(Border width) + input.tox-textfield',
-    caption: 'label.tox-label:contains(Caption) + label.tox-checkbox > input',
-    align: 'label.tox-label:contains(Alignment) + div.tox-listboxfield > .tox-listbox',
-    class: 'label.tox-label:contains(Class) + div.tox-listboxfield > .tox-listbox'
+    width: 'Width',
+    height: 'Height',
+    cellspacing: 'Cell spacing',
+    cellpadding: 'Cell padding',
+    border: 'Border width',
+    caption: 'Show caption',
+    align: 'Alignment',
+    class: 'Class'
   };
 
   const htmlEmptyTable = '<table><tr><td>X</td></tr></table>';

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogWithoutCssTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogWithoutCssTest.ts
@@ -20,7 +20,7 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     statusbar: false
   }, [ Plugin ], true);
 
-  const generalSelectors = {
+  const generalLabels = {
     width: 'Width',
     height: 'Height',
     cellspacing: 'Cell spacing',
@@ -50,12 +50,12 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     editor.setContent(getTable(1));
     setCursor(editor);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(getExpectedData(1), false, generalSelectors);
-    TableTestUtils.setDialogValues({ border: '2px' }, false, generalSelectors);
+    TableTestUtils.assertDialogValues(getExpectedData(1), false, generalLabels);
+    TableTestUtils.setDialogValues({ border: '2px' }, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, getTable(2));
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(getExpectedData(2), false, generalSelectors);
+    TableTestUtils.assertDialogValues(getExpectedData(2), false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
   });
 
@@ -74,12 +74,12 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
     editor.setContent('<table style="border-collapse: collapse;" border="1px"><tbody><tr><td>&nbsp;</td></tr></tbody></table>');
     setCursor(editor);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(getExpectedData(1, ''), false, generalSelectors);
-    TableTestUtils.setDialogValues({ border: '2px' }, false, generalSelectors);
+    TableTestUtils.assertDialogValues(getExpectedData(1, ''), false, generalLabels);
+    TableTestUtils.setDialogValues({ border: '2px' }, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, '<table style="border-collapse: collapse;" border="2px" width="100%"><tbody><tr><td>&nbsp;</td></tr></tbody></table>');
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(getExpectedData(2, '100%'), false, generalSelectors);
+    TableTestUtils.assertDialogValues(getExpectedData(2, '100%'), false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
   });
 });

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogWithoutCssTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableDialogWithoutCssTest.ts
@@ -21,14 +21,14 @@ describe('browser.tinymce.plugins.table.TableDialogTest', () => {
   }, [ Plugin ], true);
 
   const generalSelectors = {
-    width: 'label.tox-label:contains(Width) + input.tox-textfield',
-    height: 'label.tox-label:contains(Height) + input.tox-textfield',
-    cellspacing: 'label.tox-label:contains(Cell spacing) + input.tox-textfield',
-    cellpadding: 'label.tox-label:contains(Cell padding) + input.tox-textfield',
-    border: 'label.tox-label:contains(Border width) + input.tox-textfield',
-    caption: 'label.tox-label:contains(Caption) + label.tox-checkbox > input',
-    align: 'label.tox-label:contains(Alignment) + div.tox-listboxfield > .tox-listbox',
-    class: 'label.tox-label:contains(Class) + div.tox-listboxfield > .tox-listbox'
+    width: 'Width',
+    height: 'Height',
+    cellspacing: 'Cell spacing',
+    cellpadding: 'Cell padding',
+    border: 'Border width',
+    caption: 'Show caption',
+    align: 'Alignment',
+    class: 'Class'
   };
 
   const setCursor = (editor: Editor) => TinySelections.setCursor(editor, [ 0, 0, 0 ], 0);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
@@ -27,9 +27,9 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
   }, [ Plugin ], true);
 
   const generalSelectors = {
-    type: 'label.tox-label:contains(Row type) + div.tox-listboxfield > .tox-listbox',
-    align: 'label.tox-label:contains(Alignment) + div.tox-listboxfield > .tox-listbox',
-    height: 'label.tox-label:contains(Height) + input.tox-textfield'
+    type: 'Row type',
+    align: 'Alignment',
+    height: 'Height'
   };
 
   let events: Array<EditorEvent<TableModifiedEvent>> = [];

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableRowDialogTest.ts
@@ -26,7 +26,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
     }
   }, [ Plugin ], true);
 
-  const generalSelectors = {
+  const generalLabels = {
     type: 'Row type',
     align: 'Alignment',
     height: 'Height'
@@ -86,7 +86,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
     editor.setContent(baseHtml);
     TinySelections.select(editor, 'td', [ 0 ]);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(baseData, false, generalSelectors);
+    TableTestUtils.assertDialogValues(baseData, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
     assertEvents([]);
   });
@@ -100,7 +100,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
       height: '10',
       align: 'right',
       type: 'header'
-    }, false, generalSelectors);
+    }, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, '<table style="border: 1px solid black; border-collapse: collapse;" border="1"><thead><tr style="height: 10px; text-align: right;"><td>X</td></tr></thead></table>');
     assertEvents([{ type: 'tablemodified', structure: true, style: true }]);
@@ -116,7 +116,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
       height: '',
       align: '',
       type: 'header'
-    }, false, generalSelectors);
+    }, false, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, '<table><caption>CAPTION</caption><thead><tr><td>X</td></tr></thead><tbody><tr><td>Y</td></tr></tbody></table>');
     assertEvents([{ type: 'tablemodified', structure: true, style: false }]);
@@ -128,7 +128,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
     editor.setContent(advHtml);
     TinySelections.select(editor, 'td', [ 0 ]);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(advData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(advData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, false);
     assertEvents([]);
   });
@@ -153,7 +153,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
       bordercolor: 'blue',
       borderstyle: 'dotted',
       backgroundcolor: '#ff0000'
-    }, true, generalSelectors);
+    }, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor,
       '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
@@ -174,7 +174,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
 
     TinySelections.select(editor, 'tr:nth-child(1) td:nth-child(1)', [ 0 ]);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(advData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(advData, true, generalLabels);
     TableTestUtils.setDialogValues({
       align: '',
       height: '',
@@ -182,7 +182,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
       backgroundcolor: '',
       bordercolor: '',
       borderstyle: ''
-    }, true, generalSelectors);
+    }, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor,
       '<table style="border: 1px solid black; border-collapse: collapse;" border="1">' +
@@ -243,8 +243,8 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
     editor.setContent(initialHtml);
     TinySelections.select(editor, 'tr:nth-child(2) td:nth-child(2)', [ 0 ]);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(initialData, true, generalSelectors);
-    TableTestUtils.setDialogValues(newData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(initialData, true, generalLabels);
+    TableTestUtils.setDialogValues(newData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, newHtml);
     assertEvents();
@@ -299,8 +299,8 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
     editor.setContent(initialHtml);
     TinySelections.select(editor, 'tr:nth-child(2) td:nth-child(2)', [ 0 ]);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(initialData, true, generalSelectors);
-    TableTestUtils.setDialogValues(newData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(initialData, true, generalLabels);
+    TableTestUtils.setDialogValues(newData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, newHtml);
     assertEvents();
@@ -357,8 +357,8 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
     editor.setContent(initialHtml);
     TinySelections.select(editor, 'tr:nth-child(2) td:nth-child(2)', [ 0 ]);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(initialData, true, generalSelectors);
-    TableTestUtils.setDialogValues(newData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(initialData, true, generalLabels);
+    TableTestUtils.setDialogValues(newData, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, newHtml);
     assertEvents();
@@ -382,7 +382,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
 
     TinySelections.select(editor, 'tr:nth-child(1) td:nth-child(1)', [ 0 ]);
     await TableTestUtils.pOpenTableDialog(editor);
-    TableTestUtils.assertDialogValues(initialData, true, generalSelectors);
+    TableTestUtils.assertDialogValues(initialData, true, generalLabels);
     TableTestUtils.setDialogValues({
       align: '',
       height: '',
@@ -390,7 +390,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
       backgroundcolor: '',
       bordercolor: '',
       borderstyle: ''
-    }, true, generalSelectors);
+    }, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
     TinyAssertions.assertContent(editor, expectedHtml);
     assertEvents([{ type: 'tablemodified', structure: true, style: false }]);
@@ -434,7 +434,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
       backgroundcolor: '',
       bordercolor: '',
       borderstyle: ''
-    }, true, generalSelectors);
+    }, true, generalLabels);
 
     TableTestUtils.setDialogValues({
       align: '',
@@ -443,7 +443,7 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
       bordercolor: 'blue',
       borderstyle: 'dotted',
       backgroundcolor: '#ff0000'
-    }, true, generalSelectors);
+    }, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
 
     TinyAssertions.assertContent(editor,
@@ -483,12 +483,12 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
       backgroundcolor: '',
       bordercolor: '',
       borderstyle: ''
-    }, true, generalSelectors);
+    }, true, generalLabels);
 
     TableTestUtils.setDialogValues({
       align: 'center',
       backgroundcolor: 'red'
-    }, true, generalSelectors);
+    }, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
 
     TinyAssertions.assertContent(editor,
@@ -530,14 +530,14 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
       backgroundcolor: '',
       bordercolor: '',
       borderstyle: ''
-    }, true, generalSelectors);
+    }, true, generalLabels);
 
     TableTestUtils.setDialogValues({
       align: '',
       height: '50px',
       type: 'body',
       bordercolor: 'blue',
-    }, true, generalSelectors);
+    }, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
 
     TinyAssertions.assertContent(editor,
@@ -583,14 +583,14 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
       backgroundcolor: '',
       bordercolor: '',
       borderstyle: ''
-    }, true, generalSelectors);
+    }, true, generalLabels);
 
     TableTestUtils.setDialogValues({
       align: '',
       height: '50px',
       type: 'body',
       bordercolor: 'blue',
-    }, true, generalSelectors);
+    }, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
 
     TinyAssertions.assertContent(editor,
@@ -639,14 +639,14 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
       backgroundcolor: '',
       bordercolor: '',
       borderstyle: ''
-    }, true, generalSelectors);
+    }, true, generalLabels);
 
     TableTestUtils.setDialogValues({
       align: '',
       height: '50px',
       type: 'body',
       bordercolor: 'blue',
-    }, true, generalSelectors);
+    }, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
 
     TinyAssertions.assertContent(editor,
@@ -688,11 +688,11 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
     await TableTestUtils.pOpenTableDialog(editor);
     TableTestUtils.assertDialogValues({
       type: 'body',
-    }, true, generalSelectors);
+    }, true, generalLabels);
 
     TableTestUtils.setDialogValues({
       type: 'header',
-    }, true, generalSelectors);
+    }, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
 
     TinyAssertions.assertContent(editor,
@@ -743,11 +743,11 @@ describe('browser.tinymce.plugins.table.TableRowDialogTest', () => {
     await TableTestUtils.pOpenTableDialog(editor);
     TableTestUtils.assertDialogValues({
       type: 'header',
-    }, true, generalSelectors);
+    }, true, generalLabels);
 
     TableTestUtils.setDialogValues({
       type: 'body',
-    }, true, generalSelectors);
+    }, true, generalLabels);
     await TableTestUtils.pClickDialogButton(editor, true);
 
     TinyAssertions.assertContent(editor,

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
@@ -27,13 +27,6 @@ const advSelectors = {
   backgroundcolor: 'Background color'
 };
 
-// const advSelectors = {
-//   borderwidth: 'label.tox-label:contains(Border width) + input.tox-textfield',
-//   borderstyle: 'label.tox-label:contains(Border style) + div.tox-listboxfield > .tox-listbox',
-//   bordercolor: 'label.tox-label:contains(Border color) + div>input.tox-textfield',
-//   backgroundcolor: 'label.tox-label:contains(Background color) + div>input.tox-textfield'
-// };
-
 const assertTableStructure = (editor: Editor, structure: StructAssert): void => {
   const table = SelectorFind.descendant(TinyDom.body(editor), 'table').getOrDie('A table should exist');
   Assertions.assertStructure('Should be a table the expected structure', structure, table);
@@ -131,13 +124,11 @@ const gotoAdvancedTab = (): void => {
 const setTabInputValues = (data: Record<string, any>, tabSelectors: Record<string, string>): void => {
   Obj.mapToArray(tabSelectors, (value, key) => {
     if (Obj.has(data, key)) {
-      /* First argument is a selector here not a labelText therofre it will not work */
       setInputValue(tabSelectors[key], data[key]);
     }
   });
 };
 
-/* Fix all general selectors */
 const setDialogValues = (data: Record<string, any>, hasAdvanced: boolean, generalSelectors: Record<string, string>): void => {
   if (hasAdvanced) {
     gotoGeneralTab();
@@ -157,7 +148,6 @@ const assertTabContents = (data: Record<string, any>, tabSelectors: Record<strin
   });
 };
 
-/* Fix all general selectors */
 const assertDialogValues = (data: Record<string, any>, hasAdvanced: boolean, generalSelectors: Record<string, string>): void => {
   if (hasAdvanced) {
     gotoGeneralTab();

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
@@ -21,11 +21,18 @@ export interface WidthData {
 }
 
 const advSelectors = {
-  borderwidth: 'label.tox-label:contains(Border width) + input.tox-textfield',
-  borderstyle: 'label.tox-label:contains(Border style) + div.tox-listboxfield > .tox-listbox',
-  bordercolor: 'label.tox-label:contains(Border color) + div>input.tox-textfield',
-  backgroundcolor: 'label.tox-label:contains(Background color) + div>input.tox-textfield'
+  borderwidth: 'Border width',
+  borderstyle: 'Border style',
+  bordercolor: 'Border color',
+  backgroundcolor: 'Background color'
 };
+
+// const advSelectors = {
+//   borderwidth: 'label.tox-label:contains(Border width) + input.tox-textfield',
+//   borderstyle: 'label.tox-label:contains(Border style) + div.tox-listboxfield > .tox-listbox',
+//   bordercolor: 'label.tox-label:contains(Border color) + div>input.tox-textfield',
+//   backgroundcolor: 'label.tox-label:contains(Background color) + div>input.tox-textfield'
+// };
 
 const assertTableStructure = (editor: Editor, structure: StructAssert): void => {
   const table = SelectorFind.descendant(TinyDom.body(editor), 'table').getOrDie('A table should exist');
@@ -81,29 +88,29 @@ const pAssertDialogPresence = async (label: string, editor: Editor, expected: Re
 
 const pAssertListBox = async (label: string, editor: Editor, section: string, expected: { title: string; value: string }): Promise<void> => {
   const dialog = await TinyUiActions.pWaitForDialog(editor);
-  const elem = UiFinder.findIn(dialog, 'label:contains("' + section + '") + .tox-listboxfield > .tox-listbox').getOrDie();
+  const elem = UiFinder.findTargetByLabel(dialog, section).getOrDie();
   const value = Attribute.get(elem, 'data-value');
   assert.equal(value, expected.value, 'Checking listbox value: ' + label);
   const text = TextContent.get(elem);
   assert.equal(text, expected.title, 'Checking listbox text: ' + label);
 };
 
-const getInput = (selector: string) =>
-  UiFinder.findIn<HTMLInputElement>(SugarBody.body(), selector).getOrDie();
+const getInput = (labelText: string) =>
+  UiFinder.findTargetByLabel<HTMLInputElement>(SugarBody.body(), labelText).getOrDie();
 
-const assertInputValue = (label: string, selector: string, expected: string | boolean): void => {
-  const input = getInput(selector);
+const assertInputValue = (propertyKey: string, labelText: string, expected: string | boolean): void => {
+  const input = getInput(labelText);
   if (input.dom.type === 'checkbox') {
-    assert.equal(input.dom.checked, expected, `The input value for ${label} should be: ${expected}`);
+    assert.equal(input.dom.checked, expected, `The input value for ${propertyKey} should be: ${expected}`);
   } else if (Class.has(input, 'tox-listbox')) {
-    assert.equal(Attribute.get(input, 'data-value'), String(expected), `The input value for ${label} should be: ${expected}`);
+    assert.equal(Attribute.get(input, 'data-value'), String(expected), `The input value for ${propertyKey} should be: ${expected}`);
   } else {
-    assert.equal(Value.get(input), expected, `The input value for ${label} should be: ${expected}`);
+    assert.equal(Value.get(input), expected, `The input value for ${propertyKey} should be: ${expected}`);
   }
 };
 
-const setInputValue = (selector: string, value: string | boolean): void => {
-  const input = getInput(selector);
+const setInputValue = (labelText: string, value: string | boolean): void => {
+  const input = getInput(labelText);
   if (input.dom.type === 'checkbox') {
     Checked.set(input, value as boolean);
   } else if (Class.has(input, 'tox-listbox')) {
@@ -124,11 +131,13 @@ const gotoAdvancedTab = (): void => {
 const setTabInputValues = (data: Record<string, any>, tabSelectors: Record<string, string>): void => {
   Obj.mapToArray(tabSelectors, (value, key) => {
     if (Obj.has(data, key)) {
+      /* First argument is a selector here not a labelText therofre it will not work */
       setInputValue(tabSelectors[key], data[key]);
     }
   });
 };
 
+/* Fix all general selectors */
 const setDialogValues = (data: Record<string, any>, hasAdvanced: boolean, generalSelectors: Record<string, string>): void => {
   if (hasAdvanced) {
     gotoGeneralTab();
@@ -148,6 +157,7 @@ const assertTabContents = (data: Record<string, any>, tabSelectors: Record<strin
   });
 };
 
+/* Fix all general selectors */
 const assertDialogValues = (data: Record<string, any>, hasAdvanced: boolean, generalSelectors: Record<string, string>): void => {
   if (hasAdvanced) {
     gotoGeneralTab();
@@ -166,7 +176,7 @@ const pInsertTableViaGrid = async (editor: Editor, cols: number, rows: number): 
   );
   const gridSelector = (cols - 1) + (10 * (rows - 1));
   await Waiter.pTryUntil('click table grid', () =>
-    TinyUiActions.clickOnUi(editor, `div.tox-insert-table-picker div[role="button"]:nth(${gridSelector})`)
+    TinyUiActions.clickOnUi(editor, `div.tox-insert-table-picker div[role="button"]:nth-child(${gridSelector + 1})`)
   );
 };
 

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
@@ -20,7 +20,7 @@ export interface WidthData {
   readonly isPercent: boolean;
 }
 
-const advSelectors = {
+const advLabels = {
   borderwidth: 'Border width',
   borderstyle: 'Border style',
   bordercolor: 'Border color',
@@ -134,7 +134,7 @@ const setDialogValues = (data: Record<string, any>, hasAdvanced: boolean, genera
     gotoGeneralTab();
     setTabInputValues(data, generalSelectors);
     gotoAdvancedTab();
-    setTabInputValues(data, advSelectors);
+    setTabInputValues(data, advLabels);
   } else {
     setTabInputValues(data, generalSelectors);
   }
@@ -153,7 +153,7 @@ const assertDialogValues = (data: Record<string, any>, hasAdvanced: boolean, gen
     gotoGeneralTab();
     assertTabContents(data, generalSelectors);
     gotoAdvancedTab();
-    assertTabContents(data, advSelectors);
+    assertTabContents(data, advLabels);
   } else {
     assertTabContents(data, generalSelectors);
   }

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogTreeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogTreeTest.ts
@@ -1,4 +1,4 @@
-import { FocusTools, Keys } from '@ephox/agar';
+import { FocusTools, Keys, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { SugarDocument } from '@ephox/sugar';
@@ -96,7 +96,7 @@ describe('browser.tinymce.themes.silver.editor.DialogTreeTest', () => {
     TinyUiActions.keystroke(editor, Keys.up());
     FocusTools.isOn('Dir', dirElement);
     TinyUiActions.keystroke(editor, Keys.tab());
-    const dirMenuElement = FocusTools.isOnSelector('Dir menu', SugarDocument.getDocument(), '.tox-tree--directory__label:contains("Dir") > .tox-mbtn' );
+    const dirMenuElement = FocusTools.isOn('Dir menu', UiFinder.findIn(dirElement, '.tox-mbtn').getOrDie());
     TinyUiActions.keystroke(editor, Keys.tab());
     FocusTools.isOn('File 5', file5Element);
     TinyUiActions.keystroke(editor, Keys.tab(), { shiftKey: true });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, FocusTools, Keyboard, Keys, Mouse, UiFinder } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
-import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -63,7 +63,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
   const pCheckItemsAtLocation = pCheckItemsAtLocationPlus(pNoop, pNoop, (text) => MenuUtils.pOpenMenu('', text));
   const pCheckAlignItemsAtLocation = pCheckItemsAtLocationPlus(pNoop, pNoop, () => MenuUtils.pOpenAlignMenu(''));
 
-  const pCheckSubItemsAtLocation = (expectedSubmenu: string) => pCheckItemsAtLocationPlus(
+  const pCheckSubItemsAtLocation = (expectedSubmenu: string, menuAmbigousMapping: ((element: SugarElement[]) => SugarElement)) => pCheckItemsAtLocationPlus(
     async () => {
       Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.right());
       await pAssertFocusOnItem(expectedSubmenu);
@@ -73,7 +73,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
       Keyboard.activeKeyup(SugarDocument.getDocument(), Keys.escape());
       return Promise.resolve();
     },
-    (text) => MenuUtils.pOpenMenu('', text)
+    (text) => MenuUtils.pOpenMenu('', text, menuAmbigousMapping)
   );
 
   let eventCount = 0;
@@ -234,7 +234,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
       assertNoEvent();
       TinySelections.setCursor(editor, [ 0, 0 ], 'Fi'.length);
       assertEvent(1, 'Paragraph');
-      await MenuUtils.pOpenMenu('Format', 'Paragraph:first');
+      await MenuUtils.pOpenMenu('Format', 'Paragraph');
       assertEvent(1, 'Paragraph');
       await pAssertFocusOnItem('Paragraph');
       TinyUiActions.keydown(editor, Keys.down());
@@ -248,7 +248,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'First block after "h1',
         editor,
         [ false, true ].concat(Arr.range(6, Fun.never)),
-        'Heading 1:first',
+        'Heading 1',
         [ 0, 0 ], 'Fi'.length
       );
 
@@ -256,7 +256,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'Second paragraph with no set format',
         editor,
         [ true ].concat(Arr.range(7, Fun.never)),
-        'Paragraph:first',
+        'Paragraph',
         [ 1, 0 ], 'Se'.length
       );
 
@@ -264,7 +264,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'First block with the "h1" set previously',
         editor,
         [ false, true ].concat(Arr.range(6, Fun.never)),
-        'Heading 1:first',
+        'Heading 1',
         [ 0, 0 ], 'Fi'.length
       );
 
@@ -296,11 +296,12 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
 
   it('TBA: Checking style ticks and updating',
     testWithEvents('StylesTextUpdate', async (editor) => {
+      const getLast = <T>(elements: T[]) => elements[elements.length - 1];
       editor.setContent('<p>First paragraph</p><p>Second paragraph</p>');
       assertNoEvent();
       TinySelections.setCursor(editor, [ 0, 0 ], 'Fi'.length);
       assertEvent(1, 'Paragraph');
-      await MenuUtils.pOpenMenu('Format', 'Paragraph:last');
+      await MenuUtils.pOpenMenu('Format', 'Paragraph', getLast);
       assertEvent(2, 'Paragraph');
       await pAssertFocusOnItem('Headings');
       TinyUiActions.keydown(editor, Keys.right());
@@ -310,27 +311,27 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
       assertEvent(4, 'Heading 1');
       UiFinder.notExists(SugarBody.body(), '[role="menu"]');
 
-      await pCheckSubItemsAtLocation('Heading 1')(
+      await pCheckSubItemsAtLocation('Heading 1', getLast)(
         'First block after "h1',
         editor,
         [ true ].concat(Arr.range(5, Fun.never)),
-        'Heading 1:last',
+        'Heading 1',
         [ 0, 0 ], 'Fi'.length
       );
 
-      await pCheckSubItemsAtLocation('Heading 1')(
+      await pCheckSubItemsAtLocation('Heading 1', getLast)(
         'Second paragraph with no set format',
         editor,
         Arr.range(6, Fun.never),
-        'Paragraph:last',
+        'Paragraph',
         [ 1, 0 ], 'Se'.length
       );
 
-      await pCheckSubItemsAtLocation('Heading 1')(
+      await pCheckSubItemsAtLocation('Heading 1', getLast)(
         'First block with the "h1" set previously',
         editor,
         [ true ].concat(Arr.range(5, Fun.never)),
-        'Heading 1:last',
+        'Heading 1',
         [ 0, 0 ], 'Fi'.length
       );
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
@@ -48,10 +48,10 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
     })), group);
   };
 
-  const pCheckItemsAtLocationPlus = (pBeforeStep: () => Promise<void>, pAfterStep: () => Promise<void>, pOpen: (text: string) => Promise<void>) =>
-    async (label: string, editor: Editor, expectedTicks: boolean[], menuText: string, path: number[], offset: number) => {
+  const pCheckItemsAtLocationPlus = (pBeforeStep: () => Promise<void>, pAfterStep: () => Promise<void>, pOpen: (menu: MenuUtils.OpenMenu) => Promise<void>) =>
+    async (label: string, editor: Editor, expectedTicks: boolean[], menu: MenuUtils.OpenMenu, path: number[], offset: number) => {
       TinySelections.setCursor(editor, path, offset);
-      await pOpen(menuText);
+      await pOpen(menu);
       await pBeforeStep();
       assertItemTicks(label, expectedTicks);
       await pAfterStep();
@@ -60,10 +60,10 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
     };
 
   const pNoop = () => Promise.resolve();
-  const pCheckItemsAtLocation = pCheckItemsAtLocationPlus(pNoop, pNoop, (text) => MenuUtils.pOpenMenu('', text));
+  const pCheckItemsAtLocation = pCheckItemsAtLocationPlus(pNoop, pNoop, MenuUtils.pOpenMenu);
   const pCheckAlignItemsAtLocation = pCheckItemsAtLocationPlus(pNoop, pNoop, () => MenuUtils.pOpenAlignMenu(''));
 
-  const pCheckSubItemsAtLocation = (expectedSubmenu: string, menuAmbigousMapping: ((element: SugarElement[]) => SugarElement)) => pCheckItemsAtLocationPlus(
+  const pCheckSubItemsAtLocation = (expectedSubmenu: string) => pCheckItemsAtLocationPlus(
     async () => {
       Keyboard.activeKeydown(SugarDocument.getDocument(), Keys.right());
       await pAssertFocusOnItem(expectedSubmenu);
@@ -73,7 +73,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
       Keyboard.activeKeyup(SugarDocument.getDocument(), Keys.escape());
       return Promise.resolve();
     },
-    (text) => MenuUtils.pOpenMenu('', text, menuAmbigousMapping)
+    MenuUtils.pOpenMenu
   );
 
   let eventCount = 0;
@@ -129,7 +129,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'First paragraph after "centering"',
         editor,
         [ false, true, false, false ],
-        'Center',
+        { name: 'Alignment', text: 'Center' },
         [ 0, 0 ], 'Fi'.length
       );
 
@@ -137,7 +137,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'Second paragraph with no set alignment',
         editor,
         [ false, false, false, false ],
-        'Align',
+        { name: 'Alignment', text: 'Align' },
         [ 1, 0 ], 'Se'.length
       );
 
@@ -145,7 +145,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'First paragraph with the alignment set to "center" previously',
         editor,
         [ false, true, false, false ],
-        'Center',
+        { name: 'Alignment', text: 'Center' },
         [ 0, 0 ], 'Fi'.length
       );
     }));
@@ -156,7 +156,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
       assertNoEvent();
       TinySelections.setCursor(editor, [ 0, 0 ], 'Fi'.length);
       assertEvent(1, 'Verdana');
-      await MenuUtils.pOpenMenu('FontSelect', 'Verdana');
+      await MenuUtils.pOpenMenu({ name: 'FontSelect', text: 'Verdana' });
       assertEvent(1, 'Verdana');
       await pAssertFocusOnItem('Andale Mono');
       assertEvent(1, 'Verdana');
@@ -168,7 +168,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'First paragraph after "Andale Mono"',
         editor,
         [ true ].concat(Arr.range(16, Fun.never)),
-        'Andale Mono',
+        { name: 'Font family', text: 'Andale Mono' },
         [ 0, 0, 0 ], 'Fi'.length
       );
 
@@ -176,7 +176,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'Second paragraph with no set font',
         editor,
         Arr.range<boolean>(14, Fun.never).concat([ true ]).concat(Arr.range(2, Fun.never)),
-        'Verdana',
+        { name: 'Font family', text: 'Verdana' },
         [ 1, 0 ], 'Se'.length
       );
 
@@ -184,7 +184,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'First paragraph with the font set to "Andale Mono" previously',
         editor,
         [ true ].concat(Arr.range(16, Fun.never)),
-        'Andale Mono',
+        { name: 'Font family', text: 'Andale Mono' },
         [ 0, 0, 0 ], 'Fi'.length
       );
     }));
@@ -195,7 +195,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
       assertNoEvent();
       TinySelections.setCursor(editor, [ 0, 0 ], 'Fi'.length);
       assertEvent(1, '12pt');
-      await MenuUtils.pOpenMenu('FontSelect', '12pt'); // This might be fragile.
+      await MenuUtils.pOpenMenu({ name: 'FontSelect', text: '12pt' }); // This might be fragile.
       assertEvent(2, '12pt');
       await pAssertFocusOnItem('8pt');
       assertEvent(2, '12pt');
@@ -207,7 +207,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'First paragraph after "8pt',
         editor,
         [ true ].concat(Arr.range(6, Fun.never)),
-        '8pt',
+        { name: 'FontSelect', text: '8pt' },
         [ 0, 0, 0 ], 'Fi'.length
       );
 
@@ -215,7 +215,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'Second paragraph with no set font size',
         editor,
         Arr.range<boolean>(2, Fun.never).concat([ true ]).concat(Arr.range(4, Fun.never)),
-        '12pt',
+        { name: 'FontSelect', text: '12pt' },
         [ 1, 0 ], 'Se'.length
       );
 
@@ -223,7 +223,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'First paragraph with the font set to "8pt" previously',
         editor,
         [ true ].concat(Arr.range(6, Fun.never)),
-        '8pt',
+        { name: 'FontSelect', text: '8pt' },
         [ 0, 0, 0 ], 'Fi'.length
       );
     }));
@@ -234,7 +234,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
       assertNoEvent();
       TinySelections.setCursor(editor, [ 0, 0 ], 'Fi'.length);
       assertEvent(1, 'Paragraph');
-      await MenuUtils.pOpenMenu('Format', 'Paragraph');
+      await MenuUtils.pOpenMenu({ name: 'Format', text: 'Paragraph' });
       assertEvent(1, 'Paragraph');
       await pAssertFocusOnItem('Paragraph');
       TinyUiActions.keydown(editor, Keys.down());
@@ -248,7 +248,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'First block after "h1',
         editor,
         [ false, true ].concat(Arr.range(6, Fun.never)),
-        'Heading 1',
+        { name: 'Format', text: 'Heading 1' },
         [ 0, 0 ], 'Fi'.length
       );
 
@@ -256,7 +256,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'Second paragraph with no set format',
         editor,
         [ true ].concat(Arr.range(7, Fun.never)),
-        'Paragraph',
+        { name: 'Format', text: 'Paragraph' },
         [ 1, 0 ], 'Se'.length
       );
 
@@ -264,7 +264,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'First block with the "h1" set previously',
         editor,
         [ false, true ].concat(Arr.range(6, Fun.never)),
-        'Heading 1',
+        { name: 'Format', text: 'Heading 1' },
         [ 0, 0 ], 'Fi'.length
       );
 
@@ -296,12 +296,11 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
 
   it('TBA: Checking style ticks and updating',
     testWithEvents('StylesTextUpdate', async (editor) => {
-      const getLast = <T>(elements: T[]) => elements[elements.length - 1];
       editor.setContent('<p>First paragraph</p><p>Second paragraph</p>');
       assertNoEvent();
       TinySelections.setCursor(editor, [ 0, 0 ], 'Fi'.length);
       assertEvent(1, 'Paragraph');
-      await MenuUtils.pOpenMenu('Format', 'Paragraph', getLast);
+      await MenuUtils.pOpenMenu({ name: 'Format', text: 'Paragraph', matchLast: true });
       assertEvent(2, 'Paragraph');
       await pAssertFocusOnItem('Headings');
       TinyUiActions.keydown(editor, Keys.right());
@@ -311,27 +310,27 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
       assertEvent(4, 'Heading 1');
       UiFinder.notExists(SugarBody.body(), '[role="menu"]');
 
-      await pCheckSubItemsAtLocation('Heading 1', getLast)(
+      await pCheckSubItemsAtLocation('Heading 1')(
         'First block after "h1',
         editor,
         [ true ].concat(Arr.range(5, Fun.never)),
-        'Heading 1',
+        { name: 'Format', text: 'Heading 1', matchLast: true },
         [ 0, 0 ], 'Fi'.length
       );
 
-      await pCheckSubItemsAtLocation('Heading 1', getLast)(
+      await pCheckSubItemsAtLocation('Heading 1')(
         'Second paragraph with no set format',
         editor,
         Arr.range(6, Fun.never),
-        'Paragraph',
+        { name: 'Format', text: 'Paragraph', matchLast: true },
         [ 1, 0 ], 'Se'.length
       );
 
-      await pCheckSubItemsAtLocation('Heading 1', getLast)(
+      await pCheckSubItemsAtLocation('Heading 1')(
         'First block with the "h1" set previously',
         editor,
         [ true ].concat(Arr.range(5, Fun.never)),
-        'Heading 1',
+        { name: 'Format', text: 'Heading 1', matchLast: true },
         [ 0, 0 ], 'Fi'.length
       );
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
@@ -300,7 +300,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
       assertNoEvent();
       TinySelections.setCursor(editor, [ 0, 0 ], 'Fi'.length);
       assertEvent(1, 'Paragraph');
-      await MenuUtils.pOpenMenu({ name: 'Format', text: 'Paragraph', matchLast: true });
+      await MenuUtils.pOpenMenu({ name: 'Format', text: 'Paragraph', last: true });
       assertEvent(2, 'Paragraph');
       await pAssertFocusOnItem('Headings');
       TinyUiActions.keydown(editor, Keys.right());
@@ -314,7 +314,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'First block after "h1',
         editor,
         [ true ].concat(Arr.range(5, Fun.never)),
-        { name: 'Format', text: 'Heading 1', matchLast: true },
+        { name: 'Format', text: 'Heading 1', last: true },
         [ 0, 0 ], 'Fi'.length
       );
 
@@ -322,7 +322,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'Second paragraph with no set format',
         editor,
         Arr.range(6, Fun.never),
-        { name: 'Format', text: 'Paragraph', matchLast: true },
+        { name: 'Format', text: 'Paragraph', last: true },
         [ 1, 0 ], 'Se'.length
       );
 
@@ -330,7 +330,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.SilverBespokeButtonsTest'
         'First block with the "h1" set previously',
         editor,
         [ true ].concat(Arr.range(5, Fun.never)),
-        { name: 'Format', text: 'Heading 1', matchLast: true },
+        { name: 'Format', text: 'Heading 1', last: true },
         [ 0, 0 ], 'Fi'.length
       );
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, FocusTools, Keyboard, Keys, Mouse, UiFinder } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
-import { SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
+import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/StyleSelectFormatNamesTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/StyleSelectFormatNamesTest.ts
@@ -91,7 +91,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.StyleSelectFormatNamesTes
   };
 
   it('Configured style_formats are included in the styles toolbar button', async () => {
-    await MenuUtils.pOpenMenu('Format', 'Formats:last');
+    await MenuUtils.pOpenMenu('Format', 'Formats', (elements) => elements[elements.length - 1]);
     assertStyleSelectMenuItems('Checking style select items', [
       { title: 'Named inline format', element: 'span' },
       { title: 'Named block format', element: 'h1' },

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/StyleSelectFormatNamesTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/StyleSelectFormatNamesTest.ts
@@ -91,7 +91,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.StyleSelectFormatNamesTes
   };
 
   it('Configured style_formats are included in the styles toolbar button', async () => {
-    await MenuUtils.pOpenMenu('Format', 'Formats', (elements) => elements[elements.length - 1]);
+    await MenuUtils.pOpenMenu({ name: 'Format', text: 'Formats', matchLast: true });
     assertStyleSelectMenuItems('Checking style select items', [
       { title: 'Named inline format', element: 'span' },
       { title: 'Named block format', element: 'h1' },

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/StyleSelectFormatNamesTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/StyleSelectFormatNamesTest.ts
@@ -91,7 +91,7 @@ describe('browser.tinymce.themes.silver.editor.bespoke.StyleSelectFormatNamesTes
   };
 
   it('Configured style_formats are included in the styles toolbar button', async () => {
-    await MenuUtils.pOpenMenu({ name: 'Format', text: 'Formats', matchLast: true });
+    await MenuUtils.pOpenMenu({ name: 'Format', text: 'Formats', last: true });
     assertStyleSelectMenuItems('Checking style select items', [
       { title: 'Named inline format', element: 'span' },
       { title: 'Named block format', element: 'h1' },

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/UpdateToolbarButtonTextAndIconTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/UpdateToolbarButtonTextAndIconTest.ts
@@ -1,6 +1,6 @@
-import { Mouse } from '@ephox/agar';
+import { Mouse, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { Css, SugarElement } from '@ephox/sugar';
+import { Css, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
 import { TinyHooks, TinyUi, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -76,7 +76,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.UpdateToolbarButtonTextAn
 
   it('TINY-9268: Normal toolbar button can update its text', async () => {
     const selectorForToolbarButtonWithLabel = (label: string) =>
-      `.tox-tbtn.tox-tbtn--select:has(.tox-tbtn__select-label:contains("${label}"))`;
+      `.tox-tbtn.tox-tbtn--select:contains("${label}")`;
     const editor = hook.editor();
     const button = await TinyUi(editor).pWaitForUi(selectorForToolbarButtonWithLabel('Before'));
     const initialWidth = Css.get(button, 'width');
@@ -88,7 +88,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.UpdateToolbarButtonTextAn
 
   it('TINY-9268: Toggle toolbar button can update its text', async () => {
     const selectorForToolbarButtonWithLabel = (label: string) =>
-      `.tox-tbtn.tox-tbtn--select:has(.tox-tbtn__select-label:contains("${label}"))`;
+      `.tox-tbtn.tox-tbtn--select:contains("${label}")`;
     const editor = hook.editor();
     const button = await TinyUi(editor).pWaitForUi(selectorForToolbarButtonWithLabel('ToggleBefore'));
     const initialWidth = Css.get(button, 'width');
@@ -100,7 +100,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.UpdateToolbarButtonTextAn
 
   it('TINY-9268: menu toolbar button can update its text when clicking on menu item', async () => {
     const selectorForToolbarButtonWithLabel = (label: string) =>
-      `.tox-tbtn.tox-tbtn--select:has(.tox-tbtn__select-label:contains("${label}"))`;
+      `.tox-tbtn.tox-tbtn--select:contains("${label}")`;
     const editor = hook.editor();
     const button = await TinyUi(editor).pWaitForUi(selectorForToolbarButtonWithLabel('MenuBefore'));
     const initialWidth = Css.get(button, 'width');
@@ -114,7 +114,11 @@ describe('browser.tinymce.themes.silver.editor.buttons.UpdateToolbarButtonTextAn
 
   it('TINY-9268: toolbar split button can update its text when clicking on it or one of its items', async () => {
     const selectorForToolbarButtonWithLabel = (label: string) =>
-      `.tox-tbtn.tox-tbtn--select:has(.tox-tbtn__select-label:contains("${label}"))`;
+      `.tox-tbtn.tox-tbtn--select:contains("${label}")`;
+    const getChevron = (label: string) => {
+      const button = UiFinder.findIn(SugarBody.body(), selectorForToolbarButtonWithLabel(label)).getOrDie();
+      return UiFinder.findIn(Traverse.parent(button).getOrDie(), '.tox-split-button__chevron').getOrDie();
+    };
     const editor = hook.editor();
     const button = await TinyUi(editor).pWaitForUi(selectorForToolbarButtonWithLabel('SplitBefore'));
     const initialWidth = Css.get(button, 'width');
@@ -122,7 +126,7 @@ describe('browser.tinymce.themes.silver.editor.buttons.UpdateToolbarButtonTextAn
     await TinyUiActions.pWaitForUi(editor, selectorForToolbarButtonWithLabel('Split After After After After After After'));
     const currentWidth = Css.get(button, 'width');
     assert.equal(initialWidth, currentWidth);
-    TinyUiActions.clickOnToolbar(editor, `${selectorForToolbarButtonWithLabel('Split After After After After After After')} + .tox-split-button__chevron`);
+    Mouse.click(getChevron('Split After After After After After After'));
     const menuItem = await TinyUi(editor).pWaitForUi( '[aria-label="Menu item 1"]');
     Mouse.click(menuItem);
     await TinyUiActions.pWaitForUi(editor, selectorForToolbarButtonWithLabel('Split Item After After After After After After'));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorAriaLabelTest.ts
@@ -62,7 +62,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorAriaLabelTest', () => 
     await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
     TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Custom color"]');
     const dialog = await TinyUiActions.pWaitForDialog(editor);
-    const input = UiFinder.findIn<HTMLInputElement>(dialog, 'label:contains("#") + input').getOrDie();
+    const input = UiFinder.findTargetByLabel<HTMLInputElement>(dialog, '#').getOrDie();
     UiControls.setValue(input, '123123');
     const evt = new Event('input', {
       bubbles: true,
@@ -101,7 +101,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorAriaLabelTest', () => 
 
     TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Custom color"]');
     const dialog = await TinyUiActions.pWaitForDialog(editor);
-    const input = UiFinder.findIn<HTMLInputElement>(dialog, 'label:contains("#") + input').getOrDie();
+    const input = UiFinder.findTargetByLabel<HTMLInputElement>(dialog, '#').getOrDie();
     UiControls.setValue(input, '123123');
     const evt = new Event('input', {
       bubbles: true,

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -33,7 +33,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
         TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Custom color"]');
         const backgroundDialog = await TinyUiActions.pWaitForDialog(editor);
-        const backgroundDialogResult = UiFinder.findIn<HTMLInputElement>(backgroundDialog, 'label:contains("#") + input').getOrDie();
+        const backgroundDialogResult = UiFinder.findTargetByLabel<HTMLInputElement>(backgroundDialog, '#').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(backgroundDialogResult.dom.value, '80FF80'));
         TinyUiActions.cancelDialog(editor);
       });
@@ -45,7 +45,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
         TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Custom color"]');
         const textDialog = await TinyUiActions.pWaitForDialog(editor);
-        const textDialogResult = UiFinder.findIn<HTMLInputElement>(textDialog, 'label:contains("#") + input').getOrDie();
+        const textDialogResult = UiFinder.findTargetByLabel<HTMLInputElement>(textDialog, '#').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(textDialogResult.dom.value, 'FFC0CB'));
         TinyUiActions.cancelDialog(editor);
       });
@@ -164,7 +164,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
         TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Custom color"]');
         const backgroundDialog = await TinyUiActions.pWaitForDialog(editor);
-        const backgroundDialogResult = UiFinder.findIn<HTMLInputElement>(backgroundDialog, 'label:contains("#") + input').getOrDie();
+        const backgroundDialogResult = UiFinder.findTargetByLabel<HTMLInputElement>(backgroundDialog, '#').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(backgroundDialogResult.dom.value, '00FF00'));
         TinyUiActions.cancelDialog(editor);
       });
@@ -176,7 +176,7 @@ describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () 
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
         TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Custom color"]');
         const textDialog = await TinyUiActions.pWaitForDialog(editor);
-        const textDialogResult = UiFinder.findIn<HTMLInputElement>(textDialog, 'label:contains("#") + input').getOrDie();
+        const textDialogResult = UiFinder.findTargetByLabel<HTMLInputElement>(textDialog, '#').getOrDie();
         await Waiter.pTryUntil('Dialog should start with the right color', () => assert.equal(textDialogResult.dom.value, 'FF00FF'));
         TinyUiActions.cancelDialog(editor);
       });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
@@ -159,14 +159,14 @@ describe('browser.tinymce.themes.silver.editor.color.TextColorSanityTest', () =>
       UiFinder.notExists(SugarBody.body(), 'div[data-mce-color="#FF0000"]');
       TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Custom color"]');
       const dialog = await TinyUiActions.pWaitForDialog(editor);
-      const input = UiFinder.findIn<HTMLInputElement>(dialog, 'label:contains("R") + input').getOrDie();
+      const input = UiFinder.findTargetByLabel<HTMLInputElement>(dialog, 'R').getOrDie();
       UiControls.setValue(input, '255');
       const evt = new Event('input', {
         bubbles: true,
         cancelable: true
       });
       input.dom.dispatchEvent(evt);
-      const dialogResult = UiFinder.findIn<HTMLInputElement>(dialog, 'label:contains("#") + input').getOrDie();
+      const dialogResult = UiFinder.findTargetByLabel<HTMLInputElement>(dialog, '#').getOrDie();
       await Waiter.pTryUntil('Dialog has changed', () => dialogResult.dom.value === 'FF0000');
       TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Save"]');
       TinyUiActions.clickOnToolbar(editor, selectors.backcolorSplitButton);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -241,7 +241,11 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
   };
 
   const checkLastButtonGroup = (label: string, children: ApproxStructure.Builder<StructAssert[]>) => {
-    const group = UiFinder.findIn(SugarBody.body(), '.tox-pop .tox-toolbar__group:last').getOrDie();
+    const groups = UiFinder.findAllIn(SugarBody.body(), '.tox-pop .tox-toolbar__group');
+    if (groups.length === 0) {
+      throw new Error('Cannot find any toolbar group');
+    }
+    const group = groups[groups.length - 1];
     Assertions.assertStructure(
       label,
       ApproxStructure.build((s, str, arr) => s.element('div', {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
@@ -103,7 +103,11 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
   };
 
   const checkFirstButtonGroup = (label: string, children: ApproxStructure.Builder<StructAssert[]>) => {
-    const group = UiFinder.findIn(SugarBody.body(), '.tox-pop .tox-toolbar__group:first').getOrDie();
+    const groups = UiFinder.findAllIn(SugarBody.body(), '.tox-pop .tox-toolbar__group');
+    if (groups.length === 0) {
+      throw new Error('Cannot find any toolbar group');
+    }
+    const group = groups[0];
     Assertions.assertStructure(
       label,
       ApproxStructure.build((s, str, arr) => s.element('div', {
@@ -114,7 +118,11 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
   };
 
   const checkLastButtonGroup = (label: string, children: ApproxStructure.Builder<StructAssert[]>) => {
-    const group = UiFinder.findIn(SugarBody.body(), '.tox-pop .tox-toolbar__group:last').getOrDie();
+    const groups = UiFinder.findAllIn(SugarBody.body(), '.tox-pop .tox-toolbar__group');
+    if (groups.length === 0) {
+      throw new Error('Cannot find any toolbar group');
+    }
+    const group = groups[groups.length - 1];
     Assertions.assertStructure(
       label,
       ApproxStructure.build((s, str, arr) => s.element('div', {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
@@ -69,7 +69,11 @@ describe('browser.tinymce.themes.silver.editor.ContextSliderFormTest', () => {
   };
 
   const checkFirstButtonGroup = (label: string, children: ApproxStructure.Builder<StructAssert[]>) => {
-    const group = UiFinder.findIn(SugarBody.body(), '.tox-pop .tox-toolbar__group:first').getOrDie();
+    const groups = UiFinder.findAllIn(SugarBody.body(), '.tox-pop .tox-toolbar__group');
+    if (groups.length === 0) {
+      throw new Error('Cannot find any toolbar group');
+    }
+    const group = groups[0];
     Assertions.assertStructure(
       label,
       ApproxStructure.build((s, str, arr) => s.element('div', {
@@ -80,7 +84,11 @@ describe('browser.tinymce.themes.silver.editor.ContextSliderFormTest', () => {
   };
 
   const checkLastButtonGroup = (label: string, children: ApproxStructure.Builder<StructAssert[]>) => {
-    const group = UiFinder.findIn(SugarBody.body(), '.tox-pop .tox-toolbar__group:last').getOrDie();
+    const groups = UiFinder.findAllIn(SugarBody.body(), '.tox-pop .tox-toolbar__group');
+    if (groups.length === 0) {
+      throw new Error('Cannot find any toolbar group');
+    }
+    const group = groups[groups.length - 1];
     Assertions.assertStructure(
       label,
       ApproxStructure.build((s, str, arr) => s.element('div', {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarRenderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarRenderTest.ts
@@ -1,3 +1,4 @@
+import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Css } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
@@ -29,7 +30,8 @@ describe('browser.tinymce.themes.silver.editor.menubar.EditorMenubarRenderTest',
   it('TINY-10343: editor menu button with more that one word should not render the word one above the other', async () => {
     const editor = hook.editor();
 
-    const menuButtonText = await TinyUiActions.pWaitForUi(editor, 'button:contains("File foo") span');
+    const menuButton = await TinyUiActions.pWaitForUi(editor, 'button:contains("File foo")');
+    const menuButtonText = UiFinder.findIn(menuButton, 'span').getOrDie();
 
     const delta = 6;
     // Status at the moment of writting of this test:

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/DynamicTooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/DynamicTooltipTest.ts
@@ -56,7 +56,8 @@ describe('browser.tinymce.themes.silver.editor.TooltipShortcutTest', () => {
       await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
       TinyUiActions.clickOnUi(editor, 'button[data-mce-name="Custom color"]');
       const dialog = await TinyUiActions.pWaitForDialog(editor);
-      const input = UiFinder.findIn<HTMLInputElement>(dialog, 'label:contains("#") + input').getOrDie();
+      const input = UiFinder.findTargetByLabel<HTMLInputElement>(dialog, '#').getOrDie();
+
       UiControls.setValue(input, '123123');
       const evt = new Event('input', {
         bubbles: true,

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
@@ -263,7 +263,6 @@ describe('browser.tinymce.themes.silver.skin.OxideCollectionComponentTest', () =
     });
 
     const openDialog = async (editor: Editor) => {
-      /* TODO: fix */
       TinyUiActions.clickOnToolbar(editor, '.tox-tbtn.tox-tbtn--select:contains("Collection Dialog")');
       return await TinyUiActions.pWaitForDialog(editor);
     };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
@@ -263,7 +263,8 @@ describe('browser.tinymce.themes.silver.skin.OxideCollectionComponentTest', () =
     });
 
     const openDialog = async (editor: Editor) => {
-      TinyUiActions.clickOnToolbar(editor, '.tox-tbtn.tox-tbtn--select:has(.tox-tbtn__select-label:contains("Collection Dialog"))');
+      /* TODO: fix */
+      TinyUiActions.clickOnToolbar(editor, '.tox-tbtn.tox-tbtn--select:contains("Collection Dialog")');
       return await TinyUiActions.pWaitForDialog(editor);
     };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
@@ -92,7 +92,7 @@ describe('browser.tinymce.themes.silver.skin.OxideTablePickerMenuTest', () => {
       ApproxStructure.build((s, str, arr) => insertTablePickerApprox(s, str, arr, 2, 2)),
       menu
     );
-    await FocusTools.pTryOnSelector('Focus should be on 2 down, 2 across table cell', doc, '.tox-insert-table-picker > div[role="button"]:nth-child(12)');
+    await FocusTools.pTryOnSelector('Focus should be on 2 down, 2 across table cell', doc, 'div[role="button"]:nth-last-child(1 of .tox-insert-table-picker__selected)');
     TinyUiActions.keyup(editor, Keys.escape());
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
@@ -84,7 +84,7 @@ describe('browser.tinymce.themes.silver.skin.OxideTablePickerMenuTest', () => {
       ApproxStructure.build((s, str, arr) => insertTablePickerApprox(s, str, arr, 1, 1)),
       menu
     );
-    await FocusTools.pTryOnSelector('Focus should be on first table cell', doc, '.tox-insert-table-picker__selected:last');
+    await FocusTools.pTryOnSelector('Focus should be on first table cell', doc, '.tox-insert-table-picker__selected');
     TinyUiActions.keydown(editor, Keys.down());
     TinyUiActions.keydown(editor, Keys.right());
     Assertions.assertStructure(
@@ -92,7 +92,7 @@ describe('browser.tinymce.themes.silver.skin.OxideTablePickerMenuTest', () => {
       ApproxStructure.build((s, str, arr) => insertTablePickerApprox(s, str, arr, 2, 2)),
       menu
     );
-    await FocusTools.pTryOnSelector('Focus should be on 2 down, 2 across table cell', doc, '.tox-insert-table-picker__selected:last');
+    await FocusTools.pTryOnSelector('Focus should be on 2 down, 2 across table cell', doc, '.tox-insert-table-picker > div[role="button"]:nth-child(12)');
     TinyUiActions.keyup(editor, Keys.escape());
   });
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/colorpicker/ColorPickerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/colorpicker/ColorPickerTest.ts
@@ -31,20 +31,20 @@ describe('headless.tinymce.themes.silver.components.colorpicker.ColorPickerTest'
     Waiter.pTryUntil(
       'Waiting until hex updates the other fields',
       () => {
-        const input = UiFinder.findIn<HTMLInputElement>(component.element, `label:contains("${labelText}") + input`).getOrDie();
+        const input = UiFinder.findTargetByLabel<HTMLInputElement>(component.element, labelText).getOrDie();
         const value = UiControls.getValue(input);
         assert.equal(value, expected, 'Checking value in input');
       }
     );
 
   const setRgbValue = (component: AlloyComponent, value: string, colour: 'R' | 'G' | 'B') => {
-    const input = UiFinder.findIn<HTMLInputElement>(component.element, `label:contains("${colour}") + input`).getOrDie();
+    const input = UiFinder.findTargetByLabel<HTMLInputElement>(component.element, colour).getOrDie();
     UiControls.setValue(input, value);
     fireEvent(input, 'input');
   };
 
   const setHexValue = (component: AlloyComponent, value: string) => {
-    const input = UiFinder.findIn<HTMLInputElement>(component.element, `label:contains("#") + input`).getOrDie();
+    const input = UiFinder.findTargetByLabel<HTMLInputElement>(component.element, '#').getOrDie();
     UiControls.setValue(input, value);
     fireEvent(input, 'input');
   };

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
@@ -161,8 +161,9 @@ describe('headless.tinymce.themes.silver.tree.TreeTest', () => {
     store.assertEq('Dir collapsed', [ 'dir-collapsed' ]);
     store.clear();
 
+    const subdir = UiFinder.findIn(dir.element, '.tox-tree--directory').getOrDie();
     assertDirectoryExpandedState('Subdir', false, getTreeItem('.tox-tree--directory .tox-tree--directory'));
-    Mouse.clickOn(dir.element, '.tox-tree--directory .tox-trbtn.tox-tree--directory__label');
+    Mouse.clickOn(subdir, '.tox-trbtn.tox-tree--directory__label');
     assertDirectoryExpandedState('Subdir', true, getTreeItem('.tox-tree--directory .tox-tree--directory'));
     store.assertEq('Subir expanded', [ 'subdir-expanded' ]);
     store.clear();
@@ -180,7 +181,7 @@ describe('headless.tinymce.themes.silver.tree.TreeTest', () => {
     Mouse.clickOn(SugarBody.body(), '[aria-label="menuitem"]');
     store.assertEq('menuitem', [ 'menuitem' ]);
 
-    Mouse.clickOn(dir.element, '.tox-tree--directory .tox-trbtn.tox-tree--directory__label');
+    Mouse.clickOn(subdir, '.tox-trbtn.tox-tree--directory__label');
     assertDirectoryExpandedState('Subdir', false, getTreeItem('.tox-tree--directory .tox-tree--directory'));
 
   });

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/CustomDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/CustomDialogTest.ts
@@ -163,12 +163,10 @@ describe('headless.tinymce.themes.silver.window.CustomDialogTest', () => {
     );
 
     Keyboard.activeKeydown(doc, Keys.tab());
-    const field2 = UiFinder.findTargetByLabel(doc, labels.field2).getOrDie();
-    await FocusTools.pTryOn('Focus should move to second input (textarea)', field2);
+    await FocusTools.pTryOnByLabel('Focus should move to second input (textarea)', doc, labels.field2);
 
     Keyboard.activeKeydown(doc, Keys.tab());
-    const field3 = UiFinder.findTargetByLabel(doc, labels.field3).getOrDie();
-    await FocusTools.pTryOn('Focus should move to urlinput', field3);
+    await FocusTools.pTryOnByLabel('Focus should move to urlinput', doc, labels.field3);
 
     Keyboard.activeKeydown(doc, Keys.tab());
     await FocusTools.pTryOnSelector(
@@ -205,12 +203,10 @@ describe('headless.tinymce.themes.silver.window.CustomDialogTest', () => {
     assertFocusedCheckbox('Pressing <space> on unchecked checkbox', true);
 
     Keyboard.activeKeydown(doc, Keys.tab());
-    const field6 = UiFinder.findTargetByLabel(doc, labels.field6).getOrDie();
-    await FocusTools.pTryOn('Focus should move to first nested input', field6);
+    await FocusTools.pTryOnByLabel('Focus should move to first nested input', doc, labels.field6);
 
     Keyboard.activeKeydown(doc, Keys.tab());
-    const field7 = UiFinder.findTargetByLabel(doc, labels.field7).getOrDie();
-    await FocusTools.pTryOn('Focus should move to second nested input', field7);
+    await FocusTools.pTryOnByLabel('Focus should move to second nested input', doc, labels.field7);
 
     Keyboard.activeKeydown(doc, Keys.tab());
     await FocusTools.pTryOnSelector(
@@ -244,8 +240,7 @@ describe('headless.tinymce.themes.silver.window.CustomDialogTest', () => {
         return;
       }
       if (dest.label) {
-        const input = UiFinder.findTargetByLabel(doc, dest.label).getOrDie();
-        await FocusTools.pTryOn('Focus should move to ' + dest.testLabel, input);
+        await FocusTools.pTryOnByLabel('Focus should move to ' + dest.testLabel, doc, dest.label);
         return;
       }
     }), Promise.resolve());

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/CustomDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/CustomDialogTest.ts
@@ -47,16 +47,19 @@ describe('headless.tinymce.themes.silver.window.CustomDialogTest', () => {
 
   const selectors = {
     field1: 'input', // nothing more useful, because it does not have a label
-    field2: 'label:contains("F2") + .tox-textarea-wrap textarea',
-    field3: 'label:contains("F3") + .tox-form__controls-h-stack input',
     field4_a: '.tox-collection__item:contains("a")',
     field4_b: '.tox-collection__item:contains("b")',
     field5: 'input[type="checkbox"]',
-    field6: 'label:contains("nested1") + input',
-    field7: 'label:contains("nested2") + input',
     field8: 'button:contains("Cancel")',
     field9: 'button:contains("Save")',
     browseButton: 'button[data-mce-name="F3"]'
+  };
+
+  const labels = {
+    field2: 'F2',
+    field3: 'F3',
+    field6: 'nested1',
+    field7: 'nested2'
   };
 
   it('', async () => {
@@ -160,18 +163,12 @@ describe('headless.tinymce.themes.silver.window.CustomDialogTest', () => {
     );
 
     Keyboard.activeKeydown(doc, Keys.tab());
-    await FocusTools.pTryOnSelector(
-      'Focus should move to second input (textarea)',
-      doc,
-      selectors.field2
-    );
+    const field2 = UiFinder.findTargetByLabel(doc, labels.field2).getOrDie();
+    await FocusTools.pTryOn('Focus should move to second input (textarea)', field2);
 
     Keyboard.activeKeydown(doc, Keys.tab());
-    await FocusTools.pTryOnSelector(
-      'Focus should move to urlinput',
-      doc,
-      selectors.field3
-    );
+    const field3 = UiFinder.findTargetByLabel(doc, labels.field3).getOrDie();
+    await FocusTools.pTryOn('Focus should move to urlinput', field3);
 
     Keyboard.activeKeydown(doc, Keys.tab());
     await FocusTools.pTryOnSelector(
@@ -208,18 +205,12 @@ describe('headless.tinymce.themes.silver.window.CustomDialogTest', () => {
     assertFocusedCheckbox('Pressing <space> on unchecked checkbox', true);
 
     Keyboard.activeKeydown(doc, Keys.tab());
-    await FocusTools.pTryOnSelector(
-      'Focus should move to first nested input',
-      doc,
-      selectors.field6
-    );
+    const field6 = UiFinder.findTargetByLabel(doc, labels.field6).getOrDie();
+    await FocusTools.pTryOn('Focus should move to first nested input', field6);
 
     Keyboard.activeKeydown(doc, Keys.tab());
-    await FocusTools.pTryOnSelector(
-      'Focus should move to second nested input',
-      doc,
-      selectors.field7
-    );
+    const field7 = UiFinder.findTargetByLabel(doc, labels.field7).getOrDie();
+    await FocusTools.pTryOn('Focus should move to second nested input', field7);
 
     Keyboard.activeKeydown(doc, Keys.tab());
     await FocusTools.pTryOnSelector(
@@ -237,22 +228,26 @@ describe('headless.tinymce.themes.silver.window.CustomDialogTest', () => {
 
     // Now, navigate backwards
     await Arr.foldl([
-      { label: 'cancel', selector: selectors.field8 },
-      { label: 'nested2', selector: selectors.field7 },
-      { label: 'nested1', selector: selectors.field6 },
-      { label: 'checkbox', selector: selectors.field5 },
-      { label: 'charmap', selector: selectors.field4_a },
-      { label: 'browse button', selector: selectors.browseButton },
-      { label: 'f3', selector: selectors.field3 },
-      { label: 'f2', selector: selectors.field2 },
-      { label: 'first input', selector: selectors.field1 }
+      { testLabel: 'cancel', selector: selectors.field8 },
+      { testLabel: 'nested2', label: labels.field7 },
+      { testLabel: 'nested1', label: labels.field6 },
+      { testLabel: 'checkbox', selector: selectors.field5 },
+      { testLabel: 'charmap', selector: selectors.field4_a },
+      { testLabel: 'browse button', selector: selectors.browseButton },
+      { testLabel: 'f3', label: labels.field3 },
+      { testLabel: 'f2', label: labels.field2 },
+      { testLabel: 'first input', selector: selectors.field1 }
     ], (p, dest) => p.then(async () => {
       Keyboard.activeKeydown(doc, Keys.tab(), { shiftKey: true });
-      await FocusTools.pTryOnSelector(
-        'Focus should move to ' + dest.label,
-        doc,
-        dest.selector
-      );
+      if (dest.selector) {
+        await FocusTools.pTryOnSelector('Focus should move to ' + dest.testLabel, doc, dest.selector);
+        return;
+      }
+      if (dest.label) {
+        const input = UiFinder.findTargetByLabel(doc, dest.label).getOrDie();
+        await FocusTools.pTryOn('Focus should move to ' + dest.testLabel, input);
+        return;
+      }
     }), Promise.resolve());
 
     store.assertEq('Checking the testLog is empty', []);

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerRedialTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerRedialTest.ts
@@ -145,17 +145,17 @@ describe('headless.tinymce.themes.silver.window.WindowManagerRedialTest', () => 
 
   it('Check redialing a dialog', async () => {
     const dialogApi = openDialog();
-    UiFinder.exists(SugarBody.body(), 'button:contains("Destination: DialogB"):not([disabled])');
+    UiFinder.exists(SugarBody.body(), 'button:enabled:contains("Destination: DialogB")');
     Mouse.clickOn(SugarBody.body(), 'button:contains("Disable other")');
     // Button should be disabled
-    UiFinder.notExists(SugarBody.body(), 'button:contains("Destination: DialogB"):not([disabled])');
+    UiFinder.notExists(SugarBody.body(), 'button:enabled:contains("Destination: DialogB")');
 
     Mouse.clickOn(SugarBody.body(), 'button:contains("Disable other")');
     Mouse.clickOn(SugarBody.body(), 'button:contains("Destination: DialogB")');
 
     Mouse.clickOn(SugarBody.body(), 'button:contains("Enable other")');
     // Button should be enabled
-    UiFinder.exists(SugarBody.body(), 'button:contains("Destination: DialogB"):not([disabled])');
+    UiFinder.exists(SugarBody.body(), 'button:enabled:contains("Destination: DialogB")');
     Mouse.clickOn(SugarBody.body(), 'button:contains("Destination: DialogB")');
 
     Mouse.clickOn(SugarBody.body(), 'button:contains("Destination: DialogC")');

--- a/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/MenuUtils.ts
@@ -13,7 +13,7 @@ export interface OpenNestedMenus {
 export interface OpenMenu {
   readonly name: string;
   readonly text: string;
-  readonly matchLast?: boolean;
+  readonly last?: boolean;
 }
 
 const getToolbarSelector = (type: ToolbarMode, opening: boolean) => {
@@ -52,7 +52,7 @@ const pOpenMenu = async (menu: OpenMenu): Promise<void> => {
     if (buttons.length === 0) {
       return Optional.none();
     }
-    return Optional.from(menu.matchLast ? buttons[buttons.length - 1] : buttons[0]);
+    return Optional.from(menu.last ? buttons[buttons.length - 1] : buttons[0]);
   };
 
   await Waiter.pTryUntilPredicate(`Waiting for button: ${menu.text}`, () => {

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -114,7 +114,7 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
         await StickyUtils.pOpenMenuAndTestScrolling(() => MenuUtils.pOpenNestedMenus([
           {
             label: 'Open menu bar Format menu',
-            selector: 'button:contains(Format)[role=menuitem]'
+            selector: 'button[role=menuitem]:contains(Format)'
           },
           {
             label: 'then Formats submenu',

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/tooltip/HtmlPanelTooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/tooltip/HtmlPanelTooltipTest.ts
@@ -67,6 +67,7 @@ describe('browser.tinymce.themes.silver.editor.HtmlPanelTooltipTest', () => {
       TinyUiActions.closeDialog(editor);
     });
 
+    /* TODO: fix */
     it('TINY-9641: Hover custom button in htmlpanel, then tab to navigate away, should hide current tooltip and show tooltip for close button', async () => {
       const editor = hook.editor();
       await pOpenDialogAndWaitForLoad(editor, 'button[data-mce-name="custom-dialog"]');

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/tooltip/HtmlPanelTooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/tooltip/HtmlPanelTooltipTest.ts
@@ -67,7 +67,6 @@ describe('browser.tinymce.themes.silver.editor.HtmlPanelTooltipTest', () => {
       TinyUiActions.closeDialog(editor);
     });
 
-    /* TODO: fix */
     it('TINY-9641: Hover custom button in htmlpanel, then tab to navigate away, should hide current tooltip and show tooltip for close button', async () => {
       const editor = hook.editor();
       await pOpenDialogAndWaitForLoad(editor, 'button[data-mce-name="custom-dialog"]');


### PR DESCRIPTION
Related Ticket: TINY-11822

Description of Changes:
* Sizzle has been removed from dependencies.
* Tests has been adjusted to don't use jQuery specific features in selectors.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced element matching engine and new dialog management methods based on dialog titles.
  - Added new functions for selecting elements by label in various modules, improving interaction with UI elements.
  
- **Enhancements**
  - Streamlined UI interactions across image, link, table, and color picker dialogs.
  - Improved keyboard navigation, focus behavior, and overall accessibility in menus and toolbars.
  - Enhanced error handling and robustness in toolbar button interactions and dialog management.

- **Chores**
  - Removed legacy dependencies and refactored internal tests for improved performance and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->