### PR TITLE
TINY-12012: Add warning message to 'fire' event api to prepare for removal

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/util/Observable.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Observable.ts
@@ -47,7 +47,7 @@ const Observable: Observable<any> = {
    * Fires the specified event by name. Consult the
    * <a href="https://www.tiny.cloud/docs/tinymce/7/events/">event reference</a> for more details on each event.
    * <br>
-   * <em>Deprecated in TinyMCE 6.0 and has been marked for removal in TinyMCE 7.0. Use <code>dispatch</code> instead.</em>
+   * <em>Deprecated in TinyMCE 6.0 and has been marked for removal in TinyMCE 9.0. Use <code>dispatch</code> instead.</em>
    *
    * @method fire
    * @param {String} name Name of the event to fire.
@@ -59,6 +59,8 @@ const Observable: Observable<any> = {
    * instance.fire('event', {...});
    */
   fire<K extends string, U extends MappedEvent<any, K>>(name: K, args?: U, bubble?: boolean) {
+    // eslint-disable-next-line no-console
+    console.warn('The "fire" event api has been deprecated and will be removed in TinyMCE 9. Use "dispatch" instead.', new Error().stack);
     return this.dispatch(name, args, bubble);
   },
 


### PR DESCRIPTION
Related Ticket: TINY-12012

Description of Changes:
While the api has been marked as deprecated since TinyMCE 6, it did not have a warning that it was going to be deprecated. Now it does.
I don't think a changelog should be needed?

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised deprecation messaging for a legacy event-based API. The update now advises that the deprecated functionality will be removed in a later release and includes a console warning recommending an alternative approach for future compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->