### PR TITLE
TINY-11560: No longer permit overlapping regions.

### DIFF
--- a/.changes/unreleased/polaris-TINY-11560-2025-04-01.yaml
+++ b/.changes/unreleased/polaris-TINY-11560-2025-04-01.yaml
@@ -1,6 +1,6 @@
 project: polaris
 kind: Fixed
-body: `Search.findmany()` would sometimes produce overlapping areas
+body: Search.findmany() would sometimes produce overlapping areas
 time: 2025-04-01T07:44:48.91709+02:00
 custom:
     Issue: TINY-11560

--- a/.changes/unreleased/polaris-TINY-11560-2025-04-01.yaml
+++ b/.changes/unreleased/polaris-TINY-11560-2025-04-01.yaml
@@ -1,6 +1,6 @@
 project: polaris
 kind: Fixed
-body: Spellchecking would sometimes produce overlapping areas
+body: `Search.findmany()` would sometimes produce overlapping areas
 time: 2025-04-01T07:44:48.91709+02:00
 custom:
     Issue: TINY-11560

--- a/.changes/unreleased/polaris-TINY-11560-2025-04-01.yaml
+++ b/.changes/unreleased/polaris-TINY-11560-2025-04-01.yaml
@@ -1,0 +1,6 @@
+project: polaris
+kind: Fixed
+body: Spellchecking would sometimes produce overlapping areas
+time: 2025-04-01T07:44:48.91709+02:00
+custom:
+    Issue: TINY-11560

--- a/modules/phoenix/src/test/ts/atomic/search/SplitterTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/search/SplitterTest.ts
@@ -1,4 +1,4 @@
-import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, describe, it } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 
@@ -6,7 +6,7 @@ import * as Splitter from 'ephox/phoenix/search/Splitter';
 import * as Finder from 'ephox/phoenix/test/Finder';
 import * as TestRenders from 'ephox/phoenix/test/TestRenders';
 
