### PR TITLE
TINY-11876: remove deprecated css selector -ms-high-contrast

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11876-2025-03-25.yaml
+++ b/.changes/unreleased/tinymce-TINY-11876-2025-03-25.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Removed deprecated CSS media selector `-ms-high-contrast`.
+time: 2025-03-25T14:21:59.569893+01:00
+custom:
+  Issue: TINY-11876

--- a/modules/oxide/src/less/theme/content/selection/selection.less
+++ b/modules/oxide/src/less/theme/content/selection/selection.less
@@ -85,11 +85,6 @@
     position: absolute;
     right: -1px;
     top: -1px;
-
-    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-      // Provide a darker border color for IE11
-      border-color: darken(@table-selection-color, 50%);
-    }
   }
 
   img[data-mce-selected]::selection {


### PR DESCRIPTION
Related Ticket: TINY-11876

Description of Changes:
* Removed deprecated selector 

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed deprecated CSS conditions that were triggering legacy browser behaviors, ensuring cleaner and more consistent functionality.
  
- **Style**
  - Streamlined selection overlay styling by eliminating outdated adjustments, resulting in a more refined and uniform display experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->