### PR TITLE
TINY-11748: Better handling of nodechange toolbar re-rendering

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
@@ -297,10 +297,8 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
 
     editor.on('focusout', (_e) => {
       Delay.setEditorTimeout(editor, () => {
-        if (Focus.search(sink.element).isNone() && Focus.search(contextbar.element).isNone()) {
-          if (!contextToolbarResult.inSubtoolbar() || !editor.hasFocus()) {
-            close();
-          }
+        if (Focus.search(sink.element).isNone() && Focus.search(contextbar.element).isNone() && !editor.hasFocus()) {
+          close();
         }
       }, 0);
     });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
@@ -243,6 +243,8 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
   };
 
   const instantReposition = () => {
+    // Sometimes when we reposition the toolbar it might be in a transitioning state and
+    // if we try to reposition while that happens the computed position/width will be incorrect.
     Css.set(contextbar.element, 'transition', 'none');
     hideOrRepositionIfNecessary();
     Css.remove(contextbar.element, 'transition');

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -30,10 +30,15 @@ interface ContextToolbarSpec {
   readonly onBack: () => void;
 }
 
-const renderContextToolbar = (spec: ContextToolbarSpec): SketchSpec => {
+export interface ContextToolbarRenderResult {
+  readonly sketch: SketchSpec;
+  readonly inSubtoolbar: () => boolean;
+}
+
+const renderContextToolbar = (spec: ContextToolbarSpec): ContextToolbarRenderResult => {
   const stack = Cell<Array<{ bar: AlloyComponent; focus: Optional<SugarElement<HTMLElement>> }>>([ ]);
 
-  return InlineView.sketch({
+  const sketch = InlineView.sketch({
     dom: {
       tag: 'div',
       classes: [ 'tox-pop' ]
@@ -52,6 +57,7 @@ const renderContextToolbar = (spec: ContextToolbarSpec): SketchSpec => {
     },
 
     onHide: () => {
+      stack.set([ ]);
       spec.onHide();
     },
 
@@ -151,6 +157,10 @@ const renderContextToolbar = (spec: ContextToolbarSpec): SketchSpec => {
     lazySink: () => Result.value(spec.sink)
   });
 
+  return {
+    sketch,
+    inSubtoolbar: () => stack.get().length > 0
+  };
 };
 
 export {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -108,6 +108,7 @@ const renderContextToolbar = (spec: ContextToolbarSpec): ContextToolbarRenderRes
           );
 
           setTimeout(() => {
+            console.log('start');
             Css.set(comp.element, 'width', newWidth + 'px');
           }, 0);
         }),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -76,6 +76,7 @@ const renderContextToolbar = (spec: ContextToolbarSpec): ContextToolbarRenderRes
           Css.remove(elem, 'width');
 
           const currentWidth = Width.get(elem);
+          const hadFocus = Focus.search(comp.element).isSome();
 
           // Remove these so that we can property measure the width of the context form content
           Css.remove(elem, 'left');
@@ -95,15 +96,21 @@ const renderContextToolbar = (spec: ContextToolbarSpec): ContextToolbarRenderRes
           Css.set(elem, 'width', currentWidth + 'px');
 
           se.event.focus.fold(
-            () => ContextToolbarFocus.focusIn(comp),
-            (f) => {
-              // Check if focus was on a element in the toolbar then focus that
-              // otherwise focus the first element since then it was likely in the editor
-              if (Compare.contains(comp.element, f)) {
-                Focus.focus(f);
-              } else {
+            () => {
+              if (hadFocus) {
                 ContextToolbarFocus.focusIn(comp);
               }
+            },
+            (f) => {
+              Focus.active(SugarShadowDom.getRootNode(comp.element)).fold(
+                () => Focus.focus(f),
+                (active) => {
+                  // We need this extra check since if the focus is aleady on the iframe we don't want to call focus on it again since that closes the context toolbar
+                  if (!Compare.eq(active, f)) {
+                    Focus.focus(f);
+                  }
+                }
+              );
             }
           );
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -108,7 +108,6 @@ const renderContextToolbar = (spec: ContextToolbarSpec): ContextToolbarRenderRes
           );
 
           setTimeout(() => {
-            console.log('start');
             Css.set(comp.element, 'width', newWidth + 'px');
           }, 0);
         }),

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -70,7 +70,6 @@ const renderContextToolbar = (spec: ContextToolbarSpec): SketchSpec => {
           Css.remove(elem, 'width');
 
           const currentWidth = Width.get(elem);
-          const hadFocus = Focus.search(comp.element).isSome();
 
           // Remove these so that we can property measure the width of the context form content
           Css.remove(elem, 'left');
@@ -90,21 +89,15 @@ const renderContextToolbar = (spec: ContextToolbarSpec): SketchSpec => {
           Css.set(elem, 'width', currentWidth + 'px');
 
           se.event.focus.fold(
-            () => {
-              if (hadFocus) {
+            () => ContextToolbarFocus.focusIn(comp),
+            (f) => {
+              // Check if focus was on a element in the toolbar then focus that
+              // otherwise focus the first element since then it was likely in the editor
+              if (Compare.contains(comp.element, f)) {
+                Focus.focus(f);
+              } else {
                 ContextToolbarFocus.focusIn(comp);
               }
-            },
-            (f) => {
-              Focus.active(SugarShadowDom.getRootNode(comp.element)).fold(
-                () => Focus.focus(f),
-                (active) => {
-                  // We need this extra check since if the focus is aleady on the iframe we don't want to call focus on it again since that closes the context toolbar
-                  if (!Compare.eq(active, f)) {
-                    Focus.focus(f);
-                  }
-                }
-              );
             }
           );
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -1,8 +1,8 @@
-import { ApproxStructure, Assertions, FocusTools, Keyboard, Keys, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
+import { ApproxStructure, Assertions, FocusTools, Keyboard, Keys, Mouse, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Fun, Obj } from '@ephox/katamari';
 import { Attribute, SugarBody, SugarDocument, Value } from '@ephox/sugar';
-import { TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -273,7 +273,8 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
 
   const clickAway = (editor: Editor) => {
     // <a> tags make the context bar appear so click away from an a tag. We have no content so it's probably fine.
-    editor.nodeChanged();
+    TinySelections.setCursor(editor, [ ], 0);
+    Mouse.trueClick(TinyDom.body(editor));
   };
 
   const pAssertNoPopDialog = () => Waiter.pTryUntil(
@@ -408,9 +409,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     const editor = hook.editor();
     openToolbar(editor, 'get-value-after-component-detach-form');
 
-    // Fake click away inside editor
-    TinySelections.setCursor(editor, [ 0, 0 ], 0);
-    TinyContentActions.trueClick(editor);
+    clickAway(editor);
 
     await Waiter.pTryUntil('Waited to context form to close', () => {
       store.assertEq('Should be able to get value', [ 'setup', 'teardown', '300x300' ]);
@@ -421,9 +420,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     const editor = hook.editor();
     openToolbar(editor, 'set-value-after-component-detach-form');
 
-    // Fake click away inside editor
-    TinySelections.setCursor(editor, [ 0, 0 ], 0);
-    TinyContentActions.trueClick(editor);
+    clickAway(editor);
 
     await Waiter.pTryUntil('Waited to context form to close', () => {
       store.assertEq('Should be able to set value', [ 'setup', 'teardown', '500x500' ]);
@@ -498,9 +495,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
     TinyUiActions.clickOnUi(editor, 'button[aria-label="ABC"]');
     await FocusTools.pTryOnSelector('Focus should now be on input in context form', doc, 'input');
 
-    // Fake click away inside editor
-    TinySelections.setCursor(editor, [ 0, 0 ], 0);
-    TinyContentActions.trueClick(editor);
+    clickAway(editor);
 
     await Waiter.pTryUntil('Waited to context toolbar to close', () => {
       store.assertEq('Should have triggered ContextToolbarClose', [ 'setup', 'teardown', 'contexttoolbarclose' ]);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
@@ -1,8 +1,8 @@
-import { ApproxStructure, Assertions, FocusTools, Keys, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
+import { ApproxStructure, Assertions, FocusTools, Keys, Mouse, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { SugarBody, SugarDocument, Value } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -134,7 +134,8 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
 
   const clickAway = (editor: Editor) => {
     // <a> tags make the context bar appear so click away from an a tag. We have no content so it's probably fine.
-    editor.nodeChanged();
+    TinySelections.setCursor(editor, [ ], 0);
+    Mouse.trueClick(TinyDom.body(editor));
   };
 
   const pAssertNoPopDialog = () => Waiter.pTryUntil(
@@ -195,8 +196,8 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
 
   it('TINY-11342: When the context form is opened on the right side and does not fit the popup should be repositioned', async () => {
     const editor = hook.editor();
-    editor.setContent('<p style="float: right"><a href="#" style="padding-right: 100px">link</a></p>');
-    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    editor.setContent('<p style="float: right">abc<a href="#" style="padding-right: 100px">link</a></p>');
+    TinySelections.setCursor(editor, [ 0, 1 ], 1);
     await UiFinder.pWaitFor('Waiting for context toolbar to appear', SugarBody.body(), '.tox-pop[data-alloy-placement="south"]');
     TinyUiActions.clickOnUi(editor, '.tox-pop button[aria-label="ABC"]');
     await UiFinder.pWaitFor('Waiting for context toolbar to appear', SugarBody.body(), '.tox-pop[data-alloy-placement="southwest"] input');
@@ -204,8 +205,8 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
 
   it('TINY-11344: pressing `back` should show the previous toolbar', async () => {
     const editor = hook.editor();
-    editor.setContent('<div>some div</div>');
-    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    editor.setContent('<p>abc</p><div>some div</div>');
+    TinySelections.setCursor(editor, [ 1, 0 ], 1);
     await UiFinder.pWaitFor('Waiting for context toolbar to appear', SugarBody.body(), '.tox-pop[data-alloy-placement="south"]');
     TinyUiActions.clickOnUi(editor, '.tox-pop button[aria-label="ABC"]');
     TinyUiActions.clickOnUi(editor, '.tox-pop button[aria-label="Back"]');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
@@ -1,7 +1,8 @@
 import { FocusTools, Keyboard, Keys, Mouse, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { SugarBody, SugarDocument } from '@ephox/sugar';
-import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { Css, SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -30,6 +31,16 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
     }
   }, [], true);
 
+  const pClickAway = async (editor: Editor, path: number[], offset: number) => {
+    editor.focus();
+    TinySelections.setCursor(editor, path, offset);
+    Mouse.trueClick(TinyDom.body(editor));
+    await Waiter.pTryUntil(
+      'Wait for dialog to disappear after nodeChange',
+      () => UiFinder.notExists(SugarBody.body(), '.tox-pop')
+    );
+  };
+
   it('TBA: Moving selection away from the context toolbar predicate should make it disappear', async () => {
     const editor = hook.editor();
     editor.setContent('<p>One <a href="http://tiny.cloud">link</a> Two</p>');
@@ -40,12 +51,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
     TinySelections.setCursor(editor, [ 0, 1, 0 ], 'L'.length);
     editor.focus();
     await UiFinder.pWaitForVisible('Waiting for toolbar', SugarBody.body(), '.tox-pop');
-    // NOTE: This internally fires a nodeChange
-    TinySelections.setCursor(editor, [ 0, 0 ], 'O'.length);
-    await Waiter.pTryUntil(
-      'Wait for dialog to disappear after nodeChange',
-      () => UiFinder.notExists(SugarBody.body(), '.tox-pop')
-    );
+    await pClickAway(editor, [ 0, 0 ], 'O'.length);
   });
 
   context('subtoolbars', () => {
@@ -154,6 +160,53 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
       for (let i = 4; i >= 2; i--) {
         await pNavigateBackByKeyboard(i);
       }
+    });
+
+    it('TINY-11748: RepositionContextToolbar internal command', async () => {
+      const editor = hook.editor();
+
+      editor.setContent('<p>One <a href="http://tiny.cloud">link</a> Two</p>');
+      TinySelections.setCursor(editor, [ 0, 1, 0 ], 'l'.length);
+      const toolbarEl = await UiFinder.pWaitFor('Waiting for toolbar', SugarBody.body(), '.tox-pop');
+
+      await pNavigateDownInToolbarByMouse(1);
+
+      const paragraph = UiFinder.findIn(TinyDom.body(editor), 'p').getOrDie();
+      const beforeChangeLeftPos = toolbarEl.dom.getBoundingClientRect().left;
+
+      Css.set(paragraph, 'text-align', 'right');
+      editor.execCommand('RepositionContextToolbar');
+
+      await Waiter.pTryUntil('Waited for position to change', () => {
+        const afterChangeLeftPos = toolbarEl.dom.getBoundingClientRect().left;
+        assert.isAbove(afterChangeLeftPos, beforeChangeLeftPos, 'Should have repositioned the toolbar');
+      });
+
+      await pClickAway(editor, [ 0, 0 ], 'O'.length);
+    });
+
+    it('TINY-11748: Reposition toolbar on undo level added', async () => {
+      const editor = hook.editor();
+
+      editor.resetContent('<p>One <a href="http://tiny.cloud">link</a> Two</p>');
+      TinySelections.setCursor(editor, [ 0, 1, 0 ], 'l'.length);
+      const toolbarEl = await UiFinder.pWaitFor('Waiting for toolbar', SugarBody.body(), '.tox-pop');
+
+      await pNavigateDownInToolbarByMouse(1);
+      const paragraph = UiFinder.findIn(TinyDom.body(editor), 'p').getOrDie();
+      const beforeChangeLeftPos = toolbarEl.dom.getBoundingClientRect().left;
+
+      editor.focus();
+      editor.undoManager.transact(() => {
+        Css.set(paragraph, 'text-align', 'right');
+      });
+
+      await Waiter.pTryUntil('Waited for position to change', () => {
+        const afterChangeLeftPos = toolbarEl.dom.getBoundingClientRect().left;
+        assert.isAbove(afterChangeLeftPos, beforeChangeLeftPos, 'Should have repositioned the toolbar');
+      });
+
+      await pClickAway(editor, [ 0, 0 ], 'O'.length);
     });
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
@@ -69,7 +69,8 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
     const pNavigateDownInToolbarByMouse = async (index: number) => {
       Mouse.clickOn(SugarBody.body(), `.tox-tbtn[data-mce-name="test-subtoolbar${index}"]`);
       await pWaitForToolbarState(index + 1);
-      FocusTools.isOnSelector('Should be on first button', SugarDocument.getDocument(), '.tox-tbtn:nth-child(1)');
+      // FocusTools.isOnSelector('Should be on first button', SugarDocument.getDocument(), '.tox-tbtn:nth-child(1)');
+      FocusTools.isOnSelector('Should remain editor iframe', SugarDocument.getDocument(), 'iframe');
     };
 
     const pNavigateBackByMouse = async (index: number) => {
@@ -83,7 +84,8 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
         UiFinder.notExists(SugarBody.body(), '.tox-tbtn[aria-label="Back"]');
       }
 
-      FocusTools.isOnSelector('Should be on first button', SugarDocument.getDocument(), '.tox-tbtn:nth-child(1)');
+      // FocusTools.isOnSelector('Should be on first button', SugarDocument.getDocument(), '.tox-tbtn:nth-child(1)');
+      FocusTools.isOnSelector('Should remain editor iframe', SugarDocument.getDocument(), 'iframe');
     };
 
     const pNavigateDownInToolbarByKeyboard = async (index: number) => {
@@ -184,6 +186,8 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
       for (let i = 4; i >= 2; i--) {
         await pNavigateBackByKeyboard(i);
       }
+
+      await pClickAway(editor, [ 0, 0 ], 'O'.length);
     });
 
     it('TINY-11748: nodeChange reposition', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
@@ -71,7 +71,6 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
     const pNavigateDownInToolbarByMouse = async (index: number) => {
       Mouse.clickOn(SugarBody.body(), `.tox-tbtn[data-mce-name="test-subtoolbar${index}"]`);
       await pWaitForToolbarState(index + 1);
-      // FocusTools.isOnSelector('Should be on first button', SugarDocument.getDocument(), '.tox-tbtn:nth-child(1)');
       FocusTools.isOnSelector('Should remain editor iframe', SugarDocument.getDocument(), 'iframe');
     };
 
@@ -86,7 +85,6 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
         UiFinder.notExists(SugarBody.body(), '.tox-tbtn[aria-label="Back"]');
       }
 
-      // FocusTools.isOnSelector('Should be on first button', SugarDocument.getDocument(), '.tox-tbtn:nth-child(1)');
       FocusTools.isOnSelector('Should remain editor iframe', SugarDocument.getDocument(), 'iframe');
     };
 
@@ -192,7 +190,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
       await pClickAway(editor, [ 0, 0 ], 'O'.length);
     });
 
-    it('TINY-11748: nodeChange reposition', async () => {
+    it('TINY-11748: nodeChange subtoolbar reposition', async () => {
       const editor = hook.editor();
 
       editor.setContent('<p>One <a href="http://tiny.cloud">link</a> Two</p>');
@@ -216,7 +214,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
       await pClickAway(editor, [ 0, 0 ], 'O'.length);
     });
 
-    it('TINY-11748: Should not rerender on focus shift to editor when subtoolbar is showing', async () => {
+    it('TINY-11748: Should not re-render on focus shift to editor when subtoolbar is showing', async () => {
       const editor = hook.editor();
 
       editor.setContent('<p>One <a href="http://tiny.cloud">link</a> Two</p>');
@@ -231,6 +229,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
       await pWaitForToolbarState(2); // Should still be in the subtoolbar
       await pClickAway(editor, [ 0, 0 ], 'O'.length);
     });
+
     it('TINY-11748: Using enter to press buttons should not close the subtoolbar', async () => pTestActionKeyOnButton(Keys.enter()));
 
     it('TINY-11748: Using space to press buttons should not close the subtoolbar', async () => pTestActionKeyOnButton(Keys.space()));

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
@@ -63,7 +63,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
     const pNavigateDownInToolbarByMouse = async (index: number) => {
       Mouse.clickOn(SugarBody.body(), `.tox-tbtn[data-mce-name="test-subtoolbar${index}"]`);
       await pWaitForToolbarState(index + 1);
-      FocusTools.isOnSelector('Should remain editor iframe', SugarDocument.getDocument(), 'iframe');
+      FocusTools.isOnSelector('Should be on first button', SugarDocument.getDocument(), '.tox-tbtn:nth-child(1)');
     };
 
     const pNavigateBackByMouse = async (index: number) => {
@@ -77,7 +77,7 @@ describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest
         UiFinder.notExists(SugarBody.body(), '.tox-tbtn[aria-label="Back"]');
       }
 
-      FocusTools.isOnSelector('Should remain editor iframe', SugarDocument.getDocument(), 'iframe');
+      FocusTools.isOnSelector('Should be on first button', SugarDocument.getDocument(), '.tox-tbtn:nth-child(1)');
     };
 
     const pNavigateDownInToolbarByKeyboard = async (index: number) => {


### PR DESCRIPTION
Related Ticket: TINY-11748

Follow up PR

Description of Changes:
* No changelog since that was in the original PR
* Focus is now moved into the toolbar when you navigate into a subtoolbar or back from a context form or subtoolbar details why is in the ticket.

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced keyboard interaction handling for the context toolbar.
  - Added a utility for repositioning the toolbar during transitions.
  - Implemented a debounce wait function for context toolbar interactions.
- **Bug Fixes**
  - Improved logic for closing the context toolbar based on editor focus.
- **Refactor**
  - Streamlined context toolbar rendering and interaction logic.
  - Consolidated click-away functionality in tests for better maintainability.
- **Tests**
  - Expanded test coverage for context toolbar behavior and user interactions.
  - Updated test cases to utilize new utility functions for improved clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->