### PR TITLE
TINY-12015: add disc style option for unordered lists

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12015-2025-04-15.yaml
+++ b/.changes/unreleased/tinymce-TINY-12015-2025-04-15.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Added
-body: Added new `disk` style option for unordered lists.
+body: Added new `disc` style option for unordered lists.
 time: 2025-04-15T16:05:41.640261+02:00
 custom:
   Issue: TINY-12015

--- a/.changes/unreleased/tinymce-TINY-12015-2025-04-15.yaml
+++ b/.changes/unreleased/tinymce-TINY-12015-2025-04-15.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: Added new `disk` style option for unordered lists.
+time: 2025-04-15T16:05:41.640261+02:00
+custom:
+  Issue: TINY-12015

--- a/modules/tinymce/src/plugins/advlist/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/api/Options.ts
@@ -17,7 +17,7 @@ const register = (editor: Editor): void => {
 
   registerOption('advlist_bullet_styles', {
     processor: 'string[]',
-    default: 'default,circle,square'.split(',')
+    default: 'default,circle,square,disc'.split(',')
   });
 };
 

--- a/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
@@ -52,7 +52,7 @@ const addSplitButton = (editor: Editor, id: string, tooltip: string, cmd: string
     fetch: (callback) => {
       const items = Tools.map(styles, (styleValue): Menu.ChoiceMenuItemSpec => {
         const iconStyle = nodeName === ListType.OrderedList ? 'num' : 'bull';
-        const iconName = styleValue === 'disc' || styleValue === 'decimal' ? 'default' : styleValue;
+        const iconName = styleValue === 'decimal' ? 'default' : styleValue;
         const itemValue = normalizeStyleValue(styleValue);
         const displayText = styleValueToText(styleValue);
         return {

--- a/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/ui/Buttons.ts
@@ -48,7 +48,7 @@ const addSplitButton = (editor: Editor, id: string, tooltip: string, cmd: string
     tooltip,
     icon: nodeName === ListType.OrderedList ? 'ordered-list' : 'unordered-list',
     presets: 'listpreview',
-    columns: 3,
+    columns: nodeName === ListType.OrderedList ? 3 : 4,
     fetch: (callback) => {
       const items = Tools.map(styles, (styleValue): Menu.ChoiceMenuItemSpec => {
         const iconStyle = nodeName === ListType.OrderedList ? 'num' : 'bull';

--- a/modules/tinymce/src/plugins/advlist/test/ts/browser/SplitButtonTest.ts
+++ b/modules/tinymce/src/plugins/advlist/test/ts/browser/SplitButtonTest.ts
@@ -10,8 +10,8 @@ import ListsPlugin from 'tinymce/plugins/lists/Plugin';
 describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     plugins: 'advlist lists',
-    advlist_bullet_styles: 'default,lower-alpha,lower-greek,lower-roman,upper-alpha,upper-roman',
-    advlist_number_styles: 'default,circle,square',
+    advlist_bullet_styles: 'default,circle,disc,square',
+    advlist_number_styles: 'default,lower-alpha,lower-greek,lower-roman,upper-alpha,upper-roman',
     toolbar: 'numlist bullist',
     base_url: '/project/tinymce/js/tinymce'
   }, [ AdvListPlugin, ListsPlugin ]);
@@ -21,7 +21,7 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
     await TinyUiActions.pWaitForUi(editor, '.tox-menu.tox-selected-menu');
   };
 
-  const assertNumListStructure = () => {
+  const assertBullListStructure = () => {
     Assertions.assertStructure('A basic alert dialog should have these components',
       ApproxStructure.build((s, str, arr) => s.element('div', {
         classes: [ arr.has('tox-tiered-menu') ],
@@ -76,6 +76,21 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
                     ],
                     attrs: {
                       'role': str.is('menuitemradio'),
+                      'aria-label': str.is('Disc')
+                    },
+                    children: [
+                      s.element('div', {
+                        classes: [ arr.has('tox-collection__item-icon') ]
+                      })
+                    ]
+                  }),
+                  s.element('div', {
+                    classes: [
+                      arr.has('tox-menu-nav__js'),
+                      arr.has('tox-collection__item')
+                    ],
+                    attrs: {
+                      'role': str.is('menuitemradio'),
                       'aria-label': str.is('Square')
                     },
                     children: [
@@ -94,7 +109,7 @@ describe('browser.tinymce.plugins.advlist.SplitButtonTest', () => {
     );
   };
 
-  const assertBullListStructure = () => {
+  const assertNumListStructure = () => {
     Assertions.assertStructure('A basic alert dialog should have these components',
       ApproxStructure.build((s, str, arr) => s.element('div', {
         classes: [ arr.has('tox-tiered-menu') ],

--- a/modules/tinymce/src/themes/silver/main/ts/ui/icons/Icons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/icons/Icons.ts
@@ -23,6 +23,7 @@ const rtlTransform: Record<string, boolean> = {
   'paste-column-before': true,
   'unordered-list': true,
   'list-bull-circle': true,
+  'list-bull-disc': true,
   'list-bull-default': true,
   'list-bull-square': true
 };


### PR DESCRIPTION
Related Ticket: TINY-12015

Description of Changes:
* Added new `disc` style option for unordered lists
* Updated the default bullet styles to include 'disc' option
* Modified the icon name logic to properly handle the 'disc' style
* Added RTL transform support for the 'list-bull-disc' icon

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new "disc" bullet style option for unordered lists, allowing users to select this style in the editor.

- **Style**
  - Updated icon handling so that the "disc" bullet style displays its own icon instead of sharing the default icon.
  - Improved right-to-left (RTL) support for the "disc" bullet style icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->