### PR TITLE
TINY-11976: Hide onboarding plugin from help dialog

### DIFF
--- a/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
@@ -63,10 +63,9 @@ const tab = (editor: Editor): Dialog.TabSpec & { name: string } => {
   const getPluginKeys = (editor: Editor) => {
     const keys = Obj.keys(editor.plugins);
     const forcedPlugins = Options.getForcedPlugins(editor);
+    const hiddenPlugins = Type.isUndefined(forcedPlugins) ? [ 'onboarding' ] : forcedPlugins.concat([ 'onboarding' ] );
 
-    return Type.isUndefined(forcedPlugins) ?
-      keys :
-      Arr.filter(keys, (k) => !Arr.contains(forcedPlugins, k));
+    return Arr.filter(keys, (k) => !Arr.contains(hiddenPlugins, k));
   };
 
   const pluginLister = (editor: Editor) => {

--- a/modules/tinymce/src/plugins/help/test/ts/browser/IgnoreForcedPluginsTest.ts
+++ b/modules/tinymce/src/plugins/help/test/ts/browser/IgnoreForcedPluginsTest.ts
@@ -1,6 +1,8 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { after, before, describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
+import { tinymce } from 'tinymce/core/api/Tinymce';
 import HelpPlugin from 'tinymce/plugins/help/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 
@@ -8,8 +10,16 @@ import * as PluginAssert from '../module/PluginAssert';
 import { selectors } from '../module/Selectors';
 
 describe('browser.tinymce.plugins.help.IgnoreForcedPluginsTest', () => {
+  before(() => {
+    tinymce.PluginManager.add('onboarding', Fun.noop);
+  });
+
+  after(() => {
+    tinymce.PluginManager.remove('onboarding');
+  });
+
   const hook = TinyHooks.bddSetupLight({
-    plugins: 'help',
+    plugins: [ 'help', 'onboarding' ],
     toolbar: 'help',
     forced_plugins: [ 'link' ],
     base_url: '/project/tinymce/js/tinymce'
@@ -24,6 +34,17 @@ describe('browser.tinymce.plugins.help.IgnoreForcedPluginsTest', () => {
         'li a:contains("Help")': 1,
         'li a:contains("Link")': 0
       },
+      selectors.dialog,
+      selectors.pluginsTab
+    );
+  });
+
+  it('TINY-11976: Hide onboarding plugin from Help plugin list', async () => {
+    const editor = hook.editor();
+    TinyUiActions.clickOnToolbar(editor, selectors.toolbarHelpButton);
+    await PluginAssert.pAssert(
+      'Could not ignore onboarding plugin',
+      { 'li:contains("onboarding")': 0 },
       selectors.dialog,
       selectors.pluginsTab
     );


### PR DESCRIPTION
Related Ticket: TINY-11976

Description of Changes:
* Since we force the onboarding plugin on we need to hide if from the help dialog

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
