### PR TITLE
TINY-11915: Replaced swag with pure rollup and sideEffect: false

### DIFF
--- a/modules/katamari-assertions/package.json
+++ b/modules/katamari-assertions/package.json
@@ -18,7 +18,7 @@
   "license": "GPL-2.0-or-later",
   "dependencies": {
     "@ephox/bedrock-client": ">=11",
-    "@ephox/dispute": "^1.0.15",
+    "@ephox/dispute": "^1.0.16",
     "@ephox/katamari": "^10.0.0"
   },
   "sideEffects": false,

--- a/modules/katamari/package.json
+++ b/modules/katamari/package.json
@@ -17,7 +17,7 @@
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "GPL-2.0-or-later",
   "dependencies": {
-    "@ephox/dispute": "^1.0.15"
+    "@ephox/dispute": "^1.0.16"
   },
   "sideEffects": false,
   "files": [

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
@@ -419,39 +419,106 @@ const pasteColumnsExtractor = (before: boolean) => (warehouse: Warehouse, target
 const headerCellGenerator = Generators.transform('th');
 const bodyCellGenerator = Generators.transform('td');
 
-export const insertRowBefore = RunOperation.run(opInsertRowBefore, RunOperation.onCell, Fun.noop, Fun.noop, Generators.modification);
-export const insertRowsBefore = RunOperation.run(opInsertRowsBefore, RunOperation.onCells, Fun.noop, Fun.noop, Generators.modification);
-export const insertRowAfter = RunOperation.run(opInsertRowAfter, RunOperation.onCell, Fun.noop, Fun.noop, Generators.modification);
-export const insertRowsAfter = RunOperation.run(opInsertRowsAfter, RunOperation.onCells, Fun.noop, Fun.noop, Generators.modification);
-export const insertColumnBefore = RunOperation.run(opInsertColumnBefore, insertColumnExtractor(true), adjustAndRedistributeWidths, Fun.noop, Generators.modification);
-export const insertColumnsBefore = RunOperation.run(opInsertColumnsBefore, insertColumnsExtractor(true), adjustAndRedistributeWidths, Fun.noop, Generators.modification);
-export const insertColumnAfter = RunOperation.run(opInsertColumnAfter, insertColumnExtractor(false), adjustAndRedistributeWidths, Fun.noop, Generators.modification);
-export const insertColumnsAfter = RunOperation.run(opInsertColumnsAfter, insertColumnsExtractor(false), adjustAndRedistributeWidths, Fun.noop, Generators.modification);
-export const splitCellIntoColumns = RunOperation.run(opSplitCellIntoColumns, RunOperation.onUnlockedCell, resize, Fun.noop, Generators.modification);
-export const splitCellIntoRows = RunOperation.run(opSplitCellIntoRows, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.modification);
-export const eraseColumns = RunOperation.run(opEraseColumns, eraseColumnsExtractor, adjustAndRedistributeWidths, prune, Generators.modification);
-export const eraseRows = RunOperation.run(opEraseRows, RunOperation.onCells, Fun.noop, prune, Generators.modification);
-export const makeColumnHeader = RunOperation.run(opMakeColumnHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, headerCellGenerator);
-export const makeColumnsHeader = RunOperation.run(opMakeColumnsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, headerCellGenerator);
-export const unmakeColumnHeader = RunOperation.run(opUnmakeColumnHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, bodyCellGenerator);
-export const unmakeColumnsHeader = RunOperation.run(opUnmakeColumnsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, bodyCellGenerator);
-export const makeRowHeader = RunOperation.run(opMakeRowHeader, RunOperation.onCell, Fun.noop, Fun.noop, headerCellGenerator);
-export const makeRowsHeader = RunOperation.run(opMakeRowsHeader, RunOperation.onCells, Fun.noop, Fun.noop, headerCellGenerator);
-export const makeRowBody = RunOperation.run(opMakeRowBody, RunOperation.onCell, Fun.noop, Fun.noop, bodyCellGenerator);
-export const makeRowsBody = RunOperation.run(opMakeRowsBody, RunOperation.onCells, Fun.noop, Fun.noop, bodyCellGenerator);
-export const makeRowFooter = RunOperation.run(opMakeRowFooter, RunOperation.onCell, Fun.noop, Fun.noop, bodyCellGenerator);
-export const makeRowsFooter = RunOperation.run(opMakeRowsFooter, RunOperation.onCells, Fun.noop, Fun.noop, bodyCellGenerator);
-export const makeCellHeader = RunOperation.run(opMakeCellHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, headerCellGenerator);
-export const makeCellsHeader = RunOperation.run(opMakeCellsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, headerCellGenerator);
-export const unmakeCellHeader = RunOperation.run(opUnmakeCellHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, bodyCellGenerator);
-export const unmakeCellsHeader = RunOperation.run(opUnmakeCellsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, bodyCellGenerator);
-export const mergeCells = RunOperation.run(opMergeCells, RunOperation.onUnlockedMergable, resize, Fun.noop, Generators.merging);
-export const unmergeCells = RunOperation.run(opUnmergeCells, RunOperation.onUnlockedUnmergable, resize, Fun.noop, Generators.merging);
-export const pasteCells = RunOperation.run(opPasteCells, RunOperation.onPaste, resize, Fun.noop, Generators.modification);
-export const pasteColsBefore = RunOperation.run(opPasteColsBefore, pasteColumnsExtractor(true), Fun.noop, Fun.noop, Generators.modification);
-export const pasteColsAfter = RunOperation.run(opPasteColsAfter, pasteColumnsExtractor(false), Fun.noop, Fun.noop, Generators.modification);
-export const pasteRowsBefore = RunOperation.run(opPasteRowsBefore, RunOperation.onPasteByEditor, Fun.noop, Fun.noop, Generators.modification);
-export const pasteRowsAfter = RunOperation.run(opPasteRowsAfter, RunOperation.onPasteByEditor, Fun.noop, Fun.noop, Generators.modification);
+type TableOp<T> = (table: SugarElement<HTMLTableElement>, target: T, generators: Generators, behaviours?: RunOperation.OperationBehaviours) => Optional<RunOperation.RunOperationOutput>;
+
+export const insertRowBefore: TableOp<RunOperation.TargetElement> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opInsertRowBefore, RunOperation.onCell, Fun.noop, Fun.noop, Generators.modification, table, target, generators, behaviours);
+
+export const insertRowsBefore: TableOp<RunOperation.TargetSelection> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opInsertRowsBefore, RunOperation.onCells, Fun.noop, Fun.noop, Generators.modification, table, target, generators, behaviours);
+
+export const insertRowAfter: TableOp<RunOperation.TargetElement> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opInsertRowAfter, RunOperation.onCell, Fun.noop, Fun.noop, Generators.modification, table, target, generators, behaviours);
+
+export const insertRowsAfter: TableOp<RunOperation.TargetSelection> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opInsertRowsAfter, RunOperation.onCells, Fun.noop, Fun.noop, Generators.modification, table, target, generators, behaviours);
+
+export const insertColumnBefore: TableOp<RunOperation.TargetElement> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opInsertColumnBefore, insertColumnExtractor(true), adjustAndRedistributeWidths, Fun.noop, Generators.modification, table, target, generators, behaviours);
+
+export const insertColumnsBefore: TableOp<RunOperation.TargetSelection> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opInsertColumnsBefore, insertColumnsExtractor(true), adjustAndRedistributeWidths, Fun.noop, Generators.modification, table, target, generators, behaviours);
+
+export const insertColumnAfter: TableOp<RunOperation.TargetElement> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opInsertColumnAfter, insertColumnExtractor(false), adjustAndRedistributeWidths, Fun.noop, Generators.modification, table, target, generators, behaviours);
+
+export const insertColumnsAfter: TableOp<RunOperation.TargetSelection> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opInsertColumnsAfter, insertColumnsExtractor(false), adjustAndRedistributeWidths, Fun.noop, Generators.modification, table, target, generators, behaviours);
+
+export const splitCellIntoColumns: TableOp<RunOperation.TargetElement> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opSplitCellIntoColumns, RunOperation.onUnlockedCell, resize, Fun.noop, Generators.modification, table, target, generators, behaviours);
+
+export const splitCellIntoRows: TableOp<RunOperation.TargetElement> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opSplitCellIntoRows, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, Generators.modification, table, target, generators, behaviours);
+
+export const eraseColumns: TableOp<RunOperation.TargetSelection> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opEraseColumns, eraseColumnsExtractor, adjustAndRedistributeWidths, prune, Generators.modification, table, target, generators, behaviours);
+
+export const eraseRows: TableOp<RunOperation.TargetSelection> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opEraseRows, RunOperation.onCells, Fun.noop, prune, Generators.modification, table, target, generators, behaviours);
+
+export const makeColumnHeader: TableOp<RunOperation.TargetElement> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opMakeColumnHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, headerCellGenerator, table, target, generators, behaviours);
+
+export const makeColumnsHeader: TableOp<RunOperation.TargetSelection> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opMakeColumnsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, headerCellGenerator, table, target, generators, behaviours);
+
+export const unmakeColumnHeader: TableOp<RunOperation.TargetElement> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opUnmakeColumnHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, bodyCellGenerator, table, target, generators, behaviours);
+
+export const unmakeColumnsHeader: TableOp<RunOperation.TargetSelection> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opUnmakeColumnsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, bodyCellGenerator, table, target, generators, behaviours);
+
+export const makeRowHeader: TableOp<RunOperation.TargetElement> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opMakeRowHeader, RunOperation.onCell, Fun.noop, Fun.noop, headerCellGenerator, table, target, generators, behaviours);
+
+export const makeRowsHeader: TableOp<RunOperation.TargetSelection> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opMakeRowsHeader, RunOperation.onCells, Fun.noop, Fun.noop, headerCellGenerator, table, target, generators, behaviours);
+
+export const makeRowBody: TableOp<RunOperation.TargetElement> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opMakeRowBody, RunOperation.onCell, Fun.noop, Fun.noop, bodyCellGenerator, table, target, generators, behaviours);
+
+export const makeRowsBody: TableOp<RunOperation.TargetSelection> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opMakeRowsBody, RunOperation.onCells, Fun.noop, Fun.noop, bodyCellGenerator, table, target, generators, behaviours);
+
+export const makeRowFooter: TableOp<RunOperation.TargetElement> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opMakeRowFooter, RunOperation.onCell, Fun.noop, Fun.noop, bodyCellGenerator, table, target, generators, behaviours);
+
+export const makeRowsFooter: TableOp<RunOperation.TargetSelection> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opMakeRowsFooter, RunOperation.onCells, Fun.noop, Fun.noop, bodyCellGenerator, table, target, generators, behaviours);
+
+export const makeCellHeader: TableOp<RunOperation.TargetElement> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opMakeCellHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, headerCellGenerator, table, target, generators, behaviours);
+
+export const makeCellsHeader: TableOp<RunOperation.TargetSelection> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opMakeCellsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, headerCellGenerator, table, target, generators, behaviours);
+
+export const unmakeCellHeader: TableOp<RunOperation.TargetElement> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opUnmakeCellHeader, RunOperation.onUnlockedCell, Fun.noop, Fun.noop, bodyCellGenerator, table, target, generators, behaviours);
+
+export const unmakeCellsHeader: TableOp<RunOperation.TargetSelection> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opUnmakeCellsHeader, RunOperation.onUnlockedCells, Fun.noop, Fun.noop, bodyCellGenerator, table, target, generators, behaviours);
+
+export const mergeCells: TableOp<RunOperation.TargetMergable> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opMergeCells, RunOperation.onUnlockedMergable, resize, Fun.noop, Generators.merging, table, target, generators, behaviours);
+
+export const unmergeCells: TableOp<RunOperation.TargetUnmergable> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opUnmergeCells, RunOperation.onUnlockedUnmergable, resize, Fun.noop, Generators.merging, table, target, generators, behaviours);
+
+export const pasteCells: TableOp<RunOperation.TargetPaste> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opPasteCells, RunOperation.onPaste, resize, Fun.noop, Generators.modification, table, target, generators, behaviours);
+
+export const pasteColsBefore: TableOp<RunOperation.TargetPasteRows> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opPasteColsBefore, pasteColumnsExtractor(true), Fun.noop, Fun.noop, Generators.modification, table, target, generators, behaviours);
+
+export const pasteColsAfter: TableOp<RunOperation.TargetPasteRows> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opPasteColsAfter, pasteColumnsExtractor(false), Fun.noop, Fun.noop, Generators.modification, table, target, generators, behaviours);
+
+export const pasteRowsBefore: TableOp<RunOperation.TargetPasteRows> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opPasteRowsBefore, RunOperation.onPasteByEditor, Fun.noop, Fun.noop, Generators.modification, table, target, generators, behaviours);
+
+export const pasteRowsAfter: TableOp<RunOperation.TargetPasteRows> = (table, target, generators, behaviours?) =>
+  RunOperation.run(opPasteRowsAfter, RunOperation.onPasteByEditor, Fun.noop, Fun.noop, Generators.modification, table, target, generators, behaviours);
 
 export const getColumnsType = opGetColumnsType;
 export const getCellsType = opGetCellsType;

