### PR TITLE
TINY-12011: mark export plugin as deprecated

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12011-2025-04-29.yaml
+++ b/.changes/unreleased/tinymce-TINY-12011-2025-04-29.yaml
@@ -1,6 +1,0 @@
-project: tinymce
-kind: Deprecated
-body: Mark 'export' plugin as deprecated.
-time: 2025-04-29T09:09:09.978207+02:00
-custom:
-  Issue: TINY-12011


### PR DESCRIPTION
Related Ticket: TINY-12011

Description of Changes:
* mark export plugin as deprecated

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a deprecation notice for the 'export' plugin, indicating it is now deprecated and replaced by 'Export to PDF'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->