### PR TITLE
TINY-11177: Remove silent fallback to zero tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -84,20 +84,10 @@ const fetchLernaProjects = (grunt, runAllTests) => {
   // This has to be sync because grunt can't do async config
   var exec = require('child_process').execSync;
 
-  // if JSON parse fails, well, grunt will just fail /shrug
   const parseLernaList = (cmd) => {
-    try {
-      const output = exec(`yarn -s lerna ${cmd} -a --json --loglevel warn`);
-      grunt.verbose.writeln(`lerna output: ${output}`);
-      return JSON.parse(output);
-    } catch (e) {
-      // If no changes are found, then lerna returns an exit code of 1, so deal with that gracefully
-      if (e.status === 1) {
-        return [];
-      } else {
-        throw e;
-      }
-    }
+    const output = exec(`yarn -s lerna ${cmd} -a --json --loglevel warn`);
+    grunt.verbose.writeln(`lerna output: ${output}`);
+    return JSON.parse(output);
   };
 
   const changes = runAllTests ? [] : parseLernaList('changed --no-ignore-changes');

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,8 @@ standardProperties()
 
 def runBedrockTest(String name, String command, Boolean runAll, int retry = 0, int timeout = 0) {
   def bedrockCmd = command + (runAll ? " --ignore-lerna-changed=true" : "")
-  echo "Running Bedrock cmd: ${command}"
-  def testStatus = sh(script: command, returnStatus: true)
+  echo "Running Bedrock cmd: ${bedrockCmd}"
+  def testStatus = sh(script: bedrockCmd, returnStatus: true)
   junit allowEmptyResults: true, testResults: 'scratch/TEST-*.xml'
 
   if (testStatus == 4) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,7 +115,8 @@ def runSeleniumPod(String cacheName, String name, String browser, String version
           resourceRequestEphemeralStorage: '8Gi',
           resourceLimitCpu: '7',
           resourceLimitMemory: '4Gi',
-          resourceLimitEphemeralStorage: '8Gi'
+          resourceLimitEphemeralStorage: '8Gi',
+          runAsGroup: '1000', runAsUser: '1000'
         ]
   Map selenium = [
           name: "selenium",

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -16,7 +16,7 @@
     "node": ">=0.10.26"
   },
   "main": "js/tinymce/tinymce.js",
-  "types": "js/tinymce/tinymce.d.ts",
+  "types": "src/core/main/ts/api/PublicApi.ts",
   "scripts": {
     "build": "grunt buildOnly",
     "test": "grunt test",

--- a/modules/tinymce/src/core/main/ts/api/Resource.ts
+++ b/modules/tinymce/src/core/main/ts/api/Resource.ts
@@ -15,7 +15,7 @@ const awaiter = (resolveCb: (data: any) => void, rejectCb: (err?: any) => void, 
     if (!done) {
       done = true;
       if (timer !== null) {
-        clearTimeout(timer);
+        window.clearTimeout(timer);
         timer = null;
       }
       completer.apply(null, args);
@@ -25,7 +25,7 @@ const awaiter = (resolveCb: (data: any) => void, rejectCb: (err?: any) => void, 
   const reject = complete(rejectCb);
   const start = (...args: Parameters<typeof reject>) => {
     if (!done && timer === null) {
-      timer = setTimeout(() => reject.apply(null, args), timeout);
+      timer = window.setTimeout(() => reject.apply(null, args), timeout);
     }
   };
   return {

--- a/modules/tinymce/src/core/main/ts/api/util/Delay.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Delay.ts
@@ -18,7 +18,7 @@ const wrappedSetTimeout = (callback: () => void, time?: number) => {
     time = 0;
   }
 
-  return setTimeout(callback, time);
+  return window.setTimeout(callback, time);
 };
 
 const wrappedSetInterval = (callback: Function, time?: number): number => {
@@ -26,7 +26,7 @@ const wrappedSetInterval = (callback: Function, time?: number): number => {
     time = 0;
   }
 
-  return setInterval(callback, time);
+  return window.setInterval(callback, time);
 };
 
 const Delay: Delay = {
@@ -62,7 +62,7 @@ const Delay: Delay = {
       if (!editor.removed) {
         callback();
       } else {
-        clearInterval(timer);
+        window.clearInterval(timer);
       }
     }, time);
 

--- a/modules/tinymce/src/core/main/ts/api/util/Delay.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Delay.ts
@@ -21,7 +21,7 @@ const wrappedSetTimeout = (callback: () => void, time?: number) => {
   return window.setTimeout(callback, time);
 };
 
-const wrappedSetInterval = (callback: Function, time?: number): number => {
+const wrappedSetInterval = (callback: () => void, time?: number): number => {
   if (!Type.isNumber(time)) {
     time = 0;
   }

--- a/modules/tinymce/src/core/main/ts/caret/FakeCaret.ts
+++ b/modules/tinymce/src/core/main/ts/caret/FakeCaret.ts
@@ -170,7 +170,7 @@ export const FakeCaret = (editor: Editor, root: HTMLElement, isBlock: (node: Nod
   };
 
   const startBlink = () => {
-    cursorInterval = setInterval(() => {
+    cursorInterval = window.setInterval(() => {
       lastVisualCaret.on((caretState) => {
         if (hasFocus()) {
           dom.toggleClass(caretState.caret, 'mce-visual-caret-hidden');


### PR DESCRIPTION
Related Ticket: TINY-11177

Description of Changes:
* This has previously resulted in branches accidentally running no tests for days.
* I added a nice change to make linking to TinyMCE's types work before the build is complete
* Some more specific calls to `setTimeout` and `setInterval` on `window` to avoid cases where TypeScript thinks it needs to use the NodeJS variants

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal operations by ensuring timing functions use the global context for more consistent behavior.
  - Simplified workflow execution by removing error handling in background operations.

- **Chore**
  - Revised configuration paths to reflect recent module organization updates.
  - Updated user and group IDs for the Selenium pod to enhance permissions and security context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->