### PR TITLE
TINY-11843: Make docs team owner of changes (#10180)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,7 @@
 
 # Katamari changes should include the integrations team as well
 /modules/katamari/ @tinymce/tinymce-reviewers @tinymce/integrations-team
+
+# Changelogs should include docs team
+/.changes/tinymce/ @tinymce/tinymce-reviewers @tinymce/documentation-team
+**/CHANGELOG.md @tinymce/tinymce-reviewers @tinymce/documentation-team


### PR DESCRIPTION
Related Ticket: TINY-11843

Description of Changes:
* Cherry-picking this commit to add functionality in release branch

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
