### PR TITLE
TINY-11953: fix incorrectly deleted selection on chrome

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11953-2025-04-04.yaml
+++ b/.changes/unreleased/tinymce-TINY-11953-2025-04-04.yaml
@@ -1,7 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Selected anchor tag used to be removed with it's parent, while performing mceInsertContent
-  command on chrome.
+body: The `mceInsertContent` command could delete the parent block element when an anchor was selected.
 time: 2025-04-04T19:39:28.708179+02:00
 custom:
   Issue: TINY-11953

--- a/.changes/unreleased/tinymce-TINY-11953-2025-04-04.yaml
+++ b/.changes/unreleased/tinymce-TINY-11953-2025-04-04.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Selected anchor tag used to be removed with it's parent, while performing mceInsertContent
+  command on chrome.
+time: 2025-04-04T19:39:28.708179+02:00
+custom:
+  Issue: TINY-11953

--- a/modules/tinymce/src/core/main/ts/dom/NodeType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/NodeType.ts
@@ -100,7 +100,7 @@ const isDocument = isNodeType<Document>(9);
 const isDocumentFragment = isNodeType<DocumentFragment>(11);
 const isBr = matchNodeName<HTMLBRElement>('br');
 const isImg = matchNodeName<HTMLImageElement>('img');
-const isAnchor = matchNodeName<HTMLImageElement>('a');
+const isAnchor = matchNodeName<HTMLAnchorElement>('a');
 const isContentEditableTrue = hasContentEditableState('true');
 const isContentEditableFalse = hasContentEditableState('false');
 const isEditingHost = (node: Node): node is HTMLElement => isHTMLElement(node) && node.isContentEditable && Type.isNonNullable(node.parentElement) && !node.parentElement.isContentEditable;

--- a/modules/tinymce/src/core/main/ts/dom/NodeType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/NodeType.ts
@@ -100,6 +100,7 @@ const isDocument = isNodeType<Document>(9);
 const isDocumentFragment = isNodeType<DocumentFragment>(11);
 const isBr = matchNodeName<HTMLBRElement>('br');
 const isImg = matchNodeName<HTMLImageElement>('img');
+const isAnchor = matchNodeName<HTMLImageElement>('a');
 const isContentEditableTrue = hasContentEditableState('true');
 const isContentEditableFalse = hasContentEditableState('false');
 const isEditingHost = (node: Node): node is HTMLElement => isHTMLElement(node) && node.isContentEditable && Type.isNonNullable(node.parentElement) && !node.parentElement.isContentEditable;
@@ -123,6 +124,7 @@ export {
   isDocumentFragment,
   isBr,
   isImg,
+  isAnchor,
   isContentEditableTrue,
   isContentEditableFalse,
   isEditingHost,

--- a/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentCommandTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentCommandTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { LegacyUnit, TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -425,5 +425,13 @@ describe('browser.tinymce.core.content.insert.InsertContentCommandTest', () => {
     LegacyUnit.setSelection(editor, 'p', 2, 'p', 3);
     editor.execCommand('mceInsertContent', false, 'X');
     assert.equal(JSON.stringify(editor.getContent()), '"<p>a X c</p>"');
+  });
+
+  it('TINY-11953: mceInsertContent - insert content with <a> selected preserves parent tag', () => {
+    const editor = hook.editor();
+    editor.setContent('<div class="d"><p class="p"><a href="https://google.com">Link</a></p></div>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
+    editor.execCommand('mceInsertContent', false, 'Some content');
+    TinyAssertions.assertContent(editor, '<div class="d"><p class="p">Some content</p></div>');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-11953

Description of Changes:
* Selected anchor tag used to be removed with it's parent, while performing mceInsertContent
  command on chrome.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue in Chrome where inserting content with a selected hyperlink inadvertently removed its parent container. The enhanced logic now accurately preserves surrounding elements during content insertion.

- **New Features**
  - Introduced functionality to identify anchor elements within the DOM, improving content handling.

- **Tests**
  - Added a scenario to verify that content insertion with hyperlinks maintains the intended structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->