### PR TITLE
TINY-11958: fix using CSS native function in less

### DIFF
--- a/modules/oxide/src/less/theme/content/uploadcare/uploadcare.less
+++ b/modules/oxide/src/less/theme/content/uploadcare/uploadcare.less
@@ -5,7 +5,7 @@
 @uploadcare-loading-element-width: ~"min(24px, 30%)";
 
 // UPLOADCARE PLACEHOLDER
-@uploadcare-placeholder-initial-width: 600px;
+@uploadcare-placeholder-width: ~"min(100%, 600px)";
 @uploadcare-placeholder-initial-height: 80px;
 
 @uploadcare-placeholder-background-color: @background-color;
@@ -47,7 +47,7 @@
   all: initial; // prevents inheritable styles to leak into the shadow DOM
   display: inline-block;
   position: relative;
-  width: ~"min(100%, @uploadcare-placeholder-initial-width)";
+  width: @uploadcare-placeholder-width;
   height: @uploadcare-placeholder-initial-height;
 
   // shadow DOM (icon + text)

--- a/modules/oxide/src/less/theme/content/uploadcare/uploadcare.less
+++ b/modules/oxide/src/less/theme/content/uploadcare/uploadcare.less
@@ -47,7 +47,7 @@
   all: initial; // prevents inheritable styles to leak into the shadow DOM
   display: inline-block;
   position: relative;
-  width: min(100%, @uploadcare-placeholder-initial-width);
+  width: ~"min(100%, @uploadcare-placeholder-initial-width)";
   height: @uploadcare-placeholder-initial-height;
 
   // shadow DOM (icon + text)


### PR DESCRIPTION
Related Ticket: TINY-11958

Description of Changes:
 Fixing the issue with using native CSS min function in less. Followup to https://app.graphite.dev/github/pr/tinymce/tinymce/10236/TINY-11958-make-placeholder-width-responsive

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved the upload placeholder’s behavior by making its width responsive. The upload area now adapts smoothly to different screen sizes while staying within an optimal maximum width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->