### PR TITLE
TINY-11753: Revert "TINY-11753: improve keyboard navigation `figure`"

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11753-2025-02-20.yaml
+++ b/.changes/unreleased/tinymce-TINY-11753-2025-02-20.yaml
@@ -1,6 +1,0 @@
-project: tinymce
-kind: Improved
-body: When a non-editable element is selected, pressing enter now moves focus into the first editable child.
-time: 2025-02-20T08:26:57.188426766+01:00
-custom:
-    Issue: TINY-11753

--- a/modules/tinymce/src/core/main/ts/keyboard/EnterKey.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/EnterKey.ts
@@ -1,12 +1,10 @@
 import { Fun, Optional } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { PredicateFind, SugarElement } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import { EditorEvent } from '../api/util/EventDispatcher';
 import VK from '../api/util/VK';
 import { Bookmark } from '../bookmark/BookmarkTypes';
-import * as CaretFinder from '../caret/CaretFinder';
 import * as NodeType from '../dom/NodeType';
 import * as InsertNewLine from '../newline/InsertNewLine';
 import { endTypingLevelIgnoreLocks } from '../undo/TypingState';
@@ -25,16 +23,6 @@ const handleEnterKeyEvent = (editor: Editor, event: EditorEvent<KeyboardEvent>) 
   editor.undoManager.transact(() => {
     InsertNewLine.insert(editor, event);
   });
-};
-
-const manageEnterOnNonEditable = (editor: Editor, event: EditorEvent<KeyboardEvent>) => {
-  const currentNode = SugarElement.fromDom(editor.selection.getNode());
-  if (NodeType.isContentEditableFalse(currentNode.dom)) {
-    event.preventDefault();
-    PredicateFind.descendant(currentNode, (e) => NodeType.isContentEditableTrue(e.dom) && NodeType.isEditingHost(e.dom))
-      .bind((e) => CaretFinder.firstPositionIn(e.dom))
-      .each((pos) => editor.selection.setRng(pos.toRange()));
-  }
 };
 
 const isCaretAfterKoreanCharacter = (rng: Range): boolean => {
@@ -83,7 +71,6 @@ const setup = (editor: Editor): void => {
       } else {
         handleEnterKeyEvent(editor, event);
       }
-      manageEnterOnNonEditable(editor, event);
     }
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/EnterKeyTest.ts
@@ -1,6 +1,5 @@
-import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -681,25 +680,5 @@ describe('browser.tinymce.core.keyboard.EnterKeyTest', () => {
       pressEnter(editor, true);
       TinyAssertions.assertContent(editor, initialContent);
     });
-  });
-
-  it('TINY-11753: pressing enter when the seleciton is in a figure should move the selection into the figcaption', () => {
-    const editor = hook.editor();
-    editor.setContent('<figure contenteditable="false"><img src="file.png"><figcaption contenteditable="true">Caption</figcaption></figure>');
-    TinySelections.select(editor, 'figure', []);
-    TinyAssertions.assertSelection(editor, [], 0, [], 1);
-
-    TinyContentActions.keystroke(editor, Keys.enter());
-    TinyAssertions.assertCursor(editor, [ 0, 1, 0 ], 0);
-  });
-
-  it('TINY-11753: pressing enter when the seleciton is in a CEF element should move the selection into the first CET element', () => {
-    const editor = hook.editor();
-    editor.setContent('<div contenteditable="false"><img src="file.png"><span contenteditable="true">Caption</span></div>');
-    TinySelections.select(editor, 'div', []);
-    TinyAssertions.assertSelection(editor, [], 0, [], 1);
-
-    TinyContentActions.keystroke(editor, Keys.enter());
-    TinyAssertions.assertCursor(editor, [ 0, 1, 0 ], 0);
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-11753

Description of Changes:
reverted since this was moved to the next release

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the Enter key behavior for a more consistent editing experience by simplifying how keyboard input is handled in areas with non-editable content.
  
- **Revert**
  - Removed the previous automatic focus shift from non-editable elements to their editable children when pressing Enter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->