### PR TITLE
TINY-11836: No longer remove attributes to links.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11836-2025-03-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-11836-2025-03-24.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Autolink will no longer override already existing links when autolinking
+time: 2025-03-24T10:14:25.612794+01:00
+custom:
+    Issue: TINY-11836

--- a/.changes/unreleased/tinymce-TINY-11836-2025-03-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-11836-2025-03-24.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Autolink will no longer override already existing links when autolinking
+body: Autolink will no longer override already existing links when autolinking.
 time: 2025-03-24T10:14:25.612794+01:00
 custom:
     Issue: TINY-11836

--- a/modules/tinymce/src/plugins/autolink/main/ts/core/Keys.ts
+++ b/modules/tinymce/src/plugins/autolink/main/ts/core/Keys.ts
@@ -23,7 +23,7 @@ const parseCurrentLine = (editor: Editor, offset: number): ParseResult | null =>
 
   const rng = selection.getRng();
   const textSeeker = TextSeeker(dom, (node) => {
-    return dom.isBlock(node) || Obj.has(voidElements, node.nodeName.toLowerCase()) || dom.getContentEditable(node) === 'false';
+    return dom.isBlock(node) || Obj.has(voidElements, node.nodeName.toLowerCase()) || dom.getContentEditable(node) === 'false' || dom.getParent(node, 'a[href]') !== null;
   });
 
   // Descend down the end container to find the text node

--- a/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
+++ b/modules/tinymce/src/plugins/autolink/test/ts/browser/AutoLinkPluginTest.ts
@@ -203,6 +203,14 @@ describe('browser.tinymce.plugins.autolink.AutoLinkPluginTest', () => {
     TinyAssertions.assertContent(editor, '<p><a href="https://www.domain.com/"><strong>https://www.domain.com/&nbsp;</strong></a></p>');
   });
 
+  it('TINY-11836: Should not create links if the content is already a link or part of it.', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="https://www.domain.com/" target="_blank" rel="noopener">www.domain.com</a></p>');
+    TinySelections.setCursor(editor, [ 0 ], 1);
+    KeyUtils.type(editor, '\n');
+    TinyAssertions.assertContent(editor, '<p><a href="https://www.domain.com/" target="_blank" rel="noopener">www.domain.com</a></p><p>&nbsp;</p>');
+  });
+
   it('TINY-8091: should trigger when typing in the middle of brackets', () => {
     const editor = hook.editor();
     assert.equal(typeUrl(editor, '(https://www.domain.com'), '<p>(<a href="https://www.domain.com">https://www.domain.com</a>&nbsp;</p>');


### PR DESCRIPTION
Related Ticket: TINY-11836

Description of Changes:
When the cursor was placed outside of a link, and the text shown was a valid link, the autolink would create a new link out of it. If attributes were set they would be removed. We now check if a section of text is held inside of a link and if it is interrupts trying to find a link for the autolinker.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Autolink functionality now preserves existing hyperlinks, preventing them from being overridden when autolinking is applied.

- **Tests**
  - Introduced a new automated test to ensure that links are not created if the content is already a link or part of it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->