### PR TITLE
TINY-11916: move lock position in `ContextFormSizeInput`

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11916-2025-03-26.yaml
+++ b/.changes/unreleased/tinymce-TINY-11916-2025-03-26.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Changed
-body: ContextFormSizeInput's buttons order.
+body: ContextFormSizeInput's lock button now is in the middle instead that at the end.
 time: 2025-03-26T15:30:32.704440073+01:00
 custom:
     Issue: TINY-11916

--- a/.changes/unreleased/tinymce-TINY-11916-2025-03-26.yaml
+++ b/.changes/unreleased/tinymce-TINY-11916-2025-03-26.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Changed
+body: ContextFormSizeInput's buttons order.
+time: 2025-03-26T15:30:32.704440073+01:00
+custom:
+    Issue: TINY-11916

--- a/modules/oxide/src/less/theme/components/form/lock.less
+++ b/modules/oxide/src/less/theme/components/form/lock.less
@@ -7,4 +7,9 @@
   .tox-lock:not(.tox-locked) .tox-lock-icon__lock {
     display: none;
   }
+
+  .tox-context-form__group .tox-button--icon.tox-lock-context-form-size-input {
+    margin-left: @pad-sm;
+    margin-right: @pad-sm;
+  }
 }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
@@ -11,7 +11,7 @@ import {
   NativeEvents, Representing, SketchSpec, Tabstopping, Tooltipping
 } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
