### PR TITLE
TINY-12026: Marked libraries as side effect free

### DIFF
--- a/modules/acid/package.json
+++ b/modules/acid/package.json
@@ -15,6 +15,7 @@
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "GPL-2.0-or-later",
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",

--- a/modules/agar/package.json
+++ b/modules/agar/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@ephox/katamari-assertions": "^5.0.0"
   },
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",

--- a/modules/alloy/package.json
+++ b/modules/alloy/package.json
@@ -9,6 +9,7 @@
     "@ephox/sand": "^7.0.0",
     "@ephox/sugar": "^10.0.0"
   },
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",

--- a/modules/boss/package.json
+++ b/modules/boss/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/tinymce/tinymce.git",
     "directory": "modules/boss"
   },
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",

--- a/modules/boulder/package.json
+++ b/modules/boulder/package.json
@@ -24,6 +24,7 @@
   "keywords": [
     "validation"
   ],
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",

--- a/modules/bridge/package.json
+++ b/modules/bridge/package.json
@@ -18,6 +18,7 @@
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "GPL-2.0-or-later",
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",

--- a/modules/darwin/package.json
+++ b/modules/darwin/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/tinymce/tinymce.git",
     "directory": "modules/darwin"
   },
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",

--- a/modules/dragster/package.json
+++ b/modules/dragster/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/tinymce/tinymce.git",
     "directory": "modules/dragster"
   },
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",

--- a/modules/jax/package.json
+++ b/modules/jax/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@ephox/katamari": "^10.0.0"
   },
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",

--- a/modules/katamari-assertions/package.json
+++ b/modules/katamari-assertions/package.json
@@ -21,6 +21,7 @@
     "@ephox/dispute": "^1.0.15",
     "@ephox/katamari": "^10.0.0"
   },
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",

--- a/modules/katamari/package.json
+++ b/modules/katamari/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@ephox/dispute": "^1.0.15"
   },
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",

--- a/modules/mcagar/package.json
+++ b/modules/mcagar/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/tinymce/tinymce.git",
     "directory": "modules/mcagar"
   },
+  "sideEffects": false,
   "files": [
     "lib/main",
     "src/main",

--- a/modules/oxide-icons-default/package.json
+++ b/modules/oxide-icons-default/package.json
@@ -17,6 +17,7 @@
     "TinyMCE",
     "Icons"
   ],
+  "sideEffects": false,
   "files": [
     "dist",
     "README.md",

--- a/modules/oxide/package.json
+++ b/modules/oxide/package.json
@@ -19,6 +19,7 @@
   ],
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "GPL-2.0-or-later",
+  "sideEffects": false,
   "files": [
     "build/skins/content/**/*.css",
     "build/skins/content/**/*.css.map",

--- a/modules/phoenix/package.json
+++ b/modules/phoenix/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/tinymce/tinymce.git",
     "directory": "modules/phoenix"
   },
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",

--- a/modules/polaris/package.json
+++ b/modules/polaris/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/tinymce/tinymce.git",
     "directory": "modules/polaris"
   },
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",

--- a/modules/porkbun/package.json
+++ b/modules/porkbun/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/tinymce/tinymce.git",
     "directory": "modules/porkbun"
   },
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",

--- a/modules/robin/package.json
+++ b/modules/robin/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/tinymce/tinymce.git",
     "directory": "modules/robin"
   },
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",

--- a/modules/sand/package.json
+++ b/modules/sand/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/tinymce/tinymce.git",
     "directory": "modules/sand"
   },
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",

--- a/modules/snooker/package.json
+++ b/modules/snooker/package.json
@@ -2,6 +2,7 @@
   "name": "@ephox/snooker",
   "description": "This project implements the table model.",
   "version": "12.0.0",
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",

--- a/modules/sugar/package.json
+++ b/modules/sugar/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@ephox/katamari-assertions": "^5.0.0"
   },
+  "sideEffects": false,
   "files": [
     "lib/main",
     "lib/demo",


### PR DESCRIPTION
Related Ticket: TINY-12026

Description of Changes:
* Marks all the libraries as sideEffect free

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated module configurations to enable smarter bundling optimizations. These enhancements facilitate more efficient tree-shaking during the build process, potentially resulting in reduced bundle sizes and faster load times. While the interface remains unchanged, users may experience smoother module loading and runtime performance. We continue to optimize our platform for better overall efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->