### PR TITLE
TINY-11756: Default to current behavior for mathml elements if not listed as extended.

### DIFF
--- a/modules/tinymce/src/core/main/ts/html/Sanitization.ts
+++ b/modules/tinymce/src/core/main/ts/html/Sanitization.ts
@@ -245,7 +245,11 @@ const sanitizeMathmlElement = (node: Element, settings: DomParserSettings) => {
     } else if (lcTagName === 'annotation') {
       return Optional.some(NodeType.isElement(node) && hasValidEncoding(node));
     } else if (Type.isArray(settings.extended_mathml_elements)) {
-      return Optional.some(settings.extended_mathml_elements.includes(lcTagName));
+      if (settings.extended_mathml_elements.includes(lcTagName)) {
+        return Optional.from(true);
+      } else {
+        return Optional.none();
+      }
     } else {
       return Optional.none();
     }

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -802,5 +802,34 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         TinyAssertions.assertContent(editor, expected);
       });
     });
+
+    context('TINY-11756: Test for elements and attributes', () => {
+      const hook = TinyHooks.bddSetupLight<Editor>({
+        base_url: '/project/tinymce/js/tinymce',
+        custom_elements: 'math',
+        extended_mathml_elements: [ 'semantics' ],
+        extended_mathml_attributes: [ 'data-badAttribute' ]
+      }, []);
+
+      it('TINY-11756: extended mathml should allow elements and attributes', () => {
+        const editor = hook.editor();
+
+        const input = [
+          '<div>',
+          '<math><mn data-badAttribute="value">1</mn><semantics>2</semantics></math>',
+          '</div>'
+        ].join('');
+
+        editor.setContent(input);
+
+        const expected = [
+          '<div>',
+          '<math><mn data-badattribute="value">1</mn><semantics>2</semantics></math>',
+          '</div>'
+        ].join('');
+
+        TinyAssertions.assertContent(editor, expected);
+      });
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SanitizationTest.ts
@@ -121,7 +121,7 @@ describe('browser.tinymce.core.html.SanitizationTest', () => {
 
       it('TINY-11756: Custom elements, allow some', () => testNamespaceSanitizer({
         input: '<math display="inline"><semantics><mrow><mi>a</mi></mrow><mi>a</mi></semantics></math>',
-        expected: '<math display="inline"><semantics><mi></mi></semantics></math>',
+        expected: '<math display="inline"><semantics><mrow><mi>a</mi></mrow><mi>a</mi></semantics></math>',
         mathmlElements: [
           'math',
           'semantics',


### PR DESCRIPTION
Related Ticket: TINY-11756

Description of Changes:
Previous fix did not add to the acceptance list, only replaced it. This default to current behavior if it's not in the list. No changelog as the previous change has not been released.

Pre-checks:
* [x] Changelog entry added
* [x Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced processing of mathematical content to ensure that essential elements for displaying formulas are accurately preserved.
  
- **Tests**
  - Updated validations to reflect the refined sanitization approach, ensuring consistent and reliable rendering of math expressions.
  - Added new tests to validate the handling of extended MathML elements and attributes in the editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->