### PR TITLE
Don't strip MathML annotation elements upon pasting

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -1026,6 +1026,7 @@ const shouldConvertUnsafeEmbeds = option('convert_unsafe_embeds');
 const getLicenseKey = option('license_key');
 const getApiKey = option('api_key');
 const isDisabled = option('disabled');
+const getAllowedMathmlAnnotationEncodings = option('allow_mathml_annotation_encodings');
 const getExtendedMathmlAttributes = option('extended_mathml_attributes');
 const getExtendedMathmlElements = option('extended_mathml_elements');
 
@@ -1035,6 +1036,7 @@ export {
   getIframeAttrs,
   getDocType,
   getDocumentBaseUrl,
+  getAllowedMathmlAnnotationEncodings,
   getExtendedMathmlAttributes,
   getExtendedMathmlElements,
   getBodyId,

--- a/modules/tinymce/src/core/main/ts/paste/ProcessFilters.ts
+++ b/modules/tinymce/src/core/main/ts/paste/ProcessFilters.ts
@@ -15,6 +15,7 @@ const preProcess = (editor: Editor, html: string): string => {
     sanitize: Options.shouldSanitizeXss(editor),
     sandbox_iframes: Options.shouldSandboxIframes(editor),
     sandbox_iframes_exclusions: Options.getSandboxIframesExclusions(editor),
+    allow_mathml_annotation_encodings: Options.getAllowedMathmlAnnotationEncodings(editor),
     convert_unsafe_embeds: Options.shouldConvertUnsafeEmbeds(editor)
   }, editor.schema);
 


### PR DESCRIPTION
If the `allow_mathml_annotation_encodings` option is set, then we want to allow MathML content in the document, and we want to allow the use of `<semantics>` and `<annotation>` elements (if they use an acceptable encoding.)

However, with TinyMCE 7.8.0, when pasting content from the clipboard, MathML annotations are *always deleted*, regardless of `allow_mathml_annotation_encodings`.

This is similar to issue #10144, and the example that was posted in that issue also illustrates this problem:
- Open the example: https://fiddle.tiny.cloud/0wql19wqpG/0
- In the editor, press Ctrl+A, Ctrl+C, Up, Ctrl+V
- Select View > Source Code
- You'll notice that the first equation (the one you pasted) doesn't have `<semantics>` tags, but the second one (the one you copied) does.

If you're curious, we (at PhysioNet) are using a custom plugin to handle MathML.
- [Current version, which only works with TinyMCE 6](https://github.com/MIT-LCP/physionet-build/blob/f315bfad1/physionet-django/static/tinymce-plugins/pnmath.js)
- [WIP version that supports TinyMCE 7](https://github.com/MIT-LCP/physionet-build/blob/519d6a924/physionet-django/static/tinymce-plugins/pnmath.js)
