### PR TITLE
TINY-11931: Added new onboarding option

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11931-2025-03-10.yaml
+++ b/.changes/unreleased/tinymce-TINY-11931-2025-03-10.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: New `onboarding` option.
+time: 2025-03-10T09:49:22.941053+01:00
+custom:
+    Issue: TINY-11931

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -172,6 +172,7 @@ interface BaseEditorOptions {
   noneditable_regexp?: RegExp | RegExp[];
   nowrap?: boolean;
   object_resizing?: boolean | string;
+  onboarding?: boolean;
   pad_empty_with_br?: boolean;
   paste_as_text?: boolean;
   paste_block_drop?: boolean;

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -364,6 +364,15 @@ const register = (editor: Editor): void => {
     processor: 'string'
   });
 
+  registerOption('onboarding', {
+    processor: 'boolean',
+    default: true
+  });
+
+  registerOption('tiny_cloud_entry_url', {
+    processor: 'string'
+  });
+
   registerOption('theme', {
     processor: (value) => value === false || Type.isString(value) || Type.isFunction(value),
     default: 'silver'

--- a/modules/tinymce/src/core/test/ts/browser/CloudOptionsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/CloudOptionsTest.ts
@@ -38,7 +38,7 @@ describe('browser.tinymce.core.CloudOptionsTest', () => {
   });
 
   context('Option defined in init', () => {
-    let onboardingOption: boolean;
+    let onboardingOption: boolean | undefined;
     let tinyCloudEntryUrlOption: string;
 
     const addEditorEventHandler = ({ editor }: EditorEvent<{ editor: Editor }>) => {

--- a/modules/tinymce/src/core/test/ts/browser/CloudOptionsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/CloudOptionsTest.ts
@@ -1,0 +1,74 @@
+import { after, before, context, describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'tinymce/core/api/Editor';
+import EditorManager from 'tinymce/core/api/EditorManager';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+
+describe('browser.tinymce.core.CloudOptionsTest', () => {
+  context('No option defined in init', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce'
+    }, [ ]);
+
+    it('onboarding option', () => {
+      const editor = hook.editor();
+
+      assert.isTrue(editor.options.get('onboarding'), 'Should be enabled by default');
+
+      editor.options.set('onboarding', false);
+      assert.isFalse(editor.options.get('onboarding'), 'Should not be enabled is set to false');
+
+      editor.options.unset('onboarding');
+      assert.isTrue(editor.options.get('onboarding'), 'Should be back to initial value');
+    });
+
+    it('tiny_cloud_entry_url option', () => {
+      const editor = hook.editor();
+
+      assert.isUndefined(editor.options.get('tiny_cloud_entry_url'), 'Should not be defined by default');
+
+      editor.options.set('tiny_cloud_entry_url', 'custom-url');
+      assert.equal(editor.options.get('tiny_cloud_entry_url'), 'custom-url', 'Should be updated to custom url');
+
+      editor.options.unset('tiny_cloud_entry_url');
+      assert.isUndefined(editor.options.get('tiny_cloud_entry_url'), 'Should be back to initial value');
+    });
+  });
+
+  context('Option defined in init', () => {
+    let onboardingOption: boolean;
+    let tinyCloudEntryUrlOption: string;
+
+    const addEditorEventHandler = ({ editor }: EditorEvent<{ editor: Editor }>) => {
+      onboardingOption = editor.options.get('onboarding');
+      tinyCloudEntryUrlOption = editor.options.get('tiny_cloud_entry_url');
+    };
+
+    before(() => {
+      EditorManager.on('AddEditor', addEditorEventHandler);
+    });
+
+    after(() => {
+      EditorManager.off('AddEditor', addEditorEventHandler);
+    });
+
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      onboarding: false,
+      tiny_cloud_entry_url: 'custom-url',
+    }, [ ]);
+
+    it('editor options in init and `AddEditor` event', () => {
+      const editor = hook.editor();
+
+      assert.isFalse(onboardingOption, 'Should be set to false');
+      assert.isFalse(editor.options.get('onboarding'), 'Should be set to false');
+
+      assert.equal(tinyCloudEntryUrlOption, 'custom-url', 'Should be set to custom url');
+      assert.equal(editor.options.get('tiny_cloud_entry_url'), 'custom-url', 'Should be set to custom url');
+    });
+  });
+});
+


### PR DESCRIPTION
Related Ticket: TINY-11931

Description of Changes:
* Adds the new official option `onboarding`
* Add the new unofficial `tiny_cloud_entry_url` option

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced onboarding option to guide users through their initial experience.
  - Added a customizable cloud entry URL to facilitate integration with cloud services.

- **Tests**
  - Updated tests to accommodate the new onboarding option, allowing for undefined values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->