-UnitTest.test('SplitterTest', () => {
+describe('SplitterTest', () => {
 
   interface CheckItem {
     id: string;
@@ -32,19 +32,56 @@ UnitTest.test('SplitterTest', () => {
     Assert.eq('', toplevel, Arr.map(universe.get().children, TestRenders.text));
   };
 
-  checkSubdivide([ '_', 'abcdefghijklm', 'n', 'opq', 'rstuvwxyz' ], [
-    { id: 'a', start: 0, finish: 1, text: '_' },
-    { id: '?_abcdefghijklm', start: 1, finish: 14, text: 'abcdefghijklm' },
-    { id: '?_n', start: 14, finish: 15, text: 'n' },
-    { id: '?_opq', start: 15, finish: 18, text: 'opq' },
-    { id: '?_rstuvwxyz', start: 18, finish: 27, text: 'rstuvwxyz' }
-  ], 'a', [ 1, 14, 15, 18 ], Gene('root', 'root', [
-    TextGene('a', '_abcdefghijklmnopqrstuvwxyz')
-  ]));
+  it('Run tests', () => {
+    checkSubdivide([ '_', 'abcdefghijklm', 'n', 'opq', 'rstuvwxyz' ], [
+      { id: 'a', start: 0, finish: 1, text: '_' },
+      { id: '?_abcdefghijklm', start: 1, finish: 14, text: 'abcdefghijklm' },
+      { id: '?_n', start: 14, finish: 15, text: 'n' },
+      { id: '?_opq', start: 15, finish: 18, text: 'opq' },
+      { id: '?_rstuvwxyz', start: 18, finish: 27, text: 'rstuvwxyz' }
+    ], 'a', [ 1, 14, 15, 18 ], Gene('root', 'root', [
+      TextGene('a', '_abcdefghijklmnopqrstuvwxyz')
+    ]));
 
-  checkSubdivide([ '_abcdefghijklmnopqrstuvwxyz' ], [
-    { id: 'a', start: 0, finish: 27, text: '_abcdefghijklmnopqrstuvwxyz' }
-  ], 'a', [ 100 ], Gene('root', 'root', [
-    TextGene('a', '_abcdefghijklmnopqrstuvwxyz')
-  ]));
+    checkSubdivide([ '_abcdefghijklmnopqrstuvwxyz' ], [
+      { id: 'a', start: 0, finish: 27, text: '_abcdefghijklmnopqrstuvwxyz' }
+    ], 'a', [ 100 ], Gene('root', 'root', [
+      TextGene('a', '_abcdefghijklmnopqrstuvwxyz')
+    ]));
+  });
+
+  it('TINY-11560: Invalid input produces invalid output', () => {
+    checkSubdivide(
+      [ 'D.', ' ', 'dd.D', 'D', 'D.' ],
+      [
+        { id: 'p', start: 0, finish: 2, text: 'D.' },
+        { id: '?_ ', start: 2, finish: 3, text: ' ' },
+        { id: '?_dd.D', start: 3, finish: 7, text: 'dd.D' },
+        { id: '?_D', start: 7, finish: 8, text: 'D' },
+        { id: '?_D.', start: 8, finish: 10, text: 'D.' },
+      ],
+      'p',
+      [ 0, 2, 3, 7, 6, 8 ],
+      Gene('root', 'root', [
+        TextGene('p', 'D. dd.D.')
+      ])
+    );
+  });
+
+  it('TINY-11560: Valid input produces valid output.', () => {
+    checkSubdivide(
+      [ 'D.', ' ', 'dd.D', '.' ],
+      [
+        { id: 'p', start: 0, finish: 2, text: 'D.' },
+        { id: '?_ ', start: 2, finish: 3, text: ' ' },
+        { id: '?_dd.D', start: 3, finish: 7, text: 'dd.D' },
+        { id: '?_.', start: 7, finish: 8, text: '.' },
+      ],
+      'p',
+      [ 0, 2, 3, 7 ],
+      Gene('root', 'root', [
+        TextGene('p', 'D. dd.D.')
+      ])
+    );
+  });
 });

--- a/modules/polaris/src/main/ts/ephox/polaris/search/Sleuth.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/search/Sleuth.ts
@@ -10,7 +10,7 @@ const removeOverlapped = <T extends PRange>(array: T[]): T[] => {
   const sorted = sort(array);
 
   return Arr.foldl(sorted, (acc, item) => {
-    const overlaps = Arr.exists(acc, (a) => item.start >= a.start && item.finish <= a.finish);
+    const overlaps = Arr.exists(acc, (a) => (item.start >= a.start && item.finish <= a.finish) || (item.finish > a.start && item.start < a.start) || (item.finish > a.finish && item.start < a.finish));
     const matchingStartIndex = Arr.findIndex(acc, (a) => item.start === a.start);
 
     // If there's no item with matching start in acc and within the start and finish, then we append, else we skip the item

--- a/modules/polaris/src/test/ts/atomic/api/SearchFindTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/SearchFindTest.ts
@@ -56,6 +56,19 @@ describe('atomic.polaris.api.SearchFindTest', () => {
     checkAll([[ 1, 5 ]], ' [wo] and more', Pattern.unsafetoken(Safe.sanitise('[') + '[^' + Safe.sanitise(']') + ']*' + Safe.sanitise(']')));
   });
 
+  it('TINY-11560: Overlapping detected areas should not exist.', () => {
+    checkMany(
+      [
+        [ 0, 2, 'A' ],
+        [ 3, 7, 'B' ],
+      ],
+      'D. dd.D.',
+      [
+        testData(Pattern.safeword('D.'), 'A'),
+        testData(Pattern.safeword('dd.D'), 'B'),
+      ]);
+  });
+
   it('TINY-10062: checkMany ', () => {
     checkMany([], '', []);
     checkMany([


### PR DESCRIPTION
Related Ticket: TINY-11560

Description of Changes:
Previously some situations could cause the search pattern to detect parts that were overlapping, which would result in sections being repeated when the found pattern was reinserted into the editor. This fix improves the detection of overlapping sections so that it now detects partial overlapping.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where overlapping areas were produced by the search functionality, ensuring more accurate results.
- **Tests**
  - Enhanced test coverage with new scenarios to validate the detection of overlapping areas.
  - Improved organization of test cases for better readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->