### PR TITLE
Revert "TINY-11560: Slightly change word-capture regex (#10219)"

### DIFF
--- a/.changes/unreleased/polaris-TINY-11560-2025-03-10.yaml
+++ b/.changes/unreleased/polaris-TINY-11560-2025-03-10.yaml
@@ -1,6 +1,0 @@
-project: polaris
-kind: Fixed
-body: Changed word-capture regex for abbreviations to allow larger abbreviations.
-time: 2025-03-10T09:56:28.378701+01:00
-custom:
-    Issue: TINY-11560

--- a/modules/polaris/src/main/ts/ephox/polaris/words/Words.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/words/Words.ts
@@ -70,7 +70,7 @@ const findWordsWithIndices = <T>(chars: Word<T>, sChars: string[], characterMap:
         }
 
         // If the word is an abbreviation, include the next character if it's a period.
-        if (sChars[i + 1] === '.' && /^(([a-zA-Z]+)\.)+$/.test(str + '.')) {
+        if (sChars[i + 1] === '.' && /^([a-zA-Z]\.)+$/.test(str + '.')) {
           word.push(chars[i + 1]);
           indices.push({
             start: startOfWord,

--- a/modules/polaris/src/test/ts/atomic/api/WordsTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/WordsTest.ts
@@ -1,9 +1,9 @@
-import { Assert, describe, it } from '@ephox/bedrock-client';
+import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 
 import { getWords, WordOptions } from 'ephox/polaris/words/Words';
 
-describe('api.Words.words', () => {
+UnitTest.test('api.Words.words', () => {
   interface Char {
     char: string;
   }
@@ -21,82 +21,65 @@ describe('api.Words.words', () => {
     Assert.eq('', expected, actual);
   };
 
-  it('TINY-11560: Keeps dots for shortening.', () => {
-    assertWords([ 'Dr.D.', 'Doctor', 'Not.D.' ], 'Dr.D. Doctor Not.D.');
-  });
+  // splits words on whitespace
+  assertWords([ 'hello', 'world' ], 'hello world');
+  // keeps whitespace with setting
+  assertWords([ 'a', ' ', ' ', ' ', 'b' ], 'a   b', { includeWhitespace: true });
+  // removes punctuation by default
+  assertWords([ 'a', 'b' ], 'a .... b');
+  // but keeps with setting
+  assertWords([ 'a', '.', '.', '.', '.', 'b' ], 'a .... b', { includePunctuation: true });
+  // does not split on katakana words
+  assertWords([ '僕', 'の', '名', '前', 'は', 'マティアス' ], '僕の名前はマティアス');
+  // does not split on numeric separators
+  assertWords([ 'the', 'price', 'is', '3,500.50' ], 'the price is 3,500.50');
 
-  it('splits words on whitespace', () => {
-    assertWords([ 'hello', 'world' ], 'hello world');
-  });
+  assertWords([ 'http://www.google.com' ], 'http://www.google.com');
+  assertWords([ 'https://www.google.com' ], 'https://www.google.com');
+  assertWords([ 'http://www.google.com', 'abc' ], 'http://www.google.com abc');
+  assertWords([ 'bengt@mail.se' ], 'bengt@mail.se');
+  assertWords([ 'bengt@mail.se', 'abc' ], 'bengt@mail.se abc');
+  assertWords([ '1+1*1/1⋉1=1' ], '1+1*1/1⋉1=1');
+  assertWords([ '50-10' ], '50-10');
+  assertWords([ 'jack-in-the-box' ], 'jack-in-the-box');
+  assertWords([ 'n=13' ], 'n=13');
+  assertWords([ 'n<13' ], 'n<13');
+  assertWords([ '1<13' ], '1<13');
+  assertWords([ 'n>13' ], 'n>13');
+  assertWords([ '1>13' ], '1>13');
+  assertWords([ 'n≥13' ], 'n≥13');
+  assertWords([ '1≥13' ], '1≥13');
+  assertWords([ 'n≤13' ], 'n≤13');
+  assertWords([ '1≤13' ], '1≤13');
+  assertWords([ '42.6±4.2' ], '42.6±4.2');
 
-  it('keeps whitespace with setting', () => {
-    assertWords([ 'a', ' ', ' ', ' ', 'b' ], 'a   b', { includeWhitespace: true });
-  });
+  // TINY-9654: Does not split on extend characters (ex: \u0300)
+  assertWords([ 'a\u0300b' ], 'a\u0300b');
+  assertWords([ 'a\u0300bc' ], 'a\u0300bc');
+  assertWords([ 'ab\u0300c' ], 'ab\u0300c');
+  assertWords([ 'a\u0300b', 'c' ], 'a\u0300b c');
+  assertWords([ '\u0300b' ], '\u0300b');
+  assertWords([ 'a', '\u0300b' ], 'a \u0300b');
+  assertWords([ '\u0300' ], '\u0300');
+  assertWords([ '\u0300' ], '\u0300 ');
+  assertWords([ 'a\u0300' ], 'a\u0300');
+  assertWords([ 'a\u0300' ], 'a\u0300 ');
 
-  it('removes punctuation by default', () => {
-    assertWords([ 'a', 'b' ], 'a .... b');
-  });
+  // TINY-9654: Does not split on format characters (ex: \ufeff) if they do not precede a word boundary
+  // TINY-9654: Does not strip \ufeff characters (obsolete TINY-1166 fix removed)
+  assertWords([ 'a\ufeffb' ], 'a\ufeffb');
+  assertWords([ 'a\ufeffbc' ], 'a\ufeffbc');
+  assertWords([ 'ab\ufeffc' ], 'ab\ufeffc');
+  assertWords([ 'a\ufeffb', 'c' ], 'a\ufeffb c');
+  assertWords([ '\ufeffb' ], '\ufeffb');
+  assertWords([ 'a', '\ufeffb' ], 'a \ufeffb');
 
-  it('but keeps with setting', () => {
-    assertWords([ 'a', '.', '.', '.', '.', 'b' ], 'a .... b', { includePunctuation: true });
-  });
-
-  it('does not split on katakana words', () => {
-    assertWords([ '僕', 'の', '名', '前', 'は', 'マティアス' ], '僕の名前はマティアス');
-  });
-
-  it('does not split on numeric separators', () => {
-    assertWords([ 'the', 'price', 'is', '3,500.50' ], 'the price is 3,500.50');
-  });
-
-  it('Tests', () => {
-    assertWords([ 'http://www.google.com' ], 'http://www.google.com');
-    assertWords([ 'https://www.google.com' ], 'https://www.google.com');
-    assertWords([ 'http://www.google.com', 'abc' ], 'http://www.google.com abc');
-    assertWords([ 'bengt@mail.se' ], 'bengt@mail.se');
-    assertWords([ 'bengt@mail.se', 'abc' ], 'bengt@mail.se abc');
-    assertWords([ '1+1*1/1⋉1=1' ], '1+1*1/1⋉1=1');
-    assertWords([ '50-10' ], '50-10');
-    assertWords([ 'jack-in-the-box' ], 'jack-in-the-box');
-    assertWords([ 'n=13' ], 'n=13');
-    assertWords([ 'n<13' ], 'n<13');
-    assertWords([ '1<13' ], '1<13');
-    assertWords([ 'n>13' ], 'n>13');
-    assertWords([ '1>13' ], '1>13');
-    assertWords([ 'n≥13' ], 'n≥13');
-    assertWords([ '1≥13' ], '1≥13');
-    assertWords([ 'n≤13' ], 'n≤13');
-    assertWords([ '1≤13' ], '1≤13');
-    assertWords([ '42.6±4.2' ], '42.6±4.2');
-  });
-  it('TINY-9654: Does not split on extend characters (ex: \u0300)', () => {
-    assertWords([ 'a\u0300b' ], 'a\u0300b');
-    assertWords([ 'a\u0300bc' ], 'a\u0300bc');
-    assertWords([ 'ab\u0300c' ], 'ab\u0300c');
-    assertWords([ 'a\u0300b', 'c' ], 'a\u0300b c');
-    assertWords([ '\u0300b' ], '\u0300b');
-    assertWords([ 'a', '\u0300b' ], 'a \u0300b');
-    assertWords([ '\u0300' ], '\u0300');
-    assertWords([ '\u0300' ], '\u0300 ');
-    assertWords([ 'a\u0300' ], 'a\u0300');
-    assertWords([ 'a\u0300' ], 'a\u0300 ');
-  });
-
-  it('TINY-9654: Does not split on format characters (ex: \ufeff) if they do not precede a word boundary, Does not strip \ufeff characters (obsolete TINY-1166 fix removed)', () => {
-    assertWords([ 'a\ufeffb' ], 'a\ufeffb');
-    assertWords([ 'a\ufeffbc' ], 'a\ufeffbc');
-    assertWords([ 'ab\ufeffc' ], 'ab\ufeffc');
-    assertWords([ 'a\ufeffb', 'c' ], 'a\ufeffb c');
-    assertWords([ '\ufeffb' ], '\ufeffb');
-    assertWords([ 'a', '\ufeffb' ], 'a \ufeffb');
-  });
-
-  it('TINY-9654: Split on format characters if they precede a word boundary.', () => {
-  //  Some format characters overlap with whitespace characters (ex: \ufeff).
-  // Since whitespace characters are not extracted, if a whitespace-overlapping format character that precedes a word boundary is not split on, whichever word it is a part of will not be added to the list of extracted words, causing inaccuracies.
-    assertWords([ ], '\ufeff');
-    assertWords([ ], '\ufeff ');
-    assertWords([ 'a' ], 'a\ufeff');
-    assertWords([ 'a' ], 'a\ufeff ');
-  });
+  // TINY-9654: Split on format characters if they precede a word boundary. Some format characters overlap with whitespace
+  // characters (ex: \ufeff). Since whitespace characters are not extracted, if a whitespace-overlapping format character that
+  // precedes a word boundary is not split on, whichever word it is a part of will not be added to the list of extracted words,
+  // causing inaccuracies.
+  assertWords([ ], '\ufeff');
+  assertWords([ ], '\ufeff ');
+  assertWords([ 'a' ], 'a\ufeff');
+  assertWords([ 'a' ], 'a\ufeff ');
 });

--- a/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
+++ b/modules/robin/src/test/ts/atomic/words/IdentifyTest.ts
@@ -99,14 +99,14 @@ describe('atomic.robin.words.IdentifyTest', () => {
     ], '<p>Hello World</p>');
 
     check([
-      WordScope('Test.', none, some(' ')),
+      WordScope('Test', none, some('.')),
       WordScope('IF:INTEXT', some('['), some(']')),
       WordScope('Test2', some(']'), some(' ')),
       WordScope('IF', some('/'), some(']')),
     ], 'Test. [IF:INTEXT]Test2 [/IF]');
 
     check([
-      WordScope('Test.', none, some(' ')),
+      WordScope('Test', none, some('.')),
       WordScope('IF', some('/'), some(']')),
       WordScope('Test2', some(']'), some(' ')),
       WordScope('IF:INTEXT', some('['), some(']')),
@@ -117,7 +117,7 @@ describe('atomic.robin.words.IdentifyTest', () => {
     // Note, the smart quotes.
     checkWords(
       [ 'Tale', 'is', 'about', 'an', 'adorable', 'mouse', 'with', 'a', 'lute',
-        'fighting', 'giant', 'crabs.', 'Really', 'I’d', 'hope', 'that', 'was',
+        'fighting', 'giant', 'crabs', 'Really', 'I’d', 'hope', 'that', 'was',
         'enough', 'for', 'you', 'but', 'I\u2019ll', 'throw' ],
       'Tale is about an adorable mouse with a lute fighting giant crabs. ' +
       'Really I’d hope that was enough for you, but I\u2019ll throw');


### PR DESCRIPTION
This reverts commit 4dcc637c912f0339c5ae3137fd0809b096de8d93.

Related Ticket: TINY-11560

Description of Changes:
* Placeholder text

Pre-checks:
* ~~[ ] Changelog entry added~~
* ~~[ ] Tests have been added (if applicable)~~
* ~~[ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`~~

Review:
* ~~[ ] Milestone set~~
* ~~[ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refined abbreviation recognition to ensure that only correctly formatted (single-letter) abbreviations are processed, which enhances text parsing accuracy.
  
- **Tests**
  - Streamlined and clarified test cases for word and punctuation handling, ensuring consistent validation of the updated text processing behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->