-import { Cell, Fun, Id, Optional, Singleton, Unicode } from '@ephox/katamari';
+import { Cell, Fun, Id, Optional, Singleton } from '@ephox/katamari';
 import { Focus, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import { formInputEvent } from 'tinymce/themes/silver/ui/general/FormEvents';
@@ -47,7 +47,7 @@ export const renderContextFormSizeInput = (
   const pLock = AlloyFormCoupledInputs.parts.lock({
     dom: {
       tag: 'button',
-      classes: [ 'tox-lock', 'tox-button', 'tox-button--naked', 'tox-button--icon' ],
+      classes: [ 'tox-lock', 'tox-lock-context-form-size-input', 'tox-button', 'tox-button--naked', 'tox-button--icon' ],
       attributes: {
         'aria-label': translatedLabel,
         'data-mce-name': label
@@ -161,9 +161,7 @@ export const renderContextFormSizeInput = (
       // NOTE: Form coupled inputs to the FormField.sketch themselves.
       widthField,
       formGroup([
-        getLabel(Unicode.nbsp),
-        pLock,
-        getLabel(Unicode.nbsp)
+        pLock
       ]),
       heightField
     ],

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
@@ -160,11 +160,12 @@ export const renderContextFormSizeInput = (
     components: [
       // NOTE: Form coupled inputs to the FormField.sketch themselves.
       widthField,
-      heightField,
       formGroup([
         getLabel(Unicode.nbsp),
-        pLock
-      ])
+        pLock,
+        getLabel(Unicode.nbsp)
+      ]),
+      heightField
     ],
     field1Name: 'width',
     field2Name: 'height',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
@@ -82,7 +82,7 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
     }
   }, [], true);
   const inputWidthSelector = '.tox-pop .tox-toolbar__group:nth-of-type(2) .tox-focusable-wrapper:nth-of-type(1) input';
-  const inputHeightSelector = '.tox-pop .tox-toolbar__group:nth-of-type(2) .tox-focusable-wrapper:nth-of-type(2) input';
+  const inputHeightSelector = '.tox-pop .tox-toolbar__group:nth-of-type(2) .tox-focusable-wrapper:nth-of-type(3) input';
   const buttonASelector = '.tox-pop button[aria-label="A"]';
 
   afterEach(async () => {
@@ -219,35 +219,35 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
 
     const buttonBSelector = '.tox-pop button[aria-label="B"]';
     const focussableWrapperWidthSelector = '.tox-pop .tox-focusable-wrapper:nth-of-type(1)';
-    const focussableWrapperHeightSelector = '.tox-pop .tox-focusable-wrapper:nth-of-type(2)';
+    const focussableWrapperHeightSelector = '.tox-pop .tox-focusable-wrapper:nth-of-type(3)';
     const lockButtonSelector = '.tox-pop .tox-lock';
 
     FocusTools.setFocus(SugarDocument.getDocument(), buttonASelector);
     await FocusTools.pTryOnSelector('Focus should be on the A button', SugarDocument.getDocument(), buttonASelector);
     TinyUiActions.keystroke(editor, Keys.tab());
 
-    await FocusTools.pTryOnSelector('Focus should be on the first focussable wrapper', SugarDocument.getDocument(), focussableWrapperWidthSelector);
-    TinyUiActions.keystroke(editor, Keys.right());
-
-    await FocusTools.pTryOnSelector('Focus should be on the second focussable wrapper', SugarDocument.getDocument(), focussableWrapperHeightSelector);
+    await FocusTools.pTryOnSelector('Focus should be on the first focussable wrapper (width)', SugarDocument.getDocument(), focussableWrapperWidthSelector);
     TinyUiActions.keystroke(editor, Keys.right());
 
     await FocusTools.pTryOnSelector('Focus should be on the lock button wrapper', SugarDocument.getDocument(), lockButtonSelector);
     TinyUiActions.keystroke(editor, Keys.right());
 
-    await FocusTools.pTryOnSelector('Focus should stay on the lock button wrapper', SugarDocument.getDocument(), lockButtonSelector);
-    TinyUiActions.keystroke(editor, Keys.left());
+    await FocusTools.pTryOnSelector('Focus should be on the second focussable wrapper (height)', SugarDocument.getDocument(), focussableWrapperHeightSelector);
+    TinyUiActions.keystroke(editor, Keys.right());
 
-    await FocusTools.pTryOnSelector('Focus should be on the second focussable wrapper(2)', SugarDocument.getDocument(), focussableWrapperHeightSelector);
+    await FocusTools.pTryOnSelector('Focus should stay on the second focussable wrapper (height)', SugarDocument.getDocument(), focussableWrapperHeightSelector);
     TinyUiActions.keystroke(editor, Keys.enter());
 
     await FocusTools.pTryOnSelector('Focus should be on the second input', SugarDocument.getDocument(), inputHeightSelector);
     TinyUiActions.keystroke(editor, Keys.escape());
 
-    await FocusTools.pTryOnSelector('Focus should go back to the second focussable wrapper', SugarDocument.getDocument(), focussableWrapperHeightSelector);
+    await FocusTools.pTryOnSelector('Focus should go back to the second focussable wrapper (height)', SugarDocument.getDocument(), focussableWrapperHeightSelector);
     TinyUiActions.keystroke(editor, Keys.left());
 
-    await FocusTools.pTryOnSelector('Focus should be on the first focussable wrapper(2)', SugarDocument.getDocument(), focussableWrapperWidthSelector);
+    await FocusTools.pTryOnSelector('Focus should be on the lock button wrapper', SugarDocument.getDocument(), lockButtonSelector);
+    TinyUiActions.keystroke(editor, Keys.left());
+
+    await FocusTools.pTryOnSelector('Focus should be on the first focussable wrapper (width)(2)', SugarDocument.getDocument(), focussableWrapperWidthSelector);
     TinyUiActions.keystroke(editor, Keys.enter());
 
     await FocusTools.pTryOnSelector('Focus should be on the first input', SugarDocument.getDocument(), inputWidthSelector);


### PR DESCRIPTION
Related Ticket: TINY-11916

Description of Changes:
* Placeholder text

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the layout in the size adjustment form by reordering buttons and repositioning input elements. These refinements lead to smoother interactions and improved keyboard navigation.

- **Style**
  - Enhanced the visual presentation with balanced button spacing, ensuring a consistent and polished interface.
  
- **New Features**
  - The lock button in the context form size input is now positioned in the middle for improved accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->