### PR TITLE
TINY-11549: fix toolbar dimension on opening sub toolbar

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
@@ -16,7 +16,7 @@ import { applyTransitionCss } from './Transitions';
  */
 
 const elementSize = (p: SugarElement<HTMLElement>): AnchorElement => ({
-  width: Width.getOuter(p),
+  width: Math.ceil(Width.getOuterExact(p)),
   height: Height.getOuter(p)
 });
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/Width.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/Width.ts
@@ -8,11 +8,17 @@ const api = Dimension('width', (element: SugarElement<HTMLElement>) =>
   element.dom.offsetWidth
 );
 
+const apiExact = Dimension('width', (element: SugarElement<HTMLElement>) =>
+  element.dom.getBoundingClientRect().width
+);
+
 const set = (element: SugarElement<HTMLElement>, h: string | number): void => api.set(element, h);
 
 const get = (element: SugarElement<HTMLElement>): number => api.get(element);
 
 const getOuter = (element: SugarElement<HTMLElement>): number => api.getOuter(element);
+
+const getOuterExact = (element: SugarElement<HTMLElement>): number => apiExact.getOuter(element);
 
 const getInner = RuntimeSize.getInnerWidth;
 
@@ -30,6 +36,7 @@ export {
   get,
   getInner,
   getOuter,
+  getOuterExact,
   getRuntime,
   setMax
 };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/Width.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/Width.ts
@@ -1,5 +1,6 @@
 import { Dimension } from '../../impl/Dimension';
 import * as RuntimeSize from '../../impl/RuntimeSize';
+import * as SugarBody from '../node/SugarBody';
 import { SugarElement } from '../node/SugarElement';
 import * as Css from '../properties/Css';
 
@@ -8,9 +9,10 @@ const api = Dimension('width', (element: SugarElement<HTMLElement>) =>
   element.dom.offsetWidth
 );
 
-const apiExact = Dimension('width', (element: SugarElement<HTMLElement>) =>
-  element.dom.getBoundingClientRect().width
-);
+const apiExact = Dimension('width', (element: SugarElement<HTMLElement>) => {
+  const dom = element.dom;
+  return SugarBody.inBody(element) ? dom.getBoundingClientRect().width : dom.offsetWidth;
+});
 
 const set = (element: SugarElement<HTMLElement>, h: string | number): void => api.set(element, h);
 


### PR DESCRIPTION
Related Ticket: TINY-11549

Description of Changes:
the problem was almost solved with [this PR](https://github.com/tinymce/tinymce/pull/10178), but I notice that there is still some cases where this isn't working and it is where the dimension of the new toolbar has a dimension that can be rounded to the previous int (es. `1.4` -> `1`), this is because [offsetWidth returns an int](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetWidth).

I create a new API instead of changing the current one using `getBoundingClientRect().width` like in [Height](https://github.com/tinymce/tinymce/blob/main/modules/sugar/src/main/ts/ephox/sugar/api/view/Height.ts#L10) because it breaks some tables tests and since is a low level stuff I'm scared that changing it could break some other unexpected behavior

I didn't find a good way to test this, also I found [these tests](https://github.com/tinymce/tinymce/blob/main/modules/tinymce/src/plugins/quickbars/test/ts/browser/ToolbarPositionTest.ts#L18-L19) about toolbar positioning that are disabled because flaky

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the accuracy of element sizing measurements to promote more consistent and visually aligned layouts. The update incorporates a refined calculation method that adapts to each element's context, ensuring optimal precision, uniform spacing, and enhanced visual experience across the interface for end-users. This update delivers a seamless and responsive interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->