### PR TITLE
TINY-11962: Re-enabled Mac tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -231,18 +231,18 @@ timestamps {
   def winFirefox = [ browser: 'firefox', provider: 'lambdatest', os: 'windows', buckets: 1 ]
   def winEdge = [ browser: 'edge', provider: 'lambdatest', os: 'windows', buckets: 1 ]
 
-  def macChrome = [ browser: 'chrome', provider: 'lambdatest', os: 'macOS Sonoma', buckets: 1 ]
-  def macFirefox = [ browser: 'firefox', provider: 'lambdatest', os: 'macOS Sonoma', buckets: 1 ]
-  def macSafari = [ browser: 'safari', provider: 'lambdatest', os: 'macOS Sonoma', buckets: 1 ]
+  def macChrome = [ browser: 'chrome', provider: 'lambdatest', os: 'macOS Sequoia', buckets: 1 ]
+  def macFirefox = [ browser: 'firefox', provider: 'lambdatest', os: 'macOS Sequoia', buckets: 1 ]
+  def macSafari = [ browser: 'safari', provider: 'lambdatest', os: 'macOS Sequoia', buckets: 1 ]
 
   def seleniumFirefox = [ browser: 'firefox', provider: 'selenium', buckets: 1 ]
   def seleniumChrome = [ browser: 'chrome', provider: 'selenium', version: '127.0', buckets: 1 ]
   def seleniumEdge = [ browser: 'edge', provider: 'selenium', buckets: 1 ]
 
   def branchBuildPlatforms = [
-    winChrome,
-    winFirefox,
-    // macSafari,
+    // winChrome,
+    // winFirefox,
+    macSafari,
   ]
 
   def primaryBuildPlatforms = branchBuildPlatforms + [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -240,8 +240,8 @@ timestamps {
   def seleniumEdge = [ browser: 'edge', provider: 'selenium', buckets: 1 ]
 
   def branchBuildPlatforms = [
-    // winChrome,
-    // winFirefox,
+    winChrome,
+    winFirefox,
     macSafari,
   ]
 


### PR DESCRIPTION
Related Ticket: TINY-11962

Description of Changes:
* Re-enabling the tests since it seems that Lambdatest fixed the dialog issue.

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the testing configuration for macOS browsers to use a new operating system designation.
	- Re-enabled the inclusion of macOS Safari in branch builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->