### PR TITLE
TINY-12021: Add pageUid and editorUid properties

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12021-2025-04-09.yaml
+++ b/.changes/unreleased/tinymce-TINY-12021-2025-04-09.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: Added `pageUid` and `editorUid` properties to tinymce global and editor instance respectively.
+time: 2025-04-09T13:00:36.019555+10:00
+custom:
+    Issue: TINY-12021

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Id.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Id.ts
@@ -1,4 +1,6 @@
+import * as IdUtils from '../util/IdUtilts';
 import * as Num from './Num';
+import * as Type from './Type';
 
 /**
  * Generate a unique identifier.
@@ -13,7 +15,7 @@ import * as Num from './Num';
  */
 let unique = 0;
 
-export const generate = (prefix: string): string => {
+const generate = (prefix: string): string => {
   const date = new Date();
   const time = date.getTime();
   const random = Math.floor(Num.random() * 1000000000);
@@ -21,4 +23,22 @@ export const generate = (prefix: string): string => {
   unique++;
 
   return prefix + '_' + random + unique + String(time);
+};
+
+/**
+ * Generate a uuidv4 string
+ * In accordance with RFC 4122 (https://datatracker.ietf.org/doc/html/rfc4122)
+ */
+const uuidV4 = (): `${string}-${string}-${string}-${string}-${string}` => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  if (Type.isFunction(window.crypto.randomUUID) && window.isSecureContext) {
+    return window.crypto.randomUUID();
+  } else {
+    return IdUtils.uuidV4String();
+  }
+};
+
+export {
+  generate,
+  uuidV4
 };

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Id.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Id.ts
@@ -1,6 +1,5 @@
 import * as IdUtils from '../util/IdUtilts';
 import * as Num from './Num';
-import * as Type from './Type';
 
 /**
  * Generate a unique identifier.
@@ -31,7 +30,7 @@ const generate = (prefix: string): string => {
  */
 const uuidV4 = (): `${string}-${string}-${string}-${string}-${string}` => {
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  if (Type.isFunction(window.crypto.randomUUID) && window.isSecureContext) {
+  if (window.isSecureContext) {
     return window.crypto.randomUUID();
   } else {
     return IdUtils.uuidV4String();

--- a/modules/katamari/src/main/ts/ephox/katamari/util/IdUtilts.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/util/IdUtilts.ts
@@ -2,8 +2,17 @@
 
 const uuidV4Bytes = (): Uint8Array<ArrayBuffer> => {
   const bytes = window.crypto.getRandomValues(new Uint8Array(16));
+
+  // https://tools.ietf.org/html/rfc4122#section-4.1.3
+  // This will first bit mask away the most significant 4 bits (version octet)
+  // then mask in the v4 number we only care about v4 random version at this point so (byte & 0b00001111 | 0b01000000)
   bytes[6] = bytes[6] & 15 | 64;
+
+  // https://tools.ietf.org/html/rfc4122#section-4.1.1
+  // This will first bit mask away the highest two bits then masks in the highest bit so (byte & 0b00111111 | 0b10000000)
+  // So it will set the Msb0=1 & Msb1=0 described by the "The variant specified in this document." row in the table
   bytes[8] = bytes[8] & 63 | 128;
+
   return bytes;
 };
 

--- a/modules/katamari/src/main/ts/ephox/katamari/util/IdUtilts.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/util/IdUtilts.ts
@@ -1,0 +1,26 @@
+/* eslint-disable no-bitwise */
+
+const uuidV4Bytes = (): Uint8Array<ArrayBuffer> => {
+  const bytes = window.crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = bytes[6] & 15 | 64;
+  bytes[8] = bytes[8] & 63 | 128;
+  return bytes;
+};
+
+const uuidV4String = (): `${string}-${string}-${string}-${string}-${string}` => {
+  const uuid = uuidV4Bytes();
+  const getHexRange = (startIndex: number, endIndex: number) => {
+    let buff = '';
+    for (let i = startIndex; i <= endIndex; ++i) {
+      const hexByte = uuid[i].toString(16).padStart(2, '0');
+      buff = buff + hexByte;
+    }
+    return buff;
+  };
+  return `${getHexRange(0, 3)}-${getHexRange(4, 5)}-${getHexRange(6, 7)}-${getHexRange(8, 9)}-${getHexRange(10, 15)}`;
+};
+
+export {
+  uuidV4Bytes,
+  uuidV4String
+};

--- a/modules/katamari/src/test/ts/atomic/api/data/IdTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/data/IdTest.ts
@@ -1,20 +1,62 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { describe, it, context } from '@ephox/bedrock-client';
 import { assert } from 'chai';
 import fc from 'fast-check';
 
 import * as Id from 'ephox/katamari/api/Id';
+import * as IdUtils from 'ephox/katamari/util/IdUtilts';
 
-describe('atomic.katamari.api.data.IdTest', () => () => {
-  it('Unit Tests', () => {
-    const one = Id.generate('test');
-    const two = Id.generate('test');
-    assert.equal(one.indexOf('test'), 0);
-    assert.equal(two.indexOf('test'), 0);
-    assert.notEqual(one, two);
+describe('atomic.katamari.api.data.IdTest', () => {
+  context('generate', () => {
+    it('Unit Tests', () => {
+      const one = Id.generate('test');
+      const two = Id.generate('test');
+      assert.equal(one.indexOf('test'), 0);
+      assert.equal(two.indexOf('test'), 0);
+      assert.notEqual(one, two);
+    });
+
+    it('should not generate identical IDs', () => {
+      const arbId = fc.string(1, 30).map(Id.generate);
+      fc.assert(fc.property(arbId, arbId, (id1, id2) => id1 !== id2));
+    });
   });
 
-  it('should not generate identical IDs', () => {
-    const arbId = fc.string(1, 30).map(Id.generate);
-    fc.assert(fc.property(arbId, arbId, (id1, id2) => id1 !== id2));
+  context('uuidV4', () => {
+    const assertIsUuidV4 = (uuid: string): void => {
+    // From https://github.com/uuidjs/uuid/blob/main/src/regex.js
+      const v4Regex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      assert.isString(uuid);
+      assert.lengthOf(uuid, 36);
+      assert.match(uuid, v4Regex);
+      const version = parseInt(uuid.slice(14, 15), 16);
+      assert.equal(version, 4);
+    };
+
+    it('native uuids should be valid and unique', () => {
+      const length = 1000;
+      const uuids = Array.from({ length }, Id.uuidV4);
+      const [ one, two ] = uuids;
+      assertIsUuidV4(one);
+      assertIsUuidV4(two);
+      assert.notStrictEqual(one, two);
+      assert.lengthOf(new Set(uuids), length);
+    });
+
+    it('non-native uuids should be valid and unique', () => {
+      const length = 1000;
+      const uuids = Array.from({ length }, IdUtils.uuidV4String);
+      const [ one, two ] = uuids;
+      assertIsUuidV4(one);
+      assertIsUuidV4(two);
+      assert.notStrictEqual(one, two);
+      assert.lengthOf(new Set(uuids), length);
+    });
+
+    // https://datatracker.ietf.org/doc/html/rfc4122#section-4.4
+    it('uuidV4Bytes should have correct fields set from section 4.4', () => {
+      const bytes = IdUtils.uuidV4Bytes();
+      const bits = bytes[8].toString(2).padStart(8, '0');
+      assert.strictEqual(bits.substring(0, 2), '10');
+    });
   });
 });

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -1,4 +1,4 @@
-import { Arr, Fun, Type } from '@ephox/katamari';
+import { Arr, Fun, Type, Id } from '@ephox/katamari';
 
 import * as EditorContent from '../content/EditorContent';
 import * as Deprecations from '../Deprecations';
@@ -96,6 +96,14 @@ class Editor implements EditorObservable {
    * @type String
    */
   public id: string;
+
+  /**
+   * A uuid string to uniquely identify an editor across any page.
+   *
+   * @property editorUid
+   * @type String
+   */
+  public editorUid: string;
 
   /**
    * Name/Value object containing plugin instances.
@@ -271,6 +279,7 @@ class Editor implements EditorObservable {
     const self = this;
 
     this.id = id;
+    this.editorUid = Id.uuidV4();
     this.hidden = false;
     const normalizedOptions = normalizeOptions(editorManager.defaultOptions, options);
 

--- a/modules/tinymce/src/core/main/ts/api/EditorManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorManager.ts
@@ -1,4 +1,4 @@
-import { Arr, Obj, Type } from '@ephox/katamari';
+import { Arr, Obj, Type, Id } from '@ephox/katamari';
 
 import * as ErrorReporter from '../ErrorReporter';
 import * as FocusController from '../focus/FocusController';
@@ -99,6 +99,7 @@ interface EditorManager extends Observable<EditorManagerEventMap> {
   documentBaseURL: string;
   i18n: I18n;
   suffix: string;
+  pageUid: string;
 
   add (this: EditorManager, editor: Editor): Editor;
   addI18n: (code: string, item: Record<string, string>) => void;
@@ -137,6 +138,14 @@ const EditorManager: EditorManager = {
 
   documentBaseURL: null as any,
   suffix: null as any,
+
+  /**
+   * A uuid string to anonymously identify the page tinymce is loaded in
+   *
+   * @property pageUid
+   * @type String
+   */
+  pageUid: null as any,
 
   /**
    * Major version of TinyMCE build.
@@ -186,6 +195,7 @@ const EditorManager: EditorManager = {
     const self = this;
     let baseURL = '';
     let suffix = '';
+    self.pageUid = Id.uuidV4();
 
     // Get base URL for the current document
     let documentBaseURL = URI.getDocumentBaseUrl(document.location);


### PR DESCRIPTION
Related Ticket: TINY-12021

Description of Changes:
* Add `uuidV4` generator to katamari `Id` module
* Add `pageUid` to tinymce global (more specifically the EditorManager)
* Add `editorUId` to editor instance object

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [X] Milestone set
* ~~[X] Docs ticket created (if applicable)~~

GitHub issues (if applicable):
