### PR TITLE
TINY-11958: make placeholder width responsive

### DIFF
--- a/modules/oxide/src/less/theme/content/uploadcare/uploadcare.less
+++ b/modules/oxide/src/less/theme/content/uploadcare/uploadcare.less
@@ -46,7 +46,7 @@
   all: initial; // prevents inheritable styles to leak into the shadow DOM
   display: inline-block;
   position: relative;
-  width: @uploadcare-placeholder-initial-width;
+  width: min(100%, @uploadcare-placeholder-initial-width);
   height: @uploadcare-placeholder-initial-height;
 
   // shadow DOM (icon + text)

--- a/modules/oxide/src/less/theme/content/uploadcare/uploadcare.less
+++ b/modules/oxide/src/less/theme/content/uploadcare/uploadcare.less
@@ -14,6 +14,7 @@
 
 @uploadcare-placeholder-text-color: @text-color-muted;
 @uploadcare-placeholder-icon-fill: @text-color-muted;
+@uploadcare-placeholder-icon-min-width: 24px;
 
 // UPLOADCARE LOADER
 .tox-uc-loading-background {
@@ -63,6 +64,7 @@
   --tox-uploadcare-placeholder--content-gap: 8px;
 
   --tox-uploadcare-placeholder--icon-fill: @uploadcare-placeholder-icon-fill;
+  --tox-uploadcare-placeholder--icon-min-width: @uploadcare-placeholder-icon-min-width;
 
   // shadow DOM (loader)
 


### PR DESCRIPTION
Related Ticket: TINY-11958

Description of Changes:
* Updated the width property of the uploadcare placeholder to use `min(100%, @uploadcare-placeholder-initial-width)` instead of a fixed width, ensuring it doesn't exceed its container width

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Enhanced the upload placeholder's styling to ensure it adapts responsively to available space without exceeding its container.
	- Introduced a minimum width for the upload placeholder icon for improved visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->