### PR TITLE
TINY-11962: Disabled all Safari tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -242,7 +242,7 @@ timestamps {
   def branchBuildPlatforms = [
     winChrome,
     winFirefox,
-    // TODO: Re-enable when lambda test fixes their browsers
+    // TODO: Re-enable when lambda test fixes their browsers #TINY-11962
     // macSafari,
   ]
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -242,7 +242,8 @@ timestamps {
   def branchBuildPlatforms = [
     winChrome,
     winFirefox,
-    macSafari,
+    // TODO: Re-enable when lambda test fixes their browsers
+    // macSafari,
   ]
 
   def primaryBuildPlatforms = branchBuildPlatforms + [


### PR DESCRIPTION
Related Ticket: TINY-11962

Description of Changes:
* This just disables all tests for Safari until they fix lambdatest

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the build configuration to temporarily omit a specific testing platform until external improvements are made, ensuring continued system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->