--- a/modules/snooker/src/main/ts/ephox/snooker/model/RunOperation.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/RunOperation.ts
@@ -101,42 +101,50 @@ export type GenWrap<GW extends GeneratorsWrapper> = (g: Generators) => GW;
 
 export type OperationCallback<T> = (table: SugarElement<HTMLTableElement>, target: T, generators: Generators, behaviours?: OperationBehaviours) => Optional<RunOperationOutput>;
 
-const run = <RAW, INFO, GW extends GeneratorsWrapper>
-(operation: Operation<INFO, GW>, extract: Extract<RAW, INFO>, adjustment: Adjustment<INFO>, postAction: PostAction, genWrappers: GenWrap<GW>): OperationCallback<RAW> =>
-  (table: SugarElement<HTMLTableElement>, target: RAW, generators: Generators, behaviours?: OperationBehaviours): Optional<RunOperationOutput> => {
-    const warehouse = Warehouse.fromTable(table);
-    const tableSection = Optional.from(behaviours?.section).getOrThunk(TableSection.fallback);
-    const output = extract(warehouse, target).map((info) => {
-      const model = fromWarehouse(warehouse, generators);
-      const result = operation(model, info, Compare.eq, genWrappers(generators), tableSection);
-      const lockedColumns = LockedColumnUtils.getLockedColumnsFromGrid(result.grid);
-      const grid = toDetailList(result.grid);
-      return {
-        info,
-        grid,
-        cursor: result.cursor,
-        lockedColumns
-      };
-    });
+const run = <RAW, INFO, GW extends GeneratorsWrapper> (
+  operation: Operation<INFO, GW>,
+  extract: Extract<RAW, INFO>,
+  adjustment: Adjustment<INFO>,
+  postAction: PostAction,
+  genWrappers: GenWrap<GW>,
+  table: SugarElement<HTMLTableElement>,
+  target: RAW,
+  generators: Generators,
+  behaviours?: OperationBehaviours
+): Optional<RunOperationOutput> => {
+  const warehouse = Warehouse.fromTable(table);
+  const tableSection = Optional.from(behaviours?.section).getOrThunk(TableSection.fallback);
+  const output = extract(warehouse, target).map((info) => {
+    const model = fromWarehouse(warehouse, generators);
+    const result = operation(model, info, Compare.eq, genWrappers(generators), tableSection);
+    const lockedColumns = LockedColumnUtils.getLockedColumnsFromGrid(result.grid);
+    const grid = toDetailList(result.grid);
+    return {
+      info,
+      grid,
+      cursor: result.cursor,
+      lockedColumns
+    };
+  });
 
-    return output.bind((out) => {
-      const newElements = Redraw.render(table, out.grid);
-      const tableSizing = Optional.from(behaviours?.sizing).getOrThunk(() => TableSize.getTableSize(table));
-      const resizing = Optional.from(behaviours?.resize).getOrThunk(ResizeBehaviour.preserveTable);
-      adjustment(table, out.grid, out.info, { sizing: tableSizing, resize: resizing, section: tableSection });
-      postAction(table);
-      // Update locked cols attribute
-      Attribute.remove(table, LockedColumnUtils.LOCKED_COL_ATTR);
-      if (out.lockedColumns.length > 0) {
-        Attribute.set(table, LockedColumnUtils.LOCKED_COL_ATTR, out.lockedColumns.join(','));
-      }
-      return Optional.some({
-        cursor: out.cursor,
-        newRows: newElements.newRows,
-        newCells: newElements.newCells
-      });
+  return output.bind((out) => {
+    const newElements = Redraw.render(table, out.grid);
+    const tableSizing = Optional.from(behaviours?.sizing).getOrThunk(() => TableSize.getTableSize(table));
+    const resizing = Optional.from(behaviours?.resize).getOrThunk(ResizeBehaviour.preserveTable);
+    adjustment(table, out.grid, out.info, { sizing: tableSizing, resize: resizing, section: tableSection });
+    postAction(table);
+    // Update locked cols attribute
+    Attribute.remove(table, LockedColumnUtils.LOCKED_COL_ATTR);
+    if (out.lockedColumns.length > 0) {
+      Attribute.set(table, LockedColumnUtils.LOCKED_COL_ATTR, out.lockedColumns.join(','));
+    }
+    return Optional.some({
+      cursor: out.cursor,
+      newRows: newElements.newRows,
+      newCells: newElements.newCells
     });
-  };
+  });
+};
 
 const onCell = (warehouse: Warehouse, target: TargetElement): Optional<Structs.DetailExt> =>
   TableLookup.cell(target.element).bind((cell) => findInWarehouse(warehouse, cell));

--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -152,8 +152,7 @@ module.exports = function (grunt) {
                   { find: `tinymce/themes/${name}/resources`, replacement: path.resolve(__dirname, `src/themes/${name}/main/resources`) },
                   { find: `tinymce/themes/${name}`, replacement: path.resolve(__dirname, `lib/themes/${name}/main/ts`) }
                 ]
-              }),
-              swag.remapImports() // TODO: fast-check is being imported and rollup throws error
+              })
             ]
           },
           files:[
@@ -943,7 +942,7 @@ module.exports = function (grunt) {
   grunt.registerTask('start', ['webpack-dev-server']);
 
   grunt.registerTask('buildOnly', ['clean:dist', 'prod']);
-  grunt.registerTask('default', ['clean:dist', 'shell:eslint', 'prod']);
+  grunt.registerTask('default', ['clean:dist', 'prod']);
   grunt.registerTask('test', ['bedrock-auto:standard']);
   grunt.registerTask('test-manual', ['bedrock-manual']);
 };

--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -8,6 +8,8 @@ let zipUtils = require('./tools/modules/zip-helper');
 let gruntUtils = require('./tools/modules/grunt-utils');
 let gruntWebPack = require('./tools/modules/grunt-webpack');
 let swag = require('@ephox/swag');
+const nodeResolve = require('@rollup/plugin-node-resolve');
+const alias = require('@rollup/plugin-alias');
 let path = require('path');
 
 let plugins = [
@@ -72,18 +74,16 @@ module.exports = function (grunt) {
       {
         core: {
           options: {
-            treeshake: true,
             format: 'iife',
             onwarn: swag.onwarn,
             plugins: [
               FilesAsStrings,
-              swag.nodeResolve({
-                basedir: __dirname,
-                prefixes: {
-                  'tinymce/core': 'lib/core/main/ts'
-                }
-              }),
-              swag.remapImports()
+              nodeResolve(),
+              alias({
+                entries: [
+                  { find: 'tinymce/core', replacement: path.resolve(__dirname, 'lib/core/main/ts') }
+                ]
+              })
             ]
           },
           files:[
@@ -95,7 +95,6 @@ module.exports = function (grunt) {
         },
         'core-types': {
           options: {
-            treeshake: true,
             format: 'es',
             onwarn: (warning) => {
               // Ignore circular deps in types
@@ -123,24 +122,17 @@ module.exports = function (grunt) {
       gruntUtils.generate(plugins, 'plugin', (name) => {
         return {
           options: {
-            treeshake: true,
             format: 'iife',
             onwarn: swag.onwarn,
             plugins: [
               FilesAsStrings,
-              swag.nodeResolve({
-                basedir: __dirname,
-                prefixes: gruntUtils.prefixes({
-                  'tinymce/core': 'lib/globals/tinymce/core'
-                }, [
-                  [`tinymce/plugins/${name}`, `lib/plugins/${name}/main/ts`]
-                ]),
-                mappers: [
-                  swag.mappers.replaceDir('./lib/core/main/ts/api', './lib/globals/tinymce/core/api'),
-                  swag.mappers.invalidDir('./lib/core/main/ts')
+              nodeResolve(),
+              alias({
+                entries: [
+                  { find: /^tinymce\/core\/(.+)$/, replacement: path.resolve(__dirname, 'lib/globals/tinymce/core/$1') },
+                  { find: `tinymce/plugins/${name}`, replacement: path.resolve(__dirname, `lib/plugins/${name}/main/ts`) }
                 ]
-              }),
-              swag.remapImports()
+              })
             ]
           },
           files:[ { src: `lib/plugins/${name}/main/ts/Main.js`, dest: `js/tinymce/plugins/${name}/plugin.js` } ]
@@ -149,25 +141,19 @@ module.exports = function (grunt) {
       gruntUtils.generate(themes, 'theme', (name) => {
         return {
           options: {
-            treeshake: true,
             format: 'iife',
             onwarn: swag.onwarn,
             plugins: [
               FilesAsStrings,
-              swag.nodeResolve({
-                basedir: __dirname,
-                prefixes: gruntUtils.prefixes({
-                  'tinymce/core': 'lib/globals/tinymce/core'
-                }, [
-                  [`tinymce/themes/${name}/resources`, `src/themes/${name}/main/resources`],
-                  [`tinymce/themes/${name}`, `lib/themes/${name}/main/ts`]
-                ]),
-                mappers: [
-                  swag.mappers.replaceDir('./lib/core/main/ts/api', './lib/globals/tinymce/core/api'),
-                  swag.mappers.invalidDir('./lib/core/main/ts')
+              nodeResolve(),
+              alias({
+                entries: [
+                  { find: /^tinymce\/core\/(.+)$/, replacement: path.resolve(__dirname, 'lib/globals/tinymce/core/$1') },
+                  { find: `tinymce/themes/${name}/resources`, replacement: path.resolve(__dirname, `src/themes/${name}/main/resources`) },
+                  { find: `tinymce/themes/${name}`, replacement: path.resolve(__dirname, `lib/themes/${name}/main/ts`) }
                 ]
               }),
-              swag.remapImports()
+              swag.remapImports() // TODO: fast-check is being imported and rollup throws error
             ]
           },
           files:[
@@ -181,24 +167,17 @@ module.exports = function (grunt) {
       gruntUtils.generate(models, 'model', (name) => {
         return {
           options: {
-            treeshake: true,
             format: 'iife',
             onwarn: swag.onwarn,
             plugins: [
               FilesAsStrings,
-              swag.nodeResolve({
-                basedir: __dirname,
-                prefixes: gruntUtils.prefixes({
-                  'tinymce/core': 'lib/globals/tinymce/core'
-                }, [
-                  [`tinymce/models/${name}`, `lib/models/${name}/main/ts`]
-                ]),
-                mappers: [
-                  swag.mappers.replaceDir('./lib/core/main/ts/api', './lib/globals/tinymce/core/api'),
-                  swag.mappers.invalidDir('./lib/core/main/ts')
+              nodeResolve(),
+              alias({
+                entries: [
+                  { find: /^tinymce\/core\/(.+)$/, replacement: path.resolve(__dirname, 'lib/globals/tinymce/core/$1') },
+                  { find: `tinymce/models/${name}`, replacement: path.resolve(__dirname, `lib/models/${name}/main/ts`) }
                 ]
-              }),
-              swag.remapImports()
+              })
             ]
           },
           files:[
@@ -223,7 +202,6 @@ module.exports = function (grunt) {
         options: {
           ecma: 2018,
           output: {
-            comments: 'all',
             ascii_only: true
           },
           compress: {
@@ -965,7 +943,7 @@ module.exports = function (grunt) {
   grunt.registerTask('start', ['webpack-dev-server']);
 
   grunt.registerTask('buildOnly', ['clean:dist', 'prod']);
-  grunt.registerTask('default', ['clean:dist', 'shell:eslint', 'prod']);
+  grunt.registerTask('default', ['clean:dist', 'prod']);
   grunt.registerTask('test', ['bedrock-auto:standard']);
   grunt.registerTask('test-manual', ['bedrock-manual']);
 };

--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -943,7 +943,7 @@ module.exports = function (grunt) {
   grunt.registerTask('start', ['webpack-dev-server']);
 
   grunt.registerTask('buildOnly', ['clean:dist', 'prod']);
-  grunt.registerTask('default', ['clean:dist', 'prod']);
+  grunt.registerTask('default', ['clean:dist', 'shell:eslint', 'prod']);
   grunt.registerTask('test', ['bedrock-auto:standard']);
   grunt.registerTask('test-manual', ['bedrock-manual']);
 };

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -34,5 +34,9 @@
     "@tinymce/oxide": "^3.0.0",
     "@tinymce/oxide-icons-default": "^3.0.0",
     "dompurify": "3.2.4"
+  },
+  "devDependencies": {
+    "@rollup/plugin-alias": "^5.1.1",
+    "@rollup/plugin-node-resolve": "^16.0.1"
   }
 }

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -1,9 +1,9 @@
-import { Keys } from '@ephox/agar';
 import { AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Button, Disabling, Focusing, FocusInsideModes, Input, Keying, Memento, NativeEvents, Representing, SystemEvents, Tooltipping } from '@ephox/alloy';
 import { Arr, Cell, Fun, Id, Optional, Type } from '@ephox/katamari';
 import { Focus, SugarElement, Traverse } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
+import VK from 'tinymce/core/api/util/VK';
 import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 
 import * as Options from '../../../api/Options';
@@ -109,7 +109,7 @@ const createBespokeNumberInput = (editor: Editor, backstage: UiFactoryBackstage,
           onControlAttached({ onSetup, getApi }, editorOffCellStepButton),
           onControlDetached({ getApi }, editorOffCellStepButton),
           AlloyEvents.run(NativeEvents.keydown(), (comp, se) => {
-            if (se.event.raw.keyCode === Keys.space() || se.event.raw.keyCode === Keys.enter()) {
+            if (se.event.raw.keyCode === VK.SPACEBAR || se.event.raw.keyCode === VK.ENTER) {
               if (!Disabling.isDisabled(comp)) {
                 action(false);
               }

--- a/yarn.lock
+++ b/yarn.lock
@@ -974,10 +974,10 @@
     which "^2.0.0"
     xml-writer "^1.6.0"
 
-"@ephox/dispute@^1.0.15", "@ephox/dispute@^1.0.3":
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/@ephox/dispute/-/dispute-1.0.15.tgz#b16db7899b16ad5ac10dd6e26e39cbcd17804569"
-  integrity sha512-CChNuKLWX29kZ2akmB8DegHDigaXUAhFPtAkUw/7Ss/AFAuobCyfScNhOIZKNycRbcPYmbs2MLY9Z5tygG525A==
+"@ephox/dispute@^1.0.16", "@ephox/dispute@^1.0.3":
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/@ephox/dispute/-/dispute-1.0.16.tgz#feae65b14651c18326a6ca7fd3f537ee411361b2"
+  integrity sha512-qHy0c+TX4FZx6xI2EBoBqOjGlbtGqQlvK7uWMNCVkfXveJ/dWhjFKfxRR2fsIN/xOYDQ7uJ/GcD+oDpryxl1dA==
   dependencies:
     tslib "^2.0.0"
 
@@ -1688,6 +1688,31 @@
     unbzip2-stream "1.4.3"
     yargs "17.7.2"
 
+"@rollup/plugin-alias@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-alias/-/plugin-alias-5.1.1.tgz#53601d88cda8b1577aa130b4a6e452283605bf26"
+  integrity sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==
+
+"@rollup/plugin-node-resolve@^16.0.1":
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.1.tgz#2fc6b54ca3d77e12f3fb45b2a55b50720de4c95d"
+  integrity sha512-tk5YCxJWIG81umIvNkSod2qK5KyQW19qcBF/B78n1bjtOON6gzKoVeSzAE8yHCZEDmqkHKkxplExA8KzdJLJpA==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    "@types/resolve" "1.20.2"
+    deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.22.1"
+
+"@rollup/pluginutils@^5.0.1":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.1.4.tgz#bb94f1f9eaaac944da237767cdfee6c5b2262d4a"
+  integrity sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    estree-walker "^2.0.2"
+    picomatch "^4.0.2"
+
 "@rollup/rollup-android-arm-eabi@4.28.1":
   version "4.28.1"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.28.1.tgz#7f4c4d8cd5ccab6e95d6750dbe00321c1f30791e"
@@ -2365,7 +2390,12 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*", "@types/estree@1.0.6", "@types/estree@^1.0.6":
+"@types/estree@*", "@types/estree@^1.0.0", "@types/estree@^1.0.6":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.7.tgz#4158d3105276773d5b7695cd4834b1722e4f37a8"
+  integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
+
+"@types/estree@1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
@@ -2509,6 +2539,11 @@
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
+
+"@types/resolve@1.20.2":
+  version "1.20.2"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.2.tgz#97d26e00cd4a0423b4af620abecf3e6f442b7975"
+  integrity sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==
 
 "@types/retry@0.12.2":
   version "0.12.2"
@@ -5292,6 +5327,11 @@ estree-walker@^0.6.1:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
   integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
 
+estree-walker@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -7001,6 +7041,11 @@ is-lambda@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5"
   integrity sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==
+
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+  integrity sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==
 
 is-negative-zero@^2.0.3:
   version "2.0.3"
@@ -10103,7 +10148,7 @@ resolve@1.12.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.10.0, resolve@^1.11.0, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.22.10, resolve@^1.22.4, resolve@^1.9.0:
+resolve@^1.10.0, resolve@^1.11.0, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.22.1, resolve@^1.22.10, resolve@^1.22.4, resolve@^1.9.0:
   version "1.22.10"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.10.tgz#b663e83ffb09bbf2386944736baae803029b8b39"
   integrity sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==
@@ -10823,16 +10868,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10905,7 +10941,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10918,13 +10954,6 @@ strip-ansi@^3.0.0:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -12049,7 +12078,7 @@ wordwrapjs@^4.0.0:
     reduce-flatten "^2.0.0"
     typical "^5.2.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12062,15 +12091,6 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Related Ticket: TINY-11915

Description of Changes:
* Refactored snooker to not use a curried function since that caused the tree shaker to double the size of the table plugin
* Replaced swags node resolve code with rollup plugins nodeResolve and alias

- [x] Bump dispute version to one that has is marked as side effect free

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved consistency and type safety for table operations, ensuring a uniform interface for all table editing actions.
  - Updated internal event handling for number input controls to enhance reliability.

- **Chores**
  - Updated build configuration to use new plugins for module resolution and aliasing, and removed deprecated options.
  - Upgraded development dependencies for improved compatibility and stability.
  - Added new development dependencies for build tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->